### PR TITLE
test(plugin-personal-assistant): cover check-in schedule time normalization

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/checkin/schedule-resolver.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/checkin/schedule-resolver.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from "vitest";
+import { resolveCheckinSchedule } from "./schedule-resolver";
+
+const readProfile = vi.hoisted(() => ({ readLifeOpsOwnerProfile: vi.fn() }));
+
+vi.mock("../owner-profile.js", () => readProfile);
+
+const runtime = {} as never;
+
+function profileWith(overrides: Record<string, unknown>) {
+  return {
+    morningCheckinTime: undefined,
+    nightCheckinTime: undefined,
+    ...overrides,
+  };
+}
+
+describe("resolveCheckinSchedule", () => {
+  it("normalizes and zero-pads valid times", async () => {
+    readProfile.readLifeOpsOwnerProfile.mockResolvedValue(
+      profileWith({ morningCheckinTime: "9:05", nightCheckinTime: "22:30" }),
+    );
+    await expect(resolveCheckinSchedule(runtime)).resolves.toEqual({
+      morningCheckinTime: "09:05",
+      nightCheckinTime: "22:30",
+    });
+  });
+
+  it("rejects single-digit minutes (HH:MM requires two digits)", async () => {
+    readProfile.readLifeOpsOwnerProfile.mockResolvedValue(
+      profileWith({ morningCheckinTime: "7:5" }),
+    );
+    await expect(resolveCheckinSchedule(runtime)).resolves.toEqual({
+      morningCheckinTime: null,
+      nightCheckinTime: null,
+    });
+  });
+
+  it("keeps boundary values 00:00 and 23:59", async () => {
+    readProfile.readLifeOpsOwnerProfile.mockResolvedValue(
+      profileWith({ morningCheckinTime: "0:00", nightCheckinTime: "23:59" }),
+    );
+    await expect(resolveCheckinSchedule(runtime)).resolves.toEqual({
+      morningCheckinTime: "00:00",
+      nightCheckinTime: "23:59",
+    });
+  });
+
+  it("rejects hours out of range", async () => {
+    readProfile.readLifeOpsOwnerProfile.mockResolvedValue(
+      profileWith({ morningCheckinTime: "24:00" }),
+    );
+    await expect(resolveCheckinSchedule(runtime)).resolves.toEqual({
+      morningCheckinTime: null,
+      nightCheckinTime: null,
+    });
+  });
+
+  it("rejects minutes out of range", async () => {
+    readProfile.readLifeOpsOwnerProfile.mockResolvedValue(
+      profileWith({ nightCheckinTime: "12:60" }),
+    );
+    await expect(resolveCheckinSchedule(runtime)).resolves.toEqual({
+      morningCheckinTime: null,
+      nightCheckinTime: null,
+    });
+  });
+
+  it("rejects non-HH:MM shapes", async () => {
+    readProfile.readLifeOpsOwnerProfile.mockResolvedValue(
+      profileWith({ morningCheckinTime: "abc", nightCheckinTime: "-1:00" }),
+    );
+    await expect(resolveCheckinSchedule(runtime)).resolves.toEqual({
+      morningCheckinTime: null,
+      nightCheckinTime: null,
+    });
+  });
+
+  it("returns null for unconfigured or blank slots", async () => {
+    readProfile.readLifeOpsOwnerProfile.mockResolvedValue(
+      profileWith({ morningCheckinTime: "", nightCheckinTime: "   " }),
+    );
+    await expect(resolveCheckinSchedule(runtime)).resolves.toEqual({
+      morningCheckinTime: null,
+      nightCheckinTime: null,
+    });
+  });
+
+  it("trims surrounding whitespace before parsing", async () => {
+    readProfile.readLifeOpsOwnerProfile.mockResolvedValue(
+      profileWith({ morningCheckinTime: "  08:30  " }),
+    );
+    await expect(resolveCheckinSchedule(runtime)).resolves.toEqual({
+      morningCheckinTime: "08:30",
+      nightCheckinTime: null,
+    });
+  });
+
+  it("reads the profile through readLifeOpsOwnerProfile", async () => {
+    readProfile.readLifeOpsOwnerProfile.mockResolvedValue(profileWith({}));
+    await resolveCheckinSchedule(runtime);
+    expect(readProfile.readLifeOpsOwnerProfile).toHaveBeenCalledWith(runtime);
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new test file exercising the existing
`resolveCheckinSchedule` helper (check-in schedule time normalization). No
production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: 9/9 passed |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
