### PR TITLE
fix(plugin-whatsapp): keep UTF-16 surrogate pairs intact in chunking and truncateText

### DIFF
--- a/plugins/plugin-whatsapp/src/normalize.test.ts
+++ b/plugins/plugin-whatsapp/src/normalize.test.ts
@@ -116,3 +116,25 @@ describe("text chunking", () => {
     expect(truncateText("abcdefghij", 5).length).toBeLessThanOrEqual(5);
   });
 });
+
+describe("surrogate safety in WhatsApp text helpers", () => {
+  it("truncateText preserves surrogate pairs intact", () => {
+    // "😀" is 2 code units: \uD83D\uDE00
+    // "a" + "😀" has length 3; if maxLength is 4, maxLength-3 is 1 (landing before emoji)
+    // "😀".repeat(10) with maxLength=5: end=2 (full emoji), output "😀..."
+    const emojiStr = "😀".repeat(10);
+    const truncated = truncateText(emojiStr, 6);
+    expect(truncated.endsWith("...")).toBe(true);
+    expect(truncated.endsWith("\uD83D...")).toBe(false);
+  });
+
+  it("chunkWhatsAppText preserves surrogate pairs on hard breaks", () => {
+    const emojis = "😀".repeat(25); // 50 code units, no spaces or newlines
+    const chunks = chunkWhatsAppText(emojis, { limit: 9 });
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(9);
+      expect(chunk.endsWith("\uD83D")).toBe(false);
+      expect(chunk.startsWith("\uDE00")).toBe(false);
+    }
+  });
+});

--- a/plugins/plugin-whatsapp/src/normalize.ts
+++ b/plugins/plugin-whatsapp/src/normalize.ts
@@ -277,10 +277,17 @@ function splitAtBreakPoint(text: string, limit: number): { chunk: string; remain
     };
   }
 
-  // Hard break at limit
+  // Hard break at limit with surrogate safety
+  let hardBreakIndex = limit;
+  if (hardBreakIndex > 0 && hardBreakIndex < text.length) {
+    const code = text.charCodeAt(hardBreakIndex - 1);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      hardBreakIndex -= 1;
+    }
+  }
   return {
-    chunk: text.slice(0, limit),
-    remainder: text.slice(limit),
+    chunk: text.slice(0, hardBreakIndex),
+    remainder: text.slice(hardBreakIndex),
   };
 }
 
@@ -323,7 +330,14 @@ export function truncateText(text: string, maxLength: number): string {
   if (maxLength <= 3) {
     return "...".slice(0, maxLength);
   }
-  return `${text.slice(0, maxLength - 3)}...`;
+  let end = maxLength - 3;
+  if (end > 0 && end < text.length) {
+    const code = text.charCodeAt(end - 1);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      end -= 1;
+    }
+  }
+  return `${text.slice(0, end)}...`;
 }
 
 /**


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:1eb64a31bd5eb68d4347816b4940c0b21651f118 -->

## Summary
In `plugins/plugin-whatsapp/src/normalize.ts`, `splitAtBreakPoint` (used by `chunkWhatsAppText`) and `truncateText` previously sliced strings at `limit` / `maxLength - 3` without checking for UTF-16 surrogate pairs. When a hard split or ellipsis boundary landed between a high surrogate (`0xD800–0xDBFF`) and a low surrogate (`0xDC00–0xDFFF`), the surrogate pair was bisected, leaving an orphan surrogate that corrupted emojis and generated Unicode replacement characters (`\uFFFD`) in WhatsApp messages.

## Proposed Changes
1. Added surrogate-pair boundary safety in `splitAtBreakPoint` so hard breaks never split a surrogate pair across chunks.
2. Added surrogate-pair boundary safety in `truncateText` before appending an ellipsis.
3. Added unit tests in `plugins/plugin-whatsapp/src/normalize.test.ts` verifying surrogate integrity across `truncateText` and `chunkWhatsAppText`.

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-whatsapp test src/normalize.test.ts` (13/13 tests passed).

<!-- eliza-computer-attribution:v1 {"provider":"deepmind","model":"antigravity","client":"antigravity-ide","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
