### PR TITLE
fix(plugin-native-talkmode): guard in-flight TTS completion against torn-down session

### DIFF
--- a/plugins/plugin-native-talkmode/src/web.test.ts
+++ b/plugins/plugin-native-talkmode/src/web.test.ts
@@ -460,6 +460,82 @@ describe("TalkModeWeb fallback", () => {
     await expect(plugin.isEnabled()).resolves.toEqual({ enabled: true });
   });
 
+  it("surfaces a genuine synthesis error on an active session instead of swallowing it as listening (issue #27977)", async () => {
+    const utterances: FakeUtterance[] = [];
+    const synthesis = {
+      cancel: vi.fn(),
+      speaking: false,
+      speak: vi.fn((value: FakeUtterance) => {
+        utterances.push(value);
+      }),
+    };
+    setWindow({
+      SpeechRecognition: FakeRecognition,
+      speechSynthesis: synthesis,
+    });
+    setNavigator({});
+    vi.stubGlobal("SpeechSynthesisUtterance", FakeUtterance);
+    const plugin = new TalkModeWeb();
+
+    await expect(plugin.start()).resolves.toEqual({ started: true });
+    const speaking = plugin.speak({ text: "hi" });
+    await expect(plugin.getState()).resolves.toEqual({
+      state: "speaking",
+      statusText: "Speaking",
+    });
+
+    // A real synthesis failure (not a stop-initiated cancel) fires while the
+    // session is still enabled. The interrupted-case fix must not broaden to
+    // swallow this: the boundary is event.error, not this.enabled alone.
+    utterances[0]?.onerror?.({ error: "synthesis-failed" });
+    await expect(speaking).resolves.toEqual({
+      completed: false,
+      interrupted: false,
+      usedSystemTts: true,
+      error: "synthesis-failed",
+    });
+    await expect(plugin.getState()).resolves.toEqual({
+      state: "error",
+      statusText: "Speech error",
+    });
+  });
+
+  it("treats a canceled error like an interruption and returns an active session to listening (issue #27977)", async () => {
+    const utterances: FakeUtterance[] = [];
+    const synthesis = {
+      cancel: vi.fn(),
+      speaking: false,
+      speak: vi.fn((value: FakeUtterance) => {
+        utterances.push(value);
+      }),
+    };
+    setWindow({
+      SpeechRecognition: FakeRecognition,
+      speechSynthesis: synthesis,
+    });
+    setNavigator({});
+    vi.stubGlobal("SpeechSynthesisUtterance", FakeUtterance);
+    const plugin = new TalkModeWeb();
+
+    await expect(plugin.start()).resolves.toEqual({ started: true });
+    const speaking = plugin.speak({ text: "hi" });
+
+    // Some engines report a deliberate cancel as "canceled" rather than
+    // "interrupted"; on a still-enabled session that is an interruption, not a
+    // failure, so it must return to listening and be reported as interrupted.
+    utterances[0]?.onerror?.({ error: "canceled" });
+    await expect(speaking).resolves.toEqual({
+      completed: false,
+      interrupted: true,
+      usedSystemTts: true,
+      error: "canceled",
+    });
+    await expect(plugin.getState()).resolves.toEqual({
+      state: "listening",
+      statusText: "Listening",
+    });
+  });
+
   it("maps speech synthesis errors without throwing", async () => {
     const synthesis = {
       cancel: vi.fn(),

--- a/plugins/plugin-native-talkmode/src/web.test.ts
+++ b/plugins/plugin-native-talkmode/src/web.test.ts
@@ -305,6 +305,161 @@ describe("TalkModeWeb fallback", () => {
     await expect(plugin.isEnabled()).resolves.toEqual({ enabled: false });
   });
 
+  it("does not resurrect a listening state when a torn-down utterance completes after stop() (issue #27977)", async () => {
+    const utterances: FakeUtterance[] = [];
+    const synthesis = {
+      cancel: vi.fn(),
+      speaking: false,
+      // Capture the utterance without auto-completing so the test controls when
+      // the browser fires the completion event relative to stop().
+      speak: vi.fn((value: FakeUtterance) => {
+        utterances.push(value);
+      }),
+    };
+    setWindow({
+      SpeechRecognition: FakeRecognition,
+      speechSynthesis: synthesis,
+    });
+    setNavigator({});
+    vi.stubGlobal("SpeechSynthesisUtterance", FakeUtterance);
+    const plugin = new TalkModeWeb();
+
+    await expect(plugin.start()).resolves.toEqual({ started: true });
+    await expect(plugin.getState()).resolves.toEqual({
+      state: "listening",
+      statusText: "Listening",
+    });
+
+    // An agent reply flips the session into "speaking" with the utterance held
+    // pending (synthesis.speak captured it without completing).
+    const speaking = plugin.speak({ text: "hi" });
+    await expect(plugin.getState()).resolves.toEqual({
+      state: "speaking",
+      statusText: "Speaking",
+    });
+
+    // stop() tears the whole session down while the utterance is still in
+    // flight: enabled=false, recognizer nulled, synthesis cancelled, idle/Off.
+    await plugin.stop();
+    await expect(plugin.isEnabled()).resolves.toEqual({ enabled: false });
+    await expect(plugin.getState()).resolves.toEqual({
+      state: "idle",
+      statusText: "Off",
+    });
+
+    // Any stateChange after teardown would be a bug: the session is gone.
+    const afterStop = vi.fn();
+    await plugin.addListener("stateChange", afterStop);
+
+    // The browser fires onend for the utterance cancelled by stop(). Before the
+    // fix this ran setState("listening", "Listening"), resurrecting a live
+    // listening state even though nothing is capturing audio.
+    utterances[0]?.onend?.();
+    await expect(speaking).resolves.toEqual({
+      completed: true,
+      interrupted: false,
+      usedSystemTts: true,
+    });
+
+    // The stale completion must be dropped: state stays idle/Off and no
+    // stateChange is emitted after stop().
+    expect(afterStop).not.toHaveBeenCalled();
+    await expect(plugin.getState()).resolves.toEqual({
+      state: "idle",
+      statusText: "Off",
+    });
+    await expect(plugin.isEnabled()).resolves.toEqual({ enabled: false });
+  });
+
+  it("does not fabricate a speech error when stop() cancels an in-flight utterance (issue #27977)", async () => {
+    const utterances: FakeUtterance[] = [];
+    const synthesis = {
+      cancel: vi.fn(),
+      speaking: false,
+      speak: vi.fn((value: FakeUtterance) => {
+        utterances.push(value);
+      }),
+    };
+    setWindow({
+      SpeechRecognition: FakeRecognition,
+      speechSynthesis: synthesis,
+    });
+    setNavigator({});
+    vi.stubGlobal("SpeechSynthesisUtterance", FakeUtterance);
+    const plugin = new TalkModeWeb();
+
+    await expect(plugin.start()).resolves.toEqual({ started: true });
+    const speaking = plugin.speak({ text: "hi" });
+    await expect(plugin.getState()).resolves.toEqual({
+      state: "speaking",
+      statusText: "Speaking",
+    });
+
+    await plugin.stop();
+    await expect(plugin.getState()).resolves.toEqual({
+      state: "idle",
+      statusText: "Off",
+    });
+
+    const afterStop = vi.fn();
+    await plugin.addListener("stateChange", afterStop);
+
+    // Cancelling playback makes the browser fire onerror("interrupted"). This
+    // is a normal user stop, not a real speech failure. Before the fix this
+    // flipped state to idle/"Speech error", reporting a fake error.
+    utterances[0]?.onerror?.({ error: "interrupted" });
+    await expect(speaking).resolves.toEqual({
+      completed: false,
+      interrupted: true,
+      usedSystemTts: true,
+      error: "interrupted",
+    });
+    expect(afterStop).not.toHaveBeenCalled();
+    await expect(plugin.getState()).resolves.toEqual({
+      state: "idle",
+      statusText: "Off",
+    });
+  });
+
+  it("returns to listening when the current utterance completes during an active session (issue #27977)", async () => {
+    const utterances: FakeUtterance[] = [];
+    const synthesis = {
+      cancel: vi.fn(),
+      speaking: false,
+      speak: vi.fn((value: FakeUtterance) => {
+        utterances.push(value);
+      }),
+    };
+    setWindow({
+      SpeechRecognition: FakeRecognition,
+      speechSynthesis: synthesis,
+    });
+    setNavigator({});
+    vi.stubGlobal("SpeechSynthesisUtterance", FakeUtterance);
+    const plugin = new TalkModeWeb();
+
+    await expect(plugin.start()).resolves.toEqual({ started: true });
+    const speaking = plugin.speak({ text: "hi" });
+    await expect(plugin.getState()).resolves.toEqual({
+      state: "speaking",
+      statusText: "Speaking",
+    });
+
+    // The current utterance completes normally while the session is still
+    // enabled: the guard passes and capture resumes.
+    utterances[0]?.onend?.();
+    await expect(speaking).resolves.toEqual({
+      completed: true,
+      interrupted: false,
+      usedSystemTts: true,
+    });
+    await expect(plugin.getState()).resolves.toEqual({
+      state: "listening",
+      statusText: "Listening",
+    });
+    await expect(plugin.isEnabled()).resolves.toEqual({ enabled: true });
+  });
+
   it("maps speech synthesis errors without throwing", async () => {
     const synthesis = {
       cancel: vi.fn(),

--- a/plugins/plugin-native-talkmode/src/web.ts
+++ b/plugins/plugin-native-talkmode/src/web.ts
@@ -197,16 +197,44 @@ export class TalkModeWeb extends WebPlugin {
       }
 
       utterance.onend = () => {
+        // Mirror the recognition.onend teardown guard: stop() nulls
+        // currentUtterance before the browser's async end event fires, so a
+        // stale completion must not resurrect a live "listening" state on a
+        // torn-down session (enabled=false, recognizer nulled). The promise
+        // still resolves so an in-flight speak() never hangs.
+        if (this.currentUtterance !== utterance) {
+          resolve({ completed: true, interrupted: false, usedSystemTts: true });
+          return;
+        }
         this.currentUtterance = null;
         this.notifyListeners("speakComplete", { completed: true });
-        this.setState("listening", "Listening");
+        this.setState(
+          this.enabled ? "listening" : "idle",
+          this.enabled ? "Listening" : "Off",
+        );
         resolve({ completed: true, interrupted: false, usedSystemTts: true });
       };
 
       utterance.onerror = (event) => {
+        // Same teardown guard as onend. A deliberate stop() cancels playback,
+        // which the browser reports as onerror("interrupted"); that is a normal
+        // user stop, not a speech failure, so it must not fabricate a
+        // "Speech error" status on an already-idle session.
+        if (this.currentUtterance !== utterance) {
+          resolve({
+            completed: false,
+            interrupted: event.error === "interrupted",
+            usedSystemTts: true,
+            error: event.error,
+          });
+          return;
+        }
         this.currentUtterance = null;
         this.notifyListeners("speakComplete", { completed: false });
-        this.setState("idle", "Speech error");
+        this.setState(
+          this.enabled ? "listening" : "idle",
+          this.enabled ? "Listening" : "Off",
+        );
         resolve({
           completed: false,
           interrupted: event.error === "interrupted",

--- a/plugins/plugin-native-talkmode/src/web.ts
+++ b/plugins/plugin-native-talkmode/src/web.ts
@@ -201,7 +201,11 @@ export class TalkModeWeb extends WebPlugin {
         // currentUtterance before the browser's async end event fires, so a
         // stale completion must not resurrect a live "listening" state on a
         // torn-down session (enabled=false, recognizer nulled). The promise
-        // still resolves so an in-flight speak() never hangs.
+        // still resolves so an in-flight speak() never hangs. onend carries no
+        // interruption signal, so a stale end fired because stop() cut speech
+        // short is indistinguishable here from a genuine finish; the result is
+        // reported as completed and a caller doing delivery accounting must
+        // treat post-stop completion as best-effort rather than authoritative.
         if (this.currentUtterance !== utterance) {
           resolve({ completed: true, interrupted: false, usedSystemTts: true });
           return;
@@ -216,14 +220,20 @@ export class TalkModeWeb extends WebPlugin {
       };
 
       utterance.onerror = (event) => {
-        // Same teardown guard as onend. A deliberate stop() cancels playback,
-        // which the browser reports as onerror("interrupted"); that is a normal
-        // user stop, not a speech failure, so it must not fabricate a
-        // "Speech error" status on an already-idle session.
+        // Same teardown guard as onend. A deliberate stop()/stopSpeaking()
+        // cancels playback, which the browser reports as onerror("interrupted")
+        // or, on some engines, onerror("canceled"); either is a normal user stop
+        // rather than a speech failure, so it must not fabricate a "Speech
+        // error" status. Genuine synthesis failures (synthesis-failed,
+        // audio-busy, voice-unavailable, ...) are NOT interruptions and must
+        // still surface the error state on a live session — gating only on
+        // this.enabled would silently swallow them and report "Listening".
+        const interrupted =
+          event.error === "interrupted" || event.error === "canceled";
         if (this.currentUtterance !== utterance) {
           resolve({
             completed: false,
-            interrupted: event.error === "interrupted",
+            interrupted,
             usedSystemTts: true,
             error: event.error,
           });
@@ -231,13 +241,16 @@ export class TalkModeWeb extends WebPlugin {
         }
         this.currentUtterance = null;
         this.notifyListeners("speakComplete", { completed: false });
-        this.setState(
-          this.enabled ? "listening" : "idle",
-          this.enabled ? "Listening" : "Off",
-        );
+        if (!this.enabled) {
+          this.setState("idle", "Off");
+        } else if (interrupted) {
+          this.setState("listening", "Listening");
+        } else {
+          this.setState("error", "Speech error");
+        }
         resolve({
           completed: false,
-          interrupted: event.error === "interrupted",
+          interrupted,
           usedSystemTts: true,
           error: event.error,
         });


### PR DESCRIPTION
# Relates to

Closes #27977

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; focused package gates (test, typecheck, lint) pass. See **Known gaps / failures** for the full-repo `bun run verify` note.
- [x] A reviewer can confirm the change works from the deterministic before/after vitest reproduction attached below.

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts (HEAD..origin/develop == 0 at authoring).
- [x] Focused package gates pass post-sync; full-repo `bun run verify` note recorded in **Known gaps / failures**.

# Risks

Low. The change is confined to the web fallback (`plugins/plugin-native-talkmode/src/web.ts`) `speak()` completion handlers. It adds a teardown guard that mirrors the existing `recognition.onend` guard; it does not alter the native iOS/Android paths, the recognizer, or any public method signature. The in-flight `speak()` promise still resolves in every path, so no caller can hang.

# Background

## What does this PR do?

`TalkModeWeb.stop()` already guards the recognizer-restart path against a torn-down session (`recognition.onend` checks `if (this.enabled)`), but the `SpeechSynthesisUtterance` completion handlers did **not** apply the equivalent guard.

When `stop()` is called while a TTS utterance is still in flight, `stop()` sets `enabled=false`, nulls the recognizer, cancels synthesis, nulls `currentUtterance`, and sets state to `idle`/`Off`. The browser then fires the utterance's `onend` (on finish or on the `cancel` triggered by `stop()`), and the old handler unconditionally ran `setState("listening", "Listening")` — **resurrecting a live "listening" state on a torn-down session** (nothing is capturing audio, `recognition=null`, `enabled=false`). The `onerror` path was worse: a deliberate stop that cancels playback fired `onerror("interrupted")`, flipping state to `idle`/**"Speech error"** and reporting a fake error for a normal user stop. Consumers that render `getState()`/`stateChange` (the UI status pill) then show "Listening" (or "Speech error") while TalkMode is off, disagreeing with `isEnabled()`.

The fix mirrors the recognizer guard: because `stop()` sets `currentUtterance = null` before the async completion event fires, the handlers drop the stale completion with `if (this.currentUtterance !== utterance) { resolve(...); return; }`, and otherwise transition to `this.enabled ? "listening"/"Listening" : "idle"/"Off"` — never fabricating a "Speech error" for a stop-initiated cancel. The promise still resolves in every branch so an in-flight `speak()` never hangs.

## What kind of change is this?

Bug fix (non-breaking change which fixes a state-machine teardown race on the public plugin surface).

# Documentation changes needed?

My changes do not require a change to the project documentation. The public method surface and documented state machine (`idle → listening → processing → speaking → error`) are unchanged; this only corrects which state the completion handlers land in after teardown.

# Testing

## Where should a reviewer start?

`plugins/plugin-native-talkmode/src/web.test.ts` — five added tests using the existing `FakeUtterance`/`FakeRecognition` doubles:

1. `does not resurrect a listening state when a torn-down utterance completes after stop() (issue #27977)` — `start()` → `speak()` (utterance captured, not auto-completed) → `stop()` (asserts `enabled:false`, `idle`/`Off`) → late `utterance.onend()` must leave state `idle`/`Off` and emit no `stateChange`.
2. `does not fabricate a speech error when stop() cancels an in-flight utterance (issue #27977)` — same teardown, then late `onerror("interrupted")` must not produce `"Speech error"` and must stay `idle`/`Off`.
3. `returns to listening when the current utterance completes during an active session (issue #27977)` — positive path: a normal completion while still enabled returns to `listening`/`Listening`.
4. `surfaces a genuine synthesis error on an active session instead of swallowing it as listening (issue #27977)` — a real `synthesis-failed` on an enabled session (no `stop()`) must land in `error`/`Speech error`, not `listening`. Added after review feedback from @sarah-pump-ai: the original teardown guard broadened the `onerror` non-stale branch to every error code, so genuine synthesis failures were silently reported as `Listening`.
5. `treats a canceled error like an interruption and returns an active session to listening (issue #27977)` — some engines report a deliberate cancel as `onerror("canceled")` rather than `"interrupted"`; on a still-enabled session that is an interruption, so it returns to `listening` and is reported as `interrupted: true`.

## Detailed testing steps

```bash
bun install
bun run --cwd plugins/plugin-native-talkmode test       # 25 passed
bun run --cwd plugins/plugin-native-talkmode typecheck   # clean
bun run --cwd plugins/plugin-native-talkmode lint:check  # clean
```

# Evidence Gate

<!-- evidence-head:2729c90c9da53554d0346ef61afc68ba7a4f16f1 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no UI surface; this is a Capacitor plugin fallback (plugin-native-talkmode/src/web.ts), not a rendered view under packages/app|ui.
<!-- evidence-row:after-screenshots -->
- [x] `N/A - no UI surface; see above.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no interactive UI flow; the behavior is a state-machine transition proven by the deterministic vitest reproduction below.`
<!-- evidence-row:backend-logs -->
- [x] `N/A - no server runtime path; the changed code is a browser Web Speech fallback exercised by deterministic vitest doubles. The failing-then-passing test output is inlined below as the equivalent code-path proof.`
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no app frontend consumes this in the diff; the plugin state machine is verified directly via getState()/stateChange assertions in the inlined test output.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent/action/provider/prompt/model change; this is a TTS teardown-race fix.`
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - the domain artifact is the deterministic failing-before/passing-after vitest reproduction, inlined in Evidence Details below (the fork-only attachment uploader hit a headless GitHub interstitial on this host).
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface in this diff.`

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

Deterministic vitest reproduction (the code-path proof for a browser fallback with no server runtime).

**Before the fix** (base `origin/develop` `web.ts`, new tests present) — the two teardown tests FAIL:

<details>
<summary>bun run --cwd plugins/plugin-native-talkmode test (before)</summary>

```
 ❯ src/web.test.ts (12 tests | 2 failed) 47ms
     × does not resurrect a listening state when a torn-down utterance completes after stop() (issue #27977) 11ms
     × does not fabricate a speech error when stop() cancels an in-flight utterance (issue #27977) 3ms

 FAIL  src/web.test.ts > TalkModeWeb fallback > does not resurrect a listening state when a torn-down utterance completes after stop() (issue #27977)
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
Received:
  1st vi.fn() call:
    Array [
      Object {
        "previousState": "idle",
        "state": "listening",
        "statusText": "Listening",
        "usingSystemTts": true,
      },
    ]

 FAIL  src/web.test.ts > TalkModeWeb fallback > does not fabricate a speech error when stop() cancels an in-flight utterance (issue #27977)
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
Received:
  1st vi.fn() call:
    Array [
      Object {
        "previousState": "idle",
        "state": "idle",
        "statusText": "Speech error",
        "usingSystemTts": true,
      },
    ]

 Test Files  1 failed | 2 passed (3)
      Tests  2 failed | 21 passed (23)
```
</details>

**After the fix** — all pass:

<details>
<summary>bun run --cwd plugins/plugin-native-talkmode test (after)</summary>

```
 RUN  v4.1.10 /.../plugins/plugin-native-talkmode

 Test Files  3 passed (3)
      Tests  25 passed (25)
   Duration  556ms
```
</details>

<details>
<summary>typecheck + lint (after)</summary>

```
$ tsc --noEmit -p tsconfig.json        # (no output = clean)
$ bunx @biomejs/biome check .
Checked 10 files in 122ms. No fixes applied.
```
</details>

## Screenshots (before / after) + video walkthrough

N/A - no UI surface (Capacitor plugin web fallback, not a rendered view).

## Audio / voice walkthrough

N/A - no real audio round-trip is exercised or changed; this fixes the state-machine transition after `stop()`, verified deterministically with Web Speech API doubles. No native TTS/STT engine behavior changed.

## Known gaps / failures

- Full-repo `bun run verify` was not run here: it drives Turbo across ~6900 installed packages and is disproportionate for a two-file, single-plugin fix on this Raspberry Pi host. The owning package's `test` (25 passed), `typecheck` (clean), and `lint:check` (clean) all pass, and the diff touches no shared/public surface consumed elsewhere.
- Evidence artifacts are inlined rather than attached as minted URLs: the fork-only attachment uploader hit a GitHub verification interstitial in headless mode on this host. The complete before/after test output is reproduced inline above; it is deterministic and reproducible with the commands in **Detailed testing steps**.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

---

Closes #27977

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@126807701e19a2a88b7f50ce785df4b26506007a:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@126807701e19a2a88b7f50ce785df4b26506007a:packages/skills/skills/contribute-to-eliza"} -->



