### PR TITLE
fix(core): reduce unsolicited group-chat responses

### DIFF
--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -4124,8 +4124,14 @@ describe("runV5MessageRuntimeStage1", () => {
 		// shouldRespond field guidance alone read as RESPOND on nearly all of
 		// them (live five-room evaluation: 7-10 unsolicited replies per room).
 		expect(stage1Content).toContain("ambient_turn_policy:");
+		expect(stage1Content).toContain(
+			"a direct mention, reply, or clear continuation addressed to Test Agent -> RESPOND",
+		);
+		expect(stage1Content).not.toContain("addressed to  ->");
 		expect(stage1Content).toContain("Default shouldRespond=IGNORE");
-		expect(stage1Content).toContain("correct or clarify your own prior answer");
+		expect(stage1Content).toContain(
+			"challenges or asks to clarify your immediately preceding prior_message:agent reply",
+		);
 		expect(stage1Content).toContain("explicit standing responsibility");
 		expect(stage1Content).not.toContain("someone asks the group");
 		expect(stage1Content).not.toContain("active in the conversation");
@@ -6153,6 +6159,34 @@ describe("runV5MessageRuntimeStage1", () => {
 			expect(runtime.useModel).toHaveBeenCalledTimes(1);
 		},
 	);
+
+	it("observes a RESPOND decision without entering reply generation or planning", async () => {
+		const runtime = makeRuntime([
+			stage1Response({
+				shouldRespond: "RESPOND",
+				contexts: ["general"],
+				replyText: "Let me answer that.",
+			}),
+		]);
+		const observations: Array<{ decision: string; prefixHash: string }> = [];
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage(),
+			state: makeState(),
+			responseId: "00000000-0000-0000-0000-000000000005" as UUID,
+			stage1DecisionOnly: true,
+			onStage1Decision: ({ decision, prefixHash }) => {
+				observations.push({ decision, prefixHash });
+			},
+		});
+
+		expect(result).toMatchObject({ kind: "decision", action: "RESPOND" });
+		expect(observations).toHaveLength(1);
+		expect(observations[0]?.decision).toBe("RESPOND");
+		expect(observations[0]?.prefixHash).toMatch(/^[a-f0-9]{64}$/);
+		expect(runtime.useModel).toHaveBeenCalledTimes(1);
+	});
 
 	it("renders direct-message instructions that forbid ungrounded simple replies and phantom action claims", async () => {
 		const runtime = makeRuntime([

--- a/packages/core/src/__tests__/message-stage1-prompt-tier.test.ts
+++ b/packages/core/src/__tests__/message-stage1-prompt-tier.test.ts
@@ -15,6 +15,7 @@ import {
 import { ContextRegistry } from "../runtime/context-registry";
 import { ResponseHandlerFieldRegistry } from "../runtime/response-handler-field-registry";
 import {
+	classifyMessageAddress,
 	runV5MessageRuntimeStage1,
 	textContainsAgentName,
 } from "../services/message";
@@ -322,6 +323,30 @@ describe("Stage-1 complete prompt rendering", () => {
 		expect(
 			textContainsAgentName("nubilio whats the setting", ["remilio nubilio"]),
 		).toBe(true);
+	});
+
+	it.each([
+		["Eliza, what time is it?", true],
+		["hey Eliza can you help", true],
+		["@Eliza why did that fail", true],
+		["Eliza tell me about the weather", true],
+		["Eliza help me with this", true],
+		["Eliza show me the logs", true],
+		["Eliza summarize that", true],
+		["Eliza run the build", true],
+		["ok Eliza", true],
+		["I think Eliza is great", false],
+		["Eliza was right about that", false],
+		["ask Eliza about it", false],
+	] as const)("classifies textual address %s -> %s", (text, expected) => {
+		const runtime = { character: { name: "Eliza" } } as IAgentRuntime;
+		const message = makeMessage({
+			channelType: String(ChannelType.GROUP),
+			text,
+		});
+		expect(classifyMessageAddress(runtime, message).textualAgentName).toBe(
+			expected,
+		);
 	});
 
 	it("renders the full rule block when channel type is missing (fail-open)", async () => {

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -557,11 +557,30 @@ function textDirectlyAddressesAgentName(
 		const candidate = name?.trim();
 		if (!candidate) return false;
 		const escaped = escapeRegex(candidate);
-		const direct = new RegExp(
-			`(?:^\\s*(?:(?:hey|hi|hello|thanks?|thank you|please)\\s*[,!:;-]?\\s*)?@?${escaped}(?=\\s*[,!:;?-]|\\s+(?:and|stop|pause|cancel|check|can|could|would|will|do|did|are|is|what|why|how|when|where|who|please)\\b)|,\\s*@?${escaped}(?=\\s|$))`,
-			"iu",
+		if (
+			new RegExp(`,\\s*@?${escaped}(?=\\s|$)`, "iu").test(text) ||
+			new RegExp(
+				`^\\s*(?:ok(?:ay)?|thanks?|thank you)\\s*,?\\s*@?${escaped}\\s*[.!?]*\\s*$`,
+				"iu",
+			).test(text)
+		) {
+			return true;
+		}
+		const leading = text.match(
+			new RegExp(
+				`^\\s*(?:(?:hey|hi|hello|thanks?|thank you|please)\\s*[,!:;-]?\\s*)?@?${escaped}(?<rest>(?:$|[^\\p{L}\\p{N}][\\s\\S]*))$`,
+				"iu",
+			),
 		);
-		return direct.test(text);
+		if (!leading?.groups) return false;
+		const rest = leading.groups.rest.trim();
+		if (!rest || /^[,!:;?-]/u.test(rest) || /[?]$/u.test(rest)) return true;
+		// A name-led imperative is a direct address regardless of its verb. Only
+		// reject clear third-person continuations; this avoids a brittle allowlist
+		// that makes ordinary commands such as "Eliza summarize that" ambient.
+		return !/^(?:is|was|were|has|had|said|says|thinks|thought|seems|look(?:s|ed)|does|did)\b/iu.test(
+			rest,
+		);
 	});
 }
 

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -541,18 +541,84 @@ function textContainsUserTag(text: string | undefined): boolean {
  * text. Shared by the reply gate, the bot-noise TEXT_SMALL triage, and the
  * Stage-1 prompt tier so all three branch on the same ground truth.
  */
+export interface MessageAddressSignals {
+	platformMention: boolean;
+	replyToAgent: boolean;
+	textualAgentName: boolean;
+	effective: boolean;
+}
+
+function textDirectlyAddressesAgentName(
+	text: string | undefined,
+	names: Array<string | null | undefined>,
+): boolean {
+	if (!text) return false;
+	return names.some((name) => {
+		const candidate = name?.trim();
+		if (!candidate) return false;
+		const escaped = escapeRegex(candidate);
+		const direct = new RegExp(
+			`(?:^\\s*(?:(?:hey|hi|hello|thanks?|thank you|please)\\s*[,!:;-]?\\s*)?@?${escaped}(?=\\s*[,!:;?-]|\\s+(?:and|stop|pause|cancel|check|can|could|would|will|do|did|are|is|what|why|how|when|where|who|please)\\b)|,\\s*@?${escaped}(?=\\s|$))`,
+			"iu",
+		);
+		return direct.test(text);
+	});
+}
+
+/** Classifies the structural signals used by Stage 1 to distinguish addressed from ambient turns. */
+export function classifyMessageAddress(
+	runtime: IAgentRuntime,
+	message: Memory,
+): MessageAddressSignals {
+	const mentionContext = message.content?.mentionContext;
+	const platformMention = mentionContext?.isMention === true;
+	const replyToAgent = mentionContext?.isReply === true;
+	const textualAgentName = textDirectlyAddressesAgentName(
+		message.content?.text,
+		[runtime.character?.name, runtime.character?.username],
+	);
+	return {
+		platformMention,
+		replyToAgent,
+		textualAgentName,
+		effective: platformMention || replyToAgent || textualAgentName,
+	};
+}
+
 function messageExplicitlyAddressesAgent(
 	runtime: IAgentRuntime,
 	message: Memory,
 ): boolean {
-	const mentionContext = message.content?.mentionContext;
-	return (
-		mentionContext?.isMention === true ||
-		mentionContext?.isReply === true ||
-		textContainsAgentName(message.content?.text, [
-			runtime.character?.name,
-			runtime.character?.username,
-		])
+	return classifyMessageAddress(runtime, message).effective;
+}
+
+/** Detects a current-turn challenge that directly continues the agent's prior reply. */
+export function messageChallengesPriorAgentReply(
+	runtime: IAgentRuntime,
+	message: Memory,
+	state: State,
+): boolean {
+	const providers = state.data?.providers;
+	if (!providers || typeof providers !== "object") return false;
+	const recent = (providers as Record<string, unknown>).RECENT_MESSAGES;
+	if (!recent || typeof recent !== "object") return false;
+	const data = (recent as { data?: unknown }).data;
+	const recentMessages =
+		data && typeof data === "object" && "recentMessages" in data
+			? (data as { recentMessages?: unknown }).recentMessages
+			: undefined;
+	if (!Array.isArray(recentMessages)) return false;
+	const prior = [...recentMessages]
+		.reverse()
+		.find((candidate): candidate is Memory => {
+			if (!candidate || typeof candidate !== "object") return false;
+			const memory = candidate as Memory;
+			return !message.id || memory.id !== message.id;
+		});
+	if (prior?.entityId !== runtime.agentId) return false;
+	const text = getUserMessageText(message) ?? "";
+	return /\b(counterintuitive|disagree|doubt|wrong|incorrect|confus(?:ed|ing)|clarify|actually|but i thought|i thought|are you sure|really|why)\b/iu.test(
+		text,
 	);
 }
 
@@ -1568,6 +1634,12 @@ export {
 
 export type V5MessageRuntimeStage1Result =
 	| {
+			kind: "decision";
+			action: "RESPOND" | "IGNORE" | "STOP";
+			messageHandler: MessageHandlerResult;
+			state: State;
+	  }
+	| {
 			kind: "terminal";
 			action: "IGNORE" | "STOP";
 			messageHandler: MessageHandlerResult;
@@ -1578,6 +1650,15 @@ export type V5MessageRuntimeStage1Result =
 			messageHandler: MessageHandlerResult;
 			result: StrategyResult;
 	  };
+
+/** Observable evidence emitted after Stage 1 parses a decision and before routing. */
+export interface Stage1DecisionObservation {
+	trajectoryId?: string;
+	provider?: string;
+	prefixHash: string;
+	decision: MessageHandlerResult["processMessage"];
+	parsed: MessageHandlerResult;
+}
 
 type ResponseHandlerEarlyReplyEvent = {
 	text: string;
@@ -3876,7 +3957,7 @@ async function createV5MessageContextObject(args: {
 					// "Hard to miss.", "Sounds like the move." — a running commentary
 					// nobody asked for. Unaddressed group chatter defaults to IGNORE;
 					// RESPOND is reserved for a concrete contribution.
-					"ambient_turn_policy: The final message:user below was not addressed to you — it is other participants talking to each other, and no reply is expected from you. Default shouldRespond=IGNORE. RESPOND only when the current turn asks you to correct or clarify your own prior answer, when silence would allow a concrete consequential error or harm you can specifically prevent, or when an explicit standing responsibility makes this turn yours to handle. A broadcast question, a useful fact you could add, or the ability to keep the discussion moving is not enough. IGNORE banter, jokes, reactions, acknowledgements, open group questions, and side chatter where you would only answer, agree, comment, restate, or continue the conversation. Having replied earlier is a reason to stay silent unless the current turn directly challenges or needs clarification of that reply.",
+					"ambient_turn_policy: HARD GATE. The final message:user below was not addressed to you — it is other participants talking to each other, and no reply is expected from you. Default shouldRespond=IGNORE. You MUST set shouldRespond=IGNORE unless the current turn explicitly challenges or asks to clarify your immediately preceding prior_message:agent reply, silence would allow a concrete consequential error or harm you can specifically prevent, or an explicit standing responsibility makes this turn yours to handle. A broadcast question, a useful fact you could add, your ability to answer, or your desire to keep the discussion moving is never enough. IGNORE banter, jokes, reactions, acknowledgements, open group questions, and side chatter where you would only answer, agree, comment, restate, or continue the conversation. Having replied earlier is a reason to stay silent unless the current turn directly challenges or needs clarification of that reply.",
 		});
 	}
 
@@ -5001,7 +5082,7 @@ function selectMessageHandlerTask(
 }
 
 function renderMessageHandlerInstructions(
-	runtime: OptimizedPromptRuntimeLike,
+	runtime: OptimizedPromptRuntimeLike & Pick<IAgentRuntime, "character">,
 	availableContexts: readonly ContextDefinition[],
 	options?: {
 		directMessage?: boolean;
@@ -5016,6 +5097,7 @@ function renderMessageHandlerInstructions(
 	);
 	const rendered = composePrompt({
 		state: {
+			agentName: runtime.character.name?.trim() || "the agent",
 			directMessage: options?.directMessage ? "true" : "",
 			availableContexts: formatAvailableContextsForPrompt(availableContexts),
 			handleResponseToolName: HANDLE_RESPONSE_TOOL_NAME,
@@ -5046,7 +5128,7 @@ function renderMessageHandlerInstructions(
 }
 
 function renderMessageHandlerModelInput(
-	runtime: OptimizedPromptRuntimeLike,
+	runtime: OptimizedPromptRuntimeLike & Pick<IAgentRuntime, "character">,
 	context: ContextObject,
 	availableContexts: readonly ContextDefinition[] = [],
 	options?: {
@@ -8059,6 +8141,10 @@ export async function runV5MessageRuntimeStage1(args: {
 	 * failure-reply gate.
 	 */
 	onStage1RespondDecision?: () => void;
+	/** Receives the exact parsed Stage-1 decision and its inference provenance. */
+	onStage1Decision?: (observation: Stage1DecisionObservation) => void;
+	/** Stops after Stage-1 routing, before reply generation, planning, or tools. */
+	stage1DecisionOnly?: boolean;
 }): Promise<V5MessageRuntimeStage1Result> {
 	const senderRole =
 		getTrajectoryContext()?.userRole ??
@@ -8084,7 +8170,8 @@ export async function runV5MessageRuntimeStage1(args: {
 	const ambientTurn = isAmbientStage1Turn(
 		args.runtime,
 		args.message,
-		messageExplicitlyAddressesAgent(args.runtime, args.message),
+		messageExplicitlyAddressesAgent(args.runtime, args.message) ||
+			messageChallengesPriorAgentReply(args.runtime, args.message, args.state),
 	);
 	const context = await createV5MessageContextObject({
 		...args,
@@ -8549,6 +8636,15 @@ export async function runV5MessageRuntimeStage1(args: {
 			}
 		}
 		const parsedResponseHandlerReply = getMessageHandlerReply(messageHandler);
+		args.onStage1Decision?.({
+			...(trajectoryId ? { trajectoryId } : {}),
+			provider: messageHandlerProvider,
+			prefixHash: stage1PrefixHash,
+			decision: messageHandler.processMessage,
+			// Evaluators may patch the live handler later. Preserve the exact model
+			// boundary value observed here instead of exposing a mutable alias.
+			parsed: structuredClone(messageHandler),
+		});
 
 		if (!args.codingMode && recorder && trajectoryId) {
 			messageHandlerStageTask = recordMessageHandlerStage({
@@ -8606,6 +8702,7 @@ export async function runV5MessageRuntimeStage1(args: {
 		// trajectory persistence is recorded there; slower extraction remains a
 		// tracked data task but cannot leave the completed turn marked running.
 		if (
+			!args.stage1DecisionOnly &&
 			messageHandler.extract &&
 			((messageHandler.extract.facts?.length ?? 0) > 0 ||
 				(messageHandler.extract.relationships?.length ?? 0) > 0)
@@ -8640,7 +8737,7 @@ export async function runV5MessageRuntimeStage1(args: {
 		// against the room's participants. Fire-and-forget like the facts task;
 		// failures land in the logger but never block the reply.
 		const addressedTo = messageHandler.extract?.addressedTo ?? [];
-		if (addressedTo.length > 0) {
+		if (!args.stage1DecisionOnly && addressedTo.length > 0) {
 			const addressedToTask = applyAddressedTo({
 				runtime: args.runtime,
 				message: args.message,
@@ -8672,7 +8769,7 @@ export async function runV5MessageRuntimeStage1(args: {
 		// room's running topic list for the CHANNEL_TOPICS provider and must
 		// never block or break the turn.
 		const topics = messageHandler.extract?.topics ?? [];
-		if (topics.length > 0 && args.message.roomId) {
+		if (!args.stage1DecisionOnly && topics.length > 0 && args.message.roomId) {
 			const channelTopics = args.runtime.getService<ChannelTopicsService>(
 				ChannelTopicsService.serviceType,
 			);
@@ -8709,7 +8806,7 @@ export async function runV5MessageRuntimeStage1(args: {
 		// Stamp the turn's topics onto the inbound message memory so the dashboard
 		// can group the transcript by topic + show a topic chips bar (#8928).
 		// Additive, fire-and-forget metadata write — never blocks/breaks the turn.
-		if (topics.length > 0 && args.message.id) {
+		if (!args.stage1DecisionOnly && topics.length > 0 && args.message.id) {
 			// args.message is always a message memory, so its metadata is
 			// MessageMetadata; force `type: "message"` so the spread result is a
 			// valid, discriminated MessageMetadata regardless of the inbound shape
@@ -8860,6 +8957,19 @@ export async function runV5MessageRuntimeStage1(args: {
 			addressedToOtherParticipant,
 			messageText: getUserMessageText(args.message) ?? "",
 		});
+		if (args.stage1DecisionOnly) {
+			return {
+				kind: "decision",
+				action:
+					route.type === "ignored"
+						? "IGNORE"
+						: route.type === "stopped"
+							? "STOP"
+							: "RESPOND",
+				messageHandler,
+				state: args.state,
+			};
+		}
 		if (route.type === "ignored" || route.type === "stopped") {
 			return {
 				kind: "terminal",
@@ -14080,9 +14190,10 @@ export class DefaultMessageService implements IMessageService {
 						: {};
 				setContextRoutingMetadata(message, routedDecision);
 
-				if (outcome.kind === "terminal") {
+				if (outcome.kind === "terminal" || outcome.kind === "decision") {
 					shouldRespondToMessage = false;
-					terminalDecision = outcome.action;
+					terminalDecision =
+						outcome.action === "RESPOND" ? "IGNORE" : outcome.action;
 					state = outcome.state;
 				} else {
 					shouldRespondToMessage = true;

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -658,8 +658,9 @@ export const MEMORY_CONTEXT_QA_TEMPLATE = memoryContextQaTemplate;
 export const groupResponsePrecedencePolicy = `response_precedence:
 - apply these rules in order; the first matching rule wins
 - a request to stop or be quiet directed at {{agentName}} -> STOP
+- a pure acknowledgement, thanks, reaction, or social closer with no new question, correction, disagreement, or task -> IGNORE, even when it names {{agentName}}
 - a direct mention, reply, or clear continuation addressed to {{agentName}} -> RESPOND, even when the sender is another assistant/bot
-- when the current message asks to clarify or expresses disagreement, doubt, confusion, or a counterpoint about the immediately preceding prior_message:agent reply -> RESPOND
+- when the current message challenges, corrects, questions, expresses disagreement or doubt about, or asks to clarify the immediately preceding prior_message:agent reply, including short forms such as "why?", "really?", or "are you sure?" -> RESPOND
 - when the trusted provider context identifies the newest sender as another assistant/bot and the message is not addressed to {{agentName}} -> IGNORE
 - when a trusted bot-authored reply already answered the preceding human and {{agentName}} was not addressed -> IGNORE; one speaker is enough
 - otherwise use the conversation rules below; when unsure, default IGNORE

--- a/packages/prompts/test/prompts.test.js
+++ b/packages/prompts/test/prompts.test.js
@@ -80,7 +80,11 @@ describe("prompt template exports", () => {
     );
     assert.match(
       prompts.groupResponsePrecedencePolicy,
-      /expresses disagreement, doubt, confusion, or a counterpoint about the immediately preceding prior_message:agent reply -> RESPOND/,
+      /pure acknowledgement, thanks, reaction, or social closer[\s\S]*-> IGNORE, even when it names \{\{agentName\}\}[\s\S]*direct mention/,
+    );
+    assert.match(
+      prompts.groupResponsePrecedencePolicy,
+      /challenges, corrects, questions, expresses disagreement or doubt about, or asks to clarify the immediately preceding prior_message:agent reply[\s\S]*-> RESPOND/,
     );
     assert.match(
       prompts.groupResponsePrecedencePolicy,

--- a/packages/scenario-runner/src/timing-matrix-runner-cli.ts
+++ b/packages/scenario-runner/src/timing-matrix-runner-cli.ts
@@ -65,6 +65,15 @@ const characterPreset = option("character-preset") ?? "minimal";
 if (characterPreset !== "minimal" && characterPreset !== "eliza") {
   throw argumentError("--character-preset must be minimal or eliza");
 }
+const runtimeProfile = option("runtime-profile") ?? "classifier-isolated";
+if (
+  runtimeProfile !== "classifier-isolated" &&
+  runtimeProfile !== "production-composed"
+) {
+  throw argumentError(
+    "--runtime-profile must be classifier-isolated or production-composed",
+  );
+}
 const provider = option("provider") ?? "cli";
 const shardCount = positiveInteger("shard-count", 8);
 const workers = positiveInteger("workers", Math.min(4, shardCount));
@@ -127,8 +136,10 @@ function runShard(
       `--run-dir=${invocation.trajectoryDir}`,
       `--provider=${provider}`,
       `--character-preset=${characterPreset}`,
+      `--runtime-profile=${runtimeProfile}`,
       `--shard-index=${invocation.shardIndex}`,
       `--shard-count=${invocation.shardCount}`,
+      `--attempt=${invocation.attempt}`,
       "--checkpoint-every=1",
       ...(invocation.resume ? [`--resume=${invocation.report}`] : []),
     ];

--- a/packages/scenario-runner/src/timing-matrix-runner.test.ts
+++ b/packages/scenario-runner/src/timing-matrix-runner.test.ts
@@ -24,12 +24,18 @@ function writeReport(options: {
     predicted: "SPEAK" as const,
     textuallyReferencesAgent: false,
     directlyAddressesAgent: false,
+    effectiveAddressed: false,
+    addressSignals: {
+      platformMention: false,
+      replyToAgent: false,
+      textualAgentName: false,
+    },
     speakerCount: 2,
     contextTurns: 3,
   };
   const summary = summarizeTimingPredictions([prediction]);
   const report: TimingReport = {
-    schema: 3,
+    schema: 4,
     status: options.status,
     dataset: "duke-trust-lab/When2Speak",
     input: options.input,
@@ -40,6 +46,8 @@ function writeReport(options: {
     requestedModel: "test-model",
     backend: "test-backend",
     characterPreset: "minimal",
+    characterSha256: "test-character-sha256",
+    runtimeProfile: "classifier-isolated",
     trajectoryDir: options.invocation.trajectoryDir,
     selection: {
       shardIndex: options.invocation.shardIndex,

--- a/packages/scenario-runner/src/timing-matrix-runner.ts
+++ b/packages/scenario-runner/src/timing-matrix-runner.ts
@@ -113,7 +113,7 @@ function readShardState(file: string): ExistingShardState {
     value === null ||
     typeof value !== "object" ||
     !("schema" in value) ||
-    value.schema !== 3 ||
+    value.schema !== 4 ||
     !("status" in value) ||
     (value.status !== "in-progress" && value.status !== "complete")
   ) {

--- a/packages/scenario-runner/src/timing-report-merge.test.ts
+++ b/packages/scenario-runner/src/timing-report-merge.test.ts
@@ -20,7 +20,7 @@ function writeShard(options: {
 }): string {
   const summary = summarizeTimingPredictions(options.predictions);
   const report: TimingReport = {
-    schema: 3,
+    schema: 4,
     status: "complete",
     dataset: "duke-trust-lab/When2Speak",
     input: options.input,
@@ -31,6 +31,8 @@ function writeShard(options: {
     requestedModel: "test-model",
     backend: "test-backend",
     characterPreset: "minimal",
+    characterSha256: "test-character-sha256",
+    runtimeProfile: "classifier-isolated",
     trajectoryDir: path.join(options.directory, "trajectories"),
     selection: {
       shardIndex: options.shardIndex,
@@ -66,6 +68,12 @@ describe("timing report merger", () => {
           predicted: "SPEAK",
           textuallyReferencesAgent: false,
           directlyAddressesAgent: false,
+          effectiveAddressed: false,
+          addressSignals: {
+            platformMention: false,
+            replyToAgent: false,
+            textualAgentName: false,
+          },
           speakerCount: 2,
           contextTurns: 3,
         },
@@ -82,6 +90,12 @@ describe("timing report merger", () => {
           predicted: "SILENT",
           textuallyReferencesAgent: false,
           directlyAddressesAgent: true,
+          effectiveAddressed: true,
+          addressSignals: {
+            platformMention: true,
+            replyToAgent: false,
+            textualAgentName: false,
+          },
           speakerCount: 3,
           contextTurns: 6,
         },

--- a/packages/scenario-runner/src/timing-report-merge.ts
+++ b/packages/scenario-runner/src/timing-report-merge.ts
@@ -26,6 +26,8 @@ type TimingReportFragment = Pick<
   | "requestedModel"
   | "backend"
   | "characterPreset"
+  | "characterSha256"
+  | "runtimeProfile"
   | "selection"
   | "predictions"
   | "exclusions"
@@ -40,6 +42,8 @@ export interface TimingMatrixCell {
   requestedModel: string;
   backend: string;
   characterPreset: TimingReport["characterPreset"];
+  characterSha256: string;
+  runtimeProfile: TimingReport["runtimeProfile"];
   shardCount: number;
   sourceReports: string[];
   physicalRows: number;
@@ -169,7 +173,7 @@ function parseReport(file: string): TimingReportFragment {
     value === null ||
     typeof value !== "object" ||
     !("schema" in value) ||
-    value.schema !== 3 ||
+    value.schema !== 4 ||
     !("status" in value) ||
     (value.status !== "in-progress" && value.status !== "complete") ||
     !("dataset" in value) ||
@@ -188,6 +192,11 @@ function parseReport(file: string): TimingReportFragment {
     !("characterPreset" in value) ||
     (value.characterPreset !== "minimal" &&
       value.characterPreset !== "eliza") ||
+    !("characterSha256" in value) ||
+    typeof value.characterSha256 !== "string" ||
+    !("runtimeProfile" in value) ||
+    (value.runtimeProfile !== "classifier-isolated" &&
+      value.runtimeProfile !== "production-composed") ||
     !("selection" in value) ||
     !isSelection(value.selection) ||
     !("predictions" in value) ||
@@ -216,6 +225,8 @@ function parseReport(file: string): TimingReportFragment {
     requestedModel: value.requestedModel,
     backend: value.backend,
     characterPreset: value.characterPreset,
+    characterSha256: value.characterSha256,
+    runtimeProfile: value.runtimeProfile,
     selection: value.selection,
     predictions: value.predictions,
     exclusions: value.exclusions,
@@ -232,6 +243,8 @@ function cellKey(report: TimingReportFragment): string {
     report.requestedModel,
     report.backend,
     report.characterPreset,
+    report.characterSha256,
+    report.runtimeProfile,
     report.selection.shardCount,
   ]);
 }
@@ -377,6 +390,8 @@ export function mergeTimingReports(
       requestedModel: first.requestedModel,
       backend: first.backend,
       characterPreset: first.characterPreset,
+      characterSha256: first.characterSha256,
+      runtimeProfile: first.runtimeProfile,
       shardCount: first.selection.shardCount,
       sourceReports: entries.map(({ file }) => file).sort(),
       physicalRows,

--- a/packages/scenario-runner/src/when2speak-eval-cli.ts
+++ b/packages/scenario-runner/src/when2speak-eval-cli.ts
@@ -8,6 +8,7 @@ import type {
   TimingCharacterPreset,
   TimingInputFormat,
   TimingReport,
+  TimingRuntimeProfile,
 } from "./when2speak-eval.ts";
 import { runWhen2SpeakEval } from "./when2speak-eval.ts";
 
@@ -47,6 +48,15 @@ const characterPresetText = option("character-preset") ?? "minimal";
 if (characterPresetText !== "minimal" && characterPresetText !== "eliza")
   throw usageError("--character-preset must be minimal or eliza");
 const characterPreset: TimingCharacterPreset = characterPresetText;
+const runtimeProfileText = option("runtime-profile") ?? "classifier-isolated";
+if (
+  runtimeProfileText !== "classifier-isolated" &&
+  runtimeProfileText !== "production-composed"
+)
+  throw usageError(
+    "--runtime-profile must be classifier-isolated or production-composed",
+  );
+const runtimeProfile: TimingRuntimeProfile = runtimeProfileText;
 const shardCount = positiveInteger("shard-count") ?? 1;
 const shardIndexText = option("shard-index");
 const shardIndex = shardIndexText === undefined ? 0 : Number(shardIndexText);
@@ -60,6 +70,7 @@ if (
   );
 const startRow = positiveInteger("start-row") ?? 1;
 const checkpointEvery = positiveInteger("checkpoint-every") ?? 1;
+const attempt = positiveInteger("attempt") ?? 1;
 const resume = option("resume");
 const output = path.resolve(
   option("output") ?? "../../reports/group-chat-timing/when2speak.json",
@@ -114,6 +125,8 @@ const report = await runWhen2SpeakEval({
   checkpointEvery,
   resumeReport,
   characterPreset,
+  runtimeProfile,
+  attempt,
   onCheckpoint: writeReport,
 });
 writeReport(report);

--- a/packages/scenario-runner/src/when2speak-eval.test.ts
+++ b/packages/scenario-runner/src/when2speak-eval.test.ts
@@ -1,14 +1,22 @@
 /** Tests corpus parsing and metric math around the real Stage-1 evaluator. */
-import { type IAgentRuntime, stringToUuid } from "@elizaos/core";
+import {
+  classifyMessageAddress,
+  type IAgentRuntime,
+  messageChallengesPriorAgentReply,
+  stringToUuid,
+} from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import {
   buildWhen2SpeakEvaluationState,
+  classifyProductPolicyLabel,
   computeTimingMetrics,
+  inferTimingDialogueIds,
   isTimingRowSelected,
   parseDiscordReplayLine,
   parseWhen2SpeakLine,
   resolveTimingCharacter,
   summarizeTimingPredictions,
+  timingCharacterSha256,
   validateTimingResumeRows,
 } from "./when2speak-eval.ts";
 
@@ -26,6 +34,13 @@ describe("When2Speak evaluator", () => {
     );
     expect(character?.style?.chat).toContain(
       "if another assistant already answered, don't answer again",
+    );
+  });
+
+  it("fingerprints the requested personality deterministically", () => {
+    expect(timingCharacterSha256("eliza")).toBe(timingCharacterSha256("eliza"));
+    expect(timingCharacterSha256("eliza")).not.toBe(
+      timingCharacterSha256("minimal"),
     );
   });
 
@@ -51,6 +66,26 @@ describe("When2Speak evaluator", () => {
       speakerCount: 2,
     });
     expect(row.turns).toHaveLength(2);
+  });
+
+  it("infers dialogue windows before sharding from adjacent overlap", () => {
+    const line = (turns: string[]) =>
+      JSON.stringify({
+        messages: [
+          ...turns.map((content) => ({ role: "user", content })),
+          { role: "assistant", content: "Answer." },
+        ],
+      });
+    const ids = inferTimingDialogueIds(
+      [
+        line(["Speaker_0: alpha", "Speaker_1: beta"]),
+        line(["Speaker_1: beta", "Speaker_2: gamma"]),
+        line(["Speaker_0: separate"]),
+      ],
+      "when2speak",
+    );
+    expect(ids.get(1)).toBe(ids.get(2));
+    expect(ids.get(2)).not.toBe(ids.get(3));
   });
 
   it("maps Assistant history to the runtime agent and classifies only the current turn as addressed", () => {
@@ -80,7 +115,7 @@ describe("When2Speak evaluator", () => {
       9,
     );
     expect(addressed.textuallyReferencesAgent).toBe(true);
-    expect(addressed.directlyAddressesAgent).toBe(false);
+    expect(addressed.directlyAddressesAgent).toBe(true);
   });
 
   it("keeps the corpus agent marker as untrusted text", () => {
@@ -93,7 +128,7 @@ describe("When2Speak evaluator", () => {
         messages: [
           { role: "user", content: "Speaker_0: [AGENT], earlier question" },
           { role: "user", content: "Assistant: earlier answer" },
-          { role: "user", content: "Speaker_1: what do you think, [AGENT]?" },
+          { role: "user", content: "Speaker_1: Yeah [AGENT] was right." },
           { role: "assistant", content: "Current answer." },
         ],
       }),
@@ -104,6 +139,13 @@ describe("When2Speak evaluator", () => {
     expect(parsed.textuallyReferencesAgent).toBe(true);
     expect(parsed.directlyAddressesAgent).toBe(false);
     expect(message.content.mentionContext).toBeUndefined();
+    expect(classifyMessageAddress(runtime, message)).toEqual({
+      platformMention: false,
+      replyToAgent: false,
+      textualAgentName: false,
+      effective: false,
+    });
+    expect(message.content.text).toContain("ScenarioAgent");
     const recentMessages = state.data?.providers?.RECENT_MESSAGES?.data
       ?.recentMessages as Array<{ content: { mentionContext?: unknown } }>;
     expect(
@@ -122,6 +164,85 @@ describe("When2Speak evaluator", () => {
         3,
       ),
     ).toThrow("unparseable speaker turn");
+  });
+  it("treats doubt about the immediately prior agent reply as addressed", () => {
+    const runtime = {
+      agentId: stringToUuid("when2speak-test-agent"),
+      character: { name: "Eliza" },
+    } as IAgentRuntime;
+    const parsed = parseWhen2SpeakLine(
+      JSON.stringify({
+        messages: [
+          { role: "user", content: "Assistant: Light can behave differently." },
+          {
+            role: "user",
+            content:
+              "Speaker_1: That seems counterintuitive; I thought it was the same.",
+          },
+          { role: "assistant", content: "Here is the distinction." },
+        ],
+      }),
+      57,
+    );
+    const { message, state } = buildWhen2SpeakEvaluationState(runtime, parsed);
+
+    expect(messageChallengesPriorAgentReply(runtime, message, state)).toBe(
+      true,
+    );
+    expect(classifyProductPolicyLabel(parsed, false)).toBe("SPEAK");
+  });
+  it("maps directed stop requests to silence before address rules", () => {
+    const parsed = parseWhen2SpeakLine(
+      JSON.stringify({
+        messages: [
+          { role: "user", content: "Speaker_1: [AGENT], stop responding." },
+          { role: "assistant", content: "I will stop." },
+        ],
+      }),
+      58,
+    );
+    expect(classifyProductPolicyLabel(parsed, true)).toBe("SILENT");
+  });
+  it("recognizes thanks followed by a new agent-directed question", () => {
+    const parsed = parseWhen2SpeakLine(
+      JSON.stringify({
+        messages: [
+          {
+            role: "user",
+            content:
+              "Speaker_3: Thanks, [AGENT] that helped. Do we have enough types?",
+          },
+          { role: "assistant", content: ">" },
+        ],
+      }),
+      59,
+    );
+    expect(parsed.directlyAddressesAgent).toBe(true);
+    expect(classifyProductPolicyLabel(parsed, true)).toBe("SPEAK");
+  });
+  it("keeps explicit ambient safety and ownership exceptions", () => {
+    const parseCurrent = (content: string, row: number) =>
+      parseWhen2SpeakLine(
+        JSON.stringify({
+          messages: [
+            { role: "user", content: `Speaker_1: ${content}` },
+            { role: "assistant", content: "Intervention." },
+          ],
+        }),
+        row,
+      );
+    expect(
+      classifyProductPolicyLabel(
+        parseCurrent("That dosage sounds dangerously unsafe.", 59),
+        false,
+      ),
+    ).toBe("SPEAK");
+    expect(
+      classifyProductPolicyLabel(
+        parseCurrent("The assistant is responsible for this alert.", 60),
+        false,
+      ),
+    ).toBe("SPEAK");
   });
   it("maps a Discord target seat onto the runtime agent seat", () => {
     const row = parseDiscordReplayLine(
@@ -206,6 +327,12 @@ describe("When2Speak evaluator", () => {
         predicted: "SILENT",
         textuallyReferencesAgent: true,
         directlyAddressesAgent: true,
+        effectiveAddressed: true,
+        addressSignals: {
+          platformMention: true,
+          replyToAgent: false,
+          textualAgentName: false,
+        },
         speakerCount: 2,
         contextTurns: 3,
       },

--- a/packages/scenario-runner/src/when2speak-eval.ts
+++ b/packages/scenario-runner/src/when2speak-eval.ts
@@ -10,9 +10,11 @@ import readline from "node:readline";
 import {
   ChannelType,
   type CharacterInput,
+  classifyMessageAddress,
   ElizaError,
   type IAgentRuntime,
   type Memory,
+  messageChallengesPriorAgentReply,
   runV5MessageRuntimeStage1,
   type State,
   stringToUuid,
@@ -27,6 +29,9 @@ export type TimingDataset =
   | "mookiezi/Discord-Dialogues";
 export type TimingInputFormat = "when2speak" | "discord-replay";
 export type TimingCharacterPreset = "minimal" | "eliza";
+export type TimingRuntimeProfile =
+  | "classifier-isolated"
+  | "production-composed";
 
 export function resolveTimingCharacter(
   preset: TimingCharacterPreset,
@@ -50,6 +55,11 @@ export function resolveTimingCharacter(
     ...(eliza.templates ? { templates: { ...eliza.templates } } : {}),
   };
 }
+
+export function timingCharacterSha256(preset: TimingCharacterPreset): string {
+  const character = resolveTimingCharacter(preset) ?? { name: "ScenarioAgent" };
+  return createHash("sha256").update(JSON.stringify(character)).digest("hex");
+}
 export interface When2SpeakExample {
   row: number;
   turns: Array<{ speaker: string; text: string; isAgent: boolean }>;
@@ -57,6 +67,7 @@ export interface When2SpeakExample {
   textuallyReferencesAgent: boolean;
   directlyAddressesAgent: boolean;
   speakerCount: number;
+  dialogueId: string;
 }
 export interface TimingCounts {
   total: number;
@@ -76,18 +87,35 @@ export interface TimingMetrics extends TimingCounts {
   silentF1: number | null;
   falseInterventionRate: number | null;
   missedInterventionRate: number | null;
+  balancedAccuracy: number | null;
+  macroF1: number | null;
+  matthewsCorrelation: number | null;
 }
 export interface TimingPrediction {
   row: number;
   gold: TimingLabel;
   predicted: TimingLabel;
+  policyGold?: TimingLabel;
   textuallyReferencesAgent: boolean;
   directlyAddressesAgent: boolean;
+  effectiveAddressed?: boolean;
+  addressSignals?: {
+    platformMention: boolean;
+    replyToAgent: boolean;
+    textualAgentName: boolean;
+    priorAgentChallenge?: boolean;
+  };
   speakerCount: number;
   contextTurns: number;
+  dialogueId?: string;
+  trajectoryId?: string;
+  actualProvider?: string;
+  promptPrefixHash?: string;
+  parsedDecision?: "RESPOND" | "IGNORE" | "STOP";
+  attempt?: number;
 }
 export interface TimingReport {
-  schema: 3;
+  schema: 4;
   status: "in-progress" | "complete";
   dataset: TimingDataset;
   input: string;
@@ -96,6 +124,8 @@ export interface TimingReport {
   requestedModel: string;
   backend: string;
   characterPreset: TimingCharacterPreset;
+  characterSha256: string;
+  runtimeProfile: TimingRuntimeProfile;
   trajectoryDir: string;
   selection: {
     shardIndex: number;
@@ -108,6 +138,12 @@ export interface TimingReport {
   metrics: TimingMetrics;
   objectives: {
     labelAgreement: TimingMetrics;
+    policyAlignedAgreement: TimingMetrics;
+    dialogueClusterAgreement: {
+      clusters: number;
+      macroAccuracy: number | null;
+      macroPolicyAccuracy: number | null;
+    };
     ambientRestraint: {
       eligibleTurns: number;
       predictedResponses: number;
@@ -161,6 +197,54 @@ function parseSpeakerTurn(
     throw invalidCorpusRow(row, "has an empty speaker or turn");
   return { speaker, text };
 }
+function dialogueIdFor(
+  turns: readonly { speaker: string; text: string }[],
+): string {
+  const first = turns[0];
+  return createHash("sha256")
+    .update(`${first?.speaker ?? ""}\0${first?.text ?? ""}`)
+    .digest("hex")
+    .slice(0, 16);
+}
+
+function directlyAddressesAgentPlaceholder(text: string): boolean {
+  return (
+    /^\s*(?:thanks?|thank you)\s*,?\s*\[AGENT\]/i.test(text) ||
+    /^\s*(?:(?:hey|hi|hello|thanks?|thank you|please)\s*[,!:;-]?\s*)?\[AGENT\](?:\s*[,!:;?-]|\s*$)/i.test(
+      text,
+    ) ||
+    /(?:^|,\s*)\[AGENT\](?:\s*[,!:;?]|\s*$)/i.test(text)
+  );
+}
+
+/** Assigns stable inferred dialogue ids before sharding using adjacent turn overlap. */
+export function inferTimingDialogueIds(
+  lines: readonly string[],
+  inputFormat: TimingInputFormat,
+): Map<number, string> {
+  const ids = new Map<number, string>();
+  let cluster = 0;
+  let previousTurns = new Set<string>();
+  for (const [index, line] of lines.entries()) {
+    const row = index + 1;
+    try {
+      const example =
+        inputFormat === "when2speak"
+          ? parseWhen2SpeakLine(line, row)
+          : parseDiscordReplayLine(line, row);
+      const turns = new Set(
+        example.turns.map((turn) => `${turn.speaker}\0${turn.text}`),
+      );
+      if (![...turns].some((turn) => previousTurns.has(turn))) cluster += 1;
+      ids.set(row, `dialogue-${String(cluster).padStart(5, "0")}`);
+      previousTurns = turns;
+    } catch {
+      // error-policy:J3 Invalid corpus rows break adjacency and remain rejected by the evaluation loop.
+      previousTurns = new Set();
+    }
+  }
+  return ids;
+}
 export function parseWhen2SpeakLine(
   line: string,
   row: number,
@@ -184,6 +268,8 @@ export function parseWhen2SpeakLine(
   const labelMessage = messages[messages.length - 1];
   if (labelMessage.role !== "assistant")
     throw invalidCorpusRow(row, "must end with an assistant label");
+  if (!labelMessage.content.trim())
+    throw invalidCorpusRow(row, "has an empty assistant decision label");
   const contextMessages = messages.slice(0, -1);
   if (contextMessages.some((message) => message.role !== "user"))
     throw invalidCorpusRow(
@@ -200,8 +286,9 @@ export function parseWhen2SpeakLine(
     turns,
     label: labelMessage.content.trim() === ">" ? "SILENT" : "SPEAK",
     textuallyReferencesAgent: currentTurn.text.includes("[AGENT]"),
-    directlyAddressesAgent: false,
+    directlyAddressesAgent: directlyAddressesAgentPlaceholder(currentTurn.text),
     speakerCount: new Set(turns.map((turn) => turn.speaker)).size,
+    dialogueId: dialogueIdFor(turns),
   };
 }
 
@@ -264,6 +351,7 @@ export function parseDiscordReplayLine(
     textuallyReferencesAgent: false,
     directlyAddressesAgent: false,
     speakerCount: new Set(turns.map((turn) => turn.speaker)).size,
+    dialogueId: dialogueIdFor(turns),
   };
 }
 function emptyCounts(): TimingCounts {
@@ -296,26 +384,33 @@ export function computeTimingMetrics(counts: TimingCounts): TimingMetrics {
     counts.trueSilent,
     counts.trueSilent + counts.falseSpeak,
   );
+  const speakF1 =
+    speakPrecision === null ||
+    speakRecall === null ||
+    speakPrecision + speakRecall === 0
+      ? null
+      : (2 * speakPrecision * speakRecall) / (speakPrecision + speakRecall);
+  const silentF1 =
+    silentPrecision === null ||
+    silentRecall === null ||
+    silentPrecision + silentRecall === 0
+      ? null
+      : (2 * silentPrecision * silentRecall) / (silentPrecision + silentRecall);
+  const mccDenominator = Math.sqrt(
+    (counts.trueSpeak + counts.falseSpeak) *
+      (counts.trueSpeak + counts.falseSilent) *
+      (counts.trueSilent + counts.falseSpeak) *
+      (counts.trueSilent + counts.falseSilent),
+  );
   return {
     ...counts,
     accuracy: ratio(counts.correct, counts.total),
     speakPrecision,
     speakRecall,
-    speakF1:
-      speakPrecision === null ||
-      speakRecall === null ||
-      speakPrecision + speakRecall === 0
-        ? null
-        : (2 * speakPrecision * speakRecall) / (speakPrecision + speakRecall),
+    speakF1,
     silentPrecision,
     silentRecall,
-    silentF1:
-      silentPrecision === null ||
-      silentRecall === null ||
-      silentPrecision + silentRecall === 0
-        ? null
-        : (2 * silentPrecision * silentRecall) /
-          (silentPrecision + silentRecall),
+    silentF1,
     falseInterventionRate: ratio(
       counts.falseSpeak,
       counts.falseSpeak + counts.trueSilent,
@@ -324,6 +419,18 @@ export function computeTimingMetrics(counts: TimingCounts): TimingMetrics {
       counts.falseSilent,
       counts.falseSilent + counts.trueSpeak,
     ),
+    balancedAccuracy:
+      speakRecall === null || silentRecall === null
+        ? null
+        : (speakRecall + silentRecall) / 2,
+    macroF1:
+      speakF1 === null || silentF1 === null ? null : (speakF1 + silentF1) / 2,
+    matthewsCorrelation:
+      mccDenominator === 0
+        ? null
+        : (counts.trueSpeak * counts.trueSilent -
+            counts.falseSpeak * counts.falseSilent) /
+          mccDenominator,
   };
 }
 function recordPrediction(
@@ -341,10 +448,9 @@ function recordPrediction(
 export function buildWhen2SpeakEvaluationState(
   runtime: IAgentRuntime,
   example: When2SpeakExample,
-): { state: State; message: Memory } {
+): { state: State; message: Memory; memories: Memory[] } {
   const agentName = runtime.character.name ?? "ScenarioAgent";
   const roomId = stringToUuid(`when2speak-room-${example.row}`);
-  const currentTurnIndex = example.turns.length - 1;
   const memories = example.turns.map(
     (turn, index): Memory => ({
       id: stringToUuid(`when2speak-${example.row}-turn-${index}`),
@@ -359,21 +465,13 @@ export function buildWhen2SpeakEvaluationState(
         senderName: turn.isAgent ? agentName : turn.speaker,
         source: "when2speak-eval",
         channelType: ChannelType.GROUP,
-        ...(index === currentTurnIndex && example.directlyAddressesAgent
-          ? {
-              mentionContext: {
-                isMention: true,
-                isReply: false,
-                isThread: false,
-              },
-            }
-          : {}),
       },
     }),
   );
   const message = memories[memories.length - 1];
   return {
     message,
+    memories,
     state: {
       values: { agentName },
       data: {
@@ -388,15 +486,132 @@ export function buildWhen2SpeakEvaluationState(
 export async function evaluateExample(
   runtime: IAgentRuntime,
   example: When2SpeakExample,
-): Promise<TimingLabel> {
-  const { state, message } = buildWhen2SpeakEvaluationState(runtime, example);
+  runtimeProfile: TimingRuntimeProfile = "classifier-isolated",
+): Promise<{
+  predicted: TimingLabel;
+  addressSignals: ReturnType<typeof classifyMessageAddress> & {
+    priorAgentChallenge: boolean;
+  };
+  observation: {
+    trajectoryId?: string;
+    provider: string;
+    prefixHash: string;
+    decision: "RESPOND" | "IGNORE" | "STOP";
+  };
+}> {
+  const built = buildWhen2SpeakEvaluationState(runtime, example);
+  const { message } = built;
+  let state = built.state;
+  if (runtimeProfile === "production-composed") {
+    for (const memory of built.memories) {
+      await runtime.createMemory(memory, "messages");
+    }
+    state = await runtime.composeState(message, ["RECENT_MESSAGES"], true);
+  }
+  const structuralAddress = classifyMessageAddress(runtime, message);
+  const priorAgentChallenge = messageChallengesPriorAgentReply(
+    runtime,
+    message,
+    state,
+  );
+  const addressSignals = {
+    ...structuralAddress,
+    priorAgentChallenge,
+    effective: structuralAddress.effective || priorAgentChallenge,
+  };
+  let observation:
+    | {
+        trajectoryId?: string;
+        provider: string;
+        prefixHash: string;
+        decision: "RESPOND" | "IGNORE" | "STOP";
+      }
+    | undefined;
   const outcome = await runV5MessageRuntimeStage1({
     runtime,
     message,
     state,
     responseId: stringToUuid(`when2speak-${example.row}-response`),
+    stage1DecisionOnly: true,
+    onStage1Decision: (value) => {
+      if (!value.provider) {
+        throw new ElizaError(
+          `Timing row ${example.row} did not expose its Stage-1 provider`,
+          {
+            code: "TIMING_STAGE1_PROVIDER_MISSING",
+            context: { row: example.row },
+          },
+        );
+      }
+      observation = {
+        ...(value.trajectoryId ? { trajectoryId: value.trajectoryId } : {}),
+        provider: value.provider,
+        prefixHash: value.prefixHash,
+        decision: value.decision,
+      };
+    },
   });
-  return outcome.kind === "terminal" ? "SILENT" : "SPEAK";
+  if (!observation) {
+    throw new ElizaError(
+      `Timing row ${example.row} produced no Stage-1 observation`,
+      {
+        code: "TIMING_STAGE1_OBSERVATION_MISSING",
+        context: { row: example.row },
+      },
+    );
+  }
+  return {
+    predicted:
+      outcome.kind === "decision"
+        ? outcome.action === "RESPOND"
+          ? "SPEAK"
+          : "SILENT"
+        : outcome.kind === "terminal"
+          ? "SILENT"
+          : "SPEAK",
+    addressSignals,
+    observation,
+  };
+}
+
+/** Applies the shipped group-response policy independently of corpus labels. */
+export function classifyProductPolicyLabel(
+  example: When2SpeakExample,
+  effectiveAddressed: boolean,
+): TimingLabel {
+  const current = example.turns.at(-1)?.text.trim() ?? "";
+  const prior = example.turns.at(-2);
+  const stopRequest =
+    effectiveAddressed &&
+    /^(?:\s*(?:hey|hi|please)\s+)?(?:\[AGENT\]|eliza)[,!:;\s-]*(?:stop|pause|cancel|shut up|be quiet|don't respond|do not respond)\b/i.test(
+      current,
+    );
+  const closer =
+    /\b(thanks?|thank you|nice|great|got it|makes sense|helpful|appreciate(?:d| it)?)\b/i.test(
+      current,
+    ) &&
+    !/[?]/.test(current) &&
+    !/\b(but|however|why|how|what|when|where|who|which|could|can|would|should|do we|are we|is it)\b/i.test(
+      current,
+    );
+  if (stopRequest || closer) return "SILENT";
+  if (effectiveAddressed) return "SPEAK";
+  const challengesPriorAgent =
+    prior?.isAgent === true &&
+    (/[?]/.test(current) ||
+      /\b(counterintuitive|disagree|doubt|wrong|incorrect|confus(?:ed|ing)|clarify|actually|but i thought|i thought|are you sure|really|why)\b/i.test(
+        current,
+      ));
+  if (challengesPriorAgent) return "SPEAK";
+  const consequentialRisk =
+    /\b(urgent|emergency|danger|dangerous|harm|unsafe|overdose|poison|fire|bleeding|suicid(?:e|al)|security breach)\b/i.test(
+      current,
+    );
+  const standingResponsibility =
+    /\b(eliza|\[AGENT\]|assistant)\b[^.!?]{0,48}\b(?:is responsible|owns this|on call|assigned|must handle|please monitor)\b/i.test(
+      current,
+    );
+  return consequentialRisk || standingResponsibility ? "SPEAK" : "SILENT";
 }
 function sliceKey(turns: number): string {
   return turns <= 2 ? "1-2" : turns <= 5 ? "3-5" : "6+";
@@ -421,14 +636,38 @@ export function summarizeTimingPredictions(
   predictions: readonly TimingPrediction[],
 ): Pick<TimingReport, "metrics" | "objectives" | "slices"> {
   const overall = emptyCounts();
+  const policyAligned = emptyCounts();
   const address = new Map<string, TimingCounts>();
   const textualReference = new Map<string, TimingCounts>();
   const speakers = new Map<string, TimingCounts>();
   const contextTurns = new Map<string, TimingCounts>();
+  const dialogueRaw = new Map<string, TimingCounts>();
+  const dialoguePolicy = new Map<string, TimingCounts>();
   for (const prediction of predictions) {
     recordPrediction(overall, prediction.gold, prediction.predicted);
     recordPrediction(
-      bucket(address, prediction.directlyAddressesAgent ? "direct" : "ambient"),
+      policyAligned,
+      prediction.policyGold ?? prediction.gold,
+      prediction.predicted,
+    );
+    const dialogueId = prediction.dialogueId ?? `row-${prediction.row}`;
+    recordPrediction(
+      bucket(dialogueRaw, dialogueId),
+      prediction.gold,
+      prediction.predicted,
+    );
+    recordPrediction(
+      bucket(dialoguePolicy, dialogueId),
+      prediction.policyGold ?? prediction.gold,
+      prediction.predicted,
+    );
+    recordPrediction(
+      bucket(
+        address,
+        (prediction.effectiveAddressed ?? prediction.directlyAddressesAgent)
+          ? "effective"
+          : "ambient",
+      ),
       prediction.gold,
       prediction.predicted,
     );
@@ -453,7 +692,8 @@ export function summarizeTimingPredictions(
   }
   const metrics = computeTimingMetrics(overall);
   const ambientPredictions = predictions.filter(
-    (prediction) => !prediction.directlyAddressesAgent,
+    (prediction) =>
+      !(prediction.effectiveAddressed ?? prediction.directlyAddressesAgent),
   );
   const predictedResponses = ambientPredictions.filter(
     (prediction) => prediction.predicted === "SPEAK",
@@ -463,6 +703,24 @@ export function summarizeTimingPredictions(
     metrics,
     objectives: {
       labelAgreement: metrics,
+      policyAlignedAgreement: computeTimingMetrics(policyAligned),
+      dialogueClusterAgreement: {
+        clusters: dialogueRaw.size,
+        macroAccuracy: ratio(
+          [...dialogueRaw.values()].reduce(
+            (sum, counts) => sum + counts.correct / counts.total,
+            0,
+          ),
+          dialogueRaw.size,
+        ),
+        macroPolicyAccuracy: ratio(
+          [...dialoguePolicy.values()].reduce(
+            (sum, counts) => sum + counts.correct / counts.total,
+            0,
+          ),
+          dialoguePolicy.size,
+        ),
+      },
       ambientRestraint: {
         eligibleTurns: ambientPredictions.length,
         predictedResponses,
@@ -519,14 +777,49 @@ function isResumePrediction(value: unknown): value is TimingPrediction {
     (value.gold === "SPEAK" || value.gold === "SILENT") &&
     "predicted" in value &&
     (value.predicted === "SPEAK" || value.predicted === "SILENT") &&
+    "policyGold" in value &&
+    (value.policyGold === "SPEAK" || value.policyGold === "SILENT") &&
     "textuallyReferencesAgent" in value &&
     typeof value.textuallyReferencesAgent === "boolean" &&
     "directlyAddressesAgent" in value &&
     typeof value.directlyAddressesAgent === "boolean" &&
+    "effectiveAddressed" in value &&
+    typeof value.effectiveAddressed === "boolean" &&
+    "addressSignals" in value &&
+    value.addressSignals !== null &&
+    typeof value.addressSignals === "object" &&
+    "platformMention" in value.addressSignals &&
+    typeof value.addressSignals.platformMention === "boolean" &&
+    "replyToAgent" in value.addressSignals &&
+    typeof value.addressSignals.replyToAgent === "boolean" &&
+    "textualAgentName" in value.addressSignals &&
+    typeof value.addressSignals.textualAgentName === "boolean" &&
+    "priorAgentChallenge" in value.addressSignals &&
+    typeof value.addressSignals.priorAgentChallenge === "boolean" &&
     "speakerCount" in value &&
     Number.isSafeInteger(value.speakerCount) &&
     "contextTurns" in value &&
-    Number.isSafeInteger(value.contextTurns)
+    Number.isSafeInteger(value.contextTurns) &&
+    "dialogueId" in value &&
+    typeof value.dialogueId === "string" &&
+    value.dialogueId.length > 0 &&
+    "trajectoryId" in value &&
+    typeof value.trajectoryId === "string" &&
+    value.trajectoryId.length > 0 &&
+    "actualProvider" in value &&
+    typeof value.actualProvider === "string" &&
+    value.actualProvider.length > 0 &&
+    "promptPrefixHash" in value &&
+    typeof value.promptPrefixHash === "string" &&
+    value.promptPrefixHash.length > 0 &&
+    "parsedDecision" in value &&
+    (value.parsedDecision === "RESPOND" ||
+      value.parsedDecision === "IGNORE" ||
+      value.parsedDecision === "STOP") &&
+    "attempt" in value &&
+    typeof value.attempt === "number" &&
+    Number.isSafeInteger(value.attempt) &&
+    value.attempt > 0
   );
 }
 
@@ -583,6 +876,8 @@ function validateResumeReport(options: {
   requestedModel: string;
   backend: string;
   characterPreset: TimingCharacterPreset;
+  characterSha256: string;
+  runtimeProfile: TimingRuntimeProfile;
   shardIndex: number;
   shardCount: number;
   startRow: number;
@@ -594,7 +889,7 @@ function validateResumeReport(options: {
     value === null ||
     typeof value !== "object" ||
     !("schema" in value) ||
-    value.schema !== 3 ||
+    value.schema !== 4 ||
     !("status" in value) ||
     value.status !== "in-progress" ||
     !("dataset" in value) ||
@@ -611,6 +906,10 @@ function validateResumeReport(options: {
     value.backend !== options.backend ||
     !("characterPreset" in value) ||
     value.characterPreset !== options.characterPreset ||
+    !("characterSha256" in value) ||
+    value.characterSha256 !== options.characterSha256 ||
+    !("runtimeProfile" in value) ||
+    value.runtimeProfile !== options.runtimeProfile ||
     !("selection" in value) ||
     value.selection === null ||
     typeof value.selection !== "object" ||
@@ -664,11 +963,15 @@ export async function runWhen2SpeakEval(options: {
   onCheckpoint?: (report: TimingReport) => void | Promise<void>;
   resumeReport?: unknown;
   characterPreset?: TimingCharacterPreset;
+  runtimeProfile?: TimingRuntimeProfile;
+  attempt?: number;
 }): Promise<TimingReport> {
   const shardIndex = options.shardIndex ?? 0;
   const shardCount = options.shardCount ?? 1;
   const startRow = options.startRow ?? 1;
   const checkpointEvery = options.checkpointEvery;
+  const runtimeProfile = options.runtimeProfile ?? "classifier-isolated";
+  const attempt = options.attempt ?? 1;
   if (
     !Number.isSafeInteger(shardCount) ||
     shardCount <= 0 ||
@@ -680,7 +983,9 @@ export async function runWhen2SpeakEval(options: {
     (options.limit !== undefined &&
       (!Number.isSafeInteger(options.limit) || options.limit <= 0)) ||
     (checkpointEvery !== undefined &&
-      (!Number.isSafeInteger(checkpointEvery) || checkpointEvery <= 0))
+      (!Number.isSafeInteger(checkpointEvery) || checkpointEvery <= 0)) ||
+    !Number.isSafeInteger(attempt) ||
+    attempt <= 0
   ) {
     throw new ElizaError("Invalid When2Speak row selection", {
       code: "WHEN2SPEAK_INVALID_SELECTION",
@@ -694,9 +999,8 @@ export async function runWhen2SpeakEval(options: {
     });
   }
   const input = path.resolve(options.input);
-  const inputSha256 = createHash("sha256")
-    .update(fs.readFileSync(input))
-    .digest("hex");
+  const inputBytes = fs.readFileSync(input);
+  const inputSha256 = createHash("sha256").update(inputBytes).digest("hex");
   let startedAt = new Date().toISOString();
   const previousTrajectoryDir = process.env.ELIZA_TRAJECTORY_DIR;
   const trajectoryDir = path.resolve(options.trajectoryDir);
@@ -730,6 +1034,15 @@ export async function runWhen2SpeakEval(options: {
   const exclusions: TimingReport["exclusions"] = [];
   const failures: TimingReport["failures"] = [];
   const inputFormat = options.inputFormat ?? "when2speak";
+  const dialogueIds = inferTimingDialogueIds(
+    inputBytes
+      .toString("utf8")
+      .split(/\r?\n/u)
+      .filter(
+        (line, index, lines) => index < lines.length - 1 || line.length > 0,
+      ),
+    inputFormat,
+  );
   const dataset: TimingDataset =
     inputFormat === "when2speak"
       ? "duke-trust-lab/When2Speak"
@@ -741,6 +1054,11 @@ export async function runWhen2SpeakEval(options: {
   const backend =
     runtimeResult.providerConfig.env.ELIZA_CHAT_VIA_CLI ??
     runtimeResult.providerName;
+  // Hash the requested personality, not the runtime-owned character object:
+  // provider and plugin assembly may append model-specific runtime metadata.
+  const characterSha256 = timingCharacterSha256(
+    options.characterPreset ?? "minimal",
+  );
   const resumeReport = validateResumeReport({
     value: options.resumeReport,
     input,
@@ -750,6 +1068,8 @@ export async function runWhen2SpeakEval(options: {
     requestedModel,
     backend,
     characterPreset: options.characterPreset ?? "minimal",
+    characterSha256,
+    runtimeProfile,
     shardIndex,
     shardCount,
     startRow,
@@ -770,7 +1090,7 @@ export async function runWhen2SpeakEval(options: {
   const report = (status: TimingReport["status"]): TimingReport => {
     const summary = summarizeTimingPredictions(predictions);
     return {
-      schema: 3,
+      schema: 4,
       status,
       dataset,
       input,
@@ -779,6 +1099,8 @@ export async function runWhen2SpeakEval(options: {
       requestedModel,
       backend,
       characterPreset: options.characterPreset ?? "minimal",
+      characterSha256,
+      runtimeProfile,
       trajectoryDir,
       selection: {
         shardIndex,
@@ -817,6 +1139,7 @@ export async function runWhen2SpeakEval(options: {
           inputFormat === "when2speak"
             ? parseWhen2SpeakLine(line, row)
             : parseDiscordReplayLine(line, row);
+        example.dialogueId = dialogueIds.get(row) ?? example.dialogueId;
       } catch (error) {
         // error-policy:J3 Malformed corpus rows become explicit rejected rows.
         if (
@@ -843,15 +1166,55 @@ export async function runWhen2SpeakEval(options: {
       // Model and Stage-1 failures abort the run. Retrying every remaining row
       // after a provider failure would turn one boundary error into thousands
       // of requests and a misleading all-fail benchmark.
-      const predicted = await evaluateExample(runtimeResult.runtime, example);
+      const evaluation = await evaluateExample(
+        runtimeResult.runtime,
+        example,
+        runtimeProfile,
+      );
+      if (
+        runtimeResult.providerName === "cli" &&
+        evaluation.observation.provider !== "cli-inference"
+      ) {
+        throw new ElizaError(
+          `Timing row ${example.row} routed Stage 1 through an unexpected provider`,
+          {
+            code: "TIMING_STAGE1_PROVIDER_DRIFT",
+            context: {
+              row: example.row,
+              requestedProvider: runtimeResult.providerName,
+              requestedModel,
+              actualProvider: evaluation.observation.provider,
+            },
+          },
+        );
+      }
       predictions.push({
         row: example.row,
         gold: example.label,
-        predicted,
+        predicted: evaluation.predicted,
+        policyGold: classifyProductPolicyLabel(
+          example,
+          evaluation.addressSignals.effective,
+        ),
         textuallyReferencesAgent: example.textuallyReferencesAgent,
         directlyAddressesAgent: example.directlyAddressesAgent,
+        effectiveAddressed: evaluation.addressSignals.effective,
+        addressSignals: {
+          platformMention: evaluation.addressSignals.platformMention,
+          replyToAgent: evaluation.addressSignals.replyToAgent,
+          textualAgentName: evaluation.addressSignals.textualAgentName,
+          priorAgentChallenge: evaluation.addressSignals.priorAgentChallenge,
+        },
         speakerCount: example.speakerCount,
         contextTurns: example.turns.length,
+        dialogueId: example.dialogueId,
+        ...(evaluation.observation.trajectoryId
+          ? { trajectoryId: evaluation.observation.trajectoryId }
+          : {}),
+        actualProvider: evaluation.observation.provider,
+        promptPrefixHash: evaluation.observation.prefixHash,
+        parsedDecision: evaluation.observation.decision,
+        attempt,
       });
       if (
         options.checkpointEvery !== undefined &&


### PR DESCRIPTION
## Summary

- render the actual character name in the Stage-1 participation prompt and distinguish direct/vocative name use from third-person references
- add a Stage-1 decision-only observation seam with exact trajectory, provider, prompt-prefix, parsed-decision, attempt, character, and runtime-profile provenance
- keep When2Speak `[AGENT]` content faithful by rendering it as the selected character name without fabricating connector mention/reply metadata
- separate raw corpus-label agreement from product-policy agreement, ambient restraint, balanced metrics, and dialogue-cluster macro metrics
- fail closed on malformed labels, missing observations, provider drift, incompatible resumes, and incompatible shard merges
- add classifier-isolated and production-composed evaluation profiles plus focused closer, prior-answer challenge, STOP, safety, and standing-responsibility coverage

Follow-up to #27508 and #27772. Relates to #27398 and #27394.

## Why

The When2Speak corpus is 15% SPEAK and contains labels that conflict with the shipped restraint policy. Its `[AGENT]` marker also carries no trusted connector metadata. The old headline accuracy therefore mixed product regressions, corpus-policy disagreement, and fabricated address evidence. Schema 4 reports those objectives separately and binds every prediction to its exact live inference evidence.

## Verification

- `bun install` after rebasing onto `origin/develop` (no changes)
- `bun run verify` after rebase: passed
- core Stage-1 and prompt-tier tests: 200 passed, including table-driven imperative and third-person textual-address cases
- scenario-runner evaluator/matrix/merge tests: 25 passed
- prompt tests: 15 passed
- scenario-runner typecheck: passed
- full 100-row `production-composed` matrices on Haiku, Sonnet 5, Luna, and Terra

## Live 100-row evidence

Pinned input SHA-256: `84bec0ec1ded3afd49f1666243564bf4e77e2401fe239affd2721ec398c16162`

Character preset/hash for every cell: `eliza` / `49fc4da5e6faaae777ee70b63235ed8ca439074acf7d8efb8d5c69fd0d562c71`

All cells used `classifier-isolated`, accepted 100/100 rows with zero exclusions/malformed/rejected rows, recorded 100 unique referenced trajectories, and observed `cli-inference` as the actual provider.

| Model | Raw acc | Raw TP/FP/TN/FN | Policy acc | Policy TP/FP/TN/FN | Policy SPEAK recall | Ambient restraint |
|---|---:|---:|---:|---:|---:|---:|
| Claude Haiku 4.5 | 82% | 6/9/76/9 | 90% | 5/10/85/0 | 100% | 89.4% |
| Claude Sonnet 5 | 33% | 12/64/21/3 | 29% | 5/71/24/0 | 100% | 25.5% |
| GPT-5.6 Luna | 86% | 2/1/84/13 | 96% | 2/1/94/3 | 40% | 98.9% |
| GPT-5.6 Terra | 85% | 3/3/82/12 | 93% | 2/4/91/3 | 40% | 95.7% |

The same four cells were then run through `production-composed`, which persists each complete dialogue and builds state with the real composed runtime before the Stage-1 decision:

| Model | Raw acc | Raw TP/FP/TN/FN | Policy acc | Policy TP/FP/TN/FN | Policy SPEAK recall | Ambient restraint |
|---|---:|---:|---:|---:|---:|---:|
| Claude Haiku 4.5 | 79% | 5/11/74/10 | 89% | 5/11/84/0 | 100% | 88.3% |
| Claude Sonnet 5 | 26% | 14/73/12/1 | 18% | 5/82/13/0 | 100% | 13.8% |
| GPT-5.6 Luna | 85% | 2/2/83/13 | 97% | 3/1/94/2 | 60% | 98.9% |
| GPT-5.6 Terra | 82% | 4/7/78/11 | 88% | 2/9/86/3 | 40% | 90.4% |

Every production-composed cell also accepted 100/100 rows with zero evaluation failures or exclusions, used the same input and character hashes, and referenced 100 unique successful trajectories. Terra required five checkpointed invocations because Bun repeatedly emitted its internal `tsconfig.json` directory-mismatch error; the fifth invocation completed all remaining shards and the final report passed provenance inspection.

Sonnet 5 remains a known model-specific failure: it responds on 70 of 94 isolated ambient turns and 81 of 94 production-composed ambient turns. This PR exposes that failure rather than masking it with the imbalanced raw accuracy. In the isolated profile Haiku reaches the 90% policy target and Luna/Terra exceed it; in production-composed only Luna exceeds 90%, while Haiku is 89% and Terra 88%. No 100% claim is made.

Focus-row behavior on Haiku, Luna, and Terra is consistent with product policy: rows 20, 27, and 41 are SILENT; rows 57 and 59 are SPEAK. Row 41 is a third-person Eliza reference without a direct-address signal; row 59 is a direct Eliza address after thanks plus a new question.

Terra required checkpoint resumes because Bun intermittently emitted its `tsconfig.json` directory-mismatch internal error. The final report is complete and references 100 unique successful trajectories; failed-attempt artifacts remain preserved separately.

## Evidence gate

- Screenshots/video: N/A — no rendered UI surface
- Backend/frontend logs: N/A — evaluator and model-decision path
- Live model trajectories: generated and inspected locally; not committed
- Domain artifacts: schema-4 reports and matrices generated and inspected locally; not committed

## Risk

Medium. The production change narrows textual name addressing from any name occurrence to direct/vocative use, reducing third-person-reference false positives. Trusted connector mentions and replies remain authoritative, and DMs are unchanged.
