### PR TITLE
fix(plugin-x): keep UTF-16 surrogate pairs intact in post normalization and message adapter snippets

### DIFF
--- a/plugins/plugin-x/src/lifeops-message-adapter.ts
+++ b/plugins/plugin-x/src/lifeops-message-adapter.ts
@@ -1,3 +1,15 @@
+
+function truncateUtf16Safe(text: string, maxLength: number): string {
+  if (text.length <= maxLength) return text;
+  let end = maxLength;
+  if (end > 0 && end < text.length) {
+    const code = text.charCodeAt(end - 1);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      end -= 1;
+    }
+  }
+  return text.slice(0, end);
+}
 /**
  * `XDmAdapter` — a LifeOps `BaseMessageAdapter` over the X connector's direct
  * messages, letting LifeOps list, draft, and send X DMs through `XService`. Maps
@@ -89,7 +101,7 @@ function memoryToMessageRef(memory: Memory): MessageRef {
       displayName: senderHandle,
     },
     to: [],
-    snippet: body.slice(0, 200),
+    snippet: truncateUtf16Safe(body, 200),
     body,
     receivedAtMs: Number.isFinite(receivedAtMs) ? receivedAtMs : Date.now(),
     hasAttachments: false,
@@ -203,7 +215,7 @@ export class XDmAdapter extends BaseMessageAdapter {
     }
     const draftId = `twitter:${encodeURIComponent(recipient)}:${Date.now()}:${encodeDraftBody(draft.body)}`;
     const preview =
-      draft.body.length > 200 ? `${draft.body.slice(0, 197)}...` : draft.body;
+      draft.body.length > 200 ? `${truncateUtf16Safe(draft.body, 197)}...` : draft.body;
     return { draftId, preview };
   }
 

--- a/plugins/plugin-x/src/utils/twitter-post-callback.test.ts
+++ b/plugins/plugin-x/src/utils/twitter-post-callback.test.ts
@@ -307,3 +307,19 @@ describe("createTwitterPostCallback", () => {
     ).toBeUndefined();
   });
 });
+
+describe("surrogate safety in tweet text normalization", () => {
+  it("never bisects surrogate pairs when truncating overlong continuous emoji tweets", async () => {
+    const runtime = makeRuntime();
+    const client = makeClient();
+    const callback = makeCallback({ client, runtime });
+
+    const longEmojis = "😀".repeat(200); // 400 code units (exceeds TWEET_MAX_LENGTH = 280)
+    const result = await callback({ text: longEmojis } as any);
+
+    expect(result).toHaveLength(1);
+    const sentText = (result[0].content as any).text;
+    expect(sentText.endsWith("...")).toBe(true);
+    expect(sentText.endsWith("\uD83D...")).toBe(false);
+  });
+});

--- a/plugins/plugin-x/src/utils/twitter-post-callback.ts
+++ b/plugins/plugin-x/src/utils/twitter-post-callback.ts
@@ -55,7 +55,14 @@ function normalizePostText(text: string): string {
     return `${text.slice(0, spaceIndex).trim()}...`;
   }
 
-  return `${text.slice(0, TWEET_MAX_LENGTH - 3).trim()}...`;
+  let end = TWEET_MAX_LENGTH - 3;
+  if (end > 0 && end < text.length) {
+    const code = text.charCodeAt(end - 1);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      end -= 1;
+    }
+  }
+  return `${text.slice(0, end).trim()}...`;
 }
 
 export function createTwitterPostCallback({


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:23b557f6aa725b2f110f8ce155c3039d4ea3955b -->

## Summary
In `plugins/plugin-x/src/utils/twitter-post-callback.ts` and `plugins/plugin-x/src/lifeops-message-adapter.ts`, text slicing and hard truncation previously did not check for UTF-16 surrogate pairs. When a cutoff landed on a high surrogate (`0xD800–0xDBFF`), the surrogate pair was bisected, creating malformed code units in posted tweets, direct message snippets, and draft previews.

## Proposed Changes
1. Added surrogate-pair boundary safety to `normalizePostText` in `plugins/plugin-x/src/utils/twitter-post-callback.ts` so tweets truncated with ellipsis never split a surrogate pair.
2. Added `truncateUtf16Safe` in `plugins/plugin-x/src/lifeops-message-adapter.ts` for memory snippets and draft previews.
3. Added unit tests in `plugins/plugin-x/src/utils/twitter-post-callback.test.ts` verifying surrogate integrity across long emoji tweets.

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-x test src/utils/twitter-post-callback.test.ts src/lifeops-message-adapter.test.ts` (17/17 tests passed).

<!-- eliza-computer-attribution:v1 {"provider":"deepmind","model":"antigravity","client":"antigravity-ide","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
