### PR TITLE
fix(agent): harden markup sniff against whitespace padding bypass

### DIFF
--- a/packages/agent/src/api/media-store.test.ts
+++ b/packages/agent/src/api/media-store.test.ts
@@ -423,6 +423,15 @@ describe("serve-path security headers (stored-XSS defence)", () => {
     );
     expect(sniffMarkupMime(Buffer.from([0x89, 0x50, 0x4e, 0x47]))).toBeNull();
   });
+
+  it("detects SVG/HTML even when padded with excess leading whitespace", () => {
+    const paddedSvg = Buffer.from(" ".repeat(65) + "<svg onload=alert(1)></svg>");
+    expect(sniffMarkupMime(paddedSvg)).toBe("image/svg+xml");
+    const paddedHtml = Buffer.from("\n".repeat(80) + "<html><body>hi</body></html>");
+    expect(sniffMarkupMime(paddedHtml)).toBe("text/html");
+    const paddedXmlSvg = Buffer.from(" ".repeat(70) + "<?xml version='1.0'?><svg/>");
+    expect(sniffMarkupMime(paddedXmlSvg)).toBe("image/svg+xml");
+  });
 });
 
 describe("selectMediaToEvict", () => {

--- a/packages/agent/src/api/media-store.ts
+++ b/packages/agent/src/api/media-store.ts
@@ -141,7 +141,7 @@ export function sniffMarkupMime(buffer: Buffer): string | null {
   ) {
     i = 3;
   }
-  while (i < buffer.length && i < 64) {
+  while (i < buffer.length && i < 1024) {
     const c = buffer[i];
     if (c === 0x20 || c === 0x09 || c === 0x0a || c === 0x0d) {
       i += 1;


### PR DESCRIPTION
# Relates to

Fixes whitespace-padding bypass in `sniffMarkupMime` that could cause SVG/HTML masquerading as PNG to be served inline.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. One-line guard change in `packages/agent/src/api/media-store.ts` widening the leading-whitespace scan from 64 to 1024 bytes. No new dependencies, no schema/DB changes. Affects only the markup sniff used during `persistMediaBytes` to reconcile declared mime vs bytes; does not change serve-path headers or storage layout. Worst case is a padded SVG/HTML that was previously missed is now correctly stored as `image/svg+xml`/`text/html` and forced to download (intended hardening).

# Background

## What does this PR do?

Hardens `sniffMarkupMime` in `packages/agent/src/api/media-store.ts` against a stored-XSS bypass: the function skipped at most 64 bytes of leading whitespace/BOM before inspecting the payload head. An attacker could prepend 65+ spaces/newlines to `<svg`/` <html` to push the tag beyond the window, causing `persistMediaBytes` to keep a declared `image/png` and later serve it `inline` instead of `attachment`, allowing SVG script execution on the dashboard origin.

This PR raises the leading-whitespace scan limit to 1024 bytes (still bounded) and adds a behavioral test covering the padded case in the canonical suite `packages/agent/src/api/media-store.test.ts`.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

Stored-XSS defence in depth: `isInlineSafeMime` + `sniffMarkupMime` + `nosniff` + sandboxed CSP. The 64-byte cap left a trivial bypass for the reconciliation step.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/agent/src/api/media-store.ts:133` (`sniffMarkupMime`) and `packages/agent/src/api/media-store.test.ts:416` (new `detects SVG/HTML even when padded` case).

## Detailed testing steps

- Revert the production change (restore `i < 64`): `bunx vitest run packages/agent/src/api/media-store.test.ts` shows 1 failure in `detects SVG/HTML even when padded with excess leading whitespace` (`expected null to be 'image/svg+xml'`).
- Restore the fix (`i < 1024`): same suite passes 433/433.
- Existing suite `packages/agent/src/api/media-store.test.ts` continues to pass for the unpadded `sniffs SVG/HTML markup from leading bytes` case.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:d7e36175148989761b4bb1a23a42eb190d537993 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI surface changed (server-side media store utility only)`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI surface changed (server-side media store utility only)`.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked `N/A - no UI flow (server-side mime sniff hardening)`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked `N/A - exercised via unit test; no separate server log path beyond persistMediaBytes sniff`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - no frontend code path (media store is backend-only)`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - no agent/model/prompt change`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - no domain artifact beyond stored media mime correctness, verified by unit test`.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/model/prompt change.

## Backend + frontend logs

N/A - exercised via unit test; see Red/Green below.

## Screenshots (before / after) + video walkthrough

N/A - no UI surface changed (server-side media store utility only).

### Before

N/A

### After

N/A

### Walkthrough video

N/A

## Audio / voice walkthrough

N/A - no voice path.

## Known gaps / failures

- `bun run --cwd packages/agent typecheck` fails pre-existing on `../cloud/shared/src/billing/markup.ts(16,8): Cannot find module '@elizaos/cloud-sdk/browser-contracts'` on both base and head (unrelated, not introduced by this PR). Same failure reproduced on `origin/develop` with change reverted.
- `bun run verify` full lane not run due to pre-existing typecheck blocker; targeted `vitest` lane for `packages/agent/src/api/media-store.test.ts` passes (433/433).
- No `bun run check` failures: `biome check --config-path biome.json packages/agent/src/api/media-store.ts` reports `Checked 1 file in 45ms. No fixes applied.`

Red (production reverted to `i < 64`) — `bunx vitest run packages/agent/src/api/media-store.test.ts --no-coverage`:

```
 FAIL  packages/agent/src/api/media-store.test.ts > serve-path security headers (stored-XSS defence) > detects SVG/HTML even when padded with excess leading whitespace
AssertionError: expected null to be 'image/svg+xml' // Object.is equality
Expected: "image/svg+xml"
Received: null

 Test Files  1 failed | 5 passed (6)
      Tests  1 failed | 432 passed (433)
```

Green (fix restored to `i < 1024`):

```
 Test Files  6 passed (6)
      Tests  433 passed (433)
   Start at  01:05:16
   Duration  2.95s
```

Existing suite baseline (without new test) on `origin/develop` is 432/432 passing; with fix the suite is 433/433.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
