### PR TITLE
test(homepage): cover legacy-onboarding-redirect

### DIFF
--- a/packages/homepage/tests/legacy-onboarding-redirect.test.ts
+++ b/packages/homepage/tests/legacy-onboarding-redirect.test.ts
@@ -49,3 +49,97 @@ describe("legacy onboarding redirect", () => {
     ).toBeNull();
   });
 });
+
+describe("legacy onboarding redirect host matching", () => {
+  test("matches allowlisted production hosts case-insensitively", () => {
+    expect(
+      getLegacyOnboardingRedirect({
+        hostname: "ELIZA.APP",
+        pathname: "/get-started",
+        search: "?onboardingSession=session-123",
+        hash: "",
+      }),
+    ).toBe("https://cloud.eliza.app/get-started?onboardingSession=session-123");
+    expect(
+      getLegacyOnboardingRedirect({
+        hostname: "Www.Eliza.App",
+        pathname: "/get-started",
+        search: "?onboardingSession=session-123",
+        hash: "#top",
+      }),
+    ).toBe(
+      "https://cloud.eliza.app/get-started?onboardingSession=session-123#top",
+    );
+  });
+
+  test("rejects lookalike hosts that merely contain eliza.app", () => {
+    expect(
+      getLegacyOnboardingRedirect({
+        hostname: "eliza.app.evil.com",
+        pathname: "/get-started",
+        search: "?onboardingSession=session-123",
+        hash: "",
+      }),
+    ).toBeNull();
+    expect(
+      getLegacyOnboardingRedirect({
+        hostname: "noteliza.app",
+        pathname: "/get-started",
+        search: "?onboardingSession=session-123",
+        hash: "",
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("legacy onboarding redirect continuation gates", () => {
+  test("redirects only the exact /get-started pathname", () => {
+    expect(
+      getLegacyOnboardingRedirect({
+        hostname: "eliza.app",
+        pathname: "/get-started/",
+        search: "?onboardingSession=session-123",
+        hash: "",
+      }),
+    ).toBeNull();
+    expect(
+      getLegacyOnboardingRedirect({
+        hostname: "eliza.app",
+        pathname: "/Get-Started",
+        search: "?onboardingSession=session-123",
+        hash: "",
+      }),
+    ).toBeNull();
+    expect(
+      getLegacyOnboardingRedirect({
+        hostname: "eliza.app",
+        pathname: "/",
+        search: "?onboardingSession=session-123",
+        hash: "",
+      }),
+    ).toBeNull();
+  });
+
+  test("treats an empty onboardingSession value as still present", () => {
+    expect(
+      getLegacyOnboardingRedirect({
+        hostname: "eliza.app",
+        pathname: "/get-started",
+        search: "?onboardingSession=",
+        hash: "",
+      }),
+    ).toBe("https://cloud.eliza.app/get-started?onboardingSession=");
+  });
+
+  test("finds onboardingSession wherever it appears among the query parameters", () => {
+    const search = "?source=imessage&onboardingSession=session-9&app=memory";
+    expect(
+      getLegacyOnboardingRedirect({
+        hostname: "eliza.app",
+        pathname: "/get-started",
+        search,
+        hash: "",
+      }),
+    ).toBe(`https://cloud.eliza.app/get-started${search}`);
+  });
+});


### PR DESCRIPTION

## What

Adds five test cases to the existing suite for `getLegacyOnboardingRedirect` in `packages/homepage/src/lib/legacy-onboarding-redirect.ts`, covering branches the current develop suite does not exercise:

- **Case-insensitive host matching** — `ELIZA.APP` and `Www.Eliza.App` still redirect (the allowlist lowercases incoming hostnames).
- **Lookalike-host rejection** — `eliza.app.evil.com` and `noteliza.app` return `null` even with a valid path and session param (exact Set membership, not substring matching).
- **Exact pathname gate** — `/get-started/` (trailing slash), `/Get-Started` (case variant), and `/` all return `null`; only the exact `/get-started` pathname redirects.
- **Empty-valued session parameter** — `?onboardingSession=` is treated as present and redirects.
- **Parameter position independence** — `onboardingSession` is found wherever it appears among query parameters, with the search string preserved verbatim.

The diff is strictly additive: **+94 / −0**, one file. The three existing cases are byte-for-byte untouched.

## Why additive

A coverage snapshot listed this module as untested, but current origin/develop already carries a 3-case suite (landed via #26295). Per repository policy this PR only appends cases; it rewrites or deletes nothing.

## Verification (quoted from local runs at this head)

Owning runner: this package's unit lane runs under `bun test` (`packages/homepage/package.json` → `"test": "bun --conditions=eliza-source test …"`); these suites import from `bun:test`.

```
bun --conditions=eliza-source test tests/legacy-onboarding-redirect.test.ts
  bun test v1.3.14
   8 pass
   0 fail
   13 expect() calls
  Ran 8 tests across 1 file. [30.00ms]
```

(3 pre-existing + 5 new cases.)

Formatting: `bunx biome check tests/legacy-onboarding-redirect.test.ts` is clean against the repository `biome.json`.

Types: `bunx tsc --noEmit -p tsconfig.app.json` exits 0. The new file appears nowhere in tsc output — `tests/` sits outside every homepage tsc project by design (`tsconfig.app.json` includes only `src`, same as every sibling suite). A direct standalone compile of the file emits zero diagnostics mentioning it.

## Notes for reviewers

- Fork contributor: hosted CI does not run on this PR. The counts above are real local runs at this exact head against base c93ad66b05a4 (current origin/develop at filing time; no later develop commit touches either file).
- Test-only change: no production behaviour is modified.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:ad746423b068cd389fd32a83859dab3f4beba3a6 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
