### PR TITLE
fix(core): keep UTF-16 surrogate pairs intact in markdown chunkText

### DIFF
--- a/packages/core/src/markdown/chunk.chunkText.test.ts
+++ b/packages/core/src/markdown/chunk.chunkText.test.ts
@@ -41,4 +41,21 @@ describe("chunkText", () => {
 			"aaaaa",
 		]);
 	});
+
+	it("preserves UTF-16 surrogate pairs when hard breaking at limit", () => {
+		const text = "😀".repeat(10);
+		const chunks = chunkText(text, 5);
+		expect(chunks).toEqual([
+			"😀😀",
+			"😀😀",
+			"😀😀",
+			"😀😀",
+			"😀😀",
+		]);
+		for (const chunk of chunks) {
+			expect(chunk.length).toBeLessThanOrEqual(5);
+			expect(chunk.endsWith("\uD83D")).toBe(false);
+			expect(chunk.startsWith("\uDE00")).toBe(false);
+		}
+	});
 });

--- a/packages/core/src/markdown/chunk.ts
+++ b/packages/core/src/markdown/chunk.ts
@@ -46,6 +46,16 @@ export function chunkText(text: string, limit: number): string[] {
 			breakIdx = limit;
 		}
 
+		if (breakIdx > 0 && breakIdx < remaining.length) {
+			const prevCharCode = remaining.charCodeAt(breakIdx - 1);
+			if (prevCharCode >= 0xd800 && prevCharCode <= 0xdbff) {
+				breakIdx -= 1;
+				if (breakIdx === 0) {
+					breakIdx = Math.min(2, remaining.length);
+				}
+			}
+		}
+
 		const rawChunk = remaining.slice(0, breakIdx);
 		const chunk = rawChunk.trimEnd();
 		if (chunk.length > 0) {


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:16ae2f70e9baf856deebd1280b7ad6bece86dec0 -->

## Summary
`chunkText` in `packages/core/src/markdown/chunk.ts` splits over-long strings into delivery-sized chunks. When hard-breaking at the length limit, `remaining.slice(0, breakIdx)` previously truncated without checking whether `breakIdx` bisected a UTF-16 surrogate pair (0xD800–0xDBFF). This left an isolated high surrogate at the end of the current chunk and an orphaned low surrogate at the start of the next chunk, resulting in malformed unicode sequences (`\uFFFD`) and broken emojis when dispatched to client platforms.

## Proposed Changes
1. Added surrogate-pair boundary adjustment in `chunkText`: if `breakIdx` falls between a high surrogate and low surrogate, back up by 1 code unit so the entire surrogate pair stays together in the next chunk.
2. Added unit test in `packages/core/src/markdown/chunk.chunkText.test.ts` verifying that hard breaks across emoji sequences (e.g. `"😀".repeat(10)` with limit 5) never split surrogate pairs.

## Verification
- Ran vitest: `bun run --cwd packages/core test src/markdown/chunk.chunkText.test.ts` (6/6 tests passed).
- Ran all markdown tests: `bun run --cwd packages/core test src/markdown/` (20/20 tests passed).

<!-- eliza-computer-attribution:v1 {"provider":"deepmind","model":"antigravity","client":"antigravity-ide","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
