### PR TITLE
test(core): cover types/service

### DIFF
--- a/packages/core/src/types/service.test.ts
+++ b/packages/core/src/types/service.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Service abstraction contracts: error normalization, the abstract `Service`
+ * base class lifecycle, the canonical `ServiceType` registry strings, and
+ * typed service lookup delegation. Deterministic tests driving the real
+ * module with no network or model substitutes.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { IAgentRuntime } from "./runtime";
+import {
+	createServiceError,
+	getTypedService,
+	Service,
+	ServiceType,
+} from "./service";
+
+class EchoService extends Service {
+	static override serviceType = ServiceType.UNKNOWN;
+
+	override get capabilityDescription(): string {
+		return "echo service for contract tests";
+	}
+
+	runtimeRef(): unknown {
+		return this.runtime;
+	}
+
+	async stop(): Promise<void> {}
+}
+
+class BootedService extends EchoService {
+	static override async start(runtime: IAgentRuntime): Promise<Service> {
+		return new BootedService(runtime);
+	}
+}
+
+describe("createServiceError", () => {
+	it("wraps an Error instance with its message and preserves it as cause", () => {
+		const original = new Error("connection reset");
+		const normalized = createServiceError(original, "TRANSPORT_RESET");
+
+		expect(normalized.code).toBe("TRANSPORT_RESET");
+		expect(normalized.message).toBe("connection reset");
+		expect(normalized.cause).toBe(original);
+	});
+
+	it("defaults the code to UNKNOWN_ERROR for Error and string inputs", () => {
+		expect(createServiceError(new Error("boom")).code).toBe("UNKNOWN_ERROR");
+		expect(createServiceError("boom").code).toBe("UNKNOWN_ERROR");
+	});
+
+	it("coerces a plain string into the message without inventing a cause", () => {
+		const normalized = createServiceError("disk full", "STORAGE_FULL");
+
+		expect(normalized).toEqual({ code: "STORAGE_FULL", message: "disk full" });
+		expect(Object.hasOwn(normalized, "cause")).toBe(false);
+	});
+
+	it.each([
+		[42, "42"],
+		[true, "true"],
+		[null, "null"],
+	])(
+		"stringifies a non-string value %s into the message",
+		(value, expected) => {
+			expect(createServiceError(value, "VALUE_RENDER").message).toBe(expected);
+		},
+	);
+});
+
+describe("Service base class", () => {
+	it("fails fast when a subclass does not implement start()", async () => {
+		await expect(Service.start({} as IAgentRuntime)).rejects.toThrow(
+			"Service.start() must be implemented by subclass",
+		);
+	});
+
+	it("lets an overriding subclass start and hands back a live instance", async () => {
+		const runtimeStub = { getService: () => null } as IAgentRuntime;
+
+		const started = await BootedService.start(runtimeStub);
+
+		expect(started).toBeInstanceOf(BootedService);
+		expect(started).toBeInstanceOf(Service);
+	});
+
+	it("stores the provided runtime on the instance", () => {
+		const runtimeStub = { getService: () => null } as IAgentRuntime;
+
+		const instance = new EchoService(runtimeStub);
+
+		expect(instance.runtimeRef()).toBe(runtimeStub);
+	});
+
+	it("leaves the runtime unset when constructed without one", () => {
+		const bare = new EchoService();
+
+		expect(bare.runtimeRef()).toBeUndefined();
+	});
+});
+
+describe("ServiceType registry strings", () => {
+	it("keeps every registered type string distinct so Map-based registration cannot collide", () => {
+		const values = Object.values(ServiceType);
+
+		expect(new Set(values).size).toBe(values.length);
+	});
+});
+
+describe("getTypedService", () => {
+	it("forwards the requested service type to the runtime lookup and returns the identical instance", () => {
+		const requested: string[] = [];
+		const instance = new EchoService();
+		const runtimeStub = {
+			getService: (serviceType: string) => {
+				requested.push(serviceType);
+				return instance;
+			},
+		} as IAgentRuntime;
+
+		const resolved = getTypedService(runtimeStub, ServiceType.MESSAGE_SERVICE);
+
+		expect(requested).toEqual([ServiceType.MESSAGE_SERVICE]);
+		expect(resolved).toBe(instance);
+	});
+
+	it("returns null when the runtime reports no such service", () => {
+		const runtimeStub = { getService: () => null } as IAgentRuntime;
+
+		expect(getTypedService(runtimeStub, ServiceType.VIDEO)).toBeNull();
+	});
+});


### PR DESCRIPTION

Adds a colocated vitest suite for the runtime surface of `packages/core/src/types/service.ts`, which had no same-named test file anywhere on develop:

- `createServiceError`: wraps an `Error` with its message and preserves it as identity `cause`; defaults the code to `UNKNOWN_ERROR`; coerces a plain string into the message without inventing a cause; stringifies non-string values (number/boolean/null) into a usable message.
- `Service` base class: fail-fast `static start()` rejection ("Service.start() must be implemented by subclass") when a subclass does not implement it; an overriding subclass resolves to an instance satisfying both the subclass and base contracts; the constructor stores a provided runtime reference and leaves the runtime unset when constructed without one.
- `ServiceType` registry strings: every registered value stays distinct so Map-keyed runtime registration cannot silently collide.
- `getTypedService`: forwards the requested service type to `runtime.getService` unchanged and passes through both the resolved instance (identity) and null.

Evidence (this is a fork contribution; hosted CI does not run on it, so validation is quoted here):

1. `bunx vitest run src/types/service.test.ts` in packages/core against current origin/develop (`51617538d704`): Test Files 1 passed (1); Tests 13 passed (13).
2. `bunx biome check src/types/service.test.ts`: "Checked 1 file in 87ms. No fixes applied."
3. `bunx tsc --noEmit` in packages/core: the test file appears nowhere in the output — zero new errors introduced by this diff.
4. The diff touches only the new test file (+132/-0); no production behaviour changes.

Test-only change; vitest, biome and tsc counts are quoted above.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:515182ef38e393b9f7c7e4f6dc75ee73d90659fc -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
