### PR TITLE
fix(plugin-instagram): keep UTF-16 surrogate pairs intact in comment truncation

### DIFF
--- a/plugins/plugin-instagram/src/__tests__/accounts.test.ts
+++ b/plugins/plugin-instagram/src/__tests__/accounts.test.ts
@@ -312,3 +312,29 @@ describe("Instagram connector accounts", () => {
     }
   );
 });
+
+describe("Instagram comment truncation surrogate safety", () => {
+  it("never splits surrogate pairs when truncating long comments", async () => {
+    const service = Object.create(InstagramService.prototype) as InstagramService;
+    const postComment = vi.fn(async () => "123");
+    Object.assign(service, {
+      defaultAccountId: "default",
+      instagramConfig: { accountId: "default", username: "user", password: "password" },
+      isRunning: true,
+      postComment,
+    });
+    const runtime = { agentId: "00000000-0000-0000-0000-000000000001" } as IAgentRuntime;
+
+    // Repeat emojis past MAX_COMMENT_LENGTH (2200)
+    const longEmojiText = "😀".repeat(1200); // 2400 code units
+    await service.handleSendPost(runtime, {
+      text: longEmojiText,
+      metadata: { mediaId: "12345" },
+    } as Content);
+
+    expect(postComment).toHaveBeenCalledOnce();
+    const commentArg = postComment.mock.calls[0][1];
+    expect(commentArg.endsWith("...")).toBe(true);
+    expect(commentArg.endsWith("\uD83D...")).toBe(false);
+  });
+});

--- a/plugins/plugin-instagram/src/service.ts
+++ b/plugins/plugin-instagram/src/service.ts
@@ -139,7 +139,17 @@ function getInstagramTargetMetadata(target: TargetInfo): Record<string, unknown>
 }
 
 function truncateInstagramComment(text: string): string {
-  return text.length > MAX_COMMENT_LENGTH ? `${text.slice(0, MAX_COMMENT_LENGTH - 3)}...` : text;
+  if (text.length <= MAX_COMMENT_LENGTH) {
+    return text;
+  }
+  let end = MAX_COMMENT_LENGTH - 3;
+  if (end > 0 && end < text.length) {
+    const code = text.charCodeAt(end - 1);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      end -= 1;
+    }
+  }
+  return `${text.slice(0, end)}...`;
 }
 
 function getInstagramPostMetadata(content: Content): Record<string, unknown> {


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:5164a7f2d61381434dd9e4fd22018a555246d17f -->

## Summary
In `plugins/plugin-instagram/src/service.ts`, `truncateInstagramComment` previously truncated comments exceeding `MAX_COMMENT_LENGTH` (2,200) using raw `text.slice(0, MAX_COMMENT_LENGTH - 3) + "..."`. When `MAX_COMMENT_LENGTH - 3` landed on an odd code-unit boundary within a UTF-16 surrogate pair (0xD800–0xDBFF), the truncation split the surrogate pair in half, emitting a trailing high surrogate before `...` and causing unicode replacement characters (`\uFFFD`) in posted Instagram comments.

## Proposed Changes
1. Added surrogate-pair boundary safety in `truncateInstagramComment`: if the slice boundary lands between high and low surrogates, back up by 1 code unit so surrogate pairs stay intact.
2. Added unit tests in `plugins/plugin-instagram/src/__tests__/accounts.test.ts` verifying that long emoji comments never bisect surrogate pairs when truncated.

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-instagram test src/__tests__/accounts.test.ts` (23/23 tests passed).

<!-- eliza-computer-attribution:v1 {"provider":"deepmind","model":"antigravity","client":"antigravity-ide","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
