### PR TITLE
fix(agent): decode config.env escapes with single-pass scanner

### DIFF
--- a/packages/agent/src/api/config-env.test.ts
+++ b/packages/agent/src/api/config-env.test.ts
@@ -10,7 +10,11 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { persistConfigEnv } from "./config-env.ts";
+import {
+  persistConfigEnv,
+  readConfigEnv,
+  readConfigEnvSync,
+} from "./config-env.ts";
 
 let stateDir: string;
 let envSnapshot: NodeJS.ProcessEnv;
@@ -118,5 +122,50 @@ describe("persistConfigEnv still writes what config.env exists to hold", () => {
     expect(contents).toContain("UVICORN_HOST=ok");
     expect(contents).toContain("DOCKERFILE_PATH=ok");
     expect(contents).toContain("GIT_CONFIGURATION=ok");
+  });
+});
+
+describe("config.env encode/decode round-trip preserves escapes", () => {
+  it("round-trips a value containing a real newline", async () => {
+    const key = "ELIZA_ROUNDTRIP_NEWLINE";
+    const value = "a\nb";
+    await persistConfigEnv(key, value, { stateDir });
+    const out = await readConfigEnv(stateDir);
+    expect(out[key]).toBe(value);
+    expect(readConfigEnvSync(stateDir)[key]).toBe(value);
+  });
+
+  it("preserves literal backslash-n without corrupting to newline", async () => {
+    const key = "ELIZA_ROUNDTRIP_LITERAL_BS_N";
+    const value = "a\\nb";
+    await persistConfigEnv(key, value, { stateDir });
+    const out = await readConfigEnv(stateDir);
+    expect(out[key]).toBe(value);
+    expect(readConfigEnvSync(stateDir)[key]).toBe(value);
+    const raw = await readFile(path.join(stateDir, "config.env"), "utf8");
+    expect(raw).toContain(`${key}="a\\\\nb"`);
+  });
+
+  it("preserves Windows-style path with backslash", async () => {
+    const key = "ELIZA_ROUNDTRIP_WINPATH";
+    const value = "C:\\new\\file.txt";
+    await persistConfigEnv(key, value, { stateDir });
+    expect((await readConfigEnv(stateDir))[key]).toBe(value);
+    expect(readConfigEnvSync(stateDir)[key]).toBe(value);
+  });
+
+  it("round-trips quotes, backslashes and mixed escapes", async () => {
+    const key = "ELIZA_ROUNDTRIP_MIXED";
+    const value = 'a"b\\c\nd\re';
+    await persistConfigEnv(key, value, { stateDir });
+    expect((await readConfigEnv(stateDir))[key]).toBe(value);
+    expect(readConfigEnvSync(stateDir)[key]).toBe(value);
+  });
+
+  it("round-trips literal backslash before quoted quote", async () => {
+    const key = "ELIZA_ROUNDTRIP_BS_QUOTE";
+    const value = 'a\\"b';
+    await persistConfigEnv(key, value, { stateDir });
+    expect((await readConfigEnv(stateDir))[key]).toBe(value);
   });
 });

--- a/packages/agent/src/api/config-env.ts
+++ b/packages/agent/src/api/config-env.ts
@@ -249,11 +249,35 @@ function decodeValue(raw: string): string {
   ) {
     const inner = trimmed.slice(1, -1);
     if (first === '"') {
-      return inner
-        .replace(/\\n/g, "\n")
-        .replace(/\\r/g, "\r")
-        .replace(/\\"/g, '"')
-        .replace(/\\\\/g, "\\");
+      let out = "";
+      for (let i = 0; i < inner.length; i += 1) {
+        const ch = inner[i];
+        if (ch === "\\" && i + 1 < inner.length) {
+          const next = inner[i + 1];
+          if (next === "n") {
+            out += "\n";
+            i += 1;
+            continue;
+          }
+          if (next === "r") {
+            out += "\r";
+            i += 1;
+            continue;
+          }
+          if (next === '"') {
+            out += '"';
+            i += 1;
+            continue;
+          }
+          if (next === "\\") {
+            out += "\\";
+            i += 1;
+            continue;
+          }
+        }
+        out += ch ?? "";
+      }
+      return out;
     }
     return inner;
   }


### PR DESCRIPTION
# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Single function `decodeValue()` in `config-env.ts` — parsing only, no API change. Fixes corruption of literal `\n` sequences (e.g., Windows paths).

# Background

## What does this PR do?

Fixes sequential `replace(/\\n/) -> replace(/\\r/) -> replace(/\\"/) -> replace(/\\\\)` in `decodeValue()` which corrupted literal backslash-n (`a\` + `n` literal) into a newline. Encoding `a\\nb` as `"a\\nb"` then decoding incorrectly produced `a` + newline + `b`. Replaced with single-pass scanner that respects escape boundaries.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/agent/src/api/config-env.test.ts` — new round-trip tests for literal backslash-n and Windows paths.

## Detailed testing steps

- `bun run --cwd packages/agent vitest run src/api/config-env.test.ts --coverage.enabled=false` — 30 pass (red: 2 fail when reverted).
- Existing hijack-vector tests still pass (28).

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:39841fd774adaacefbfc080c0cce3ca5d5a961a4 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI surface`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI surface`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - no UI surface`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - backend unit test; logs not applicable`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend change`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - no LLM change`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - no domain artifact`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM change.

## Backend + frontend logs

N/A - backend unit test; logs not applicable.

## Screenshots (before / after) + video walkthrough

N/A - no UI surface.

### Before

N/A - no UI surface.

### After

N/A - no UI surface.

### Walkthrough video

N/A - no UI surface.

## Audio / voice walkthrough

N/A - no voice change.

## Known gaps / failures

- `bun run verify` full-repo fails on pre-existing `yaml` missing in scripts (reproduced on `origin/develop` at same base SHA).

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`


---

## Red / Green Evidence

**Red (buggy sequential replace — literal `a\`+`n` corrupted):**

```
FAIL  config.env encode/decode round-trip preserves escapes > preserves literal backslash-n without corrupting to newline
  expected 'a\
  b' to be 'a\nb' // Object.is equality

FAIL  config.env encode/decode round-trip preserves escapes > preserves Windows-style path with backslash
  expected 'C:\new\file.txt' to be 'C:\new\file.txt'
  Received: C:\
  ew\file.txt (newline injected)

Test Files  1 failed (1)
     Tests  2 failed | 28 passed (30)
```

**Green (fixed single-pass scanner):**

```
Test Files  1 passed (1)
     Tests  30 passed (30)
Duration  2.70s
```
