### PR TITLE
test(cloud-api): cover twilio-call-status

### DIFF
--- a/packages/cloud/api/v1/twilio/voice/lib/twilio-call-status.test.ts
+++ b/packages/cloud/api/v1/twilio/voice/lib/twilio-call-status.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Behavioral coverage for Twilio call lifecycle receipt normalization.
+ *
+ * Provider callbacks deliver statuses like "completed"/"in-progress" with
+ * arbitrary casing; app-local statuses ("requesting", "submission-unknown")
+ * never come from the provider. Terminal statuses drive webhook settlement,
+ * so the set membership must stay exact.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  isTerminalTwilioCallStatus,
+  normalizeTwilioProviderCallStatus,
+  parseTwilioSequenceNumber,
+  TWILIO_CALL_STATUSES,
+} from "./twilio-call-status";
+
+describe("normalizeTwilioProviderCallStatus", () => {
+  test("normalizes provider statuses with trim and lowercasing", () => {
+    expect(normalizeTwilioProviderCallStatus("Completed")).toBe("completed");
+    expect(normalizeTwilioProviderCallStatus(" in-progress ")).toBe("in-progress");
+    expect(normalizeTwilioProviderCallStatus("queued")).toBe("queued");
+    expect(normalizeTwilioProviderCallStatus("NO-ANSWER")).toBe("no-answer");
+  });
+
+  test("accepts every provider-sent status", () => {
+    for (const status of [
+      "queued",
+      "initiated",
+      "ringing",
+      "in-progress",
+      "completed",
+      "busy",
+      "failed",
+      "no-answer",
+      "canceled",
+    ]) {
+      expect(normalizeTwilioProviderCallStatus(status)).toBe(status);
+    }
+  });
+
+  test("rejects app-local statuses the provider never sends", () => {
+    expect(normalizeTwilioProviderCallStatus("requesting")).toBeNull();
+    expect(normalizeTwilioProviderCallStatus("submission-unknown")).toBeNull();
+    expect(normalizeTwilioProviderCallStatus("hangup-requested")).toBeNull();
+  });
+
+  test("rejects unknown or blank values", () => {
+    expect(normalizeTwilioProviderCallStatus("not-a-status")).toBeNull();
+    expect(normalizeTwilioProviderCallStatus("")).toBeNull();
+    expect(normalizeTwilioProviderCallStatus("   ")).toBeNull();
+  });
+});
+
+describe("isTerminalTwilioCallStatus", () => {
+  test("treats completion and failure outcomes as terminal", () => {
+    for (const status of [
+      "completed",
+      "busy",
+      "failed",
+      "no-answer",
+      "canceled",
+      "provider-error",
+    ]) {
+      expect(isTerminalTwilioCallStatus(status)).toBe(true);
+    }
+  });
+
+  test("treats in-flight statuses as non-terminal", () => {
+    for (const status of [
+      "requesting",
+      "queued",
+      "initiated",
+      "ringing",
+      "in-progress",
+      "hangup-requested",
+      "submission-unknown",
+    ]) {
+      expect(isTerminalTwilioCallStatus(status)).toBe(false);
+    }
+  });
+
+  test("is case-sensitive like the callbacks that emit it", () => {
+    expect(isTerminalTwilioCallStatus("Completed")).toBe(false);
+  });
+});
+
+describe("parseTwilioSequenceNumber", () => {
+  test("parses plain digit strings", () => {
+    expect(parseTwilioSequenceNumber("42")).toBe(42);
+    expect(parseTwilioSequenceNumber("0")).toBe(0);
+    expect(parseTwilioSequenceNumber("9007199254740991")).toBe(9007199254740991);
+  });
+
+  test("rejects undefined, empty, and malformed input", () => {
+    expect(parseTwilioSequenceNumber(undefined)).toBeNull();
+    expect(parseTwilioSequenceNumber("")).toBeNull();
+    expect(parseTwilioSequenceNumber("12a")).toBeNull();
+    expect(parseTwilioSequenceNumber("12.5")).toBeNull();
+    expect(parseTwilioSequenceNumber("-3")).toBeNull();
+    expect(parseTwilioSequenceNumber("1 2")).toBeNull();
+  });
+
+  test("rejects values outside the safe-integer range", () => {
+    expect(parseTwilioSequenceNumber("9007199254740992")).toBeNull();
+    expect(parseTwilioSequenceNumber("99999999999999999999")).toBeNull();
+  });
+});
+
+describe("TWILIO_CALL_STATUSES", () => {
+  test("lists every provider-sent status", () => {
+    for (const status of [
+      "queued",
+      "initiated",
+      "ringing",
+      "in-progress",
+      "completed",
+      "busy",
+      "failed",
+      "no-answer",
+      "canceled",
+    ]) {
+      expect(TWILIO_CALL_STATUSES).toContain(status);
+    }
+  });
+});


### PR DESCRIPTION
# Test coverage: twilio-call-status

Behavioral coverage for Twilio call lifecycle receipt normalization.

## Relates to

- `normalizeTwilioProviderCallStatus` / `isTerminalTwilioCallStatus` / `parseTwilioSequenceNumber` in `packages/cloud/api/v1/twilio/voice/lib/twilio-call-status.ts` had no unit coverage.

## Background

Twilio callbacks deliver statuses with arbitrary casing; app-local statuses (`requesting`, `submission-unknown`) never come from the provider. Terminal statuses drive webhook settlement, so set membership must stay exact. The tests pin the normalize/terminal/sequence contracts plus the exported status inventory.

## Testing

- `bun test v1/twilio/voice/lib/twilio-call-status.test.ts` from `packages/cloud/api` → **11 pass / 0 fail / 53 expect calls**.

## Evidence

<!-- evidence-row:backend-logs -->
- [x] backend-logs: local `bun test` run output — 11 pass, 0 fail, 53 expect() calls
<!-- evidence-row:domain-artifacts -->
- [ ] domain-artifacts: N/A (unit test only)
<!-- evidence-row:before-screenshots -->
- [ ] before-screenshots: N/A
<!-- evidence-row:after-screenshots -->
- [ ] after-screenshots: N/A
<!-- evidence-row:walkthrough-video -->
- [ ] walkthrough-video: N/A
<!-- evidence-row:frontend-logs -->
- [ ] frontend-logs: N/A
<!-- evidence-row:llm-trajectory -->
- [ ] llm-trajectory: N/A

AI provider/model: deepseek / deepseek-v4-flash
<!-- slop-contribution-attribution:v1 -->
