### PR TITLE
fix(plugin-zerollama): keep UTF-16 surrogate pairs intact in HTTP error detail truncation

### DIFF
--- a/plugins/plugin-zerollama/__tests__/availability.shape.test.ts
+++ b/plugins/plugin-zerollama/__tests__/availability.shape.test.ts
@@ -67,4 +67,22 @@ describe("Ollama model availability", () => {
     });
     expect(fetchMock).not.toHaveBeenCalled();
   });
+  it("truncates error response detail without bisecting surrogate pairs", async () => {
+    const emojis = "🔥".repeat(400); // 800 code units > 500
+    const fetchMock = vi.fn(async () => new Response(emojis, { status: 500 }));
+
+    try {
+      await ensureModelAvailable("qwen3:0.6b", "http://localhost:11434/api", fetchMock);
+      expect.fail("should have thrown");
+    } catch (err: any) {
+      expect(err.code).toBe("OLLAMA_MODEL_LOOKUP_FAILED");
+      for (const char of err.message) {
+        expect(
+          /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(
+            char,
+          ),
+        ).toBe(false);
+      }
+    }
+  });
 });

--- a/plugins/plugin-zerollama/models/audio.ts
+++ b/plugins/plugin-zerollama/models/audio.ts
@@ -141,10 +141,22 @@ async function fetchAudioFromUrl(url: string, signal?: AbortSignal): Promise<Blo
   }
 }
 
+function truncateText(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  let end = maxChars;
+  if (end > 0 && end < text.length) {
+    const code = text.charCodeAt(end - 1);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      end -= 1;
+    }
+  }
+  return text.slice(0, end);
+}
+
 async function readHttpErrorDetail(response: Response): Promise<string> {
   try {
     const detail = (await response.text()).trim();
-    return detail.length > 0 ? detail.slice(0, 500) : "empty response body";
+    return detail.length > 0 ? truncateText(detail, 500) : "empty response body";
   } catch (error) {
     // error-policy:J4 the status remains authoritative and the unavailable
     // diagnostic body is represented explicitly.

--- a/plugins/plugin-zerollama/models/availability.ts
+++ b/plugins/plugin-zerollama/models/availability.ts
@@ -4,10 +4,22 @@
  */
 import { ElizaError, logger } from "@elizaos/core";
 
+function truncateText(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  let end = maxChars;
+  if (end > 0 && end < text.length) {
+    const code = text.charCodeAt(end - 1);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      end -= 1;
+    }
+  }
+  return text.slice(0, end);
+}
+
 async function responseDetail(response: Response): Promise<string> {
   try {
     const body = (await response.text()).trim();
-    return body.length > 0 ? body.slice(0, 500) : response.statusText;
+    return body.length > 0 ? truncateText(body, 500) : response.statusText;
   } catch (error) {
     // error-policy:J4 the HTTP status remains authoritative; preserve an
     // explicit unavailable marker instead of disguising the missing body.


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:290a3f07e4a986f3d8dc00c4ae633d9eea8d3590 -->

## Summary
In `plugins/plugin-zerollama`, `responseDetail` in `availability.ts` and `readHttpErrorDetail` in `audio.ts` used raw string slicing `.slice(0, 500)` on error response text, which can bisect multi-byte UTF-16 surrogate pairs (such as emojis or complex unicode characters in API error payloads) at index 500, producing orphaned surrogate characters (`\uFFFD`).

## Proposed Changes
1. Added surrogate-pair safe boundary truncation helper `truncateText`.
2. Applied `truncateText` in `responseDetail` (`availability.ts`) and `readHttpErrorDetail` (`audio.ts`).
3. Added unit test in `__tests__/availability.shape.test.ts` verifying that error responses containing emojis are cleanly truncated without split surrogates.

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-zerollama test __tests__/availability.shape.test.ts` (6/6 tests passed).

<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-3-5-sonnet","client":"antigravity","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
