### PR TITLE
test(examples): cover agent

### DIFF
--- a/packages/examples/code/src/lib/agent.test.ts
+++ b/packages/examples/code/src/lib/agent.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Unit coverage for the Code example's runtime assembly entrypoints:
+ * initializeAgent's fail-fast provider configuration matrix (explicit
+ * providers, claude/codex aliases, ELIZA_CODE_MODEL_PROVIDER fallback,
+ * case/whitespace normalization) and shutdownAgent's stop delegation.
+ * Real deterministic harness against process.env with snapshot restore;
+ * cases stop at the first boundary a unit test can observe without
+ * constructing a live AgentRuntime (the success path needs a database).
+ */
+
+import type { AgentRuntime } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { initializeAgent, shutdownAgent } from "./agent.ts";
+
+/**
+ * initializeAgent reads AND mutates these via applyElizaCodeProviderEnv, so
+ * every case starts from a clean slate and afterEach restores the original
+ * machine environment.
+ */
+const CONTROLLED_VARS = [
+  "ELIZA_CODE_PROVIDER",
+  "ELIZA_CODE_MODEL_PROVIDER",
+  "ELIZA_CODE_API_KEY",
+  "ELIZA_CODE_BASE_URL",
+  "ELIZA_CODE_MODEL_POWERFUL",
+  "ELIZA_CODE_MODEL_FAST",
+  "OPENAI_API_KEY",
+  "OPENAI_BASE_URL",
+  "OPENAI_LARGE_MODEL",
+  "OPENAI_SMALL_MODEL",
+  "OPENAI_MEDIUM_MODEL",
+  "ANTHROPIC_API_KEY",
+] as const;
+
+let savedEnv: Record<string, string | undefined>;
+
+beforeEach(() => {
+  savedEnv = {};
+  for (const key of CONTROLLED_VARS) {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  for (const key of CONTROLLED_VARS) {
+    const value = savedEnv[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+});
+
+describe("initializeAgent", () => {
+  it("rejects when no provider is configured", async () => {
+    await expect(initializeAgent({ loadDotenv: false })).rejects.toThrowError(
+      /No model provider configured/,
+    );
+  });
+
+  it("requires ANTHROPIC_API_KEY for an explicit anthropic provider", async () => {
+    process.env.ELIZA_CODE_PROVIDER = "anthropic";
+    await expect(initializeAgent({ loadDotenv: false })).rejects.toThrowError(
+      "ANTHROPIC_API_KEY is required (ELIZA_CODE_PROVIDER=anthropic).",
+    );
+  });
+
+  it("requires OPENAI_API_KEY for an explicit openai provider", async () => {
+    process.env.ELIZA_CODE_PROVIDER = "openai";
+    await expect(initializeAgent({ loadDotenv: false })).rejects.toThrowError(
+      "OPENAI_API_KEY is required (ELIZA_CODE_PROVIDER=openai).",
+    );
+  });
+
+  it("maps the claude alias onto the anthropic key requirement", async () => {
+    process.env.ELIZA_CODE_PROVIDER = "claude";
+    await expect(initializeAgent({ loadDotenv: false })).rejects.toThrowError(
+      "ANTHROPIC_API_KEY is required (ELIZA_CODE_PROVIDER=anthropic).",
+    );
+  });
+
+  it("maps the codex alias onto the openai key requirement", async () => {
+    process.env.ELIZA_CODE_PROVIDER = "codex";
+    await expect(initializeAgent({ loadDotenv: false })).rejects.toThrowError(
+      "OPENAI_API_KEY is required (ELIZA_CODE_PROVIDER=openai).",
+    );
+  });
+
+  it("falls back to ELIZA_CODE_MODEL_PROVIDER for the explicit choice", async () => {
+    process.env.ELIZA_CODE_MODEL_PROVIDER = "anthropic";
+    await expect(initializeAgent({ loadDotenv: false })).rejects.toThrowError(
+      "ANTHROPIC_API_KEY is required (ELIZA_CODE_PROVIDER=anthropic).",
+    );
+  });
+
+  it("trims and case-folds the explicit provider before validating", async () => {
+    process.env.ELIZA_CODE_PROVIDER = "  Anthropic ";
+    await expect(initializeAgent({ loadDotenv: false })).rejects.toThrowError(
+      "ANTHROPIC_API_KEY is required (ELIZA_CODE_PROVIDER=anthropic).",
+    );
+  });
+
+  it("treats a whitespace-only provider as unset and reports no configuration", async () => {
+    process.env.ELIZA_CODE_PROVIDER = "   ";
+    await expect(initializeAgent({ loadDotenv: false })).rejects.toThrowError(
+      /No model provider configured/,
+    );
+  });
+
+  it("lets an explicit provider win over an auto-detectable anthropic key", async () => {
+    process.env.ELIZA_CODE_PROVIDER = "openai";
+    process.env.ANTHROPIC_API_KEY = "key-anthropic";
+    await expect(initializeAgent({ loadDotenv: false })).rejects.toThrowError(
+      "OPENAI_API_KEY is required (ELIZA_CODE_PROVIDER=openai).",
+    );
+  });
+});
+
+describe("shutdownAgent", () => {
+  it("stops the runtime exactly once", async () => {
+    let stopCalls = 0;
+    const runtime = {
+      stop: async () => {
+        stopCalls += 1;
+      },
+    } as unknown as AgentRuntime;
+
+    await shutdownAgent(runtime);
+
+    expect(stopCalls).toBe(1);
+  });
+
+  it("propagates a stop failure to the caller", async () => {
+    const runtime = {
+      stop: async () => {
+        throw new Error("runtime stop failed");
+      },
+    } as unknown as AgentRuntime;
+
+    await expect(shutdownAgent(runtime)).rejects.toThrowError(
+      "runtime stop failed",
+    );
+  });
+});


### PR DESCRIPTION

## Summary

Adds the first unit suite for `packages/examples/code/src/lib/agent.ts` — the Code example's runtime-assembly entrypoints (`initializeAgent`, `shutdownAgent`). No same-named test file existed anywhere on develop when this branch was cut.

## What is covered

The suite drives the real module (no mocks of the subject) and pins every fail-fast branch a unit test can observe without constructing a live `AgentRuntime` (the success path requires a database-backed runtime):

- **No provider configured** â rejects with `No model provider configured...`
- **Explicit `ELIZA_CODE_PROVIDER=anthropic|openai`** missing the matching key â rejects with the exact `ANTHROPIC_API_KEY is required (...)` / `OPENAI_API_KEY is required (...)` messages
- **Aliases**: `claude` maps onto the anthropic requirement, `codex` onto the openai requirement
- **Fallback precedence**: `ELIZA_CODE_MODEL_PROVIDER` is honored when `ELIZA_CODE_PROVIDER` is unset
- **Normalization**: surrounding whitespace/case is trimmed before validation; a whitespace-only value counts as unset and falls through to auto-detect
- **Explicit beats auto-detect**: an explicit provider is demanded even when an auto-detectable `ANTHROPIC_API_KEY` is present
- **`shutdownAgent`** stops the runtime exactly once and propagates a `stop()` failure to the caller

Every case snapshots the twelve provider-related env vars `initializeAgent` reads/mutates (via `applyElizaCodeProviderEnv`) and restores them afterwards, so the machine environment is untouched regardless of ambient config.

## Verification

Test-only diff: one new file, +147/-0, no production behavior changed.

- Owning runner (`packages/examples/code` `"test"` script is bun): `bun test --conditions=eliza-source src/lib/agent.test.ts` â **11 pass, 0 fail** across 1 file
- Cross-check: `bunx vitest run packages/examples/code/src/lib/agent.test.ts` â **11 passed (11)**, 1 file passed
- `bunx biome check src/lib/agent.test.ts` â clean, no fixes applied
- `tsc --noEmit` in `packages/examples/code`: zero mentions of `agent.test.ts` in output

## Notes

- Fork contribution: hosted CI does not run on this pull request; the counts above are from local runs quoted verbatim.
- Deliberately out of scope: exercising the full `initializeAgent` happy path would construct a live database-backed runtime; that belongs to integration/e2e lanes.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:256245dbed9a74b3d5d04a83309547c430e69533 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
