### PR TITLE
fix(plugin-vision): keep UTF-16 surrogate pairs intact in vision scene description truncation

### DIFF
--- a/plugins/plugin-vision/src/action.ts
+++ b/plugins/plugin-vision/src/action.ts
@@ -1,3 +1,14 @@
+function truncateUtf16Safe(text: string, maxLength: number): string {
+  if (text.length <= maxLength) return text;
+  let end = maxLength;
+  if (end > 0 && end < text.length) {
+    const code = text.charCodeAt(end - 1);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      end -= 1;
+    }
+  }
+  return text.slice(0, end);
+}
 /**
  * Vision action handler that routes structured sub-operations for capture,
  * describe, mode changes, entity naming, and screen element grounding.
@@ -393,7 +404,7 @@ async function runDescribe(
     }
 
     const thought = `Analyzed the visual scene at ${timestamp}.`;
-    const text = description.slice(0, MAX_VISION_TEXT_LENGTH);
+    const text = truncateUtf16Safe(description, MAX_VISION_TEXT_LENGTH);
 
     await saveExecutionRecord(runtime, message, thought, text, ["VISION"]);
     if (callback) {
@@ -418,7 +429,7 @@ async function runDescribe(
         actionName: "VISION",
         op: "describe",
         sceneTimestamp: scene.timestamp,
-        sceneDescription: scene.description.slice(0, MAX_VISION_TEXT_LENGTH),
+        sceneDescription: truncateUtf16Safe(scene.description, MAX_VISION_TEXT_LENGTH),
         sceneChanged: scene.sceneChanged,
         changePercentage: scene.changePercentage,
         audioTranscription: scene.audioTranscription || undefined,


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:c63669c921d6e7809b7ae57ede4d7ebf76727900 -->

## Summary
In `plugins/plugin-vision/src/action.ts` (`runDescribe`), vision scene descriptions are clamped to `MAX_VISION_TEXT_LENGTH` (4000 chars) for callback execution records and structured action data responses using raw `.slice(0, MAX_VISION_TEXT_LENGTH)`. If the 4000th character index falls between a UTF-16 surrogate pair (`0xD800–0xDBFF`), the pair was bisected, creating orphaned surrogate characters that produce `\uFFFD` Unicode replacements in vision action execution logs and scene metadata.

## Proposed Changes
1. Added surrogate-pair boundary safety in `runDescribe` (`plugins/plugin-vision/src/action.ts`) for clamping scene description texts and action output payloads.

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-vision test src/action.structured.test.ts` (6/6 tests passed).

<!-- eliza-computer-attribution:v1 {"provider":"deepmind","model":"antigravity","client":"antigravity-ide","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
