### PR TITLE
test(ui): cover index

### DIFF
--- a/packages/ui/src/cloud/analytics/index.test.ts
+++ b/packages/ui/src/cloud/analytics/index.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Unit tests for the cloud analytics route barrel: verifies the
+ * `registerCloudRoute` side effect consumed by `CloudRouterShell` (path,
+ * grouping, authed-by-default policy, lazily split page element) and the
+ * re-exported time-range helpers, driven through the module's public exports.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  type CloudRouteDef,
+  getCloudRoute,
+  listCloudRoutes,
+} from "../shell/cloud-route-registry";
+import {
+  ANALYTICS_ROUTE_PATH,
+  ANALYTICS_TIME_RANGES,
+  AnalyticsPage,
+  DEFAULT_ANALYTICS_TIME_RANGE,
+  projectionPeriodsForRange,
+  resolveTimeRangeParam,
+} from "./index.ts";
+
+describe("cloud/analytics index", () => {
+  describe("route registration side effect", () => {
+    it("registers the canonical org-level analytics route", () => {
+      const route = getCloudRoute(ANALYTICS_ROUTE_PATH);
+
+      expect(route).toBeDefined();
+      expect(route?.path).toBe("cloud/analytics");
+      expect(route?.group).toBe("cloud");
+      // Authed-by-default: no public exposure opt-in, no central gate.
+      expect(route?.public).toBeUndefined();
+      expect(route?.publicAccess).toBeUndefined();
+      expect(route?.gate).toBeUndefined();
+    });
+
+    it("exposes exactly one registry entry whose element is the exported lazy page", () => {
+      const entries = listCloudRoutes().filter(
+        (candidate) => candidate.path === ANALYTICS_ROUTE_PATH,
+      );
+
+      expect(entries).toHaveLength(1);
+      const [entry] = entries as [CloudRouteDef];
+      expect(entry.element).toBe(AnalyticsPage);
+      // Code-splitting contract: the shell mounts a React.lazy component so
+      // the chart bundle loads only when the view opens.
+      const element = entry.element as { $$typeof?: symbol };
+      expect(element.$$typeof).toBe(Symbol.for("react.lazy"));
+    });
+  });
+
+  describe("re-exported resolveTimeRangeParam", () => {
+    it("round-trips every advertised time-range bucket", () => {
+      for (const range of ANALYTICS_TIME_RANGES) {
+        expect(resolveTimeRangeParam(range)).toBe(range);
+      }
+    });
+
+    it("falls back to the exported default for missing or unknown params", () => {
+      expect(resolveTimeRangeParam(null)).toBe(DEFAULT_ANALYTICS_TIME_RANGE);
+      expect(resolveTimeRangeParam(undefined)).toBe(
+        DEFAULT_ANALYTICS_TIME_RANGE,
+      );
+      expect(resolveTimeRangeParam("")).toBe(DEFAULT_ANALYTICS_TIME_RANGE);
+      expect(resolveTimeRangeParam("yearly")).toBe(
+        DEFAULT_ANALYTICS_TIME_RANGE,
+      );
+      expect(resolveTimeRangeParam("DAILY")).toBe(DEFAULT_ANALYTICS_TIME_RANGE);
+      expect(resolveTimeRangeParam(" daily ")).toBe(
+        DEFAULT_ANALYTICS_TIME_RANGE,
+      );
+    });
+  });
+
+  describe("re-exported projectionPeriodsForRange", () => {
+    it("maps each bucket to its documented projection horizon in days", () => {
+      expect(projectionPeriodsForRange("daily")).toBe(1);
+      expect(projectionPeriodsForRange("weekly")).toBe(7);
+      expect(projectionPeriodsForRange("monthly")).toBe(30);
+    });
+  });
+});


### PR DESCRIPTION

## What

Adds the first unit suite for `packages/ui/src/cloud/analytics/index.ts` — no same-named test file exists anywhere on current `develop` at filing time. **Test-only diff: one new file, +81/-0, no production behavior change.**

The module's runtime job is its import-time side effect plus its public barrel, so the suite drives both through real consumers:

- **Route registration** (`registerCloudRoute` side effect consumed by `CloudRouterShell`): registers `"cloud/analytics"` under `ANALYTICS_ROUTE_PATH` with `group: "cloud"`, authed-by-default (`public`, `publicAccess`, `gate` all absent), and exactly one registry entry for the path.
- **Code-splitting contract**: the registered element is the exported `AnalyticsPage` itself and carries React's lazy marker, so the chart bundle loads only when the view opens.
- **Re-exported `resolveTimeRangeParam`**: round-trips every advertised bucket in `ANALYTICS_TIME_RANGES`; falls back to `DEFAULT_ANALYTICS_TIME_RANGE` for `null`, `undefined`, empty string, unknown (`"yearly"`), case-mismatched (`"DAILY"`), and untrimmed (`" daily "`) params.
- **Re-exported `projectionPeriodsForRange`**: maps `daily`/`weekly`/`monthly` to their documented horizons of 1/7/30 days.

No mocks: assertions run against the real registry store and the real helper implementations via the module's own exports.

## Evidence (run locally against current `origin/develop` = `51617538d704`)

This is a fork contribution — hosted CI does not run on this PR. All counts below were executed locally immediately before filing:

- `bunx vitest run src/cloud/analytics/index.test.ts --config ./vitest.config.ts` (in `packages/ui`): **1 test file passed, 5/5 tests passed**, 0 failed, 0 skipped.
- `bunx biome check src/cloud/analytics/index.test.ts`: **clean**.
- `bunx tsc --noEmit` (in `packages/ui`): **zero diagnostics reference `index.test.ts`**. The package has 8 pre-existing errors, all in unrelated files (`src/components/apps/extensions/surface.helpers.test.ts` ×7, `src/components/character/character-hub-helpers.test.ts` ×1) — present without this change.
- The diff contains exactly one new test file and no deletions.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:de6301a3941d4af37a28a550ed5b4da22018eea3 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
