### PR TITLE
test(ui): cover use-admin-gate

### DIFF
--- a/packages/ui/src/cloud/admin/data/use-admin-gate.test.tsx
+++ b/packages/ui/src/cloud/admin/data/use-admin-gate.test.tsx
@@ -99,3 +99,228 @@ describe("useAdminGate session resolution (no Steward provider mounted — the p
     expect(result.current.isAuthenticated).toBe(false);
   });
 });
+
+// --- Gate resolution beyond session presence --------------------------------
+// The dev bypass and the production HEAD probe are driven through the REAL
+// hook, real react-query, and the real persisted-JWT auth path above; only
+// the HTTP transport (`apiFetch`) is faked, because jsdom has no Eliza Cloud
+// backend to answer the moderation probe. Vitest itself runs with
+// `import.meta.env.DEV === true`, so the bypass branch is the harness default
+// and the production branch is reached by flipping DEV off per test.
+
+vi.mock("../../lib/api-client", () => ({ apiFetch: vi.fn() }));
+
+const ORIGINAL_DEV = import.meta.env.DEV;
+
+async function apiFetchMock() {
+  const mod = await import("../../lib/api-client");
+  return vi.mocked(mod.apiFetch);
+}
+
+// vitest.config.ts sets `globals: false`, so @testing-library/react cannot
+// self-register auto-cleanup; without this every hook stays mounted and
+// earlier observers leak into later assertions.
+async function cleanupMounted() {
+  const { cleanup } = await import("@testing-library/react");
+  cleanup();
+}
+
+function headProbeResponse(headers: Record<string, string>): Response {
+  return new Response(null, { status: 200, headers });
+}
+
+describe("useAdminGate dev bypass (the vitest harness runs a dev build)", () => {
+  afterEach(cleanupMounted);
+
+  it("grants a signed-in local user super_admin without touching the network", async () => {
+    storage.setItem(
+      "steward_session_token",
+      makeJwt({ userId: "u1", exp: Math.floor(Date.now() / 1000) + 600 }),
+    );
+
+    const { result } = renderHook(() => useAdminGate(), { wrapper });
+
+    await waitFor(() => expect(result.current.isAuthenticated).toBe(true));
+    expect(result.current.isAdmin).toBe(true);
+    expect(result.current.role).toBe("super_admin");
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isError).toBe(false);
+
+    const mock = await apiFetchMock();
+    expect(mock).not.toHaveBeenCalled();
+  });
+
+  it("keeps a signed-out dev visitor out with no role", async () => {
+    const { result } = renderHook(() => useAdminGate(), { wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(result.current.isAdmin).toBe(false);
+    expect(result.current.role).toBe(null);
+  });
+});
+
+describe("useAdminGate production HEAD-probe gate (dev bypass disabled)", () => {
+  beforeEach(() => {
+    import.meta.env.DEV = false;
+  });
+
+  afterEach(async () => {
+    import.meta.env.DEV = ORIGINAL_DEV;
+    (await apiFetchMock()).mockReset();
+    await cleanupMounted();
+  });
+
+  it("admits an admin from the moderation probe's X-Is-Admin/X-Admin-Role headers", async () => {
+    storage.setItem(
+      "steward_session_token",
+      makeJwt({ userId: "u1", exp: Math.floor(Date.now() / 1000) + 600 }),
+    );
+    const mock = await apiFetchMock();
+    mock.mockResolvedValueOnce(
+      headProbeResponse({
+        "x-is-admin": "true",
+        "x-admin-role": "moderator",
+      }),
+    );
+
+    const { result } = renderHook(() => useAdminGate(), { wrapper });
+
+    await waitFor(() =>
+      expect(result.current).toMatchObject({
+        isAdmin: true,
+        role: "moderator",
+        isLoading: false,
+        isError: false,
+        isAuthenticated: true,
+      }),
+    );
+    expect(mock).toHaveBeenCalledTimes(1);
+    expect(mock).toHaveBeenCalledWith("/api/v1/admin/moderation", {
+      method: "HEAD",
+    });
+  });
+
+  it("drops an unrecognized role header to null but keeps the admin admitted", async () => {
+    storage.setItem(
+      "steward_session_token",
+      makeJwt({ userId: "u1", exp: Math.floor(Date.now() / 1000) + 600 }),
+    );
+    const mock = await apiFetchMock();
+    mock.mockResolvedValueOnce(
+      headProbeResponse({ "x-is-admin": "true", "x-admin-role": "owner" }),
+    );
+
+    const { result } = renderHook(() => useAdminGate(), { wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.isAdmin).toBe(true);
+    expect(result.current.role).toBe(null);
+    expect(result.current.isError).toBe(false);
+  });
+
+  it("keys admission on X-Is-Admin alone — a valid role header cannot grant access by itself", async () => {
+    storage.setItem(
+      "steward_session_token",
+      makeJwt({ userId: "u1", exp: Math.floor(Date.now() / 1000) + 600 }),
+    );
+    const mock = await apiFetchMock();
+    mock.mockResolvedValueOnce(
+      headProbeResponse({
+        "x-is-admin": "false",
+        "x-admin-role": "super_admin",
+      }),
+    );
+
+    const { result } = renderHook(() => useAdminGate(), { wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.isAdmin).toBe(false);
+    expect(result.current.role).toBe("super_admin");
+  });
+
+  it("reports an error and denies access when the HEAD probe fails", async () => {
+    storage.setItem(
+      "steward_session_token",
+      makeJwt({ userId: "u1", exp: Math.floor(Date.now() / 1000) + 600 }),
+    );
+    const mock = await apiFetchMock();
+    mock.mockRejectedValueOnce(new Error("probe failed"));
+
+    const { result } = renderHook(() => useAdminGate(), { wrapper });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.isAdmin).toBe(false);
+    expect(result.current.role).toBe(null);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isAuthenticated).toBe(true);
+  });
+
+  it("never issues the HEAD probe for a signed-out visitor", async () => {
+    const { result } = renderHook(() => useAdminGate(), { wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    const mock = await apiFetchMock();
+    expect(mock).not.toHaveBeenCalled();
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(result.current.isAdmin).toBe(false);
+    expect(result.current.role).toBe(null);
+  });
+
+  it("holds isLoading with deny-by-default fields while the probe is in flight", async () => {
+    storage.setItem(
+      "steward_session_token",
+      makeJwt({ userId: "u1", exp: Math.floor(Date.now() / 1000) + 600 }),
+    );
+    const mock = await apiFetchMock();
+    mock.mockReturnValueOnce(new Promise<Response>(() => {}));
+
+    const { result } = renderHook(() => useAdminGate(), { wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(true));
+    expect(result.current.isAdmin).toBe(false);
+    expect(result.current.role).toBe(null);
+    expect(result.current.isError).toBe(false);
+    expect(result.current.isAuthenticated).toBe(true);
+  });
+
+  it("serves a remount within staleTime from the cache instead of re-probing", async () => {
+    storage.setItem(
+      "steward_session_token",
+      makeJwt({ userId: "u1", exp: Math.floor(Date.now() / 1000) + 600 }),
+    );
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const clientWrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    );
+    const mock = await apiFetchMock();
+    mock.mockResolvedValueOnce(
+      headProbeResponse({ "x-is-admin": "true", "x-admin-role": "viewer" }),
+    );
+    const callsAtStart = mock.mock.calls.length;
+
+    const first = renderHook(() => useAdminGate(), {
+      wrapper: clientWrapper,
+    });
+    await waitFor(() => expect(first.result.current.isAdmin).toBe(true));
+    expect(first.result.current.role).toBe("viewer");
+    expect(mock.mock.calls.length - callsAtStart).toBe(1);
+    first.unmount();
+
+    const second = renderHook(() => useAdminGate(), {
+      wrapper: clientWrapper,
+    });
+    await waitFor(() =>
+      expect(second.result.current.isAuthenticated).toBe(true),
+    );
+    expect(second.result.current.isAdmin).toBe(true);
+    expect(second.result.current.role).toBe("viewer");
+    // staleTime is 5 minutes — the remount must be served by the cache, not
+    // by a second HEAD probe.
+    expect(mock.mock.calls.length - callsAtStart).toBe(1);
+    second.unmount();
+  });
+});


### PR DESCRIPTION

## What this changes

Adds unit coverage for `packages/ui/src/cloud/admin/data/use-admin-gate.ts` — the consolidated admin gate consumed by the `AdminGate` route gate, the admin chrome, and per-action role checks. This is a **test-only diff: +225/−0 appended to the existing suite; no existing line is touched and no production behaviour changes.**

The suite on `develop` covered session resolution only (persisted-JWT present / absent / expired). The added cases cover the rest of the hook's observable contract:

**Dev bypass (vitest runs a dev build, so this is the harness default):**
- a signed-in local user is granted `super_admin` with **zero network calls**
- a signed-out dev visitor stays denied with no role

**Production HEAD-probe gate (`import.meta.env.DEV` forced off per test):**
- admission from the moderation probe's `X-Is-Admin`/`X-Admin-Role` headers, including the exact endpoint/method contract (`HEAD /api/v1/admin/moderation`)
- an unrecognized role header (`owner`) drops to `null` while the user stays admitted
- `X-Is-Admin: false` denies even when a valid role header is present — the role surfaces, admission does not follow it (observed behaviour, pinned as-is)
- probe failure → `isError`, deny-by-default fields
- a signed-out visitor never issues the probe at all
- an in-flight probe holds `isLoading` with deny-by-default fields
- a remount within `staleTime` is served from cache — still exactly one probe

## How it is tested

Runs through the package's configured vitest/jsdom harness. The real hook, real react-query, and the real persisted-JWT auth path are exercised end to end; only the HTTP transport (`apiFetch`) is faked, because jsdom has no Eliza Cloud backend to answer the moderation probe. No `expectTypeOf` anywhere.

## Evidence

- `bunx vitest run src/cloud/admin/data/use-admin-gate.test.tsx` (in `packages/ui`, against `origin/develop` @ `51617538d704`): **12 passed (12)** — 3 pre-existing + 9 new
- `bunx biome check --write src/cloud/admin/data/use-admin-gate.test.tsx`: clean ("Checked 1 file... No fixes applied")
- `bunx tsc --noEmit` in `packages/ui`: zero mentions of the test file
- `git diff --cached origin/develop --numstat` on the touched path: `225 0` — additions only

## Notes

- Fork contribution: hosted CI does not run on this PR; the counts above are quoted from local runs at the pushed head's base commit.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:45b1e194541c6a60db08433195c4079472c848b0 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
