### PR TITLE
fix(plugin-slack): make truncateText UTF-16 surrogate safe

### DIFF
--- a/plugins/plugin-slack/src/formatting.test.ts
+++ b/plugins/plugin-slack/src/formatting.test.ts
@@ -174,6 +174,13 @@ describe("truncateText", () => {
     expect(truncateText("short", 10)).toBe("short");
     expect(truncateText("abcdefghij", 5)).toBe("abcd…");
   });
+
+  it("never splits surrogate pairs when truncating emoji text", () => {
+    const text = `abc${"😀".repeat(5)}`;
+    const out = truncateText(text, 6, "…");
+    expect(out.length).toBeLessThanOrEqual(6);
+    expect(out.endsWith("\uD83D…")).toBe(false);
+  });
 });
 
 describe("permalink build/parse round-trip", () => {

--- a/plugins/plugin-slack/src/formatting.ts
+++ b/plugins/plugin-slack/src/formatting.ts
@@ -487,7 +487,15 @@ export function truncateText(
   if (text.length <= maxLength) {
     return text;
   }
-  return text.slice(0, maxLength - ellipsis.length) + ellipsis;
+  const target = Math.max(0, maxLength - ellipsis.length);
+  let end = target;
+  if (end > 0 && end < text.length) {
+    const code = text.charCodeAt(end - 1);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      end -= 1;
+    }
+  }
+  return text.slice(0, end) + ellipsis;
 }
 
 /**


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:d92f6c284b9239b858a3d160a660272075d56ea4 -->

## Summary
In `plugins/plugin-slack/src/formatting.ts`, `truncateText` previously used raw `text.slice(0, maxLength - ellipsis.length) + ellipsis`. When `maxLength - ellipsis.length` landed between a UTF-16 surrogate pair (0xD800–0xDBFF), the truncation split the surrogate pair in half, emitting a dangling high surrogate before `…` and causing unicode replacement characters (`\uFFFD`) in outbound Slack messages and thread previews.

## Proposed Changes
1. Added surrogate-pair boundary check in `truncateText`: if the slice boundary falls between high and low surrogates, back up by 1 code unit so surrogate pairs remain intact.
2. Added unit test in `plugins/plugin-slack/src/formatting.test.ts` verifying that `truncateText` never bisects surrogate pairs when truncating emoji-rich strings.

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-slack test src/formatting.test.ts` (64/64 tests passed).

<!-- eliza-computer-attribution:v1 {"provider":"deepmind","model":"antigravity","client":"antigravity-ide","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
