### PR TITLE
test(wallet): cover DexScreener error message normalization

### DIFF
--- a/plugins/plugin-wallet/src/analytics/dexscreener/errors.test.ts
+++ b/plugins/plugin-wallet/src/analytics/dexscreener/errors.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { dexScreenerErrorMessage } from "./errors";
+
+describe("dexScreenerErrorMessage", () => {
+  it("returns a raw string unchanged", () => {
+    expect(dexScreenerErrorMessage("rate limited")).toBe("rate limited");
+    expect(dexScreenerErrorMessage("")).toBe("");
+  });
+
+  it("returns the message of an Error instance", () => {
+    expect(dexScreenerErrorMessage(new Error("boom"))).toBe("boom");
+  });
+
+  it("prefers the nested response.data.message for fetch errors", () => {
+    const caught = {
+      response: { data: { message: "DexScreener API: 429" } },
+      message: "Request failed with status code 429",
+    };
+    expect(dexScreenerErrorMessage(caught)).toBe("DexScreener API: 429");
+  });
+
+  it("falls back to the top-level message when response data has none", () => {
+    const caught = { response: { data: {} }, message: "socket hang up" };
+    expect(dexScreenerErrorMessage(caught)).toBe("socket hang up");
+  });
+
+  it("falls back to the top-level message when response is absent", () => {
+    expect(dexScreenerErrorMessage({ message: "ECONNRESET" })).toBe(
+      "ECONNRESET",
+    );
+  });
+
+  it("returns the generic fallback for unknown shapes", () => {
+    expect(dexScreenerErrorMessage(42)).toBe("Request failed");
+    expect(dexScreenerErrorMessage(null)).toBe("Request failed");
+    expect(dexScreenerErrorMessage(undefined)).toBe("Request failed");
+  });
+
+  it("returns the generic fallback when both messages are non-strings", () => {
+    expect(
+      dexScreenerErrorMessage({ response: { data: { message: 42 } } }),
+    ).toBe("Request failed");
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new test file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `Test Files  1 passed (1)
      Tests  7 passed (7)` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
