### PR TITLE
fix(core): share depth budget across wrapper levels in parseActionParams

### DIFF
--- a/packages/core/src/action-parameter-value.test.ts
+++ b/packages/core/src/action-parameter-value.test.ts
@@ -377,6 +377,43 @@ describe("parseActionParams", () => {
 			expect((error as ElizaError).code).toBe(ACTION_PARAMETER_UNBOUNDED);
 		}
 	});
+
+	it("shares the depth budget across wrapper levels", () => {
+		function nestObject(depth: number): unknown {
+			let value: unknown = "x";
+			for (let index = 0; index < depth; index += 1) {
+				value = { next: value };
+			}
+			return value;
+		}
+		// 28-deep payload via wrapper stays within MAX 32 (28 + 4 wrapper levels = 32)
+		expect(
+			parseActionParams({
+				params: { A: { payload: nestObject(28) } },
+			}).has("A"),
+		).toBe(true);
+		// 29-deep payload via wrapper exceeds budget (29 + 4 = 33)
+		try {
+			parseActionParams({
+				params: { A: { payload: nestObject(29) } },
+			});
+			expect.unreachable("wrapper depth should fail closed one past budget");
+		} catch (error) {
+			expect(error).toBeInstanceOf(ElizaError);
+			expect((error as ElizaError).code).toBe(ACTION_PARAMETER_UNBOUNDED);
+		}
+		// Fallback without params wrapper allows deeper payload (30 + 2 = 32)
+		expect(parseActionParams({ A: { payload: nestObject(30) } }).has("A")).toBe(
+			true,
+		);
+		try {
+			parseActionParams({ A: { payload: nestObject(31) } });
+			expect.unreachable("fallback depth should fail closed one past budget");
+		} catch (error) {
+			expect(error).toBeInstanceOf(ElizaError);
+			expect((error as ElizaError).code).toBe(ACTION_PARAMETER_UNBOUNDED);
+		}
+	});
 });
 
 describe("validateActionParams", () => {

--- a/packages/core/src/action-parameter-value.ts
+++ b/packages/core/src/action-parameter-value.ts
@@ -166,10 +166,10 @@ function parseActionParamsRecord(
 				typeof paramsValue === "object" &&
 				!isArrayRecord(paramsValue)
 			) {
-				return collectActionParams(paramsValue, ctx);
+				return collectActionParams(paramsValue, ctx, 1);
 			}
 		}
-		return collectActionsFromEntries(rootEntries, ctx);
+		return collectActionsFromEntries(rootEntries, ctx, 0);
 	} finally {
 		ctx.visiting.delete(parsed);
 	}
@@ -178,6 +178,7 @@ function parseActionParamsRecord(
 function collectActionParams(
 	candidate: object,
 	ctx: WalkContext,
+	depthBase: number,
 ): Map<string, ActionParameters> {
 	if (ctx.visiting.has(candidate)) {
 		failUnbounded({ cycle: true });
@@ -187,6 +188,7 @@ function collectActionParams(
 		return collectActionsFromEntries(
 			ownEnumerableStringDataEntries(candidate, ctx),
 			ctx,
+			depthBase + 1,
 		);
 	} finally {
 		ctx.visiting.delete(candidate);
@@ -196,6 +198,7 @@ function collectActionParams(
 function collectActionsFromEntries(
 	actionEntries: Array<[string, unknown]>,
 	ctx: WalkContext,
+	baseDepth: number,
 ): Map<string, ActionParameters> {
 	const result = new Map<string, ActionParameters>();
 	for (const [actionName, paramsValue] of actionEntries) {
@@ -218,7 +221,7 @@ function collectActionsFromEntries(
 				defineDataProperty(
 					params,
 					paramName,
-					toActionParameterValueInner(paramValue, 0, ctx, true),
+					toActionParameterValueInner(paramValue, baseDepth + 2, ctx, true),
 				);
 			}
 			if (Object.keys(params).length > 0) {


### PR DESCRIPTION
# Relates to

N/A - isolated bug fix with no linked issue.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Changes depth accounting only for the planner JSON walk. No new dependencies, no protocol change. Honest payloads up to budget unchanged; over-budget payloads now correctly rejected.

# Background

## What does this PR do?

Fixes depth-budget bypass in `parseActionParams`. `collectActionsFromEntries` called `toActionParameterValueInner(paramValue, 0, ...)` for every param, resetting depth to 0 inside the wrapper. A 29-deep object via `params.A.payload` therefore counted as 29 not 33 and passed `MAX_ACTION_PARAMETER_DEPTH=32`. Thread `baseDepth` through `parseActionParamsRecord` -> `collectActionParams` -> `collectActionsFromEntries` so wrapper levels contribute (4 levels via `params`, 2 levels fallback). Now 28-deep via wrapper passes (28+4=32) and 29-deep throws (29+4=33); fallback 30 passes (30+2=32), 31 throws.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/core/src/action-parameter-value.ts` diff (4 lines) and `packages/core/src/action-parameter-value.test.ts` new `shares the depth budget` block.

## Detailed testing steps

```bash
bun test packages/core/src/action-parameter-value.test.ts
```

- Red (production reverted, test kept): 1 failed `shares the depth budget across wrapper levels` (`expect.unreachable` not hit because `nestObject(29)` via wrapper did not throw), 25 passed, 1 failed.
- Green (restored): 26 passed, 0 failed.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:0b86ff3437b7b15ac16d3f4fdda21e7bbb5baf69 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - backend-only core walk fix with no visual surface`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - backend-only core walk fix with no visual surface`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - backend-only core walk fix with no visual surface`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - exercised via unit test harness; no long-running server path`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - no frontend contract touched`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - deterministic parser walk; no live model path`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - parser only; no persistence side-effects`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

N/A - deterministic parser walk; no live model path.

## Backend + frontend logs

Backend: unit test harness covers the walk.

<details><summary>Red (production reverted, test kept) — 1 fail</summary>

```
(fail) parseActionParams > shares the depth budget across wrapper levels [0.34ms]
  25 pass
  1 fail
  84 expect() calls
Ran 26 tests across 1 file.
```

Full run showed `29 object via params: PASS` (did not throw) triggering `expect.unreachable`.
</details>

<details><summary>Green (restored) — 0 fail</summary>

```
26 pass
0 fail
88 expect() calls
Ran 26 tests across 1 file. [171.00ms]
```

</details>

Existing suite `bun test packages/core/src/action-parameter-value.test.ts` passes post-fix. Baseline re-run with change reverted fails exactly on new test as above, confirming red->green is caused by production fix, not test harness.

## Screenshots (before / after) + video walkthrough

N/A - backend-only core walk fix with no visual surface.

### Before

N/A

### After

N/A

### Walkthrough video

N/A

## Audio / voice walkthrough

N/A

## Known gaps / failures

None. `bun run --cwd packages/core typecheck` passes (generates keyword data, tsc --noEmit clean). `bun run --cwd packages/core lint` passes with 4 pre-existing warnings in unrelated file `mock-runtime.test.ts` (any), no errors on changed files.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
