### PR TITLE
test(agent-skills): cover Binance compat text-content extraction

### DIFF
--- a/plugins/plugin-agent-skills/src/binance/compat-utils.test.ts
+++ b/plugins/plugin-agent-skills/src/binance/compat-utils.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { extractCompatTextContent } from "./compat-utils";
+
+describe("extractCompatTextContent", () => {
+  it("passes a raw string through unchanged", () => {
+    expect(extractCompatTextContent("hello")).toBe("hello");
+    expect(extractCompatTextContent("")).toBe("");
+  });
+
+  it("joins text parts from an array, skipping non-text entries", () => {
+    const content = [
+      { type: "text", text: "first " },
+      { type: "text", text: "second" },
+      { type: "image", text: "ignored" },
+      { type: "text", text: "" },
+    ];
+    expect(extractCompatTextContent(content)).toBe("first second");
+  });
+
+  it("skips non-object and missing-text array entries", () => {
+    const content = [null, 42, "raw", { text: "kept" }, { type: "text" }];
+    expect(extractCompatTextContent(content)).toBe("kept");
+  });
+
+  it("keeps text-only array entries even without an explicit type", () => {
+    expect(extractCompatTextContent([{ text: "a" }, { text: "b" }])).toBe("ab");
+  });
+
+  it("reads a { text } object payload", () => {
+    expect(extractCompatTextContent({ text: "object text" })).toBe(
+      "object text",
+    );
+  });
+
+  it("returns empty string for a { text } object with non-string text", () => {
+    expect(extractCompatTextContent({ text: 123 })).toBe("");
+    expect(extractCompatTextContent({ text: "" })).toBe("");
+  });
+
+  it("returns empty string for unsupported shapes", () => {
+    expect(extractCompatTextContent(null)).toBe("");
+    expect(extractCompatTextContent(undefined)).toBe("");
+    expect(extractCompatTextContent(42)).toBe("");
+    expect(extractCompatTextContent(true)).toBe("");
+  });
+
+  it("drops text entries whose type is not the string 'text'", () => {
+    expect(extractCompatTextContent([{ type: "Text", text: "x" }])).toBe("");
+    expect(extractCompatTextContent([{ type: "text", text: "x" }])).toBe("x");
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new test file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `Test Files  1 passed (1)
      Tests  8 passed (8)` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
