### PR TITLE
test(ui): cover cloud-api-test-server

### DIFF
--- a/packages/ui/src/cloud/applications/cloud-api-test-server.test.ts
+++ b/packages/ui/src/cloud/applications/cloud-api-test-server.test.ts
@@ -1,0 +1,273 @@
+/**
+ * Unit tests for the cloud API test-server launcher. The suite drives the real
+ * spawn/handshake behaviour with throwaway bun fixture scripts staged in a
+ * temporary repo root (no network server needed): parse success, split and
+ * oversized stdout chunks, first-match precedence, forced env/cwd injection,
+ * timeout rejection, exit-before-listening, and spawn failure.
+ */
+import type { ChildProcess } from "node:child_process";
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  realpath,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { startCloudApiTestServer } from "./__e2e__/cloud-api-test-server.ts";
+
+const DEV_SCRIPT_RELPATH = join(
+  "packages",
+  "cloud",
+  "scripts",
+  "admin",
+  "dev",
+  "cloud-api-hono-dev.ts",
+);
+
+const KEEP_ALIVE = "setInterval(() => {}, 10_000);";
+
+// A fixture that never reports listening must not outlive the test even when
+// the launcher rejects and the handle stays private to it.
+const SILENT_WITH_WATCHDOG = [
+  KEEP_ALIVE,
+  "setTimeout(() => process.exit(0), 30_000);",
+].join("\n");
+
+const createdRepoRoots: string[] = [];
+const spawnedChildren: ChildProcess[] = [];
+
+afterEach(async () => {
+  vi.useRealTimers();
+  for (const child of spawnedChildren.splice(0)) {
+    if (child.exitCode === null && child.signalCode === null) {
+      child.kill("SIGKILL");
+    }
+  }
+  await Promise.all(
+    createdRepoRoots
+      .splice(0)
+      .map((root) => rm(root, { recursive: true, force: true })),
+  );
+});
+
+async function stageFixture(script: string): Promise<string> {
+  const repoRoot = await mkdtemp(join(tmpdir(), "cloud-api-test-server-"));
+  const scriptPath = join(repoRoot, DEV_SCRIPT_RELPATH);
+  await mkdir(dirname(scriptPath), { recursive: true });
+  await writeFile(scriptPath, script);
+  createdRepoRoots.push(repoRoot);
+  return repoRoot;
+}
+
+function track(child: ChildProcess): ChildProcess {
+  spawnedChildren.push(child);
+  return child;
+}
+
+function exited(child: ChildProcess): boolean {
+  return child.exitCode !== null || child.signalCode !== null;
+}
+
+async function waitForExit(child: ChildProcess): Promise<void> {
+  if (exited(child)) return;
+  await new Promise<void>((resolve) => {
+    child.once("exit", () => resolve());
+  });
+}
+
+describe("startCloudApiTestServer", () => {
+  it("resolves with the advertised base URL and a live child once the listening line appears", async () => {
+    const repoRoot = await stageFixture(
+      [
+        'console.log("[cloud-api-hono-dev] listening on http://127.0.0.1:46311");',
+        KEEP_ALIVE,
+      ].join("\n"),
+    );
+
+    const { child, baseUrl } = await startCloudApiTestServer({
+      repoRoot,
+      env: process.env,
+    });
+    track(child);
+
+    expect(baseUrl).toBe("http://127.0.0.1:46311");
+    expect(typeof child.pid).toBe("number");
+    expect(exited(child)).toBe(false);
+
+    child.kill("SIGTERM");
+    await waitForExit(child);
+  }, 20_000);
+
+  it("spawns the dev script inside repoRoot and forces API_DEV_HOST/API_DEV_PORT while forwarding the caller env", async () => {
+    const repoRoot = await stageFixture(
+      [
+        'import { writeFileSync } from "node:fs";',
+        'writeFileSync(new URL("./probe.json", import.meta.url), JSON.stringify({ host: process.env.API_DEV_HOST, port: process.env.API_DEV_PORT, marker: process.env.PROBE_MARKER, cwd: process.cwd() }));',
+        'console.log("[cloud-api-hono-dev] listening on http://127.0.0.1:46312");',
+        KEEP_ALIVE,
+      ].join("\n"),
+    );
+
+    const { child, baseUrl } = await startCloudApiTestServer({
+      repoRoot,
+      env: { ...process.env, PROBE_MARKER: "caller-env-passthrough" },
+    });
+    track(child);
+
+    try {
+      expect(baseUrl).toBe("http://127.0.0.1:46312");
+      const probe = JSON.parse(
+        await readFile(
+          join(repoRoot, DEV_SCRIPT_RELPATH, "../probe.json"),
+          "utf8",
+        ),
+      ) as { host: string; port: string; marker: string; cwd: string };
+      expect(probe.host).toBe("127.0.0.1");
+      expect(probe.port).toBe("0");
+      expect(probe.marker).toBe("caller-env-passthrough");
+      expect(probe.cwd).toBe(await realpath(repoRoot));
+    } finally {
+      child.kill("SIGTERM");
+      await waitForExit(child);
+    }
+  }, 20_000);
+
+  it("reassembles the listening line when it arrives split across separate stdout chunks", async () => {
+    const repoRoot = await stageFixture(
+      [
+        'process.stdout.write("[cloud-api-ho");',
+        'setTimeout(() => { process.stdout.write("no-dev] listening on http://127.0.0.1:46313\\n"); }, 200);',
+        KEEP_ALIVE,
+      ].join("\n"),
+    );
+
+    const { child, baseUrl } = await startCloudApiTestServer({
+      repoRoot,
+      env: process.env,
+    });
+    track(child);
+
+    try {
+      expect(baseUrl).toBe("http://127.0.0.1:46313");
+    } finally {
+      child.kill("SIGTERM");
+      await waitForExit(child);
+    }
+  }, 20_000);
+
+  it("still finds the listening line after more than 8 KiB of earlier output", async () => {
+    const repoRoot = await stageFixture(
+      [
+        'process.stdout.write("#".repeat(9_000) + "\\n");',
+        'console.log("[cloud-api-hono-dev] listening on http://127.0.0.1:46314");',
+        KEEP_ALIVE,
+      ].join("\n"),
+    );
+
+    const { child, baseUrl } = await startCloudApiTestServer({
+      repoRoot,
+      env: process.env,
+    });
+    track(child);
+
+    try {
+      expect(baseUrl).toBe("http://127.0.0.1:46314");
+    } finally {
+      child.kill("SIGTERM");
+      await waitForExit(child);
+    }
+  }, 20_000);
+
+  it("settles on the first advertised address and ignores later duplicates", async () => {
+    const repoRoot = await stageFixture(
+      [
+        'console.log("[cloud-api-hono-dev] listening on http://127.0.0.1:46315");',
+        'console.log("[cloud-api-hono-dev] listening on http://127.0.0.1:46316");',
+        KEEP_ALIVE,
+      ].join("\n"),
+    );
+
+    const { child, baseUrl } = await startCloudApiTestServer({
+      repoRoot,
+      env: process.env,
+    });
+    track(child);
+
+    try {
+      expect(baseUrl).toBe("http://127.0.0.1:46315");
+    } finally {
+      child.kill("SIGTERM");
+      await waitForExit(child);
+    }
+  }, 20_000);
+
+  it("rejects with the timeout message when no listening line is reported in time", async () => {
+    const repoRoot = await stageFixture(SILENT_WITH_WATCHDOG);
+
+    await expect(
+      startCloudApiTestServer({
+        repoRoot,
+        env: process.env,
+        timeoutMs: 500,
+      }),
+    ).rejects.toThrow(
+      "cloud-api-hono-dev did not report its listening address within 500ms",
+    );
+  }, 20_000);
+
+  it("uses the default 120 second budget when timeoutMs is omitted", async () => {
+    const repoRoot = await stageFixture(SILENT_WITH_WATCHDOG);
+
+    vi.useFakeTimers();
+    const pending = startCloudApiTestServer({ repoRoot, env: process.env });
+    const outcome = expect(pending).rejects.toThrow(
+      "cloud-api-hono-dev did not report its listening address within 120000ms",
+    );
+    await vi.advanceTimersByTimeAsync(120_000);
+    await outcome;
+  }, 20_000);
+
+  it("reports the exit code when the dev server exits before listening", async () => {
+    const repoRoot = await stageFixture("process.exit(3);");
+
+    await expect(
+      startCloudApiTestServer({ repoRoot, env: process.env }),
+    ).rejects.toThrow(
+      "cloud-api-hono-dev exited before listening (code 3, signal null)",
+    );
+  }, 20_000);
+
+  it("reports the signal when the dev server is killed before listening", async () => {
+    const repoRoot = await stageFixture(
+      "process.kill(process.pid, 'SIGKILL');",
+    );
+
+    await expect(
+      startCloudApiTestServer({ repoRoot, env: process.env }),
+    ).rejects.toThrow(
+      "cloud-api-hono-dev exited before listening (code null, signal SIGKILL)",
+    );
+  }, 20_000);
+
+  it("propagates the spawn error when bun cannot be resolved", async () => {
+    const repoRoot = await stageFixture(SILENT_WITH_WATCHDOG);
+
+    let caught: unknown;
+    try {
+      await startCloudApiTestServer({
+        repoRoot,
+        env: {},
+        timeoutMs: 5_000,
+      });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as NodeJS.ErrnoException).code).toBe("ENOENT");
+  }, 20_000);
+});


### PR DESCRIPTION

## What

Adds a unit suite for `packages/ui/src/cloud/applications/__e2e__/cloud-api-test-server.ts`, which previously had no same-named test anywhere in the repo (verified against current `origin/develop` with `git ls-tree -r`). The module had exactly one exported function and zero coverage of its child-process handshake logic.

## How it is tested

The suite drives the real module end to end — no mocks on the subject under test. Each case stages a temporary `repoRoot` containing a throwaway `packages/cloud/scripts/admin/dev/cloud-api-hono-dev.ts` fixture script, then lets `startCloudApiTestServer` spawn a real `bun` child process against it and asserts on what the launcher actually does:

- resolves with the advertised base URL and a live child once the listening line appears;
- spawns inside `repoRoot` and forces `API_DEV_HOST=127.0.0.1` / `API_DEV_PORT=0` while forwarding caller env vars (observed by a probe file written by the spawned process);
- reassembles the listening line split across separate stdout chunks;
- still finds the listening line after more than 8 KiB of earlier output (rolling buffer window);
- settles on the first advertised address and ignores later duplicates;
- rejects with the exact timeout message under an explicit short budget, and applies the default 120 s budget when `timeoutMs` is omitted (fake timers);
- reports `(code 3, signal null)` when the dev server exits before listening, and `(code null, signal SIGKILL)` when it is killed before listening;
- propagates the spawn error (`ENOENT`) when the runtime binary cannot be resolved.

## File placement

The suite lives at `src/cloud/applications/cloud-api-test-server.test.ts` — adjacent to, not inside, `__e2e__/`: the package unit config excludes `**/__e2e__/**` from the standard lane (`packages/ui/vitest.config.ts`), so a suite placed beside the module would never run in CI. Importing a helper out of an `__e2e__/` directory into a colocated unit test follows existing precedent (`src/cloud/__tests__/optional-wallet-peer-stub.test.ts`, `src/testing/e2e-runner/suggestions-bundle.test.ts`).

## Evidence (test-only change)

Run at this head against `origin/develop` @ `1f236fd1f58f9a5be09e5ac10c439040a7ea6a3c`:

- `bunx vitest run src/cloud/applications/cloud-api-test-server.test.ts` → **Test Files 1 passed (1), Tests 10 passed (10)** (~1 s).
- `bunx biome check src/cloud/applications/cloud-api-test-server.test.ts` → clean, no fixes applied.
- `bunx tsc --noEmit` in `packages/ui` → the new test file appears nowhere in the output.
- The diff is one new test file, +273/−0; no production code paths are touched.

This is a fork contribution: hosted CI does not run on this pull request, so the counts above are quoted directly rather than implied from checks.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:57722320f9c21c2c3b7904f89947d06587095f9f -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
