### PR TITLE
fix(cloud): isolate hash-router rings by namespace

### DIFF
--- a/packages/cloud/services/gateway-discord/src/hash-router.ts
+++ b/packages/cloud/services/gateway-discord/src/hash-router.ts
@@ -20,6 +20,10 @@ interface RingState {
 const rings = new Map<string, RingState>();
 const refreshes = new Map<string, Promise<RingState | undefined>>();
 
+function ringKey(namespace: string, serviceName: string): string {
+	return `${namespace}/${serviceName}`;
+}
+
 function parseServerUrl(serverUrl: string): {
   serviceName: string;
   namespace: string;
@@ -104,16 +108,19 @@ function sameIPs(a: string[], b: string[]): boolean {
 }
 
 function updateRing(
+  namespace: string,
   serviceName: string,
   podIPs: string[],
   existing?: RingState,
 ): RingState | undefined {
+  const key = ringKey(namespace, serviceName);
   if (podIPs.length === 0) {
     if (existing) {
       logger.info("[hash-router] All pods gone, clearing ring", {
         serviceName,
+        namespace,
       });
-      rings.delete(serviceName);
+      rings.delete(key);
     }
     return undefined;
   }
@@ -143,11 +150,12 @@ function updateRing(
     lastRefresh: now,
     lastAttempt: now,
   };
-  rings.set(serviceName, state);
+  rings.set(key, state);
   return state;
 }
 
 function retainUsableStaleRing(
+  namespace: string,
   serviceName: string,
   existing: RingState | undefined,
 ): RingState | undefined {
@@ -158,9 +166,10 @@ function retainUsableStaleRing(
   }
   logger.warn("[hash-router] Discovery failed, dropping stale ring", {
     serviceName,
+    namespace,
     staleForMs,
   });
-  rings.delete(serviceName);
+  rings.delete(ringKey(namespace, serviceName));
   return undefined;
 }
 
@@ -168,11 +177,11 @@ function refreshRing(
   serviceName: string,
   namespace: string,
 ): Promise<RingState | undefined> {
-  const refreshKey = `${namespace}/${serviceName}`;
+  const refreshKey = ringKey(namespace, serviceName);
   const inFlight = refreshes.get(refreshKey);
   if (inFlight) return inFlight;
 
-  const current = rings.get(serviceName);
+  const current = rings.get(refreshKey);
   if (current) current.lastAttempt = Date.now();
 
   let refresh!: Promise<RingState | undefined>;
@@ -180,8 +189,17 @@ function refreshRing(
     try {
       const resolution = await resolvePodIPs(serviceName, namespace);
       return resolution.ok
-        ? updateRing(serviceName, resolution.podIPs, rings.get(serviceName))
-        : retainUsableStaleRing(serviceName, rings.get(serviceName));
+        ? updateRing(
+            namespace,
+            serviceName,
+            resolution.podIPs,
+            rings.get(refreshKey),
+          )
+        : retainUsableStaleRing(
+            namespace,
+            serviceName,
+            rings.get(refreshKey),
+          );
     } finally {
       if (refreshes.get(refreshKey) === refresh) {
         refreshes.delete(refreshKey);
@@ -217,7 +235,7 @@ export async function getHashTargets(
 
   const { serviceName, namespace, port } = parseServerUrl(serverUrl);
 
-  let entry = rings.get(serviceName);
+  let entry = rings.get(ringKey(namespace, serviceName));
   const now = Date.now();
 
   if (!entry || now - entry.lastRefresh > MAX_STALE_RING_MS) {

--- a/packages/cloud/services/gateway-discord/tests/hash-router.test.ts
+++ b/packages/cloud/services/gateway-discord/tests/hash-router.test.ts
@@ -220,4 +220,34 @@ describe("hash router", () => {
 
     await expect(getHashTargets(serverUrl, "user-1", 2)).resolves.toEqual([]);
   });
+
+  test("isolates rings by namespace for same serviceName", async () => {
+    spyOn(common, "readServiceAccountToken").mockReturnValue("test-token");
+    spyOn(common, "readServiceAccountCaCert").mockReturnValue(null);
+    spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.includes("/namespaces/staging/")) {
+        return endpointSliceResponse(["10.1.0.5"]);
+      }
+      if (url.includes("/namespaces/eliza-agents/")) {
+        return endpointSliceResponse(["10.0.0.1", "10.0.0.2"]);
+      }
+      return endpointSliceResponse([]);
+    });
+
+    const prod = await getHashTargets(
+      "http://agent-server.eliza-agents.svc.cluster.local:3000",
+      "userA",
+      1,
+    );
+    const staging = await getHashTargets(
+      "http://agent-server.staging.svc.cluster.local:3000",
+      "userA",
+      1,
+    );
+
+    expect(prod[0]).toMatch(/10\.0\.0\.\d+:3000/);
+    expect(staging[0]).toBe("10.1.0.5:3000");
+    expect(prod[0]).not.toBe(staging[0]);
+  });
 });


### PR DESCRIPTION
# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Hash-router ring map key change from serviceName to namespace/serviceName. Matches refreshes key; no API change.

# Background

## What does this PR do?

Fixes namespace collision where `rings` keyed only by `serviceName` caused `agent-server` in `eliza-agents` and `staging` to share the same pod-IP ring, leaking targets across tenants. Now keys by `${namespace}/${serviceName}` and updates `updateRing`/`retainUsableStaleRing` to use the same key.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/services/gateway-discord/tests/hash-router.test.ts` — new test isolates same serviceName across namespaces.

## Detailed testing steps

- `bun test packages/cloud/services/gateway-discord/tests/hash-router.test.ts` — 11 pass (red: 1 fail when reverted).

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:892e95ae7f72059829954d1eff344177f6d4423d -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI surface`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI surface`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - no UI surface`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - backend unit test; logs not applicable`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend change`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - no LLM change`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - no domain artifact`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM change.

## Backend + frontend logs

N/A - backend unit test; logs not applicable.

## Screenshots (before / after) + video walkthrough

N/A - no UI surface.

### Before

N/A - no UI surface.

### After

N/A - no UI surface.

### Walkthrough video

N/A - no UI surface.

## Audio / voice walkthrough

N/A - no voice change.

## Known gaps / failures

- `bun run verify` full-repo fails on pre-existing `yaml` missing (reproduced on `origin/develop` at same base SHA).

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`


---

## Red / Green Evidence

**Red (buggy shared ring — namespace collision):**

```
FAIL  isolates rings by namespace for same serviceName
  expected "10.1.0.5:3000" but received "10.0.0.2:3000" (staging returned prod IPs)
  Tests  1 failed | 10 passed (11)
```

**Green (fixed isolated rings):**

```
11 pass
0 fail
20 expect() calls
```
