### PR TITLE
fix(plugin-imessage): keep UTF-16 surrogate pairs intact in splitMessageForIMessage

### DIFF
--- a/plugins/plugin-imessage/__tests__/integration.test.ts
+++ b/plugins/plugin-imessage/__tests__/integration.test.ts
@@ -1133,3 +1133,18 @@ describe("parseContactsOutput", () => {
     expect(map.get("+15559999999")?.name).toBe("OK");
   });
 });
+
+describe("splitMessageForIMessage surrogate safety", () => {
+  it("never bisects surrogate pairs when breaking at maxLength", () => {
+    // "😀" is 2 code units: \uD83D\uDE00
+    // Long continuous emojis with no newlines or spaces
+    const longEmojis = "😀".repeat(500); // 1000 code units
+    const chunks = splitMessageForIMessage(longEmojis, 100);
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(100);
+      expect(chunk.endsWith("\uD83D")).toBe(false);
+      expect(chunk.startsWith("\uDE00")).toBe(false);
+    }
+  });
+});

--- a/plugins/plugin-imessage/src/types.ts
+++ b/plugins/plugin-imessage/src/types.ts
@@ -308,6 +308,13 @@ export function splitMessageForIMessage(
       }
     }
 
+    if (breakPoint > 0 && breakPoint < remaining.length) {
+      const code = remaining.charCodeAt(breakPoint - 1);
+      if (code >= 0xd800 && code <= 0xdbff) {
+        breakPoint -= 1;
+      }
+    }
+
     chunks.push(remaining.slice(0, breakPoint).trimEnd());
     remaining = remaining.slice(breakPoint).trimStart();
   }


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:3b53a9017b23f8d5183f5e2c0ad4bdd5832d89b7 -->

## Summary
In `plugins/plugin-imessage/src/types.ts`, `splitMessageForIMessage` splits long messages into chunks bounded by `maxLength`. When breaking at a hard limit boundary (e.g. continuous emoji strings without whitespace or newlines), the slice previously did not check if the break point fell between a UTF-16 high surrogate (`0xD800–0xDBFF`) and low surrogate (`0xDC00–0xDFFF`), bisecting the pair and creating malformed unicode code units in dispatched iMessage chunks.

## Proposed Changes
1. Added surrogate-pair boundary safety in `splitMessageForIMessage`:
   ```ts
   if (breakPoint > 0 && breakPoint < remaining.length) {
     const code = remaining.charCodeAt(breakPoint - 1);
     if (code >= 0xd800 && code <= 0xdbff) {
       breakPoint -= 1;
     }
   }
   ```
2. Added unit test in `plugins/plugin-imessage/__tests__/integration.test.ts` verifying that splitting continuous emoji strings preserves surrogate pair integrity across all chunks.

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-imessage test __tests__/integration.test.ts` (87/87 tests passed).

<!-- eliza-computer-attribution:v1 {"provider":"deepmind","model":"antigravity","client":"antigravity-ide","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
