### PR TITLE
fix(meetings): discard stale ASR response when a speaker resubmits before the orphaned request returns

### DIFF
--- a/plugins/plugin-meetings/src/pipeline/__tests__/speaker-streams.test.ts
+++ b/plugins/plugin-meetings/src/pipeline/__tests__/speaker-streams.test.ts
@@ -255,6 +255,71 @@ describe("SpeakerStreamManager", () => {
     expect(h.manager.getPendingSnapshot("a")).toBeNull();
   });
 
+  it("discards a stale response even after the same speaker resubmits, and still accepts the genuine one", async () => {
+    const h = harness();
+    h.manager.addSpeaker("a", "Alice");
+
+    // Submission #1 (generation 0) goes in flight.
+    h.manager.feedAudio("a", seconds(2));
+    vi.advanceTimersByTime(2000);
+    expect(h.submissions).toHaveLength(1);
+
+    // Speaker change / mute / leave flushes while the gen-0 request is still
+    // outstanding: fullReset bumps the generation and clears inFlight, but the
+    // orphaned network request cannot be cancelled.
+    await h.manager.flushSpeaker("a");
+
+    // The same speaker resumes talking. A pending gen-0 request is still
+    // outstanding, so no new submission may start — that would overwrite the
+    // stale-response guard and let the orphan through (the reported defect).
+    h.manager.feedAudio("a", seconds(2));
+    vi.advanceTimersByTime(2000);
+    expect(h.submissions).toHaveLength(1);
+
+    // The orphaned gen-0 response finally returns (twice, enough to cross the
+    // confirm threshold if it were wrongly accepted). It must be discarded and
+    // never poison the transcript.
+    h.manager.handleTranscriptionResult("a", "stale text from old context");
+    h.manager.handleTranscriptionResult("a", "stale text from old context");
+    expect(h.confirmed).toHaveLength(0);
+    expect(h.confirmed.map((c) => c.text)).not.toContain(
+      "stale text from old context",
+    );
+
+    // With the orphan drained, the resumed audio submits as generation 1 and
+    // its genuine response confirms normally — the stream is not wedged.
+    vi.advanceTimersByTime(2000);
+    expect(h.submissions).toHaveLength(2);
+    h.manager.handleTranscriptionResult("a", "fresh words after resume");
+    h.manager.feedAudio("a", seconds(2));
+    vi.advanceTimersByTime(2000);
+    expect(h.submissions).toHaveLength(3);
+    h.manager.handleTranscriptionResult("a", "fresh words after resume");
+    expect(h.confirmed.map((c) => c.text)).toEqual([
+      "fresh words after resume",
+    ]);
+  });
+
+  it("never runs a second concurrent submission while an orphaned request is outstanding", async () => {
+    const h = harness();
+    h.manager.addSpeaker("a", "Alice");
+    h.manager.feedAudio("a", seconds(2));
+    vi.advanceTimersByTime(2000);
+    await h.manager.flushSpeaker("a"); // orphan gen-0 left in flight
+
+    // Feed audio and let several cadence ticks fire: the pending orphan blocks
+    // every one, so exactly one request is ever in flight.
+    h.manager.feedAudio("a", seconds(4));
+    vi.advanceTimersByTime(6000);
+    expect(h.submissions).toHaveLength(1);
+
+    // Only once the orphan resolves does the next submission become eligible.
+    h.manager.handleTranscriptionResult("a", "stale text from old context");
+    vi.advanceTimersByTime(2000);
+    expect(h.submissions).toHaveLength(2);
+    expect(h.confirmed).toHaveLength(0);
+  });
+
   it("speaker-change flush emits the forming transcript immediately", async () => {
     const h = harness();
     h.manager.addSpeaker("a", "Alice");

--- a/plugins/plugin-meetings/src/pipeline/speaker-streams.ts
+++ b/plugins/plugin-meetings/src/pipeline/speaker-streams.ts
@@ -98,6 +98,18 @@ export class SpeakerStreamManager {
   private readonly buffers = new Map<string, SpeakerBuffer>();
   private readonly timers = new Map<string, ReturnType<typeof setInterval>>();
   private readonly submitGeneration = new Map<string, number>();
+  /**
+   * Count of ASR requests dispatched but not yet resolved, per speaker. A
+   * request stays counted across a `fullReset()` (which clears `inFlight` and
+   * bumps `generation` but cannot cancel the outstanding network call), so a
+   * new submission is never started while an orphaned request is still in
+   * flight. That keeps `submitGeneration` pinned to the orphan's generation,
+   * letting the generation guard discard its late response instead of
+   * overwriting the slot and accepting stale text. The pipeline guarantees
+   * exactly one `handleTranscriptionResult` per `onSegmentReady`, so this
+   * counter always drains and never stalls the stream.
+   */
+  private readonly pendingSubmissions = new Map<string, number>();
   private readonly minAudioDurationSec: number;
   private readonly submitIntervalSec: number;
   private readonly confirmThreshold: number;
@@ -197,9 +209,16 @@ export class SpeakerStreamManager {
     if (!buffer) return;
 
     buffer.inFlight = false;
+    // Every response drains exactly one dispatched request, even a stale one
+    // whose buffer was reset — otherwise the counter would wedge and block all
+    // future submissions for this speaker.
+    this.clearOnePending(speakerKey);
 
     // Discard stale responses: buffer was fully reset while this request was
-    // in flight — accepting it would poison lastTranscript with old text.
+    // in flight — accepting it would poison lastTranscript with old text. The
+    // pendingSubmissions gate prevents a newer submission from overwriting
+    // submitGeneration while this orphan is outstanding, so the comparison
+    // still holds even when the same speaker resumed and resubmitted.
     const submitGen = this.submitGeneration.get(speakerKey);
     if (submitGen !== undefined && submitGen < buffer.generation) return;
 
@@ -375,6 +394,7 @@ export class SpeakerStreamManager {
 
     this.buffers.delete(speakerKey);
     this.submitGeneration.delete(speakerKey);
+    this.pendingSubmissions.delete(speakerKey);
   }
 
   removeAll(): void {
@@ -398,7 +418,11 @@ export class SpeakerStreamManager {
       return;
     }
 
-    if (this.unconfirmedSamples(buffer) > 0 && !buffer.inFlight) {
+    if (
+      this.unconfirmedSamples(buffer) > 0 &&
+      !buffer.inFlight &&
+      !this.hasPendingSubmission(speakerKey)
+    ) {
       buffer.idleSubmitted = true;
       logger.debug(
         `[MeetingPipeline] Flush-submit for "${buffer.speakerName}" (${(
@@ -442,7 +466,8 @@ export class SpeakerStreamManager {
 
   private trySubmit(speakerKey: string): void {
     const buffer = this.buffers.get(speakerKey);
-    if (!buffer || buffer.inFlight) return;
+    if (!buffer || buffer.inFlight || this.hasPendingSubmission(speakerKey))
+      return;
 
     const unconfirmedSec = this.unconfirmedSamples(buffer) / this.sampleRate;
     const totalSec = buffer.totalSamples / this.sampleRate;
@@ -518,6 +543,10 @@ export class SpeakerStreamManager {
 
     buffer.inFlight = true;
     this.submitGeneration.set(buffer.speakerKey, buffer.generation);
+    this.pendingSubmissions.set(
+      buffer.speakerKey,
+      (this.pendingSubmissions.get(buffer.speakerKey) ?? 0) + 1,
+    );
 
     try {
       this.onSegmentReady(
@@ -527,9 +556,24 @@ export class SpeakerStreamManager {
         purpose,
       );
     } catch (err) {
+      // The dispatch never left the process, so no handleTranscriptionResult
+      // will drain it — release the counter here to keep the stream moving.
       buffer.inFlight = false;
+      this.clearOnePending(buffer.speakerKey);
       logger.error({ err }, "[MeetingPipeline] onSegmentReady threw");
     }
+  }
+
+  /** True while an ASR request for this speaker is dispatched but unresolved. */
+  private hasPendingSubmission(speakerKey: string): boolean {
+    return (this.pendingSubmissions.get(speakerKey) ?? 0) > 0;
+  }
+
+  /** Release one outstanding submission slot; never drops below zero. */
+  private clearOnePending(speakerKey: string): void {
+    const remaining = (this.pendingSubmissions.get(speakerKey) ?? 0) - 1;
+    if (remaining > 0) this.pendingSubmissions.set(speakerKey, remaining);
+    else this.pendingSubmissions.delete(speakerKey);
   }
 
   /** Emit a confirmed segment. Does NOT reset the buffer. */


### PR DESCRIPTION
# Relates to

Closes #27871

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; package gates (test/typecheck/lint) pass. Repo-wide `bun run verify` is not runnable on this constrained host — see **Known gaps**.
- [x] A reviewer can confirm the change works from the before/after evidence below without reading the code.

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts (`git rev-list --count HEAD..origin/develop` = 0).
- [x] Owning-package gates pass post-sync; the unrelated repo-wide blocker is documented in **Known gaps / failures**.

# Risks

Low, and tightly bounded. The change is confined to `plugins/plugin-meetings/src/pipeline/speaker-streams.ts` with **no public API/signature change** — the two pipeline callsites (`onSegmentReady`/`handleTranscriptionResult`) are untouched. The only behavioral change is that a speaker whose buffer was force-reset while a request was still in flight will not start a *second concurrent* ASR request until the orphaned one resolves; because the pipeline guarantees exactly one `handleTranscriptionResult` per `onSegmentReady` (success, insufficient-credits, or error), the counter always drains within one ASR round-trip and the stream cannot stall.

# Background

## What does this PR do?

`SpeakerStreamManager`'s stale-response guard was defeated when the **same speaker** started a new ASR submission before an orphaned in-flight request returned.

`flushSpeaker()` (fired on speaker change / mute / leave via the MS Teams caption-router, Zoom speaker-attribution, and pipeline teardown) calls `fullReset()` while a request is still in flight: it bumps `buffer.generation` and clears `inFlight`, but cannot cancel or track the outstanding network request. The discard guard relies on the single-slot `submitGeneration` map, so when the same `speakerKey` then feeds audio and the 2s cadence fires a **new** submission (generation N+1), `submitGeneration` is overwritten to N+1. When the **original** generation-N response finally arrives (ASR latency + up to 3 retries with backoff = seconds), the guard compares `N+1 < N+1` — false — and processes it. That poisons `lastTranscript`/`confirmCount` with old-context text, which is confirmed and **emitted into the meeting transcript**, and clears `inFlight` for the genuinely-outstanding N+1 request, allowing a second concurrent submission. The code's own comment (“Discard stale responses … accepting it would poison lastTranscript with old text”) documents the invariant the code failed to uphold.

**Fix:** track a per-speaker `pendingSubmissions` counter that *survives* `fullReset()`. A new submission cannot start while a prior request is unresolved, so `submitGeneration` stays pinned to the orphan's generation and the existing generation guard discards the late response exactly as it does in the no-resubmit case. The counter is incremented at dispatch, decremented on every `handleTranscriptionResult` path (and on a synchronous `onSegmentReady` failure), and cleared in `removeSpeaker`. The `trySubmit` and `flushSpeaker` idle-submit paths now also gate on it so no second concurrent submission ever runs.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a documentation change — no public API, config, or behavior contract surface changed.

# Testing

## Where should a reviewer start?

`plugins/plugin-meetings/src/pipeline/__tests__/speaker-streams.test.ts` — the existing `discards stale in-flight results after a full reset` test is kept, and two new regression tests cover the reported sequence.

## Detailed testing steps

```bash
bun run --cwd plugins/plugin-meetings test        # 28 files, 266 tests pass
bun run --cwd plugins/plugin-meetings typecheck   # clean
bun run --cwd plugins/plugin-meetings lint:check  # clean
```

New tests (all real, exercising the changed contract):
1. **reset-then-resubmit-then-stale** — the orphaned gen-N response is discarded and never confirmed, and the genuine gen-(N+1) response is still accepted and confirmed normally.
2. **no second concurrent submission** — while an orphaned request is outstanding, repeated cadence ticks never start a second request; the next submission becomes eligible only once the orphan resolves.

# Evidence Gate

<!-- evidence-head:86a9fcd96e925304330cf9cf9a722985e6c594b7 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend ASR streaming logic; no UI surface changed.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend ASR streaming logic; no UI surface changed.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing UI flow; internal transcript-correctness logic verified by deterministic tests.
<!-- evidence-row:backend-logs -->
- [ ] N/A - release-asset upload is not permitted for a fork contributor on elizaOS/eliza (HTTP 404); the complete before/after reproduction logs are inline under Evidence Details.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend request/response involved in this path.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no prompt/model/provider/action behavior changed; stale-response correlation in the streaming buffer, driven via injectable clock + captured callbacks.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - see inline before/after confirmed-transcript logs under Evidence Details; release-asset upload is blocked for fork contributors.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

The reproduction drives `SpeakerStreamManager` through its injectable clock and captured callbacks (exactly the pipeline's contract), asserting on the confirmed-segment callback — the value that becomes a meeting transcript line.

**BEFORE (origin/develop source) — the confirmed transcript is poisoned:**

```
RUN  v4.1.10 /home/home/Developer/eliza-swarm/state/worktrees/issue-27871/plugins/plugin-meetings
stdout | src/pipeline/__tests__/stale-race-probe.test.ts > stale-race probe (#27871) > reset-then-resubmit-then-stale must not poison the transcript
PROBE confirmed: ["stale text from old context"]
 ❯ src/pipeline/__tests__/stale-race-probe.test.ts (1 test | 1 failed) 15ms
     × reset-then-resubmit-then-stale must not poison the transcript 13ms
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯
 FAIL  src/pipeline/__tests__/stale-race-probe.test.ts > stale-race probe (#27871) > reset-then-resubmit-then-stale must not poison the transcript
AssertionError: expected [ 'stale text from old context' ] to not include 'stale text from old context'
 ❯ src/pipeline/__tests__/stale-race-probe.test.ts:25:46
     23|     manager.handleTranscriptionResult("spk", "stale text from old cont…
     24|     console.log("PROBE confirmed:", JSON.stringify(confirmed.map((c) =…
     25|     expect(confirmed.map((c) => c.text)).not.toContain("stale text fro…
       |                                              ^
     26|     vi.useRealTimers();
     27|   });
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯
 Test Files  1 failed (1)
      Tests  1 failed (1)
   Start at  17:10:01
   Duration  29.86s (transform 27.24s, setup 0ms, import 29.38s, tests 15ms, environment 0ms)
```

**AFTER (this branch) — the same reproduction passes; the stale response is discarded:**

```
RUN  v4.1.10 /home/home/Developer/eliza-swarm/state/worktrees/issue-27871/plugins/plugin-meetings
 Test Files  1 passed (1)
      Tests  1 passed (1)
   Start at  17:10:41
   Duration  19.68s (transform 17.52s, setup 0ms, import 19.09s, tests 10ms, environment 0ms)
```

**Focused regression suite (this branch):**

```
RUN  v4.1.10 /home/home/Developer/eliza-swarm/state/worktrees/issue-27871/plugins/plugin-meetings


 Test Files  1 passed (1)
      Tests  14 passed (14)
   Start at  17:09:33
   Duration  15.04s (transform 13.17s, setup 0ms, import 14.80s, tests 41ms, environment 0ms)
```

**Full package gates (this branch):**

```
RUN  v4.1.10 /home/home/Developer/eliza-swarm/state/worktrees/issue-27871/plugins/plugin-meetings


 Test Files  28 passed (28)
      Tests  266 passed (266)
   Start at  17:11:11
   Duration  55.46s (transform 54.56s, setup 0ms, import 141.72s, tests 9.15s, environment 8ms)

===== TYPECHECK =====
$ tsc --noEmit
exit typecheck: 0
===== LINT =====
$ bunx @biomejs/biome check .
Checked 102 files in 790ms. No fixes applied.
```

## Screenshots (before / after) + video walkthrough

`N/A - no UI change (backend streaming-ASR buffer logic under plugins/plugin-meetings/src/pipeline).`

### Before

`N/A - no UI change.`

### After

`N/A - no UI change.`

### Walkthrough video

`N/A - no UI change.`

## Audio / voice walkthrough

`N/A - no audio round-trip, TTS, or STT model behavior changed; this is stale-response correlation in the per-speaker streaming buffer, proven deterministically with synthetic Float32Array audio.`

## Known gaps / failures

- Repo-wide `bun run verify` is not runnable end-to-end on this constrained ARM host: `bun install` initially tripped the machine's global `minimumReleaseAge` supply-chain guard on an unrelated recently-published `@cloudflare/playwright` (a `packages/app` dependency). Install completed and workspace deps (`@elizaos/core`, `@elizaos/shared`) were built from source; the owning package's `test`, `typecheck`, and `lint:check` all pass. This is an environment limitation, not a defect in the change, and does not touch `plugins/plugin-meetings`.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

---
AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@86a9fcd96e925304330cf9cf9a722985e6c594b7:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@86a9fcd96e925304330cf9cf9a722985e6c594b7:packages/skills/skills/contribute-to-eliza"} -->