### PR TITLE
fix(plugin-discord): keep UTF-16 surrogate pairs intact in truncateText

### DIFF
--- a/plugins/plugin-discord/__tests__/messaging-format.test.ts
+++ b/plugins/plugin-discord/__tests__/messaging-format.test.ts
@@ -14,6 +14,7 @@ import {
 	parseMessageLink,
 	sanitizeThreadName,
 	stripDiscordFormatting,
+	truncateText,
 	truncateUtf16Safe,
 } from "../messaging.ts";
 
@@ -91,5 +92,19 @@ describe("message link build/parse round-trip", () => {
 			messageId: "3",
 		});
 		expect(parseMessageLink("https://example.com/x")).toBeNull();
+	});
+});
+describe("truncateText", () => {
+	it("preserves UTF-16 surrogate pairs when truncating", () => {
+		const emojis = "🎉".repeat(10);
+		const result = truncateText(emojis, 5);
+		expect(result.endsWith("…")).toBe(true);
+		for (const char of result) {
+			expect(
+				/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(
+					char,
+				),
+			).toBe(false);
+		}
 	});
 });

--- a/plugins/plugin-discord/inbound-envelope.ts
+++ b/plugins/plugin-discord/inbound-envelope.ts
@@ -116,7 +116,14 @@ function buildChannelLabel(
 function truncateText(text: string, maxChars: number): string {
 	const trimmed = text.trim();
 	if (trimmed.length <= maxChars) return trimmed;
-	return `${trimmed.slice(0, maxChars - 3)}...`;
+	let end = maxChars - 3;
+	if (end > 0 && end < trimmed.length) {
+		const code = trimmed.charCodeAt(end - 1);
+		if (code >= 0xd800 && code <= 0xdbff) {
+			end -= 1;
+		}
+	}
+	return `${trimmed.slice(0, end)}...`;
 }
 
 function sanitizeReplyReferenceText(text: string): string {

--- a/plugins/plugin-discord/messaging.ts
+++ b/plugins/plugin-discord/messaging.ts
@@ -495,7 +495,14 @@ export function truncateText(
 	if (text.length <= maxLength) {
 		return text;
 	}
-	return text.slice(0, maxLength - ellipsis.length) + ellipsis;
+	let end = maxLength - ellipsis.length;
+	if (end > 0 && end < text.length) {
+		const code = text.charCodeAt(end - 1);
+		if (code >= 0xd800 && code <= 0xdbff) {
+			end -= 1;
+		}
+	}
+	return text.slice(0, end) + ellipsis;
 }
 
 /**


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:f61f9de5f70dc04314f8368113a2283eb80b991b -->

## Summary
In `plugins/plugin-discord`, `truncateText` in `messaging.ts` and `inbound-envelope.ts` used raw string slicing `text.slice(0, maxLength - ellipsis.length)` / `trimmed.slice(0, maxChars - 3)` which can bisect multi-byte UTF-16 surrogate pairs (such as emojis) at the slice boundary, generating orphaned surrogate characters (`\uFFFD`).

## Proposed Changes
1. Added surrogate-pair safe boundary back-off check before slicing in `truncateText` across `messaging.ts` and `inbound-envelope.ts`.
2. Added unit test in `__tests__/messaging-format.test.ts` verifying that emoji sequences are truncated cleanly without broken surrogate pairs.

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-discord test __tests__/messaging-format.test.ts` (9/9 tests passed).

<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-3-5-sonnet","client":"antigravity","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
