### PR TITLE
test(ui): cover view-event-bus

### DIFF
--- a/packages/ui/src/views/view-event-bus.test.ts
+++ b/packages/ui/src/views/view-event-bus.test.ts
@@ -1,0 +1,127 @@
+// @vitest-environment jsdom
+/**
+ * Unit coverage for the cross-view event bus: emit envelope shape, typed and
+ * wildcard subscriptions, multiple-subscriber fan-out, and unsubscribe
+ * semantics. Deterministic — exercises the synchronous same-window transport;
+ * the jsdom harness has no BroadcastChannel and none is asserted.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  emitViewEvent,
+  onAnyViewEvent,
+  onViewEvent,
+  type ViewEvent,
+} from "./view-event-bus";
+
+const unsubscribers: (() => void)[] = [];
+
+function track(unsubscribe: () => void): () => void {
+  unsubscribers.push(unsubscribe);
+  return unsubscribe;
+}
+
+afterEach(() => {
+  for (const unsubscribe of unsubscribers.splice(0)) unsubscribe();
+});
+
+describe("emitViewEvent + onViewEvent", () => {
+  it("delivers the full event envelope to a type subscriber", () => {
+    const received: ViewEvent[] = [];
+    track(
+      onViewEvent("wallet:balance:updated", (event) => received.push(event)),
+    );
+
+    emitViewEvent("wallet:balance:updated", { balance: 42 }, "wallet-view");
+
+    expect(received).toHaveLength(1);
+    const event = received[0];
+    expect(event.type).toBe("wallet:balance:updated");
+    expect(event.payload).toEqual({ balance: 42 });
+    expect(event.sourceViewId).toBe("wallet-view");
+    expect(typeof event.timestamp).toBe("number");
+  });
+
+  it("does not deliver other types to a typed subscription", () => {
+    const handler = vi.fn();
+    track(onViewEvent("chat:new", handler));
+
+    emitViewEvent("wallet:balance:updated", {});
+    emitViewEvent("chat:new", { text: "hi" });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler.mock.calls[0][0].payload).toEqual({ text: "hi" });
+  });
+
+  it("stops delivery once the returned unsubscribe is called", () => {
+    const typed = vi.fn();
+    const unsubscribe = onViewEvent("agent:push", typed);
+    emitViewEvent("agent:push", { first: true });
+    unsubscribe();
+    emitViewEvent("agent:push", { second: true });
+    expect(typed).toHaveBeenCalledTimes(1);
+    expect(typed.mock.calls[0][0].payload).toEqual({ first: true });
+
+    const wildcard = vi.fn();
+    const offAny = onAnyViewEvent(wildcard);
+    emitViewEvent("agent:push", { third: true });
+    offAny();
+    emitViewEvent("agent:push", { fourth: true });
+    expect(wildcard).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("onAnyViewEvent", () => {
+  it("delivers every emitted event regardless of type", () => {
+    const seen = vi.fn();
+    track(onAnyViewEvent(seen));
+
+    emitViewEvent("a:first", { n: 1 });
+    emitViewEvent("b:second", { n: 2 }, "other-view");
+
+    expect(seen).toHaveBeenCalledTimes(2);
+    expect(seen.mock.calls.map(([event]) => event.type)).toEqual([
+      "a:first",
+      "b:second",
+    ]);
+    expect(seen.mock.calls[1][0].sourceViewId).toBe("other-view");
+  });
+
+  it("notifies every active subscriber for a single emission", () => {
+    const typed = vi.fn();
+    const wildcard = vi.fn();
+    track(onViewEvent("docs:saved", typed));
+    track(onAnyViewEvent(wildcard));
+
+    emitViewEvent("docs:saved", { id: "d1" });
+
+    expect(typed).toHaveBeenCalledTimes(1);
+    expect(wildcard).toHaveBeenCalledTimes(1);
+    expect(typed.mock.calls[0][0]).toMatchObject({ payload: { id: "d1" } });
+  });
+
+  it("delivers synchronously within the emitting call", () => {
+    let observed = false;
+    track(
+      onAnyViewEvent(() => {
+        observed = true;
+      }),
+    );
+
+    emitViewEvent("sync:probe");
+
+    expect(observed).toBe(true);
+  });
+});
+
+describe("emit defaults", () => {
+  it("defaults the payload to an empty object and sourceViewId to undefined", () => {
+    const received: ViewEvent[] = [];
+    track(onAnyViewEvent((event) => received.push(event)));
+
+    emitViewEvent("presence:tick");
+
+    expect(received).toHaveLength(1);
+    expect(received[0].payload).toEqual({});
+    expect(received[0].sourceViewId).toBeUndefined();
+  });
+});


### PR DESCRIPTION

## What

Adds the first unit suite for `packages/ui/src/views/view-event-bus.ts` — the cross-view pub-sub bus that mounted views and agent pushes communicate through. Purely additive test file: **+127/-0**, no existing file is touched.

## Coverage (7 cases)

- `emitViewEvent` delivers a complete envelope to typed subscribers: exact `type`, `payload`, `sourceViewId`, numeric `timestamp`.
- Typed subscriptions filter by type; non-matching emissions never invoke the handler.
- `onAnyViewEvent` receives every emission regardless of type, with source attribution preserved.
- One emission fans out to every active subscriber (typed + wildcard).
- Delivery is synchronous within the emitting call — consumers can read state right after emit.
- Unsubscribe stops delivery for both subscription kinds.
- Omitted payload defaults to an empty object; omitted `sourceViewId` stays undefined.

## Harness notes

The package's vitest config defaults to the node environment, so the file declares `// @vitest-environment jsdom` per house convention. The jsdom harness provides no `BroadcastChannel`, so only the synchronous same-window CustomEvent transport is exercised and asserted — no cross-tab behavior is claimed or tested here.

## Verification

- `bunx vitest run --config ./vitest.config.ts src/views/view-event-bus.test.ts` (packages/ui): **Test Files 1 passed, Tests 7 passed / 7** — re-run against current origin/develop immediately before filing.
- `bunx biome check --write packages/ui/src/views/view-event-bus.test.ts`: clean, no remaining findings.
- `tsc --noEmit -p tsconfig.json` in packages/ui: the new file appears nowhere in the output.

This PR comes from a fork, so hosted CI does not run on it; the local runs quoted above are the verification. The diff touches only the new test file and changes no production behavior.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:b0df1b72f4eafde02310591c052d72f4d52bcdba -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
