### PR TITLE
fix(plugin-zerollama): keep UTF-16 surrogate pairs intact in truncateEmbedInput

### DIFF
--- a/plugins/plugin-zerollama/__tests__/embedding.shape.test.ts
+++ b/plugins/plugin-zerollama/__tests__/embedding.shape.test.ts
@@ -157,3 +157,20 @@ describe("Ollama embeddings", () => {
     expect(embedMock).not.toHaveBeenCalled();
   });
 });
+
+describe("surrogate safety in embedding truncation", () => {
+  it("never bisects surrogate pairs when truncating overlong text", async () => {
+    embedMock.mockResolvedValue({
+      embedding: [1],
+      usage: undefined,
+    });
+    const { runtime } = createRuntime({ OLLAMA_EMBED_MAX_CHARS: "9" });
+    const longEmojis = "😀".repeat(10); // 20 code units
+
+    await handleTextEmbedding(runtime, { text: longEmojis });
+
+    const callArg = embedMock.mock.calls[0][0] as { value: string };
+    expect(callArg.value.length).toBeLessThanOrEqual(9);
+    expect(callArg.value.endsWith("\uD83D")).toBe(false);
+  });
+});

--- a/plugins/plugin-zerollama/utils/embed-context.ts
+++ b/plugins/plugin-zerollama/utils/embed-context.ts
@@ -39,14 +39,26 @@ export function embedMaxCharsForContext(contextLength: number): number {
 }
 
 export function truncateEmbedInput(input: string | string[], maxChars: number): string | string[] {
+  function truncateString(text: string): string {
+    if (text.length <= maxChars) return text;
+    let end = maxChars;
+    if (end > 0 && end < text.length) {
+      const code = text.charCodeAt(end - 1);
+      if (code >= 0xd800 && code <= 0xdbff) {
+        end -= 1;
+      }
+    }
+    return text.slice(0, end);
+  }
+
   if (typeof input === "string") {
     if (input.length <= maxChars) return input;
     logger.warn(
       `[Ollama] Embedding input too long (${input.length} chars), truncating to ${maxChars}`
     );
-    return input.slice(0, maxChars);
+    return truncateString(input);
   }
-  return input.map((text) => (text.length > maxChars ? text.slice(0, maxChars) : text));
+  return input.map((text) => (text.length > maxChars ? truncateString(text) : text));
 }
 
 export function isEmbedContextOverflow(error: unknown): boolean {


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:8ffb9d5d7a127b05bce5d1742353f92fa5c0f847 -->

## Summary
In `plugins/plugin-zerollama/utils/embed-context.ts`, `truncateEmbedInput` previously truncated long embedding inputs using raw `.slice(0, maxChars)`. When an oversized text boundary landed between a UTF-16 high surrogate (`0xD800–0xDBFF`) and low surrogate (`0xDC00–0xDFFF`), the surrogate pair was bisected, passing invalid UTF-8 byte sequences into the local daemon / llama.cpp embedding tokenizer.

## Proposed Changes
1. Added surrogate-pair boundary safety to `truncateEmbedInput` in `plugins/plugin-zerollama/utils/embed-context.ts` so truncated string and array inputs never retain an unpaired high surrogate.
2. Added unit tests in `plugins/plugin-zerollama/__tests__/embedding.shape.test.ts` verifying surrogate integrity across embedding truncation.

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-zerollama test __tests__/embedding.shape.test.ts` (62/62 tests passed).

<!-- eliza-computer-attribution:v1 {"provider":"deepmind","model":"antigravity","client":"antigravity-ide","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
