### PR TITLE
fix(scripts): ignore null package exports in buildWorkspaceSourceAliases

### DIFF
--- a/packages/scripts/__tests__/vitest-source-aliases.test.ts
+++ b/packages/scripts/__tests__/vitest-source-aliases.test.ts
@@ -149,3 +149,26 @@ describe("workspace source aliases", () => {
     );
   });
 });
+
+  test("ignores null exports without crashing", () => {
+    const repoRoot = mkdtempSync(
+      path.join(tmpdir(), "eliza-vitest-null-exports-"),
+    );
+    temporaryRoots.push(repoRoot);
+    const packageDir = path.join(repoRoot, "packages", "agent");
+    mkdirSync(path.join(packageDir, "src"), { recursive: true });
+    writeFileSync(path.join(packageDir, "src", "index.ts"), "export {};\n");
+    writeFileSync(
+      path.join(packageDir, "package.json"),
+      JSON.stringify({
+        name: "@elizaos/agent",
+        exports: {
+          ".": "./dist/index.js",
+          "./runtime/runtime-installation-id": null,
+        },
+      }),
+    );
+
+    const aliases = buildWorkspaceSourceAliases(repoRoot);
+    expect(aliases.some((a) => typeof a.find !== "string" && a.find.test("@elizaos/agent"))).toBe(true);
+  });

--- a/packages/scripts/vitest/source-aliases.ts
+++ b/packages/scripts/vitest/source-aliases.ts
@@ -65,7 +65,13 @@ function getWorkspaceSourceEntry(
   const exportedSourceAliases = Object.entries(
     packageJson.exports ?? {},
   ).flatMap(([subpath, target]) => {
-    if (subpath === "." || typeof target === "string") return [];
+    if (
+      subpath === "." ||
+      typeof target === "string" ||
+      !target ||
+      typeof target !== "object"
+    )
+      return [];
     const source = target["eliza-source"];
     const sourcePath =
       typeof source === "string"


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:2abcff70f3847b0b11a8917576ebfb1fd638cbd5 -->

Fixes #27302

## Summary
In `packages/scripts/vitest/source-aliases.ts`, `getWorkspaceSourceEntry` previously assumed every object-valued export target in `package.json` was non-null. When packages declare null exports (such as `"./runtime/runtime-installation-id": null`), `typeof target === "object"` evaluates to true, and accessing `target["eliza-source"]` caused `TypeError: Cannot read properties of null (reading 'eliza-source')`.

## Proposed Changes
1. Added null / non-object check in `packages/scripts/vitest/source-aliases.ts`:
   ```ts
   if (
     subpath === "." ||
     typeof target === "string" ||
     !target ||
     typeof target !== "object"
   )
     return [];
   ```
2. Added unit tests in `packages/scripts/__tests__/vitest-source-aliases.test.ts` verifying that null exports in `package.json` are ignored without throwing.

## Verification
- Ran vitest: `bun test packages/scripts/__tests__/vitest-source-aliases.test.ts` (4/4 tests passed).

<!-- eliza-computer-attribution:v1 {"provider":"deepmind","model":"antigravity","client":"antigravity-ide","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
