### PR TITLE
fix(plugin-inbox): derive unsubscribe scan chronology by timestamp, not Gmail arrival order

### DIFF
--- a/plugins/plugin-inbox/src/inbox/unsubscribe-service.ts
+++ b/plugins/plugin-inbox/src/inbox/unsubscribe-service.ts
@@ -314,11 +314,27 @@ export class InboxUnsubscribeService {
         continue;
       }
       existing.messageCount += 1;
-      existing.latestSeenAt = message.receivedAt;
-      existing.latestMessageId = message.id;
-      existing.latestThreadId = message.threadId;
       existing.allMessageIds.push(message.id);
       existing.allThreadIds.push(message.threadId);
+      // Gmail's `users.messages.list` (consumed via the Gmail seam without
+      // re-sorting) returns newest-first, so iteration order is not chronology.
+      // Derive the extremes by timestamp instead of assuming arrival order:
+      // extend firstSeenAt downward, latestSeenAt upward, and only re-point the
+      // latest-message pointers when this message is at least as new as the
+      // current latest. Unparseable timestamps leave the extremes unchanged.
+      const receivedAtMs = Date.parse(message.receivedAt);
+      if (Number.isFinite(receivedAtMs)) {
+        const firstSeenMs = Date.parse(existing.firstSeenAt);
+        if (!Number.isFinite(firstSeenMs) || receivedAtMs < firstSeenMs) {
+          existing.firstSeenAt = message.receivedAt;
+        }
+        const latestSeenMs = Date.parse(existing.latestSeenAt);
+        if (!Number.isFinite(latestSeenMs) || receivedAtMs >= latestSeenMs) {
+          existing.latestSeenAt = message.receivedAt;
+          existing.latestMessageId = message.id;
+          existing.latestThreadId = message.threadId;
+        }
+      }
       if (existing.sampleSubjects.length < 5) {
         existing.sampleSubjects.push(message.subject);
       }

--- a/plugins/plugin-inbox/test/unsubscribe-scan-order.probe.test.ts
+++ b/plugins/plugin-inbox/test/unsubscribe-scan-order.probe.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Deterministic probe for the unsubscribe scan chronology defect (#27807).
+ *
+ * Mocks {@link InboxGmailGateway} so `searchGmail` returns three messages from a
+ * single sender in Gmail's native newest-first order (the ordering
+ * `plugin-google-workspace` GoogleGmailClient.searchMessages returns from
+ * `gmail.users.messages.list`). The aggregation in `scanEmailSubscriptions`
+ * must derive `firstSeenAt` = oldest, `latestSeenAt` = newest, and point
+ * `latestMessageId`/`latestThreadId` at the newest message regardless of
+ * iteration order. This probe fails before the fix (firstSeenAt collapses to
+ * the newest message) and passes after; the permanent regression coverage lives
+ * in `unsubscribe-service.test.ts`.
+ */
+
+import type { IAgentRuntime, UUID } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import type { InboxGmailGateway } from "../src/inbox/google-gmail-seam.ts";
+import type { InboxUnsubscribeRepository } from "../src/inbox/unsubscribe-repository.ts";
+import { InboxUnsubscribeService } from "../src/inbox/unsubscribe-service.ts";
+
+const AGENT_ID = "11111111-1111-1111-1111-111111111111" as UUID;
+
+function probeMessage(id: string, receivedAt: string) {
+  return {
+    id: `${AGENT_ID}:google:owner:gmail:${id}`,
+    externalId: id,
+    agentId: AGENT_ID,
+    provider: "google" as const,
+    side: "owner" as const,
+    threadId: `thread-${id}`,
+    subject: `digest ${id}`,
+    from: "Brand News",
+    fromEmail: "news@brand.com",
+    replyTo: null,
+    to: [],
+    cc: [],
+    snippet: "",
+    receivedAt,
+    isUnread: true,
+    isImportant: false,
+    likelyReplyNeeded: false,
+    triageScore: 70,
+    triageReason: "Unread inbox message.",
+    labels: ["UNREAD", "INBOX"],
+    htmlLink: null,
+    metadata: {
+      googlePlugin: true,
+      headers: { "List-Unsubscribe": "<https://brand.com/unsub>" },
+    },
+    syncedAt: "2026-06-17T09:00:00.000Z",
+    updatedAt: "2026-06-17T09:00:00.000Z",
+    connectorAccountId: "acct-1",
+    grantId: "connector-account:acct-1",
+    accountEmail: "owner@example.com",
+  };
+}
+
+describe("scanEmailSubscriptions ordering probe (#27807)", () => {
+  it("derives chronological extremes from Gmail's newest-first feed", async () => {
+    // Gmail returns newest-first: m3 (newest) → m2 → m1 (oldest).
+    const messages = [
+      probeMessage("m3", "2026-06-17T09:00:00.000Z"),
+      probeMessage("m2", "2026-06-16T09:00:00.000Z"),
+      probeMessage("m1", "2026-06-15T09:00:00.000Z"),
+    ];
+    const gmail: InboxGmailGateway = {
+      requireGmailGrant: vi.fn(async () => ({
+        id: "connector-account:acct-1",
+        agentId: AGENT_ID,
+        provider: "google" as const,
+        connectorAccountId: "acct-1",
+        side: "owner" as const,
+        identity: {},
+        identityEmail: "owner@example.com",
+        grantedScopes: [],
+        capabilities: ["google.gmail.triage"],
+        tokenRef: null,
+        mode: "local" as const,
+        executionTarget: "local" as const,
+        sourceOfTruth: "connector_account" as const,
+        preferredByAgent: true,
+        cloudConnectionId: null,
+        metadata: {},
+        lastRefreshAt: null,
+        createdAt: "2026-06-17T00:00:00.000Z",
+        updatedAt: "2026-06-17T00:00:00.000Z",
+      })),
+      searchGmail: vi.fn(async () => ({
+        query: "scan",
+        messages,
+        source: "synced" as const,
+        syncedAt: "2026-06-17T09:00:00.000Z",
+        summary: {
+          totalCount: messages.length,
+          unreadCount: messages.length,
+          importantCount: 0,
+          replyNeededCount: 0,
+        },
+      })),
+      sendMailtoUnsubscribeEmail: vi.fn(async () => undefined),
+      createGmailFilterForSender: vi.fn(async () => ({ filterId: null })),
+      trashGmailThread: vi.fn(async () => undefined),
+    } as unknown as InboxGmailGateway;
+    const repository = {
+      createEmailUnsubscribe: async () => undefined,
+      listEmailUnsubscribes: async () => [],
+    } as unknown as InboxUnsubscribeRepository;
+
+    const service = new InboxUnsubscribeService(
+      { agentId: AGENT_ID } as unknown as IAgentRuntime,
+      { gmail, repository },
+    );
+    const result = await service.scanEmailSubscriptions();
+    const sender = result.senders.find(
+      (candidate) => candidate.senderEmail === "news@brand.com",
+    );
+
+    expect(sender?.firstSeenAt).toBe("2026-06-15T09:00:00.000Z");
+    expect(sender?.latestSeenAt).toBe("2026-06-17T09:00:00.000Z");
+    expect(sender?.latestMessageId).toBe(`${AGENT_ID}:google:owner:gmail:m3`);
+    expect(sender?.latestThreadId).toBe("thread-m3");
+  });
+});

--- a/plugins/plugin-inbox/test/unsubscribe-service.test.ts
+++ b/plugins/plugin-inbox/test/unsubscribe-service.test.ts
@@ -83,12 +83,14 @@ function gmailMessage(args: {
   listUnsubscribe?: string;
   listUnsubscribePost?: string;
   listId?: string;
+  receivedAt?: string;
 }) {
   const headers: Record<string, string> = {};
   if (args.listUnsubscribe) headers["List-Unsubscribe"] = args.listUnsubscribe;
   if (args.listUnsubscribePost)
     headers["List-Unsubscribe-Post"] = args.listUnsubscribePost;
   if (args.listId) headers["List-Id"] = args.listId;
+  const receivedAt = args.receivedAt ?? "2026-06-17T08:00:00.000Z";
   return {
     id: `${AGENT_ID}:google:owner:gmail:${args.id}`,
     externalId: args.id,
@@ -103,7 +105,7 @@ function gmailMessage(args: {
     to: [],
     cc: [],
     snippet: "",
-    receivedAt: "2026-06-17T08:00:00.000Z",
+    receivedAt,
     isUnread: true,
     isImportant: false,
     likelyReplyNeeded: false,
@@ -112,8 +114,8 @@ function gmailMessage(args: {
     labels: ["UNREAD", "INBOX"],
     htmlLink: null,
     metadata: { googlePlugin: true, headers },
-    syncedAt: "2026-06-17T08:00:00.000Z",
-    updatedAt: "2026-06-17T08:00:00.000Z",
+    syncedAt: receivedAt,
+    updatedAt: receivedAt,
     connectorAccountId: "acct-1",
     grantId: "connector-account:acct-1",
     accountEmail: "owner@example.com",
@@ -286,6 +288,124 @@ describe("InboxUnsubscribeService", () => {
       expect(searchGmail).toHaveBeenCalledWith(
         expect.not.objectContaining({ maxResults: expect.anything() }),
       );
+    });
+
+    // Gmail's users.messages.list (via GoogleGmailClient.searchMessages) returns
+    // newest-first, and the Gmail seam consumes that order without re-sorting.
+    // Regression for #27807: the per-sender aggregation must derive firstSeenAt
+    // = oldest, latestSeenAt = newest, and point latestMessageId/latestThreadId
+    // at the newest message regardless of arrival order — never assume
+    // iteration order equals chronology.
+    it("derives first/latest extremes from a newest-first Gmail feed", async () => {
+      const gateway = makeGateway({
+        messages: [
+          gmailMessage({
+            id: "m3",
+            fromEmail: "news@brand.com",
+            listUnsubscribe: "<https://brand.com/unsub>",
+            receivedAt: "2026-06-17T09:00:00.000Z",
+          }),
+          gmailMessage({
+            id: "m2",
+            fromEmail: "news@brand.com",
+            listUnsubscribe: "<https://brand.com/unsub>",
+            receivedAt: "2026-06-16T09:00:00.000Z",
+          }),
+          gmailMessage({
+            id: "m1",
+            fromEmail: "news@brand.com",
+            listUnsubscribe: "<https://brand.com/unsub>",
+            receivedAt: "2026-06-15T09:00:00.000Z",
+          }),
+        ],
+      });
+      const { service } = makeService(gateway);
+
+      const result = await service.scanEmailSubscriptions();
+      const brand = result.senders.find(
+        (sender) => sender.senderEmail === "news@brand.com",
+      );
+
+      expect(brand?.messageCount).toBe(3);
+      expect(brand?.firstSeenAt).toBe("2026-06-15T09:00:00.000Z");
+      expect(brand?.latestSeenAt).toBe("2026-06-17T09:00:00.000Z");
+      expect(brand?.latestMessageId).toBe(`${AGENT_ID}:google:owner:gmail:m3`);
+      expect(brand?.latestThreadId).toBe("thread-m3");
+    });
+
+    it("is order-independent when the newest message arrives in the middle", async () => {
+      const gateway = makeGateway({
+        messages: [
+          gmailMessage({
+            id: "m2",
+            fromEmail: "news@brand.com",
+            listUnsubscribe: "<https://brand.com/unsub>",
+            receivedAt: "2026-06-16T09:00:00.000Z",
+          }),
+          gmailMessage({
+            id: "m3",
+            fromEmail: "news@brand.com",
+            listUnsubscribe: "<https://brand.com/unsub>",
+            receivedAt: "2026-06-17T09:00:00.000Z",
+          }),
+          gmailMessage({
+            id: "m1",
+            fromEmail: "news@brand.com",
+            listUnsubscribe: "<https://brand.com/unsub>",
+            receivedAt: "2026-06-15T09:00:00.000Z",
+          }),
+        ],
+      });
+      const { service } = makeService(gateway);
+
+      const result = await service.scanEmailSubscriptions();
+      const brand = result.senders.find(
+        (sender) => sender.senderEmail === "news@brand.com",
+      );
+
+      expect(brand?.firstSeenAt).toBe("2026-06-15T09:00:00.000Z");
+      expect(brand?.latestSeenAt).toBe("2026-06-17T09:00:00.000Z");
+      expect(brand?.latestMessageId).toBe(`${AGENT_ID}:google:owner:gmail:m3`);
+      expect(brand?.latestThreadId).toBe("thread-m3");
+    });
+
+    it("keeps valid extremes when one message has an unparseable receivedAt", async () => {
+      const gateway = makeGateway({
+        messages: [
+          gmailMessage({
+            id: "m2",
+            fromEmail: "news@brand.com",
+            listUnsubscribe: "<https://brand.com/unsub>",
+            receivedAt: "2026-06-16T09:00:00.000Z",
+          }),
+          gmailMessage({
+            id: "bad",
+            fromEmail: "news@brand.com",
+            listUnsubscribe: "<https://brand.com/unsub>",
+            receivedAt: "not-a-date",
+          }),
+          gmailMessage({
+            id: "m1",
+            fromEmail: "news@brand.com",
+            listUnsubscribe: "<https://brand.com/unsub>",
+            receivedAt: "2026-06-15T09:00:00.000Z",
+          }),
+        ],
+      });
+      const { service } = makeService(gateway);
+
+      const result = await service.scanEmailSubscriptions();
+      const brand = result.senders.find(
+        (sender) => sender.senderEmail === "news@brand.com",
+      );
+
+      // The unparseable message still counts, but never becomes an extreme and
+      // never hijacks the latest-message pointer.
+      expect(brand?.messageCount).toBe(3);
+      expect(brand?.firstSeenAt).toBe("2026-06-15T09:00:00.000Z");
+      expect(brand?.latestSeenAt).toBe("2026-06-16T09:00:00.000Z");
+      expect(brand?.latestMessageId).toBe(`${AGENT_ID}:google:owner:gmail:m2`);
+      expect(brand?.latestThreadId).toBe("thread-m2");
     });
   });
 


### PR DESCRIPTION
# Relates to

Closes #27807

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync. Package-scoped `test` / `typecheck` / `lint` were run (see below). The repo-wide `bun run verify` gate is not clean on this machine due to **pre-existing, unrelated** dependency typecheck errors (documented under **Known gaps**); none touch the changed file.
- [x] A reviewer can confirm the change works from the evidence below with a single vitest command.

# Sync with develop

- [x] Branch is based on the latest `origin/develop` (`git rev-list --left-right --count HEAD...origin/develop` → `0  0` at authoring time); zero conflicts.
- [x] Focused package gates pass post-sync; the unrelated `verify` blocker is documented under **Known gaps / failures**.

# Risks

Low. The change is confined to one aggregation loop in `InboxUnsubscribeService.scanEmailSubscriptions`. It corrects previously-inverted per-sender chronology metadata; it does not alter the HTTP/mailto unsubscribe flow, the SSRF guard, the authorization gate, persistence schema, or any public type. All 14 pre-existing unit tests plus the full 242-test plugin-inbox unit suite stay green.

# Background

## What does this PR do?

`InboxUnsubscribeService.scanEmailSubscriptions` aggregated per-sender metadata assuming Gmail search results arrive **oldest-first**. They do not. The Gmail seam (`google-gmail-seam.ts` → `plugin-google-workspace` `GoogleGmailClient.searchMessages` → `gmail.users.messages.list`) returns messages **newest-first** and passes that order through without re-sorting.

The old loop seeded `firstSeenAt` / `latestSeenAt` / `latestMessageId` / `latestThreadId` from the first message per sender, then on **every** subsequent message overwrote `latestSeenAt` / `latestMessageId` / `latestThreadId` unconditionally. With newest-first input this inverts chronology:

- `firstSeenAt` becomes the **newest** message's time,
- `latestSeenAt` becomes the **oldest**,
- `latestMessageId` / `latestThreadId` point at the **oldest** message.

That inverted data flows into the scan feed (`EmailSubscriptionScanResult`) and the persisted `EmailUnsubscribeRecord.metadata.latestMessageId/latestThreadId`, so any UI or downstream logic reading "first seen", "latest seen", or the latest-message pointer was wrong.

**Fix (one function, ~15 lines):** aggregate by timestamp instead of arrival order. Extend `firstSeenAt` downward (min) and `latestSeenAt` upward (max) by `Date.parse` comparison, and only re-point `latestMessageId`/`latestThreadId` when the message is at least as new as the current latest. Unparseable `receivedAt` values leave the extremes and pointers unchanged, and a missing/invalid seeded extreme is recovered on the next parseable message. This makes the aggregation order-independent and respects the upstream newest-first contract of `gmail.ts` `searchMessages`.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation. The behavior of the documented scan result is corrected to match its type contract (`firstSeenAt`/`latestSeenAt`/`latestMessageId`), not redefined.

# Testing

## Where should a reviewer start?

Reproduce with the single command the issue cites, from `plugins/plugin-inbox`:

```bash
node ../../node_modules/.bin/vitest run --config ./vitest.config.ts \
  test/unsubscribe-scan-order.probe.test.ts test/unsubscribe-service.test.ts
```

`test/unsubscribe-scan-order.probe.test.ts` is the deterministic reproduction from the issue: a mock `InboxGmailGateway` returns three messages from `news@brand.com` in Gmail's newest-first order (`m3` @ 2026-06-17, `m2` @ 2026-06-16, `m1` @ 2026-06-15). Before the fix it fails at the `firstSeenAt` assertion (`expected '2026-06-17T09:00:00.000Z' to be '2026-06-15T09:00:00.000Z'`); after the fix it passes.

## Detailed testing steps

Three permanent regression cases were added to `test/unsubscribe-service.test.ts`:

1. **newest-first feed** → asserts `firstSeenAt`=oldest, `latestSeenAt`=newest, `latestMessageId`/`latestThreadId`=newest.
2. **shuffled order** (newest message in the middle) → asserts the same extremes, proving order-independence.
3. **one unparseable `receivedAt`** → asserts the valid extremes still win and the bad message never hijacks the latest-message pointer.

# Evidence Gate

<!-- evidence-head:12ab48f8a831f953136598ba4e17c69db1c82f14 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only change in a service aggregation loop; no rendered UI surface is added or modified in this PR.
<!-- evidence-row:after-screenshots -->
- [x] `N/A - backend-only change; no rendered UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - backend-only change; the user-facing flow is a data field corrected in the scan result/persisted record, verified by the deterministic tests below.`
<!-- evidence-row:backend-logs -->
- [x] Real `InboxUnsubscribeService` code path exercised end to end against an injected mock gateway (before FAIL → after PASS).

<details>
<summary>backend service test output (before FAIL / after PASS)</summary>

```
BEFORE fix — probe reproduction FAILS:
 × derives chronological extremes from Gmail's newest-first feed
 AssertionError: expected '2026-06-17T09:00:00.000Z' to be '2026-06-15T09:00:00.000Z'
 Expected: "2026-06-15T09:00:00.000Z"
 Received: "2026-06-17T09:00:00.000Z"
   at test/unsubscribe-scan-order.probe.test.ts:118:33
 Tests  1 failed (1)

AFTER fix — probe + regressions PASS:
 ✓ scanEmailSubscriptions ordering probe (#27807) > derives chronological extremes from Gmail's newest-first feed
 ✓ scanEmailSubscriptions > derives first/latest extremes from a newest-first Gmail feed
 ✓ scanEmailSubscriptions > is order-independent when the newest message arrives in the middle
 ✓ scanEmailSubscriptions > keeps valid extremes when one message has an unparseable receivedAt
 Test Files  2 passed (2)
      Tests  18 passed (18)
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend request/response is involved in this service-layer fix.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent/action/provider/prompt/model behavior changes; this is deterministic aggregation logic.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact = the corrected `EmailSubscriptionSender` aggregation for `news@brand.com` from a newest-first Gmail feed (`m3`@2026-06-17 → `m2`@2026-06-16 → `m1`@2026-06-15).

<details>
<summary>corrected per-sender aggregation output asserted by the tests</summary>

```
Input (Gmail newest-first): m3 2026-06-17T09:00Z, m2 2026-06-16T09:00Z, m1 2026-06-15T09:00Z
Corrected EmailSubscriptionSender for news@brand.com:
  messageCount    = 3
  firstSeenAt     = 2026-06-15T09:00:00.000Z   (oldest — was wrongly the newest before the fix)
  latestSeenAt    = 2026-06-17T09:00:00.000Z   (newest — was wrongly the oldest before the fix)
  latestMessageId = <agentId>:google:owner:gmail:m3   (newest — was m1 before the fix)
  latestThreadId  = thread-m3                          (newest — was thread-m1 before the fix)
Unparseable-receivedAt case: the bad message still counts (messageCount=3) but never becomes an extreme or the latest pointer.
```

</details>

<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model changes.`

## Backend + frontend logs

Frontend: `N/A - service-layer fix, no frontend path.`

Backend: the `InboxUnsubscribeService` code path runs end to end against an injected mock `InboxGmailGateway` and fake repository (no live Gmail needed). Before the fix, the exact reproduction from the issue fails on the inverted `firstSeenAt`; after the fix the same probe plus the new order-independence and unparseable-timestamp regressions pass.

<details>
<summary><b>BEFORE fix — probe reproduction FAILS (inverted chronology)</b></summary>

```
 ❯ test/unsubscribe-scan-order.probe.test.ts (1 test | 1 failed) 24ms
     × derives chronological extremes from Gmail's newest-first feed 16ms

⎯⎯⎯ Failed Tests 1 ⎯⎯⎯

 FAIL  test/unsubscribe-scan-order.probe.test.ts > scanEmailSubscriptions ordering probe (#27807) > derives chronological extremes from Gmail's newest-first feed
AssertionError: expected '2026-06-17T09:00:00.000Z' to be '2026-06-15T09:00:00.000Z' // Object.is equality

Expected: "2026-06-15T09:00:00.000Z"
Received: "2026-06-17T09:00:00.000Z"

 ❯ test/unsubscribe-scan-order.probe.test.ts:118:33
    118|     expect(sender?.firstSeenAt).toBe("2026-06-15T09:00:00.000Z");

 Test Files  1 failed (1)
      Tests  1 failed (1)
```

</details>

<details>
<summary><b>AFTER fix — probe + regressions PASS (order-independent)</b></summary>

```
 ✓ test/unsubscribe-scan-order.probe.test.ts > scanEmailSubscriptions ordering probe (#27807) > derives chronological extremes from Gmail's newest-first feed 14ms
 ✓ test/unsubscribe-service.test.ts > ... > scanEmailSubscriptions > groups senders and classifies the unsubscribe method from headers 43ms
 ✓ test/unsubscribe-service.test.ts > ... > scanEmailSubscriptions > falls back to manual_only when no List-Unsubscribe header is present 3ms
 ✓ test/unsubscribe-service.test.ts > ... > scanEmailSubscriptions > derives first/latest extremes from a newest-first Gmail feed 2ms
 ✓ test/unsubscribe-service.test.ts > ... > scanEmailSubscriptions > is order-independent when the newest message arrives in the middle 2ms
 ✓ test/unsubscribe-service.test.ts > ... > scanEmailSubscriptions > keeps valid extremes when one message has an unparseable receivedAt 2ms
 ✓ test/unsubscribe-service.test.ts > ... > unsubscribeEmailSender authorization gate > rejects without explicit userAuthorization (HTTP 409) 5ms
 ✓ test/unsubscribe-service.test.ts > ... > performs an HTTP one-click POST and records success 14ms
 ✓ ... (all HTTP one-click / mailto / manage-gate / SSRF-closed / redirect-loopback cases) ...
 Test Files  2 passed (2)
      Tests  18 passed (18)
```

Full plugin-inbox unit suite after the fix:

```
 Test Files  28 passed | 1 skipped (29)
      Tests  242 passed | 2 skipped (244)
```

</details>

## The one-function diff

<details>
<summary><b>src/inbox/unsubscribe-service.ts</b></summary>

```diff
       existing.messageCount += 1;
-      existing.latestSeenAt = message.receivedAt;
-      existing.latestMessageId = message.id;
-      existing.latestThreadId = message.threadId;
       existing.allMessageIds.push(message.id);
       existing.allThreadIds.push(message.threadId);
+      // Gmail's `users.messages.list` (consumed via the Gmail seam without
+      // re-sorting) returns newest-first, so iteration order is not chronology.
+      // Derive the extremes by timestamp instead of assuming arrival order:
+      // extend firstSeenAt downward, latestSeenAt upward, and only re-point the
+      // latest-message pointers when this message is at least as new as the
+      // current latest. Unparseable timestamps leave the extremes unchanged.
+      const receivedAtMs = Date.parse(message.receivedAt);
+      if (Number.isFinite(receivedAtMs)) {
+        const firstSeenMs = Date.parse(existing.firstSeenAt);
+        if (!Number.isFinite(firstSeenMs) || receivedAtMs < firstSeenMs) {
+          existing.firstSeenAt = message.receivedAt;
+        }
+        const latestSeenMs = Date.parse(existing.latestSeenAt);
+        if (!Number.isFinite(latestSeenMs) || receivedAtMs >= latestSeenMs) {
+          existing.latestSeenAt = message.receivedAt;
+          existing.latestMessageId = message.id;
+          existing.latestThreadId = message.threadId;
+        }
+      }
```

</details>

## Upstream ordering contract

`plugins/plugin-google-workspace/src/gmail.ts` `searchMessages` calls `gmail.users.messages.list({ userId: "me", q, maxResults })` and returns the results in the Gmail API's default order (newest-first) with no ascending re-sort. `google-gmail-seam.ts` `searchGmail` maps that order straight through. The aggregation must therefore treat iteration order as unordered w.r.t. time — which this fix does.

## Screenshots (before / after) + video walkthrough

`N/A - backend-only service change; no rendered UI surface.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT surface involved.`

## Known gaps / failures

- **Repo-wide `bun run verify` not clean on this machine — pre-existing, unrelated.** `plugins/plugin-inbox` `tsc --noEmit` surfaces errors only in *dependency* files not touched by this PR (`packages/core/src/cloud-routing.ts` needing the built `@elizaos/cloud-routing`, and `plugins/plugin-google-workspace/src/lifeops-message-adapter.ts` — e.g. `Property 'listMessages' does not exist on type 'GoogleGmailAdapter'`). Filtering to the changed file (`unsubscribe-service.ts`) and its tests yields **zero** type errors. `bun run lint:check` for the package is clean (`Checked 69 files … No fixes applied`).
- **Evidence artifacts are inlined rather than attached as GitHub URLs.** The fork-only attachment uploader could not complete a GitHub login (it stops at a device-verification interstitial) and the shared `pr-evidence` release requires push access this fork account lacks. All proof is therefore pasted inline above; the reviewer can regenerate every line with the single vitest command in **Testing**.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@12ab48f8a831f953136598ba4e17c69db1c82f14:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@12ab48f8a831f953136598ba4e17c69db1c82f14:packages/skills/skills/contribute-to-eliza"} -->