### PR TITLE
test(homepage): cover client

### DIFF
--- a/packages/homepage/tests/api-client.test.ts
+++ b/packages/homepage/tests/api-client.test.ts
@@ -184,4 +184,150 @@ describe("elizacloud API client", () => {
       "elizacloud API error 401: Unauthorized resource",
     );
   });
+
+  it("normalizes paths without a leading slash", async () => {
+    let observedUrl = "";
+
+    globalThis.fetch = (async (
+      input: RequestInfo | URL,
+      _init?: RequestInit,
+    ) => {
+      observedUrl = input.toString();
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    await elizacloudFetch("v1/no-slash");
+
+    expect(observedUrl).toBe("https://api.eliza.app/v1/no-slash");
+  });
+
+  it("keeps multiple params in insertion order", async () => {
+    let observedUrl = "";
+
+    globalThis.fetch = (async (
+      input: RequestInfo | URL,
+      _init?: RequestInit,
+    ) => {
+      observedUrl = input.toString();
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    await elizacloudFetch("/v1/items", {
+      params: { mode: "fast", page: "2" },
+    });
+
+    expect(observedUrl).toBe("https://api.eliza.app/v1/items?mode=fast&page=2");
+  });
+
+  it("honors VITE_ELIZACLOUD_API_URL and strips its trailing slash", () => {
+    const envWithClient = import.meta.env as unknown as {
+      VITE_ELIZACLOUD_API_URL?: string;
+    };
+    const originalEnvUrl = envWithClient.VITE_ELIZACLOUD_API_URL;
+
+    try {
+      envWithClient.VITE_ELIZACLOUD_API_URL = "https://staging.eliza.app/";
+      expect(getElizacloudUrl()).toBe("https://staging.eliza.app");
+    } finally {
+      if (originalEnvUrl === undefined) {
+        delete envWithClient.VITE_ELIZACLOUD_API_URL;
+      } else {
+        envWithClient.VITE_ELIZACLOUD_API_URL = originalEnvUrl;
+      }
+    }
+  });
+
+  it("returns the text body when a success response is not json", async () => {
+    globalThis.fetch = (async () => {
+      return new Response("plain-text-body", {
+        status: 200,
+        headers: { "Content-Type": "text/plain" },
+      });
+    }) as typeof fetch;
+
+    const res = await elizacloudFetch<string>("/v1/healthz");
+    expect(res).toBe("plain-text-body");
+  });
+
+  it("sends Content-Type application/json by default and lets caller headers win", async () => {
+    let observedHeaders: Record<string, string> = {};
+
+    globalThis.fetch = (async (
+      _input: RequestInfo | URL,
+      init?: RequestInit,
+    ) => {
+      observedHeaders = init?.headers as Record<string, string>;
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    await elizacloudFetch("/v1/upload", {
+      method: "POST",
+      headers: {
+        "Content-Type": "text/plain",
+        "X-Custom": "custom-value",
+      },
+    });
+
+    expect(observedHeaders["Content-Type"]).toBe("text/plain");
+    expect(observedHeaders["X-Custom"]).toBe("custom-value");
+  });
+
+  it("returns null token when window is undefined", () => {
+    delete (globalThis as unknown as { window?: Window }).window;
+
+    expect(getAuthToken()).toBeNull();
+  });
+
+  it("omits Authorization header when no session token exists", async () => {
+    let observedAuthHeader: string | undefined;
+
+    globalThis.fetch = (async (
+      _input: RequestInfo | URL,
+      init?: RequestInit,
+    ) => {
+      const headers = init?.headers as Record<string, string>;
+      observedAuthHeader = headers?.Authorization;
+      return new Response(JSON.stringify({ anonymous: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    const res = await elizacloudAuthFetch<{ anonymous: boolean }>("/v1/feed");
+
+    expect(res).toEqual({ anonymous: true });
+    expect(observedAuthHeader).toBeUndefined();
+  });
+
+  it("lets a caller Authorization header override the session Bearer token", async () => {
+    mockStorage.eliza_app_session = "session-token-abc";
+    let observedAuthHeader: string | undefined;
+
+    globalThis.fetch = (async (
+      _input: RequestInfo | URL,
+      init?: RequestInit,
+    ) => {
+      const headers = init?.headers as Record<string, string>;
+      observedAuthHeader = headers?.Authorization;
+      return new Response(JSON.stringify({ user: "bob" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    await elizacloudAuthFetch<{ user: string }>("/v1/me", {
+      headers: { Authorization: "Bearer caller-token-xyz" },
+    });
+
+    expect(observedAuthHeader).toBe("Bearer caller-token-xyz");
+  });
 });


### PR DESCRIPTION

## Summary

Extends the existing suite for `packages/homepage/src/lib/api/client.ts` (`tests/api-client.test.ts`) with eight new behavioural cases. Append-only: **+146/−0 on a single file**; every pre-existing case is untouched.

The module already had partial coverage; this PR fills the branches its suite did not reach:

- **Path normalization** — `elizacloudFetch("v1/no-slash")` resolves to `https://api.eliza.app/v1/no-slash`.
- **Query params order** — multiple `params` entries are serialized in insertion order (`?mode=fast&page=2`).
- **Base URL override** — `VITE_ELIZACLOUD_API_URL` is honored by `getElizacloudUrl()` and a trailing slash is stripped.
- **Non-JSON success responses** — a `text/plain` 200 response returns the raw text body instead of attempting JSON parsing.
- **Header merge precedence** — requests default to `Content-Type: application/json`, and caller-supplied headers win over the defaults.
- **`getAuthToken()` without a DOM** — returns `null` when `window` is undefined.
- **Anonymous auth fetch** — `elizacloudAuthFetch` sends no `Authorization` header when no session token exists.
- **Caller Authorization precedence** — an explicit caller `Authorization` header overrides the session Bearer token (headers spread order).

All expectations record behaviour observed by driving the real module through the package's own runner; nothing asserts aspirational behaviour.

## Verification

Fork contributor: hosted CI does not run on this PR. Local evidence, all quoted counts are real runs:

- **Tests** (owning runner, per `packages/homepage/package.json`): `bun --conditions=eliza-source test tests/api-client.test.ts` under bun 1.3.14 → **14 pass, 0 fail, 23 expect() calls across 1 file** (6 pre-existing + 8 new). Re-fetched and re-run against current `origin/develop` (`51617538d704`) immediately before filing.
- **Biome**: `bunx biome check --write packages/homepage/tests/api-client.test.ts` against the repository `biome.json` → checked, no fixes needed.
- **TypeScript**: `bunx tsc -b` in `packages/homepage` → 0 errors package-wide; the touched file appears nowhere in the output.
- **Diff shape**: one file, `packages/homepage/tests/api-client.test.ts`, +146 insertions, 0 deletions.

Test-only change: no production behaviour is modified.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:bee4e4ed2bc27d449ebbb242a39d5d9d1be955c5 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
