### PR TITLE
fix(delivery): require turn-bound user consent to send a draft (#25284)

### DIFF
--- a/packages/core/src/features/advanced-capabilities/actions/message-progressive-read.test.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/message-progressive-read.test.ts
@@ -11,7 +11,9 @@ import type {
 	IAgentRuntime,
 	Memory,
 	ReadView,
+	Room,
 	UUID,
+	World,
 } from "../../../types/index.ts";
 import { messageAction } from "./message.ts";
 
@@ -52,6 +54,21 @@ function runtimeFor(
 		agentId: AGENT_ID,
 		getMemoryById,
 		getParticipantsForRoom,
+		// #25284: the umbrella resolves the caller's principal role before
+		// dispatching; grant the harness sender ADMIN in the room's world so
+		// these op-logic tests exercise the read op, not the role floor.
+		getRoom: async () =>
+			({
+				id: ROOM_ID,
+				worldId: "00000000-0000-0000-0000-0000000000dd",
+			}) as Room,
+		getWorld: async () =>
+			({
+				id: "00000000-0000-0000-0000-0000000000dd",
+				metadata: {
+					roles: { [REQUESTER_ID]: "ADMIN" },
+				},
+			}) as World,
 	});
 }
 

--- a/packages/core/src/features/advanced-capabilities/actions/message.list-muted.test.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/message.list-muted.test.ts
@@ -66,14 +66,29 @@ function mockRuntime(
 	const worlds = new Map<string, World>(
 		(seed?.worlds ?? []).map((world) => [world.id, world]),
 	);
+	// #25284: the umbrella resolves the caller's principal role before
+	// dispatching. These op-logic tests are not about the role floor, so the
+	// harness grants the harness sender ADMIN via a fallback world whenever
+	// the seed does not provide one (seeds that DO provide worlds keep their
+	// own world set untouched).
+	const fallbackWorld = {
+		id: "00000000-0000-0000-0000-0000000000dd",
+		agentId: AGENT_ID,
+		metadata: { roles: { "00000000-0000-0000-0000-0000000000cc": "ADMIN" } },
+	} as World;
+	const fallbackRoom = {
+		id: "00000000-0000-0000-0000-0000000000bb",
+		worldId: "00000000-0000-0000-0000-0000000000dd",
+		source: "discord",
+	} as Room;
 	return {
 		agentId: AGENT_ID,
 		logger: { debug() {}, info() {}, warn() {}, error() {} },
 		getMessageConnectors: () => connectors,
 		getParticipantUserState: async (roomId: UUID, entityId: UUID) =>
 			states.get(`${roomId}:${entityId}`) ?? null,
-		getRoom: async (roomId: UUID) => rooms.get(roomId) ?? null,
-		getWorld: async (worldId: UUID) => worlds.get(worldId) ?? null,
+		getRoom: async (roomId: UUID) => rooms.get(roomId) ?? fallbackRoom,
+		getWorld: async (worldId: UUID) => worlds.get(worldId) ?? fallbackWorld,
 	} as unknown as IAgentRuntime;
 }
 
@@ -152,12 +167,16 @@ describe("MESSAGE op=list_channels — muted flag", () => {
 			},
 		);
 		// The guild-id → worldId mapping is createUniqueUuid-based; answer for
-		// any id so the mapping stays the resolver's concern.
+		// any id so the mapping stays the resolver's concern. The granted role
+		// rides along (#25284) so the op-logic under test runs, not the floor.
 		(runtime as unknown as { getWorld: unknown }).getWorld = async () =>
 			({
 				id: MUTED_WORLD_ID,
 				agentId: AGENT_ID,
-				metadata: { agentMuteState: "MUTED" },
+				metadata: {
+					agentMuteState: "MUTED",
+					roles: { "00000000-0000-0000-0000-0000000000cc": "ADMIN" },
+				},
 			}) as World;
 		const result = await runOp(runtime, { action: "list_channels" });
 		const data = result.data as { channels: { muted: boolean }[] };

--- a/packages/core/src/features/advanced-capabilities/actions/message.manage-server.test.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/message.manage-server.test.ts
@@ -23,6 +23,9 @@ const ROOM_ID = "00000000-0000-0000-0000-0000000000bb";
 const SENDER_ID = "00000000-0000-0000-0000-0000000000cc";
 const LINKED_ID = "00000000-0000-0000-0000-0000000000dd";
 const DESTINATION_WORLD_ID = "00000000-0000-0000-0000-0000000000ee";
+// Source world A: where the outer MESSAGE turn was already admitted as ADMIN
+// before the manage_server destination-authorization logic runs.
+const SOURCE_WORLD_ID = "00000000-0000-0000-0000-0000000000ab";
 const DESTINATION_ROOM_ID = "00000000-0000-0000-0000-0000000000ff";
 const ACCOUNT_ID = "primary";
 
@@ -84,6 +87,16 @@ function harness(options?: {
 	const runtime = createMockRuntime({
 		agentId: AGENT_ID,
 		logger: { debug() {}, info() {}, warn() {}, error() {} },
+		// #25284's per-op role admission resolves the caller's SOURCE world via
+		// getRoom/getWorld before delegating; model the suite's premise that the
+		// turn was already admitted as ADMIN in world A. Destination-world
+		// authorization stays the handler's own job (tests below prove it).
+		getRoom: async (roomId: UUID) => ({
+			id: roomId,
+			worldId: SOURCE_WORLD_ID as UUID,
+			agentId: AGENT_ID,
+			source: "discord",
+		}),
 		getMessageConnectors: () => [
 			{
 				source: "discord",
@@ -112,19 +125,29 @@ function harness(options?: {
 			},
 		],
 		getWorld: async (worldId: UUID) =>
-			worldId === DESTINATION_WORLD_ID
+			worldId === SOURCE_WORLD_ID
 				? {
-						id: DESTINATION_WORLD_ID as UUID,
+						id: SOURCE_WORLD_ID as UUID,
 						agentId: AGENT_ID as UUID,
 						messageServerId: stringToUuid(activeServerId),
-						metadata: authorizedEntityId
-							? {
-									roles: { [authorizedEntityId]: "ADMIN" },
-									roleSources: { [authorizedEntityId]: "manual" },
-								}
-							: {},
+						metadata: {
+							roles: { [SENDER_ID]: "ADMIN" },
+							roleSources: { [SENDER_ID]: "manual" },
+						},
 					}
-				: null,
+				: worldId === DESTINATION_WORLD_ID
+					? {
+							id: DESTINATION_WORLD_ID as UUID,
+							agentId: AGENT_ID as UUID,
+							messageServerId: stringToUuid(activeServerId),
+							metadata: authorizedEntityId
+								? {
+										roles: { [authorizedEntityId]: "ADMIN" },
+										roleSources: { [authorizedEntityId]: "manual" },
+									}
+								: {},
+						}
+					: null,
 		getRooms: async (worldId: UUID) =>
 			worldId === DESTINATION_WORLD_ID && options?.includeBinding !== false
 				? [

--- a/packages/core/src/features/advanced-capabilities/actions/message.send-routing.test.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/message.send-routing.test.ts
@@ -528,10 +528,16 @@ describe("MESSAGE op=send admin/owner target (app + connector transports)", () =
 			agentId: AGENT_ID,
 			logger: { debug() {}, info() {}, warn() {}, error() {} },
 			getMessageConnectors: () => [],
-			// #25284: getRoom stays null (entity-search path must stay
-			// relationship-free); the granted harness world resolves via the
-			// baseMessage discordServerId metadata.
-			getRoom: async () => null,
+			// The harness world grants this sender ADMIN.
+			// #27932 review §2: send is no longer USER-admissible; the client_chat
+			// source registers no connector world-id metadata key, so the
+			// caller's ADMIN world resolves via the room's worldId here —
+			// getRoom returning a world-bearing room is deliberate in this
+			// harness; entity search itself stays relationship-free.
+			getRoom: async () => ({
+				id: ROOM_ID,
+				worldId: "00000000-0000-0000-0000-0000000000dd",
+			}),
 			getWorld: (async () => ({
 				id: "00000000-0000-0000-0000-0000000000dd",
 				metadata: { roles: { [SENDER_ID]: "ADMIN" } },
@@ -717,9 +723,20 @@ describe("MESSAGE op=send delivery-claim ambiguity is judged on distinct destina
 					},
 				};
 			}) as IAgentRuntime["getService"],
-			getRoom: async () => ({ id: ROOM_ID, name: "app", source: "app" }),
+			// #27932 review §2: send is no longer USER-admissible; resolve the
+			// caller's ADMIN world via the room's worldId (getWorld returns the
+			// ADMIN world; entity search is otherwise relationship-free).
+			getRoom: async () => ({
+				id: ROOM_ID,
+				name: "app",
+				source: "app",
+				worldId: "00000000-0000-0000-0000-0000000000dd",
+			}),
 			getEntitiesForRoom: async () => [entity],
-			getWorld: (async () => null) as IAgentRuntime["getWorld"],
+			getWorld: (async () => ({
+				id: "00000000-0000-0000-0000-0000000000dd",
+				metadata: { roles: { [SENDER_ID]: "ADMIN" } },
+			})) as IAgentRuntime["getWorld"],
 			getEntityById: (async (id: string) =>
 				id === SHADOW_ID ? entity : null) as IAgentRuntime["getEntityById"],
 			getRelationships: (async () => []) as IAgentRuntime["getRelationships"],

--- a/packages/core/src/features/advanced-capabilities/actions/message.send-routing.test.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/message.send-routing.test.ts
@@ -13,6 +13,8 @@ import type {
 	Component,
 	IAgentRuntime,
 	Memory,
+	Room,
+	World,
 } from "../../../types/index.ts";
 import { ServiceType } from "../../../types/index.ts";
 import { messageAction } from "./message.ts";
@@ -31,6 +33,11 @@ const baseMessage = {
 	agentId: AGENT_ID,
 	content: { text: "tell shadow to stop smoking", source: "discord" },
 	createdAt: 1,
+	// #25284: the umbrella resolves the caller's principal role before
+	// dispatching; the harness world that grants this sender ADMIN is
+	// resolved from the discord world-id metadata key (getRoom stays null in
+	// most harnesses so the entity-search path stays relationship-free).
+	metadata: { discordServerId: "00000000-0000-0000-0000-0000000000dd" },
 } as unknown as Memory;
 
 type SentMessage = {
@@ -73,7 +80,14 @@ describe("MESSAGE op=send exact-beats-prefix tier (ambiguity over-fire fix)", ()
 					resolveTargets,
 				},
 			],
+			// #25284: getRoom stays null (entity-search path must stay
+			// relationship-free); the granted harness world resolves via the
+			// baseMessage discordServerId metadata.
 			getRoom: async () => null,
+			getWorld: (async () => ({
+				id: "00000000-0000-0000-0000-0000000000dd",
+				metadata: { roles: { [SENDER_ID]: "ADMIN" } },
+			})) as IAgentRuntime["getWorld"],
 			getEntitiesForRoom: async () => [],
 			getEntityById: (async () => null) as IAgentRuntime["getEntityById"],
 			getRelationships: (async () => []) as IAgentRuntime["getRelationships"],
@@ -184,7 +198,14 @@ describe("MESSAGE op=send unresolved recipient asks upfront (no doomed send)", (
 					resolveTargets: async () => [],
 				},
 			],
+			// #25284: getRoom stays null (entity-search path must stay
+			// relationship-free); the granted harness world resolves via the
+			// baseMessage discordServerId metadata.
 			getRoom: async () => null,
+			getWorld: (async () => ({
+				id: "00000000-0000-0000-0000-0000000000dd",
+				metadata: { roles: { [SENDER_ID]: "ADMIN" } },
+			})) as IAgentRuntime["getWorld"],
 			getEntitiesForRoom: async () =>
 				matchingLiteralEntity ? [literalEntity] : [],
 			getEntityById: (async (id: string) =>
@@ -378,9 +399,26 @@ describe("MESSAGE op=send last-delivered-channel preference", () => {
 			}) as IAgentRuntime["getService"],
 			// The room's source has no registered connector, so the room-first
 			// member path stays out of the way and the entity path is exercised.
-			getRoom: async () => ({ id: ROOM_ID, name: "app", source: "app" }),
+			// #25284: the room carries the granted world so the caller resolves
+			// ADMIN (not the local-sender GUEST floor for source "app") before
+			// the entity-path op under test runs.
+			getRoom: (async () =>
+				({
+					id: ROOM_ID,
+					name: "app",
+					source: "app",
+					worldId: "00000000-0000-0000-0000-0000000000dd",
+				}) as Room) as IAgentRuntime["getRoom"],
 			getEntitiesForRoom: async () => [entity],
-			getWorld: (async () => null) as IAgentRuntime["getWorld"],
+			// #25284: this block exercises the channel-preference entity path,
+			// not the role floor; grant the harness sender ADMIN via the
+			// room's world so the USER floor admits the op under test.
+			getWorld: (async () =>
+				({
+					id: "00000000-0000-0000-0000-0000000000dd",
+					agentId: AGENT_ID,
+					metadata: { roles: { [SENDER_ID]: "ADMIN" } },
+				}) as World) as IAgentRuntime["getWorld"],
 			getEntityById: (async (id: string) =>
 				id === SHADOW_ID ? entity : null) as IAgentRuntime["getEntityById"],
 			getRelationships: (async () => []) as IAgentRuntime["getRelationships"],
@@ -490,7 +528,14 @@ describe("MESSAGE op=send admin/owner target (app + connector transports)", () =
 			agentId: AGENT_ID,
 			logger: { debug() {}, info() {}, warn() {}, error() {} },
 			getMessageConnectors: () => [],
+			// #25284: getRoom stays null (entity-search path must stay
+			// relationship-free); the granted harness world resolves via the
+			// baseMessage discordServerId metadata.
 			getRoom: async () => null,
+			getWorld: (async () => ({
+				id: "00000000-0000-0000-0000-0000000000dd",
+				metadata: { roles: { [SENDER_ID]: "ADMIN" } },
+			})) as IAgentRuntime["getWorld"],
 			getSetting: (() => undefined) as IAgentRuntime["getSetting"],
 			sendMessageToTarget: async (target, content) => {
 				sends.push({
@@ -553,7 +598,14 @@ describe("MESSAGE op=send admin/owner target (app + connector transports)", () =
 					resolveTargets,
 				},
 			],
+			// #25284: getRoom stays null (entity-search path must stay
+			// relationship-free); the granted harness world resolves via the
+			// baseMessage discordServerId metadata.
 			getRoom: async () => null,
+			getWorld: (async () => ({
+				id: "00000000-0000-0000-0000-0000000000dd",
+				metadata: { roles: { [SENDER_ID]: "ADMIN" } },
+			})) as IAgentRuntime["getWorld"],
 			getSetting: (() => undefined) as IAgentRuntime["getSetting"],
 			sendMessageToTarget: async (target, content) => {
 				sends.push({

--- a/packages/core/src/features/advanced-capabilities/actions/message.test.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/message.test.ts
@@ -45,6 +45,19 @@ function mockRuntime(connectors: unknown[]): IAgentRuntime {
 		agentId: "00000000-0000-0000-0000-000000000001",
 		logger: { debug() {}, info() {}, warn() {}, error() {} },
 		getMessageConnectors: () => connectors,
+		// #25284: the umbrella resolves the caller's principal role before
+		// dispatching; give the harness sender an explicit world grant so these
+		// op-logic tests exercise their op, not the role floor.
+		getRoom: async () => ({
+			id: "00000000-0000-0000-0000-0000000000bb",
+			worldId: "00000000-0000-0000-0000-0000000000dd",
+		}),
+		getWorld: async () => ({
+			id: "00000000-0000-0000-0000-0000000000dd",
+			metadata: {
+				roles: { "00000000-0000-0000-0000-0000000000cc": "ADMIN" },
+			},
+		}),
 	} as unknown as IAgentRuntime;
 }
 
@@ -362,7 +375,19 @@ describe("MESSAGE op=send owner-binding gate", () => {
 			logger: { debug() {}, info() {}, warn() {}, error() {} },
 			getService: (type: string) =>
 				type === "connector_account" ? manager : null,
-			getRoom: async () => null,
+			// #25284: the umbrella resolves the caller's principal role before
+			// dispatching; grant the harness sender ADMIN so these owner-binding
+			// tests exercise the account gate, not the role floor.
+			getRoom: async () => ({
+				id: "00000000-0000-0000-0000-0000000000bb",
+				worldId: "00000000-0000-0000-0000-0000000000dd",
+			}),
+			getWorld: async () => ({
+				id: "00000000-0000-0000-0000-0000000000dd",
+				metadata: {
+					roles: { "00000000-0000-0000-0000-0000000000cc": "ADMIN" },
+				},
+			}),
 			getMessageConnectors: () => [
 				{
 					source: "matrix",
@@ -492,7 +517,18 @@ describe("MESSAGE op=send delivery evidence", () => {
 					contexts: [],
 				},
 			],
-			getRoom: async () => null,
+			// #25284: grant the harness sender ADMIN so these delivery-evidence
+			// tests exercise the send path, not the role floor.
+			getRoom: async () => ({
+				id: "00000000-0000-0000-0000-0000000000bb",
+				worldId: "00000000-0000-0000-0000-0000000000dd",
+			}),
+			getWorld: async () => ({
+				id: "00000000-0000-0000-0000-0000000000dd",
+				metadata: {
+					roles: { "00000000-0000-0000-0000-0000000000cc": "ADMIN" },
+				},
+			}),
 			sendMessageToTarget: async () => outcome,
 			ensureWorldExists: async () => undefined,
 			ensureRoomExists: async () => undefined,
@@ -745,6 +781,9 @@ describe("MESSAGE op=send room-first name resolution (over-routing fix)", () => 
 			source: "discord",
 			channelId: "chan-1",
 			serverId: "guild-1",
+			// #25284: link the room to a world that grants the harness sender
+			// ADMIN so these resolution tests exercise routing, not the floor.
+			worldId: "00000000-0000-0000-0000-0000000000dd",
 		};
 	}
 
@@ -776,6 +815,13 @@ describe("MESSAGE op=send room-first name resolution (over-routing fix)", () => 
 				},
 			],
 			getRoom: async () => roomFixture(),
+			// #25284: grant the harness sender ADMIN in the fixture world.
+			getWorld: async () => ({
+				id: "00000000-0000-0000-0000-0000000000dd",
+				metadata: {
+					roles: { "00000000-0000-0000-0000-0000000000cc": "ADMIN" },
+				},
+			}),
 			getEntitiesForRoom: async () => options.roomEntities,
 			getMemories: async () => [],
 			getEntityById: (options.getEntityById ??
@@ -988,7 +1034,18 @@ describe("MESSAGE op=send unvetted-recipient confirmation gate (stranger-DM clos
 					],
 				},
 			],
+			// #25284: getRoom returns null (the entity-search path must stay
+			// relationship-free); the caller's world is resolved from the
+			// message's discordServerId metadata instead, granting the harness
+			// sender ADMIN so these gate tests exercise the recipient gate, not
+			// the role floor.
 			getRoom: async () => null,
+			getWorld: async () => ({
+				id: "00000000-0000-0000-0000-0000000000dd",
+				metadata: {
+					roles: { "00000000-0000-0000-0000-0000000000cc": "ADMIN" },
+				},
+			}),
 			getEntitiesForRoom: async () => options.roomEntities ?? [],
 			getEntityById: (async (id: string) =>
 				options.known
@@ -1057,7 +1114,13 @@ describe("MESSAGE op=send unvetted-recipient confirmation gate (stranger-DM clos
 	): Promise<ActionResult> {
 		const result = await messageAction.handler(
 			runtime,
-			{ ...message, content: { text, source: "discord" } } as Memory,
+			{
+				...message,
+				content: { text, source: "discord" },
+				// #25284: the harness world (which grants this sender ADMIN)
+				// is resolved from the discord world-id metadata key.
+				metadata: { discordServerId: "00000000-0000-0000-0000-0000000000dd" },
+			} as Memory,
 			undefined,
 			{
 				parameters: {

--- a/packages/core/src/features/advanced-capabilities/actions/message.test.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/message.test.ts
@@ -1372,4 +1372,45 @@ describe("MESSAGE op=send unvetted-recipient confirmation gate (stranger-DM clos
 			awaitingUserInput: true,
 		});
 	});
+
+	it("switching operations WITHOUT saying yes re-arms for the new operation instead of reporting a decline (#27932 review §3a)", async () => {
+		// The non-affirmative switch: preview for operation A is armed, then
+		// the next turn requests a DIFFERENT send (new body bytes — the
+		// digest covers {target, content}) without answering the first
+		// preview. requireConfirmation consumed A's record and returned
+		// cancelled with A's metadata; the digest cannot match the new
+		// operation, so the fix re-arms for it. Reporting "declined" for a
+		// request the user never answered — while leaving the new operation
+		// unarmed — was the §3a bug (a false decline + a dead slot).
+		const { runtime, sends } = harness({ known: false });
+		await send(runtime, "message fuzzymatch saying hey"); // arm op A
+
+		const switchTurn = await send(
+			runtime,
+			"message fuzzymatch saying I'm late instead",
+			{
+				body: "I'm late instead",
+				messageId: "00000000-0000-0000-0000-0000000000a2",
+			},
+		);
+		// Not a decline: the user asked for a new send, so the new preview is
+		// armed and awaits its own confirmation.
+		expect(switchTurn.data).toMatchObject({
+			confirmationRequired: true,
+			awaitingUserInput: true,
+			cancelled: false,
+		});
+		expect(sends).toHaveLength(0);
+
+		// The next affirmative now confirms the NEW operation's bytes (the
+		// armed record), not the superseded preview — the planner re-supplies
+		// the same operation parameters on the confirming turn, so the
+		// recomputed digest matches the re-armed record.
+		const confirmed = await send(runtime, "yes", {
+			body: "I'm late instead",
+			messageId: "00000000-0000-0000-0000-0000000000a3",
+		});
+		expect(confirmed.success).toBe(true);
+		expect(sends).toHaveLength(1);
+	});
 });

--- a/packages/core/src/features/advanced-capabilities/actions/message.test.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/message.test.ts
@@ -1115,12 +1115,14 @@ describe("MESSAGE op=send unvetted-recipient confirmation gate (stranger-DM clos
 			body?: string;
 			roomId?: string;
 			thread?: string;
+			messageId?: string;
 		},
 	): Promise<ActionResult> {
 		const result = await messageAction.handler(
 			runtime,
 			{
 				...message,
+				id: overrides?.messageId ?? message.id,
 				content: { text, source: "discord" },
 				// #25284: the harness world (which grants this sender ADMIN)
 				// is resolved from the discord world-id metadata key.
@@ -1163,7 +1165,10 @@ describe("MESSAGE op=send unvetted-recipient confirmation gate (stranger-DM clos
 		expect(first.data).toMatchObject({ awaitingUserInput: true });
 		expect(sends).toHaveLength(0);
 
-		const second = await send(runtime, "yes");
+		// A distinct later user turn carries the affirmative.
+		const second = await send(runtime, "yes", {
+			messageId: "00000000-0000-0000-0000-0000000000a2",
+		});
 		expect(second.success).toBe(true);
 		expect(sends).toHaveLength(1);
 		expect(sends[0].target).toMatchObject({ entityId: STRANGER_PLATFORM_ID });
@@ -1172,7 +1177,9 @@ describe("MESSAGE op=send unvetted-recipient confirmation gate (stranger-DM clos
 	it("a declined confirmation cancels the send", async () => {
 		const { runtime, sends } = harness({ known: false });
 		await send(runtime, "message fuzzymatch saying hey");
-		const second = await send(runtime, "no, don't do that");
+		const second = await send(runtime, "no, don't do that", {
+			messageId: "00000000-0000-0000-0000-0000000000a2",
+		});
 
 		expect(second.success).toBe(false);
 		expect(second.data).toMatchObject({ cancelled: true });
@@ -1242,6 +1249,7 @@ describe("MESSAGE op=send unvetted-recipient confirmation gate (stranger-DM clos
 		const second = await send(runtime, "yes", {
 			body: "substituted hostile bytes",
 			roomId: "00000000-0000-0000-0000-0000000000e1",
+			messageId: "00000000-0000-0000-0000-0000000000a2",
 		});
 
 		// Fail-closed: cache miss re-arms a fresh confirmation for the NEW
@@ -1259,6 +1267,7 @@ describe("MESSAGE op=send unvetted-recipient confirmation gate (stranger-DM clos
 
 		const second = await send(runtime, "yes", {
 			body: "substituted hostile bytes",
+			messageId: "00000000-0000-0000-0000-0000000000a2",
 		});
 
 		expect(sends).toHaveLength(0);
@@ -1277,6 +1286,7 @@ describe("MESSAGE op=send unvetted-recipient confirmation gate (stranger-DM clos
 
 		const second = await send(runtime, "yes", {
 			thread: "00000000-0000-0000-0000-0000000000f2",
+			messageId: "00000000-0000-0000-0000-0000000000a2",
 		});
 
 		expect(sends).toHaveLength(0);
@@ -1289,19 +1299,58 @@ describe("MESSAGE op=send unvetted-recipient confirmation gate (stranger-DM clos
 	it("a re-prompted confirmation of the substituted payload proceeds (loop terminates)", async () => {
 		// After a mismatch re-prompt (above), the substituted payload's OWN
 		// confirmation record is armed; the user deliberately confirming THOSE
-		// bytes sends exactly those bytes — nothing else.
+		// bytes on a distinct later message sends exactly those bytes.
 		const { runtime, sends } = harness({ known: false });
 		await send(runtime, "message fuzzymatch saying hey"); // arm original bytes
 		const rePrompt = await send(runtime, "yes", {
 			body: "re-prompted and deliberately confirmed",
-		}); // mismatch → arms record for the new payload
+			messageId: "00000000-0000-0000-0000-0000000000a2",
+		}); // mismatch → re-arms for the new payload
 		expect(rePrompt.data).toMatchObject({ awaitingUserInput: true });
 
 		const confirmed = await send(runtime, "yes", {
 			body: "re-prompted and deliberately confirmed",
+			messageId: "00000000-0000-0000-0000-0000000000a3",
 		});
 		expect(confirmed.success).toBe(true);
 		expect(sends).toHaveLength(1);
 		expect(sends[0].target).toMatchObject({ entityId: STRANGER_PLATFORM_ID });
+	});
+
+	it("an affirmative cannot be consumed by a re-invocation of the SAME message that armed it (#25284 review: distinct-turn bound)", async () => {
+		// Same-message self-consumption: the planner re-invoking the action
+		// for the same yes-shaped user message must not treat that message
+		// as both the arming request and its confirmation.
+		const { runtime, sends } = harness({ known: false });
+		const first = await send(runtime, "message fuzzymatch saying hey");
+		expect(first.data).toMatchObject({ awaitingUserInput: true });
+
+		// Identical message id re-invoked with an explicit send param.
+		const reInvoke = await send(runtime, "message fuzzymatch saying hey");
+		expect(sends).toHaveLength(0);
+		expect(reInvoke.data).toMatchObject({ awaitingUserInput: true });
+	});
+
+	it("a stale armed preview cannot be selected after a newer operation re-armed the slot (#25284 review: single slot)", async () => {
+		// Preview A arms; substitute B re-arms the slot (overwrites A); the
+		// user says yes (intending B). A planner re-supplying A's exact bytes
+		// must find the slot describes B — not the stale A record.
+		const { runtime, sends } = harness({ known: false });
+		await send(runtime, "message fuzzymatch saying hey"); // arm A
+		const rePrompt = await send(runtime, "yes", {
+			body: "operation B bytes",
+			messageId: "00000000-0000-0000-0000-0000000000a2",
+		}); // consumes A (digest mismatch → re-arms slot for B)
+		expect(rePrompt.data).toMatchObject({ awaitingUserInput: true });
+
+		// Planner now supplies A's bytes on the SAME message that said yes to B.
+		const stale = await send(runtime, "yes", {
+			messageId: "00000000-0000-0000-0000-0000000000a2",
+		}); // slot describes B → digest mismatch for A → re-arm + pending
+		expect(sends).toHaveLength(0);
+		expect(stale.data).toMatchObject({
+			confirmationRequired: true,
+			awaitingUserInput: true,
+		});
 	});
 });

--- a/packages/core/src/features/advanced-capabilities/actions/message.test.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/message.test.ts
@@ -1353,4 +1353,23 @@ describe("MESSAGE op=send unvetted-recipient confirmation gate (stranger-DM clos
 			awaitingUserInput: true,
 		});
 	});
+
+	it("a stale armed preview for ANOTHER recipient cannot be selected (#25284 review: one slot per room)", async () => {
+		// Preview to recipient A arms the room's single slot; a yes arriving
+		// with bytes for a different recipient B must not consume A's record
+		// — the digest covers the full TargetInfo, so any recipient change is
+		// a mismatch that re-arms and sends nothing.
+		const { runtime, sends } = harness({ known: false });
+		await send(runtime, "message fuzzymatch saying hey"); // arm for A
+
+		const second = await send(runtime, "yes", {
+			body: "substituted bytes aimed at recipient B",
+			messageId: "00000000-0000-0000-0000-0000000000a2",
+		});
+		expect(sends).toHaveLength(0);
+		expect(second.data).toMatchObject({
+			confirmationRequired: true,
+			awaitingUserInput: true,
+		});
+	});
 });

--- a/packages/core/src/features/advanced-capabilities/actions/message.test.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/message.test.ts
@@ -1111,6 +1111,11 @@ describe("MESSAGE op=send unvetted-recipient confirmation gate (stranger-DM clos
 	async function send(
 		runtime: IAgentRuntime,
 		text: string,
+		overrides?: {
+			body?: string;
+			roomId?: string;
+			thread?: string;
+		},
 	): Promise<ActionResult> {
 		const result = await messageAction.handler(
 			runtime,
@@ -1120,6 +1125,7 @@ describe("MESSAGE op=send unvetted-recipient confirmation gate (stranger-DM clos
 				// #25284: the harness world (which grants this sender ADMIN)
 				// is resolved from the discord world-id metadata key.
 				metadata: { discordServerId: "00000000-0000-0000-0000-0000000000dd" },
+				...(overrides?.roomId ? { roomId: overrides.roomId } : {}),
 			} as Memory,
 			undefined,
 			{
@@ -1128,7 +1134,8 @@ describe("MESSAGE op=send unvetted-recipient confirmation gate (stranger-DM clos
 					persist: false,
 					target: "fuzzymatch",
 					targetKind: "user",
-					message: "hey there",
+					message: overrides?.body ?? "hey there",
+					...(overrides?.thread ? { thread: overrides.thread } : {}),
 				},
 			},
 			undefined,
@@ -1221,5 +1228,80 @@ describe("MESSAGE op=send unvetted-recipient confirmation gate (stranger-DM clos
 		expect(result.data).not.toMatchObject({ confirmationRequired: true });
 		expect(sends).toHaveLength(1);
 		expect(sends[0].target).toMatchObject({ entityId: KNOWN_PLATFORM_ID });
+	});
+
+	it("does not authorize substituted bytes from another room (#25284 review: confirmation is turn-bound)", async () => {
+		// ss251's adversarial case: a safe preview in room A arms the pending
+		// record; a later planner turn answering `yes` from room B with
+		// different outbound bytes must NOT consume that confirmation.
+		const { runtime, sends } = harness({ known: false });
+		const first = await send(runtime, "message fuzzymatch saying hey");
+		expect(first.data).toMatchObject({ awaitingUserInput: true });
+		expect(sends).toHaveLength(0);
+
+		const second = await send(runtime, "yes", {
+			body: "substituted hostile bytes",
+			roomId: "00000000-0000-0000-0000-0000000000e1",
+		});
+
+		// Fail-closed: cache miss re-arms a fresh confirmation for the NEW
+		// room+payload instead of delivering anything.
+		expect(sends).toHaveLength(0);
+		expect(second.data).toMatchObject({
+			confirmationRequired: true,
+			awaitingUserInput: true,
+		});
+	});
+
+	it("does not authorize substituted bytes in the same room (#25284 review: payload is bound)", async () => {
+		const { runtime, sends } = harness({ known: false });
+		await send(runtime, "message fuzzymatch saying hey");
+
+		const second = await send(runtime, "yes", {
+			body: "substituted hostile bytes",
+		});
+
+		expect(sends).toHaveLength(0);
+		expect(second.data).toMatchObject({
+			confirmationRequired: true,
+			awaitingUserInput: true,
+		});
+	});
+
+	it("does not authorize a send retargeted to a different thread (#25284 review: target is bound)", async () => {
+		// The confirmation digest covers the full resolved TargetInfo, so a
+		// `yes` carrying a different threadId is a cache miss and re-prompts
+		// instead of delivering to the substituted thread.
+		const { runtime, sends } = harness({ known: false });
+		await send(runtime, "message fuzzymatch saying hey"); // arm thread X
+
+		const second = await send(runtime, "yes", {
+			thread: "00000000-0000-0000-0000-0000000000f2",
+		});
+
+		expect(sends).toHaveLength(0);
+		expect(second.data).toMatchObject({
+			confirmationRequired: true,
+			awaitingUserInput: true,
+		});
+	});
+
+	it("a re-prompted confirmation of the substituted payload proceeds (loop terminates)", async () => {
+		// After a mismatch re-prompt (above), the substituted payload's OWN
+		// confirmation record is armed; the user deliberately confirming THOSE
+		// bytes sends exactly those bytes — nothing else.
+		const { runtime, sends } = harness({ known: false });
+		await send(runtime, "message fuzzymatch saying hey"); // arm original bytes
+		const rePrompt = await send(runtime, "yes", {
+			body: "re-prompted and deliberately confirmed",
+		}); // mismatch → arms record for the new payload
+		expect(rePrompt.data).toMatchObject({ awaitingUserInput: true });
+
+		const confirmed = await send(runtime, "yes", {
+			body: "re-prompted and deliberately confirmed",
+		});
+		expect(confirmed.success).toBe(true);
+		expect(sends).toHaveLength(1);
+		expect(sends[0].target).toMatchObject({ entityId: STRANGER_PLATFORM_ID });
 	});
 });

--- a/packages/core/src/features/advanced-capabilities/actions/message.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/message.ts
@@ -75,6 +75,7 @@ import { hasActionContext } from "../../../utils/action-validation.ts";
 import { requireConfirmation } from "../../../utils/confirmation.ts";
 import { getActiveRoutingContextsForTurn } from "../../../utils/context-routing.ts";
 import { createHash } from "../../../utils/crypto-compat.ts";
+import { stableStringify } from "../../../utils/deterministic.ts";
 import { isObjectRecord as isRecord } from "../../../utils/type-guards.ts";
 import { toWellFormedUnicode } from "../../../utils/well-formed.ts";
 import { stringToUuid } from "../../../utils.ts";
@@ -3103,40 +3104,6 @@ async function handleSend(
 		return gate;
 	}
 
-	// A direct-to-person delivery resolved from an unvetted source (connector
-	// fuzzy match / raw explicit target) must be a known recipient — present in
-	// this room or relationship-backed — or explicitly confirmed by the user.
-	if (isUnvettedDirectUserCandidate(selected)) {
-		const known = await recipientIsKnownEntity(runtime, message, target);
-		if (!known) {
-			const decision = await requireConfirmation({
-				runtime,
-				message,
-				actionName: "MESSAGE",
-				pendingKey: `send:${selected.connector.source}:${String(target.entityId)}`,
-				prompt: `Send this via ${selected.connector.label} to ${selected.label}? They are not in this room, your contacts, or your relationship graph.`,
-			});
-			if (decision.status !== "confirmed") {
-				const pending = decision.status === "pending";
-				return {
-					success: pending,
-					text: pending
-						? `"${selected.label}" on ${selected.connector.label} is not in this room or the user's relationship graph. Ask the user to confirm sending to this recipient (yes/no) before the message is delivered; nothing was sent.`
-						: "The user declined sending to this recipient; nothing was sent.",
-					data: {
-						actionName: "MESSAGE",
-						operation: "send",
-						confirmationRequired: pending,
-						awaitingUserInput: pending,
-						cancelled: !pending,
-						source: selected.connector.source,
-						targetLabel: selected.label,
-					},
-				};
-			}
-		}
-	}
-
 	// Room-first member delivery: the utterance lands in the shared channel, so
 	// address the intended member by name unless the text already does.
 	const outboundMessage =
@@ -3159,6 +3126,51 @@ async function handleSend(
 		};
 	}
 	const content = applyContentShaping(selected.connector, builtContent);
+
+	// A direct-to-person delivery resolved from an unvetted source (connector
+	// fuzzy match / raw explicit target) must be a known recipient — present in
+	// this room or relationship-backed — or explicitly confirmed by the user.
+	if (isUnvettedDirectUserCandidate(selected)) {
+		const known = await recipientIsKnownEntity(runtime, message, target);
+		if (!known) {
+			// Turn-bound (#27932 review): the pending record keys on the source
+			// room and a SHA-256 digest of the complete effective send
+			// operation — the outbound Content AND the full resolved TargetInfo
+			// (thread/room/channel/server/account routing fields) — so a
+			// confirmation armed by a safe preview can never authorize later
+			// planner-supplied bytes, a different thread, or a `yes` issued
+			// from a different room. Any change is a cache miss and re-prompts.
+			const confirmationFingerprint = createHash("sha256")
+				.update(stableStringify({ target, content }))
+				.digest("hex")
+				.slice(0, 32);
+			const decision = await requireConfirmation({
+				runtime,
+				message,
+				actionName: "MESSAGE",
+				pendingKey: `send:${selected.connector.source}:${String(target.entityId)}:${message.roomId}:${confirmationFingerprint}`,
+				prompt: `Send this via ${selected.connector.label} to ${selected.label}? They are not in this room, your contacts, or your relationship graph.`,
+			});
+			if (decision.status !== "confirmed") {
+				const pending = decision.status === "pending";
+				return {
+					success: pending,
+					text: pending
+						? `"${selected.label}" on ${selected.connector.label} is not in this room or the user's relationship graph. Ask the user to confirm sending to this recipient (yes/no) before the message is delivered; nothing was sent.`
+						: "The user declined sending to this recipient; nothing was sent.",
+					data: {
+						actionName: "MESSAGE",
+						operation: "send",
+						confirmationRequired: pending,
+						awaitingUserInput: pending,
+						cancelled: !pending,
+						source: selected.connector.source,
+						targetLabel: selected.label,
+					},
+				};
+			}
+		}
+	}
 
 	let persisted: Memory | undefined;
 	let providerMessageId: string | undefined;

--- a/packages/core/src/features/advanced-capabilities/actions/message.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/message.ts
@@ -3133,25 +3133,71 @@ async function handleSend(
 	if (isUnvettedDirectUserCandidate(selected)) {
 		const known = await recipientIsKnownEntity(runtime, message, target);
 		if (!known) {
-			// Turn-bound (#27932 review): the pending record keys on the source
-			// room and a SHA-256 digest of the complete effective send
-			// operation — the outbound Content AND the full resolved TargetInfo
-			// (thread/room/channel/server/account routing fields) — so a
-			// confirmation armed by a safe preview can never authorize later
-			// planner-supplied bytes, a different thread, or a `yes` issued
-			// from a different room. Any change is a cache miss and re-prompts.
+			// Turn-bound (#27932 review): one pending record per actor+action
+			// per connector+recipient+room (single slot — a new operation
+			// OVERWRITES any prior armed preview, so a stale record can never
+			// be selected). The record carries a SHA-256 digest of the complete
+			// effective send operation — the outbound Content AND the full
+			// resolved TargetInfo — and the arming message id; consumption
+			// requires a DIFFERENT, later user message whose recomputed digest
+			// matches byte-for-byte. Substituted bytes, a different thread or
+			// target, a different room, a same-message re-invocation, or a
+			// planner re-emit across two turns all re-prompt instead of
+			// sending; the provider call stays at zero on every mismatch.
 			const confirmationFingerprint = createHash("sha256")
 				.update(stableStringify({ target, content }))
 				.digest("hex")
 				.slice(0, 32);
-			const decision = await requireConfirmation({
+			const armArgs = {
 				runtime,
 				message,
-				actionName: "MESSAGE",
-				pendingKey: `send:${selected.connector.source}:${String(target.entityId)}:${message.roomId}:${confirmationFingerprint}`,
+				actionName: "MESSAGE" as const,
+				pendingKey: `send:${selected.connector.source}:${String(target.entityId)}:${message.roomId}`,
 				prompt: `Send this via ${selected.connector.label} to ${selected.label}? They are not in this room, your contacts, or your relationship graph.`,
-			});
-			if (decision.status !== "confirmed") {
+				metadata: {
+					confirmationFingerprint,
+					armedByMessageId: String(message.id ?? ""),
+				},
+			};
+			let decision = await requireConfirmation(armArgs);
+			let metadata = (decision.metadata ?? {}) as {
+				confirmationFingerprint?: string;
+				armedByMessageId?: string;
+			};
+			let digestMatches =
+				metadata.confirmationFingerprint === confirmationFingerprint;
+			// Same-message self-consumption guard: the arming invocation
+			// itself can never confirm (or cancel) its own record — only a
+			// distinct later user message may consume it.
+			let distinctTurn = metadata.armedByMessageId !== String(message.id ?? "");
+			if (
+				(decision.status === "confirmed" || decision.status === "cancelled") &&
+				!distinctTurn
+			) {
+				// This same message armed the record, so its reply shape is its
+				// own request text, not a later user's affirmative: fail closed
+				// and re-arm (idempotent retry of the preview).
+				decision = await requireConfirmation(armArgs);
+				metadata = (decision.metadata ?? {}) as typeof metadata;
+				digestMatches =
+					metadata.confirmationFingerprint === confirmationFingerprint;
+				distinctTurn = metadata.armedByMessageId !== String(message.id ?? "");
+			}
+			if (
+				decision.status === "confirmed" &&
+				(!digestMatches || !distinctTurn)
+			) {
+				// The consumed record described a DIFFERENT operation: the
+				// affirmative did not authorize THESE bytes. Fail closed and
+				// re-arm for the current operation so the user can
+				// deliberately confirm it on a later message.
+				decision = await requireConfirmation(armArgs);
+				metadata = (decision.metadata ?? {}) as typeof metadata;
+				digestMatches =
+					metadata.confirmationFingerprint === confirmationFingerprint;
+				distinctTurn = metadata.armedByMessageId !== String(message.id ?? "");
+			}
+			if (decision.status !== "confirmed" || !digestMatches || !distinctTurn) {
 				const pending = decision.status === "pending";
 				return {
 					success: pending,

--- a/packages/core/src/features/advanced-capabilities/actions/message.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/message.ts
@@ -3133,16 +3133,18 @@ async function handleSend(
 	if (isUnvettedDirectUserCandidate(selected)) {
 		const known = await recipientIsKnownEntity(runtime, message, target);
 		if (!known) {
-			// Turn-bound (#27932 review): one pending record per actor+action
-			// per connector+recipient+room (single slot — a new operation
-			// OVERWRITES any prior armed preview, so a stale record can never
-			// be selected). The record carries a SHA-256 digest of the complete
+			// Turn-bound (#27932 review): exactly ONE pending send confirmation
+			// per actor per room (the helper's cache key already prefixes
+			// actor+action; this key adds only the room). A new operation
+			// OVERWRITES any prior armed preview — even for a different
+			// recipient or connector — so no stale record can ever be
+			// selected. The record carries a SHA-256 digest of the complete
 			// effective send operation — the outbound Content AND the full
 			// resolved TargetInfo — and the arming message id; consumption
-			// requires a DIFFERENT, later user message whose recomputed digest
+			// requires a DIFFERENT user message whose recomputed digest
 			// matches byte-for-byte. Substituted bytes, a different thread or
 			// target, a different room, a same-message re-invocation, or a
-			// planner re-emit across two turns all re-prompt instead of
+			// yes aimed at a superseded preview all re-prompt instead of
 			// sending; the provider call stays at zero on every mismatch.
 			const confirmationFingerprint = createHash("sha256")
 				.update(stableStringify({ target, content }))
@@ -3152,7 +3154,7 @@ async function handleSend(
 				runtime,
 				message,
 				actionName: "MESSAGE" as const,
-				pendingKey: `send:${selected.connector.source}:${String(target.entityId)}:${message.roomId}`,
+				pendingKey: `send:${message.roomId}`,
 				prompt: `Send this via ${selected.connector.label} to ${selected.label}? They are not in this room, your contacts, or your relationship graph.`,
 				metadata: {
 					confirmationFingerprint,

--- a/packages/core/src/features/advanced-capabilities/actions/message.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/message.ts
@@ -85,6 +85,11 @@ import { manageMessageAction } from "../../messaging/triage/actions/manageMessag
 import { respondToMessageAction } from "../../messaging/triage/actions/respondToMessage.ts";
 import { scheduleDraftSendAction } from "../../messaging/triage/actions/scheduleDraftSend.ts";
 import { searchMessagesAction as searchInboxMessagesAction } from "../../messaging/triage/actions/searchMessages.ts";
+import {
+	PRINCIPAL_RANK_ADMIN,
+	PRINCIPAL_RANK_USER,
+	resolveMessagePrincipalRole,
+} from "../../messaging/triage/actions/send-consent.ts";
 import { sendDraftAction } from "../../messaging/triage/actions/sendDraft.ts";
 import { triageMessagesAction } from "../../messaging/triage/actions/triageMessages.ts";
 import { getDefaultTriageService } from "../../messaging/triage/triage-service.ts";
@@ -148,6 +153,30 @@ const MESSAGE_DESCRIPTION =
 	"Addressed messaging action: DMs, groups, channels, rooms, threads, servers, users, inboxes, drafts, and authorized cross-world continuity. Use list_worlds to discover durable worlds shared by the verified requester and this agent, list_rooms to inspect the current or an authorized worldId, and read_message to page an exact provider message or email body. Use manage_server for structural server administration on a connector that supports it (create/edit/delete channels, categories, and roles, permission overwrites, member roles, invites, moderation, guild templates) — gated by connector configuration. Public feed publishing uses POST.";
 const MESSAGE_COMPRESSED =
 	"primary message action send read_channel read_with_contact read_message search list_channels list_servers list_connections list_worlds list_rooms join leave react edit delete pin get_user manage_server triage list_inbox search_inbox draft_reply draft_followup respond send_draft schedule_draft_send manage dm group channel room thread user server world inbox draft connections platforms reachable";
+
+/**
+ * Ops an ordinary USER principal may execute (#25284). The umbrella's exposure
+ * gate is USER so owned/delegated delivery paths are reachable by ordinary
+ * users; every op NOT in this set keeps its historical ADMIN floor, enforced
+ * per-op inside the handler regardless of how the action was reached. The
+ * admitted set is exactly the outbound compose/deliver surface: `send`
+ * (direct compose-and-deliver, whose unvetted-recipient path already requires
+ * user confirmation), the draft-compose ops, and `send_draft`, which carries
+ * its own turn-bound consent gate in the leaf. Read/triage topology and every
+ * destructive or scheduling op stays ADMIN.
+ */
+const MESSAGE_USER_OPS: ReadonlySet<MessageOperation> = new Set([
+	"send",
+	"draft_reply",
+	"draft_followup",
+	"respond",
+	"send_draft",
+]);
+
+/** True iff op belongs to the USER-admissible set above (#25284). */
+function messageOpAdmitsUser(op: MessageOperation): boolean {
+	return MESSAGE_USER_OPS.has(op);
+}
 
 // ---------------------------------------------------------------------------
 // Param coercion / op normalization
@@ -5808,13 +5837,6 @@ export const MESSAGE_PARAMETERS: ActionParameter[] = [
 		schema: { type: "string" },
 	},
 	{
-		name: "confirmed",
-		description: "Explicit send confirmation for op=send_draft.",
-		required: false,
-		subactions: ["send_draft"],
-		schema: { type: "boolean" },
-	},
-	{
 		name: "sendAt",
 		description: "Scheduled send time for op=schedule_draft_send.",
 		required: false,
@@ -6226,7 +6248,12 @@ export const messageAction: Action = {
 	routingHint:
 		"send/read/search/triage messages on a connector or channel, discover authorized worlds/rooms, or manage the inbox/drafts -> MESSAGE; do NOT use to reply in the CURRENT chat/thread -> REPLY, to join/mute/follow a channel -> ROOM, or to publish to a public feed/timeline -> POST",
 	contexts: MESSAGE_CONTEXTS,
-	roleGate: { minRole: "ADMIN" },
+	// USER floor per #25284 so ordinary users can deliver their own confirmed
+	// drafts (owned/delegated delivery). Every operation that is NOT a
+	// user-admissible send path re-enforces the historical ADMIN floor inside
+	// the handler (USER_OP_FLOORS below), so lowering exposure cannot widen
+	// any other op.
+	roleGate: { minRole: "USER" },
 	parameters: MESSAGE_PARAMETERS,
 	examples: (spec?.examples ?? []) as ActionExample[][],
 	validate: async (runtime, message, state, options) => {
@@ -6246,6 +6273,45 @@ export const messageAction: Action = {
 		refreshDescriptions(messageAction, runtime);
 		const params = paramsFromOptions(options);
 		const op = inferOp(params);
+		// Per-op floor (#25284): exposure is USER so owned/delegated send paths
+		// are reachable by ordinary users, but every op that is not a
+		// user-admissible send path keeps its historical ADMIN floor here, at
+		// execution, regardless of how the action was reached — and the
+		// user-admissible ops still require at least USER, so GUEST and
+		// unresolvable principals are denied on every op.
+		const admission = await resolveMessagePrincipalRole(runtime, message);
+		if (admission.rank < PRINCIPAL_RANK_ADMIN && !messageOpAdmitsUser(op)) {
+			logger.warn(
+				`[MESSAGE] op=${op} denied: caller role ${admission.role} below ADMIN`,
+			);
+			return {
+				success: false,
+				text: `That messaging operation requires admin access; the current caller is ${admission.role}.`,
+				error: "MESSAGE_OP_ROLE_DENIED",
+				data: {
+					actionName: "MESSAGE",
+					operation: op,
+					error: "MESSAGE_OP_ROLE_DENIED",
+					callerRole: admission.role,
+				},
+			};
+		}
+		if (admission.rank < PRINCIPAL_RANK_USER) {
+			logger.warn(
+				`[MESSAGE] op=${op} denied: caller role ${admission.role} below USER`,
+			);
+			return {
+				success: false,
+				text: `Messaging requires at least user access; the current caller is ${admission.role}.`,
+				error: "MESSAGE_OP_ROLE_DENIED",
+				data: {
+					actionName: "MESSAGE",
+					operation: op,
+					error: "MESSAGE_OP_ROLE_DENIED",
+					callerRole: admission.role,
+				},
+			};
+		}
 		switch (op) {
 			case "send":
 				return handleSend(runtime, message, state, params);

--- a/packages/core/src/features/advanced-capabilities/actions/message.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/message.ts
@@ -156,23 +156,21 @@ const MESSAGE_COMPRESSED =
 	"primary message action send read_channel read_with_contact read_message search list_channels list_servers list_connections list_worlds list_rooms join leave react edit delete pin get_user manage_server triage list_inbox search_inbox draft_reply draft_followup respond send_draft schedule_draft_send manage dm group channel room thread user server world inbox draft connections platforms reachable";
 
 /**
- * Ops an ordinary USER principal may execute (#25284). The umbrella's exposure
- * gate is USER so owned/delegated delivery paths are reachable by ordinary
- * users; every op NOT in this set keeps its historical ADMIN floor, enforced
- * per-op inside the handler regardless of how the action was reached. The
- * admitted set is exactly the outbound compose/deliver surface: `send`
- * (direct compose-and-deliver, whose unvetted-recipient path already requires
- * user confirmation), the draft-compose ops, and `send_draft`, which carries
- * its own turn-bound consent gate in the leaf. Read/triage topology and every
+ * Ops an ordinary USER principal may execute (#25284, narrowed per #27932
+ * review). The umbrella's exposure gate is USER so the consent-gated
+ * draft-delivery path is reachable by ordinary users; every op NOT in this
+ * set keeps its historical ADMIN floor, enforced per-op inside the handler
+ * regardless of how the action was reached. The admitted set is exactly
+ * `send_draft` — the op whose leaf carries the turn-bound consent gate
+ * (#25284). Direct `send`, `draft_reply`, `draft_followup`, and `respond`
+ * stay ADMIN: `respond` drafts and delivers in one turn with no consent
+ * gate, `send`'s confirmation covers only the unvetted-recipient branch,
+ * and `delegateToTriage` dispatches leaf handlers without re-reading their
+ * `roleGate`, so admitting them here would silently bypass the ADMIN floors
+ * those leaf actions still declare. Read/triage topology and every
  * destructive or scheduling op stays ADMIN.
  */
-const MESSAGE_USER_OPS: ReadonlySet<MessageOperation> = new Set([
-	"send",
-	"draft_reply",
-	"draft_followup",
-	"respond",
-	"send_draft",
-]);
+const MESSAGE_USER_OPS: ReadonlySet<MessageOperation> = new Set(["send_draft"]);
 
 /** True iff op belongs to the USER-admissible set above (#25284). */
 function messageOpAdmitsUser(op: MessageOperation): boolean {
@@ -3136,8 +3134,12 @@ async function handleSend(
 			// Turn-bound (#27932 review): exactly ONE pending send confirmation
 			// per actor per room (the helper's cache key already prefixes
 			// actor+action; this key adds only the room). A new operation
-			// OVERWRITES any prior armed preview — even for a different
-			// recipient or connector — so no stale record can ever be
+			// consumes any prior armed preview — even for a different
+			// recipient or connector — on the arming turn: requireConfirmation
+			// resolves (and deletes) the prior record, and because the digest
+			// below cannot match the consumed record's operation, the code
+			// re-arms for the NEW operation regardless of whether the turn
+			// was an affirmative or not. No stale record can ever be
 			// selected. The record carries a SHA-256 digest of the complete
 			// effective send operation — the outbound Content AND the full
 			// resolved TargetInfo — and the arming message id; consumption
@@ -3186,13 +3188,22 @@ async function handleSend(
 				distinctTurn = metadata.armedByMessageId !== String(message.id ?? "");
 			}
 			if (
-				decision.status === "confirmed" &&
+				(decision.status === "confirmed" || decision.status === "cancelled") &&
 				(!digestMatches || !distinctTurn)
 			) {
 				// The consumed record described a DIFFERENT operation: the
-				// affirmative did not authorize THESE bytes. Fail closed and
-				// re-arm for the current operation so the user can
-				// deliberately confirm it on a later message.
+				// reply did not authorize THESE bytes. This covers a genuine
+				// affirmative aimed at a superseded preview AND a
+				// non-affirmative turn (e.g. switching recipients without
+				// saying yes): requireConfirmation consumed the prior record
+				// either way, and reporting "declined" for a request the
+				// user never answered — while leaving the new operation
+				// unarmed — would be wrong twice. Fail closed and re-arm
+				// for the current operation so the user can deliberately
+				// confirm it on a later message. A genuine "no" still
+				// reports declined: there the fingerprint matches and the
+				// turn is distinct, so this guard is false and nothing
+				// re-arms.
 				decision = await requireConfirmation(armArgs);
 				metadata = (decision.metadata ?? {}) as typeof metadata;
 				digestMatches =

--- a/packages/core/src/features/advanced-capabilities/actions/message.world-room-discovery.test.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/message.world-room-discovery.test.ts
@@ -39,6 +39,11 @@ const worlds: World[] = [
 		name: "Discord Guild",
 		agentId: AGENT,
 		messageServerId: "00000000-0000-0000-0000-000000000031" as UUID,
+		// #25284: the MESSAGE umbrella now resolves the caller's principal
+		// role before dispatching; these topology tests exercise discovery
+		// logic, not the role floor, so the fixture sender holds ADMIN in
+		// the world its room resolves to.
+		metadata: { roles: { [DISCORD_OWNER]: "ADMIN" } },
 	},
 	{
 		id: TELEGRAM_WORLD,
@@ -161,6 +166,10 @@ function harness(channelType: ChannelType = ChannelType.DM): Harness {
 		),
 		getRoomsByIds,
 		getWorldsByIds,
+		// #25284: the umbrella resolves the caller's role through the room's
+		// world; resolve from the fixture set so the granted ADMIN above is
+		// visible to the admission check.
+		getWorld: vi.fn(async (worldId: UUID) => worldById.get(worldId) ?? null),
 	} as unknown as IAgentRuntime;
 	const message = {
 		id: "00000000-0000-0000-0000-000000000041" as UUID,

--- a/packages/core/src/features/messaging/triage/__tests__/deferred-send.test.ts
+++ b/packages/core/src/features/messaging/triage/__tests__/deferred-send.test.ts
@@ -18,6 +18,7 @@ import {
 	formatSendAtIso,
 	scheduleDraftSendAction,
 } from "../actions/scheduleDraftSend.ts";
+import { draftConsentDigest } from "../actions/send-consent.ts";
 import { BaseMessageAdapter } from "../adapters/base.ts";
 import { registerDeferredMessageScheduler } from "../deferred-send-scheduler.ts";
 import {
@@ -200,8 +201,8 @@ describe("durable deferred MESSAGE core contract", () => {
 		service.getStore().saveDraft(draft());
 
 		const [first, second] = await Promise.all([
-			service.sendDraft(rt, "draft-1"),
-			service.sendDraft(rt, "draft-1"),
+			service.sendDraft(rt, "draft-1", draftConsentDigest(draft())),
+			service.sendDraft(rt, "draft-1", draftConsentDigest(draft())),
 		]);
 
 		expect(adapter.sendCount).toBe(1);

--- a/packages/core/src/features/messaging/triage/__tests__/triage-service.test.ts
+++ b/packages/core/src/features/messaging/triage/__tests__/triage-service.test.ts
@@ -5,6 +5,7 @@
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { IAgentRuntime } from "../../../../types/index.ts";
+import { draftConsentDigest } from "../actions/send-consent.ts";
 import { MessageRefStore } from "../message-ref-store.ts";
 import {
 	__resetDefaultTriageServiceForTests,
@@ -71,6 +72,16 @@ function draft(
 		sent: false,
 		...overrides,
 	};
+}
+
+/**
+ * Digest of the currently stored draft for id, or a placeholder when the
+ * draft does not exist (the NOT_FOUND path fires before digest validation).
+ * Send-route tests must thread the digest of the exact record they intend.
+ */
+function digestFor(service: TriageService, draftId: string): string {
+	const record = service.getStore().getDraft(draftId);
+	return record ? draftConsentDigest(record) : `digest-for-${draftId}`;
 }
 
 function adapter(
@@ -479,32 +490,53 @@ describe("TriageService management and drafts", () => {
 });
 
 describe("TriageService immediate delivery", () => {
+	it("fails closed when a send route omits the consent digest (#25284 r4)", async () => {
+		const sendDraft = vi.fn(async () => ({ externalId: "unexpected" }));
+		const service = new TriageService(new MessageRefStore());
+		service.register(adapter("gmail", { sendDraft }));
+		service.getStore().saveDraft(draft());
+
+		// Untyped callers can still omit the digest at runtime; the boundary
+		// must reject before the adapter is ever contacted.
+		await expect(
+			service.sendDraft(runtime(), "draft-1", undefined as unknown as string),
+		).rejects.toMatchObject({
+			code: "MESSAGE_DRAFT_CONSENT_DIGEST_REQUIRED",
+		});
+		await expect(
+			service.sendDraft(runtime(), "draft-1", ""),
+		).rejects.toMatchObject({
+			code: "MESSAGE_DRAFT_CONSENT_DIGEST_REQUIRED",
+		});
+		expect(sendDraft).not.toHaveBeenCalled();
+	});
+
 	it("rejects missing drafts, unavailable adapters, and empty provider receipts", async () => {
 		const service = new TriageService(new MessageRefStore());
-		await expect(service.sendDraft(runtime(), "missing")).rejects.toMatchObject(
-			{
-				code: "MESSAGE_DRAFT_NOT_FOUND",
-			},
-		);
+		await expect(
+			service.sendDraft(runtime(), "missing", digestFor(service, "missing")),
+		).rejects.toMatchObject({
+			code: "MESSAGE_DRAFT_NOT_FOUND",
+		});
 
 		service.getStore().saveDraft(draft());
 		service.register(adapter("gmail", { isAvailable: () => false }));
-		await expect(service.sendDraft(runtime(), "draft-1")).rejects.toMatchObject(
-			{
-				code: "MESSAGE_ADAPTER_UNAVAILABLE",
-			},
-		);
+		await expect(
+			service.sendDraft(runtime(), "draft-1", digestFor(service, "draft-1")),
+		).rejects.toMatchObject({
+			code: "MESSAGE_ADAPTER_UNAVAILABLE",
+		});
 
 		service.register(
 			adapter("gmail", {
 				sendDraft: async () => ({ externalId: "  " }),
 			}),
 		);
-		await expect(service.sendDraft(runtime(), "draft-1")).rejects.toMatchObject(
-			{
-				code: "MESSAGE_PROVIDER_RECEIPT_MISSING",
-			},
-		);
+		await expect(
+			service.sendDraft(runtime(), "draft-1", digestFor(service, "draft-1")),
+		).rejects.toMatchObject({
+			code: "MESSAGE_PROVIDER_RECEIPT_MISSING",
+		});
 	});
 
 	it("returns already-sent drafts without contacting the adapter", async () => {
@@ -517,7 +549,9 @@ describe("TriageService immediate delivery", () => {
 		});
 		service.getStore().saveDraft(sent);
 
-		await expect(service.sendDraft(runtime(), "sent")).resolves.toEqual(sent);
+		await expect(
+			service.sendDraft(runtime(), "sent", digestFor(service, "sent")),
+		).resolves.toEqual(sent);
 		expect(sendDraft).not.toHaveBeenCalled();
 	});
 
@@ -537,14 +571,22 @@ describe("TriageService immediate delivery", () => {
 		service.register(adapter("gmail", { sendDraft }));
 		service.getStore().saveDraft(draft());
 
-		const first = service.sendDraft(runtime(), "draft-1");
-		const duplicate = service.sendDraft(runtime(), "draft-1");
+		const first = service.sendDraft(
+			runtime(),
+			"draft-1",
+			digestFor(service, "draft-1"),
+		);
+		const duplicate = service.sendDraft(
+			runtime(),
+			"draft-1",
+			digestFor(service, "draft-1"),
+		);
 		release?.();
 		await expect(Promise.all([first, duplicate])).rejects.toThrow(
 			"temporary provider failure",
 		);
 		await expect(
-			service.sendDraft(runtime(), "draft-1"),
+			service.sendDraft(runtime(), "draft-1", digestFor(service, "draft-1")),
 		).resolves.toMatchObject({
 			sent: true,
 			sentExternalId: "provider-retry",
@@ -586,6 +628,43 @@ describe("TriageService immediate delivery", () => {
 			sentExternalId: "provider-message-1",
 		});
 		expect(service.getStore().getDraft("durable-draft")).toEqual(sent);
+	});
+
+	it("fails closed when the rehydrated snapshot mutates before the replay send (#25284 r4)", async () => {
+		// The deferred replay binds the digest of the snapshot it rehydrated;
+		// a mutation landing in the isAvailable await — after the rehydrate
+		// save, before the pre-adapter revalidation read — must fail closed
+		// instead of delivering the swapped bytes.
+		const createDraft = vi.fn(async () => ({
+			draftId: "provider-local-draft",
+			preview: "provider preview",
+		}));
+		const sendDraft = vi.fn(async () => ({
+			externalId: "provider-message-1",
+		}));
+		const service = new TriageService(new MessageRefStore());
+		service.register(
+			adapter("gmail", {
+				createDraft,
+				sendDraft,
+				isAvailable: () => {
+					service.getStore().saveDraft(
+						draft("provider-local-draft", {
+							body: "Swapped hostile bytes.",
+						}),
+					);
+					return true;
+				},
+			}),
+		);
+		const snapshot = draft("durable-draft", { body: "Original bytes." });
+
+		await expect(
+			service.sendPersistedDraft(runtime(), snapshot),
+		).rejects.toMatchObject({
+			code: "MESSAGE_DRAFT_CONSENT_DIGEST_MISMATCH",
+		});
+		expect(sendDraft).not.toHaveBeenCalled();
 	});
 
 	it("rejects persisted sends when recreation is unavailable or lacks an id", async () => {

--- a/packages/core/src/features/messaging/triage/actions/_shared.ts
+++ b/packages/core/src/features/messaging/triage/actions/_shared.ts
@@ -408,7 +408,6 @@ export function parseDraftFollowupParams(
 
 export interface SendDraftParams {
 	draftId: string;
-	confirmed: boolean;
 }
 export function parseSendDraftParams(
 	options: HandlerOptions | undefined,
@@ -416,8 +415,7 @@ export function parseSendDraftParams(
 	const params = getParams(options);
 	const draftId = asString(params.draftId ?? params.id);
 	if (!draftId) return { error: "draftId is required" };
-	const confirmed = asBool(params.confirmed) ?? false;
-	return { draftId, confirmed };
+	return { draftId };
 }
 
 export function parseSearchMessagesParams(

--- a/packages/core/src/features/messaging/triage/actions/respondToMessage.test.ts
+++ b/packages/core/src/features/messaging/triage/actions/respondToMessage.test.ts
@@ -362,4 +362,80 @@ describe("respondToMessageAction", () => {
 		expect(adapter.sent).toEqual(["draft-1"]);
 		expect(result.text).toBe("Replied on gmail.");
 	});
+
+	it("fails closed when the drafted record mutates before the immediate send (#25284 r4)", async () => {
+		// The immediate-send route binds the digest of the record drafted
+		// this turn; the binding is enforced at the service's pre-adapter
+		// revalidation, so bytes swapped into the store during the adapter
+		// availability check must reject with the typed mismatch instead of
+		// delivering.
+		const adapter = new RecordingAdapter();
+		const service = getDefaultTriageService();
+		adapter.isAvailable = () => {
+			const record = service.getStore().getDraft("draft-1");
+			if (record) {
+				service.getStore().saveDraft({
+					...record,
+					body: "Swapped hostile bytes.",
+				});
+			}
+			return true;
+		};
+		register(adapter);
+		getDefaultMessageRefStore().saveMessage(messageRef());
+
+		await expect(
+			respondToMessageAction.handler(runtime(), turn, undefined, {
+				parameters: { messageId: "message-1", body: "Legit body." },
+			} as never),
+		).rejects.toMatchObject({
+			code: "MESSAGE_DRAFT_CONSENT_DIGEST_MISMATCH",
+		});
+		expect(adapter.sent).toEqual([]);
+	});
+
+	it("fails closed when the queued reply mutates before owner-approved replay (#25284 r4)", async () => {
+		const adapter = new RecordingAdapter();
+		register(adapter);
+		getDefaultMessageRefStore().saveMessage(messageRef());
+		const currentRuntime = runtime();
+		let executor: (() => Promise<{ externalId: string }>) | undefined;
+		const policy: SendPolicy = {
+			async shouldRequireApproval() {
+				return true;
+			},
+			async enqueueApproval(_runtime, draft, send) {
+				executor = send;
+				return { requestId: "approval-2", preview: draft.body };
+			},
+		};
+		registerSendPolicy(currentRuntime, policy);
+
+		const result = await respondToMessageAction.handler(
+			currentRuntime,
+			turn,
+			undefined,
+			{
+				parameters: { messageId: "message-1", body: "Approved text" },
+			} as never,
+		);
+		expect(result.success).toBe(true);
+		if (!executor) throw new Error("Expected an approval executor");
+
+		// Swap hostile bytes into the store between enqueue and the
+		// owner-approved replay: the bound digest must reject them.
+		const record = getDefaultTriageService().getStore().getDraft("draft-1");
+		if (!record) throw new Error("Expected the drafted record in the store");
+		getDefaultTriageService()
+			.getStore()
+			.saveDraft({
+				...record,
+				body: "Swapped hostile bytes.",
+			});
+
+		await expect(executor()).rejects.toMatchObject({
+			code: "MESSAGE_DRAFT_CONSENT_DIGEST_MISMATCH",
+		});
+		expect(adapter.sent).toEqual([]);
+	});
 });

--- a/packages/core/src/features/messaging/triage/actions/respondToMessage.ts
+++ b/packages/core/src/features/messaging/triage/actions/respondToMessage.ts
@@ -6,6 +6,9 @@
  * registered, hands the draft off for owner approval. When the request omits a
  * concrete body it synthesizes a conservative, approval-gated acknowledgment
  * from the original message's subject/snippet rather than guessing content.
+ * Every send route binds the consent digest of the exact drafted snapshot, so
+ * a draft mutated between drafting and delivery (or between enqueue and
+ * owner-approved replay) fails closed (#25284).
  */
 import { logger } from "../../../../logger.ts";
 import type {
@@ -29,6 +32,7 @@ import {
 	type RespondToMessageParams,
 	validateMessageAction,
 } from "./_shared.ts";
+import { draftConsentDigest } from "./send-consent.ts";
 
 async function resolveTargetMessageId(
 	runtime: IAgentRuntime,
@@ -161,10 +165,18 @@ export const respondToMessageAction: Action = {
 			};
 			const required = await policy.shouldRequireApproval(runtime, draftReq);
 			if (required) {
+				// Bind the replay to the exact drafted snapshot (#25284 review
+				// r4): the digest pins delivery to the record this turn's request
+				// produced — a draft mutated between enqueue and owner-approved
+				// replay fails closed instead of delivering bytes the approval
+				// never covered.
+				const consentedDigest = draftConsentDigest(record);
 				const enq = await policy.enqueueApproval(runtime, draftReq, () =>
-					service.sendDraft(runtime, record.draftId).then((r) => ({
-						externalId: r.sentExternalId ?? `pending:${r.draftId}`,
-					})),
+					service
+						.sendDraft(runtime, record.draftId, consentedDigest)
+						.then((r) => ({
+							externalId: r.sentExternalId ?? `pending:${r.draftId}`,
+						})),
 				);
 				const text = `I've drafted the reply on ${record.source} — it's waiting for approval before it goes out.`;
 				logger.info(
@@ -196,7 +208,16 @@ export const respondToMessageAction: Action = {
 			}
 		}
 
-		const sent = await service.sendDraft(runtime, record.draftId);
+		// Bind the immediate send to the snapshot drafted this turn (#25284
+		// review r4): the user's request dictated this body on this turn, so
+		// the digest of the just-created record is the snapshot-intent proof
+		// the service boundary requires; a mutation between draftReply and
+		// send fails closed instead of delivering unvetted bytes.
+		const sent = await service.sendDraft(
+			runtime,
+			record.draftId,
+			draftConsentDigest(record),
+		);
 		const text = `Replied on ${sent.source}.`;
 		logger.info(
 			`[RespondToMessage] sent draftId=${sent.draftId} externalId=${sent.sentExternalId ?? "unknown"}`,

--- a/packages/core/src/features/messaging/triage/actions/send-consent.test.ts
+++ b/packages/core/src/features/messaging/triage/actions/send-consent.test.ts
@@ -251,6 +251,80 @@ describe("#25284 send-consent gate — planner flags can never authorize", () =>
 	});
 });
 
+describe("#25284 send-consent gate — interrogative replies are questions, not consent (#27932 review)", () => {
+	const interrogatives = [
+		"did you send it?",
+		"Did you send the email?",
+		"does it send?",
+		"did that send?",
+		"thanks did you send it",
+		"did you send it just now?",
+		"did you send it",
+		// RP review R1: a question mark ANYWHERE makes the reply a question,
+		// even when trailing punctuation/quotes/words would otherwise survive
+		// the residue filter and reduce to a bare affirmative.
+		"send it?!",
+		"send it?.",
+		'"send it?"',
+		"send it? please",
+		"ok send it? thanks",
+		"ok？send it",
+		// RP review R2: non-Latin question-mark forms must not survive either.
+		"send it؟",
+		"send it﹖",
+		"send it︖",
+		// RP review R3: the class is now the complete Unicode question-mark
+		// set (name-derived) — pin the exotic locales it called out.
+		"send it¿",
+		"send it՞",
+		"send it؟ yes",
+		// RP review R3b: medieval question mark + interrobangs.
+		"send it⹔",
+		"send it‽",
+		"send it⸘",
+	];
+	for (const text of interrogatives) {
+		it(`interrogative "${text}" re-prompts instead of sending`, async () => {
+			const runtime = makeRuntime();
+			const draft = seedDraft();
+			await runSendDraft({
+				runtime,
+				message: makeMessage({ text: "send the draft" }),
+				parameters: { draftId: draft.draftId },
+			});
+			const result = await runSendDraft({
+				runtime,
+				message: makeMessage({ text }),
+				parameters: { draftId: draft.draftId },
+			});
+			expect(result.data).toMatchObject({ consentStatus: "stale" });
+			expect(sendSpy).toHaveBeenCalledTimes(0);
+		});
+	}
+
+	it("a reply carrying a question mark is a question, while terminal punctuation without one still confirms", async () => {
+		// Belt-and-braces must be additive: "ok send it?" — the user asking
+		// whether to send — stays a question (stale), but "ok, send it." with
+		// terminal punctuation still confirms. Punctuation is already
+		// stripped by the residue filter; only the QUESTION MARK carries
+		// question intent.
+		const runtime = makeRuntime();
+		const draft = seedDraft();
+		await runSendDraft({
+			runtime,
+			message: makeMessage({ text: "send the draft" }),
+			parameters: { draftId: draft.draftId },
+		});
+		const result = await runSendDraft({
+			runtime,
+			message: makeMessage({ text: "ok send it?" }),
+			parameters: { draftId: draft.draftId },
+		});
+		expect(result.data).toMatchObject({ consentStatus: "stale" });
+		expect(sendSpy).toHaveBeenCalledTimes(0);
+	});
+});
+
 describe("#25284 send-consent gate — qualified/modified confirmation refuses", () => {
 	const qualified = [
 		"yes, but change the subject",

--- a/packages/core/src/features/messaging/triage/actions/send-consent.test.ts
+++ b/packages/core/src/features/messaging/triage/actions/send-consent.test.ts
@@ -1,0 +1,824 @@
+/**
+ * Deterministic action coverage for the #25284 send-consent gate: planner
+ * tool-call flags can never authorize a send_draft, only a real subsequent
+ * user turn confirming the exact previewed draft snapshot can, and every
+ * mutated/replayed/concurrent/cross-actor/cross-room path sends nothing.
+ * Harness is fully deterministic — an in-memory runtime cache plus a spy
+ * adapter around the real TriageService/MessageRefStore; no live model.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type {
+	ActionResult,
+	HandlerCallback,
+	HandlerOptions,
+	IAgentRuntime,
+	Memory,
+	State,
+	UUID,
+} from "../../../../types/index.ts";
+import { BaseMessageAdapter } from "../adapters/base.ts";
+import {
+	__resetDefaultTriageServiceForTests,
+	getDefaultTriageService,
+} from "../triage-service.ts";
+import type {
+	DraftRecord,
+	DraftRequest,
+	MessageAdapterCapabilities,
+	MessageRef,
+} from "../types.ts";
+import {
+	__resetSendConsentStateForTests,
+	draftConsentDigest,
+	PRINCIPAL_RANK_ADMIN,
+	PRINCIPAL_RANK_USER,
+	resolveMessagePrincipalRole,
+	SEND_CONSENT_TTL_MS,
+} from "./send-consent.ts";
+import { sendDraftAction } from "./sendDraft.ts";
+
+const AGENT_ID = "00000000-0000-0000-0000-0000000000aa" as UUID;
+const USER_ID = "11111111-1111-1111-1111-111111111111" as UUID;
+const ROOM_ID = "22222222-2222-2222-2222-222222222222" as UUID;
+const OTHER_ROOM_ID = "33333333-3333-3333-3333-333333333333" as UUID;
+const WORLD_ID = "66666666-6666-6666-6666-666666666666" as UUID;
+
+/** In-memory cache satisfying the IAgentRuntime cache surface the gate uses. */
+function makeCache(): Pick<
+	IAgentRuntime,
+	"getCache" | "setCache" | "deleteCache"
+> & { __map: Map<string, unknown> } {
+	const map = new Map<string, unknown>();
+	return {
+		__map: map,
+		getCache: async <T>(key: string) => map.get(key) as T | undefined,
+		setCache: async <T>(key: string, value: T) => {
+			map.set(key, value);
+			return true;
+		},
+		deleteCache: async (key: string) => map.delete(key),
+	};
+}
+
+let messageIdCounter = 0;
+function makeMessage(args: {
+	entityId?: UUID;
+	roomId?: UUID;
+	text?: string;
+	/** Explicit message id + createdAt for turn-ordering tests (#25284 r1). */
+	id?: string;
+	createdAt?: number;
+}): Memory {
+	messageIdCounter += 1;
+	return {
+		id: (args.id ??
+			`44444444-4444-4444-4444-${String(messageIdCounter).padStart(12, "0")}`) as UUID,
+		entityId: args.entityId ?? USER_ID,
+		agentId: AGENT_ID,
+		roomId: args.roomId ?? ROOM_ID,
+		createdAt: args.createdAt ?? Date.now(),
+		content: { text: args.text ?? "", source: "test" },
+	} as Memory;
+}
+
+/**
+ * Spy adapter: records every sendDraft call and returns a distinct external id.
+ * The provider spy is the proof that a path did or did not deliver. Registered
+ * on the REAL TriageService so the full draft-store → in-flight dedupe →
+ * provider path executes.
+ */
+const sendSpy = vi.fn();
+
+class SpyAdapter extends BaseMessageAdapter {
+	readonly source = "gmail" as const;
+	isAvailable(): boolean {
+		return true;
+	}
+	capabilities(): MessageAdapterCapabilities {
+		return {
+			list: false,
+			search: false,
+			manage: {},
+			send: { reply: true, new: true },
+			worlds: "single",
+			channels: "none",
+		};
+	}
+	protected listMessagesImpl(): Promise<MessageRef[]> {
+		return Promise.resolve([]);
+	}
+	protected async createDraftImpl(
+		_runtime: IAgentRuntime,
+		draft: DraftRequest,
+	): Promise<{ draftId: string; preview: string }> {
+		return { draftId: `spy:${draft.body}`, preview: draft.body };
+	}
+	async sendDraft(
+		_runtime: IAgentRuntime,
+		draftId: string,
+	): Promise<{ externalId: string }> {
+		// Record the bytes actually delivered: resolve the id to the current
+		// store snapshot, so byte-level assertions can prove WHICH content a
+		// path sent (#25284 r3).
+		const record = getDefaultTriageService().getStore().getDraft(draftId);
+		sendSpy(draftId, record?.body ?? null);
+		return { externalId: `ext-${sendSpy.mock.calls.length}` };
+	}
+}
+
+function makeRuntime(args?: {
+	worldRoles?: Record<string, string>;
+	agentId?: UUID;
+	noWorld?: boolean;
+}): IAgentRuntime {
+	const cache = makeCache();
+	const agentId = args?.agentId ?? AGENT_ID;
+	const roles: Record<string, string> = args?.worldRoles ?? {
+		[USER_ID]: "USER",
+	};
+	const world = {
+		id: WORLD_ID,
+		metadata: { roles },
+	};
+	const runtime = {
+		agentId,
+		...cache,
+		getRoom: async () =>
+			args?.noWorld ? null : { id: ROOM_ID, worldId: WORLD_ID },
+		getWorld: async () => (args?.noWorld ? null : world),
+	} as unknown as IAgentRuntime;
+	return runtime;
+}
+
+function seedDraft(overrides?: Partial<DraftRecord>): DraftRecord {
+	const record: DraftRecord = {
+		draftId: "local:test-draft-1",
+		source: "gmail",
+		to: [{ identifier: "jane@example.com", displayName: "Jane" }],
+		body: "Running five minutes late.",
+		subject: undefined,
+		preview: "[gmail] To: Jane\nRunning five minutes late.",
+		createdAtMs: Date.now(),
+		sent: false,
+		...overrides,
+	};
+	getDefaultTriageService().getStore().saveDraft(record);
+	return record;
+}
+
+/** Invoke the real action handler the way the umbrella dispatch does. */
+async function runSendDraft(args: {
+	runtime: IAgentRuntime;
+	message: Memory;
+	parameters: Record<string, unknown>;
+	callbacks?: HandlerCallback[];
+}): Promise<ActionResult> {
+	const options = { parameters: args.parameters } as unknown as HandlerOptions;
+	const result = await sendDraftAction.handler(
+		args.runtime,
+		args.message,
+		undefined as unknown as State,
+		options,
+	);
+	return result as ActionResult;
+}
+
+beforeEach(() => {
+	__resetDefaultTriageServiceForTests();
+	__resetSendConsentStateForTests();
+	sendSpy.mockClear();
+	getDefaultTriageService().register(new SpyAdapter());
+});
+
+afterEach(async () => {
+	// The service reset in beforeEach also drops the process-global default's
+	// store, and each test builds its own runtime/cache, so pending consent
+	// records cannot leak between tests. Nothing further to clear.
+});
+
+describe("#25284 send-consent gate — planner flags can never authorize", () => {
+	it("planner-asserted confirmed:true sends nothing on the first turn", async () => {
+		const runtime = makeRuntime();
+		const draft = seedDraft();
+		const result = await runSendDraft({
+			runtime,
+			message: makeMessage({ text: "send the draft" }),
+			parameters: { draftId: draft.draftId, confirmed: true },
+		});
+		expect(result.data).toMatchObject({
+			requiresConfirmation: true,
+			consentStatus: "pending",
+		});
+		expect(sendSpy).toHaveBeenCalledTimes(0);
+	});
+
+	it("planner-asserted confirmed:true STILL sends nothing on a later turn unless the user text confirms", async () => {
+		const runtime = makeRuntime();
+		const draft = seedDraft();
+		// Turn 1: preview ask (arms consent)
+		await runSendDraft({
+			runtime,
+			message: makeMessage({ text: "send the draft" }),
+			parameters: { draftId: draft.draftId, confirmed: true },
+		});
+		// Turn 2: planner again asserts confirmed:true but the USER text is a question
+		const result = await runSendDraft({
+			runtime,
+			message: makeMessage({ text: "what would it look like?" }),
+			parameters: { draftId: draft.draftId, confirmed: true },
+		});
+		expect(result.data).toMatchObject({ consentStatus: "stale" });
+		expect(sendSpy).toHaveBeenCalledTimes(0);
+	});
+
+	it("an explicit user 'yes' on a later turn sends exactly once", async () => {
+		const runtime = makeRuntime();
+		const draft = seedDraft();
+		await runSendDraft({
+			runtime,
+			message: makeMessage({ text: "send the draft" }),
+			parameters: { draftId: draft.draftId },
+		});
+		const result = await runSendDraft({
+			runtime,
+			message: makeMessage({ text: "yes" }),
+			parameters: { draftId: draft.draftId },
+		});
+		expect(result.success).toBe(true);
+		expect(result.data).not.toHaveProperty("requiresConfirmation");
+		expect(sendSpy).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe("#25284 send-consent gate — qualified/modified confirmation refuses", () => {
+	const qualified = [
+		"yes, but change the subject",
+		"yes send it to Bob instead",
+		"ok but wait until tomorrow",
+	];
+	for (const text of qualified) {
+		it(`qualified reply "${text}" does not authorize`, async () => {
+			const runtime = makeRuntime();
+			const draft = seedDraft();
+			await runSendDraft({
+				runtime,
+				message: makeMessage({ text: "send the draft" }),
+				parameters: { draftId: draft.draftId },
+			});
+			const result = await runSendDraft({
+				runtime,
+				message: makeMessage({ text }),
+				parameters: { draftId: draft.draftId },
+			});
+			expect(result.data).toMatchObject({ consentStatus: "stale" });
+			expect(sendSpy).toHaveBeenCalledTimes(0);
+		});
+	}
+
+	it("bare affirmatives authorize", async () => {
+		const runtime = makeRuntime();
+		const draft = seedDraft();
+		await runSendDraft({
+			runtime,
+			message: makeMessage({ text: "send the draft" }),
+			parameters: { draftId: draft.draftId },
+		});
+		const result = await runSendDraft({
+			runtime,
+			message: makeMessage({ text: "ok, send it." }),
+			parameters: { draftId: draft.draftId },
+		});
+		expect(result.success).toBe(true);
+		expect(sendSpy).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe("#25284 send-consent gate — cross-actor/cross-room/mutation/replay", () => {
+	it("a different actor's yes does not authorize", async () => {
+		const runtime = makeRuntime();
+		const draft = seedDraft();
+		await runSendDraft({
+			runtime,
+			message: makeMessage({ text: "send the draft" }),
+			parameters: { draftId: draft.draftId },
+		});
+		// The other actor has no role in this world: the per-op principal
+		// floor denies them outright — before consent is even consulted.
+		const result = await runSendDraft({
+			runtime,
+			message: makeMessage({
+				entityId: "55555555-5555-5555-5555-555555555555" as UUID,
+				text: "yes",
+			}),
+			parameters: { draftId: draft.draftId },
+		});
+		expect(result.success).toBe(false);
+		expect(result.data).toMatchObject({
+			error: "SEND_PRINCIPAL_ROLE_DENIED",
+			callerRole: "GUEST",
+		});
+		expect(sendSpy).toHaveBeenCalledTimes(0);
+	});
+
+	it("a GUEST-role sender is denied even for their own previewed draft", async () => {
+		const runtime = makeRuntime({ worldRoles: { [USER_ID]: "GUEST" } });
+		const draft = seedDraft();
+		const result = await runSendDraft({
+			runtime,
+			message: makeMessage({ text: "yes" }),
+			parameters: { draftId: draft.draftId },
+		});
+		expect(result.success).toBe(false);
+		expect(result.data).toMatchObject({ error: "SEND_PRINCIPAL_ROLE_DENIED" });
+		expect(sendSpy).toHaveBeenCalledTimes(0);
+	});
+
+	it("a yes from a different room does not authorize the original room's draft", async () => {
+		const runtime = makeRuntime();
+		const draft = seedDraft();
+		await runSendDraft({
+			runtime,
+			message: makeMessage({ text: "send the draft" }),
+			parameters: { draftId: draft.draftId },
+		});
+		const result = await runSendDraft({
+			runtime,
+			message: makeMessage({ roomId: OTHER_ROOM_ID, text: "yes" }),
+			parameters: { draftId: draft.draftId },
+		});
+		// The other room's turn arms ITS OWN pending record for that room
+		// (single-pending is per actor+room); it can never confirm the
+		// original room's armed consent, and nothing is sent.
+		expect(result.data).toMatchObject({ consentStatus: "pending" });
+		expect(sendSpy).toHaveBeenCalledTimes(0);
+		// The original room must still require its own confirmation.
+		const again = await runSendDraft({
+			runtime,
+			message: makeMessage({ text: "yes" }),
+			parameters: { draftId: draft.draftId },
+		});
+		expect(again.data).toMatchObject({
+			draftId: draft.draftId,
+			externalId: "ext-1",
+		});
+		expect(sendSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("a mutated draft (edited body) re-arms the CURRENT preview instead of dead-ending", async () => {
+		const runtime = makeRuntime();
+		const draft = seedDraft();
+		await runSendDraft({
+			runtime,
+			message: makeMessage({ text: "send the draft" }),
+			parameters: { draftId: draft.draftId },
+		});
+		seedDraft({
+			draftId: draft.draftId,
+			body: "Actually — send this instead.",
+		});
+		// The "yes" answered the ORIGINAL preview, so it must not send the
+		// mutated bytes; the gate re-arms the mutated preview instead.
+		const result = await runSendDraft({
+			runtime,
+			message: makeMessage({ text: "yes" }),
+			parameters: { draftId: draft.draftId },
+		});
+		expect(result.data).toMatchObject({ consentStatus: "pending" });
+		expect(sendSpy).toHaveBeenCalledTimes(0);
+		// A subsequent bare yes now answers the MUTATED preview and sends.
+		const confirmed = await runSendDraft({
+			runtime,
+			message: makeMessage({ text: "yes" }),
+			parameters: { draftId: draft.draftId },
+		});
+		// A confirmed send returns the sent-record marker (externalId), not
+		// a consentStatus key.
+		expect(confirmed.data).toMatchObject({ externalId: expect.any(String) });
+		expect(sendSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("an older affirmative turn replayed after arming never confirms (#25284 r1 F2)", async () => {
+		const runtime = makeRuntime();
+		const draft = seedDraft();
+		await runSendDraft({
+			runtime,
+			message: makeMessage({
+				id: "arm-1",
+				createdAt: 5_000,
+				text: "send the draft",
+			}),
+			parameters: { draftId: draft.draftId },
+		});
+		const replay = await runSendDraft({
+			runtime,
+			message: makeMessage({ id: "old-0", createdAt: 1_000, text: "yes" }),
+			parameters: { draftId: draft.draftId },
+		});
+		expect(replay.data).toMatchObject({ consentStatus: "stale" });
+		expect(sendSpy).toHaveBeenCalledTimes(0);
+		// The record survives the blocked replay; a genuine later yes works.
+		const good = await runSendDraft({
+			runtime,
+			message: makeMessage({ id: "new-2", createdAt: 6_000, text: "yes" }),
+			parameters: { draftId: draft.draftId },
+		});
+		expect(good.data).toMatchObject({ externalId: expect.any(String) });
+		expect(sendSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("replay: a second yes after a confirmed send does not send again", async () => {
+		const runtime = makeRuntime();
+		const draft = seedDraft();
+		await runSendDraft({
+			runtime,
+			message: makeMessage({ text: "send the draft" }),
+			parameters: { draftId: draft.draftId },
+		});
+		await runSendDraft({
+			runtime,
+			message: makeMessage({ text: "yes" }),
+			parameters: { draftId: draft.draftId },
+		});
+		expect(sendSpy).toHaveBeenCalledTimes(1);
+		const result = await runSendDraft({
+			runtime,
+			message: makeMessage({ text: "yes" }),
+			parameters: { draftId: draft.draftId },
+		});
+		expect(sendSpy).toHaveBeenCalledTimes(1);
+		// The service short-circuits on sent drafts; the result is the prior record.
+		expect(result.success).toBe(true);
+	});
+
+	it("refusal cancels the pending consent and sends nothing", async () => {
+		const runtime = makeRuntime();
+		const draft = seedDraft();
+		await runSendDraft({
+			runtime,
+			message: makeMessage({ text: "send the draft" }),
+			parameters: { draftId: draft.draftId },
+		});
+		const result = await runSendDraft({
+			runtime,
+			message: makeMessage({ text: "no, cancel it" }),
+			parameters: { draftId: draft.draftId },
+		});
+		expect(result.data).toMatchObject({
+			cancelled: true,
+			consentStatus: "cancelled",
+		});
+		expect(sendSpy).toHaveBeenCalledTimes(0);
+	});
+
+	it("a refusal clause AFTER an affirmative cancels too (#25284 r1 F4)", async () => {
+		for (const reply of [
+			"yes please don't send",
+			"ok, don't send it",
+			"sure — cancel that",
+		]) {
+			const runtime = makeRuntime();
+			const draft = seedDraft();
+			await runSendDraft({
+				runtime,
+				message: makeMessage({ text: "send the draft" }),
+				parameters: { draftId: draft.draftId },
+			});
+			const result = await runSendDraft({
+				runtime,
+				message: makeMessage({ text: reply }),
+				parameters: { draftId: draft.draftId },
+			});
+			expect(result.data).toMatchObject({ consentStatus: "cancelled" });
+			expect(sendSpy).toHaveBeenCalledTimes(0);
+			sendSpy.mockClear();
+		}
+		// After a cancellation nothing is armed: a bare yes re-arms a
+		// preview rather than sending.
+		const runtime = makeRuntime();
+		const draft = seedDraft();
+		await runSendDraft({
+			runtime,
+			message: makeMessage({ text: "send the draft" }),
+			parameters: { draftId: draft.draftId },
+		});
+		await runSendDraft({
+			runtime,
+			message: makeMessage({ text: "ok, don't send it" }),
+			parameters: { draftId: draft.draftId },
+		});
+		const rearm = await runSendDraft({
+			runtime,
+			message: makeMessage({ text: "yes" }),
+			parameters: { draftId: draft.draftId },
+		});
+		expect(rearm.data).toMatchObject({ consentStatus: "pending" });
+		expect(sendSpy).toHaveBeenCalledTimes(0);
+	});
+});
+
+describe("#25284 send-consent gate — concurrency", () => {
+	it("two simultaneous yes turns produce exactly one provider call", async () => {
+		const runtime = makeRuntime();
+		const draft = seedDraft();
+		await runSendDraft({
+			runtime,
+			message: makeMessage({ text: "send the draft" }),
+			parameters: { draftId: draft.draftId },
+		});
+		const results = await Promise.all([
+			runSendDraft({
+				runtime,
+				message: makeMessage({ text: "yes" }),
+				parameters: { draftId: draft.draftId },
+			}),
+			runSendDraft({
+				runtime,
+				message: makeMessage({ text: "yes" }),
+				parameters: { draftId: draft.draftId },
+			}),
+		]);
+		expect(sendSpy).toHaveBeenCalledTimes(1);
+		const successes = results.filter(
+			(r) => !r.data?.requiresConfirmation,
+		).length;
+		// Exactly one confirmation wins; the loser re-arms the preview or is
+		// idempotently short-circuited by the service's sent flag.
+		expect(successes).toBeGreaterThanOrEqual(1);
+	});
+});
+
+describe("#25284 per-op principal admission", () => {
+	it("the agent itself resolves OWNER", async () => {
+		const runtime = makeRuntime();
+		const admission = await resolveMessagePrincipalRole(
+			runtime,
+			makeMessage({ entityId: AGENT_ID }),
+		);
+		expect(admission.role).toBe("OWNER");
+	});
+
+	it("an unresolvable LOCAL sender keeps the historical USER floor; unknown connector sources stay GUEST", async () => {
+		const runtime = makeRuntime({ noWorld: true });
+		const local = await resolveMessagePrincipalRole(
+			runtime,
+			makeMessage({ entityId: USER_ID }),
+		);
+		// local/test-source traffic keeps the roles.ts USER floor
+		expect(local.rank).toBe(PRINCIPAL_RANK_USER);
+
+		const connector = await resolveMessagePrincipalRole(runtime, {
+			...makeMessage({ entityId: USER_ID }),
+			content: { text: "yes", source: "discord" },
+		} as Memory);
+		// an unknown non-local connector sender cannot outrank a resolved stranger
+		expect(connector.role).toBe("GUEST");
+		expect(connector.rank).toBeLessThan(PRINCIPAL_RANK_USER);
+	});
+
+	it("a role-store failure fails closed below USER, never the local-sender floor (#25284 r1 F1)", async () => {
+		const runtime = {
+			agentId: AGENT_ID,
+			getRoom: async () => {
+				throw new Error("db down");
+			},
+		} as unknown as IAgentRuntime;
+		const admission = await resolveMessagePrincipalRole(
+			runtime,
+			makeMessage({ entityId: USER_ID }),
+		);
+		// An authorization-system outage must deny, not grant: rank 0 sits
+		// below every tier including GUEST.
+		expect(admission.rank).toBe(0);
+		expect(admission.rank).toBeLessThan(PRINCIPAL_RANK_USER);
+	});
+
+	it("role floors compare against the canonical ranks", () => {
+		expect(PRINCIPAL_RANK_USER).toBeLessThan(PRINCIPAL_RANK_ADMIN);
+	});
+});
+
+describe("#25284 consent digest stability", () => {
+	it("digest ignores derived/post-send bookkeeping but binds content", () => {
+		const base: DraftRecord = {
+			draftId: "d1",
+			source: "telegram",
+			to: [{ identifier: "bob" }],
+			body: "hello",
+			preview: "[telegram] To: bob\nhello",
+			createdAtMs: 1_000,
+			sent: false,
+		};
+		expect(draftConsentDigest(base)).toBe(
+			draftConsentDigest({ ...base, sent: true, sentExternalId: "ext-1" }),
+		);
+		expect(draftConsentDigest(base)).toBe(
+			draftConsentDigest({ ...base, preview: "different preview" }),
+		);
+		expect(draftConsentDigest(base)).not.toBe(
+			draftConsentDigest({ ...base, body: "changed" }),
+		);
+		expect(draftConsentDigest(base)).not.toBe(
+			draftConsentDigest({
+				...base,
+				to: [{ identifier: "bob" }, { identifier: "alice" }],
+			}),
+		);
+	});
+
+	it("recipient order does not change the digest", () => {
+		const a: DraftRecord = {
+			draftId: "d1",
+			source: "telegram",
+			to: [{ identifier: "bob", displayName: "Bob" }, { identifier: "alice" }],
+			body: "hello",
+			preview: "p",
+			createdAtMs: 1,
+			sent: false,
+		};
+		expect(draftConsentDigest(a)).toBe(
+			draftConsentDigest({
+				...a,
+				to: [
+					{ identifier: "alice" },
+					{ identifier: "bob", displayName: "Bob" },
+				],
+			}),
+		);
+	});
+});
+
+describe("#25284 send-consent gate — RP review round 3 findings", () => {
+	it("an expired arming cannot be confirmed by a later yes (TTL)", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(1_000_000);
+		try {
+			const runtime = makeRuntime();
+			const draft = seedDraft();
+			// Turn 1 arms the consent.
+			await runSendDraft({
+				runtime,
+				message: makeMessage({ id: "m-arm", createdAt: 1_000_000, text: "" }),
+				parameters: { draftId: draft.draftId },
+			});
+			expect(sendSpy).toHaveBeenCalledTimes(0);
+			// Wall clock advances past the 5-minute TTL window.
+			vi.advanceTimersByTime(SEND_CONSENT_TTL_MS + 60_000);
+			const result = await runSendDraft({
+				runtime,
+				message: makeMessage({
+					id: "m-yes-late",
+					createdAt: 1_000_000 + SEND_CONSENT_TTL_MS + 60_000,
+					text: "yes",
+				}),
+				parameters: { draftId: draft.draftId },
+			});
+			expect(sendSpy).toHaveBeenCalledTimes(0);
+			expect(result.data?.requiresConfirmation).toBe(true);
+			// The expiry path must leave a CONFIRMABLE re-armed preview: a
+			// later bare yes on a fresh turn now sends exactly once.
+			const sent = await runSendDraft({
+				runtime,
+				message: makeMessage({
+					id: "m-yes-fresh",
+					createdAt: 1_000_000 + SEND_CONSENT_TTL_MS + 120_000,
+					text: "yes",
+				}),
+				parameters: { draftId: draft.draftId },
+			});
+			expect(sendSpy).toHaveBeenCalledTimes(1);
+			expect(String(sent.text)).toContain("Sent it.");
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("a role-eligible different USER cannot consume another actor's pending consent", async () => {
+		const OTHER_USER: UUID = "55555555-5555-5555-5555-555555555555" as UUID;
+		const runtime = makeRuntime({
+			worldRoles: { [USER_ID]: "USER", [OTHER_USER]: "USER" },
+		});
+		const draft = seedDraft();
+		// USER arms consent for their own preview in the room.
+		await runSendDraft({
+			runtime,
+			message: makeMessage({ id: "m-arm", createdAt: 1_000, text: "" }),
+			parameters: { draftId: draft.draftId },
+		});
+		// A different role-eligible USER says yes in the same room.
+		const result = await runSendDraft({
+			runtime,
+			message: makeMessage({
+				entityId: OTHER_USER,
+				id: "m-other-yes",
+				createdAt: 2_000,
+				text: "yes",
+			}),
+			parameters: { draftId: draft.draftId },
+		});
+		expect(sendSpy).toHaveBeenCalledTimes(0);
+		expect(result.data?.requiresConfirmation).toBe(true);
+	});
+
+	it("a draft mutated between the consent gate and the provider call sends nothing and re-previews (TOCTOU)", async () => {
+		const runtime = makeRuntime();
+		const draft = seedDraft();
+		const t0 = 1_000;
+		await runSendDraft({
+			runtime,
+			message: makeMessage({ id: "m-arm", createdAt: t0, text: "" }),
+			parameters: { draftId: draft.draftId },
+		});
+		// Mutate the stored bytes so the SECOND store read — the one inside
+		// TriageService.sendDraft, after the gate already confirmed the
+		// first read — observes different content than what was consented.
+		const store = getDefaultTriageService().getStore();
+		const realGet = store.getDraft.bind(store);
+		let reads = 0;
+		vi.spyOn(store, "getDraft").mockImplementation((id: string) => {
+			const rec = realGet(id);
+			reads += 1;
+			// Read 1: the action's `existing` load (consented). Read 2: the
+			// service's post-load validation. Read 3: the pre-adapter
+			// revalidation — the LAST instant the service can still refuse.
+			// Mutate there: the swap must fail closed with zero sends.
+			if (reads === 3 && rec) {
+				const mutated = { ...rec, body: "Swapped hostile bytes." };
+				store.saveDraft(mutated);
+				return mutated;
+			}
+			return rec;
+		});
+		const result = await runSendDraft({
+			runtime,
+			message: makeMessage({ id: "m-yes", createdAt: t0 + 1, text: "yes" }),
+			parameters: { draftId: draft.draftId },
+		});
+		expect(sendSpy).toHaveBeenCalledTimes(0);
+		expect(result.data?.requiresConfirmation).toBe(true);
+		expect(String(result.text)).toContain("changed after you approved");
+		// Complete the designed cycle: the mismatch recovery ARMED the
+		// mutated preview it showed, so a fresh later user yes sends exactly
+		// the bytes the user just saw — one send, mutated body, nothing else.
+		const sent = await runSendDraft({
+			runtime,
+			message: makeMessage({
+				id: "m-yes-mutated",
+				createdAt: t0 + 2,
+				text: "yes",
+			}),
+			parameters: { draftId: draft.draftId },
+		});
+		expect(sendSpy).toHaveBeenCalledTimes(1);
+		expect(sendSpy).toHaveBeenLastCalledWith(
+			draft.draftId,
+			"Swapped hostile bytes.",
+		);
+		expect(String(sent.text)).toContain("Sent it.");
+	});
+
+	it("a failed send can be re-confirmed after re-arming (consumed key is per-arming)", async () => {
+		const runtime = makeRuntime();
+		const draft = seedDraft();
+		const t0 = 1_000;
+		await runSendDraft({
+			runtime,
+			message: makeMessage({ id: "m-arm", createdAt: t0, text: "" }),
+			parameters: { draftId: draft.draftId },
+		});
+		// Consume the arming's consent via a real user yes, with the provider
+		// call itself FAILING after consent was consumed (a transient
+		// provider outage, exercised through the action path).
+		sendSpy.mockImplementationOnce(() => {
+			throw new Error("provider 503");
+		});
+		await expect(
+			runSendDraft({
+				runtime,
+				message: makeMessage({
+					id: "m-yes",
+					createdAt: t0 + 1,
+					text: "yes",
+				}),
+				parameters: { draftId: draft.draftId },
+			}),
+		).rejects.toThrow("provider 503");
+		expect(sendSpy).toHaveBeenCalledTimes(1);
+		// Re-arm via a new preview turn (the planner re-presents the draft).
+		const rearmed = await runSendDraft({
+			runtime,
+			message: makeMessage({ id: "m-arm2", createdAt: t0 + 2, text: "" }),
+			parameters: { draftId: draft.draftId },
+		});
+		expect(rearmed.data?.requiresConfirmation).toBe(true);
+		// The NEXT later user yes confirms again: the consumed set must not
+		// block a fresh arming of the same content after a failed send.
+		const resent = await runSendDraft({
+			runtime,
+			message: makeMessage({ id: "m-yes2", createdAt: t0 + 3, text: "yes" }),
+			parameters: { draftId: draft.draftId },
+		});
+		expect(sendSpy).toHaveBeenCalledTimes(2);
+		expect(String(resent.text)).toContain("Sent it.");
+	});
+});

--- a/packages/core/src/features/messaging/triage/actions/send-consent.ts
+++ b/packages/core/src/features/messaging/triage/actions/send-consent.ts
@@ -1,0 +1,513 @@
+/**
+ * Turn-bound user consent for sending an outbound draft (#25284).
+ *
+ * A send may be authorized only by a real subsequent user turn that answered
+ * the preview the agent showed. Planner tool-call arguments — most notably a
+ * `confirmed: true` boolean — are model-authored and never count as consent
+ * (the GHSA-rqm7 class; `llmConfirmedFlagIsAuthoritative` is unconditionally
+ * false in utils/confirmation.ts). This module implements the two-phase flow
+ * for the MESSAGE send_draft op only: phase one stashes a pending record
+ * binding the requester's actor, room, the arming turn's message id and
+ * timestamp, and a SHA-256 digest of a canonical encoding of every
+ * delivery-relevant field in the draft snapshot; phase two — on a LATER user
+ * turn, proven by a different message id AND a timestamp that does not
+ * predate the arming turn — admits only an unqualified affirmative that
+ * carries an affirmative anchor, with the record's draft binding still
+ * matching, and consumes the record exactly once per arming (the
+ * process-local consumed set — keyed by arming, not digest alone — picks
+ * the single winner among concurrent invocations; losers re-surface the
+ * preview ask, and a fresh arming after a failed or policy-held send can be
+ * confirmed again). A refusal clause anywhere in the reply cancels outright.
+ * A mutated draft re-arms the CURRENT preview (fresh
+ * digest, arming turn, and TTL) so the next bare "yes" answers what the user
+ * last saw instead of dead-ending. Exactly one pending record exists per
+ * actor+room — arming a new draft replaces it, so a later bare "yes" can only
+ * ever authorize the most recently previewed draft, never one the planner
+ * silently swaps in. Durable cross-process/restart idempotency is owned by
+ * #24244 (delivery intents); the service-level in-flight map plus the draft's
+ * `sent` flag are the second layer limiting duplicate provider calls.
+ *
+ * Consumed by `sendDraft.ts`; deliberately stricter than the generic
+ * `requireConfirmation` helper, which binds neither room nor draft content and
+ * accepts a prefix affirmative. The owner SendPolicy gate remains a separate,
+ * independent gate that runs after this one.
+ */
+import crypto from "node:crypto";
+import { logger } from "../../../../logger.ts";
+import {
+	CANONICAL_ROLE_RANK,
+	checkSenderRole,
+	getUnresolvedSenderRoleFloor,
+} from "../../../../roles.ts";
+import { unwrapUserMessageText } from "../../../../security/incoming-message-security.ts";
+import type { IAgentRuntime, Memory } from "../../../../types/index.ts";
+import type { DraftRecord } from "../types.ts";
+
+/** How long a previewed send stays confirmable before it must be re-previewed. */
+export const SEND_CONSENT_TTL_MS = 5 * 60_000;
+
+const SEND_CONSENT_ACTION = "MESSAGE_SEND_DRAFT";
+
+/**
+ * Affirmative anchors: a confirming reply must contain at least one of these
+ * on top of reducing to cue words only. Without the anchor requirement a
+ * filler-only reply ("please", "now", "the draft") would authorize a send.
+ */
+const AFFIRMATIVE_ANCHORS = new Set([
+	"yes",
+	"yeah",
+	"yep",
+	"y",
+	"ok",
+	"okay",
+	"sure",
+	"confirm",
+	"confirmed",
+	"approve",
+	"approved",
+	"go",
+	"proceed",
+	"send",
+	"sends",
+	"sendt",
+	"si",
+	"sí",
+	"oui",
+	"ja",
+	"hai",
+	"はい",
+	"确认",
+	"確認",
+	"확인",
+	"네",
+	"是",
+	"好的",
+	"envía",
+	"envia",
+	"manda",
+	"发送",
+	"发吧",
+	"送信",
+	"送って",
+	"보내",
+	"보내세요",
+]);
+
+/**
+ * Bare-affirmation detector using the residue approach proven in the life
+ * create-consent gate: strip send cues, draft references, politeness filler,
+ * and punctuation; the reply counts as consent only when NOTHING substantive
+ * survives AND at least one affirmative anchor survived. "yes", "ok, send
+ * it.", and "Send that Gmail reply now." all qualify; "yes, but change the
+ * subject", "send it to Bob instead", "ok but wait until tomorrow", and
+ * filler-only replies like "please" or "the draft" do not.
+ */
+const SEND_CUE_WORDS = new Set([
+	...AFFIRMATIVE_ANCHORS,
+	// affirmation/timing particles that may accompany an anchor
+	"sending",
+	"sent",
+	"ahead",
+	"do",
+	"did",
+	"does",
+	"it",
+	"out",
+	"して",
+	// politeness filler
+	"please",
+	"pls",
+	"now",
+	"just",
+	"exactly",
+	"thanks",
+	"thank",
+	"you",
+	"merci",
+	// generic draft references (the exact draft identity is bound by digest,
+	// never re-parsed from the reply)
+	"the",
+	"a",
+	"an",
+	"that",
+	"this",
+	"those",
+	"these",
+	"one",
+	"draft",
+	"message",
+	"reply",
+	"email",
+	"mail",
+	"note",
+	"im",
+	"text",
+	"sms",
+	"dm",
+	"gmail",
+	"imessage",
+	"whatsapp",
+	"telegram",
+	"discord",
+	"slack",
+]);
+
+function isBareSendAffirmation(text: string): boolean {
+	const residue = text
+		.toLowerCase()
+		.replace(/[^\p{L}\p{N}]+/gu, " ")
+		.trim();
+	if (residue.length === 0) return false;
+	let sawAnchor = false;
+	for (const word of residue.split(/\s+/)) {
+		if (!SEND_CUE_WORDS.has(word)) return false;
+		if (AFFIRMATIVE_ANCHORS.has(word)) sawAnchor = true;
+	}
+	return sawAnchor;
+}
+
+/**
+ * Unambiguous refusals clear the pending record immediately. A refusal is
+ * recognized anywhere in the reply — leading ("no"), trailing after an
+ * affirmative ("yes please don't send"), or standalone ("ok, don't send
+ * it") — because an affirmative that carries a refusal clause must never
+ * count as consent, and leaving the record armed after the user said not to
+ * send is both a UX bug and one careless later "yes" away from a wrong send.
+ * The clause set stays English-only on purpose: it only ever CANCELS, so a
+ * missed non-English refusal degrades to a re-preview ask, never to a send.
+ */
+const REFUSAL_RE =
+	/(?:^|[\s,.!?;:…。！？、])(?:no|nope|nah|cancel|stop|don'?t|do not|never mind|nevermind|abort)\b/iu;
+
+type SendConsentStatus =
+	| { status: "pending"; preview: string }
+	| { status: "confirmed" }
+	| { status: "cancelled" }
+	| { status: "stale"; preview: string };
+
+interface PendingSendConsent {
+	readonly actionName: string;
+	readonly entityId: string;
+	readonly roomId: string;
+	readonly draftId: string;
+	readonly digest: string;
+	/** Identity of this arming: strictly increasing, so re-arms never collide in the consumed set. */
+	readonly seq: number;
+	/** Message id of the turn that armed this record; consent must arrive on a different, later turn. */
+	readonly armedMessageId: string;
+	/** Wall-clock `createdAt` of the arming turn; a confirming turn must not predate it. */
+	readonly armedAtMs: number;
+	readonly createdAt: number;
+	readonly ttlMs: number;
+}
+
+/**
+ * Canonical JSON: object keys sorted at every depth so key order can never
+ * change the digest of otherwise-identical content.
+ */
+function canonicalize(value: unknown): unknown {
+	if (Array.isArray(value)) return value.map(canonicalize);
+	if (value && typeof value === "object") {
+		const record = value as Record<string, unknown>;
+		return Object.fromEntries(
+			Object.keys(record)
+				.sort()
+				.map((key) => [key, canonicalize(record[key])]),
+		);
+	}
+	return value;
+}
+
+/**
+ * SHA-256 digest of a canonical JSON encoding of every delivery-relevant
+ * field in the immutable draft snapshot. JSON string encoding makes delimiter
+ * collisions impossible (every field is unambiguously quoted/escaped), unlike
+ * the earlier raw-field join. `preview` and bookkeeping (`sent`,
+ * `sentExternalId`, `scheduledForMs`, `scheduledId`, `scheduleCommit`) are
+ * excluded because they are derived or post-send state, not things the user
+ * is consenting to.
+ */
+export function draftConsentDigest(record: DraftRecord): string {
+	const payload = canonicalize({
+		id: record.draftId,
+		src: record.source,
+		reply: record.inReplyToId ?? "",
+		thread: record.threadId ?? "",
+		world: record.worldId ?? "",
+		channel: record.channelId ?? "",
+		to: [...record.to]
+			.map((r) => [r.identifier, r.displayName ?? ""] as const)
+			// Sort by the complete canonical tuple: identifier-only sorting
+			// lets reordered duplicate identifiers with different
+			// displayNames change the digest, breaking the
+			// recipient-order-canonicalization invariant (#25284 review r1).
+			.sort(([ai, ad], [bi, bd]) =>
+				ai < bi ? -1 : ai > bi ? 1 : ad < bd ? -1 : ad > bd ? 1 : 0,
+			),
+		subject: record.subject ?? "",
+		body: record.body,
+		meta: record.metadata === undefined ? "" : record.metadata,
+	});
+	return crypto
+		.createHash("sha256")
+		.update(JSON.stringify(payload), "utf8")
+		.digest("hex");
+}
+
+/**
+ * One pending consent per actor+room (#25284 review round 2): a bare "yes"
+ * can only ever authorize the newest previewed draft for that conversation —
+ * the planner cannot keep several drafts armed and pick one after the fact.
+ */
+function cacheKey(entityId: string, roomId: string): string {
+	return `send-consent:${SEND_CONSENT_ACTION}:${entityId}:${roomId}`;
+}
+
+function isFresh(pending: PendingSendConsent): boolean {
+	return Date.now() - pending.createdAt <= pending.ttlMs;
+}
+
+/**
+ * Monotonic arming sequence: every arming (fresh or re-arm) gets a strictly
+ * increasing counter so two armings in the same millisecond remain distinct
+ * consumed keys — a failed or policy-held send's re-arm must never collide
+ * with the spent key of the arming that preceded it (#25284 r3). Kept
+ * separate from `createdAt`, which stays a real epoch-ms freshness clock.
+ */
+let armingSeq = 0;
+function nextArmingSeq(): number {
+	armingSeq += 1;
+	return armingSeq;
+}
+
+/**
+ * Two-phase send-consent gate for one conversation (actor+room).
+ *
+ * Call on every send_draft invocation with the draft the planner wants to
+ * send. The first call stashes the binding and returns `pending` — the caller
+ * must surface the preview ask. On a later turn (different message id), an
+ * unqualified affirmative carrying an affirmative anchor, with the armed
+ * draft's digest still matching, returns `confirmed` exactly once per process
+ * (the consumed set picks the single winner; losers re-arm the preview); a
+ * refusal returns `cancelled`; anything else — the same turn re-invoking,
+ * a different draft than the one armed, an edited draft, an expired record,
+ * or qualified confirmation text — returns `stale` (or a fresh `pending` when
+ * nothing was armed), and the caller re-arms the preview.
+ */
+export async function gateSendDraftConsent(args: {
+	runtime: IAgentRuntime;
+	message: Memory;
+	draft: DraftRecord;
+	ttlMs?: number;
+}): Promise<SendConsentStatus> {
+	const ttlMs =
+		typeof args.ttlMs === "number" &&
+		Number.isFinite(args.ttlMs) &&
+		args.ttlMs > 0
+			? args.ttlMs
+			: SEND_CONSENT_TTL_MS;
+	const entityId = String(args.message.entityId ?? "");
+	const roomId = String(args.message.roomId ?? "");
+	const messageId = String(args.message.id ?? "");
+	const key = cacheKey(entityId, roomId);
+	const digest = draftConsentDigest(args.draft);
+	const userText = unwrapUserMessageText(args.message).trim();
+	// Trusted message timestamp (ms epoch) used to prove the confirming turn
+	// is subsequent to the arming turn. Connectors stamp `createdAt` server-
+	// side from their ingest time; an unparsable value fails closed below.
+	const messageCreatedAt = Number(args.message.createdAt);
+
+	let existing: PendingSendConsent | undefined =
+		await args.runtime.getCache<PendingSendConsent>(key);
+	if (existing && !isFresh(existing)) {
+		// Expired: clear it BEFORE arming the replacement so the fresh record
+		// is never deleted out from under the preview we are about to return.
+		await args.runtime.deleteCache(key).catch(() => {
+			/* error-policy:J6 best-effort cleanup of the expired record */
+		});
+		existing = undefined;
+	}
+
+	if (!existing) {
+		const pending: PendingSendConsent = {
+			actionName: SEND_CONSENT_ACTION,
+			entityId,
+			roomId,
+			draftId: args.draft.draftId,
+			digest,
+			armedMessageId: messageId,
+			armedAtMs: Number.isFinite(messageCreatedAt)
+				? messageCreatedAt
+				: Date.now(),
+			createdAt: Date.now(),
+			seq: nextArmingSeq(),
+			ttlMs,
+		};
+		await args.runtime.setCache(key, pending);
+		return { status: "pending", preview: args.draft.preview };
+	}
+
+	// Same-turn re-invocation (planner re-calls send_draft while settling the
+	// same message) can never confirm: consent must arrive on a LATER user
+	// turn, proven by a different message id...
+	if (messageId === existing.armedMessageId) {
+		return { status: "stale", preview: args.draft.preview };
+	}
+	// ...AND by a turn that did not exist before the preview was armed. A
+	// different id alone is replayable: an older affirmative (or one the
+	// planner dug out of history) must never satisfy the gate. Unparsable or
+	// missing createdAt fails closed — the turn cannot be proven subsequent.
+	if (
+		!Number.isFinite(messageCreatedAt) ||
+		messageCreatedAt < existing.armedAtMs
+	) {
+		return { status: "stale", preview: args.draft.preview };
+	}
+
+	// A refusal clause anywhere in the reply cancels outright, before any
+	// re-arming: the user said not to send, so no preview stays armed.
+	if (REFUSAL_RE.test(userText)) {
+		await args.runtime.deleteCache(key);
+		return { status: "cancelled" };
+	}
+
+	// The planner is presenting a draft whose consent digest differs from
+	// the armed one — a different draft, or a mutated version of it. Either
+	// way the consent the user gave does not describe these bytes: replace
+	// the binding with THIS draft (fresh digest, arming turn, and TTL) and
+	// re-preview, so the next bare "yes" answers what the user last saw
+	// instead of dead-ending or authorizing content they never saw.
+	if (existing.digest !== digest) {
+		const pending: PendingSendConsent = {
+			actionName: SEND_CONSENT_ACTION,
+			entityId,
+			roomId,
+			draftId: args.draft.draftId,
+			digest,
+			armedMessageId: messageId,
+			armedAtMs: Number.isFinite(messageCreatedAt)
+				? messageCreatedAt
+				: Date.now(),
+			createdAt: Date.now(),
+			seq: nextArmingSeq(),
+			ttlMs,
+		};
+		await args.runtime.setCache(key, pending);
+		logger.warn(
+			`[SendDraft] consent re-armed for draftId=${args.draft.draftId} (digest changed); re-preview`,
+		);
+		return { status: "pending", preview: args.draft.preview };
+	}
+
+	// A later turn whose text is not a bare affirmative keeps the unchanged
+	// preview armed without consuming it.
+	if (!isBareSendAffirmation(userText)) {
+		return { status: "stale", preview: args.draft.preview };
+	}
+
+	// Single-winner consumption within this process: the consumed set decides
+	// among concurrent invocations of the SAME arming; losers get `stale` and
+	// re-surface the preview ask (the winner either delivered or hold/failed it —
+	// either way this arming is spent; a NEW arming below gets a fresh consumed
+	// key). The key is bound to the arming (`seq`), not just the digest, so
+	// a later re-arm of the same content after a failed or policy-held send can
+	// be confirmed again instead of colliding with the spent key. Cross-process
+	// and cross-restart idempotency are owned by #24244 (delivery intents), and
+	// the service-level in-flight map plus the draft's `sent` flag are the second
+	// layer limiting duplicate provider calls.
+	const consumedKey = `${key}:${existing.digest}:${existing.seq}`;
+	if (consumedConsentKeys.has(consumedKey)) {
+		return { status: "stale", preview: args.draft.preview };
+	}
+	consumedConsentKeys.add(consumedKey);
+	noteConsumedKeyPrune();
+	await args.runtime.deleteCache(key);
+	return { status: "confirmed" };
+}
+
+/**
+ * Consumed consent keys, process-local. Bounded by the TTL window: entries
+ * are pruned opportunistically so the set cannot grow unboundedly in a
+ * long-running process.
+ */
+const consumedConsentKeys = new Set<string>();
+const CONSUMED_SET_MAX = 512;
+
+function noteConsumedKeyPrune(): void {
+	if (consumedConsentKeys.size <= CONSUMED_SET_MAX) return;
+	const excess = consumedConsentKeys.size - CONSUMED_SET_MAX;
+	let dropped = 0;
+	for (const k of consumedConsentKeys) {
+		consumedConsentKeys.delete(k);
+		dropped += 1;
+		if (dropped >= excess) break;
+	}
+}
+
+/** Test hook: drop a pending consent record without resolving it. */
+export async function clearSendDraftConsent(args: {
+	runtime: IAgentRuntime;
+	entityId: string;
+	roomId: string;
+}): Promise<void> {
+	await args.runtime.deleteCache(cacheKey(args.entityId, args.roomId));
+}
+
+/** Test hook: forget consumed-consent markers so a new suite starts clean. */
+export function __resetSendConsentStateForTests(): void {
+	consumedConsentKeys.clear();
+}
+
+/**
+ * Per-op principal admission for the MESSAGE send path (#25284): owned/
+ * delegated delivery is a USER capability, so USER and above are admitted and
+ * GUEST is denied. Mirrors `resolveToolCallUserRoles` in the tool-call
+ * executor: the agent itself is OWNER; any other sender resolves through the
+ * canonical role resolution; an unresolvable role ranks below every tier
+ * (fail-closed) rather than silently authorizing a send. A role-resolution
+ * FAILURE keeps the source-dependent unresolved-sender floor (roles.ts
+ * convention): local/API senders keep their historical USER admission while
+ * unresolved connector senders stay GUEST — never above their source's tier.
+ */
+export interface MessagePrincipalAdmission {
+	readonly role: string;
+	readonly rank: number;
+}
+
+export const PRINCIPAL_RANK_USER = CANONICAL_ROLE_RANK.USER;
+export const PRINCIPAL_RANK_ADMIN = CANONICAL_ROLE_RANK.ADMIN;
+
+function principalRank(role: string): number {
+	// Unknown strings rank 0 — below GUEST — so unresolved principals can
+	// never pass a floor. Lookup, not an identity assertion.
+	return CANONICAL_ROLE_RANK[role as keyof typeof CANONICAL_ROLE_RANK] ?? 0;
+}
+
+export async function resolveMessagePrincipalRole(
+	runtime: IAgentRuntime,
+	message: Memory,
+): Promise<MessagePrincipalAdmission> {
+	if (message.entityId === runtime.agentId) {
+		return { role: "OWNER", rank: principalRank("OWNER") };
+	}
+	try {
+		const result = await checkSenderRole(runtime, message);
+		// No resolvable world/room: apply the shared local-sender floor so
+		// local/API/harness traffic keeps its historical USER behavior while
+		// unknown connector senders stay GUEST (roles.ts convention).
+		const role = result?.role ?? getUnresolvedSenderRoleFloor(message);
+		return { role, rank: principalRank(role) };
+	} catch (error) {
+		// error-policy:J4 A role-resolution FAILURE must surface as a visible
+		// denial, never as a thrown error that could skip the gate or crash
+		// the turn. Unlike a clean no-world lookup (which may keep the
+		// trusted local-source floor), an exception means the authorization
+		// system itself is unhealthy: fail closed to an unresolvable
+		// principal ranked below every tier — never the local-sender USER
+		// floor, which would authorize sends during an outage.
+		logger.warn(
+			`[SendConsent] principal role resolution failed: ${String(error)}`,
+		);
+		return { role: "UNRESOLVED", rank: principalRank("UNRESOLVED") };
+	}
+}

--- a/packages/core/src/features/messaging/triage/actions/send-consent.ts
+++ b/packages/core/src/features/messaging/triage/actions/send-consent.ts
@@ -108,9 +108,6 @@ const SEND_CUE_WORDS = new Set([
 	"sending",
 	"sent",
 	"ahead",
-	"do",
-	"did",
-	"does",
 	"it",
 	"out",
 	"して",
@@ -151,12 +148,36 @@ const SEND_CUE_WORDS = new Set([
 	"discord",
 	"slack",
 ]);
+// NOTE (#27932 review): interrogative auxiliaries ("do", "did", "does") are
+// deliberately NOT cue words. With "did" admitted, "did you send it?" reduced
+// to cue words only with "send" as an anchor and authorized an irreversible
+// send off a question about whether the send happened. A question is never an
+// answer to the preview; the residue test below plus the question-mark check
+// fail these closed.
+// Any Unicode question-mark codepoint marks a question. The class is the
+// complete set of codepoints whose Unicode name contains "QUESTION MARK"
+// (including TAG QUESTION MARK U+E003F and MEDIEVAL QUESTION MARK U+2E54,
+// Unicode 14) plus the interrobang family (⁇ ⁈ ⁉ ‽ ⸘) — question semantics
+// per the Unicode names list. Derived from the Unicode data, not hand-picked,
+// so no locale's question shape (Arabic ؟, Armenian ՞, Greek ;, Ethiopic ፧,
+// Vai ꘏, Chakma 𑅃, inverted ¿, …) is missed. None is alphanumeric, so none
+// participates in the residue filter below; a question always fails closed.
+const QUESTION_MARK_RE = /[?¿;՞؟፧᥅⁇⁈⁉‽⸘❓❔⩻⩼⳺⳻⸮꘏꛷︖﹖？⹔𑅃𞥟🯄󠀿]/u;
 
 function isBareSendAffirmation(text: string): boolean {
-	const residue = text
-		.toLowerCase()
-		.replace(/[^\p{L}\p{N}]+/gu, " ")
-		.trim();
+	const lowered = text.toLowerCase();
+	// ANY question mark makes the reply a question about the send ("did you
+	// send it?", "ok send it?"), not an answer to the preview — regardless of
+	// trailing punctuation, quotes, or trailing words ("send it?!", "\"send
+	// it?\"", "send it? please"). Checked before punctuation stripping
+	// because the residue filter would otherwise erase the mark and turn the
+	// question into a bare affirmative. Covers the Unicode question-mark
+	// forms (full-width ？, Arabic ؟, small ﹖, presentation ︖, inverted ⸮,
+	// interrobangs ⁇⁈⁉) so no locale's question shape survives stripping.
+	// False positives (an affirmative that quotes a question) merely
+	// re-prompt: fail-safe direction.
+	if (QUESTION_MARK_RE.test(lowered)) return false;
+	const residue = lowered.replace(/[^\p{L}\p{N}]+/gu, " ").trim();
 	if (residue.length === 0) return false;
 	let sawAnchor = false;
 	for (const word of residue.split(/\s+/)) {

--- a/packages/core/src/features/messaging/triage/actions/sendDraft.ts
+++ b/packages/core/src/features/messaging/triage/actions/sendDraft.ts
@@ -4,18 +4,22 @@
  * supplied it extracts the target platform, recipient, and body from the user's
  * request (via `outboundDraftOptionsFromMessage`, which is model-driven so it
  * works in any language) and persists a draft; when a draft id is supplied it
- * sends that draft. If the TriageService adapter cannot create a draft it falls
+ * sends that draft — but only after a real user turn confirmed the previewed
+ * draft (#25284). If the TriageService adapter cannot create a draft it falls
  * back to a locally stored draft so the confirmation flow still works.
  *
- * Two independent gates guard every send. The user-confirmation gate refuses to
- * send without an explicit `confirmed: true`, returning a preview instead; the
- * owner SendPolicy gate (when a policy is registered) can defer any send for
- * owner approval, enqueuing the sendDraft executor for later replay.
+ * Two independent gates guard every send. The user-consent gate
+ * (`gateSendDraftConsent`) refuses to send until a subsequent user turn — never
+ * a planner-authored parameter — answers the preview with an unqualified
+ * affirmative for the exact same draft snapshot, actor, and room; the owner
+ * SendPolicy gate (when a policy is registered) can defer any send for owner
+ * approval, enqueuing the sendDraft executor for later replay.
  *
  * `outboundDraftOptionsFromMessage` is exported for the unit tests in
  * `sendDraft.test.ts`.
  */
 import crypto from "node:crypto";
+import { ElizaError } from "../../../../errors.ts";
 import { logger } from "../../../../logger.ts";
 import type {
 	Action,
@@ -44,6 +48,12 @@ import {
 	parseSendDraftParams,
 	validateMessageAction,
 } from "./_shared.ts";
+import {
+	draftConsentDigest,
+	gateSendDraftConsent,
+	PRINCIPAL_RANK_USER,
+	resolveMessagePrincipalRole,
+} from "./send-consent.ts";
 
 const OUTBOUND_DRAFT_PARAMETERS: ActionParameter[] = [
 	{
@@ -237,18 +247,23 @@ function saveLocalOutboundDraft(args: {
 }
 
 /**
- * SAFETY INVARIANT: MESSAGE must never send without an explicit
- * `confirmed: true` parameter. When confirmation is missing the handler
- * returns the preview and asks the user to confirm.
+ * SAFETY INVARIANT: MESSAGE must never send on planner-authored arguments. The
+ * `confirmed` boolean is gone from the parameter surface; a send is authorized
+ * only by `gateSendDraftConsent`, which requires a real subsequent user turn
+ * (#25284).
  */
 export const sendDraftAction: Action = {
 	name: "MESSAGE",
 	contexts: ["messaging", "email", "contacts"],
-	roleGate: { minRole: "ADMIN" },
+	// USER+ per #25284: owned/delegated delivery is a user capability; GUEST is
+	// denied. This leaf is only reachable through the umbrella MESSAGE action,
+	// which keeps its own exposure gate; this floor is the send-specific
+	// admission the umbrella cannot express per-op.
+	roleGate: { minRole: "USER" },
 	description:
-		"Create or send an owner-scoped outbound message draft. Use this for first-turn requests like 'send a Telegram message to Jane saying I am late', 'DM Bob on Discord', 'email Alice the notes', and 'text Sam that I am outside'. Without confirmed=true it only creates or previews the draft and asks for confirmation; it never sends directly.",
+		"Create or send an owner-scoped outbound message draft. Use this for first-turn requests like 'send a Telegram message to Jane saying I am late', 'DM Bob on Discord', 'email Alice the notes', and 'text Sam that I am outside'. It creates or previews the draft and asks for confirmation; a later user reply that confirms the preview is the only thing that sends it.",
 	descriptionCompressed:
-		"outbound draft/send Telegram|Discord|email|SMS|iMessage|WhatsApp|DM; requires confirmed=true",
+		"outbound draft/send Telegram|Discord|email|SMS|iMessage|WhatsApp|DM; send requires a confirming user turn",
 	similes: [
 		"DISPATCH_DRAFT",
 		"CONFIRM_AND_SEND",
@@ -257,12 +272,6 @@ export const sendDraftAction: Action = {
 	],
 	parameters: [
 		{ ...draftIdParameter, required: false },
-		{
-			name: "confirmed",
-			description: "Whether the user explicitly confirmed sending the draft.",
-			required: false,
-			schema: { type: "boolean" as const, default: false },
-		},
 		...OUTBOUND_DRAFT_PARAMETERS,
 	],
 	examples: [
@@ -354,6 +363,18 @@ export const sendDraftAction: Action = {
 			logger.info(
 				`[SendDraft] created outbound draft draftId=${record.draftId} source=${record.source}`,
 			);
+			// Arm the consent gate at creation (#25284 review round 2): the
+			// preview this turn shows is the one the next user turn answers,
+			// instead of leaving the draft un-armed and demanding a second
+			// confirm cycle.
+			const armed = await gateSendDraftConsent({
+				runtime,
+				message: _message,
+				draft: record,
+			});
+			logger.info(
+				`[SendDraft] consent armed at creation: status=${armed.status} draftId=${record.draftId}`,
+			);
 			if (callback) {
 				await callback({ text, action: "MESSAGE" });
 			}
@@ -378,16 +399,62 @@ export const sendDraftAction: Action = {
 			return { success: false, text: msg, error: msg };
 		}
 
-		if (!parsed.confirmed) {
-			// The confirm prompt is the designed ask the user must answer:
-			// verified + turnComplete make it the sole delivery, worded like a
-			// person asking; the draftId stays planner-facing in data.
-			const text = `Here's what I'm about to send: ${existing.preview} — want me to send it?`;
-			logger.info(`[SendDraft] confirmation gate: draftId=${parsed.draftId}`);
+		// Per-op principal admission (#25284): the umbrella MESSAGE gate covers
+		// exposure, but send_draft specifically admits USER+ (owned/delegated
+		// delivery) and denies GUEST. Fail closed when the sender's role cannot
+		// be resolved.
+		const admission = await resolveMessagePrincipalRole(runtime, _message);
+		if (admission.rank < PRINCIPAL_RANK_USER) {
+			const text = `Sending drafts requires at least user access; the current caller is ${admission.role}.`;
+			logger.warn(
+				`[SendDraft] role denied: role=${admission.role} draftId=${parsed.draftId}`,
+			);
+			return {
+				success: false,
+				text,
+				error: "SEND_PRINCIPAL_ROLE_DENIED",
+				data: {
+					actionName: "MESSAGE",
+					error: "SEND_PRINCIPAL_ROLE_DENIED",
+					callerRole: admission.role,
+				},
+			};
+		}
+
+		const consent = await gateSendDraftConsent({
+			runtime,
+			message: _message,
+			draft: existing,
+		});
+		if (consent.status !== "confirmed") {
+			const text =
+				consent.status === "cancelled"
+					? "Cancelled — I won't send that draft."
+					: `Here's what I'm about to send: ${existing.preview} — want me to send it?`;
+			const data =
+				consent.status === "cancelled"
+					? {
+							requiresConfirmation: false,
+							cancelled: true,
+							draftId: existing.draftId,
+							source: existing.source,
+						}
+					: {
+							requiresConfirmation: true,
+							preview: existing.preview,
+							draftId: existing.draftId,
+							source: existing.source,
+							to: existing.to,
+						};
+			logger.info(
+				`[SendDraft] consent gate: status=${consent.status} draftId=${parsed.draftId}`,
+			);
 			if (callback) {
 				await callback({ text, action: "MESSAGE" });
 			}
 			return {
+				// A pending preview ask completes the turn; a refusal completes it
+				// too. Both are the designed ask/answer, not failures.
 				success: true,
 				text,
 				userFacingText: text,
@@ -395,18 +462,17 @@ export const sendDraftAction: Action = {
 				turnComplete: true,
 				continueChain: false,
 				data: {
-					requiresConfirmation: true,
-					preview: existing.preview,
-					draftId: existing.draftId,
-					source: existing.source,
+					...data,
+					consentStatus: consent.status,
 				},
 			};
 		}
 
-		// Owner-policy gate (separate from the user-confirmation gate above):
+		// Owner-policy gate (separate from the user-consent gate above):
 		// hosts can register a SendPolicy that defers any outbound send until
 		// owner approval. When the policy enqueues, we report pending and
 		// hand the executor (sendDraft) over for later replay.
+		const consentedDigest = draftConsentDigest(existing);
 		const policy = getSendPolicy(runtime);
 		if (policy) {
 			const draftReq: DraftRequest = {
@@ -423,9 +489,15 @@ export const sendDraftAction: Action = {
 			const required = await policy.shouldRequireApproval(runtime, draftReq);
 			if (required) {
 				const enq = await policy.enqueueApproval(runtime, draftReq, () =>
-					service.sendDraft(runtime, parsed.draftId).then((rec) => ({
-						externalId: rec.sentExternalId ?? `pending:${rec.draftId}`,
-					})),
+					// Bind the replay to the consented snapshot too (#25284): if
+					// the draft mutates between consent and owner-approved
+					// replay, the send fails closed instead of delivering
+					// unconsented bytes.
+					service
+						.sendDraft(runtime, parsed.draftId, consentedDigest)
+						.then((rec) => ({
+							externalId: rec.sentExternalId ?? `pending:${rec.draftId}`,
+						})),
 				);
 				// The pending-approval notice is the complete answer to this turn:
 				// verified + turnComplete make it the sole delivery, human-worded;
@@ -457,7 +529,76 @@ export const sendDraftAction: Action = {
 			}
 		}
 
-		const sent = await service.sendDraft(runtime, parsed.draftId);
+		const sent = await service
+			.sendDraft(runtime, parsed.draftId, consentedDigest)
+			.catch((error: unknown) => {
+				// error-policy:J1 boundary translation — the consented snapshot no
+				// longer matches the stored draft (mutated between the gate and
+				// the provider call). Fail closed: nothing went out; re-preview so
+				// the next user turn consents the bytes that exist now (#25284).
+				if (
+					error instanceof ElizaError &&
+					error.code === "MESSAGE_DRAFT_CONSENT_DIGEST_MISMATCH"
+				) {
+					logger.warn(
+						`[SendDraft] consented snapshot mismatch: draftId=${parsed.draftId} — re-previewing`,
+					);
+					return null;
+				}
+				throw error;
+			});
+		if (!sent) {
+			const fresh = service.getStore().getDraft(parsed.draftId);
+			// Arm the consent for the preview we are about to show (#25284
+			// r3): the mismatch preview must be confirmable by the NEXT user
+			// turn, not just re-displayed. If arming fails, the recovery is
+			// a visibly DEGRADED state — an explicit retry hint, never a
+			// confirmation prompt that was not actually armed (the next bare
+			// yes would only re-ask, misrepresenting the gate).
+			let armed = false;
+			if (fresh) {
+				const gate = await gateSendDraftConsent({
+					runtime,
+					message: _message,
+					draft: fresh,
+				}).catch(() => {
+					/* error-policy:J4 arming failure degrades to an explicit retry ask below */
+					return null;
+				});
+				armed = gate?.status === "pending" || gate?.status === "stale";
+			}
+			const text = !fresh
+				? "That draft is no longer available."
+				: armed
+					? `That draft changed after you approved it — here's the current version: ${fresh.preview} — still want me to send it?`
+					: "That draft changed after you approved it, and I couldn't stage a new confirmation right now — please ask me to send it again in a moment.";
+			const data = fresh
+				? {
+						requiresConfirmation: true,
+						preview: armed ? fresh.preview : "",
+						draftId: parsed.draftId,
+						source: fresh.source,
+						consentArmed: armed,
+					}
+				: {
+						requiresConfirmation: false,
+						draftId: parsed.draftId,
+						source: existing.source,
+						consentArmed: false,
+					};
+			if (callback) {
+				await callback({ text, action: "MESSAGE" });
+			}
+			return {
+				success: true,
+				text,
+				userFacingText: text,
+				verifiedUserFacing: true,
+				turnComplete: true,
+				continueChain: false,
+				data,
+			};
+		}
 		// The sent confirmation is the complete answer to a single-operation
 		// turn: verified + turnComplete make it the sole delivery; the draftId
 		// stays planner-facing in data.

--- a/packages/core/src/features/messaging/triage/index.ts
+++ b/packages/core/src/features/messaging/triage/index.ts
@@ -12,6 +12,7 @@ export { manageMessageAction } from "./actions/manageMessage.ts";
 export { respondToMessageAction } from "./actions/respondToMessage.ts";
 export { scheduleDraftSendAction } from "./actions/scheduleDraftSend.ts";
 export { searchMessagesAction } from "./actions/searchMessages.ts";
+export { draftConsentDigest } from "./actions/send-consent.ts";
 export { sendDraftAction } from "./actions/sendDraft.ts";
 export { triageMessagesAction } from "./actions/triageMessages.ts";
 export { BaseMessageAdapter, filterInMemory } from "./adapters/base.ts";

--- a/packages/core/src/features/messaging/triage/triage-service.ts
+++ b/packages/core/src/features/messaging/triage/triage-service.ts
@@ -13,6 +13,7 @@
 import { ElizaError } from "../../../errors.ts";
 import { logger } from "../../../logger.ts";
 import type { IAgentRuntime } from "../../../types/index.ts";
+import { draftConsentDigest } from "./actions/send-consent.ts";
 import { filterInMemory } from "./adapters/base.ts";
 import { getDeferredMessageScheduler } from "./deferred-send-scheduler.ts";
 import {
@@ -66,6 +67,8 @@ export interface MessageSearchResult {
 export class TriageService {
 	private adapters = new Map<MessageSource, MessageAdapter>();
 	private sendsInFlight = new Map<string, Promise<DraftRecord>>();
+	/** Consent digest each in-flight send was armed with, for digest-bound joins. */
+	private sendsInFlightDigests = new Map<string, string>();
 	private persistedSendsInFlight = new Map<string, Promise<DraftRecord>>();
 	private schedulesInFlight = new Map<
 		string,
@@ -478,6 +481,7 @@ export class TriageService {
 	async sendDraft(
 		runtime: IAgentRuntime,
 		draftId: string,
+		consentDigest?: string,
 	): Promise<DraftRecord> {
 		const record = this.store.getDraft(draftId);
 		if (!record) {
@@ -487,18 +491,58 @@ export class TriageService {
 				severity: "ephemeral",
 			});
 		}
+		// Snapshot binding (#25284 RP review): when the caller consented a
+		// specific draft snapshot, the bytes that actually go out must match
+		// it. The user confirmed a preview; a draft mutated between the
+		// consent gate and the provider call (TOCTOU) must fail closed here —
+		// never deliver content the user never saw — and surface as a fresh
+		// preview ask at the action boundary.
+		if (
+			consentDigest !== undefined &&
+			draftConsentDigest(record) !== consentDigest
+		) {
+			throw new ElizaError(
+				`The draft changed after it was confirmed; re-preview before sending (draftId=${draftId}).`,
+				{
+					code: "MESSAGE_DRAFT_CONSENT_DIGEST_MISMATCH",
+					context: { draftId },
+					severity: "ephemeral",
+				},
+			);
+		}
 		if (record.sent) return record;
 		const sendKey = `${String(runtime.agentId)}:${record.source}:${draftId}`;
 		const pending = this.sendsInFlight.get(sendKey);
-		if (pending) return pending;
+		const pendingDigest = this.sendsInFlightDigests.get(sendKey);
+		if (pending) {
+			// Digest-bound join (#25284 r3): a caller that consented a
+			// specific snapshot must never piggyback on an in-flight send
+			// armed with a different (or absent) binding — join only when
+			// the digests match.
+			if (pendingDigest !== consentDigest) {
+				throw new ElizaError(
+					`A different send of this draft is already in flight; re-preview before sending (draftId=${draftId}).`,
+					{
+						code: "MESSAGE_DRAFT_CONSENT_DIGEST_MISMATCH",
+						context: { draftId },
+						severity: "ephemeral",
+					},
+				);
+			}
+			return pending;
+		}
 
-		const send = this.sendDraftOnce(runtime, record);
+		const send = this.sendDraftOnce(runtime, record, consentDigest);
 		this.sendsInFlight.set(sendKey, send);
+		if (consentDigest !== undefined) {
+			this.sendsInFlightDigests.set(sendKey, consentDigest);
+		}
 		try {
 			return await send;
 		} finally {
 			if (this.sendsInFlight.get(sendKey) === send) {
 				this.sendsInFlight.delete(sendKey);
+				this.sendsInFlightDigests.delete(sendKey);
 			}
 		}
 	}
@@ -506,6 +550,7 @@ export class TriageService {
 	private async sendDraftOnce(
 		runtime: IAgentRuntime,
 		record: DraftRecord,
+		consentDigest: string | undefined,
 	): Promise<DraftRecord> {
 		const adapter = this.adapters.get(record.source);
 		if (!adapter?.isAvailable(runtime)) {
@@ -517,6 +562,26 @@ export class TriageService {
 					severity: "ephemeral",
 				},
 			);
+		}
+		// Revalidate on the freshest store state immediately before the
+		// adapter call (#25284 r2): isAvailable and in-flight setup can await,
+		// and every await is another mutation window. The adapter contract is
+		// that sendDraft delivers the create-time snapshot for the id it is
+		// handed (adapters keep their own write-once cache); this check pins
+		// the service-side record to the consented digest at the last instant
+		// we still control.
+		if (consentDigest !== undefined) {
+			const latest = this.store.getDraft(record.draftId);
+			if (!latest || draftConsentDigest(latest) !== consentDigest) {
+				throw new ElizaError(
+					`The draft changed after it was confirmed; re-preview before sending (draftId=${record.draftId}).`,
+					{
+						code: "MESSAGE_DRAFT_CONSENT_DIGEST_MISMATCH",
+						context: { draftId: record.draftId },
+						severity: "ephemeral",
+					},
+				);
+			}
 		}
 		const { externalId } = await adapter.sendDraft(runtime, record.draftId);
 		if (typeof externalId !== "string" || externalId.trim().length === 0) {

--- a/packages/core/src/features/messaging/triage/triage-service.ts
+++ b/packages/core/src/features/messaging/triage/triage-service.ts
@@ -481,8 +481,26 @@ export class TriageService {
 	async sendDraft(
 		runtime: IAgentRuntime,
 		draftId: string,
-		consentDigest?: string,
+		consentDigest: string,
 	): Promise<DraftRecord> {
+		// Fail closed at the boundary (#25284 review r4): the digest is the
+		// only proof a send route intends the exact stored snapshot. An
+		// absent or blank digest — possible only from untyped callers, since
+		// the signature requires it — is a route that skipped consent
+		// binding entirely, so it must never fall back to sending ungated.
+		if (
+			typeof consentDigest !== "string" ||
+			consentDigest.trim().length === 0
+		) {
+			throw new ElizaError(
+				`Sending draft ${draftId} requires a consent digest binding the exact snapshot; route the digest of the record you intend to deliver.`,
+				{
+					code: "MESSAGE_DRAFT_CONSENT_DIGEST_REQUIRED",
+					context: { draftId },
+					severity: "fatal",
+				},
+			);
+		}
 		const record = this.store.getDraft(draftId);
 		if (!record) {
 			throw new ElizaError(`No draft found for id ${draftId}`, {
@@ -491,16 +509,15 @@ export class TriageService {
 				severity: "ephemeral",
 			});
 		}
-		// Snapshot binding (#25284 RP review): when the caller consented a
-		// specific draft snapshot, the bytes that actually go out must match
-		// it. The user confirmed a preview; a draft mutated between the
-		// consent gate and the provider call (TOCTOU) must fail closed here —
-		// never deliver content the user never saw — and surface as a fresh
-		// preview ask at the action boundary.
-		if (
-			consentDigest !== undefined &&
-			draftConsentDigest(record) !== consentDigest
-		) {
+		// Snapshot binding (#25284 RP review): the digest that authorized the
+		// route must match the bytes that actually go out — for the send_draft
+		// action it is the preview the user confirmed; for one-turn and
+		// deferred routes it is the snapshot their originating action
+		// produced. A draft mutated between that authorization and the
+		// provider call (TOCTOU) fails closed here — never deliver content
+		// the authorizing turn never saw — and surfaces as a fresh preview
+		// ask at the action boundary.
+		if (draftConsentDigest(record) !== consentDigest) {
 			throw new ElizaError(
 				`The draft changed after it was confirmed; re-preview before sending (draftId=${draftId}).`,
 				{
@@ -515,10 +532,9 @@ export class TriageService {
 		const pending = this.sendsInFlight.get(sendKey);
 		const pendingDigest = this.sendsInFlightDigests.get(sendKey);
 		if (pending) {
-			// Digest-bound join (#25284 r3): a caller that consented a
-			// specific snapshot must never piggyback on an in-flight send
-			// armed with a different (or absent) binding — join only when
-			// the digests match.
+			// Digest-bound join (#25284 r3): a caller must never piggyback on an
+			// in-flight send armed with a different binding — join only when the
+			// digests match.
 			if (pendingDigest !== consentDigest) {
 				throw new ElizaError(
 					`A different send of this draft is already in flight; re-preview before sending (draftId=${draftId}).`,
@@ -534,9 +550,7 @@ export class TriageService {
 
 		const send = this.sendDraftOnce(runtime, record, consentDigest);
 		this.sendsInFlight.set(sendKey, send);
-		if (consentDigest !== undefined) {
-			this.sendsInFlightDigests.set(sendKey, consentDigest);
-		}
+		this.sendsInFlightDigests.set(sendKey, consentDigest);
 		try {
 			return await send;
 		} finally {
@@ -550,7 +564,7 @@ export class TriageService {
 	private async sendDraftOnce(
 		runtime: IAgentRuntime,
 		record: DraftRecord,
-		consentDigest: string | undefined,
+		consentDigest: string,
 	): Promise<DraftRecord> {
 		const adapter = this.adapters.get(record.source);
 		if (!adapter?.isAvailable(runtime)) {
@@ -570,18 +584,16 @@ export class TriageService {
 		// handed (adapters keep their own write-once cache); this check pins
 		// the service-side record to the consented digest at the last instant
 		// we still control.
-		if (consentDigest !== undefined) {
-			const latest = this.store.getDraft(record.draftId);
-			if (!latest || draftConsentDigest(latest) !== consentDigest) {
-				throw new ElizaError(
-					`The draft changed after it was confirmed; re-preview before sending (draftId=${record.draftId}).`,
-					{
-						code: "MESSAGE_DRAFT_CONSENT_DIGEST_MISMATCH",
-						context: { draftId: record.draftId },
-						severity: "ephemeral",
-					},
-				);
-			}
+		const latest = this.store.getDraft(record.draftId);
+		if (!latest || draftConsentDigest(latest) !== consentDigest) {
+			throw new ElizaError(
+				`The draft changed after it was confirmed; re-preview before sending (draftId=${record.draftId}).`,
+				{
+					code: "MESSAGE_DRAFT_CONSENT_DIGEST_MISMATCH",
+					context: { draftId: record.draftId },
+					severity: "ephemeral",
+				},
+			);
 		}
 		const { externalId } = await adapter.sendDraft(runtime, record.draftId);
 		if (typeof externalId !== "string" || externalId.trim().length === 0) {
@@ -683,7 +695,14 @@ export class TriageService {
 			sent: false,
 		};
 		this.store.saveDraft(hydrated);
-		const sent = await this.sendDraft(runtime, hydrated.draftId);
+		// Bind the send to the rehydrated snapshot (#25284 review r4): the
+		// replay must carry the same snapshot-intent proof every other send
+		// route does, closing the rehydrate→send mutation window.
+		const sent = await this.sendDraft(
+			runtime,
+			hydrated.draftId,
+			draftConsentDigest(hydrated),
+		);
 		if (hydrated.draftId === snapshot.draftId) return sent;
 		if (!sent.sentExternalId) {
 			throw new ElizaError(

--- a/packages/core/src/features/messaging/triage/types.ts
+++ b/packages/core/src/features/messaging/triage/types.ts
@@ -258,6 +258,15 @@ export interface MessageAdapter {
 		runtime: IAgentRuntime,
 		draft: DraftRequest,
 	): Promise<{ draftId: string; preview: string }>;
+	/**
+	 * Sends a draft by id. CONSENT-RELEVANT INVARIANT (#25284): a `draftId`
+	 * identifies ONE immutable delivery snapshot for its whole lifecycle.
+	 * The id maps to the create-time request bytes the adapter captured when
+	 * `createDraft` produced it — implementations MUST deliver exactly those
+	 * bytes and MUST NOT re-read mutable draft state at send time. The
+	 * service's consent digest pins the same snapshot; anything else the
+	 * adapter sends is by definition content the user never consented to.
+	 */
 	sendDraft(
 		runtime: IAgentRuntime,
 		draftId: string,

--- a/packages/core/src/generated/action-docs.ts
+++ b/packages/core/src/generated/action-docs.ts
@@ -534,17 +534,6 @@ export const coreActionsSpec = {
 						"Draft identifier for action=send_draft or action=schedule_draft_send.",
 				},
 				{
-					name: "confirmed",
-					description:
-						"Whether the user explicitly confirmed sending for action=send_draft.",
-					required: false,
-					schema: {
-						type: "boolean",
-					},
-					descriptionCompressed:
-						"Whether the user explicitly confirmed sending for action=send_draft.",
-				},
-				{
 					name: "sendAt",
 					description: "Scheduled send time for action=schedule_draft_send.",
 					required: false,
@@ -2262,17 +2251,6 @@ export const allActionsSpec = {
 					},
 					descriptionCompressed:
 						"Draft identifier for action=send_draft or action=schedule_draft_send.",
-				},
-				{
-					name: "confirmed",
-					description:
-						"Whether the user explicitly confirmed sending for action=send_draft.",
-					required: false,
-					schema: {
-						type: "boolean",
-					},
-					descriptionCompressed:
-						"Whether the user explicitly confirmed sending for action=send_draft.",
 				},
 				{
 					name: "sendAt",

--- a/packages/core/src/index.browser.ts
+++ b/packages/core/src/index.browser.ts
@@ -86,6 +86,7 @@ export type {
 } from "./features/messaging/triage";
 export {
 	BaseMessageAdapter,
+	draftConsentDigest,
 	filterInMemory,
 	getDefaultMessageRefStore,
 	getDeferredMessageScheduler,

--- a/packages/core/src/index.node.ts
+++ b/packages/core/src/index.node.ts
@@ -170,6 +170,7 @@ export {
 	__resetDefaultMessageRefStoreForTests,
 	__resetDefaultTriageServiceForTests,
 	BaseMessageAdapter,
+	draftConsentDigest,
 	draftFollowupAction,
 	draftReplyAction,
 	getDefaultMessageRefStore,

--- a/packages/core/src/roles.ts
+++ b/packages/core/src/roles.ts
@@ -257,10 +257,17 @@ const LOCAL_UNRESOLVED_ROLE_SOURCES = new Set([
 	MESSAGE_SOURCE_CODING_AGENT,
 	MESSAGE_SOURCE_AGENT_GREETING,
 	"api",
+	// Owner-app client surfaces (packages/app-core owner-app adapters'
+	// OWNER_APP_SOURCES): an app sender is the account owner on a local,
+	// no-world control surface, so it keeps the USER floor rather than
+	// dropping to GUEST before any world role can resolve.
+	"app",
 	"benchmark",
 	"dashboard",
 	"deep-link",
+	"eliza_app",
 	"event",
+	"in_app",
 	"ios-local",
 	"local-voice",
 	"owner_app",

--- a/packages/docs/action-catalog.md
+++ b/packages/docs/action-catalog.md
@@ -61,7 +61,6 @@ Primary action for addressed messaging surfaces: DMs, group chats, channels, roo
 | `subject` | no | string | Optional subject for email-like draft operations. |
 | `messageId` | no | string | Platform message ID, full message ID, or stored memory ID for react/edit/delete/pin/respond/manage. |
 | `draftId` | no | string | Draft identifier for action=send_draft or action=schedule_draft_send. |
-| `confirmed` | no | boolean | Whether the user explicitly confirmed sending for action=send_draft. |
 | `sendAt` | no | string | Scheduled send time for action=schedule_draft_send. |
 | `emoji` | no | string | Reaction value for action=react. |
 | `pin` | no | boolean | Pin state for action=pin. Use false to unpin when supported. |

--- a/packages/prompts/specs/actions/core.json
+++ b/packages/prompts/specs/actions/core.json
@@ -423,15 +423,6 @@
           "descriptionCompressed": "draft id"
         },
         {
-          "name": "confirmed",
-          "description": "Whether the user explicitly confirmed sending for action=send_draft.",
-          "required": false,
-          "schema": {
-            "type": "boolean"
-          },
-          "descriptionCompressed": "send confirmed"
-        },
-        {
           "name": "sendAt",
           "description": "Scheduled send time for action=schedule_draft_send.",
           "required": false,

--- a/plugins/plugin-google-workspace/src/gmail-canonical-delivery.real.test.ts
+++ b/plugins/plugin-google-workspace/src/gmail-canonical-delivery.real.test.ts
@@ -124,7 +124,13 @@ describe("canonical principal to Gmail delivery", () => {
       id: WORLD_ID,
       agentId: runtime.agentId,
       name: "Fixture world",
-      metadata: { type: "fixture" },
+      // The sender is the fixture's owner-principal (named "Owner" below), and
+      // #25284's per-op MESSAGE role gate resolves world roles from this
+      // ownership record: without it the sender ranks GUEST and op=send is
+      // denied (MESSAGE_OP_ROLE_DENIED) before the claim-authority branch
+      // under test can run. Recording the ownership keeps this suite about
+      // canonical delivery claims, not role admission.
+      metadata: { type: "fixture", ownership: { ownerId: SENDER_ID } },
     });
     await runtime.ensureRoomExists({
       id: ROOM_ID,

--- a/plugins/plugin-google-workspace/src/lifeops-message-adapter.test.ts
+++ b/plugins/plugin-google-workspace/src/lifeops-message-adapter.test.ts
@@ -48,7 +48,9 @@ function runtimeWithGoogleService(service: Record<string, unknown>): IAgentRunti
     ...service,
   };
   return {
-    agentId: "agent-1",
+    // Matches actionMessage.entityId so the agent-self OWNER path applies
+    // (the harness has no room/world surface for role resolution).
+    agentId: "00000000-0000-0000-0000-000000000001",
     getService: vi.fn((serviceType: string) => (serviceType === "google" ? googleService : null)),
     emitEvent: vi.fn(async () => undefined),
     reportError: vi.fn(),
@@ -227,6 +229,48 @@ describe("GoogleGmailAdapter", () => {
         domainEventId: "gmail_reply:acct_google_1:sent_1",
       })
     );
+  });
+
+  it("captures the reply envelope at create time; a later cache refresh cannot change what is sent (#25284)", async () => {
+    let currentMessage = gmailMessage();
+    const listGmailTriageMessages = vi.fn(async () => [currentMessage]);
+    const sendGmailReply = vi.fn(async () => ({ messageId: "sent_immutable" }));
+    const runtime = runtimeWithGoogleService({
+      listGmailTriageMessages,
+      sendGmailReply,
+    });
+    const adapter = new GoogleGmailAdapter();
+    await adapter.listMessages(runtime, { worldIds: ["acct_google_1"] });
+
+    const draft = await adapter.createDraft(runtime, {
+      inReplyToId: "gmail:msg_1",
+      body: "Original plan.",
+    });
+
+    // The provider's view of the message CHANGES after the preview was
+    // armed: different sender, subject, and threading headers. The send
+    // must use the create-time envelope, not this refreshed state.
+    currentMessage = gmailMessage({
+      from: { identifier: "attacker@example.com", displayName: "Attacker" },
+      subject: "You won a prize",
+      metadata: {
+        messageIdHeader: "<fake@example.com>",
+        references: "<fake-root@example.com>",
+      },
+    });
+    await adapter.listMessages(runtime, { worldIds: ["acct_google_1"] });
+
+    await adapter.sendDraft(runtime, draft.draftId);
+
+    expect(sendGmailReply).toHaveBeenCalledTimes(1);
+    expect(sendGmailReply).toHaveBeenCalledWith({
+      accountId: "acct_google_1",
+      to: ["guest@example.com"],
+      subject: "Planning call",
+      bodyText: "Original plan.",
+      inReplyTo: "<msg_1@example.com>",
+      references: "<root@example.com>",
+    });
   });
 
   it("sends a real-client mapped reply to Reply-To instead of From", async () => {
@@ -427,10 +471,14 @@ describe("GoogleGmailAdapter", () => {
   });
 });
 
+// The caller is the agent itself (OWNER): these rows exercise the Gmail
+// adapter's read path, not principal admission — the harness runtime has no
+// room/world surface, so any non-agent caller would fail role resolution and
+// be denied by the per-op gate before reaching the adapter (#25284).
 const actionMessage = {
   id: "00000000-0000-0000-0000-0000000000aa",
   roomId: "00000000-0000-0000-0000-0000000000bb",
-  entityId: "00000000-0000-0000-0000-0000000000cc",
+  entityId: "00000000-0000-0000-0000-000000000001",
   agentId: "00000000-0000-0000-0000-000000000001",
   content: { text: "read the email", source: "client_chat" },
   createdAt: 1,

--- a/plugins/plugin-google-workspace/src/lifeops-message-adapter.ts
+++ b/plugins/plugin-google-workspace/src/lifeops-message-adapter.ts
@@ -56,6 +56,21 @@ type GoogleGmailAdapterService = Pick<IGoogleGmailService, (typeof GMAIL_ADAPTER
 interface GmailDraftContext {
   readonly request: DraftRequest;
   readonly preview: string;
+  /**
+   * Immutable reply envelope captured at createDraft time (#25284): the
+   * consent-relevant recipient, account, subject, and threading headers are
+   * resolved from the message ONCE, when the preview the user confirms is
+   * built, and never re-read at send time. A cache refresh between preview
+   * and delivery must not change what Gmail sends.
+   */
+  readonly replyEnvelope?: {
+    readonly accountId: string;
+    readonly to: string;
+    readonly subject: string;
+    readonly inReplyTo: string | null;
+    readonly references: string | null;
+    readonly externalId: string;
+  };
 }
 
 const GMAIL_READ_REFERENCE_PREFIX = "gmail-email-v1.";
@@ -551,10 +566,23 @@ export class GoogleGmailAdapter extends BaseMessageAdapter {
       this.draftCache.set(draftId, { request: draft, preview });
       return { draftId, preview };
     }
-    await this.ensureMessage(runtime, draft.inReplyToId);
+    const message = await this.ensureMessage(runtime, draft.inReplyToId);
     const messageId = externalMessageId(draft.inReplyToId);
     const draftId = `gmail-draft:${messageId}:${Date.now()}`;
-    this.draftCache.set(draftId, { request: draft, preview });
+    // Capture the complete reply envelope now: sendDraft must deliver
+    // exactly these bytes/headers, never a re-resolved mutable ref (#25284).
+    this.draftCache.set(draftId, {
+      request: draft,
+      preview,
+      replyEnvelope: {
+        accountId: messageAccountId(message),
+        to: metadataString(message.metadata ?? {}, "replyTo") ?? message.from.identifier,
+        subject: message.subject ?? "Re: your message",
+        inReplyTo: metadataString(message.metadata ?? {}, "messageIdHeader"),
+        references: metadataString(message.metadata ?? {}, "references"),
+        externalId: message.externalId,
+      },
+    });
     return { draftId, preview };
   }
 
@@ -577,26 +605,27 @@ export class GoogleGmailAdapter extends BaseMessageAdapter {
       });
       return { externalId: sent.messageId ?? `gmail-new:${draftId}` };
     }
-    const message = await this.ensureMessage(runtime, request.inReplyToId);
-    const replyTarget =
-      metadataString(message.metadata ?? {}, "replyTo") ?? message.from.identifier;
+    const envelope = draft.replyEnvelope;
+    if (!envelope) {
+      throw new Error(`[GoogleGmailAdapter] cached draft ${draftId} has no reply envelope`);
+    }
     const sent = await service.sendGmailReply({
-      accountId: messageAccountId(message),
-      to: [replyTarget],
-      subject: message.subject ?? "Re: your message",
+      accountId: envelope.accountId,
+      to: [envelope.to],
+      subject: envelope.subject,
       bodyText: request.body,
-      inReplyTo: metadataString(message.metadata ?? {}, "messageIdHeader"),
-      references: metadataString(message.metadata ?? {}, "references"),
+      inReplyTo: envelope.inReplyTo,
+      references: envelope.references,
     });
     if (sent.messageId) {
       await emitCommittedGmailMutation(runtime, {
-        messageId: message.externalId,
+        messageId: envelope.externalId,
         operation: "replied",
-        domainEventId: `gmail_reply:${messageAccountId(message)}:${sent.messageId}`,
+        domainEventId: `gmail_reply:${envelope.accountId}:${sent.messageId}`,
       });
     }
     return {
-      externalId: sent.messageId ?? `gmail-reply:${message.externalId}`,
+      externalId: sent.messageId ?? `gmail-reply:${envelope.externalId}`,
     };
   }
 

--- a/plugins/plugin-inbox/src/actions/inbox.ts
+++ b/plugins/plugin-inbox/src/actions/inbox.ts
@@ -42,6 +42,7 @@ import type {
 } from "@elizaos/core";
 import {
   describeUserReference,
+  draftConsentDigest,
   getDefaultTriageService,
   hasRoleAccess,
   logger,
@@ -686,7 +687,15 @@ async function replyToEntry(args: {
     };
   }
 
-  const sent = await service.sendDraft(args.runtime, draft.draftId);
+  // Bind the send to the exact snapshot replyToEntry drafted this turn
+  // (#25284 review r4): every TriageService.sendDraft route must carry the
+  // consent digest of the record it intends to deliver; the service fails
+  // closed without it.
+  const sent = await service.sendDraft(
+    args.runtime,
+    draft.draftId,
+    draftConsentDigest(draft),
+  );
   await args.repo.markResolved(args.entry.id, {
     draftResponse: args.body,
     autoReplied: true,


### PR DESCRIPTION
## Summary

Closes #25284 (narrow blocker fix under parent #24244).

Removes the model-callable `confirmed: true` tool argument from the `MESSAGE` `send_draft` operation. A send is now authorized only by **gateSendDraftConsent** (`packages/core/src/features/messaging/triage/actions/send-consent.ts`):

- **Two-phase, turn-bound consent.** Phase 1 arms a pending record binding actor + room + arming-turn message id + timestamp + a SHA-256 digest of a canonical encoding of every delivery-relevant draft field (source, recipients, thread/channel/world, body, subject, metadata, creation identity). Phase 2 — on a **later** user turn (different message id, timestamp not before arming, within a 5-minute TTL) — admits only an unqualified bare affirmative carrying an affirmative anchor (multi-language), consumes the record exactly once per arming, and sends.
- **Refusals cancel outright** (refusal clause anywhere in the reply, including after an affirmative). Qualified replies, cross-actor, cross-room, mutated drafts, replayed older affirmatives, and expired records never send — they re-arm the **current** preview so the next bare "yes" answers what the user last saw.
- **Snapshot binding through to the provider.** `TriageService.sendDraft(runtime, draftId, consentDigest?)` validates the digest against the freshly-loaded record and revalidates immediately before the adapter call; a mutated draft fails closed with typed `MESSAGE_DRAFT_CONSENT_DIGEST_MISMATCH` and the action re-arms + re-previews the current bytes. In-flight send dedupe joins are digest-bound. The owner-policy replay executor is bound to the same consented digest.
- **Immutable adapter snapshot contract.** `MessageAdapter.sendDraft` now documents (types.ts) that a draftId identifies one immutable create-time delivery snapshot; the Gmail reply adapter was repaired to capture its full reply envelope (recipient/Reply-To, account, subject, threading headers) at `createDraft` time instead of re-resolving at send time, with an attacker-refresh regression test.
- **Per-op principal admission.** The umbrella `MESSAGE` action lowers its exposure floor to USER for the owned/delegated send surface only; every other op re-enforces the historical ADMIN floor per-op at execution (fail-closed on unresolvable principals). GUEST stays denied.

## Root cause

The shipped gate treated a planner-authored tool-call argument (`confirmed: true`) as user authorization. Any planner could fabricate consent and send an existing draft. The gate also excluded ordinary USER principals from owned/delegated delivery.

## What changed

| Area | Files |
| --- | --- |
| Consent gate (new) | `packages/core/src/features/messaging/triage/actions/send-consent.ts` (513 lines: gate, digest, principal admission) |
| Action wiring | `sendDraft.ts` (creation-time arming, gate consumption, role admission, digest-bound send + armed recovery), `_shared.ts` (param surface), `message.ts` (umbrella floor + per-op re-enforcement) |
| Service | `triage-service.ts` (digest validation, pre-adapter revalidation, digest-bound in-flight joins) |
| Adapter contract + Gmail | `types.ts` (immutable-snapshot invariant), `plugins/plugin-google-workspace/src/lifeops-message-adapter.ts` (create-time reply envelope) |
| Tests | `send-consent.test.ts` (779 lines, 26 rows), updated message suites, Gmail attacker-refresh regression row |
| Generated docs | `action-docs.ts`, `action-catalog.md`, `prompts/specs/actions/core.json` — `confirmed` parameter removed |

## Evidence

Planner-fabricated consent can no longer send — RED control: on `origin/develop`, `MESSAGE {action: send_draft, draftId, confirmed: true}` sends immediately with zero user turns; on this branch the same call arms a preview and sends nothing, and an extra runtime `confirmed: true` property is not even parsed. Provider spies observe exactly zero calls for planner-flag-only, qualified replies, cross-actor (including a role-eligible different USER), cross-room, mutated drafts, replayed older affirmatives, expired (fake-timer TTL) records, GUEST senders, and TOCTOU mutations at every store-read boundary; exactly one call for the happy path; exactly two for the failed-send re-confirm path (first call fails with a real thrown provider 503 through the action).

<!-- evidence-row:before-screenshots -->
- [ ] N/A - core + plugin server-side change only; no UI surface touched (packages/core messaging + plugins/plugin-google-workspace).

<!-- evidence-row:after-screenshots -->
- [ ] N/A - core + plugin server-side change only; no UI surface touched (packages/core messaging + plugins/plugin-google-workspace).

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-visible UI flow; deterministic action tests with provider-call count proofs cover the behavior end to end.

<!-- evidence-row:backend-logs -->
- [ ] N/A - rebase-only head move (no behavior change); verified at new head: packages/core suite 12142/12143 (1 eliza-package-paths failure IDENTICAL on pristine develop control — pre-existing/environmental); google-workspace 404/404 + typecheck rc=0; plugin-inbox default lane 229/229 + typecheck rc=0 (.real-runtime suites fail collection on develop too); clean 10-commit rebase onto develop 3a7f438a9e

Full-suite re-verification (2026-09-01T05:50Z, fresh frozen-lockfile worktree at head 9c47076d54, pinned bun 1.3.14; keywords + core/shared/prompts built; develop reds attributed by same-harness control at develop tip): core 11,442/11,442, google-workspace 394/394, inbox unit suites 81/81. Earlier rebase verification (2026-09-01T02:25Z): rebased 127f2e97fa -> 9c47076d54 onto develop tip 870f4ec960 (454 commits absorbed, 0 textual conflicts). One SEMANTIC conflict resolved: develop's new gmail-canonical-delivery.real.test.ts sends op=send from a fixture principal that resolves to GUEST, and #25284's per-op MESSAGE role gate (send keeps its ADMIN floor) correctly denied it (MESSAGE_OP_ROLE_DENIED) before the claim branch ran — control run at develop tip passes 393/393 because develop lacks the gate. Repair: record the fixture sender as world owner (ownership.ownerId) so the suite still proves exactly its claim-authority semantics. plugin-inbox's 4 real-runtime/live-llm/real-db suites fail at import on BOTH this head and pristine develop (DEV_CLOUD_STEWARD_OPERATIONAL_ENV_KEYS not iterable) — develop red. CI retriggered on push.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code touched; changed files live in packages/core and plugins/plugin-google-workspace only.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model-prompting or inference-path change; the change REMOVES a model-controlled input (the confirmed tool argument), and the deterministic harness exercises the action path with spy providers, not a live model.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — the behavioral proof is the deterministic action-test battery (26 rows, `send-consent.test.ts`) summarized here and the independent dual-reviewer record:
<details><summary>zero/one/two provider-call proofs (spy-observed)</summary>

```
zero-send paths (all spy-asserted toHaveBeenCalledTimes(0)):
  planner confirmed:true alone (first turn AND later turn)
  qualified affirmation  "yes, but change the subject"
  refusal                 "no" / "yes please don't send"
  cross-actor             different entityId, role-eligible USER
  cross-room              same actor, other roomId
  mutated draft           digest mismatch re-arms, never sends stale bytes
  replay                  older affirmative turn (timestamp < armedAtMs)
  expired                 fake-timer TTL advance past 5-minute window
  GUEST sender            below USER floor
  TOCTOU                  store mutated at read-1/read-2/read-3 boundaries
one-send paths:
  happy path              arm -> later bare "yes" -> exactly 1 provider call
  TTL re-arm              expired yes re-arms; fresh later yes sends once
  TOCTOU recovery         mutated preview re-armed; fresh yes sends the
                          mutated bytes the user just saw (spy asserts the
                          exact delivered body "Swapped hostile bytes.")
two-send path:
  provider 503            first call throws through the action; re-arm;
                          next yes sends (2 total calls, failure recoverable)
Gmail envelope immutability:
  attacker refresh        provider message view swapped (attacker sender/
                          subject/headers) after preview; send uses the
                          create-time envelope exactly
```
</details>
<details><summary>dual-reviewer convergence (RepoPrompt gpt-5.6-sol, 5 rounds)</summary>

```
R1 REQUEST_CHANGES: P1 TOCTOU consent-not-bound-to-sent-bytes; P2 loser
   re-arm claim; P2 failed-send permanently consumed consent; P2 missing
   rows -> all execution-verified then fixed (digest-threaded send,
   per-arming consumed keys, 4 new rows, RED control).
R2 REQUEST_CHANGES: P1 residual post-validation await window; P2 recovery
   preview not armed; P3 row sharpness -> fixed (pre-adapter revalidation,
   armed recovery, fake-timer TTL / real provider-503 / read-3 mutation).
R3 REQUEST_CHANGES: P1 in-flight join not digest-bound; P1 adapter
   invariant undocumented; P2 unarmed-preview edge; P3 incomplete cycle ->
   fixed (digest-guarded joins, immutable-snapshot contract, J4 visible
   degrade, byte-recording spy + completed confirm cycle).
R4 REQUEST_CHANGES: P1 Gmail reply adapter re-resolved envelope at send
   time -> fixed (create-time immutable envelope; the 3 harness failures
   were the per-op role gate denying an unresolvable mock caller).
R5 APPROVE: envelope complete, fail-closed, no new findings; cross-process
   intents correctly scoped to parent #24244.
```
</details>

## Attribution

AI provider/model: zai / glm-5.3 (implementation) + gpt-5.6-sol (RepoPrompt CE review agent, 5 rounds)
Client / agent tooling: Hermes Agent
Contribution skill revision: elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [hermes-t3rpz]
<!-- eliza-computer-attribution:v1 {"provider":"zai","model":"glm-5.3","client":"Hermes Agent","skill_revision":"elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza"} -->
<!-- evidence-head:def3a8fd1b6ad7235b0e113728d3e46dd757189c -->










