### PR TITLE
fix(core): guard unwrapWholeCodeFence against non-string inputs

### DIFF
--- a/packages/core/src/utils/code-fence.test.ts
+++ b/packages/core/src/utils/code-fence.test.ts
@@ -28,4 +28,21 @@ describe("unwrapWholeCodeFence", () => {
 			"x",
 		);
 	});
+
+	it("returns null for non-string inputs instead of throwing", () => {
+		expect(
+			unwrapWholeCodeFence(null as unknown as string, ["json"]),
+		).toBeNull();
+		expect(
+			unwrapWholeCodeFence(undefined as unknown as string, ["json"]),
+		).toBeNull();
+		expect(unwrapWholeCodeFence(123 as unknown as string, ["json"])).toBeNull();
+		expect(unwrapWholeCodeFence({} as unknown as string, ["json"])).toBeNull();
+		expect(
+			unwrapWholeCodeFence("```json\n{}\n```", null as unknown as string[]),
+		).toBeNull();
+		expect(
+			unwrapWholeCodeFence("```json\n{}\n```", "json" as unknown as string[]),
+		).toBeNull();
+	});
 });

--- a/packages/core/src/utils/code-fence.ts
+++ b/packages/core/src/utils/code-fence.ts
@@ -4,6 +4,9 @@ export function unwrapWholeCodeFence(
 	value: string,
 	languages: readonly string[],
 ): string | null {
+	if (typeof value !== "string" || !Array.isArray(languages)) {
+		return null;
+	}
 	if (!value.startsWith("```") || !value.endsWith("```") || value.length < 6) {
 		return null;
 	}


### PR DESCRIPTION
# Relates to

N/A - isolated bug fix with no linked issue.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Adds early return null for non-string/array inputs. No behavior change for honest string fences.

# Background

## What does this PR do?

Fixes TypeError when `unwrapWholeCodeFence` receives non-string `value` (null, number, object) or non-array `languages` from untrusted model output. Previously called `value.startsWith`/`toLowerCase` directly and threw. Now returns `null` early for `typeof value !== "string"` or `!Array.isArray(languages)`, matching the parser's existing null-on-invalid contract.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/core/src/utils/code-fence.ts` 3-line guard and `code-fence.test.ts` new non-string case.

## Detailed testing steps

```bash
bun test packages/core/src/utils/code-fence.test.ts
```

- Red (production reverted, test kept): 3 pass, 1 fail (`returns null for non-string inputs`)
- Green (restored): 4 pass, 0 fail, 13 expect() calls

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:92c6156bbb9a18a1665a8b42684f0a1147309a4e -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - pure parser util; no visual surface`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - pure parser util; no visual surface`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - pure parser util; no visual surface`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked
      `N/A - exercised via unit test harness`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - no frontend`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - deterministic parser; no live model`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - no persistence`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

N/A - deterministic parser; no live model.

## Backend + frontend logs

<details><summary>Red (production reverted) — 1 fail</summary>

```
3 pass
1 fail
7 expect() calls
Ran 4 tests across 1 file.
```

Non-string inputs threw TypeError instead of returning null.
</details>

<details><summary>Green (restored) — 0 fail</summary>

```
4 pass
0 fail
13 expect() calls
Ran 4 tests across 1 file.
```

</details>

# Screenshots (before / after) + video walkthrough

N/A - pure parser util; no visual surface.

### Before

N/A

### After

N/A

### Walkthrough video

N/A

## Audio / voice walkthrough

N/A

## Known gaps / failures

None. `bun run --cwd packages/core typecheck` passes. `bun run --cwd packages/core lint` passes.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
