### PR TITLE
test(ui): cover datacore

### DIFF
--- a/packages/ui/src/__tests__/stories-datacore-orb.test.ts
+++ b/packages/ui/src/__tests__/stories-datacore-orb.test.ts
@@ -1,0 +1,319 @@
+/**
+ * Unit coverage for the datacore orb concept: descriptor registration,
+ * gyroscope assembly into the parent group, per-ring spin/tilt-easing/emissive
+ * animation, respond-lock hysteresis, and teardown. Harness is deterministic:
+ * the real builder runs against a plain-object renderer stand-in, which the
+ * module accepts because it takes the WebGPU module as an injected parameter.
+ */
+import { describe, expect, it } from "vitest";
+import { concept } from "../../stories/src/concepts/datacore";
+import type { OrbFrame, OrbUniforms } from "../../stories/src/orb-kit";
+
+class FakeGeometry {
+  disposed = 0;
+  constructor(
+    public readonly kind: string,
+    public readonly args: readonly number[],
+  ) {}
+  dispose(): void {
+    this.disposed += 1;
+  }
+}
+
+class FakeMaterial {
+  disposed = 0;
+  flatShading = false;
+  metalness = 0;
+  roughness = 0;
+  emissive = new FakeColor(0, 0, 0);
+  emissiveIntensity = 0;
+  dispose(): void {
+    this.disposed += 1;
+  }
+}
+
+class FakeColor {
+  constructor(
+    public r: number,
+    public g: number,
+    public b: number,
+  ) {}
+  setRGB(r: number, g: number, b: number): void {
+    this.r = r;
+    this.g = g;
+    this.b = b;
+  }
+}
+
+class FakeMesh {
+  rotation = { x: 0, y: 0, z: 0 };
+  scale = {
+    value: 1,
+    setScalar(v: number): void {
+      this.value = v;
+    },
+  };
+  constructor(
+    public geometry: FakeGeometry,
+    public material: FakeMaterial,
+  ) {}
+}
+
+function must<T>(value: T | undefined | null): T {
+  if (value === undefined || value === null) throw new Error("missing item");
+  return value;
+}
+
+function makeUniforms(): OrbUniforms {
+  return {
+    uTime: { value: 0 },
+    uEnergy: { value: 0 },
+    uLow: { value: 0 },
+    uListen: { value: 0 },
+    uRespond: { value: 0 },
+    uAspect: { value: 1 },
+    uAccent: { value: null },
+  };
+}
+
+function makeHarness() {
+  const geometries: FakeGeometry[] = [];
+  const materials: FakeMaterial[] = [];
+  const THREE = {
+    TorusGeometry: class extends FakeGeometry {
+      constructor(...args: number[]) {
+        super("torus", args);
+        geometries.push(this);
+      }
+    },
+    IcosahedronGeometry: class extends FakeGeometry {
+      constructor(...args: number[]) {
+        super("icosahedron", args);
+        geometries.push(this);
+      }
+    },
+    MeshPhysicalNodeMaterial: class extends FakeMaterial {
+      constructor() {
+        super();
+        materials.push(this);
+      }
+    },
+    MeshStandardNodeMaterial: class extends FakeMaterial {
+      constructor() {
+        super();
+        materials.push(this);
+      }
+    },
+    Color: FakeColor,
+    Mesh: FakeMesh,
+  };
+  const parent = {
+    children: [] as FakeMesh[],
+    add(child: FakeMesh): void {
+      parent.children.push(child);
+    },
+    remove(child: FakeMesh): void {
+      const index = parent.children.indexOf(child);
+      if (index >= 0) parent.children.splice(index, 1);
+    },
+  };
+  const handle = concept.build(THREE, {}, makeUniforms(), parent);
+  return { handle, parent, geometries, materials };
+}
+
+function frame(over: Partial<OrbFrame>): OrbFrame {
+  return { time: 0, energy: 0, low: 0, listen: 0, respond: 0, ...over };
+}
+
+describe("datacore concept descriptor", () => {
+  it("registers the datacore label in the sci-fi family with a callable builder", () => {
+    expect(concept.id).toBe("datacore");
+    expect(concept.label).toBe("datacore");
+    expect(concept.family).toBe("sci-fi");
+    expect(typeof concept.build).toBe("function");
+  });
+});
+
+describe("datacore assembly", () => {
+  it("adds three gyro rings, the nucleus, and the accent ring to the parent in order", () => {
+    const { parent, geometries } = makeHarness();
+    expect(parent.children).toHaveLength(5);
+    expect(geometries.map((g) => g.kind)).toEqual([
+      "torus",
+      "torus",
+      "torus",
+      "icosahedron",
+      "torus",
+    ]);
+    expect(geometries[0]?.args).toEqual([0.55, 0.028, 12, 80]);
+    expect(geometries[1]?.args).toEqual([0.8, 0.022, 12, 80]);
+    expect(geometries[2]?.args).toEqual([1.05, 0.018, 12, 80]);
+    expect(geometries[3]?.args).toEqual([0.18, 1]);
+    expect(geometries[4]?.args).toEqual([0.32, 0.012, 8, 60]);
+  });
+
+  it("seeds each ring mesh and the accent ring at their natural rest tilts", () => {
+    const { parent } = makeHarness();
+    const [ring0, ring1, ring2, , accent] = parent.children;
+    expect(must(ring0).rotation.x).toBe(Math.PI * 0.5);
+    expect(must(ring0).rotation.z).toBe(0);
+    expect(must(ring1).rotation.x).toBe(Math.PI * 0.28);
+    expect(must(ring1).rotation.z).toBe(Math.PI * 0.14);
+    expect(must(ring2).rotation.x).toBe(Math.PI * 0.12);
+    expect(must(ring2).rotation.z).toBe(Math.PI * 0.62);
+    expect(must(accent).rotation.x).toBe(Math.PI * 0.3);
+  });
+
+  it("bases rings on a flat-shaded chrome gem with faint cyan emissive and flares the nucleus", () => {
+    const { materials } = makeHarness();
+    const [ringMat, , , nucleusMat, accentMat] = materials;
+    expect(must(ringMat).flatShading).toBe(true);
+    expect(must(ringMat).metalness).toBe(1);
+    expect(must(ringMat).roughness).toBeCloseTo(0.18, 12);
+    expect(must(ringMat).emissive.r).toBe(0);
+    expect(must(ringMat).emissive.g).toBeCloseTo(0.55, 12);
+    expect(must(ringMat).emissive.b).toBeCloseTo(0.72, 12);
+    expect(must(ringMat).emissiveIntensity).toBeCloseTo(0.18, 12);
+    expect(must(nucleusMat).metalness).toBeCloseTo(0.6, 12);
+    expect(must(nucleusMat).roughness).toBeCloseTo(0.25, 12);
+    expect(must(nucleusMat).emissiveIntensity).toBeCloseTo(0.9, 12);
+    expect(must(accentMat).emissive.r).toBeCloseTo(0.8, 12);
+    expect(must(accentMat).emissive.g).toBeCloseTo(0.45, 12);
+    expect(must(accentMat).emissive.b).toBe(0);
+  });
+});
+
+describe("datacore per-frame animation", () => {
+  it("accumulates each ring's spin on its own axis over one fixed 0.016 s step", () => {
+    const { handle, parent } = makeHarness();
+    handle.frame(frame({}));
+    const [ring0, ring1, ring2] = parent.children;
+    expect(must(ring0).rotation.y).toBeCloseTo(0.72 * 0.016, 12);
+    expect(must(ring1).rotation.x).toBeCloseTo(
+      Math.PI * 0.28 + 0.48 * 0.016,
+      12,
+    );
+    expect(must(ring2).rotation.z).toBeCloseTo(
+      Math.PI * 0.62 + 0.31 * 0.016,
+      12,
+    );
+  });
+
+  it("leaves the non-spin axes pinned at rest while idle", () => {
+    const { handle, parent } = makeHarness();
+    handle.frame(frame({}));
+    const [ring0, ring1, ring2] = parent.children;
+    expect(must(ring0).rotation.x).toBe(Math.PI * 0.5);
+    expect(must(ring1).rotation.z).toBe(Math.PI * 0.14);
+    expect(must(ring2).rotation.x).toBe(Math.PI * 0.12);
+  });
+
+  it("scales spin speed up by 2.4x at full voice energy", () => {
+    const { handle, parent } = makeHarness();
+    handle.frame(frame({ energy: 0 }));
+    const idleRy = must(parent.children[0]).rotation.y;
+    handle.frame(frame({ energy: 1 }));
+    const energizedDelta = must(parent.children[0]).rotation.y - idleRy;
+    expect(energizedDelta).toBeCloseTo(0.72 * 2.4 * 0.016, 12);
+  });
+
+  it("flares ring emissive with energy and shifts cyan toward amber while responding", () => {
+    const { handle, materials } = makeHarness();
+    const ringMat = must(materials[0]);
+    handle.frame(frame({ energy: 0.5 }));
+    expect(ringMat.emissiveIntensity).toBeCloseTo(0.455, 12);
+    expect(ringMat.emissive.r).toBe(0);
+    expect(ringMat.emissive.g).toBeCloseTo(0.7, 12);
+    expect(ringMat.emissive.b).toBeCloseTo(0.86, 12);
+    handle.frame(frame({ energy: 0.5, respond: 1 }));
+    expect(ringMat.emissive.r).toBeCloseTo(0.63, 12);
+    expect(ringMat.emissive.g).toBeCloseTo(0.56, 12);
+    expect(ringMat.emissive.b).toBeCloseTo(0.328, 12);
+    expect(ringMat.emissiveIntensity).toBeCloseTo(0.905, 12);
+  });
+
+  it("steps the accent ring 0.022 radians per frame at rest regardless of the timestep constant", () => {
+    const { handle, parent, materials } = makeHarness();
+    const accent = must(parent.children[4]);
+    const accentMat = must(materials[4]);
+    handle.frame(frame({ energy: 1 }));
+    expect(accent.rotation.z).toBeCloseTo(0.066, 12);
+    expect(accentMat.emissiveIntensity).toBeCloseTo(0.9, 12);
+  });
+
+  it("pulses the nucleus scale with time and energy, spins it slowly, and warms its glow on respond", () => {
+    const { handle, parent, materials } = makeHarness();
+    const nucleus = must(parent.children[3]);
+    const nucleusMat = must(materials[3]);
+    handle.frame(frame({ energy: 0.2, respond: 0.5 }));
+    expect(nucleus.scale.value).toBeCloseTo(1.169, 12);
+    expect(nucleus.rotation.y).toBe(0);
+    expect(nucleus.rotation.x).toBe(0);
+    expect(nucleusMat.emissive.r).toBeCloseTo(0.4, 12);
+    expect(nucleusMat.emissive.g).toBeCloseTo(0.7, 12);
+    expect(nucleusMat.emissive.b).toBeCloseTo(0.62, 12);
+    expect(nucleusMat.emissiveIntensity).toBeCloseTo(1.78, 12);
+    const quarterPulse = Math.PI / (2 * 3.8);
+    handle.frame(frame({ time: quarterPulse }));
+    expect(nucleus.scale.value).toBeCloseTo(1.06, 6);
+    expect(nucleus.rotation.y).toBeCloseTo(0.165347, 6);
+    expect(nucleus.rotation.x).toBeCloseTo(0.111609, 6);
+  });
+});
+
+describe("datacore respond lock", () => {
+  it("holds rings toward the shared plane after a respond peak ends, then drifts back to natural tilts", () => {
+    const { handle, parent } = makeHarness();
+    handle.frame(frame({ respond: 1 }));
+    const onsetRx = must(parent.children[0]).rotation.x;
+    expect(onsetRx).toBeCloseTo(Math.PI * 0.5 * 0.94, 9);
+    let minRx = onsetRx;
+    for (let i = 0; i < 60; i += 1) {
+      handle.frame(frame({}));
+      const rx = must(parent.children[0]).rotation.x;
+      expect(rx).toBeLessThan(minRx);
+      minRx = rx;
+    }
+    expect(minRx).toBeLessThan(0.1);
+    for (let i = 0; i < 300; i += 1) {
+      handle.frame(frame({}));
+    }
+    const recovered = must(parent.children[0]).rotation.x;
+    expect(recovered).toBeGreaterThan(minRx);
+    expect(recovered).toBeGreaterThan(1.5);
+  });
+
+  it("does not latch the hold when respond peaks at exactly 0.5", () => {
+    const { handle, parent } = makeHarness();
+    handle.frame(frame({ respond: 0.5 }));
+    expect(must(parent.children[0]).rotation.x).toBeCloseTo(
+      Math.PI * 0.5 * 0.94,
+      9,
+    );
+    handle.frame(frame({}));
+    expect(must(parent.children[0]).rotation.x).toBeCloseTo(
+      Math.PI * 0.5 * 0.9415,
+      9,
+    );
+  });
+
+  it("keeps mid-band respond above 0.1 in the fast locked easing even without an onset", () => {
+    const { handle, parent } = makeHarness();
+    handle.frame(frame({ respond: 0.3 }));
+    expect(must(parent.children[0]).rotation.x).toBeCloseTo(
+      Math.PI * 0.5 * 0.94,
+      9,
+    );
+  });
+});
+
+describe("datacore teardown", () => {
+  it("removes all five meshes from the parent and disposes each geometry and material once", () => {
+    const { handle, parent, geometries, materials } = makeHarness();
+    expect(parent.children).toHaveLength(5);
+    handle.dispose();
+    expect(parent.children).toHaveLength(0);
+    expect(geometries.map((g) => g.disposed)).toEqual([1, 1, 1, 1, 1]);
+    expect(materials.map((m) => m.disposed)).toEqual([1, 1, 1, 1, 1]);
+  });
+});


### PR DESCRIPTION

## What

Adds the first unit suite for the datacore voice-orb concept
(`packages/ui/stories/src/concepts/datacore.ts`) as
`packages/ui/src/__tests__/stories-datacore-orb.test.ts` — one new file,
+319/-0, nothing else touched.

Placement note: the package's vitest lane collects only `src/**`, root
`__tests__/**`, and `test/**/*.mjs`, so a spec sitting next to the source
under `stories/` would never be collected by any runner. Testing story
modules from collected paths follows the existing
`src/**/__tests__/*-stories-smoke` precedent.

## Coverage (14 cases, real behavior — not lockstep restatement)

The suite drives the real builder through the module's own dependency seam
(it takes the WebGPU module as an injected parameter) using a deterministic
plain-object renderer stand-in. Asserted behavior was read off the source
and verified by running it:

- descriptor registration: id/label `datacore`, family `sci-fi`, callable builder
- assembly: three torus rings + faceted icosahedron nucleus + thin accent
  ring added to the parent in order, with exact geometry constructor args;
  each mesh seeded at its natural rest tilt; chrome-gem ring materials with
  cyan emissive base; nucleus/accent material setup
- animation frame: per-ring spin accumulation on its own axis over the fixed
  0.016 s step (y/x/z respectively), non-spin axes pinned at rest while idle,
  spin scaled by 2.4x at full voice energy
- glow math: ring emissive color lerp cyan-to-amber with respond and
  intensity flare from energy/respond; accent ring steps 0.022 rad per frame
  independent of the timestep constant and warms with energy; nucleus pulse
  scale, slow spin, and amber shift on respond
- respond lock hysteresis: hold persists ~1.2 s after a respond peak ends
  before easing back to natural tilts; onset requires strictly >0.5 (exactly
  0.5 does not latch); respond in (0.1, 0.5] keeps fast locked easing without
  latching the hold
- teardown: dispose removes all five meshes from the parent and disposes each
  geometry and material exactly once

## Evidence (test-only change; no production behavior modified)

Fork PR: hosted CI does not run on it. All checks below were executed locally
on this exact head against `origin/develop@51617538d7`.

- vitest: `bunx vitest run src/__tests__/stories-datacore-orb.test.ts` in
  `packages/ui` -> `Test Files  1 passed (1)` / `Tests  14 passed (14)`
- biome: `bunx biome check --write src/__tests__/stories-datacore-orb.test.ts`
  -> `Checked 1 file in 16ms. No fixes applied.` (config proven present:
  repo-root `biome.json`, non-sparse checkout)
- typecheck: `bunx tsc --noEmit` in `packages/ui` -> zero mentions of
  `stories-datacore-orb` in output (no new errors introduced by this file)
- diff scope: exactly one new test file, +319/-0; no deletions, no other
  files touched

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:ee2cc55600fb00221657bfa70c988fa045c6f01a -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

- Evidence bonus waived (`FACTORY_NO_EVIDENCE`): unattended session cannot
  finalize an interactive identity.slop.cash OAuth trace. Not a blocker for a
  test-only diff — vitest/biome/tsc counts are quoted verbatim above.
- No other gaps: no command failures; no device or live-service dependency.

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
