### PR TITLE
test(plugin-discord): cover ingress readiness timeout fail-closed

### DIFF
--- a/plugins/plugin-discord/readiness.test.ts
+++ b/plugins/plugin-discord/readiness.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { waitForDiscordIngressReadiness } from "./readiness";
+
+describe("waitForDiscordIngressReadiness", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("resolves immediately when ready is null or undefined", async () => {
+		await expect(waitForDiscordIngressReadiness(null)).resolves.toBeUndefined();
+		await expect(
+			waitForDiscordIngressReadiness(undefined),
+		).resolves.toBeUndefined();
+	});
+
+	it("resolves when the ready promise settles first", async () => {
+		await expect(
+			waitForDiscordIngressReadiness(Promise.resolve()),
+		).resolves.toBeUndefined();
+	});
+
+	it("rejects with a fail-closed timeout error when hydration never settles", async () => {
+		vi.useFakeTimers();
+		const never = new Promise<void>(() => {});
+		const pending = waitForDiscordIngressReadiness(never, 1_000);
+
+		const assertion = expect(pending).rejects.toThrow(
+			"Discord ready-time identity hydration timed out after 1000ms",
+		);
+		await vi.advanceTimersByTimeAsync(1_000);
+		await assertion;
+	});
+
+	it("honors a custom timeout window in the error message", async () => {
+		vi.useFakeTimers();
+		const never = new Promise<void>(() => {});
+		const pending = waitForDiscordIngressReadiness(never, 42);
+
+		const assertion = expect(pending).rejects.toThrow("timed out after 42ms");
+		await vi.advanceTimersByTimeAsync(42);
+		await assertion;
+	});
+
+	it("clears the timer once the ready promise wins the race", async () => {
+		vi.useFakeTimers();
+		const gate = vi.fn<void, []>();
+		const ready = new Promise<void>((resolve) => {
+			gate.mockImplementation(resolve);
+		});
+		const pending = waitForDiscordIngressReadiness(ready, 5_000);
+		gate();
+		await pending;
+
+		// No dangling timer should remain after a successful settle.
+		const remaining = vi.getTimerCount();
+		expect(remaining).toBe(0);
+	});
+
+	it("propagates an underlying ready failure without wrapping", async () => {
+		await expect(
+			waitForDiscordIngressReadiness(Promise.reject(new Error("boom"))),
+		).rejects.toThrow("boom");
+	});
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new test file exercising the existing
`waitForDiscordIngressReadiness` helper (fail-closed ingress timeout). No
production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: 6/6 passed |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
