### PR TITLE
fix(prompts): make compressPromptDescription sentinel unforgeable against caller text

### DIFF
--- a/packages/prompts/src/prompt-compression.ts
+++ b/packages/prompts/src/prompt-compression.ts
@@ -90,8 +90,13 @@ function protectTechnicalSpans(value: string): {
   const protectedValues: string[] = [];
   let text = value;
 
+  let sentinelPrefix = "__elizaProtected_";
+  while (value.includes(sentinelPrefix)) {
+    sentinelPrefix += "_";
+  }
+
   const protect = (span: string): string => {
-    const token = `__elizaProtected${protectedValues.length}__`;
+    const token = `${sentinelPrefix}${protectedValues.length}__`;
     protectedValues.push(span);
     return token;
   };
@@ -107,11 +112,13 @@ function protectTechnicalSpans(value: string): {
     });
   }
 
+  const restorePattern = new RegExp(`${sentinelPrefix}(\\d+)__`, "g");
+
   return {
     text,
     restore: (restoredText: string) =>
       restoredText.replace(
-        /__elizaProtected(\d+)__/g,
+        restorePattern,
         (_match, index: string) => protectedValues[Number(index)] ?? "",
       ),
   };

--- a/packages/prompts/test/prompt-compression.test.js
+++ b/packages/prompts/test/prompt-compression.test.js
@@ -36,3 +36,20 @@ describe("compressPromptDescription punctuation normalization", () => {
     );
   });
 });
+
+describe("compressPromptDescription sentinel preservation", () => {
+  it("preserves literal sentinels without corruption", () => {
+    expect(compressPromptDescription("A __elizaProtected0__ B")).toBe(
+      "A __elizaProtected0__ B",
+    );
+    expect(compressPromptDescription("value __elizaProtected99__ end")).toBe(
+      "value __elizaProtected99__ end",
+    );
+  });
+
+  it("preserves literal sentinels when real protected spans are present", () => {
+    expect(
+      compressPromptDescription("Run `code()` here __elizaProtected0__ done"),
+    ).toBe("Run `code()` here __elizaProtected0__ done");
+  });
+});


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:448e57f57951695ec6ad7c51153ddcfafa4e4262 -->

Fixes #27491

## Summary
`compressPromptDescription` in `packages/prompts/src/prompt-compression.ts` masks technical spans (code, URLs, paths, SCREAMING_CASE) behind placeholder tokens of the fixed form `__elizaProtected<n>__`, then restores them by regex-replacing `/__elizaProtected(\d+)__/g`. Because the sentinel pattern was static, any input description that literally contained `__elizaProtected<n>__` was corrupted or deleted during restoration.

## Proposed Changes
1. Updated `protectTechnicalSpans` to derive a collision-free sentinel prefix (`__elizaProtected_...__`) dynamically based on the input text:
   ```ts
   let sentinelPrefix = "__elizaProtected_";
   while (value.includes(sentinelPrefix)) {
     sentinelPrefix += "_";
   }
   ```
2. Constructed the restore regular expression dynamically using the derived collision-free prefix.
3. Added unit tests in `packages/prompts/test/prompt-compression.test.js` verifying that literal sentinel strings are preserved intact with and without other protected spans.

## Verification
- Ran tests: `bun test packages/prompts/test/prompt-compression.test.js` (25/25 tests passed).

<!-- eliza-computer-attribution:v1 {"provider":"deepmind","model":"antigravity","client":"antigravity-ide","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
