### PR TITLE
test(ui): cover globals

### DIFF
--- a/packages/ui/src/utils/globals.test.ts
+++ b/packages/ui/src/utils/globals.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Verifies the terminal verbose globals: the explicit verbose flag and the
+ * LOG_LEVEL priority ladder gate debug output, a failing logger never breaks
+ * callers, and the yes flag tracks state independently of verbosity.
+ *
+ * The real module under test drives every case; spies only observe the
+ * logger and console boundaries. Module-level flags are reset before each
+ * case so pass order never matters.
+ */
+import { logger } from "@elizaos/logger";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { theme } from "../terminal/theme";
+import {
+  isVerbose,
+  isYes,
+  logVerbose,
+  setVerbose,
+  setYes,
+  shouldLogVerbose,
+} from "./globals";
+
+const originalLogLevel = process.env.LOG_LEVEL;
+
+beforeEach(() => {
+  delete process.env.LOG_LEVEL;
+  setVerbose(false);
+  setYes(false);
+});
+
+afterEach(() => {
+  if (originalLogLevel === undefined) {
+    delete process.env.LOG_LEVEL;
+  } else {
+    process.env.LOG_LEVEL = originalLogLevel;
+  }
+  vi.restoreAllMocks();
+});
+
+describe("verbose flag", () => {
+  it("defaults to off", () => {
+    expect(isVerbose()).toBe(false);
+    expect(shouldLogVerbose()).toBe(false);
+  });
+
+  it("round-trips through setVerbose", () => {
+    setVerbose(true);
+    expect(isVerbose()).toBe(true);
+    expect(shouldLogVerbose()).toBe(true);
+
+    setVerbose(false);
+    expect(isVerbose()).toBe(false);
+  });
+});
+
+describe("shouldLogVerbose LOG_LEVEL gating", () => {
+  it.each(["trace", "debug", "DEBUG", "Trace"])(
+    "enables verbose output when LOG_LEVEL=%s",
+    (level) => {
+      process.env.LOG_LEVEL = level;
+      expect(shouldLogVerbose()).toBe(true);
+    },
+  );
+
+  it.each(["info", "warn", "error", "fatal", "silent", "not-a-level"])(
+    "keeps verbose output off when LOG_LEVEL=%s",
+    (level) => {
+      process.env.LOG_LEVEL = level;
+      expect(shouldLogVerbose()).toBe(false);
+    },
+  );
+
+  it("treats an unset LOG_LEVEL like info", () => {
+    delete process.env.LOG_LEVEL;
+    expect(shouldLogVerbose()).toBe(false);
+  });
+
+  it("lets the explicit verbose flag override a quiet LOG_LEVEL", () => {
+    process.env.LOG_LEVEL = "fatal";
+    setVerbose(true);
+    expect(shouldLogVerbose()).toBe(true);
+  });
+});
+
+describe("logVerbose output routing", () => {
+  let debugSpy: ReturnType<typeof vi.spyOn>;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    debugSpy = vi.spyOn(logger, "debug").mockImplementation(() => {});
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+  });
+
+  it("stays fully silent when verbose is off and LOG_LEVEL is quiet", () => {
+    process.env.LOG_LEVEL = "info";
+
+    logVerbose("hidden");
+
+    expect(debugSpy).not.toHaveBeenCalled();
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it("routes through the structured logger but not the console when only LOG_LEVEL enables it", () => {
+    process.env.LOG_LEVEL = "debug";
+
+    logVerbose("env-only");
+
+    expect(debugSpy).toHaveBeenCalledTimes(1);
+    expect(debugSpy).toHaveBeenCalledWith({ message: "env-only" }, "verbose");
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it("adds muted console output only when the verbose flag is set", () => {
+    setVerbose(true);
+
+    logVerbose("flag-only");
+
+    expect(debugSpy).toHaveBeenCalledWith({ message: "flag-only" }, "verbose");
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy).toHaveBeenCalledWith(theme.muted("flag-only"));
+  });
+
+  it("survives a throwing logger and still prints once verbose is set", () => {
+    setVerbose(true);
+    debugSpy.mockImplementation(() => {
+      throw new Error("logger backend exploded");
+    });
+
+    expect(() => logVerbose("resilient")).not.toThrow();
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy).toHaveBeenCalledWith(theme.muted("resilient"));
+  });
+});
+
+describe("yes flag", () => {
+  it("defaults to off and round-trips independently of verbosity", () => {
+    expect(isYes()).toBe(false);
+
+    setYes(true);
+    setVerbose(true);
+    expect(isYes()).toBe(true);
+    expect(isVerbose()).toBe(true);
+
+    setYes(false);
+    expect(isYes()).toBe(false);
+    expect(isVerbose()).toBe(true);
+  });
+});


### PR DESCRIPTION

## What

Adds a colocated unit suite for `packages/ui/src/utils/globals.ts`, which has no test coverage on current `develop`. Test-only change: one new file, +147/-0, no production code touched.

## Why

The module gates CLI verbose output on two independent signals (an explicit verbose flag and the `LOG_LEVEL` priority ladder) and routes output between the structured logger and the muted console. None of that was pinned by any existing suite, so a gating or routing regression would ship silently.

## Coverage

- **verbose flag**: defaults off; round-trips through `setVerbose`; feeds `shouldLogVerbose`.
- **LOG_LEVEL gating**: `trace`/`debug` enable verbose output case-insensitively; `info` and quieter levels keep it off; an unknown level string falls back to the info-equivalent priority; unset behaves like `info`; the explicit flag overrides a quiet level.
- **logVerbose routing**: fully silent when gated off; structured-logger-only when enabled by `LOG_LEVEL` alone; adds muted console output only when the verbose flag is set; a throwing logger never propagates and printing still happens.
- **yes flag**: tracks state independently of verbosity.

Every case drives the real module; spies observe only the logger/console boundaries, matching the sibling `tts-debug.test.ts` conventions.

## Evidence (fork contributor — hosted CI does NOT run on this PR)

Verified locally against `origin/develop` at `1f236fd1f58f` immediately before filing:

- `bunx vitest run --config ./vitest.config.ts src/utils/globals.test.ts`: **1 file passed (1), 19 passed (19)** — re-run against current develop just before filing, same result.
- `bunx biome check --write packages/ui/src/utils/globals.test.ts`: checked 1 file, no fixes needed.
- `tsc --noEmit -p tsconfig.json` in packages/ui: reports 14 pre-existing errors, all in unrelated files (`capability-handoff.ts`, `core/cloud-routing.ts`, two cloud component tests); `globals.test.ts` appears nowhere in the output.

This pull request changes no production behavior; the diff touches only the new test file.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

N/A - standalone test-coverage addition; no linked issue.

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
      Branch tip is exactly `origin/develop` @ `1f236fd1f58f` plus this one
      commit; zero conflicts possible on a single new file.
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
      Recorded in **Known gaps / failures**: unattended lane ran scoped gates
      (package vitest, biome, tsc) rather than the full workspace verify.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.
      The quoted vitest count is reproducible with one command (see Testing).

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

Low — additive, test-only. No production file is modified; worst case is a
flaky or wrong expectation in the new suite, which cannot affect runtime
behavior of any consumer.

# Background

## What does this PR do?

Adds `packages/ui/src/utils/globals.test.ts`, a colocated vitest suite covering the previously untested verbose-logging globals (flag round-trips, LOG_LEVEL priority gating, logger/console output routing, logger-failure resilience, independent yes flag).

## What kind of change is this?

Tests — non-breaking change which adds unit coverage only (no behavior change).

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

`packages/ui/src/utils/globals.test.ts` — read it next to
`packages/ui/src/utils/globals.ts`, which it exercises directly.

## Detailed testing steps

```bash
cd packages/ui && bunx vitest run --config ./vitest.config.ts src/utils/globals.test.ts
```

Expected: `Test Files  1 passed (1)`, `Tests  19 passed (19)`.

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:f9e19caf219bcd6f2dfa9ceabb1d5929c9c58a9c -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
      N/A - test-only change; no rendered UI surface exists before or after.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
      N/A - test-only change; nothing renders.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
      N/A - no user flow; behavior is covered by the quoted vitest run.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
      N/A - unit-level module; the vitest run (19/19 passed) is the execution log.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
      N/A - no network or browser surface is exercised.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
      N/A - no model call path touched.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
      N/A - no domain state involved.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.
      N/A - the diff contains no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

N/A - test-only change; no rendered surface.

### After

N/A - test-only change; no rendered surface.

### Walkthrough video

N/A - no user flow; see Testing for the one-command reproduction.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

- Full workspace `bun run verify` was not run from this unattended lane; the
  scoped gates were run instead and are quoted above (package vitest 19/19,
  biome clean, tsc output contains no reference to the new file).
- Evidence waiver: unattended session cannot finalize an interactive
  identity.slop.cash OAuth trace, so no receipt/trace is attached
  (`FACTORY_NO_EVIDENCE` declared at filing time).
- Hosted CI does not run on this fork's pull requests; all quoted counts come
  from local runs against `origin/develop` @ `1f236fd1f58f`.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
