### PR TITLE
fix(core): use truncateWellFormed for 10k character scanning and safety clamps

### DIFF
--- a/packages/core/src/features/basic-capabilities/index.ts
+++ b/packages/core/src/features/basic-capabilities/index.ts
@@ -1,3 +1,4 @@
+import { truncateWellFormed } from "../../utils/well-formed.ts";
 /**
  * Basic Capabilities
  *
@@ -218,7 +219,7 @@ function textContainsAgentName(
 		return false;
 	}
 
-	const safeText = text.length > 10_000 ? text.slice(0, 10_000) : text;
+	const safeText = truncateWellFormed(text, 10_000);
 	return names.some((name) => {
 		const candidate = name?.trim();
 		if (!candidate) {
@@ -238,7 +239,7 @@ function textContainsUserTag(text: string | undefined): boolean {
 		return false;
 	}
 
-	const safeText = text.length > 10_000 ? text.slice(0, 10_000) : text;
+	const safeText = truncateWellFormed(text, 10_000);
 	return /<@!?[^>]+>|@\w+/u.test(safeText);
 }
 

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -519,7 +519,7 @@ function textContainsUserTag(text: string | undefined): boolean {
 		return false;
 	}
 
-	const safeText = text.length > 10_000 ? text.slice(0, 10_000) : text;
+	const safeText = truncateWellFormed(text, 10_000);
 	return /<@!?[^>]+>|@\w+/u.test(safeText);
 }
 
@@ -10564,7 +10564,7 @@ function isStopResponse(
 }
 
 function unwrapPlannerIdentifier(value: string): string {
-	const safe = value.length > 10_000 ? value.slice(0, 10_000) : value;
+	const safe = truncateWellFormed(value, 10_000);
 	const trimmed = safe
 		.trim()
 		.replace(/^(?:[-*]|\d+[.)])\s+/, "")

--- a/packages/core/src/services/message/direct-action-heuristics.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.ts
@@ -1,3 +1,4 @@
+import { truncateWellFormed } from "../../utils/well-formed.ts";
 /**
  * Pre-model heuristics that decide which registered actions a raw message should
  * directly trigger: local-shell inspection, web/live-info lookup, coding-task
@@ -18,7 +19,7 @@ export interface DirectActionInferenceHooks {
 }
 
 function unwrapPlannerIdentifier(value: string): string {
-	const safe = value.length > 10_000 ? value.slice(0, 10_000) : value;
+	const safe = truncateWellFormed(value, 10_000);
 	const trimmed = safe
 		.trim()
 		.replace(/^(?:[-*]|\d+[.)])\s+/, "")

--- a/packages/core/src/services/message/fallback-reply.ts
+++ b/packages/core/src/services/message/fallback-reply.ts
@@ -1,3 +1,4 @@
+import { truncateWellFormed } from "../../utils/well-formed.ts";
 /**
  * Classifies model-call failures — rate-limit/429, credit exhaustion/402,
  * auth 401/403, and transient provider errors worth failing over to another
@@ -178,7 +179,7 @@ const BILLING_KEYWORDS_RE =
 /** Cap a value before running a regex scan so a pathological provider payload
  *  cannot turn a substring match into a catastrophic-backtracking DoS. */
 function clampForScan(value: string): string {
-	return value.length > 10_000 ? value.slice(0, 10_000) : value;
+	return truncateWellFormed(value, 10_000);
 }
 
 export function isInsufficientCreditsMessage(message: string): boolean {


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:b1c8bd03b174deac9fda7ac165eb9d43213fd1f6 -->

## Summary
Across `packages/core/src/features/basic-capabilities/index.ts`, `packages/core/src/services/message/direct-action-heuristics.ts`, `packages/core/src/services/message/fallback-reply.ts`, and `packages/core/src/services/message.ts`, long inputs were clamped for safety scans using raw `text.length > 10_000 ? text.slice(0, 10_000) : text`. When the 10,000 code unit cutoff landed on a high surrogate, the slice bisected a UTF-16 surrogate pair, generating an orphaned surrogate code unit and causing regex parsing warnings or corrupt string tokens.

## Proposed Changes
1. Replaced raw `.slice(0, 10_000)` clamping with `truncateWellFormed(..., 10_000)` across message services and basic capabilities.
2. Verified that all regex scans and message parsing hooks remain intact while preventing surrogate pair bisection.

## Verification
- Ran vitest: `bun run --cwd packages/core test src/services/message/ src/utils/well-formed.test.ts` (221/221 tests passed).

<!-- eliza-computer-attribution:v1 {"provider":"deepmind","model":"antigravity","client":"antigravity-ide","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
