### PR TITLE
test(homepage): cover contact

### DIFF
--- a/packages/homepage/tests/contact.test.ts
+++ b/packages/homepage/tests/contact.test.ts
@@ -150,3 +150,70 @@ describe("Eliza contact links", () => {
     ).rejects.toThrow("Clipboard access is unavailable");
   });
 });
+
+describe("Eliza contact edge behaviour", () => {
+  test("falls back to the default WhatsApp sender outside production when config is absent or invalid", () => {
+    expect(resolveWhatsAppNumber(undefined, false)).toBe("+14159611510");
+    expect(resolveWhatsAppNumber("not-a-phone", false)).toBe("+14159611510");
+    expect(resolveWhatsAppNumber("+15551234567", false)).toBe("+15551234567");
+  });
+
+  test("normalizes configured E.164 senders with strict digit boundaries", () => {
+    expect(resolveWhatsAppNumber("  +15551234567  ", true)).toBe(
+      "+15551234567",
+    );
+    expect(resolveWhatsAppNumber("+12345678", true)).toBe("+12345678");
+    expect(resolveWhatsAppNumber("+1234567", true)).toBeNull();
+    expect(resolveWhatsAppNumber("+02345678", true)).toBeNull();
+    expect(resolveWhatsAppNumber("+123456789012345", true)).toBe(
+      "+123456789012345",
+    );
+    expect(resolveWhatsAppNumber("+1234567890123456", true)).toBeNull();
+  });
+
+  test("prefers userAgentData.platform and falls back to the userAgent string for native links", () => {
+    expect(
+      canOpenElizaSmsLink({
+        platform: "Win32",
+        userAgentData: { platform: "iPad" },
+      }),
+    ).toBe(true);
+    expect(
+      canOpenElizaSmsLink({
+        platform: "iPad",
+        userAgentData: { platform: "Windows" },
+      }),
+    ).toBe(false);
+    expect(
+      canOpenElizaSmsLink({
+        platform: "",
+        userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
+      }),
+    ).toBe(true);
+    expect(canOpenElizaSmsLink({ platform: "", userAgent: "iPod touch" })).toBe(
+      true,
+    );
+    expect(canOpenElizaSmsLink({ platform: "", userAgent: "" })).toBe(false);
+  });
+
+  test("hands off custom SMS messages through a lossless percent-encoded href", async () => {
+    const message = "call me & stay weird 🤖 100%";
+    const location = { href: "https://eliza.app/" };
+    await expect(
+      openOrCopyElizaMessage(
+        { location, navigator: { platform: "MacIntel" } },
+        message,
+      ),
+    ).resolves.toBe("handoff");
+    expect(location.href).toBe(buildElizaSmsHref(message));
+    const encoded = location.href.split("&body=")[1];
+    expect(encoded).toBeDefined();
+    expect(decodeURIComponent(encoded ?? "")).toBe(message);
+  });
+
+  test("percent-encodes URL-significant characters in SMS bodies", () => {
+    expect(buildElizaSmsHref("a&b=c d?e#f/g:h")).toBe(
+      "sms:+18087881821?&body=a%26b%3Dc%20d%3Fe%23f%2Fg%3Ah",
+    );
+  });
+});


### PR DESCRIPTION

## Summary

Adds unit test coverage for `packages/homepage/src/lib/contact.ts` by extending the existing suite at `packages/homepage/tests/contact.test.ts`. This is a test-only change: **+67 lines in one test file, zero deletions, no production behavior touched.**

The module already had a suite pinning its happy paths; this PR appends five new cases covering branches that had no coverage:

- `resolveWhatsAppNumber` non-production fallback: absent or invalid config resolves to the default `+14159611510` sender outside production, while a valid configured value is kept.
- `resolveWhatsAppNumber` E.164 normalization boundaries through the public API: surrounding whitespace is trimmed, 8 digits minimum accepted, 7 digits rejected, leading zero rejected, 15 digits maximum accepted, 16 digits rejected.
- `canOpenElizaSmsLink` platform detection precedence: `userAgentData.platform` wins over `platform`, and the `userAgent` string is consulted when neither yields a known platform (`Macintosh` and `iPod` match; empty navigator does not).
- `openOrCopyElizaMessage` custom-message handoff: the composed SMS href carries the caller's message percent-encoded, and `decodeURIComponent` round-trips it losslessly.
- `buildElizaSmsHref` percent-encodes URL-significant characters (`&`, `=`, `?`, `#`, `/`, `:`) so they cannot break the `sms:` URI.

Every expectation records observed behavior of the current module; nothing aspirational was smuggled into the test-only diff.

## Evidence (fork PR: hosted CI does not run on this repository's fork PRs; local counts below)

- Runner check: this package's unit lane is owned by **bun test** (`packages/homepage/package.json` `test` script), so counts are quoted from that runner, not vitest.
- `bun --conditions=eliza-source test tests/contact.test.ts` (bun test v1.3.14) against current `origin/develop` (`51617538d704126b0d308654ccaaff091e474a67`): **13 passed / 0 failed, 56 expect() calls** (8 pre-existing cases untouched + 5 added).
- Tooling sanity: checkout is not sparse; root `biome.json` and `tsconfig.json` exist, so checks ran with real config.
- `bunx biome check tests/contact.test.ts`: clean, no fixes needed.
- `bunx tsc --noEmit -p tsconfig.app.json` in `packages/homepage`: zero errors; the new test file appears nowhere in the output.
- Diff scope: exactly one file, `packages/homepage/tests/contact.test.ts`, +67/-0 — purely additive, no existing case modified or removed.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:335b8b5b5c390988d8355f9241b5668c978f5c03 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
