### PR TITLE
test(shared): cover boot-config-store

### DIFF
--- a/packages/shared/src/config/boot-config-store.test.ts
+++ b/packages/shared/src/config/boot-config-store.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Unit coverage for the shared boot-config store (global-slot write-once
+ * semantics and the window-mirror pre-boot seed) and the pure character-catalog
+ * resolver. Deterministic, no network; the process-global slot is captured in
+ * beforeEach and restored in afterEach so no state leaks between cases.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  type AppBootConfig,
+  type CharacterCatalogData,
+  DEFAULT_BOOT_CONFIG,
+  getBootConfig,
+  resolveCharacterCatalog,
+  setBootConfig,
+} from "./boot-config-store.ts";
+
+// The symbol-string keys are the cross-bundle contract shared by the core,
+// shared, and ui copies of this store, so tests address them directly.
+const STORE_KEY = Symbol.for("elizaos.app.boot-config");
+const WINDOW_KEY = "__ELIZAOS_APP_BOOT_CONFIG__";
+
+const globals = globalThis as Record<PropertyKey, unknown>;
+
+let priorStore: unknown;
+let priorWindow: unknown;
+let hadStore = false;
+let hadWindow = false;
+
+beforeEach(() => {
+  hadStore = STORE_KEY in globals;
+  hadWindow = WINDOW_KEY in globals;
+  priorStore = globals[STORE_KEY];
+  priorWindow = globals[WINDOW_KEY];
+  delete globals[STORE_KEY];
+  delete globals[WINDOW_KEY];
+});
+
+afterEach(() => {
+  if (hadStore) {
+    globals[STORE_KEY] = priorStore;
+  } else {
+    delete globals[STORE_KEY];
+  }
+  if (hadWindow) {
+    globals[WINDOW_KEY] = priorWindow;
+  } else {
+    delete globals[WINDOW_KEY];
+  }
+});
+
+function bootConfig(overrides: Partial<AppBootConfig> = {}): AppBootConfig {
+  return { ...structuredClone(DEFAULT_BOOT_CONFIG), ...overrides };
+}
+
+function catalog(
+  overrides: Partial<CharacterCatalogData> = {},
+): CharacterCatalogData {
+  return {
+    assets: [
+      { id: 1, slug: "nova", title: "Nova", sourceName: "nova_v2" },
+      { id: 2, slug: "orion", title: "Orion", sourceName: "orion_v1" },
+    ],
+    injectedCharacters: [
+      {
+        catchphrase: "gm",
+        name: "Morning Bot",
+        avatarAssetId: 2,
+        voicePresetId: "warm",
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe("getBootConfig", () => {
+  it("seeds defaults when neither a store nor a window mirror exists", () => {
+    expect(getBootConfig()).toEqual(DEFAULT_BOOT_CONFIG);
+    // Seeding publishes the store and mirrors its current value into the
+    // window key so a later bootstrap bundle reads the same object.
+    expect(globals[WINDOW_KEY]).toBe(getBootConfig());
+  });
+
+  it("seeds from a pre-boot window mirror before creating the store", () => {
+    const mirrored = bootConfig({ apiBase: "https://mirror.example" });
+    globals[WINDOW_KEY] = mirrored;
+    expect(getBootConfig()).toBe(mirrored);
+  });
+
+  it("lets an established store win over a stale window mirror", () => {
+    const established = bootConfig({ cloudApiBase: "https://store.example" });
+    const stale = bootConfig({ cloudApiBase: "https://stale.example" });
+    globals[STORE_KEY] = { current: established };
+    globals[WINDOW_KEY] = stale;
+    expect(getBootConfig()).toBe(established);
+    // The write-once rule means the mirror is never rewritten by readers.
+    expect(globals[WINDOW_KEY]).toBe(stale);
+  });
+
+  it("treats a malformed store slot as absent and re-seeds", () => {
+    const mirrored = bootConfig({ assetBaseUrl: "/assets/" });
+    globals[STORE_KEY] = 42;
+    globals[WINDOW_KEY] = mirrored;
+    expect(getBootConfig()).toBe(mirrored);
+  });
+});
+
+describe("setBootConfig", () => {
+  it("replaces the current config and refreshes the window mirror", () => {
+    const first = bootConfig({ apiBase: "https://first.example" });
+    setBootConfig(first);
+    expect(getBootConfig()).toBe(first);
+    expect(globals[WINDOW_KEY]).toBe(first);
+
+    const second = bootConfig({ apiBase: "https://second.example" });
+    setBootConfig(second);
+    expect(getBootConfig()).toBe(second);
+    expect(globals[WINDOW_KEY]).toBe(second);
+  });
+});
+
+describe("resolveCharacterCatalog", () => {
+  it("derives canonical VRM asset paths from slug and source name", () => {
+    const resolved = resolveCharacterCatalog(catalog());
+    expect(resolved.assets[0]).toEqual({
+      id: 1,
+      slug: "nova",
+      title: "Nova",
+      sourceName: "nova_v2",
+      compressedVrmPath: "vrms/nova.vrm.gz",
+      rawVrmPath: "vrms/nova.vrm",
+      previewPath: "vrms/previews/nova.png",
+      backgroundPath: "vrms/backgrounds/nova.png",
+      sourceVrmFilename: "nova_v2.vrm",
+    });
+  });
+
+  it("counts assets and picks the first as the default", () => {
+    const resolved = resolveCharacterCatalog(catalog());
+    expect(resolved.assetCount).toBe(2);
+    expect(resolved.defaultAsset?.slug).toBe("nova");
+    // Unknown ids fall back to the default asset.
+    expect(resolved.getAsset(999)?.slug).toBe("nova");
+  });
+
+  it("resolves an empty catalog to zero assets and a null default", () => {
+    const resolved = resolveCharacterCatalog({
+      assets: [],
+      injectedCharacters: [],
+    });
+    expect(resolved.assetCount).toBe(0);
+    expect(resolved.defaultAsset).toBeNull();
+    expect(resolved.injectedCharacterCount).toBe(0);
+    expect(resolved.getAsset(1)).toBeNull();
+  });
+
+  it("links each injected character to its avatar asset by id", () => {
+    const resolved = resolveCharacterCatalog(catalog());
+    expect(resolved.injectedCharacterCount).toBe(1);
+    const character = resolved.getInjectedCharacter("gm");
+    expect(character?.name).toBe("Morning Bot");
+    expect(character?.avatarAsset.slug).toBe("orion");
+    expect(character?.voicePresetId).toBe("warm");
+  });
+
+  it("falls back to the default asset when an injected id is unknown", () => {
+    const resolved = resolveCharacterCatalog(
+      catalog({
+        injectedCharacters: [
+          { catchphrase: "hi", name: "Lost Bot", avatarAssetId: 99 },
+        ],
+      }),
+    );
+    expect(resolved.injectedCharacters[0]?.avatarAsset.slug).toBe("nova");
+  });
+
+  it("throws when an injected character has no asset and no default exists", () => {
+    expect(() =>
+      resolveCharacterCatalog(
+        catalog({
+          assets: [],
+          injectedCharacters: [
+            { catchphrase: "hi", name: "Ghost", avatarAssetId: 99 },
+          ],
+        }),
+      ),
+    ).toThrowError(/Missing avatar asset 99 for Ghost\./);
+  });
+
+  it("resolves lookups by catchphrase, with the last duplicate winning", () => {
+    const resolved = resolveCharacterCatalog(
+      catalog({
+        injectedCharacters: [
+          { catchphrase: "gm", name: "First", avatarAssetId: 1 },
+          { catchphrase: "gm", name: "Second", avatarAssetId: 2 },
+          { catchphrase: "gn", name: "Night", avatarAssetId: 1 },
+        ],
+      }),
+    );
+    expect(resolved.getInjectedCharacter("gm")?.name).toBe("Second");
+    expect(resolved.getInjectedCharacter("gn")?.name).toBe("Night");
+    expect(resolved.getInjectedCharacter("unknown")).toBeNull();
+  });
+});


### PR DESCRIPTION

Adds a dedicated unit suite for `packages/shared/src/config/boot-config-store.ts`, which previously had no coverage anywhere in the repo (the same-named `packages/ui` module is a separate React-context file with its own suite; this is the store-only shared runtime entry).

What is covered, driving the real module with no mocks:

- `getBootConfig`: seeds `DEFAULT_BOOT_CONFIG` when no state exists; adopts a pre-boot window-mirror config before creating the store; an established store wins over a stale mirror and readers never rewrite the write-once window key; a malformed (non-object) store slot is treated as absent.
- `setBootConfig`: replaces `current` and refreshes the window mirror on every call.
- `resolveCharacterCatalog`: canonical VRM path derivation (`vrms/<slug>.vrm.gz`, raw, preview, background, source filename); asset count and first-asset default; empty catalog resolves to zero assets and a null default; injected characters link by avatar id, fall back to the default asset on unknown ids, and throw `Missing avatar asset <id> for <name>.` when neither exists; catchphrase lookups miss to null with last-duplicate-wins.

The process-global slot (`Symbol.for("elizaos.app.boot-config")` and `__ELIZAOS_APP_BOOT_CONFIG__`) is captured in `beforeEach` and restored in `afterEach`, so cases are isolated and leak nothing into other suites.

Evidence (test-only change, no production behaviour touched):

- `bunx vitest run src/config/boot-config-store.test.ts` (packages/shared): **Test Files 1 passed (1), Tests 12 passed (12)** — re-run against current `origin/develop` immediately before filing; the module and its imports are byte-identical between my base and current develop.
- `bunx biome check packages/shared/src/config/boot-config-store.test.ts`: clean ("No fixes applied") after one formatting pass.
- `bunx tsc --noEmit -p tsconfig.json` in `packages/shared`: the new test file appears nowhere in output (zero errors introduced by this diff).

Note: we are a fork contributor, so hosted CI does not run on this pull request; the local runs above are the verification record. The diff adds exactly one new test file (+N/-0).

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:967cb11f92450e47d4587cac1fbbb9116590bb96 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
