### PR TITLE
test(evidence): cover color-math

### DIFF
--- a/packages/evidence/src/analyzers/__tests__/color-math.test.ts
+++ b/packages/evidence/src/analyzers/__tests__/color-math.test.ts
@@ -21,6 +21,41 @@ describe("classifyColor", () => {
     expect(classifyColor(100, 200, 80)).toBe("other");
     expect(classifyColor(0, 150, 0)).toBe("other");
   });
+
+  it("requires blue strictly above brightness 90", () => {
+    expect(classifyColor(0, 0, 91)).toBe("blue");
+    expect(classifyColor(0, 0, 90)).toBe("other");
+  });
+
+  it("requires blue to dominate red and green by more than 30", () => {
+    expect(classifyColor(60, 0, 95)).toBe("blue");
+    expect(classifyColor(61, 0, 91)).toBe("other");
+  });
+
+  it("requires red strictly above 150 for orange", () => {
+    expect(classifyColor(151, 100, 41)).toBe("orange");
+    expect(classifyColor(150, 100, 40)).toBe("other");
+  });
+
+  it("requires green to beat blue by more than 15 for orange", () => {
+    expect(classifyColor(220, 131, 115)).toBe("orange");
+    expect(classifyColor(220, 130, 115)).toBe("other");
+  });
+
+  it("rejects orange when blue reaches 140", () => {
+    expect(classifyColor(200, 160, 139)).toBe("orange");
+    expect(classifyColor(200, 160, 140)).toBe("other");
+  });
+
+  it("keeps mildly tinted greys neutral below a spread of 20", () => {
+    expect(classifyColor(135, 125, 130)).toBe("neutral");
+    expect(classifyColor(109, 109, 129)).toBe("other");
+  });
+
+  it("never reads saturated brand colours as neutral", () => {
+    expect(classifyColor(244, 81, 30)).toBe("orange");
+    expect(classifyColor(0, 0, 255)).toBe("blue");
+  });
 });
 
 describe("colorFractionsFromRaw", () => {
@@ -69,11 +104,64 @@ describe("colorFractionsFromRaw", () => {
       neutral_fraction: 0,
     });
   });
+
+  it("rounds fractions to four decimals over a single pixel", () => {
+    const buf = new Uint8Array([
+      10,
+      20,
+      200, // blue
+      120,
+      122,
+      121, // neutral
+      120,
+      122,
+      121, // neutral
+    ]);
+    const f = colorFractionsFromRaw(buf, 3);
+    expect(f.blue_fraction).toBe(0.3333);
+    expect(f.neutral_fraction).toBe(0.6667);
+  });
+
+  it("counts other-classified pixels in the denominator only", () => {
+    const buf = new Uint8Array([
+      10,
+      20,
+      200, // blue
+      100,
+      200,
+      80, // other
+    ]);
+    const f = colorFractionsFromRaw(buf, 3);
+    expect(f).toEqual({
+      blue_fraction: 0.5,
+      orange_fraction: 0,
+      neutral_fraction: 0,
+    });
+  });
+
+  it("reads Node Buffer input the same as Uint8Array", () => {
+    const buf = Buffer.from([10, 20, 200, 10, 20, 200]);
+    const f = colorFractionsFromRaw(buf, 3);
+    expect(f.blue_fraction).toBe(1);
+    expect(f.orange_fraction).toBe(0);
+    expect(f.neutral_fraction).toBe(0);
+  });
+
+  it("classifies a single solid pixel fully into its bucket", () => {
+    const f = colorFractionsFromRaw(new Uint8Array([120, 122, 121]), 3);
+    expect(f.neutral_fraction).toBe(1);
+  });
 });
 
 describe("round4", () => {
   it("rounds to four decimals", () => {
     expect(round4(0.123456)).toBe(0.1235);
     expect(round4(0.5)).toBe(0.5);
+  });
+
+  it("collapses trailing zeros and underflows sub-half ten-thousandths", () => {
+    expect(round4(1)).toBe(1);
+    expect(round4(0.30001)).toBe(0.3);
+    expect(round4(0.00004)).toBe(0);
   });
 });


### PR DESCRIPTION

## What

Additive test coverage for `packages/evidence/src/analyzers/color-math.ts` (appended to the existing suite at `packages/evidence/src/analyzers/__tests__/color-math.test.ts`). No production code is touched.

The module already had a suite on `develop`, so this PR is **append-only** (+88/−0): every pre-existing case is preserved verbatim and 12 new cases are added.

## Why

`classifyColor` encodes strict threshold inequalities (`b > r + 30 && b > g + 30 && b > 90`; `r > 150 && r > g + 25 && g > b + 15 && b < 140`; spread `< 20`) that the existing cases never probe at their boundaries, and `colorFractionsFromRaw`/`round4` had uncovered rounding and input-type behaviour. The new cases pin:

- blue rejected exactly at brightness 90 and when the dominance margin is exactly 30 (`(0,0,90)`, `(61,0,91)` fall through to `other`)
- orange rejected exactly at red 150, at a green−blue margin of exactly 15, and when blue reaches 140
- mildly tinted greys stay neutral below spread 20; saturated brand colours (`244,81,30`, `(0,0,255)`) never read as neutral
- fractions round to four decimals over non-trivial ratios (`1/3 → 0.3333`, `2/3 → 0.6667`)
- `other` pixels count in the denominator only
- Node `Buffer` input behaves identically to `Uint8Array` (the declared parameter union)
- single-pixel buffers classify fully into one bucket
- `round4` collapses trailing zeros and underflows sub-half ten-thousandths (`1 → 1`, `0.30001 → 0.3`, `0.00004 → 0`)

All expectations record observed behaviour of the current implementation — this is a coverage-only diff with no behavioural change intended or made.

## Evidence

Test-only change from a fork, so hosted CI does not run on this PR. Local verification at head `ac3cdacc9d3e09ca7ae5e80ee1c8d0db6331ef94` on `origin/develop` @ `51617538d704`, re-fetched and re-run immediately before filing:

- `bunx vitest run packages/evidence/src/analyzers/__tests__/color-math.test.ts` → **Test Files: 1 passed (1), Tests: 20 passed (20)** (8 pre-existing + 12 new)
- `bunx biome check packages/evidence/src/analyzers/__tests__/color-math.test.ts` → clean ("No fixes applied" after write)
- `bunx tsc --noEmit` in `packages/evidence` → 0 errors package-wide; the test file appears nowhere in the output
- `git diff origin/develop..HEAD --stat` → exactly one file, `88 insertions(+), 0 deletions(-)`

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:ac3cdacc9d3e09ca7ae5e80ee1c8d0db6331ef94 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
