### PR TITLE
test(ui): cover api JSON response helpers

### DIFF
--- a/packages/ui/src/api/response.test.ts
+++ b/packages/ui/src/api/response.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Unit coverage for the shared HTTP JSON response helpers in
+ * packages/ui/src/api/response.ts: status/content-type framing, the
+ * stack-field scrub applied before serialization, Error-instance shaping,
+ * and the headers-sent no-op guard. The node ServerResponse is a minimal
+ * recorded double; the serialization and scrubbing under test are the real
+ * module logic.
+ */
+import type http from "node:http";
+import { describe, expect, it } from "vitest";
+import { sendJson, sendJsonError } from "./response";
+
+function makeRes() {
+  const recorded: {
+    headers: Record<string, string>;
+    ended: boolean;
+    bodies: string[];
+  } = {
+    headers: {},
+    ended: false,
+    bodies: [],
+  };
+  let headersSent = false;
+  const res = {
+    get headersSent() {
+      return headersSent;
+    },
+    statusCode: 200,
+    setHeader(name: string, value: string) {
+      recorded.headers[name] = value;
+    },
+    end(body?: string) {
+      recorded.ended = true;
+      if (body !== undefined) recorded.bodies.push(body);
+    },
+  };
+  return {
+    res: res as unknown as http.ServerResponse,
+    markHeadersSent() {
+      headersSent = true;
+    },
+    status(): number {
+      return (res as unknown as { statusCode: number }).statusCode;
+    },
+    recorded,
+    lastBody(): Record<string, unknown> {
+      expect(recorded.bodies).toHaveLength(1);
+      return JSON.parse(recorded.bodies[0]) as Record<string, unknown>;
+    },
+  };
+}
+
+describe("sendJson", () => {
+  it("writes the status code, JSON content type, and serialized body", () => {
+    const { res, recorded, lastBody, status } = makeRes();
+    sendJson(res, 201, { ok: true });
+    expect(status()).toBe(201);
+    expect(recorded.headers["content-type"]).toBe(
+      "application/json; charset=utf-8",
+    );
+    expect(lastBody()).toEqual({ ok: true });
+  });
+
+  it("strips stack and stackTrace fields at every depth", () => {
+    const { res, lastBody } = makeRes();
+    sendJson(res, 500, {
+      message: "boom",
+      stack: "Error: boom\n    at top",
+      detail: { stackTrace: "frames", keep: 1 },
+      list: [{ stack: "inner" }],
+    });
+    const body = lastBody();
+    expect(body.message).toBe("boom");
+    expect(body.stack).toBeUndefined();
+    const detail = body.detail as Record<string, unknown>;
+    expect(detail.stackTrace).toBeUndefined();
+    expect(detail.keep).toBe(1);
+    const listItem = (body.list as Array<Record<string, unknown>>)[0];
+    expect(listItem.stack).toBeUndefined();
+  });
+
+  it("shapes top-level Error instances into { error: message }", () => {
+    const { res, lastBody } = makeRes();
+    sendJson(res, 500, new Error("kaboom"));
+    expect(lastBody()).toEqual({ error: "kaboom" });
+  });
+
+  it("falls back to a generic message for empty-error instances", () => {
+    const { res, lastBody } = makeRes();
+    sendJson(res, 500, new Error(""));
+    expect(lastBody()).toEqual({ error: "Internal error" });
+  });
+
+  it("scrubs Error instances nested inside arrays and objects", () => {
+    const { res, lastBody } = makeRes();
+    sendJson(res, 200, [new Error("first"), { nested: new Error("second") }]);
+    const body = lastBody();
+    expect(body[0]).toEqual({ error: "first" });
+    expect((body[1] as Record<string, unknown>).nested).toEqual({
+      error: "second",
+    });
+  });
+
+  it("is a no-op when headers were already sent", () => {
+    const { res, recorded, markHeadersSent } = makeRes();
+    markHeadersSent();
+    sendJson(res, 500, { secret: "should not write" });
+    expect(recorded.bodies).toHaveLength(0);
+    expect(recorded.ended).toBe(false);
+    expect(Object.keys(recorded.headers)).toHaveLength(0);
+  });
+});
+
+describe("sendJsonError", () => {
+  it("wraps the message into an { error } JSON payload", () => {
+    const { res, recorded, lastBody, status } = makeRes();
+    sendJsonError(res, 404, "not found");
+    expect(status()).toBe(404);
+    expect(recorded.headers["content-type"]).toBe(
+      "application/json; charset=utf-8",
+    );
+    expect(lastBody()).toEqual({ error: "not found" });
+  });
+
+  it("stays silent after headers were sent", () => {
+    const { res, recorded, markHeadersSent } = makeRes();
+    markHeadersSent();
+    sendJsonError(res, 400, "late failure");
+    expect(recorded.bodies).toHaveLength(0);
+    expect(recorded.ended).toBe(false);
+  });
+});


### PR DESCRIPTION

Adds a unit suite for `packages/ui/src/api/response.ts` — the shared JSON response helpers used by the app's local API surfaces (`sendJson`, `sendJsonError`).

Coverage drives the real module logic through a minimal recorded `http.ServerResponse` double:

- status code + `application/json; charset=utf-8` framing and body serialization
- the stack-field scrub: `stack` / `stackTrace` keys removed at every nesting depth while sibling fields survive
- `Error` instances shaped into `{ error: message }`, including the empty-message fallback to `"Internal error"`
- Errors nested inside arrays and objects scrubbed identically
- the `headersSent` no-op guard for both helpers

Test-only change: the diff is one new file (+132/−0); no production code is touched.

Evidence:

- `bunx vitest run src/api/response.test.ts` (packages/ui): 1 file passed, 8 tests passed (re-run against current origin/develop immediately before filing)
- `bunx biome check packages/ui/src/api/response.test.ts`: clean, no fixes applied
- `bunx tsc --noEmit` (packages/ui): the new test file appears nowhere in the output

Note: this PR comes from a fork contributor, so hosted CI does not run on it; the counts above are from local runs at head `c9fed7b60c`.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:c9fed7b60ccf0684c5d8adccfd93d1b68681cf14 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
