### PR TITLE
test(ui): cover api-explorer cloud domain barrel

### DIFF
--- a/packages/ui/src/cloud/api-explorer/index.test.ts
+++ b/packages/ui/src/cloud/api-explorer/index.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Unit coverage for the api-explorer cloud-domain barrel: the stable
+ * section/route ids, its import-time registration into the shared cloud-route
+ * registry consumed by CloudRouterShell, override re-registration semantics,
+ * and the fail-closed public-access policy. Drives the real registry and real
+ * sibling modules — no mocks.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  CLOUD_PUBLIC_ROUTE_ACCESS,
+  getCloudRoute,
+  getCloudRouteRegistryVersion,
+  subscribeCloudRoutes,
+} from "../shell/cloud-route-registry";
+import {
+  API_EXPLORER_ROUTE_PATH,
+  API_EXPLORER_SECTION_ID,
+  ApiExplorerRoute,
+  ApiExplorerSurface,
+  ApiTester,
+  AuthManager,
+  apiExplorerCloudRoute,
+  registerApiExplorerCloudRoute,
+  useExplorerApiKey,
+} from "./index";
+
+afterEach(() => {
+  // Restore the canonical import-time registration after override cases.
+  registerApiExplorerCloudRoute();
+});
+
+describe("api-explorer cloud domain ids", () => {
+  it("publishes stable section and route path ids", () => {
+    expect(API_EXPLORER_SECTION_ID).toBe("api-explorer");
+    expect(API_EXPLORER_ROUTE_PATH).toBe("cloud/api-explorer");
+  });
+});
+
+describe("api-explorer cloud route registration", () => {
+  it("registers the standalone surface at import time as a private cloud-group route", () => {
+    const registered = getCloudRoute(API_EXPLORER_ROUTE_PATH);
+
+    expect(registered?.path).toBe(API_EXPLORER_ROUTE_PATH);
+    expect(registered?.group).toBe("cloud");
+    expect(registered?.public ?? false).toBe(false);
+    expect(registered?.gate).toBeUndefined();
+    expect(registered?.element).toBeTruthy();
+    // The registry stores a spread copy of the definition, so the element the
+    // shell will render is the exact lazy element this module publishes.
+    expect(registered?.element).toBe(apiExplorerCloudRoute.element);
+  });
+
+  it("re-registration merges overrides over the published route and notifies shell subscribers", () => {
+    const notified = vi.fn();
+    const unsubscribe = subscribeCloudRoutes(notified);
+    const versionBefore = getCloudRouteRegistryVersion();
+
+    try {
+      registerApiExplorerCloudRoute({ gate: "admin" });
+
+      const updated = getCloudRoute(API_EXPLORER_ROUTE_PATH);
+      expect(updated?.gate).toBe("admin");
+      // Fields absent from the override survive the merge unchanged.
+      expect(updated?.path).toBe(API_EXPLORER_ROUTE_PATH);
+      expect(updated?.group).toBe("cloud");
+      expect(updated?.element).toBe(apiExplorerCloudRoute.element);
+      expect(getCloudRouteRegistryVersion()).toBeGreaterThan(versionBefore);
+      expect(notified).toHaveBeenCalled();
+    } finally {
+      unsubscribe();
+    }
+  });
+
+  it("refuses to flip the explorer route public without reviewed opt-in and leaves it private", () => {
+    const versionBefore = getCloudRouteRegistryVersion();
+
+    expect(() => registerApiExplorerCloudRoute({ public: true })).toThrow(
+      /CLOUD_PUBLIC_ROUTE_ACCESS/,
+    );
+
+    // The rejection happens before any mutation: same element, still private,
+    // and the shell-visible version never advanced.
+    const intact = getCloudRoute(API_EXPLORER_ROUTE_PATH);
+    expect(intact?.public ?? false).toBe(false);
+    expect(intact?.element).toBe(apiExplorerCloudRoute.element);
+    expect(getCloudRouteRegistryVersion()).toBe(versionBefore);
+  });
+
+  it("accepts a reviewed public override carrying CLOUD_PUBLIC_ROUTE_ACCESS", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      registerApiExplorerCloudRoute({
+        public: true,
+        publicAccess: CLOUD_PUBLIC_ROUTE_ACCESS,
+      });
+
+      const flipped = getCloudRoute(API_EXPLORER_ROUTE_PATH);
+      expect(flipped?.public).toBe(true);
+      expect(flipped?.publicAccess).toBe(CLOUD_PUBLIC_ROUTE_ACCESS);
+      // Flipping a previously private route is loud in dev/test.
+      expect(warn).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.stringContaining(
+          "cloud-routes.private-to-public-reregistration",
+        ),
+      );
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});
+
+describe("api-explorer runtime exports", () => {
+  it("re-exports the surfaces and hook callers bind from the barrel", () => {
+    expect(ApiExplorerSurface).toBeDefined();
+    expect(ApiExplorerRoute).toBeDefined();
+    expect(ApiTester).toBeDefined();
+    expect(AuthManager).toBeDefined();
+    expect(typeof useExplorerApiKey).toBe("function");
+  });
+});


### PR DESCRIPTION

## What this adds

`packages/ui/src/cloud/api-explorer/index.ts` had no co-located test anywhere in the repo. This PR adds one new test file — `packages/ui/src/cloud/api-explorer/index.test.ts` — and changes no production code. The diff is a single new file, +122/-0.

The module is not just a barrel: it owns the import-time registration of `cloud/api-explorer` into the shared cloud-route registry, which CloudRouterShell consumes and which the legacy media-generator redirects target. The suite drives that real boundary with the real registry and real sibling modules (no mocks; the only spy is the `console.warn` diagnostic interception used by the existing `cloud-route-registry.test.ts`).

## What the suite covers

- Stable ids: `API_EXPLORER_SECTION_ID === "api-explorer"`, `API_EXPLORER_ROUTE_PATH === "cloud/api-explorer"`.
- Import-time registration: after importing the barrel, `getCloudRoute("cloud/api-explorer")` returns a private (`public` unset), ungated, `"cloud"`-group route whose element is the exact lazy element this module publishes.
- Re-registration override semantics: `registerApiExplorerCloudRoute({ gate })` merges over the published route (path/group/element preserved), advances the registry version, and notifies shell subscribers via `subscribeCloudRoutes`.
- Fail-closed public policy through the helper: an override with `public: true` and no `CLOUD_PUBLIC_ROUTE_ACCESS` throws, leaves the registered route private with its element intact, and does not advance the registry version (rejection happens before mutation).
- Reviewed public opt-in: carrying `CLOUD_PUBLIC_ROUTE_ACCESS` succeeds and emits the `cloud-routes.private-to-public-reregistration` dev diagnostic.
- Runtime re-export surface callers bind from the barrel (`ApiExplorerSurface`, `ApiExplorerRoute`, `ApiTester`, `AuthManager`, `useExplorerApiKey`).

## Evidence (test-only change)

Run against current `origin/develop` (`51617538d704126b0d308654ccaaff091e474a67`) immediately before filing:

- `bunx vitest run src/cloud/api-explorer/index.test.ts` (in `packages/ui`): **Test Files 1 passed (1), Tests 6 passed (6)**.
- `bunx biome check --write src/cloud/api-explorer/index.test.ts`: clean on re-check ("Checked 1 file ... No fixes applied").
- `bunx tsc --noEmit` in `packages/ui`: pre-existing errors exist elsewhere in the package, but grepping the full output for `api-explorer/index.test` finds **nothing** — the new file introduces zero type errors.
- The diff touches only the new test file.

This is a fork contribution, so hosted CI does not run on this pull request; the counts above are from local runs quoted verbatim.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:5bb5badc277ed581aa6a6866e94298ba31f54af7 -->

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-eliza"} -->
