### PR TITLE
fix(core): cap semaphore permits on release to prevent unbounded growth

### DIFF
--- a/packages/core/src/utils/batch-queue/semaphore.test.ts
+++ b/packages/core/src/utils/batch-queue/semaphore.test.ts
@@ -64,4 +64,71 @@ describe("Semaphore", () => {
 		expect(sem.queueLength).toBe(0);
 		expect(sem.availablePermits).toBe(1);
 	});
+
+	it("caps permits on extra release without paired acquire", async () => {
+		const sem = new Semaphore(1);
+		await sem.acquire();
+		expect(sem.availablePermits).toBe(0);
+		sem.release();
+		expect(sem.availablePermits).toBe(1);
+		sem.release();
+		expect(sem.availablePermits).toBe(1);
+		sem.release();
+		expect(sem.availablePermits).toBe(1);
+	});
+
+	it("does not allow double release to create extra concurrency", async () => {
+		const sem = new Semaphore(1);
+		await sem.acquire();
+		sem.release();
+		sem.release();
+		expect(sem.availablePermits).toBe(1);
+		await sem.acquire();
+		expect(sem.availablePermits).toBe(0);
+		let secondAcquired = false;
+		const second = sem.acquire().then(() => {
+			secondAcquired = true;
+		});
+		await Promise.resolve();
+		expect(secondAcquired).toBe(false);
+		expect(sem.queueLength).toBe(1);
+		sem.release();
+		await second;
+		expect(secondAcquired).toBe(true);
+		expect(sem.availablePermits).toBe(0);
+		sem.release();
+		expect(sem.availablePermits).toBe(1);
+	});
+
+	it("caps permits at initial capacity for larger semaphores", async () => {
+		const sem = new Semaphore(2);
+		await sem.acquire();
+		await sem.acquire();
+		expect(sem.availablePermits).toBe(0);
+		sem.release();
+		expect(sem.availablePermits).toBe(1);
+		sem.release();
+		expect(sem.availablePermits).toBe(2);
+		sem.release();
+		expect(sem.availablePermits).toBe(2);
+		sem.release();
+		expect(sem.availablePermits).toBe(2);
+	});
+
+	it("hands off to waiter without inflating permits", async () => {
+		const sem = new Semaphore(1);
+		await sem.acquire();
+		let waiterAcquired = false;
+		const waiter = sem.acquire().then(() => {
+			waiterAcquired = true;
+		});
+		expect(sem.queueLength).toBe(1);
+		sem.release();
+		await waiter;
+		expect(waiterAcquired).toBe(true);
+		expect(sem.availablePermits).toBe(0);
+		expect(sem.queueLength).toBe(0);
+		sem.release();
+		expect(sem.availablePermits).toBe(1);
+	});
 });

--- a/packages/core/src/utils/batch-queue/semaphore.ts
+++ b/packages/core/src/utils/batch-queue/semaphore.ts
@@ -10,13 +10,16 @@
  */
 export class Semaphore {
 	private permits: number;
+	private maxPermits: number;
 	private waiters: Array<() => void> = [];
 
 	constructor(count: number) {
-		this.permits =
+		const sanitized =
 			typeof count === "number" && Number.isFinite(count)
 				? Math.max(1, Math.floor(count))
 				: 1;
+		this.permits = sanitized;
+		this.maxPermits = sanitized;
 	}
 
 	/** Number of currently available permits. */
@@ -41,11 +44,13 @@ export class Semaphore {
 	}
 
 	release(): void {
-		this.permits += 1;
 		const next = this.waiters.shift();
-		if (next && this.permits > 0) {
-			this.permits -= 1;
+		if (next) {
 			next();
+			return;
+		}
+		if (this.permits < this.maxPermits) {
+			this.permits += 1;
 		}
 	}
 }


### PR DESCRIPTION
# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Single utility class change (`Semaphore.release`). Only caps permit count; handoff logic preserved. No new dependencies or API surface changes.

# Background

## What does this PR do?

Fixes `Semaphore.release()` unbounded growth. Extra `release()` without paired `acquire()` previously inflated `availablePermits` beyond the constructed capacity, breaking throttle guarantees for `BatchProcessor` and `PromptDispatcher`. Now stores `maxPermits` and caps `release()` at that ceiling, handing off directly to waiters without incrementing.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/core/src/utils/batch-queue/semaphore.test.ts` — new edge-case tests for cap behavior.

## Detailed testing steps

- `bun test packages/core/src/utils/batch-queue/semaphore.test.ts` — 8 pass (red: 3 fail when reverted).
- `bun test packages/core/src/utils/batch-queue/batch-processor.test.ts` — 21 pass (no regression).

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:7f460a9fee8f458ff8a8a8a53bc872805c8ee2b7 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI surface`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI surface`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - no UI surface`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - backend unit test; logs not applicable`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend change`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - no LLM change`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - no domain artifact`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM change.

## Backend + frontend logs

N/A - backend unit test; logs not applicable.

## Screenshots (before / after) + video walkthrough

N/A - no UI surface.

### Before

N/A - no UI surface.

### After

N/A - no UI surface.

### Walkthrough video

N/A - no UI surface.

## Audio / voice walkthrough

N/A - no voice change.

## Known gaps / failures

- `bun run verify` full-repo verify fails on unrelated pre-existing module resolution for `yaml` import in `packages/scripts/ci-bun-version-contract.mjs` and `priority-queue`/`process-batch` logger errors (reproduced on `origin/develop` at same base SHA). Scoped package tests and type generation pass; only affected-path gates are required under exception doc.
- `bun test packages/core/src/utils/batch-queue/` pre-existing 2 failures in `priority-queue.test.ts`/`process-batch.test.ts` due to missing `@elizaos/logger` module (reproduced on `origin/develop` with change reverted).

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`


---

## Red / Green Evidence

**Red (production reverted to buggy `release()` — permits unbounded):**

```
bun test v1.3.11 (af24e281)

  (fail) Semaphore > caps permits on extra release without paired acquire [0.64ms]
  error: expect(received).toBe(expected) Expected: 1 Received: 2
  (fail) Semaphore > does not allow double release to create extra concurrency [0.01ms]
  error: expect(received).toBe(expected) Expected: 1 Received: 2
  (fail) Semaphore > caps permits at initial capacity for larger semaphores [0.07ms]
  error: expect(received).toBe(expected) Expected: 2 Received: 3

  5 pass
  3 fail
```

**Green (fixed — caps at maxPermits, handoff without inflate):**

```
bun test v1.3.11 (af24e281)
  8 pass
  0 fail
  39 expect() calls
  Ran 8 tests across 1 file. [17.00ms]
```
