### PR TITLE
fix(core): guard computeBackoff against non-finite inputs

### DIFF
--- a/packages/core/src/utils/retry.test.ts
+++ b/packages/core/src/utils/retry.test.ts
@@ -93,6 +93,29 @@ describe("computeBackoff", () => {
 			expect(computeBackoff(policy, 6)).toBe(500);
 		}
 	});
+
+	it("returns a finite delay for non-finite policy or attempt inputs", () => {
+		const base: BackoffPolicy = {
+			initialMs: 100,
+			maxMs: 1000,
+			factor: 2,
+			jitter: 0,
+		};
+		expect(computeBackoff({ ...base, factor: Number.NaN }, 1)).toBe(0);
+		expect(computeBackoff({ ...base, initialMs: Number.POSITIVE_INFINITY }, 1)).toBe(0);
+		expect(computeBackoff({ ...base, maxMs: Number.NaN }, 1)).toBe(0);
+		expect(computeBackoff({ ...base, jitter: Number.NaN }, 1)).toBe(0);
+		expect(computeBackoff(base, Number.NaN)).toBe(0);
+		expect(computeBackoff(base, Number.POSITIVE_INFINITY)).toBe(0);
+		const overflow: BackoffPolicy = {
+			initialMs: Number.MAX_VALUE,
+			maxMs: 10_000,
+			factor: 2,
+			jitter: 0,
+		};
+		expect(computeBackoff(overflow, 10)).toBe(10_000);
+		expect(Number.isFinite(computeBackoff(base, 1.9))).toBe(true);
+	});
 });
 
 describe("resolveRetryConfig", () => {

--- a/packages/core/src/utils/retry.ts
+++ b/packages/core/src/utils/retry.ts
@@ -79,9 +79,26 @@ export type BackoffPolicy = {
  * @returns Delay in milliseconds
  */
 export function computeBackoff(policy: BackoffPolicy, attempt: number): number {
-	const base = policy.initialMs * policy.factor ** Math.max(attempt - 1, 0);
+	if (
+		!Number.isFinite(policy.initialMs) ||
+		!Number.isFinite(policy.maxMs) ||
+		!Number.isFinite(policy.factor) ||
+		!Number.isFinite(policy.jitter) ||
+		!Number.isFinite(attempt)
+	) {
+		return 0;
+	}
+	const safeAttempt = Math.max(0, Math.floor(attempt) - 1);
+	const base = policy.initialMs * policy.factor ** safeAttempt;
+	if (!Number.isFinite(base)) {
+		return policy.maxMs;
+	}
 	const jitter = base * policy.jitter * Math.random();
-	return Math.min(policy.maxMs, Math.round(base + jitter));
+	const withJitter = base + jitter;
+	if (!Number.isFinite(withJitter)) {
+		return policy.maxMs;
+	}
+	return Math.min(policy.maxMs, Math.round(withJitter));
 }
 
 // ============================================================================


### PR DESCRIPTION
# Relates to

Fixes `computeBackoff` returning non-finite delays when policy fields or attempt are `NaN`/`Infinity`, which caused `sleep(NaN)` tight-loop retries.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Single function `packages/core/src/utils/retry.ts:81` now validates `isFinite` on all `BackoffPolicy` fields and `attempt`, floors the attempt to an integer before exponentiation, and caps overflowed `base`/`withJitter` at `maxMs`. No new deps, no schema/DB change. Valid inputs keep identical exponential/jitter math (verified by existing tests). Invalid inputs previously produced `NaN`/`Infinity` delays; now they deterministically return `0` or `maxMs`, preventing tight-loop DoS.

# Background

## What does this PR do?

Hardens `computeBackoff` against non-finite inputs. The public export had no `isFinite` guard, so `factor=NaN` (via mis-configured policy or manual construction) produced `NaN` delays, and `initialMs=Infinity` or huge overflow produced `Infinity`. `retryAsync` feeds the result into `sleep()`, where `setTimeout(NaN)` fires immediately, collapsing backoff to a tight retry loop. The fix returns `0` for any non-finite field/attempt and caps overflow at `maxMs`, plus floors the attempt to integer.

Adds a behavioral test in the canonical suite `packages/core/src/utils/retry.test.ts` covering `NaN`/`Infinity`/overflow and fractional attempts.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

Sibling `resolveRetryConfig` already sanitizes via `clampNumber`/`asFiniteNumber`, but `computeBackoff` is a public export that callers can invoke directly with an arbitrary `BackoffPolicy`. Without self-guarding it can emit a `NaN` that disables backoff entirely.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/core/src/utils/retry.ts:81` and `packages/core/src/utils/retry.test.ts:99` (new `returns a finite delay for non-finite policy or attempt inputs`).

## Detailed testing steps

- Revert `retry.ts` to baseline (`const base = policy.initialMs * policy.factor ** Math.max(attempt - 1, 0); …`): `bunx vitest run packages/core/src/utils/retry.test.ts --no-coverage` fails 1/32 (`expected 0 to be 100` on the NaN-factor case, and would otherwise return `NaN` for other non-finite inputs).
- Restore fix: same suite passes 32/32.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:8241983a8a6b0fba3ec53fed84df32d43248fba9 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI surface (core utility only)`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI surface (core utility only)`.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked `N/A - no UI flow (core retry math)`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked `N/A - exercised via unit test; no separate server log`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - no frontend code path`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - no agent/model/prompt change`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - no domain artifact beyond retry delay correctness, verified by unit test`.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/model/prompt change.

## Backend + frontend logs

N/A - exercised via unit test; see Red/Green below.

## Screenshots (before / after) + video walkthrough

N/A - no UI surface.

### Before

N/A

### After

N/A

### Walkthrough video

N/A

## Audio / voice walkthrough

N/A

## Known gaps / failures

- `bun run --cwd packages/agent typecheck` fails pre-existing on `../cloud/shared/src/billing/markup.ts: Cannot find module '@elizaos/cloud-sdk/browser-contracts'` on both base and head (unrelated).
- `biome check --config-path biome.json packages/core/src/utils/retry.ts` passes (`Checked 1 file`).
- Full `bun run verify` lane not run due to pre-existing typecheck blocker; targeted vitest lane passes.

Red (reverted) — `bunx vitest run packages/core/src/utils/retry.test.ts --no-coverage`:

```
 FAIL  packages/core/src/utils/retry.test.ts > computeBackoff > returns a finite delay for non-finite policy or attempt inputs
AssertionError: expected 100 to be +0 // Object.is equality

 Test Files  1 failed (1)
      Tests  1 failed | 31 passed (32)
```

Green (restored):

```
 Test Files  1 passed (1)
      Tests  32 passed (32)
   Start at  01:07:13
   Duration  1.82s
```

Existing baseline on `origin/develop` without new test is 31/31 passing; with fix the suite is 32/32.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
