### PR TITLE
fix(plugin-matrix): keep UTF-16 surrogate pairs intact in message preview debug logging

### DIFF
--- a/plugins/plugin-matrix/src/service.ts
+++ b/plugins/plugin-matrix/src/service.ts
@@ -26,6 +26,7 @@ import {
   resolveAliasedEnvValue,
   Service,
   type TargetInfo,
+  truncateWellFormed,
   type UUID,
 } from "@elizaos/core";
 import * as sdk from "matrix-js-sdk";
@@ -1295,7 +1296,7 @@ export class MatrixService extends Service implements IMatrixService {
     };
 
     logger.debug(
-      `Matrix message from ${message.senderInfo.displayName || message.sender} in ${room.name || roomId}: ${message.content.slice(0, 50)}...`
+      `Matrix message from ${message.senderInfo.displayName || message.sender} in ${room.name || roomId}: ${truncateWellFormed(message.content, 50)}...`
     );
 
     // Plugin-local event other code may listen for (the MatrixMessage/MatrixRoom payload).


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:b9b1a5016e68f9ff27ce85b6099f3db11bbe79c0 -->

## Summary
In `plugins/plugin-matrix/src/service.ts`, the incoming message preview in debug logging used raw `message.content.slice(0, 50) + "..."`. If index 50 lands within a UTF-16 surrogate pair (0xD800–0xDBFF), the high surrogate is retained without its corresponding low surrogate, causing unicode replacement characters or log formatter parse warnings.

## Proposed Changes
1. Added surrogate-pair boundary check in `plugins/plugin-matrix/src/service.ts` before truncating the debug log message preview.

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-matrix test src/__tests__/connector.test.ts` (9/9 tests passed).

<!-- eliza-computer-attribution:v1 {"provider":"deepmind","model":"antigravity","client":"antigravity-ide","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
