### PR TITLE
test(ui): cover useConnectorMode mode resolution

### DIFF
--- a/packages/ui/src/components/connectors/ConnectorModeSelector.hooks.test.ts
+++ b/packages/ui/src/components/connectors/ConnectorModeSelector.hooks.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Unit tests for `useConnectorMode` (`ConnectorModeSelector.hooks.ts`):
+ * default-mode seeding, cloud/lens filtering of the available mode list,
+ * automatic re-defaulting when a selected mode stops being offered, and the
+ * mode -> setup-plugin mapping. Fully deterministic — drives the real
+ * connector-mode registry seed data (discord) through the real helpers; no
+ * network, no DOM, no module mocks.
+ */
+// @vitest-environment jsdom
+
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useConnectorMode } from "./ConnectorModeSelector.hooks";
+import { CONNECTOR_PLUGIN_MANAGED_MODE_ID } from "./connector-account-options";
+
+describe("useConnectorMode", () => {
+  it("seeds the ranked default and hides cloud-only modes while offline", () => {
+    const { result } = renderHook(() => useConnectorMode("discord"));
+    expect(result.current.modes.map((mode) => mode.id)).toEqual([
+      "local",
+      "bot",
+    ]);
+    expect(result.current.selectedMode).toBe("bot");
+    expect(result.current.setupPluginId).toBe("discord");
+  });
+
+  it("offers the managed gateway first and defaults to it once cloud connects", () => {
+    const { result } = renderHook(() =>
+      useConnectorMode("x", { elizaCloudConnected: true }),
+    );
+    const ids = result.current.modes.map((mode) => mode.id);
+    expect(ids[0]).toBe(CONNECTOR_PLUGIN_MANAGED_MODE_ID);
+    expect(ids).toContain("oauth");
+    expect(ids).toContain("local-oauth");
+    expect(ids).toContain("developer");
+    expect(result.current.selectedMode).toBe(CONNECTOR_PLUGIN_MANAGED_MODE_ID);
+    expect(result.current.setupPluginId).toBe(
+      "connector-account-management:x:x",
+    );
+  });
+
+  it("offers the catalog-backed managed mode even while offline", () => {
+    const { result } = renderHook(() => useConnectorMode("x"));
+    expect(result.current.modes.map((mode) => mode.id)).toEqual([
+      CONNECTOR_PLUGIN_MANAGED_MODE_ID,
+      "local-oauth",
+      "developer",
+    ]);
+    expect(result.current.selectedMode).toBe(CONNECTOR_PLUGIN_MANAGED_MODE_ID);
+  });
+
+  it("keeps an explicit selection that is still offered", () => {
+    const { result } = renderHook(() =>
+      useConnectorMode("discord", { elizaCloudConnected: true }),
+    );
+    act(() => {
+      result.current.setSelectedMode("local");
+    });
+    expect(result.current.selectedMode).toBe("local");
+    expect(result.current.setupPluginId).toBe("discordlocal");
+  });
+
+  it("re-defaults when the chosen mode is filtered out by a later option change", () => {
+    const { result, rerender } = renderHook(
+      ({
+        connected,
+        provisioned,
+      }: {
+        connected: boolean;
+        provisioned: boolean;
+      }) =>
+        useConnectorMode("discord", {
+          elizaCloudConnected: connected,
+          cloudProvisioned: provisioned,
+        }),
+      { initialProps: { connected: true, provisioned: false } },
+    );
+    act(() => {
+      result.current.setSelectedMode("local");
+    });
+    expect(result.current.selectedMode).toBe("local");
+    rerender({ connected: true, provisioned: true });
+    expect(result.current.modes.map((mode) => mode.id)).not.toContain("local");
+    expect(result.current.selectedMode).not.toBe("local");
+  });
+
+  it("filters modes to the active channel-mode lens", () => {
+    const { result } = renderHook(() =>
+      useConnectorMode("discord", {
+        elizaCloudConnected: true,
+        channelMode: "delegate",
+      }),
+    );
+    const ids = result.current.modes
+      .filter((mode) => mode.id !== CONNECTOR_PLUGIN_MANAGED_MODE_ID)
+      .map((mode) => mode.id);
+    expect(ids).toEqual(["local"]);
+    expect(result.current.selectedMode).toBe("local");
+  });
+
+  it("degrades to an empty selection for a connector with no declared modes", () => {
+    const { result } = renderHook(() =>
+      useConnectorMode("totally-unknown-connector"),
+    );
+    expect(result.current.modes).toEqual([]);
+    expect(result.current.selectedMode).toBe("");
+    expect(result.current.setupPluginId).toBeNull();
+  });
+});


### PR DESCRIPTION

## What

Adds `ConnectorModeSelector.hooks.test.ts`, a unit suite for `useConnectorMode` — the hook that seeds, filters, and re-defaults the connector setup-mode selection consumed by `ConnectorModeSelector`.

## Why

The hook had no direct coverage. Its contract — ranked default seeding, cloud-only and managed-cloud filtering, plugin-managed mode injection from the shared account catalog, channel-lens filtering, and automatic re-defaulting when a selected mode stops being offered — was only exercised incidentally through component stories. This pins it at the unit layer.

## How tested

- `bunx vitest run src/components/connectors/ConnectorModeSelector.hooks.test.ts` (in packages/ui): **7 passed / 7, 1 file** — re-run against current `origin/develop` (`51617538d704`) immediately before filing; every dependency file is byte-identical between the working tree and that revision.
- `bunx biome check src/components/connectors/ConnectorModeSelector.hooks.test.ts`: clean.
- `bunx tsc --noEmit` (packages/ui): the new test file appears nowhere in the output.

The suite drives the real connector-mode registry seed data and the real `@elizaos/shared` connector account catalog through the real helpers — no module mocks and no `vi.fn` stand-ins for the system under test. Expectations record observed behavior, including that the catalog-backed `plugin-managed` mode is offered (and becomes the default) even while offline, that connecting adds the cloud-only mode to the list, that `hideOnManagedCloud` removes a chosen mode and the hook re-defaults, and that connectors absent from the catalog (e.g. `discord`) never receive a managed mode while unknown connectors degrade to an empty selection.

This is a test-only diff: one new file (+109/-0), no production code touched. As a fork contributor, hosted CI does not run on this pull request; the counts above are quoted from local runs.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:f6d3df3e18c36e958e07bc22f52671b56b92f248 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
