### PR TITLE
fix(plugin-github): keep UTF-16 surrogate pairs intact in PR and issue body previews

### DIFF
--- a/plugins/plugin-github/src/action-helpers.test.ts
+++ b/plugins/plugin-github/src/action-helpers.test.ts
@@ -6,6 +6,7 @@ import {
   requireString,
   requireStringArray,
   splitRepo,
+  truncateUtf16Safe,
 } from "./action-helpers.ts";
 
 /**
@@ -137,5 +138,19 @@ describe("isConfirmed", () => {
   it("is always false regardless of the supplied flag", () => {
     expect(isConfirmed({ confirmed: true })).toBe(false);
     expect(isConfirmed(undefined)).toBe(false);
+  });
+});
+
+describe("truncateUtf16Safe", () => {
+  it("never bisects surrogate pairs when truncating", () => {
+    // "😀" is 2 code units: \uD83D\uDE00
+    const text = "hello " + "😀".repeat(10); // length 6 + 20 = 26
+    const truncated = truncateUtf16Safe(text, 7); // cutoff at index 7 is in the middle of first emoji
+    expect(truncated).toBe("hello ");
+    expect(truncated.endsWith("\uD83D")).toBe(false);
+  });
+
+  it("returns text as-is when within limit", () => {
+    expect(truncateUtf16Safe("hello", 10)).toBe("hello");
   });
 });

--- a/plugins/plugin-github/src/action-helpers.ts
+++ b/plugins/plugin-github/src/action-helpers.ts
@@ -269,3 +269,15 @@ export function describeSelection(selection: GitHubAccountSelection): string {
     ? `${selection.role} (${selection.accountId})`
     : selection.role;
 }
+
+export function truncateUtf16Safe(text: string, maxLength: number): string {
+  if (text.length <= maxLength) return text;
+  let end = maxLength;
+  if (end > 0 && end < text.length) {
+    const code = text.charCodeAt(end - 1);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      end -= 1;
+    }
+  }
+  return text.slice(0, end);
+}

--- a/plugins/plugin-github/src/actions/issue-op.ts
+++ b/plugins/plugin-github/src/actions/issue-op.ts
@@ -1,3 +1,4 @@
+import { truncateUtf16Safe } from "../action-helpers.js";
 /**
  * Single router action covering the GitHub issue lifecycle ops: create,
  * assign, close, reopen, comment, label. Dispatched to by the umbrella
@@ -279,7 +280,7 @@ function buildPreview(
       case "label":
         return ` with [${labels?.join(", ") ?? ""}]`;
       case "comment":
-        return body ? ` body: "${body.slice(0, 120)}"` : "";
+        return body ? ` body: "${truncateUtf16Safe(body, 120)}"` : "";
       default:
         return "";
     }

--- a/plugins/plugin-github/src/actions/pr-op.ts
+++ b/plugins/plugin-github/src/actions/pr-op.ts
@@ -15,6 +15,7 @@ import { logger, requireConfirmation } from "@elizaos/core";
 import {
   buildResolvedClient,
   describeSelection,
+  truncateUtf16Safe,
   requireNumber,
   requireString,
   resolveAccountSelection,
@@ -177,7 +178,7 @@ async function runReview(
 
   const preview =
     `About to ${action.replace("-", " ")} PR ${repo}#${number}` +
-    (body ? ` with body: "${body.slice(0, 120)}"` : "") +
+    (body ? ` with body: "${truncateUtf16Safe(body, 120)}"` : "") +
     ` as ${describeSelection(selection)}.`;
   const decision = await requireConfirmation({
     runtime,


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:980d975ab71f5e2a9fa8a85c547deb986f434bae -->

## Summary
In `plugins/plugin-github/src/actions/pr-op.ts` and `plugins/plugin-github/src/actions/issue-op.ts`, confirmation prompts build a truncated 120-character preview of the pull request / issue comment body using raw `body.slice(0, 120)`. If character 120 lands on a high surrogate (`0xD800–0xDBFF`), the surrogate pair is split, leaving an invalid trailing code unit that causes unicode decode warnings and broken text rendering in user confirmation prompts.

## Proposed Changes
1. Added `truncateUtf16Safe` helper in `plugins/plugin-github/src/action-helpers.ts` that detects and avoids slicing between UTF-16 high and low surrogate code units.
2. Updated `pr-op.ts` and `issue-op.ts` to use `truncateUtf16Safe(body, 120)`.
3. Added unit tests in `plugins/plugin-github/src/action-helpers.test.ts` verifying surrogate pair safety during truncation.

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-github test src/action-helpers.test.ts` (75/75 tests passed).

<!-- eliza-computer-attribution:v1 {"provider":"deepmind","model":"antigravity","client":"antigravity-ide","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
