### PR TITLE
chore(synthetic-world): remove unused cloud-test-mocks dev dependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1112,7 +1112,6 @@
         "@elizaos/shared": "workspace:*",
       },
       "devDependencies": {
-        "@elizaos/cloud-test-mocks": "workspace:*",
         "@typescript/native": "npm:typescript@^7.0.2",
         "bun-types": "*",
       },

--- a/packages/synthetic-world/package.json
+++ b/packages/synthetic-world/package.json
@@ -23,7 +23,6 @@
     "@elizaos/shared": "workspace:*"
   },
   "devDependencies": {
-    "@elizaos/cloud-test-mocks": "workspace:*",
     "@typescript/native": "npm:typescript@^7.0.2",
     "bun-types": "*"
   },


### PR DESCRIPTION
## Summary
`packages/synthetic-world` declares `@elizaos/cloud-test-mocks` as a dev dependency with **zero source, test, build, or script references** (verified with repo-wide grep).

## Fix
Remove the unused dev dependency from `packages/synthetic-world/package.json`. Other plugins (`plugin-maps`, `plugin-linear`) still reference the package and are untouched.

Closes #27173.