### PR TITLE
fix(plugin-whatsapp): keep UTF-16 surrogate pairs intact in truncateText

### DIFF
--- a/plugins/plugin-whatsapp/src/normalize.test.ts
+++ b/plugins/plugin-whatsapp/src/normalize.test.ts
@@ -115,4 +115,17 @@ describe("text chunking", () => {
     expect(truncateText("short", 20)).toBe("short");
     expect(truncateText("abcdefghij", 5).length).toBeLessThanOrEqual(5);
   });
+
+  it("truncateText preserves UTF-16 surrogate pairs when truncating", () => {
+    const emojis = "🎉".repeat(10); // 20 code units
+    const result = truncateText(emojis, 6); // 6 limit - 3 = 3 code units -> backed off to 2 (1 emoji)
+    expect(result.endsWith("...")).toBe(true);
+    for (const char of result) {
+      expect(
+        /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(
+          char,
+        ),
+      ).toBe(false);
+    }
+  });
 });

--- a/plugins/plugin-whatsapp/src/normalize.ts
+++ b/plugins/plugin-whatsapp/src/normalize.ts
@@ -323,7 +323,14 @@ export function truncateText(text: string, maxLength: number): string {
   if (maxLength <= 3) {
     return "...".slice(0, maxLength);
   }
-  return `${text.slice(0, maxLength - 3)}...`;
+  let end = maxLength - 3;
+  if (end > 0 && end < text.length) {
+    const code = text.charCodeAt(end - 1);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      end -= 1;
+    }
+  }
+  return `${text.slice(0, end)}...`;
 }
 
 /**


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:803c2b43f13568a02df126d729cf37b565a25fe8 -->

## Summary
In `plugins/plugin-whatsapp/src/normalize.ts`, `truncateText` used raw string slicing `text.slice(0, maxLength - 3)` which can bisect multi-byte UTF-16 surrogate pairs (such as emojis) at the slice boundary, generating orphaned surrogate characters (`\uFFFD`).

## Proposed Changes
1. Added surrogate-pair safe boundary back-off check before slicing in `truncateText`.
2. Added unit test in `src/normalize.test.ts` verifying that emoji sequences are truncated cleanly without broken surrogate pairs.

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-whatsapp test src/normalize.test.ts` (12/12 tests passed).

<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-3-5-sonnet","client":"antigravity","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
