### PR TITLE
test(cloud-shared): cover idempotent-webhook-recorder

### DIFF
--- a/packages/cloud/shared/src/lib/services/idempotent-webhook-recorder.test.ts
+++ b/packages/cloud/shared/src/lib/services/idempotent-webhook-recorder.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Pins the in-memory idempotent webhook recorder contract: the first
+ * (provider, eventId) pair records, repeats are suppressed, and providers are
+ * isolated from one another.
+ */
+import { describe, expect, test } from "bun:test";
+import { createInMemoryIdempotentWebhookRecorder } from "./idempotent-webhook-recorder";
+
+describe("createInMemoryIdempotentWebhookRecorder", () => {
+  test("records a first-seen event as new", async () => {
+    const recorder = createInMemoryIdempotentWebhookRecorder();
+    expect(await recorder.recordIfNew("twilio", "event-1")).toBe(true);
+  });
+
+  test("rejects a repeated event for the same provider", async () => {
+    const recorder = createInMemoryIdempotentWebhookRecorder();
+    await recorder.recordIfNew("twilio", "event-1");
+    expect(await recorder.recordIfNew("twilio", "event-1")).toBe(false);
+  });
+
+  test("accepts a distinct event id for the same provider", async () => {
+    const recorder = createInMemoryIdempotentWebhookRecorder();
+    await recorder.recordIfNew("twilio", "event-1");
+    expect(await recorder.recordIfNew("twilio", "event-2")).toBe(true);
+  });
+
+  test("isolates providers from one another", async () => {
+    const recorder = createInMemoryIdempotentWebhookRecorder();
+    await recorder.recordIfNew("twilio", "event-1");
+    expect(await recorder.recordIfNew("stripe", "event-1")).toBe(true);
+  });
+
+  test("stays idempotent across repeated interleaved calls", async () => {
+    const recorder = createInMemoryIdempotentWebhookRecorder();
+    expect(await recorder.recordIfNew("a", "1")).toBe(true);
+    expect(await recorder.recordIfNew("b", "1")).toBe(true);
+    expect(await recorder.recordIfNew("a", "1")).toBe(false);
+    expect(await recorder.recordIfNew("a", "2")).toBe(true);
+    expect(await recorder.recordIfNew("b", "1")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Adds behavior coverage for `createInMemoryIdempotentWebhookRecorder` (`packages/cloud/shared/src/lib/services/idempotent-webhook-recorder.ts`), the webhook replay-suppression helper used by cloud webhook paths. The module currently has no test file.

The tests pin the dedupe contract: first `(provider, eventId)` records as new, repeats are suppressed, distinct event ids pass, and providers are isolated from one another.

## Testing

- `bun test src/lib/services/idempotent-webhook-recorder.test.ts`: 5 pass / 0 fail
- `bunx biome check`: clean

<!-- evidence-row:backend-logs -->
- [x] backend-logs: local bun test output — 5 pass, 0 fail (full shared suite run: 30 pass / 0 fail across 4 files)

AI provider/model: deepseek / deepseek-v4-flash
<!-- slop-contribution-attribution:v1 -->
