### PR TITLE
test(core): cover schema-builder

### DIFF
--- a/packages/core/src/types/__tests__/schema-builder.test.ts
+++ b/packages/core/src/types/__tests__/schema-builder.test.ts
@@ -23,4 +23,41 @@ describe("snakeToCamel", () => {
 		// 连续下划线：只有 _ 后跟字母/数字的会被转换
 		expect(snakeToCamel("a__b")).toBe("a_B");
 	});
+
+	it("leaves trailing underscores in place", () => {
+		expect(snakeToCamel("agent_")).toBe("agent_");
+		expect(snakeToCamel("_")).toBe("_");
+	});
+
+	it("returns an empty string unchanged", () => {
+		expect(snakeToCamel("")).toBe("");
+	});
+
+	it("preserves uppercase segments the regex does not match", () => {
+		expect(snakeToCamel("table_NAME")).toBe("table_NAME");
+		expect(snakeToCamel("Agent_ID")).toBe("Agent_ID");
+	});
+
+	it("converts a leading underscore followed by digits", () => {
+		expect(snakeToCamel("_384")).toBe("384");
+	});
+
+	it("collapses multi-segment names mixing words and numbers", () => {
+		expect(snakeToCamel("sha_256_hash")).toBe("sha256Hash");
+		expect(snakeToCamel("content_vec_1536")).toBe("contentVec1536");
+		expect(snakeToCamel("message_id_v2")).toBe("messageIdV2");
+	});
+
+	it("keeps digits without an underscore prefix unchanged", () => {
+		expect(snakeToCamel("v2")).toBe("v2");
+	});
+
+	it("keeps one underscore when doubled before a digit", () => {
+		expect(snakeToCamel("a__1")).toBe("a_1");
+	});
+
+	it("is idempotent on already-converted names", () => {
+		const once = snakeToCamel("user_profile_name");
+		expect(snakeToCamel(once)).toBe(once);
+	});
 });


### PR DESCRIPTION

## What

Adds unit coverage for `packages/core/src/types/schema-builder.ts`, appending 8 new cases to the existing `snakeToCamel` suite at `packages/core/src/types/__tests__/schema-builder.test.ts`. Purely additive: `+37/-0` on a single test file; no production code is touched.

## Why

The suite existed but left observable branches of the `/_([a-z0-9])/g` replacement uncovered. The new cases pin real behavior driven through the live module (no mocks):

- trailing underscores stay in place (`"agent_"` → `"agent_"`, lone `"_"` → `"_"`)
- empty string returns empty string
- uppercase segments the regex does not match are preserved (`"table_NAME"` → `"table_NAME"`, `"Agent_ID"` → `"Agent_ID"`)
- leading underscore before digits converts (`"_384"` → `"384"`)
- multi-segment names mixing words and numbers collapse correctly (`"sha_256_hash"` → `"sha256Hash"`, `"content_vec_1536"` → `"contentVec1536"`, `"message_id_v2"` → `"messageIdV2"`)
- digits without an underscore prefix are untouched (`"v2"` → `"v2"`)
- doubled underscore before a digit keeps exactly one (`"a__1"` → `"a_1"`)
- conversion is idempotent on already-converted names

Every expectation above was observed from the real module before being asserted.

## Verification (test-only change)

- `bunx vitest run packages/core/src/types/__tests__/schema-builder.test.ts` → **Test Files 1 passed (1), Tests 12 passed (12)** (4 pre-existing cases intact + 8 new)
- `bunx biome check --write packages/core/src/types/__tests__/schema-builder.test.ts` → clean, no fixes applied
- `bunx tsc --noEmit` in `packages/core` → zero occurrences of `schema-builder.test` in output (no new type errors from this diff)
- Diff is a single test file, `+37/-0`; no existing case was modified or removed

Note: this repository does not run hosted CI on pull requests from forks; the commands and counts above were executed locally and quoted verbatim.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:1dddd05fcca9f9c3c64265af07630aaf7b1db9d3 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
