### PR TITLE
fix(plugin-discord): make truncateText UTF-16 surrogate safe

### DIFF
--- a/plugins/plugin-discord/__tests__/messaging-format.test.ts
+++ b/plugins/plugin-discord/__tests__/messaging-format.test.ts
@@ -14,6 +14,7 @@ import {
 	parseMessageLink,
 	sanitizeThreadName,
 	stripDiscordFormatting,
+	truncateText,
 	truncateUtf16Safe,
 } from "../messaging.ts";
 
@@ -54,6 +55,15 @@ describe("mentions round-trip", () => {
 		expect(extractAllUserMentions("hi <@1> and <@!2>")).toEqual(["1", "2"]);
 		expect(messageContainsMention("yo <@!42> there", "42")).toBe(true);
 		expect(messageContainsMention("no mention", "42")).toBe(false);
+	});
+});
+
+describe("truncateText", () => {
+	it("delegates to truncateUtf16Safe and never splits surrogate pairs", () => {
+		const text = `abc${"😀".repeat(5)}`;
+		const out = truncateText(text, 6, "…");
+		expect(out.length).toBeLessThanOrEqual(6);
+		expect(out.endsWith("\uD83D…")).toBe(false);
 	});
 });
 

--- a/plugins/plugin-discord/messaging.ts
+++ b/plugins/plugin-discord/messaging.ts
@@ -492,10 +492,7 @@ export function truncateText(
 	maxLength: number,
 	ellipsis = "…",
 ): string {
-	if (text.length <= maxLength) {
-		return text;
-	}
-	return text.slice(0, maxLength - ellipsis.length) + ellipsis;
+	return truncateUtf16Safe(text, maxLength, ellipsis);
 }
 
 /**


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:03c5fdbca71fd58363894c86ff80eb16e60d7721 -->

## Summary
In `plugins/plugin-discord/messaging.ts`, `truncateText` previously used raw `text.slice(0, maxLength - ellipsis.length) + ellipsis`, while `truncateUtf16Safe` was implemented alongside it with surrogate pair boundary safety. Direct callers of `truncateText` could split UTF-16 surrogate pairs (such as multi-byte emojis or supplementary characters) into trailing high surrogates, producing malformed unicode output (`\uFFFD`) and broken Discord message previews.

## Proposed Changes
1. Updated `truncateText` to delegate directly to `truncateUtf16Safe`, guaranteeing that all truncation through `truncateText` preserves complete surrogate pairs.
2. Added unit tests in `plugins/plugin-discord/__tests__/messaging-format.test.ts` verifying that `truncateText` never bisects surrogate pairs when truncating emoji-rich strings.

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-discord test __tests__/messaging-format.test.ts` (9/9 tests passed).

<!-- eliza-computer-attribution:v1 {"provider":"deepmind","model":"antigravity","client":"antigravity-ide","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
