### PR TITLE
test(ui): cover cloud applications barrel

### DIFF
--- a/packages/ui/src/cloud/applications/index.test.ts
+++ b/packages/ui/src/cloud/applications/index.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Verifies the Applications cloud-domain barrel against the real cloud-route
+ * registry: both surfaces are wired at import time under the exported path
+ * constants, the import-time side effect leaves the legacy `cloud/applications`
+ * paths to the moved-route handoff, re-registration preserves element identity
+ * while moving the entries later in registration order, subscribers hear
+ * exactly the registrations until they unsubscribe, and both route elements are
+ * code-split React.lazy components. Runs through the package's configured
+ * harness (jsdom) against the live `Symbol.for`-keyed registry store — no
+ * module mocks.
+ */
+// @vitest-environment jsdom
+
+import { describe, expect, it } from "vitest";
+import {
+  getCloudRoute,
+  getCloudRouteRegistryVersion,
+  listCloudRoutes,
+  registerCloudRoute,
+  subscribeCloudRoutes,
+} from "../shell/cloud-route-registry";
+import {
+  APPLICATIONS_DETAIL_ROUTE_PATH,
+  APPLICATIONS_LEGACY_DETAIL_ROUTE_PATH,
+  APPLICATIONS_LEGACY_LIST_ROUTE_PATH,
+  APPLICATIONS_LIST_ROUTE_PATH,
+  applicationsDetailCloudRoute,
+  applicationsListCloudRoute,
+  registerApplicationsCloudRoutes,
+} from "./index";
+
+function registrationOrder(path: string): number {
+  const index = listCloudRoutes().findIndex((route) => route.path === path);
+  expect(index, `route ${path} should be registered`).toBeGreaterThanOrEqual(0);
+  return index;
+}
+
+function ProbeRoute() {
+  return null;
+}
+
+describe("applications cloud barrel — import-time registration", () => {
+  it("resolves the canonical list URL to the registered list route", () => {
+    // Looked up by the literal slug a link/router would use, then tied back to
+    // the exported constant, so the constant and the live registration cannot
+    // drift apart silently.
+    expect(getCloudRoute("cloud/apps")?.path).toBe(
+      APPLICATIONS_LIST_ROUTE_PATH,
+    );
+    expect(getCloudRoute(APPLICATIONS_LIST_ROUTE_PATH)).toMatchObject({
+      group: "cloud",
+      element: applicationsListCloudRoute.element,
+    });
+  });
+
+  it("resolves the canonical detail URL to the registered detail route", () => {
+    expect(getCloudRoute("cloud/apps/:id")?.path).toBe(
+      APPLICATIONS_DETAIL_ROUTE_PATH,
+    );
+    expect(getCloudRoute(APPLICATIONS_DETAIL_ROUTE_PATH)).toMatchObject({
+      group: "cloud",
+      element: applicationsDetailCloudRoute.element,
+    });
+  });
+
+  it("leaves the legacy cloud/applications paths unregistered", () => {
+    // The legacy spellings belong to registerMovedApplicationsCloudRoutes
+    // (retired-Apps redirect); importing the barrel alone must not claim them.
+    expect(getCloudRoute(APPLICATIONS_LEGACY_LIST_ROUTE_PATH)).toBeUndefined();
+    expect(
+      getCloudRoute(APPLICATIONS_LEGACY_DETAIL_ROUTE_PATH),
+    ).toBeUndefined();
+  });
+});
+
+describe("registerApplicationsCloudRoutes — re-registration semantics", () => {
+  it("re-registration replaces both entries and lands them after previously-later routes", () => {
+    // A route any other cloud domain registers after ours starts later in the
+    // shell's registration order; re-registering Applications must move both
+    // of its routes past that route — the documented last-write-wins store.
+    const probePath = "applications-index-test/probe";
+    registerCloudRoute({ path: probePath, element: ProbeRoute });
+    expect(registrationOrder(APPLICATIONS_LIST_ROUTE_PATH)).toBeLessThan(
+      registrationOrder(probePath),
+    );
+    expect(registrationOrder(APPLICATIONS_DETAIL_ROUTE_PATH)).toBeLessThan(
+      registrationOrder(probePath),
+    );
+
+    registerApplicationsCloudRoutes();
+
+    expect(registrationOrder(APPLICATIONS_LIST_ROUTE_PATH)).toBeGreaterThan(
+      registrationOrder(probePath),
+    );
+    expect(registrationOrder(APPLICATIONS_DETAIL_ROUTE_PATH)).toBeGreaterThan(
+      registrationOrder(probePath),
+    );
+    // Re-registration passes the same exported defs, so the registry entry a
+    // consumer reads keeps pointing at the original lazy element — it was
+    // replaced, not rebuilt as a second component.
+    expect(getCloudRoute(APPLICATIONS_LIST_ROUTE_PATH)?.element).toBe(
+      applicationsListCloudRoute.element,
+    );
+    expect(getCloudRoute(APPLICATIONS_DETAIL_ROUTE_PATH)?.element).toBe(
+      applicationsDetailCloudRoute.element,
+    );
+    expect(getCloudRoute(APPLICATIONS_DETAIL_ROUTE_PATH)).toMatchObject({
+      group: "cloud",
+    });
+  });
+
+  it("bumps the registry snapshot version once per registration", () => {
+    const before = getCloudRouteRegistryVersion();
+    registerApplicationsCloudRoutes();
+    expect(getCloudRouteRegistryVersion() - before).toBe(2);
+  });
+
+  it("notifies subscribers per registration and stops after unsubscribe", () => {
+    let notifications = 0;
+    const unsubscribe = subscribeCloudRoutes(() => {
+      notifications += 1;
+    });
+
+    registerApplicationsCloudRoutes();
+    expect(notifications).toBe(2);
+
+    unsubscribe();
+    registerApplicationsCloudRoutes();
+    expect(notifications).toBe(2);
+  });
+});
+
+describe("applications route elements — code splitting contract", () => {
+  it("mounts both surfaces as distinct React.lazy elements", () => {
+    const listElement = applicationsListCloudRoute.element as {
+      $$typeof?: unknown;
+    };
+    const detailElement = applicationsDetailCloudRoute.element as {
+      $$typeof?: unknown;
+    };
+    expect(listElement.$$typeof).toBe(Symbol.for("react.lazy"));
+    expect(detailElement.$$typeof).toBe(Symbol.for("react.lazy"));
+    expect(applicationsListCloudRoute.element).not.toBe(
+      applicationsDetailCloudRoute.element,
+    );
+  });
+});


### PR DESCRIPTION

## What

Adds a unit suite for the Applications cloud-domain barrel (`packages/ui/src/cloud/applications/index.ts`), which has no same-named test file anywhere on `develop`. The diff is one new file (+147/-0); no production behaviour changes.

## What the suite verifies

The tests drive the real `cloud-route-registry` store (the `Symbol.for`-keyed registry that `CloudRouterShell` consumes) - no module mocks:

- import-time registration: both routes resolve under the canonical slugs `cloud/apps` and `cloud/apps/:id`, tied back to the exported path constants and `group: "cloud"`
- side-effect scope: importing the barrel alone leaves the legacy `cloud/applications` and `cloud/applications/:id` spellings unregistered (they belong to the moved-route handoff, not this barrel)
- re-registration semantics: calling the exported `registerApplicationsCloudRoutes()` replaces both entries, lands them after previously-later registrations (last-write-wins order), and preserves lazy-element identity instead of rebuilding the components
- the registry snapshot version bumps by exactly 2 per registration call; subscribers are notified once per registration and stop after unsubscribing
- both route elements are distinct `React.lazy` wrappers (code-splitting contract)

## Evidence (test-only change; counts quoted from the final local run)

- `bunx vitest run --config ./vitest.config.ts src/cloud/applications/index.test.ts` from `packages/ui`: **Test Files 1 passed (1), Tests 7 passed (7)**. Re-run against current `origin/develop` (51617538d704) immediately before filing; nothing under `packages/ui/src/cloud/applications/` or the route registry changed between the base I branched from and that head, so these counts reproduce there.
- `bunx @biomejs/biome check --write src/cloud/applications/index.test.ts`: exit 0 (one formatting fix applied on the first pass, clean afterwards).
- `bunx tsc --noEmit -p tsconfig.json` in `packages/ui`: the new test file appears nowhere in the output (8 pre-existing errors in unrelated files).

## Scope

This PR touches only `packages/ui/src/cloud/applications/index.test.ts`. It adds coverage and changes no production behaviour.

## CI note

We are a fork contributor, so hosted CI does not run on this pull request. The local runs quoted above stand in for it.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:43e6ea2e0a2d5acc1b6bee018ddf8290e35c0543 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
