### PR TITLE
fix(core): keep UTF-16 surrogate pairs intact in RecursiveCharacterTextSplitter

### DIFF
--- a/packages/core/src/utils/recursive-character-text-splitter.test.ts
+++ b/packages/core/src/utils/recursive-character-text-splitter.test.ts
@@ -265,4 +265,23 @@ describe("splitText", () => {
 			},
 		);
 	});
+
+	it("preserves UTF-16 surrogate pairs when falling back to character-level split", async () => {
+		const text = "😀🎉🚀🌟🔥";
+		const splitter = new RecursiveCharacterTextSplitter({
+			chunkSize: 4,
+			chunkOverlap: 0,
+			separators: [""],
+		});
+		const chunks = await splitter.splitText(text);
+		expect(chunks).toEqual([
+			"😀🎉",
+			"🚀🌟",
+			"🔥",
+		]);
+		for (const chunk of chunks) {
+			expect(chunk.endsWith("\uD83D")).toBe(false);
+			expect(chunk.startsWith("\uDE00")).toBe(false);
+		}
+	});
 });

--- a/packages/core/src/utils/recursive-character-text-splitter.test.ts
+++ b/packages/core/src/utils/recursive-character-text-splitter.test.ts
@@ -267,21 +267,20 @@ describe("splitText", () => {
 	});
 
 	it("preserves UTF-16 surrogate pairs when falling back to character-level split", async () => {
-		const text = "😀🎉🚀🌟🔥";
+		const text = "😀🎉🚀";
 		const splitter = new RecursiveCharacterTextSplitter({
-			chunkSize: 4,
+			chunkSize: 3,
 			chunkOverlap: 0,
 			separators: [""],
 		});
 		const chunks = await splitter.splitText(text);
-		expect(chunks).toEqual([
-			"😀🎉",
-			"🚀🌟",
-			"🔥",
-		]);
-		for (const chunk of chunks) {
-			expect(chunk.endsWith("\uD83D")).toBe(false);
-			expect(chunk.startsWith("\uDE00")).toBe(false);
+		expect(chunks).toEqual(["😀", "🎉", "🚀"]);
+		for (const c of chunks) {
+			expect(
+				/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(
+					c,
+				),
+			).toBe(false);
 		}
 	});
 });

--- a/packages/core/src/utils/recursive-character-text-splitter.ts
+++ b/packages/core/src/utils/recursive-character-text-splitter.ts
@@ -54,7 +54,7 @@ export class RecursiveCharacterTextSplitter {
 				splits = text.split(separator);
 			}
 		} else {
-			splits = text.split("");
+			splits = Array.from(text);
 		}
 		return splits.filter((s) => s !== "");
 	}


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:d07d428f15f7b62c2ba165fb6b73d1b42de05b8f -->

## Summary
In `RecursiveCharacterTextSplitter.splitOnSeparator` (`packages/core/src/utils/recursive-character-text-splitter.ts`), falling back to character-level splitting with `separator === ""` previously used `text.split("")`. Because `String.prototype.split("")` separates by 16-bit code units rather than Unicode code points, any character above the Basic Multilingual Plane (such as emojis or supplementary symbols) was split between its high and low surrogate units (`\uD83D` / `\uDE00`), leading to corrupted character fragments and encoding errors downstream.

## Proposed Changes
1. Updated `splitOnSeparator` to use `Array.from(text)` when splitting on the empty-string character separator, preserving full Unicode code points and surrogate pairs intact.
2. Added unit test in `packages/core/src/utils/recursive-character-text-splitter.test.ts` verifying that character-level splitting over emoji sequences never splits surrogate pairs.

## Verification
- Ran vitest: `bun run --cwd packages/core test src/utils/recursive-character-text-splitter.test.ts` (32/32 tests passed).

<!-- eliza-computer-attribution:v1 {"provider":"deepmind","model":"antigravity","client":"antigravity-ide","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
