### PR TITLE
fix(shared): truncate fractional marketCapRank instead of rounding

### DIFF
--- a/packages/shared/src/wallet/market-overview.test.ts
+++ b/packages/shared/src/wallet/market-overview.test.ts
@@ -75,6 +75,91 @@ describe("wallet market-overview shared domain", () => {
     ).toBeNull();
   });
 
+  it("truncates fractional marketCapRank instead of rounding", () => {
+    // CoinGecko occasionally returns rank as float string; must truncate not round
+    expect(
+      mapCoinGeckoMarket({
+        id: "test",
+        symbol: "tst",
+        name: "Test",
+        current_price: 10,
+        price_change_percentage_24h: 5,
+        market_cap_rank: "200.6",
+      })?.marketCapRank,
+    ).toBe(200);
+    expect(
+      mapCoinGeckoMarket({
+        id: "test",
+        symbol: "tst",
+        name: "Test",
+        current_price: 10,
+        price_change_percentage_24h: 5,
+        market_cap_rank: 200.6,
+      })?.marketCapRank,
+    ).toBe(200);
+    expect(
+      mapCoinGeckoMarket({
+        id: "test",
+        symbol: "tst",
+        name: "Test",
+        current_price: 10,
+        price_change_percentage_24h: 5,
+        market_cap_rank: "199.9",
+      })?.marketCapRank,
+    ).toBe(199);
+    expect(
+      mapCoinGeckoMarket({
+        id: "test",
+        symbol: "tst",
+        name: "Test",
+        current_price: 10,
+        price_change_percentage_24h: 5,
+        market_cap_rank: 199.9,
+      })?.marketCapRank,
+    ).toBe(199);
+    // integer ranks unchanged
+    expect(
+      mapCoinGeckoMarket({
+        id: "test",
+        symbol: "tst",
+        name: "Test",
+        current_price: 10,
+        price_change_percentage_24h: 5,
+        market_cap_rank: 150,
+      })?.marketCapRank,
+    ).toBe(150);
+    // mover cap: 200.6 truncated to 200 is within cap, 200.6 rounded to 201 would be excluded
+    const record = (
+      id: string,
+      rank: number | null,
+      change: number,
+    ): CoinGeckoMarketRecord => ({
+      id,
+      symbol: id.toUpperCase(),
+      name: id,
+      currentPriceUsd: 10,
+      change24hPct: change,
+      marketCapRank: rank,
+      imageUrl: null,
+    });
+    const markets = [record("a", 200, 10), record("b", 201, 20)];
+    // also test via mapped fractional record that truncates into cap
+    const fractional = mapCoinGeckoMarket({
+      id: "c",
+      symbol: "c",
+      name: "C",
+      current_price: 10,
+      price_change_percentage_24h: 30,
+      market_cap_rank: "200.6",
+    });
+    expect(fractional).not.toBeNull();
+    if (!fractional) throw new Error("expected fractional market");
+    expect(fractional.marketCapRank).toBe(200);
+    const movers = buildMarketMovers([...markets, fractional]);
+    expect(movers.map((m) => m.id)).toContain("c");
+    expect(movers.map((m) => m.id)).not.toContain("b");
+  });
+
   it("flags stablecoins by id or symbol", () => {
     const usdc: CoinGeckoMarketRecord = {
       id: "usd-coin",

--- a/packages/shared/src/wallet/market-overview.ts
+++ b/packages/shared/src/wallet/market-overview.ts
@@ -94,7 +94,7 @@ function coerceNumber(value: unknown): number | null {
 function coerceInteger(value: unknown): number | null {
   const parsed = coerceNumber(value);
   if (parsed === null) return null;
-  return Number.isInteger(parsed) ? parsed : Math.round(parsed);
+  return Number.isInteger(parsed) ? parsed : Math.trunc(parsed);
 }
 
 /** Build the CoinGecko `/coins/markets` request URL (USD, 24h change). */


### PR DESCRIPTION
# Relates to

N/A - market-overview rank truncation fix.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Isolated to `packages/shared/src/wallet/market-overview.ts` `coerceInteger` helper used for `market_cap_rank` only. Changes rounding to truncation; integer ranks unchanged. Affects mover ranking near the 200 cap only; previously mis-classified 200.x ranks.

# Background

## What does this PR do?

Fixes fractional `marketCapRank` handling. `coerceInteger` used `Math.round` for non-integer parsed values, so `"200.6"` -> `201` (excluded from movers, since `>200`) while `"199.9"` -> `200` (included). The rank should be truncated (200.6 -> 200, 199.9 -> 199) to avoid off-by-one errors at the rank 200 boundary used by `buildMarketMovers`. Replace `Math.round` with `Math.trunc`.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/shared/src/wallet/market-overview.test.ts` - new `truncates fractional marketCapRank instead of rounding` case.

## Detailed testing steps

- `bun run --cwd packages/shared test --run src/wallet/market-overview.test.ts` should show 7 pass (previously 6 pass 1 fail when reverted).

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows` sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:d42bae068fb19625791d92b1dc48282e6dc7848b -->

Any change testable on the frontend is not mergeable without a video walkthrough, before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the description or a comment), or write `N/A - <reason>` on the row. Do not leave evidence rows blank. Videos must be **MP4** (GitHub renders them inline); prefer **JPG over PNG** for screenshots. Do not commit evidence files to the repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - no UI surface`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - no UI surface`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - no UI flow`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - pure shared helper, unit test evidence`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend logs`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - no model change`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - no domain artifacts`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - no visual surface`.

# Evidence Details

## Real LLM-call trajectory

N/A - no model change.

## Backend + frontend logs

N/A - pure shared helper, unit test evidence.

Red -> Green:

<details><summary>Red (reverted `packages/shared/src/wallet/market-overview.ts`)</summary>

```
FAIL  src/wallet/market-overview.test.ts > wallet market-overview shared domain > truncates fractional marketCapRank instead of rounding
AssertionError: expected 201 to be 200 // Object.is equality

- Expected
+ Received

- 200
+ 201

 ❯ src/wallet/market-overview.test.ts:89:7
     expect(
       mapCoinGeckoMarket({
         id: "test",
         symbol: "tst",
         name: "Test",
         current_price: 10,
         price_change_percentage_24h: 5,
         market_cap_rank: "200.6",
       })?.marketCapRank,
     ).toBe(200);

 Test Files  1 failed (1)
      Tests  1 failed | 6 passed (7)
```

</details>

<details><summary>Green (fixed)</summary>

```
$ node ../scripts/run-vitest.mjs run --config ./vitest.config.ts --run src/wallet/market-overview.test.ts

 Test Files  1 passed (1)
      Tests  7 passed (7)
   Duration  212ms
```

</details>

Package checks:
```
bun run --cwd packages/shared typecheck  # pass
bun run biome check --write packages/shared/src/wallet/market-overview.ts packages/shared/src/wallet/market-overview.test.ts  # Checked 2 files in 17ms, No fixes applied
```

## Screenshots (before / after) + video walkthrough

N/A - no UI surface.

### Before

N/A - no UI surface.

### After

N/A - no UI surface.

### Walkthrough video

N/A - no UI flow.

## Audio / voice walkthrough

N/A - no voice change.

## Known gaps / failures

None. `git diff --check` clean.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow [Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
