### PR TITLE
fix(plugin-browser): keep UTF-16 surrogate pairs intact in browser page message summaries

### DIFF
--- a/plugins/plugin-browser/src/message-adapter.test.ts
+++ b/plugins/plugin-browser/src/message-adapter.test.ts
@@ -84,3 +84,39 @@ describe("BrowserBridgeAdapter", () => {
     ).resolves.toEqual([]);
   });
 });
+
+describe("BrowserBridgeAdapter surrogate safety", () => {
+  it("never bisects surrogate pairs when summarizing long pages", async () => {
+    const longEmojis = "😀".repeat(300); // 600 code units (exceeds 500 max length)
+    const page = {
+      id: "page-2",
+      agentId: "agent-1",
+      browser: "chrome",
+      profileId: "default",
+      windowId: "window-1",
+      tabId: "tab-1",
+      url: "https://example.com",
+      title: "Title",
+      selectionText: null,
+      mainText: longEmojis,
+      headings: [],
+      links: [],
+      forms: [],
+      capturedAt: "2026-06-02T12:00:00.000Z",
+      metadata: {},
+    };
+    const routeService = {
+      getCurrentBrowserPage: vi.fn(async () => page),
+    };
+    const runtime = {
+      agentId: "agent-1",
+      getService: vi.fn(() => routeService),
+    } as unknown as IAgentRuntime;
+    const adapter = new BrowserBridgeAdapter();
+
+    const messages = await adapter.listMessages(runtime, { limit: 5 });
+    expect(messages).toHaveLength(1);
+    expect(messages[0].snippet.endsWith("...")).toBe(true);
+    expect(messages[0].snippet.endsWith("\uD83D...")).toBe(false);
+  });
+});

--- a/plugins/plugin-browser/src/message-adapter.ts
+++ b/plugins/plugin-browser/src/message-adapter.ts
@@ -49,7 +49,15 @@ function summarizePage(page: BrowserBridgePageContext): string {
     page.mainText?.trim() ||
     page.title.trim() ||
     page.url;
-  return text.length > 500 ? `${text.slice(0, 497)}...` : text;
+  if (text.length <= 500) return text;
+  let end = 497;
+  if (end > 0 && end < text.length) {
+    const code = text.charCodeAt(end - 1);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      end -= 1;
+    }
+  }
+  return `${text.slice(0, end)}...`;
 }
 
 function pageToMessageRef(page: BrowserBridgePageContext): MessageRef {


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:026095306ba4c3bf7ae04978284360e18c840f8c -->

## Summary
In `plugins/plugin-browser/src/message-adapter.ts`, `summarizePage` generates a 500-character snippet for browser bridge page messages using raw `text.slice(0, 497) + "..."`. If index 497 falls within a UTF-16 surrogate pair (`0xD800–0xDBFF`), the high surrogate is orphaned before the ellipsis, resulting in Unicode replacement characters (`\uFFFD`) in browser triage message snippets.

## Proposed Changes
1. Added surrogate-pair boundary safety to `summarizePage` in `plugins/plugin-browser/src/message-adapter.ts`.
2. Added unit tests in `plugins/plugin-browser/src/message-adapter.test.ts` verifying surrogate integrity across long emoji-laden page contexts.

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-browser test src/message-adapter.test.ts` (3/3 tests passed).

<!-- eliza-computer-attribution:v1 {"provider":"deepmind","model":"antigravity","client":"antigravity-ide","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
