### PR TITLE
fix(shared): mergeStreamingText drops chars from leading repeated-character delta runs

### DIFF
--- a/packages/shared/src/utils/streaming-text.test.ts
+++ b/packages/shared/src/utils/streaming-text.test.ts
@@ -91,6 +91,53 @@ describe("streaming text named regressions", () => {
     });
   });
 
+  it("preserves leading repeated-character runs streamed one token at a time", () => {
+    // Regression for #28041: the regressive-snapshot guard used to fire on a
+    // single-char delta whose char equals the buffer's leading char, dropping
+    // every char after the second. A run of >=3 identical chars anchored at the
+    // string start ("...", "!!!", "---", the "```" code fence) must survive.
+    const stream = (tokens: string[]) =>
+      tokens.reduce((acc, token) => mergeStreamingText(acc, token), "");
+    expect(stream([".", ".", "."])).toBe("...");
+    expect(stream(["!", "!", "!"])).toBe("!!!");
+    expect(stream(["-", "-", "-"])).toBe("---");
+    expect(stream(["#", "#", "#", " ", "H"])).toBe("### H");
+
+    // A markdown code fence followed by a language tag: the third backtick used
+    // to be swallowed, corrupting code-block rendering in the legacy per-token
+    // chat path.
+    let fence = "";
+    for (const token of ["`", "`", "`", "j", "s"]) {
+      fence = mergeStreamingText(fence, token);
+    }
+    expect(fence).toBe("```js");
+
+    // Step-level classification: the third "." is a real append, not unchanged.
+    expect(resolveStreamingUpdate("..", ".")).toEqual({
+      kind: "append",
+      nextText: "...",
+      emittedText: ".",
+    });
+    expect(computeStreamingDelta("``", "`")).toBe("`");
+  });
+
+  it("still ignores genuine regressive snapshots and non-tail single chars", () => {
+    // A multi-char prefix of the buffer is a stale snapshot, not an append.
+    expect(mergeStreamingText("hello world", "hello")).toBe("hello world");
+    expect(resolveStreamingUpdate("hello world", "hello")).toEqual({
+      kind: "unchanged",
+      nextText: "hello world",
+      emittedText: "",
+    });
+    // A single char that is the leading char but does NOT match the tail stays
+    // a regressive no-op (buffer "ab" already advanced past the leading "a").
+    expect(mergeStreamingText("ab", "a")).toBe("ab");
+    // A single whitespace delta remains regressive, matching the equality path.
+    expect(mergeStreamingText("  x", " ")).toBe("  x");
+    // Full-snapshot growth (incoming starts with existing) is unchanged.
+    expect(mergeStreamingText(".", "...")).toBe("...");
+  });
+
   it("deduplicates overlapping suffix/prefix fragments", () => {
     expect(mergeStreamingText("Hello wor", "world")).toBe("Hello world");
     expect(computeStreamingDelta("Hello wor", "world")).toBe("ld");
@@ -156,7 +203,18 @@ describe("streaming text fuzz invariants", () => {
   it("ignores regressive snapshots that are prefixes of existing text", () => {
     fc.assert(
       fc.property(textArbitrary, textArbitrary, (prefix, suffix) => {
-        fc.pre(!(suffix === "" && prefix.length === 1 && /\S/u.test(prefix)));
+        // A single non-whitespace char that also matches the buffer's tail is a
+        // repeated-character append (#28041), not a regressive snapshot, so it
+        // is excluded here alongside the existing equality carve-out.
+        fc.pre(
+          !(
+            prefix.length === 1 &&
+            /\S/u.test(prefix) &&
+            `${prefix}${suffix}`
+              .normalize("NFC")
+              .endsWith(prefix.normalize("NFC"))
+          ),
+        );
         const existing = `${prefix}${suffix}`;
 
         expect(mergeStreamingText(existing, prefix)).toBe(existing);

--- a/packages/shared/src/utils/streaming-text.test.ts
+++ b/packages/shared/src/utils/streaming-text.test.ts
@@ -91,26 +91,35 @@ describe("streaming text named regressions", () => {
     });
   });
 
-  it("preserves leading repeated-character runs streamed one token at a time", () => {
+  it("reconstructs any non-whitespace stream one token at a time", () => {
     // Regression for #28041: the regressive-snapshot guard used to fire on a
-    // single-char delta whose char equals the buffer's leading char, dropping
-    // every char after the second. A run of >=3 identical chars anchored at the
-    // string start ("...", "!!!", "---", the "```" code fence) must survive.
+    // single-char delta equal to the buffer's leading char, dropping every
+    // occurrence of that char after the first. A one-char snapshot of a longer
+    // buffer carries no information, so all non-whitespace single-char deltas
+    // must append -- character-by-character streaming is lossless.
     const stream = (tokens: string[]) =>
       tokens.reduce((acc, token) => mergeStreamingText(acc, token), "");
+    // Leading runs of identical chars ("...", "!!!", "---", the "```" fence).
     expect(stream([".", ".", "."])).toBe("...");
     expect(stream(["!", "!", "!"])).toBe("!!!");
     expect(stream(["-", "-", "-"])).toBe("---");
     expect(stream(["#", "#", "#", " ", "H"])).toBe("### H");
 
-    // A markdown code fence followed by a language tag: the third backtick used
-    // to be swallowed, corrupting code-block rendering in the legacy per-token
-    // chat path.
-    let fence = "";
-    for (const token of ["`", "`", "`", "j", "s"]) {
-      fence = mergeStreamingText(fence, token);
-    }
-    expect(fence).toBe("```js");
+    // Interior chars equal to the leading char used to be swallowed too: the
+    // guard only tested `buffer[0] === incoming`. Streaming "aba" dropped the
+    // final "a", and code identifiers lost repeated letters.
+    expect(stream([..."aba"])).toBe("aba");
+    expect(stream([..."const c = 1"])).toBe("const c = 1");
+    expect(stream([..."- item one\n- item two"])).toBe(
+      "- item one\n- item two",
+    );
+
+    // The PR's own motivating example: a full markdown code block streamed one
+    // char at a time must round-trip, including the CLOSING fence -- which the
+    // narrower tail-only fix still dropped (buffer started with a backtick but
+    // ended with a newline by then).
+    const codeBlock = "```js\nconst x = 1\n```";
+    expect(stream([...codeBlock])).toBe(codeBlock);
 
     // Step-level classification: the third "." is a real append, not unchanged.
     expect(resolveStreamingUpdate("..", ".")).toEqual({
@@ -119,19 +128,22 @@ describe("streaming text named regressions", () => {
       emittedText: ".",
     });
     expect(computeStreamingDelta("``", "`")).toBe("`");
+    // A single char equal to the buffer's leading char but not its tail now
+    // appends instead of being dropped.
+    expect(mergeStreamingText("ab", "a")).toBe("aba");
+    expect(mergeStreamingText("ahbbh", "a")).toBe("ahbbha");
   });
 
-  it("still ignores genuine regressive snapshots and non-tail single chars", () => {
-    // A multi-char prefix of the buffer is a stale snapshot, not an append.
+  it("still ignores genuine multi-character regressive snapshots", () => {
+    // A multi-char prefix of the buffer is a stale snapshot, not an append; the
+    // single-char carve-out does not widen to multi-character deltas.
     expect(mergeStreamingText("hello world", "hello")).toBe("hello world");
     expect(resolveStreamingUpdate("hello world", "hello")).toEqual({
       kind: "unchanged",
       nextText: "hello world",
       emittedText: "",
     });
-    // A single char that is the leading char but does NOT match the tail stays
-    // a regressive no-op (buffer "ab" already advanced past the leading "a").
-    expect(mergeStreamingText("ab", "a")).toBe("ab");
+    expect(mergeStreamingText("abcdef", "abc")).toBe("abcdef");
     // A single whitespace delta remains regressive, matching the equality path.
     expect(mergeStreamingText("  x", " ")).toBe("  x");
     // Full-snapshot growth (incoming starts with existing) is unchanged.
@@ -203,18 +215,11 @@ describe("streaming text fuzz invariants", () => {
   it("ignores regressive snapshots that are prefixes of existing text", () => {
     fc.assert(
       fc.property(textArbitrary, textArbitrary, (prefix, suffix) => {
-        // A single non-whitespace char that also matches the buffer's tail is a
-        // repeated-character append (#28041), not a regressive snapshot, so it
-        // is excluded here alongside the existing equality carve-out.
-        fc.pre(
-          !(
-            prefix.length === 1 &&
-            /\S/u.test(prefix) &&
-            `${prefix}${suffix}`
-              .normalize("NFC")
-              .endsWith(prefix.normalize("NFC"))
-          ),
-        );
+        // Every non-whitespace single-char delta is a token append (#28041),
+        // not a regressive snapshot, so it is excluded here alongside the
+        // existing equality carve-out. Multi-character prefixes remain
+        // regressive and are still asserted below.
+        fc.pre(!(prefix.length === 1 && /\S/u.test(prefix)));
         const existing = `${prefix}${suffix}`;
 
         expect(mergeStreamingText(existing, prefix)).toBe(existing);

--- a/packages/shared/src/utils/streaming-text.ts
+++ b/packages/shared/src/utils/streaming-text.ts
@@ -131,8 +131,18 @@ export function mergeStreamingText(existing: string, incoming: string): string {
     return incoming;
   }
 
-  // Ignore clearly regressive snapshots.
-  if (existingNorm.startsWith(incomingNorm)) {
+  // Ignore clearly regressive snapshots, but never let this guard swallow a
+  // plausible repeated single-character append. When the buffer already starts
+  // with the same char as an incoming one-char delta, the guard would fire
+  // before the overlap loop and drop every char after the second, so a leading
+  // run of identical chars streamed one token at a time ("...", "!!!", the
+  // "```" of a code fence) rendered truncated. Defer to the overlap loop, which
+  // already appends a single-char delta that matches the tail of the buffer.
+  const isRepeatedCharAppend =
+    incoming.length === 1 &&
+    /\S/u.test(incoming) &&
+    existingNorm.endsWith(incomingNorm);
+  if (existingNorm.startsWith(incomingNorm) && !isRepeatedCharAppend) {
     return existing;
   }
 

--- a/packages/shared/src/utils/streaming-text.ts
+++ b/packages/shared/src/utils/streaming-text.ts
@@ -132,17 +132,17 @@ export function mergeStreamingText(existing: string, incoming: string): string {
   }
 
   // Ignore clearly regressive snapshots, but never let this guard swallow a
-  // plausible repeated single-character append. When the buffer already starts
-  // with the same char as an incoming one-char delta, the guard would fire
-  // before the overlap loop and drop every char after the second, so a leading
-  // run of identical chars streamed one token at a time ("...", "!!!", the
-  // "```" of a code fence) rendered truncated. Defer to the overlap loop, which
-  // already appends a single-char delta that matches the tail of the buffer.
-  const isRepeatedCharAppend =
-    incoming.length === 1 &&
-    /\S/u.test(incoming) &&
-    existingNorm.endsWith(incomingNorm);
-  if (existingNorm.startsWith(incomingNorm) && !isRepeatedCharAppend) {
+  // single-character delta. A one-char snapshot of a longer buffer carries no
+  // information, so it is never a real regressive snapshot; under delta framing
+  // it is the next token and must append. The guard fires on
+  // `existingNorm.startsWith(incomingNorm)`, which for a one-char delta is just
+  // `buffer[0] === incoming` -- swallowing every occurrence of the buffer's
+  // leading char ("...", "!!!", the "```" fence, and any interior char equal to
+  // the first). Defer all non-whitespace single-char deltas to the overlap
+  // loop, which appends them; genuine regressive snapshots are multi-character
+  // and still caught here.
+  const isSingleCharDelta = incoming.length === 1 && /\S/u.test(incoming);
+  if (existingNorm.startsWith(incomingNorm) && !isSingleCharDelta) {
     return existing;
   }
 


### PR DESCRIPTION
# Relates to

Closes #28041

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and the owning-package gates were run after sync; the one
      repo-wide `bun run verify` blocker is recorded under **Known gaps**.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased onto the latest `origin/develop` (`126807701e`); zero conflicts
      (branch is 0 commits behind at capture time).
- [x] Owning-package `test` + `typecheck` + `lint:check` pass post-sync; the
      full-repo `bun run verify` blocker is documented in **Known gaps** below.

# Risks

Low. The change is a few lines inside one pure, side-effect-free function
(`mergeStreamingText`) in `@elizaos/shared`. It only narrows the early-return
condition of the regressive-snapshot guard so that **every** non-whitespace
single-character delta defers to the append/overlap logic; every other branch is
untouched, and genuine multi-character regressive snapshots are still caught. A
property-fuzz suite (1500 runs) plus named regressions guard the surrounding
contract, including lossless character-by-character reconstruction.

# Background

## What does this PR do?

`mergeStreamingText` in `packages/shared/src/utils/streaming-text.ts` reconciles
streamed token deltas for the legacy per-token chat path (used by `@elizaos/ui`
`useChatSend`/`useStreamingText` and voice-chat-recording).

Its regressive-snapshot guard ran **before** the append/overlap logic:

```ts
if (existingNorm.startsWith(incomingNorm)) return existing;
```

When the accumulated buffer already started with the same character as an
incoming single-character delta, the delta was discarded as if it were a stale
snapshot. So any **leading run of ≥3 identical characters** streamed one token at
a time lost every char after the second:

| stream | before | after (fixed) |
| --- | --- | --- |
| `"." "." "."` | `".."` | `"..."` |
| `"!" "!" "!"` | `"!!"` | `"!!!"` |
| `` "`" "`" "`" "j" "s" `` | `` "``js" `` | `` "```js" `` |

The `` "```" `` case additionally corrupted markdown code-block rendering in the
chat UI. The function's own documented contract is to "Preserve repeated
single-character deltas"; before this fix it only held for the 1→2 transition and
for runs *not* anchored at the string start (e.g. `"soooo"` worked because it
starts with `s`).

A one-character snapshot of a longer buffer carries no information, so it is
never a real regressive snapshot; under delta framing it is the next token and
must append. An earlier revision of this PR skipped the guard only when the
incoming char also matched the buffer **tail**, which still dropped every
*interior* char equal to the buffer's leading char — streaming `"aba"` yielded
`"ab"`, `"const c = 1"` yielded `"const  = 1"`, and the **closing** `` "```" ``
fence of a streamed code block was swallowed entirely (buffer started with a
backtick but ended with a newline by then). This was raised in review and is
fixed here.

**Fix:** skip the regressive guard for any single **non-whitespace** delta,
deferring to the existing overlap loop — which returns `existing + incoming` for
a single char. Character-by-character streaming is now lossless for any
non-whitespace content. Genuine regressive snapshots (multi-char prefixes like
`"hello"` of `"hello world"`, or `"abc"` of `"abcdef"`) and whitespace deltas
are unchanged.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation. The behavior now
matches the function's existing in-code contract comment ("Preserve repeated
single-character deltas").

# Testing

## Where should a reviewer start?

`packages/shared/src/utils/streaming-text.test.ts` — the named regression
`reconstructs any non-whitespace stream one token at a time` (leading runs,
interior repeats, `"aba"`, a full code block round-trip) and the
`still ignores genuine multi-character regressive snapshots` guard, plus the
corrected precondition on the `ignores regressive snapshots that are prefixes of
existing text` fuzz property.

## Detailed testing steps

```bash
cd packages/shared
# focused (fails on the pre-fix source, passes with the fix)
node ../scripts/run-vitest.mjs run --config ./vitest.config.ts src/utils/streaming-text.test.ts
# full package suite (no regressions)
bun run test
bun run typecheck   # only pre-existing cross-package module errors, see Known gaps
bun run lint:check
```

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:91750ee8c161c99784b03e8c329860a829caf686 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots — `N/A - pure string-reconciliation function in @elizaos/shared; no rendered UI surface is added or changed by this PR.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots — `N/A - pure string-reconciliation function in @elizaos/shared; no rendered UI surface is added or changed by this PR.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough — `N/A - no UI/user flow changes; the fix is a pure library function verified by the failing-then-passing unit reproduction below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs — `N/A - the changed function is a synchronous pure helper with no server/runtime logging path; end-to-end proof is the vitest reproduction below.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs — `N/A - no request/response or component change; consumer call sites (useStreamingText) are unchanged and covered by the library test.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory — `N/A - no agent/action/provider/prompt/model change; this is a deterministic text-merge utility.`
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - deterministic pure-function fix; the domain artifact is the failing-then-passing vitest reproduction pasted inline in Evidence Details (no attachable binary output).
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review — `N/A - no rendered visual surface in this diff.`

# Evidence Details

## Real LLM-call trajectory

`N/A - deterministic pure function; no model call involved.`

## Backend + frontend logs

`N/A - pure library function; no server or client runtime log path is exercised.`
The end-to-end proof for this change is the deterministic reproduction below,
which runs the real (unmodified) source under the shared package's vitest runner.

### Failing BEFORE the fix (source at `develop`, new regression tests present)

<details><summary>vitest — streaming-text.test.ts (1 failed | 15 passed)</summary>

```
 FAIL  src/utils/streaming-text.test.ts > streaming text named regressions > reconstructs any non-whitespace stream one token at a time
AssertionError: expected '..' to be '...' // Object.is equality
Received: ".."
    103|     expect(stream([".", ".", "."])).toBe("...");
    104|     expect(stream(["!", "!", "!"])).toBe("!!!");
    105|     expect(stream(["-", "-", "-"])).toBe("---");

 Test Files  1 failed (1)
      Tests  1 failed | 15 passed (16)
```

</details>

### Also failing under the earlier NARROW fix (tail-only carve-out at `7faa87d`)

The first revision of this PR rescued only single-char deltas matching the
buffer tail, so the broadened regression still failed on interior repeats and
the closing code fence — the residual defect surfaced in review.

<details><summary>vitest — streaming-text.test.ts (1 failed | 15 passed)</summary>

```
 FAIL  src/utils/streaming-text.test.ts > streaming text named regressions > reconstructs any non-whitespace stream one token at a time
AssertionError: expected 'ab' to be 'aba' // Object.is equality
Received: "ab"

 Test Files  1 failed (1)
      Tests  1 failed | 15 passed (16)
```

</details>

### Passing AFTER the fix

<details><summary>vitest — streaming-text.test.ts (16 passed)</summary>

```
 ✓ streaming text named regressions > preserves repeated single-character deltas
 ✓ streaming text named regressions > reconstructs any non-whitespace stream one token at a time
 ✓ streaming text named regressions > still ignores genuine multi-character regressive snapshots
 ✓ streaming text named regressions > deduplicates overlapping suffix/prefix fragments
 ✓ streaming text named regressions > accepts cumulative provider snapshots without duplicating text
 ✓ streaming text named regressions > classifies in-place revisions as replacements
 ✓ streaming text fuzz invariants > treats cumulative snapshots as replacements, not duplicated appends
 ✓ streaming text fuzz invariants > ignores regressive snapshots that are prefixes of existing text
 ✓ streaming text fuzz invariants > keeps append/update classification consistent with merged output

 Test Files  1 passed (1)
      Tests  16 passed (16)
```

A full code block streamed one character at a time now round-trips exactly,
including the closing fence:
`stream([..."```js\nconst x = 1\n```"]) === "```js\nconst x = 1\n```"`.

</details>

### Full `@elizaos/shared` package suite — no regressions

<details><summary>bun run test — packages/shared</summary>

```
 Test Files  246 passed (246)
      Tests  2922 passed (2922)
   Duration  160.48s
```

</details>

### typecheck + lint (owning package)

<details><summary>bun run typecheck / lint:check — packages/shared</summary>

```
$ bunx @biomejs/biome check src
Checked 523 files in 2s. No fixes applied.

# typecheck: only pre-existing cross-package module-resolution errors remain
# (verified identical on HEAD~1 via `git stash`):
#   ../core/src/cloud-routing.ts(12,8): TS2307 Cannot find module '@elizaos/cloud-routing'
#   ../core/src/cloud-routing.ts(19,8): TS2307 Cannot find module '@elizaos/cloud-routing'
#   src/todo-cutover.ts(8,30):        TS2307 Cannot find module '@elizaos/core/edge'
# None reference streaming-text.ts; they require unbuilt sibling package dist.
```

</details>

## Screenshots (before / after) + video walkthrough

`N/A - this PR changes a pure string-merge utility in @elizaos/shared and adds no
rendered `.tsx`/`.css`/`.svg`. The user-visible effect (a chat reply that opens
with "..." or a "```" code fence rendering intact) is driven entirely by this
function's output, which is asserted deterministically by the reproduction above.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT code changed.`

## Known gaps / failures

- `bun run verify` (full-repo gate) was not run to completion on this machine:
  `bun install` requires `--minimum-release-age=0` here because an unrelated
  transitive dep (`@cloudflare/playwright@1.3.6`) trips a local install-age
  policy, and the full verify pulls the entire monorepo build/typecheck graph.
  The owning package's `test`, `typecheck` (pre-existing cross-package errors
  only, unchanged from `HEAD~1`), and `lint:check` all pass. Scope is one pure
  function in `@elizaos/shared`.
- Evidence is pasted inline (permitted by this template) rather than as minted
  attachment URLs: the immutable-URL upload flow could not authenticate its
  headless GitHub session in this environment (verification interstitial). The
  artifacts are deterministic text logs, reproducible with the commands above.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

---

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@126807701e19a2a88b7f50ce785df4b26506007a:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@126807701e19a2a88b7f50ce785df4b26506007a:packages/skills/skills/contribute-to-eliza"} -->


