### PR TITLE
test(homepage): cover release-availability

### DIFF
--- a/packages/homepage/tests/release-availability.test.ts
+++ b/packages/homepage/tests/release-availability.test.ts
@@ -87,4 +87,46 @@ describe("isReleaseAvailable", () => {
       }),
     ).toBe(true);
   });
+
+  test("deduplicates download ids before checking the required set", () => {
+    const duplicated = completeDownloads
+      .slice(0, 4)
+      .concat({ ...completeDownloads[0], id: "macos-arm64" });
+    expect(duplicated).toHaveLength(5);
+    expect(
+      isReleaseAvailable({ tagName: "v1.0.0", downloads: duplicated }),
+    ).toBe(false);
+  });
+
+  test("returns true when downloads carry extra ids beyond the required five", () => {
+    expect(
+      isReleaseAvailable({
+        tagName: "v1.0.0",
+        downloads: [
+          ...completeDownloads,
+          { ...completeDownloads[0], id: "future-platform" },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  test("returns false when exactly one required id is missing even with an extra present", () => {
+    const missingAndroidApk = completeDownloads
+      .filter((download) => download.id !== "android-apk")
+      .concat({ ...completeDownloads[0], id: "decoy-extra" });
+    expect(missingAndroidApk).toHaveLength(5);
+    expect(
+      isReleaseAvailable({ tagName: "v1.0.0", downloads: missingAndroidApk }),
+    ).toBe(false);
+  });
+
+  test("matches the required ids case-sensitively", () => {
+    const uppercased = completeDownloads.map((download) => ({
+      ...download,
+      id: download.id.toUpperCase(),
+    }));
+    expect(
+      isReleaseAvailable({ tagName: "v1.0.0", downloads: uppercased }),
+    ).toBe(false);
+  });
 });


### PR DESCRIPTION

## What

Adds four behavioral cases to the existing `packages/homepage/tests/release-availability.test.ts` suite for `isReleaseAvailable` (`packages/homepage/src/lib/release-availability.ts`). Purely additive: +42/-0, no existing case or line is modified, and no production code changes.

The suite already pinned the sentinel branch (tagName `"unavailable"`), empty downloads, a single-of-five partial set, and the complete five-download true path. This change covers the remaining decision semantics the UI availability branch relies on:

- **Duplicate-ID collapse**: five download entries whose ids dedupe to four distinct values must still fail — pins the `Set`-based membership check against duplicate payloads.
- **Superset acceptance**: extra unknown ids alongside the required five pass — pins that the check is "required subset", not exact-set equality.
- **Completeness**: exactly one required id missing (with a decoy extra present) fails — complements the superset case by proving every required id is individually enforced.
- **Case sensitivity**: uppercased ids fail — pins exact-case matching so a casing drift in generated release data cannot expose download cards.

All expectations record observed behavior of the module; nothing aspirational.

## Evidence

This is a test-only diff from a fork contributor — hosted CI does not run on this PR. Local verification on the exact head:

- Runner check: this package's own `test` script runs these suites with `bun test`, not vitest, so counts below are from the owning runner.
- `bun --conditions=eliza-source test tests/release-availability.test.ts` (from `packages/homepage`): **9 pass, 0 fail** (5 pre-existing + 4 new), 11 expect() calls.
- `bunx biome check --write packages/homepage/tests/release-availability.test.ts`: clean ("Checked 1 file… No fixes applied").
- Typecheck: `tests/` is outside every tsc project in this package (`tsconfig.app.json` includes only `src`); the owning-package program check (`tsc --noEmit -p tsconfig.app.json`) reports nothing for this file, and a standalone strict `tsc --noEmit` over the test file itself (same compiler options plus the package's `@/*` paths mapping) exits 0 with zero errors.
- Diff shape: one file, 42 insertions, 0 deletions vs current `origin/develop`; re-fetched and re-run immediately before filing with identical counts.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:67384edded4211af2fdc407c2bbc48d166d2839f -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
