### PR TITLE
fix(agent): safely guard task input in taskMetadata for triggers runtime

### DIFF
--- a/packages/agent/src/triggers/runtime.test.ts
+++ b/packages/agent/src/triggers/runtime.test.ts
@@ -19,6 +19,7 @@ import {
   executeTriggerTask,
   listTriggerTasks,
   readTriggerConfig,
+  readTriggerRuns,
   registerTriggerTaskWorker,
   TRIGGER_TASK_NAME,
   TRIGGER_TASK_TAGS,
@@ -1643,5 +1644,12 @@ describe("listTriggerTasks", () => {
 
     const tasks = await listTriggerTasks(runtime);
     expect(tasks).toEqual([]);
+  });
+
+  it("safely handles null or non-object task in readTriggerConfig and readTriggerRuns", () => {
+    expect(readTriggerConfig(null as unknown as Task)).toBeNull();
+    expect(readTriggerConfig(undefined as unknown as Task)).toBeNull();
+    expect(readTriggerRuns(null as unknown as Task)).toEqual([]);
+    expect(readTriggerRuns(undefined as unknown as Task)).toEqual([]);
   });
 });

--- a/packages/agent/src/triggers/runtime.ts
+++ b/packages/agent/src/triggers/runtime.ts
@@ -226,6 +226,7 @@ function eventFilterMatches(
 }
 
 function taskMetadata(task: Task): TriggerTaskMetadata {
+  if (!task || typeof task !== "object") return {};
   const metadata = task.metadata;
   return metadata && typeof metadata === "object" && !Array.isArray(metadata)
     ? (metadata as TriggerTaskMetadata)


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Safely returns empty metadata object `{}` when null or non-object task is passed to `taskMetadata` in `triggers/runtime.ts`.

# Background

## What does this PR do?

In `packages/agent/src/triggers/runtime.ts`, `taskMetadata` directly accessed `task.metadata`. When `readTriggerConfig` or `readTriggerRuns` was invoked with `null` or `undefined` task arguments, it threw `TypeError: Cannot read properties of null (reading 'metadata')`. Guarding with `if (!task || typeof task !== "object") return {}` enables safe execution and returns `null` or empty array as expected.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Inspect `packages/agent/src/triggers/runtime.ts` and `runtime.test.ts`.

## Detailed testing steps

Run `bunx vitest run src/triggers/runtime.test.ts` in `packages/agent`.

# Evidence Gate

<!-- evidence-head:58ca9aa5f20ee1d6b8fca1236289705934cad8af -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - backend logic change only`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - unit test verified`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend changes`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - trigger runtime helper change`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - pure helper function`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - no visual changes`.

# Evidence Details

## Red (reverted)
```
FAIL src/triggers/runtime.test.ts > listTriggerTasks > safely handles null or non-object task in readTriggerConfig and readTriggerRuns
TypeError: Cannot read properties of null (reading 'metadata')
 ❯ taskMetadata src/triggers/runtime.ts:229:25
 ❯ readTriggerConfig src/triggers/runtime.ts:236:19
Test Files 1 failed (1), Tests 1 failed | 45 passed (46)
```

## Green (restored)
```
✓ src/triggers/runtime.test.ts (46 tests) 805ms
Test Files 1 passed (1), Tests 46 passed (46)
```

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

