### PR TITLE
test(examples): cover TaskPane

### DIFF
--- a/packages/examples/code/src/components/task-pane.test.ts
+++ b/packages/examples/code/src/components/task-pane.test.ts
@@ -594,3 +594,194 @@ describe("TaskPane render details", () => {
     expect(trace).not.toContain("\u2014");
   });
 });
+
+describe("TaskPane rename edge cases", () => {
+  it("skips the service call when the edited name trims to empty", async () => {
+    const service = recordingService();
+    const component = paneWithService(service);
+    const task = taskWith("anon", { name: "" });
+    seedCurrent(component, task);
+    component.syncFocus(true);
+    component.handleInput("e");
+    component.handleInput("r");
+    component.handleInput("\r");
+    await flush();
+    expect(service.calls.map((call) => call.method)).toEqual([]);
+  });
+
+  it("commits characters typed into the rename editor", async () => {
+    const service = recordingService();
+    const { component, taskId } = focusedInEditMode(service);
+    component.handleInput("r");
+    component.handleInput("!");
+    component.handleInput("\r");
+    await flush();
+    expect(service.calls.map((call) => call.method)).toEqual(["renameTask"]);
+    expect(service.calls[0]?.args).toEqual([taskId, "Build feature!"]);
+  });
+});
+
+describe("TaskPane detail placeholders", () => {
+  it("shows placeholder copy when output and trace views are empty", () => {
+    const component = pane();
+    seedCurrent(
+      component,
+      taskWith("quiet", { name: "Quiet", status: "pending" }),
+    );
+    const rendered = component.renderContent(80, 24).join("\n");
+    expect(rendered).toContain("No output yet.");
+
+    component.syncFocus(true);
+    component.handleInput("t");
+    const traced = component.renderContent(80, 24).join("\n");
+    expect(traced).toContain("Trace");
+    expect(traced).toContain("No trace yet.");
+  });
+
+  it("marks a running current task as live and defaults its sub-agent label", () => {
+    const component = pane();
+    seedCurrent(
+      component,
+      taskWith("live", { name: "Live wire", status: "running" }),
+    );
+    const rendered = component.renderContent(80, 24).join("\n");
+    expect(rendered).toContain("(live)");
+    expect(rendered).toContain("Sub-agent: eliza");
+    expect(rendered).toContain("\ud83d\udd04");
+  });
+});
+
+describe("TaskPane trace formatting details", () => {
+  it("renders info and warning notes plus status messages with separators", () => {
+    const component = pane();
+    const task = taskWith("levels", { name: "Levels", status: "running" });
+    task.metadata.trace = [
+      { kind: "note", level: "info", message: "started", ts: 1, seq: 1 },
+      { kind: "note", level: "warning", message: "slow", ts: 2, seq: 2 },
+      {
+        kind: "status",
+        status: "paused",
+        message: "awaiting input",
+        ts: 3,
+        seq: 3,
+      },
+      {
+        kind: "tool_result",
+        iteration: 1,
+        name: "shell",
+        success: true,
+        output: "ok",
+        outputPreview: "fine",
+        ts: 4,
+        seq: 4,
+      },
+    ];
+    seedCurrent(component, task);
+    component.syncFocus(true);
+    component.handleInput("t");
+    const trace = component.renderContent(80, 24).join("\n");
+    expect(trace).toContain("\u2139\ufe0f started");
+    expect(trace).toContain("\u26a0\ufe0f slow");
+    expect(trace).toContain("paused \u2014 awaiting input");
+    expect(trace).toContain("RESULT: shell \u2713");
+    expect(trace).toContain("fine");
+  });
+});
+
+describe("TaskPane status icons", () => {
+  it("renders the paused execution icon", () => {
+    const component = pane();
+    useStore
+      .getState()
+      .setTasks([taskWith("hold", { name: "Hold", status: "paused" })]);
+    const rendered = component.renderContent(80, 24).join("\n");
+    expect(rendered).toContain("\u23f8\ufe0f");
+    expect(rendered).toContain("Hold");
+  });
+});
+
+describe("TaskPane help surfaces", () => {
+  it("switches the help line between browse and edit modes", () => {
+    const component = pane();
+    seedCurrent(component, codeTask());
+    component.syncFocus(true);
+    let rendered = component.renderContent(80, 24).join("\n");
+    expect(rendered).toContain("\u2191\u2193 select \u2022 Enter switch");
+    expect(rendered).toContain("d done/open");
+
+    component.handleInput("e");
+    rendered = component.renderContent(80, 24).join("\n");
+    expect(rendered).toContain("Edit: a agent");
+    expect(rendered).toContain("r rename");
+    expect(rendered).toContain("p pause/resume");
+  });
+});
+
+describe("TaskPane confirmation persistence", () => {
+  it("keeps the delete dialog open for unrecognized keys until confirmed", async () => {
+    const service = recordingService();
+    const { component, taskId } = focusedInEditMode(service);
+    component.handleInput("x");
+    component.handleInput("z");
+    expect(component.renderContent(80, 24).join("\n")).toContain(
+      "Confirm delete? (y/n)",
+    );
+    expect(service.calls).toEqual([]);
+
+    component.handleInput("Y");
+    await flush();
+    expect(service.calls.map((call) => call.method)).toEqual(["deleteTask"]);
+    expect(service.calls[0]?.args).toEqual([taskId]);
+  });
+});
+
+describe("TaskPane selection propagation", () => {
+  it("mirrors keyboard selection into the task service", async () => {
+    const service = recordingService();
+    const component = paneWithService(service);
+    const first = codeTask();
+    const second: CodeTask = {
+      ...first,
+      id: stringToUuid("task-pane:mapped"),
+      name: "Mapped",
+    };
+    useStore.getState().setTasks([first, second]);
+    component.syncFocus(true);
+    component.handleInput("\x1b[B");
+    component.handleInput("\r");
+    await flush();
+    expect(useStore.getState().getCurrentTask()?.name).toBe("Mapped");
+    expect(service.calls.map((call) => call.method)).toEqual([
+      "setCurrentTask",
+    ]);
+    expect(service.calls[0]?.args).toEqual([stringToUuid("task-pane:mapped")]);
+  });
+
+  it("resets detail scrolling when the selection changes", () => {
+    const component = pane();
+    const chatty = taskWith("chatty", {
+      name: "Chatty",
+      status: "running",
+      output: Array.from({ length: 15 }, (_, i) => `line ${i}`),
+    });
+    const still = taskWith("still", { name: "Still" });
+    useStore.getState().setTasks([chatty, still]);
+    useStore.getState().setCurrentTaskId(chatty.id ?? null);
+    component.syncFocus(true);
+    component.handleInput("\x1b[1;5A");
+    component.handleInput("\x1b[1;5A");
+    expect(component.renderContent(80, 24).join("\n")).toContain(
+      "[\u2193 2 newer lines]",
+    );
+
+    component.handleInput("\x1b[B");
+    component.handleInput("\r");
+    expect(useStore.getState().currentTaskId).toBe(
+      stringToUuid("task-pane:still"),
+    );
+    const rendered = component.renderContent(80, 24).join("\n");
+    expect(rendered).not.toContain("newer lines");
+    expect(rendered).toContain("No output yet.");
+    expect(rendered).toContain("Still");
+  });
+});


### PR DESCRIPTION

## What this changes

Follow-up test coverage for `packages/examples/code/src/components/TaskPane.ts`, strictly **additive** to the suite created by #26601 (merged earlier today). This PR appends **10 new cases (+191/-0)** in 7 new `describe` blocks at the end of `packages/examples/code/src/components/task-pane.test.ts`. No existing line is touched; no production code changes.

Branches pinned that neither the original suite nor #26601 covered:

- **Rename edge cases** — an edited name that trims to empty suppresses the `renameTask` service call entirely; characters typed into the rename editor are committed (`"Build feature"` + `!` → `"Build feature!"`), not just the prefilled name.
- **Detail placeholders** — `No output yet.` and `No trace yet.` render for a task with empty output/trace views.
- **Live marker + default label** — a running current task shows `(live)` in the detail header and falls back to `Sub-agent: eliza` when `metadata.subAgentType` is absent.
- **Trace formatting** — info (`ℹ️`) and warning (`⚠️`) note icons, status events with messages rendered as `paused — awaiting input` (the em-dash counterpart to #26601's bare-status case), and successful tool results as `RESULT: shell ✓`.
- **Status icons** — the paused `⏸️` execution icon (completed/failed/cancelled were already pinned).
- **Help surfaces** — the help line switches between browse (`↑↓ select • Enter switch • …`) and edit (`Edit: a agent • r rename • p pause/resume`) variants.
- **Confirmation persistence** — unrecognized keys leave the delete dialog open with zero service calls until a later `Y` confirms.
- **Selection propagation** — keyboard selection mirrors into the task service via `setCurrentTask(taskId)` (store *and* service dual-write), and switching tasks resets the detail scroll offset (the `[↓ N newer lines]` indicator clears).

All cases drive the real `TaskPane` class through real `VirtualTerminal`/`TUI` hosts and assert on rendered output, recorded service calls, and store transitions — no mocks of the module under test, no `expectTypeOf`.

## Evidence (fork PR — hosted CI does not run on this repository's PRs)

Counts quoted from the final revision of this branch:

- Owning lane (`packages/examples/code` runs its unit lane with bun): `bun test --conditions=eliza-source src/components/task-pane.test.ts` → **32 pass, 0 fail, 104 expect() calls, 1 file** (22 pre-existing + 10 new).
- Merge-readiness lane: `bunx vitest run packages/examples/code/src/components/task-pane.test.ts` → **Test Files 1 passed (1), Tests 32 passed (32)**.
- Re-ran both after `biome check --write`; results unchanged.
- `bunx biome check packages/examples/code/src/components/task-pane.test.ts` → clean ("Checked 1 file… No fixes applied" after formatting).
- `bunx tsc --noEmit` in `packages/examples/code`, grepped for the touched file: **no output** (zero errors introduced by this diff).

## Scope

Diff touches exactly one file: `packages/examples/code/src/components/task-pane.test.ts`, **+191/-0** (pure addition). Test-only change — no production behaviour is modified.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:e412cd89ca8c357c96b3d1c9520c8481ce6b9fff -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
