### PR TITLE
fix(ui): alias cloud-sdk browser-contracts so UI tests resolve without a build

### DIFF
--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -209,6 +209,13 @@ export default defineConfig({
         ),
       },
       {
+        find: /^@elizaos\/cloud-sdk\/browser-contracts$/,
+        replacement: resolve(
+          monorepoRoot,
+          "packages/cloud/sdk/src/browser-contracts/index.ts",
+        ),
+      },
+      {
         find: /^@elizaos\/cloud-sdk\/cloud-setup-session$/,
         replacement: resolve(
           monorepoRoot,


### PR DESCRIPTION
# Relates to

No existing issue — found while reviewing [#27801](https://github.com/elizaOS/eliza/pull/27801), whose new suite failed to transform in my checkout for a reason that had nothing to do with that PR.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Based on current `origin/develop` at `51617538d7`; zero conflicts. Exact head `f79df8390d11aac5255e31d0bdfa4bcf0dec75d2`.

# Risks

Very low. Seven lines adding one `resolve.alias` entry to the UI test config, following the shape of the two `@elizaos/cloud-sdk` entries directly above it. No production code, no runtime behavior, no other config key touched. The alias only widens what resolves — a suite that passed before still resolves the same module, now from source instead of `dist`.

# Background

## What does this PR do?

`packages/ui/vitest.config.ts` maps `@elizaos/cloud-sdk` subpaths to their sources so the UI lane resolves them where the SDK's `dist/` has not been built. Two entries exist today:

```ts
{ find: /^@elizaos\/cloud-sdk\/redemption-contract$/,   replacement: resolve(monorepoRoot, "packages/cloud/sdk/src/redemption-contract.ts") },
{ find: /^@elizaos\/cloud-sdk\/cloud-setup-session$/,   replacement: resolve(monorepoRoot, "packages/cloud/sdk/src/cloud-setup-session/index.ts") },
```

The surrounding aliases state the rationale outright — workspace packages "built to `dist/` only … alias to stubs so the import resolves in CI where their `dist/` isn't built."

`browser-contracts` never got an entry, and **eight** UI sources import it:

```
src/cloud/mcps/McpEditorDialog.tsx
src/cloud/applications/components/app-analytics.tsx
src/cloud/instances/AgentDetailPage.tsx
src/cloud/instances/components/agent-card.tsx
src/cloud/instances/components/agent-actions.tsx
src/cloud/instances/components/eliza-agent-pricing-banner.tsx
src/cloud/instances/components/agent-cost-badge.tsx
src/cloud/instances/components/eliza-agents-table.tsx
```

Its export map points at `./dist/browser-contracts/index.js`, so with no built SDK every suite that reaches one of those modules dies during transform:

```
Error: Failed to resolve import "@elizaos/cloud-sdk/browser-contracts"
  from "src/cloud/applications/components/app-analytics.tsx". Does the file exist?
```

That is not hypothetical for CI: the **Client Tests** job runs `bun install --frozen-lockfile`, then `build:views`, then `test:client`. Nothing in that path builds `packages/cloud/sdk`, and the package has no `prepare`/`postinstall` hook, so the lane's ability to transform these components rests on an artifact it never produces. Adding the matching alias makes the lane build-independent, which is what the neighbouring entries already do for their subpaths.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

Remove `packages/cloud/sdk/dist`, then run `packages/ui`'s `src/cloud/applications/components/app-analytics.test.tsx` with and without this alias. That existing suite is the smallest reproduction.

## Detailed testing steps

1. Check out exact head `f79df8390d11aac5255e31d0bdfa4bcf0dec75d2`, and ensure `packages/cloud/sdk/dist` does not exist (that is the state a fresh `bun install` leaves).
2. From `packages/ui`, `bun x vitest run src/cloud/applications/components/app-analytics.test.tsx` → **1/1**. On `origin/develop` with the same empty `dist`, the identical command fails during transform with the `Failed to resolve import` above and runs **0** tests.
3. Whole-directory comparison, same empty `dist`, 200 test files under `src/cloud`:
   - `origin/develop`: **36 failed / 164 passed**
   - this head: **26 failed / 174 passed**

   Ten test files stop failing; none regress.
4. Pinned Biome on the changed file: exit 0, captured directly.

<!-- evidence-head:f79df8390d11aac5255e31d0bdfa4bcf0dec75d2 -->

## Evidence

<!-- evidence-row:before-screenshots -->
- Before screenshots: N/A — test-resolution configuration with no UI surface.
<!-- evidence-row:after-screenshots -->
- After screenshots: N/A — test-resolution configuration with no UI surface.
<!-- evidence-row:walkthrough-video -->
- Walkthrough video: N/A — the before/after runs below are the proof.
<!-- evidence-row:backend-logs -->
- Backend logs:

<details><summary>develop vs this head with the SDK dist removed — vitest output</summary>

```
# origin/develop 51617538d7 — packages/ui, packages/cloud/sdk/dist absent
$ bun x vitest run src/cloud/applications/components/app-analytics.test.tsx
Error: Failed to resolve import "@elizaos/cloud-sdk/browser-contracts"
  from "src/cloud/applications/components/app-analytics.tsx". Does the file exist?
 Test Files  1 failed (1)
      Tests  no tests

# head f79df8390d — same command, same empty dist
 Test Files  1 passed (1)
      Tests  1 passed (1)

# whole directory, 200 files, same empty dist
# origin/develop
 Test Files  36 failed | 164 passed (200)
# head
 Test Files  26 failed | 174 passed (200)
```

</details>

<!-- evidence-row:frontend-logs -->
- Frontend console/network logs: N/A — no application code changed; this is test-runner resolution only.
<!-- evidence-row:llm-trajectory -->
- Live-model trajectory: N/A — deterministic module resolution, no agent path.
<!-- evidence-row:domain-artifacts -->
- Domain artifacts:

<details><summary>Static gates and the CI path that skips the build</summary>

```
$ node_modules/.bin/biome check packages/ui/vitest.config.ts
Checked 1 file. No fixes applied.        (exit 0, captured directly)

$ git diff --stat origin/develop..HEAD
 packages/ui/vitest.config.ts | 7 +++++++
 1 file changed, 7 insertions(+)

Client Tests job (.github/workflows/test.yml), in order:
  bun install --frozen-lockfile   (setup-bun-workspace)
  bun run build:views
  bun run test:client
-> packages/cloud/sdk is never built; its package.json has no prepare or
   postinstall hook, so dist/browser-contracts/index.js is not produced.

$ grep -rln "@elizaos/cloud-sdk/browser-contracts" packages/ui/src | wc -l
8
```

</details>

<!-- evidence-row:ocr-review -->
- OCR review: N/A — no captured imagery.

# Known gaps / failures

- `bun run verify` (repo-wide) was not run: hand-wired review worktree (packages linked from the main checkout) cannot support the full gate honestly; the focused before/after comparison and Biome above stand in.
- The 26 files still failing in step 3 fail for reasons unrelated to this change and fail identically on `origin/develop` — chiefly `@elizaos/capacitor-secure-store`, a native dependency my worktree does not install. I did not touch that; it needs a real environment to judge, and it is a separate question from this alias.

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: Claude Code
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Attribution status: self-reported
— [nxn-claude-code]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"Claude Code","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza"} -->
