### PR TITLE
test(elizaos): cover info

### DIFF
--- a/packages/elizaos/templates/min-plugin/tests/info.test.ts
+++ b/packages/elizaos/templates/min-plugin/tests/info.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Behavioural coverage for the scaffolded min-plugin info provider: identity
+ * metadata and the static provider result returned across repeated
+ * resolutions without depending on runtime arguments.
+ */
+
+import { describe, expect, it } from "vitest";
+import { infoProvider } from "../src/providers/info.js";
+
+type ProviderGetArgs = Parameters<typeof infoProvider.get>;
+
+describe("infoProvider", () => {
+  it("exposes the templated plugin identity metadata", () => {
+    expect(infoProvider.name).toBe("__PLUGIN_NAME___INFO");
+    expect(infoProvider.description).toBe(
+      "Static info provider for the __PLUGIN_NAME__ plugin.",
+    );
+  });
+
+  it("resolves the complete active payload without touching runtime arguments", async () => {
+    const result = await infoProvider.get(
+      undefined as unknown as ProviderGetArgs[0],
+      undefined as unknown as ProviderGetArgs[1],
+      undefined as unknown as ProviderGetArgs[2],
+    );
+
+    expect(result).toEqual({
+      text: "[__PLUGIN_NAME__] active",
+      values: { pluginName: "__PLUGIN_NAME__" },
+      data: {},
+    });
+  });
+
+  it("returns a fresh result object on every resolution", async () => {
+    const resolve = () =>
+      infoProvider.get(
+        undefined as unknown as ProviderGetArgs[0],
+        undefined as unknown as ProviderGetArgs[1],
+        undefined as unknown as ProviderGetArgs[2],
+      );
+
+    const first = await resolve();
+    const second = await resolve();
+
+    expect(first).toEqual(second);
+    expect(first).not.toBe(second);
+    expect(Object.is(first.values, second.values)).toBe(false);
+  });
+});


### PR DESCRIPTION

## What

Adds a new unit suite for the scaffolded min-plugin info provider at
`packages/elizaos/templates/min-plugin/tests/info.test.ts` (+49/-0, single new
test file, no production changes).

The suite drives the real `infoProvider` module (no mocks) and covers:

- templated identity metadata (`name`, `description`) exposed to provider catalogs;
- the complete `ProviderResult` returned by `get()` - `text`, `values.pluginName`,
  and empty `data` - resolving without reading any runtime arguments;
- a fresh result object per resolution (results are neither cached nor shared).

## Evidence

Test-only change. All checks were run locally against current `origin/develop`
immediately before filing.

**vitest** (owning config `packages/elizaos/templates/min-plugin/vitest.config.ts`):

```
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

**tsc** - `bunx tsc --noEmit -p tsconfig.json` in
`packages/elizaos/templates/min-plugin`: zero errors package-wide;
`grep 'info.test'` over the output finds no match for the new file.

**biome** - no biome lane governs this path by design: the repository-root
`biome.json` excludes `packages/elizaos/templates`, and the scaffold's own
`biome.json` scopes its lint to `src/**`. Formatting was verified instead via
`bunx biome format --stdin-file-path=tests/info.test.ts` under the template's
formatter settings: byte-identical output.

## CI note

This pull request is filed from a fork, so hosted CI does not run on it. The
checks quoted above are the complete local verification for this diff; it
touches only a new test file and changes no production behaviour.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:5ee6b7d99cfe9c2ab4d12f79d2ac0b88f2b7f229 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
