### PR TITLE
fix(agent): safely handle non-string key in isSensitiveConfigKey

### DIFF
--- a/packages/agent/src/config/sensitive-keys.test.ts
+++ b/packages/agent/src/config/sensitive-keys.test.ts
@@ -31,6 +31,13 @@ describe("isSensitiveConfigKey", () => {
     expect(isSensitiveConfigKey("models.large.maxTokens")).toBe(false);
     expect(isSensitiveConfigKey("models.large.max_tokens")).toBe(false);
   });
+
+  it("safely returns false for non-string, null, or undefined keys", () => {
+    expect(isSensitiveConfigKey(null as unknown as string)).toBe(false);
+    expect(isSensitiveConfigKey(undefined as unknown as string)).toBe(false);
+    expect(isSensitiveConfigKey(123 as unknown as string)).toBe(false);
+    expect(isSensitiveConfigKey("" as unknown as string)).toBe(false);
+  });
 });
 
 describe("sensitive config handling", () => {

--- a/packages/agent/src/config/sensitive-keys.ts
+++ b/packages/agent/src/config/sensitive-keys.ts
@@ -32,6 +32,7 @@ const SENSITIVE_CAMEL_KEY_RE =
 const SENSITIVE_CONCAT_KEY_RE = /(?:master|signing|ssh|encryption)key$/i;
 
 export function isSensitiveConfigKey(key: string): boolean {
+  if (typeof key !== "string" || !key) return false;
   const lastSegment = key.split(".").at(-1) ?? key;
   const normalized = lastSegment.replace(/[-_\s]/g, "").toLowerCase();
   if (/^maxtokens?$/.test(normalized)) return false;


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Safely returns `false` when non-string or empty keys are passed to `isSensitiveConfigKey` in `sensitive-keys.ts`.

# Background

## What does this PR do?

In `packages/agent/src/config/sensitive-keys.ts`, `isSensitiveConfigKey` performed `key.split(".")` without checking if `key` is a string. When config crawlers or UI property inspectors passed non-string, `null`, or `undefined` keys, it threw `TypeError: Cannot read properties of null (reading 'split')`. Adding `if (typeof key !== "string" || !key) return false` ensures safe classification.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Inspect `packages/agent/src/config/sensitive-keys.ts` and `sensitive-keys.test.ts`.

## Detailed testing steps

Run `bunx vitest run src/config/sensitive-keys.test.ts` in `packages/agent`.

# Evidence Gate

<!-- evidence-head:14254c52ae6543a717f88187a46eb511175eb1f8 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - backend logic change only`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - backend logic change only`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - unit test verified`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend changes`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - config sensitivity classifier change`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - pure helper function`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - no visual changes`.

# Evidence Details

## Red (reverted)
```
FAIL src/config/sensitive-keys.test.ts > isSensitiveConfigKey > safely returns false for non-string, null, or undefined keys
TypeError: Cannot read properties of null (reading 'split')
 ❯ isSensitiveConfigKey src/config/sensitive-keys.ts:35:27
Test Files 1 failed (1), Tests 1 failed | 16 passed (17)
```

## Green (restored)
```
✓ src/config/sensitive-keys.test.ts (17 tests) 19ms
Test Files 1 passed (1), Tests 17 passed (17)
```

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

