### PR TITLE
test(plugin-agent-orchestrator): cover sandbox stub action

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/actions/__tests__/sandbox-stub.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/__tests__/sandbox-stub.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  buildStoreVariantBlockedMessage: vi.fn((s: string) => `${s} unavailable`),
+}));
+
+vi.mock(
+  "@elizaos/core",
+  () => ({
+    buildStoreVariantBlockedMessage: mocks.buildStoreVariantBlockedMessage,
+  }),
+  { virtual: true },
+);
+
+import { createTerminalUnsupportedTasksAction } from "./sandbox-stub.ts";
+
+describe("createTerminalUnsupportedTasksAction", () => {
+  it("builds an unavailable tasks action", async () => {
+    const action = createTerminalUnsupportedTasksAction({
+      message: "sandboxed",
+      reason: "store build",
+    });
+    expect(action.name).toBe("TASKS");
+    expect(action.suppressPostActionContinuation).toBe(true);
+  });
+
+  it("handler returns a user-facing error without spawning", async () => {
+    const action = createTerminalUnsupportedTasksAction({
+      message: "sandboxed",
+      reason: "store build",
+    });
+    const callback = vi.fn();
+    const result = await action.handler(
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      callback as never,
+    );
+    expect(callback).toHaveBeenCalled();
+    expect(result).toBeDefined();
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new `__tests__` file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `isolated npx vitest run -> 2 passed` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: 92d692518c3d832ac9b203076ef691a54e61a9fa
