### PR TITLE
test(goals): cover db sql value coercers

### DIFF
--- a/plugins/plugin-goals/src/db/sql.test.ts
+++ b/plugins/plugin-goals/src/db/sql.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Unit coverage for goals SQL value coercers.
+ *
+ * Behavioral risk: these helpers shape untrusted DB/JSON values into typed
+ * primitives for the goals back-end. A wrong coercion (e.g. `"false"` treated
+ * as truthy, `NaN` accepted as a number, JSON arrays passed as objects)
+ * would silently corrupt goal records or crash the write path.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  asObject,
+  parseJsonRecord,
+  parseJsonValue,
+  toBoolean,
+  toNumber,
+  toText,
+} from "./sql.ts";
+
+describe("asObject", () => {
+  it("returns null for null/undefined", () => {
+    expect(asObject(null)).toBeNull();
+    expect(asObject(undefined)).toBeNull();
+  });
+
+  it("returns null for non-objects", () => {
+    expect(asObject("str")).toBeNull();
+    expect(asObject(42)).toBeNull();
+    expect(asObject(true)).toBeNull();
+  });
+
+  it("returns null for arrays", () => {
+    expect(asObject([])).toBeNull();
+    expect(asObject([1, 2])).toBeNull();
+  });
+
+  it("passes plain objects through", () => {
+    expect(asObject({ a: 1 })).toEqual({ a: 1 });
+  });
+});
+
+describe("toText", () => {
+  it("passes strings through", () => {
+    expect(toText("hello")).toBe("hello");
+  });
+
+  it("uses the fallback for null/undefined", () => {
+    expect(toText(null, "fb")).toBe("fb");
+    expect(toText(undefined, "fb")).toBe("fb");
+  });
+
+  it("stringifies numbers and booleans", () => {
+    expect(toText(42)).toBe("42");
+    expect(toText(true)).toBe("true");
+    expect(toText(0)).toBe("0");
+  });
+});
+
+describe("toNumber", () => {
+  it("passes finite numbers through", () => {
+    expect(toNumber(3.5)).toBe(3.5);
+    expect(toNumber(0)).toBe(0);
+  });
+
+  it("parses numeric strings", () => {
+    expect(toNumber("42")).toBe(42);
+    expect(toNumber("-1.5")).toBe(-1.5);
+  });
+
+  it("rejects non-finite numbers", () => {
+    expect(toNumber(Number.NaN, 7)).toBe(7);
+    expect(toNumber(Number.POSITIVE_INFINITY, 7)).toBe(7);
+  });
+
+  it("falls back for unparseable input", () => {
+    expect(toNumber("abc", 7)).toBe(7);
+    expect(toNumber(null, 7)).toBe(7);
+    expect(toNumber({}, 7)).toBe(7);
+  });
+});
+
+describe("toBoolean", () => {
+  it("passes booleans through", () => {
+    expect(toBoolean(true)).toBe(true);
+    expect(toBoolean(false)).toBe(false);
+  });
+
+  it("treats non-zero numbers as true", () => {
+    expect(toBoolean(1)).toBe(true);
+    expect(toBoolean(-3)).toBe(true);
+    expect(toBoolean(0)).toBe(false);
+  });
+
+  it("parses truthy string spellings case-insensitively", () => {
+    for (const v of ["1", "true", "yes", "on", " TRUE ", "Yes", "ON"]) {
+      expect(toBoolean(v)).toBe(true);
+    }
+  });
+
+  it("parses falsy string spellings", () => {
+    for (const v of ["0", "false", "no", "off", " FALSE "]) {
+      expect(toBoolean(v)).toBe(false);
+    }
+  });
+
+  it("falls back for unknown spellings", () => {
+    expect(toBoolean("maybe", true)).toBe(true);
+    expect(toBoolean("maybe", false)).toBe(false);
+  });
+});
+
+describe("parseJsonValue", () => {
+  it("returns fallback for missing JSON values", () => {
+    expect(parseJsonValue(null, "fb")).toBe("fb");
+    expect(parseJsonValue(undefined, "fb")).toBe("fb");
+    expect(parseJsonValue("", "fb")).toBe("fb");
+  });
+
+  it("passes objects through untouched", () => {
+    const obj = { x: 1 };
+    expect(parseJsonValue(obj, null)).toBe(obj);
+  });
+
+  it("parses JSON strings", () => {
+    expect(parseJsonValue('{"a":1}', null)).toEqual({ a: 1 });
+    expect(parseJsonValue("[1,2]", [])).toEqual([1, 2]);
+  });
+
+  it("throws a prefixed error on invalid JSON strings", () => {
+    expect(() => parseJsonValue("{oops", null)).toThrow(
+      /\[GoalsSql\] Invalid JSON value/,
+    );
+  });
+
+  it("throws on non-object, non-string scalars", () => {
+    expect(() => parseJsonValue(42, null)).toThrow(
+      /\[GoalsSql\] Expected JSON string or object, received number/,
+    );
+  });
+});
+
+describe("parseJsonRecord", () => {
+  it("returns {} for missing values", () => {
+    expect(parseJsonRecord(null)).toEqual({});
+    expect(parseJsonRecord("")).toEqual({});
+  });
+
+  it("parses a JSON object string", () => {
+    expect(parseJsonRecord('{"k":"v"}')).toEqual({ k: "v" });
+  });
+
+  it("throws for JSON arrays", () => {
+    expect(() => parseJsonRecord("[1]")).toThrow(
+      /\[GoalsSql\] Expected JSON object/,
+    );
+  });
+
+  it("throws for JSON scalars", () => {
+    expect(() => parseJsonRecord('"str"')).toThrow(
+      /\[GoalsSql\] Expected JSON object/,
+    );
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new test file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: 25/25 passed |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used