### PR TITLE
fix(plugin-coding-tools): keep UTF-16 surrogate pairs intact in truncate helper

### DIFF
--- a/plugins/plugin-coding-tools/src/lib/format.test.ts
+++ b/plugins/plugin-coding-tools/src/lib/format.test.ts
@@ -247,3 +247,16 @@ describe("capTranscriptForChat", () => {
     expect(head.endsWith("content")).toBe(true);
   });
 });
+
+describe("truncate surrogate safety", () => {
+  it("never bisects surrogate pairs when max cutoff lands inside a pair", () => {
+    // "a" + 10 emojis (20 code units): length 21.
+    // max = 5: cutoff lands between high and low surrogate of the 3rd emoji.
+    const longEmojiText = "a" + "😀".repeat(10);
+    const r = truncate(longEmojiText, 5);
+
+    expect(r.truncated).toBe(true);
+    const head = r.text.split("\n")[0];
+    expect(head.endsWith("\uD83D")).toBe(false);
+  });
+});

--- a/plugins/plugin-coding-tools/src/lib/format.ts
+++ b/plugins/plugin-coding-tools/src/lib/format.ts
@@ -152,8 +152,15 @@ export function truncate(
   max: number,
 ): { text: string; truncated: boolean } {
   if (s.length <= max) return { text: s, truncated: false };
+  let end = max;
+  if (end > 0 && end < s.length) {
+    const code = s.charCodeAt(end - 1);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      end -= 1;
+    }
+  }
   return {
-    text: `${s.slice(0, max)}\n…[truncated, ${s.length - max} more chars]`,
+    text: `${s.slice(0, end)}\n…[truncated, ${s.length - max} more chars]`,
     truncated: true,
   };
 }


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:1ee534cc0a4222ede3b73ccc3c4305226433baf1 -->

## Summary
In `plugins/plugin-coding-tools/src/lib/format.ts`, the shared `truncate` helper truncated text beyond `max` using raw `.slice(0, max)`. When the maximum character budget lands on an odd boundary between a UTF-16 surrogate pair (`0xD800–0xDBFF`), the pair was bisected, leaving an unpaired high surrogate immediately before the newline and `…[truncated, N more chars]` notice.

## Proposed Changes
1. Added surrogate-pair boundary safety to `truncate` in `plugins/plugin-coding-tools/src/lib/format.ts`.
2. Added unit tests in `plugins/plugin-coding-tools/src/lib/format.test.ts` verifying surrogate integrity on clamped outputs.

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-coding-tools test src/lib/format.test.ts` (39/39 tests passed).

<!-- eliza-computer-attribution:v1 {"provider":"deepmind","model":"antigravity","client":"antigravity-ide","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
