### PR TITLE
test(native-filesystem): cover device path sanitisation

### DIFF
--- a/plugins/plugin-native-filesystem/src/path.test.ts
+++ b/plugins/plugin-native-filesystem/src/path.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Tests for device-filesystem path sanitisation.
+ *
+ * Materiality: every relative path from a caller passes through
+ * `normalizeDevicePath` before either backend touches it. Accepting an
+ * absolute path, a `..` segment, or a NUL byte here would let a caller read
+ * or write outside the backend root (path traversal on the device bridge).
+ * The `.`-segment post-normalize check is defense-in-depth: a path that
+ * collapses to the root must be rejected unless explicitly allowed.
+ */
+import { describe, expect, it } from "vitest";
+import { normalizeDevicePath } from "./path";
+
+describe("normalizeDevicePath", () => {
+	it("rejects empty paths unless allowRoot is set", () => {
+		expect(() => normalizeDevicePath("")).toThrow(/path is required/);
+		expect(normalizeDevicePath("", { allowRoot: true })).toEqual({
+			relative: "",
+			segments: [],
+		});
+	});
+
+	it("rejects non-string inputs", () => {
+		expect(() => normalizeDevicePath(null as unknown as string)).toThrow(
+			/path is required/,
+		);
+		expect(() => normalizeDevicePath(42 as unknown as string)).toThrow(
+			/path is required/,
+		);
+	});
+
+	it("rejects NUL bytes", () => {
+		expect(() => normalizeDevicePath("a\0b")).toThrow(/NUL byte/);
+	});
+
+	it("rejects absolute POSIX paths", () => {
+		expect(() => normalizeDevicePath("/etc/passwd")).toThrow(
+			/absolute paths are not allowed/,
+		);
+		expect(() => normalizeDevicePath("/")).toThrow(
+			/absolute paths are not allowed/,
+		);
+	});
+
+	it("rejects absolute Windows paths in both separator styles", () => {
+		expect(() => normalizeDevicePath("C:/Users/x")).toThrow(
+			/absolute paths are not allowed/,
+		);
+		expect(() => normalizeDevicePath("C:\\Users\\x")).toThrow(
+			/absolute paths are not allowed/,
+		);
+	});
+
+	it("rejects `..` traversal segments anywhere in the path", () => {
+		for (const hostile of ["..", "../x", "a/../b", "a/../../b", "a/.."]) {
+			expect(() => normalizeDevicePath(hostile)).toThrow(
+				/path traversal is not allowed/,
+			);
+		}
+	});
+
+	it("rejects paths that normalize to the root", () => {
+		expect(() => normalizeDevicePath("a/..", { allowRoot: true })).toThrow(
+			/path traversal is not allowed/,
+		);
+	});
+
+	it("normalizes separators and redundant slashes", () => {
+		expect(normalizeDevicePath("a\\b//c/")).toEqual({
+			relative: "a/b/c",
+			segments: ["a", "b", "c"],
+		});
+	});
+
+	it("collapses interior dot segments to the canonical form", () => {
+		expect(normalizeDevicePath("a/./b")).toEqual({
+			relative: "a/b",
+			segments: ["a", "b"],
+		});
+	});
+
+	it("preserves dot-prefixed segments (hidden files) as data", () => {
+		expect(normalizeDevicePath(".hidden/file")).toEqual({
+			relative: ".hidden/file",
+			segments: [".hidden", "file"],
+		});
+	});
+
+	it("allows the root explicitly via allowRoot", () => {
+		expect(normalizeDevicePath(".", { allowRoot: true })).toEqual({
+			relative: "",
+			segments: [],
+		});
+		expect(normalizeDevicePath("", { allowRoot: true })).toEqual({
+			relative: "",
+			segments: [],
+		});
+	});
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new test file exercising existing exported
pure function `normalizeDevicePath` (path sanitisation). No
production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `Test Files 1 passed (1); Tests 11 passed (11)` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
