### PR TITLE
test(ui): cover jni-voice-harness

### DIFF
--- a/packages/ui/src/voice/jni-voice-harness.test.ts
+++ b/packages/ui/src/voice/jni-voice-harness.test.ts
@@ -8,7 +8,7 @@
  * the 20-entry recent-turns ring buffer surfaced through `status()`.
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { JniVoiceHarnessOptions } from "./jni-voice-harness";
+import type { installJniVoiceHarness } from "./jni-voice-harness";
 import type {
   JniAttributedTurn,
   JniCompletedPcmTurn,
@@ -105,6 +105,11 @@ vi.mock("./jni-voice-pipeline", () => ({
   JniVoicePipeline: FakeJniVoicePipeline,
 }));
 
+type JniVoiceHarnessOptions = Parameters<typeof installJniVoiceHarness>[0];
+
+// Tests re-import the subject after vi.resetModules() so its private
+// singletons (pipeline, recentTurns, installed flag) start fresh; the static
+// value binding keeps the option types tied to the real source.
 async function loadHarness(options: JniVoiceHarnessOptions = {}) {
   const module = await import("./jni-voice-harness");
   return module.installJniVoiceHarness(options);

--- a/packages/ui/src/voice/jni-voice-harness.test.ts
+++ b/packages/ui/src/voice/jni-voice-harness.test.ts
@@ -8,7 +8,6 @@
  * the 20-entry recent-turns ring buffer surfaced through `status()`.
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { installJniVoiceHarness } from "./jni-voice-harness";
 import type {
   JniAttributedTurn,
   JniCompletedPcmTurn,
@@ -105,11 +104,14 @@ vi.mock("./jni-voice-pipeline", () => ({
   JniVoicePipeline: FakeJniVoicePipeline,
 }));
 
-type JniVoiceHarnessOptions = Parameters<typeof installJniVoiceHarness>[0];
-
 // Tests re-import the subject after vi.resetModules() so its private
-// singletons (pipeline, recentTurns, installed flag) start fresh; the static
-// value binding keeps the option types tied to the real source.
+// singletons (pipeline, recentTurns, installed flag) start fresh; the option
+// type is queried off that same dynamic module so it stays tied to source.
+type JniVoiceHarnessModule = typeof import("./jni-voice-harness");
+type JniVoiceHarnessOptions = Parameters<
+  JniVoiceHarnessModule["installJniVoiceHarness"]
+>[0];
+
 async function loadHarness(options: JniVoiceHarnessOptions = {}) {
   const module = await import("./jni-voice-harness");
   return module.installJniVoiceHarness(options);

--- a/packages/ui/src/voice/jni-voice-harness.test.ts
+++ b/packages/ui/src/voice/jni-voice-harness.test.ts
@@ -1,0 +1,376 @@
+// @vitest-environment jsdom
+/**
+ * Unit coverage for the JNI voice harness control surface
+ * (`installJniVoiceHarness`) driving the real harness while the native bridge
+ * plugins, local-agent client, and `JniVoicePipeline` collaborators are mocked:
+ * pins lazy single-pipeline wiring and option derivation, start/stop lifecycle
+ * results, the structured status fallback when the voice ABI probe fails, and
+ * the 20-entry recent-turns ring buffer surfaced through `status()`.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { JniVoiceHarnessOptions } from "./jni-voice-harness";
+import type {
+  JniAttributedTurn,
+  JniCompletedPcmTurn,
+  JniVoicePipelineOptions,
+} from "./jni-voice-pipeline";
+import type { VoiceTurnSignal } from "./voice-turn-signal";
+
+class FakeJniVoicePipeline {
+  framesSent = 0;
+  playbackFramesReceived = 0;
+  lastEchoErleDb = 0;
+  turnsObserved = 0;
+  turnListener: ((turn: JniAttributedTurn) => void) | null = null;
+  startOutcome: { started: boolean; error?: string } | { failure: unknown } = {
+    started: true,
+  };
+  onStop: (() => void) | undefined;
+
+  constructor(
+    readonly talkMode: unknown,
+    readonly voicePlugin: unknown,
+    readonly options: JniVoicePipelineOptions,
+  ) {
+    pipelineCaptures.instances.push(this);
+    if (pipelineCaptures.nextStart) {
+      this.startOutcome = pipelineCaptures.nextStart;
+    }
+  }
+
+  private running = false;
+
+  get isRunning(): boolean {
+    return this.running;
+  }
+
+  onTurn(listener: (turn: JniAttributedTurn) => void): () => void {
+    this.turnListener = listener;
+    return () => {
+      this.turnListener = null;
+    };
+  }
+
+  async start(): Promise<{ started: boolean; error?: string }> {
+    if ("failure" in this.startOutcome) throw this.startOutcome.failure;
+    if (!this.startOutcome.started) return this.startOutcome;
+    this.running = true;
+    return { started: true };
+  }
+
+  async stop(): Promise<void> {
+    this.onStop?.();
+    this.running = false;
+  }
+}
+
+const pipelineCaptures: {
+  instances: FakeJniVoicePipeline[];
+  nextStart: { started: boolean; error?: string } | { failure: unknown } | null;
+} = {
+  instances: [],
+  nextStart: null,
+};
+
+const shared = {
+  talkModePlugin: {} as Record<string, unknown>,
+  elizaVoicePlugin: { voiceAbiVersion: vi.fn() },
+};
+
+const clientState = {
+  bases: [] as (string | undefined)[],
+  rawRequest: vi.fn(),
+};
+
+vi.mock("../api", () => ({
+  ElizaClient: class {
+    rawRequest = clientState.rawRequest;
+
+    constructor(baseUrl?: string) {
+      clientState.bases.push(baseUrl);
+    }
+  },
+}));
+
+vi.mock("../bridge/native-plugins", () => ({
+  getTalkModePlugin: () => shared.talkModePlugin,
+  getElizaVoicePlugin: () => shared.elizaVoicePlugin,
+}));
+
+vi.mock("../first-run/mobile-runtime-mode", () => ({
+  MOBILE_LOCAL_AGENT_API_BASE: "http://127.0.0.1:3000",
+}));
+
+vi.mock("./jni-voice-pipeline", () => ({
+  JniVoicePipeline: FakeJniVoicePipeline,
+}));
+
+async function loadHarness(options: JniVoiceHarnessOptions = {}) {
+  const module = await import("./jni-voice-harness");
+  return module.installJniVoiceHarness(options);
+}
+
+function signalFixture(
+  overrides: Partial<VoiceTurnSignal> = {},
+): VoiceTurnSignal {
+  return {
+    endOfTurnProbability: 0.92,
+    nextSpeaker: "user",
+    agentShouldSpeak: false,
+    source: "test",
+    ...overrides,
+  };
+}
+
+function attributedTurnFixture(
+  overrides: Partial<JniAttributedTurn> = {},
+): JniAttributedTurn {
+  return {
+    turnId: "t1",
+    samples: 16_000,
+    durationMs: 1_000,
+    embeddingNorm: 1.02,
+    embedding: new Float32Array(),
+    diarizLabels: new Int8Array(),
+    diarizDistinctClasses: 1,
+    signal: signalFixture(),
+    ...overrides,
+  };
+}
+
+function completedPcmTurnFixture(): JniCompletedPcmTurn {
+  return {
+    turnId: "t1",
+    audio: { pcm: new Float32Array([0.5, -0.5]), sampleRate: 16_000 },
+    signal: signalFixture(),
+  };
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  pipelineCaptures.instances.length = 0;
+  pipelineCaptures.nextStart = null;
+  clientState.bases.length = 0;
+  clientState.rawRequest = vi.fn();
+  shared.talkModePlugin = {};
+  shared.elizaVoicePlugin = { voiceAbiVersion: vi.fn() };
+  window.__jniVoice = undefined;
+});
+
+describe("installJniVoiceHarness window attachment", () => {
+  it("attaches the first control to window.__jniVoice and keeps it stable across reinstalls", async () => {
+    const first = await loadHarness();
+    expect(window.__jniVoice).toBe(first);
+
+    const second = await loadHarness();
+    expect(second).not.toBe(first);
+    expect(window.__jniVoice).toBe(first);
+
+    expect(await second.status()).toEqual(await first.status());
+  });
+});
+
+describe("pipeline wiring and lifecycle", () => {
+  it("constructs the pipeline lazily on first use with the bridge plugins and derived options", async () => {
+    const control = await loadHarness({
+      bundleDir: "/data/eliza-1/bundle",
+      knownSpeakerEntityIds: ["owner-1"],
+    });
+    expect(pipelineCaptures.instances).toHaveLength(0);
+
+    await control.start();
+
+    expect(pipelineCaptures.instances).toHaveLength(1);
+    const instance = pipelineCaptures.instances[0];
+    if (!instance) throw new Error("pipeline was not constructed");
+    expect(instance.talkMode).toBe(shared.talkModePlugin);
+    expect(instance.voicePlugin).toBe(shared.elizaVoicePlugin);
+    expect(instance.options.bundleDir).toBe("/data/eliza-1/bundle");
+    expect(instance.options.knownSpeakerEntityIds).toEqual(["owner-1"]);
+    expect(typeof instance.options.onCompletedPcmTurn).toBe("function");
+  });
+
+  it("reuses one pipeline across installs and later starts, ignoring later options", async () => {
+    const first = await loadHarness({ bundleDir: "/first" });
+    await first.start();
+
+    const second = await loadHarness({ bundleDir: "/second" });
+    await expect(second.start()).resolves.toEqual({ started: true });
+
+    expect(pipelineCaptures.instances).toHaveLength(1);
+    expect(pipelineCaptures.instances[0]?.options.bundleDir).toBe("/first");
+    expect(second.isRunning()).toBe(true);
+  });
+
+  it("strips the completed-turn forwarder when forwarding is disabled", async () => {
+    const control = await loadHarness({ forwardCompletedPcmTurns: false });
+    await control.start();
+
+    expect(
+      pipelineCaptures.instances[0]?.options.onCompletedPcmTurn,
+    ).toBeUndefined();
+  });
+
+  it("passes an explicit completed-turn handler through by reference even when forwarding is disabled", async () => {
+    const explicit = vi.fn();
+    const control = await loadHarness({
+      onCompletedPcmTurn: explicit,
+      forwardCompletedPcmTurns: false,
+    });
+    await control.start();
+
+    expect(pipelineCaptures.instances[0]?.options.onCompletedPcmTurn).toBe(
+      explicit,
+    );
+  });
+
+  it("returns a failed capture result verbatim and leaves forwarding inert", async () => {
+    pipelineCaptures.nextStart = { started: false, error: "mic busy" };
+    const control = await loadHarness();
+
+    await expect(control.start()).resolves.toEqual({
+      started: false,
+      error: "mic busy",
+    });
+    expect(control.isRunning()).toBe(false);
+
+    const instance = pipelineCaptures.instances[0];
+    if (!instance) throw new Error("pipeline was not constructed");
+    const forwarded = instance.options.onCompletedPcmTurn;
+    if (!forwarded) throw new Error("forwarder missing");
+    await expect(forwarded(completedPcmTurnFixture())).resolves.toBeUndefined();
+    expect(clientState.rawRequest).not.toHaveBeenCalled();
+  });
+
+  it("propagates a throwing pipeline start", async () => {
+    pipelineCaptures.nextStart = { failure: new Error("native crash") };
+    const control = await loadHarness();
+
+    await expect(control.start()).rejects.toThrow("native crash");
+    expect(control.isRunning()).toBe(false);
+  });
+
+  it("stop reports the frame count captured before stopping", async () => {
+    const control = await loadHarness();
+    await control.start();
+    const instance = pipelineCaptures.instances[0];
+    if (!instance) throw new Error("pipeline was not constructed");
+    instance.framesSent = 7;
+    instance.onStop = () => {
+      instance.framesSent = 99;
+    };
+
+    await expect(control.stop()).resolves.toEqual({
+      stopped: true,
+      framesSent: 7,
+    });
+    expect(control.isRunning()).toBe(false);
+    expect(instance.framesSent).toBe(99);
+  });
+});
+
+describe("status reporting", () => {
+  it.each([
+    ["an Error rejection", new Error("bridge offline"), "bridge offline"],
+    ["a non-Error rejection", "bridge unavailable", "bridge unavailable"],
+  ])(
+    "reports structured defaults with %s from the ABI probe before the pipeline exists",
+    async (_label, rejection, expectedError) => {
+      shared.elizaVoicePlugin.voiceAbiVersion.mockRejectedValueOnce(rejection);
+      const control = await loadHarness();
+
+      const status = await control.status();
+
+      expect(status.running).toBe(false);
+      expect(status.framesSent).toBe(0);
+      expect(status.playbackFramesReceived).toBe(0);
+      expect(status.lastEchoErleDb).toBe(0);
+      expect(status.turnsObserved).toBe(0);
+      expect(status.recentTurns).toEqual([]);
+      expect(status.error).toBe(expectedError);
+      expect("abi" in status).toBe(false);
+    },
+  );
+
+  it("aggregates live pipeline counters, recorded turns, and the voice ABI", async () => {
+    const abi = { loaded: true, vad: 1, speaker: 1, diariz: 1 };
+    shared.elizaVoicePlugin.voiceAbiVersion.mockResolvedValueOnce(abi);
+    const control = await loadHarness();
+    await control.start();
+
+    const instance = pipelineCaptures.instances[0];
+    if (!instance) throw new Error("pipeline was not constructed");
+    instance.framesSent = 3;
+    instance.playbackFramesReceived = 5;
+    instance.lastEchoErleDb = -8.25;
+    instance.turnsObserved = 4;
+    instance.turnListener?.(
+      attributedTurnFixture({
+        turnId: "t9",
+        durationMs: 1_500,
+        embeddingNorm: 0.97,
+        diarizDistinctClasses: 2,
+        signal: signalFixture({
+          agentShouldSpeak: true,
+          nextSpeaker: "agent",
+        }),
+      }),
+    );
+
+    const status = await control.status();
+
+    expect(status.running).toBe(true);
+    expect(status.framesSent).toBe(3);
+    expect(status.playbackFramesReceived).toBe(5);
+    expect(status.lastEchoErleDb).toBe(-8.25);
+    expect(status.turnsObserved).toBe(4);
+    expect(status.abi).toEqual(abi);
+    expect("error" in status).toBe(false);
+    expect(status.recentTurns).toEqual([
+      {
+        turnId: "t9",
+        durationMs: 1_500,
+        embeddingNorm: 0.97,
+        diarizDistinctClasses: 2,
+        agentShouldSpeak: true,
+        nextSpeaker: "agent",
+      },
+    ]);
+  });
+
+  it("caps recentTurns at twenty entries and drops the oldest first", async () => {
+    const control = await loadHarness();
+    await control.start();
+    const instance = pipelineCaptures.instances[0];
+    if (!instance) throw new Error("pipeline was not constructed");
+
+    for (let index = 1; index <= 22; index += 1) {
+      instance.turnListener?.(
+        attributedTurnFixture({
+          turnId: `t${String(index).padStart(2, "0")}`,
+        }),
+      );
+    }
+
+    const status = await control.status();
+    expect(status.recentTurns).toHaveLength(20);
+    expect(status.recentTurns[0]?.turnId).toBe("t03");
+    expect(status.recentTurns.at(-1)?.turnId).toBe("t22");
+  });
+
+  it("returns defensive copies of recentTurns on every status read", async () => {
+    const control = await loadHarness();
+    await control.start();
+    const instance = pipelineCaptures.instances[0];
+    if (!instance) throw new Error("pipeline was not constructed");
+    instance.turnListener?.(attributedTurnFixture({ turnId: "only" }));
+
+    const first = await control.status();
+    first.recentTurns.pop();
+
+    const second = await control.status();
+    expect(second.recentTurns).toHaveLength(1);
+    expect(second.recentTurns[0]?.turnId).toBe("only");
+    expect(second.recentTurns).not.toBe(first.recentTurns);
+  });
+});


### PR DESCRIPTION

# Summary

Adds a new unit suite for `packages/ui/src/voice/jni-voice-harness.ts`, which has no same-named test coverage on develop: the existing `jni-voice-harness-timeout.test.ts` pins only the completed-PCM-turn deadline path. This suite drives the real control surface returned by `installJniVoiceHarness()` and mocks only collaborators that cannot exist off-device — the Capacitor bridge plugins, the local-agent HTTP client, and the `JniVoicePipeline` boundary.

## What is covered

- **Window attachment** — the first installed control is published at `window.__jniVoice`; reinstalls keep the published handle stable while returning fresh but equivalent controls.
- **Lazy pipeline wiring** — nothing is constructed until first use; construction receives the talk-mode / voice plugins by identity and the derived options (`bundleDir`, `knownSpeakerEntityIds`, forwarder).
- **One-pipeline singleton** across installs and later starts; later options are ignored.
- **Forwarding derivation** — forwarding is on by default, stripped when `forwardCompletedPcmTurns === false`, and an explicit `onCompletedPcmTurn` wins by reference even when forwarding is disabled.
- **Start lifecycle** — a failed capture result is returned verbatim; a throwing start propagates; `isRunning()` stays false; after a failed start the forwarder resolves inertly without touching the local-agent client.
- **Stop contract** — `{ stopped: true, framesSent }` carries the frame count captured *before* the pipeline stops; a counter bump during stop does not leak into the result.
- **Status reporting** — structured defaults with the ABI-probe failure surfaced as `error` (both `Error` messages and non-Error rejections stringified, no `abi` key); live aggregation of pipeline counters plus ABI on success; the 20-entry FIFO cap on `recentTurns` (oldest dropped); summary mapping of attributed turns (`signal.agentShouldSpeak`, `signal.nextSpeaker`); and defensive copies of `recentTurns` on every read.

## Diff shape

Test-only change: one new file (`packages/ui/src/voice/jni-voice-harness.test.ts`), +376/−0. No production behavior changed, no existing test modified or removed.

# Testing

Fork contributor: hosted CI does not run on this PR; local results below are from the exact head `199751f0f8aecd7b07fe913296c332d3b0dda71e`.

```bash
cd packages/ui && bunx vitest run --config ./vitest.config.ts src/voice/jni-voice-harness.test.ts
```

Result (re-run against current origin/develop immediately before filing):

```text
 Test Files  1 passed (1)
      Tests  13 passed (13)
```

Lint and typecheck:

```text
bunx biome check packages/ui/src/voice/jni-voice-harness.test.ts
  → Checked 1 file in 12ms. No fixes applied. (clean)

bunx tsc --noEmit   # in packages/ui
  → src/voice/jni-voice-harness.test.ts appears nowhere in the output;
    remaining errors are pre-existing files untouched by this diff.
```

No `expectTypeOf` / type-only assertions are used; every case asserts runtime behavior through the real module.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:9a9b7fadf8b3545cb32b20a4520a06f39663a5ed -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
