### PR TITLE
fix(plugin-slack): keep UTF-16 surrogate pairs intact in truncateText

### DIFF
--- a/plugins/plugin-slack/src/formatting.test.ts
+++ b/plugins/plugin-slack/src/formatting.test.ts
@@ -174,6 +174,19 @@ describe("truncateText", () => {
     expect(truncateText("short", 10)).toBe("short");
     expect(truncateText("abcdefghij", 5)).toBe("abcd…");
   });
+
+  it("preserves UTF-16 surrogate pairs when truncating", () => {
+    const emojis = "🎉".repeat(10); // 20 code units
+    const result = truncateText(emojis, 5); // 5 chars limit - 1 ellipsis = 4 chars (2 emojis)
+    expect(result.endsWith("…")).toBe(true);
+    for (const char of result) {
+      expect(
+        /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(
+          char,
+        ),
+      ).toBe(false);
+    }
+  });
 });
 
 describe("permalink build/parse round-trip", () => {

--- a/plugins/plugin-slack/src/formatting.ts
+++ b/plugins/plugin-slack/src/formatting.ts
@@ -487,7 +487,14 @@ export function truncateText(
   if (text.length <= maxLength) {
     return text;
   }
-  return text.slice(0, maxLength - ellipsis.length) + ellipsis;
+  let end = maxLength - ellipsis.length;
+  if (end > 0 && end < text.length) {
+    const code = text.charCodeAt(end - 1);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      end -= 1;
+    }
+  }
+  return text.slice(0, end) + ellipsis;
 }
 
 /**


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:5754baaa726f557afcf22a73c8137d48e606abe0 -->

## Summary
In `plugins/plugin-slack/src/formatting.ts`, `truncateText` used raw string slicing `text.slice(0, maxLength - ellipsis.length)` which can bisect multi-byte UTF-16 surrogate pairs (such as emojis) at the slice boundary, generating invalid lone surrogate characters (`\uFFFD`).

## Proposed Changes
1. Added surrogate-pair safe boundary back-off check before slicing in `truncateText`.
2. Added unit test in `src/formatting.test.ts` verifying that emoji sequences are truncated cleanly without broken surrogate pairs.

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-slack test src/formatting.test.ts` (64/64 tests passed).

<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-3-5-sonnet","client":"antigravity","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
