### PR TITLE
fix(core): reset confirmRegex lastIndex to handle global-flag regex

### DIFF
--- a/packages/core/src/utils/confirmation.test.ts
+++ b/packages/core/src/utils/confirmation.test.ts
@@ -229,4 +229,64 @@ describe("confirmation utilities", () => {
 		expect(llmConfirmedFlagIsAuthoritative(1)).toBe(false);
 		expect(llmConfirmedFlagIsAuthoritative({})).toBe(false);
 	});
+
+	it("handles global-flag confirmRegex without lastIndex alternation", async () => {
+		const globalRegex = /yes/gi;
+		const runtime = createMockRuntime();
+
+		// First pending + confirm: should be confirmed
+		const m1: Memory = {
+			entityId: "user-1",
+			content: { text: "delete" },
+		} as unknown as Memory;
+		await requireConfirmation({
+			runtime,
+			message: m1,
+			actionName: "DELETE_ITEM",
+			pendingKey: "item:g1",
+			prompt: "Delete?",
+			confirmRegex: globalRegex,
+		});
+		const m2: Memory = {
+			entityId: "user-1",
+			content: { text: "yes" },
+		} as unknown as Memory;
+		const d1 = await requireConfirmation({
+			runtime,
+			message: m2,
+			actionName: "DELETE_ITEM",
+			pendingKey: "item:g1",
+			prompt: "Delete?",
+			confirmRegex: globalRegex,
+		});
+		expect(d1.status).toBe("confirmed");
+
+		// Reuse same regex object for a second independent confirmation:
+		// without lastIndex reset it would alternate to cancelled.
+		const m3: Memory = {
+			entityId: "user-1",
+			content: { text: "delete again" },
+		} as unknown as Memory;
+		await requireConfirmation({
+			runtime,
+			message: m3,
+			actionName: "DELETE_ITEM",
+			pendingKey: "item:g2",
+			prompt: "Delete?",
+			confirmRegex: globalRegex,
+		});
+		const m4: Memory = {
+			entityId: "user-1",
+			content: { text: "yes" },
+		} as unknown as Memory;
+		const d2 = await requireConfirmation({
+			runtime,
+			message: m4,
+			actionName: "DELETE_ITEM",
+			pendingKey: "item:g2",
+			prompt: "Delete?",
+			confirmRegex: globalRegex,
+		});
+		expect(d2.status).toBe("confirmed");
+	});
 });

--- a/packages/core/src/utils/confirmation.ts
+++ b/packages/core/src/utils/confirmation.ts
@@ -160,6 +160,7 @@ export async function requireConfirmation(
 	// Existing pending record found — interpret the user's reply.
 	await args.runtime.deleteCache(cacheKey);
 
+	confirmRegex.lastIndex = 0;
 	const status: ConfirmationStatus = confirmRegex.test(userText)
 		? "confirmed"
 		: "cancelled";


### PR DESCRIPTION
# Relates to

N/A - global regex alternation

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. One-line lastIndex reset before RegExp.test. No behavior change for default regex (non-global).

# Background

## What does this PR do?

`requireConfirmation` accepts caller-supplied `confirmRegex`. If it carries `g`/`y`, `RegExp.test` retains `lastIndex`, so identical "yes" alternates confirmed/cancelled. Fix resets `confirmRegex.lastIndex = 0` before test.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/core/src/utils/confirmation.test.ts`

## Detailed testing steps

```bash
bunx vitest run packages/core/src/utils/confirmation.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:af023e0d2b6185a14c4d9bf1618f628a231c2d79 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI surface`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no UI surface`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - no UI surface`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - backend unit test only`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - no frontend surface`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - no LLM change`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - no domain artifact`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM change.

## Backend + frontend logs

<details>
<summary>Red vs Green</summary>

**Red (reverted):**
```
 FAIL  handles global-flag confirmRegex without lastIndex alternation
AssertionError: expected 'cancelled' to be 'confirmed'
 Tests  1 failed | 7 passed (8)
```

**Green (with fix):**
```
 Test Files  1 passed (1)
      Tests  8 passed (8)
```

</details>

## Screenshots (before / after) + video walkthrough

N/A - no UI surface.

### Before

N/A - no UI surface.

### After

N/A - no UI surface.

### Walkthrough video

N/A - no UI surface.

## Audio / voice walkthrough

N/A - no voice change.

## Known gaps / failures

None.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`