### PR TITLE
test(ui): cover serialise

### DIFF
--- a/packages/ui/src/utils/serialise.test.ts
+++ b/packages/ui/src/utils/serialise.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Unit coverage for the UI package's serialise boundary, which re-exports
+ * createSerialise (the shared sequential promise queue) to @elizaos/ui/utils
+ * consumers. Drives the real queue through this module — no harness, no mocks.
+ */
+import { describe, expect, it } from "vitest";
+import { createSerialise } from "./serialise";
+
+describe("createSerialise", () => {
+  it("runs a single task on an empty queue and returns its value", async () => {
+    const run = createSerialise();
+
+    await expect(run(async () => 7)).resolves.toBe(7);
+  });
+
+  it("executes queued tasks strictly in submission order regardless of task duration", async () => {
+    const run = createSerialise();
+    const executionOrder: number[] = [];
+
+    const slow = run(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      executionOrder.push(1);
+      return "slow";
+    });
+    const fast = run(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      executionOrder.push(2);
+      return "fast";
+    });
+    const instant = run(async () => {
+      executionOrder.push(3);
+      return "instant";
+    });
+
+    await expect(Promise.all([slow, fast, instant])).resolves.toEqual([
+      "slow",
+      "fast",
+      "instant",
+    ]);
+    expect(executionOrder).toEqual([1, 2, 3]);
+  });
+
+  it("preserves FIFO order for back-to-back submissions without artificial delays", async () => {
+    const run = createSerialise();
+    const executionOrder: number[] = [];
+
+    const tasks = [1, 2, 3, 4].map((n) =>
+      run(async () => {
+        executionOrder.push(n);
+        return n * 10;
+      }),
+    );
+
+    await expect(Promise.all(tasks)).resolves.toEqual([10, 20, 30, 40]);
+    expect(executionOrder).toEqual([1, 2, 3, 4]);
+  });
+
+  it("starts a task submitted after the previous completion immediately", async () => {
+    const run = createSerialise();
+    const markers: string[] = [];
+
+    await run(async () => {
+      markers.push("first-ran");
+    });
+    markers.push("second-submitted");
+    await run(async () => {
+      markers.push("second-ran");
+    });
+
+    expect(markers).toEqual(["first-ran", "second-submitted", "second-ran"]);
+  });
+
+  it("passes the thrown error through unwrapped to the caller", async () => {
+    const run = createSerialise();
+    const boom = new Error("boom");
+
+    let caught: unknown;
+    try {
+      await run(async () => {
+        throw boom;
+      });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBe(boom);
+  });
+
+  it("keeps draining queued tasks after consecutive failures", async () => {
+    const run = createSerialise();
+    const executionOrder: string[] = [];
+
+    const first = run(async () => {
+      executionOrder.push("fail-1");
+      throw new Error("first failure");
+    });
+    const second = run(async () => {
+      executionOrder.push("fail-2");
+      throw new Error("second failure");
+    });
+    const third = run(async () => {
+      executionOrder.push("recovered");
+      return "still-works";
+    });
+
+    await expect(first).rejects.toThrow("first failure");
+    await expect(second).rejects.toThrow("second failure");
+    await expect(third).resolves.toBe("still-works");
+    expect(executionOrder).toEqual(["fail-1", "fail-2", "recovered"]);
+  });
+
+  it("rejects a synchronous throw and keeps the queue usable", async () => {
+    const run = createSerialise();
+
+    const syncThrow = (() => {
+      throw new Error("sync-boom");
+    }) as unknown as () => Promise<string>;
+    const failed = run(syncThrow);
+    const next = run(async () => "after-sync-throw");
+
+    await expect(failed).rejects.toThrow("sync-boom");
+    await expect(next).resolves.toBe("after-sync-throw");
+  });
+
+  it("rejects non-function arguments with a TypeError and leaves the queue unaffected", async () => {
+    const run = createSerialise();
+    const invalid = [null, undefined, "not-a-function"];
+
+    for (const value of invalid) {
+      await expect(
+        run(value as unknown as () => Promise<number>),
+      ).rejects.toBeInstanceOf(TypeError);
+      await expect(
+        run(value as unknown as () => Promise<number>),
+      ).rejects.toThrow("Expected function for serialised execution");
+    }
+
+    await expect(run(async () => "still-alive")).resolves.toBe("still-alive");
+  });
+
+  it("does not serialise tasks across independent queues", async () => {
+    const queueA = createSerialise();
+    const queueB = createSerialise();
+    const completionOrder: string[] = [];
+
+    const slowInA = queueA(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      completionOrder.push("a");
+      return "a";
+    });
+    const quickInB = queueB(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      completionOrder.push("b");
+      return "b";
+    });
+
+    await expect(Promise.all([slowInA, quickInB])).resolves.toEqual(["a", "b"]);
+    expect(completionOrder).toEqual(["b", "a"]);
+  });
+});


### PR DESCRIPTION

## Summary

Adds a new unit test suite for `packages/ui/src/utils/serialise.ts`, which re-exports `createSerialise` (the shared sequential promise-queue factory) to `@elizaos/ui/utils` consumers. The module had no same-named test anywhere in `packages/ui`.

The suite drives the real queue through this UI-package import path and asserts observed runtime behavior only — no mocks, no type-level assertions:

- single task on an empty queue resolves with its value
- strict submission-order execution regardless of per-task duration
- FIFO order for back-to-back submissions without artificial delays
- immediate start for tasks submitted after the previous completion (queue drains)
- thrown errors pass through unwrapped (same error instance)
- queue keeps draining after consecutive failures
- synchronous throw inside the callback rejects, and the queue stays usable
- non-function arguments reject with `TypeError("Expected function for serialised execution")` and leave the lock unaffected
- independent queues do not serialise each other

## Scope

Test-only change: one new file (`packages/ui/src/utils/serialise.test.ts`, +160/-0). No production behavior is modified.

## Evidence

Fork contributor note: hosted CI does not run on this repository's pull requests from forks; the checks below were executed locally against current `origin/develop`.

1. `bunx vitest run src/utils/serialise.test.ts` (in `packages/ui`): **Test Files 1 passed (1), Tests 9 passed (9)**. Re-fetched `origin/develop` immediately before filing and re-ran: **1 passed (1), 9 passed (9)**. Neither `packages/ui/src/utils/serialise.ts` nor any serialise test changed on develop between the first run and the re-run.
2. `bunx biome check --write packages/ui/src/utils/serialise.test.ts`: clean (applied safe formatting fixes once; subsequent check clean).
3. `bunx tsc --noEmit` in `packages/ui`: ran to completion with 14 pre-existing error lines from in-progress files in the shared working tree; **zero** occurrences of `serialise.test` in the output.
4. Diff touches only the one new test file.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:48edd76a0f56dc143341cb9d0ce319ee14f4e8f7 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
