### PR TITLE
test(ui): cover user

### DIFF
--- a/packages/ui/src/cloud/account-security/data/user.test.tsx
+++ b/packages/ui/src/cloud/account-security/data/user.test.tsx
@@ -1,0 +1,231 @@
+/** Verifies the `useUserProfile` hook (session gating, `/api/v1/user` envelope unwrap, DTO → UserProfile adaptation) against mocked transport/session collaborators only. */
+// @vitest-environment jsdom
+
+import type { CurrentUserDto } from "@elizaos/cloud-sdk";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { api } from "../../lib/api-client";
+import { useSessionAuth } from "../../lib/use-session-auth";
+import { useUserProfile } from "./user";
+
+// The network transport and the session provider are the two boundaries this
+// hook owns glue for; both are replaced whole so the suite drives the real
+// gating, envelope-unwrapping, and Date-adaptation logic in between.
+vi.mock("../../lib/api-client", () => ({ api: vi.fn() }));
+vi.mock("../../lib/use-session-auth", () => ({ useSessionAuth: vi.fn() }));
+
+const apiMock = vi.mocked(api);
+const sessionMock = vi.mocked(useSessionAuth);
+
+function makeDto(overrides: Partial<CurrentUserDto> = {}): CurrentUserDto {
+  return {
+    id: "user-1",
+    email: "operator@example.com",
+    email_verified: true,
+    wallet_address: null,
+    wallet_chain_type: null,
+    wallet_verified: false,
+    name: "Operator",
+    avatar: null,
+    organization_id: "org-1",
+    role: "owner",
+    steward_user_id: "steward-1",
+    telegram_id: null,
+    telegram_username: null,
+    telegram_first_name: null,
+    telegram_photo_url: null,
+    discord_id: null,
+    discord_username: null,
+    discord_global_name: null,
+    discord_avatar_url: null,
+    whatsapp_id: null,
+    whatsapp_name: null,
+    phone_number: null,
+    phone_verified: null,
+    is_anonymous: false,
+    anonymous_session_id: null,
+    expires_at: "2026-12-31T23:59:59.000Z",
+    nickname: null,
+    work_function: null,
+    preferences: null,
+    email_notifications: true,
+    response_notifications: false,
+    is_active: true,
+    created_at: "2026-01-15T10:30:00.000Z",
+    updated_at: "2026-02-20T12:00:00.000Z",
+    organization: {
+      id: "org-1",
+      name: "Acme",
+      slug: "acme",
+      billing_email: "billing@acme.example.com",
+      credit_balance: "4200",
+      is_active: true,
+      created_at: "2025-11-01T08:00:00.000Z",
+      updated_at: "2026-03-05T09:45:00.000Z",
+    },
+    ...overrides,
+  };
+}
+
+function setSession(state: {
+  ready: boolean;
+  authenticated: boolean;
+  userId?: string;
+}): void {
+  sessionMock.mockReturnValue({
+    ready: state.ready,
+    authenticated: state.authenticated,
+    user:
+      state.userId === undefined
+        ? null
+        : { id: state.userId, email: "operator@example.com" },
+  });
+}
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+function mountProfile() {
+  return renderHook(() => useUserProfile(), { wrapper });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("useUserProfile", () => {
+  it("does not fire the profile request before the session check is ready", async () => {
+    setSession({ ready: false, authenticated: true, userId: "user-1" });
+
+    const { result } = mountProfile();
+
+    await waitFor(() => expect(result.current.fetchStatus).toBe("idle"));
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(apiMock).not.toHaveBeenCalled();
+    expect(result.current.isReady).toBe(false);
+    expect(result.current.user).toBeNull();
+  });
+
+  it("does not fire the profile request when the session is ready but signed out", async () => {
+    setSession({ ready: true, authenticated: false });
+
+    const { result } = mountProfile();
+
+    await waitFor(() => expect(result.current.fetchStatus).toBe("idle"));
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(apiMock).not.toHaveBeenCalled();
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(result.current.user).toBeNull();
+  });
+
+  it("fetches /api/v1/user once for a signed-in session and adapts timestamps to Dates", async () => {
+    setSession({ ready: true, authenticated: true, userId: "user-1" });
+    apiMock.mockResolvedValue({ success: true, data: makeDto() });
+
+    const { result } = mountProfile();
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(apiMock).toHaveBeenCalledTimes(1);
+    expect(apiMock).toHaveBeenCalledWith("/api/v1/user");
+    expect(result.current.isAuthenticated).toBe(true);
+    expect(result.current.isReady).toBe(true);
+
+    const profile = result.current.user;
+    if (!profile) throw new Error("expected the adapted profile to resolve");
+
+    // Envelope unwrapped: fields come from res.data, not the raw envelope.
+    expect(profile.email).toBe("operator@example.com");
+    expect(profile.role).toBe("owner");
+    expect(profile.organization_id).toBe("org-1");
+    expect(profile.wallet_verified).toBe(false);
+    expect(profile.email_notifications).toBe(true);
+    expect(profile.response_notifications).toBe(false);
+    expect(profile.is_anonymous).toBe(false);
+    expect(profile.is_active).toBe(true);
+    expect(profile.steward_user_id).toBe("steward-1");
+
+    // Timestamp strings arrive as real Date instances.
+    expect(profile.created_at).toBeInstanceOf(Date);
+    expect(profile.created_at.toISOString()).toBe("2026-01-15T10:30:00.000Z");
+    expect(profile.updated_at).toBeInstanceOf(Date);
+    expect(profile.updated_at.toISOString()).toBe("2026-02-20T12:00:00.000Z");
+    expect(profile.expires_at).toBeInstanceOf(Date);
+    expect(profile.expires_at?.toISOString()).toBe("2026-12-31T23:59:59.000Z");
+
+    // Organization summary keeps its scalar fields and gains Date columns.
+    expect(profile.organization).not.toBeNull();
+    expect(profile.organization?.name).toBe("Acme");
+    expect(profile.organization?.slug).toBe("acme");
+    expect(profile.organization?.credit_balance).toBe("4200");
+    expect(profile.organization?.billing_email).toBe(
+      "billing@acme.example.com",
+    );
+    expect(profile.organization?.created_at).toBeInstanceOf(Date);
+    expect(profile.organization?.created_at.toISOString()).toBe(
+      "2025-11-01T08:00:00.000Z",
+    );
+    expect(profile.organization?.updated_at.toISOString()).toBe(
+      "2026-03-05T09:45:00.000Z",
+    );
+  });
+
+  it("keeps an absent organization as null instead of fabricating one", async () => {
+    setSession({ ready: true, authenticated: true, userId: "user-1" });
+    apiMock.mockResolvedValue({
+      success: true,
+      data: makeDto({ organization: null }),
+    });
+
+    const { result } = mountProfile();
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const profile = result.current.user;
+    if (!profile) throw new Error("expected the adapted profile to resolve");
+    expect(profile.organization).toBeNull();
+    expect(profile.created_at).toBeInstanceOf(Date);
+  });
+
+  it("reads a missing expiry as null rather than an invalid Date", async () => {
+    setSession({ ready: true, authenticated: true, userId: "user-1" });
+    apiMock.mockResolvedValue({
+      success: true,
+      data: makeDto({ expires_at: null }),
+    });
+
+    const { result } = mountProfile();
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const profile = result.current.user;
+    if (!profile) throw new Error("expected the adapted profile to resolve");
+    expect(profile.expires_at).toBeNull();
+    expect(profile.updated_at).toBeInstanceOf(Date);
+  });
+
+  it("surfaces a failed profile request as an error without retrying or exposing a user", async () => {
+    setSession({ ready: true, authenticated: true, userId: "user-1" });
+    apiMock.mockRejectedValue(new Error("request failed with status 503"));
+
+    const { result } = mountProfile();
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(apiMock).toHaveBeenCalledTimes(1);
+    expect(result.current.user).toBeNull();
+  });
+});


### PR DESCRIPTION

## Summary

Adds the missing unit suite for `packages/ui/src/cloud/account-security/data/user.ts` — the `useUserProfile` hook had no same-named test file anywhere on current develop. Test-only change: no production behaviour is modified (+231/-0, one new file).

## What is covered

- No profile request fires before the synchronous session check reports ready: `fetchStatus` stays idle and the transport is never invoked.
- No request fires when the session is ready but signed out; `isAuthenticated` surfaces false.
- A signed-in session fetches `/api/v1/user` exactly once, unwraps the `{ success, data }` envelope, and adapts ISO timestamp strings into real `Date` instances for `created_at`, `updated_at`, `expires_at`, and the nested organization summary.
- An absent organization stays `null` instead of being fabricated.
- A missing expiry reads as `null`, not an invalid Date.
- A failed profile request surfaces as error state without retrying, with `user` still null.

The only replaced collaborators are the two boundaries the hook glues together — the HTTP transport (`api`) and the session provider (`useSessionAuth`). Everything between them (gating, envelope unwrap, DTO → `UserProfile` adaptation) executes for real through `renderHook` + React Query, following the sibling convention in `src/cloud/admin/data/use-admin-gate.test.tsx`.

## Evidence (test-only PR)

- `bunx vitest run src/cloud/account-security/data/user.test.tsx` from `packages/ui`: **Test Files 1 passed (1), Tests 6 passed (6)** — re-run against current origin/develop (51617538d704) immediately before filing.
- `bunx biome check --write src/cloud/account-security/data/user.test.tsx`: clean.
- `bunx tsc --noEmit` in `packages/ui`: the new test file appears nowhere in the output.
- The diff touches only the new test file.
- Fork contributor: hosted CI does not run on this PR — the counts above are local runs quoted verbatim.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:fba084066426796a02743538d7a24eef7b42e052 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
