### PR TITLE
test(ui): cover desktop-bug-report

### DIFF
--- a/packages/ui/src/utils/desktop-bug-report.test.ts
+++ b/packages/ui/src/utils/desktop-bug-report.test.ts
@@ -1,0 +1,325 @@
+/**
+ * Verifies the desktop bug-report helpers keep one exact Electrobun bridge
+ * contract: outside the desktop runtime every helper degrades to a null or
+ * void result without touching the preload RPC, and inside it each helper
+ * dispatches its canonical rpc method with verbatim params and propagates the
+ * native receipt (including a null receipt) unchanged. The diagnostics
+ * formatter is pinned as a full ordered sheet covering every fallback branch.
+ * Deterministic unit harness: the preload seam is a plain object installed on
+ * `globalThis.window`, matching how the real Electrobun preload injects it.
+ */
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import {
+  createDesktopBugReportBundle,
+  type DesktopBugReportDiagnostics,
+  formatDesktopBugReportDiagnostics,
+  loadDesktopBugReportDiagnostics,
+  openDesktopLogsFolder,
+} from "./desktop-bug-report";
+
+interface DesktopBridgeTestWindow {
+  __electrobunWindowId?: number;
+  __electrobunWebviewId?: number;
+  __ELIZA_ELECTROBUN_RPC__?: {
+    request: Record<string, (params?: unknown) => Promise<unknown>>;
+    onMessage?: (
+      messageName: string,
+      listener: (payload: unknown) => void,
+    ) => void;
+    offMessage?: (
+      messageName: string,
+      listener: (payload: unknown) => void,
+    ) => void;
+  };
+}
+
+const originalWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
+const desktopWindow = {} as DesktopBridgeTestWindow;
+
+beforeEach(() => {
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: desktopWindow,
+  });
+});
+
+afterEach(() => {
+  delete desktopWindow.__ELIZA_ELECTROBUN_RPC__;
+  delete desktopWindow.__electrobunWindowId;
+  delete desktopWindow.__electrobunWebviewId;
+});
+
+afterAll(() => {
+  if (originalWindow) {
+    Object.defineProperty(globalThis, "window", originalWindow);
+  } else {
+    Reflect.deleteProperty(globalThis, "window");
+  }
+});
+
+function installElectrobunRpc(
+  handlers: Record<string, (params?: unknown) => Promise<unknown>>,
+): void {
+  desktopWindow.__electrobunWebviewId = 7;
+  desktopWindow.__ELIZA_ELECTROBUN_RPC__ = {
+    request: handlers,
+    onMessage: vi.fn(),
+    offMessage: vi.fn(),
+  };
+}
+
+function makeDiagnostics(
+  overrides: Partial<DesktopBugReportDiagnostics> = {},
+): DesktopBugReportDiagnostics {
+  return {
+    state: "running",
+    phase: "ready",
+    updatedAt: "2026-08-24T00:00:00Z",
+    lastError: null,
+    agentName: "Eliza",
+    port: 3000,
+    startedAt: 1700000000000,
+    platform: "darwin",
+    arch: "arm64",
+    configDir: "/Users/user/.eliza",
+    logPath: "/Users/user/.eliza/logs/agent.log",
+    statusPath: "/Users/user/.eliza/status.json",
+    logTail: "All systems go",
+    ...overrides,
+  };
+}
+
+describe("loadDesktopBugReportDiagnostics", () => {
+  it("returns null when there is no window at all", async () => {
+    Reflect.deleteProperty(globalThis, "window");
+
+    await expect(loadDesktopBugReportDiagnostics()).resolves.toBeNull();
+  });
+
+  it("returns null on a plain web window without electrobun markers", async () => {
+    await expect(loadDesktopBugReportDiagnostics()).resolves.toBeNull();
+  });
+
+  it("loads startup diagnostics through desktopGetStartupDiagnostics in the desktop runtime", async () => {
+    const diagnostics = makeDiagnostics({ state: "starting", phase: "boot" });
+    const handler = vi.fn(async () => diagnostics);
+    installElectrobunRpc({ desktopGetStartupDiagnostics: handler });
+
+    const result = await loadDesktopBugReportDiagnostics();
+
+    expect(result).toEqual(diagnostics);
+    expect(handler).toHaveBeenCalledOnce();
+    expect(handler).toHaveBeenCalledWith(undefined);
+  });
+
+  it("resolves null when only a window id marks the runtime and no RPC exists", async () => {
+    desktopWindow.__electrobunWindowId = 3;
+
+    await expect(loadDesktopBugReportDiagnostics()).resolves.toBeNull();
+  });
+
+  it("resolves null when the diagnostics handler is not registered yet", async () => {
+    installElectrobunRpc({});
+
+    await expect(loadDesktopBugReportDiagnostics()).resolves.toBeNull();
+  });
+});
+
+describe("openDesktopLogsFolder", () => {
+  it("never reaches the logs-folder handler outside the electrobun runtime", async () => {
+    const handler = vi.fn(async () => "opened");
+    // A populated request map alone does not mark an electrobun runtime:
+    // without callable onMessage/offMessage the guard must still block.
+    desktopWindow.__ELIZA_ELECTROBUN_RPC__ = {
+      request: { desktopOpenLogsFolder: handler },
+    };
+
+    await expect(openDesktopLogsFolder()).resolves.toBeUndefined();
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("opens the logs folder through desktopOpenLogsFolder and resolves void", async () => {
+    const handler = vi.fn(async () => ({ ok: true }));
+    installElectrobunRpc({ desktopOpenLogsFolder: handler });
+
+    await expect(openDesktopLogsFolder()).resolves.toBeUndefined();
+    expect(handler).toHaveBeenCalledOnce();
+    expect(handler).toHaveBeenCalledWith(undefined);
+  });
+
+  it("resolves undefined instead of throwing when the handler is missing", async () => {
+    installElectrobunRpc({});
+
+    await expect(openDesktopLogsFolder()).resolves.toBeUndefined();
+  });
+});
+
+describe("createDesktopBugReportBundle", () => {
+  it("returns null without touching the bridge outside the electrobun runtime", async () => {
+    const handler = vi.fn(async () => null);
+    desktopWindow.__ELIZA_ELECTROBUN_RPC__ = {
+      request: { desktopCreateBugReportBundle: handler },
+    };
+
+    await expect(
+      createDesktopBugReportBundle({
+        reportMarkdown: "# Report",
+        reportJson: { ok: true },
+      }),
+    ).resolves.toBeNull();
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("passes the report payloads through to desktopCreateBugReportBundle verbatim", async () => {
+    const bundle = {
+      directory: "/Users/user/.eliza/bug-reports/2026-08-24T00-00-00",
+      reportMarkdownPath:
+        "/Users/user/.eliza/bug-reports/2026-08-24T00-00-00/report.md",
+      reportJsonPath:
+        "/Users/user/.eliza/bug-reports/2026-08-24T00-00-00/report.json",
+      startupLogPath: "/Users/user/.eliza/logs/agent.log",
+      startupStatusPath: "/Users/user/.eliza/status.json",
+    };
+    const reportJson = { appVersion: "1.9.0", notes: "crash on launch" };
+    const options = {
+      reportMarkdown: "# Report\nbody",
+      reportJson,
+      prefix: "eliza-bug",
+    };
+    let receivedParams: unknown;
+    const handler = vi.fn(async (params?: unknown) => {
+      receivedParams = params;
+      return bundle;
+    });
+    installElectrobunRpc({ desktopCreateBugReportBundle: handler });
+
+    const result = await createDesktopBugReportBundle(options);
+
+    expect(result).toEqual(bundle);
+    expect(handler).toHaveBeenCalledOnce();
+    expect(receivedParams).toEqual(options);
+  });
+
+  it("does not add a prefix key when the caller omits it, and propagates a null receipt", async () => {
+    let receivedParams: unknown;
+    const handler = vi.fn(async (params?: unknown) => {
+      receivedParams = params;
+      return null;
+    });
+    installElectrobunRpc({ desktopCreateBugReportBundle: handler });
+
+    await expect(
+      createDesktopBugReportBundle({
+        reportMarkdown: "# Report",
+        reportJson: {},
+      }),
+    ).resolves.toBeNull();
+    expect(receivedParams).toEqual({
+      reportMarkdown: "# Report",
+      reportJson: {},
+    });
+    expect(Object.keys(receivedParams as Record<string, unknown>)).toEqual([
+      "reportMarkdown",
+      "reportJson",
+    ]);
+  });
+
+  it("resolves null when the bundle handler is not registered", async () => {
+    installElectrobunRpc({});
+
+    await expect(
+      createDesktopBugReportBundle({
+        reportMarkdown: "# Report",
+        reportJson: {},
+      }),
+    ).resolves.toBeNull();
+  });
+});
+
+describe("formatDesktopBugReportDiagnostics", () => {
+  it("renders the complete diagnostics sheet in canonical field order", () => {
+    const formatted = formatDesktopBugReportDiagnostics(
+      makeDiagnostics({
+        appVersion: "1.9.0",
+        appRuntime: "electrobun",
+        packaged: true,
+        locale: "en-US",
+      }),
+    );
+
+    expect(formatted).toBe(
+      [
+        "App Version: 1.9.0",
+        "Runtime: electrobun",
+        "Packaged: yes",
+        "Platform: darwin arm64",
+        "Locale: en-US",
+        "Startup State: running",
+        "Startup Phase: ready",
+        "Last Error: none",
+        "Agent Name: Eliza",
+        "Port: 3000",
+        "Updated At: 2026-08-24T00:00:00Z",
+        "Log Path: /Users/user/.eliza/logs/agent.log",
+        "Status Path: /Users/user/.eliza/status.json",
+      ].join("\n"),
+    );
+  });
+
+  it("falls back to unknown for absent version, runtime, locale, agent name and port fields", () => {
+    const formatted = formatDesktopBugReportDiagnostics(
+      makeDiagnostics({ agentName: null, port: null }),
+    );
+
+    expect(formatted).toContain("App Version: unknown");
+    expect(formatted).toContain("Runtime: unknown");
+    expect(formatted).toContain("Packaged: unknown");
+    expect(formatted).toContain("Locale: unknown");
+    expect(formatted).toContain("Agent Name: unknown");
+    expect(formatted).toContain("Port: unknown");
+  });
+
+  it("reports packaged as no when explicitly false, not unknown", () => {
+    const formatted = formatDesktopBugReportDiagnostics(
+      makeDiagnostics({ packaged: false }),
+    );
+
+    expect(formatted).toContain("Packaged: no");
+  });
+
+  it("echoes the recorded last error instead of none", () => {
+    const formatted = formatDesktopBugReportDiagnostics(
+      makeDiagnostics({ lastError: "Port already in use" }),
+    );
+
+    expect(formatted).toContain("Last Error: Port already in use");
+  });
+
+  it("renders an errored startup snapshot with its state, phase and null fields degraded", () => {
+    const formatted = formatDesktopBugReportDiagnostics(
+      makeDiagnostics({
+        state: "error",
+        phase: "backend-crashed",
+        lastError: "EADDRINUSE",
+        agentName: null,
+        port: null,
+        packaged: false,
+      }),
+    );
+
+    expect(formatted).toContain("Startup State: error");
+    expect(formatted).toContain("Startup Phase: backend-crashed");
+    expect(formatted).toContain("Last Error: EADDRINUSE");
+    expect(formatted).toContain("Packaged: no");
+    expect(formatted).toContain("Agent Name: unknown");
+    expect(formatted).toContain("Port: unknown");
+  });
+});


### PR DESCRIPTION

Adds a deterministic unit suite for `packages/ui/src/utils/desktop-bug-report.ts`, which had no same-named test file on develop. The diff is a single new test file (+325/-0); no production code is touched. It complements the existing `src/utils/__tests__/desktop-bug-report-standalone.test.ts` without modifying it.

## What is covered

- **`loadDesktopBugReportDiagnostics` / `openDesktopLogsFolder` / `createDesktopBugReportBundle`:** outside an Electrobun runtime every helper degrades to `null`/`undefined` without dispatching into the bridge — including the sharp case where a populated request map exists but runtime markers do not, proving the guard actually gates dispatch. Inside the runtime each helper dispatches its canonical rpc method (`desktopGetStartupDiagnostics`, `desktopOpenLogsFolder`, `desktopCreateBugReportBundle`) with verbatim params and propagates the native receipt unchanged, including a `null` receipt and a not-yet-registered handler.
- **`createDesktopBugReportBundle` params contract:** options pass through byte-for-byte (`reportMarkdown`, `reportJson`, optional `prefix`), and an omitted `prefix` adds no key to the wire params.
- **`formatDesktopBugReportDiagnostics`:** the complete sheet is pinned as one exact string in canonical field order; every fallback branch is exercised — `unknown` for absent version/runtime/locale/agent name/port, `Packaged: no` for explicit `false` (a branch the existing standalone suite does not cover), echoed vs `none` last error, and a degraded error-state snapshot.

The suite drives the real module through the same `globalThis.window` preload seam the Electrobun runtime injects (`__electrobunWebviewId` + `__ELIZA_ELECTROBUN_RPC__`), so assertions exercise actual dispatch and result propagation at the bridge boundary rather than mock round-trips. No `vi.mock` of the module under test.

## Verification (observed on this branch)

- `bunx vitest run src/utils/desktop-bug-report.test.ts` from `packages/ui` (vitest 4.1.10): **1 test file passed, 17 tests passed**, 0 failed.
- `bunx biome check src/utils/desktop-bug-report.test.ts`: clean — "Checked 1 file … No fixes applied."
- `bunx tsc --noEmit -p tsconfig.json` in `packages/ui`: this file appears nowhere in the output (remaining lines are pre-existing errors in files that are not part of this diff).
- Diff touches only `packages/ui/src/utils/desktop-bug-report.test.ts`.

## Note on CI

This pull request comes from a fork, so hosted CI does not run on it. The counts above are real local runs against current `develop`.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
      The branch was cut from `origin/develop` @ 1f236fd1f5, which is still
      upstream HEAD at filing time.
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
      Not run for this single-file test-only diff; scoped gates were run
      instead (vitest 17/17, biome clean, tsc clean for this file) — see
      **Verification**. Recorded as a known gap below.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below. Not run — see known gaps.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

Low. The diff adds one new test file and changes no production code, exports,
or runtime behavior. Worst case is a flaky or wrong expectation in a new test,
which is isolated from all other suites.

# Background

## What does this PR do?

Adds unit coverage for `packages/ui/src/utils/desktop-bug-report.ts` (Electrobun
bug-report diagnostics: bridge helpers + formatter), which had no same-named
test on develop.

## What kind of change is this?

Improvements (misc. changes to existing features) — test-only coverage; no
behavioural change.

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

My changes do not require a change to the project documentation.

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

`packages/ui/src/utils/desktop-bug-report.test.ts` — one describe block per
exported function, plus the formatter branch matrix.

## Detailed testing steps

```bash
cd packages/ui && bunx vitest run src/utils/desktop-bug-report.test.ts
bunx biome check src/utils/desktop-bug-report.test.ts
bunx tsc --noEmit   # this file appears nowhere in the output
```

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:441dfc38201591520f609c0326fb252c97e4c93c -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
      N/A - test-only change; no rendered UI surface is touched by this diff.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
      N/A - test-only change; no rendered UI surface is touched by this diff.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
      N/A - test-only change; no user-facing flow changed.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
      N/A - the vitest run quoted above is the execution log for this diff.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
      N/A - unit-suite output quoted in **Verification**; no network path touched.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
      N/A - no model-call, prompt, or provider code changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
      N/A - no domain artifacts are produced by this diff.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.
      N/A - no rendered visual surface; the diff contains only a `.test.ts` file.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

N/A - test-only change; nothing visual changed.

### After

N/A - test-only change; nothing visual changed.

### Walkthrough video

N/A - test-only change.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

N/A - no voice/transcript/TTS path touched by this diff.

## Known gaps / failures

- Full `bun run verify` was not executed for this single-file test-only diff;
  scoped gates (vitest, biome, tsc for the touched file) are quoted above and
  all pass. No production code is included in the diff.
- Hosted CI does not run on fork pull requests; all counts are from local runs
  against `origin/develop` @ 1f236fd1f5 (still upstream HEAD at filing time).

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
