### PR TITLE
test(ui): cover voice-chat-audio-playback

### DIFF
--- a/packages/ui/src/voice/voice-chat-audio-playback.test.ts
+++ b/packages/ui/src/voice/voice-chat-audio-playback.test.ts
@@ -1,0 +1,453 @@
+/**
+ * Unit coverage for `playDecodedVoiceAudio`, the shared decoded-TTS playback
+ * lifecycle: generation gating before and during decode, analyser/source graph
+ * wiring, the playback-reference tap lifecycle, guarded teardown on natural end
+ * versus the speech-timeout fallback, and the playback-start event contract.
+ * The module under test runs real; the Web Audio graph nodes and the frame-pump
+ * tap are structural doubles standing in for their browser-only boundaries.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { PlaybackFramePump } from "./playback-frame-pump";
+import {
+  type DecodedVoicePlaybackOptions,
+  playDecodedVoiceAudio,
+} from "./voice-chat-audio-playback";
+import type { SpeakTask, VoicePlaybackStartEvent } from "./voice-chat-types";
+
+interface FakeNode {
+  connections: FakeNode[];
+  disconnectCount: number;
+  connect(target: FakeNode): FakeNode;
+  disconnect(): void;
+}
+
+function makeNode(): FakeNode {
+  const node: FakeNode = {
+    connections: [],
+    disconnectCount: 0,
+    connect(target) {
+      node.connections.push(target);
+      return target;
+    },
+    disconnect() {
+      node.disconnectCount += 1;
+    },
+  };
+  return node;
+}
+
+interface FakeAnalyser extends FakeNode {
+  fftSize: number;
+  smoothingTimeConstant: number;
+}
+
+function makeAnalyser(): FakeAnalyser {
+  const analyser: FakeAnalyser = {
+    connections: [],
+    disconnectCount: 0,
+    fftSize: 0,
+    smoothingTimeConstant: 0,
+    connect(target) {
+      analyser.connections.push(target);
+      return target;
+    },
+    disconnect() {
+      analyser.disconnectCount += 1;
+    },
+  };
+  return analyser;
+}
+
+interface FakeSource extends FakeNode {
+  buffer: unknown;
+  onended: (() => void) | null;
+  starts: unknown[];
+  start(when?: number): void;
+}
+
+function makeSource(): FakeSource {
+  const source: FakeSource = {
+    connections: [],
+    disconnectCount: 0,
+    buffer: null,
+    onended: null,
+    starts: [],
+    connect(target) {
+      source.connections.push(target);
+      return target;
+    },
+    disconnect() {
+      source.disconnectCount += 1;
+    },
+    start(when?: number) {
+      source.starts.push(when ?? 0);
+    },
+  };
+  return source;
+}
+
+interface FakeTap {
+  startCalls: Array<number | undefined>;
+  stopCalls: Array<{ reset?: boolean; drain?: boolean } | undefined>;
+  start(startTimestampMs?: number): void;
+  stop(options?: { reset?: boolean; drain?: boolean }): Promise<void>;
+}
+
+function makeTap(): FakeTap {
+  const tap: FakeTap = {
+    startCalls: [],
+    stopCalls: [],
+    start(startTimestampMs?: number) {
+      tap.startCalls.push(startTimestampMs);
+    },
+    async stop(options?: { reset?: boolean; drain?: boolean }) {
+      tap.stopCalls.push(options);
+    },
+  };
+  return tap;
+}
+
+interface FakeBuffer {
+  duration: number;
+}
+
+function makeBuffer(durationSec: number): FakeBuffer {
+  return { duration: durationSec };
+}
+
+async function settle(): Promise<void> {
+  for (let i = 0; i < 5; i += 1) {
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  }
+}
+
+function first<T>(items: T[]): T {
+  const item = items[0];
+  if (item === undefined) {
+    throw new Error("expected at least one recorded item");
+  }
+  return item;
+}
+
+function harness(buffer: FakeBuffer = makeBuffer(2)) {
+  const generationRef = { current: 1 };
+  const analyserRef: { current: FakeAnalyser | null } = { current: null };
+  const timeDomainDataRef: { current: Float32Array<ArrayBuffer> | null } = {
+    current: null,
+  };
+  const audioSourceRef: { current: FakeSource | null } = { current: null };
+  const playbackFrameTapRef: { current: FakeTap | null } = { current: null };
+  const activeTaskFinishRef: { current: (() => void) | null } = {
+    current: null,
+  };
+  const speechTimeoutRef: { current: ReturnType<typeof setTimeout> | null } = {
+    current: null,
+  };
+
+  const createdAnalysers: FakeAnalyser[] = [];
+  const createdSources: FakeSource[] = [];
+  const taps: FakeTap[] = [];
+  const startedEvents: VoicePlaybackStartEvent[] = [];
+  const destination = makeNode();
+  const clearSpeechTimers = vi.fn();
+
+  let holdDecode = false;
+  let releaseDecode: (() => void) | null = null;
+
+  const context = {
+    destination,
+    createAnalyser(): FakeAnalyser {
+      const analyser = makeAnalyser();
+      createdAnalysers.push(analyser);
+      return analyser;
+    },
+    createBufferSource(): FakeSource {
+      const source = makeSource();
+      createdSources.push(source);
+      return source;
+    },
+    decodeAudioData(): Promise<FakeBuffer> {
+      if (!holdDecode) return Promise.resolve(buffer);
+      return new Promise<FakeBuffer>((resolve) => {
+        releaseDecode = () => resolve(buffer);
+      });
+    },
+  };
+
+  const pump = {
+    tapSource: async (): Promise<FakeTap> => {
+      const tap = makeTap();
+      taps.push(tap);
+      return tap;
+    },
+  };
+
+  const task: SpeakTask = {
+    text: "hello there",
+    append: false,
+    segment: "full",
+    telemetry: { messageId: "m-1" },
+  };
+
+  function run(
+    overrides?: Partial<DecodedVoicePlaybackOptions>,
+  ): Promise<void> {
+    return playDecodedVoiceAudio({
+      context: context as unknown as AudioContext,
+      audioBytes: new Uint8Array([1, 2, 3, 4]),
+      generation: 1,
+      generationRef,
+      provider: "browser",
+      text: task.text,
+      task,
+      cached: false,
+      analyserRef:
+        analyserRef as unknown as DecodedVoicePlaybackOptions["analyserRef"],
+      timeDomainDataRef,
+      audioSourceRef:
+        audioSourceRef as unknown as DecodedVoicePlaybackOptions["audioSourceRef"],
+      playbackFrameTapRef:
+        playbackFrameTapRef as unknown as DecodedVoicePlaybackOptions["playbackFrameTapRef"],
+      activeTaskFinishRef,
+      speechTimeoutRef,
+      getPlaybackFramePump: () => pump as unknown as PlaybackFramePump,
+      clearSpeechTimers,
+      emitPlaybackStart: (event) => startedEvents.push(event),
+      ...overrides,
+    });
+  }
+
+  return {
+    generationRef,
+    analyserRef,
+    timeDomainDataRef,
+    audioSourceRef,
+    playbackFrameTapRef,
+    activeTaskFinishRef,
+    speechTimeoutRef,
+    createdAnalysers,
+    createdSources,
+    destination,
+    taps,
+    startedEvents,
+    clearSpeechTimers,
+    holdNextDecode: () => {
+      holdDecode = true;
+    },
+    releaseDecode: () => {
+      releaseDecode?.();
+    },
+    run,
+  };
+}
+
+describe("playDecodedVoiceAudio", () => {
+  it("returns before decoding when the generation is already stale", async () => {
+    const h = harness();
+    h.generationRef.current = 7;
+
+    await h.run({ generation: 1 });
+
+    expect(h.createdAnalysers).toHaveLength(0);
+    expect(h.createdSources).toHaveLength(0);
+    expect(h.startedEvents).toHaveLength(0);
+    expect(h.analyserRef.current).toBeNull();
+    expect(h.audioSourceRef.current).toBeNull();
+  });
+
+  it("abandons the clip when the generation goes stale during decode", async () => {
+    const h = harness();
+    h.holdNextDecode();
+
+    const pending = h.run({ generation: 1 });
+    await settle();
+    h.generationRef.current = 99;
+    h.releaseDecode();
+    await pending;
+
+    expect(h.createdAnalysers).toHaveLength(0);
+    expect(h.createdSources).toHaveLength(0);
+    expect(h.startedEvents).toHaveLength(0);
+    expect(h.analyserRef.current).toBeNull();
+    expect(h.audioSourceRef.current).toBeNull();
+  });
+
+  it("wires source into analyser into destination and publishes the refs", async () => {
+    const h = harness();
+    const pending = h.run();
+    await settle();
+
+    expect(h.createdSources).toHaveLength(1);
+    const source = first(h.createdSources);
+    const analyser = first(h.createdAnalysers);
+    expect(analyser.fftSize).toBe(2048);
+    expect(analyser.smoothingTimeConstant).toBe(0.8);
+    expect(source.connections).toContain(analyser);
+    expect(analyser.connections).toContain(h.destination);
+    expect(source.starts).toEqual([0]);
+    expect(h.analyserRef.current).toBe(analyser);
+    expect(h.timeDomainDataRef.current?.length).toBe(2048);
+    expect(h.audioSourceRef.current).toBe(source);
+
+    h.activeTaskFinishRef.current?.();
+    await pending;
+  });
+
+  it("emits the playback-start event with task telemetry spread in", async () => {
+    const h = harness();
+    const pending = h.run();
+    await settle();
+    h.activeTaskFinishRef.current?.();
+    await pending;
+
+    expect(h.startedEvents).toHaveLength(1);
+    const event = first(h.startedEvents);
+    expect(event.text).toBe("hello there");
+    expect(event.segment).toBe("full");
+    expect(event.provider).toBe("browser");
+    expect(event.cached).toBe(false);
+    expect(typeof event.startedAtMs).toBe("number");
+    expect(event.messageId).toBe("m-1");
+  });
+
+  it("starts the tap once playback begins and stops it with reset on finish", async () => {
+    const h = harness();
+    const pending = h.run();
+    await settle();
+
+    expect(h.taps).toHaveLength(1);
+    const tap = first(h.taps);
+    expect(tap.startCalls).toHaveLength(1);
+    expect(h.playbackFrameTapRef.current).toBe(tap);
+
+    h.activeTaskFinishRef.current?.();
+    await pending;
+
+    expect(tap.stopCalls).toEqual([{ reset: true }]);
+    expect(h.playbackFrameTapRef.current).toBeNull();
+  });
+
+  it("tears down the graph, clears speech timers, and clears its own refs on natural end", async () => {
+    const h = harness();
+    const pending = h.run();
+    await settle();
+    const source = first(h.createdSources);
+    const analyser = first(h.createdAnalysers);
+
+    source.onended?.();
+    await pending;
+
+    expect(h.clearSpeechTimers).toHaveBeenCalledTimes(1);
+    expect(h.activeTaskFinishRef.current).toBeNull();
+    expect(h.audioSourceRef.current).toBeNull();
+    expect(source.disconnectCount).toBe(1);
+    expect(analyser.disconnectCount).toBe(1);
+  });
+
+  it("leaves a foreign activeTaskFinishRef untouched on teardown", async () => {
+    const h = harness();
+    const pending = h.run();
+    await settle();
+
+    const foreign = vi.fn();
+    h.activeTaskFinishRef.current = foreign;
+    first(h.createdSources).onended?.();
+    await pending;
+
+    expect(h.activeTaskFinishRef.current).toBe(foreign);
+  });
+
+  it("leaves a foreign audioSourceRef untouched on teardown", async () => {
+    const h = harness();
+    const pending = h.run();
+    await settle();
+
+    const foreign = makeSource();
+    h.audioSourceRef.current =
+      foreign as unknown as typeof h.audioSourceRef.current;
+    first(h.createdSources).onended?.();
+    await pending;
+
+    expect(h.audioSourceRef.current).toBe(foreign);
+  });
+
+  it("treats a second finish invocation as a no-op", async () => {
+    const h = harness();
+    const pending = h.run();
+    await settle();
+    const source = first(h.createdSources);
+    const finisher = h.activeTaskFinishRef.current;
+
+    source.onended?.();
+    await pending;
+    expect(finisher).not.toBeNull();
+    finisher?.();
+
+    expect(first(h.taps).stopCalls).toHaveLength(1);
+    expect(source.disconnectCount).toBe(1);
+    expect(h.clearSpeechTimers).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps a tap attachment failure audible-only and finishes cleanly", async () => {
+    const h = harness();
+    const failingPump = {
+      tapSource: () => Promise.reject(new Error("worklet exploded")),
+    };
+    const pending = h.run({
+      getPlaybackFramePump: () => failingPump as unknown as PlaybackFramePump,
+    });
+    await settle();
+
+    expect(h.playbackFrameTapRef.current).toBeNull();
+    expect(h.startedEvents).toHaveLength(1);
+
+    first(h.createdSources).onended?.();
+    await pending;
+
+    expect(h.clearSpeechTimers).toHaveBeenCalledTimes(1);
+    expect(h.audioSourceRef.current).toBeNull();
+  });
+
+  it("finishes through the speech timeout at duration*1000+1200ms", async () => {
+    vi.useFakeTimers();
+    try {
+      const h = harness(makeBuffer(2));
+      const pending = h.run();
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(h.speechTimeoutRef.current).not.toBeNull();
+      await vi.advanceTimersByTimeAsync(3199);
+      expect(h.startedEvents).toHaveLength(1);
+      expect(h.clearSpeechTimers).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1);
+      await pending;
+
+      expect(h.clearSpeechTimers).toHaveBeenCalledTimes(1);
+      expect(h.audioSourceRef.current).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("holds short clips open for at least the 2500ms timeout floor", async () => {
+    vi.useFakeTimers();
+    try {
+      const h = harness(makeBuffer(0.2));
+      const pending = h.run();
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(0);
+
+      await vi.advanceTimersByTimeAsync(2499);
+      expect(h.clearSpeechTimers).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1);
+      await pending;
+
+      expect(h.clearSpeechTimers).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});


### PR DESCRIPTION

## What

Adds a new unit suite for `packages/ui/src/voice/voice-chat-audio-playback.ts` — the shared decoded-TTS playback lifecycle that every Web Audio TTS provider path goes through. The module previously had no test coverage anywhere in the repo.

## Why

This module owns load-bearing playback orchestration: generation gating against stale clips (before and after an async decode), analyser/source graph wiring, the shared playback-reference tap lifecycle (`PlaybackTapLifecycle`), guarded teardown whose ref-clears must only fire when the refs still hold *this* task's values, the double-finish guard, and the speech-timeout fallback that keeps a wedged `onended` from hanging a voice turn forever. None of these branches were covered by any existing suite.

## How

The module under test runs real end to end. The only doubles are structural fakes standing in for browser-only boundaries: Web Audio graph nodes (a plain recording object graph) and the optional frame-pump tap. Timeout math is proven with fake timers; everything else runs on real microtask/macrotask scheduling.

Coverage:

- returns before decoding when the generation is already stale (no decode call, no graph nodes)
- abandons the clip when the generation goes stale during decode
- wires source -> analyser -> destination with fftSize 2048 / smoothing 0.8 and publishes the analyser, time-domain buffer, and source refs
- emits the playback-start event with task telemetry spread into it (`messageId` etc.)
- starts the tap once playback begins and stops it with `{ reset: true }` on finish
- natural-end teardown: clears speech timers, disconnects both nodes, clears its own active-task-finish and audio-source refs
- leaves a foreign `activeTaskFinishRef` untouched (identity guard)
- leaves a foreign `audioSourceRef` untouched (same-source guard)
- treats a second finish invocation as a no-op
- degrades to audible-only playback when tap attachment rejects (error-policy J4 path)
- speech timeout fires at exactly `duration * 1000 + 1200` ms (proven at 3199 vs 3200 ms)
- short clips are held open for at least the 2500 ms floor (proven at 2499 vs 2500 ms)

## Evidence

Test-only change: the diff is one new file, `packages/ui/src/voice/voice-chat-audio-playback.test.ts`, +453/-0. No production behavior is changed.

Run against `origin/develop` @ `51617538d7` (the parent of head `dec5ecc19b`), whose copies of the module and its entire import closure (`playback-frame-pump.ts`, `voice-chat-types.ts`, `utils/tts-debug.ts`) are byte-identical to the tree the counts were produced in:

- `bunx vitest run --config ./vitest.config.ts src/voice/voice-chat-audio-playback.test.ts` (in `packages/ui`) -> Test Files 1 passed (1), Tests 12 passed (12)
- `bunx biome check src/voice/voice-chat-audio-playback.test.ts` -> clean, 0 problems ("Checked 1 file", no fixes needed)
- `bunx tsc --noEmit -p tsconfig.json` (in `packages/ui`) -> the new test file appears nowhere in the output; the 14 reported errors are pre-existing in other files (`../core/src/cloud-routing.ts`, `src/capability-handoff.ts`) and unchanged by this diff

Note: this PR comes from a fork, so hosted CI does not run on it — the counts above are from local runs quoted verbatim.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:dec5ecc19b9c7e6bbebf9e71729edb073d6376e6 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
