### PR TITLE
test(ui): cover transient-fetch

### DIFF
--- a/packages/ui/src/utils/transient-fetch.test.ts
+++ b/packages/ui/src/utils/transient-fetch.test.ts
@@ -1,0 +1,130 @@
+/** Unit coverage for the best-effort-hydration fetch failure classifier; deterministic, no I/O. */
+
+import { describe, expect, it } from "vitest";
+import { ApiError } from "../api/client-types-core";
+import { isTransientOptionalFetchFailure } from "./transient-fetch";
+
+describe("isTransientOptionalFetchFailure", () => {
+  it("rejects values that are not Error instances, including ApiError-shaped plain objects", () => {
+    expect(isTransientOptionalFetchFailure(null)).toBe(false);
+    expect(isTransientOptionalFetchFailure(undefined)).toBe(false);
+    expect(isTransientOptionalFetchFailure("Failed to fetch")).toBe(false);
+    expect(
+      isTransientOptionalFetchFailure({ name: "ApiError", kind: "timeout" }),
+    ).toBe(false);
+  });
+
+  it("recognises a raw TypeError from fetch() rejecting before any response", () => {
+    expect(
+      isTransientOptionalFetchFailure(new TypeError("Failed to fetch")),
+    ).toBe(true);
+    expect(isTransientOptionalFetchFailure(new TypeError("NetworkError"))).toBe(
+      true,
+    );
+    expect(isTransientOptionalFetchFailure(new TypeError("Load failed"))).toBe(
+      true,
+    );
+  });
+
+  it("matches those raw messages case-insensitively", () => {
+    expect(
+      isTransientOptionalFetchFailure(new TypeError("failed to fetch")),
+    ).toBe(true);
+    expect(isTransientOptionalFetchFailure(new TypeError("LOAD FAILED"))).toBe(
+      true,
+    );
+  });
+
+  it("does not treat a programming TypeError as transient", () => {
+    expect(
+      isTransientOptionalFetchFailure(
+        new TypeError("Cannot read properties of undefined (reading 'map')"),
+      ),
+    ).toBe(false);
+  });
+
+  it("requires the whole message to be the transient phrase, not a prefix", () => {
+    expect(
+      isTransientOptionalFetchFailure(new TypeError(" Failed to fetch")),
+    ).toBe(false);
+    expect(
+      isTransientOptionalFetchFailure(
+        new TypeError("Failed to fetch: net::ERR_CONNECTION_RESET"),
+      ),
+    ).toBe(false);
+  });
+
+  it("treats an ApiError timeout as transient regardless of message wording", () => {
+    expect(
+      isTransientOptionalFetchFailure(
+        new ApiError({
+          kind: "timeout",
+          path: "/api/agents",
+          message: "Request timed out after 8000ms",
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("treats an ApiError network failure that never got a response as transient", () => {
+    for (const message of ["Failed to fetch", "request aborted"]) {
+      expect(
+        isTransientOptionalFetchFailure(
+          new ApiError({
+            kind: "network",
+            path: "/api/agents",
+            message,
+          }),
+        ),
+      ).toBe(true);
+    }
+  });
+
+  it("does not treat an ApiError network failure carrying another message as transient", () => {
+    expect(
+      isTransientOptionalFetchFailure(
+        new ApiError({
+          kind: "network",
+          path: "/api/agents",
+          message: "socket hang up mid-response",
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("does not treat http or parse ApiErrors as transient", () => {
+    expect(
+      isTransientOptionalFetchFailure(
+        new ApiError({
+          kind: "http",
+          status: 503,
+          path: "/api/agents",
+          message: "Service Unavailable",
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      isTransientOptionalFetchFailure(
+        new ApiError({
+          kind: "parse",
+          path: "/api/agents",
+          message: "Unexpected token < in JSON",
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("keys on the error name, so an ordinary Error with a kind property is still surfaced", () => {
+    const lookalike = Object.assign(new Error("Request aborted"), {
+      kind: "network",
+    });
+    expect(isTransientOptionalFetchFailure(lookalike)).toBe(false);
+  });
+
+  it("does not classify unrelated error types as transient", () => {
+    expect(
+      isTransientOptionalFetchFailure(new RangeError("out of range")),
+    ).toBe(false);
+    expect(isTransientOptionalFetchFailure(new Error("boom"))).toBe(false);
+  });
+});


### PR DESCRIPTION

## What

Adds `packages/ui/src/utils/transient-fetch.test.ts`, a unit suite for `isTransientOptionalFetchFailure` in `packages/ui/src/utils/transient-fetch.ts`. That module had no test file anywhere in the repo; this is coverage only, with no production change.

The suite drives the real classifier and, for the `ApiError` shapes it was written against, the real `ApiError` class from `packages/ui/src/api/client-types-core.ts`. It covers every branch:

- non-Error inputs are rejected (including a plain object shaped like an `ApiError`);
- raw `TypeError` rejections ("Failed to fetch", "NetworkError", "Load failed") match case-insensitively;
- the message must be exactly the transient phrase — decorated messages (`"Failed to fetch: net::ERR_CONNECTION_RESET"`, leading whitespace) do not match;
- a programming `TypeError` is not transient;
- `ApiError` `kind: "timeout"` is transient regardless of wording;
- `ApiError` `kind: "network"` is transient only for "Failed to fetch" / "Request aborted";
- `ApiError` `kind: "http"` / `"parse"` and ordinary errors (even one carrying a `kind` property) stay surfaced.

## Evidence

Test-only diff: 1 new file, +130/−0. This PR comes from a fork, so hosted CI does not run on it; local results:

- `bunx vitest run src/utils/transient-fetch.test.ts` (in `packages/ui`) — **1 file passed, 11 tests passed**, 0 failed.
- `bunx biome check src/utils/transient-fetch.test.ts` — clean, no fixes needed after formatting.
- `bunx tsc --noEmit` in `packages/ui` — no diagnostic mentions `transient-fetch`.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:07ab8dc639f8783670a8fc2cbba545f7486b1bcd -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
