### PR TITLE
test(wallet): cover CCTP V2 bridge ABI structure

### DIFF
--- a/plugins/plugin-wallet/src/sdk/bridge/abis.test.ts
+++ b/plugins/plugin-wallet/src/sdk/bridge/abis.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { MessageTransmitterV2Abi, TokenMessengerV2Abi } from "./abis.ts";
+
+describe("CCTP V2 ABIs", () => {
+  describe("TokenMessengerV2Abi", () => {
+    it("exposes depositForBurn with burn inputs", () => {
+      const fn = TokenMessengerV2Abi.find((e) => e.name === "depositForBurn");
+      expect(fn).toBeDefined();
+      expect(fn?.type).toBe("function");
+      expect(fn?.stateMutability).toBe("nonpayable");
+      const inputTypes = fn?.inputs.map((i) => i.type) ?? [];
+      expect(inputTypes).toContain("uint256"); // amount
+      expect(inputTypes).toContain("uint32"); // destinationDomain
+      expect(inputTypes).toContain("bytes32"); // mintRecipient
+      expect(inputTypes).toContain("address"); // burnToken
+      expect(fn?.outputs?.[0]?.type).toBe("uint64"); // nonce
+    });
+
+    it("exposes depositForBurnWithHook with hookData", () => {
+      const fn = TokenMessengerV2Abi.find(
+        (e) => e.name === "depositForBurnWithHook",
+      );
+      expect(fn).toBeDefined();
+      const inputTypes = fn?.inputs.map((i) => i.type) ?? [];
+      expect(inputTypes).toContain("bytes"); // hookData
+    });
+
+    it("exposes localMessageTransmitter view returning address", () => {
+      const fn = TokenMessengerV2Abi.find(
+        (e) => e.name === "localMessageTransmitter",
+      );
+      expect(fn?.type).toBe("function");
+      expect(fn?.stateMutability).toBe("view");
+      expect(fn?.outputs?.[0]?.type).toBe("address");
+    });
+
+    it("exposes localDomain view returning uint32", () => {
+      const fn = TokenMessengerV2Abi.find((e) => e.name === "localDomain");
+      expect(fn?.stateMutability).toBe("view");
+      expect(fn?.outputs?.[0]?.type).toBe("uint32");
+    });
+  });
+
+  describe("MessageTransmitterV2Abi", () => {
+    it("exposes receiveMessage for minting on destination chain", () => {
+      const fn = MessageTransmitterV2Abi.find(
+        (e) => e.name === "receiveMessage",
+      );
+      expect(fn).toBeDefined();
+      expect(fn?.type).toBe("function");
+      expect(fn?.stateMutability).toBe("nonpayable");
+    });
+
+    it("exposes usedNonces for replay protection", () => {
+      const fn = MessageTransmitterV2Abi.find((e) => e.name === "usedNonces");
+      expect(fn).toBeDefined();
+      expect(fn?.stateMutability).toBe("view");
+      expect(fn?.inputs?.[0]?.type).toBe("bytes32");
+      expect(fn?.outputs?.[0]?.type).toBe("uint256");
+    });
+  });
+
+  it("all ABI entries are well-formed", () => {
+    for (const abi of [TokenMessengerV2Abi, MessageTransmitterV2Abi]) {
+      for (const entry of abi) {
+        expect(entry.name).toBeTruthy();
+        expect(entry.type).toBeTruthy();
+        if (entry.type === "function") {
+          expect(entry.inputs).toBeDefined();
+          expect(entry.outputs).toBeDefined();
+        }
+      }
+    }
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new `__tests__` file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `Test Files  1 passed (1)\n      Tests  7 passed (7)` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: 92d692518c3d832ac9b203076ef691a54e61a9fa
