### PR TITLE
fix(core): reject non-serializable top-level JSON in atomic writes

### DIFF
--- a/packages/core/src/utils/atomic-json.test.ts
+++ b/packages/core/src/utils/atomic-json.test.ts
@@ -134,5 +134,48 @@ describe("atomic-json", () => {
 				TypeError,
 			);
 		});
+
+		it("rejects undefined top-level value instead of writing literal undefined", async () => {
+			const target = path.join(tempDir, "undefined-async.json");
+			await expect(writeJsonAtomic(target, undefined)).rejects.toThrow(
+				TypeError,
+			);
+			await expect(writeJsonAtomic(target, undefined)).rejects.toThrow(
+				/Converting undefined value to JSON is not supported/,
+			);
+			expect(await readJsonFile(target)).toBeNull();
+			const files = await fsp.readdir(tempDir);
+			expect(files.filter((f) => f.includes("undefined-async"))).toEqual([]);
+		});
+
+		it("rejects symbol top-level value", async () => {
+			const target = path.join(tempDir, "symbol-async.json");
+			await expect(
+				writeJsonAtomic(target, Symbol("x") as unknown as object),
+			).rejects.toThrow(TypeError);
+			expect(await readJsonFile(target)).toBeNull();
+		});
+
+		it("rejects undefined top-level value synchronously", () => {
+			const target = path.join(tempDir, "undefined-sync.json");
+			expect(() => writeJsonAtomicSync(target, undefined)).toThrow(TypeError);
+			expect(() => writeJsonAtomicSync(target, undefined)).toThrow(
+				/Converting undefined value to JSON is not supported/,
+			);
+			expect(readJsonFileSync(target)).toBeNull();
+			const files = fs.readdirSync(tempDir);
+			expect(files.filter((f) => f.includes("undefined-sync"))).toEqual([]);
+		});
+
+		it("does not leak stale tmp file on undefined rejection", async () => {
+			const target = path.join(tempDir, "leak-check.json");
+			await expect(writeJsonAtomic(target, undefined)).rejects.toThrow(
+				TypeError,
+			);
+			const files = await fsp.readdir(tempDir);
+			expect(files).toEqual([]);
+			await writeJsonAtomic(target, { ok: 1 });
+			expect(await readJsonFile<{ ok: number }>(target)).toEqual({ ok: 1 });
+		});
 	});
 });

--- a/packages/core/src/utils/atomic-json.ts
+++ b/packages/core/src/utils/atomic-json.ts
@@ -61,6 +61,11 @@ function tmpPathFor(filePath: string): string {
 
 function serialize(value: unknown, opts: NormalizedWriteOptions): string {
 	const body = JSON.stringify(value, null, opts.indent);
+	if (body === undefined) {
+		throw new TypeError(
+			`Converting ${typeof value} value to JSON is not supported`,
+		);
+	}
 	return opts.trailingNewline ? `${body}\n` : body;
 }
 


### PR DESCRIPTION
# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Single helper `serialize()` in `atomic-json.ts` now throws early for non-serializable top-level values. No API change; previously produced corrupt `undefined` files or `ERR_INVALID_ARG_TYPE`.

# Background

## What does this PR do?

Fixes `atomic-json` `serialize()` where `JSON.stringify(undefined)` returns `undefined` and was coerced to `"undefined\n"` (or passed as `undefined` to `writeFile`). Now throws `TypeError("Converting undefined value to JSON is not supported")` before tmp creation, matching `fs-extra-lite` and preventing stale artifacts.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/core/src/utils/atomic-json.test.ts` — new validation for undefined/symbol top-level values and leak check.

## Detailed testing steps

- `bun test packages/core/src/utils/atomic-json.test.ts` — 14 pass (red: 2 fail when reverted).
- Existing concurrent write and ENOENT tests still pass.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:0960021b231cb89bbe114da1fcafdadf351e5b63 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI surface`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI surface`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - no UI surface`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - backend unit test; logs not applicable`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend change`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - no LLM change`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - no domain artifact`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM change.

## Backend + frontend logs

N/A - backend unit test; logs not applicable.

## Screenshots (before / after) + video walkthrough

N/A - no UI surface.

### Before

N/A - no UI surface.

### After

N/A - no UI surface.

### Walkthrough video

N/A - no UI surface.

## Audio / voice walkthrough

N/A - no voice change.

## Known gaps / failures

- `bun run verify` full-repo fails on pre-existing `yaml` module missing in scripts and unrelated package type errors (reproduced on `origin/develop` at same base SHA).

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`


---

## Red / Green Evidence

**Red (buggy `serialize` without guard — `JSON.stringify(undefined)` => undefined):**

```
atomic-json > concurrency and validation > rejects undefined top-level value instead of writing literal undefined [0.49ms]
  error: expect(received).toThrow(expected) Expected pattern: /Converting undefined value to JSON is not supported/
  Received message: "The \"data\" argument must be of type string or an instance of Buffer, TypedArray, or DataView"
  (fail) 2 fail, 12 pass

atomic-json > concurrency and validation > rejects undefined top-level value synchronously [0.26ms]
  error: expect(received).toThrow(expected) Expected pattern: /Converting undefined value to JSON is not supported/
  Received message: "The \"data\" argument must be of type string or an instance of Buffer, TypedArray, or DataView"
```

**Green (fixed — early TypeError, no tmp leak):**

```
bun test v1.3.11 (af24e281)
  14 pass
  0 fail
  29 expect() calls
  Ran 14 tests across 1 file. [39.00ms]
```
