### PR TITLE
fix(plugin-personal-assistant): keep UTF-16 surrogate pairs intact in truncateReason

### DIFF
--- a/plugins/plugin-personal-assistant/src/actions/resolve-request-surrogates.test.ts
+++ b/plugins/plugin-personal-assistant/src/actions/resolve-request-surrogates.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { buildResolveRequestChoice } from "./resolve-request";
+
+describe("buildResolveRequestChoice surrogate safety", () => {
+  it("truncates long reasons without bisecting surrogate pairs", () => {
+    const emojis = "🔥".repeat(100); // 200 code units > 48
+    const choice = buildResolveRequestChoice("approve", [
+      {
+        id: "req-1",
+        action: "send_email",
+        channel: "email",
+        reason: emojis,
+        payload: {},
+        createdAt: "2026-08-24T00:00:00Z",
+      } as any,
+    ]);
+
+    expect(choice.options).toHaveLength(1);
+    const label = choice.options[0].label;
+    expect(label.endsWith("…")).toBe(true);
+    for (const char of label) {
+      expect(
+        /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(
+          char,
+        ),
+      ).toBe(false);
+    }
+  });
+});

--- a/plugins/plugin-personal-assistant/src/actions/resolve-request.ts
+++ b/plugins/plugin-personal-assistant/src/actions/resolve-request.ts
@@ -277,7 +277,15 @@ function formatPending(requests: ReadonlyArray<ApprovalRequest>): string {
 /** Chip labels stay glanceable; the full reason lives in the queue row. */
 function truncateReason(reason: string, max = 48): string {
   const trimmed = reason.trim();
-  return trimmed.length <= max ? trimmed : `${trimmed.slice(0, max - 1)}…`;
+  if (trimmed.length <= max) return trimmed;
+  let end = max - 1;
+  if (end > 0 && end < trimmed.length) {
+    const code = trimmed.charCodeAt(end - 1);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      end -= 1;
+    }
+  }
+  return `${trimmed.slice(0, end)}…`;
 }
 
 /**


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:15388d8b526008b53ca0e43a2f3b95909aff2c02 -->

## Summary
In `plugins/plugin-personal-assistant/src/actions/resolve-request.ts`, `truncateReason` used raw string slicing `.slice(0, max - 1)` on request reasons, which can split multi-byte UTF-16 surrogate pairs (e.g. emojis in user request descriptions) at the boundary, emitting lone surrogate characters (`\uFFFD`).

## Proposed Changes
1. Added surrogate-pair safe boundary truncation logic to `truncateReason`.
2. Added unit test in `src/actions/resolve-request-surrogates.test.ts`.

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-personal-assistant test src/actions/resolve-request-surrogates.test.ts` (passed).

<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-3-5-sonnet","client":"antigravity","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
