### PR TITLE
fix(core): use unique tmp file for project registry writes

### DIFF
--- a/packages/core/src/utils/project-registry.test.ts
+++ b/packages/core/src/utils/project-registry.test.ts
@@ -238,4 +238,40 @@ describe("project-registry", () => {
 		expect(reg?.activeProjectId).toBe("p1");
 		expect(reg?.projects[0]?.name).toBe("a");
 	});
+
+	it("uses unique tmp file per write and leaves no stale tmp", () => {
+		const reg = {
+			version: 1 as const,
+			activeProjectId: null,
+			projects: [],
+		};
+		// Mock Date.now to same millisecond to prove sequence counter provides uniqueness
+		const origDateNow = Date.now;
+		let call = 0;
+		(Date as unknown as { now: () => number }).now = () => 1_700_000_000_000;
+		try {
+			writeProjectRegistry(reg, env);
+			writeProjectRegistry(reg, env);
+			const files = (() => {
+				try {
+					return (
+						require("node:fs").readdirSync(stateDir) as string[]
+					);
+				} catch {
+					return [];
+				}
+			})();
+			expect(files).toEqual(["projects.json"]);
+			// Verify tmp was unique by checking that two writes didn't collide on same pid.tmp name:
+			// Old code would have used `${path}.${pid}.tmp` — if we had a stale file there, new code would not overwrite it.
+			const stale = `${projectRegistryPath(env)}.${process.pid}.tmp`;
+			writeFileSync(stale, "stale", "utf8");
+			writeProjectRegistry(reg, env);
+			// New code leaves stale file untouched (unique tmp), old code would have overwritten it
+			expect(readFileSync(stale, "utf8")).toBe("stale");
+			rmSync(stale, { force: true });
+		} finally {
+			(Date as unknown as { now: () => number }).now = origDateNow;
+		}
+	});
 });

--- a/packages/core/src/utils/project-registry.ts
+++ b/packages/core/src/utils/project-registry.ts
@@ -27,6 +27,7 @@ import {
 	readFileSync,
 	realpathSync,
 	renameSync,
+	rmSync,
 	writeFileSync,
 } from "node:fs";
 import { dirname, join, resolve } from "node:path";
@@ -217,6 +218,13 @@ function canonicalizeLocalPath(localPath: string): string {
  * `isProjectRegistry` rejects both as `null`, but only the latter holds a user's
  * projects a downgrade would silently drop.
  */
+let tmpSequenceCounter = 0n;
+
+function tmpPathFor(filePath: string): string {
+	tmpSequenceCounter += 1n;
+	return `${filePath}.tmp-${process.pid}-${Date.now()}-${tmpSequenceCounter}`;
+}
+
 function readRegistryVersionOnDisk(env: NodeJS.ProcessEnv): number | null {
 	const filePath = projectRegistryPath(env);
 	let raw: string;
@@ -265,9 +273,19 @@ export function writeProjectRegistry(
 	}
 	const filePath = projectRegistryPath(env);
 	mkdirSync(dirname(filePath), { recursive: true });
-	const tmpPath = `${filePath}.${process.pid}.tmp`;
-	writeFileSync(tmpPath, `${JSON.stringify(registry, null, 2)}\n`, "utf8");
-	renameSync(tmpPath, filePath);
+	const tmpPath = tmpPathFor(filePath);
+	try {
+		writeFileSync(tmpPath, `${JSON.stringify(registry, null, 2)}\n`, "utf8", {
+			flag: "wx",
+		});
+		renameSync(tmpPath, filePath);
+	} finally {
+		try {
+			rmSync(tmpPath, { force: true });
+		} catch {
+			// error-policy:J6 best-effort tmp cleanup; must not mask write/rename error.
+		}
+	}
 	return registry;
 }
 


### PR DESCRIPTION
# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Single file `project-registry.ts` atomic write helper now uses unique tmp per call with `wx` and cleanup. Mirrors `atomic-json.ts` already merged pattern. No API change.

# Background

## What does this PR do?

Fixes deterministic tmp `${filePath}.${pid}.tmp` collision. Two concurrent `upsertProject`/`writeProjectRegistry` calls shared the same tmp, overwriting each other before rename, and a crash left a stale tmp that next write reused. Now uses `${filePath}.tmp-${pid}-${Date.now()}-${seq}` with `wx` and best-effort cleanup.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/core/src/utils/project-registry.test.ts` — new test for unique tmp and stale-file preservation.

## Detailed testing steps

- `bun --cwd packages/core vitest run src/utils/project-registry.test.ts --coverage.enabled=false` — 14 pass (red: 1 fail when reverted).
- Existing legacy synthesis and upsert tests still pass.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:8fc6f7eb8f6ea05ca3bdb4ddf99581a868432e52 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI surface`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI surface`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - no UI surface`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - backend unit test; logs not applicable`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend change`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - no LLM change`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - no domain artifact`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM change.

## Backend + frontend logs

N/A - backend unit test; logs not applicable.

## Screenshots (before / after) + video walkthrough

N/A - no UI surface.

### Before

N/A - no UI surface.

### After

N/A - no UI surface.

### Walkthrough video

N/A - no UI surface.

## Audio / voice walkthrough

N/A - no voice change.

## Known gaps / failures

- `bun run verify` full-repo fails on pre-existing `yaml` missing (reproduced on `origin/develop` at same base SHA).

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`


---

## Red / Green Evidence

**Red (buggy deterministic `${pid}.tmp` — stale file overwritten):**

```
FAIL  src/utils/project-registry.test.ts > project-registry > uses unique tmp file per write and leaves no stale tmp
  Error: ENOENT: no such file or directory, open '.../projects.json.73469.tmp'
    expect(readFileSync(stale, "utf8")).toBe("stale") — stale file was overwritten by buggy tmp reuse, then deleted on rename
  Tests  1 failed | 13 passed (14)
```

**Green (fixed unique tmp — stale preserved, no leakage):**

```
Test Files  1 passed (1)
     Tests  14 passed (14)
  Duration  122ms
```
