### PR TITLE
fix(plugin-agent-orchestrator): keep UTF-16 surrogate pairs intact in elideLongBlocks

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/transcript-sanitizer.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/transcript-sanitizer.test.ts
@@ -203,3 +203,16 @@ describe("stripStructuredProofLines", () => {
     expect(out).not.toContain("APP_CREATE_DONE");
   });
 });
+
+describe("elideLongBlocks surrogate safety", () => {
+  it("never bisects surrogate pairs when calculating headBudget", () => {
+    // "a" + 1000 emojis (2000 code units): total length 2001.
+    // With maxChars = 100, marker length is ~42, headBudget is ~57.
+    // Since "a" is 1 char, odd headBudget lands between surrogate pair halves!
+    const longEmojiText = "a" + "😀".repeat(1000);
+    const out = elideLongBlocks(longEmojiText, 100);
+
+    const head = out.split("\n")[0];
+    expect(head.endsWith("\uD83D")).toBe(false);
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/services/transcript-sanitizer.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/transcript-sanitizer.ts
@@ -73,7 +73,14 @@ export function elideLongBlocks(
   const marker = `… [output truncated — ${text.length} chars total]`;
   const headBudget = maxChars - marker.length - 1; // 1 = joining newline
   if (headBudget <= 0) return marker; // degenerate tiny cap: marker only
-  return `${text.slice(0, headBudget).trimEnd()}\n${marker}`;
+  let end = headBudget;
+  if (end > 0 && end < text.length) {
+    const code = text.charCodeAt(end - 1);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      end -= 1;
+    }
+  }
+  return `${text.slice(0, end).trimEnd()}\n${marker}`;
 }
 
 /**


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:551e9b7ec12429598a2801998f1decd0c85c6468 -->

## Summary
In `plugins/plugin-agent-orchestrator/src/services/transcript-sanitizer.ts`, `elideLongBlocks` clamps long sub-agent deliverable prose to `headBudget` characters before appending the `… [output truncated — N chars total]` marker using raw `.slice(0, headBudget)`. When `headBudget` lands between the halves of a UTF-16 surrogate pair (`0xD800–0xDBFF`), the surrogate pair is split, leaving an orphaned high surrogate character before the newline and marker, resulting in Unicode replacement characters (`\uFFFD`) in relay messages.

## Proposed Changes
1. Added surrogate-pair boundary safety to `elideLongBlocks` in `plugins/plugin-agent-orchestrator/src/services/transcript-sanitizer.ts`.
2. Added unit tests in `plugins/plugin-agent-orchestrator/__tests__/unit/transcript-sanitizer.test.ts` verifying surrogate integrity across truncated relay deliverables.

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-agent-orchestrator test __tests__/unit/transcript-sanitizer.test.ts` (21/21 tests passed).

<!-- eliza-computer-attribution:v1 {"provider":"deepmind","model":"antigravity","client":"antigravity-ide","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
