### PR TITLE
fix(core): quality signals can invert a 9x relevance gap in experience recall

### DIFF
--- a/packages/core/src/features/advanced-capabilities/experience/service.findSimilar.test.ts
+++ b/packages/core/src/features/advanced-capabilities/experience/service.findSimilar.test.ts
@@ -117,3 +117,93 @@ describe("ExperienceService.findSimilarExperiences — shared recall embed fail-
 		await service.stop();
 	});
 });
+
+describe("ExperienceService.findSimilarExperiences — relevance outranks quality", () => {
+	const REL = "00000000-0000-0000-0000-00000000e101" as UUID;
+	const IRR = "00000000-0000-0000-0000-00000000e102" as UUID;
+	const DAY = 24 * 60 * 60 * 1000;
+
+	// Query vector is [1,0,0], so cosine similarity is just the first component.
+	function ranked(id: UUID, first: number, quality: "best" | "worst"): Memory {
+		const now = Date.now();
+		const best = quality === "best";
+		return {
+			id,
+			entityId: AGENT_ID,
+			agentId: AGENT_ID,
+			roomId: AGENT_ID,
+			createdAt: best ? now : now - 365 * DAY,
+			content: {
+				text: "",
+				type: "experience",
+				data: {
+					id,
+					agentId: AGENT_ID,
+					type: ExperienceType.LEARNING,
+					outcome: OutcomeType.SUCCESS,
+					context: "ctx",
+					action: "act",
+					result: "res",
+					learning: best ? "low-relevance" : "high-relevance",
+					domain: "general",
+					tags: ["t"],
+					keywords: ["k"],
+					confidence: best ? 1 : 0,
+					importance: best ? 1 : 0,
+					createdAt: best ? now : now - 365 * DAY,
+					updatedAt: best ? now : now - 365 * DAY,
+					accessCount: best ? 50 : 0,
+					embedding: [first, Math.sqrt(1 - first * first), 0],
+				},
+			},
+		} as unknown as Memory;
+	}
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	test("a 9x less similar experience does not outrank a relevant one on quality alone", async () => {
+		embedRecallQuery.mockResolvedValue([1, 0, 0]);
+		const runtime = createMockRuntime({
+			agentId: AGENT_ID,
+			getCurrentRunId: () => "33333333-3333-3333-3333-333333333333",
+			getMemories: vi.fn(async () => [
+				ranked(REL, 0.45, "worst"), // cosine 0.45, worst-possible quality
+				ranked(IRR, 0.05, "best"), // cosine 0.05 (at the floor), perfect quality
+			]),
+			upsertMemory: vi.fn(async () => true),
+			useModel: vi.fn(async () => [1, 0, 0]),
+		});
+
+		const service = await ExperienceService.start(runtime);
+		const results = await service.findSimilarExperiences("query", 5);
+
+		// Additive scoring (similarity*0.7 + quality*0.3) ranked "low-relevance"
+		// first: 0.05*0.7 + 1*0.3 = 0.335 beats 0.45*0.7 + 0*0.3 = 0.315.
+		expect(results[0]?.learning).toBe("high-relevance");
+
+		await service.stop();
+	});
+
+	test("quality still decides between comparably relevant experiences", async () => {
+		embedRecallQuery.mockResolvedValue([1, 0, 0]);
+		const runtime = createMockRuntime({
+			agentId: AGENT_ID,
+			getCurrentRunId: () => "33333333-3333-3333-3333-333333333333",
+			getMemories: vi.fn(async () => [
+				ranked(REL, 0.5, "worst"), // only 1.11x more similar — inside the window
+				ranked(IRR, 0.45, "best"),
+			]),
+			upsertMemory: vi.fn(async () => true),
+			useModel: vi.fn(async () => [1, 0, 0]),
+		});
+
+		const service = await ExperienceService.start(runtime);
+		const results = await service.findSimilarExperiences("query", 5);
+
+		expect(results[0]?.learning).toBe("low-relevance");
+
+		await service.stop();
+	});
+});

--- a/packages/core/src/features/advanced-capabilities/experience/service.ts
+++ b/packages/core/src/features/advanced-capabilities/experience/service.ts
@@ -913,13 +913,16 @@ export class ExperienceService extends Service {
 	 * Find similar experiences using vector search + reranking.
 	 *
 	 * Reranking strategy:
-	 *   Vector similarity is the dominant signal (70%) — an irrelevant experience
-	 *   should never outrank a relevant one just because it has high confidence.
-	 *   Quality signals (confidence, importance) act as tiebreakers among
-	 *   similarly-relevant results (30% combined).
+	 *   Vector similarity is the primary signal and quality signals (confidence,
+	 *   importance, recency, access frequency) scale it rather than adding to it,
+	 *   so quality can only reorder results that are already comparably relevant.
+	 *   The bound is exact: quality multiplies the score by 0.7..1.0, so it can
+	 *   overturn at most a 1/0.7 = 1.43x similarity ratio. Beyond that ratio the
+	 *   more similar experience always ranks higher, whatever its quality.
 	 *
-	 *   A minimum similarity threshold filters out noise so quality signals
-	 *   can't promote genuinely irrelevant experiences.
+	 *   A minimum similarity threshold additionally drops candidates that are not
+	 *   plausibly relevant at all. Note the threshold alone does not bound the
+	 *   reorder window — the multiplicative form is what does that.
 	 */
 	async findSimilarExperiences(text: string, limit = 5): Promise<Experience[]> {
 		if (!text || this.experiences.size === 0) {
@@ -990,8 +993,13 @@ export class ExperienceService extends Service {
 				recencyFactor * 0.12 +
 				accessFactor * 0.08;
 
-			// Final reranking score: similarity dominates (70%), quality tiebreaks (30%)
-			const rerankScore = similarity * 0.7 + qualityScore * 0.3;
+			// Quality scales similarity rather than being added to it, so the
+			// window in which quality may reorder results is relative (a 1/0.7 =
+			// 1.43x similarity ratio) rather than absolute. Adding a 0..0.3 quality
+			// term instead would let quality overturn any similarity gap below
+			// 3/7 = 0.4286, which at the low end of the admissible range inverts
+			// an order-of-magnitude relevance difference.
+			const rerankScore = similarity * (0.7 + 0.3 * qualityScore);
 
 			scored.push({ experience, score: rerankScore });
 		}


### PR DESCRIPTION
# Relates to

No existing issue — found while auditing `packages/core` for invariants that are documented but not enforced.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts. Branched from `1f236fd1f58f9a5be09e5ac10c439040a7ea6a3c`.
- [x] `bun install` and `bun run verify` were run after sync. `verify` exits non-zero on three unrelated plugin builds; reproduced on clean `develop` and recorded under **Known gaps / failures**.
- [x] A reviewer can confirm the change works without reading the code: the added test fails on the old formula and passes on the new one, and the arithmetic is in the description.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5[1m]` (diagnosis, fix, tests, verification)
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - direct interactive session, contribute-to-eliza skill not used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop` (`1f236fd1`); zero conflicts.
- [x] `bun run verify` run post-sync; the exact unrelated blocker is documented in **Known gaps / failures**.

# Risks

**Low.** One expression and one docstring in `ExperienceService.findSimilarExperiences`, plus tests. It changes the *ordering* of experience recall results, not what is admitted (`SIMILARITY_FLOOR` is untouched) and not any persisted data. Results that were already correctly ordered by relevance stay ordered; what changes is that quality can no longer invert a large relevance gap.

# Background

## What does this PR do?

`findSimilarExperiences` documents this reranking contract:

> Vector similarity is the dominant signal (70%) — an irrelevant experience should never outrank a relevant one just because it has high confidence. Quality signals (confidence, importance) act as tiebreakers among similarly-relevant results (30% combined).
>
> A minimum similarity threshold filters out noise so quality signals can't promote genuinely irrelevant experiences.

The scoring does not enforce it:

```ts
const rerankScore = similarity * 0.7 + qualityScore * 0.3;
```

`qualityScore` is normalised to `0..1`, so it contributes a fixed **0.3** of headroom, while a similarity gap costs **0.7 per unit**. Quality therefore wins whenever

```
dSimilarity * 0.7  <  dQuality * 0.3     =>     dSimilarity < 3/7 = 0.4286
```

That window is **absolute**, and `SIMILARITY_FLOOR = 0.05` admits candidates well inside it. Worked example, both admitted:

| experience | cosine | quality | score |
|---|---|---|---|
| genuinely relevant, worst-possible quality | 0.45 | 0.0 | `0.45*0.7 + 0*0.3` = **0.315** |
| barely admissible, perfect quality | 0.05 | 1.0 | `0.05*0.7 + 1*0.3` = **0.335** |

The **9x less similar** experience is returned first. The comment above the floor says it "Prevents high-quality but irrelevant experiences from appearing" — it bounds *admission*, not *ranking*.

The fix makes quality **scale** similarity instead of being added to it:

```ts
const rerankScore = similarity * (0.7 + 0.3 * qualityScore);
```

The reorder window becomes **relative** rather than absolute: quality multiplies the score by `0.7..1.0`, so it can overturn at most a `1/0.7 = 1.4286x` similarity ratio, and beyond that the more similar experience always wins regardless of quality. Quality still decides between comparably relevant results, which is what the docstring asks for.

| pair | ratio | additive | multiplicative |
|---|---|---|---|
| 0.05 (q=1) vs 0.10 (q=0) | 2.00x | inverted | correct |
| 0.05 (q=1) vs 0.20 (q=0) | 4.00x | inverted | correct |
| 0.05 (q=1) vs 0.45 (q=0) | 9.00x | inverted | correct |
| 0.40 (q=1) vs 0.50 (q=0) | 1.25x | quality wins | quality wins *(intended)* |
| 0.70 (q=1) vs 0.80 (q=0) | 1.14x | quality wins | quality wins *(intended)* |

The docstring is updated to state the guarantee the code now actually provides, including the exact 1.43x bound, rather than the one it previously asserted.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

No project-documentation change. The in-file docstring is corrected as part of this PR, because it was the thing asserting the invariant that did not hold.

# Testing

## Where should a reviewer start?

`packages/core/src/features/advanced-capabilities/experience/service.findSimilar.test.ts` — the new `relevance outranks quality` describe block. The first test is the bug; the second exists to prove the fix does not over-correct.

## Detailed testing steps

```bash
bun x vitest run packages/core/src/features/advanced-capabilities/experience/
```

Red/green on the first test, confirmed by reverting only the scoring line:

```
additive     (similarity * 0.7 + qualityScore * 0.3):  1 failed | 3 passed
             AssertionError: expected 'low-relevance' to be 'high-relevance'
multiplicative (similarity * (0.7 + 0.3 * qualityScore)):  4 passed
```

Whole feature directory on this branch: **13 files, 81 tests, all passing.**

The second test (`quality still decides between comparably relevant experiences`, a 1.11x pair) passes under **both** formulas — it is there to catch a fix that swings too far and disables quality reordering altogether.

# Evidence Gate

<!-- evidence-head:4c62781c29653a84026cfcccba8194032a22fba4 -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - no UI surface. The diff is one scoring expression, one docstring and one test file, all in packages/core.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - no UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-facing flow; the observable behaviour is the ordering of an array returned by a core service, shown by the test assertions above.`
<!-- evidence-row:backend-logs -->
- [x] Test-runner output showing the code path and the red/green transition is inline under **Detailed testing steps**.
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend involved.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent/action/provider/prompt/model change. The recall embedder is mocked in this suite and the change is pure arithmetic on an already-computed cosine similarity.`
<!-- evidence-row:domain-artifacts -->
- [x] The domain artifact is the returned ordering; both orderings are asserted directly in the tests.
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no model call is involved in the changed code path. findSimilarExperiences receives a query embedding and computes cosine similarity; the arithmetic this PR changes runs after that.`

## Backend + frontend logs

Backend, from `bun x vitest run packages/core/src/features/advanced-capabilities/experience/`:

```
 Test Files  13 passed (13)
      Tests  81 passed (81)
```

With only the scoring line reverted to the additive form:

```
 FAIL  service.findSimilar.test.ts > relevance outranks quality
       > a 9x less similar experience does not outrank a relevant one on quality alone
 AssertionError: expected 'low-relevance' to be 'high-relevance'
      Tests  1 failed | 3 passed (4)
```

Frontend: `N/A - no frontend involved.`

## Screenshots (before / after) + video walkthrough

`N/A - no UI change.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT surface touched.`

## Known gaps / failures

`bun run verify` exits `127`. **186 of 194 tasks succeed, including every `@elizaos/core` task.** The failures are three plugin builds this PR does not touch:

```
@elizaos/plugin-doordash:build:   error: script "build:js" exited with code 127
@elizaos/capacitor-talkmode:build: error: script "build" exited with code 1
@elizaos/capacitor-swabble:build:  error: script "build" exited with code 1
```

The root cause is a missing binary in my environment, not a code failure:

```
$ tsup --config ../tsup.plugin-packages.shared.ts
/bin/bash: tsup: command not found
```

I checked this rather than assuming it. Added a clean `git worktree` at `1f236fd1` — **zero changes from me** — and ran the same task there:

```
$ bun run --cwd plugins/plugin-doordash build
$ tsup --config ../tsup.plugin-packages.shared.ts
/bin/bash: tsup: command not found
error: script "build" exited with code 127
```

Identical on untouched `develop`, in packages this PR does not modify. Flagging it rather than ticking the sync gate as clean. Happy to re-run once the toolchain is available if you would rather see a fully green `verify`.
