### PR TITLE
test(sql): cover adapter readiness error classification

### DIFF
--- a/plugins/plugin-sql/src/adapter-readiness.test.ts
+++ b/plugins/plugin-sql/src/adapter-readiness.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import {
+  createAdapterReadinessError,
+  describeAdapterReadinessError,
+  isMissingDatabaseAdapterError,
+} from "./adapter-readiness";
+
+describe("describeAdapterReadinessError", () => {
+  it("returns the Error message for Error instances", () => {
+    expect(describeAdapterReadinessError(new Error("boom"))).toBe("boom");
+  });
+
+  it("stringifies non-Error values", () => {
+    expect(describeAdapterReadinessError("raw string")).toBe("raw string");
+    expect(describeAdapterReadinessError(42)).toBe("42");
+    expect(describeAdapterReadinessError(undefined)).toBe("undefined");
+    expect(describeAdapterReadinessError(null)).toBe("null");
+  });
+});
+
+describe("isMissingDatabaseAdapterError", () => {
+  it("returns true when the message carries the missing-adapter marker", () => {
+    expect(isMissingDatabaseAdapterError(new Error("Database adapter not registered"))).toBe(true);
+    expect(isMissingDatabaseAdapterError("Database adapter not registered for agent 7")).toBe(true);
+  });
+
+  it("returns false for unrelated errors and values", () => {
+    expect(isMissingDatabaseAdapterError(new Error("connection refused"))).toBe(false);
+    expect(isMissingDatabaseAdapterError("nope")).toBe(false);
+    expect(isMissingDatabaseAdapterError(null)).toBe(false);
+    expect(isMissingDatabaseAdapterError(undefined)).toBe(false);
+  });
+});
+
+describe("createAdapterReadinessError", () => {
+  it("wraps the cause with the typed code and preserves context", () => {
+    const cause = new Error("underlying failure");
+    const err = createAdapterReadinessError(cause, {
+      agentId: "agent-123",
+      entrypoint: "node",
+    });
+
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe("ElizaError");
+    expect(err.code).toBe("DB_ADAPTER_READY_CHECK_FAILED");
+    expect(err.message).toBe("Database adapter readiness check failed");
+    expect(err.cause).toBe(cause);
+    expect(err.context).toEqual({
+      agentId: "agent-123",
+      entrypoint: "node",
+    });
+  });
+
+  it("preserves the entrypoint and agentId verbatim (no mutation)", () => {
+    const err = createAdapterReadinessError(new Error("x"), {
+      agentId: "agent-9",
+      entrypoint: "browser",
+    });
+    expect(err.context.entrypoint).toBe("browser");
+    expect(err.context.agentId).toBe("agent-9");
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new test file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `<TEST_OUTPUT>` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
