### PR TITLE
fix(core): actionable error for a mis-spelled SECRET_SALT override, keeping the strict opt-in

### DIFF
--- a/packages/core/src/settings.salt.test.ts
+++ b/packages/core/src/settings.salt.test.ts
@@ -73,23 +73,34 @@ describe("getSalt (W1-060)", () => {
 		expect(getSalt()).toBe("secretsalt");
 	});
 
-	it.each(["1", "yes", "on", "TRUE", "true "])(
-		"honors the override set to %j, using canonical env truthiness",
+	it.each(["TRUE", "true", " true "])(
+		"honors the override for the exact value %j (case/whitespace insensitive)",
 		(flag) => {
 			process.env.NODE_ENV = "production";
 			process.env.ELIZA_ALLOW_DEFAULT_SECRET_SALT = flag;
-			// Before the fix this matched only exactly "true", so any of these
-			// silently failed the override and threw a hard boot error.
 			expect(getSalt()).toBe("secretsalt");
 		},
 	);
 
-	it.each(["false", "0", "no", "", "  "])(
-		"still throws in production when the override is falsy (%j)",
+	it.each(["1", "yes", "on", "enabled"])(
+		"still throws for a truthy-but-not-\"true\" override (%j), but names the exact required value",
 		(flag) => {
 			process.env.NODE_ENV = "production";
 			process.env.ELIZA_ALLOW_DEFAULT_SECRET_SALT = flag;
-			expect(() => getSalt()).toThrow(/SECRET_SALT must be set/);
+			// The exact-match gate stays fail-closed — this must NOT enable the
+			// publicly known salt — but the error tells the operator what to set.
+			expect(() => getSalt()).toThrow(/must be exactly "true"/);
+		},
+	);
+
+	it.each(["false", "0", "no", "", "  ", "maybe"])(
+		"throws the generic message when the override is absent or falsy (%j)",
+		(flag) => {
+			process.env.NODE_ENV = "production";
+			process.env.ELIZA_ALLOW_DEFAULT_SECRET_SALT = flag;
+			expect(() => getSalt()).toThrow(
+				/Set ELIZA_ALLOW_DEFAULT_SECRET_SALT=true to override/,
+			);
 		},
 	);
 });

--- a/packages/core/src/settings.salt.test.ts
+++ b/packages/core/src/settings.salt.test.ts
@@ -72,4 +72,24 @@ describe("getSalt (W1-060)", () => {
 		process.env.ELIZA_ALLOW_DEFAULT_SECRET_SALT = "true";
 		expect(getSalt()).toBe("secretsalt");
 	});
+
+	it.each(["1", "yes", "on", "TRUE", "true "])(
+		"honors the override set to %j, using canonical env truthiness",
+		(flag) => {
+			process.env.NODE_ENV = "production";
+			process.env.ELIZA_ALLOW_DEFAULT_SECRET_SALT = flag;
+			// Before the fix this matched only exactly "true", so any of these
+			// silently failed the override and threw a hard boot error.
+			expect(getSalt()).toBe("secretsalt");
+		},
+	);
+
+	it.each(["false", "0", "no", "", "  "])(
+		"still throws in production when the override is falsy (%j)",
+		(flag) => {
+			process.env.NODE_ENV = "production";
+			process.env.ELIZA_ALLOW_DEFAULT_SECRET_SALT = flag;
+			expect(() => getSalt()).toThrow(/SECRET_SALT must be set/);
+		},
+	);
 });

--- a/packages/core/src/settings.ts
+++ b/packages/core/src/settings.ts
@@ -19,6 +19,7 @@
  * as a usable secret.
  */
 import { createUniqueUuid } from "./entities";
+import { isTruthyEnvValue } from "./env-utils";
 import { ElizaError } from "./errors";
 import { logger } from "./logger";
 import type {
@@ -136,7 +137,11 @@ export function getSalt(): string {
 	const isProduction = nodeEnv === "production";
 	const allowDefaultSaltRaw =
 		getEnv("ELIZA_ALLOW_DEFAULT_SECRET_SALT", "") || "";
-	const allowDefaultSalt = allowDefaultSaltRaw.toLowerCase() === "true";
+	// Use the workspace's canonical env-flag truthiness (1/true/yes/y/on/enabled,
+	// trimmed and case-insensitive) rather than an exact "true" match, so the
+	// documented override does not silently fail on `1`, `yes`, or a trailing
+	// space and hard-crash boot via the production throw below.
+	const allowDefaultSalt = isTruthyEnvValue(allowDefaultSaltRaw);
 
 	const isDefaultOrUnset =
 		envSalt === "" || envSalt === LEGACY_DEFAULT_SECRET_SALT;

--- a/packages/core/src/settings.ts
+++ b/packages/core/src/settings.ts
@@ -137,19 +137,31 @@ export function getSalt(): string {
 	const isProduction = nodeEnv === "production";
 	const allowDefaultSaltRaw =
 		getEnv("ELIZA_ALLOW_DEFAULT_SECRET_SALT", "") || "";
-	// Use the workspace's canonical env-flag truthiness (1/true/yes/y/on/enabled,
-	// trimmed and case-insensitive) rather than an exact "true" match, so the
-	// documented override does not silently fail on `1`, `yes`, or a trailing
-	// space and hard-crash boot via the production throw below.
-	const allowDefaultSalt = isTruthyEnvValue(allowDefaultSaltRaw);
+	// Strict opt-in is deliberate: this flag permits keying production ciphertext by
+	// the publicly known LEGACY_DEFAULT_SECRET_SALT, so it requires the literal word
+	// "true" and does NOT accept the broader truthy set (1/yes/on/…) other flags use.
+	// Only whitespace and case are ignored, so a trailing space off a .env line
+	// (`=true `) still works rather than silently failing the override.
+	const allowDefaultSalt = allowDefaultSaltRaw.trim().toLowerCase() === "true";
 
 	const isDefaultOrUnset =
 		envSalt === "" || envSalt === LEGACY_DEFAULT_SECRET_SALT;
 
 	if (isProduction && isDefaultOrUnset && !allowDefaultSalt) {
+		// An operator who set a truthy-but-not-"true" spelling (1/yes/on/"true ")
+		// clearly intended to opt in; the generic message reads as if the flag were
+		// unset and sends them in the wrong direction. Name the exact required value.
+		const looksLikeIntendedOptIn =
+			allowDefaultSaltRaw.trim() !== "" &&
+			isTruthyEnvValue(allowDefaultSaltRaw);
 		throw new Error(
-			"SECRET_SALT must be set to a non-default value in production. " +
-				"Set ELIZA_ALLOW_DEFAULT_SECRET_SALT=true to override (not recommended).",
+			looksLikeIntendedOptIn
+				? "SECRET_SALT must be set to a non-default value in production. " +
+					`ELIZA_ALLOW_DEFAULT_SECRET_SALT must be exactly "true" to override ` +
+					`(got ${JSON.stringify(allowDefaultSaltRaw)}); the override is intentionally ` +
+					"strict because it permits a publicly known salt (not recommended)."
+				: "SECRET_SALT must be set to a non-default value in production. " +
+					"Set ELIZA_ALLOW_DEFAULT_SECRET_SALT=true to override (not recommended).",
 		);
 	}
 


### PR DESCRIPTION
# Relates to

No existing issue. Found while auditing `packages/core` env-flag handling. **Revised after review** — see the "Revised after review" note below.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop`, branched from the latest (`51617538`), zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync; `verify`'s only failures are unrelated plugin builds (`tsup: command not found`), `@elizaos/core` clean — see **Known gaps / failures**.
- [x] A reviewer can confirm the change without reading the code: the tests below pin every spelling's outcome.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5[1m]` (diagnosis, fix, tests, verification)
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - direct interactive session, contribute-to-eliza skill not used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from the latest `origin/develop` (`51617538`); zero conflicts.
- [x] `bun run verify` run post-sync; the unrelated blocker is in **Known gaps / failures**.

# Risks

**Low, and lower than the first revision.** The security gate is unchanged in strength: production still refuses to run on the publicly known salt unless the operator sets the literal word `true`. This revision only (a) ignores surrounding whitespace on that word and (b) improves the error message for a truthy-but-not-`true` value. No new crash path; the falsy path is unchanged.

# Background

## Revised after review

The first version of this PR widened the override to the full truthy set (`1`/`yes`/`on`/…) via `isTruthyEnvValue`. The review (nothingxnowhere, reproduced both sides at the prior head) correctly pushed back: `ELIZA_ALLOW_DEFAULT_SECRET_SALT`'s *only* function is to permit keying production ciphertext by the **publicly known** `LEGACY_DEFAULT_SECRET_SALT = "secretsalt"` (settings.ts:72, "Never key ciphertext by the publicly known constant"). A strict exact-match opt-in on that gate is a deliberate fail-closed choice, and the failure it produces is a **loud throw naming the exact variable and value**, not a silent one. Widening it would let a stray `=1` silently run production on a known salt.

That is right, so this revision keeps the strict opt-in and fixes the real ergonomic problem instead.

## What this PR now does

`getSalt()` gate (`packages/core/src/settings.ts`):

```ts
// requires the literal word "true"; ignores case and surrounding whitespace,
// but does NOT accept the broad truthy set (1/yes/on/…).
const allowDefaultSalt = allowDefaultSaltRaw.trim().toLowerCase() === "true";
```

Two behavioral changes, both narrow:

1. **`=true ` with a trailing space now works.** A trailing space off a `.env` line previously failed the exact match and crashed boot. Trimming the word `true` does not widen the gate — it still requires the operator to type `true`, not a synonym.
2. **A truthy-but-not-`true` value gets an actionable error.** In the production+default-salt branch that already throws, if the value is truthy per the workspace helper (`1`/`yes`/`on`/`enabled`) the message now names the exact required value:

   ```
   ELIZA_ALLOW_DEFAULT_SECRET_SALT must be exactly "true" to override (got "1");
   the override is intentionally strict because it permits a publicly known salt.
   ```

   The gate does **not** open for these — production still throws — the operator is just told what to type. Absent/falsy values still get the original generic message.

`README.md:172` and the generic throw both still say `=true`, and that remains the accepted value, so there is no doc drift.

## What kind of change is this?

Bug fix / UX (non-breaking; the security gate's strength is unchanged).

# Documentation changes needed?

No. The accepted value is still the word `true`, matching `README.md:172` and the throw message.

# Testing

## Where should a reviewer start?

`packages/core/src/settings.salt.test.ts` — three `it.each` blocks pin every spelling.

## Detailed testing steps

```bash
bun x vitest run packages/core/src/settings.salt.test.ts     # 20 passed
```

- honored (returns `"secretsalt"`): `true`, `TRUE`, `" true "` — the word, case/space-insensitive
- still throws, message `/must be exactly "true"/`: `1`, `yes`, `on`, `enabled` — gate stays closed
- generic throw `/Set ELIZA_ALLOW_DEFAULT_SECRET_SALT=true to override/`: `false`, `0`, `no`, `""`, `"  "`, `maybe`

# Evidence Gate

<!-- evidence-head:e3c7ba06dbc9b869aefc2fcb0d9d11e0486406ae -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - no UI surface; the diff is boot-time env parsing in packages/core.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - no UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-facing flow; the behaviour is whether a process boots and with which salt, asserted by tests.`
<!-- evidence-row:backend-logs -->
- [x] Test output with per-spelling outcomes is inline under **Detailed testing steps** and below.
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent/model path; boot-time env parsing.`
<!-- evidence-row:domain-artifacts -->
- [x] The domain artifact is getSalt()'s throw/return decision, asserted directly.
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no model call in the changed path.`

## Backend + frontend logs

`bun x vitest run packages/core/src/settings.salt.test.ts` → **20 passed**. Frontend: `N/A`.

## Screenshots (before / after) + video walkthrough

`N/A - no UI change.`

## Audio / voice walkthrough

`N/A.`

## Known gaps / failures

`bun run verify` exits non-zero on plugin builds this PR does not touch (`@elizaos/plugin-doordash` and a `@elizaos/capacitor-*` package) with `tsup: command not found` (exit 127) — a missing build binary in my environment, not a code failure, in packages this PR does not modify. `@elizaos/core` builds and tests cleanly. Flagging rather than marking the sync gate clean.
