### PR TITLE
test(elizaos): cover version

### DIFF
--- a/packages/elizaos/src/commands/version.test.ts
+++ b/packages/elizaos/src/commands/version.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Integration coverage for the `version` CLI command's stdout contract: the
+ * real command runs against the installed package manifest on disk with no
+ * module mocks, and only the console boundary is captured for assertions.
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { version } from "./version";
+
+const commandDir = dirname(fileURLToPath(import.meta.url));
+const manifest = JSON.parse(
+  readFileSync(resolve(commandDir, "../../package.json"), "utf-8"),
+) as { name: string; version: string };
+
+const ANSI_SGR = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, "g");
+
+// Direct assignment rather than vi.spyOn: vitest's own console interception
+// leaves spy call records empty, so the boundary is swapped and restored here.
+function renderVersionOutput(): string[] {
+  const calls: string[] = [];
+  const original = console.log;
+  console.log = ((...args: unknown[]) => {
+    const first = args.at(0);
+    calls.push(first === undefined ? "" : String(first).replace(ANSI_SGR, ""));
+  }) as typeof console.log;
+  try {
+    version();
+  } finally {
+    console.log = original;
+  }
+  return calls;
+}
+
+describe("version", () => {
+  it("renders an eight-line block padded by blank lines around the banner", () => {
+    const lines = renderVersionOutput();
+    expect(lines).toHaveLength(8);
+    expect(lines[0]).toBe("");
+    expect(lines[1]).toBe("elizaOS CLI");
+    expect(lines[2]).toBe("");
+    expect(lines[7]).toBe("");
+  });
+
+  it("reports the installed manifest version on an indented Version line before the Package line", () => {
+    const lines = renderVersionOutput();
+    const versionLine = lines.indexOf(`  Version:  ${manifest.version}`);
+    const packageLine = lines.findIndex((line) =>
+      line.startsWith("  Package:"),
+    );
+    expect(versionLine).toBeGreaterThanOrEqual(0);
+    expect(versionLine).toBeLessThan(packageLine);
+  });
+
+  it("reports the installed manifest package name on an indented Package line", () => {
+    const lines = renderVersionOutput();
+    expect(lines).toContain(`  Package:  ${manifest.name}`);
+  });
+
+  it("keeps the upgrade tagline on its own indented line", () => {
+    const lines = renderVersionOutput();
+    expect(lines[6]).toBe("  Create and upgrade elizaOS projects and plugins.");
+  });
+});


### PR DESCRIPTION

## What

Adds `packages/elizaos/src/commands/version.test.ts` (+66/-0, new file only) — unit/integration coverage for the `version` CLI command. Test-only diff: no production code is touched.

## Coverage

The suite drives the real `version()` command (real `readPackageJson()` against the installed `packages/elizaos/package.json`) and pins the observable stdout contract at the console boundary:

- the rendered block is exactly eight lines with blank-line padding around the bold banner;
- the banner reads `elizaOS CLI`;
- an indented `  Version:  <version>` line carries the manifest's actual version and precedes the `  Package:` line;
- an indented `  Package:  <name>` line carries the manifest's actual package name (`elizaos`);
- the upgrade tagline stays on its own indented line.

Assertions compare command output to values read independently from the package manifest on disk, so the suite records observed behavior rather than restating module inputs. ANSI SGR sequences are normalized before comparison so the contract holds in both color and no-color environments.

Note for reviewers: `src/commands/__tests__/cli-version.test.ts` already exists on develop but is mock-based and currently fails collection on develop — its `import { version } from "./version.ts"` resolves to the nonexistent `src/commands/__tests__/version.ts`. That file is left untouched here per additive-only policy; this PR adds complementary working coverage as a separate new file.

## Evidence

- Fork contributor: hosted CI does NOT run on this PR; results below are local runs.
- Base: origin/develop @ `51617538d704126b0d308654ccaaff091e474a67`.
- `bunx vitest run src/commands/version.test.ts` (in `packages/elizaos`): **Test Files 1 passed (1), Tests 4 passed (4)**.
- `bunx biome check --write src/commands/version.test.ts`: clean ("Checked 1 file ... No fixes applied" after formatting pass).
- `bunx tsc --noEmit` (in `packages/elizaos`): **0 errors**; `version.test.ts` appears nowhere in the output.
- Diff touches only the new test file (+66/-0); no deletions anywhere.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:1bf32de483ad3d02fa320accf4cfe5c026ae742f -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
