### PR TITLE
fix(plugin-browser): keep UTF-16 surrogate pairs intact in summarizePage

### DIFF
--- a/plugins/plugin-browser/src/message-adapter.test.ts
+++ b/plugins/plugin-browser/src/message-adapter.test.ts
@@ -83,4 +83,47 @@ describe("BrowserBridgeAdapter", () => {
       }),
     ).resolves.toEqual([]);
   });
+
+  it("truncates long page content without splitting surrogate pairs", async () => {
+    // 300 emojis = 600 UTF-16 code units > 500 max limit
+    const emojis = "😀".repeat(300);
+    const page = {
+      id: "page-emoji",
+      agentId: "agent-1",
+      browser: "chrome",
+      profileId: "default",
+      windowId: "window-1",
+      tabId: "tab-1",
+      url: "https://example.com/emojis",
+      title: "Emoji Page",
+      selectionText: null,
+      mainText: emojis,
+      headings: [],
+      links: [],
+      forms: [],
+      capturedAt: "2026-06-02T12:00:00.000Z",
+      metadata: {},
+    };
+    const routeService = {
+      getCurrentBrowserPage: vi.fn(async () => page),
+    };
+    const runtime = {
+      agentId: "agent-1",
+      getService: vi.fn(() => routeService),
+    } as unknown as IAgentRuntime;
+    const adapter = new BrowserBridgeAdapter();
+
+    const messages = await adapter.listMessages(runtime, { limit: 1 });
+    expect(messages).toHaveLength(1);
+    const snippet = messages[0].snippet;
+    expect(snippet.endsWith("...")).toBe(true);
+    const body = snippet.slice(0, -3);
+    for (const char of body) {
+      expect(
+        /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(
+          char,
+        ),
+      ).toBe(false);
+    }
+  });
 });

--- a/plugins/plugin-browser/src/message-adapter.ts
+++ b/plugins/plugin-browser/src/message-adapter.ts
@@ -49,7 +49,15 @@ function summarizePage(page: BrowserBridgePageContext): string {
     page.mainText?.trim() ||
     page.title.trim() ||
     page.url;
-  return text.length > 500 ? `${text.slice(0, 497)}...` : text;
+  if (text.length <= 500) return text;
+  let end = 497;
+  if (end > 0 && end < text.length) {
+    const code = text.charCodeAt(end - 1);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      end -= 1;
+    }
+  }
+  return `${text.slice(0, end)}...`;
 }
 
 function pageToMessageRef(page: BrowserBridgePageContext): MessageRef {


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:181eca59eca284063e5d79de4b4c35b8137c6a62 -->

## Summary
In `plugins/plugin-browser/src/message-adapter.ts`, `summarizePage` used raw `.slice(0, 497)` to truncate page text, which can bisect multi-byte UTF-16 surrogate pairs (like emojis) at index 497, emitting lone surrogates (`\uFFFD`).

## Proposed Changes
1. Added surrogate-pair boundary safety checks before slicing in `summarizePage`.
2. Added unit test in `src/message-adapter.test.ts` verifying intact surrogate pairs after truncation.

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-browser test src/message-adapter.test.ts` (3/3 tests passed).

<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-3-5-sonnet","client":"antigravity","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
