### PR TITLE
fix(core): preserve semicolons inside quoted Content-Disposition filename

### DIFF
--- a/packages/core/src/media/fetch.test.ts
+++ b/packages/core/src/media/fetch.test.ts
@@ -155,6 +155,17 @@ describe("fetchRemoteMedia", () => {
 		expect(result.fileName).toBe("report.txt");
 	});
 
+	it("preserves semicolons inside quoted filename= values", async () => {
+		const result = await fetchWithContentDisposition(
+			'attachment; filename="my;file.pdf"',
+		);
+		expect(result.fileName).toBe("my;file.pdf");
+		const result2 = await fetchWithContentDisposition(
+			"attachment; filename='a;b.txt'",
+		);
+		expect(result2.fileName).toBe("a;b.txt");
+	});
+
 	it("keeps surrogate pairs intact in diagnostic error snippets", async () => {
 		const { readErrorBodySnippet } = await import("./fetch.ts");
 		const emojiBody = `${"a".repeat(50)}🦊${"b".repeat(50)}`;

--- a/packages/core/src/media/fetch.ts
+++ b/packages/core/src/media/fetch.ts
@@ -100,9 +100,12 @@ function parseContentDispositionFileName(
 			return getBasename(encoded);
 		}
 	}
-	const match = /filename\s*=\s*([^;]+)/i.exec(header);
-	if (match?.[1]) {
-		return getBasename(stripQuotes(match[1].trim()));
+	const match = /filename\s*=\s*(?:"([^"]*)"|'([^']*)'|([^;\s]+))/i.exec(header);
+	if (match) {
+		const raw = (match[1] ?? match[2] ?? match[3] ?? "").trim();
+		if (raw) {
+			return getBasename(stripQuotes(raw));
+		}
 	}
 	return undefined;
 }


### PR DESCRIPTION
# Relates to

Fixes truncated `Content-Disposition` filename when the quoted value contains a semicolon.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. One regex in `packages/core/src/media/fetch.ts:103` changed from `([^;]+)` (semicolon-terminated token) to a quoted-aware `(?:"([^"]*)"|'([^']*)'|([^;\s]+))` capture. No new deps, no schema/DB change. Only affects `Content-Disposition: filename=` parsing; `filename*` (RFC 5987) path unchanged. Existing filename parsing (`report.txt`) unchanged. Worst case is a filename with semicolon inside quotes now correctly preserved (previously truncated to the part before `;` and could lose extension/MIME).

# Background

## What does this PR do?

Hardens `parseContentDispositionFileName` to handle semicolons inside quoted `filename=` values. The old `[^;]+` terminated at the first `;`, so `filename="my;file.pdf"` was parsed as `my` (then `getBasename` + missing extension logic produced `my.txt` or `bin`), losing the real extension and causing the downstream `detectMime`/`extensionForMime` to mis-classify the file. The fix captures quoted strings atomically.

Adds a behavioral test in the canonical suite `packages/core/src/media/fetch.test.ts` for `my;file.pdf` and `a;b.txt`.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

`Content-Disposition` `filename=` with a quoted value may legally contain `;` per RFC 6266; the previous parser was quote-unaware and truncated such names, which is observable when a remote server serves `my;file.pdf` style names.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/core/src/media/fetch.ts:103` and `packages/core/src/media/fetch.test.ts:158`.

## Detailed testing steps

- Revert `fetch.ts` to baseline (`/filename\s*=\s*([^;]+)/`): `bunx vitest run packages/core/src/media/fetch.test.ts` fails 1/13 (`expected 'my.txt' to be 'my;file.pdf'`).
- Restore fix: same suite passes 13/13.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:1e4faea8444d859cba2d17cf7a56dc66db4df92a -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI surface (core media fetch utility)`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI surface (core media fetch utility)`.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked `N/A - no UI flow`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked `N/A - exercised via unit test`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - no frontend code path`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - no agent/model/prompt change`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - no domain artifact beyond filename parsing, verified by unit test`.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/model/prompt change.

## Backend + frontend logs

N/A - exercised via unit test.

## Screenshots (before / after) + video walkthrough

N/A - no UI surface.

### Before

N/A

### After

N/A

### Walkthrough video

N/A

## Audio / voice walkthrough

N/A

## Known gaps / failures

- `bun run --cwd packages/agent typecheck` fails pre-existing on `../cloud/shared/src/billing/markup.ts: Cannot find module '@elizaos/cloud-sdk/browser-contracts'` on both base and head.
- `biome check --config-path biome.json packages/core/src/media/fetch.ts` passes (`Checked 1 file`).
- Full `bun run verify` not run due to pre-existing typecheck blocker; targeted vitest lane passes.

Red (reverted) — `bunx vitest run packages/core/src/media/fetch.test.ts --no-coverage` (with `--exclude` for `.claude`):

```
 FAIL  packages/core/src/media/fetch.test.ts > fetchRemoteMedia > preserves semicolons inside quoted filename= values
AssertionError: expected 'my.txt' to be 'my;file.pdf'

 Test Files  1 failed (1)
      Tests  1 failed | 12 passed (13)
```

Green (restored):

```
 Test Files  1 passed (1)
      Tests  13 passed (13)
```

Baseline on `origin/develop` without new test is 12/12 passing.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
