### PR TITLE
test(homepage): cover onboarding-continuation

### DIFF
--- a/packages/homepage/tests/onboarding-continuation.test.ts
+++ b/packages/homepage/tests/onboarding-continuation.test.ts
@@ -85,4 +85,76 @@ describe("resolveOnboardingEntryStep", () => {
       }),
     ).toBeNull();
   });
+
+  test("authentication outranks an in-flight Discord OAuth callback", () => {
+    expect(
+      resolveOnboardingEntryStep({
+        onboardingSessionId: SESSION,
+        isAuthenticated: true,
+        isLinkMode: false,
+        discordCode: "oauth-code",
+        methodParam: null,
+      }),
+    ).toBe("CONTINUATION_LINK");
+  });
+
+  test("authentication outranks an explicit method override", () => {
+    expect(
+      resolveOnboardingEntryStep({
+        onboardingSessionId: SESSION,
+        isAuthenticated: true,
+        isLinkMode: false,
+        discordCode: null,
+        methodParam: "telegram",
+      }),
+    ).toBe("CONTINUATION_LINK");
+  });
+
+  test("an empty session id is not a continuation", () => {
+    expect(
+      resolveOnboardingEntryStep({
+        onboardingSessionId: "",
+        isAuthenticated: false,
+        isLinkMode: false,
+        discordCode: null,
+        methodParam: null,
+      }),
+    ).toBeNull();
+  });
+
+  test("unauthenticated link mode never lands on sign-in", () => {
+    expect(
+      resolveOnboardingEntryStep({
+        onboardingSessionId: SESSION,
+        isAuthenticated: false,
+        isLinkMode: true,
+        discordCode: null,
+        methodParam: null,
+      }),
+    ).toBeNull();
+  });
+
+  test("an empty Discord code does not divert a signed-out continuation", () => {
+    expect(
+      resolveOnboardingEntryStep({
+        onboardingSessionId: SESSION,
+        isAuthenticated: false,
+        isLinkMode: false,
+        discordCode: "",
+        methodParam: null,
+      }),
+    ).toBe("ONBOARDING_SIGN_IN");
+  });
+
+  test("an empty method parameter does not divert a signed-out continuation", () => {
+    expect(
+      resolveOnboardingEntryStep({
+        onboardingSessionId: SESSION,
+        isAuthenticated: false,
+        isLinkMode: false,
+        discordCode: null,
+        methodParam: "",
+      }),
+    ).toBe("ONBOARDING_SIGN_IN");
+  });
 });


### PR DESCRIPTION

## What

Additively extends `packages/homepage/tests/onboarding-continuation.test.ts` with six cases for `resolveOnboardingEntryStep` (`packages/homepage/src/lib/onboarding-continuation.ts`). **Test-only change:** no production code is touched.

**Note on scope:** when this PR was prepared, current `origin/develop` already carried a suite at this path (the target snapshot predated it). Per the repo's additive-only rule for existing suites, this diff strictly ADDS cases - `git diff --stat` shows `72 insertions(+), 0 deletions(-)`; no existing case was rewritten or removed, so all six original cases ship unchanged.

## Cases added (all previously uncovered behaviour)

1. Authentication outranks an in-flight Discord OAuth callback - `isAuthenticated: true` + `discordCode` returns `"CONTINUATION_LINK"`, pinning that the authenticated check precedes the OAuth-callback bail-out.
2. Authentication outranks an explicit method override - `isAuthenticated: true` + `methodParam: "telegram"` returns `"CONTINUATION_LINK"` (same precedence).
3. An empty-string session id is not a continuation - `""` is falsy and returns `null`.
4. Unauthenticated link mode never lands on sign-in - `isLinkMode: true` alone diverts, independent of auth state.
5. An empty-string `discordCode` does not divert a signed-out continuation - returns `"ONBOARDING_SIGN_IN"`, pinning falsy-or semantics of the callback guard.
6. An empty-string method parameter does not divert a signed-out continuation - returns `"ONBOARDING_SIGN_IN"`.

All expectations were observed by driving the real module; nothing is asserted from mocks.

## Evidence (test-only PR)

- Owning runner: this package's `test` lane runs the suite via `bun --conditions=eliza-source test tests/onboarding-continuation.test.ts`. Result: **12 pass / 0 fail, 12 expect() calls** (6 pre-existing + 6 added).
- `bunx biome check packages/homepage/tests/onboarding-continuation.test.ts`: clean ("Checked 1 file ... No fixes applied"), root `biome.json` present and the tree is not sparse-checked-out.
- TypeScript: `packages/homepage/tsconfig.app.json` includes only `src/`, so a package-wide project check would never see this file. The test file was checked directly with the package's compiler options against an untouched sibling suite as control: the only diagnostic mentioning this file is the pre-existing environmental `TS2307: Cannot find module 'bun:test'` on the base import (identical class of error appears on the untouched control suite). The added lines introduce zero new errors versus control.
- This diff touches exactly one file: `packages/homepage/tests/onboarding-continuation.test.ts`.

This is a fork contribution, so hosted CI does not run on this pull request; the counts above are quoted from local runs at head `81974f1d1c31464348dbe64cf729729245d9c7be`.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:81974f1d1c31464348dbe64cf729729245d9c7be -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
