### PR TITLE
test(ui): cover useWakeController

### DIFF
--- a/packages/ui/src/voice/useWakeController.test.tsx
+++ b/packages/ui/src/voice/useWakeController.test.tsx
@@ -3,6 +3,7 @@
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SwabbleWakeWordEvent } from "../bridge/native-plugins";
+import type { FusedWakeEvent } from "./fused-wake-bridge";
 
 // Capture the registered wakeWord listener so tests can fire native detections.
 let wakeListener: ((e?: SwabbleWakeWordEvent) => void) | null = null;
@@ -142,5 +143,207 @@ describe("useWakeController", () => {
     // The controller only honors the selected path's detector — a stray Swabble
     // event on the two-stage path is dropped.
     expect(onWake).not.toHaveBeenCalled();
+  });
+});
+
+describe("useWakeController — subscription lifecycle, reset, and confirm-window edges", () => {
+  beforeEach(() => {
+    wakeListener = null;
+    removeSpy.mockClear();
+  });
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function makeFusedSource() {
+    let listener: ((event: FusedWakeEvent) => void) | null = null;
+    const source = (l: (event: FusedWakeEvent) => void) => {
+      listener = l;
+      return () => {
+        listener = null;
+      };
+    };
+    const fireFused = (event: FusedWakeEvent) =>
+      act(async () => {
+        listener?.(event);
+      });
+    return { source, fireFused };
+  }
+
+  it("removes the native wakeWord listener on unmount", async () => {
+    const { unmount } = renderHook(() =>
+      useWakeController({
+        enabled: true,
+        alwaysOn: false,
+        characterName: "eliza",
+        onWake: vi.fn(),
+      }),
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(wakeListener).not.toBeNull();
+    unmount();
+    expect(removeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels a still-resolving addListener when unmounted before it lands", async () => {
+    const { unmount } = renderHook(() =>
+      useWakeController({
+        enabled: true,
+        alwaysOn: false,
+        characterName: "eliza",
+        onWake: vi.fn(),
+      }),
+    );
+    // Unmount synchronously, before the async addListener promise resolves.
+    unmount();
+    await act(async () => {
+      await Promise.resolve();
+    });
+    // The late handle must still be removed — no orphaned native subscription.
+    expect(removeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("discards an armed Stage-A candidate when wake is disabled mid-window", async () => {
+    const onWake = vi.fn<(d: WakeDetection) => void>();
+    const { source, fireFused } = makeFusedSource();
+    let t = 1000;
+    const options = {
+      enabled: true,
+      alwaysOn: false,
+      characterName: "ada", // no shipped head → two-stage ASR
+      capabilities: FUSED,
+      onWake,
+      fusedWakeSource: source,
+      now: () => t,
+    };
+    const { rerender } = renderHook(() => useWakeController(options));
+
+    // Arm a candidate so the controller sits inside the confirm window.
+    await fireFused({ stage: "stage-a-candidate" });
+
+    // Disabling wake force-resets: the armed candidate is abandoned.
+    options.enabled = false;
+    rerender();
+    options.enabled = true;
+    rerender();
+
+    // A transcript arriving after re-enable finds no candidate to resolve…
+    t = 1200;
+    await fireFused({
+      stage: "stage-b-transcript",
+      transcript: "hey ada what's up",
+    });
+    expect(onWake).not.toHaveBeenCalled();
+
+    // …and a fresh handshake completes normally afterwards.
+    await fireFused({ stage: "stage-a-candidate" });
+    t = 1300;
+    await fireFused({
+      stage: "stage-b-transcript",
+      transcript: "hey ada go",
+    });
+    expect(onWake).toHaveBeenCalledTimes(1);
+    expect(onWake.mock.calls[0][0].path).toBe("two-stage-asr");
+  });
+
+  it("abandons the candidate when the confirm window lapses, then recovers", async () => {
+    vi.useFakeTimers();
+    try {
+      const onWake = vi.fn<(d: WakeDetection) => void>();
+      const { source, fireFused } = makeFusedSource();
+      let t = 1000;
+      renderHook(() =>
+        useWakeController({
+          enabled: true,
+          alwaysOn: false,
+          characterName: "ada",
+          capabilities: FUSED,
+          onWake,
+          fusedWakeSource: source,
+          now: () => t,
+          confirmWindowMs: 300,
+          tickMs: 100,
+        }),
+      );
+      await fireFused({ stage: "stage-a-candidate" });
+      expect(onWake).not.toHaveBeenCalled();
+
+      // Ticks inside the window keep the candidate armed.
+      await act(async () => {
+        t = 1250;
+        vi.advanceTimersByTime(250);
+      });
+      expect(onWake).not.toHaveBeenCalled();
+
+      // Crossing the window abandons it — silence never confirms a wake.
+      await act(async () => {
+        t = 1350;
+        vi.advanceTimersByTime(100);
+      });
+      await fireFused({
+        stage: "stage-b-transcript",
+        transcript: "hey ada go",
+      });
+      expect(onWake).not.toHaveBeenCalled();
+
+      // The controller is not stuck: a later handshake still completes.
+      await fireFused({ stage: "stage-a-candidate" });
+      t = 1550;
+      await fireFused({
+        stage: "stage-b-transcript",
+        transcript: "hey ada go",
+      });
+      expect(onWake).toHaveBeenCalledTimes(1);
+      expect(onWake.mock.calls[0][0].path).toBe("two-stage-asr");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("emits no confidence when the native event omits it", async () => {
+    const onWake = vi.fn<(d: WakeDetection) => void>();
+    renderHook(() =>
+      useWakeController({
+        enabled: true,
+        alwaysOn: false,
+        characterName: "eliza",
+        onWake,
+      }),
+    );
+    await fireWake({
+      wakeWord: "eliza",
+      command: "go",
+      transcript: "hey eliza go",
+      postGap: 0.4,
+    });
+    expect(onWake).toHaveBeenCalledTimes(1);
+    expect(onWake.mock.calls[0][0].wakeWord).toBe("eliza");
+    expect(onWake.mock.calls[0][0].transcript).toBe("hey eliza go");
+    expect(onWake.mock.calls[0][0].command).toBe("go");
+    expect(onWake.mock.calls[0][0].confidence).toBeUndefined();
+    expect(onWake.mock.calls[0][0].path).toBe("swabble-fallback");
+  });
+
+  it("honours custom trainedHeads when selecting the detection path", async () => {
+    const onWake = vi.fn<(d: WakeDetection) => void>();
+    const { source, fireFused } = makeFusedSource();
+    const { result } = renderHook(() =>
+      useWakeController({
+        enabled: true,
+        alwaysOn: false,
+        characterName: "ada",
+        capabilities: FUSED,
+        trainedHeads: new Set(["ada"]),
+        onWake,
+        fusedWakeSource: source,
+      }),
+    );
+    expect(result.current.path).toBe("head-fast-path");
+    await fireFused({ stage: "head-fired", confidence: 0.7 });
+    expect(onWake).toHaveBeenCalledTimes(1);
+    expect(onWake.mock.calls[0][0].wakeWord).toBe("ada");
+    expect(onWake.mock.calls[0][0].path).toBe("head-fast-path");
   });
 });


### PR DESCRIPTION

## What

Adds six test cases to the existing suite for `packages/ui/src/voice/useWakeController.ts`, covering hook-level branches the current cases did not reach. **Test-only change: one file modified, +203/−0, no production code touched.**

The existing suites already cover the happy-path Swabble pass-through, always-on inertness, path selection basics, and the fused head-fire / Stage-A→Stage-B handshake. This PR appends a sibling `describe` block (pure additions — no existing line is modified) driving the real hook through:

1. **Native-listener removal on unmount** — the shared `removeSpy` fixture existed but was never asserted; unmount now provably removes the `wakeWord` listener.
2. **Unmount before `addListener` resolves** — the late handle is still removed via the hook's `cancelled` path, so no orphaned native subscription survives.
3. **Reset discards an armed Stage-A candidate** — disabling wake mid-confirm-window abandons the candidate (the `reset` effect), and a transcript arriving after re-enable confirms nothing; a fresh handshake afterwards completes normally.
4. **Confirm-window lapse** — with injectable `now`/`tickMs`, ticks inside the window keep the candidate armed, crossing `confirmWindowMs` abandons it, silence never confirms a wake, and the controller is not stuck: a later Stage-A→Stage-B handshake still emits.
5. **Confidence omitted by the native event** — the emitted detection carries no confidence when Swabble provides none.
6. **Custom `trainedHeads`** — a host-declared trained head flips "ada" from `two-stage-asr` to `head-fast-path`, and a fused head-fire emits with that path.

## Evidence

- `bunx vitest run src/voice/useWakeController.test.tsx --config ./vitest.config.ts` (packages/ui vitest lane): **Test Files 1 passed (1), Tests 11 passed (11)** — 5 pre-existing + 6 new.
- `bunx biome check --write packages/ui/src/voice/useWakeController.test.tsx`: clean, no fixes applied.
- `bunx tsc --noEmit -p tsconfig.json` in `packages/ui`: the new test file appears nowhere in the output; the pre-existing error set is byte-identical to an untouched-control run taken before the edit (14 pre-existing errors elsewhere in the package, none under `src/voice/`).
- The diff touches only `packages/ui/src/voice/useWakeController.test.tsx` (+203/−0).

## Notes for reviewers

- This is a fork contribution: **hosted CI does not run on this PR**, so the counts above are quoted from local runs at head `1b3eae911961ec056c91fb31cbd6b2597e78295c` (branch based on current `develop`).
- All new cases drive the real module (`useWakeController` → `wakeControllerReducer` → real effect wiring); mocks exist only at the Capacitor native-plugin boundary, matching the file's existing convention. No type-level assertions are used.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:1b3eae911961ec056c91fb31cbd6b2597e78295c -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
