### PR TITLE
test(examples): expand agent-client streaming coverage

### DIFF
--- a/packages/examples/code/src/lib/agent-client.streaming.test.ts
+++ b/packages/examples/code/src/lib/agent-client.streaming.test.ts
@@ -647,3 +647,193 @@ describe("AgentClient client lifecycle, turn plumbing, and clearing", () => {
     ).resolves.toBeUndefined();
   });
 });
+
+describe("AgentClient turn option gating and response precedence", () => {
+  beforeEach(() => {
+    resetAgentClient();
+  });
+
+  it("throws when the attached runtime has no message service", async () => {
+    const runtime = {
+      ensureConnection: async () => {},
+    } as unknown as IAgentRuntime;
+
+    getAgentClient().setRuntime(runtime);
+    await expect(
+      getAgentClient().sendMessage({
+        room: makeRoom(),
+        text: "hello",
+        identity: makeIdentity(),
+      }),
+    ).rejects.toThrow("Runtime message service not available");
+  });
+
+  it("connects the room before handing the turn to the message service", async () => {
+    const events: string[] = [];
+    const runtime = {
+      ensureConnection: async () => {
+        events.push("connection");
+      },
+      messageService: {
+        handleMessage: async () => {
+          events.push("handle");
+          return { didRespond: true, responseMessages: [] };
+        },
+      },
+    } as unknown as IAgentRuntime;
+
+    getAgentClient().setRuntime(runtime);
+    await getAgentClient().sendMessage({
+      room: makeRoom(),
+      text: "status",
+      identity: makeIdentity(),
+    });
+
+    expect(events).toEqual(["connection", "handle"]);
+  });
+
+  it("emits nothing for empty stream chunks so callback text still streams whole", async () => {
+    const deltas: string[] = [];
+
+    const runtime = makeRuntime(
+      async (_runtime, _message, callback, options) => {
+        await options?.onStreamChunk?.("", "response-id");
+        await callback?.({ text: "done" });
+        return { didRespond: true, responseMessages: [] };
+      },
+    );
+
+    getAgentClient().setRuntime(runtime);
+    const response = await getAgentClient().sendMessage({
+      room: makeRoom(),
+      text: "stream empty",
+      identity: makeIdentity(),
+      onDelta: (delta) => deltas.push(delta),
+    });
+
+    expect(response).toBe("done");
+    expect(deltas).toEqual(["done"]);
+  });
+
+  it("replaces diverging final callback text without emitting a spurious delta", async () => {
+    const deltas: string[] = [];
+
+    const runtime = makeRuntime(
+      async (_runtime, _message, callback, options) => {
+        await options?.onStreamChunk?.("AAA", "response-id", "AAA");
+        await callback?.({ text: "BBB" });
+        return { didRespond: true, responseMessages: [] };
+      },
+    );
+
+    getAgentClient().setRuntime(runtime);
+    const response = await getAgentClient().sendMessage({
+      room: makeRoom(),
+      text: "diverge",
+      identity: makeIdentity(),
+      onDelta: (delta) => deltas.push(delta),
+    });
+
+    expect(response).toBe("BBB");
+    expect(deltas).toEqual(["AAA"]);
+  });
+
+  it("ignores callback content without usable text and adopts the result text", async () => {
+    let seenCallback: HandlerCallback | undefined;
+
+    const runtime = makeRuntime(async (_runtime, _message, callback) => {
+      seenCallback = callback;
+      await callback?.({});
+      await callback?.({ text: undefined });
+      return {
+        didRespond: true,
+        responseContent: { text: "adopted from result" },
+        responseMessages: [],
+      };
+    });
+
+    getAgentClient().setRuntime(runtime);
+    const response = await getAgentClient().sendMessage({
+      room: makeRoom(),
+      text: "guard arms",
+      identity: makeIdentity(),
+    });
+
+    expect(typeof seenCallback).toBe("function");
+    expect(response).toBe("adopted from result");
+  });
+
+  it("keeps the streamed response when the result carries different content", async () => {
+    const deltas: string[] = [];
+
+    const runtime = makeRuntime(
+      async (_runtime, _message, _callback, options) => {
+        await options?.onStreamChunk?.(
+          "live answer",
+          "response-id",
+          "live answer",
+        );
+        return {
+          didRespond: true,
+          responseContent: { text: "stale persisted copy" },
+          responseMessages: [],
+        };
+      },
+    );
+
+    getAgentClient().setRuntime(runtime);
+    const response = await getAgentClient().sendMessage({
+      room: makeRoom(),
+      text: "precedence",
+      identity: makeIdentity(),
+      onDelta: (delta) => deltas.push(delta),
+    });
+
+    expect(response).toBe("live answer");
+    expect(deltas).toEqual(["live answer"]);
+  });
+
+  it("attaches only codingMode to the turn options when no delta sink is provided", async () => {
+    let seenOptions: HandleMessageOptions | undefined;
+
+    const runtime = makeRuntime(
+      async (_runtime, _message, _callback, options) => {
+        seenOptions = options;
+        return { didRespond: true, responseMessages: [] };
+      },
+    );
+
+    getAgentClient().setRuntime(runtime);
+    const response = await getAgentClient().sendMessage({
+      room: makeRoom(),
+      text: "coding only",
+      identity: makeIdentity(),
+      codingMode: true,
+    });
+
+    expect(response).toBe("");
+    expect(seenOptions).toEqual({ codingMode: true });
+  });
+
+  it("attaches only abortSignal when it is the sole option", async () => {
+    let seenOptions: HandleMessageOptions | undefined;
+    const abortController = new AbortController();
+
+    const runtime = makeRuntime(
+      async (_runtime, _message, _callback, options) => {
+        seenOptions = options;
+        return { didRespond: true, responseMessages: [] };
+      },
+    );
+
+    getAgentClient().setRuntime(runtime);
+    await getAgentClient().sendMessage({
+      room: makeRoom(),
+      text: "abort only",
+      identity: makeIdentity(),
+      abortSignal: abortController.signal,
+    });
+
+    expect(seenOptions).toEqual({ abortSignal: abortController.signal });
+  });
+});


### PR DESCRIPTION

## Summary

Additive-only unit-test expansion for `packages/examples/code/src/lib/agent-client.ts`. The module's existing suite landed in #26590; this diff **strictly adds cases** to `packages/examples/code/src/lib/agent-client.streaming.test.ts` (+190/-0, single test file, no production code touched).

New cases pin real behavior the current suite does not yet cover:

- throws `Runtime message service not available` when a runtime is attached without a message service
- room connection is established before the message service handles the turn
- empty stream chunks emit nothing and leave the final callback text intact
- a diverging final callback text replaces the response without emitting a spurious delta
- callback content without usable text (`{}`, `{ text: undefined }`) is ignored and the result text is adopted
- a streamed response keeps precedence over differing `responseContent`
- option gating: `codingMode` alone attaches only `{ codingMode: true }`; `abortSignal` alone attaches only `{ abortSignal }`

All expectations were observed from running the real module through a stub `IAgentRuntime` — no mock-returns-X-assert-X cases, no type-level assertions.

## Evidence (test-only PR; no production behavior changed)

- `bunx vitest run packages/examples/code/src/lib/agent-client.streaming.test.ts`: **Test Files 1 passed (1), Tests 29 passed (29)** (21 pre-existing + 8 added)
- Owning package lane (`bun test --conditions=eliza-source src/lib/agent-client.streaming.test.ts` in `packages/examples/code`): **29 pass, 0 fail** — re-run after formatting with identical counts
- `bunx biome check --write` on the touched file: clean
- `bunx tsc --noEmit` in `packages/examples/code`: zero diagnostics mentioning the touched file

Note: this repository does not run hosted CI on fork pull requests; the counts above were produced locally against current `develop` (`51617538d704`) immediately before filing.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:51617538d704126b0d308654ccaaff091e474a67 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
