### PR TITLE
test(computeruse): cover route path component decoding

### DIFF
--- a/plugins/plugin-computeruse/src/routes/route-utils.test.ts
+++ b/plugins/plugin-computeruse/src/routes/route-utils.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { decodePathComponent } from "./route-utils";
+
+describe("decodePathComponent", () => {
+  it("passes through plain segments unchanged", () => {
+    expect(decodePathComponent("abc")).toBe("abc");
+    expect(decodePathComponent("")).toBe("");
+  });
+
+  it("decodes percent-encoded characters", () => {
+    expect(decodePathComponent("a%20b")).toBe("a b");
+    expect(decodePathComponent("%2Fetc%2Fpasswd")).toBe("/etc/passwd");
+  });
+
+  it("decodes UTF-8 multibyte sequences", () => {
+    expect(decodePathComponent("%E4%B8%AD%E6%96%87")).toBe("中文");
+  });
+
+  it("returns null for malformed percent-encoding", () => {
+    expect(decodePathComponent("%zz")).toBeNull();
+    expect(decodePathComponent("a%")).toBeNull();
+    expect(decodePathComponent("%E4%B8%AD%")).toBeNull();
+  });
+
+  it("returns null for a lone surrogate escape", () => {
+    expect(decodePathComponent("%ED%A0%80")).toBeNull();
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new test file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `Test Files  1 passed (1)
      Tests  5 passed (5)` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
