### PR TITLE
fix(plugin-inbox): keep UTF-16 surrogate pairs intact in buildEmailCurationPrompt

### DIFF
--- a/plugins/plugin-inbox/src/inbox/email-curation.ts
+++ b/plugins/plugin-inbox/src/inbox/email-curation.ts
@@ -1626,6 +1626,18 @@ export function validateCurationDecisionCitations(
   return errors;
 }
 
+function truncateUtf16Safe(text: string, limit: number): string {
+  if (text.length <= limit) return text;
+  let end = limit;
+  if (end > 0 && end < text.length) {
+    const code = text.charCodeAt(end - 1);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      end -= 1;
+    }
+  }
+  return text.slice(0, end);
+}
+
 export function buildEmailCurationPrompt(
   input: EmailCurationInput | EmailCurationCandidate,
 ): string {
@@ -1642,8 +1654,8 @@ export function buildEmailCurationPrompt(
           formatEmailCurationField("fromEmail", candidate.fromEmail ?? ""),
           formatEmailCurationField("subject", text.subject),
           formatEmailCurationField("snippet", text.snippet),
-          formatEmailCurationField("headers", text.headers.slice(0, 2000)),
-          formatEmailCurationField("body", text.body.slice(0, 8000)),
+          formatEmailCurationField("headers", truncateUtf16Safe(text.headers, 2000)),
+          formatEmailCurationField("body", truncateUtf16Safe(text.body, 8000)),
         ].join("\n"),
       ),
     ].join("\n");

--- a/plugins/plugin-inbox/test/inbox-curation.test.ts
+++ b/plugins/plugin-inbox/test/inbox-curation.test.ts
@@ -16,9 +16,10 @@
 
 import type { IAgentRuntime, UUID } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
-import type {
-  EmailCurationIdentityHook,
-  EmailCurationPolicyHook,
+import {
+  type EmailCurationIdentityHook,
+  type EmailCurationPolicyHook,
+  buildEmailCurationPrompt,
 } from "../src/inbox/email-curation.ts";
 import { InboxService } from "../src/inbox/service.ts";
 import type { InboundMessage } from "../src/inbox/types.ts";
@@ -190,5 +191,19 @@ describe("InboxService.triageWithCuration", () => {
       item.curation.action,
     );
     expect(result.curation.decisions).toHaveLength(1);
+  });
+});
+
+describe("buildEmailCurationPrompt surrogate safety", () => {
+  it("never bisects surrogate pairs when clamping headers or body", () => {
+    // "a" + 4500 emojis (9000 code units): length 9001.
+    // 8000 boundary lands between high and low surrogate of the 4000th emoji.
+    const candidate = inbound({
+      id: "msg-surrogate",
+      body: "a" + "😀".repeat(4500),
+    });
+    const prompt = buildEmailCurationPrompt(candidate);
+    expect(prompt).not.toContain("\uD83D\n");
+    expect(prompt).not.toContain("\uD83D<");
   });
 });


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:27626a469ffe44d024c91d8b1aa4aa6372d8a2fa -->

## Summary
In `plugins/plugin-inbox/src/inbox/email-curation.ts`, `buildEmailCurationPrompt` clamped email headers to 2000 characters and body to 8000 characters using raw `.slice()`. When the 2000th or 8000th character boundary lands between the halves of a UTF-16 surrogate pair (`0xD800–0xDBFF`), the pair was bisected, leaving an orphan high surrogate character that corrupts the prompt with Unicode replacement characters (`\uFFFD`).

## Proposed Changes
1. Added surrogate-pair boundary safety in `buildEmailCurationPrompt` (`plugins/plugin-inbox/src/inbox/email-curation.ts`) for header and body truncation.
2. Added unit tests in `plugins/plugin-inbox/test/inbox-curation.test.ts` verifying surrogate integrity across email curation prompts.

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-inbox test test/inbox-curation.test.ts` (6/6 tests passed).

<!-- eliza-computer-attribution:v1 {"provider":"deepmind","model":"antigravity","client":"antigravity-ide","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
