### PR TITLE
fix(core): guard non-finite coordinates in location helpers

### DIFF
--- a/packages/core/src/utils/channel-utils.test.ts
+++ b/packages/core/src/utils/channel-utils.test.ts
@@ -230,6 +230,42 @@ describe("formatLocationText", () => {
 			"🛰 Live location: 37.774900, -122.419400\nSharing live route for 15 mins",
 		);
 	});
+
+	it("returns empty string for non-finite coordinates instead of leaking NaN/Infinity", () => {
+		expect(
+			formatLocationText({
+				latitude: Number.NaN,
+				longitude: -122.4194,
+			}),
+		).toBe("");
+		expect(
+			formatLocationText({
+				latitude: Number.POSITIVE_INFINITY,
+				longitude: -122.4194,
+			}),
+		).toBe("");
+		expect(
+			formatLocationText({
+				latitude: 37.7749,
+				longitude: Number.NEGATIVE_INFINITY,
+			}),
+		).toBe("");
+		expect(
+			formatLocationText({
+				latitude: Number.NaN,
+				longitude: Number.NaN,
+				name: "Nowhere",
+			}),
+		).toBe("");
+		expect(
+			formatLocationText({
+				latitude: 37.7749,
+				longitude: Number.NaN,
+				isLive: true,
+				caption: "caption should not leak",
+			}),
+		).toBe("");
+	});
 });
 
 describe("toLocationContext", () => {
@@ -272,6 +308,36 @@ describe("toLocationContext", () => {
 
 			expect(context.LocationAccuracy).toBeUndefined();
 		}
+	});
+
+	it("guards non-finite latitude/longitude in location context", () => {
+		for (const bad of [
+			Number.NaN,
+			Number.POSITIVE_INFINITY,
+			Number.NEGATIVE_INFINITY,
+		]) {
+			const ctxLat = toLocationContext({
+				latitude: bad,
+				longitude: -122.4194,
+			});
+			expect(Number.isFinite(ctxLat.LocationLat)).toBe(true);
+			expect(ctxLat.LocationLat).toBe(0);
+
+			const ctxLon = toLocationContext({
+				latitude: 37.7749,
+				longitude: bad,
+			});
+			expect(Number.isFinite(ctxLon.LocationLon)).toBe(true);
+			expect(ctxLon.LocationLon).toBe(0);
+		}
+		const both = toLocationContext({
+			latitude: Number.NaN,
+			longitude: Number.POSITIVE_INFINITY,
+			accuracy: 10,
+		});
+		expect(both.LocationLat).toBe(0);
+		expect(both.LocationLon).toBe(0);
+		expect(both.LocationAccuracy).toBe(10);
 	});
 });
 

--- a/packages/core/src/utils/channel-utils.ts
+++ b/packages/core/src/utils/channel-utils.ts
@@ -488,6 +488,7 @@ function formatAccuracy(accuracy?: number): string {
 }
 
 function formatCoords(latitude: number, longitude: number): string {
+	if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) return "";
 	return `${latitude.toFixed(6)}, ${longitude.toFixed(6)}`;
 }
 
@@ -499,6 +500,12 @@ function formatCoords(latitude: number, longitude: number): string {
  */
 export function formatLocationText(location: NormalizedLocation): string {
 	const resolved = resolveLocation(location);
+	if (
+		!Number.isFinite(resolved.latitude) ||
+		!Number.isFinite(resolved.longitude)
+	) {
+		return "";
+	}
 	const coords = formatCoords(resolved.latitude, resolved.longitude);
 	const accuracy = formatAccuracy(resolved.accuracy);
 	const caption = resolved.caption?.trim();
@@ -545,9 +552,11 @@ export function toLocationContext(
 		resolved.accuracy >= 0
 			? resolved.accuracy
 			: undefined;
+	const lat = Number.isFinite(resolved.latitude) ? resolved.latitude : 0;
+	const lon = Number.isFinite(resolved.longitude) ? resolved.longitude : 0;
 	return {
-		LocationLat: resolved.latitude,
-		LocationLon: resolved.longitude,
+		LocationLat: lat,
+		LocationLon: lon,
 		LocationAccuracy: accuracy,
 		LocationName: resolved.name,
 		LocationAddress: resolved.address,


### PR DESCRIPTION
# Relates to

N/A - location helper NaN guard, no issue tracked.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Isolated to `packages/core/src/utils/channel-utils.ts` pure formatting helpers. Adds `Number.isFinite` guards only; no API type change (LocationContext still returns numbers, non-finite coerced to 0). Existing callers that already pass finite coords are unaffected. Failing closed on NaN/Infinity prevents leak into model prompts.

# Background

## What does this PR do?

Guards non-finite coordinates in location helpers. `formatCoords` called `toFixed` on any number, so `NaN`/`Infinity` leaked as `"NaN, -122.419400"` into `formatLocationText` (`"📍 NaN, NaN"`). `toLocationContext` forwarded non-finite `latitude`/`longitude` directly to `LocationLat`/`LocationLon`. Now `formatCoords` returns `""` for non-finite, `formatLocationText` returns `""` early, and `toLocationContext` coerces non-finite to `0`.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/core/src/utils/channel-utils.test.ts` - two new cases: `returns empty string for non-finite coordinates` and `guards non-finite latitude/longitude in location context`.

## Detailed testing steps

- `bun run --cwd packages/core test --run src/utils/channel-utils.test.ts` should show 21 pass (previously 19 pass 2 fail when reverted).

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows` sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:ffbc5aeb23fa05006fd7faacc3c9d59b1c54fcbd -->

Any change testable on the frontend is not mergeable without a video walkthrough, before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the description or a comment), or write `N/A - <reason>` on the row. Do not leave evidence rows blank. Videos must be **MP4** (GitHub renders them inline); prefer **JPG over PNG** for screenshots. Do not commit evidence files to the repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - non-UI logic`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - non-UI logic`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - non-UI logic`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - unit test evidence`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend logs`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - no model change`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - no domain artifacts`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - no visual surface`.

# Evidence Details

## Real LLM-call trajectory

N/A - no model change.

## Backend + frontend logs

N/A - unit test evidence.

Red -> Green:

<details><summary>Red (reverted `packages/core/src/utils/channel-utils.ts`)</summary>

```
FAIL  src/utils/channel-utils.test.ts > formatLocationText > returns empty string for non-finite coordinates instead of leaking NaN/Infinity
AssertionError: expected '📍 NaN, -122.419400' to be '' // Object.is equality

Expected: ""
Received: "📍 NaN, -122.419400"

 ❯ src/utils/channel-utils.test.ts:240:5

 FAIL  src/utils/channel-utils.test.ts > toLocationContext > guards non-finite latitude/longitude in location context
AssertionError: expected false to be true // Object.is equality
Expected: true
Received: false
❯ src/utils/channel-utils.test.ts:323:48
    expect(Number.isFinite(ctxLat.LocationLat)).toBe(true);

 Test Files  1 failed (1)
      Tests  2 failed | 19 passed (21)
```

</details>

<details><summary>Green (fixed)</summary>

```
$ node ../scripts/run-vitest.mjs run --run src/utils/channel-utils.test.ts

 Test Files  1 passed (1)
      Tests  21 passed (21)
   Duration  93ms
```

</details>

Package checks:
```
bun run --cwd packages/core typecheck  # pass
bun run biome check --write packages/core/src/utils/channel-utils.ts packages/core/src/utils/channel-utils.test.ts  # Checked 2 files, Fixed 1 file
```

## Screenshots (before / after) + video walkthrough

N/A - non-UI logic.

### Before

N/A - non-UI logic.

### After

N/A - non-UI logic.

### Walkthrough video

N/A - non-UI logic.

## Audio / voice walkthrough

N/A - no voice change.

## Known gaps / failures

None. `git diff --check` clean.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow [Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
