### PR TITLE
fix(plugin-telegram): keep UTF-16 surrogate pairs intact in splitMessage

### DIFF
--- a/plugins/plugin-telegram/src/messageManager.test.ts
+++ b/plugins/plugin-telegram/src/messageManager.test.ts
@@ -974,3 +974,24 @@ describe("MessageManager typing-indicator resilience", () => {
     expect(sendMessage).toHaveBeenCalledTimes(1);
   });
 });
+describe("MessageManager splitMessage surrogate safety", () => {
+  it("splits messages without bisecting surrogate pairs", () => {
+    const manager = new MessageManager(
+      { telegram: {} } as never,
+      { agentId: "agent-1", getSetting: () => undefined } as never,
+    );
+    const splitMessage = (manager as any).splitMessage.bind(manager);
+    const emojis = "🎉".repeat(3000); // 6000 code units > 4096 MAX_MESSAGE_LENGTH
+    const chunks: string[] = splitMessage(emojis);
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      for (const char of chunk) {
+        expect(
+          /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(
+            char,
+          ),
+        ).toBe(false);
+      }
+    }
+  });
+});

--- a/plugins/plugin-telegram/src/messageManager.ts
+++ b/plugins/plugin-telegram/src/messageManager.ts
@@ -1404,8 +1404,15 @@ export class MessageManager {
         }
 
         if (availableLength > 0) {
-          currentChunk += remaining.slice(0, availableLength);
-          remaining = remaining.slice(availableLength);
+          let splitIdx = availableLength;
+          if (splitIdx < remaining.length) {
+            const code = remaining.charCodeAt(splitIdx - 1);
+            if (code >= 0xd800 && code <= 0xdbff) {
+              splitIdx -= 1;
+            }
+          }
+          currentChunk += remaining.slice(0, splitIdx);
+          remaining = remaining.slice(splitIdx);
         }
 
         if (currentChunk) {


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:be24bfcc074276b677d83e60928d9e1c1491dcb3 -->

## Summary
In `plugins/plugin-telegram/src/messageManager.ts`, `splitMessage` used raw string slicing `remaining.slice(0, availableLength)` when filling message chunks to `MAX_MESSAGE_LENGTH`. If `availableLength` falls between the high and low surrogate code units of a multi-byte UTF-16 character (such as an emoji), the surrogate pair is bisected across consecutive chunks, emitting broken replacement characters (`\uFFFD`).

## Proposed Changes
1. Added surrogate-pair safe boundary back-off check before slicing in `appendSegment` within `splitMessage`.
2. Added unit test in `src/messageManager.test.ts`.

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-telegram test src/messageManager.test.ts` (28/28 tests passed).

<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-3-5-sonnet","client":"antigravity","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
