### PR TITLE
test(homepage): cover wallet-linking

### DIFF
--- a/packages/homepage/tests/wallet-linking.test.ts
+++ b/packages/homepage/tests/wallet-linking.test.ts
@@ -78,3 +78,119 @@ WALLET-LINKING-END -->`);
     ).toThrow("Enter a valid Solana address.");
   });
 });
+
+describe("wallet linking validation edges", () => {
+  const VALID_SOLANA = "11111111111111111111111111111111";
+  const VALID_ETHEREUM = "0x1111111111111111111111111111111111111111";
+
+  test("trims surrounding whitespace before validating EVM addresses", () => {
+    expect(isValidEthereumAddress(`  ${VALID_ETHEREUM}  `)).toBe(true);
+    expect(isValidEthereumAddress("   ")).toBe(false);
+  });
+
+  test("trims surrounding whitespace before validating Solana addresses", () => {
+    expect(isValidSolanaAddress(`  ${VALID_SOLANA}  `)).toBe(true);
+    expect(isValidSolanaAddress("\t\n")).toBe(false);
+  });
+
+  test("rejects a maximum-length Solana string that decodes to 33 bytes", () => {
+    expect(isValidSolanaAddress("z".repeat(44))).toBe(false);
+  });
+});
+
+describe("wallet linking README serialization edges", () => {
+  const FIXED_NOW = new Date("2026-08-24T00:00:00.000Z");
+  const VALID_SOLANA = "11111111111111111111111111111111";
+  const VALID_ETHEREUM = "0x1111111111111111111111111111111111111111";
+
+  function payloadOf(marker: string): unknown {
+    return JSON.parse(marker.split("\n").slice(1, -1).join("\n"));
+  }
+
+  test("serializes a Solana-only profile with no Ethereum entry", () => {
+    const marker = generateWalletReadmeComment(
+      { solana: VALID_SOLANA },
+      FIXED_NOW,
+    );
+    expect(payloadOf(marker)).toEqual({
+      lastUpdated: "2026-08-24T00:00:00.000Z",
+      wallets: [{ chain: "solana", address: VALID_SOLANA }],
+    });
+    expect(marker.startsWith("<!-- WALLET-LINKING-BEGIN")).toBe(true);
+    expect(marker.endsWith("WALLET-LINKING-END -->")).toBe(true);
+  });
+
+  test("serializes an Ethereum-only profile with no Solana entry", () => {
+    const marker = generateWalletReadmeComment(
+      { ethereum: VALID_ETHEREUM },
+      FIXED_NOW,
+    );
+    expect(payloadOf(marker)).toEqual({
+      lastUpdated: "2026-08-24T00:00:00.000Z",
+      wallets: [{ chain: "ethereum", address: VALID_ETHEREUM }],
+    });
+  });
+
+  test("treats whitespace-only addresses as absent at the boundary", () => {
+    expect(() =>
+      generateWalletReadmeComment(
+        { ethereum: "   ", solana: "\n\t " },
+        FIXED_NOW,
+      ),
+    ).toThrow("Add at least one public wallet address.");
+  });
+
+  test("stores whitespace-trimmed address values in the payload", () => {
+    const marker = generateWalletReadmeComment(
+      { ethereum: `  ${VALID_ETHEREUM}  `, solana: ` ${VALID_SOLANA} ` },
+      FIXED_NOW,
+    );
+    expect(payloadOf(marker)).toEqual({
+      lastUpdated: "2026-08-24T00:00:00.000Z",
+      wallets: [
+        { chain: "ethereum", address: VALID_ETHEREUM },
+        { chain: "solana", address: VALID_SOLANA },
+      ],
+    });
+  });
+
+  test("defaults the timestamp to wall-clock time when omitted", () => {
+    const beforeMs = Date.now();
+    const marker = generateWalletReadmeComment({ ethereum: VALID_ETHEREUM });
+    const afterMs = Date.now();
+    const parsed = payloadOf(marker) as { lastUpdated: string };
+    const stampMs = Date.parse(parsed.lastUpdated);
+    expect(Number.isNaN(stampMs)).toBe(false);
+    expect(stampMs).toBeGreaterThanOrEqual(beforeMs);
+    expect(stampMs).toBeLessThanOrEqual(afterMs);
+  });
+
+  test("reports the EVM failure before the Solana failure", () => {
+    expect(() =>
+      generateWalletReadmeComment(
+        { ethereum: "not-an-address", solana: "not-a-solana-address" },
+        FIXED_NOW,
+      ),
+    ).toThrow("Enter a valid EVM address.");
+    expect(() =>
+      generateWalletReadmeComment(
+        { ethereum: VALID_ETHEREUM, solana: "not-a-solana-address" },
+        FIXED_NOW,
+      ),
+    ).toThrow("Enter a valid Solana address.");
+  });
+
+  test("exposes a typed validation error carrying its own name", () => {
+    let thrown: unknown = null;
+    try {
+      generateWalletReadmeComment({}, FIXED_NOW);
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(WalletAddressValidationError);
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as WalletAddressValidationError).name).toBe(
+      "WalletAddressValidationError",
+    );
+  });
+});


### PR DESCRIPTION

## Summary

Additive-only test coverage for `packages/homepage/src/lib/wallet-linking.ts`, appended to the suite that already exists at `packages/homepage/tests/wallet-linking.test.ts` on develop. The diff is a single test file, +116/-0; no production code changes and no existing case was modified or removed.

## New cases

Validation edges:

- trims surrounding whitespace before validating EVM addresses (padded valid address accepted; blank string rejected)
- trims surrounding whitespace before validating Solana addresses (padded valid address accepted; whitespace-only rejected by the charset window)
- rejects a maximum-length 44-character base58 string that decodes to 33 bytes (`"z".repeat(44)` passes the charset window but fails the exactly-32-byte requirement)

Serialization edges of `generateWalletReadmeComment`:

- Solana-only profile serializes with no Ethereum entry (exercises the null-filter for the absent chain) and keeps the hidden BEGIN/END marker envelope
- Ethereum-only profile serializes with no Solana entry
- whitespace-only addresses are treated as absent and rejected with "Add at least one public wallet address."
- padded address values are stored trimmed in the marker JSON payload (asserted by parsing the embedded JSON a consumer would parse)
- the default timestamp parameter falls within the observed wall-clock window when omitted
- an invalid EVM address is reported before an invalid Solana address when both are present (error precedence)
- `WalletAddressValidationError` is an `Error` subclass carrying its own `name`

All expectations record observed behavior of the current implementation on develop (`51617538d704`); nothing aspirational.

## Evidence (fork contributor — hosted CI does not run on this PR)

This package's own test lane runs this file under **bun test** (per its `test` script, bun pinned 1.3.14):

```
bun --conditions=eliza-source test tests/wallet-linking.test.ts
15 pass
0 fail
31 expect() calls
Ran 15 tests across 1 file.
```

(5 pre-existing cases untouched + 10 added.)

- `bunx biome check --write tests/wallet-linking.test.ts` — clean, "No fixes applied"
- `bunx tsc --noEmit` in `packages/homepage` — the new test file appears nowhere in the output (zero type errors introduced); pre-existing diagnostics elsewhere are unchanged and not part of this diff
- Diff scope: `git diff --stat origin/develop <head>` shows only `packages/homepage/tests/wallet-linking.test.ts | 116 +++...`, insertions only

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:0e47059ab3c4e7f7866c120bb05a1cfd39dda106 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
