### PR TITLE
test(ui): cover view-event-types

### DIFF
--- a/packages/ui/src/views/view-event-types.test.ts
+++ b/packages/ui/src/views/view-event-types.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Covers the VIEW_EVENTS registry: every declared event name must be a
+ * distinct, non-empty wire string, and publishing through the real view event
+ * bus must route each constant to exactly its own subscriber (payload,
+ * source, ordering, and unsubscribe behaviour included).
+ *
+ * Harness: real pub-sub over the jsdom window transport — no mocks.
+ */
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  emitViewEvent,
+  onAnyViewEvent,
+  onViewEvent,
+  type ViewEvent,
+} from "./view-event-bus";
+import { VIEW_EVENTS } from "./view-event-types";
+
+const EVENT_NAMES = Object.values(VIEW_EVENTS);
+
+const cleanups: Array<() => void> = [];
+afterEach(() => {
+  for (const off of cleanups.splice(0)) off();
+});
+
+describe("VIEW_EVENTS registry", () => {
+  it("declares at least one event", () => {
+    expect(EVENT_NAMES.length).toBeGreaterThan(0);
+  });
+
+  it("maps every key to a non-empty string name", () => {
+    for (const [key, name] of Object.entries(VIEW_EVENTS)) {
+      expect(typeof name, `${key} must map to a string`).toBe("string");
+      expect(name.length, `${key} must not be empty`).toBeGreaterThan(0);
+    }
+  });
+
+  it("never reuses one event name for two keys", () => {
+    const seen = new Map<string, string>();
+    for (const [key, name] of Object.entries(VIEW_EVENTS)) {
+      const owner = seen.get(name);
+      expect(
+        owner,
+        `${key} reuses the event name "${name}" already owned by ${owner ?? "?"}`,
+      ).toBeUndefined();
+      seen.set(name, key);
+    }
+  });
+});
+
+describe("VIEW_EVENTS routed through the view event bus", () => {
+  it.each(Object.entries(VIEW_EVENTS))(
+    "%s delivers its published payload to its own subscriber",
+    (key, name) => {
+      const received: ViewEvent[] = [];
+      cleanups.push(
+        onViewEvent(name, (event) => {
+          received.push(event);
+        }),
+      );
+
+      const payload = { [key]: true, seq: 1 };
+      emitViewEvent(name, payload, "agent");
+
+      expect(received).toHaveLength(1);
+      const event = received[0];
+      expect(event.type).toBe(name);
+      expect(event.payload).toEqual(payload);
+      expect(event.sourceViewId).toBe("agent");
+      expect(typeof event.timestamp).toBe("number");
+      expect(event.timestamp).toBeGreaterThan(0);
+    },
+  );
+
+  it("does not deliver one event name to subscribers of a different name", () => {
+    const focused: string[] = [];
+    const blurred: string[] = [];
+    cleanups.push(
+      onViewEvent(VIEW_EVENTS.VIEW_FOCUSED, (event) => {
+        focused.push(event.type);
+      }),
+    );
+    cleanups.push(
+      onViewEvent(VIEW_EVENTS.VIEW_BLURRED, (event) => {
+        blurred.push(event.type);
+      }),
+    );
+
+    emitViewEvent(VIEW_EVENTS.AGENT_NAVIGATE, {});
+    expect(focused).toHaveLength(0);
+    expect(blurred).toHaveLength(0);
+
+    emitViewEvent(VIEW_EVENTS.VIEW_FOCUSED, {});
+    expect(focused).toEqual([VIEW_EVENTS.VIEW_FOCUSED]);
+    expect(blurred).toHaveLength(0);
+  });
+
+  it("shows an any-event observer every declared kind exactly once, in emission order", () => {
+    const observed: string[] = [];
+    cleanups.push(
+      onAnyViewEvent((event) => {
+        observed.push(event.type);
+      }),
+    );
+
+    for (const name of EVENT_NAMES) emitViewEvent(name, {});
+
+    expect(observed).toEqual(EVENT_NAMES);
+  });
+
+  it("stops delivering to a subscriber after it unsubscribes", () => {
+    const seen: string[] = [];
+    const off = onViewEvent(VIEW_EVENTS.SETTINGS_CHANGED, (event) => {
+      seen.push(event.type);
+    });
+    off();
+
+    emitViewEvent(VIEW_EVENTS.SETTINGS_CHANGED, {});
+    expect(seen).toHaveLength(0);
+  });
+});


### PR DESCRIPTION

Adds the first unit suite for `packages/ui/src/views/view-event-types.ts` â the VIEW_EVENTS registry consumed by the view event bus. New co-located file only (`view-event-types.test.ts`, +121/â0); no production behaviour is touched.

**What the suite covers**

- Registry integrity: every declared event name is a non-empty string, and no two keys share one wire name. TypeScript cannot enforce distinctness of the literal values, so an accidental copy-paste duplicate would silently cross-wire two logical events â this pins that invariant without restating any literal.
- Publisher/subscriber contract driven through the real bus (jsdom window transport, no mocks): each of the eight constants publishes to exactly its own subscriber with payload, `sourceViewId`, and timestamp intact.
- Routing isolation: emitting one event name never fires subscribers registered under a different name.
- An `onAnyViewEvent` observer sees every declared kind exactly once, in emission order.
- Unsubscribe stops delivery.

**Evidence (run locally at head 9496628fa2 against current develop)**

- `bunx vitest run src/views/view-event-types.test.ts` (packages/ui): **Test Files 1 passed (1), Tests 14 passed (14)**.
- `bunx biome check --write src/views/view-event-types.test.ts`: clean ("Checked 1 file... No fixes applied").
- `bunx tsc --noEmit` (packages/ui): zero diagnostics reference `view-event-types.test.ts`; pre-existing package errors elsewhere are untouched by this diff.

Note: we are a fork contributor, so hosted CI does not run on this pull request; the counts above are quoted from local runs at the pushed head.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:9496628fa2deb1aab6419b2aa34aa0f398f30224 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
