### PR TITLE
chore(shared): remove three unused direct dependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1067,21 +1067,16 @@
         "@elizaos/registry": "workspace:*",
         "chalk": "^6.0.0",
         "drizzle-orm": "0.45.2",
-        "phonemizer": "^1.2.1",
         "react": "^19.0.0",
         "yaml": "^2.8.2",
         "zod": "^4.4.3",
       },
       "devDependencies": {
-        "@types/figlet": "^1.7.0",
         "@typescript/native": "npm:typescript@^7.0.2",
         "bun-types": "^1.3.12",
         "typescript": "^6.0.3",
         "vite": "^8.0.0",
         "vitest": "^4.1.10",
-      },
-      "optionalDependencies": {
-        "figlet": "^1.11.0",
       },
     },
     "packages/skills": {
@@ -6271,8 +6266,6 @@
     "@types/express": ["@types/express@5.0.6", "", { "dependencies": { "@types/body-parser": "*", "@types/express-serve-static-core": "^5.0.0", "@types/serve-static": "^2" } }, "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA=="],
 
     "@types/express-serve-static-core": ["@types/express-serve-static-core@5.1.3", "", { "dependencies": { "@types/node": "*", "@types/qs": "*", "@types/range-parser": "*", "@types/send": "*" } }, "sha512-dPfW8NFiOF4wOHc7+N/QSxlY9cfSsenewGbAz8C8U/MULPd/YZ27LvJUIlzaXie7e6Ove9YunJGgC9tbHD2cKw=="],
-
-    "@types/figlet": ["@types/figlet@1.7.0", "", {}, "sha512-KwrT7p/8Eo3Op/HBSIwGXOsTZKYiM9NpWRBJ5sVjWP/SmlS+oxxRvJht/FNAtliJvja44N3ul1yATgohnVBV0Q=="],
 
     "@types/fluent-ffmpeg": ["@types/fluent-ffmpeg@2.1.28", "", { "dependencies": { "@types/node": "*" } }, "sha512-5ovxsDwBcPfJ+eYs1I/ZpcYCnkce7pvH9AHSvrZllAp1ZPpTRDZAFjF3TRFbukxSgIYTTNYePbS0rKUmaxVbXw=="],
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -542,16 +542,11 @@
     "@elizaos/registry": "workspace:*",
     "chalk": "^6.0.0",
     "drizzle-orm": "0.45.2",
-    "phonemizer": "^1.2.1",
     "react": "^19.0.0",
     "yaml": "^2.8.2",
     "zod": "^4.4.3"
   },
-  "optionalDependencies": {
-    "figlet": "^1.11.0"
-  },
   "devDependencies": {
-    "@types/figlet": "^1.7.0",
     "bun-types": "^1.3.12",
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "^6.0.3",


### PR DESCRIPTION
Closes #27169.


## Summary

Remove the unused `phonemizer`, optional `figlet`, and `@types/figlet` direct dependencies from `@elizaos/shared`, then regenerate the root lockfile. The real runtime owners remain unchanged: `@elizaos/plugin-local-inference` still owns `phonemizer`, and `@elizaos/app-core` still owns `figlet`.

Audited base: `126807701e19a2a88b7f50ce785df4b26506007a` (`origin/develop`)

Validated PR head: `8cda82353189179fdf3c6e6712fe83dd9085cf83`

## Acceptance criteria

- [x] Exact searches rerun. No `packages/shared` source import/reference exists for the three packages; the two runtime consumers remain in their owning manifests.
- [x] Removed `phonemizer` from shared dependencies, `figlet` from shared optional dependencies, and `@types/figlet` from shared dev dependencies.
- [x] Regenerated `bun.lock`. The shared importer lost all three entries; the now-unowned `@types/figlet` package record was removed. Global `figlet` and `phonemizer` records remain because app-core and plugin-local-inference still consume them.
- [x] Frozen install passed on the exact PR head.
- [x] Shared build, full tests, `tsc --noEmit`, and lint passed.
- [x] The exact phonemizer and figlet consumer tests passed by absolute test-file path; both consumer package typechecks passed.
- [x] Root `bun run verify` passed on the exact PR head.
- [x] Exact commands, exit statuses, elapsed times, and maximum resident-set sizes are recorded below.

## Before / after reproduction

Before, at `126807701e19a2a88b7f50ce785df4b26506007a`:

```text
$ /usr/bin/time -l node -e '<manifest assertion>' /Volumes/thescoho_1TB/Developer/worktrees/eliza-27169/packages/shared/package.json
FAIL unexpected @elizaos/shared direct dependencies: dependencies:phonemizer=^1.2.1, optionalDependencies:figlet=^1.11.0, devDependencies:@types/figlet=^1.7.0
        0.04 real         0.02 user         0.00 sys
            47038464  maximum resident set size
```

After:

```text
$ /usr/bin/time -l node -e '<same manifest assertion>' /Volumes/thescoho_1TB/Developer/worktrees/eliza-27169/packages/shared/package.json
PASS @elizaos/shared has no targeted direct dependencies
        0.03 real         0.02 user         0.00 sys
            47087616  maximum resident set size
```

Exact source and ownership searches:

```text
$ if rg -n --glob '*.{ts,tsx,js,jsx,mjs,cjs}' 'from[[:space:]]+["'"'](phonemizer|figlet)["'"']|import\(["'"'](phonemizer|figlet)["'"']\)|require\(["'"'](phonemizer|figlet)["'"']\)' packages/shared; then echo 'FAIL shared source consumer found'; exit 1; else echo 'PASS no packages/shared source imports of phonemizer or figlet'; fi
PASS no packages/shared source imports of phonemizer or figlet

$ if rg -n --glob '*.{ts,tsx,js,jsx,mjs,cjs}' '@types/figlet' packages/shared; then echo 'FAIL shared source reference found'; exit 1; else echo 'PASS no packages/shared source references to @types/figlet'; fi
PASS no packages/shared source references to @types/figlet

$ node -e '<print owning manifests>'
plugins/plugin-local-inference/package.json {"phonemizer":"^1.2.1"}
packages/app-core/package.json {"figlet":"^1.11.0"}

$ if awk '/"packages\/shared": \{/{found=1} found{print} /"packages\/skills": \{/{exit}' bun.lock | rg -n '"(phonemizer|figlet|@types/figlet)"'; then echo 'FAIL packages/shared lock importer still contains a targeted dependency'; exit 1; else echo 'PASS packages/shared lock importer has no targeted dependencies'; fi
PASS packages/shared lock importer has no targeted dependencies

$ if rg -n '"@types/figlet"' bun.lock; then echo 'FAIL unowned @types/figlet package record remains'; exit 1; else echo 'PASS bun.lock has no @types/figlet package record'; fi
PASS bun.lock has no @types/figlet package record
```

Open-overlap search:

```text
$ gh pr list --repo elizaOS/eliza --state open --search '27169 OR "remove three unused direct dependencies" OR "phonemizer figlet shared"' --json number,title,headRefName,url
[]
```

## Verification

All commands below ran from the isolated issue worktree. Maximum RSS is the `maximum resident set size` value printed by macOS `/usr/bin/time -l`.

| Command | Status | Actual terminal summary | Elapsed | Max RSS |
| --- | ---: | --- | ---: | ---: |
| `bun install --lockfile-only` | 0 | `Saved bun.lock (3997 packages) [4.68s]` | 4.70s | 842,022,912 B |
| `bunx @biomejs/biome check --write packages/shared/package.json bun.lock` | 0 | `Checked 1 file in 7ms. No fixes applied.` | 3.73s | 48,201,728 B |
| `bun install --frozen-lockfile` at exact head | 0 | `Checked 3721 installs across 3997 packages (no changes) [4.80s]` | 4.83s | 206,651,392 B |
| `bun run --cwd /Volumes/thescoho_1TB/Developer/worktrees/eliza-27169/packages/shared build` | 0 | `[rewrite-dist-relative-imports] rewrote 5 file(s)` | 2.54s | 639,500,288 B |
| `bun run --cwd /Volumes/thescoho_1TB/Developer/worktrees/eliza-27169/packages/shared test` | 0 | `Test Files 246 passed (246)` / `Tests 2920 passed (2920)` | 28.83s | 528,826,368 B |
| `bun run --cwd /Volumes/thescoho_1TB/Developer/worktrees/eliza-27169/packages/shared typecheck` | 0 | `tsc --noEmit -p tsconfig.json` | 1.12s | 1,251,098,624 B |
| `bun run --cwd /Volumes/thescoho_1TB/Developer/worktrees/eliza-27169/packages/shared lint:check` | 0 | `Checked 523 files in 373ms. No fixes applied.` | 3.46s | 140,443,648 B |
| `node /Volumes/thescoho_1TB/Developer/worktrees/eliza-27169/packages/scripts/run-vitest.mjs run --config /Volumes/thescoho_1TB/Developer/worktrees/eliza-27169/plugins/plugin-local-inference/vitest.config.ts /Volumes/thescoho_1TB/Developer/worktrees/eliza-27169/plugins/plugin-local-inference/src/services/voice/kokoro/__tests__/phonemizer.test.ts` | 0 | `Test Files 1 passed (1)` / `Tests 3 passed (3)` | 0.87s | 107,692,032 B |
| `node /Volumes/thescoho_1TB/Developer/worktrees/eliza-27169/packages/scripts/run-vitest.mjs run --config /Volumes/thescoho_1TB/Developer/worktrees/eliza-27169/packages/app-core/vitest.config.ts /Volumes/thescoho_1TB/Developer/worktrees/eliza-27169/packages/app-core/src/runtime/dev-settings-figlet-heading.test.ts` | 0 | `Test Files 1 passed (1)` / `Tests 18 passed (18)` | 0.54s | 112,099,328 B |
| `bun run --cwd /Volumes/thescoho_1TB/Developer/worktrees/eliza-27169/plugins/plugin-local-inference typecheck` | 0 | `tsc --noEmit -p tsconfig.json` | 2.86s | 1,412,644,864 B |
| `bun run --cwd /Volumes/thescoho_1TB/Developer/worktrees/eliza-27169/packages/app-core typecheck` | 0 | `tsc --noEmit -p tsconfig.json` | 4.91s | 4,703,584,256 B |
| `bun run verify` at `8cda82353189179fdf3c6e6712fe83dd9085cf83` | 0 | `[anti-larp] scanned 11213 test files — 0 focused, 0 orphaned skip(s)` / `[anti-larp] clean — no focused tests, no untracked skips.` | 57.82s | 1,858,519,040 B |

Exact final root output:

```text
$ bun run verify
[audit-test-lane-membership] ✓ every test-bearing package is accounted for
[view-inventory] 20 target(s), 0 exclusion(s); wrote reports/view-bundle-inventory.json
[plugin-view-inventory] 39 view(s) from 21 source(s): 17 built-in, 22 plugin; wrote reports/plugin-view-inventory.json and reports/plugin-view-inventory.md
[anti-larp] scanned 11213 test files — 0 focused, 0 orphaned skip(s)
[anti-larp] clean — no focused tests, no untracked skips.
EXIT_STATUS=0
       57.82 real        57.81 user        11.19 sys
          1858519040  maximum resident set size
```

### Control and setup notes

- The first shared test run in the fresh worktree exited 1 because generated i18n files were absent (`31 failed | 215 passed`, `2496 passed`). Running the documented shared build generated those files; the identical full-path test then passed all 246 files and 2,920 tests.
- Before prerequisite builds, branch shared typecheck reported three missing built-workspace module errors. The untouched detached control at the exact base SHA reported those same three plus two additional environment-resolution errors, so the change introduced zero new errors. After building the documented prerequisites, branch shared typecheck passed with exit 0.
- The first root verify attempt exited 1 at 212/214 Turbo tasks because this worktree's installed `@elevenlabs/elevenlabs-js@2.64.0` artifact was missing its declared `index.d.ts`; the identical locked artifact in the shared checkout contained it. Restoring the incomplete installed artifact introduced no source changes. The final exact-head root verify above passed.

## Evidence gate

- [x] Logs: command output and measurements are quoted above.
- [x] Domain artifact: `packages/shared/package.json` and `bun.lock` diff; exact source/importer/owner searches are quoted above.
- [x] Screenshots: N/A - source-only dependency manifest and lockfile cleanup; no rendered behavior changed.
- [x] Recordings: N/A - source-only dependency manifest and lockfile cleanup; no interactive flow changed.
- [x] Live-model trajectories: N/A - no model, prompt, action, provider, or agent behavior changed.


# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:8cda82353189179fdf3c6e6712fe83dd9085cf83 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-eliza"} -->
