### PR TITLE
fix(plugin-form): gate required external/uncertain fields so submit() cannot drop an unconfirmed required value

### DIFF
--- a/plugins/plugin-form/src/service-required-external.test.ts
+++ b/plugins/plugin-form/src/service-required-external.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Regression coverage for FormService required-field gating on unsatisfied
+ * external and uncertain fields. Deterministic, no live model: a custom
+ * `payment` external control type is registered against the component-store
+ * mock, then the ready-transition and submit() gate are exercised while a
+ * required field is `pending` (activated, valueless) or `uncertain`
+ * (low-confidence extraction). Proves that submit() rejects and no
+ * value-dropping FormSubmission is recorded until the field is genuinely
+ * satisfied, and that confirmation/acceptance re-opens the happy path.
+ */
+import type { Component, IAgentRuntime, UUID } from "@elizaos/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { FormService } from "./service";
+import type { ControlType, FormDefinition } from "./types";
+
+const entityId = "00000000-0000-4000-8000-000000000201" as UUID;
+const roomId = "00000000-0000-4000-8000-000000000202" as UUID;
+const agentId = "00000000-0000-4000-8000-000000000203" as UUID;
+
+function makeRuntime() {
+  const components = new Map<string, Component>();
+  const keyFor = (entity: UUID, type: string) => `${entity}:${type}`;
+
+  return {
+    agentId,
+    getRoom: vi.fn(async () => ({ id: roomId, worldId: agentId })),
+    getComponent: vi.fn(async (entity: UUID, type: string) =>
+      components.get(keyFor(entity, type)),
+    ),
+    getComponents: vi.fn(async (entity: UUID) =>
+      Array.from(components.values()).filter((c) => c.entityId === entity),
+    ),
+    createComponent: vi.fn(async (component: Component) => {
+      components.set(keyFor(component.entityId, component.type), component);
+    }),
+    updateComponent: vi.fn(async (component: Component) => {
+      components.set(keyFor(component.entityId, component.type), component);
+    }),
+    deleteComponent: vi.fn(async (id: UUID) => {
+      for (const [key, component] of components) {
+        if (component.id === id) components.delete(key);
+      }
+    }),
+    emitEvent: vi.fn(async () => undefined),
+    registerTaskWorker: vi.fn(),
+    getTaskWorker: vi.fn(() => undefined),
+    logger: {
+      debug: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      info: vi.fn(),
+    },
+  } as unknown as IAgentRuntime;
+}
+
+const paymentType: ControlType = {
+  id: "payment",
+  activate: async () => ({
+    reference: "pay-ref-1",
+    instructions: "Send 0.5 SOL to the address to complete checkout",
+    address: "SoLPaYmEnTaDdReSs",
+  }),
+};
+
+function checkoutForm(): FormDefinition {
+  return {
+    id: "checkout",
+    name: "Checkout",
+    controls: [
+      { key: "pay", label: "Payment", type: "payment", required: true },
+    ],
+  };
+}
+
+describe("FormService required external field gating", () => {
+  let service: FormService;
+
+  beforeEach(async () => {
+    service = (await FormService.start(makeRuntime())) as FormService;
+    service.registerControlType(paymentType);
+  });
+
+  it("rejects submit() while a required external field is pending and confirmed value re-opens it", async () => {
+    service.registerForm(checkoutForm());
+
+    const session = await service.startSession("checkout", entityId, roomId);
+
+    // Activate the external payment: status becomes "pending" with NO value.
+    await service.activateExternalField(session.id, entityId, "pay");
+
+    const activated = await service.getActiveSession(entityId, roomId);
+    expect(activated?.fields.pay?.status).toBe("pending");
+    expect(activated?.fields.pay?.value).toBeUndefined();
+    // A pending required external field must NOT flip the session to ready.
+    expect(activated?.status).toBe("active");
+
+    // submit() must throw rather than record a value-dropping submission.
+    await expect(service.submit(session.id, entityId)).rejects.toThrow(
+      "Not all required fields are filled",
+    );
+
+    // No submission should have been recorded by the rejected submit.
+    await expect(service.getSubmissions(entityId, "checkout")).resolves.toEqual(
+      [],
+    );
+
+    // Confirm the external field -> status "filled" with a real value.
+    await service.confirmExternalField(
+      session.id,
+      entityId,
+      "pay",
+      "confirmed",
+      {
+        txId: "tx-abc",
+      },
+    );
+
+    const confirmed = await service.getActiveSession(entityId, roomId);
+    expect(confirmed?.fields.pay?.status).toBe("filled");
+    expect(confirmed?.status).toBe("ready");
+
+    // Now submit succeeds and the submission includes the required field.
+    const submission = await service.submit(session.id, entityId);
+    expect(submission.values.pay).toBe("confirmed");
+    expect(submission.mappedValues?.pay).toBe("confirmed");
+
+    const recorded = await service.getSubmissions(entityId, "checkout");
+    expect(recorded).toHaveLength(1);
+    expect(recorded[0]?.values.pay).toBe("confirmed");
+  });
+
+  it("does not flip to ready and blocks submit() while a required field is uncertain", async () => {
+    service.registerForm({
+      id: "profile",
+      name: "Profile",
+      controls: [
+        { key: "email", label: "Email", type: "email", required: true },
+      ],
+    });
+
+    const session = await service.startSession("profile", entityId, roomId);
+
+    // Low-confidence extraction -> status "uncertain" (has a value, but unmet).
+    await service.updateField(
+      session.id,
+      entityId,
+      "email",
+      "jane@example.com",
+      0.2,
+      "extraction",
+    );
+
+    const uncertain = await service.getActiveSession(entityId, roomId);
+    expect(uncertain?.fields.email?.status).toBe("uncertain");
+    // An uncertain required field must not be treated as complete.
+    expect(uncertain?.status).toBe("active");
+
+    await expect(service.submit(session.id, entityId)).rejects.toThrow(
+      "Not all required fields are filled",
+    );
+
+    // Accepting the uncertain value satisfies the gate.
+    await service.confirmField(session.id, entityId, "email", true);
+
+    const accepted = await service.getActiveSession(entityId, roomId);
+    expect(accepted?.fields.email?.status).toBe("filled");
+
+    const submission = await service.submit(session.id, entityId);
+    expect(submission.values.email).toBe("jane@example.com");
+  });
+});

--- a/plugins/plugin-form/src/service.ts
+++ b/plugins/plugin-form/src/service.ts
@@ -1651,7 +1651,16 @@ export class FormService extends Service {
   // ============================================================================
 
   /**
-   * Check if all required fields are filled
+   * Check if all required fields are filled.
+   *
+   * A required field is only satisfied when its state is genuinely complete:
+   * status is not `empty`, `invalid`, `uncertain`, or `pending`, AND it holds a
+   * concrete value. This blocks both the ready-transition and submit() for a
+   * required external field that has been activated but not yet confirmed
+   * (status `pending`, value `undefined`) and for a low-confidence extraction
+   * awaiting confirmation (status `uncertain`). Without the value guard an
+   * unconfirmed payment/signature would be recorded as completed and its value
+   * silently dropped from the FormSubmission — a data-integrity failure.
    */
   private checkAllRequiredFilled(
     session: FormSession,
@@ -1664,7 +1673,10 @@ export class FormService extends Service {
       if (
         !fieldState ||
         fieldState.status === "empty" ||
-        fieldState.status === "invalid"
+        fieldState.status === "invalid" ||
+        fieldState.status === "uncertain" ||
+        fieldState.status === "pending" ||
+        fieldState.value === undefined
       ) {
         return false;
       }


### PR DESCRIPTION
# Relates to

Closes #27773

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync. Package gates (`test`, `typecheck`, `lint:check`) pass; full `bun run verify` is not runnable in this sandbox (see **Known gaps**).
- [x] A reviewer can confirm the change works without reading the code, from the before/after test output and the captured `FormSubmission` below.

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts (`HEAD..origin/develop` == 0 commits at push time).
- [x] Focused package gates pass post-sync; the unrelated repo-wide `verify` blocker is documented in **Known gaps / failures**.

# Risks

Low. The change tightens a single private helper, `FormService.checkAllRequiredFilled()`, so it now rejects required fields that are genuinely unsatisfied. It never loosens the gate. Behavioral effect is scoped to sessions containing a required field in `pending` (activated external, valueless), `uncertain` (low-confidence), or otherwise value-less state — those now correctly block the `ready` transition and `submit()` until confirmed. No public type, DTO, or export changes.

# Background

## What does this PR do?

`FormService.checkAllRequiredFilled()` only rejected a required field whose status was `empty` or `invalid` (or missing). Two other states were silently treated as "filled":

- **`pending`** — a required external field (e.g. `payment`/`signature`) that has been activated via `activateExternalField()` but not yet confirmed. It has **no value**.
- **`uncertain`** — a low-confidence extraction awaiting `confirmField()` acceptance.

Consequences on a real user path (`activateExternalField` + `submit` are public `FormService` methods driven by the form evaluator/actions, and external "payment" types are an advertised feature):

1. The session prematurely transitioned to `ready` and fired the `onReady` hook.
2. `submit()` passed its required-fields gate and recorded a `FormSubmission` whose `values`/`mappedValues` **silently omitted** the required field, marked the session `submitted`, saved autofill, and ran the `onSubmit` worker.

A checkout/payment form could therefore be recorded as completed **before the payment was actually confirmed** — a silent data-integrity failure.

The fix: a required field counts as satisfied only when its status is not `empty`/`invalid`/`uncertain`/`pending` **and** it holds a concrete value (`value !== undefined`). The value guard covers the pending/external case directly. This gates both the ready-transition (`updateField`/`confirmExternalField`) and `submit()`. External fields become ready only after `confirmExternalField` sets status `filled` + value; uncertain fields only after `confirmField(..., true)`.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation. The corrected behavior (external fields ready only after `confirmExternalField`) already matches what `plugins/plugin-form/CLAUDE.md` and `README.md` document ("External types require three steps: subfields fill → activate → confirmExternalField").

# Testing

## Where should a reviewer start?

`plugins/plugin-form/src/service.ts` — the `checkAllRequiredFilled()` helper (the only production change), and the new deterministic regression suite `plugins/plugin-form/src/service-required-external.test.ts`.

## Detailed testing steps

```bash
bun run --cwd packages/core build          # provide @elizaos/core dist for vitest resolution
bun run --cwd packages/shared build        # provide @elizaos/shared dist
bun run --cwd plugins/plugin-form test      # 11 files, 150 tests pass
bun run --cwd plugins/plugin-form typecheck # clean
bun run --cwd plugins/plugin-form lint:check
```

The three new assertions match the issue's reproduction exactly:
1. A required external field left `pending` blocks `submit()` (throws `"Not all required fields are filled"`) and records **no** submission; after `confirmExternalField(...)` the session becomes `ready`, `submit()` succeeds, and the submission **includes** the payment value.
2. A required `uncertain` extraction does **not** flip the session to `ready` and blocks `submit()` until `confirmField(..., true)` accepts it.

# Evidence Gate

<!-- evidence-head:a2c79388eae204b937bde7813fac34a9ed9b4d13 -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - service-layer bug fix in @elizaos/plugin-form; no rendered UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - service-layer bug fix; no rendered UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-facing UI flow; the changed path is a service method exercised by deterministic vitest below.`
<!-- evidence-row:backend-logs -->
- [ ] N/A - attachment-URL minting is unavailable in this sandbox (fork login hit a GitHub verification interstitial); the real structured [FormService] logs and before/after vitest output are pasted inline under Evidence Details > Backend + frontend logs.
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend surface in this change.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - deterministic fix with no model call; the reproduction and fix use the package's mock runtime, no live model.`
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - same attachment-URL limitation; the captured FormSubmission (values:{} under buggy code vs. corrected rejection) is pasted inline under Evidence Details > Domain artifact.
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - deterministic; no live-model call. The reproduction and regression suite run against the package's existing component-store mock runtime with no network or credentials.`

## Backend + frontend logs

Frontend: `N/A - no frontend surface.`

Backend — **failing BEFORE the fix** (buggy `checkAllRequiredFilled`), showing `submit()` resolving with a value-dropping `FormSubmission` and the session flipping to `ready`:

<details>
<summary>vitest — failing before fix</summary>

```
 ❯ src/service-required-external.test.ts (2 tests | 2 failed) 34ms
     × rejects submit() while a required external field is pending and confirmed value re-opens it 25ms
     × does not flip to ready and blocks submit() while a required field is uncertain 8ms
⎯⎯⎯ Failed Tests 2 ⎯⎯⎯
 FAIL  src/service-required-external.test.ts > ... > rejects submit() while a required external field is pending and confirmed value re-opens it
AssertionError: promise resolved "{ …(10) }" instead of rejecting
- Expected
+ Received
- Error { "message": "rejected promise", ... }
+ {
+   "entityId": "00000000-0000-4000-8000-000000000201",
+   "formId": "checkout",
+   "mappedValues": {},
+   "sessionId": "42d7309a-0413-4795-87d3-1ec453210f8a",
+   "submittedAt": 1787581944777,
+   "values": {},
  }
 ❯ src/service-required-external.test.ts:98:54
 FAIL  src/service-required-external.test.ts > ... > does not flip to ready and blocks submit() while a required field is uncertain
AssertionError: expected 'ready' to be 'active' // Object.is equality
Expected: "active"
Received: "ready"
 ❯ src/service-required-external.test.ts:156:31
 Test Files  1 failed (1)
      Tests  2 failed (2)
```
</details>

Backend — **passing AFTER the fix**:

<details>
<summary>vitest — passing after fix (new suite)</summary>

```
 Test Files  1 passed (1)
      Tests  2 passed (2)
```
</details>

<details>
<summary>vitest — full plugin-form suite after fix</summary>

```
 Test Files  11 passed (11)
      Tests  150 passed (150)
```
</details>

## Screenshots (before / after) + video walkthrough

### Before

`N/A - no UI surface.`

### After

`N/A - no UI surface.`

### Walkthrough video

`N/A - no UI flow; behavior is proven by the before/after vitest output and the captured domain artifact.`

## Audio / voice walkthrough

`N/A - no voice/audio surface.`

## Domain artifact — captured `FormSubmission`

Direct capture of the object `submit()` produced while the required `payment` field was still `pending` (buggy code) versus the corrected rejection:

<details>
<summary>FormSubmission dropped-value capture</summary>

```
--- BUGGY (before fix) ---
BUGGY: submit() RESOLVED with FormSubmission:
{
  "values": {},
  "mappedValues": {},
  "sessionStatusAfter": "submitted",
  "submittedAt": 1787582125029
}

--- FIXED (after fix) ---
FIXED: submit() threw: Not all required fields are filled
```
</details>

The buggy `values: {}` / `mappedValues: {}` prove the required `pay` field was silently dropped while the submission was still recorded as completed. After the fix, `submit()` throws until `confirmExternalField` sets a real value.

## Known gaps / failures

- **Repo-wide `bun run verify` not run here.** This sandbox enforces a global `minimumReleaseAge` supply-chain guard that blocks resolving a recent transitive dev dependency (`@cloudflare/playwright`) unrelated to this change, and the full `verify` gate builds the entire workspace. I ran the owning package's `test` (150 passing), `typecheck` (clean), and `lint:check` (clean) after building `@elizaos/core` and `@elizaos/shared` for vitest resolution. Not a blocker for a single-helper service fix; CI will run the full gate.
- **Evidence attached inline rather than as minted attachment URLs.** The fork-only attachment/release upload path is not authenticated in this environment (login hit a verification interstitial), so the real log text and captured `FormSubmission` are pasted inline in `<details>` blocks above per the template's inline-artifact allowance.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

---

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@1f236fd1f58f9a5be09e5ac10c439040a7ea6a3c:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@1f236fd1f58f9a5be09e5ac10c439040a7ea6a3c:packages/skills/skills/contribute-to-eliza"} -->

