### PR TITLE
fix(plugin-google-workspace): keep UTF-16 surrogate pairs intact in message clipping and subject truncation

### DIFF
--- a/plugins/plugin-google-workspace/src/gmail-message-connector.test.ts
+++ b/plugins/plugin-google-workspace/src/gmail-message-connector.test.ts
@@ -359,3 +359,26 @@ describe("isEmailAddress", () => {
     expect(isEmailAddress(42)).toBe(false);
   });
 });
+
+describe("deriveSubject surrogate pair safety", () => {
+  it("never splits surrogate pairs when truncating long subject lines", async () => {
+    const { runtime, sendGmailMessage } = runtimeStub({
+      accounts: [CONNECTED_ACCOUNT],
+    });
+    const registration = createGmailMessageConnector(runtime);
+
+    // Subject is derived from first line: repeat emoji past SUBJECT_MAX_LENGTH (120)
+    const longEmojiText = "😀".repeat(70); // length 140
+    await invokeSend(
+      registration,
+      runtime,
+      { channelId: "shadow@example.com" },
+      { text: longEmojiText }
+    );
+
+    expect(sendGmailMessage).toHaveBeenCalledOnce();
+    const sentSubject = sendGmailMessage.mock.calls[0][0].subject;
+    expect(sentSubject.endsWith("...")).toBe(true);
+    expect(sentSubject.endsWith("\uD83D...")).toBe(false);
+  });
+});

--- a/plugins/plugin-google-workspace/src/gmail-message-connector.ts
+++ b/plugins/plugin-google-workspace/src/gmail-message-connector.ts
@@ -168,9 +168,17 @@ function subjectFromContent(content: Content): string {
   const firstLine = String(content.text ?? "")
     .split("\n", 1)[0]
     .trim();
-  return firstLine.length <= SUBJECT_MAX_LENGTH
-    ? firstLine
-    : `${firstLine.slice(0, SUBJECT_MAX_LENGTH - 3)}...`;
+  if (firstLine.length <= SUBJECT_MAX_LENGTH) {
+    return firstLine;
+  }
+  let end = SUBJECT_MAX_LENGTH - 3;
+  if (end > 0 && end < firstLine.length) {
+    const code = firstLine.charCodeAt(end - 1);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      end -= 1;
+    }
+  }
+  return `${firstLine.slice(0, end)}...`;
 }
 
 async function sendGmailFromTarget(

--- a/plugins/plugin-google-workspace/src/lifeops-message-adapter.ts
+++ b/plugins/plugin-google-workspace/src/lifeops-message-adapter.ts
@@ -46,7 +46,16 @@ interface GmailDraftContext {
 }
 
 function clip(value: string, maxLength: number): string {
-  return value.length > maxLength ? `${value.slice(0, maxLength - 3)}...` : value;
+  if (value.length <= maxLength) return value;
+  const target = Math.max(0, maxLength - 3);
+  let end = target;
+  if (end > 0 && end < value.length) {
+    const code = value.charCodeAt(end - 1);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      end -= 1;
+    }
+  }
+  return `${value.slice(0, end)}...`;
 }
 
 function refId(messageId: string): string {


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:2ef6f03c8ed6ba20054f60bb6615f3e5c8888ad7 -->

## Summary
In `plugins/plugin-google-workspace`, `clip` (`src/lifeops-message-adapter.ts`) and `subjectFromContent` (`src/gmail-message-connector.ts`) truncate long message strings with `.slice(0, maxLength - 3)`. When the target boundary falls after a high surrogate code unit (0xD800–0xDBFF), the truncation split the surrogate pair in half, emitting a dangling high surrogate before `...` and causing unicode corruption (`\uFFFD`).

## Proposed Changes
1. Added surrogate-pair boundary check in `clip` (`lifeops-message-adapter.ts`): if the slice boundary falls between high and low surrogates, back up by 1 code unit so surrogate pairs remain intact.
2. Added surrogate-pair boundary check in `subjectFromContent` (`gmail-message-connector.ts`).
3. Added unit test in `src/gmail-message-connector.test.ts` verifying that subject lines derived from long emoji strings never split surrogate pairs.

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-google-workspace test src/gmail-message-connector.test.ts src/lifeops-message-adapter.test.ts` (21/21 tests passed).

<!-- eliza-computer-attribution:v1 {"provider":"deepmind","model":"antigravity","client":"antigravity-ide","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
