### PR TITLE
fix(build): suppress spurious turbo output warning for synthetic-world

### DIFF
--- a/packages/synthetic-world/turbo.json
+++ b/packages/synthetic-world/turbo.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "outputs": []
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- `@elizaos/synthetic-world` runs `tsc --noEmit` as its build step — no output files are produced
- The root `turbo.json` declares `outputs: ["dist/**"]`, so turbo warns on every full-workspace build:
  ```
  WARNING  no output files found for task @elizaos/synthetic-world#build. Please check your `outputs` key in `turbo.json`
  ```
- Add a package-level `turbo.json` that extends the root config and sets `outputs: []`, matching what the build script actually does

## Test plan

- [ ] Run `bun run build` — `WARNING no output files found for task @elizaos/synthetic-world#build` no longer appears
- [ ] Run `node packages/scripts/run-turbo.mjs run build --filter=@elizaos/synthetic-world` — exits cleanly with no warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)