### PR TITLE
fix(core): use truncateWellFormed across media, trajectory, dialogue, and prompt services

### DIFF
--- a/packages/core/src/media/fetch.ts
+++ b/packages/core/src/media/fetch.ts
@@ -1,3 +1,4 @@
+import { truncateWellFormed } from "../utils.js";
 /**
  * Fetches remote media through DNS-pinned SSRF protection, enforces byte
  * limits, and derives safe filenames and MIME metadata.
@@ -107,7 +108,7 @@ async function readErrorBodySnippet(
 		if (collapsed.length <= maxChars) {
 			return collapsed;
 		}
-		return `${collapsed.slice(0, maxChars - 1)}…`;
+		return `${truncateWellFormed(collapsed, maxChars - 1)}…`;
 	} catch {
 		// error-policy:J7 The HTTP status remains authoritative when its optional
 		// diagnostic body snippet cannot be read.

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -1883,7 +1883,7 @@ export function subAgentCompletionRelayBody(
 	if (!body) return undefined;
 	const maxLength = 1500;
 	return body.length > maxLength
-		? `${body.slice(0, maxLength - 1).trimEnd()}…`
+		? `${truncateWellFormed(body, maxLength - 1).trimEnd()}…`
 		: body;
 }
 
@@ -2225,7 +2225,7 @@ function cleanPriorDialogueSpeakerName(value: unknown): string | undefined {
 	if (typeof value !== "string") return undefined;
 	const normalized = value.trim().split(/\s+/).join(" ");
 	if (!normalized) return undefined;
-	return normalized.length > 80 ? `${normalized.slice(0, 77)}...` : normalized;
+	return normalized.length > 80 ? `${truncateWellFormed(normalized, 77)}...` : normalized;
 }
 
 function senderIdentityName(value: unknown): string | undefined {

--- a/packages/core/src/services/optimized-prompt-resolver.ts
+++ b/packages/core/src/services/optimized-prompt-resolver.ts
@@ -1,3 +1,4 @@
+import { truncateWellFormed } from "../utils.js";
 /**
  * Helper that resolves the system prompt for one of the five core decision
  * tasks. Each runtime call site already constructs a baseline prompt; this
@@ -83,10 +84,10 @@ function trimDemonstrationInput(rawInput: string): string {
 		return candidate;
 	}
 	if (candidate && candidate.length > 0) {
-		return `${candidate.slice(0, 600).trimEnd()} …`;
+		return `${truncateWellFormed(candidate, 600).trimEnd()} …`;
 	}
 	if (rawInput.length <= 600) return rawInput;
-	return `${rawInput.slice(0, 400).trimEnd()}\n…\n${rawInput.slice(-200).trimStart()}`;
+	return `${truncateWellFormed(rawInput, 400).trimEnd()}\n…\n${rawInput.slice(-200).trimStart()}`;
 }
 
 function injectDemonstrations(

--- a/packages/core/src/services/trajectory-json.ts
+++ b/packages/core/src/services/trajectory-json.ts
@@ -1,3 +1,4 @@
+import { truncateWellFormed } from "../utils.js";
 /**
  * Bounded JSON normalization shared by every trajectory persistence owner.
  * Per-node caps protect individual fields while a single traversal and output
@@ -30,7 +31,7 @@ function truncateTrajectoryString(value: string): string {
 		0,
 		TRAJECTORY_JSON_MAX_STRING_CHARS - TRAJECTORY_JSON_TRUNCATION_SUFFIX.length,
 	);
-	return `${value.slice(0, previewLength)}${TRAJECTORY_JSON_TRUNCATION_SUFFIX}`;
+	return `${truncateWellFormed(value, previewLength)}${TRAJECTORY_JSON_TRUNCATION_SUFFIX}`;
 }
 
 function jsonByteLength(value: JsonValue): number {


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:c425746673496154196501f5c8e940e64528f69d -->

## Summary
In `@elizaos/core`, multiple string truncation call sites (`truncateTrajectoryString`, `readErrorBodySnippet`, `subAgentCompletionRelayBody`, `cleanPriorDialogueSpeakerName`, and `trimDemonstrationInput`) were performing raw `.slice(0, N)` slicing. When the cutoff falls on a UTF-16 surrogate code unit (`0xD800–0xDBFF`), raw slicing severs the surrogate pair, leaving an unpaired surrogate character (`\uFFFD` / broken emoji) in JSON trajectories, media error logs, dialogue speaker headers, and in-context demonstration prompts.

## Proposed Changes
- Replaced raw `.slice(0, N)` with `truncateWellFormed(..., N)` across:
  - `packages/core/src/services/trajectory-json.ts` (`truncateTrajectoryString`)
  - `packages/core/src/media/fetch.ts` (`readErrorBodySnippet`)
  - `packages/core/src/services/message.ts` (`subAgentCompletionRelayBody`, `cleanPriorDialogueSpeakerName`)
  - `packages/core/src/services/optimized-prompt-resolver.ts` (`trimDemonstrationInput`)

## Verification
- Ran vitest / bun test across core services suite: all tests passed.

<!-- eliza-computer-attribution:v1 {"provider":"deepmind","model":"antigravity","client":"antigravity-ide","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
