### PR TITLE
fix(plugin-meetings): keep UTF-16 surrogate pairs intact in meeting transcript truncation

### DIFF
--- a/plugins/plugin-meetings/src/actions/actions.test.ts
+++ b/plugins/plugin-meetings/src/actions/actions.test.ts
@@ -430,4 +430,51 @@ describe("GET_MEETING_TRANSCRIPT", () => {
     expect(await v(has.runtime, msg("hello there"), NO_STATE)).toBe(false);
     expect(await v(has.runtime, msg("show me the notes"), NO_STATE)).toBe(true);
   });
+  it("getMeetingTranscript truncates long transcript without bisecting surrogate pairs", async () => {
+    const emojis = "🔥".repeat(3000); // 6000 code units > 4000 limit
+    const row = {
+      id: "trans-emoji",
+      content: {
+        text: `Alice: ${emojis}`,
+        transcript: JSON.stringify({
+          id: "trans-emoji",
+          status: "ready",
+          segments: [
+            {
+              id: "seg-1",
+              speakerLabel: "Alice",
+              startMs: 0,
+              endMs: 1000,
+              text: emojis,
+              words: [],
+            },
+          ],
+        }),
+      },
+      metadata: { type: "custom", source: "transcript" },
+    } as unknown as Memory;
+    const h = harness({
+      service: svc([session({ transcriptId: "trans-emoji" })]),
+      memories: { "trans-emoji": row },
+    });
+    const res = await getMeetingTranscriptAction.handler(
+      h.runtime,
+      msg("show the transcript"),
+      NO_STATE,
+      {},
+      h.cb,
+    );
+    expect(res).toMatchObject({
+      success: true,
+      data: { sessionId: "sess-a", transcriptId: "trans-emoji" },
+    });
+    expect(res.text).toContain("(truncated");
+    for (const char of res.text) {
+      expect(
+        /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(
+          char,
+        ),
+      ).toBe(false);
+    }
+  });
 });

--- a/plugins/plugin-meetings/src/actions/get-meeting-transcript.ts
+++ b/plugins/plugin-meetings/src/actions/get-meeting-transcript.ts
@@ -26,6 +26,18 @@ import {
 /** Cap the inline reply; the full record lives in the Transcripts view. */
 const MAX_REPLY_CHARS = 4_000;
 
+function truncateTranscriptText(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  let end = maxChars;
+  if (end > 0 && end < text.length) {
+    const code = text.charCodeAt(end - 1);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      end -= 1;
+    }
+  }
+  return text.slice(0, end);
+}
+
 async function handler(
   runtime: IAgentRuntime,
   message: Memory,
@@ -72,7 +84,7 @@ async function handler(
   }
   const clipped =
     text.length > MAX_REPLY_CHARS
-      ? `${text.slice(0, MAX_REPLY_CHARS)}\n… (truncated — open transcript ${transcript.id} in the Transcripts view for the full record)`
+      ? `${truncateTranscriptText(text, MAX_REPLY_CHARS)}\n… (truncated — open transcript ${transcript.id} in the Transcripts view for the full record)`
       : text;
   return reply(
     callback,


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:a25fbab23941ea2dcb49acf11297d234eef79771 -->

## Summary
In `plugins/plugin-meetings/src/actions/get-meeting-transcript.ts`, `text.slice(0, MAX_REPLY_CHARS)` used raw string slicing to truncate long transcripts, which can split multi-byte UTF-16 surrogate pairs (e.g. emojis or complex multi-code-unit symbols in speech transcripts) at index 4000, emitting broken surrogate characters (`\uFFFD`).

## Proposed Changes
1. Added surrogate-pair safe boundary truncation helper `truncateTranscriptText`.
2. Applied `truncateTranscriptText` in `handleGetMeetingTranscript`.
3. Added unit test in `src/actions/actions.test.ts` verifying that long transcripts containing emojis are truncated cleanly without orphaned surrogate characters.

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-meetings test src/actions/actions.test.ts` (21/21 tests passed).

<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-3-5-sonnet","client":"antigravity","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
