### PR TITLE
test(plugin-notion): cover bounded response reading

### DIFF
--- a/plugins/plugin-notion/src/__tests__/bounded-response.test.ts
+++ b/plugins/plugin-notion/src/__tests__/bounded-response.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { readBoundedResponse } from "./bounded-response.ts";
+
+function streamFrom(chunks: Uint8Array[]): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(chunk);
+      controller.close();
+    },
+  });
+}
+
+const errors = {
+  tooLarge: (n: number | null) => new Error(`too large: ${n}`),
+  timedOut: () => new Error("timed out"),
+  readFailed: (cause: unknown) => new Error(`read failed: ${String(cause)}`),
+};
+
+describe("readBoundedResponse", () => {
+  it("reads bodies within the limit", async () => {
+    const response = new Response(streamFrom([new Uint8Array([1, 2, 3])]), {
+      headers: { "Content-Length": "3" },
+    });
+    const data = await readBoundedResponse(response, 10, 1000, errors);
+    expect(data).toEqual(new Uint8Array([1, 2, 3]));
+  });
+
+  it("rejects declared content-length over the limit", async () => {
+    const response = new Response(streamFrom([new Uint8Array([1])]), {
+      headers: { "Content-Length": "999" },
+    });
+    await expect(readBoundedResponse(response, 10, 1000, errors)).rejects.toThrow("too large");
+  });
+
+  it("rejects bodies exceeding the limit mid-stream", async () => {
+    const response = new Response(streamFrom([new Uint8Array(20), new Uint8Array(20)]));
+    await expect(readBoundedResponse(response, 10, 1000, errors)).rejects.toThrow("too large");
+  });
+
+  it("returns empty for bodies without a stream", async () => {
+    const response = new Response(null);
+    const data = await readBoundedResponse(response, 10, 1000, errors);
+    expect(data).toEqual(new Uint8Array());
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new test file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `isolated npx vitest run -> 4 passed` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
