### PR TITLE
test(core): cover index

### DIFF
--- a/packages/core/src/validation/index.test.ts
+++ b/packages/core/src/validation/index.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Behavioral coverage for the validation barrel entry point: every runtime
+ * export consumers reach through src/validation/index must resolve to a
+ * working implementation. Drives the real functions through the public
+ * import path, exercising branches the submodule suites leave open (missing
+ * recent-history, maximum-length rejection, empty requirement sets, and
+ * canonical-key passthrough); deterministic, no mocks or harnesses.
+ */
+import { describe, expect, it } from "vitest";
+import type { Memory } from "../types";
+import {
+	checkRequiredSecrets,
+	getValidationPattern,
+	hasValidationPattern,
+	inferValidationPatternKey,
+	validateActionKeywords,
+	validateActionRegex,
+	validateSecretKey,
+	validateSecrets,
+} from "./index.ts";
+
+const memory = (text?: string) => ({ content: { text } }) as Memory;
+
+describe("validateActionKeywords via index", () => {
+	it("tolerates a missing or null recent-messages list", () => {
+		expect(
+			validateActionKeywords(
+				memory("run the task"),
+				undefined as unknown as Memory[],
+				["task"],
+			),
+		).toBe(true);
+		expect(
+			validateActionKeywords(
+				memory("nothing relevant here"),
+				null as unknown as Memory[],
+				["task"],
+			),
+		).toBe(false);
+	});
+
+	it("matches a keyword found only in retained history", () => {
+		const recent = [memory("please review"), memory("the deployment")];
+		expect(
+			validateActionKeywords(memory("current"), recent, ["deployment"]),
+		).toBe(true);
+	});
+
+	it("does not match a phrase spanning the newline join between messages", () => {
+		const recent = [memory("please review"), memory("the deployment")];
+		expect(
+			validateActionKeywords(memory("current"), recent, ["review the"]),
+		).toBe(false);
+	});
+});
+
+describe("validateActionRegex via index", () => {
+	it("scans the joined history and preserves caller-supplied flags", () => {
+		expect(
+			validateActionRegex(memory("Say HELLO WORLD"), [], /hello world/i),
+		).toBe(true);
+		expect(
+			validateActionRegex(
+				memory("first"),
+				[memory("second"), memory("third")],
+				/^second$/m,
+			),
+		).toBe(true);
+	});
+
+	it("returns false when no message carries text", () => {
+		expect(validateActionRegex(memory(), [], /anything/)).toBe(false);
+	});
+});
+
+describe("validateSecretKey via index", () => {
+	it("rejects below-minimum lengths before evaluating the pattern", () => {
+		const short = validateSecretKey("OPENAI_API_KEY", "sk-short");
+		expect(short.isValid).toBe(false);
+		expect(short.error).toBe(
+			"OPENAI_API_KEY is too short (minimum 20 characters)",
+		);
+	});
+
+	it("rejects above-maximum lengths even when the prefix looks right", () => {
+		const long = validateSecretKey("ELEVENLABS_API_KEY", "a".repeat(40));
+		expect(long.isValid).toBe(false);
+		expect(long.error).toBe(
+			"ELEVENLABS_API_KEY is too long (maximum 32 characters)",
+		);
+	});
+
+	it("accepts well-formed connection strings and rejects other schemes", () => {
+		expect(
+			validateSecretKey(
+				"DATABASE_URL",
+				"postgresql://user:pass@localhost:5432/db",
+			).isValid,
+		).toBe(true);
+		const bad = validateSecretKey("DATABASE_URL", "ftp://nope.invalid");
+		expect(bad.isValid).toBe(false);
+		expect(bad.error).toBe("Database URL must be a valid connection string");
+	});
+
+	it("applies basic checks to keys without a dedicated pattern", () => {
+		expect(validateSecretKey("CUSTOM_THING", "   ").error).toBe(
+			"Secret value cannot be empty",
+		);
+
+		const placeholder = validateSecretKey("CUSTOM_THING", "set-xxx-in-env");
+		expect(placeholder.isValid).toBe(false);
+		expect(placeholder.error).toBe("Secret appears to be a placeholder value");
+
+		const shortButUsable = validateSecretKey("CUSTOM_THING", "tiny");
+		expect(shortButUsable.isValid).toBe(true);
+		expect(shortButUsable.warning).toBe("Secret value seems unusually short");
+	});
+});
+
+describe("batch and lookup helpers via index", () => {
+	it("validates each entry independently in the map form", () => {
+		const results = validateSecrets({
+			OK_KEY: "a-solid-value-here",
+			BAD_KEY: "",
+		});
+		expect(results.OK_KEY.isValid).toBe(true);
+		expect(results.BAD_KEY.isValid).toBe(false);
+	});
+
+	it("treats empty-string values as missing and empty requirements as met", () => {
+		const out = checkRequiredSecrets({ PRESENT: "" }, ["PRESENT"]);
+		expect(out.missing).toEqual(["PRESENT"]);
+		expect(out.valid).toBe(false);
+		expect(checkRequiredSecrets({}, []).valid).toBe(true);
+	});
+
+	it("exposes pattern lookups for known and unknown keys", () => {
+		expect(hasValidationPattern("SLACK_APP_TOKEN")).toBe(true);
+		expect(hasValidationPattern("NOT_A_REAL_KEY")).toBe(false);
+		expect(getValidationPattern("TWITTER_2FA_SECRET")?.maxLength).toBe(32);
+		expect(getValidationPattern("NOT_A_REAL_KEY")).toBeUndefined();
+	});
+
+	it("maps variant names to canonical patterns and passes others through", () => {
+		expect(inferValidationPatternKey("slack_app")).toBe("SLACK_APP_TOKEN");
+		expect(inferValidationPatternKey("MY_DISCORD_TOKEN")).toBe(
+			"DISCORD_BOT_TOKEN",
+		);
+		expect(inferValidationPatternKey("totally_custom")).toBe("totally_custom");
+	});
+});


### PR DESCRIPTION

## Summary

Adds `packages/core/src/validation/index.test.ts`, a new vitest suite covering the validation barrel entry point (`packages/core/src/validation/index.ts`), which had no same-named test file on `develop`.

The suite imports every runtime export through the public barrel path and drives the real implementations with no mocks:

- `validateActionKeywords`: missing/null recent-history lists, keywords found only in retained history, and the newline join boundary that prevents cross-message phrase matches.
- `validateActionRegex`: caller-supplied flags preserved (`/i`, line anchors with `/m`) across the joined history; false when no message carries text.
- `validateSecretKey`: minimum-length rejection fires before pattern evaluation (exact error text), maximum-length rejection on `ELEVENLABS_API_KEY`, connection-string acceptance/rejection for `DATABASE_URL`, and the basic path for keys without patterns (empty value, placeholder detection, short-value warning).
- Batch and lookup helpers: per-entry independence in `validateSecrets`, empty-string values treated as missing plus empty requirement sets as satisfied in `checkRequiredSecrets`, pattern lookups for known/unknown keys, and `inferValidationPatternKey` variant mapping with case-preserving passthrough.

The branches exercised here are ones the existing submodule suites (`keywords.test.ts`, `secrets.test.ts`, `regex-state.test.ts`) leave open; no existing test was modified. This is a test-only change: production behaviour is untouched.

## Evidence

- `bunx vitest run src/validation/index.test.ts` (in `packages/core`, against `1619812de8b4`, whose parent is the then-current `origin/develop` tip `51617538d704`): **Test Files 1 passed (1), Tests 13 passed (13)**. Re-run after final formatting with identical counts.
- Re-verified immediately before filing: `origin/develop` still at `51617538d704`; zero drift in `packages/core/src/validation/`.
- `bunx biome check --write packages/core/src/validation/index.test.ts`: clean after formatting; follow-up `bunx biome check` reports "Checked 1 file... No fixes applied".
- `bunx tsc --noEmit` in `packages/core`: grep for `index.test.ts` over full output returns nothing — the new file contributes zero type errors.
- Diff is a single new file: `packages/core/src/validation/index.test.ts`, +151/-0.
- Fork contributor: hosted CI does **not** run on this pull request. The counts above are from local runs quoted verbatim.

## Attribution

Filed via the factory rail by provider `opencode`, model `ox-alpha`, client `opencode`.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:1619812de8b4b0fd2c99da1169a545bb038f7358 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
