### PR TITLE
test(ui): cover view-event-bus

### DIFF
--- a/packages/ui/src/views/view-event-bus.test.ts
+++ b/packages/ui/src/views/view-event-bus.test.ts
@@ -1,0 +1,174 @@
+// @vitest-environment jsdom
+/**
+ * Unit coverage for the cross-view event bus: emit envelope shape, typed and
+ * catch-all same-window subscription, FIFO delivery ordering, unsubscribe,
+ * and listener-free emission. Drives the real module over jsdom's window
+ * CustomEvent transport; no mocks.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  emitViewEvent,
+  onAnyViewEvent,
+  onViewEvent,
+  type ViewEvent,
+} from "./view-event-bus";
+
+function collect(into: ViewEvent[]) {
+  return (event: ViewEvent) => {
+    into.push(event);
+  };
+}
+
+describe("emitViewEvent envelope", () => {
+  it("delivers type, payload, sourceViewId and timestamp to a matching subscriber", () => {
+    const received: ViewEvent[] = [];
+    const unsubscribe = onViewEvent(
+      "wallet:balance:updated",
+      collect(received),
+    );
+
+    const before = Date.now();
+    emitViewEvent(
+      "wallet:balance:updated",
+      { address: "0xabc" },
+      "wallet-view",
+    );
+    const after = Date.now();
+    unsubscribe();
+
+    expect(received).toHaveLength(1);
+    const event = received[0];
+    expect(event.type).toBe("wallet:balance:updated");
+    expect(event.payload).toEqual({ address: "0xabc" });
+    expect(event.sourceViewId).toBe("wallet-view");
+    expect(typeof event.timestamp).toBe("number");
+    expect(event.timestamp).toBeGreaterThanOrEqual(before);
+    expect(event.timestamp).toBeLessThanOrEqual(after);
+  });
+
+  it("defaults payload to an empty object and sourceViewId to undefined when omitted", () => {
+    const received: ViewEvent[] = [];
+    const unsubscribe = onAnyViewEvent(collect(received));
+
+    emitViewEvent("agent:pushed");
+    unsubscribe();
+
+    expect(received).toHaveLength(1);
+    const event = received[0];
+    expect(event.payload).toEqual({});
+    expect(event.sourceViewId).toBeUndefined();
+    expect(Object.keys(event).sort()).toEqual([
+      "payload",
+      "sourceViewId",
+      "timestamp",
+      "type",
+    ]);
+  });
+
+  it("does not throw when nothing is subscribed", () => {
+    expect(() => {
+      emitViewEvent("views:no-listeners", { any: true });
+      emitViewEvent("views:no-listeners");
+    }).not.toThrow();
+  });
+});
+
+describe("onViewEvent filtering", () => {
+  it("matches only the exact event type", () => {
+    const received: ViewEvent[] = [];
+    const unsubscribe = onViewEvent("chat:closed", collect(received));
+
+    emitViewEvent("chat:open");
+    emitViewEvent("chat:closed:by-user");
+    emitViewEvent("chat:closed");
+
+    unsubscribe();
+
+    expect(received).toHaveLength(1);
+    expect(received[0].type).toBe("chat:closed");
+  });
+
+  it("stops delivering after unsubscribe and resumes after resubscribing", () => {
+    const received: ViewEvent[] = [];
+    let unsubscribe = onViewEvent("nav:tab", collect(received));
+
+    emitViewEvent("nav:tab", { n: 1 });
+    unsubscribe();
+
+    emitViewEvent("nav:tab", { n: 2 });
+
+    unsubscribe = onViewEvent("nav:tab", collect(received));
+    emitViewEvent("nav:tab", { n: 3 });
+    unsubscribe();
+
+    expect(received.map((event) => event.payload)).toEqual([
+      { n: 1 },
+      { n: 3 },
+    ]);
+  });
+
+  it("delivers every registered subscriber its own copy of the same emission", () => {
+    const first: ViewEvent[] = [];
+    const second: ViewEvent[] = [];
+    const unsubFirst = onViewEvent("files:saved", collect(first));
+    const unsubSecond = onViewEvent("files:saved", collect(second));
+
+    emitViewEvent("files:saved", { path: "/tmp/a.txt" }, "editor-view");
+
+    unsubFirst();
+    unsubSecond();
+
+    expect(first).toHaveLength(1);
+    expect(second).toHaveLength(1);
+    expect(second[0]).toEqual(first[0]);
+    expect(second[0].sourceViewId).toBe("editor-view");
+  });
+});
+
+describe("onAnyViewEvent", () => {
+  it("receives events of every type in emission order", () => {
+    const received: ViewEvent[] = [];
+    const unsubscribe = onAnyViewEvent(collect(received));
+
+    emitViewEvent("a:first");
+    emitViewEvent("b:second", { i: 2 });
+    emitViewEvent("c:third");
+
+    unsubscribe();
+
+    expect(received.map((event) => event.type)).toEqual([
+      "a:first",
+      "b:second",
+      "c:third",
+    ]);
+    expect(received[1].payload).toEqual({ i: 2 });
+  });
+
+  it("ignores events emitted after unsubscribe and tolerates double-unsubscribe", () => {
+    const received: ViewEvent[] = [];
+    const unsubscribe = onAnyViewEvent(collect(received));
+
+    emitViewEvent("x:before");
+    unsubscribe();
+    unsubscribe();
+    emitViewEvent("x:after");
+
+    expect(received.map((event) => event.type)).toEqual(["x:before"]);
+  });
+
+  it("sees the identical event object a filtered subscriber sees for one emission", () => {
+    const viaAny: ViewEvent[] = [];
+    const viaTyped: ViewEvent[] = [];
+    const unsubAny = onAnyViewEvent(collect(viaAny));
+    const unsubTyped = onViewEvent("sync:done", collect(viaTyped));
+
+    emitViewEvent("sync:done", { items: 3 });
+
+    unsubAny();
+    unsubTyped();
+
+    expect(viaAny).toHaveLength(1);
+    expect(viaTyped).toHaveLength(1);
+    expect(viaTyped[0]).toBe(viaAny[0]);
+  });
+});


### PR DESCRIPTION

## What

Adds `packages/ui/src/views/view-event-bus.test.ts` — a new unit suite for the cross-view event bus (`emitViewEvent`, `onViewEvent`, `onAnyViewEvent`). Test-only change: one new file, +174/-0, no production code touched.

## Why

`view-event-bus.ts` had no same-named suite anywhere on develop. It is the pub/sub seam mounted views and agent-side pushes rely on, so its envelope contract and subscription semantics are worth pinning before refactors.

## Coverage

Behavioral tests driving the real module over the same-window transport (jsdom `CustomEvent`); no mocks of the system under test:

- Emit envelope: `type` / `payload` / `sourceViewId` passthrough, `timestamp` bounded by the emit window; payload defaults to `{}` and `sourceViewId` to `undefined` when omitted, with the exact emitted key set asserted.
- Typed subscription filters on exact type only (`chat:closed` must not match `chat:closed:by-user` or `chat:open`).
- Catch-all subscription receives every event in emission order.
- Unsubscribe stops delivery and tolerates a double call; resubscribing resumes delivery.
- Multiple subscribers each receive the same emission; a filtered and a catch-all subscriber observe the identical event object.
- Emitting with zero subscribers does not throw.

## Evidence

- `bunx vitest run src/views/view-event-bus.test.ts` (in `packages/ui`): **Test Files 1 passed (1); Tests 9 passed (9)** — re-run against current `origin/develop` (`1f236fd1f58f`) immediately before filing.
- `bunx biome check src/views/view-event-bus.test.ts`: clean (no fixes applied).
- `bunx tsc --noEmit` in `packages/ui`: zero diagnostics mentioning `view-event-bus.test`.
- The diff touches only `packages/ui/src/views/view-event-bus.test.ts` (+174/-0).

## CI note

Fork contributor: hosted CI does not run on this PR. The counts above are local runs quoted verbatim.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:b1c73858938f7ae58b87575e3f30c293ab3fce36 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
