### PR TITLE
fix(plugin-notes): keep UTF-16 surrogate pairs intact in parseNoteContent title/body splitting

### DIFF
--- a/plugins/plugin-notes/src/__tests__/validation.test.ts
+++ b/plugins/plugin-notes/src/__tests__/validation.test.ts
@@ -178,3 +178,17 @@ describe("Notes boundary validation", () => {
     });
   });
 });
+
+describe("parseNoteContent surrogate safety", () => {
+  it("never bisects surrogate pairs when splitting overlong first line", () => {
+    // "😀" is 2 code units: \uD83D\uDE00
+    // "a" + 150 emojis: length 1 + 300 = 301 (exceeds MAX_TITLE_LENGTH = 240)
+    // index 240 lands between high and low surrogate of the 120th emoji!
+    const longEmojiTitle = "a" + "😀".repeat(150);
+    const result = parseNoteContent(longEmojiTitle);
+
+    expect(result.title.length).toBeLessThanOrEqual(240);
+    expect(result.title.endsWith("\uD83D")).toBe(false);
+    expect(result.body.startsWith("\uDE00")).toBe(false);
+  });
+});

--- a/plugins/plugin-notes/src/validation.ts
+++ b/plugins/plugin-notes/src/validation.ts
@@ -112,8 +112,15 @@ export function parseNoteContent(
   });
   const [firstLine = "", ...remainingLines] = content.split(/\r?\n/);
   const trimmedFirstLine = firstLine.trim();
-  const title = trimmedFirstLine.slice(0, MAX_TITLE_LENGTH).trim();
-  const overflow = trimmedFirstLine.slice(MAX_TITLE_LENGTH).trim();
+  let splitIndex = MAX_TITLE_LENGTH;
+  if (splitIndex > 0 && splitIndex < trimmedFirstLine.length) {
+    const code = trimmedFirstLine.charCodeAt(splitIndex - 1);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      splitIndex -= 1;
+    }
+  }
+  const title = trimmedFirstLine.slice(0, splitIndex).trim();
+  const overflow = trimmedFirstLine.slice(splitIndex).trim();
   const body = [overflow, ...remainingLines].join("\n").trim();
   return {
     title: parseRequiredTitle(title, `${field}.firstLine`),


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:3e84bc7a296fafc9c137cf7fb1f6adfe3657b022 -->

## Summary
In `plugins/plugin-notes/src/validation.ts`, `parseNoteContent` parses user-authored note text by taking the first 240 characters of the first line as the `title` and overflowing the remainder into `body`. When the 240-character split point lands inside a UTF-16 surrogate pair (`0xD800–0xDBFF`), the pair was bisected, leaving an unpaired high surrogate at the end of `title` and an unpaired low surrogate at the beginning of `body`.

## Proposed Changes
1. Added surrogate-pair boundary safety in `parseNoteContent` (`plugins/plugin-notes/src/validation.ts`) so title/body splitting never bisects a surrogate pair.
2. Added unit tests in `plugins/plugin-notes/src/__tests__/validation.test.ts` verifying surrogate integrity across long emoji-laden note titles.

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-notes test src/__tests__/validation.test.ts` (17/17 tests passed).

<!-- eliza-computer-attribution:v1 {"provider":"deepmind","model":"antigravity","client":"antigravity-ide","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
