### PR TITLE
test(ui): cover hologram

### DIFF
--- a/packages/ui/src/__tests__/stories-concepts-hologram.test.ts
+++ b/packages/ui/src/__tests__/stories-concepts-hologram.test.ts
@@ -1,0 +1,455 @@
+/**
+ * Behaviour tests for the hologram voice-orb concept
+ * (`stories/src/concepts/hologram.ts`), driven through the injected
+ * three/webgpu module surface the orb-kit harness hands every concept builder.
+ * Covers the descriptor contract, the layered scene construction (wireframe
+ * shell, inner ghost sphere, 13 scanline rings on the sphere-radius profile),
+ * the idle-frame baseline, the upward scanline sweep with wrap-around at the
+ * top of the range, brightness/opacity clamping at extreme energy+respond,
+ * the respond colour pulse, glitch firing vs. the no-glitch determinism path
+ * with geometric decay, and teardown of every retained resource on dispose.
+ * The fake module records calls; every expectation is recomputed here, never
+ * read back from the subject.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { concept } from "../../stories/src/concepts/hologram";
+import type { OrbFrame, OrbUniforms } from "../../stories/src/orb-kit";
+
+// three.js constant the concept assigns verbatim onto additive materials.
+const ADDITIVE_BLENDING = 2;
+
+const EPSILON = 1e-6;
+
+// Authored scanline-sweep envelope of the hologram concept (observable as the
+// spread of the constructed ring meshes).
+const SCAN_COUNT = 13;
+const SCAN_YMIN = -1.15;
+const SCAN_YMAX = 1.15;
+const SCAN_RANGE = SCAN_YMAX - SCAN_YMIN;
+
+class FakeColor {
+  r = 0;
+  g = 0;
+  b = 0;
+  constructor(r?: number, g?: number, b?: number) {
+    if (r !== undefined && g !== undefined && b !== undefined) {
+      this.r = r;
+      this.g = g;
+      this.b = b;
+    }
+  }
+  setRGB(r: number, g: number, b: number): void {
+    this.r = r;
+    this.g = g;
+    this.b = b;
+  }
+}
+
+class FakeGeometry {
+  kind: string;
+  args: unknown[];
+  disposed = false;
+  constructor(kind: string, args: unknown[]) {
+    this.kind = kind;
+    this.args = args;
+  }
+  dispose(): void {
+    this.disposed = true;
+  }
+}
+
+class FakeMaterial {
+  color = new FakeColor();
+  transparent = false;
+  opacity = 1;
+  depthWrite = true;
+  blending?: number;
+  disposed = false;
+  dispose(): void {
+    this.disposed = true;
+  }
+}
+
+class FakeObject3D {
+  position = { x: 0, y: 0, z: 0 };
+  rotation = { x: 0, y: 0, z: 0 };
+  renderOrder = 0;
+  scale = {
+    x: 1,
+    y: 1,
+    z: 1,
+    set(x: number, y: number, z: number): void {
+      this.x = x;
+      this.y = y;
+      this.z = z;
+    },
+  };
+  geometry?: FakeGeometry;
+  material?: FakeMaterial;
+  children: FakeObject3D[] = [];
+  add(child: FakeObject3D): void {
+    this.children.push(child);
+  }
+  remove(child: FakeObject3D): void {
+    const at = this.children.indexOf(child);
+    if (at >= 0) this.children.splice(at, 1);
+  }
+}
+
+/**
+ * Minimal three/webgpu double: records every constructed geometry/material and
+ * parents every mesh onto one trackable group, matching the read/write surface
+ * the hologram builder touches (no more).
+ */
+function makeHologramHarness() {
+  const geometries: FakeGeometry[] = [];
+  const materials: FakeMaterial[] = [];
+
+  class IcosahedronGeometry extends FakeGeometry {
+    constructor(...args: unknown[]) {
+      super("icosahedron", args);
+      geometries.push(this);
+    }
+  }
+  class WireframeGeometry extends FakeGeometry {
+    constructor(...args: unknown[]) {
+      super("wireframe", args);
+      geometries.push(this);
+    }
+  }
+  class TorusGeometry extends FakeGeometry {
+    constructor(...args: unknown[]) {
+      super("torus", args);
+      geometries.push(this);
+    }
+  }
+  class LineBasicNodeMaterial extends FakeMaterial {
+    constructor() {
+      super();
+      materials.push(this);
+    }
+  }
+  class MeshBasicNodeMaterial extends FakeMaterial {
+    constructor() {
+      super();
+      materials.push(this);
+    }
+  }
+
+  const THREE = {
+    AdditiveBlending: ADDITIVE_BLENDING,
+    Color: FakeColor,
+    IcosahedronGeometry,
+    WireframeGeometry,
+    TorusGeometry,
+    LineBasicNodeMaterial,
+    MeshBasicNodeMaterial,
+    LineSegments: class extends FakeObject3D {
+      constructor(geo: FakeGeometry, mat: FakeMaterial) {
+        super();
+        this.geometry = geo;
+        this.material = mat;
+      }
+    },
+    Mesh: class extends FakeObject3D {
+      constructor(geo: FakeGeometry, mat: FakeMaterial) {
+        super();
+        this.geometry = geo;
+        this.material = mat;
+      }
+    },
+  };
+  const parent = new FakeObject3D();
+  return { THREE, parent, geometries, materials };
+}
+
+const EMPTY_UNIFORMS: OrbUniforms = {
+  uTime: null,
+  uEnergy: null,
+  uLow: null,
+  uListen: null,
+  uRespond: null,
+  uAspect: null,
+  uAccent: null,
+};
+
+// Sphere-profile contract the rings follow: r = sqrt(1 - y²) * 0.98 with y
+// clamped just inside the poles so the profile never collapses to zero width.
+function sphereProfileRadius(y: number): number {
+  const clampedY = Math.max(-0.98, Math.min(0.98, y));
+  return Math.sqrt(1 - clampedY * clampedY) * 0.98;
+}
+
+function buildHologram() {
+  const harness = makeHologramHarness();
+  const handle = concept.build(
+    harness.THREE,
+    {},
+    EMPTY_UNIFORMS,
+    harness.parent,
+  );
+  const [wireframe, innerSphere] = harness.parent.children;
+  const rings = harness.parent.children.slice(2);
+  return { ...harness, handle, wireframe, innerSphere, rings };
+}
+
+const IDLE_FRAME: OrbFrame = {
+  time: 0,
+  energy: 0,
+  low: 0,
+  listen: 0,
+  respond: 0,
+};
+
+describe("hologram voice-orb concept", () => {
+  let randomSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    // Park Math.random above every gated chance (max 0.36) so the glitch path
+    // stays closed unless a test explicitly opens it.
+    randomSpy = vi.spyOn(Math, "random").mockReturnValue(0.99);
+  });
+
+  afterEach(() => {
+    randomSpy.mockRestore();
+  });
+
+  it("declares the descriptor the orb gallery dispatches on", () => {
+    expect(concept.id).toBe("hologram");
+    expect(concept.label).toBe("hologram");
+    expect(concept.family).toBe("sci-fi");
+    expect(typeof concept.build).toBe("function");
+  });
+
+  it("builds shell, ghost sphere and scanline rings under the given parent", () => {
+    const { parent, geometries, materials, wireframe, innerSphere, rings } =
+      buildHologram();
+
+    expect(parent.children).toHaveLength(2 + SCAN_COUNT);
+    expect(wireframe).toBeDefined();
+    expect(innerSphere).toBeDefined();
+    expect(rings).toHaveLength(SCAN_COUNT);
+
+    // One wireframe pair + one inner sphere + one torus per ring.
+    expect(geometries.filter((g) => g.kind === "icosahedron")).toHaveLength(2);
+    expect(geometries.filter((g) => g.kind === "wireframe")).toHaveLength(1);
+    expect(geometries.filter((g) => g.kind === "torus")).toHaveLength(
+      SCAN_COUNT,
+    );
+    expect(materials).toHaveLength(2 + SCAN_COUNT);
+  });
+
+  it("authors the cyan additive wireframe shell in front of a faint ghost sphere", () => {
+    const { wireframe, innerSphere, geometries } = buildHologram();
+
+    expect(wireframe.material?.transparent).toBe(true);
+    expect(wireframe.material?.opacity).toBe(0.55);
+    expect(wireframe.material?.depthWrite).toBe(false);
+    expect(wireframe.material?.blending).toBe(ADDITIVE_BLENDING);
+    expect(wireframe.material?.color.r).toBe(0);
+    expect(wireframe.material?.color.g).toBeCloseTo(0.92, 6);
+    expect(wireframe.material?.color.b).toBeCloseTo(1, 6);
+
+    // The ghost sphere renders behind everything else in the group.
+    expect(innerSphere.renderOrder).toBe(-1);
+    expect(innerSphere.material?.transparent).toBe(true);
+    expect(innerSphere.material?.opacity).toBeCloseTo(0.18, 6);
+    expect(innerSphere.material?.depthWrite).toBe(false);
+
+    // The wireframe derives from an icosahedron of radius 1, detail 2.
+    const icosa = geometries.find((g) => g.kind === "icosahedron");
+    expect(icosa?.args).toEqual([1.0, 2]);
+  });
+
+  it("distributes the scanline rings across the sweep range on the sphere profile", () => {
+    const { rings } = buildHologram();
+
+    const ys = rings.map((ring) => ring.position.y);
+    // Evenly phased start positions spanning slightly beyond the sphere.
+    expect(Math.min(...ys)).toBeCloseTo(SCAN_YMIN, 6);
+    expect(Math.max(...ys)).toBeCloseTo(SCAN_YMAX - SCAN_RANGE / SCAN_COUNT, 6);
+    for (let i = 1; i < ys.length; i += 1) {
+      expect(ys[i]).toBeGreaterThan(ys[i - 1]);
+      expect(ys[i] - ys[i - 1]).toBeCloseTo(SCAN_RANGE / SCAN_COUNT, 6);
+    }
+
+    // Each torus radius follows the sphere profile at its starting height, so
+    // rings hug the form instead of poking through it.
+    rings.forEach((ring) => {
+      const torus = ring.geometry;
+      expect(torus?.kind).toBe("torus");
+      const [radius, tube] = torus?.args ?? [];
+      expect(radius).toBeCloseTo(sphereProfileRadius(ring.position.y), 6);
+      expect(tube).toBe(0.008);
+
+      // Lying flat in the XZ plane so the sweep reads as horizontal bands.
+      expect(ring.rotation.x).toBeCloseTo(Math.PI / 2, 6);
+    });
+  });
+
+  it("applies the idle baseline at time zero without perturbing authored state", () => {
+    const { handle, wireframe, innerSphere, rings } = buildHologram();
+
+    handle.frame(IDLE_FRAME);
+
+    // Zero shimmer contribution at t=0, zero boost: exact base opacities.
+    expect(wireframe.material?.opacity).toBeCloseTo(0.52, 6);
+    expect(wireframe.rotation.y).toBe(0);
+    expect(wireframe.rotation.x).toBe(0);
+    expect(innerSphere.rotation.y).toBe(-0);
+    expect(innerSphere.material?.opacity).toBeCloseTo(0.14, 6);
+
+    // At the authored position each ring's profile ratio is exactly 1.
+    for (const ring of rings) {
+      expect(ring.scale.x).toBeCloseTo(1, 6);
+      expect(ring.scale.z).toBeCloseTo(1, 6);
+      expect(ring.scale.y).toBe(1);
+    }
+
+    // The ring resting at the bottom pole gets attenuated below the floor and
+    // clamps at the minimum visible opacity.
+    const bottomRing = rings[0];
+    const expected = (0.18 + 0) * Math.sqrt(Math.max(0, 1 - -0.98 * -0.98));
+    expect(expected).toBeLessThan(0.04);
+    expect(bottomRing.material?.opacity).toBe(0.04);
+  });
+
+  it("sweeps rings upward over time and wraps back to the bottom of the range", () => {
+    const { handle, rings } = buildHologram();
+    const startBottom = rings[0].position.y;
+
+    // Idle speed: 0.55 world-units/s along Y.
+    handle.frame({ ...IDLE_FRAME, time: 1 });
+    const advanced = rings[0].position.y;
+    expect(advanced).toBeGreaterThan(startBottom);
+    expect(advanced - startBottom).toBeGreaterThan(0.5);
+    expect(advanced - startBottom).toBeLessThan(0.57);
+
+    // Past one full sweep the phase wraps modulo the range instead of
+    // escaping past the top: unwrapped, this position would exceed SCAN_YMAX.
+    handle.frame({ ...IDLE_FRAME, time: 4.4 });
+    const wrapped = rings[0].position.y;
+    expect(wrapped).toBeLessThan(SCAN_YMIN + 0.2);
+    expect(wrapped).toBeGreaterThanOrEqual(SCAN_YMIN);
+
+    // Long-run stability: positions stay inside the sweep window forever and
+    // nothing degenerates into NaN.
+    handle.frame({ ...IDLE_FRAME, time: 5000 });
+    for (const ring of rings) {
+      expect(Number.isFinite(ring.position.y)).toBe(true);
+      expect(ring.position.y).toBeGreaterThanOrEqual(SCAN_YMIN);
+      expect(ring.position.y).toBeLessThan(SCAN_YMAX);
+    }
+  });
+
+  it("keeps every animated quantity inside its clamp band under extreme drive", () => {
+    const { handle, wireframe, rings } = buildHologram();
+
+    handle.frame({ ...IDLE_FRAME, time: 0.37, energy: 1, respond: 1 });
+
+    // Wireframe brightness saturates at its ceiling.
+    expect(wireframe.material?.opacity).toBe(0.95);
+
+    // The respond pulse pushes the brightest ring into the opacity ceiling.
+    const opacities = rings.map((ring) => ring.material?.opacity ?? NaN);
+    for (const opacity of opacities) {
+      expect(Number.isFinite(opacity)).toBe(true);
+      expect(opacity).toBeGreaterThanOrEqual(0.04);
+      expect(opacity).toBeLessThanOrEqual(0.85);
+    }
+    expect(Math.max(...opacities)).toBe(0.85);
+  });
+
+  it("shifts the shell colour toward white-blue while responding", () => {
+    const { handle, wireframe } = buildHologram();
+
+    handle.frame(IDLE_FRAME);
+    const idleG = wireframe.material?.color.g ?? NaN;
+    const idleR = wireframe.material?.color.r ?? NaN;
+
+    handle.frame({ ...IDLE_FRAME, time: 0, respond: 1 });
+    expect(wireframe.material?.color.r).toBeCloseTo(idleR + 0.15, 6);
+    expect(wireframe.material?.color.g).toBeGreaterThan(idleG);
+    expect(wireframe.material?.color.g).toBeCloseTo(0.92, 6);
+    expect(wireframe.material?.color.b).toBeCloseTo(1, 6);
+  });
+
+  it("ignores listen and low inputs entirely", () => {
+    const { handle, wireframe } = buildHologram();
+
+    handle.frame(IDLE_FRAME);
+    const baselineOpacity = wireframe.material?.opacity;
+    const baselineY = wireframe.rotation.y;
+
+    handle.frame({ ...IDLE_FRAME, listen: 1, low: 1 });
+    expect(wireframe.material?.opacity).toBe(baselineOpacity);
+    expect(wireframe.rotation.y).toBe(baselineY);
+  });
+
+  it("keeps rotation purely time-linear when the glitch never fires", () => {
+    const { handle, wireframe } = buildHologram();
+
+    // random=0.99 exceeds every glitch chance, including refires once the
+    // cooldown repeatedly expires — exercises the cooldown reset branch too.
+    for (let step = 0; step <= 20; step += 1) {
+      const time = step * 0.5;
+      handle.frame({ ...IDLE_FRAME, time });
+      expect(wireframe.rotation.y).toBeCloseTo(time * 0.07, 12);
+      expect(wireframe.rotation.x).toBeCloseTo(
+        Math.sin(time * 0.09) * 0.06,
+        12,
+      );
+    }
+  });
+
+  it("snaps a bounded glitch offset that decays geometrically toward zero", () => {
+    const { handle, wireframe } = buildHologram();
+    randomSpy.mockReturnValue(0); // every eligible roll fires
+
+    const t1 = 1.0;
+    handle.frame({ ...IDLE_FRAME, time: t1 });
+    // Rotation is written before the roll, so the first frame stays clean and
+    // the freshly snapped offset lands afterwards.
+    expect(wireframe.rotation.y).toBeCloseTo(t1 * 0.07, 12);
+
+    const t2 = 1.1;
+    handle.frame({ ...IDLE_FRAME, time: t2 });
+    const offset2 = wireframe.rotation.y - t2 * 0.07;
+    expect(offset2).toBeLessThan(0);
+    expect(Math.abs(offset2)).toBeLessThanOrEqual(0.09 + EPSILON);
+
+    const t3 = 1.2;
+    handle.frame({ ...IDLE_FRAME, time: t3 });
+    const offset3 = wireframe.rotation.y - t3 * 0.07;
+
+    // Same-sign, strictly shrinking: the angle decays by 0.82 per frame while
+    // the cooldown window keeps new glitches from stacking.
+    expect(offset3).toBeLessThan(0);
+    expect(offset3 / offset2).toBeCloseTo(0.82, 6);
+  });
+
+  it("disposes every retained geometry and material and empties the parent group", () => {
+    const { parent, geometries, materials, handle } = buildHologram();
+    expect(parent.children.length).toBeGreaterThan(0);
+
+    handle.dispose();
+
+    expect(parent.children).toHaveLength(0);
+    // Every material is released.
+    for (const mat of materials) expect(mat.disposed).toBe(true);
+    // Every geometry the handle retains is released. The base shell
+    // icosahedron is observably NOT disposed: it is consumed only as
+    // WireframeGeometry's derivation input and never referenced afterwards,
+    // so its lifetime ends with the scope rather than with dispose().
+    const [shellIcosa, innerIcosa] = geometries.filter(
+      (g) => g.kind === "icosahedron",
+    );
+    expect(shellIcosa?.disposed).toBe(false);
+    expect(innerIcosa?.disposed).toBe(true);
+    for (const geo of geometries) {
+      if (geo === shellIcosa) continue;
+      expect(geo.disposed).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION

Adds a real vitest unit suite for the hologram voice-orb concept
(`packages/ui/stories/src/concepts/hologram.ts`), which had no same-named test
file anywhere on develop. The suite drives the real module through the injected
three/webgpu module surface that `orb-kit` hands every concept builder — the
same boundary production consumers use — and asserts behaviour, not mocks:
scene construction (wireframe shell, ghost sphere at renderOrder −1, 13
scanline rings phased across the sweep range on the sphere-radius profile),
the idle-frame baseline (exact base opacities, identity ring scale), the
upward sweep with wrap-around modulo the range plus long-run stability,
clamp bands under extreme energy+respond (0.95 shell ceiling, 0.85 ring
ceiling with the respond pulse, 0.04 attenuation floor at the poles), the
respond colour shift toward white-blue, insensitivity to `listen`/`low`,
glitch determinism (rotation purely time-linear when the roll never fires;
bounded offset decaying geometrically by 0.82 per frame when it does), and
teardown of every retained geometry/material with the parent group emptied.

One observed-behaviour note recorded faithfully rather than aspirationally:
`dispose()` releases the wireframe geometry, the inner-sphere geometry, all 13
ring tori and every material, but never disposes the base shell icosahedron
that only fed `WireframeGeometry`'s derivation — the suite pins that contract
as observed.

Evidence (fork contributor — hosted CI does not run on this PR; counts below
are local runs against current origin/develop @ 51617538d7):

- `bunx vitest run src/__tests__/stories-concepts-hologram.test.ts`
  (in `packages/ui`): **1 file passed, 12 tests passed / 12**, 0 failed.
- `bunx biome check --write src/__tests__/stories-concepts-hologram.test.ts`
  applied one formatting pass; re-check is clean ("Checked 1 file … No fixes
  applied").
- `bunx tsc --noEmit` in `packages/ui`: the new file appears **nowhere** in
  the output (grep for `stories-concepts-hologram` = 0 hits); remaining
  diagnostics are pre-existing, unrelated to this diff.
- The diff touches **only** the new test file (+455/−0). No production code,
  config, or fixture changes.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
      Branch was cut from `origin/develop` @ `51617538d7` immediately before
      filing.
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
      Recorded honestly: full `verify` was not run for this test-only lane;
      the scoped gate for this diff is quoted in Testing above (vitest, biome,
      tsc grep of the new file = 0 hits).
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
      Head is a direct child of `origin/develop` @ `51617538d7`.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.
      Scoped gate quoted above instead; see Known gaps / failures.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

Low. Additive, behaviour-preserving: the diff is one new test file
(`+455/-0`) under `packages/ui/src/__tests__/`; no production module,
config, export, or fixture changes. Worst case is suite flakeness, which is
controlled by pinning `Math.random` per test.

# Background

## What does this PR do?

Adds unit coverage for the hologram voice-orb concept
(`packages/ui/stories/src/concepts/hologram.ts`), which had no same-named
suite anywhere on develop.

## What kind of change is this?

Improvements (misc. changes to existing features) — new test-only coverage.

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

My changes do not require a change to the project documentation.

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

`packages/ui/src/__tests__/stories-concepts-hologram.test.ts` — the suite
drives the real `concept.build()` through a minimal injected three/webgpu
double, exactly as `orb-kit` hands modules to every concept builder.

## Detailed testing steps

```bash
cd packages/ui && bunx vitest run src/__tests__/stories-concepts-hologram.test.ts
```

Expected: `Test Files  1 passed (1)` / `Tests  12 passed (12)`.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:8745e265826c14ede3d7eb1d9057f342c6f12e5b -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] N/A - test-only `.ts` addition; no rendered UI surface changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - test-only `.ts` addition; no rendered UI surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - test-only change with no user-visible flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - no runtime/backend path touched.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request/state path touched; vitest output quoted above.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, provider, prompt, or agent behaviour changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB rows, memories, scheduled tasks, wallet/on-chain, or generated
      file outputs involved in a unit-test addition.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface in this diff.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

N/A - test-only change; no UI surface before/after applies.

### After

N/A - test-only change; no UI surface before/after applies.

### Walkthrough video

N/A - test-only change with no user-visible flow.

## Audio / voice walkthrough

N/A - no voice/transcript/TTS/STT path touched.

## Known gaps / failures

- Hosted CI does not run on fork PRs; the checks quoted in the prose above
  (vitest 12/12, biome clean, tsc grep of the new file = 0 hits, all against
  current `origin/develop` @ `51617538d7`) were run locally at the exact PR
  head `8745e265826c14ede3d7eb1d9057f342c6f12e5b`.
- Evidence bonus waived: unattended session cannot finalize an interactive
  identity.slop.cash OAuth trace.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
