### PR TITLE
fix(agent): handle escapes in vfs shell tokenizer

### DIFF
--- a/packages/agent/src/services/vfs-builtin-shell.test.ts
+++ b/packages/agent/src/services/vfs-builtin-shell.test.ts
@@ -208,4 +208,32 @@ describe("runVfsBuiltinShell", () => {
 
     expect(result).toMatchObject({ exitCode: 0, stderr: "" });
   });
+
+  it("tokenizes escaped quotes inside double-quoted args", async () => {
+    const result = await runVfsBuiltinShell({
+      cwdUri: "vfs://escape/",
+      command: "sh",
+      args: ["-c", 'echo "a \\"b\\" c"'],
+    });
+    expect(result).toMatchObject({ exitCode: 0, stdout: 'a "b" c\n' });
+  });
+
+  it("handles backslashes and single-quoted escapes correctly", async () => {
+    const result = await runVfsBuiltinShell({
+      cwdUri: "vfs://escape2/",
+      command: "sh",
+      args: ["-c", 'echo "a\\\\b" && echo \'a\\b\''],
+    });
+    expect(result.stdout).toContain("a\\b\n");
+    expect(result.stdout).toContain("a\\b\n");
+  });
+
+  it("preserves quoted paths with spaces via echo", async () => {
+    const result = await runVfsBuiltinShell({
+      cwdUri: "vfs://spaces/",
+      command: "sh",
+      args: ["-c", 'echo "file with spaces.txt"'],
+    });
+    expect(result).toMatchObject({ exitCode: 0, stdout: "file with spaces.txt\n" });
+  });
 });

--- a/packages/agent/src/services/vfs-builtin-shell.ts
+++ b/packages/agent/src/services/vfs-builtin-shell.ts
@@ -547,11 +547,53 @@ function normalizeAbsoluteVirtualPath(input: string): string {
 
 function tokenize(input: string): string[] {
   const tokens: string[] = [];
-  const re = /"([^"]*)"|'([^']*)'|(\S+)/g;
-  let match = re.exec(input);
-  while (match) {
-    tokens.push(match[1] ?? match[2] ?? match[3] ?? "");
-    match = re.exec(input);
+  let current = "";
+  let quote: "'" | '"' | null = null;
+  let escaped = false;
+  let inToken = false;
+
+  for (let i = 0; i < input.length; i += 1) {
+    const ch = input[i] ?? "";
+    if (escaped) {
+      current += ch;
+      escaped = false;
+      inToken = true;
+      continue;
+    }
+    if (ch === "\\" && quote !== "'") {
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      if (ch === quote) {
+        quote = null;
+        continue;
+      }
+      current += ch;
+      inToken = true;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch as "'" | '"';
+      inToken = true;
+      continue;
+    }
+    if (/\s/.test(ch)) {
+      if (inToken) {
+        tokens.push(current);
+        current = "";
+        inToken = false;
+      }
+      continue;
+    }
+    current += ch;
+    inToken = true;
+  }
+  if (escaped) {
+    current += "\\";
+  }
+  if (inToken || current.length > 0 || quote !== null) {
+    tokens.push(current);
   }
   return tokens;
 }


### PR DESCRIPTION
# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Single function `tokenize` in `vfs-builtin-shell.ts` — parsing only. Fixes quoted echo/cat with escaped quotes and paths with spaces.

# Background

## What does this PR do?

Fixes `tokenize` regex that ignored `\"`/`\\` escapes inside quotes. `echo "a \"b\" c"` was tokenised as 3 broken tokens, producing wrong stdout. Replaced with scanner that respects escaped state per `splitScriptSegments` logic.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/agent/src/services/vfs-builtin-shell.test.ts` — new tests for escaped quotes, backslashes, and quoted paths.

## Detailed testing steps

- `bun --cwd packages/agent vitest run src/services/vfs-builtin-shell.test.ts --coverage.enabled=false` — 16 pass (red: 1 fail when reverted).

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:c7e6974797ee065a6f03e101fa673d0f3dd9af4a -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI surface`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI surface`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - no UI surface`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - backend unit test; logs not applicable`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend change`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - no LLM change`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - no domain artifact`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM change.

## Backend + frontend logs

N/A - backend unit test; logs not applicable.

## Screenshots (before / after) + video walkthrough

N/A - no UI surface.

### Before

N/A - no UI surface.

### After

N/A - no UI surface.

### Walkthrough video

N/A - no UI surface.

## Audio / voice walkthrough

N/A - no voice change.

## Known gaps / failures

- `bun run verify` full-repo fails on pre-existing `yaml` missing (reproduced on `origin/develop` at same base SHA).

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`


---

## Red / Green Evidence

**Red (buggy regex — escaped quote broken):**

```
FAIL  tokenizes escaped quotes inside double-quoted args
  expected stdout 'a "b" c\n' but received 'a \ b\" c" \n' (fragmented tokens)
  Tests  1 failed | 15 passed (16)
```

**Green (fixed scanner):**

```
Test Files  1 passed (1)
     Tests  16 passed (16)
```
