### PR TITLE
fix(core): keep UTF-16 surrogate pairs intact in chunkMarkdownText

### DIFF
--- a/packages/core/src/markdown/chunk.chunkMarkdownText.test.ts
+++ b/packages/core/src/markdown/chunk.chunkMarkdownText.test.ts
@@ -61,6 +61,23 @@ describe("chunkMarkdownText", () => {
 		expect(reopened.length).toBeGreaterThan(0);
 	});
 
+	it("preserves UTF-16 surrogate pairs when breaking markdown at limit", () => {
+		const text = "😀".repeat(10);
+		const chunks = chunkMarkdownText(text, 5);
+		expect(chunks).toEqual([
+			"😀😀",
+			"😀😀",
+			"😀😀",
+			"😀😀",
+			"😀😀",
+		]);
+		for (const chunk of chunks) {
+			expect(chunk.length).toBeLessThanOrEqual(5);
+			expect(chunk.endsWith("\uD83D")).toBe(false);
+			expect(chunk.startsWith("\uDE00")).toBe(false);
+		}
+	});
+
 	it("property: every chunk fits the limit for arbitrary fenced markdown", () => {
 		const piece = fc.constantFrom(
 			"word ",

--- a/packages/core/src/markdown/chunk.ts
+++ b/packages/core/src/markdown/chunk.ts
@@ -242,6 +242,16 @@ export function chunkMarkdownText(text: string, limit: number): string[] {
 					: undefined;
 		}
 
+		if (breakIdx > 0 && breakIdx < remaining.length) {
+			const prevCharCode = remaining.charCodeAt(breakIdx - 1);
+			if (prevCharCode >= 0xd800 && prevCharCode <= 0xdbff) {
+				breakIdx -= 1;
+				if (breakIdx === 0) {
+					breakIdx = Math.min(2, remaining.length);
+				}
+			}
+		}
+
 		let rawChunk = remaining.slice(0, breakIdx);
 		if (!rawChunk) {
 			break;


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:7b417cc3f1c1d0a89451442ecb11498af4cda51d -->

## Summary
In `packages/core/src/markdown/chunk.ts`, `chunkMarkdownText` splits markdown strings to satisfy hard character length limits across messaging platforms. When taking hard breaks at the length limit, `remaining.slice(0, breakIdx)` previously did not check whether `breakIdx` bisected a UTF-16 surrogate pair (0xD800–0xDBFF). This produced broken high surrogate units at the end of chunks and broken low surrogate units at the start of following chunks, causing unicode replacement characters (`\uFFFD`) and corrupted emojis.

## Proposed Changes
1. Added surrogate-pair boundary adjustment in `chunkMarkdownText`: when `breakIdx` lands between a high surrogate and low surrogate, back up by 1 code unit so the entire surrogate pair stays intact in the next chunk.
2. Added unit test in `packages/core/src/markdown/chunk.chunkMarkdownText.test.ts` verifying that breaking markdown containing emoji sequences (e.g. `"😀".repeat(10)` with limit 5) never bisects surrogate pairs.

## Verification
- Ran vitest: `bun run --cwd packages/core test src/markdown/chunk.chunkMarkdownText.test.ts` (5/5 tests passed).
- Ran all markdown tests: `bun run --cwd packages/core test src/markdown/` (20/20 tests passed).

<!-- eliza-computer-attribution:v1 {"provider":"deepmind","model":"antigravity","client":"antigravity-ide","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
