### PR TITLE
test(cloud-shared): cover suffix-stripping

### DIFF
--- a/packages/cloud/shared/src/lib/services/ai-pricing/suffix-stripping.test.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing/suffix-stripping.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Behavioral coverage for versioned-snapshot suffix stripping of model ids.
+ *
+ * The contract: dated (`-2024-06-05`, `-20240605`), labelled (`-latest`,
+ * `-preview`, `-beta`) and numeric (`-001`) suffixes are stripped from model
+ * ids so pricing lookup under the canonical unsuffixed id succeeds. Numeric
+ * suffixes require at least two dash-separated segments to remain after the
+ * provider slash so `openai/gpt-4` never collapses to `openai/gpt`.
+ */
+import { describe, expect, test } from "bun:test";
+import { stripVersionedSnapshotSuffix } from "./suffix-stripping";
+
+describe("stripVersionedSnapshotSuffix", () => {
+  test("strips ISO-date suffixes", () => {
+    expect(stripVersionedSnapshotSuffix("openai/gpt-4o-2024-11-20")).toBe(
+      "openai/gpt-4o",
+    );
+    expect(stripVersionedSnapshotSuffix("openai/o1-2024-12-17")).toBe(
+      "openai/o1",
+    );
+  });
+
+  test("strips compact dated suffixes (year-anchored)", () => {
+    expect(stripVersionedSnapshotSuffix("google/gemini-2.0-flash-20240605")).toBe(
+      "google/gemini-2.0-flash",
+    );
+  });
+
+  test("does not strip unrelated 8-digit run ids", () => {
+    expect(stripVersionedSnapshotSuffix("anthropic/claude-12345678")).toBeNull();
+  });
+
+  test("strips labelled suffixes", () => {
+    expect(stripVersionedSnapshotSuffix("openai/gpt-4o-latest")).toBe("openai/gpt-4o");
+    expect(stripVersionedSnapshotSuffix("openai/gpt-4o-preview")).toBe("openai/gpt-4o");
+    expect(stripVersionedSnapshotSuffix("openai/gpt-4o-beta")).toBe("openai/gpt-4o");
+  });
+
+  test("strips numeric suffixes when enough segments remain", () => {
+    expect(stripVersionedSnapshotSuffix("google/gemini-2.0-flash-001")).toBe(
+      "google/gemini-2.0-flash",
+    );
+    expect(stripVersionedSnapshotSuffix("openai/gpt-4o-1234")).toBe("openai/gpt-4o");
+  });
+
+  test("refuses to collapse a provider to a bare name (numeric safety rail)", () => {
+    // After stripping "-4", only one dash segment ("gpt") would remain.
+    expect(stripVersionedSnapshotSuffix("openai/gpt-4")).toBeNull();
+  });
+
+  test("returns null when no rule applies", () => {
+    expect(stripVersionedSnapshotSuffix("openai/gpt-4o")).toBeNull();
+    expect(stripVersionedSnapshotSuffix("deepseek/deepseek-chat")).toBeNull();
+  });
+
+  test("returns null for degenerate results", () => {
+    expect(stripVersionedSnapshotSuffix("-latest")).toBeNull();
+    expect(stripVersionedSnapshotSuffix("provider/-001")).toBeNull();
+    expect(stripVersionedSnapshotSuffix("-2024-06-05")).toBeNull();
+  });
+
+  test("is case-sensitive like the catalog entries it matches", () => {
+    expect(stripVersionedSnapshotSuffix("openai/gpt-4o-Latest")).toBeNull();
+  });
+});


### PR DESCRIPTION
# Test coverage: suffix-stripping

Behavioral coverage for versioned-snapshot suffix stripping of model ids in the ai-pricing catalog.

## Relates to

- `stripVersionedSnapshotSuffix` in `packages/cloud/shared/src/lib/services/ai-pricing/suffix-stripping.ts` had no unit coverage.

## Background

BitRouter catalogs models under snapshot ids (`google/gemini-2.0-flash-001`) while clients send the canonical unsuffixed id. The helper strips dated/labelled/numeric suffixes so pricing lookup succeeds, with a safety rail preventing `openai/gpt-4` from collapsing to `openai/gpt`. The tests pin every rule branch plus the degenerate-result and case-sensitivity guards.

## Testing

- `bun test src/lib/services/ai-pricing/suffix-stripping.test.ts` from `packages/cloud/shared` → **9 pass / 0 fail / 16 expect calls**.

## Evidence

<!-- evidence-row:backend-logs -->
- [x] backend-logs: local `bun test` run output — 9 pass, 0 fail, 16 expect() calls
<!-- evidence-row:domain-artifacts -->
- [ ] domain-artifacts: N/A (unit test only)
<!-- evidence-row:before-screenshots -->
- [ ] before-screenshots: N/A
<!-- evidence-row:after-screenshots -->
- [ ] after-screenshots: N/A
<!-- evidence-row:walkthrough-video -->
- [ ] walkthrough-video: N/A
<!-- evidence-row:frontend-logs -->
- [ ] frontend-logs: N/A
<!-- evidence-row:llm-trajectory -->
- [ ] llm-trajectory: N/A

AI provider/model: deepseek / deepseek-v4-flash
<!-- slop-contribution-attribution:v1 -->
