### PR TITLE
fix(plugin-wallet): keep UTF-16 surrogate pairs intact in news truncateText helper

### DIFF
--- a/plugins/plugin-wallet/src/analytics/news/utils/formatters.test.ts
+++ b/plugins/plugin-wallet/src/analytics/news/utils/formatters.test.ts
@@ -36,6 +36,8 @@ describe("text helpers", () => {
   it("truncateText, getSentimentEmoji, formatNumber, extractTokenSymbol, stripHtml", () => {
     expect(truncateText("short", 200)).toBe("short");
     expect(truncateText("abcdef", 3)).toBe("abc...");
+    // Surrogate pair safety: boundary lands between emoji surrogates
+    expect(truncateText("ab" + String.fromCodePoint(0x1F600) + "cd", 3)).toBe("ab...");
     expect(getSentimentEmoji("positive")).toBe("😊");
     expect(getSentimentEmoji("negative")).toBe("😟");
     expect(getSentimentEmoji(undefined)).toBe("😐");

--- a/plugins/plugin-wallet/src/analytics/news/utils/formatters.ts
+++ b/plugins/plugin-wallet/src/analytics/news/utils/formatters.ts
@@ -67,7 +67,14 @@ export function truncateText(text: string, maxLength: number = 200): string {
   if (text.length <= maxLength) {
     return text;
   }
-  return `${text.substring(0, maxLength)}...`;
+  let end = maxLength;
+  if (end > 0 && end < text.length) {
+    const code = text.charCodeAt(end - 1);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      end -= 1;
+    }
+  }
+  return `${text.substring(0, end)}...`;
 }
 
 /**


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:7ea341e1c46965b4a06e5bdd418937e0e16b9721 -->

## Summary
In `plugins/plugin-wallet/src/analytics/news/utils/formatters.ts`, `truncateText` used `text.substring(0, maxLength)` without surrogate-pair boundary safety. When `maxLength` lands between the high and low surrogate of a 4-byte UTF-16 code point (e.g. emojis in news summaries or DeFi headlines), the string ends with a lone high surrogate that renders as a replacement character (`\uFFFD`).

## Proposed Changes
1. Added surrogate-pair boundary safety in `truncateText` (`plugins/plugin-wallet/src/analytics/news/utils/formatters.ts`).
2. Added unit test in `plugins/plugin-wallet/src/analytics/news/utils/formatters.test.ts` verifying that surrogate pairs at the boundary are preserved intact without bisecting.

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-wallet test src/analytics/news/utils/formatters.test.ts` (4/4 tests passed).

<!-- eliza-computer-attribution:v1 {"provider":"deepmind","model":"antigravity","client":"antigravity-ide","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
