### PR TITLE
fix(core): reject odd-length hex in fromHex

### DIFF
--- a/packages/core/src/utils/buffer.test.ts
+++ b/packages/core/src/utils/buffer.test.ts
@@ -28,6 +28,15 @@ describe("hex / string round-trips", () => {
 		expect(bufferToString(fromHex("48 65 6c 6c 6f"))).toBe("Hello");
 	});
 
+	it("fromHex rejects odd-length hex instead of silently dropping a nibble", () => {
+		expect(() => fromHex("abc")).toThrow(TypeError);
+		expect(() => fromHex("0x01")).toThrow(TypeError);
+		expect(() => fromHex("a")).toThrow(TypeError);
+		// even-length still round-trips
+		expect(toHex(fromHex("0a0b"))).toBe("0a0b");
+		expect(bufferToString(fromHex("0a"))).toBe("\n");
+	});
+
 	it("base64 ⇄ utf8", () => {
 		expect(bufferToString(fromString("SGVsbG8=", "base64"))).toBe("Hello");
 		expect(bufferToString(fromString("Hi"), "base64")).toBe("SGk=");

--- a/packages/core/src/utils/buffer.ts
+++ b/packages/core/src/utils/buffer.ts
@@ -27,6 +27,9 @@ function hasNativeBuffer(): boolean {
 export function fromHex(hex: string): BufferLike {
 	// Clean the hex string to remove non-hex characters
 	const cleanHex = hex.replace(/[^0-9a-fA-F]/g, "");
+	if (cleanHex.length % 2 !== 0) {
+		throw new TypeError("fromHex: odd-length hex string");
+	}
 
 	if (hasNativeBuffer()) {
 		return Buffer.from(cleanHex, "hex");


### PR DESCRIPTION
# Relates to

N/A - isolated bug fix with no linked issue.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Adds fail-closed guard to hex parsing; no new deps. Previously odd hex silently truncated; now throws TypeError which callers must handle. No honest even-length path changes.

# Background

## What does this PR do?

Fixes silent truncation in `fromHex`. It stripped non-hex chars then passed `cleanHex` directly to `Buffer.from(hex,"hex")` (Node) which drops last nibble on odd length, and to `new Uint8Array(cleanHex.length/2)` (browser) which truncates. `"abc"` (3 chars) became 1 byte `ab` instead of error. Added `cleanHex.length %2 !==0` guard throwing `TypeError` before either path.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/core/src/utils/buffer.ts` 3-line guard and `buffer.test.ts` new `rejects odd-length` case.

## Detailed testing steps

```bash
bun test packages/core/src/utils/buffer.test.ts
```

- Red (production reverted, test kept): 8 pass, 1 fail (`fromHex rejects odd-length hex`)
- Green (restored): 9 pass, 0 fail, 26 expect() calls

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:21c2cdd3ad8c1ec9fb56d641b193d92e0a7672ec -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - pure buffer util with no visual surface`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - pure buffer util with no visual surface`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - pure buffer util with no visual surface`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - exercised via unit test harness`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - no frontend contract`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - deterministic util; no live model`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - no persistence`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

N/A - deterministic util; no live model.

## Backend + frontend logs

<details><summary>Red (production reverted) — 1 fail</summary>

```
8 pass
1 fail
22 expect() calls
Ran 9 tests across 1 file.
```

New `rejects odd-length` test fails because `fromHex("abc")` did not throw.
</details>

<details><summary>Green (restored) — 0 fail</summary>

```
9 pass
0 fail
26 expect() calls
Ran 9 tests across 1 file.
```

</details>

Baseline re-run with guard reverted fails exactly on new test, confirming fix.

## Screenshots (before / after) + video walkthrough

N/A - pure buffer util with no visual surface.

### Before

N/A

### After

N/A

### Walkthrough video

N/A

## Audio / voice walkthrough

N/A

## Known gaps / failures

None. `bun run --cwd packages/core typecheck` passes. `bun run --cwd packages/core lint` passes (4 warnings in unrelated file).

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
