### PR TITLE
test(ui): cover useVoiceConfig

### DIFF
--- a/packages/ui/src/voice/useVoiceConfig.test.tsx
+++ b/packages/ui/src/voice/useVoiceConfig.test.tsx
@@ -148,3 +148,103 @@ describe("useVoiceConfig character preset resolution", () => {
     expect(hoisted.updateConfig).not.toHaveBeenCalled();
   });
 });
+
+import { VOICE_CONFIG_UPDATED_EVENT } from "../events";
+
+describe("useVoiceConfig bootstrap and event pipeline", () => {
+  it("degrades to provider defaults without throwing when the saved config is unreadable", async () => {
+    hoisted.getConfig.mockRejectedValue(
+      new Error("config endpoint unavailable"),
+    );
+
+    const { result } = renderHook(() => useVoiceConfig("en"));
+
+    await waitFor(() => expect(result.current.voiceBootstrapTick).toBe(1));
+    expect(result.current.voiceConfig.provider).toBe("robot-voice");
+  });
+
+  it("keeps the bootstrap tick gated at zero when the hook unmounts mid-load", async () => {
+    let resolveGetConfig: (value: unknown) => void = () => {};
+    hoisted.getConfig.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveGetConfig = resolve;
+        }),
+    );
+
+    const { result, unmount } = renderHook(() => useVoiceConfig("en"));
+    unmount();
+    resolveGetConfig({});
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(hoisted.getConfig).toHaveBeenCalledTimes(1);
+    expect(result.current.voiceBootstrapTick).toBe(0);
+  });
+
+  it("adopts a broadcast config payload without refetching", async () => {
+    hoisted.getConfig.mockResolvedValue({});
+
+    const { result } = renderHook(() => useVoiceConfig("en"));
+    await waitFor(() => expect(result.current.voiceBootstrapTick).toBe(1));
+
+    await waitFor(() => {
+      window.dispatchEvent(
+        new CustomEvent(VOICE_CONFIG_UPDATED_EVENT, {
+          detail: {
+            provider: "elevenlabs",
+            elevenlabs: { voiceId: JIN_VOICE_ID },
+          },
+        }),
+      );
+      return expect(result.current.voiceBootstrapTick).toBeGreaterThan(1);
+    });
+    expect(hoisted.getConfig).toHaveBeenCalledTimes(1);
+    expect(result.current.voiceConfig.provider).toBe("elevenlabs");
+    expect(result.current.voiceConfig.elevenlabs?.voiceId).toBe(JIN_VOICE_ID);
+  });
+
+  it("falls back to a full reload when a broadcast payload is not a config object", async () => {
+    hoisted.getConfig.mockResolvedValue({});
+
+    const { result } = renderHook(() => useVoiceConfig("en"));
+    await waitFor(() => expect(result.current.voiceBootstrapTick).toBe(1));
+
+    window.dispatchEvent(
+      new CustomEvent(VOICE_CONFIG_UPDATED_EVENT, { detail: undefined }),
+    );
+    await waitFor(() => expect(hoisted.getConfig).toHaveBeenCalledTimes(2));
+    expect(result.current.voiceBootstrapTick).toBe(2);
+  });
+
+  it("re-fetches on demand and adopts the newer saved config", async () => {
+    hoisted.getConfig
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ ui: { presetId: "jin" } });
+
+    const { result } = renderHook(() => useVoiceConfig("en"));
+    await waitFor(() => expect(result.current.voiceBootstrapTick).toBe(1));
+
+    result.current.reloadVoiceConfig();
+
+    await waitFor(() => expect(result.current.voiceBootstrapTick).toBe(2));
+    expect(result.current.voiceConfig.elevenlabs?.voiceId).toBe(JIN_VOICE_ID);
+    expect(hoisted.getConfig).toHaveBeenCalledTimes(2);
+  });
+
+  it("reloads through getConfig when the UI language changes", async () => {
+    hoisted.getConfig.mockResolvedValue({});
+
+    const { rerender, result } = renderHook(
+      ({ uiLanguage }) => useVoiceConfig(uiLanguage),
+      { initialProps: { uiLanguage: "en" } },
+    );
+    await waitFor(() => expect(result.current.voiceBootstrapTick).toBe(1));
+
+    rerender({ uiLanguage: "de" });
+
+    await waitFor(() => expect(hoisted.getConfig).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(result.current.voiceBootstrapTick).toBe(2));
+  });
+});


### PR DESCRIPTION

## What

Extends `packages/ui/src/voice/useVoiceConfig.test.tsx` with six new cases covering hook behaviors the existing suite does not exercise. Purely additive: **+100/-0** against the file present on `develop` (base blob `c559156ef5e1` hash-verified before appending; branch base `51617538d704`). No production code is touched.

Note: `develop` already carries this suite (as `.tsx`, which is easy to miss when grepping for same-named `.ts` files); this PR deliberately extends it rather than rewriting it, per the repo's no-deleted-coverage rule.

## New coverage

- A failed `client.getConfig()` degrades to provider defaults without throwing and still settles `voiceBootstrapTick` at 1 — the value the docs say gates auto-speak.
- Unmounting mid-load keeps the tick gated at `0`: neither voice-config state nor the tick is written after unmount (mounted-guard behavior).
- A `VOICE_CONFIG_UPDATED_EVENT` carrying an object payload is adopted verbatim — explicit `elevenlabs` provider and `voiceId` survive `applyVoiceProviderDefaults` untouched — with **no** refetch.
- The same event with a non-object payload (`detail: undefined`) falls back to a full reload through `getConfig`.
- Manual `reloadVoiceConfig()` refetches and adopts the newer saved config (preset-derived voice appears).
- Changing `uiLanguage` re-runs the load pipeline (second `getConfig` call, tick advances to 2).

## Verification

Fork contribution — hosted CI does not run on this PR; local runs quoted below are the whole evidence set, consistent with a test-only diff:

- `vitest run --config ./vitest.config.ts src/voice/useVoiceConfig.test.tsx` in `packages/ui`: **Test Files 1 passed (1), Tests 12 passed (12)** (6 pre-existing + 6 new), exit 0.
- `biome check --write` on the file, then re-check: clean ("No fixes applied"); the diff remains +100/-0 after formatting.
- `tsc --noEmit` in `packages/ui`: **zero errors reference `useVoiceConfig.test`**. Nine pre-existing errors exist in unrelated files (`surface.helpers.test.ts`, `character-hub-helpers.test.ts`) that this diff does not touch.
- The diff touches exactly one file: `packages/ui/src/voice/useVoiceConfig.test.tsx`.

Mocks sit only at true boundaries (`client.getConfig`, preset/state hooks), mirroring the existing fixtures; every asserted outcome was checked against the resolver source (`character-voice-config.ts`) before being written, not assumed.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:d3c2a343e84a98b3106cb2e089cc9559754e1baa -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
