### PR TITLE
test(ui): cover fog

### DIFF
--- a/packages/ui/src/__tests__/stories-concepts-fog.test.ts
+++ b/packages/ui/src/__tests__/stories-concepts-fog.test.ts
@@ -1,0 +1,636 @@
+/**
+ * Behaviour tests for the fog voice-orb concept
+ * (`stories/src/concepts/fog.ts`), driven through the injected three/webgpu
+ * module surface the orb-kit harness hands every concept builder. Covers the
+ * descriptor contract, the ten-shell layered scene (descending radii,
+ * translucent slate-blue NormalBlending materials, sparse haze-mote cloud),
+ * per-frame spin classification per axis with alternating directions, bounded
+ * positional drift, the opacity respond/listen formula with its 0.24 ceiling,
+ * the energy breathe scale, mote rewrite bounds with `needsUpdate` signalling,
+ * input-insensitivity to `low`, frame determinism, and full teardown on
+ * dispose. The double records calls; every expectation is recomputed here,
+ * never read back from the subject.
+ */
+
+import { describe, expect, it } from "vitest";
+import { concept } from "../../stories/src/concepts/fog";
+
+// three.js constant value the concept assigns verbatim onto materials.
+const NORMAL_BLENDING = 1;
+
+const EPSILON = 1e-6;
+
+class FakeColor {
+  r = 0;
+  g = 0;
+  b = 0;
+  constructor(r?: number, g?: number, b?: number) {
+    if (r !== undefined && g !== undefined && b !== undefined) {
+      this.r = r;
+      this.g = g;
+      this.b = b;
+    }
+  }
+  setRGB(r: number, g: number, b: number): void {
+    this.r = r;
+    this.g = g;
+    this.b = b;
+  }
+}
+
+class FakeBufferAttribute {
+  array: Float32Array;
+  itemSize: number;
+  count: number;
+  needsUpdate = false;
+  constructor(array: Float32Array, itemSize: number) {
+    this.array = array;
+    this.itemSize = itemSize;
+    this.count = array.length / itemSize;
+  }
+  getX(i: number): number {
+    return this.array[i * 3];
+  }
+  getY(i: number): number {
+    return this.array[i * 3 + 1];
+  }
+  getZ(i: number): number {
+    return this.array[i * 3 + 2];
+  }
+  setXYZ(i: number, x: number, y: number, z: number): void {
+    this.array[i * 3] = x;
+    this.array[i * 3 + 1] = y;
+    this.array[i * 3 + 2] = z;
+  }
+}
+
+class FakeGeometry {
+  attributes: Record<string, FakeBufferAttribute> = {};
+  disposed = false;
+  setAttribute(name: string, attribute: FakeBufferAttribute): void {
+    this.attributes[name] = attribute;
+  }
+  dispose(): void {
+    this.disposed = true;
+  }
+}
+
+/** Sphere stand-in recording the radius and segmentation it was built with. */
+class FakeSphereGeometry extends FakeGeometry {
+  radius: number;
+  widthSegments: number;
+  heightSegments: number;
+  constructor(radius: number, widthSegments: number, heightSegments: number) {
+    super();
+    this.radius = radius;
+    this.widthSegments = widthSegments;
+    this.heightSegments = heightSegments;
+  }
+}
+
+class FakeMaterial {
+  color = new FakeColor();
+  opacity = 1;
+  transparent = false;
+  depthWrite = true;
+  blending = 0;
+  size = 1;
+  disposed = false;
+  dispose(): void {
+    this.disposed = true;
+  }
+}
+
+class FakeObject3D {
+  geometry: FakeGeometry;
+  material: FakeMaterial;
+  rotation = { x: 0, y: 0, z: 0 };
+  position = { x: 0, y: 0, z: 0 };
+  scale = {
+    x: 1,
+    y: 1,
+    z: 1,
+    setScalar(v: number): void {
+      this.x = v;
+      this.y = v;
+      this.z = v;
+    },
+  };
+  frustumCulled = true;
+  constructor(geometry: FakeGeometry, material: FakeMaterial) {
+    this.geometry = geometry;
+    this.material = material;
+  }
+}
+
+function makeThreeModule() {
+  const sphereGeometries: FakeSphereGeometry[] = [];
+  const bufferGeometries: FakeGeometry[] = [];
+  const materials: FakeMaterial[] = [];
+  const objects: FakeObject3D[] = [];
+  const THREE = {
+    SphereGeometry: class extends FakeSphereGeometry {
+      constructor(...args: ConstructorParameters<typeof FakeSphereGeometry>) {
+        super(...args);
+        sphereGeometries.push(this);
+      }
+    },
+    BufferGeometry: class extends FakeGeometry {
+      constructor() {
+        super();
+        bufferGeometries.push(this);
+      }
+    },
+    BufferAttribute: FakeBufferAttribute,
+    Color: FakeColor,
+    MeshBasicNodeMaterial: class extends FakeMaterial {
+      constructor() {
+        super();
+        materials.push(this);
+      }
+    },
+    PointsNodeMaterial: class extends FakeMaterial {
+      constructor() {
+        super();
+        materials.push(this);
+      }
+    },
+    Mesh: class extends FakeObject3D {
+      constructor(geometry: FakeGeometry, material: FakeMaterial) {
+        super(geometry, material);
+        objects.push(this);
+      }
+    },
+    Points: class extends FakeObject3D {
+      constructor(geometry: FakeGeometry, material: FakeMaterial) {
+        super(geometry, material);
+        objects.push(this);
+      }
+    },
+    NormalBlending: NORMAL_BLENDING,
+  };
+  return { THREE, sphereGeometries, bufferGeometries, materials, objects };
+}
+
+function makeParent() {
+  return {
+    children: [] as FakeObject3D[],
+    add(child: FakeObject3D): void {
+      this.children.push(child);
+    },
+    remove(child: FakeObject3D): void {
+      const index = this.children.indexOf(child);
+      if (index >= 0) this.children.splice(index, 1);
+    },
+  };
+}
+
+const UNIFORMS = {
+  uTime: null,
+  uEnergy: null,
+  uLow: null,
+  uListen: null,
+  uRespond: null,
+  uAspect: null,
+  uAccent: null,
+};
+
+const SHELL_COUNT = 10;
+
+interface BuiltScene {
+  handle: ReturnType<typeof concept.build>;
+  parent: ReturnType<typeof makeParent>;
+  shells: FakeObject3D[];
+  motes: FakeObject3D;
+  shellGeometries: FakeSphereGeometry[];
+  moteGeometry: FakeGeometry;
+}
+
+/** Builds the concept against fresh doubles and splits parent children into shells + motes. */
+function buildScene(): BuiltScene {
+  const { THREE, sphereGeometries, bufferGeometries } = makeThreeModule();
+  const parent = makeParent();
+  const handle = concept.build(THREE, {}, UNIFORMS, parent);
+  const shells = parent.children.slice(0, SHELL_COUNT) as FakeObject3D[];
+  const motes = parent.children[SHELL_COUNT] as FakeObject3D;
+  return {
+    handle,
+    parent,
+    shells,
+    motes,
+    shellGeometries: sphereGeometries,
+    moteGeometry: bufferGeometries[0],
+  };
+}
+
+/** Per-shell animated state, stringified for whole-state equality checks. */
+function shellSnapshot(scene: BuiltScene): string[] {
+  return scene.shells.map(
+    (mesh) =>
+      `${mesh.rotation.x},${mesh.rotation.y},${mesh.rotation.z},${
+        mesh.position.x
+      },${mesh.position.y},${mesh.position.z},${mesh.scale.x},${
+        (mesh.material as FakeMaterial).opacity
+      },${(mesh.material as FakeMaterial).color.r},${
+        (mesh.material as FakeMaterial).color.g
+      },${(mesh.material as FakeMaterial).color.b}`,
+  );
+}
+
+describe("fog concept descriptor", () => {
+  it("registers under the fog id with the mood family and a callable builder", () => {
+    expect(concept.id).toBe("fog");
+    expect(concept.label).toBe("fog");
+    expect(concept.family).toBe("mood");
+    expect(typeof concept.build).toBe("function");
+  });
+});
+
+describe("fog build: layered shell scene", () => {
+  it("adds ten sphere shells followed by one haze-mote cloud to the parent", () => {
+    const scene = buildScene();
+    expect(scene.parent.children).toHaveLength(SHELL_COUNT + 1);
+    expect(scene.shellGeometries).toHaveLength(SHELL_COUNT);
+    expect(scene.moteGeometry).toBeInstanceOf(FakeGeometry);
+    for (const geo of scene.shellGeometries) {
+      expect(geo.widthSegments).toBe(24);
+      expect(geo.heightSegments).toBe(16);
+    }
+    expect(scene.motes.frustumCulled).toBe(false);
+  });
+
+  it("stacks the shells inner-to-outer: radii descend monotonically within unit scale", () => {
+    const scene = buildScene();
+    const radii = scene.shellGeometries.map((geo) => geo.radius);
+    for (let i = 1; i < radii.length; i += 1) {
+      expect(radii[i]).toBeLessThan(radii[i - 1]);
+    }
+    expect(radii[radii.length - 1]).toBeGreaterThanOrEqual(0.7);
+    expect(radii[0]).toBeLessThanOrEqual(1.25);
+  });
+
+  it("configures every shell as translucent unblotted normal-blended haze", () => {
+    const scene = buildScene();
+    for (const mesh of scene.shells) {
+      const mat = mesh.material as FakeMaterial;
+      expect(mat.transparent).toBe(true);
+      expect(mat.depthWrite).toBe(false);
+      expect(mat.blending).toBe(NORMAL_BLENDING);
+      expect(mat.opacity).toBeGreaterThanOrEqual(0.1);
+      expect(mat.opacity).toBeLessThanOrEqual(0.15);
+    }
+  });
+
+  it("gives every shell a muted slate-blue hue ordered blue over green over red, repeating at most one", () => {
+    const scene = buildScene();
+    const seen = new Set<string>();
+    for (const mesh of scene.shells) {
+      const color = (mesh.material as FakeMaterial).color;
+      expect(color.b).toBeGreaterThan(color.g);
+      expect(color.g).toBeGreaterThan(color.r);
+      for (const channel of [color.r, color.g, color.b]) {
+        expect(channel).toBeGreaterThanOrEqual(0.3);
+        expect(channel).toBeLessThanOrEqual(0.65);
+      }
+      seen.add(`${color.r},${color.g},${color.b}`);
+    }
+    expect(seen.size).toBe(SHELL_COUNT - 1);
+  });
+
+  it("configures the mote cloud as small dim slate-blue translucent points", () => {
+    const scene = buildScene();
+    const mat = scene.motes.material as FakeMaterial;
+    expect(mat.transparent).toBe(true);
+    expect(mat.depthWrite).toBe(false);
+    expect(mat.blending).toBe(NORMAL_BLENDING);
+    expect(mat.opacity).toBeCloseTo(0.4, 10);
+    expect(mat.size).toBeCloseTo(0.022, 10);
+    expect(mat.color.b).toBeGreaterThan(mat.color.g);
+    expect(mat.color.g).toBeGreaterThan(mat.color.r);
+    const pos = (scene.motes.geometry as FakeGeometry).attributes.position;
+    expect(pos.itemSize).toBe(3);
+    expect(pos.count).toBe(80);
+    for (let vi = 0; vi < pos.count; vi += 1) {
+      const r = Math.hypot(pos.getX(vi), pos.getY(vi), pos.getZ(vi));
+      expect(r).toBeGreaterThanOrEqual(0.5 - EPSILON);
+      expect(r).toBeLessThanOrEqual(1.25 + EPSILON);
+    }
+  });
+});
+
+describe("fog frame animation", () => {
+  const IDLE = { time: 0, energy: 0, low: 0, listen: 0, respond: 0 };
+
+  it("rests perfectly still at time zero: every rotation is zero and scale is unity", () => {
+    const scene = buildScene();
+    scene.handle.frame(IDLE);
+    for (const mesh of scene.shells) {
+      // Negative spin directions turn 0 * -1 into -0; compare numerically.
+      expect(mesh.rotation.x).toBeCloseTo(0, 10);
+      expect(mesh.rotation.y).toBeCloseTo(0, 10);
+      expect(mesh.rotation.z).toBeCloseTo(0, 10);
+      expect(mesh.scale.x).toBe(1);
+      expect(mesh.scale.y).toBe(1);
+      expect(mesh.scale.z).toBe(1);
+    }
+  });
+
+  it("leaves shell opacity at its build-time base when energy inputs are neutral", () => {
+    const scene = buildScene();
+    const bases = scene.shells.map(
+      (mesh) => (mesh.material as FakeMaterial).opacity,
+    );
+    scene.handle.frame(IDLE);
+    scene.shells.forEach((mesh, si) => {
+      expect((mesh.material as FakeMaterial).opacity).toBeCloseTo(
+        bases[si],
+        10,
+      );
+    });
+  });
+
+  it("resets the mote cloud opacity from the build-time 0.4 to the animated 0.34 floor", () => {
+    const scene = buildScene();
+    expect((scene.motes.material as FakeMaterial).opacity).toBeCloseTo(0.4, 10);
+    scene.handle.frame(IDLE);
+    expect((scene.motes.material as FakeMaterial).opacity).toBeCloseTo(
+      0.34,
+      10,
+    );
+  });
+
+  it("breathes the whole stack uniformly with energy: scalar scale of 1 + energy * 0.06", () => {
+    const scene = buildScene();
+    scene.handle.frame({ ...IDLE, energy: 0.5 });
+    for (const mesh of scene.shells) {
+      expect(mesh.scale.x).toBeCloseTo(1.03, 10);
+      expect(mesh.scale.y).toBeCloseTo(1.03, 10);
+      expect(mesh.scale.z).toBeCloseTo(1.03, 10);
+    }
+    scene.handle.frame({ ...IDLE, energy: 1 });
+    for (const mesh of scene.shells) {
+      expect(mesh.scale.x).toBeCloseTo(1.06, 10);
+      expect(mesh.scale.y).toBeCloseTo(1.06, 10);
+      expect(mesh.scale.z).toBeCloseTo(1.06, 10);
+    }
+  });
+
+  it("lifts colour toward cooler blue on respond by fixed per-channel offsets", () => {
+    const scene = buildScene();
+    // Copy channels out before framing: setRGB mutates the captured color.
+    const bases = scene.shells.map((mesh) => {
+      const color = (mesh.material as FakeMaterial).color;
+      return { r: color.r, g: color.g, b: color.b };
+    });
+    scene.handle.frame({ ...IDLE, respond: 1 });
+    scene.shells.forEach((mesh, si) => {
+      const color = (mesh.material as FakeMaterial).color;
+      expect(color.r).toBeCloseTo(bases[si].r + 0.05, 10);
+      expect(color.g).toBeCloseTo(bases[si].g + 0.06, 10);
+      expect(color.b).toBeCloseTo(bases[si].b + 0.08, 10);
+    });
+  });
+
+  it("raises opacity by 0.015 at full respond without ever reaching the 0.24 ceiling", () => {
+    const scene = buildScene();
+    const bases = scene.shells.map(
+      (mesh) => (mesh.material as FakeMaterial).opacity,
+    );
+    scene.handle.frame({ ...IDLE, respond: 1 });
+    scene.shells.forEach((mesh, si) => {
+      const lifted = (mesh.material as FakeMaterial).opacity;
+      expect(lifted).toBeCloseTo(Math.min(0.24, bases[si] + 0.015), 10);
+      expect(lifted).toBeLessThan(0.24);
+    });
+  });
+
+  it("dims opacity by 0.008 at full listen, stacking subtractively with respond", () => {
+    const scene = buildScene();
+    const bases = scene.shells.map(
+      (mesh) => (mesh.material as FakeMaterial).opacity,
+    );
+    scene.handle.frame({ ...IDLE, listen: 1 });
+    scene.shells.forEach((mesh, si) => {
+      expect((mesh.material as FakeMaterial).opacity).toBeCloseTo(
+        bases[si] - 0.008,
+        10,
+      );
+    });
+    scene.handle.frame({ ...IDLE, respond: 1, listen: 0.5 });
+    scene.shells.forEach((mesh, si) => {
+      expect((mesh.material as FakeMaterial).opacity).toBeCloseTo(
+        Math.min(0.24, bases[si] + 0.015 - 0.004),
+        10,
+      );
+    });
+  });
+
+  it("spins each shell at a constant signed rate about exactly one axis", () => {
+    const scene = buildScene();
+    const times = [2, 12, 22];
+    const readings = times.map((time) => {
+      scene.handle.frame({ ...IDLE, time });
+      return scene.shells.map(
+        (mesh) => [mesh.rotation.x, mesh.rotation.y, mesh.rotation.z] as const,
+      );
+    });
+    const axisCounts = { x: 0, y: 0, z: 0 } as Record<string, number>;
+    const directions: number[] = [];
+    for (let si = 0; si < SHELL_COUNT; si += 1) {
+      let spinningAxis = -1;
+      let rate = 0;
+      for (let axis = 0; axis < 3; axis += 1) {
+        const r1 =
+          (readings[1][si][axis] - readings[0][si][axis]) /
+          (times[1] - times[0]);
+        const r2 =
+          (readings[2][si][axis] - readings[1][si][axis]) /
+          (times[2] - times[1]);
+        if (Math.abs(r1 - r2) < 1e-9 && Math.abs(r1) > 1e-6) {
+          expect(spinningAxis).toBe(-1);
+          spinningAxis = axis;
+          rate = r1;
+        }
+      }
+      expect(spinningAxis).toBeGreaterThanOrEqual(0);
+      axisCounts["xyz"[spinningAxis]] += 1;
+      directions.push(Math.sign(rate));
+      expect(Math.abs(rate)).toBeGreaterThanOrEqual(0.006);
+      expect(Math.abs(rate)).toBeLessThanOrEqual(0.015);
+    }
+    expect(axisCounts).toEqual({ x: 3, y: 5, z: 2 });
+    for (let si = 1; si < directions.length; si += 1) {
+      expect(directions[si]).toBe(-directions[si - 1]);
+    }
+  });
+
+  it("keeps non-spinning rotation components inside their small wobble bounds", () => {
+    const scene = buildScene();
+    // Classify each shell's spin axis first: only that component grows
+    // linearly; a wobble's apparent rate stays under 0.002 rad/s.
+    scene.handle.frame({ ...IDLE, time: 100 });
+    const early = scene.shells.map(
+      (mesh) => [mesh.rotation.x, mesh.rotation.y, mesh.rotation.z] as const,
+    );
+    scene.handle.frame({ ...IDLE, time: 200 });
+    const late = scene.shells.map(
+      (mesh) => [mesh.rotation.x, mesh.rotation.y, mesh.rotation.z] as const,
+    );
+    const spinAxes = early.map((from, si) => {
+      for (let axis = 0; axis < 3; axis += 1) {
+        if (Math.abs((late[si][axis] - from[axis]) / 100) > 0.002) return axis;
+      }
+      return -1;
+    });
+    for (let step = 0; step <= 30; step += 1) {
+      scene.handle.frame({ ...IDLE, time: step * 1.7 });
+      scene.shells.forEach((mesh, si) => {
+        const angles = [mesh.rotation.x, mesh.rotation.y, mesh.rotation.z];
+        for (let axis = 0; axis < 3; axis += 1) {
+          if (axis === spinAxes[si]) continue;
+          expect(Math.abs(angles[axis])).toBeLessThanOrEqual(0.08 + EPSILON);
+        }
+      });
+    }
+  });
+
+  it("wanders each shell centre on bounded sinusoidal drift of amplitude 0.025", () => {
+    const scene = buildScene();
+    const mins = scene.shells.map(() => [
+      Number.POSITIVE_INFINITY,
+      Number.POSITIVE_INFINITY,
+      Number.POSITIVE_INFINITY,
+    ]);
+    const maxs = scene.shells.map(() => [
+      Number.NEGATIVE_INFINITY,
+      Number.NEGATIVE_INFINITY,
+      Number.NEGATIVE_INFINITY,
+    ]);
+    for (let step = 0; step <= 120; step += 1) {
+      scene.handle.frame({ ...IDLE, time: step * 2.03 });
+      scene.shells.forEach((mesh, si) => {
+        for (let axis = 0; axis < 3; axis += 1) {
+          const v = [mesh.position.x, mesh.position.y, mesh.position.z][axis];
+          mins[si][axis] = Math.min(mins[si][axis], v);
+          maxs[si][axis] = Math.max(maxs[si][axis], v);
+        }
+      });
+    }
+    for (let si = 0; si < SHELL_COUNT; si += 1) {
+      for (let axis = 0; axis < 3; axis += 1) {
+        const range = maxs[si][axis] - mins[si][axis];
+        expect(range).toBeGreaterThan(0.03);
+        expect(range).toBeLessThanOrEqual(0.05 + 1e-9);
+      }
+    }
+  });
+
+  it("rewrites all eighty mote positions inside the shell volume and flags the attribute dirty", () => {
+    const scene = buildScene();
+    const pos = (scene.motes.geometry as FakeGeometry).attributes
+      .position as FakeBufferAttribute;
+    scene.handle.frame({ ...IDLE, time: 37 });
+    expect(pos.needsUpdate).toBe(true);
+    for (let vi = 0; vi < pos.count; vi += 1) {
+      const x = pos.getX(vi);
+      const y = pos.getY(vi);
+      const z = pos.getZ(vi);
+      expect(Number.isFinite(x)).toBe(true);
+      expect(Number.isFinite(y)).toBe(true);
+      expect(Number.isFinite(z)).toBe(true);
+      const r = Math.hypot(x, y, z);
+      expect(r).toBeGreaterThanOrEqual(0.42 - EPSILON);
+      expect(r).toBeLessThanOrEqual(1.33 + EPSILON);
+    }
+  });
+
+  it("actually moves the motes between distant frames rather than pinning them", () => {
+    const scene = buildScene();
+    const pos = (scene.motes.geometry as FakeGeometry).attributes
+      .position as FakeBufferAttribute;
+    scene.handle.frame({ ...IDLE, time: 0 });
+    const before = Float32Array.from(pos.array);
+    scene.handle.frame({ ...IDLE, time: 40 });
+    let travel = 0;
+    for (let i = 0; i < before.length; i += 1) {
+      travel += Math.abs(pos.array[i] - before[i]);
+    }
+    expect(travel).toBeGreaterThan(5);
+  });
+
+  it("ignores the low band entirely: only time, energy, listen and respond move anything", () => {
+    const scene = buildScene();
+    scene.handle.frame({
+      time: 4,
+      energy: 0.3,
+      low: 0,
+      listen: 0.2,
+      respond: 0.4,
+    });
+    const baseline = [
+      ...shellSnapshot(scene),
+      Float32Array.from(
+        (scene.motes.geometry as FakeGeometry).attributes.position.array,
+      ).join(","),
+    ];
+    scene.handle.frame({
+      time: 4,
+      energy: 0.3,
+      low: 1,
+      listen: 0.2,
+      respond: 0.4,
+    });
+    const replay = [
+      ...shellSnapshot(scene),
+      Float32Array.from(
+        (scene.motes.geometry as FakeGeometry).attributes.position.array,
+      ).join(","),
+    ];
+    expect(replay).toEqual(baseline);
+  });
+
+  it("is deterministic: replaying the same frame reproduces the same world state", () => {
+    const scene = buildScene();
+    const PEAK = { time: 9, energy: 0.8, low: 0.3, listen: 0.4, respond: 0.9 };
+    scene.handle.frame(PEAK);
+    const first = [
+      ...shellSnapshot(scene),
+      Float32Array.from(
+        (scene.motes.geometry as FakeGeometry).attributes.position.array,
+      ).join(","),
+    ];
+    scene.handle.frame(PEAK);
+    const second = [
+      ...shellSnapshot(scene),
+      Float32Array.from(
+        (scene.motes.geometry as FakeGeometry).attributes.position.array,
+      ).join(","),
+    ];
+    expect(second).toEqual(first);
+  });
+});
+
+describe("fog dispose", () => {
+  it("disposes every geometry and material and detaches everything it added", () => {
+    const scene = buildScene();
+    const allGeometries: FakeGeometry[] = [
+      ...scene.shellGeometries,
+      scene.moteGeometry,
+    ];
+    const allMaterials = scene.parent.children.map(
+      (child) => child.material as FakeMaterial,
+    );
+    expect(allGeometries).toHaveLength(SHELL_COUNT + 1);
+    expect(allMaterials).toHaveLength(SHELL_COUNT + 1);
+
+    scene.handle.dispose();
+
+    for (const geometry of allGeometries) {
+      expect(geometry.disposed).toBe(true);
+    }
+    for (const material of allMaterials) {
+      expect(material.disposed).toBe(true);
+    }
+    expect(scene.parent.children).toHaveLength(0);
+  });
+});


### PR DESCRIPTION

## What

Adds a new unit suite for the fog voice-orb concept (`packages/ui/stories/src/concepts/fog.ts`), placed with the package's collected tests at `packages/ui/src/__tests__/stories-concepts-fog.test.ts`. Test-only: no production source, config, or export changes — exactly one new file, +636/−0.

## Why

`fog.ts` had no same-named test anywhere on develop. The concept is consumed through `stories/src/concepts/index.ts`, which registers it in the CONCEPTS list the voice-orb gallery iterates, so every shell/mote behaviour the gallery relies on was unverified. The suite drives the real module through the same injected three/webgpu module surface the orb-kit harness hands every concept builder, and every expectation is recomputed independently — no mocked return value is asserted against itself.

## Coverage (21 cases)

- Descriptor contract: id/label `fog`, family `mood`, callable builder.
- Scene structure: ten sphere shells (24×16 segments, radii strictly descending within [0.7, 1.25]) followed by one 80-mote Points cloud with `frustumCulled = false`.
- Material contract: translucent, `depthWrite = false`, NormalBlending; slate-blue channel ordering (b > g > r) on every shell and on the mote cloud; build-time opacities 0.4 (motes) and [0.1, 0.15] (shells); mote size 0.022; initial mote radii within [0.5, 1.25].
- Frame animation: exact rest at t=0 (all rotations zero, unity scale); breathe scale `1 + energy·0.06` applied as a uniform scalar; respond colour lift of +0.05/+0.06/+0.08 per channel and opacity lift +0.015 held under the 0.24 ceiling; listen dim −0.008 stacking subtractively with respond via the same `min(0.24, …)` formula; each shell spins at a constant signed rate about exactly one axis (population {x:3, y:5, z:2}) with directions alternating across the stack while non-spinning components stay inside their ≤0.08 wobble bounds; shell centres wander on bounded ±0.025 sinusoidal drift on all three axes; every frame rewrites all 80 mote positions inside r ∈ [0.42, 1.33], actually moves them between distant frames, and flags the position attribute `needsUpdate`; mote opacity resets from the build-time 0.4 to the animated 0.34 floor (`0.34 + respond·0.12`).
- Input contract: the `low` band is provably unread (identical whole-state snapshot with low 0 vs 1); replaying any frame reproduces byte-identical world state (stateless per-frame math).
- Teardown: dispose releases all 11 geometries and all 11 materials and detaches everything the builder added.

## Evidence

Fork contributor: hosted CI does not run on this pull request; verification below is local. Base: current origin/develop `51617538d7`.

- `bunx vitest run src/__tests__/stories-concepts-fog.test.ts` in `packages/ui`: **Test Files 1 passed (1); Tests 21 passed (21)** (~150 ms). Re-fetched and re-run immediately before filing.
- `bunx biome check --write packages/ui/src/__tests__/stories-concepts-fog.test.ts` (root biome.json): clean — "Checked 1 file … No fixes applied".
- `bunx tsc --noEmit` in `packages/ui`: greping the output for `stories-concepts-fog` returns nothing — the new file introduces zero type errors.
- `git diff --stat origin/develop HEAD`: one file changed, +636/−0 (the new test only).

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:94c3aad719bb3d5c9bb14c18b0959648d6d3831c -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
