### PR TITLE
test(plugin-google-workspace): cover capability scopes metadata

### DIFF
--- a/plugins/plugin-google-workspace/src/__tests__/scopes.test.ts
+++ b/plugins/plugin-google-workspace/src/__tests__/scopes.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import {
+  GOOGLE_CAPABILITIES,
+  GOOGLE_CAPABILITY_GROUPS,
+  GOOGLE_CAPABILITY_METADATA,
+  GOOGLE_CAPABILITY_SCOPES,
+} from "./scopes.ts";
+
+describe("GOOGLE_CAPABILITY_METADATA", () => {
+  it("covers every capability", () => {
+    for (const capability of GOOGLE_CAPABILITIES) {
+      expect(GOOGLE_CAPABILITY_METADATA[capability]).toBeDefined();
+    }
+  });
+
+  it("maps each capability to its group", () => {
+    for (const capability of GOOGLE_CAPABILITIES) {
+      const meta = GOOGLE_CAPABILITY_METADATA[capability];
+      expect(GOOGLE_CAPABILITY_GROUPS).toContain(meta.group);
+      expect(meta.group).toBe(capability.split(".")[0]);
+    }
+  });
+
+  it("gives every capability at least one scope", () => {
+    for (const capability of GOOGLE_CAPABILITIES) {
+      const scopes = GOOGLE_CAPABILITY_SCOPES[capability];
+      expect(scopes.length).toBeGreaterThan(0);
+      for (const scope of scopes) {
+        expect(scope).toContain("https://www.googleapis.com/auth/");
+      }
+    }
+  });
+
+  it("labels every capability", () => {
+    for (const capability of GOOGLE_CAPABILITIES) {
+      const meta = GOOGLE_CAPABILITY_METADATA[capability];
+      expect(meta.label.length).toBeGreaterThan(0);
+      expect(meta.description.length).toBeGreaterThan(10);
+    }
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new `__tests__` file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `isolated npx vitest run -> 4 passed` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: 92d692518c3d832ac9b203076ef691a54e61a9fa
