### PR TITLE
fix(plugin-health): reject non-ISO timestamps in normalizeOptionalIsoString

### DIFF
--- a/plugins/plugin-health/src/util/normalize.test.ts
+++ b/plugins/plugin-health/src/util/normalize.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Unit test for plugin-health value-normalisation helpers.
+ *
+ * Materiality: `normalizeOptionalIsoString` validates timestamps via
+ * `Date.parse`, which accepts non-ISO formats ("2024/01/15", "Jan 15 2024",
+ * "2024-01-15 10:30:00"). The helper's contract and error message say the
+ * value "must be an ISO string"; accepting Date.parse-lenient input means
+ * malformed provider payloads pass validation and flow downstream with
+ * non-canonical timestamps. These tests pin the ISO-8601 boundary.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  fail,
+  normalizeOptionalBoolean,
+  normalizeOptionalFiniteNumber,
+  normalizeOptionalIsoString,
+  normalizeOptionalString,
+  requireNonEmptyString,
+} from "./normalize.js";
+
+describe("requireNonEmptyString", () => {
+  it("trims and returns non-empty strings", () => {
+    expect(requireNonEmptyString("  hello  ", "field")).toBe("hello");
+  });
+
+  it("rejects non-string and blank values", () => {
+    expect(() => requireNonEmptyString("", "field")).toThrow(
+      /non-empty string/,
+    );
+    expect(() => requireNonEmptyString("   ", "field")).toThrow(
+      /non-empty string/,
+    );
+    expect(() => requireNonEmptyString(42, "field")).toThrow(
+      /non-empty string/,
+    );
+    expect(() => requireNonEmptyString(null, "field")).toThrow(
+      /non-empty string/,
+    );
+  });
+});
+
+describe("normalizeOptionalString", () => {
+  it("returns undefined for missing values", () => {
+    expect(normalizeOptionalString(undefined)).toBeUndefined();
+    expect(normalizeOptionalString(null)).toBeUndefined();
+  });
+
+  it("returns undefined for non-string values", () => {
+    expect(normalizeOptionalString(7)).toBeUndefined();
+    expect(normalizeOptionalString({})).toBeUndefined();
+  });
+
+  it("trims strings and collapses blanks to undefined", () => {
+    expect(normalizeOptionalString("  ok  ")).toBe("ok");
+    expect(normalizeOptionalString("   ")).toBeUndefined();
+  });
+});
+
+describe("normalizeOptionalBoolean", () => {
+  it("passes booleans through", () => {
+    expect(normalizeOptionalBoolean(true, "f")).toBe(true);
+    expect(normalizeOptionalBoolean(false, "f")).toBe(false);
+  });
+
+  it("maps string/number truthy markers", () => {
+    expect(normalizeOptionalBoolean("true", "f")).toBe(true);
+    expect(normalizeOptionalBoolean(1, "f")).toBe(true);
+    expect(normalizeOptionalBoolean("false", "f")).toBe(false);
+    expect(normalizeOptionalBoolean(0, "f")).toBe(false);
+  });
+
+  it("returns undefined for unrecognised values", () => {
+    expect(normalizeOptionalBoolean("yes", "f")).toBeUndefined();
+    expect(normalizeOptionalBoolean("1", "f")).toBeUndefined();
+    expect(normalizeOptionalBoolean(2, "f")).toBeUndefined();
+  });
+});
+
+describe("normalizeOptionalIsoString", () => {
+  it("accepts canonical ISO-8601 timestamps", () => {
+    expect(normalizeOptionalIsoString("2024-01-15T10:30:00Z", "ts")).toBe(
+      "2024-01-15T10:30:00Z",
+    );
+    expect(
+      normalizeOptionalIsoString("2024-01-15T10:30:00.123+02:00", "ts"),
+    ).toBe("2024-01-15T10:30:00.123+02:00");
+    expect(normalizeOptionalIsoString("2024-01-15", "ts")).toBe("2024-01-15");
+  });
+
+  it("rejects Date.parse-lenient non-ISO formats", () => {
+    // Date.parse accepts all of these; the ISO contract must not.
+    expect(() => normalizeOptionalIsoString("2024/01/15", "ts")).toThrow(
+      /must be a valid ISO timestamp/,
+    );
+    expect(() => normalizeOptionalIsoString("Jan 15 2024", "ts")).toThrow(
+      /must be a valid ISO timestamp/,
+    );
+    expect(() =>
+      normalizeOptionalIsoString("2024-01-15 10:30:00", "ts"),
+    ).toThrow(/must be a valid ISO timestamp/);
+    expect(() => normalizeOptionalIsoString("01/02/2024", "ts")).toThrow(
+      /must be a valid ISO timestamp/,
+    );
+  });
+
+  it("rejects unparseable and out-of-range values", () => {
+    expect(() => normalizeOptionalIsoString("garbage", "ts")).toThrow(
+      /must be a valid ISO timestamp/,
+    );
+    expect(() => normalizeOptionalIsoString("2024-13-45", "ts")).toThrow(
+      /must be a valid ISO timestamp/,
+    );
+    expect(() => normalizeOptionalIsoString(123, "ts")).toThrow(
+      /must be an ISO string/,
+    );
+  });
+
+  it("returns undefined for missing and blank values", () => {
+    expect(normalizeOptionalIsoString(undefined, "ts")).toBeUndefined();
+    expect(normalizeOptionalIsoString(null, "ts")).toBeUndefined();
+    expect(normalizeOptionalIsoString("   ", "ts")).toBeUndefined();
+  });
+});
+
+describe("normalizeOptionalFiniteNumber", () => {
+  it("passes finite numbers through", () => {
+    expect(normalizeOptionalFiniteNumber(3.5, "n")).toBe(3.5);
+    expect(normalizeOptionalFiniteNumber(0, "n")).toBe(0);
+  });
+
+  it("parses numeric strings", () => {
+    expect(normalizeOptionalFiniteNumber("42", "n")).toBe(42);
+    expect(normalizeOptionalFiniteNumber("3.14", "n")).toBe(3.14);
+  });
+
+  it("rejects non-finite and non-numeric values", () => {
+    expect(() => normalizeOptionalFiniteNumber(Number.NaN, "n")).toThrow(
+      /finite number/,
+    );
+    expect(() =>
+      normalizeOptionalFiniteNumber(Number.POSITIVE_INFINITY, "n"),
+    ).toThrow(/finite number/);
+    expect(() => normalizeOptionalFiniteNumber("abc", "n")).toThrow(
+      /finite number/,
+    );
+    expect(() => normalizeOptionalFiniteNumber({}, "n")).toThrow(
+      /finite number/,
+    );
+  });
+
+  it("returns null for missing values", () => {
+    expect(normalizeOptionalFiniteNumber(undefined, "n")).toBeNull();
+    expect(normalizeOptionalFiniteNumber(null, "n")).toBeNull();
+  });
+});
+
+describe("fail", () => {
+  it("throws an error carrying status and optional code", () => {
+    try {
+      fail(422, "bad payload", "BAD_PAYLOAD");
+    } catch (error) {
+      const e = error as Error & { status?: number; code?: string };
+      expect(e.message).toBe("bad payload");
+      expect(e.status).toBe(422);
+      expect(e.code).toBe("BAD_PAYLOAD");
+      return;
+    }
+    throw new Error("fail() did not throw");
+  });
+});

--- a/plugins/plugin-health/src/util/normalize.ts
+++ b/plugins/plugin-health/src/util/normalize.ts
@@ -48,6 +48,13 @@ export function normalizeOptionalBoolean(
   return undefined;
 }
 
+// Strict ISO-8601 shape gate. `Date.parse` alone is far too lenient: it also
+// accepts "2024/01/15", "Jan 15 2024", and "2024-01-15 10:30:00", so relying
+// on it lets non-ISO payloads through a helper whose contract (and error
+// message) promises an ISO timestamp.
+const ISO_8601_REGEX =
+  /^\d{4}-\d{2}-\d{2}(?:T\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?(?:Z|[+-]\d{2}:\d{2})?)?$/;
+
 export function normalizeOptionalIsoString(
   value: unknown,
   field: string,
@@ -58,7 +65,7 @@ export function normalizeOptionalIsoString(
   }
   const trimmed = (value as string).trim();
   if (trimmed.length === 0) return undefined;
-  if (Number.isNaN(Date.parse(trimmed))) {
+  if (!ISO_8601_REGEX.test(trimmed) || Number.isNaN(Date.parse(trimmed))) {
     fail(400, `${field} must be a valid ISO timestamp`);
   }
   return trimmed;


### PR DESCRIPTION
# Relates to

<!-- No issue; hardening for plugin-health's value-normalisation helpers. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. `normalizeOptionalIsoString` now rejects non-ISO date strings that
`Date.parse` would previously accept (e.g. `2024/01/15`, `Jan 15 2024`,
`2024-01-15 10:30:00`). This matches the helper's documented contract and
error message ("must be an ISO string" / "must be a valid ISO timestamp");
callers feeding canonical ISO-8601 values are unaffected. The stricter gate
is the intended behaviour, not a behaviour regression.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `Test Files 1 passed (1) / Tests 17 passed (17)` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file + helper fix diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: 92d692518c3d832ac9b203076ef691a54e61a9fa
