### PR TITLE
fix(plugin-personal-assistant): keep UTF-16 surrogate pairs intact in reason and proactive snippet truncation

### DIFF
--- a/plugins/plugin-personal-assistant/src/actions/resolve-request.ts
+++ b/plugins/plugin-personal-assistant/src/actions/resolve-request.ts
@@ -277,7 +277,15 @@ function formatPending(requests: ReadonlyArray<ApprovalRequest>): string {
 /** Chip labels stay glanceable; the full reason lives in the queue row. */
 function truncateReason(reason: string, max = 48): string {
   const trimmed = reason.trim();
-  return trimmed.length <= max ? trimmed : `${trimmed.slice(0, max - 1)}…`;
+  if (trimmed.length <= max) return trimmed;
+  let end = max - 1;
+  if (end > 0 && end < trimmed.length) {
+    const code = trimmed.charCodeAt(end - 1);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      end -= 1;
+    }
+  }
+  return `${trimmed.slice(0, end)}…`;
 }
 
 /**

--- a/plugins/plugin-personal-assistant/src/activity-profile/proactive-planner.ts
+++ b/plugins/plugin-personal-assistant/src/activity-profile/proactive-planner.ts
@@ -824,7 +824,14 @@ function summarizeSnippet(value: string): string | null {
   if (trimmed.length <= 72) {
     return trimmed;
   }
-  return `${trimmed.slice(0, 69).trimEnd()}...`;
+  let end = 69;
+  if (end > 0 && end < trimmed.length) {
+    const code = trimmed.charCodeAt(end - 1);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      end -= 1;
+    }
+  }
+  return `${trimmed.slice(0, end).trimEnd()}...`;
 }
 
 function isBusyDay(


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:df8a2fd8337ef2ed4a66e9009c784788fde646b2 -->

## Summary
In `plugins/plugin-personal-assistant/src/activity-profile/proactive-planner.ts` (`summarizeSnippet`) and `plugins/plugin-personal-assistant/src/actions/resolve-request.ts` (`truncateReason`), text truncation previously used raw `.slice(0, N)`. When the cutoff lands between a UTF-16 high surrogate (`0xD800–0xDBFF`) and low surrogate (`0xDC00–0xDFFF`), the surrogate pair is split, leaving an orphan high surrogate character that causes Unicode replacement (`\uFFFD`) and malformed emoji rendering in proactive summaries and action chip reason labels.

## Proposed Changes
1. Added surrogate-pair boundary safety in `summarizeSnippet` (`proactive-planner.ts`).
2. Added surrogate-pair boundary safety in `truncateReason` (`resolve-request.ts`).

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-personal-assistant test src/activity-profile/proactive-worker.test.ts` (15/15 tests passed).

<!-- eliza-computer-attribution:v1 {"provider":"deepmind","model":"antigravity","client":"antigravity-ide","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
