### PR TITLE
fix(plugin-calendar): keep UTF-16 surrogate pairs intact in event description truncation

### DIFF
--- a/plugins/plugin-calendar/src/actions/calendar-handler.ts
+++ b/plugins/plugin-calendar/src/actions/calendar-handler.ts
@@ -3446,6 +3446,18 @@ function extractCalendarGroundedMatchIds(
   return [...new Set(ids)];
 }
 
+function truncateCalendarText(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  let end = maxChars;
+  if (end > 0 && end < text.length) {
+    const code = text.charCodeAt(end - 1);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      end -= 1;
+    }
+  }
+  return text.slice(0, end);
+}
+
 function formatCalendarCandidateForGrounding(
   candidate: RankedCalendarSearchCandidate,
 ): string {
@@ -3459,7 +3471,7 @@ function formatCalendarCandidateForGrounding(
     `title: ${candidate.event.title}`,
     `startAt: ${candidate.event.startAt}`,
     `location: ${candidate.event.location}`,
-    `description: ${(candidate.event.description).slice(0, 240)}`,
+    `description: ${truncateCalendarText(candidate.event.description, 240)}`,
     `attendees: ${attendees}`,
   ].join("\n");
 }
@@ -3631,7 +3643,7 @@ export function formatCalendarSearchResults(
       lines.push(`  Location: ${event.location}`);
     }
     if (event.description) {
-      lines.push(`  ${event.description.slice(0, 120)}`);
+      lines.push(`  ${truncateCalendarText(event.description, 120)}`);
     }
   }
   return lines.join("\n");

--- a/plugins/plugin-calendar/src/actions/calendar-truncation-surrogates.test.ts
+++ b/plugins/plugin-calendar/src/actions/calendar-truncation-surrogates.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+describe("calendar description surrogate safety", () => {
+  it("truncates description without bisecting surrogate pairs", () => {
+    function truncateCalendarText(text: string, maxChars: number): string {
+      if (text.length <= maxChars) return text;
+      let end = maxChars;
+      if (end > 0 && end < text.length) {
+        const code = text.charCodeAt(end - 1);
+        if (code >= 0xd800 && code <= 0xdbff) {
+          end -= 1;
+        }
+      }
+      return text.slice(0, end);
+    }
+
+    const emojis = "🎉".repeat(100); // 200 code units
+    const truncated = truncateCalendarText(emojis, 121);
+    expect(truncated.length).toBe(120); // rounded down to avoid cutting high surrogate
+    for (const char of truncated) {
+      expect(
+        /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(
+          char,
+        ),
+      ).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:ab7ca9d60f519b54ac70239633deed236e943a8f -->

## Summary
In `plugins/plugin-calendar/src/actions/calendar-handler.ts`, `candidate.event.description.slice(0, 240)` and `event.description.slice(0, 120)` used raw string slicing on event descriptions, which can bisect multi-byte UTF-16 surrogate pairs (e.g. calendar title/description emojis) at the slice boundary, generating orphaned surrogate characters (`\uFFFD`).

## Proposed Changes
1. Added surrogate-pair safe boundary truncation helper `truncateCalendarText`.
2. Applied `truncateCalendarText` in `formatCalendarCandidateForGrounding` and `formatCalendarSearchResults`.
3. Added unit test in `src/actions/calendar-truncation-surrogates.test.ts`.

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-calendar test src/actions/calendar-truncation-surrogates.test.ts` (passed).

<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-3-5-sonnet","client":"antigravity","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
