### PR TITLE
test(ui): cover errors

### DIFF
--- a/packages/ui/src/utils/errors.test.ts
+++ b/packages/ui/src/utils/errors.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Unit coverage for the ui error-helper boundary (`utils/errors.ts`) that ui
+ * consumers such as ConversationsSidebar import instead of reaching into
+ * `@elizaos/shared` directly. Pure functions, no harness.
+ */
+import { describe, expect, it } from "vitest";
+import { errorMessage, isRedirectResponse, isTimeoutError } from "./errors";
+
+describe("errorMessage", () => {
+  it("extracts the message of an Error instance", () => {
+    expect(errorMessage(new Error("Agent request failed"))).toBe(
+      "Agent request failed",
+    );
+    expect(errorMessage(new TypeError("not a function"))).toBe(
+      "not a function",
+    );
+  });
+
+  it("stringifies non-Error caught values", () => {
+    expect(errorMessage("Custom error string")).toBe("Custom error string");
+    expect(errorMessage(42)).toBe("42");
+    expect(errorMessage(true)).toBe("true");
+    expect(errorMessage(null)).toBe("null");
+    expect(errorMessage(undefined)).toBe("undefined");
+    expect(errorMessage({ code: "X" })).toBe("[object Object]");
+  });
+
+  it("preserves an intentionally empty Error message", () => {
+    expect(errorMessage(new Error())).toBe("");
+  });
+
+  it("falls back safely when primitive conversion throws", () => {
+    const poisoned = new Proxy(
+      {},
+      {
+        get(_target, prop) {
+          if (prop === "toString" || prop === Symbol.toPrimitive) {
+            throw new Error("hostile toString");
+          }
+          return undefined;
+        },
+      },
+    );
+    expect(errorMessage(poisoned)).toBe("[object Object]");
+
+    expect(errorMessage(Object.create(null))).toBe("[object Object]");
+  });
+
+  it("falls back safely when an Error's message getter itself throws", () => {
+    class HostileMessage extends Error {
+      override get message(): string {
+        throw new Error("getter exploded");
+      }
+    }
+    const hostile = new HostileMessage("shadowed");
+    // The Error constructor installs `message` as an own property that
+    // shadows the prototype getter; remove it so the throwing getter runs.
+    delete (hostile as { message?: unknown }).message;
+    expect(errorMessage(hostile)).toBe("[object Error]");
+  });
+});
+
+describe("isTimeoutError", () => {
+  it("accepts Error instances named TimeoutError or AbortError regardless of message", () => {
+    const timeoutErr = new Error("gateway said no");
+    timeoutErr.name = "TimeoutError";
+    expect(isTimeoutError(timeoutErr)).toBe(true);
+
+    const abortErr = new Error("user cancelled");
+    abortErr.name = "AbortError";
+    expect(isTimeoutError(abortErr)).toBe(true);
+  });
+
+  it("matches timeout wording in Error messages case-insensitively", () => {
+    expect(isTimeoutError(new Error("Request TIMED OUT after 5000ms"))).toBe(
+      true,
+    );
+    expect(isTimeoutError(new Error("Socket Timeout"))).toBe(true);
+    expect(isTimeoutError(new Error("Connection refused"))).toBe(false);
+  });
+
+  it("matches duck-typed objects by name or string message", () => {
+    expect(isTimeoutError({ name: "TimeoutError" })).toBe(true);
+    expect(isTimeoutError({ name: "AbortError" })).toBe(true);
+    expect(isTimeoutError({ message: "operation timed out" })).toBe(true);
+    expect(isTimeoutError({ message: "invalid payload" })).toBe(false);
+  });
+
+  it("rejects objects whose message is not a string", () => {
+    expect(isTimeoutError({ message: 42 })).toBe(false);
+    expect(isTimeoutError({})).toBe(false);
+    expect(isTimeoutError(["timeout"])).toBe(false);
+  });
+
+  it("classifies plain strings by their wording", () => {
+    expect(isTimeoutError("request timed out")).toBe(true);
+    expect(isTimeoutError("Network TIMEOUT")).toBe(true);
+    expect(isTimeoutError("Bad request")).toBe(false);
+  });
+
+  it("short-circuits on falsy and non-string primitives", () => {
+    expect(isTimeoutError(null)).toBe(false);
+    expect(isTimeoutError(undefined)).toBe(false);
+    expect(isTimeoutError("")).toBe(false);
+    expect(isTimeoutError(0)).toBe(false);
+    expect(isTimeoutError(123)).toBe(false);
+    expect(isTimeoutError(false)).toBe(false);
+  });
+});
+
+describe("isRedirectResponse", () => {
+  it("accepts every 3xx status class including the range boundaries", () => {
+    expect(isRedirectResponse({ status: 300 } as Response)).toBe(true);
+    expect(isRedirectResponse({ status: 301 } as Response)).toBe(true);
+    expect(isRedirectResponse({ status: 302 } as Response)).toBe(true);
+    expect(isRedirectResponse({ status: 303 } as Response)).toBe(true);
+    expect(isRedirectResponse({ status: 307 } as Response)).toBe(true);
+    expect(isRedirectResponse({ status: 308 } as Response)).toBe(true);
+    expect(isRedirectResponse({ status: 399 } as Response)).toBe(true);
+  });
+
+  it("rejects statuses outside [300, 400)", () => {
+    expect(isRedirectResponse({ status: 200 } as Response)).toBe(false);
+    expect(isRedirectResponse({ status: 299 } as Response)).toBe(false);
+    expect(isRedirectResponse({ status: 400 } as Response)).toBe(false);
+    expect(isRedirectResponse({ status: 404 } as Response)).toBe(false);
+    expect(isRedirectResponse({ status: 500 } as Response)).toBe(false);
+  });
+
+  it("rejects missing, non-numeric, and non-finite statuses", () => {
+    expect(isRedirectResponse(null as unknown as Response)).toBe(false);
+    expect(isRedirectResponse(undefined as unknown as Response)).toBe(false);
+    expect(isRedirectResponse({} as Response)).toBe(false);
+    expect(isRedirectResponse({ status: "302" } as unknown as Response)).toBe(
+      false,
+    );
+    expect(
+      isRedirectResponse({ status: Number.NaN } as unknown as Response),
+    ).toBe(false);
+    expect(
+      isRedirectResponse({
+        status: Number.POSITIVE_INFINITY,
+      } as unknown as Response),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION

Adds a new unit suite for `packages/ui/src/utils/errors.ts`, the error-helper boundary that ui consumers such as `ConversationsSidebar.tsx` import instead of reaching into `@elizaos/shared` directly.

The module re-exports three runtime helpers (`errorMessage`, `isRedirectResponse`, `isTimeoutError`). The suite drives the real implementations through the ui barrel and asserts observed behavior only:

- `errorMessage` (= core `formatError`): Error message extraction, stringification of non-Error values (`42` -> `"42"`, `null` -> `"null"`, plain object -> `"[object Object]"`), preserved empty messages, and the guarded fallback when primitive conversion throws (poisoned `toString` proxy, null-prototype object -> `"[object Object]"`, throwing `message` getter on an Error subclass -> `"[object Error]"` after its shadowing own property is removed).
- `isTimeoutError`: name-based classification (`TimeoutError`/`AbortError`), case-insensitive timeout wording in messages and plain strings, duck-typed objects, non-string `message` rejection, and falsy/non-string primitive short-circuits (`""`, `0`, `false`, `null`, `undefined`, arrays).
- `isRedirectResponse`: every 3xx class including exact range boundaries (`300`..`308`, `399`) accepted, statuses outside `[300, 400)` rejected, and missing/string/`NaN`/`Infinity` statuses plus `null`/`undefined` safely rejected.

No production code is touched: the diff is one new test file, +146/-0. No mocks stand in for the system under test; no type-level assertions are used.

Evidence (quoted, not implied): `bunx vitest run src/utils/errors.test.ts` in `packages/ui` = **1 file passed, 14 tests passed (14/14)**, re-run green against current `origin/develop` (`1f236fd1f5`, module unchanged vs base). `bunx biome check` on the file is clean after one formatting pass. `bunx tsc --noEmit` in `packages/ui` reports zero diagnostics referencing `errors.test`. As a fork contributor, hosted CI does not run on this PR; the local counts above are the complete evidence set for this test-only change.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:ee29047890b044c47c85db3293cffc254a1972e6 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
