### PR TITLE
test(ui): cover lattice

### DIFF
--- a/packages/ui/stories/src/concepts/lattice.test.ts
+++ b/packages/ui/stories/src/concepts/lattice.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Unit coverage for the `lattice` voice-orb concept builder. Drives the real
+ * `concept.build` against the real `three/webgpu` classes (headless-safe: no
+ * GPU device or DOM is touched) and asserts the observable scene-graph
+ * contract: cage + instanced-node construction, unique-vertex deduplication,
+ * initial instance placement, frame state driven by time/energy/respond,
+ * pulse-wave instance scaling bounds, and full resource teardown. Fully
+ * deterministic — no clock, no RNG.
+ */
+import * as THREE from "three/webgpu";
+import { describe, expect, it, vi } from "vitest";
+import type { OrbFrame, OrbUniforms } from "../orb-kit.ts";
+import { concept } from "./lattice.ts";
+
+/** Same loose boundary type orb-kit uses for the injected renderer module. */
+type WebGPU = Record<string, any>;
+
+const THREE_WEBGPU = THREE as unknown as WebGPU;
+
+const NO_UNIFORMS = {} as OrbUniforms;
+
+function frame(time: number, energy: number, respond: number): OrbFrame {
+  return { time, energy, low: 0, listen: 0, respond };
+}
+
+interface Vec3 {
+  x: number;
+  y: number;
+  z: number;
+}
+
+function newMatrix(): any {
+  return new THREE_WEBGPU.Matrix4();
+}
+
+function positionOf(m: any): Vec3 {
+  return { x: m.elements[12], y: m.elements[13], z: m.elements[14] };
+}
+
+function buildLattice(): {
+  parent: any;
+  handle: { frame: (f: OrbFrame) => void; dispose: () => void };
+  struts: any;
+  nodes: any;
+} {
+  const parent = new THREE_WEBGPU.Group();
+  const handle = concept.build(THREE_WEBGPU, {}, NO_UNIFORMS, parent);
+  // Build order is fixed by the concept: struts first, nodes second.
+  const struts = parent.children[0];
+  const nodes = parent.children[1];
+  return { parent, handle, struts, nodes };
+}
+
+/** Uniform instance scale encoded on a matrix built by Object3D.setScalar. */
+function instanceScale(m: any): number {
+  return m.elements[0];
+}
+
+describe("lattice concept descriptor", () => {
+  it("registers under id 'lattice' in the geometric family with a callable builder", () => {
+    expect(concept.id).toBe("lattice");
+    expect(concept.label).toBe("lattice");
+    expect(concept.family).toBe("geometric");
+    expect(typeof concept.build).toBe("function");
+  });
+});
+
+describe("lattice build", () => {
+  it("adds exactly two children to the parent: a strut LineSegments cage and an InstancedMesh of nodes", () => {
+    const { parent, struts, nodes } = buildLattice();
+    expect(parent.children.length).toBe(2);
+    expect(struts).toBeInstanceOf(THREE_WEBGPU.LineSegments);
+    expect(nodes).toBeInstanceOf(THREE_WEBGPU.InstancedMesh);
+
+    const strutGeo = struts.geometry as any;
+    const cageVerts = strutGeo.attributes.position.count;
+    // The cage is a wireframe: edges come in start/end pairs.
+    expect(cageVerts % 2).toBe(0);
+  });
+
+  it("instances one node per unique icosa vertex, far fewer than the raw face vertices", () => {
+    const { struts, nodes } = buildLattice();
+    // Observed on three 0.184: IcosahedronGeometry(1, 2) carries 540
+    // non-indexed face vertices which collapse to 92 unique positions under
+    // the concept's 4-decimal-place keying.
+    const rawVerts = (new THREE_WEBGPU.IcosahedronGeometry(1, 2) as any)
+      .attributes.position.count;
+    expect(rawVerts).toBeGreaterThan(nodes.count);
+    expect(nodes.count).toBe(92);
+    // The strut cage geometry is independent of the node instances.
+    expect(struts.geometry).not.toBe(nodes.geometry);
+  });
+
+  it("places each node instance on the unit sphere exactly once, with unit initial scale", () => {
+    const { nodes } = buildLattice();
+    const m = newMatrix();
+    const seen = new Set<string>();
+    let minRadius = Number.POSITIVE_INFINITY;
+    let maxRadius = 0;
+    for (let i = 0; i < nodes.count; i++) {
+      nodes.getMatrixAt(i, m);
+      const p = positionOf(m);
+      const radius = Math.hypot(p.x, p.y, p.z);
+      minRadius = Math.min(minRadius, radius);
+      maxRadius = Math.max(maxRadius, radius);
+      seen.add(`${p.x.toFixed(4)},${p.y.toFixed(4)},${p.z.toFixed(4)}`);
+      expect(instanceScale(m)).toBeCloseTo(1, 9);
+    }
+    // Every node sits on the cage surface (radius 1 ± 4dp rounding slack).
+    expect(minRadius).toBeGreaterThan(0.999);
+    expect(maxRadius).toBeLessThan(1.001);
+    // No duplicate placements: one instance per unique vertex.
+    expect(seen.size).toBe(nodes.count);
+  });
+});
+
+describe("lattice frame", () => {
+  it("holds the idle pose at zero time, energy and respond", () => {
+    const { handle, struts, nodes } = buildLattice();
+    (nodes.material as any).emissiveIntensity = -1; // sentinel: frame must overwrite
+    handle.frame(frame(0, 0, 0));
+    const strutMat = struts.material as any;
+    const nodeMat = nodes.material as any;
+    expect(struts.rotation.y).toBe(0);
+    expect(struts.rotation.x).toBe(0);
+    expect(struts.scale.x).toBeCloseTo(1, 12);
+    expect(nodeMat.emissiveIntensity).toBeCloseTo(1.2, 12);
+    // Cool cyan base, dimmed to idle brightness 0.55.
+    expect(strutMat.color.r).toBeCloseTo(0.3025, 9);
+    expect(strutMat.color.g).toBeCloseTo(0.484, 9);
+    expect(strutMat.color.b).toBeCloseTo(0.55, 9);
+    expect(nodeMat.emissive.r).toBeCloseTo(0.4, 9);
+    expect(nodeMat.emissive.g).toBeCloseTo(0.9, 9);
+    expect(nodeMat.emissive.b).toBeCloseTo(1.0, 9);
+  });
+
+  it("rotates forward with time at the idle speed", () => {
+    const { handle, struts, nodes } = buildLattice();
+    handle.frame(frame(2, 0, 0));
+    expect(struts.rotation.y).toBeCloseTo(0.12, 12);
+    expect(struts.rotation.x).toBeCloseTo(Math.sin(2 * 0.09) * 0.14, 12);
+    // Nodes share the cage orientation.
+    expect(nodes.rotation.y).toBeCloseTo(0.12, 12);
+  });
+
+  it("speeds rotation, breathes the whole frame and lerps colours toward orange on respond", () => {
+    const { handle, struts, nodes } = buildLattice();
+    handle.frame(frame(1, 1, 1));
+    const strutMat = struts.material as any;
+    const nodeMat = nodes.material as any;
+    // Rotation speed rises from 0.06 to 0.18 rad/s.
+    expect(struts.rotation.y).toBeCloseTo(0.18, 12);
+    // Breathing scale: 1 + 0.12 respond + 0.04 energy.
+    expect(struts.scale.x).toBeCloseTo(1.16, 12);
+    expect(nodes.scale.x).toBeCloseTo(1.16, 12);
+    // Strut colour reaches the accent hue at full brightness 1.55.
+    expect(strutMat.color.r).toBeCloseTo(1.55, 9);
+    expect(strutMat.color.g).toBeCloseTo(0.34 * 1.55, 9);
+    expect(strutMat.color.b).toBeCloseTo(0, 9);
+    // Opacity hits the hard ceiling at this energy+respond combination.
+    expect(strutMat.opacity).toBe(1);
+    // Node emissive follows the same accent lerp.
+    expect(nodeMat.emissive.r).toBeCloseTo(1.0, 9);
+    expect(nodeMat.emissive.g).toBeCloseTo(0.34, 9);
+    expect(nodeMat.emissive.b).toBeCloseTo(0, 9);
+    expect(nodeMat.emissiveIntensity).toBeCloseTo(5.2, 12);
+  });
+
+  it("raises opacity, breathing and emissive intensity with energy alone, below the ceiling", () => {
+    const { handle, struts, nodes } = buildLattice();
+    handle.frame(frame(0, 1, 0));
+    const strutMat = struts.material as any;
+    expect(struts.rotation.y).toBe(0);
+    expect(struts.scale.x).toBeCloseTo(1.04, 12);
+    expect(strutMat.opacity).toBeCloseTo(0.85, 12);
+    expect((nodes.material as any).emissiveIntensity).toBeCloseTo(3.7, 12);
+  });
+
+  it("oscillates every node instance between 0.7x and 1.3x scale across the pulse wave", () => {
+    const { handle, nodes } = buildLattice();
+    const m = newMatrix();
+    let observedMin = Number.POSITIVE_INFINITY;
+    let observedMax = 0;
+    for (let t = 0; t <= 3; t += 0.11) {
+      handle.frame(frame(t, 0, 0));
+      for (let i = 0; i < nodes.count; i++) {
+        nodes.getMatrixAt(i, m);
+        const s = instanceScale(m);
+        observedMin = Math.min(observedMin, s);
+        observedMax = Math.max(observedMax, s);
+        expect(s).toBeGreaterThanOrEqual(0.7 - 1e-9);
+        expect(s).toBeLessThanOrEqual(1.3 + 1e-9);
+      }
+    }
+    // The wave genuinely swings rather than freezing at a constant size.
+    expect(observedMin).toBeLessThanOrEqual(0.72);
+    expect(observedMax).toBeGreaterThanOrEqual(1.28);
+  });
+});
+
+describe("lattice dispose", () => {
+  it("disposes both geometries and both materials and removes both meshes from the parent", () => {
+    const { parent, handle, struts, nodes } = buildLattice();
+    const resources = [
+      struts.geometry,
+      struts.material,
+      nodes.geometry,
+      nodes.material,
+    ];
+    const spies = resources.map((r) => vi.spyOn(r, "dispose"));
+    handle.dispose();
+    for (const spy of spies) {
+      expect(spy).toHaveBeenCalledTimes(1);
+    }
+    expect(parent.children.length).toBe(0);
+  });
+});


### PR DESCRIPTION

## What

Adds `packages/ui/stories/src/concepts/lattice.test.ts` — a new vitest suite covering the `lattice` voice-orb concept builder (`concept.build` / `frame` / `dispose`). **Test-only diff: one new file, +217/−0. No production behaviour is changed.**

The module had no same-named test anywhere on `develop` when this branch was cut (verified via `git ls-tree -r origin/develop | grep 'lattice\.(test|spec)\.ts$'` immediately before filing).

## How it exercises the real module

The suite drives the real `concept.build` against the **real `three/webgpu` classes** headlessly (geometry, materials and scene-graph objects are pure JS; no GPU device or DOM needed) and asserts observable behaviour only:

- **Construction:** exactly two children added to the parent group — a strut `LineSegments` cage (edge geometry comes in start/end pairs) and an `InstancedMesh`.
- **Unique-vertex deduplication:** observed on three 0.184, `IcosahedronGeometry(1, 2)` carries 540 non-indexed face vertices which collapse to **92** node instances under the concept's 4-decimal-place keying; every instance translation lies on the unit sphere, every initial instance scale is 1, and no two instances share a rounded position.
- **`frame()` idle pose:** rotation `y = time × 0.06`, `x = sin(time·0.09)·0.14`, breathe scale 1, opacity 0.4, emissive intensity 1.2, cool-cyan base colours.
- **`frame()` respond/energy paths:** rotation speed rises to 0.18 rad/s at `respond = 1`, whole-frame breathing scale 1.16, strut colour lerps to the orange accent at brightness 1.55, opacity hits its hard ceiling (exactly 1), node emissive follows the same accent lerp, emissive intensity 5.2. Energy alone raises opacity to 0.85 (below the ceiling) without rotating.
- **Pulse wave:** sweeping time across frames, every instance scale stays within `[0.7, 1.3]` and genuinely swings (observed min ≤ 0.72, max ≥ 1.28) rather than freezing.
- **`dispose()` teardown:** each of the four created resources (two geometries, two materials) is disposed exactly once and both meshes are removed from the parent (0 children remain).

Expectations record what the code actually does on current `develop`; nothing aspirational is asserted.

## Evidence

All commands re-run against freshly fetched current `origin/develop` immediately before filing:

- `bunx vitest run packages/ui/stories/src/concepts/lattice.test.ts` → **Test Files 1 passed (1), Tests 10 passed (10)** (~196 ms).
- `bunx biome check packages/ui/stories/src/concepts/lattice.test.ts` → exit 0, no errors (only the package's standard warn-level `noExplicitAny` notes that the orb-kit boundary sources themselves carry).
- `tsc --noEmit --strict` (stories project compiler options, TS 7.0.2) over the file → exit 0, and the filename appears nowhere in the output.
- `git diff --numstat origin/develop...head` → `217  0  packages/ui/stories/src/concepts/lattice.test.ts` (single new test file, no deletions).

Note: this PR is filed from a contributor fork, so hosted CI does not run on it — the counts above are quoted from the local runs described here.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:8c75b89c682b4b8aa5fe78658ee2024268af1497 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
