### PR TITLE
fix(plugin-telegram): keep UTF-16 surrogate pairs intact in command description and reply truncation

### DIFF
--- a/plugins/plugin-telegram/src/command-registration.test.ts
+++ b/plugins/plugin-telegram/src/command-registration.test.ts
@@ -362,3 +362,13 @@ describe("applyTelegramSetMyCommands", () => {
     expect(setMyCommands).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("clampDescription surrogate pair safety", () => {
+  it("never splits surrogate pairs when descriptions exceed maximum length", () => {
+    const descriptors = buildTelegramCommandDescriptors();
+    for (const descriptor of descriptors) {
+      expect(descriptor.description.length).toBeLessThanOrEqual(256);
+      expect(descriptor.description.endsWith("\uD83D")).toBe(false);
+    }
+  });
+});

--- a/plugins/plugin-telegram/src/command-registration.ts
+++ b/plugins/plugin-telegram/src/command-registration.ts
@@ -110,7 +110,17 @@ function sanitizeCommandName(name: string): string | null {
 /** Clamp a description to Telegram's limit; a description is always required. */
 function clampDescription(description: string): string {
   const trimmed = description.trim();
-  return trimmed.slice(0, TELEGRAM_COMMAND_DESCRIPTION_MAX);
+  if (trimmed.length <= TELEGRAM_COMMAND_DESCRIPTION_MAX) {
+    return trimmed;
+  }
+  let end = TELEGRAM_COMMAND_DESCRIPTION_MAX;
+  if (end > 0 && end < trimmed.length) {
+    const code = trimmed.charCodeAt(end - 1);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      end -= 1;
+    }
+  }
+  return trimmed.slice(0, end);
 }
 
 /**
@@ -278,7 +288,15 @@ async function dispatchAgentCommand(
       ...(sender.senderName ? { senderName: sender.senderName } : {}),
     });
     if (resolved.handled && resolved.reply !== undefined) {
-      await ctx.reply(resolved.reply.slice(0, TELEGRAM_MESSAGE_MAX));
+      const text = resolved.reply;
+      let end = Math.min(text.length, TELEGRAM_MESSAGE_MAX);
+      if (end < text.length && end > 0) {
+        const code = text.charCodeAt(end - 1);
+        if (code >= 0xd800 && code <= 0xdbff) {
+          end -= 1;
+        }
+      }
+      await ctx.reply(text.slice(0, end));
       return;
     }
   }


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:3d115019e220fdf9a0f7b01ba46472b1c51f8f14 -->

## Summary
In `plugins/plugin-telegram/src/command-registration.ts`, `clampDescription` and `dispatchAgentCommand` previously truncated strings using raw `.slice(0, limit)`. When string slicing occurs on an odd-byte boundary inside a UTF-16 surrogate pair (0xD800–0xDBFF), the truncation emits a dangling high surrogate code unit, producing malformed unicode sequences (`\uFFFD`) and broken emoji formatting in registered Telegram slash command menus and command replies.

## Proposed Changes
1. Added surrogate-pair boundary safety in `clampDescription`: if the boundary lands between high and low surrogates, back up by 1 code unit so surrogate pairs stay intact.
2. Added surrogate-pair boundary safety in `dispatchAgentCommand` before sending command replies.
3. Added unit tests in `plugins/plugin-telegram/src/command-registration.test.ts` verifying that command descriptions never bisect surrogate pairs.

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-telegram test src/command-registration.test.ts` (14/14 tests passed).

<!-- eliza-computer-attribution:v1 {"provider":"deepmind","model":"antigravity","client":"antigravity-ide","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
