### PR TITLE
test(finances): cover subscription playbook lookup

### DIFF
--- a/plugins/plugin-finances/src/subscriptions-playbooks.test.ts
+++ b/plugins/plugin-finances/src/subscriptions-playbooks.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Unit coverage for the subscription-cancellation playbook registry lookup:
+ * `findLifeOpsSubscriptionPlaybook` resolves a discovered subscription
+ * (service name, slug, or alias) to the automation playbook used to cancel
+ * it. A wrong match routes the user into another service's cancellation
+ * flow — a real behavioral hazard — so matching must be exact on
+ * key/serviceName/aliases and conservative on fuzzy substring fallback.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  findLifeOpsSubscriptionPlaybook,
+  listLifeOpsSubscriptionPlaybooks,
+} from "./subscriptions-playbooks";
+
+describe("listLifeOpsSubscriptionPlaybooks", () => {
+  it("returns a non-empty registry with unique keys", () => {
+    const playbooks = listLifeOpsSubscriptionPlaybooks();
+    expect(playbooks.length).toBeGreaterThan(10);
+    const keys = new Set(playbooks.map((p) => p.key));
+    expect(keys.size).toBe(playbooks.length);
+  });
+});
+
+describe("findLifeOpsSubscriptionPlaybook", () => {
+  it("returns null for empty input", () => {
+    expect(findLifeOpsSubscriptionPlaybook(null)).toBeNull();
+    expect(findLifeOpsSubscriptionPlaybook(undefined)).toBeNull();
+    expect(findLifeOpsSubscriptionPlaybook("")).toBeNull();
+  });
+
+  it("matches by exact service name", () => {
+    expect(findLifeOpsSubscriptionPlaybook("Netflix")?.key).toBe("netflix");
+    expect(findLifeOpsSubscriptionPlaybook("Spotify")?.key).toBe("spotify");
+  });
+
+  it("matches by registry key", () => {
+    expect(findLifeOpsSubscriptionPlaybook("disney_plus")?.key).toBe(
+      "disney_plus",
+    );
+  });
+
+  it("matches by alias", () => {
+    expect(findLifeOpsSubscriptionPlaybook("coursera")?.key).toBe(
+      "coursera_plus",
+    );
+  });
+
+  it("normalizes case, punctuation, and whitespace", () => {
+    expect(findLifeOpsSubscriptionPlaybook("  NETFLIX!  ")?.key).toBe(
+      "netflix",
+    );
+    expect(findLifeOpsSubscriptionPlaybook("Disney+")?.key).toBe("disney_plus");
+    expect(findLifeOpsSubscriptionPlaybook("Amazon Prime Video")?.key).toBe(
+      "amazon_prime_video",
+    );
+  });
+
+  it("returns null when no playbook matches", () => {
+    expect(
+      findLifeOpsSubscriptionPlaybook("Definitely Not A Service"),
+    ).toBeNull();
+  });
+
+  it("does not fuzzy-match a bare substring onto a larger service name", () => {
+    // "apple" is a substring of "apple_tv_plus" and "apple_subscriptions",
+    // but the fuzzy fallback only fires when the *input* contains a full
+    // registered name — a bare fragment must not route the user into a
+    // wrong service's cancellation flow.
+    expect(findLifeOpsSubscriptionPlaybook("apple")).toBeNull();
+  });
+
+  it("matches a service name containing spaces after normalization", () => {
+    expect(findLifeOpsSubscriptionPlaybook("Google Play")?.key).toBe(
+      "google_play",
+    );
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for the subscription-cancellation playbook lookup. -->

## Summary

Adds focused unit coverage for `findLifeOpsSubscriptionPlaybook` and `listLifeOpsSubscriptionPlaybooks` in `plugins/plugin-finances/src/subscriptions-playbooks.ts`. A wrong match here routes a user into another service's cancellation flow — so the tests pin the matching contract: exact matches on `key`/`serviceName`/`aliases`, case/punctuation/whitespace normalization, the conservative fuzzy fallback (a bare substring fragment like `"apple"` must NOT match `apple_tv_plus`/`apple_subscriptions`), and `null` for unknown services.

No production code is modified.

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new test file exercising existing exported pure
functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `<TEST_OUTPUT>` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
