### PR TITLE
test(health): cover default circadian contract honesty

### DIFF
--- a/plugins/plugin-health/src/contracts/circadian-default.test.ts
+++ b/plugins/plugin-health/src/contracts/circadian-default.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { createDefaultCircadianInsightContract } from "./circadian-default";
+
+describe("createDefaultCircadianInsightContract", () => {
+  it("reports an uncalibrated sleep window with no fabricated values", async () => {
+    const contract = createDefaultCircadianInsightContract();
+    const window = await contract.getCurrentSleepWindow();
+    expect(window).toEqual({
+      state: null,
+      confidence: 0,
+      lastWakeAtIso: null,
+      currentSleepStartedAtIso: null,
+      bedtimeTargetAtIso: null,
+    });
+  });
+
+  it("reports an uncalibrated scheduling window with an explicit reason", async () => {
+    const contract = createDefaultCircadianInsightContract();
+    const window = await contract.inferOptimalSchedulingWindow();
+    expect(window).toEqual({
+      recommendedAtIso: null,
+      nextMealLabel: null,
+      windowStartIso: null,
+      windowEndIso: null,
+      confidence: 0,
+      reason: "circadian inference not calibrated",
+    });
+  });
+
+  it("returns no latest insight until a richer implementation is registered", async () => {
+    const contract = createDefaultCircadianInsightContract();
+    await expect(contract.getLatestInsight()).resolves.toBeNull();
+  });
+
+  it("keeps all contract methods async", () => {
+    const contract = createDefaultCircadianInsightContract();
+    expect(contract.getCurrentSleepWindow()).toBeInstanceOf(Promise);
+    expect(contract.inferOptimalSchedulingWindow()).toBeInstanceOf(Promise);
+    expect(contract.getLatestInsight()).toBeInstanceOf(Promise);
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# What & why

Adds focused tests for `createDefaultCircadianInsightContract`
(`plugins/plugin-health/src/contracts/circadian-default.ts`), the default
`CircadianInsightContract` registered during plugin init. Consumers (e.g.
`app-lifeops` SCHEDULE / SCHEDULED_TASK) read through this contract, so the
tests pin the honesty contract: until a richer implementation is registered,
callers must see `state=null` / `recommendedAtIso=null` with an explicit
"not calibrated" reason — never a fabricated meaningful zero — and all
methods stay async.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition exercising existing exported functions; no production
code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `<TEST_OUTPUT>` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: 92d692518c3d832ac9b203076ef691a54e61a9fa
