### PR TITLE
test(scenario-runner): cover browser-task-assertions

### DIFF
--- a/packages/scenario-runner/src/scenario-assertions/__tests__/browser-task-assertions.test.ts
+++ b/packages/scenario-runner/src/scenario-assertions/__tests__/browser-task-assertions.test.ts
@@ -381,4 +381,107 @@ describe("expectTurnBrowserTask", () => {
     expect(message).toContain("Expected turn upload:");
     expect(message).toContain("actions [UPLOAD_FILE].");
   });
+
+  it("serializes seen payloads when a turn task does not satisfy the expectation", () => {
+    const message = expectTurnBrowserTask({
+      description: "turn upload done",
+      completed: true,
+    })(
+      turn([
+        browserAction("UPLOAD_FILE", {
+          completed: false,
+          artifactCount: 1,
+        }),
+      ]),
+    );
+    expect(message).toContain("Expected turn upload done:");
+    expect(message).toContain("saw browserTask payloads");
+    expect(message).toContain('"completed":false');
+  });
+});
+
+describe("browser-task assertion edge coverage", () => {
+  it("rejects an absent completed field against an explicit completed:false expectation", () => {
+    const check = expectScenarioBrowserTask({
+      description: "still open",
+      completed: false,
+    });
+    expect(typeof check(ctx([browserAction("POLL_STATUS", {})]))).toBe(
+      "string",
+    );
+    expect(
+      check(
+        ctx([
+          browserAction("POLL_STATUS", {}),
+          browserAction("POLL_STATUS", { completed: false }),
+        ]),
+      ),
+    ).toBeUndefined();
+  });
+
+  it.each([
+    ["needsHuman", { needsHuman: "true" }],
+    ["approvalRequired", { approvalRequired: 1 }],
+    ["approvalSatisfied", { approvalSatisfied: null }],
+  ] as const)(
+    "rejects a malformed %s boolean from the shape guard",
+    (_field, malformed) => {
+      const check = expectScenarioBrowserTask({
+        description: "well-formed booleans",
+      });
+      expect(check(ctx([browserAction("ASK_APPROVAL", malformed)]))).toContain(
+        "no browserTask payload found",
+      );
+    },
+  );
+
+  it("rejects a numeric blockedReason from the shape guard", () => {
+    const check = expectScenarioBrowserTask({
+      description: "string reason required",
+    });
+    expect(
+      check(ctx([browserAction("FILL_FORM", { blockedReason: 403 })])),
+    ).toContain("no browserTask payload found");
+  });
+
+  it("counts a browserTask carried by a failed action result", () => {
+    const check = expectScenarioBrowserTask({
+      description: "blocked by captcha",
+      blockedReasonIncludes: "captcha",
+    });
+    expect(
+      check(
+        ctx([
+          action({
+            actionName: "FILL_FORM",
+            result: {
+              success: false,
+              error: "captcha wall",
+              data: { browserTask: { blockedReason: "CAPTCHA challenge" } },
+            },
+          }),
+        ]),
+      ),
+    ).toBeUndefined();
+  });
+
+  it("ignores a null data payload entirely", () => {
+    const message = expectScenarioBrowserTask({
+      description: "task done",
+      actionName: "UPLOAD_FILE",
+    })(ctx([action({ actionName: "UPLOAD_FILE", result: { data: null } })]));
+    expect(message).toContain("no browserTask payload found");
+    expect(message).toContain("[UPLOAD_FILE]");
+  });
+
+  it("never matches blockedReasonIncludes when the reason field is absent or empty", () => {
+    const check = expectScenarioBrowserTask({
+      description: "reason required",
+      blockedReasonIncludes: "captcha",
+    });
+    expect(typeof check(ctx([browserAction("FILL_FORM", {})]))).toBe("string");
+    expect(
+      typeof check(ctx([browserAction("FILL_FORM", { blockedReason: "" })])),
+    ).toBe("string");
+  });
 });


### PR DESCRIPTION

## What

Extends the existing suite for
`packages/scenario-runner/src/scenario-assertions/browser-task-assertions.ts`
with **nine additional vitest cases** covering real branches of the module that
were not pinned anywhere on develop. Purely additive: **+103 / -0**, single test
file, no existing line touched.

Newly covered behaviour (all observed against the real module, no mocks):

- An **absent** `completed` field fails an explicit `completed: false`
  expectation (`undefined !== false`), while an explicit `completed: false`
  task among non-matching ones still satisfies it.
- The shape guard rejects malformed boolean fields beyond `completed`:
  `needsHuman: "true"`, `approvalRequired: 1`, `approvalSatisfied: null`.
- The shape guard rejects a numeric `blockedReason` (`403`).
- `extractBrowserTask` ignores `result.success`: a browserTask carried by a
  **failed** action result still counts toward assertions such as
  `blockedReasonIncludes`. This pins the boundary callers rely on when
  asserting why a browser action did not complete.
- A `null` `result.data` payload is ignored entirely.
- `blockedReasonIncludes` never matches an absent or empty-string reason.
- `expectTurnBrowserTask` serializes seen payloads in its failure message when
  a turn-level task does not satisfy the expectation.

## Verification

Fork contributor: hosted CI does not run on this pull request. All checks were
run locally on this exact head.

1. `bunx vitest run packages/scenario-runner/src/scenario-assertions/__tests__/browser-task-assertions.test.ts`

   ```
   Test Files  1 passed (1)
        Tests  41 passed (41)
   ```

   32 pre-existing cases still pass untouched; 9 are new in this diff.

2. `bunx biome check --write <test file>` — clean
   (`Checked 1 file ... No fixes applied.`).

3. `bunx tsc --noEmit` inside `packages/scenario-runner` — the new test file
   appears nowhere in the output (zero new type errors).

4. The diff touches only
   `packages/scenario-runner/src/scenario-assertions/__tests__/browser-task-assertions.test.ts`
   (+103 / -0). No production code changed.

Note: a same-named suite landed on develop after this target was picked, so
this PR adds cases to it rather than creating a file — nothing existing is
rewritten, reorganised, or deleted.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:7f94e68ed629f34259207cb0077bea326ac4b39e -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
