### PR TITLE
test(examples): cover identity

### DIFF
--- a/packages/examples/code/src/lib/identity.test.ts
+++ b/packages/examples/code/src/lib/identity.test.ts
@@ -1,0 +1,181 @@
+/** Exercises session-identity generation, UUID validation, and room-id derivation against the real core helpers. */
+import { describe, expect, it } from "bun:test";
+import { stringToUuid } from "@elizaos/core";
+import {
+  createRoomElizaId,
+  ensureSessionIdentity,
+  getMainRoomElizaId,
+  isUuidString,
+} from "./identity.js";
+
+const V4_A = "3f2504e0-4f89-41d3-9a0c-0305e82c3301";
+const V4_B = "9b2f1c6e-8a47-4e5a-b1c3-7d90e2f4a6b8";
+const V4_C = "c1a7e5f3-2b48-49d6-8e0a-5f3b7c9d1e2a";
+
+describe("isUuidString", () => {
+  it("accepts a canonical lowercase v4 UUID", () => {
+    expect(isUuidString(V4_A)).toBe(true);
+  });
+
+  it("accepts uppercase hex (case-insensitive)", () => {
+    expect(isUuidString(V4_A.toUpperCase())).toBe(true);
+  });
+
+  it("accepts non-v4 versions within [1-5]", () => {
+    expect(isUuidString("12345678-1234-1678-9234-123456789abc")).toBe(true);
+    expect(isUuidString("12345678-1234-5678-9234-123456789abc")).toBe(true);
+  });
+
+  it("rejects version digits outside [1-5]", () => {
+    expect(isUuidString("12345678-1234-0678-9234-123456789abc")).toBe(false);
+    expect(isUuidString("12345678-1234-7678-9234-123456789abc")).toBe(false);
+  });
+
+  it("rejects an invalid variant nibble", () => {
+    expect(isUuidString("12345678-1234-4678-c234-123456789abc")).toBe(false);
+  });
+
+  it("rejects malformed and empty input", () => {
+    expect(isUuidString("not-a-uuid")).toBe(false);
+    expect(isUuidString("3f2504e04f8941d39a0c0305e82c3301")).toBe(false);
+    expect(isUuidString("")).toBe(false);
+  });
+});
+
+describe("ensureSessionIdentity", () => {
+  it("echoes a fully valid identity back unchanged", () => {
+    const input = {
+      projectId: V4_A,
+      userId: V4_B,
+      worldId: V4_C,
+      messageServerId: "d2b8f6a4-3c59-4a71-9b0e-6d4f8a2c5e7b",
+    };
+
+    expect(ensureSessionIdentity(input)).toEqual(input);
+  });
+
+  it("generates a fresh random projectId and userId when absent", () => {
+    const first = ensureSessionIdentity();
+    const second = ensureSessionIdentity();
+
+    expect(isUuidString(first.projectId)).toBe(true);
+    expect(isUuidString(first.userId)).toBe(true);
+    expect(first.projectId).not.toBe(second.projectId);
+    expect(first.userId).not.toBe(second.userId);
+  });
+
+  it("derives world and message-server ids from the generated projectId", () => {
+    const identity = ensureSessionIdentity();
+
+    expect(identity.worldId).toBe(
+      stringToUuid(`eliza-code:world:${identity.projectId}`),
+    );
+    expect(identity.messageServerId).toBe(
+      stringToUuid(`eliza-code:server:${identity.projectId}`),
+    );
+  });
+
+  it("derives world and message-server ids from a supplied projectId", () => {
+    const identity = ensureSessionIdentity({
+      projectId: V4_A,
+      userId: V4_B,
+    });
+
+    expect(identity.projectId).toBe(V4_A);
+    expect(identity.userId).toBe(V4_B);
+    expect(identity.worldId).toBe(stringToUuid(`eliza-code:world:${V4_A}`));
+    expect(identity.messageServerId).toBe(
+      stringToUuid(`eliza-code:server:${V4_A}`),
+    );
+  });
+
+  it("replaces invalid projectId/userId but keeps valid world/messageServer ids", () => {
+    const identity = ensureSessionIdentity({
+      projectId: "not-a-uuid",
+      userId: "",
+      worldId: V4_C,
+      messageServerId: "d2b8f6a4-3c59-4a71-9b0e-6d4f8a2c5e7b",
+    });
+
+    expect(identity.projectId).not.toBe("not-a-uuid");
+    expect(isUuidString(identity.projectId)).toBe(true);
+    expect(identity.userId).not.toBe("");
+    expect(isUuidString(identity.userId)).toBe(true);
+    expect(identity.worldId).toBe(V4_C);
+    expect(identity.messageServerId).toBe(
+      "d2b8f6a4-3c59-4a71-9b0e-6d4f8a2c5e7b",
+    );
+  });
+
+  it("regenerates derived fields when they are themselves invalid", () => {
+    const identity = ensureSessionIdentity({ projectId: V4_A, worldId: "" });
+
+    expect(identity.projectId).toBe(V4_A);
+    expect(identity.worldId).toBe(
+      stringToUuid(`eliza-code:world:${identity.projectId}`),
+    );
+    expect(identity.worldId).not.toBe("");
+  });
+});
+
+describe("room id derivation", () => {
+  it("returns one stable main-room id per project", () => {
+    const identity = ensureSessionIdentity({ projectId: V4_A });
+    const first = getMainRoomElizaId(identity);
+    const second = getMainRoomElizaId(identity);
+
+    expect(first).toBe(second);
+    expect(first).toBe(stringToUuid(`eliza-code:room:${V4_A}:main`));
+  });
+
+  it("gives different projects different main-room ids", () => {
+    const a = getMainRoomElizaId(ensureSessionIdentity({ projectId: V4_A }));
+    const b = getMainRoomElizaId(ensureSessionIdentity({ projectId: V4_B }));
+
+    expect(a).not.toBe(b);
+  });
+
+  it("creates a unique room id on every call", () => {
+    const identity = ensureSessionIdentity({ projectId: V4_A });
+    const main = getMainRoomElizaId(identity);
+    const a = createRoomElizaId(identity);
+    const b = createRoomElizaId(identity);
+
+    expect(a).not.toBe(b);
+    expect(a).not.toBe(main);
+    expect(b).not.toBe(main);
+    expect(a).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+    );
+    expect(b).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+    );
+  });
+
+  it("derives core-format ids that this module's own [1-5] validator rejects", () => {
+    // stringToUuid stamps a custom version nibble of 0, so derived world,
+    // server, and room ids are NOT accepted by isUuidString even though
+    // random projectId/userId values are.
+    const identity = ensureSessionIdentity({ projectId: V4_A, userId: V4_B });
+
+    expect(isUuidString(identity.worldId)).toBe(false);
+    expect(isUuidString(identity.messageServerId)).toBe(false);
+    expect(isUuidString(getMainRoomElizaId(identity))).toBe(false);
+    expect(isUuidString(createRoomElizaId(identity))).toBe(false);
+  });
+
+  it("round-trips a persisted identity to the same derived ids", () => {
+    const original = ensureSessionIdentity({
+      projectId: V4_A,
+      userId: V4_B,
+    });
+    const reloaded = ensureSessionIdentity({
+      projectId: original.projectId,
+      userId: original.userId,
+      worldId: original.worldId,
+      messageServerId: original.messageServerId,
+    });
+
+    expect(reloaded).toEqual(original);
+  });
+});


### PR DESCRIPTION

## Summary

Adds a new unit test suite for `packages/examples/code/src/lib/identity.ts` — the session-identity helpers the `eliza-code` TUI persists to `.eliza-code/session.json`. Test-only change: no production file is touched, diff is +181/-0 in a single new file.

The module had no same-named test anywhere on `develop` at filing time (verified against current `origin/develop` via `git ls-tree`, and `gh api --cache 0` search showed no open PR touching this path).

## What the suite covers

17 cases driving the real module and the real `@elizaos/core` `stringToUuid` — no mocks:

- `isUuidString`: canonical lowercase v4 accepted; uppercase accepted (`i` flag); versions 1–5 accepted; version 0/7 rejected; invalid variant nibble rejected; malformed / dash-less / empty strings rejected.
- `ensureSessionIdentity`: fully-valid input echoed unchanged; absent input generates fresh random `projectId`/`userId` (distinct across calls); derived `worldId`/`messageServerId` equal `stringToUuid("eliza-code:world:<projectId>")` / `"eliza-code:server:<projectId>"`; derivation uses a *supplied* valid projectId when world/server ids are missing; invalid (`"not-a-uuid"`, empty-string) fields are replaced while sibling valid fields are preserved.
- Room ids: `getMainRoomElizaId` deterministic per project and distinct across projects, equal to the documented seed string; `createRoomElizaId` unique per call and never collides with the main id.
- Documented real interaction: `stringToUuid` stamps a custom version nibble of 0 (`packages/core/src/utils.ts`), so all *derived* ids deliberately fail this module's own `[1-5]` version regex even though random v4 ids pass. A round-trip of a persisted identity back through `ensureSessionIdentity` reproduces identical derived ids because their derivation depends only on `projectId`.

One expectation was corrected during authoring after observing real output rather than assumed behavior: derived ids are **not** `isUuidString`-valid. The suite asserts what the code does.

## Verification (real counts)

Runner note: this package's own gate is `bun test --conditions=eliza-source src` (`packages/examples/code/package.json`), and its existing suites import from `bun:test`. Root vitest cannot collect any file in this package — `Cannot find package 'bun:test'` (reproduced on pre-existing siblings as well) — so the authoritative counts are from the owning runner:

```
$ cd packages/examples/code && bun test --conditions=eliza-source src/lib/identity.test.ts
 17 pass
 0 fail
 43 expect() calls
Ran 17 tests across 1 file. [317.00ms]
```

Re-run against current `origin/develop` immediately before filing (base `51617538d704126b0d308654ccaaff091e474a67`, which the branch is cut from).

- `bunx biome check --write src/lib/identity.test.ts` → clean ("Checked 1 file ... Fixed 1 file", formatting only).
- `bunx tsc --noEmit` in `packages/examples/code` → zero mentions of `identity.test.ts` in output (no new type errors).
- Diff touches only `packages/examples/code/src/lib/identity.test.ts` (+181/-0). No deletions.

## Notes

- Fork contributor: hosted CI does **not** run on this PR; the counts above were executed locally with the repository's pinned toolchain (bun 1.3.14) and are quoted verbatim.
- No `vi.hoisted`, no `expectTypeOf`, no mocks standing in for the system under test.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:cd3e65d7e639a1d246ba22f63807effce701116c -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
