### PR TITLE
test(core): cover index

### DIFF
--- a/packages/core/src/types/index.test.ts
+++ b/packages/core/src/types/index.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Exercises the runtime re-export surface of the canonical type-system barrel
+ * (`src/types/index.ts`). The barrel re-exports a small set of runtime values
+ * explicitly because bare star exports get tree-shaken away; each helper here
+ * is driven through that public path to prove it resolves to a working
+ * implementation — prompt composition (`addHeader`, `composePromptFromState`),
+ * the legacy XML response parser (`parseKeyValueXml`), view-kind resolution
+ * and gating, surface-manifest resolution with the wallpaper gate, and
+ * pending-action attention weights. Deterministic assertions with no model or
+ * database in the loop.
+ */
+import { describe, expect, it } from "vitest";
+import {
+	addHeader,
+	composePromptFromState,
+	IMMERSIVE_WALLPAPER_SURFACE,
+	isAlwaysOnViewKind,
+	isViewVisible,
+	PENDING_USER_ACTION_WEIGHT,
+	parseKeyValueXml,
+	resolveSurfaceBackgroundPolicy,
+	resolveSurfaceManifest,
+	resolveViewKind,
+	type State,
+	surfaceGrants,
+} from "./index";
+
+describe("prompt helpers re-exported through the barrel", () => {
+	it("addHeader prepends the header to a non-empty body", () => {
+		expect(addHeader("# World Information", "body text")).toBe(
+			"# World Information\nbody text\n",
+		);
+	});
+
+	it("addHeader returns the bare header when the body is empty", () => {
+		expect(addHeader("Header", "")).toBe("Header");
+	});
+
+	it("addHeader omits an empty header line entirely", () => {
+		expect(addHeader("", "Body")).toBe("Body\n");
+	});
+
+	it("composePromptFromState interpolates top-level state into the template", () => {
+		const state: State = {
+			agentName: "Alice",
+			values: {},
+			data: {},
+			text: "",
+		};
+		expect(
+			composePromptFromState({ state, template: "Hello, {{agentName}}!" }),
+		).toBe("Hello, Alice!");
+	});
+
+	it("composePromptFromState flattens state.values into the template context", () => {
+		const state: State = {
+			agentName: "Ada",
+			values: { userName: "Bob" },
+			data: {},
+			text: "",
+		};
+		expect(
+			composePromptFromState({
+				state,
+				template: "{{agentName}} meets {{userName}}",
+			}),
+		).toBe("Ada meets Bob");
+	});
+});
+
+describe("parseKeyValueXml re-exported through the barrel", () => {
+	it("parses a response block with entities and comma-separated actions", () => {
+		const parsed = parseKeyValueXml(
+			"<response><message>Hello &amp; bye</message><actions>send, reply</actions></response>",
+		);
+		expect(parsed).toEqual({
+			message: "Hello & bye",
+			actions: ["send", "reply"],
+		});
+	});
+
+	it("fails closed on empty input", () => {
+		expect(parseKeyValueXml("")).toBeNull();
+	});
+
+	it("rejects plain prose that contains no XML block", () => {
+		expect(parseKeyValueXml("just words, nothing structured")).toBeNull();
+	});
+});
+
+describe("view-kind helpers re-exported through the barrel", () => {
+	it("resolveViewKind keeps explicit kinds over the legacy developerOnly flag", () => {
+		expect(resolveViewKind({ viewKind: "system" })).toBe("system");
+		expect(resolveViewKind({ developerOnly: true })).toBe("developer");
+		expect(resolveViewKind(null)).toBe("release");
+	});
+
+	it("isViewVisible gates declarations end-to-end under the enabled set", () => {
+		const off = { developer: false, preview: false };
+		const devOn = { developer: true, preview: false };
+		expect(isViewVisible({ developerOnly: true }, off)).toBe(false);
+		expect(isViewVisible({ developerOnly: true }, devOn)).toBe(true);
+		expect(isViewVisible(undefined, off)).toBe(true); // defaults to release
+	});
+
+	it("isAlwaysOnViewKind marks release always-on but preview toggleable", () => {
+		expect(isAlwaysOnViewKind("release")).toBe(true);
+		expect(isAlwaysOnViewKind("preview")).toBe(false);
+	});
+});
+
+describe("surface-manifest helpers re-exported through the barrel", () => {
+	it("resolves safe defaults for an absent declaration", () => {
+		const resolved = resolveSurfaceManifest(null);
+		expect(resolved.background).toBe("opaque");
+		expect(resolved.header).toBe("normal");
+		expect(resolved.isolation).toBe("in-process");
+		expect(resolved.lifecycle).toBe("ephemeral");
+		expect(surfaceGrants(resolved, "navigate")).toBe(false);
+	});
+
+	it("forces shared backgrounds opaque without the wallpaper grant", () => {
+		expect(
+			resolveSurfaceBackgroundPolicy({
+				surface: { background: "shared" },
+			}),
+		).toBe("opaque");
+		expect(
+			resolveSurfaceBackgroundPolicy({
+				surface: { background: "shared", capabilities: ["wallpaper"] },
+			}),
+		).toBe("shared");
+	});
+
+	it("falls back to legacy policy fields and lets the manifest win", () => {
+		expect(resolveSurfaceManifest({ headerPolicy: "modal" }).header).toBe(
+			"modal",
+		);
+		expect(
+			resolveSurfaceManifest({
+				surface: { header: "fullscreen" },
+				headerPolicy: "modal",
+			}).header,
+		).toBe("fullscreen");
+	});
+
+	it("collapses duplicate capability grants", () => {
+		const resolved = resolveSurfaceManifest({
+			surface: { capabilities: ["storage", "storage"] },
+		});
+		expect(surfaceGrants(resolved, "storage")).toBe(true);
+		expect(resolved.capabilities.size).toBe(1);
+	});
+
+	it("resolves the canonical immersive wallpaper surface to a painted manifest", () => {
+		const resolved = resolveSurfaceManifest({
+			surface: IMMERSIVE_WALLPAPER_SURFACE,
+		});
+		expect(resolved.background).toBe("shared");
+		expect(resolved.isolation).toBe("immersive");
+		expect(surfaceGrants(resolved, "wallpaper")).toBe(true);
+		expect(surfaceGrants(resolved, "background:apply")).toBe(true);
+		expect(surfaceGrants(resolved, "navigate")).toBe(false);
+	});
+});
+
+describe("PENDING_USER_ACTION_WEIGHT re-exported through the barrel", () => {
+	it("covers every documented pending-action kind with a finite weight", () => {
+		const kinds = [
+			"approval",
+			"task_approval",
+			"choice",
+			"credential",
+			"credential_request",
+			"clarifying_question",
+			"blocked_task",
+			"prompt",
+			"pending_prompt",
+		] as const;
+		for (const kind of kinds) {
+			expect(Number.isFinite(PENDING_USER_ACTION_WEIGHT[kind])).toBe(true);
+		}
+	});
+
+	it("ranks a hard block above a waiting prompt", () => {
+		expect(PENDING_USER_ACTION_WEIGHT.blocked_task).toBeGreaterThan(
+			PENDING_USER_ACTION_WEIGHT.prompt,
+		);
+	});
+
+	it("groups approvals and choices into one severity class", () => {
+		expect(PENDING_USER_ACTION_WEIGHT.approval).toBe(
+			PENDING_USER_ACTION_WEIGHT.task_approval,
+		);
+		expect(PENDING_USER_ACTION_WEIGHT.approval).toBe(
+			PENDING_USER_ACTION_WEIGHT.choice,
+		);
+	});
+});


### PR DESCRIPTION

## What

Adds one new colocated vitest suite, `packages/core/src/types/index.test.ts`, covering the **runtime** re-export surface of the canonical core type-system barrel (`packages/core/src/types/index.ts`). The barrel deliberately re-exports a small set of runtime values explicitly because bare star exports get tree-shaken away; this suite drives each of them through the public `./index` path and asserts they resolve to working implementations:

- prompt helpers: `addHeader` (header/body joining incl. empty-header and empty-body branches) and `composePromptFromState` (template interpolation plus the `state.values` flattening consumers rely on)
- legacy structured-response parser `parseKeyValueXml`: entity decoding, comma-separated `actions` splitting, fail-closed `null` on empty input, rejection of non-XML prose
- view-kind resolution/gating: `resolveViewKind` precedence (explicit kind > legacy `developerOnly` > `"release"`), end-to-end `isViewVisible`, `isAlwaysOnViewKind`
- surface manifests: safe defaults for absent declarations, the wallpaper gate (`background: "shared"` forced opaque without the `wallpaper` grant), legacy-field fallback vs manifest precedence, capability de-duplication, and resolution of the canonical `IMMERSIVE_WALLPAPER_SURFACE`
- `PENDING_USER_ACTION_WEIGHT`: full kind coverage with finite weights, hard-block > waiting-prompt ranking, approval/choice severity grouping

No production code is modified. The diff is exactly one new test file (+199/−0).

## Evidence (local verification only — this is a fork pull request, hosted CI does not run on it)

All counts below are from the actual runs on this exact head (`587b0054c3d64a81a18bef11bb2699fa3d328021`, base `origin/develop` @ `1f236fd1f58f9a5be09e5ac10c439040a7ea6a3c`), re-fetched and re-run immediately before filing:

1. `bunx vitest run src/types/index.test.ts` (in `packages/core`) — **Test Files 1 passed (1), Tests 19 passed (19)**, duration ~0.5s. Runner for `@elizaos/core` is vitest (`node ../scripts/run-vitest.mjs run`).
2. `bunx biome check --write packages/core/src/types/index.test.ts` (repo root, repository `biome.json`) — `Checked 1 file ... Fixed 1 file`, exit 0.
3. `bunx tsc --noEmit` (in `packages/core`), output grepped for `types/index.test.ts` — no match; the new file contributes zero TypeScript diagnostics.
4. This pull request touches only the test file named above; behaviour-preserving by construction.

No mocks stand in for the system under test: every case calls the real exported function through the barrel import path.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:587b0054c3d64a81a18bef11bb2699fa3d328021 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
