### PR TITLE
test(homepage): cover country-flag

### DIFF
--- a/packages/homepage/tests/country-flag.test.tsx
+++ b/packages/homepage/tests/country-flag.test.tsx
@@ -1,0 +1,159 @@
+/**
+ * Render-boundary coverage for the phone-picker country flag glyph.
+ *
+ * Mounts the real CountryFlag component in jsdom and asserts the markup a
+ * caller observes: regional-indicator rendering, invalid-code passthrough,
+ * and the accessibility attributes the picker relies on. Deterministic —
+ * no network, storage, or provider involvement.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+
+const React = await import("react");
+const { createRoot } = await import("react-dom/client");
+const { JSDOM } = await import("jsdom");
+const { CountryFlag } = await import("../src/components/login/country-flag");
+
+const originalWindowDescriptor = Object.getOwnPropertyDescriptor(
+  globalThis,
+  "window",
+);
+const originalDocumentDescriptor = Object.getOwnPropertyDescriptor(
+  globalThis,
+  "document",
+);
+const originalNavigatorDescriptor = Object.getOwnPropertyDescriptor(
+  globalThis,
+  "navigator",
+);
+
+function restoreProperty(
+  target: object,
+  property: PropertyKey,
+  descriptor: PropertyDescriptor | undefined,
+): void {
+  if (descriptor) Object.defineProperty(target, property, descriptor);
+  else Reflect.deleteProperty(target, property);
+}
+
+function setupDom(): Window {
+  const dom = new JSDOM('<!DOCTYPE html><div id="root"></div>', {
+    url: "http://localhost/get-started",
+    pretendToBeVisual: true,
+  });
+  const { window } = dom;
+  const g = globalThis as unknown as Record<string, unknown>;
+  g.window = window;
+  g.document = window.document;
+  g.navigator = window.navigator;
+  g.IS_REACT_ACT_ENVIRONMENT = true;
+  return window as unknown as Window;
+}
+
+async function renderCountryFlag(props: {
+  countryCode: string;
+  className?: string;
+  title?: string;
+}): Promise<Element> {
+  const window = setupDom();
+  const container = window.document.getElementById("root");
+  if (!container) throw new Error("root element not found");
+  const root = createRoot(container);
+  await React.act(async () => {
+    root.render(React.createElement(CountryFlag, props));
+  });
+  return container;
+}
+
+afterEach(() => {
+  restoreProperty(globalThis, "window", originalWindowDescriptor);
+  restoreProperty(globalThis, "document", originalDocumentDescriptor);
+  restoreProperty(globalThis, "navigator", originalNavigatorDescriptor);
+});
+
+describe("CountryFlag", () => {
+  test("renders the regional indicator pair for an uppercase ISO code", async () => {
+    const container = await renderCountryFlag({ countryCode: "US" });
+    expect(container.querySelector("span")?.textContent).toBe(
+      "\u{1F1FA}\u{1F1F8}",
+    );
+  });
+
+  test("maps a second code independently of the first", async () => {
+    const container = await renderCountryFlag({ countryCode: "FR" });
+    expect(container.querySelector("span")?.textContent).toBe(
+      "\u{1F1EB}\u{1F1F7}",
+    );
+  });
+
+  test("normalizes lowercase codes to uppercase before mapping", async () => {
+    const container = await renderCountryFlag({ countryCode: "br" });
+    expect(container.querySelector("span")?.textContent).toBe(
+      "\u{1F1E7}\u{1F1F7}",
+    );
+  });
+
+  test("passes a three-letter code through in its original case", async () => {
+    const container = await renderCountryFlag({ countryCode: "usa" });
+    expect(container.querySelector("span")?.textContent).toBe("usa");
+  });
+
+  test("passes a code containing a digit through unchanged", async () => {
+    const container = await renderCountryFlag({ countryCode: "U1" });
+    expect(container.querySelector("span")?.textContent).toBe("U1");
+  });
+
+  test("passes non-ASCII letters through unchanged", async () => {
+    const container = await renderCountryFlag({ countryCode: "Éa" });
+    expect(container.querySelector("span")?.textContent).toBe("Éa");
+  });
+
+  test("renders an empty glyph for an empty country code", async () => {
+    const container = await renderCountryFlag({ countryCode: "" });
+    const span = container.querySelector("span");
+    expect(span?.textContent).toBe("");
+    expect(span?.getAttribute("aria-label")).toBe("");
+  });
+
+  test("exposes role img with the raw code as the accessible name", async () => {
+    const container = await renderCountryFlag({ countryCode: "JP" });
+    const span = container.querySelector('span[role="img"]');
+    expect(span).not.toBeNull();
+    expect(span?.getAttribute("aria-label")).toBe("JP");
+  });
+
+  test("defaults both title attribute and accessible name to the raw code", async () => {
+    const container = await renderCountryFlag({ countryCode: "DE" });
+    const span = container.querySelector("span");
+    expect(span?.getAttribute("title")).toBe("DE");
+    expect(span?.getAttribute("aria-label")).toBe("DE");
+  });
+
+  test("an explicit title overrides both the title attribute and aria-label", async () => {
+    const container = await renderCountryFlag({
+      countryCode: "US",
+      title: "United States",
+    });
+    const span = container.querySelector("span");
+    expect(span?.getAttribute("title")).toBe("United States");
+    expect(span?.getAttribute("aria-label")).toBe("United States");
+  });
+
+  test("keeps caller classes ahead of the fixed utility classes", async () => {
+    const container = await renderCountryFlag({
+      countryCode: "US",
+      className: "my-flag h-8 w-8",
+    });
+    const className = container.querySelector("span")?.className ?? "";
+    expect(className.startsWith("my-flag h-8 w-8")).toBe(true);
+    expect(className).toContain(
+      "inline-flex items-center justify-center text-base leading-none",
+    );
+  });
+
+  test("renders the fixed utilities when no className is provided", async () => {
+    const container = await renderCountryFlag({ countryCode: "US" });
+    expect(container.querySelector("span")?.className).toContain(
+      "inline-flex items-center justify-center text-base leading-none",
+    );
+  });
+});


### PR DESCRIPTION

## What

Adds `packages/homepage/tests/country-flag.test.tsx`, a bun:test suite for the homepage phone-picker's `CountryFlag` component (`packages/homepage/src/components/login/country-flag.tsx`), which had no dedicated unit coverage.

The suite mounts the real component in jsdom (same harness pattern as `tests/get-started-continuation-render.test.tsx`) and asserts caller-observed markup:

- Regional-indicator glyph rendering for uppercase ISO codes (`US`, `FR`)
- Lowercase input normalization (`br` maps to the Brazil flag pair)
- Passthrough of rejected codes in their ORIGINAL case: three-letter (`usa`), digit-containing (`U1`), non-ASCII letters (`Éa`), and the empty string
- Accessibility contract: `role="img"`; `aria-label` and `title` defaulting to the raw code; an explicit `title` prop overriding both
- Class composition: caller classes are kept ahead of the fixed utility classes, which render even when `className` is omitted

## Why

`CountryFlag` renders for every row of the get-started phone-number country picker. Its two-letter validation regex and `127397`-offset regional-indicator encoding are observable behavior with zero prior coverage; the suite pins the consumer-visible contract (glyph output plus accessible name) so normalization or a11y regressions surface at unit level.

## Evidence (test-only change; no production behavior modified)

- The diff touches exactly one new file: `+159 / −0`.
- Runner: this package's lane executes under Bun (`package.json` `test` script), so the quoted run uses the gating runner, not vitest:
  `bun --conditions=eliza-source test packages/homepage/tests/country-flag.test.tsx`
  - **12 pass / 0 fail / 17 expect() calls**, re-run against current `origin/develop` immediately before filing
  - Bun's coverage table reports **100.00% functions / 100.00% lines** for `country-flag.tsx`
- `bunx biome check --write packages/homepage/tests/country-flag.test.tsx` → `Checked 1 file … No fixes applied` (clean)
- `tsc -b` in `packages/homepage` finishes with zero diagnostics mentioning `country-flag`. Note: `tests/**` sits outside `tsconfig.app.json`'s `include: ["src"]` by repo design, exactly as for every existing homepage suite.
- No type-level assertions, no `vi.hoisted`, no module mocks — the real component is driven through `react-dom/client` `createRoot` inside jsdom.

## CI note

We are a fork contributor: hosted CI does not run on this pull request. All counts above come from local runs against current `origin/develop`.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:8f189b5f841026aaf3044f7ed7558f466d4c7381 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
