### PR TITLE
fix(plugin-wechat): keep UTF-16 surrogate pairs intact in ReplyDispatcher chunking

### DIFF
--- a/plugins/plugin-wechat/src/index.test.ts
+++ b/plugins/plugin-wechat/src/index.test.ts
@@ -359,3 +359,23 @@ describe("@elizaos/plugin-wechat", () => {
     expect(client.sendText).toHaveBeenNthCalledWith(2, "wxid_alice", "world");
   });
 });
+
+  it("never bisects surrogate pairs when chunking outgoing text", async () => {
+    const sentChunks: string[] = [];
+    const client = {
+      sendText: vi.fn(async (_to: string, chunk: string) => {
+        sentChunks.push(chunk);
+      }),
+    } as unknown as ProxyClient;
+    // "a" + 4 emojis (8 code units): length 9.
+    // chunkSize = 5: hard break lands between surrogate halves of the 3rd emoji.
+    const dispatcher = new ReplyDispatcher({ client, chunkSize: 5 });
+
+    await dispatcher.sendText("wxid_alice", "a" + "😀".repeat(4));
+
+    expect(sentChunks.length).toBeGreaterThan(1);
+    for (const chunk of sentChunks) {
+      expect(chunk.endsWith("\uD83D")).toBe(false);
+      expect(chunk.startsWith("\uDE00")).toBe(false);
+    }
+  });

--- a/plugins/plugin-wechat/src/reply-dispatcher.ts
+++ b/plugins/plugin-wechat/src/reply-dispatcher.ts
@@ -70,6 +70,13 @@ export class ReplyDispatcher {
         breakAt = this.chunkSize;
       }
 
+      if (breakAt > 0 && breakAt < remaining.length) {
+        const code = remaining.charCodeAt(breakAt - 1);
+        if (code >= 0xd800 && code <= 0xdbff) {
+          breakAt -= 1;
+        }
+      }
+
       chunks.push(remaining.slice(0, breakAt));
       remaining = remaining.slice(breakAt).trimStart();
     }


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:038050d36159740387567be5638c5fe9d04fb147 -->

## Summary
In `plugins/plugin-wechat/src/reply-dispatcher.ts`, `ReplyDispatcher.chunk` splits long outbound messages into chunks of size `chunkSize` (default 2000). When a hard break boundary or split point lands between a UTF-16 surrogate pair (`0xD800–0xDBFF`), the surrogate pair was bisected. The first chunk ended with an unpaired high surrogate and the second chunk began with an unpaired low surrogate, resulting in `\uFFFD` / broken emoji characters in outgoing WeChat messages.

## Proposed Changes
1. Added surrogate-pair boundary safety in `ReplyDispatcher.chunk` (`plugins/plugin-wechat/src/reply-dispatcher.ts`).
2. Added unit tests in `plugins/plugin-wechat/src/index.test.ts` verifying surrogate integrity across chunked WeChat message replies.

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-wechat test src/index.test.ts` (12/12 tests passed).

<!-- eliza-computer-attribution:v1 {"provider":"deepmind","model":"antigravity","client":"antigravity-ide","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
