### PR TITLE
fix(plugin-notes): keep UTF-16 surrogate pairs intact in note and details truncation

### DIFF
--- a/plugins/plugin-notes/src/interact.ts
+++ b/plugins/plugin-notes/src/interact.ts
@@ -49,10 +49,22 @@ function sentence(value: string): string {
   return /[.!?]$/.test(text) ? text : `${text}.`;
 }
 
+function truncateDetailsText(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  let end = maxChars;
+  if (end > 0 && end < text.length) {
+    const code = text.charCodeAt(end - 1);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      end -= 1;
+    }
+  }
+  return text.slice(0, end);
+}
+
 function humanDetails(value: string): string {
   const details = value.trim();
   return details.length > 0
-    ? ` — ${details.slice(0, PLANNER_SUMMARY_EXCERPT_LENGTH)}`
+    ? ` — ${truncateDetailsText(details, PLANNER_SUMMARY_EXCERPT_LENGTH)}`
     : "";
 }
 

--- a/plugins/plugin-notes/src/provider.test.ts
+++ b/plugins/plugin-notes/src/provider.test.ts
@@ -262,4 +262,27 @@ describe("SAVED_NOTES provider", () => {
     expect(text).toContain("(truncated)");
     expect(text.length).toBeLessThan(1_000);
   });
+  it("truncates an oversized note body without bisecting surrogate pairs", () => {
+    const emojis = "🎉".repeat(3000);
+    const text = renderSavedNotesText([
+      {
+        id: "note-emoji",
+        title: "emojis",
+        body: emojis,
+        color: "slate",
+        createdAt: "2026-08-14T12:00:00.000Z",
+        updatedAt: "2026-08-14T12:00:00.000Z",
+      },
+    ]);
+
+    expect(text).toContain("emojis");
+    expect(text).toContain("(truncated)");
+    for (const char of text) {
+      expect(
+        /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(
+          char,
+        ),
+      ).toBe(false);
+    }
+  });
 });

--- a/plugins/plugin-notes/src/provider.ts
+++ b/plugins/plugin-notes/src/provider.ts
@@ -43,11 +43,23 @@ const UNAVAILABLE: ProviderResult = {
 };
 
 /** One line per note: the label is the note's own first line, never invented. */
+function truncateNoteText(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  let end = maxChars;
+  if (end > 0 && end < text.length) {
+    const code = text.charCodeAt(end - 1);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      end -= 1;
+    }
+  }
+  return text.slice(0, end);
+}
+
 function noteLine(note: StickyNote): string {
   const body = note.body.trim();
   const full = body.length > 0 ? `${note.title} — ${body}` : note.title;
   return full.length > MAX_NOTE_LINE_LENGTH
-    ? `${full.slice(0, MAX_NOTE_LINE_LENGTH - "… (truncated)".length)}… (truncated)`
+    ? `${truncateNoteText(full, MAX_NOTE_LINE_LENGTH - "… (truncated)".length)}… (truncated)`
     : full;
 }
 


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:a37a820ea546c715a9ae815650bfa15740142d55 -->

## Summary
In `plugins/plugin-notes`, `noteLine` in `provider.ts` and `humanDetails` in `interact.ts` used raw string slicing on note content, which can bisect multi-byte UTF-16 surrogate pairs (such as emojis or complex unicode characters) at the cutoff boundary, emitting orphaned high surrogates (`\uFFFD`).

## Proposed Changes
1. Added surrogate-pair safe boundary truncation helpers `truncateNoteText` and `truncateDetailsText`.
2. Applied safe truncation to note bodies in `provider.ts` and excerpt details in `interact.ts`.
3. Added unit test in `src/provider.test.ts` verifying that oversized notes containing emojis are truncated cleanly without orphaned surrogate characters.

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-notes test src/provider.test.ts` (9/9 tests passed).

<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-3-5-sonnet","client":"antigravity","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
