### PR TITLE
fix(agent): safely handle non-string tags in decodeScheduleTag and stripScheduleTags

### DIFF
--- a/packages/agent/src/triggers/workbench-migration.test.ts
+++ b/packages/agent/src/triggers/workbench-migration.test.ts
@@ -78,6 +78,25 @@ describe("decodeScheduleTag", () => {
     expect(decodeScheduleTag([])).toBeNull();
     expect(decodeScheduleTag(undefined)).toBeNull();
   });
+
+  it("safely ignores non-string elements in tags", () => {
+    expect(
+      decodeScheduleTag([
+        null as unknown as string,
+        123 as unknown as string,
+        "schedule:0 9 * * 1-5",
+      ]),
+    ).toEqual({
+      triggerType: "cron",
+      cronExpression: "0 9 * * 1-5",
+    });
+    expect(
+      decodeScheduleTag([
+        null as unknown as string,
+        undefined as unknown as string,
+      ]),
+    ).toBeNull();
+  });
 });
 
 describe("migrateWorkbenchScheduleTags", () => {

--- a/packages/agent/src/triggers/workbench-migration.ts
+++ b/packages/agent/src/triggers/workbench-migration.ts
@@ -40,6 +40,7 @@ export function decodeScheduleTag(
   tags: readonly string[] | undefined,
 ): DecodedScheduleTag | null {
   for (const tag of tags ?? []) {
+    if (typeof tag !== "string") continue;
     if (tag.startsWith(SCHEDULE_TAG_PREFIX)) {
       const cronExpression = tag.slice(SCHEDULE_TAG_PREFIX.length).trim();
       if (cronExpression) return { triggerType: "cron", cronExpression };
@@ -55,7 +56,9 @@ export function decodeScheduleTag(
 function stripScheduleTags(tags: readonly string[] | undefined): string[] {
   return (tags ?? []).filter(
     (tag) =>
-      !tag.startsWith(SCHEDULE_TAG_PREFIX) && !tag.startsWith(EVENT_TAG_PREFIX),
+      typeof tag === "string" &&
+      !tag.startsWith(SCHEDULE_TAG_PREFIX) &&
+      !tag.startsWith(EVENT_TAG_PREFIX),
   );
 }
 


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Safely ignores non-string items in `tags` array inside `decodeScheduleTag` and `stripScheduleTags` during workbench trigger migration.

# Background

## What does this PR do?

In `packages/agent/src/triggers/workbench-migration.ts`, `decodeScheduleTag` and `stripScheduleTags` iterate over `tags` assuming all entries are strings and immediately call `tag.startsWith()`. If a task contains non-string tag entries (e.g. `null` or numbers from corrupted task state or external sources), calling `startsWith` throws `TypeError: null is not an object (evaluating 'tag.startsWith')`. Guarding with `typeof tag === "string"` ensures graceful skipping.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Inspect `packages/agent/src/triggers/workbench-migration.ts` and `workbench-migration.test.ts`.

## Detailed testing steps

Run `bun test --cwd packages/agent src/triggers/workbench-migration.test.ts`.

# Evidence Gate

<!-- evidence-head:5c08e0f0c3ecb83b3908ecc9aa7a2fd11528964d -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - backend logic change only`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - unit test verified`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend changes`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - trigger migration helper change`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - pure migration helper function`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - no visual changes`.

# Evidence Details

## Red (reverted)
```
TypeError: null is not an object (evaluating 'tag.startsWith')
      at decodeScheduleTag (/Users/naynaingoo/Downloads/eliza-develop/.worktrees/hunt-1787565657/packages/agent/src/triggers/workbench-migration.ts:43:9)
(fail) decodeScheduleTag > safely ignores non-string elements in tags
6 pass, 1 fail
```

## Green (restored)
```
(pass) decodeScheduleTag > safely ignores non-string elements in tags
7 pass, 0 fail, 23 expect() calls
```

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

