### PR TITLE
test(ui): cover liquidmetal

### DIFF
--- a/packages/ui/src/__tests__/stories-concepts-liquidmetal.test.ts
+++ b/packages/ui/src/__tests__/stories-concepts-liquidmetal.test.ts
@@ -1,0 +1,549 @@
+/**
+ * Behaviour tests for the liquid-metal voice-orb concept
+ * (`stories/src/concepts/liquidmetal.ts`), driven through the injected
+ * three/webgpu + three/tsl module surfaces the orb-kit harness hands every
+ * concept builder. Covers the descriptor contract, scene assembly (one
+ * chrome sphere retuned from the orb-kit gem default to a smooth mirror),
+ * the voice-reactive fresnel rim wired through the live uniforms, per-frame
+ * churn (purely radial displacement, amplitude envelope, energy-linear idle
+ * wobble, respond-threshold crest sharpening with its exact 0.01 boundary,
+ * normal recompute + dirty flag, yaw/pitch drift, insensitivity to
+ * `listen`/`low`, replay determinism), and full teardown on dispose. The
+ * doubles record calls and evaluate lazily; every expectation is recomputed
+ * here, never read back from the subject.
+ */
+
+import { describe, expect, it } from "vitest";
+import { concept } from "../../stories/src/concepts/liquidmetal";
+
+const EPSILON = 1e-6;
+
+// Declared in liquidmetal.ts: ±0.12 max displacement, amplitude driven by
+// amp = MAX_DISP * (0.3 + energy*0.9 + respond*0.35), whose worst case at
+// full energy + full respond is 0.12 * 1.55.
+const BASE_RADIUS = 0.95;
+const SPHERE_VERTICES = (48 + 1) * (32 + 1);
+const AMPLITUDE_WORST_CASE = 0.12 * (0.3 + 0.9 + 0.35);
+
+class FakeColor {
+  r = 0;
+  g = 0;
+  b = 0;
+  constructor(r?: number, g?: number, b?: number) {
+    if (r !== undefined && g !== undefined && b !== undefined) {
+      this.r = r;
+      this.g = g;
+      this.b = b;
+    }
+  }
+}
+
+class FakeBufferAttribute {
+  array: Float32Array;
+  itemSize: number;
+  count: number;
+  needsUpdate = false;
+  constructor(array: Float32Array, itemSize: number) {
+    this.array = array;
+    this.itemSize = itemSize;
+    this.count = array.length / itemSize;
+  }
+  getX(i: number): number {
+    return this.array[i * 3];
+  }
+  getY(i: number): number {
+    return this.array[i * 3 + 1];
+  }
+  getZ(i: number): number {
+    return this.array[i * 3 + 2];
+  }
+}
+
+class FakeGeometry {
+  attributes: Record<string, FakeBufferAttribute> = {};
+  normalsComputed = 0;
+  disposed = false;
+  setAttribute(name: string, attribute: FakeBufferAttribute): void {
+    this.attributes[name] = attribute;
+  }
+  computeVertexNormals(): void {
+    this.normalsComputed += 1;
+  }
+  dispose(): void {
+    this.disposed = true;
+  }
+}
+
+/**
+ * Genuine UV-sphere vertex grid: every vertex sits exactly on the requested
+ * radius, laid out as (heightSegments+1) rows x (widthSegments+1) columns.
+ */
+class FakeSphereGeometry extends FakeGeometry {
+  radius: number;
+  widthSegments: number;
+  heightSegments: number;
+  constructor(radius: number, widthSegments: number, heightSegments: number) {
+    super();
+    this.radius = radius;
+    this.widthSegments = widthSegments;
+    this.heightSegments = heightSegments;
+    const rows = heightSegments + 1;
+    const cols = widthSegments + 1;
+    const positions = new Float32Array(rows * cols * 3);
+    let cursor = 0;
+    for (let iy = 0; iy < rows; iy += 1) {
+      const v = iy / heightSegments;
+      const theta = v * Math.PI;
+      const sinTheta = Math.sin(theta);
+      const cosTheta = Math.cos(theta);
+      for (let ix = 0; ix < cols; ix += 1) {
+        const u = ix / widthSegments;
+        const phi = u * Math.PI * 2;
+        positions[cursor] = -radius * sinTheta * Math.cos(phi);
+        positions[cursor + 1] = radius * cosTheta;
+        positions[cursor + 2] = radius * sinTheta * Math.sin(phi);
+        cursor += 3;
+      }
+    }
+    this.setAttribute("position", new FakeBufferAttribute(positions, 3));
+  }
+}
+
+class FakeMaterial {
+  color = new FakeColor();
+  flatShading = false;
+  roughness = 1;
+  metalness = 0;
+  envMapIntensity = 1;
+  emissiveNode: RimNode | null = null;
+  disposed = false;
+  dispose(): void {
+    this.disposed = true;
+  }
+}
+
+interface Vector3Like {
+  x: number;
+  y: number;
+  z: number;
+}
+
+class FakeObject3D {
+  geometry: FakeGeometry;
+  material: FakeMaterial;
+  rotation: Vector3Like = { x: 0, y: 0, z: 0 };
+  constructor(geometry: FakeGeometry, material: FakeMaterial) {
+    this.geometry = geometry;
+    this.material = material;
+  }
+}
+
+// --- Minimal lazy-evaluating TSL surface -----------------------------------
+//
+// The rim-light expression only needs scalar algebra over constants and two
+// live uniforms (`uAccent`, `uRespond`); view vectors enter the dot product
+// as fixed scalar leaves. Nodes evaluate on read, so mutating a uniform's
+// `.value` after build re-prices the whole graph — the same live-binding
+// contract the harness relies on when it updates uniforms each frame.
+
+type RimInput = RimNode | number;
+
+function toRim(input: RimInput): RimNode {
+  return input instanceof RimNode ? input : RimNode.of(() => input);
+}
+
+class RimNode {
+  private readonly evaluate: () => number;
+  private readonly box?: { value: number };
+  constructor(evaluate: () => number, box?: { value: number }) {
+    this.evaluate = evaluate;
+    this.box = box;
+  }
+  static of(evaluate: () => number): RimNode {
+    return new RimNode(evaluate);
+  }
+  get value(): number {
+    return this.box ? this.box.value : this.evaluate();
+  }
+  set value(next: number) {
+    if (!this.box) {
+      throw new Error("only uniform nodes accept live writes");
+    }
+    this.box.value = next;
+  }
+  mul(other: RimInput): RimNode {
+    const o = toRim(other);
+    return RimNode.of(() => this.value * o.value);
+  }
+  add(other: RimInput): RimNode {
+    const o = toRim(other);
+    return RimNode.of(() => this.value + o.value);
+  }
+  abs(): RimNode {
+    return RimNode.of(() => Math.abs(this.value));
+  }
+  oneMinus(): RimNode {
+    return RimNode.of(() => 1 - this.value);
+  }
+  pow(exponent: RimInput): RimNode {
+    const e = toRim(exponent);
+    return RimNode.of(() => this.value ** e.value);
+  }
+  dot(other: RimInput): RimNode {
+    return this.mul(other);
+  }
+}
+
+/** A node whose price is read from a mutable box — the harness uniform. */
+function rimUniform(initial: number): RimNode {
+  const box = { value: initial };
+  return new RimNode(() => box.value, box);
+}
+
+function makeTslModule(normalViewLeaf: number, viewDirLeaf: number) {
+  return {
+    vec3: (..._components: number[]): RimNode => RimNode.of(() => Number.NaN),
+    float: (x: number): RimNode => RimNode.of(() => x),
+    mix: (_a: RimInput, _b: RimInput, _t: RimInput): RimNode =>
+      RimNode.of(() => Number.NaN),
+    normalView: RimNode.of(() => normalViewLeaf),
+    positionViewDirection: RimNode.of(() => viewDirLeaf),
+  };
+}
+
+function makeThreeModule() {
+  const sphereGeometries: FakeSphereGeometry[] = [];
+  const materials: FakeMaterial[] = [];
+  const objects: FakeObject3D[] = [];
+  const THREE = {
+    SphereGeometry: class extends FakeSphereGeometry {
+      constructor(...args: ConstructorParameters<typeof FakeSphereGeometry>) {
+        super(...args);
+        sphereGeometries.push(this);
+      }
+    },
+    Color: FakeColor,
+    MeshPhysicalNodeMaterial: class extends FakeMaterial {
+      constructor() {
+        super();
+        materials.push(this);
+      }
+    },
+    Mesh: class extends FakeObject3D {
+      constructor(geometry: FakeGeometry, material: FakeMaterial) {
+        super(geometry, material);
+        objects.push(this);
+      }
+    },
+  };
+  return { THREE, sphereGeometries, materials, objects };
+}
+
+function makeParent() {
+  return {
+    children: [] as FakeObject3D[],
+    add(child: FakeObject3D): void {
+      this.children.push(child);
+    },
+    remove(child: FakeObject3D): void {
+      const index = this.children.indexOf(child);
+      if (index >= 0) this.children.splice(index, 1);
+    },
+  };
+}
+
+/** Scalar stand-ins for the vec3 accent colour / respond uniform pair. */
+const NORMAL_VIEW_LEAF = 0.62;
+const VIEW_DIRECTION_LEAF = 1;
+const FRESNEL_AT_LEAVES = (1 - NORMAL_VIEW_LEAF * VIEW_DIRECTION_LEAF) ** 3;
+
+function buildScene(accentInitial = 1, respondInitial = 0) {
+  const { THREE, sphereGeometries, materials, objects } = makeThreeModule();
+  const parent = makeParent();
+  const uAccent = rimUniform(accentInitial);
+  const uRespond = rimUniform(respondInitial);
+  const handle = concept.build(
+    THREE,
+    makeTslModule(NORMAL_VIEW_LEAF, VIEW_DIRECTION_LEAF),
+    {
+      uTime: null,
+      uEnergy: null,
+      uLow: null,
+      uListen: null,
+      uRespond,
+      uAspect: null,
+      uAccent,
+    },
+    parent,
+  );
+  const mesh = parent.children[0] as FakeObject3D;
+  const positionAttr = (mesh.geometry as FakeSphereGeometry).attributes
+    .position;
+  const basePositions = Array.from(positionAttr.array);
+  return {
+    handle,
+    parent,
+    mesh,
+    positionAttr,
+    basePositions,
+    materials,
+    objects,
+    sphereGeometries,
+    uAccent,
+    uRespond,
+  };
+}
+
+type Scene = ReturnType<typeof buildScene>;
+
+/** Signed radial and tangential displacement of one vertex after a frame. */
+function radialDecomposition(
+  scene: Scene,
+  i: number,
+): { radial: number; tangential: number } {
+  const bx = scene.basePositions[i * 3];
+  const by = scene.basePositions[i * 3 + 1];
+  const bz = scene.basePositions[i * 3 + 2];
+  const len = Math.sqrt(bx * bx + by * by + bz * bz);
+  const dx = bx / len;
+  const dy = by / len;
+  const dz = bz / len;
+  const px = scene.positionAttr.array[i * 3];
+  const py = scene.positionAttr.array[i * 3 + 1];
+  const pz = scene.positionAttr.array[i * 3 + 2];
+  const ex = px - bx;
+  const ey = py - by;
+  const ez = pz - bz;
+  const radial = ex * dx + ey * dy + ez * dz;
+  const cx = ey * dz - ez * dy;
+  const cy = ez * dx - ex * dz;
+  const cz = ex * dy - ey * dx;
+  const tangential = Math.sqrt(cx * cx + cy * cy + cz * cz);
+  return { radial, tangential };
+}
+
+describe("liquidmetal concept descriptor", () => {
+  it("registers under the liquidmetal id with the abstract family and a callable builder", () => {
+    expect(concept.id).toBe("liquidmetal");
+    expect(concept.label).toBe("liquid");
+    expect(concept.family).toBe("abstract");
+    expect(typeof concept.build).toBe("function");
+  });
+});
+
+describe("liquidmetal build: scene assembly", () => {
+  it("adds exactly one chrome sphere mesh to the parent at the declared tessellation", () => {
+    const scene = buildScene();
+    expect(scene.parent.children).toHaveLength(1);
+    expect(scene.objects).toHaveLength(1);
+    expect(scene.sphereGeometries).toHaveLength(1);
+    const geo = scene.mesh.geometry as FakeSphereGeometry;
+    expect(geo.radius).toBeCloseTo(BASE_RADIUS, 10);
+    expect(geo.widthSegments).toBe(48);
+    expect(geo.heightSegments).toBe(32);
+    expect(scene.positionAttr.itemSize).toBe(3);
+    expect(scene.positionAttr.count).toBe(SPHERE_VERTICES);
+    // Every seeded vertex sits on the requested sphere.
+    for (let i = 0; i < scene.positionAttr.count; i += 1) {
+      const x = scene.positionAttr.getX(i);
+      const y = scene.positionAttr.getY(i);
+      const z = scene.positionAttr.getZ(i);
+      expect(Math.sqrt(x * x + y * y + z * z)).toBeCloseTo(BASE_RADIUS, 5);
+    }
+  });
+
+  it("retunes the kit chrome-gem material into a smooth mirror finish", () => {
+    const scene = buildScene();
+    expect(scene.materials).toHaveLength(1);
+    const mat = scene.mesh.material;
+    // makeChromeGem seeds flatShading=true / roughness=0.18 — the concept
+    // overrides them for the liquid-mirror look:
+    expect(mat.flatShading).toBe(false);
+    expect(mat.roughness).toBeCloseTo(0.03, 10);
+    expect(mat.metalness).toBe(1);
+    expect(mat.envMapIntensity).toBeCloseTo(1.8, 10);
+    expect(mat.color.r).toBeCloseTo(0.95, 10);
+    expect(mat.color.g).toBeCloseTo(0.97, 10);
+    expect(mat.color.b).toBeCloseTo(1.0, 10);
+  });
+
+  it("wires a fresnel rim light that re-prices live with uAccent and uRespond", () => {
+    const scene = buildScene();
+    const rim = scene.mesh.material.emissiveNode;
+    expect(rim).not.toBeNull();
+    const restGlow = rim?.value ?? 0;
+    expect(restGlow).toBeCloseTo(1 * FRESNEL_AT_LEAVES * (0.08 + 0 * 0.55), 12);
+    // Live binding: raising respond brightens the rim by exactly the
+    // declared (0.08 + 0.55*respond)/0.08 factor...
+    scene.uRespond.value = 1;
+    expect(rim?.value).toBeCloseTo(restGlow * ((0.08 + 0.55) / 0.08), 12);
+    // ...and the accent scales it linearly.
+    scene.uRespond.value = 0;
+    scene.uAccent.value = 2.5;
+    expect(rim?.value).toBeCloseTo(restGlow * 2.5, 12);
+  });
+});
+
+describe("liquidmetal frame animation", () => {
+  const IDLE = { time: 0, energy: 0, low: 0, listen: 0, respond: 0 };
+  const MID = { time: 4.2, energy: 0.5, low: 0.25, listen: 1, respond: 0.5 };
+  const PEAK = { time: 9, energy: 1, low: 0, listen: 0, respond: 1 };
+
+  it("moves every vertex strictly along its own radial direction", () => {
+    const scene = buildScene();
+    const beats = [IDLE, MID, PEAK, { ...IDLE, time: 100 }];
+    for (let step = 0; step <= 8; step += 1) {
+      const beat = beats[step % beats.length];
+      scene.handle.frame({ ...beat, time: beat.time + step * 1.3 });
+      for (let i = 0; i < scene.positionAttr.count; i += 1) {
+        const { tangential } = radialDecomposition(scene, i);
+        expect(tangential).toBeLessThan(1e-5);
+      }
+    }
+  });
+
+  it("keeps every vertex inside the declared amplitude envelope while staying alive at idle", () => {
+    const scene = buildScene();
+    const beats = [IDLE, MID, PEAK, { ...PEAK, energy: 1, respond: 1 }];
+    let idleMaxDisplacement = 0;
+    for (let step = 0; step <= 16; step += 1) {
+      const beat = beats[step % beats.length];
+      scene.handle.frame({ ...beat, time: beat.time + step * 0.9 });
+      for (let i = 0; i < scene.positionAttr.count; i += 1) {
+        const { radial } = radialDecomposition(scene, i);
+        const magnitude = Math.abs(radial);
+        expect(magnitude).toBeLessThanOrEqual(AMPLITUDE_WORST_CASE + EPSILON);
+        if (beat.energy === 0 && beat.respond === 0) {
+          idleMaxDisplacement = Math.max(idleMaxDisplacement, magnitude);
+        }
+      }
+    }
+    // The mercury blob undulates even with the mic silent.
+    expect(idleMaxDisplacement).toBeGreaterThan(0.001);
+  });
+
+  it("scales the idle wobble linearly with energy at a frozen clock", () => {
+    const quiet = buildScene();
+    quiet.handle.frame({ ...IDLE, energy: 0 });
+    const loud = buildScene();
+    loud.handle.frame({ ...IDLE, energy: 0.5 });
+    // Amplitude ratio (0.3 + 0.5*0.9)/(0.3 + 0) = 2.5 must hold per vertex.
+    const expectedRatio = (0.3 + 0.5 * 0.9) / 0.3;
+    let significant = 0;
+    for (let i = 0; i < quiet.positionAttr.count; i += 1) {
+      const base = radialDecomposition(quiet, i).radial;
+      if (Math.abs(base) < 1e-3) continue;
+      significant += 1;
+      const boosted = radialDecomposition(loud, i).radial;
+      expect(boosted / base).toBeCloseTo(expectedRatio, 2);
+    }
+    expect(significant).toBeGreaterThan(SPHERE_VERTICES / 2);
+  });
+
+  it("sharpens crests past the linear amplitude gain once respond crosses its threshold", () => {
+    const raw = buildScene();
+    raw.handle.frame({ ...IDLE, respond: 0 });
+    const spiked = buildScene();
+    spiked.handle.frame({ ...IDLE, respond: 0.5 });
+    // Amplitude alone would scale every displacement by (0.475/0.3).
+    const amplitudeRatio = (0.3 + 0.5 * 0.35) / 0.3;
+    let amplifiedBeyondAmplitude = 0;
+    for (let i = 0; i < raw.positionAttr.count; i += 1) {
+      const before = radialDecomposition(raw, i).radial;
+      if (Math.abs(before) < 1e-4) continue;
+      const after = radialDecomposition(spiked, i).radial;
+      // Crest sharpening never flips a ripple's phase...
+      expect(Math.sign(after)).toBe(Math.sign(before));
+      if (after > before * amplitudeRatio * (1 + 1e-3)) {
+        amplifiedBeyondAmplitude += 1;
+      }
+    }
+    // ...and the power curve pushes crests beyond what amplitude alone does.
+    expect(amplifiedBeyondAmplitude).toBeGreaterThan(0);
+  });
+
+  it("leaves sub-threshold respond unsharpened: 0.01 tracks pure amplitude scaling", () => {
+    const raw = buildScene();
+    raw.handle.frame({ ...IDLE, respond: 0 });
+    const boundary = buildScene();
+    boundary.handle.frame({ ...IDLE, respond: 0.01 });
+    const amplitudeRatio = (0.3 + 0.01 * 0.35) / 0.3;
+    for (let i = 0; i < raw.positionAttr.count; i += 1) {
+      const before = radialDecomposition(raw, i).radial;
+      if (Math.abs(before) < 1e-3) continue;
+      const after = radialDecomposition(boundary, i).radial;
+      expect(after / before).toBeCloseTo(amplitudeRatio, 2);
+    }
+  });
+
+  it("marks the position attribute dirty and recomputes normals on every frame", () => {
+    const scene = buildScene();
+    const geo = scene.mesh.geometry as FakeSphereGeometry;
+    expect(geo.normalsComputed).toBe(0);
+    expect(scene.positionAttr.needsUpdate).toBe(false);
+    for (let frameIndex = 1; frameIndex <= 5; frameIndex += 1) {
+      scene.handle.frame({ ...MID, time: MID.time + frameIndex });
+      expect(scene.positionAttr.needsUpdate).toBe(true);
+      expect(geo.normalsComputed).toBe(frameIndex);
+    }
+  });
+
+  it("drifts yaw linearly with time while pitching on a bounded slow sine", () => {
+    const scene = buildScene();
+    const t = 13.7;
+    scene.handle.frame({ ...MID, time: t });
+    expect(scene.mesh.rotation.y).toBeCloseTo(t * 0.08, 10);
+    expect(scene.mesh.rotation.x).toBeCloseTo(Math.sin(t * 0.055) * 0.14, 10);
+    expect(Math.abs(scene.mesh.rotation.x)).toBeLessThanOrEqual(0.14);
+  });
+
+  it("ignores listen and low: only time, energy and respond move anything", () => {
+    const scene = buildScene();
+    const snapshot = () =>
+      JSON.stringify({
+        vertices: Array.from(scene.positionAttr.array),
+        pitch: scene.mesh.rotation.x,
+        yaw: scene.mesh.rotation.y,
+      });
+    scene.handle.frame({
+      time: 4,
+      energy: 0.3,
+      low: 0,
+      listen: 0,
+      respond: 0.2,
+    });
+    const baseline = snapshot();
+    scene.handle.frame({
+      time: 4,
+      energy: 0.3,
+      low: 1,
+      listen: 1,
+      respond: 0.2,
+    });
+    expect(snapshot()).toBe(baseline);
+  });
+
+  it("replays the same instant identically: positions never accumulate drift", () => {
+    const scene = buildScene();
+    scene.handle.frame({ ...PEAK, time: 7.3 });
+    const first = JSON.stringify(Array.from(scene.positionAttr.array));
+    scene.handle.frame({ ...IDLE, time: 100 });
+    scene.handle.frame({ ...PEAK, time: 7.3 });
+    expect(JSON.stringify(Array.from(scene.positionAttr.array))).toBe(first);
+  });
+});
+
+describe("liquidmetal dispose", () => {
+  it("disposes the geometry and material once and detaches its mesh from the parent", () => {
+    const scene = buildScene();
+    const geo = scene.mesh.geometry as FakeSphereGeometry;
+    expect(geo.disposed).toBe(false);
+    expect(scene.parent.children).toHaveLength(1);
+
+    scene.handle.dispose();
+
+    expect(geo.disposed).toBe(true);
+    expect(scene.mesh.material.disposed).toBe(true);
+    expect(scene.parent.children).toHaveLength(0);
+  });
+});


### PR DESCRIPTION

## What

Adds a new unit suite for the liquid-metal voice-orb concept at
`packages/ui/stories/src/concepts/liquidmetal.ts`, which had no same-named test
file anywhere on `develop`. The diff is one new file,
`packages/ui/src/__tests__/stories-concepts-liquidmetal.test.ts` (+549/-0); no
production code is touched.

## Why

The concept module is pure runtime behaviour with zero coverage: it assembles a
chrome sphere through the injected `three/webgpu` + `three/tsl` surfaces, retunes
the orb-kit gem material into a smooth mirror, wires a fresnel rim light through
the live `uAccent`/`uRespond` uniforms, and deforms 1,617 vertices every frame.
The suite follows the established `stories-concepts-*` convention (see
`stories-concepts-lava.test.ts`) and drives the real module through hand-rolled
in-memory doubles whose calls are recorded; every expectation is recomputed in
the test, never read back from the subject.

## Coverage

- Descriptor contract: `id: "liquidmetal"`, `label: "liquid"`,
  `family: "abstract"`, callable builder.
- Scene assembly: exactly one sphere mesh on the parent at radius 0.95 with
  48x32 segments (1,617 vertices), material retuned from the
  `makeChromeGem` defaults (`flatShading: false`, `roughness: 0.03`,
  `metalness: 1`, `envMapIntensity: 1.8`, colour `(0.95, 0.97, 1.0)`).
- Rim light: lazy-evaluated TSL stand-ins prove the emissive graph re-prices
  live with `uRespond` (exact `(0.08 + 0.55*respond)/0.08` factor) and scales
  linearly with `uAccent`.
- Frame animation, all recomputed independently:
  - displacement stays purely radial for every vertex across beats
    (tangential residual < 1e-5);
  - amplitude envelope holds at the declared worst case
    `0.12 * (0.3 + 0.9 + 0.35)` while the blob still moves at idle;
  - idle wobble scales exactly linearly with energy (per-vertex ratio
    `(0.3+0.45)/0.3 = 2.5`);
  - crest sharpening activates only above the respond threshold and pushes
    crests beyond pure amplitude gain without ever flipping phase;
  - the threshold boundary itself: `respond = 0.01` still tracks pure
    amplitude scaling (strict `>` branch);
  - position attribute marked dirty + normals recomputed once per frame;
  - yaw drifts linearly (`0.08 * t`) while pitch rides its bounded sine;
  - `listen`/`low` inputs provably change nothing (byte-identical snapshot);
  - replaying the same instant reproduces byte-identical positions.
- Teardown: geometry + material disposed, mesh removed from the parent.

## Verification

Fork contributor: hosted CI does not run on this pull request; the checks below
were executed locally against this exact head.

- `bunx vitest run src/__tests__/stories-concepts-liquidmetal.test.ts`
  (in `packages/ui`): **1 file passed, 14 tests passed / 14** (~0.4s).
- `bunx biome check src/__tests__/stories-concepts-liquidmetal.test.ts`: clean
  ("Checked 1 file ... No fixes applied"), against the repo's pinned
  `biome.json`.
- `bunx tsc --noEmit` in `packages/ui`: the new file appears nowhere in the
  output (zero type errors introduced).
- The diff touches only the new test file (+549/-0).

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:7875a4c6ac67c598fe71900ea9fe2b09be26f5ec -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
