### PR TITLE
fix(ui): do not surface unowned rate-limit alerts on signed-out login

### DIFF
--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
@@ -926,12 +926,16 @@ export default function StewardLoginSection() {
           return;
         }
       } catch (sessionError) {
+        // error-policy:J4 Session restoration failure must not blast a
+        // rate-limit or transport alert over the working signed-out
+        // provider form: the recovery path is unrelated to the options
+        // the user is about to choose, and a 429 from an unowned surface
+        // was observed on staging with no action submitted (#27712).
+        // The user can still sign in; recovery simply does not happen.
         if (!cancelled) {
-          setError(
-            getErrorMessage(
-              sessionError,
-              "Could not restore the local Steward session",
-            ),
+          console.debug(
+            "[steward-login] session restoration failed (non-blocking)",
+            sessionError,
           );
         }
       } finally {


### PR DESCRIPTION
## Summary
Session restoration wrote unrelated failures (including a 429 observed on staging with no action submitted) into the shared page-level error state, which the signed-out provider form rendered as a global red `Too many requests` alert below the entire option stack — with no source, retry metadata, or operation-specific recovery.

## Fix
Session restoration failure is now non-blocking and logged to the console instead of polluting the shared error state. A signed-out user no longer sees a rate-limit alert unless a specific login operation actually returned a rate-limit response. Provider discovery failures still surface (that path is what the form depends on).

## Acceptance
- [x] Signed-out user sees no rate-limit alert unless a specific login operation returned a rate-limit response.
- [x] Provider discovery failure still surfaces (unchanged path).
- [x] Session restoration failure degrades gracefully (console debug, form usable).

Closes #27712.