### PR TITLE
test(elizacloud): cover cache-warming 503 retry detection

### DIFF
--- a/plugins/plugin-elizacloud/src/utils/warming.test.ts
+++ b/plugins/plugin-elizacloud/src/utils/warming.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Tests for `warmingRetryWaitSeconds` — cloud cache-warming 503 detection.
+ *
+ * Core contract: only the gateway's explicit warming shape earns a retry
+ * wait; every other status or body yields null so callers fail fast. A
+ * warming 503 must survive a body peek (clone) so the caller can still
+ * consume the response, and retryAfter is clamped to the 3s ceiling with a
+ * 1.5s default.
+ */
+
+import { describe, expect, it } from "vitest";
+import { warmingRetryWaitSeconds } from "./warming";
+
+function jsonResponse(status: number, body: unknown): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { "content-type": "application/json" },
+	});
+}
+
+describe("warmingRetryWaitSeconds", () => {
+	it("returns null for non-503 statuses", async () => {
+		const resp = jsonResponse(500, { error: { code: "internal" } });
+		expect(await warmingRetryWaitSeconds(resp)).toBeNull();
+	});
+
+	it("returns null for a 503 without a warming shape", async () => {
+		const resp = jsonResponse(503, { error: { code: "rate_limited" } });
+		expect(await warmingRetryWaitSeconds(resp)).toBeNull();
+	});
+
+	it("recognizes a top-level _cache_warming code", async () => {
+		const resp = jsonResponse(503, { code: "model_cache_warming" });
+		expect(await warmingRetryWaitSeconds(resp)).toBe(1.5);
+	});
+
+	it("recognizes an error-nested _cache_warming code", async () => {
+		const resp = jsonResponse(503, {
+			error: { code: "admission_cache_warming" },
+		});
+		expect(await warmingRetryWaitSeconds(resp)).toBe(1.5);
+	});
+
+	it("recognizes service_unavailable as a warming shape", async () => {
+		const codeResp = jsonResponse(503, { error: { code: "service_unavailable" } });
+		expect(await warmingRetryWaitSeconds(codeResp)).toBe(1.5);
+
+		const typeResp = jsonResponse(503, { error: { type: "service_unavailable" } });
+		expect(await warmingRetryWaitSeconds(typeResp)).toBe(1.5);
+	});
+
+	it("respects a positive retryAfter under the ceiling", async () => {
+		const resp = jsonResponse(503, {
+			error: { code: "model_cache_warming", retryAfter: 2 },
+		});
+		expect(await warmingRetryWaitSeconds(resp)).toBe(2);
+	});
+
+	it("clamps retryAfter to the 3s ceiling", async () => {
+		const resp = jsonResponse(503, {
+			error: { code: "model_cache_warming", retryAfter: 30 },
+		});
+		expect(await warmingRetryWaitSeconds(resp)).toBe(3);
+	});
+
+	it("falls back to 1.5s for zero or invalid retryAfter", async () => {
+		const zero = jsonResponse(503, {
+			error: { code: "model_cache_warming", retryAfter: 0 },
+		});
+		expect(await warmingRetryWaitSeconds(zero)).toBe(1.5);
+
+		const negative = jsonResponse(503, {
+			error: { code: "model_cache_warming", retryAfter: -5 },
+		});
+		expect(await warmingRetryWaitSeconds(negative)).toBe(1.5);
+
+		const nan = jsonResponse(503, {
+			error: { code: "model_cache_warming", retryAfter: NaN },
+		});
+		expect(await warmingRetryWaitSeconds(nan)).toBe(1.5);
+	});
+
+	it("reads the body via a clone, leaving the caller's body intact", async () => {
+		const resp = jsonResponse(503, { error: { code: "model_cache_warming" } });
+		const wait = await warmingRetryWaitSeconds(resp);
+
+		expect(wait).toBe(1.5);
+		// The caller can still consume the original body.
+		const body = (await resp.json()) as { error: { code: string } };
+		expect(body.error.code).toBe("model_cache_warming");
+	});
+
+	it("returns null for a non-JSON 503 body", async () => {
+		const resp = new Response("<html>Service Unavailable</html>", {
+			status: 503,
+			headers: { "content-type": "text/html" },
+		});
+		expect(await warmingRetryWaitSeconds(resp)).toBeNull();
+	});
+
+	it("returns null for an empty 503 body", async () => {
+		const resp = new Response("", { status: 503 });
+		expect(await warmingRetryWaitSeconds(resp)).toBeNull();
+	});
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new test file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `Test Files  1 passed (1)
      Tests  11 passed (11)` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
