### PR TITLE
test(examples): cover load-env

### DIFF
--- a/packages/examples/code/src/lib/__tests__/load-env.test.ts
+++ b/packages/examples/code/src/lib/__tests__/load-env.test.ts
@@ -35,4 +35,36 @@ describe("loadEnv", () => {
     loadEnv();
     expect(mocks.config).toHaveBeenCalledTimes(1);
   });
+
+  it("probes an absolute monorepo-root .env path derived from this module", () => {
+    mocks.existsSync.mockReturnValue(true);
+    loadEnv();
+    expect(mocks.existsSync).toHaveBeenCalledTimes(1);
+    const probed = String(mocks.existsSync.mock.calls[0]?.[0]);
+    const normalized = probed.split(/[/\\]/).join("/");
+    expect(normalized.endsWith("/packages/.env")).toBe(true);
+  });
+
+  it("loads cwd .env through dotenv defaults so shell env is never clobbered", () => {
+    mocks.existsSync.mockReturnValue(true);
+    loadEnv();
+    const cwdOptions = (mocks.config.mock.calls[0]?.[0] ?? {}) as {
+      path?: unknown;
+      override?: unknown;
+      quiet?: unknown;
+    };
+    expect(cwdOptions.quiet).toBe(true);
+    expect(cwdOptions).not.toHaveProperty("path");
+    expect(cwdOptions.override).toBeUndefined();
+  });
+
+  it("loads exactly the root .env path it probed", () => {
+    mocks.existsSync.mockReturnValue(true);
+    loadEnv();
+    const probed = String(mocks.existsSync.mock.calls[0]?.[0]);
+    const rootOptions = (mocks.config.mock.calls[1]?.[0] ?? {}) as {
+      path?: unknown;
+    };
+    expect(rootOptions.path).toBe(probed);
+  });
 });


### PR DESCRIPTION

## What

Strictly additive coverage for `loadEnv()` in `packages/examples/code/src/lib/load-env.ts`, appended to the existing suite at `packages/examples/code/src/lib/__tests__/load-env.test.ts`.

Diff is one test file, **+32/-0** on top of `origin/develop` @ `51617538d704126b0d308654ccaaff091e474a67` (head `87388dd61af04b1fdfca551fab207aae16ba27e6`). No production behavior changes.

## New cases

1. **Root probe path** — `existsSync` receives exactly one argument: an absolute path ending `/packages/.env`, derived from this module's URL (pins the loader contract that a repo-level `.env` is honored when running from inside the package).
2. **cwd load uses dotenv defaults** — the first `config()` call carries `{ quiet: true }` only: no `path`, no `override`. If it ever gained `override: true`, running from anywhere with a local `.env` would clobber shell-exported variables; this pins that it cannot.
3. **Probe/load consistency** — the second `config()` call loads precisely the `.env` path that was probed, so the existence check can never drift from the file actually loaded.

## Evidence (local, pinned toolchain)

- `bunx vitest run packages/examples/code/src/lib/__tests__/load-env.test.ts` → **Test Files 1 passed (1), Tests 5 passed (5)** (2 pre-existing + 3 new). Re-fetched and re-run against current `origin/develop` immediately before filing.
- `bunx biome check --write <file>` → clean, "Checked 1 file… No fixes applied" against the repo `biome.json`.
- `tsc --noEmit` in `packages/examples/code` → `grep 'load-env.test'` over the output matches nothing (zero new type errors attributable to this diff).

## Notes

- This is a fork contribution: hosted CI does not run on this PR. The counts above are quoted from local runs; nothing here should be read as CI-green.
- The pre-existing two cases use `vi.hoisted(...)`, which is undefined under this package's own `bun test` runner (pinned Bun 1.3.14), so that file fails collection under `bun test` on develop today. The added cases intentionally use no `vi.hoisted`; repairing the existing block would require deleting lines from a base test file, which would break this PR's strictly-additive guarantee, so it is left untouched here.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:87388dd61af04b1fdfca551fab207aae16ba27e6 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
