### PR TITLE
test(plugin-blocker): cover sender role fail-closed check

### DIFF
--- a/plugins/plugin-blocker/src/services/website-blocker/roles.test.ts
+++ b/plugins/plugin-blocker/src/services/website-blocker/roles.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { checkSenderRole } from "./roles";
+
+const mocks = vi.hoisted(() => ({
+  coreCheckSenderRole: vi.fn(),
+}));
+
+vi.mock("@elizaos/core", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("@elizaos/core")>();
+  return { ...mod, checkSenderRole: mocks.coreCheckSenderRole };
+});
+
+const runtime = {
+  agentId: "agent-1",
+  roomId: "room-1",
+  entityId: "entity-1",
+} as never;
+
+const message = {
+  roomId: "room-1",
+  entityId: "entity-1",
+} as never;
+
+describe("checkSenderRole", () => {
+  beforeEach(() => {
+    mocks.coreCheckSenderRole.mockReset();
+  });
+
+  it("returns the core role check result when one is resolved", async () => {
+    const roleResult = { role: "admin", allowed: true };
+    mocks.coreCheckSenderRole.mockResolvedValue(roleResult);
+    await expect(checkSenderRole(runtime, message)).resolves.toBe(roleResult);
+    expect(mocks.coreCheckSenderRole).toHaveBeenCalledWith(runtime, message);
+  });
+
+  it("throws a descriptive fail-closed error when the core check returns null", async () => {
+    mocks.coreCheckSenderRole.mockResolvedValue(null);
+    await expect(checkSenderRole(runtime, message)).rejects.toThrow(
+      "world/room/entity setup is broken",
+    );
+  });
+
+  it("includes the room, entity and agent ids in the error", async () => {
+    mocks.coreCheckSenderRole.mockResolvedValue(null);
+    await expect(checkSenderRole(runtime, message)).rejects.toThrow(
+      "roomId=room-1",
+    );
+    await expect(checkSenderRole(runtime, message)).rejects.toThrow(
+      "entityId=entity-1",
+    );
+    await expect(checkSenderRole(runtime, message)).rejects.toThrow(
+      "agentId=agent-1",
+    );
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new test file exercising the existing
`checkSenderRole` helper (sender role fail-closed check). No
production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: 3/3 passed |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
