### PR TITLE
test(ui): cover audio-frame-diarization-harness

### DIFF
--- a/packages/ui/src/voice/audio-frame-diarization-harness.test.ts
+++ b/packages/ui/src/voice/audio-frame-diarization-harness.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Unit coverage for installDiarizationPumpHarness, the on-device diarization
+ * verification control: inert off-window behavior, one-shot window
+ * attachment, lazy single-pump wiring to the TalkMode plugin, stop-time
+ * frame-count snapshotting, live isRunning mirroring, and the bounded
+ * local-agent status request. The harness logic runs for real; its native,
+ * client, and pump collaborators are stubbed in-module.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../api", () => {
+  const clientState = {
+    baseUrl: undefined as string | undefined,
+    fetchImpl: (async () => ({ ok: true })) as (
+      ...args: unknown[]
+    ) => Promise<unknown>,
+  };
+  class StubElizaClient {
+    constructor(baseUrl?: string) {
+      clientState.baseUrl = baseUrl;
+    }
+    fetch(...args: unknown[]) {
+      return clientState.fetchImpl(...args);
+    }
+  }
+  return { __clientState: clientState, ElizaClient: StubElizaClient };
+});
+
+vi.mock("../bridge/native-plugins", () => {
+  const stubTalkModePlugin = { id: "stub-talk-mode-plugin" };
+  return {
+    __stubTalkModePlugin: stubTalkModePlugin,
+    getTalkModePlugin: () => stubTalkModePlugin,
+  };
+});
+
+vi.mock("../first-run/mobile-runtime-mode", () => ({
+  MOBILE_LOCAL_AGENT_API_BASE: "http://127.0.0.1:3000",
+}));
+
+vi.mock("./audio-frame-pump", () => {
+  class StubAudioFramePump {
+    static instances: StubAudioFramePump[] = [];
+    readonly talkModePlugin: unknown;
+    isRunning = false;
+    framesSent = 0;
+    startCalls = 0;
+    stopCalls = 0;
+    nextStartResult: {
+      started: boolean;
+      suspendedStt?: boolean;
+      error?: string;
+    } = { started: true };
+    constructor(talkModePlugin: unknown) {
+      this.talkModePlugin = talkModePlugin;
+      StubAudioFramePump.instances.push(this);
+    }
+    async start() {
+      this.startCalls += 1;
+      this.isRunning = this.nextStartResult.started;
+      return this.nextStartResult;
+    }
+    async stop() {
+      this.stopCalls += 1;
+      this.framesSent += 1;
+      this.isRunning = false;
+      return { stopped: true };
+    }
+  }
+  return { AudioFramePump: StubAudioFramePump };
+});
+
+import * as apiModule from "../api";
+import * as nativePlugins from "../bridge/native-plugins";
+import { installDiarizationPumpHarness } from "./audio-frame-diarization-harness";
+import { AudioFramePump } from "./audio-frame-pump";
+
+interface StubClientState {
+  baseUrl: string | undefined;
+  fetchImpl: (...args: unknown[]) => Promise<unknown>;
+}
+
+interface StubPumpInstance {
+  talkModePlugin: unknown;
+  isRunning: boolean;
+  framesSent: number;
+  startCalls: number;
+  stopCalls: number;
+  nextStartResult: { started: boolean; suspendedStt?: boolean; error?: string };
+}
+
+interface StubPumpConstructor {
+  instances: StubPumpInstance[];
+  new (talkModePlugin: unknown): StubPumpInstance;
+}
+
+const clientState = (apiModule as unknown as { __clientState: StubClientState })
+  .__clientState;
+const stubTalkModePlugin = (
+  nativePlugins as unknown as { __stubTalkModePlugin: unknown }
+).__stubTalkModePlugin;
+const PumpStub = AudioFramePump as unknown as StubPumpConstructor;
+
+function currentPump(): StubPumpInstance {
+  return PumpStub.instances[PumpStub.instances.length - 1];
+}
+
+function installedWindowControl(): unknown {
+  return (globalThis as { window?: { __diarizationPump?: unknown } }).window
+    ?.__diarizationPump;
+}
+
+describe("installDiarizationPumpHarness", () => {
+  describe("without a window", () => {
+    it("returns a usable control and defers all pump construction", () => {
+      expect(typeof window).toBe("undefined");
+
+      const control = installDiarizationPumpHarness();
+
+      expect(control.isRunning()).toBe(false);
+      expect(PumpStub.instances).toHaveLength(0);
+    });
+  });
+
+  describe("window attachment", () => {
+    beforeEach(() => {
+      (globalThis as { window?: unknown }).window = {};
+    });
+
+    afterEach(() => {
+      delete (globalThis as { window?: unknown }).window;
+    });
+
+    it("attaches the first control and keeps it stable across re-installs", () => {
+      const first = installDiarizationPumpHarness();
+      expect(installedWindowControl()).toBe(first);
+
+      const second = installDiarizationPumpHarness();
+      expect(installedWindowControl()).toBe(first);
+      expect(second).not.toBe(first);
+
+      const fromWindow = installedWindowControl() as ReturnType<
+        typeof installDiarizationPumpHarness
+      >;
+      expect(fromWindow).toBe(first);
+      expect(fromWindow.isRunning).toBeTypeOf("function");
+      expect(fromWindow.status).toBeTypeOf("function");
+      expect(second.isRunning()).toBe(false);
+    });
+  });
+
+  describe("status transport", () => {
+    it("routes status through the bounded local-agent client", async () => {
+      const payload = { libLoaded: true, framesReceived: 2, turns: [] };
+      const fetchImpl = vi.fn(async () => payload);
+      clientState.fetchImpl = fetchImpl;
+
+      const control = installDiarizationPumpHarness();
+      await expect(control.status()).resolves.toBe(payload);
+
+      expect(clientState.baseUrl).toBe("http://127.0.0.1:3000");
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+      expect(fetchImpl).toHaveBeenCalledWith(
+        "/api/voice/audio-frames/status",
+        { method: "GET", headers: { accept: "application/json" } },
+        { timeoutMs: 15_000 },
+      );
+    });
+
+    it("surfaces bounded-client failures untouched", async () => {
+      const boom = new Error("status hop timed out");
+      clientState.fetchImpl = async () => {
+        throw boom;
+      };
+
+      const control = installDiarizationPumpHarness();
+      await expect(control.status()).rejects.toBe(boom);
+    });
+  });
+
+  describe("pump lifecycle", () => {
+    it("builds one pump lazily on first use, wired to the TalkMode plugin", async () => {
+      const control = installDiarizationPumpHarness();
+      const before = PumpStub.instances.length;
+
+      await expect(control.start()).resolves.toEqual({ started: true });
+
+      expect(PumpStub.instances).toHaveLength(before + 1);
+      expect(currentPump().talkModePlugin).toBe(stubTalkModePlugin);
+      expect(currentPump().startCalls).toBe(1);
+    });
+
+    it("reuses the same pump across calls and passes results through live", async () => {
+      const control = installDiarizationPumpHarness();
+      const before = PumpStub.instances.length;
+      const pump = currentPump();
+      const startCallsBefore = pump.startCalls;
+      pump.nextStartResult = { started: false, error: "capture denied" };
+
+      await expect(control.start()).resolves.toEqual({
+        started: false,
+        error: "capture denied",
+      });
+
+      expect(PumpStub.instances).toHaveLength(before);
+      expect(pump.startCalls).toBe(startCallsBefore + 1);
+    });
+
+    it("reports the frame count captured before teardown runs", async () => {
+      const control = installDiarizationPumpHarness();
+      const pump = currentPump();
+      const stopCallsBefore = pump.stopCalls;
+      pump.framesSent = 6;
+
+      await expect(control.stop()).resolves.toEqual({
+        stopped: true,
+        framesSent: 6,
+      });
+
+      expect(pump.stopCalls).toBe(stopCallsBefore + 1);
+      expect(pump.framesSent).toBe(7);
+    });
+
+    it("mirrors the live pump's running state", () => {
+      const control = installDiarizationPumpHarness();
+      const pump = currentPump();
+
+      pump.isRunning = true;
+      expect(control.isRunning()).toBe(true);
+
+      pump.isRunning = false;
+      expect(control.isRunning()).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION

## What

Adds `packages/ui/src/voice/audio-frame-diarization-harness.test.ts` — a new, additive unit suite (+235/-0, one new test file, no production changes) for `installDiarizationPumpHarness()` in `packages/ui/src/voice/audio-frame-diarization-harness.ts`, which previously had no same-named suite anywhere in the repo. The existing `audio-frame-diarization-harness-timeout.test.ts` covers only the status-deadline path and is left untouched.

## Coverage

Eight behavior-level cases over the real harness logic (collaborators stubbed in-module):

- **Inert off-window** — returns a usable control without any `window`, and defers all pump construction (`AudioFramePump` never instantiated until first use).
- **Window attachment** — first install attaches the control to `window.__diarizationPump`; re-installs never reattach (first wins) while every call still returns an independently usable control.
- **Status transport** — routes through the bounded local-agent client pinned at `MOBILE_LOCAL_AGENT_API_BASE`, issuing exactly `GET /api/voice/audio-frames/status` with `accept: application/json` and `timeoutMs: 15000`; resolves with the payload identity and propagates bounded-client failures untouched (same error object).
- **Pump lifecycle** — lazily constructs a single pump wired to the TalkMode plugin, reuses it across calls, passes each start result through live; `stop()` reports the frame count captured **before** teardown mutates it; `isRunning()` mirrors the live pump state.

## Evidence

Test-only diff; no production behavior changed.

- `bunx vitest run src/voice/audio-frame-diarization-harness.test.ts` (in `packages/ui`) → **1 file passed, 8 passed / 8 total**, re-run against current `origin/develop` (`51617538d7`) immediately before filing.
- `bunx biome check --write` on the new file → clean, "No fixes applied".
- `bunx tsc --noEmit` in `packages/ui` → zero diagnostics mentioning the new file.

Note: we are a fork contributor — hosted CI does not run on this pull request; the counts above are quoted from local runs at the head commit (`c9fd354a4f`).

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:c9fd354a4f960774a2c5452b565f1c2bd48c0480 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
