### PR TITLE
test(ui): cover page-scoped-conversations

### DIFF
--- a/packages/ui/src/components/pages/page-scoped-conversations.test.ts
+++ b/packages/ui/src/components/pages/page-scoped-conversations.test.ts
@@ -1,0 +1,358 @@
+/**
+ * Unit coverage for page-scoped-conversations: browser intro-copy selection by
+ * Agent Browser Bridge state, page-scope tagging predicates, metadata/routing
+ * builders, and the reuse/update/create reconciliation decisions of
+ * resolve/reset against a mocked conversations API boundary.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Conversation } from "../../api/client-types-chat";
+import type { ConversationMetadata } from "../../api/client-types-core";
+
+vi.mock("../../api", () => ({
+  client: {
+    listConversations: vi.fn(),
+    createConversation: vi.fn(),
+    updateConversation: vi.fn(),
+    deleteConversation: vi.fn(),
+  },
+}));
+
+import { client } from "../../api";
+import {
+  buildPageScopedConversationMetadata,
+  buildPageScopedRoutingMetadata,
+  getBrowserPageScopeCopy,
+  isPageScopedConversation,
+  isPageScopedConversationMetadata,
+  PAGE_SCOPE_VERSION,
+  resetPageScopedConversation,
+  resolvePageScopedConversation,
+} from "./page-scoped-conversations";
+
+function makeConversation(overrides: Partial<Conversation> = {}): Conversation {
+  return {
+    id: "c1",
+    title: "Browser",
+    roomId: "r1",
+    createdAt: "2026-08-24T10:00:00Z",
+    updatedAt: "2026-08-24T10:00:00Z",
+    ...overrides,
+  };
+}
+
+const mocked = {
+  listConversations: vi.mocked(client.listConversations),
+  createConversation: vi.mocked(client.createConversation),
+  updateConversation: vi.mocked(client.updateConversation),
+  deleteConversation: vi.mocked(client.deleteConversation),
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe("isPageScopedConversation", () => {
+  it("rejects nullish conversations and missing metadata", () => {
+    expect(isPageScopedConversation(null)).toBe(false);
+    expect(isPageScopedConversation(undefined)).toBe(false);
+    expect(
+      isPageScopedConversation(makeConversation({ metadata: undefined })),
+    ).toBe(false);
+  });
+
+  it("accepts page- prefixed scopes and rejects bare scopes", () => {
+    expect(
+      isPageScopedConversation(
+        makeConversation({ metadata: { scope: "page-wallet" } }),
+      ),
+    ).toBe(true);
+    expect(
+      isPageScopedConversation(
+        makeConversation({ metadata: { scope: "general" } }),
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects non-string scopes at runtime", () => {
+    const hostile = makeConversation({
+      metadata: { scope: 42 } as unknown as ConversationMetadata,
+    });
+    expect(isPageScopedConversation(hostile)).toBe(false);
+  });
+});
+
+describe("isPageScopedConversationMetadata", () => {
+  it("mirrors the predicate for raw metadata", () => {
+    expect(isPageScopedConversationMetadata(null)).toBe(false);
+    expect(isPageScopedConversationMetadata(undefined)).toBe(false);
+    expect(isPageScopedConversationMetadata({ scope: "page-phone" })).toBe(
+      true,
+    );
+    expect(isPageScopedConversationMetadata({ scope: "general" })).toBe(false);
+  });
+});
+
+describe("buildPageScopedConversationMetadata", () => {
+  it("emits scope alone when no options are given", () => {
+    const metadata = buildPageScopedConversationMetadata("page-apps");
+    expect(metadata).toEqual({ scope: "page-apps" });
+    expect("pageId" in metadata).toBe(false);
+    expect("sourceConversationId" in metadata).toBe(false);
+  });
+
+  it("stamps pageId and sourceConversationId only when provided", () => {
+    const metadata = buildPageScopedConversationMetadata("page-browser", {
+      pageId: "p1",
+      sourceConversationId: "c9",
+    });
+    expect(metadata).toEqual({
+      scope: "page-browser",
+      pageId: "p1",
+      sourceConversationId: "c9",
+    });
+  });
+});
+
+describe("buildPageScopedRoutingMetadata", () => {
+  it("routes the browser scope with its context list and version stamp", () => {
+    const routing = buildPageScopedRoutingMetadata("page-browser");
+    expect(routing.taskId).toBe("page-browser");
+    expect(routing.surface).toBe("page-scoped");
+    expect(routing.surfaceVersion).toBe(PAGE_SCOPE_VERSION);
+    expect(routing.__responseContext).toEqual({
+      primaryContext: "browser",
+      secondaryContexts: ["page", "page-browser", "browser", "documents"],
+    });
+  });
+
+  it("routes other scopes through their own contexts", () => {
+    const routing = buildPageScopedRoutingMetadata("page-connectors");
+    expect(routing.__responseContext).toEqual({
+      primaryContext: "connectors",
+      secondaryContexts: [
+        "page",
+        "page-connectors",
+        "connectors",
+        "social_posting",
+      ],
+    });
+  });
+
+  it("adds pageId and sourceConversationId at the top level when provided", () => {
+    const routing = buildPageScopedRoutingMetadata("page-wallet", {
+      pageId: "p2",
+      sourceConversationId: "c3",
+    });
+    expect(routing.pageId).toBe("p2");
+    expect(routing.sourceConversationId).toBe("c3");
+    expect("pageId" in buildPageScopedRoutingMetadata("page-wallet")).toBe(
+      false,
+    );
+  });
+});
+
+describe("getBrowserPageScopeCopy", () => {
+  it("describes the connected bridge with fallback label Chrome", () => {
+    const copy = getBrowserPageScopeCopy({ browserBridgeConnected: true });
+    expect(copy.title).toBe("Browser chat");
+    expect(copy.body).toContain("Agent Browser Bridge is connected in Chrome.");
+  });
+
+  it("trims labels and joins browser / profile when both exist", () => {
+    const copy = getBrowserPageScopeCopy({
+      browserBridgeConnected: true,
+      browserLabel: "  Brave  ",
+      profileLabel: " Work ",
+    });
+    expect(copy.body).toContain("connected in Brave / Work.");
+    expect(copy.systemAddendum).toContain(
+      "Agent Browser Bridge is connected in Brave / Work.",
+    );
+  });
+
+  it("falls back to Chrome when the browser label is blank", () => {
+    const copy = getBrowserPageScopeCopy({
+      browserBridgeConnected: true,
+      browserLabel: "   ",
+      profileLabel: null,
+    });
+    expect(copy.body).toContain("connected in Chrome.");
+  });
+
+  it("uses the embedded-browser copy when install is unavailable", () => {
+    const copy = getBrowserPageScopeCopy({
+      browserBridgeConnected: false,
+      browserBridgeInstallAvailable: false,
+    });
+    expect(copy.body).toContain("embedded browser");
+    expect(copy.systemAddendum).toContain(
+      "Agent Browser Bridge is not available in this runtime",
+    );
+  });
+
+  it("asks to connect the extension in the default state", () => {
+    const copy = getBrowserPageScopeCopy({ browserBridgeConnected: false });
+    expect(copy.title).toBe("Connect your browser");
+    expect(copy.body).toContain("Install the Eliza Browser extension");
+  });
+});
+
+describe("resolvePageScopedConversation", () => {
+  it("returns the newest matching conversation untouched when title and metadata agree", async () => {
+    const older = makeConversation({
+      id: "old",
+      updatedAt: "2026-08-24T09:00:00Z",
+      metadata: { scope: "page-browser" },
+    });
+    const newer = makeConversation({
+      id: "new",
+      updatedAt: "2026-08-24T11:00:00Z",
+      metadata: { scope: "page-browser" },
+    });
+    const mismatch = makeConversation({
+      id: "other-scope",
+      updatedAt: "2026-08-24T12:00:00Z",
+      metadata: { scope: "general" },
+    });
+    mocked.listConversations.mockResolvedValue({
+      conversations: [mismatch, older, newer],
+    });
+
+    const result = await resolvePageScopedConversation({
+      scope: "page-browser",
+    });
+
+    expect(result).toBe(newer);
+    expect(mocked.updateConversation).not.toHaveBeenCalled();
+    expect(mocked.createConversation).not.toHaveBeenCalled();
+  });
+
+  it("updates the existing row when the title drifted", async () => {
+    const existing = makeConversation({
+      id: "drift",
+      title: "Old name",
+      metadata: { scope: "page-browser", pageId: "p1" },
+    });
+    mocked.listConversations.mockResolvedValue({ conversations: [existing] });
+    const updated = makeConversation({ id: "drift", title: "Browser" });
+    mocked.updateConversation.mockResolvedValue({ conversation: updated });
+
+    const result = await resolvePageScopedConversation({
+      scope: "page-browser",
+      pageId: "p1",
+    });
+
+    expect(result).toBe(updated);
+    expect(mocked.updateConversation).toHaveBeenCalledWith("drift", {
+      title: "Browser",
+      metadata: { scope: "page-browser", pageId: "p1" },
+    });
+    expect(mocked.createConversation).not.toHaveBeenCalled();
+  });
+
+  it("creates a conversation with the scope default title when none matches", async () => {
+    mocked.listConversations.mockResolvedValue({ conversations: [] });
+    const created = makeConversation({ id: "fresh" });
+    mocked.createConversation.mockResolvedValue({ conversation: created });
+
+    const result = await resolvePageScopedConversation({
+      scope: "page-settings",
+    });
+
+    expect(result).toBe(created);
+    expect(mocked.createConversation).toHaveBeenCalledWith("Settings", {
+      metadata: { scope: "page-settings" },
+    });
+    expect(mocked.updateConversation).not.toHaveBeenCalled();
+  });
+
+  it("trims the requested title and falls back to the default when blank", async () => {
+    mocked.listConversations.mockResolvedValue({ conversations: [] });
+    mocked.createConversation.mockResolvedValue({
+      conversation: makeConversation(),
+    });
+
+    await resolvePageScopedConversation({
+      scope: "page-browser",
+      title: "  My Chat  ",
+    });
+    expect(mocked.createConversation).toHaveBeenLastCalledWith("My Chat", {
+      metadata: { scope: "page-browser" },
+    });
+
+    await resolvePageScopedConversation({
+      scope: "page-browser",
+      title: "   ",
+    });
+    expect(mocked.createConversation).toHaveBeenLastCalledWith("Browser", {
+      metadata: { scope: "page-browser" },
+    });
+  });
+});
+
+describe("resetPageScopedConversation", () => {
+  it("deletes every matching conversation, then creates a fresh one", async () => {
+    mocked.listConversations.mockResolvedValue({
+      conversations: [
+        makeConversation({
+          id: "a",
+          metadata: { scope: "page-browser", pageId: "p1" },
+        }),
+        makeConversation({
+          id: "b",
+          metadata: { scope: "page-browser", pageId: "p1" },
+        }),
+        makeConversation({ id: "keep", metadata: { scope: "page-character" } }),
+        makeConversation({
+          id: "other-page",
+          metadata: { scope: "page-browser", pageId: "p2" },
+        }),
+      ],
+    });
+    const fresh = makeConversation({ id: "new-seed" });
+    mocked.createConversation.mockResolvedValue({ conversation: fresh });
+
+    const result = await resetPageScopedConversation({
+      scope: "page-browser",
+      pageId: "p1",
+    });
+
+    expect(result).toBe(fresh);
+    expect(mocked.deleteConversation).toHaveBeenCalledTimes(2);
+    expect(mocked.deleteConversation).toHaveBeenCalledWith("a");
+    expect(mocked.deleteConversation).toHaveBeenCalledWith("b");
+    expect(mocked.createConversation).toHaveBeenCalledWith("Browser", {
+      metadata: { scope: "page-browser", pageId: "p1" },
+    });
+  });
+
+  it("still creates a fresh conversation when a deletion fails", async () => {
+    mocked.listConversations.mockResolvedValue({
+      conversations: [
+        makeConversation({ id: "gone", metadata: { scope: "page-apps" } }),
+      ],
+    });
+    mocked.deleteConversation.mockRejectedValue(new Error("already deleting"));
+    const fresh = makeConversation({ id: "after-failure" });
+    mocked.createConversation.mockResolvedValue({ conversation: fresh });
+
+    const result = await resetPageScopedConversation({ scope: "page-apps" });
+
+    expect(result).toBe(fresh);
+    expect(mocked.createConversation).toHaveBeenCalled();
+  });
+
+  it("skips deletion entirely when nothing matches", async () => {
+    mocked.listConversations.mockResolvedValue({ conversations: [] });
+    mocked.createConversation.mockResolvedValue({
+      conversation: makeConversation({ id: "only" }),
+    });
+
+    await resetPageScopedConversation({ scope: "page-plugins" });
+
+    expect(mocked.deleteConversation).not.toHaveBeenCalled();
+    expect(mocked.createConversation).toHaveBeenCalledWith("Plugins", {
+      metadata: { scope: "page-plugins" },
+    });
+  });
+});


### PR DESCRIPTION

Adds a colocated unit suite for the page-scoped conversation model: `packages/ui/src/components/pages/page-scoped-conversations.test.ts` (new file, test-only diff).

Covered surface, driving the real module:

- `isPageScopedConversation` / `isPageScopedConversationMetadata`: nullish inputs, missing metadata, non-`page-` scopes, and a non-string `scope` at runtime.
- `buildPageScopedConversationMetadata` / `buildPageScopedRoutingMetadata`: scope-only emission, optional `pageId`/`sourceConversationId` stamping, per-scope routing contexts, and the `PAGE_SCOPE_VERSION` surface-version stamp.
- `getBrowserPageScopeCopy`: connected bridge (label fallback to Chrome, blank-label trim, browser/profile join), install-unavailable embedded-browser copy, and the default connect-the-extension branch.
- `resolvePageScopedConversation`: newest-match reuse without writes, title-drift update payload, create with scope default title, and title trimming/blank fallback.
- `resetPageScopedConversation`: delete-all-matching then recreate, resilience to a failing deletion (`Promise.allSettled` path), and zero-delete no-match case.

The API transport is mocked at the `client` boundary so reconciliation decisions can be asserted without network; every other collaborator is the real module.

Evidence at head `51617538d704126b0d308654ccaaff091e474a67` (current `origin/develop`):

- `bunx vitest run --config ./vitest.config.ts src/components/pages/page-scoped-conversations.test.ts` in `packages/ui`: Test Files 1 passed (1), Tests 21 passed (21).
- `bunx biome check src/components/pages/page-scoped-conversations.test.ts`: clean, no fixes applied.
- `bunx tsc --noEmit` in `packages/ui`: no diagnostics mention the new file.

This is a fork contribution, so hosted CI does not run on this PR; the counts above are from local runs of exactly this head. The diff touches only the new test file (+358/-0); no production behavior changes.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:7b91491d2f18e98013e1d4b3fa251de1745c9af1 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
