### PR TITLE
test(ui): cover index

### DIFF
--- a/packages/ui/src/cloud/admin/index.test.ts
+++ b/packages/ui/src/cloud/admin/index.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Verifies the Admin cloud-domain barrel against the real cloud-route
+ * registries: all three admin surfaces are wired at import time under the
+ * exported path constants, every route declares the `admin` gate AND that gate
+ * resolves to the real `AdminGate` component (an unregistered gate renders a
+ * fail-closed denial, so the pairing is load-bearing), no admin route is
+ * public, re-registration preserves element identity while moving the entries
+ * later in registration order, subscribers hear exactly the registrations
+ * until they unsubscribe, and each route element is a distinct code-split
+ * React.lazy component. Runs through the package's configured harness (jsdom)
+ * against the live `Symbol.for`-keyed stores — no module mocks.
+ */
+// @vitest-environment jsdom
+
+import { describe, expect, it } from "vitest";
+import {
+  getCloudRoute,
+  getCloudRouteGate,
+  getCloudRouteRegistryVersion,
+  listCloudRoutes,
+  registerCloudRoute,
+  subscribeCloudRoutes,
+} from "../shell/cloud-route-registry";
+import { AdminGate } from "./AdminGate";
+import {
+  ADMIN_MODERATION_ROUTE_PATH,
+  ADMIN_REDEMPTIONS_ROUTE_PATH,
+  ADMIN_ROUTE_GATE,
+  ADMIN_RPC_STATUS_ROUTE_PATH,
+  adminModerationCloudRoute,
+  adminRedemptionsCloudRoute,
+  adminRpcStatusCloudRoute,
+  registerAdminCloudRoutes,
+} from "./index";
+
+const ADMIN_ROUTE_PATHS = [
+  ADMIN_MODERATION_ROUTE_PATH,
+  ADMIN_REDEMPTIONS_ROUTE_PATH,
+  ADMIN_RPC_STATUS_ROUTE_PATH,
+] as const;
+
+function registrationOrder(path: string): number {
+  const index = listCloudRoutes().findIndex((route) => route.path === path);
+  expect(index, `route ${path} should be registered`).toBeGreaterThanOrEqual(0);
+  return index;
+}
+
+function ProbeRoute(): null {
+  return null;
+}
+
+describe("admin cloud barrel — import-time registration", () => {
+  it("resolves each admin URL to its registered route under the exported constants", () => {
+    // Looked up by the literal slugs a link/router would use, then tied back
+    // to the exported constants, so the constants and the live registrations
+    // cannot drift apart silently.
+    expect(getCloudRoute("cloud/admin")?.path).toBe(
+      ADMIN_MODERATION_ROUTE_PATH,
+    );
+    expect(getCloudRoute("cloud/admin/redemptions")?.path).toBe(
+      ADMIN_REDEMPTIONS_ROUTE_PATH,
+    );
+    expect(getCloudRoute("cloud/admin/rpc-status")?.path).toBe(
+      ADMIN_RPC_STATUS_ROUTE_PATH,
+    );
+    expect(getCloudRoute(ADMIN_MODERATION_ROUTE_PATH)).toMatchObject({
+      group: "admin",
+      gate: ADMIN_ROUTE_GATE,
+      element: adminModerationCloudRoute.element,
+    });
+    expect(getCloudRoute(ADMIN_REDEMPTIONS_ROUTE_PATH)).toMatchObject({
+      group: "admin",
+      gate: ADMIN_ROUTE_GATE,
+      element: adminRedemptionsCloudRoute.element,
+    });
+    expect(getCloudRoute(ADMIN_RPC_STATUS_ROUTE_PATH)).toMatchObject({
+      group: "admin",
+      gate: ADMIN_ROUTE_GATE,
+      element: adminRpcStatusCloudRoute.element,
+    });
+  });
+
+  it("pairs every admin route with the admin gate that is actually registered", () => {
+    // The shell wraps route bodies in the gate looked up BY NAME; a gate name
+    // without a registered component renders a fail-closed denial instead of
+    // the page, so the route→gate→component chain must be intact end to end.
+    expect(ADMIN_ROUTE_GATE).toBe("admin");
+    expect(getCloudRouteGate(ADMIN_ROUTE_GATE)).toBe(AdminGate);
+    for (const path of ADMIN_ROUTE_PATHS) {
+      const gateName = getCloudRoute(path)?.gate;
+      expect(gateName, `route ${path} must declare a gate`).toBeTruthy();
+      expect(getCloudRouteGate(gateName as string)).toBe(AdminGate);
+    }
+  });
+
+  it("keeps every admin route private", () => {
+    // Admin surfaces are role-gated business ops; none may opt into public
+    // exposure, and none carries the public-access opt-in marker.
+    for (const path of ADMIN_ROUTE_PATHS) {
+      const route = getCloudRoute(path);
+      expect(route, `route ${path} should be registered`).toBeDefined();
+      expect(route?.public).not.toBe(true);
+      expect(route?.publicAccess).toBeUndefined();
+    }
+  });
+});
+
+describe("registerAdminCloudRoutes — re-registration semantics", () => {
+  it("re-registration replaces all three entries and lands them after previously-later routes", () => {
+    // A route any other cloud domain registers after ours starts later in the
+    // shell's registration order; re-registering Admin must move all three of
+    // its routes past that route — the documented last-write-wins store.
+    const probePath = "admin-index-test/probe";
+    registerCloudRoute({ path: probePath, element: ProbeRoute });
+    expect(registrationOrder(ADMIN_MODERATION_ROUTE_PATH)).toBeLessThan(
+      registrationOrder(probePath),
+    );
+    expect(registrationOrder(ADMIN_REDEMPTIONS_ROUTE_PATH)).toBeLessThan(
+      registrationOrder(probePath),
+    );
+    expect(registrationOrder(ADMIN_RPC_STATUS_ROUTE_PATH)).toBeLessThan(
+      registrationOrder(probePath),
+    );
+
+    registerAdminCloudRoutes();
+
+    expect(registrationOrder(ADMIN_MODERATION_ROUTE_PATH)).toBeGreaterThan(
+      registrationOrder(probePath),
+    );
+    expect(registrationOrder(ADMIN_REDEMPTIONS_ROUTE_PATH)).toBeGreaterThan(
+      registrationOrder(probePath),
+    );
+    expect(registrationOrder(ADMIN_RPC_STATUS_ROUTE_PATH)).toBeGreaterThan(
+      registrationOrder(probePath),
+    );
+    // Registration passes the same exported defs, so the registry entries a
+    // consumer reads keep pointing at the original lazy elements — replaced,
+    // not rebuilt as second components.
+    expect(getCloudRoute(ADMIN_MODERATION_ROUTE_PATH)?.element).toBe(
+      adminModerationCloudRoute.element,
+    );
+    expect(getCloudRoute(ADMIN_REDEMPTIONS_ROUTE_PATH)?.element).toBe(
+      adminRedemptionsCloudRoute.element,
+    );
+    expect(getCloudRoute(ADMIN_RPC_STATUS_ROUTE_PATH)?.element).toBe(
+      adminRpcStatusCloudRoute.element,
+    );
+  });
+
+  it("keeps the documented relative order of the three admin surfaces", () => {
+    registerAdminCloudRoutes();
+    expect(registrationOrder(ADMIN_MODERATION_ROUTE_PATH)).toBeLessThan(
+      registrationOrder(ADMIN_REDEMPTIONS_ROUTE_PATH),
+    );
+    expect(registrationOrder(ADMIN_REDEMPTIONS_ROUTE_PATH)).toBeLessThan(
+      registrationOrder(ADMIN_RPC_STATUS_ROUTE_PATH),
+    );
+  });
+
+  it("bumps the registry snapshot version once per route registration", () => {
+    const before = getCloudRouteRegistryVersion();
+    registerAdminCloudRoutes();
+    expect(getCloudRouteRegistryVersion() - before).toBe(3);
+  });
+
+  it("notifies subscribers per registration and stops after unsubscribe", () => {
+    let notifications = 0;
+    const unsubscribe = subscribeCloudRoutes(() => {
+      notifications += 1;
+    });
+
+    registerAdminCloudRoutes();
+    expect(notifications).toBe(3);
+
+    unsubscribe();
+    registerAdminCloudRoutes();
+    expect(notifications).toBe(3);
+  });
+});
+
+describe("admin route elements — code splitting contract", () => {
+  it("mounts all three surfaces as distinct React.lazy elements", () => {
+    const elements = [
+      adminModerationCloudRoute.element,
+      adminRedemptionsCloudRoute.element,
+      adminRpcStatusCloudRoute.element,
+    ] as Array<{ $$typeof?: unknown }>;
+    for (const element of elements) {
+      expect(element.$$typeof).toBe(Symbol.for("react.lazy"));
+    }
+    expect(elements[0]).not.toBe(elements[1]);
+    expect(elements[1]).not.toBe(elements[2]);
+    expect(elements[0]).not.toBe(elements[2]);
+  });
+});


### PR DESCRIPTION

## Summary

Adds a colocated unit suite for `packages/ui/src/cloud/admin/index.ts`, which previously had no same-named test anywhere in the repo. Test-only change: **no production behaviour is modified** — the diff is a single new file, +195/−0.

The barrel registers the admin cloud surfaces into the shared cloud-route registries as an import-time side effect, so the suite drives the real `Symbol.for`-keyed stores in `cloud/shell/cloud-route-registry.ts` (jsdom, no module mocks):

- **Import-time registration** — each admin URL slug (`cloud/admin`, `cloud/admin/redemptions`, `cloud/admin/rpc-status`) resolves to a registered route tied back to its exported path constant, with `group: "admin"`, the declared gate, and element identity matching the exported `CloudRouteDef`s.
- **Route → gate → component pairing** — every route's gate name resolves through `getCloudRouteGate` to the real `AdminGate` component. The shell wraps bodies in the gate looked up by name and an unregistered gate renders fail-closed, so this chain is load-bearing for every admin surface.
- **Privacy invariant** — none of the three routes is public and none carries the `CLOUD_PUBLIC_ROUTE_ACCESS` opt-in marker.
- **Re-registration semantics** — `registerAdminCloudRoutes()` replaces all three entries last-write-wins, moves them past a probe route registered later, preserves lazy-element identity (replaced, not rebuilt), and keeps the documented moderation → redemptions → rpc-status order.
- **Store contracts** — registry snapshot version bumps exactly once per route (+3 per call); subscribers hear exactly three notifications per call and stop after unsubscribing.
- **Code-splitting contract** — all three route elements are distinct `React.lazy` components (`Symbol.for("react.lazy")`).

## Verification

Fork contributor: hosted CI does not run on this PR. All counts below are from local runs with the branch based on current `origin/develop`; the target module blob is byte-identical between the two.

- `bunx vitest run src/cloud/admin/index.test.ts` (in `packages/ui`) → **Test Files 1 passed (1), Tests 8 passed (8)**, re-run green after formatting.
- `bunx biome check --write src/cloud/admin/index.test.ts` → clean ("Checked 1 file … Fixed 1 file", import ordering only; suite re-run green afterwards).
- `bunx tsc --noEmit` in `packages/ui` → the new file appears nowhere in the output (`grep 'index.test.ts'` finds no match).
- The diff touches only the new test file.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:b7f73cecaf38a37664ae326f4ad91d178c0bb4bd -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
