### PR TITLE
test(ui): cover useVoiceSettingsApplyChannel

### DIFF
--- a/packages/ui/src/voice/useVoiceSettingsApplyChannel.test.tsx
+++ b/packages/ui/src/voice/useVoiceSettingsApplyChannel.test.tsx
@@ -14,6 +14,7 @@ import {
   loadOsIntentAutoStartConsent,
   loadVadAutoStop,
   saveContinuousChatMode,
+  saveOsIntentAutoStartConsent,
   saveVadAutoStop,
 } from "../state/persistence";
 import { emitViewEvent } from "../views/view-event-bus";
@@ -98,6 +99,145 @@ describe("useVoiceSettingsApplyChannel", () => {
     });
 
     apply({ osIntentAutoStartTranscription: true });
+    expect(loadOsIntentAutoStartConsent()).toEqual({
+      voice: true,
+      transcription: true,
+    });
+  });
+});
+
+describe("useVoiceSettingsApplyChannel payload validation edges", () => {
+  it("ignores a continuous value whose type is not string", () => {
+    saveContinuousChatMode("vad-gated");
+    render(<Channel />);
+
+    apply({ continuous: 42 });
+    expect(loadContinuousChatMode()).toBe("vad-gated");
+
+    apply({ continuous: null });
+    expect(loadContinuousChatMode()).toBe("vad-gated");
+  });
+
+  it("rejects array and null vadAutoStop payloads wholesale", () => {
+    saveVadAutoStop({ silenceMs: 777, speechRmsThreshold: 0.123 });
+    render(<Channel />);
+
+    apply({ vadAutoStop: [] });
+    expect(loadVadAutoStop()).toEqual({
+      silenceMs: 777,
+      speechRmsThreshold: 0.123,
+    });
+
+    apply({ vadAutoStop: null });
+    expect(loadVadAutoStop()).toEqual({
+      silenceMs: 777,
+      speechRmsThreshold: 0.123,
+    });
+  });
+
+  it("does not partially apply a pair whose speechRmsThreshold alone is missing", () => {
+    saveVadAutoStop({ silenceMs: 777, speechRmsThreshold: 0.123 });
+    render(<Channel />);
+
+    apply({ vadAutoStop: { silenceMs: 500 } });
+
+    expect(loadVadAutoStop()).toEqual({
+      silenceMs: 777,
+      speechRmsThreshold: 0.123,
+    });
+  });
+
+  it("rejects non-finite VAD numbers", () => {
+    saveVadAutoStop({ silenceMs: 777, speechRmsThreshold: 0.123 });
+    render(<Channel />);
+
+    apply({ vadAutoStop: { silenceMs: Number.NaN, speechRmsThreshold: 0.01 } });
+    apply({
+      vadAutoStop: {
+        silenceMs: 400,
+        speechRmsThreshold: Number.POSITIVE_INFINITY,
+      },
+    });
+
+    expect(loadVadAutoStop()).toEqual({
+      silenceMs: 777,
+      speechRmsThreshold: 0.123,
+    });
+  });
+
+  it("persists an explicit false consent while the absent sibling keeps its stored value", () => {
+    saveOsIntentAutoStartConsent({ voice: true, transcription: true });
+    render(<Channel />);
+
+    apply({ osIntentAutoStartVoice: false });
+
+    expect(loadOsIntentAutoStartConsent()).toEqual({
+      voice: false,
+      transcription: true,
+    });
+  });
+
+  it("ignores a consent field whose type is not boolean while persisting the valid sibling", () => {
+    saveOsIntentAutoStartConsent({ voice: true, transcription: true });
+    render(<Channel />);
+
+    apply({
+      osIntentAutoStartVoice: "yes",
+      osIntentAutoStartTranscription: false,
+    });
+
+    expect(loadOsIntentAutoStartConsent()).toEqual({
+      voice: true,
+      transcription: false,
+    });
+  });
+
+  it("leaves stored consent untouched when a broadcast carries no consent field", () => {
+    saveContinuousChatMode("vad-gated");
+    saveOsIntentAutoStartConsent({ voice: true, transcription: true });
+    render(<Channel />);
+
+    apply({ continuous: "always-on" });
+
+    expect(loadContinuousChatMode()).toBe("always-on");
+    expect(loadOsIntentAutoStartConsent()).toEqual({
+      voice: true,
+      transcription: true,
+    });
+  });
+
+  it("lets a later valid broadcast replace earlier mirror values", () => {
+    render(<Channel />);
+
+    apply({
+      continuous: "off",
+      vadAutoStop: { silenceMs: 1200, speechRmsThreshold: 0.004 },
+    });
+    apply({
+      continuous: "always-on",
+      vadAutoStop: { silenceMs: 800, speechRmsThreshold: 0.005 },
+    });
+
+    expect(loadContinuousChatMode()).toBe("always-on");
+    expect(loadVadAutoStop()).toEqual({
+      silenceMs: 800,
+      speechRmsThreshold: 0.005,
+    });
+  });
+
+  it("writes nothing when the broadcast payload is empty", () => {
+    saveContinuousChatMode("vad-gated");
+    saveVadAutoStop({ silenceMs: 777, speechRmsThreshold: 0.123 });
+    saveOsIntentAutoStartConsent({ voice: true, transcription: true });
+    render(<Channel />);
+
+    apply({});
+
+    expect(loadContinuousChatMode()).toBe("vad-gated");
+    expect(loadVadAutoStop()).toEqual({
+      silenceMs: 777,
+      speechRmsThreshold: 0.123,
+    });
     expect(loadOsIntentAutoStartConsent()).toEqual({
       voice: true,
       transcription: true,


### PR DESCRIPTION

## What

Extends the existing jsdom suite for `useVoiceSettingsApplyChannel` — the
always-mounted bridge that re-seeds the voice localStorage mirrors when a
chat-driven `voice-settings:apply` broadcast arrives. **Test-only change: no
production file is touched.**

The suite on `develop` already covered the happy path, one invalid-mode case,
single-field isolation, and consent merging. This PR appends nine cases for
branches nothing reached yet, each driving a real broadcast through
`emitViewEvent` into the real persistence layer (no stubs):

- non-string `continuous` values (`42`, `null`) are ignored and the stored mode survives;
- array and `null` `vadAutoStop` payloads are rejected wholesale;
- a pair missing only `speechRmsThreshold` is not partially applied (the valid `silenceMs` is not written alone);
- non-finite VAD numbers (`NaN`, `Infinity`) are rejected;
- an explicit `false` consent value persists as `false` while the absent sibling keeps its stored value;
- a consent field of the wrong type (`"yes"`) is ignored while the valid boolean sibling still persists;
- a broadcast carrying no consent field leaves stored consent untouched;
- a later valid broadcast replaces earlier mirror values (last write wins);
- an empty payload writes nothing to any mirror.

Seeded mirrors use deliberately non-default values so a malformed write would be
visible through the loaders rather than masked by their sanitizing defaults.

## Evidence

Fork contributor note: hosted CI does not run on this pull request; the checks
below were executed locally at head `013e36e3105a3572bce8e764a3b371770bbdafee`
(base `origin/develop` @ `51617538d704126b0d308654ccaaff091e474a67`).

1. `vitest run --config ./vitest.config.ts src/voice/useVoiceSettingsApplyChannel.test.tsx` in `packages/ui`: **1 file passed, 13 tests passed / 0 failed** (4 pre-existing + 9 new). Re-run after formatting with identical counts.
2. `bunx biome check --write packages/ui/src/voice/useVoiceSettingsApplyChannel.test.tsx`: clean (one formatting normalization applied, then re-verified).
3. `tsc --noEmit -p tsconfig.json` in `packages/ui` (strict; tsconfig includes all of `src`, only stories excluded): zero diagnostics referencing the new test file.
4. Diff is exactly one test file against `origin/develop`: `packages/ui/src/voice/useVoiceSettingsApplyChannel.test.tsx`, **+140/-0** — every existing line is byte-identical, additions only.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
      The single commit's parent is `origin/develop` @ `51617538d704126b0d308654ccaaff091e474a67`.
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
      Not run for this additive test-only diff; the scoped gates actually
      affected (vitest, biome, tsc) are quoted in **Evidence** above, and the
      gap is recorded under **Known gaps / failures**.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below. Run the single vitest command under **Testing**
      and observe `13 passed`.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

Low. The diff adds test cases only; no production module, build output, or
runtime behavior changes, so there is no user-facing surface at risk. The only
maintenance risk is that future intentional changes to payload validation will
need to update these expectations — which is the suite's job.

# Background

## What does this PR do?

Appends nine jsdom cases to the existing `useVoiceSettingsApplyChannel` suite,
covering validation branches (non-string continuous modes; array/null and
non-finite `vadAutoStop`; pairs invalid only in `speechRmsThreshold`), consent
merge semantics (explicit `false`, wrong-typed fields, unrelated broadcasts),
last-write-wins overwrite, and the empty-payload no-op.

## What kind of change is this?

Improvements (misc. changes to existing features) — test coverage only; no
production file is modified.

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

My changes do not require a change to the project documentation.

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

`packages/ui/src/voice/useVoiceSettingsApplyChannel.test.tsx`, second
`describe("useVoiceSettingsApplyChannel payload validation edges")` block — nine
appended `it` cases; the four pre-existing cases above it are byte-identical to
`develop`.

## Detailed testing steps

```bash
cd packages/ui
NODE_OPTIONS="--no-experimental-webstorage --disable-warning=ExperimentalWarning" \
  bunx vitest run --config ./vitest.config.ts src/voice/useVoiceSettingsApplyChannel.test.tsx
```

Expected: `Test Files 1 passed (1)`, `Tests 13 passed (13)`.

None: Automated tests are acceptable.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:013e36e3105a3572bce8e764a3b371770bbdafee -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
      N/A - no rendered surface is affected; the hook under test returns
      `null` and the change touches no component output.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
      N/A - same reason: test-only diff with zero rendered-surface change.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
      N/A - no user-facing flow changes; behavior is asserted by automated tests.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
      N/A - no backend path involved; assertions read localStorage directly.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
      N/A - no network requests are part of this module's contract.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
      N/A - no agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
      N/A - test writes only jsdom localStorage mirrors inside the suite process.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.
      N/A - the change has no rendered visual surface (headless hook test).

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

N/A - no rendered visual surface (test-only change).

### After

N/A - no rendered visual surface (test-only change).

### Walkthrough video

N/A - no user-facing flow change; the vitest command under **Testing** is the
reproduction.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

N/A - the module persists preference mirrors; it touches no audio capture or
playback pipeline, so there is no audible round-trip to record.

## Known gaps / failures

- `bun run verify` (full repo gate) was not executed: this diff is one additive
  test file, and the gates its content can affect were run scoped instead —
  vitest 13/13 passed, `biome check --write` clean, strict `tsc --noEmit` in
  `packages/ui` reports zero diagnostics for the new file.
- Hosted CI does not run on fork pull requests; all quoted counts were observed
  locally at head `013e36e3105a3572bce8e764a3b371770bbdafee`.
- Evidence bonus waived (`FACTORY_NO_EVIDENCE`): an unattended session cannot
  finalize an interactive identity.slop.cash OAuth trace.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
