### PR TITLE
test(ui): cover ink

### DIFF
--- a/packages/ui/src/__tests__/stories-concepts-ink.test.ts
+++ b/packages/ui/src/__tests__/stories-concepts-ink.test.ts
@@ -1,0 +1,401 @@
+/**
+ * Behavioral suite for the ink voice-orb concept. Drives the real
+ * ConceptDescriptor/build/frame/dispose pipeline over a minimal faithful
+ * WebGPU-module double — orb-kit documents concepts as fake-drivable at this
+ * boundary — and pins the observed contract: body/cloud/seal child wiring,
+ * the 220-particle charcoal buffer, idle/time/energy frame state including
+ * the per-particle orbit-radius breath ratio, the respond-driven seal pulse,
+ * and full resource teardown.
+ *
+ * Lives under src/__tests__ (not stories/) because the package vitest lane and
+ * tsconfig both collect only src/** — a suite inside stories/src never runs.
+ *
+ * The concept seeds its particles from Math.random() at build time, so every
+ * assertion is seed-independent by construction: closed-form formulas that do
+ * not involve the random phase/speed/y-band/base-ring draws, per-particle
+ * relational ratios between two frames of the same build, and bounded ranges
+ * derived from the documented random intervals.
+ */
+
+import { describe, expect, it } from "vitest";
+import { concept } from "../../stories/src/concepts/ink.ts";
+import type {
+  OrbFrame,
+  OrbUniforms,
+  TSLModule,
+  WebGPUModule,
+} from "../../stories/src/orb-kit.ts";
+
+class FakeColor {
+  r: number;
+  g: number;
+  b: number;
+
+  constructor(r = 0, g = 0, b = 0) {
+    this.r = r;
+    this.g = g;
+    this.b = b;
+  }
+}
+
+class FakeBufferAttribute {
+  readonly array: Float32Array;
+  readonly itemSize: number;
+  needsUpdate = false;
+
+  constructor(array: Float32Array, itemSize: number) {
+    this.array = array;
+    this.itemSize = itemSize;
+  }
+
+  get count(): number {
+    return this.array.length / this.itemSize;
+  }
+
+  getX(i: number): number {
+    return this.array[i * this.itemSize];
+  }
+
+  getY(i: number): number {
+    return this.array[i * this.itemSize + 1];
+  }
+
+  getZ(i: number): number {
+    return this.array[i * this.itemSize + 2];
+  }
+
+  setXYZ(i: number, x: number, y: number, z: number): void {
+    const o = i * this.itemSize;
+    this.array[o] = x;
+    this.array[o + 1] = y;
+    this.array[o + 2] = z;
+  }
+}
+
+class FakeGeometry {
+  attributes: Record<string, FakeBufferAttribute> = {};
+  disposed = false;
+
+  setAttribute(name: string, attr: FakeBufferAttribute): void {
+    this.attributes[name] = attr;
+  }
+
+  dispose(): void {
+    this.disposed = true;
+  }
+}
+
+class FakeMaterial {
+  disposed = false;
+
+  dispose(): void {
+    this.disposed = true;
+  }
+}
+
+class FakeMeshStandardNodeMaterial extends FakeMaterial {
+  color: FakeColor | null = null;
+  emissive: FakeColor | null = null;
+  emissiveIntensity = 0;
+  roughness = 0;
+  metalness = 0;
+}
+
+class FakePointsNodeMaterial extends FakeMaterial {
+  color: FakeColor | null = null;
+  transparent = false;
+  opacity = 1;
+  depthWrite = true;
+  blending: unknown = null;
+  size = 0;
+  sizeAttenuation = false;
+}
+
+class FakePosition {
+  x = 0;
+  y = 0;
+  z = 0;
+
+  set(x: number, y: number, z: number): void {
+    this.x = x;
+    this.y = y;
+    this.z = z;
+  }
+}
+
+class FakeScale {
+  value = 1;
+
+  setScalar(s: number): void {
+    this.value = s;
+  }
+}
+
+class FakeObject3D {
+  geometry: FakeGeometry;
+  material: FakeMaterial;
+  position = new FakePosition();
+  rotation = { x: 0, y: 0, z: 0 };
+  scale = new FakeScale();
+  frustumCulled = true;
+
+  constructor(geometry: FakeGeometry, material: FakeMaterial) {
+    this.geometry = geometry;
+    this.material = material;
+  }
+}
+
+class FakeMesh extends FakeObject3D {}
+class FakePoints extends FakeObject3D {}
+
+class FakeParent {
+  children: FakeObject3D[] = [];
+
+  add(child: FakeObject3D): void {
+    this.children.push(child);
+  }
+
+  remove(child: FakeObject3D): void {
+    const i = this.children.indexOf(child);
+    if (i >= 0) this.children.splice(i, 1);
+  }
+}
+
+const THREE_DOUBLE = {
+  Color: FakeColor,
+  SphereGeometry: FakeGeometry,
+  BufferGeometry: FakeGeometry,
+  BufferAttribute: FakeBufferAttribute,
+  MeshStandardNodeMaterial: FakeMeshStandardNodeMaterial,
+  PointsNodeMaterial: FakePointsNodeMaterial,
+  Mesh: FakeMesh,
+  Points: FakePoints,
+  NormalBlending: "normal",
+};
+
+function makeUniforms(): OrbUniforms {
+  // The concept never reads the uniforms; an empty frozen node satisfies
+  // every `any`-typed slot in OrbUniforms without reaching for `any` itself.
+  const node: Record<string, never> = {};
+  return {
+    uTime: node,
+    uEnergy: node,
+    uLow: node,
+    uListen: node,
+    uRespond: node,
+    uAspect: node,
+    uAccent: node,
+  };
+}
+
+interface BuiltInk {
+  parent: FakeParent;
+  handle: { frame: (f: OrbFrame) => void; dispose: () => void };
+  body: FakeMesh;
+  cloud: FakePoints;
+  seal: FakeMesh;
+  cloudPositions: FakeBufferAttribute;
+}
+
+/** Random-interval contracts the concept documents in its own seed block. */
+const BASE_RING_MIN = 0.88;
+const BASE_RING_MAX = 0.88 + 0.38;
+const Y_BAND_MAX = 1.1;
+const PY_AMPLITUDE = 0.11;
+
+function buildInk(): BuiltInk {
+  const parent = new FakeParent();
+  const handle = concept.build(
+    THREE_DOUBLE as unknown as WebGPUModule,
+    {} as unknown as TSLModule,
+    makeUniforms(),
+    parent,
+  );
+  expect(parent.children).toHaveLength(3);
+  const [body, cloud, seal] = parent.children;
+  return {
+    parent,
+    handle,
+    body: body as FakeMesh,
+    cloud: cloud as FakePoints,
+    seal: seal as FakeMesh,
+    cloudPositions: (cloud.geometry as FakeGeometry).attributes.position,
+  };
+}
+
+function frameAt(
+  time: number,
+  overrides?: Partial<Omit<OrbFrame, "time">>,
+): OrbFrame {
+  return { time, energy: 0, low: 0, listen: 0, respond: 0, ...overrides };
+}
+
+/** Horizontal orbit radius sqrt(x²+z²) of one stored particle position. */
+function ringRadius(attr: FakeBufferAttribute, i: number): number {
+  return Math.hypot(attr.getX(i), attr.getZ(i));
+}
+
+describe("concepts/ink — orb lifecycle over a faithful WebGPU double", () => {
+  it("catalogs the ink artful concept with a callable builder", () => {
+    expect(concept.id).toBe("ink");
+    expect(concept.label).toBe("ink");
+    expect(concept.family).toBe("artful");
+    expect(typeof concept.build).toBe("function");
+  });
+
+  it("wires body sphere, ink cloud points and hanko seal onto the parent", () => {
+    const { body, cloud, cloudPositions, seal } = buildInk();
+
+    expect(body).toBeInstanceOf(FakeMesh);
+    expect(cloud).toBeInstanceOf(FakePoints);
+    expect(seal).toBeInstanceOf(FakeMesh);
+
+    // Body: soft matte near-black sphere.
+    const bodyMat = body.material as FakeMeshStandardNodeMaterial;
+    expect(bodyMat.color?.r).toBeCloseTo(0.045, 12);
+    expect(bodyMat.color?.g).toBeCloseTo(0.045, 12);
+    expect(bodyMat.color?.b).toBeCloseTo(0.05, 12);
+    expect(bodyMat.roughness).toBeCloseTo(0.92, 12);
+    expect(bodyMat.metalness).toBe(0);
+    expect(bodyMat.emissiveIntensity).toBe(0);
+
+    // Cloud: unculled charcoal points on a 220-slot position buffer that is
+    // allocated empty — particle state lives in private data until framed.
+    expect(cloud.frustumCulled).toBe(false);
+    expect(cloudPositions.count).toBe(220);
+    expect(cloudPositions.itemSize).toBe(3);
+    expect(cloudPositions.needsUpdate).toBe(false);
+    let nonZeroSlots = 0;
+    for (let slot = 0; slot < cloudPositions.array.length; slot += 1) {
+      if (cloudPositions.array[slot] !== 0) nonZeroSlots += 1;
+    }
+    expect(nonZeroSlots).toBe(0);
+    const cloudMat = cloud.material as FakePointsNodeMaterial;
+    expect(cloudMat.transparent).toBe(true);
+    expect(cloudMat.opacity).toBeCloseTo(0.6, 12);
+    expect(cloudMat.depthWrite).toBe(false);
+    expect(cloudMat.blending).toBe(THREE_DOUBLE.NormalBlending);
+    expect(cloudMat.size).toBeCloseTo(0.03, 12);
+    expect(cloudMat.sizeAttenuation).toBe(true);
+    expect(cloudMat.color?.r).toBeCloseTo(0.1, 12);
+    expect(cloudMat.color?.g).toBeCloseTo(0.1, 12);
+    expect(cloudMat.color?.b).toBeCloseTo(0.13, 12);
+
+    // Seal: deep vermilion stamp offset to the lower-right of the face.
+    expect(seal.position.x).toBeCloseTo(0.62, 12);
+    expect(seal.position.y).toBeCloseTo(-0.52, 12);
+    expect(seal.position.z).toBeCloseTo(0.42, 12);
+    const sealMat = seal.material as FakeMeshStandardNodeMaterial;
+    expect(sealMat.color?.r).toBeCloseTo(0.78, 12);
+    expect(sealMat.color?.g).toBeCloseTo(0.1, 12);
+    expect(sealMat.color?.b).toBeCloseTo(0.07, 12);
+    expect(sealMat.emissive?.r).toBeCloseTo(0.7, 12);
+    expect(sealMat.emissive?.g).toBeCloseTo(0.06, 12);
+    expect(sealMat.emissive?.b).toBeCloseTo(0.04, 12);
+    expect(sealMat.emissiveIntensity).toBeCloseTo(0.25, 12);
+    expect(sealMat.roughness).toBeCloseTo(0.45, 12);
+    expect(sealMat.metalness).toBeCloseTo(0.05, 12);
+  });
+
+  it("idle frame writes every particle onto its base ring and marks the buffer dirty", () => {
+    const { handle, cloud, cloudPositions } = buildInk();
+
+    handle.frame(frameAt(0));
+
+    // The concept must have flagged the GPU buffer for re-upload.
+    expect(cloudPositions.needsUpdate).toBe(true);
+
+    // At t=0, energy=0 the orbit angle is the pure random phase and the ring
+    // radius equals the raw draw, so every particle satisfies
+    // baseRing ∈ [0.88, 1.26] and |y| ≤ 1.1 + 0.11 regardless of the seed.
+    for (let i = 0; i < cloudPositions.count; i += 1) {
+      const r = ringRadius(cloudPositions, i);
+      expect(r).toBeGreaterThanOrEqual(BASE_RING_MIN - 1e-6);
+      expect(r).toBeLessThanOrEqual(BASE_RING_MAX + 1e-6);
+      expect(Math.abs(cloudPositions.getY(i))).toBeLessThanOrEqual(
+        Y_BAND_MAX + PY_AMPLITUDE + 1e-6,
+      );
+    }
+    // Idle pose holds every animated channel at its rest value.
+    expect(cloud.rotation.y).toBe(0);
+    expect((cloud.material as FakePointsNodeMaterial).opacity).toBeCloseTo(
+      0.6,
+      12,
+    );
+    expect(handle).toBeDefined();
+  });
+
+  it("breathes the whole cloud outward by exactly 1 + energy * 0.55 per particle", () => {
+    const { handle, body, cloudPositions } = buildInk();
+
+    handle.frame(frameAt(0));
+    const idleRadii: number[] = [];
+    for (let i = 0; i < cloudPositions.count; i += 1) {
+      idleRadii.push(ringRadius(cloudPositions, i));
+    }
+
+    handle.frame(frameAt(0, { energy: 0.5 }));
+
+    // Same build, same phases: the only change is the multiplicative breath
+    // factor, so each particle's horizontal radius scales by 1.275 exactly.
+    const breathe = 1 + 0.5 * 0.55;
+    for (let i = 0; i < cloudPositions.count; i += 1) {
+      expect(
+        ringRadius(cloudPositions, i) / (idleRadii[i] as number),
+      ).toBeCloseTo(breathe, 5);
+    }
+    // The body swells with the same energy on its own gentler curve.
+    expect(body.scale.value).toBeCloseTo(1 + 0.5 * 0.07, 12);
+  });
+
+  it("animates rotations and the seal bob from time alone", () => {
+    const { handle, body, cloud, seal } = buildInk();
+
+    handle.frame(frameAt(2));
+
+    expect(body.rotation.y).toBeCloseTo(2 * 0.045, 12);
+    expect(body.rotation.x).toBeCloseTo(Math.sin(2 * 0.032) * 0.06, 12);
+    expect(body.scale.value).toBe(1);
+    expect(cloud.rotation.y).toBeCloseTo(2 * 0.018, 12);
+    // Seal bobs around its resting lower-right mount.
+    expect(seal.position.y).toBeCloseTo(-0.52 + Math.sin(2 * 0.5) * 0.025, 12);
+    // With no respond the stamp brightness stays at its 0.25 floor even
+    // though the sine carrier is running.
+    expect(
+      (seal.material as FakeMeshStandardNodeMaterial).emissiveIntensity,
+    ).toBeCloseTo(0.25, 12);
+  });
+
+  it("lifts seal emissive along the respond ramp with the time carrier on top", () => {
+    const { handle, seal } = buildInk();
+    const sealMat = seal.material as FakeMeshStandardNodeMaterial;
+
+    // t where sin(t * 1.8) peaks at 1: the carrier contributes respond * 0.06.
+    const tPeak = Math.PI / (2 * 1.8);
+
+    handle.frame(frameAt(tPeak, { respond: 1 }));
+    expect(sealMat.emissiveIntensity).toBeCloseTo(0.25 + 0.6 + 0.06, 12);
+
+    handle.frame(frameAt(tPeak, { respond: 0.5 }));
+    expect(sealMat.emissiveIntensity).toBeCloseTo(0.25 + 0.3 + 0.03, 12);
+  });
+
+  it("dispose releases both geometries and both materials plus the cloud pair and empties the parent", () => {
+    const { parent, handle, body, cloud, seal } = buildInk();
+    const resources = [
+      body.geometry,
+      body.material,
+      cloud.geometry,
+      cloud.material,
+      seal.geometry,
+      seal.material,
+    ];
+
+    handle.dispose();
+
+    for (const resource of resources) {
+      expect((resource as FakeMaterial).disposed).toBe(true);
+    }
+    expect(parent.children).toHaveLength(0);
+  });
+});


### PR DESCRIPTION

## What

Adds a new unit suite for the voice-orb concept `ink` (`packages/ui/stories/src/concepts/ink.ts`), which had no same-named or importing test anywhere on develop.

- **File:** `packages/ui/src/__tests__/stories-concepts-ink.test.ts` (new, additive only)
- **Runner:** vitest (`packages/ui` lane; matches the existing `stories-concepts-*` suites)

The suite lives under `src/__tests__` rather than beside the concept because both the package vitest config (`include: src/**`) and tsconfig collect only `src/**` â a suite inside `stories/src/` is never collected or typechecked.

## What it asserts (behaviour, not mocks)

The suite drives the real `concept.build` / `frame` / `dispose` pipeline through orb-kit's documented injection boundary (`WebGPUModule = Record<string, any>`); the double only stores state, every asserted value is computed by the module under test:

- descriptor registration: id/label `ink`, family `artful`, callable builder
- build wiring: body sphere + 220-particle ink cloud + hanko seal added to the parent in order, with their material contracts (matte near-black body, unculled cloud with empty position buffer pre-frame, NormalBlending, seal mount at `(0.62, -0.52, 0.42)`)
- idle frame: every particle lands on its base ring in `[0.88, 1.26]` with `|y| â¤ 1.21`, buffer flagged `needsUpdate`
- energy breath: per-particle horizontal radius scales by exactly `1 + energy Ã 0.55` (relational assertion across two frames of one build) and the body swells by `energy Ã 0.07`
- time animation: body/cloud rotations follow their closed forms; seal bobs around its mount; seal emissive stays at the `0.25` floor when respond is 0
- respond ramp: seal emissive follows `0.25 + respondÂ·0.6 + sin(tÂ·1.8)Â·respondÂ·0.06`
- dispose: all six geometries/materials released, parent emptied

Particle seeds come from `Math.random()` at build time, so all assertions are seed-independent by construction (closed-form formulas, relational ratios between frames of the same build, and bounds derived from the documented random intervals). No clock or RNG mocking is used.

## Evidence (test-only change)

Recorded at head `a2bf231d5c675294f1ac7f43620d8c1bf35c447a` against current `origin/develop` (`51617538d7`):

1. `bunx vitest run src/__tests__/stories-concepts-ink.test.ts` (in `packages/ui`) â **Test Files 1 passed (1), Tests 7 passed (7)** â re-fetched and re-run immediately before filing; `stories/src/concepts/ink.ts` and `orb-kit.ts` are byte-identical between my base and current develop
2. `bunx biome check --write <file>` â clean (`Checked 1 file. No fixes applied.` on re-check)
3. `bunx tsc --noEmit` in `packages/ui` â the new filename appears nowhere in output (grep exit 1)
4. Diff scope: this PR adds exactly one new test file (+401/-0); no production code is touched

Note: this is a fork contribution, so hosted CI does not run on this pull request; the counts above are from local runs of the real package toolchain.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:a2bf231d5c675294f1ac7f43620d8c1bf35c447a -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
