### PR TITLE
fix(agent): keep workspace plugin discovery alive past a broken symlink

### DIFF
--- a/packages/agent/src/api/plugin-discovery-helpers.ts
+++ b/packages/agent/src/api/plugin-discovery-helpers.ts
@@ -372,7 +372,7 @@ function workspacePluginIdFromPackageName(npmName: string): string | null {
   return normalized.slice("@elizaos/plugin-".length);
 }
 
-function discoverWorkspacePluginPackages(
+export function discoverWorkspacePluginPackages(
   packageRoot: string,
 ): WorkspacePluginPackage[] {
   const scanRoots = [
@@ -389,7 +389,12 @@ function discoverWorkspacePluginPackages(
 
     for (const dirName of fs.readdirSync(scanRoot).sort()) {
       const rootDir = path.join(scanRoot, dirName);
-      if (!fs.statSync(rootDir).isDirectory()) {
+      // `readdirSync` lists broken symlinks, and `statSync` follows the link,
+      // so a stale entry (a removed worktree, an unlinked package) would throw
+      // ENOENT and abort discovery for the whole workspace. Resolving through
+      // the link is deliberate: symlinked plugin directories are supported.
+      const rootStat = fs.statSync(rootDir, { throwIfNoEntry: false });
+      if (!rootStat?.isDirectory()) {
         continue;
       }
 

--- a/packages/agent/src/api/plugin-discovery-helpers.workspace-scan.test.ts
+++ b/packages/agent/src/api/plugin-discovery-helpers.workspace-scan.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Workspace plugin scanning against a real on-disk fixture, covering entries
+ * that `readdirSync` reports but `statSync` cannot resolve.
+ *
+ * Discovery runs during `startApiServer`, so a single unreadable directory
+ * entry deciding whether the agent boots is the behavior under test here.
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { discoverWorkspacePluginPackages } from "./plugin-discovery-helpers";
+
+const tempRoots: string[] = [];
+
+function makeWorkspace(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-plugin-scan-"));
+  tempRoots.push(root);
+  fs.mkdirSync(path.join(root, "plugins"), { recursive: true });
+  return root;
+}
+
+function writePlugin(root: string, dirName: string, npmName: string): void {
+  const dir = path.join(root, "plugins", dirName);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, "package.json"),
+    JSON.stringify({ name: npmName, version: "1.0.0" }),
+    "utf8",
+  );
+}
+
+afterEach(() => {
+  while (tempRoots.length > 0) {
+    const root = tempRoots.pop();
+    if (root) fs.rmSync(root, { force: true, recursive: true });
+  }
+});
+
+describe("discoverWorkspacePluginPackages", () => {
+  it("skips a broken symlink and still discovers the real plugins beside it", () => {
+    const root = makeWorkspace();
+    writePlugin(root, "plugin-alpha", "@elizaos/plugin-alpha");
+    fs.symlinkSync(
+      path.join(root, "plugins", "plugin-was-removed"),
+      path.join(root, "plugins", "plugin-dangling"),
+    );
+
+    const discovered = discoverWorkspacePluginPackages(root);
+
+    expect(discovered.map((plugin) => plugin.id)).toEqual(["alpha"]);
+  });
+
+  it("resolves a plugin directory reached through a symlink", () => {
+    const root = makeWorkspace();
+    const external = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-external-"));
+    tempRoots.push(external);
+    fs.writeFileSync(
+      path.join(external, "package.json"),
+      JSON.stringify({ name: "@elizaos/plugin-linked", version: "1.0.0" }),
+      "utf8",
+    );
+    fs.symlinkSync(external, path.join(root, "plugins", "plugin-linked"));
+
+    const discovered = discoverWorkspacePluginPackages(root);
+
+    expect(discovered.map((plugin) => plugin.id)).toEqual(["linked"]);
+  });
+
+  it("ignores plain files sitting in a scan root", () => {
+    const root = makeWorkspace();
+    writePlugin(root, "plugin-beta", "@elizaos/plugin-beta");
+    fs.writeFileSync(
+      path.join(root, "plugins", "README.md"),
+      "# plugins",
+      "utf8",
+    );
+
+    const discovered = discoverWorkspacePluginPackages(root);
+
+    expect(discovered.map((plugin) => plugin.id)).toEqual(["beta"]);
+  });
+});


### PR DESCRIPTION
# Relates to

No existing issue — found while reviewing other PRs: a stale symlink in my checkout's `plugins/` directory made every `startApiServer` test in `packages/agent` fail with an `ENOENT` that named a path nobody had asked about.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Based on current `origin/develop` at `51617538d7`; zero conflicts. Exact head `bfb28ddd7719ae7365a5229c7df9195155415ec3`.

# Risks

Low. One directory-entry check in the workspace scan plus a new test file. The scan still resolves through symlinks, so symlinked plugin directories are discovered exactly as before; the only behavior change is that an entry which does not resolve is skipped instead of throwing.

# Background

## What does this PR do?

`discoverWorkspacePluginPackages` walked each scan root with `readdirSync` and then called `fs.statSync` on every entry:

```ts
for (const dirName of fs.readdirSync(scanRoot).sort()) {
  const rootDir = path.join(scanRoot, dirName);
  if (!fs.statSync(rootDir).isDirectory()) {
```

`readdirSync` reports broken symlinks, and `statSync` resolves through the link, so a single stale entry under `plugins/` or `packages/` — a removed worktree, an unlinked package, an interrupted `bun install` — throws `ENOENT` out of the loop. The `existsSync(scanRoot)` guard above it covers the scan root, not its entries.

That throw is not contained. Discovery is reached from `startApiServer` → `discoverPluginsFromManifest` → `mergeWorkspacePluginEntries` → `discoverWorkspacePluginPackages`, so one unresolvable directory entry stops the agent from booting, and the error names only the dangling path — not the scan, and not the plugin system. I lost real time to exactly this before recognizing what the message meant.

The entry now resolves with `{ throwIfNoEntry: false }` and is skipped when it does not resolve to a directory:

```ts
const rootStat = fs.statSync(rootDir, { throwIfNoEntry: false });
if (!rootStat?.isDirectory()) {
  continue;
}
```

Resolving *through* the link is kept deliberately, and the comment in the diff says so: `lstatSync` would report a symlinked plugin directory as a non-directory and silently drop plugins the workspace genuinely provides. `{ throwIfNoEntry: false }` suppresses only `ENOENT`, so a genuinely surprising failure (`EACCES`, `ELOOP`) still surfaces rather than being swallowed — no catch, so no `error-policy` annotation is needed.

`discoverWorkspacePluginPackages` gains an `export` so the behavior can be tested against a real fixture; it is additive, and no existing consumer changes.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`plugin-discovery-helpers.workspace-scan.test.ts`. It builds real temporary workspaces on disk — no stubbed `fs` — and the first case is the reported failure.

## Detailed testing steps

1. Check out exact head `bfb28ddd7719ae7365a5229c7df9195155415ec3`.
2. From `packages/agent`: `bun x vitest run src/api/plugin-discovery-helpers.workspace-scan.test.ts` → **3/3**.
3. Counterfactual, isolated to the guard: restore only the `if (!fs.statSync(rootDir).isDirectory()) {` line (keep the `export`) and re-run → **1 failed | 2 passed**, the failure being `skips a broken symlink and still discovers the real plugins beside it` with the original `ENOENT: no such file or directory, stat '…/plugins/plugin-dangling'`. The symlink-resolution and plain-file cases pass on both sides, which is what shows the fix does not narrow discovery.
4. Neighbouring suites: `plugin-discovery-helpers.test.ts`, `.prefix-label.test.ts`, `.surrogate.test.ts` plus the new file → **72/72 across 4 files**.
5. Pinned Biome on both changed files: exit 0, captured directly. `git diff --check`: clean. `tsc --noEmit` on `packages/agent`: zero diagnostics naming `plugin-discovery-helpers`.

<!-- evidence-head:bfb28ddd7719ae7365a5229c7df9195155415ec3 -->

## Evidence

<!-- evidence-row:before-screenshots -->
- Before screenshots: N/A — server-side discovery behavior with no UI surface.
<!-- evidence-row:after-screenshots -->
- After screenshots: N/A — server-side discovery behavior with no UI surface.
<!-- evidence-row:walkthrough-video -->
- Walkthrough video: N/A — the isolated counterfactual below is the proof.
<!-- evidence-row:backend-logs -->
- Backend logs:

<details><summary>Head vs guard-only counterfactual — vitest output</summary>

```
# head bfb28ddd77 — packages/agent
$ bun x vitest run src/api/plugin-discovery-helpers.workspace-scan.test.ts
 Test Files  1 passed (1)
      Tests  3 passed (3)

# only the statSync guard reverted (export kept), same test file
     x skips a broken symlink and still discovers the real plugins beside it 8ms
Error: ENOENT: no such file or directory, stat
  '/var/folders/s3/.../T/eliza-plugin-scan-DQmzdK/plugins/plugin-dangling'
      Tests  1 failed | 2 passed (3)

# how this surfaced originally, before the fix (packages/agent server suite)
Error: ENOENT: no such file or directory, stat '<repo>/plugins/node_modules'
  at discoverWorkspacePluginPackages src/api/plugin-discovery-helpers.ts:392:15
  at mergeWorkspacePluginEntries src/api/plugin-discovery-helpers.ts:443:24
  at discoverPluginsFromManifest src/api/plugin-discovery-helpers.ts:1117:10
  at startApiServer src/api/server.ts:3802:19

# neighbouring discovery suites at head
 Test Files  4 passed (4)
      Tests  72 passed (72)
```

</details>

<!-- evidence-row:frontend-logs -->
- Frontend console/network logs: N/A — no frontend surface changed.
<!-- evidence-row:llm-trajectory -->
- Live-model trajectory: N/A — deterministic filesystem behavior, no agent path.
<!-- evidence-row:domain-artifacts -->
- Domain artifacts:

<details><summary>Static gates at exact head</summary>

```
$ node_modules/.bin/biome check \
    packages/agent/src/api/plugin-discovery-helpers.ts \
    packages/agent/src/api/plugin-discovery-helpers.workspace-scan.test.ts
Checked 2 files in 25ms. No fixes applied.   (exit 0, captured directly)

$ git diff --check                            (clean, exit 0)

$ tsc --noEmit -p packages/agent/tsconfig.json
0 diagnostics naming plugin-discovery-helpers
(remaining diagnostics are unrelated missing-dependency resolutions in
 plugin-wallet / plugin-wifi, reproduced without this change)

$ git diff --stat origin/develop..HEAD
 packages/agent/src/api/plugin-discovery-helpers.ts |  9 ++-
 ...plugin-discovery-helpers.workspace-scan.test.ts | 84 ++++++++++++++++++++++
 2 files changed, 91 insertions(+), 2 deletions(-)
```

</details>

<!-- evidence-row:ocr-review -->
- OCR review: N/A — no captured imagery.

# Known gaps / failures

- `bun run verify` (repo-wide) was not run: hand-wired review worktree (packages linked from the main checkout) cannot support the full gate honestly; the focused package suites, Biome, and typecheck above stand in.
- `ELOOP` (a symlink cycle in a scan root) still propagates. That is deliberate — `{ throwIfNoEntry: false }` suppresses only `ENOENT`, and a cycle is a genuinely surprising condition worth surfacing rather than skipping silently. Say the word if you would rather the scan tolerate that too.

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: Claude Code
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Attribution status: self-reported
— [nxn-claude-code]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"Claude Code","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza"} -->
