### PR TITLE
test(blocker): cover selfcontrol role-check null guard

### DIFF
--- a/plugins/plugin-blocker/src/services/website-blocker/roles.test.ts
+++ b/plugins/plugin-blocker/src/services/website-blocker/roles.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Unit coverage for the selfcontrol role check wrapper.
+ *
+ * Behavioral risk: a null result from the core role check means the
+ * world/room/entity setup is broken. The wrapper must surface that as an
+ * explicit error (with the offending ids) instead of silently hiding the
+ * action from the LLM — a silent null would make gated actions disappear
+ * without any diagnosable signal.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { checkSenderRoleMock } = vi.hoisted(() => ({
+  checkSenderRoleMock: vi.fn(),
+}));
+
+vi.mock("@elizaos/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@elizaos/core")>();
+  return {
+    ...actual,
+    checkSenderRole: checkSenderRoleMock,
+  };
+});
+
+import { checkSenderRole } from "./roles.ts";
+
+const runtime = { agentId: "agent-123" } as never;
+const message = {
+  roomId: "room-456",
+  entityId: "entity-789",
+} as never;
+
+beforeEach(() => {
+  checkSenderRoleMock.mockReset();
+});
+
+describe("checkSenderRole", () => {
+  it("passes through a valid role result", async () => {
+    const result = { role: "admin", ok: true };
+    checkSenderRoleMock.mockResolvedValue(result);
+    await expect(checkSenderRole(runtime, message)).resolves.toBe(result);
+    expect(checkSenderRoleMock).toHaveBeenCalledWith(runtime, message);
+  });
+
+  it("throws a descriptive error when the core check returns null", async () => {
+    checkSenderRoleMock.mockResolvedValue(null);
+    await expect(checkSenderRole(runtime, message)).rejects.toThrow(
+      /checkSenderRole returned null/,
+    );
+    await expect(checkSenderRole(runtime, message)).rejects.toThrow(
+      /roomId=room-456/,
+    );
+    await expect(checkSenderRole(runtime, message)).rejects.toThrow(
+      /entityId=entity-789/,
+    );
+    await expect(checkSenderRole(runtime, message)).rejects.toThrow(
+      /agentId=agent-123/,
+    );
+  });
+
+  it("does not swallow undefined results (treats as broken setup too)", async () => {
+    checkSenderRoleMock.mockResolvedValue(undefined);
+    await expect(checkSenderRole(runtime, message)).rejects.toThrow(
+      /checkSenderRole returned null/,
+    );
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new test file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: 3/3 passed |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used