### PR TITLE
test(ui): cover nebula

### DIFF
--- a/packages/ui/stories/src/concepts/nebula.test.ts
+++ b/packages/ui/stories/src/concepts/nebula.test.ts
@@ -1,0 +1,291 @@
+/**
+ * Unit coverage for the `nebula` voice-orb concept builder. Drives the real
+ * `concept.build` against the real `three/webgpu` classes (headless-safe: no
+ * GPU device or DOM is touched) and asserts the observable scene-graph
+ * contract: dust/star/core point-cloud construction with fixed vertex counts,
+ * radius bounds invariant under the build's RNG, material blending/opacity
+ * contracts, the differential galactic tilt, frame state driven by
+ * time/energy/respond including the twinkle accumulator and magenta flush,
+ * and full resource teardown.
+ */
+import * as THREE from "three/webgpu";
+import { describe, expect, it, vi } from "vitest";
+import type { OrbFrame, OrbUniforms } from "../orb-kit.ts";
+import { concept } from "./nebula.ts";
+
+/** Same loose boundary type orb-kit uses for the injected renderer module. */
+type WebGPU = Record<string, any>;
+
+const THREE_WEBGPU = THREE as unknown as WebGPU;
+
+const NO_UNIFORMS = {} as OrbUniforms;
+
+function frame(time: number, energy: number, respond: number): OrbFrame {
+  return { time, energy, low: 0, listen: 0, respond };
+}
+
+function buildNebula(): {
+  parent: any;
+  handle: { frame: (f: OrbFrame) => void; dispose: () => void };
+  dust: any;
+  stars: any;
+  core: any;
+} {
+  const parent = new THREE_WEBGPU.Group();
+  const handle = concept.build(THREE_WEBGPU, {}, NO_UNIFORMS, parent);
+  // Build order is fixed by the concept: dust cloud, stars, core.
+  const dust = parent.children[0];
+  const stars = parent.children[1];
+  const core = parent.children[2];
+  return { parent, handle, dust, stars, core };
+}
+
+describe("nebula concept descriptor", () => {
+  it("registers under id 'nebula' in the abstract family with a callable builder", () => {
+    expect(concept.id).toBe("nebula");
+    expect(concept.label).toBe("nebula");
+    expect(concept.family).toBe("abstract");
+    expect(typeof concept.build).toBe("function");
+  });
+});
+
+describe("nebula build", () => {
+  it("adds exactly three Points children to the parent, none frustum-culled", () => {
+    const { parent, dust, stars, core } = buildNebula();
+    expect(parent.children.length).toBe(3);
+    expect(dust).toBeInstanceOf(THREE_WEBGPU.Points);
+    expect(stars).toBeInstanceOf(THREE_WEBGPU.Points);
+    expect(core).toBeInstanceOf(THREE_WEBGPU.Points);
+    for (const points of [dust, stars, core]) {
+      expect(points.frustumCulled).toBe(false);
+    }
+  });
+
+  it("builds a 680-point dust cloud whose vertices carry per-point colors", () => {
+    const { dust } = buildNebula();
+    const pos = dust.geometry.attributes.position;
+    const col = dust.geometry.attributes.color;
+    expect(pos.count).toBe(680);
+    expect(col.count).toBe(680);
+    expect(pos.itemSize).toBe(3);
+    expect(col.itemSize).toBe(3);
+  });
+
+  it("clusters dust inside the max build radius of 1.28", () => {
+    const { dust } = buildNebula();
+    const pos = dust.geometry.attributes.position as any;
+    let maxRadius = 0;
+    for (let i = 0; i < pos.count; i++) {
+      const r = Math.hypot(pos.getX(i), pos.getY(i), pos.getZ(i));
+      maxRadius = Math.max(maxRadius, r);
+      expect(r).toBeGreaterThanOrEqual(-1e-9);
+    }
+    expect(maxRadius).toBeLessThanOrEqual(1.28 + 1e-9);
+  });
+
+  it("keeps every dust color channel within [0, 1]", () => {
+    const { dust } = buildNebula();
+    const col = dust.geometry.attributes.color as any;
+    for (let i = 0; i < col.count; i++) {
+      for (const c of [col.getX(i), col.getY(i), col.getZ(i)]) {
+        expect(c).toBeGreaterThanOrEqual(0);
+        expect(c).toBeLessThanOrEqual(1);
+      }
+    }
+  });
+
+  it("builds exactly 44 star points without a color attribute", () => {
+    const { stars } = buildNebula();
+    expect(stars.geometry.attributes.position.count).toBe(44);
+    expect(stars.geometry.attributes.color).toBeUndefined();
+  });
+
+  it("scatters stars between radius 0.08 and 1.26", () => {
+    const { stars } = buildNebula();
+    const pos = stars.geometry.attributes.position as any;
+    let minRadius = Number.POSITIVE_INFINITY;
+    let maxRadius = 0;
+    for (let i = 0; i < pos.count; i++) {
+      const r = Math.hypot(pos.getX(i), pos.getY(i), pos.getZ(i));
+      minRadius = Math.min(minRadius, r);
+      maxRadius = Math.max(maxRadius, r);
+    }
+    expect(minRadius).toBeGreaterThanOrEqual(0.08 - 1e-9);
+    expect(maxRadius).toBeLessThanOrEqual(1.26 + 1e-9);
+  });
+
+  it("anchors the core with 3 points hugging the origin", () => {
+    const { core } = buildNebula();
+    const pos = core.geometry.attributes.position as any;
+    expect(pos.count).toBe(3);
+    for (let i = 0; i < pos.count; i++) {
+      expect(Math.abs(pos.getX(i))).toBeLessThanOrEqual(0.01 + 1e-12);
+      expect(Math.abs(pos.getY(i))).toBeLessThanOrEqual(0.01 + 1e-12);
+      expect(Math.abs(pos.getZ(i))).toBeLessThanOrEqual(0.01 + 1e-12);
+    }
+  });
+
+  it("gives all three clouds their own transparent, depth-write-off normal-blended PointsNodeMaterial", () => {
+    const { dust, stars, core } = buildNebula();
+    for (const points of [dust, stars, core]) {
+      const mat = points.material as any;
+      expect(mat).toBeInstanceOf(THREE_WEBGPU.PointsNodeMaterial);
+      expect(mat.transparent).toBe(true);
+      expect(mat.depthWrite).toBe(false);
+      // Deliberately NOT additive: additive dust vanishes into the bright sky.
+      expect(mat.blending).toBe(THREE_WEBGPU.NormalBlending);
+      expect(mat.blending).not.toBe(THREE_WEBGPU.AdditiveBlending);
+    }
+  });
+
+  it("applies the documented per-cloud material constants", () => {
+    const { dust, stars, core } = buildNebula();
+    const dustMat = dust.material as any;
+    const starMat = stars.material as any;
+    const coreMat = core.material as any;
+    expect(dustMat.vertexColors).toBe(true);
+    expect(dustMat.size).toBeCloseTo(0.075, 12);
+    expect(dustMat.sizeAttenuation).toBe(true);
+    expect(dustMat.opacity).toBeCloseTo(0.92, 12);
+    expect(starMat.color.r).toBeCloseTo(1.0, 12);
+    expect(starMat.color.g).toBeCloseTo(0.52, 12);
+    expect(starMat.color.b).toBeCloseTo(0.86, 12);
+    expect(starMat.size).toBeCloseTo(0.055, 12);
+    expect(starMat.opacity).toBeCloseTo(0.9, 12);
+    expect(coreMat.color.r).toBeCloseTo(0.42, 12);
+    expect(coreMat.color.g).toBeCloseTo(0.16, 12);
+    expect(coreMat.color.b).toBeCloseTo(0.78, 12);
+    expect(coreMat.size).toBeCloseTo(0.42, 12);
+    expect(coreMat.opacity).toBeCloseTo(0.5, 12);
+  });
+
+  it("tilts the dust plane more than the star plane for galactic depth", () => {
+    const { dust, stars, core } = buildNebula();
+    expect(dust.rotation.x).toBeCloseTo(0.22, 12);
+    expect(stars.rotation.x).toBeCloseTo(0.18, 12);
+    expect(core.rotation.x).toBe(0);
+  });
+});
+
+describe("nebula frame", () => {
+  it("overwrites stale material state with the idle pose at zero time, energy and respond", () => {
+    const { handle, dust, stars, core } = buildNebula();
+    const dustMat = dust.material as any;
+    const starMat = stars.material as any;
+    dustMat.opacity = -1; // sentinels: frame must overwrite both
+    starMat.opacity = -1;
+    handle.frame(frame(0, 0, 0));
+    expect(dust.rotation.y).toBe(0);
+    expect(stars.rotation.y).toBe(0);
+    expect(core.rotation.y).toBe(0);
+    expect(dust.rotation.z).toBeCloseTo(0, 12);
+    expect(stars.rotation.z).toBeCloseTo(Math.cos(0) * 0.05, 12);
+    expect(dust.scale.x).toBeCloseTo(1, 12);
+    expect(stars.scale.x).toBeCloseTo(0.98, 12);
+    expect(dustMat.opacity).toBeCloseTo(0.62, 12);
+    // Twinkle phase advances BEFORE the formula runs, so the very first
+    // painted frame already samples phase 0.09 (observed), scaled by the
+    // idle respond/energy factor of 0.7.
+    expect(starMat.opacity).toBeCloseTo(
+      (0.72 + Math.sin(0.09 * 2.3) * 0.18 + Math.cos(0.09 * 3.7) * 0.08) * 0.7,
+      12,
+    );
+    // Neutral tint when not responding.
+    expect(dustMat.color.r).toBeCloseTo(1, 12);
+    expect(dustMat.color.g).toBeCloseTo(1, 12);
+    expect(dustMat.color.b).toBeCloseTo(1, 12);
+    expect(core.material.opacity).toBeCloseTo(0.22, 12);
+    expect((core.material as any).size).toBeCloseTo(0.38, 12);
+  });
+
+  it("swirls each layer at its own multiple of the shared speed", () => {
+    const { handle, dust, stars, core } = buildNebula();
+    handle.frame(frame(2, 0, 0));
+    const speed = 0.055;
+    expect(dust.rotation.y).toBeCloseTo(2 * speed, 12);
+    expect(stars.rotation.y).toBeCloseTo(2 * speed * 0.65, 12);
+    expect(core.rotation.y).toBeCloseTo(2 * speed * 1.1, 12);
+  });
+
+  it("boosts swirl speed with energy", () => {
+    const { handle, dust } = buildNebula();
+    handle.frame(frame(1, 1, 0));
+    expect(dust.rotation.y).toBeCloseTo(0.055 + 1 * 0.18, 12);
+  });
+
+  it("drifts the planes on z with slow out-of-phase oscillations", () => {
+    const { handle, dust, stars } = buildNebula();
+    handle.frame(frame(3, 0, 0));
+    expect(dust.rotation.z).toBeCloseTo(Math.sin(3 * 0.07) * 0.06, 12);
+    expect(stars.rotation.z).toBeCloseTo(Math.cos(3 * 0.05) * 0.05, 12);
+  });
+
+  it("breathes the whole cloud outward on respond plus energy", () => {
+    const { handle, dust, stars } = buildNebula();
+    handle.frame(frame(0, 1, 1));
+    expect(dust.scale.x).toBeCloseTo(1 + 1 * 0.12 + 1 * 0.06, 12);
+    expect(stars.scale.x).toBeCloseTo(0.98 + 1 * 0.1 + 1 * 0.04, 12);
+  });
+
+  it("pulses dust opacity above its idle base with energy and respond", () => {
+    const { handle, dust } = buildNebula();
+    handle.frame(frame(0, 1, 1));
+    // Observed behaviour: the formula is unclamped, so full energy+respond
+    // lands slightly above 1 rather than saturating.
+    expect(dust.material.opacity).toBeCloseTo(0.62 + 0.32 + 0.08, 12);
+  });
+
+  it("flushes the dust tint toward magenta in proportion to respond", () => {
+    const { handle, dust } = buildNebula();
+    handle.frame(frame(0, 0, 1));
+    expect(dust.material.color.r).toBeCloseTo(1.35, 12);
+    expect(dust.material.color.g).toBeCloseTo(0.72, 12);
+    expect(dust.material.color.b).toBeCloseTo(1.18, 12);
+    handle.frame(frame(0, 0, 0.5));
+    expect(dust.material.color.r).toBeCloseTo(1.175, 12);
+    expect(dust.material.color.g).toBeCloseTo(0.86, 12);
+    expect(dust.material.color.b).toBeCloseTo(1.09, 12);
+  });
+
+  it("advances the twinkle accumulator across frames instead of resetting it", () => {
+    const { handle, stars } = buildNebula();
+    const starMat = stars.material as any;
+    handle.frame(frame(0, 0, 0));
+    const first = starMat.opacity;
+    handle.frame(frame(0, 0, 0));
+    // Phase advances before each paint: the two calls sample 0.09 then 0.18;
+    // multiplier stays 0.7.
+    const twinkleAtPhase = (phase: number) =>
+      (0.72 + Math.sin(phase * 2.3) * 0.18 + Math.cos(phase * 3.7) * 0.08) *
+      0.7;
+    expect(first).toBeCloseTo(twinkleAtPhase(0.09), 12);
+    expect(starMat.opacity).toBeCloseTo(twinkleAtPhase(0.18), 12);
+  });
+
+  it("pulses the core's opacity and size on energy and respond", () => {
+    const { handle, core } = buildNebula();
+    handle.frame(frame(0, 1, 1));
+    expect(core.material.opacity).toBeCloseTo(0.22 + 0.28 + 0.22, 12);
+    expect((core.material as any).size).toBeCloseTo(0.38 + 0.18 + 0.12, 12);
+  });
+});
+
+describe("nebula dispose", () => {
+  it("disposes all three geometries and materials and removes all three clouds from the parent", () => {
+    const { parent, handle, dust, stars, core } = buildNebula();
+    const resources = [
+      dust.geometry,
+      dust.material,
+      stars.geometry,
+      stars.material,
+      core.geometry,
+      core.material,
+    ];
+    const spies = resources.map((r) => vi.spyOn(r, "dispose"));
+    handle.dispose();
+    for (const spy of spies) {
+      expect(spy).toHaveBeenCalledTimes(1);
+    }
+    expect(parent.children.length).toBe(0);
+  });
+});


### PR DESCRIPTION

## What

Adds a unit test suite for the nebula voice-orb concept (`packages/ui/stories/src/concepts/nebula.ts`), which had no same-named test file anywhere on `develop`.

The suite drives the real `concept.build` against real `three/webgpu` classes (headless-safe, no GPU/DOM) and asserts observable behaviour only:

- **descriptor**: id/label/family registration and callable builder
- **build**: exactly three `THREE.Points` children (dust 680 vertices with a per-point color attribute, stars 44 without one, core 3 points at origin), none frustum-culled; dust radius ≤ 1.28 and star radius ∈ [0.08, 1.26] — bounds invariant under the builder's RNG; all color channels within [0,1]; each cloud gets its own transparent, depth-write-off, normal-blended `PointsNodeMaterial` (deliberately *not* additive) with the documented sizes/opacities/colors; differential galactic tilt (dust 0.22 vs stars 0.18)
- **frame**: idle pose overwrites stale material state; per-layer swirl multiples of the shared speed (0.65× stars, 1.1× core); energy boost; out-of-phase z-drift; breathe scaling; unclamped dust opacity pulse (observed 1.02 at full energy+respond — recorded as-is, no aspirational clamp); respond-proportional magenta tint flush; twinkle phase accumulator advancing across frames (phase advances before paint, so the first frame samples 0.09); core opacity/size pulse
- **dispose**: all six geometries/materials disposed exactly once, all three clouds removed from the parent

No mocks asserting mocks, no type-level assertions (`expectTypeOf` absent), no snapshot of literals — every expectation was observed by running the module.

## Evidence

Test-only change; diff is one new file, +291/−0 (`git diff --name-status`: `A packages/ui/stories/src/concepts/nebula.test.ts`). No production file touched. Counts below are local runs quoted verbatim; as a fork contributor hosted CI does not run on this PR.

1. **vitest** (against current `origin/develop`, whose `nebula.ts` blob `3de3f88e` is byte-identical to the tested tree):

   ```
   Test Files  1 passed (1)
        Tests  21 passed (21)
   ```

2. **biome** — `bunx biome check packages/ui/stories/src/concepts/nebula.test.ts` exits 0. It reports 18 `lint/suspicious/noExplicitAny` warnings, which is the established profile for these concept suites at the loose orb-kit renderer boundary (the neighbouring concept tests carry the same rule warnings under the same root config); zero errors, formatting clean.

3. **tsc** — strict per-file check with the stories package's compiler options exits 0; `grep nebula.test.ts` over output finds nothing. Note: `packages/ui/stories/tsconfig.json` currently fails config parse on `develop` itself (`TS5102: Option 'baseUrl' has been removed` under the repo-pinned TypeScript 6.0.3) — that error exists identically before this PR's file is added, so the suite was checked via direct invocation with the same options minus the removed key. Fixing that upstream config drift is production work outside a test-only diff.

4. This pull request touches only the test file named above.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:e9d932551572d615a9e380bb694494f486f298f2 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
