### PR TITLE
test(ui): cover use-personal-entry

### DIFF
--- a/packages/ui/src/cloud/app-mode/use-personal-entry.test.tsx
+++ b/packages/ui/src/cloud/app-mode/use-personal-entry.test.tsx
@@ -1,0 +1,338 @@
+/** Verifies the rowless personal-entry hook — the one-shot session-bound /join handoff channel, the authenticated resolution path through the real join flow onto a stubbed fetch transport (exact failure shapes: missing Steward token, unavailable identity endpoint, invalid identity), the retry:false/staleTime query policy, and the durable binding + first-run effects — through the package's configured test harness (jsdom, real renderHook, hand-rolled fetch stub; no module mocks). */
+// @vitest-environment jsdom
+
+import { STEWARD_TOKEN_KEY } from "@elizaos/shared/steward-session-client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  loadPersistedActiveServer,
+  loadPersistedFirstRunComplete,
+} from "../../state/persistence";
+import type { JoinFlowResult } from "../join/lib/run-join-flow";
+import {
+  personalEntryBindingId,
+  publishPersonalEntryHandoff,
+  usePersonalEntry,
+} from "./use-personal-entry";
+
+function base64url(value: unknown): string {
+  return btoa(JSON.stringify(value))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+// A minimally-valid Steward JWT: readStoredStewardToken only base64-decodes
+// the payload (userId + a future exp); no signature check.
+function makeStewardToken(userId: string): string {
+  return [
+    base64url({ alg: "none", typ: "JWT" }),
+    base64url({
+      userId,
+      email: `${userId}@b.test`,
+      exp: Math.floor(Date.now() / 1000) + 3600,
+    }),
+    "sig",
+  ].join(".");
+}
+
+function signInAs(token: string): void {
+  localStorage.setItem(STEWARD_TOKEN_KEY, token);
+}
+
+interface PersonalCall {
+  url: string;
+  authorization: string | null;
+}
+
+const realFetch = globalThis.fetch;
+let personalCalls: PersonalCall[];
+
+function stubNetwork(personal?: () => Response): void {
+  personalCalls = [];
+  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    if (personal && url.endsWith("/api/v1/eliza/personal")) {
+      personalCalls.push({
+        url,
+        authorization: new Headers(init?.headers).get("authorization"),
+      });
+      return Promise.resolve(personal());
+    }
+    return Promise.resolve(
+      new Response(JSON.stringify({ error: `unstubbed ${url}` }), {
+        status: 500,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+  }) as typeof fetch;
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const PERSONAL_ID = "personal:00000000-0000-5000-8000-000000000001";
+
+function sharedIdentityOk(): () => Response {
+  return () =>
+    jsonResponse(200, {
+      success: true,
+      data: {
+        identity: {
+          id: PERSONAL_ID,
+          displayName: "Eliza",
+          runtime: "shared",
+        },
+      },
+    });
+}
+
+// What the real runJoinFlow returns for the stubbed shared identity above:
+// the id triple collapses onto the personal id and the shared REST base is
+// built from the default direct-cloud origin with the encoded agent id.
+function networkResolution(): JoinFlowResult {
+  return {
+    personalElizaId: PERSONAL_ID,
+    agentId: PERSONAL_ID,
+    activeAgentId: PERSONAL_ID,
+    agentName: "Eliza",
+    apiBase: `https://api.eliza.app/api/v1/eliza/agents/${encodeURIComponent(PERSONAL_ID)}`,
+    runtime: "shared",
+  };
+}
+
+const HANDOFF_RESULT: JoinFlowResult = {
+  personalElizaId: PERSONAL_ID,
+  agentId: PERSONAL_ID,
+  activeAgentId: "00000000-0000-4000-8000-000000000002",
+  agentName: "Handoff Eliza",
+  apiBase: "https://shared.eliza.app",
+  runtime: "shared",
+};
+
+function renderPersonalEntry(options?: {
+  enabled?: boolean;
+  queryClient?: QueryClient;
+}) {
+  const queryClient =
+    options?.queryClient ??
+    new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  function wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  }
+  const rendered = renderHook(
+    () => usePersonalEntry(options?.enabled ?? true),
+    {
+      wrapper,
+    },
+  );
+  return { ...rendered, queryClient };
+}
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+  globalThis.fetch = realFetch;
+});
+
+describe("personalEntryBindingId", () => {
+  it("binds the resolved personal Eliza under the cloud: namespace keyed by its agent id", () => {
+    expect(personalEntryBindingId(HANDOFF_RESULT)).toBe(`cloud:${PERSONAL_ID}`);
+  });
+
+  it("distinct agents bind under distinct ids", () => {
+    const other: JoinFlowResult = {
+      ...HANDOFF_RESULT,
+      agentId: "personal:ffffffff-0000-5000-8000-000000000009",
+    };
+    expect(personalEntryBindingId(other)).not.toBe(
+      personalEntryBindingId(HANDOFF_RESULT),
+    );
+  });
+});
+
+describe("usePersonalEntry — enabled gate", () => {
+  it("enabled=false holds the query idle with zero Cloud traffic even when signed in", async () => {
+    signInAs(makeStewardToken("u1"));
+    stubNetwork(sharedIdentityOk());
+
+    const { result } = renderPersonalEntry({ enabled: false });
+    await waitFor(() => expect(result.current.fetchStatus).toBe("idle"));
+
+    expect(result.current.status).toBe("pending");
+    expect(result.current.data).toBeUndefined();
+    expect(personalCalls).toEqual([]);
+  });
+});
+
+describe("usePersonalEntry — one-shot session-bound handoff", () => {
+  it("consumes a matching-session handoff in place without calling the identity endpoint", async () => {
+    const token = makeStewardToken("u1");
+    signInAs(token);
+    publishPersonalEntryHandoff(token, HANDOFF_RESULT);
+    stubNetwork(sharedIdentityOk());
+
+    const { result } = renderPersonalEntry();
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(HANDOFF_RESULT);
+    expect(result.current.data?.agentName).toBe("Handoff Eliza");
+    expect(personalCalls).toEqual([]);
+  });
+
+  it("a consumed receipt is single-use: the next consumer resolves through the network", async () => {
+    const token = makeStewardToken("u1");
+    signInAs(token);
+    publishPersonalEntryHandoff(token, HANDOFF_RESULT);
+    stubNetwork(sharedIdentityOk());
+
+    const first = renderPersonalEntry();
+    await waitFor(() => expect(first.result.current.isSuccess).toBe(true));
+    expect(first.result.current.data).toEqual(HANDOFF_RESULT);
+    expect(personalCalls).toEqual([]);
+    first.unmount();
+
+    // A fresh query cache re-runs the queryFn; the receipt must be gone, so
+    // resolution now goes through the real join-flow transport.
+    const second = renderPersonalEntry();
+    await waitFor(() => expect(second.result.current.isSuccess).toBe(true));
+    expect(second.result.current.data).toEqual(networkResolution());
+    expect(personalCalls).toHaveLength(1);
+  });
+
+  it("a mismatched-session receipt is discarded once and cannot be replayed by its rightful owner later", async () => {
+    const staleToken = makeStewardToken("stale");
+    publishPersonalEntryHandoff(staleToken, HANDOFF_RESULT);
+
+    const liveToken = makeStewardToken("live");
+    signInAs(liveToken);
+    stubNetwork(sharedIdentityOk());
+
+    const first = renderPersonalEntry();
+    await waitFor(() => expect(first.result.current.isSuccess).toBe(true));
+    expect(first.result.current.data).toEqual(networkResolution());
+    expect(personalCalls).toEqual([
+      {
+        url: expect.stringContaining("/api/v1/eliza/personal"),
+        authorization: `Bearer ${liveToken}`,
+      },
+    ]);
+    first.unmount();
+
+    // Even the publishing session gets nothing: the mismatched take already
+    // destroyed the receipt, so a stale identity can never boot chat.
+    signInAs(staleToken);
+    const second = renderPersonalEntry();
+    await waitFor(() => expect(second.result.current.isSuccess).toBe(true));
+    expect(second.result.current.data).toEqual(networkResolution());
+    expect(personalCalls).toHaveLength(2);
+    expect(personalCalls[1]?.authorization).toBe(`Bearer ${staleToken}`);
+  });
+});
+
+describe("usePersonalEntry — resolution", () => {
+  it("without a Steward session the query errors with the entry-gate message and sends nothing", async () => {
+    stubNetwork(sharedIdentityOk());
+
+    const { result } = renderPersonalEntry();
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect((result.current.error as Error).message).toBe(
+      "PersonalEntry: no Steward session token for an authenticated entry.",
+    );
+    expect(personalCalls).toEqual([]);
+    expect(loadPersistedActiveServer()).toBeNull();
+  });
+
+  it("resolves the authoritative binding through the real join flow and persists it", async () => {
+    const token = makeStewardToken("u1");
+    signInAs(token);
+    stubNetwork(sharedIdentityOk());
+
+    const { result } = renderPersonalEntry();
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(networkResolution());
+    expect(personalCalls).toEqual([
+      {
+        url: expect.stringContaining("/api/v1/eliza/personal"),
+        authorization: `Bearer ${token}`,
+      },
+    ]);
+
+    const server = loadPersistedActiveServer();
+    expect(server?.id).toBe(`cloud:${PERSONAL_ID}`);
+    expect(server?.accessToken).toBe(token);
+    expect(loadPersistedFirstRunComplete()).toBe(true);
+  });
+
+  it("an unavailable identity endpoint errors after exactly one attempt (retry: false) and persists nothing", async () => {
+    const token = makeStewardToken("u1");
+    signInAs(token);
+    stubNetwork(() => jsonResponse(503, { error: "down" }));
+
+    const { result } = renderPersonalEntry();
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    // No retry storm: the entry gate must fall back to /join promptly.
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    expect(personalCalls).toHaveLength(1);
+    expect(loadPersistedActiveServer()).toBeNull();
+    expect(loadPersistedFirstRunComplete()).toBe(false);
+  });
+
+  it("an invalid identity payload errors before any binding or completion bit is persisted", async () => {
+    const token = makeStewardToken("u1");
+    signInAs(token);
+    stubNetwork(() =>
+      jsonResponse(200, {
+        success: true,
+        data: {
+          identity: {
+            id: "not-a-personal-id",
+            displayName: "Eliza",
+            runtime: "shared",
+          },
+        },
+      }),
+    );
+
+    const { result } = renderPersonalEntry();
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect((result.current.error as Error).message).toBe(
+      "Eliza Cloud returned an invalid personal Eliza identity.",
+    );
+    expect(personalCalls).toHaveLength(1);
+    expect(loadPersistedActiveServer()).toBeNull();
+    expect(loadPersistedFirstRunComplete()).toBe(false);
+  });
+
+  it("staleTime=Infinity serves repeat mounts from cache without re-resolving", async () => {
+    const token = makeStewardToken("u1");
+    signInAs(token);
+    stubNetwork(sharedIdentityOk());
+
+    const first = renderPersonalEntry();
+    await waitFor(() => expect(first.result.current.isSuccess).toBe(true));
+    expect(personalCalls).toHaveLength(1);
+    first.unmount();
+
+    const second = renderPersonalEntry({
+      queryClient: first.queryClient,
+    });
+    await waitFor(() => expect(second.result.current.isSuccess).toBe(true));
+
+    expect(second.result.current.data).toEqual(networkResolution());
+    expect(personalCalls).toHaveLength(1);
+  });
+});


### PR DESCRIPTION

## What

Adds a new unit suite for the rowless personal-entry hook, `packages/ui/src/cloud/app-mode/use-personal-entry.ts`, which had no same-named test file anywhere in the repo. The diff is one new file, +338/−0; no production code is touched.

## How it is tested

The suite mounts the real hook through the package's configured harness (jsdom, `renderHook` + a real `QueryClient`) and drives the real dependency chain — the Steward session in `localStorage`, the real join-flow controller, the real persistence writers — over a hand-rolled `globalThis.fetch` stub at the transport boundary. No module mocks.

Covered behaviour (11 cases):

- `personalEntryBindingId` binds under `cloud:<agentId>`; distinct agents bind under distinct ids.
- `enabled=false` holds the query idle with zero Cloud traffic even when signed in.
- A matching-session `/join` handoff is consumed in place without calling the identity endpoint; a receipt is single-use; a mismatched-session receipt is destroyed once and cannot be replayed by its rightful owner later.
- Missing Steward token → query error with the exact entry-gate message and no network traffic.
- Healthy identity endpoint → resolution through the real join flow returns the shared-runtime result, sends `Bearer <session token>` to `/api/v1/eliza/personal`, and persists the `cloud:<id>` active server (with access token) plus the first-run completion bit.
- Unavailable identity endpoint → error after exactly one attempt (`retry: false`), nothing persisted.
- Invalid identity payload → error before any binding or completion bit is persisted.
- `staleTime: Infinity` serves repeat mounts from cache without re-resolving.

## Evidence (local runs, quoted)

- `bunx vitest run src/cloud/app-mode/use-personal-entry.test.tsx` (in `packages/ui`, tree at current `origin/develop` `1f236fd1f5`): **Test Files 1 passed (1), Tests 11 passed (11)**.
- `bunx biome check src/cloud/app-mode/use-personal-entry.test.tsx`: clean ("Checked 1 file … No fixes applied").
- `bunx tsc --noEmit` in `packages/ui`: the new test file appears nowhere in the output (the 14 reported errors are pre-existing files from unrelated in-flight work, none of them part of this diff).
- The diff touches only the new test file (+338/−0).

As a fork contributor, hosted CI does not run on this pull request; the counts above are local runs quoted verbatim.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:69b5ab83e8f47b80306e1d2678c5a8507d72f0f1 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
