### PR TITLE
test(ui): cover origami

### DIFF
--- a/packages/ui/stories/src/concepts/origami.test.ts
+++ b/packages/ui/stories/src/concepts/origami.test.ts
@@ -1,0 +1,271 @@
+/**
+ * Unit coverage for the `origami` voice-orb concept builder. Drives the real
+ * `concept.build` against the real `three/webgpu` classes (headless-safe: no
+ * GPU device or DOM is touched) and asserts the observable scene-graph
+ * contract: two counter-posed tetrahedra under per-solid pivots, flat paper
+ * materials, charcoal crease lines parented to their solids, frame state
+ * driven by time/energy/respond including the respond-clamped crease flare,
+ * and full resource teardown. Fully deterministic — no clock, no RNG.
+ */
+import * as THREE from "three/webgpu";
+import { describe, expect, it, vi } from "vitest";
+import type { OrbFrame, OrbUniforms } from "../orb-kit.ts";
+import { concept } from "./origami.ts";
+
+/** Same loose boundary type orb-kit uses for the injected renderer module. */
+type WebGPU = Record<string, any>;
+
+const THREE_WEBGPU = THREE as unknown as WebGPU;
+
+const NO_UNIFORMS = {} as OrbUniforms;
+
+function frame(time: number, energy: number, respond: number): OrbFrame {
+  return { time, energy, low: 0, listen: 0, respond };
+}
+
+function buildOrigami(): {
+  parent: any;
+  handle: { frame: (f: OrbFrame) => void; dispose: () => void };
+  pivotA: any;
+  pivotB: any;
+  meshA: any;
+  meshB: any;
+} {
+  const parent = new THREE_WEBGPU.Group();
+  const handle = concept.build(THREE_WEBGPU, {}, NO_UNIFORMS, parent);
+  // Build order is fixed by the concept: upright solid first, inverted second.
+  const pivotA = parent.children[0];
+  const pivotB = parent.children[1];
+  const meshA = pivotA.children[0];
+  const meshB = pivotB.children[0];
+  return { parent, handle, pivotA, pivotB, meshA, meshB };
+}
+
+function creaseLinesOf(mesh: any): any {
+  return mesh.children[0];
+}
+
+/** Largest vertex distance from the origin — the tetrahedron's build radius. */
+function maxVertexRadius(geometry: any): number {
+  const pos = geometry.attributes.position;
+  let max = 0;
+  for (let i = 0; i < pos.count; i++) {
+    max = Math.max(max, Math.hypot(pos.getX(i), pos.getY(i), pos.getZ(i)));
+  }
+  return max;
+}
+
+describe("origami concept descriptor", () => {
+  it("registers under id 'origami' in the artful family with a callable builder", () => {
+    expect(concept.id).toBe("origami");
+    expect(concept.label).toBe("origami");
+    expect(concept.family).toBe("artful");
+    expect(typeof concept.build).toBe("function");
+  });
+});
+
+describe("origami build", () => {
+  it("adds exactly two pivot groups to the parent, each wrapping a single tetrahedron mesh", () => {
+    const { parent, pivotA, pivotB, meshA, meshB } = buildOrigami();
+    expect(parent.children.length).toBe(2);
+    expect(pivotA).toBeInstanceOf(THREE_WEBGPU.Group);
+    expect(pivotB).toBeInstanceOf(THREE_WEBGPU.Group);
+    expect(pivotA.children.length).toBe(1);
+    expect(pivotB.children.length).toBe(1);
+    expect(meshA).toBeInstanceOf(THREE_WEBGPU.Mesh);
+    expect(meshB).toBeInstanceOf(THREE_WEBGPU.Mesh);
+  });
+
+  it("builds an upright tetrahedron of radius 0.9 and a smaller inverted one of radius 0.78", () => {
+    const { meshA, meshB } = buildOrigami();
+    // Polyhedron vertices normalize onto the sphere with ~1e-8 float slack.
+    expect(maxVertexRadius(meshA.geometry)).toBeCloseTo(0.9, 6);
+    expect(maxVertexRadius(meshB.geometry)).toBeCloseTo(0.78, 6);
+    // The inner solid nests point-down inside the upright one via the flip.
+    expect(meshA.rotation.x).toBe(0);
+    expect(meshB.rotation.x).toBe(Math.PI);
+  });
+
+  it("gives both solids independent flat-shaded paper materials with the documented constants", () => {
+    const { meshA, meshB } = buildOrigami();
+    const matA = meshA.material;
+    const matB = meshB.material;
+    expect(matA).toBeInstanceOf(THREE_WEBGPU.MeshStandardNodeMaterial);
+    expect(matB).toBeInstanceOf(THREE_WEBGPU.MeshStandardNodeMaterial);
+    expect(matA).not.toBe(matB);
+    for (const mat of [matA, matB]) {
+      expect(mat.flatShading).toBe(true);
+      expect(mat.roughness).toBeCloseTo(0.86, 12);
+      expect(mat.metalness).toBe(0);
+      expect(mat.transparent).toBe(false);
+    }
+    // Outer shell paper-white; inner solid warmed ever so slightly toward ivory.
+    expect(matA.color.r).toBeCloseTo(0.97, 12);
+    expect(matA.color.g).toBeCloseTo(0.95, 12);
+    expect(matA.color.b).toBeCloseTo(0.91, 12);
+    expect(matB.color.r).toBeCloseTo(0.99, 12);
+    expect(matB.color.g).toBeCloseTo(0.96, 12);
+    expect(matB.color.b).toBeCloseTo(0.9, 12);
+  });
+
+  it("parents charcoal crease LineSegments to each solid so they inherit its transform", () => {
+    const { meshA, meshB } = buildOrigami();
+    const linesA = creaseLinesOf(meshA);
+    const linesB = creaseLinesOf(meshB);
+    expect(linesA).toBeInstanceOf(THREE_WEBGPU.LineSegments);
+    expect(linesB).toBeInstanceOf(THREE_WEBGPU.LineSegments);
+    expect(linesA.parent).toBe(meshA);
+    expect(linesB.parent).toBe(meshB);
+    // Six tetrahedron edges come out as six start/end vertex pairs.
+    expect(linesA.geometry.attributes.position.count).toBe(12);
+    expect(linesA.geometry).not.toBe(meshA.geometry);
+    expect(linesB.geometry).not.toBe(meshB.geometry);
+    for (const lines of [linesA, linesB]) {
+      const mat = lines.material;
+      expect(mat).toBeInstanceOf(THREE_WEBGPU.LineBasicNodeMaterial);
+      expect(mat.transparent).toBe(true);
+      expect(mat.opacity).toBeCloseTo(0.9, 12);
+      expect(mat.color.r).toBeCloseTo(0.14, 12);
+      expect(mat.color.g).toBeCloseTo(0.12, 12);
+      expect(mat.color.b).toBeCloseTo(0.1, 12);
+    }
+  });
+});
+
+describe("origami frame", () => {
+  it("overwrites stale material state with the idle pose at zero time, energy and respond", () => {
+    const { handle, pivotA, pivotB, meshA, meshB } = buildOrigami();
+    const matA = meshA.material;
+    const matB = meshB.material;
+    const creaseMatA = creaseLinesOf(meshA).material;
+    matA.emissiveIntensity = -1; // sentinels: frame must overwrite all three
+    matB.emissiveIntensity = -1;
+    creaseMatA.color.setRGB(9, 9, 9);
+    handle.frame(frame(0, 0, 0));
+    // No breathe at t=0; only the fixed 0.4 unfold phase offset remains.
+    expect(pivotA.scale.x).toBeCloseTo(1, 12);
+    expect(pivotB.scale.x).toBeCloseTo(1, 12);
+    expect(pivotA.rotation.y).toBeCloseTo(Math.sin(0.4) * 0.08, 12);
+    expect(pivotB.rotation.y).toBeCloseTo(-Math.sin(0.4) * 0.08 * 0.6, 12);
+    expect(matA.emissiveIntensity).toBe(0);
+    expect(matB.emissiveIntensity).toBe(0);
+    expect(creaseMatA.color.r).toBeCloseTo(0.14, 12);
+    expect(creaseMatA.color.g).toBeCloseTo(0.12, 12);
+    expect(creaseMatA.color.b).toBeCloseTo(0.1, 12);
+  });
+
+  it("counter-rotates the two solids around Y with opposite base speeds plus the shared unfold wobble", () => {
+    const { handle, pivotA, pivotB } = buildOrigami();
+    handle.frame(frame(2, 0, 0));
+    const unfold = Math.sin(2 * 0.55 + 0.4) * 0.08;
+    expect(pivotA.rotation.y).toBeCloseTo(2 * 0.09 + unfold, 12);
+    expect(pivotB.rotation.y).toBeCloseTo(-2 * 0.07 - unfold * 0.6, 12);
+    expect(pivotA.rotation.y).toBeGreaterThan(0);
+    expect(pivotB.rotation.y).toBeLessThan(0);
+  });
+
+  it("wobbles each solid on X with its own slow out-of-phase oscillation around the inversion flip", () => {
+    const { handle, pivotA, pivotB } = buildOrigami();
+    handle.frame(frame(3, 0, 0));
+    expect(pivotA.rotation.x).toBeCloseTo(Math.sin(3 * 0.32) * 0.06, 12);
+    expect(pivotB.rotation.x).toBeCloseTo(
+      Math.PI + Math.sin(3 * 0.28 + 1.1) * 0.05,
+      12,
+    );
+  });
+
+  it("breathes the inner solid at 0.7x the outer amplitude while idle", () => {
+    const { handle, pivotA, pivotB } = buildOrigami();
+    handle.frame(frame(1, 0, 0));
+    const breathe = Math.sin(0.8) * 0.06;
+    expect(pivotA.scale.x).toBeCloseTo(1 + breathe, 12);
+    expect(pivotB.scale.x).toBeCloseTo(1 - breathe * 0.7, 12);
+  });
+
+  it("widens the breathe and adds a direct respond opening on top", () => {
+    const { handle, pivotA, pivotB } = buildOrigami();
+    handle.frame(frame(1, 0, 1));
+    const breathe = Math.sin(0.8) * (0.06 + 0.14);
+    expect(pivotA.scale.x).toBeCloseTo(1 + breathe + 0.06, 12);
+    expect(pivotB.scale.x).toBeCloseTo(1 - breathe * 0.7 + 0.04, 12);
+    expect(pivotA.scale.x).toBeGreaterThan(pivotB.scale.x);
+  });
+
+  it("flares the emissive edge catch with energy and respond, dimmer on the inner solid", () => {
+    const { handle, meshA, meshB } = buildOrigami();
+    handle.frame(frame(0, 1, 1));
+    const ei = 1 * 0.35 + 1 * 0.12;
+    const matA = meshA.material;
+    const matB = meshB.material;
+    expect(matA.emissiveIntensity).toBeCloseTo(ei, 12);
+    expect(matB.emissiveIntensity).toBeCloseTo(ei * 0.7, 12);
+    // Both share the warm white edge colour.
+    for (const mat of [matA, matB]) {
+      expect(mat.emissive.r).toBeCloseTo(1.0, 12);
+      expect(mat.emissive.g).toBeCloseTo(0.97, 12);
+      expect(mat.emissive.b).toBeCloseTo(0.88, 12);
+    }
+  });
+
+  it("ramps crease lines from charcoal toward the accent in proportion to respond", () => {
+    const { handle, meshA, meshB } = buildOrigami();
+    handle.frame(frame(0, 0, 0.5));
+    for (const lines of [creaseLinesOf(meshA), creaseLinesOf(meshB)]) {
+      const c = lines.material.color;
+      expect(c.r).toBeCloseTo(0.14 + 0.86 * 0.5, 12);
+      expect(c.g).toBeCloseTo(0.12 + 0.22 * 0.5, 12);
+      expect(c.b).toBeCloseTo(0.1 - 0.1 * 0.5, 12);
+    }
+  });
+
+  it("clamps the crease flare at full respond so over-range respond cannot overshoot the accent", () => {
+    const { handle, meshA, meshB } = buildOrigami();
+    handle.frame(frame(0, 0, 1));
+    const clamped = [creaseLinesOf(meshA), creaseLinesOf(meshB)].map(
+      (lines) => [
+        lines.material.color.r,
+        lines.material.color.g,
+        lines.material.color.b,
+      ],
+    );
+    for (const [r, g, b] of clamped) {
+      expect(r).toBeCloseTo(1.0, 12);
+      expect(g).toBeCloseTo(0.34, 12);
+      expect(b).toBeCloseTo(0.0, 12);
+    }
+    // respond=2 saturates the min() instead of pushing past the accent hue.
+    handle.frame(frame(0, 0, 2));
+    const overshot = [creaseLinesOf(meshA), creaseLinesOf(meshB)].map(
+      (lines) => [
+        lines.material.color.r,
+        lines.material.color.g,
+        lines.material.color.b,
+      ],
+    );
+    expect(overshot).toEqual(clamped);
+  });
+});
+
+describe("origami dispose", () => {
+  it("disposes both tetrahedron geometry/material pairs plus both crease pairs and removes both pivots from the parent", () => {
+    const { parent, handle, meshA, meshB } = buildOrigami();
+    const linesA = creaseLinesOf(meshA);
+    const linesB = creaseLinesOf(meshB);
+    const resources = [
+      meshA.geometry,
+      meshA.material,
+      meshB.geometry,
+      meshB.material,
+      linesA.geometry,
+      linesA.material,
+      linesB.geometry,
+      linesB.material,
+    ];
+    const spies = resources.map((r) => vi.spyOn(r, "dispose"));
+    handle.dispose();
+    for (const spy of spies) {
+      expect(spy).toHaveBeenCalledTimes(1);
+    }
+    expect(parent.children.length).toBe(0);
+  });
+});


### PR DESCRIPTION

## What

Adds a new co-located unit suite, `packages/ui/stories/src/concepts/origami.test.ts`, covering the `origami` voice-orb concept builder (the module had no same-named test file anywhere on `develop`). **Test-only change: no production source is touched** (+271/−0, one new file).

The suite drives the real `concept.build` against the real `three/webgpu` classes — headless-safe, no GPU device or DOM needed, no mocks standing in for the system under test:

- **descriptor contract** — registers under id/label `origami`, family `artful`, callable builder.
- **build wiring** — exactly two pivot groups on the parent; upright tetrahedron radius 0.9 and inverted twin radius 0.78 (vertex-radius measured from real geometry) flipped by `rotation.x = π`; independent flat-shaded paper materials (`flatShading`, roughness 0.86, metalness 0, opaque; outer paper-white vs inner ivory); charcoal crease `LineSegments` parented to each solid with six start/end edge pairs, transparent at opacity 0.9.
- **frame state** — idle pose overwrites stale material sentinels (including the fixed 0.4 unfold phase offset at t=0); counter-rotation at ±0.09/−0.07 rad/s around Y plus the shared unfold wobble; out-of-phase X wobbles around the inversion flip; breathe amplitude of the inner solid at exactly 0.7× the outer with an additive respond opening; emissive flare `energy·0.35 + respond·0.12` on the outer and 0.7× that on the inner, both sharing the warm-white edge colour; crease flare ramps charcoal→accent in proportion to respond and is clamped by `min(1, respond)` so over-range respond cannot overshoot.
- **dispose lifecycle** — all eight geometry/material resources disposed exactly once and both pivots removed from the parent.

## Verification

Fork contributor: hosted CI does not run on this PR — the counts below are from local runs against this exact head, quoted verbatim.

- `bunx vitest run packages/ui/stories/src/concepts/origami.test.ts` (repo-root lane): **Test Files 1 passed (1), Tests 14 passed (14)** — deterministic, no clock/RNG.
- `bunx biome check --write packages/ui/stories/src/concepts/origami.test.ts`: clean, 0 errors (9 pre-existing-class `noExplicitAny` warnings, identical to the sibling concept suites `lattice.test.ts` / `nebula.test.ts`, which carry 34 of the same class).
- `bunx tsc --noEmit -p packages/ui/stories/tsconfig.json` (strict config that includes this file): zero diagnostics mentioning `origami.test.ts`; same for the owning package gate `bunx tsc --noEmit` in `packages/ui`.

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [ ] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

Low — additive test-only diff (+271/−0, one new file); no production behaviour, public surface, or dependency changes.

# Background

## What does this PR do?

Adds `packages/ui/stories/src/concepts/origami.test.ts`: 14 deterministic vitest cases covering the origami voice-orb concept (descriptor registration, scene-graph build wiring, frame animation state incl. the respond clamp, full dispose teardown).

## What kind of change is this?

Improvements (misc. changes to existing features) — test coverage only.

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

`packages/ui/stories/src/concepts/origami.test.ts` — read it next to its subject `origami.ts`; sibling suites `lattice.test.ts` / `nebula.test.ts` show the same house pattern.

## Detailed testing steps

```
bunx vitest run packages/ui/stories/src/concepts/origami.test.ts
bunx biome check packages/ui/stories/src/concepts/origami.test.ts
bunx tsc --noEmit -p packages/ui/stories/tsconfig.json
```

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:e3a91979be9e6eebd2a63c4dcfe6d52d1fff924a -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only change; the diff adds one unit test file and touches no rendered UI, production code path, or agent/provider surface. Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only change; the diff adds one unit test file and touches no rendered UI, production code path, or agent/provider surface. After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - test-only change; the diff adds one unit test file and touches no rendered UI, production code path, or agent/provider surface. A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
<!-- evidence-row:backend-logs -->
- [ ] N/A - test-only change; the diff adds one unit test file and touches no rendered UI, production code path, or agent/provider surface. Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - test-only change; the diff adds one unit test file and touches no rendered UI, production code path, or agent/provider surface. Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - test-only change; the diff adds one unit test file and touches no rendered UI, production code path, or agent/provider surface. Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - test-only change; the diff adds one unit test file and touches no rendered UI, production code path, or agent/provider surface. Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
<!-- evidence-row:ocr-review -->
- [ ] N/A - test-only change; the diff adds one unit test file and touches no rendered UI, production code path, or agent/provider surface. OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

- Full-repo `bun run verify` was not run for this scoped lane; the exact-head evidence above covers the touched file (vitest 14/14, biome 0 errors, tsc zero mentions). No unrelated failures encountered.
- Hosted CI cannot run on fork branches; counts are quoted from local runs at head `e3a91979be9e6eebd2a63c4dcfe6d52d1fff924a`.

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: opencode/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ox-macbook]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
