### PR TITLE
test(core): cover setup

### DIFF
--- a/packages/core/src/types/setup.test.ts
+++ b/packages/core/src/types/setup.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Behavioral coverage for the setup state-machine helpers exported from
+ * types/setup.ts: ordered step transitions at both sequence boundaries,
+ * unknown-step handling, completion membership, and progress math that
+ * excludes the COMPLETE marker from its denominator. Drives the real
+ * module; no mocks stand in for the subject under test.
+ */
+
+import { describe, expect, test } from "vitest";
+import {
+	calculateProgress,
+	getNextStep,
+	getPreviousStep,
+	getStepIndex,
+	isStepCompleted,
+	SETUP_STEP_ORDER,
+	type SetupContext,
+	SetupStep,
+} from "./setup";
+
+function makeContext(completedSteps: SetupStep[]): SetupContext {
+	return {
+		currentStep: SetupStep.WELCOME,
+		completedSteps,
+		settings: {},
+		errors: [],
+		startedAt: 0,
+		lastActivityAt: 0,
+		platform: "test",
+		mode: "cli",
+		sessionId: "session-1",
+	};
+}
+
+describe("getStepIndex", () => {
+	test("returns 0 for the first step and length - 1 for the terminal step", () => {
+		expect(getStepIndex(SetupStep.WELCOME)).toBe(0);
+		expect(getStepIndex(SetupStep.COMPLETE)).toBe(SETUP_STEP_ORDER.length - 1);
+	});
+
+	test("returns -1 for a step outside the sequence", () => {
+		expect(getStepIndex("NOPE" as SetupStep)).toBe(-1);
+	});
+});
+
+describe("getNextStep", () => {
+	test("advances from the first step to the second", () => {
+		expect(getNextStep(SetupStep.WELCOME)).toBe(SetupStep.RISK_ACK);
+	});
+
+	test("advances into COMPLETE from the last actionable step", () => {
+		expect(getNextStep(SetupStep.SKILLS)).toBe(SetupStep.COMPLETE);
+	});
+
+	test("returns null at the end of the sequence", () => {
+		expect(getNextStep(SetupStep.COMPLETE)).toBeNull();
+	});
+
+	test("returns null for an unknown step instead of advancing", () => {
+		expect(getNextStep("NOPE" as SetupStep)).toBeNull();
+	});
+});
+
+describe("getPreviousStep", () => {
+	test("returns null at the beginning of the sequence", () => {
+		expect(getPreviousStep(SetupStep.WELCOME)).toBeNull();
+	});
+
+	test("steps back one position from a middle step", () => {
+		expect(getPreviousStep(SetupStep.RISK_ACK)).toBe(SetupStep.WELCOME);
+	});
+
+	test("steps back from COMPLETE to the last actionable step", () => {
+		expect(getPreviousStep(SetupStep.COMPLETE)).toBe(SetupStep.SKILLS);
+	});
+
+	test("returns null for an unknown step instead of stepping back", () => {
+		expect(getPreviousStep("NOPE" as SetupStep)).toBeNull();
+	});
+});
+
+describe("walking the sequence via getNextStep", () => {
+	test("a forward walk from WELCOME visits every step in order and stops at COMPLETE", () => {
+		const walked: SetupStep[] = [];
+		let cursor: SetupStep | null = SetupStep.WELCOME;
+		while (cursor !== null) {
+			walked.push(cursor);
+			cursor = getNextStep(cursor);
+		}
+		expect(walked).toEqual([...SETUP_STEP_ORDER]);
+		expect(walked[walked.length - 1]).toBe(SetupStep.COMPLETE);
+	});
+
+	test("walking backwards from COMPLETE reaches WELCOME without passing it", () => {
+		const walked: SetupStep[] = [];
+		let cursor: SetupStep | null = SetupStep.COMPLETE;
+		while (cursor !== null) {
+			walked.push(cursor);
+			cursor = getPreviousStep(cursor);
+		}
+		expect(walked).toEqual([...SETUP_STEP_ORDER].reverse());
+		expect(walked[walked.length - 1]).toBe(SetupStep.WELCOME);
+	});
+});
+
+describe("isStepCompleted", () => {
+	test("is false for every step on a fresh context", () => {
+		for (const step of SETUP_STEP_ORDER) {
+			expect(isStepCompleted(makeContext([]), step)).toBe(false);
+		}
+	});
+
+	test("reports only steps recorded in completedSteps", () => {
+		const context = makeContext([SetupStep.WELCOME, SetupStep.RISK_ACK]);
+		expect(isStepCompleted(context, SetupStep.WELCOME)).toBe(true);
+		expect(isStepCompleted(context, SetupStep.AUTH)).toBe(false);
+	});
+});
+
+describe("calculateProgress", () => {
+	test("an empty context reports 0 percent", () => {
+		expect(calculateProgress(makeContext([]))).toBe(0);
+	});
+
+	test("every actionable step completed reports 100 percent", () => {
+		const all = makeContext([
+			SetupStep.WELCOME,
+			SetupStep.RISK_ACK,
+			SetupStep.AUTH,
+			SetupStep.CHANNELS,
+			SetupStep.SKILLS,
+		]);
+		expect(calculateProgress(all)).toBe(100);
+	});
+
+	test("partial completion is rounded to whole percents of the five actionable steps", () => {
+		expect(
+			calculateProgress(
+				makeContext([SetupStep.WELCOME, SetupStep.RISK_ACK, SetupStep.AUTH]),
+			),
+		).toBe(60);
+	});
+
+	test("the COMPLETE marker does not inflate progress when present alone", () => {
+		expect(calculateProgress(makeContext([SetupStep.COMPLETE]))).toBe(0);
+	});
+
+	test("the COMPLETE marker is excluded from the completed count alongside real steps", () => {
+		expect(
+			calculateProgress(makeContext([SetupStep.AUTH, SetupStep.COMPLETE])),
+		).toBe(20);
+	});
+
+	test("duplicate entries each count toward the reported percentage", () => {
+		expect(
+			calculateProgress(makeContext([SetupStep.AUTH, SetupStep.AUTH])),
+		).toBe(40);
+	});
+});


### PR DESCRIPTION

## Summary

Adds `packages/core/src/types/setup.test.ts`, a new vitest suite covering the setup state-machine helpers exported from `packages/core/src/types/setup.ts`. This is a test-only change: no production code is modified (+159/-0, single new file).

The setup step sequence is consumed by real callers — `providers/setup-progress.ts`, `services/setup-state.ts`, `services/setup-cli.ts`, and the `elizaos create` command — and none of the transition/progress helpers in `types/setup.ts` had direct coverage on develop.

## What is covered (drives the real module)

- `getStepIndex`: 0-indexed positions, terminal-step index, `-1` for an unknown step.
- `getNextStep`: forward transitions, `null` at the end of the sequence, `null` for an unknown step (the index `-1` branch).
- `getPreviousStep`: backward transitions, `null` at the start of the sequence, `null` for an unknown step.
- Forward/backward walks across the whole sequence terminate exactly at `COMPLETE` / `WELCOME` in order.
- `isStepCompleted`: membership semantics on a fresh context and a partially completed context.
- `calculateProgress`: 0% when empty, 100% when all five actionable steps are done, partial rounding, the `COMPLETE` marker being excluded from the completed count (it does not inflate progress), and duplicate entries each counting toward the percentage.

All expectations record observed behavior of the current implementation; nothing aspirational is asserted.

## Evidence

- `bunx vitest run src/types/setup.test.ts` (packages/core): **Test Files 1 passed (1), Tests 20 passed (20)** — re-fetched and re-run against current `origin/develop` immediately before pushing.
- `bunx biome check packages/core/src/types/setup.test.ts`: **Checked 1 file, No fixes applied** (exit 0) against the repository's pinned `biome.json`.
- `bunx tsc --noEmit` in `packages/core`: grep for `setup.test.ts` over the output returns nothing — the new file introduces zero TypeScript errors.

## CI note

This pull request comes from a fork, so hosted CI does not run on it. The counts above are quoted from local runs against current `develop`.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:ab22d7b410919bab9a18dac1bb35c48b37b696d3 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
