### PR TITLE
test(sql): cover node env and pglite dir resolution

### DIFF
--- a/plugins/plugin-sql/src/utils.node.test.ts
+++ b/plugins/plugin-sql/src/utils.node.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Unit coverage for plugin-sql node path/env resolution — tilde expansion,
+ * .env discovery walking up from a start directory, and the PGlite data
+ * directory resolution with monorepo detection and env overrides. A wrong
+ * resolution here would point the adapter at the wrong on-disk database or
+ * silently read the wrong .env during startup.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@elizaos/core", () => ({
+  ElizaError: class ElizaError extends Error {
+    code?: string;
+    context?: unknown;
+    constructor(message: string, opts?: { code?: string; context?: unknown; cause?: unknown }) {
+      super(message);
+      this.code = opts?.code;
+      this.context = opts?.context;
+    }
+  },
+}));
+
+vi.mock("dotenv", () => ({
+  default: {
+    config: vi.fn(() => {
+      process.env.PGLITE_DATA_DIR = "/dotenv/db";
+      return { parsed: {} };
+    }),
+  },
+  config: vi.fn(() => {
+    process.env.PGLITE_DATA_DIR = "/dotenv/db";
+    return { parsed: {} };
+  }),
+}));
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { expandTildePath, resolveEnvFile, resolvePgliteDir } from "./utils.node.ts";
+
+let tempRoot: string;
+
+beforeEach(() => {
+  tempRoot = mkdtempSync(path.join(tmpdir(), "sql-node-"));
+});
+
+afterEach(() => {
+  rmSync(tempRoot, { recursive: true, force: true });
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+describe("expandTildePath", () => {
+  it("returns the path unchanged when it does not start with ~", () => {
+    expect(expandTildePath("/data/db")).toBe("/data/db");
+    expect(expandTildePath("relative/path")).toBe("relative/path");
+  });
+
+  it("joins a tilde prefix onto cwd", () => {
+    const cwd = path.join(tempRoot, "app");
+    mkdirSync(cwd, { recursive: true });
+    vi.spyOn(process, "cwd").mockReturnValue(cwd);
+    expect(expandTildePath("~/data/db")).toBe(path.join(cwd, "/data/db"));
+  });
+
+  it("expands a bare tilde to cwd", () => {
+    const cwd = path.join(tempRoot, "app");
+    mkdirSync(cwd, { recursive: true });
+    vi.spyOn(process, "cwd").mockReturnValue(cwd);
+    expect(expandTildePath("~")).toBe(cwd);
+  });
+});
+
+describe("resolveEnvFile", () => {
+  it("finds the .env in the start directory", () => {
+    writeFileSync(path.join(tempRoot, ".env"), "A=1\n");
+    expect(resolveEnvFile(tempRoot)).toBe(path.join(tempRoot, ".env"));
+  });
+
+  it("walks up parent directories to find a .env", () => {
+    writeFileSync(path.join(tempRoot, ".env"), "A=1\n");
+    const nested = path.join(tempRoot, "a", "b", "c");
+    mkdirSync(nested, { recursive: true });
+    expect(resolveEnvFile(nested)).toBe(path.join(tempRoot, ".env"));
+  });
+
+  it("returns the start-dir candidate when no .env exists above", () => {
+    const nested = path.join(tempRoot, "a", "b");
+    mkdirSync(nested, { recursive: true });
+    expect(resolveEnvFile(nested)).toBe(path.join(nested, ".env"));
+  });
+
+  it("prefers the closest .env to the start directory", () => {
+    writeFileSync(path.join(tempRoot, ".env"), "A=root\n");
+    const nested = path.join(tempRoot, "a");
+    mkdirSync(nested, { recursive: true });
+    writeFileSync(path.join(nested, ".env"), "A=nested\n");
+    expect(resolveEnvFile(nested)).toBe(path.join(nested, ".env"));
+  });
+
+  it("defaults to process.cwd() when no start dir is given", () => {
+    const cwd = path.join(tempRoot, "cwd-app");
+    mkdirSync(cwd, { recursive: true });
+    writeFileSync(path.join(cwd, ".env"), "A=1\n");
+    vi.spyOn(process, "cwd").mockReturnValue(cwd);
+    expect(resolveEnvFile()).toBe(path.join(cwd, ".env"));
+  });
+});
+
+describe("resolvePgliteDir", () => {
+  it("honors an explicit dir argument", () => {
+    vi.stubEnv("ELIZA_BENCH_DISABLE_DOTENV", "1");
+    expect(resolvePgliteDir("/explicit/db")).toBe("/explicit/db");
+  });
+
+  it("honors PGLITE_DATA_DIR over fallback", () => {
+    vi.stubEnv("ELIZA_BENCH_DISABLE_DOTENV", "1");
+    vi.stubEnv("PGLITE_DATA_DIR", "/from/env/db");
+    expect(resolvePgliteDir(undefined, "/fallback/db")).toBe("/from/env/db");
+  });
+
+  it("uses the fallback dir when env is disabled and no env var is set", () => {
+    vi.stubEnv("ELIZA_BENCH_DISABLE_DOTENV", "1");
+    expect(resolvePgliteDir(undefined, "/fallback/db")).toBe("/fallback/db");
+  });
+
+  it("resolves a tilde-prefixed dir", () => {
+    vi.stubEnv("ELIZA_BENCH_DISABLE_DOTENV", "1");
+    const cwd = path.join(tempRoot, "app");
+    mkdirSync(cwd, { recursive: true });
+    vi.spyOn(process, "cwd").mockReturnValue(cwd);
+    expect(resolvePgliteDir("~/db", undefined)).toBe(path.join(cwd, "/db"));
+  });
+
+  it("detects a monorepo cwd and defaults under .eliza/.elizadb", () => {
+    vi.stubEnv("ELIZA_BENCH_DISABLE_DOTENV", "1");
+    const cwd = path.join(tempRoot, "repo");
+    mkdirSync(path.join(cwd, "packages", "core"), { recursive: true });
+    vi.spyOn(process, "cwd").mockReturnValue(cwd);
+    expect(resolvePgliteDir(undefined, undefined)).toBe(path.join(cwd, ".eliza", ".elizadb"));
+  });
+
+  it("detects a monorepo two levels up", () => {
+    vi.stubEnv("ELIZA_BENCH_DISABLE_DOTENV", "1");
+    // cwd sits inside a package, e.g. <repo>/packages/plugin-sql
+    const cwd = path.join(tempRoot, "repo", "packages", "plugin-sql");
+    mkdirSync(path.join(tempRoot, "repo", "packages", "core"), {
+      recursive: true,
+    });
+    vi.spyOn(process, "cwd").mockReturnValue(cwd);
+    expect(resolvePgliteDir(undefined, undefined)).toBe(
+      path.join(tempRoot, "repo", ".eliza", ".elizadb")
+    );
+  });
+
+  it("falls back to cwd/.eliza/.elizadb outside a monorepo", () => {
+    vi.stubEnv("ELIZA_BENCH_DISABLE_DOTENV", "1");
+    const cwd = path.join(tempRoot, "standalone");
+    mkdirSync(cwd, { recursive: true });
+    vi.spyOn(process, "cwd").mockReturnValue(cwd);
+    expect(resolvePgliteDir(undefined, undefined)).toBe(path.join(cwd, ".eliza", ".elizadb"));
+  });
+
+  it("loads .env when dotenv is not disabled", () => {
+    const cwd = path.join(tempRoot, "env-app");
+    mkdirSync(cwd, { recursive: true });
+    writeFileSync(path.join(cwd, ".env"), "PGLITE_DATA_DIR=/dotenv/db\n");
+    vi.spyOn(process, "cwd").mockReturnValue(cwd);
+    // dotenv mock writes PGLITE_DATA_DIR into the environment on config().
+    expect(resolvePgliteDir(undefined, "/fallback/db")).toBe("/dotenv/db");
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for existing pure path/env resolution helpers. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# What changed

Unit coverage for the plugin-sql node path/env helpers in `utils.node.ts`:

- `expandTildePath`: passthrough for non-tilde paths, tilde join onto cwd
- `resolveEnvFile`: `.env` discovery in the start dir, walking up parents,
  closest-file preference, `process.cwd()` default
- `resolvePgliteDir`: explicit dir / `PGLITE_DATA_DIR` / fallback precedence,
  monorepo detection (cwd and two-up), non-monorepo cwd fallback, tilde
  expansion, and `.env` loading when dotenv is not disabled

A wrong resolution would point the adapter at the wrong on-disk database or
silently read the wrong `.env` during startup.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new test file exercising existing exported pure
functions with temp-dir fixtures. No production code is modified, no runtime
behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `npx vitest run plugins/plugin-sql/src/utils.node.test.ts` — 16 passed (16) |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: 92d692518c3d832ac9b203076ef691a54e61a9fa
