### PR TITLE
fix(messaging): truthful per-part attachment delivery outcomes (Slack + iMessage)

### DIFF
--- a/packages/core/src/features/advanced-capabilities/actions/message.test.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/message.test.ts
@@ -717,6 +717,41 @@ describe("MESSAGE op=send delivery evidence", () => {
 		expect(createMemory).not.toHaveBeenCalled();
 	});
 
+	it("does not direct local-effect sends to provider reconciliation when the outbound record fails", async () => {
+		const localEffectReceipt: SendHandlerReceipt = {
+			providerMessageIds: [
+				"imessage-effect:9c1e5b1a-0000-4000-8000-000000000003:send",
+			],
+			acceptedAt: 1_780_000_000_000,
+			persistence: { status: "persisted", memoryIds: [] },
+			evidenceKind: "local-effect",
+		};
+		const { result } = await sendWithOutcome(
+			{
+				kind: "delivered",
+				receipt: localEffectReceipt,
+				memories: [],
+			},
+			{ outboundPersistenceFailure: new Error("database unavailable") },
+		);
+		expect(result.success).toBe(false);
+		expect(result.data).toMatchObject({
+			error: "MESSAGE_DELIVERED_PERSISTENCE_FAILED",
+			acceptance: "accepted",
+			persistenceStatus: "failed",
+			persistenceCode: "MESSAGE_OUTBOUND_MEMORY_PERSISTENCE_FAILED",
+			newDelivery: true,
+			persisted: false,
+		});
+		expect(result.text).toMatch(/do not resend/i);
+		expect(result.text).toContain("the requested local outbound record failed");
+		expect(result.text).toMatch(/no provider message ids to reconcile/i);
+		expect(result.text).toContain("reached its target");
+		expect(result.text).not.toMatch(/reconcile provider messages/i);
+		expect(result.text).not.toMatch(/reconcile the accepted provider message/i);
+		expect(result.text).not.toContain("imessage-effect:");
+	});
+
 	it("reports provider acceptance when local persistence failed without resending", async () => {
 		const failedReceipt: SendHandlerReceipt = {
 			providerMessageIds: ["discord-message-accepted"],

--- a/packages/core/src/features/advanced-capabilities/actions/message.test.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/message.test.ts
@@ -639,6 +639,84 @@ describe("MESSAGE op=send delivery evidence", () => {
 		expect(createMemory).not.toHaveBeenCalled();
 	});
 
+	it("never asks an operator to reconcile local-effect markers as provider ids", async () => {
+		const localEffectReceipt: SendHandlerReceipt = {
+			providerMessageIds: [
+				"imessage-effect:9c1e5b1a-0000-4000-8000-000000000001:send",
+			],
+			acceptedAt: 1_780_000_000_000,
+			persistence: {
+				status: "not_attempted",
+				reason:
+					"iMessage AppleScript sends return no provider message ids; effect stamps are local completion markers.",
+			},
+			evidenceKind: "local-effect",
+		};
+		const { result, upsertMemory, createMemory } = await sendWithOutcome({
+			kind: "partially_delivered",
+			receipt: localEffectReceipt,
+			memories: [],
+			code: "IMESSAGE_PARTIAL_DELIVERY",
+			message:
+				"iMessage delivered 2 text chunk(s) and 0 attachment(s) before failing: AppleScript error.",
+		});
+		expect(result.success).toBe(false);
+		expect(result.data).toMatchObject({
+			error: "MESSAGE_PARTIAL_DELIVERY",
+			acceptance: "partial",
+			newDelivery: true,
+		});
+		expect(result.text).toMatch(/do not retry blindly/i);
+		expect(result.text).toMatch(/no provider message ids to reconcile/i);
+		expect(result.text).toContain("reached the target");
+		expect(result.text).not.toMatch(/reconcile provider messages/i);
+		expect(result.text).not.toContain("imessage-effect:");
+		expect(upsertMemory).not.toHaveBeenCalled();
+		expect(createMemory).not.toHaveBeenCalled();
+	});
+
+	it("does not direct local-effect sends to provider reconciliation when persistence failed", async () => {
+		const localEffectReceipt: SendHandlerReceipt = {
+			providerMessageIds: [
+				"imessage-effect:9c1e5b1a-0000-4000-8000-000000000002:send",
+			],
+			acceptedAt: 1_780_000_000_000,
+			persistence: {
+				status: "failed",
+				failures: [
+					{
+						providerMessageId:
+							"imessage-effect:9c1e5b1a-0000-4000-8000-000000000002:send",
+						stage: "memory",
+						code: "PERSISTENCE_FAILED",
+						message: "database unavailable",
+					},
+				],
+			},
+			evidenceKind: "local-effect",
+		};
+		const { result, upsertMemory, createMemory } = await sendWithOutcome({
+			kind: "delivered",
+			receipt: localEffectReceipt,
+			memories: [],
+		});
+		expect(result.success).toBe(false);
+		expect(result.data).toMatchObject({
+			error: "MESSAGE_DELIVERED_PERSISTENCE_FAILED",
+			acceptance: "accepted",
+			persistenceStatus: "failed",
+			newDelivery: true,
+		});
+		expect(result.text).toMatch(/do not resend/i);
+		expect(result.text).toMatch(/no provider message ids to reconcile/i);
+		expect(result.text).toContain("reached its target");
+		expect(result.text).not.toMatch(/reconcile provider messages/i);
+		expect(result.text).not.toMatch(/reconcile the accepted provider message/i);
+		expect(result.text).not.toContain("imessage-effect:");
+		expect(upsertMemory).not.toHaveBeenCalled();
+		expect(createMemory).not.toHaveBeenCalled();
+	});
+
 	it("reports provider acceptance when local persistence failed without resending", async () => {
 		const failedReceipt: SendHandlerReceipt = {
 			providerMessageIds: ["discord-message-accepted"],

--- a/packages/core/src/features/advanced-capabilities/actions/message.test.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/message.test.ts
@@ -666,6 +666,15 @@ describe("MESSAGE op=send delivery evidence", () => {
 			acceptance: "partial",
 			newDelivery: true,
 		});
+		// The structured surface must agree with the guidance text: ids
+		// carried from a local-effect receipt are labelled as such so a
+		// metadata consumer cannot misread them as provider-backed.
+		expect(result.data).toMatchObject({
+			providerMessageIds: [
+				"imessage-effect:9c1e5b1a-0000-4000-8000-000000000001:send",
+			],
+			evidenceKind: "local-effect",
+		});
 		expect(result.text).toMatch(/do not retry blindly/i);
 		expect(result.text).toMatch(/no provider message ids to reconcile/i);
 		expect(result.text).toContain("reached the target");
@@ -707,6 +716,8 @@ describe("MESSAGE op=send delivery evidence", () => {
 			persistenceStatus: "failed",
 			newDelivery: true,
 		});
+		// Structured surface labels local-effect ids (persistence-failure path).
+		expect(result.data).toMatchObject({ evidenceKind: "local-effect" });
 		expect(result.text).toMatch(/do not resend/i);
 		expect(result.text).toMatch(/no provider message ids to reconcile/i);
 		expect(result.text).toContain("reached its target");
@@ -743,6 +754,8 @@ describe("MESSAGE op=send delivery evidence", () => {
 			newDelivery: true,
 			persisted: false,
 		});
+		// Structured surface labels local-effect ids (outbound-record path).
+		expect(result.data).toMatchObject({ evidenceKind: "local-effect" });
 		expect(result.text).toMatch(/do not resend/i);
 		expect(result.text).toContain("the requested local outbound record failed");
 		expect(result.text).toMatch(/no provider message ids to reconcile/i);

--- a/packages/core/src/features/advanced-capabilities/actions/message.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/message.ts
@@ -3190,10 +3190,17 @@ async function handleSend(
 			);
 		}
 		if (disposition.kind === "partially_delivered") {
+			// Local-effect receipts carry locally generated completion markers,
+			// not provider-issued ids; guidance must never tell an operator to
+			// reconcile ids against a provider that issued none.
+			const partialDeliveryGuidance =
+				disposition.receipt.evidenceKind === "local-effect"
+					? `${selected.connector.label} delivered part of the message, but the complete payload was not delivered. Do not retry blindly; the delivered parts reached the target and the transport returned no provider message ids to reconcile. ${disposition.message}`
+					: `${selected.connector.label} accepted part of the message, but the complete payload was not delivered. Do not retry blindly; provider messages ${disposition.receipt.providerMessageIds.join(", ")} already exist. ${disposition.message}`;
 			return opFailure(
 				"send",
 				"MESSAGE_PARTIAL_DELIVERY",
-				`${selected.connector.label} accepted part of the message, but the complete payload was not delivered. Do not retry blindly; provider messages ${disposition.receipt.providerMessageIds.join(", ")} already exist. ${disposition.message}`,
+				partialDeliveryGuidance,
 				{
 					source: selected.connector.source,
 					target,
@@ -3218,10 +3225,17 @@ async function handleSend(
 			(disposition.receipt.persistence.status === "partial" ||
 				disposition.receipt.persistence.status === "failed")
 		) {
+			// Local-effect receipts carry locally generated completion markers,
+			// not provider-issued ids; guidance must never tell an operator to
+			// reconcile ids against a provider that issued none.
+			const persistenceFailureGuidance =
+				disposition.receipt.evidenceKind === "local-effect"
+					? `The complete message reached its target via ${selected.connector.label}, but local delivery evidence was not fully persisted. The transport returned no provider message ids to reconcile; do not resend.`
+					: `The provider accepted the complete message via ${selected.connector.label}, but local delivery evidence was not fully persisted. Do not resend; reconcile provider messages ${disposition.receipt.providerMessageIds.join(", ")}.`;
 			return opFailure(
 				"send",
 				"MESSAGE_DELIVERED_PERSISTENCE_FAILED",
-				`The provider accepted the complete message via ${selected.connector.label}, but local delivery evidence was not fully persisted. Do not resend; reconcile provider messages ${disposition.receipt.providerMessageIds.join(", ")}.`,
+				persistenceFailureGuidance,
 				{
 					source: selected.connector.source,
 					target,
@@ -3275,10 +3289,17 @@ async function handleSend(
 			const providerMessageIds =
 				disposition.receipt?.providerMessageIds ??
 				(providerMessageId ? [providerMessageId] : undefined);
+			// Local-effect receipts carry locally generated completion markers,
+			// not provider-issued ids; guidance must never tell an operator to
+			// reconcile ids against a provider that issued none.
+			const outboundRecordGuidance =
+				disposition.receipt?.evidenceKind === "local-effect"
+					? `The complete message reached its target via ${selected.connector.label}, but the requested local outbound record failed. The transport returned no provider message ids to reconcile; do not resend.`
+					: `The provider accepted the complete message via ${selected.connector.label}, but the requested local outbound record failed. Do not resend; reconcile the accepted provider message${providerMessageIds?.length === 1 ? "" : "s"}${providerMessageIds ? ` ${providerMessageIds.join(", ")}` : ""}.`;
 			return opFailure(
 				"send",
 				"MESSAGE_DELIVERED_PERSISTENCE_FAILED",
-				`The provider accepted the complete message via ${selected.connector.label}, but the requested local outbound record failed. Do not resend; reconcile the accepted provider message${providerMessageIds?.length === 1 ? "" : "s"}${providerMessageIds ? ` ${providerMessageIds.join(", ")}` : ""}.`,
+				outboundRecordGuidance,
 				{
 					source: selected.connector.source,
 					target,

--- a/packages/core/src/features/advanced-capabilities/actions/message.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/message.ts
@@ -3211,6 +3211,10 @@ async function handleSend(
 					acceptance: "partial",
 					responseMessageId: disposition.providerMessageId,
 					providerMessageIds: disposition.receipt.providerMessageIds,
+					// Absent discriminator documents the provider default; the structured
+					// surface states it explicitly so metadata consumers cannot misread
+					// local-effect markers as provider-backed ids.
+					evidenceKind: disposition.receipt.evidenceKind ?? "provider",
 					replayed: disposition.replayed,
 					persistenceStatus: disposition.receipt.persistence.status,
 					newDelivery: !disposition.replayed,
@@ -3245,6 +3249,7 @@ async function handleSend(
 					acceptance: "accepted",
 					responseMessageId: providerMessageId,
 					providerMessageIds: disposition.receipt.providerMessageIds,
+					evidenceKind: disposition.receipt.evidenceKind ?? "provider",
 					persistenceStatus: disposition.receipt.persistence.status,
 					replayed: disposition.replayed,
 					newDelivery: !disposition.replayed,
@@ -3309,6 +3314,7 @@ async function handleSend(
 					acceptance: "accepted",
 					responseMessageId: providerMessageId,
 					providerMessageIds,
+					evidenceKind: disposition.receipt?.evidenceKind ?? "provider",
 					persistenceStatus: "failed",
 					persistenceCode: persistence.code,
 					persistenceMessage: persistence.message,

--- a/packages/core/src/types/messaging.test.ts
+++ b/packages/core/src/types/messaging.test.ts
@@ -19,6 +19,66 @@ const receipt = (
 	persistence: { status: "persisted", memoryIds: [] },
 });
 
+describe("send-handler receipt evidence kind", () => {
+	it("accepts local-effect receipts so transports without provider ids stay valid evidence", () => {
+		const localEffect: SendHandlerReceipt = {
+			providerMessageIds: ["imessage-effect:abcd1234:text:1"],
+			acceptedAt: 1_780_000_000_000,
+			persistence: {
+				status: "not_attempted",
+				reason: "AppleScript sends return no provider message ids.",
+			},
+			evidenceKind: "local-effect",
+		};
+		const outcome = {
+			kind: "delivered",
+			receipt: localEffect,
+			memories: [] as Memory[],
+		} as const;
+		const disposition = inspectSendHandlerResult(outcome);
+		expect(disposition.kind).toBe("delivered");
+		// The additive label survives the structural inspection and never
+		// invalidates the receipt (#23104 review blocker 3).
+		if (disposition.kind === "delivered" && disposition.receipt) {
+			expect(disposition.receipt.evidenceKind).toBe("local-effect");
+		}
+		expect(isSendHandlerOutcome(outcome)).toBe(true);
+	});
+
+	it("keeps provider the implicit default for unlabeled receipts", () => {
+		const outcome = {
+			kind: "delivered",
+			receipt: receipt(),
+			memories: [] as Memory[],
+		} as const;
+		const disposition = inspectSendHandlerResult(outcome);
+		expect(disposition.kind).toBe("delivered");
+		expect(
+			disposition.kind === "delivered"
+				? disposition.receipt?.evidenceKind
+				: undefined,
+		).toBeUndefined();
+	});
+
+	it("rejects receipts carrying an unrecognized evidenceKind at the structural boundary", () => {
+		const outcome = {
+			kind: "delivered",
+			receipt: {
+				...receipt(),
+				evidenceKind: "anything",
+			},
+			memories: [] as Memory[],
+			// Intentionally outside the outcome union: an unknown evidence kind
+			// must be rejected, which requires bypassing the union's own check.
+		} as unknown as Parameters<typeof inspectSendHandlerResult>[0];
+		// The discriminator decides whether ids are provider-reconcilable; an
+		// unknown value must invalidate the receipt instead of silently
+		// defaulting to "provider".
+		expect(isSendHandlerOutcome(outcome)).toBe(false);
+		expect(inspectSendHandlerResult(outcome).kind).not.toBe("delivered");
+	});
+});
+
 describe("send-handler delivery evidence", () => {
 	it("treats legacy void and malformed structural outcomes as unknown", () => {
 		expect(inspectSendHandlerResult(undefined)).toMatchObject({

--- a/packages/core/src/types/messaging.ts
+++ b/packages/core/src/types/messaging.ts
@@ -77,6 +77,16 @@ export interface SendHandlerReceipt {
 	providerMessageIds: readonly [string, ...string[]];
 	acceptedAt: number;
 	persistence: SendHandlerPersistence;
+	/**
+	 * What the ids above actually are. `"provider"` (the documented default)
+	 * means ids issued by the remote provider and reconcilable against it.
+	 * `"local-effect"` means ids that are locally generated completion
+	 * markers for sends whose transport returns no provider identity at all
+	 * (e.g. AppleScript-driven Messages.app); they are unique per send and
+	 * stable evidence that an external effect happened, but they must never
+	 * be treated as provider-backed message ids for reconciliation.
+	 */
+	evidenceKind?: "provider" | "local-effect";
 }
 
 /** The final provider id from a non-empty delivery receipt. */
@@ -192,13 +202,21 @@ function isSendHandlerPersistence(
 function isSendHandlerReceipt(value: unknown): value is SendHandlerReceipt {
 	if (typeof value !== "object" || value === null) return false;
 	const candidate = value as Partial<SendHandlerReceipt>;
-	return (
-		isStringArray(candidate.providerMessageIds) &&
-		candidate.providerMessageIds.length > 0 &&
-		typeof candidate.acceptedAt === "number" &&
-		Number.isFinite(candidate.acceptedAt) &&
-		isSendHandlerPersistence(candidate.persistence)
-	);
+	if (!isStringArray(candidate.providerMessageIds)) return false;
+	if (candidate.providerMessageIds.length <= 0) return false;
+	if (typeof candidate.acceptedAt !== "number") return false;
+	if (!Number.isFinite(candidate.acceptedAt)) return false;
+	// The evidence-kind discriminator decides whether the ids are
+	// provider-reconcilable; an unrecognized value must invalidate the
+	// receipt rather than silently default to "provider".
+	if (
+		candidate.evidenceKind !== undefined &&
+		candidate.evidenceKind !== "provider" &&
+		candidate.evidenceKind !== "local-effect"
+	) {
+		return false;
+	}
+	return isSendHandlerPersistence(candidate.persistence);
 }
 
 /** Narrow an untrusted connector return to a complete structural outcome. */

--- a/plugins/plugin-imessage/AGENTS.md
+++ b/plugins/plugin-imessage/AGENTS.md
@@ -25,7 +25,7 @@ Adds iMessage send/receive capability through either local macOS Messages or Blo
 
 *Data routes* (`src/data-routes.ts`):
 - `GET    /api/imessage/messages` — recent messages (`?chatId=&limit=`)
-- `POST   /api/imessage/messages` — send a message (`{ to|chatId, text, mediaUrl? }`)
+- `POST   /api/imessage/messages` — send a message (`{ to|chatId, text, mediaUrl?|mediaUrls? }`; legacy singular first, duplicate URLs rejected)
 - `POST   /api/imessage/webhook/blooio` — signed Blooio `message.received` delivery
 - `GET    /api/imessage/chats` — list chats (DMs + groups) from chat.db
 - `GET    /api/imessage/contacts` — list Apple Contacts (full detail)

--- a/plugins/plugin-imessage/CLAUDE.md
+++ b/plugins/plugin-imessage/CLAUDE.md
@@ -25,7 +25,7 @@ Adds iMessage send/receive capability through either local macOS Messages or Blo
 
 *Data routes* (`src/data-routes.ts`):
 - `GET    /api/imessage/messages` — recent messages (`?chatId=&limit=`)
-- `POST   /api/imessage/messages` — send a message (`{ to|chatId, text, mediaUrl? }`)
+- `POST   /api/imessage/messages` — send a message (`{ to|chatId, text, mediaUrl?|mediaUrls? }`; legacy singular first, duplicate URLs rejected)
 - `POST   /api/imessage/webhook/blooio` — signed Blooio `message.received` delivery
 - `GET    /api/imessage/chats` — list chats (DMs + groups) from chat.db
 - `GET    /api/imessage/contacts` — list Apple Contacts (full detail)

--- a/plugins/plugin-imessage/__tests__/outbound-media.test.ts
+++ b/plugins/plugin-imessage/__tests__/outbound-media.test.ts
@@ -44,7 +44,7 @@ function makeRuntime(registrations: MessageConnectorRegistration[]): IAgentRunti
 }
 
 describe("iMessage connector — outbound media dispatch", () => {
-  it("passes the first attachment URL through to sendMessage as mediaUrl", async () => {
+  it("passes every attachment URL through to sendMessage as mediaUrls (#23104)", async () => {
     const registrations: MessageConnectorRegistration[] = [];
     const runtime = makeRuntime(registrations);
     const service = {
@@ -68,7 +68,7 @@ describe("iMessage connector — outbound media dispatch", () => {
     );
 
     expect(service.sendMessage).toHaveBeenCalledWith("+14155552671", "here is the file", {
-      mediaUrl: "/media/generated-speech.mp3",
+      mediaUrls: ["/media/generated-speech.mp3"],
       accountId: "default",
     });
   });
@@ -97,7 +97,7 @@ describe("iMessage connector — outbound media dispatch", () => {
     );
 
     expect(service.sendMessage).toHaveBeenCalledWith("+14155552671", "", {
-      mediaUrl: "/media/pic.png",
+      mediaUrls: ["/media/pic.png"],
       accountId: "default",
     });
   });
@@ -161,7 +161,7 @@ describe("iMessage service — media → AppleScript attachment build", () => {
     await writeFile(fixturePath, "media");
     try {
       const result = await svc.sendMessage("+14155552671", "caption", {
-        mediaUrl: fixturePath,
+        mediaUrls: [fixturePath],
       });
 
       expect(result.success).toBe(true);
@@ -197,7 +197,7 @@ describe("iMessage service — media → AppleScript attachment build", () => {
     await writeFile(fixturePath, "media");
     try {
       await svc.sendMessage("+14155552671", "", {
-        mediaUrl: pathToFileURL(fixturePath).href,
+        mediaUrls: [pathToFileURL(fixturePath).href],
       });
 
       // Media-only send → exactly one (attachment) script, no text script.
@@ -246,7 +246,7 @@ describe("iMessage service — media → AppleScript attachment build", () => {
     );
 
     const result = await svc.sendMessage("+14155552671", "", {
-      mediaUrl: `/api/media/${hash}.png`,
+      mediaUrls: [`/api/media/${hash}.png`],
     });
 
     expect(result.success).toBe(true);
@@ -262,7 +262,7 @@ describe("iMessage service — media → AppleScript attachment build", () => {
     await writeFile(fixturePath, "media");
     try {
       const result = await svc.sendMessage("+14155552671", "x".repeat(8_050), {
-        mediaUrl: fixturePath,
+        mediaUrls: [fixturePath],
       });
 
       expect(result.success).toBe(true);
@@ -280,7 +280,7 @@ describe("iMessage service — media → AppleScript attachment build", () => {
     await writeFile(fixturePath, "oversized");
     try {
       const result = await svc.sendMessage("+14155552671", "caption must not leak", {
-        mediaUrl: fixturePath,
+        mediaUrls: [fixturePath],
         maxBytes: 4,
       });
 
@@ -296,7 +296,7 @@ describe("iMessage service — media → AppleScript attachment build", () => {
     const { svc, scripts } = makeService();
 
     const result = await svc.sendMessage("+14155552671", "", {
-      mediaUrl: "http://169.254.169.254/latest/meta-data",
+      mediaUrls: ["http://169.254.169.254/latest/meta-data"],
     });
 
     expect(result.success).toBe(false);
@@ -304,7 +304,7 @@ describe("iMessage service — media → AppleScript attachment build", () => {
     expect(scripts).toHaveLength(0);
   });
 
-  it("marks the outbound event as hasMedia when a mediaUrl is present", async () => {
+  it("marks the outbound event as hasMedia when a mediaUrls list is present", async () => {
     const runtime = {
       agentId: "agent-1" as UUID,
       emitEvent: vi.fn(),
@@ -324,7 +324,7 @@ describe("iMessage service — media → AppleScript attachment build", () => {
     const fixturePath = join(fixtureDir, "a.png");
     await writeFile(fixturePath, "media");
     try {
-      await svc.sendMessage("+14155552671", "x", { mediaUrl: fixturePath });
+      await svc.sendMessage("+14155552671", "x", { mediaUrls: [fixturePath] });
     } finally {
       await rm(fixtureDir, { recursive: true, force: true });
     }

--- a/plugins/plugin-imessage/src/data-routes.ts
+++ b/plugins/plugin-imessage/src/data-routes.ts
@@ -66,7 +66,7 @@ interface IMessageServiceLike {
     to: string,
     text: string,
     options?: {
-      mediaUrl?: string;
+      mediaUrls?: string[];
       maxBytes?: number;
     }
   ): Promise<{
@@ -250,28 +250,37 @@ async function handleSendMessage(
       to?: string;
       chatId?: string;
       text?: string;
+      /** Legacy singular form; still accepted, equivalent to one-entry mediaUrls. */
       mediaUrl?: string;
+      mediaUrls?: string[];
       maxBytes?: number;
     }) ?? {};
 
   const to = body.to?.trim() || "";
   const chatId = body.chatId?.trim() || "";
   const text = body.text?.trim() || "";
-  const mediaUrl = body.mediaUrl?.trim() || undefined;
+  const mediaUrls = [
+    ...(body.mediaUrl?.trim() ? [body.mediaUrl.trim()] : []),
+    ...(Array.isArray(body.mediaUrls)
+      ? body.mediaUrls
+          .map((url) => (typeof url === "string" ? url.trim() : ""))
+          .filter((url) => url.length > 0)
+      : []),
+  ];
 
   if (!to && !chatId) {
     res.status(400).json(buildSetupError("bad_request", "either to or chatId is required"));
     return;
   }
 
-  if (!text && !mediaUrl) {
+  if (!text && mediaUrls.length === 0) {
     res.status(400).json(buildSetupError("bad_request", "either text or mediaUrl is required"));
     return;
   }
 
   try {
     const result = await service.sendMessage(chatId ? `chat_id:${chatId}` : to, text, {
-      ...(mediaUrl ? { mediaUrl } : {}),
+      ...(mediaUrls.length > 0 ? { mediaUrls } : {}),
       ...(typeof body.maxBytes === "number" ? { maxBytes: body.maxBytes } : {}),
     });
     if (!result.success) {

--- a/plugins/plugin-imessage/src/data-routes.ts
+++ b/plugins/plugin-imessage/src/data-routes.ts
@@ -259,13 +259,41 @@ async function handleSendMessage(
   const to = body.to?.trim() || "";
   const chatId = body.chatId?.trim() || "";
   const text = body.text?.trim() || "";
+
+  // Validate the untrusted body once at the boundary (#23104 review blocker
+  // 2): a requested part that is non-string or blank makes the whole request
+  // invalid BEFORE any external send — mixed input must never be silently
+  // normalized down to its valid subset.
+  if (body.mediaUrl !== undefined && typeof body.mediaUrl !== "string") {
+    res
+      .status(400)
+      .json(buildSetupError("bad_request", "mediaUrl must be a non-empty string when provided"));
+    return;
+  }
+  if (body.mediaUrls !== undefined && !Array.isArray(body.mediaUrls)) {
+    res
+      .status(400)
+      .json(buildSetupError("bad_request", "mediaUrls must be an array of non-empty strings"));
+    return;
+  }
+  const hasBlankMediaUrl = body.mediaUrl !== undefined && body.mediaUrl.trim() === "";
+  const invalidMediaUrlEntry = Array.isArray(body.mediaUrls)
+    ? body.mediaUrls.find((url) => typeof url !== "string" || url.trim() === "")
+    : undefined;
+  if (hasBlankMediaUrl || invalidMediaUrlEntry !== undefined) {
+    res
+      .status(400)
+      .json(
+        buildSetupError(
+          "bad_request",
+          "mediaUrl/mediaUrls entries must be non-empty strings; blank or non-string requested parts are rejected instead of dropped"
+        )
+      );
+    return;
+  }
   const mediaUrls = [
-    ...(body.mediaUrl?.trim() ? [body.mediaUrl.trim()] : []),
-    ...(Array.isArray(body.mediaUrls)
-      ? body.mediaUrls
-          .map((url) => (typeof url === "string" ? url.trim() : ""))
-          .filter((url) => url.length > 0)
-      : []),
+    ...(body.mediaUrl ? [body.mediaUrl.trim()] : []),
+    ...(body.mediaUrls ?? []).map((url) => url.trim()),
   ];
 
   if (!to && !chatId) {

--- a/plugins/plugin-imessage/src/data-routes.ts
+++ b/plugins/plugin-imessage/src/data-routes.ts
@@ -295,6 +295,20 @@ async function handleSendMessage(
     ...(body.mediaUrl ? [body.mediaUrl.trim()] : []),
     ...(body.mediaUrls ?? []).map((url) => url.trim()),
   ];
+  // A repeated URL is an ambiguous duplicate request, not a multi-part send:
+  // fail closed before the first external send rather than attaching the same
+  // file twice (same-URL check from the #23104 review follow-up).
+  if (new Set(mediaUrls).size !== mediaUrls.length) {
+    res
+      .status(400)
+      .json(
+        buildSetupError(
+          "bad_request",
+          "mediaUrl/mediaUrls must not request the same attachment URL twice; duplicate requested parts are rejected instead of sent twice"
+        )
+      );
+    return;
+  }
 
   if (!to && !chatId) {
     res.status(400).json(buildSetupError("bad_request", "either to or chatId is required"));

--- a/plugins/plugin-imessage/src/outbound-multi-attachment.test.ts
+++ b/plugins/plugin-imessage/src/outbound-multi-attachment.test.ts
@@ -72,7 +72,7 @@ function createService(overrides?: {
 describe("iMessage multi-attachment delivery", () => {
   it("sends every requested attachment, not only the first", async () => {
     const h = createService();
-    const result = await h.service.sendMessage("+15550001111", "two files", {
+    const result = await h.service.sendMessage("+155****1111", "two files", {
       mediaUrls: ["https://x/first.png", "https://x/second.png"],
     });
 
@@ -98,7 +98,7 @@ describe("iMessage multi-attachment delivery", () => {
       },
     });
 
-    const result = await h.service.sendMessage("+15550001111", "caption", {
+    const result = await h.service.sendMessage("+155****1111", "caption", {
       // good resolves FIRST, then bad rejects: the already-staged good file
       // must be cleaned up by the fail-fast path rather than leaked.
       mediaUrls: ["https://x/good.png", "https://x/bad.png"],
@@ -125,7 +125,7 @@ describe("iMessage multi-attachment delivery", () => {
       },
     });
 
-    const result = await h.service.sendMessage("+15550001111", "caption", {
+    const result = await h.service.sendMessage("+155****1111", "caption", {
       mediaUrls: ["https://x/a.png", "https://x/b.png"],
     });
 
@@ -146,7 +146,7 @@ describe("iMessage multi-attachment delivery", () => {
       }),
     });
 
-    const result = await h.service.sendMessage("+15550001111", "caption", {
+    const result = await h.service.sendMessage("+155****1111", "caption", {
       mediaUrls: ["https://x/a.png"],
     });
 
@@ -166,7 +166,7 @@ describe("iMessage multi-attachment delivery", () => {
       },
     });
 
-    const result = await h.service.sendMessage("+15550001111", "caption", {
+    const result = await h.service.sendMessage("+155****1111", "caption", {
       mediaUrls: ["https://x/a.png", "https://x/b.png", "https://x/c.png"],
     });
 
@@ -178,12 +178,41 @@ describe("iMessage multi-attachment delivery", () => {
 
   it("keeps single-attachment sends working (regression of the common path)", async () => {
     const h = createService();
-    const result = await h.service.sendMessage("+15550001111", "one file", {
+    const result = await h.service.sendMessage("+155****1111", "one file", {
       mediaUrls: ["https://x/only.png"],
     });
 
     expect(result.success).toBe(true);
     expect(h.sendAttachmentCalls).toHaveLength(1);
     expect(h.cleanedPaths).toHaveLength(1);
+  });
+
+  it("stamps every delivered part with a per-send unique local-effect marker (#23104 review blocker 3)", async () => {
+    // Two sends, each failing partway so delivered.effectStamps is returned.
+    // Stamps must be unique within a send AND across sends: AppleScript
+    // returns no provider ids, so a repeatable counter like "text-1" would
+    // masquerade as reconcilable provider evidence.
+    const failAfterText = {
+      sendResolvedAttachment: async () => ({ success: false, error: "boom" }),
+    };
+    const first = createService(failAfterText);
+    const second = createService(failAfterText);
+    const one = await first.service.sendMessage("+155****1111", "first send", {
+      mediaUrls: ["https://x/a.png"],
+    });
+    const two = await second.service.sendMessage("+155****1111", "second send", {
+      mediaUrls: ["https://x/b.png"],
+    });
+
+    for (const result of [one, two]) {
+      expect(result.success).toBe(false);
+      expect(result.delivered?.effectStamps).toHaveLength(1);
+      for (const stamp of result.delivered?.effectStamps ?? []) {
+        expect(stamp).toMatch(/^imessage-effect:[0-9a-f-]{36}:(text|attachment):\d+$/);
+      }
+    }
+    const oneStamps = one.delivered?.effectStamps ?? [];
+    const twoStamps = two.delivered?.effectStamps ?? [];
+    expect(new Set([...oneStamps, ...twoStamps]).size).toBe(oneStamps.length + twoStamps.length);
   });
 });

--- a/plugins/plugin-imessage/src/outbound-multi-attachment.test.ts
+++ b/plugins/plugin-imessage/src/outbound-multi-attachment.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Multi-attachment delivery truth for the iMessage connector (#23104).
+ * sendMessage must attempt EVERY requested attachment — never a first-only
+ * selection — resolve all bytes before the first external send, and clean up
+ * every staged temp directory on every exit path. The AppleScript seams are
+ * stubbed so the suite runs offline with no Messages.app.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { IMessageService } from "./service";
+
+function createService(overrides?: {
+  resolveOutboundMedia?: (url: string) => Promise<{ path: string; cleanup: () => Promise<void> }>;
+  sendResolvedAttachment?: (
+    to: string,
+    path: string
+  ) => Promise<{ success: boolean; error?: string }>;
+}) {
+  const cleanedPaths: string[] = [];
+  const sendAttachmentCalls: Array<{ to: string; path: string }> = [];
+  const sendTextCalls: Array<{ to: string; text: string }> = [];
+  const resolveCalls: string[] = [];
+  let seq = 0;
+  const service = Object.create(IMessageService.prototype) as IMessageService & {
+    settings: unknown;
+    sendMessage: IMessageService["sendMessage"];
+    resolveOutboundMedia: (
+      url: string,
+      maxBytes?: number
+    ) => Promise<{ path: string; cleanup: () => Promise<void> }>;
+    sendResolvedAttachment: (
+      to: string,
+      path: string
+    ) => Promise<{ success: boolean; error?: string }>;
+    sendSingleMessage: (to: string, text: string) => Promise<{ success: boolean; error?: string }>;
+  };
+  Object.assign(service, {
+    settings: { pollIntervalMs: 0 },
+    resolveOutboundMedia:
+      overrides?.resolveOutboundMedia ??
+      (vi.fn(async (url: string) => {
+        resolveCalls.push(url);
+        seq += 1;
+        return {
+          path: `/tmp/staged-${seq}-${url.split("/").pop()}`,
+          cleanup: async () => {
+            cleanedPaths.push(`/tmp/staged-${seq}-${url.split("/").pop()}`);
+          },
+        };
+      }) as unknown as IMessageService extends never ? never : typeof service.resolveOutboundMedia),
+    sendResolvedAttachment: async (to: string, path: string) => {
+      sendAttachmentCalls.push({ to, path });
+      if (overrides?.sendResolvedAttachment) {
+        return overrides.sendResolvedAttachment(to, path);
+      }
+      return { success: true };
+    },
+    sendSingleMessage: vi.fn(async (to: string, text: string) => {
+      sendTextCalls.push({ to, text });
+      return { success: true, messageId: `m-${sendTextCalls.length}` };
+    }),
+  });
+  return {
+    service,
+    sendAttachmentCalls,
+    sendTextCalls,
+    cleanedPaths,
+    resolveCalls,
+  };
+}
+
+describe("iMessage multi-attachment delivery", () => {
+  it("sends every requested attachment, not only the first", async () => {
+    const h = createService();
+    const result = await h.service.sendMessage("+15550001111", "two files", {
+      mediaUrls: ["https://x/first.png", "https://x/second.png"],
+    });
+
+    expect(result.success).toBe(true);
+    expect(h.sendAttachmentCalls).toHaveLength(2);
+    expect(h.sendAttachmentCalls[0]?.path).toContain("first");
+    expect(h.sendAttachmentCalls[1]?.path).toContain("second");
+  });
+
+  it("resolves ALL attachment bytes before the first external send", async () => {
+    const cleanedOkStaging: string[] = [];
+    const h = createService({
+      resolveOutboundMedia: (url: string) => {
+        if (url.includes("bad")) {
+          return Promise.reject(new Error("ssrf blocked"));
+        }
+        return Promise.resolve({
+          path: "/tmp/ok",
+          cleanup: async () => {
+            cleanedOkStaging.push(url);
+          },
+        });
+      },
+    });
+
+    const result = await h.service.sendMessage("+15550001111", "caption", {
+      // good resolves FIRST, then bad rejects: the already-staged good file
+      // must be cleaned up by the fail-fast path rather than leaked.
+      mediaUrls: ["https://x/good.png", "https://x/bad.png"],
+    });
+
+    // Fail fast: nothing reached Messages.app, and the earlier staged file
+    // was cleaned up rather than leaked.
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("attachment resolution error");
+    expect(h.sendTextCalls).toHaveLength(0);
+    expect(h.sendAttachmentCalls).toHaveLength(0);
+    expect(cleanedOkStaging).toEqual(["https://x/good.png"]);
+  });
+
+  it("reports delivered-part evidence when a later attachment fails after text went out", async () => {
+    let sendCount = 0;
+    const h = createService({
+      sendResolvedAttachment: async () => {
+        sendCount += 1;
+        if (sendCount === 2) {
+          return { success: false, error: "AppleScript attachment error: boom" };
+        }
+        return { success: true };
+      },
+    });
+
+    const result = await h.service.sendMessage("+15550001111", "caption", {
+      mediaUrls: ["https://x/a.png", "https://x/b.png"],
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.delivered).toBeDefined();
+    expect(result.delivered?.textChunks).toBe(1);
+    expect(result.delivered?.attachments).toBe(1);
+    expect(result.delivered?.effectStamps).toHaveLength(2);
+  });
+
+  it("never lets a staging-cleanup rejection fail an already-delivered send (J6)", async () => {
+    const h = createService({
+      resolveOutboundMedia: async (url: string) => ({
+        path: `/tmp/staged-${url.split("/").pop()}`,
+        cleanup: async () => {
+          throw new Error("EBUSY: directory in use");
+        },
+      }),
+    });
+
+    const result = await h.service.sendMessage("+15550001111", "caption", {
+      mediaUrls: ["https://x/a.png"],
+    });
+
+    // Delivery already succeeded; cleanup failure is diagnostic only.
+    expect(result.success).toBe(true);
+  });
+
+  it("cleans up every staged directory when a later attachment fails to send", async () => {
+    let sendCount = 0;
+    const h = createService({
+      sendResolvedAttachment: async (_to, _path) => {
+        sendCount += 1;
+        if (sendCount === 2) {
+          return { success: false, error: "AppleScript attachment error: boom" };
+        }
+        return { success: true };
+      },
+    });
+
+    const result = await h.service.sendMessage("+15550001111", "caption", {
+      mediaUrls: ["https://x/a.png", "https://x/b.png", "https://x/c.png"],
+    });
+
+    expect(result.success).toBe(false);
+    expect(h.sendAttachmentCalls).toHaveLength(2); // c was never attempted after b failed
+    // All staged dirs cleaned: both resolved-before-send attachments.
+    expect(h.cleanedPaths).toHaveLength(3);
+  });
+
+  it("keeps single-attachment sends working (regression of the common path)", async () => {
+    const h = createService();
+    const result = await h.service.sendMessage("+15550001111", "one file", {
+      mediaUrls: ["https://x/only.png"],
+    });
+
+    expect(result.success).toBe(true);
+    expect(h.sendAttachmentCalls).toHaveLength(1);
+    expect(h.cleanedPaths).toHaveLength(1);
+  });
+});

--- a/plugins/plugin-imessage/src/routes-e2e.test.ts
+++ b/plugins/plugin-imessage/src/routes-e2e.test.ts
@@ -55,7 +55,7 @@ interface SendResult {
 }
 
 interface ImessageServiceCalls {
-  sent: Array<{ to: string; text: string; mediaUrl?: string; maxBytes?: number }>;
+  sent: Array<{ to: string; text: string; mediaUrls?: string[]; maxBytes?: number }>;
   addContact: Array<Record<string, unknown>>;
   updateContact: Array<{ id: string; patch: Record<string, unknown> }>;
   deleteContact: string[];
@@ -115,12 +115,12 @@ function makeImessageService(overrides: ImessageServiceOverrides, calls: Imessag
     sendMessage: async (
       to: string,
       text: string,
-      options?: { mediaUrl?: string; maxBytes?: number }
+      options?: { mediaUrls?: string[]; maxBytes?: number }
     ): Promise<SendResult> => {
       calls.sent.push({
         to,
         text,
-        mediaUrl: options?.mediaUrl,
+        mediaUrls: options?.mediaUrls,
         maxBytes: options?.maxBytes,
       });
       return overrides.sendResult ?? { success: true, messageId: "m-1", chatId: "c-1" };
@@ -375,6 +375,26 @@ describe("plugin-imessage data routes (real dispatch)", () => {
     const body = (await res.json()) as { error: { code: string; message: string } };
     expect(body.error.code).toBe("bad_request");
     expect(body.error.message).toContain("to or chatId");
+  });
+
+  it("POST /api/imessage/messages sends legacy mediaUrl plus mediaUrls with legacy first", async () => {
+    const calls: ImessageServiceCalls = {
+      sent: [],
+      addContact: [],
+      updateContact: [],
+      deleteContact: [],
+    };
+    const base = await startServer(makeRuntime({ imessage: { connected: true }, calls }));
+    const res = await sendJson(base, "POST", "/api/imessage/messages", {
+      to: "+155****1111",
+      text: "both forms",
+      mediaUrl: "/media/legacy.png",
+      mediaUrls: ["/media/a.png", "  ", "/media/b.png"],
+    });
+    expect(res.status).toBe(200);
+    expect(calls.sent).toHaveLength(1);
+    // Legacy singular first, then valid plural entries; whitespace dropped.
+    expect(calls.sent[0]?.mediaUrls).toEqual(["/media/legacy.png", "/media/a.png", "/media/b.png"]);
   });
 
   it("POST /api/imessage/messages rejects a body missing both text and mediaUrl with 400", async () => {

--- a/plugins/plugin-imessage/src/routes-e2e.test.ts
+++ b/plugins/plugin-imessage/src/routes-e2e.test.ts
@@ -377,7 +377,68 @@ describe("plugin-imessage data routes (real dispatch)", () => {
     expect(body.error.message).toContain("to or chatId");
   });
 
-  it("POST /api/imessage/messages sends legacy mediaUrl plus mediaUrls with legacy first", async () => {
+  it("POST /api/imessage/messages rejects a blank entry in mediaUrls with 400", async () => {
+    const calls: ImessageServiceCalls = {
+      sent: [],
+      addContact: [],
+      updateContact: [],
+      deleteContact: [],
+    };
+    const base = await startServer(makeRuntime({ imessage: { connected: true }, calls }));
+    const res = await sendJson(base, "POST", "/api/imessage/messages", {
+      to: "+155****1111",
+      text: "mixed",
+      mediaUrls: ["/media/a.png", "  "],
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: { code: string; message: string } };
+    expect(body.error.code).toBe("bad_request");
+    expect(body.error.message).toContain("mediaUrls");
+    // Nothing was sent: the invalid part was rejected before the first send.
+    expect(calls.sent).toHaveLength(0);
+  });
+
+  it("POST /api/imessage/messages rejects a non-string entry in mediaUrls with 400", async () => {
+    const calls: ImessageServiceCalls = {
+      sent: [],
+      addContact: [],
+      updateContact: [],
+      deleteContact: [],
+    };
+    const base = await startServer(makeRuntime({ imessage: { connected: true }, calls }));
+    const res = await sendJson(base, "POST", "/api/imessage/messages", {
+      to: "+155****1111",
+      text: "mixed",
+      mediaUrls: ["/media/a.png", 42],
+    });
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: { message: string } }).error.message).toContain(
+      "mediaUrls"
+    );
+    expect(calls.sent).toHaveLength(0);
+  });
+
+  it("POST /api/imessage/messages rejects a non-array mediaUrls with 400", async () => {
+    const calls: ImessageServiceCalls = {
+      sent: [],
+      addContact: [],
+      updateContact: [],
+      deleteContact: [],
+    };
+    const base = await startServer(makeRuntime({ imessage: { connected: true }, calls }));
+    const res = await sendJson(base, "POST", "/api/imessage/messages", {
+      to: "+155****1111",
+      text: "wrong type",
+      mediaUrls: "/media/a.png",
+    });
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: { message: string } }).error.message).toContain(
+      "mediaUrls"
+    );
+    expect(calls.sent).toHaveLength(0);
+  });
+
+  it("POST /api/imessage/messages sends legacy mediaUrl plus valid mediaUrls with legacy first", async () => {
     const calls: ImessageServiceCalls = {
       sent: [],
       addContact: [],
@@ -389,12 +450,56 @@ describe("plugin-imessage data routes (real dispatch)", () => {
       to: "+155****1111",
       text: "both forms",
       mediaUrl: "/media/legacy.png",
-      mediaUrls: ["/media/a.png", "  ", "/media/b.png"],
+      mediaUrls: ["/media/a.png", "/media/b.png"],
     });
     expect(res.status).toBe(200);
     expect(calls.sent).toHaveLength(1);
-    // Legacy singular first, then valid plural entries; whitespace dropped.
+    // Legacy singular first, then valid plural entries in request order.
     expect(calls.sent[0]?.mediaUrls).toEqual(["/media/legacy.png", "/media/a.png", "/media/b.png"]);
+  });
+
+  it("POST /api/imessage/messages rejects a blank legacy mediaUrl with 400", async () => {
+    const calls: ImessageServiceCalls = {
+      sent: [],
+      addContact: [],
+      updateContact: [],
+      deleteContact: [],
+    };
+    const base = await startServer(makeRuntime({ imessage: { connected: true }, calls }));
+    const res = await sendJson(base, "POST", "/api/imessage/messages", {
+      to: "+155****1111",
+      text: "blank legacy",
+      mediaUrl: "   ",
+    });
+    // A whitespace-only requested part must be rejected as a mixed request,
+    // not silently normalized out of existence; but the send is not content-
+    // empty because text is present — expectation: rejected for the blank
+    // requested part itself.
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: { message: string } }).error.message).toContain(
+      "mediaUrl"
+    );
+    expect(calls.sent).toHaveLength(0);
+  });
+
+  it("POST /api/imessage/messages rejects a non-string legacy mediaUrl with 400", async () => {
+    const calls: ImessageServiceCalls = {
+      sent: [],
+      addContact: [],
+      updateContact: [],
+      deleteContact: [],
+    };
+    const base = await startServer(makeRuntime({ imessage: { connected: true }, calls }));
+    const res = await sendJson(base, "POST", "/api/imessage/messages", {
+      to: "+155****1111",
+      text: "typed legacy",
+      mediaUrl: { url: "/media/a.png" },
+    });
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: { message: string } }).error.message).toContain(
+      "mediaUrl"
+    );
+    expect(calls.sent).toHaveLength(0);
   });
 
   it("POST /api/imessage/messages rejects a body missing both text and mediaUrl with 400", async () => {

--- a/plugins/plugin-imessage/src/routes-e2e.test.ts
+++ b/plugins/plugin-imessage/src/routes-e2e.test.ts
@@ -458,6 +458,30 @@ describe("plugin-imessage data routes (real dispatch)", () => {
     expect(calls.sent[0]?.mediaUrls).toEqual(["/media/legacy.png", "/media/a.png", "/media/b.png"]);
   });
 
+  it("POST /api/imessage/messages rejects duplicate parts across mediaUrl and mediaUrls with 400", async () => {
+    // Same URL requested through both forms is ambiguous duplicate input,
+    // not a two-part send: the fail-closed boundary rejects it before the
+    // first external send instead of attaching the same file twice.
+    const calls: ImessageServiceCalls = {
+      sent: [],
+      addContact: [],
+      updateContact: [],
+      deleteContact: [],
+    };
+    const base = await startServer(makeRuntime({ imessage: { connected: true }, calls }));
+    const res = await sendJson(base, "POST", "/api/imessage/messages", {
+      to: "+155****1111",
+      text: "duplicate part",
+      mediaUrl: "/media/legacy.png",
+      mediaUrls: ["/media/legacy.png"],
+    });
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: { message: string } }).error.message).toContain(
+      "duplicate"
+    );
+    expect(calls.sent).toHaveLength(0);
+  });
+
   it("POST /api/imessage/messages rejects a blank legacy mediaUrl with 400", async () => {
     const calls: ImessageServiceCalls = {
       sent: [],

--- a/plugins/plugin-imessage/src/send-handler-receipt.test.ts
+++ b/plugins/plugin-imessage/src/send-handler-receipt.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Receipt truthfulness for the iMessage send handler (#23104 review
+ * blocker 3). AppleScript sends return no provider message ids; the handler
+ * must never present local completion markers as provider-backed evidence.
+ * This suite captures the REAL sendHandler closure from
+ * registerSendHandlers (only service.sendMessage and the runtime registry
+ * are stubbed), so it exercises the production receipt-construction path.
+ */
+
+import {
+  type Content,
+  isSendHandlerOutcome,
+  type Media,
+  type SendHandlerOutcome,
+  type TargetInfo,
+} from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { IMessageService } from "./service";
+
+type IMessageLike = {
+  sendMessage: (
+    to: string,
+    text: string,
+    options?: { mediaUrls?: string[]; accountId?: string; maxBytes?: number }
+  ) => Promise<{
+    success: boolean;
+    messageId?: string;
+    chatId?: string;
+    error?: string;
+    delivered?: { textChunks: number; attachments: number; effectStamps: string[] };
+  }>;
+};
+
+interface CapturedRegistration {
+  source: string;
+  sendHandler: (
+    runtime: unknown,
+    target: TargetInfo,
+    content: Content
+  ) => Promise<SendHandlerOutcome>;
+}
+
+function captureRegistration(service: IMessageLike): CapturedRegistration {
+  const registration = { captured: undefined as CapturedRegistration | undefined };
+  const runtime = {
+    agentId: "agent-1",
+    registerMessageConnector: (reg: CapturedRegistration) => {
+      registration.captured = reg;
+    },
+  } as unknown as Parameters<typeof IMessageService.registerSendHandlers>[0];
+  IMessageService.registerSendHandlers(
+    runtime,
+    // The handler only touches sendMessage on the happy paths under test;
+    // statusMetadata reads getStatus() once during registration, so supply
+    // the minimal surface the real path reaches.
+    { sendMessage: service.sendMessage, getStatus: () => ({}) } as unknown as IMessageService
+  );
+  if (!registration.captured?.sendHandler) {
+    throw new Error("sendHandler was not registered");
+  }
+  return registration.captured;
+}
+
+const target: TargetInfo = {
+  source: "imessage",
+  channelId: "+155****1111",
+  accountId: "default",
+} as TargetInfo;
+
+function contentWith(text: string, mediaUrls: string[]): Content {
+  return {
+    text,
+    ...(mediaUrls.length > 0
+      ? {
+          attachments: mediaUrls.map((url, index) => ({ id: `m${index}`, url }) as Media),
+        }
+      : {}),
+  } as Content;
+}
+
+describe("iMessage send-handler receipt truthfulness", () => {
+  it("marks a delivered receipt as local-effect evidence with a fresh unique stamp, never the service's synthetic messageId", async () => {
+    const sendMessage = vi.fn(async () => ({
+      success: true,
+      // The service's AppleScript path returns a repeatable Date.now() echo;
+      // it must NOT become receipt evidence.
+      messageId: "1735560000000",
+      chatId: "+155****1111",
+    }));
+    const reg = captureRegistration({ sendMessage });
+    const first = await reg.sendHandler(undefined, target, contentWith("hello", []));
+    const second = await reg.sendHandler(undefined, target, contentWith("hello again", []));
+
+    for (const outcome of [first, second]) {
+      expect(outcome.kind).toBe("delivered");
+      expect(isSendHandlerOutcome(outcome)).toBe(true);
+      if (outcome.kind !== "delivered") return;
+      expect(outcome.receipt.evidenceKind).toBe("local-effect");
+      expect(outcome.receipt.providerMessageIds[0]).not.toBe("1735560000000");
+      expect(outcome.receipt.providerMessageIds[0]).toMatch(/^imessage-effect:[0-9a-f-]{36}:send$/);
+    }
+    // Two successful sends in the same millisecond still produce distinct
+    // receipt evidence (deterministic collision coverage).
+    const ids =
+      first.kind === "delivered" && second.kind === "delivered"
+        ? [first.receipt.providerMessageIds[0], second.receipt.providerMessageIds[0]]
+        : [];
+    expect(new Set(ids).size).toBe(2);
+  });
+
+  it("exposes stable, per-send-unique local-effect stamps on partial delivery", async () => {
+    const sendMessage = vi.fn(async () => ({
+      success: false,
+      error: "AppleScript attachment error: boom",
+      delivered: {
+        textChunks: 2,
+        attachments: 1,
+        effectStamps: [
+          "imessage-effect:send-abc:0",
+          "imessage-effect:send-abc:1",
+          "imessage-effect:send-abc:2",
+        ],
+      },
+    }));
+    const reg = captureRegistration({ sendMessage });
+    const outcome = await reg.sendHandler(
+      undefined,
+      target,
+      contentWith("two chunks", ["https://x/a.png"])
+    );
+
+    expect(outcome.kind).toBe("partially_delivered");
+    if (outcome.kind !== "partially_delivered") return;
+    expect(outcome.receipt.evidenceKind).toBe("local-effect");
+    // Effect stamps must not masquerade as provider ids: they are locally
+    // generated completion markers for parts that reached Messages.app.
+    expect(
+      outcome.receipt.providerMessageIds.every((id) => id.startsWith("imessage-effect:"))
+    ).toBe(true);
+    expect(outcome.message).toContain("2 text chunk");
+    expect(outcome.message).toContain("1 attachment");
+  });
+
+  it("passes service-provided effect stamps through verbatim and marks them local-effect", async () => {
+    const sendMessage = vi.fn(async () => ({
+      success: false,
+      error: "AppleScript error: boom",
+      delivered: {
+        textChunks: 1,
+        attachments: 0,
+        effectStamps: ["imessage-effect:aaaa1111:text:1"],
+      },
+    }));
+    const reg = captureRegistration({ sendMessage });
+    const first = await reg.sendHandler(undefined, target, contentWith("one", []));
+    const second = await reg.sendHandler(undefined, target, contentWith("two", []));
+
+    expect(first.kind).toBe("partially_delivered");
+    expect(second.kind).toBe("partially_delivered");
+    if (second.kind !== "partially_delivered" || first.kind !== "partially_delivered") return;
+    // The handler does not re-stamp: service.sendMessage owns per-send
+    // uniqueness (asserted in outbound-multi-attachment.test.ts); the handler
+    // owns labeling the evidence kind so callers never misread the stamps.
+    expect(first.receipt.providerMessageIds).toEqual(["imessage-effect:aaaa1111:text:1"]);
+    expect(second.receipt.providerMessageIds).toEqual(["imessage-effect:aaaa1111:text:1"]);
+    expect(first.receipt.evidenceKind).toBe("local-effect");
+  });
+
+  it("issues a locally generated unique stamp regardless of the service's messageId", async () => {
+    const sendMessage = vi.fn(async () => ({
+      success: true,
+      chatId: "+155****1111",
+    }));
+    const reg = captureRegistration({ sendMessage });
+    const outcome = await reg.sendHandler(undefined, target, contentWith("hello", []));
+
+    expect(outcome.kind).toBe("delivered");
+    if (outcome.kind !== "delivered") return;
+    expect(outcome.receipt.providerMessageIds).toHaveLength(1);
+    // The stamp is never a raw Date.now() echo and never a bare counter: it
+    // must be unique per send and clearly labeled as local-effect evidence.
+    expect(outcome.receipt.evidenceKind).toBe("local-effect");
+    expect(outcome.receipt.providerMessageIds[0]).not.toMatch(/^\d+$/);
+  });
+});

--- a/plugins/plugin-imessage/src/send-handler-receipt.test.ts
+++ b/plugins/plugin-imessage/src/send-handler-receipt.test.ts
@@ -166,6 +166,27 @@ describe("iMessage send-handler receipt truthfulness", () => {
     expect(first.receipt.evidenceKind).toBe("local-effect");
   });
 
+  it("returns not_delivered, never an empty-id partial receipt, when the first chunk fails", async () => {
+    // I3 mutation pin (attentionhead + ss251 reviews): a first-text-chunk
+    // failure reaches the handler with delivered.effectStamps === []. The
+    // effectStamps.length > 0 guard must route it to not_delivered — without
+    // it the handler would build a partially_delivered receipt with
+    // providerMessageIds: [], violating the readonly [string, ...string[]]
+    // contract and producing a receipt isSendHandlerReceipt rejects.
+    const sendMessage = vi.fn(async () => ({
+      success: false,
+      error: "AppleScript error: first chunk rejected",
+      delivered: { textChunks: 0, attachments: 0, effectStamps: [] },
+    }));
+    const reg = captureRegistration({ sendMessage });
+    const outcome = await reg.sendHandler(undefined, target, contentWith("only chunk", []));
+
+    expect(outcome.kind).toBe("not_delivered");
+    if (outcome.kind !== "not_delivered") return;
+    expect(outcome.code).toBe("IMESSAGE_SEND_FAILED");
+    expect(outcome.message).toBe("AppleScript error: first chunk rejected");
+  });
+
   it("issues a locally generated unique stamp regardless of the service's messageId", async () => {
     const sendMessage = vi.fn(async () => ({
       success: true,

--- a/plugins/plugin-imessage/src/service.ts
+++ b/plugins/plugin-imessage/src/service.ts
@@ -35,6 +35,7 @@ import {
   type MessageConnectorUserContext,
   readResponseWithLimit,
   resolveAttachmentBytes,
+  type SendHandlerOutcome,
   Service,
   ServiceType,
   type TargetInfo,
@@ -230,6 +231,25 @@ type ResolvedOutboundMedia = {
   cleanup: () => Promise<void>;
 };
 
+/**
+ * Best-effort teardown of every staged outbound attachment directory. A
+ * cleanup rejection must never convert a delivered (or J1-failed) send into a
+ * thrown failure: Messages.app already consumed the bytes, so the loss is the
+ * temp dir lifetime only, and it is warned and swallowed.
+ */
+async function cleanupResolvedMedia(mediaList: readonly ResolvedOutboundMedia[]): Promise<void> {
+  const results = await Promise.allSettled(mediaList.map((resolved) => resolved.cleanup()));
+  for (const [index, outcome] of results.entries()) {
+    if (outcome.status === "rejected") {
+      // error-policy:J6 teardown-only failure is diagnostic, never a failed
+      // delivery; the OS reclaims tmpdir contents on reboot at worst.
+      logger.warn(
+        `[imessage] Failed to remove outbound attachment staging directory for ${mediaList[index]?.path}: ${outcome.reason instanceof Error ? outcome.reason.message : String(outcome.reason)}`
+      );
+    }
+  }
+}
+
 function normalizeOutboundMediaMaxBytes(raw: number | undefined): number {
   if (raw === undefined) return DEFAULT_CONNECTOR_ATTACHMENT_MAX_BYTES;
   if (!Number.isSafeInteger(raw) || raw <= 0) {
@@ -368,11 +388,12 @@ function normalizeIMessageConnectorHandle(value: string): string {
   return normalizeContactHandle(normalizedTarget) || normalizedTarget;
 }
 
-function firstAttachmentUrl(content: Content): string | undefined {
-  const attachment = content.attachments?.find(
-    (item) => typeof item.url === "string" && item.url.trim().length > 0
-  );
-  return attachment?.url?.trim();
+function attachmentUrls(content: Content): string[] {
+  return (content.attachments ?? [])
+    .map((item) =>
+      typeof item.url === "string" && item.url.trim().length > 0 ? item.url.trim() : undefined
+    )
+    .filter((url): url is string => url !== undefined);
 }
 
 function statusMetadata(status: IMessageServiceStatus): Record<string, string | boolean | null> {
@@ -789,27 +810,81 @@ export class IMessageService extends Service implements IIMessageService {
           : "local-macos-messages-single-account",
         status: statusMetadata(status),
       },
-      sendHandler: async (_runtime: IAgentRuntime, target: TargetInfo, content: Content) => {
+      sendHandler: async (
+        _runtime: IAgentRuntime,
+        target: TargetInfo,
+        content: Content
+      ): Promise<SendHandlerOutcome> => {
         const accountId = assertLocalIMessageAccount(readTargetAccountId(target));
         const text = renderIMessageInteractionText(content, resolveInteractionAppBaseUrl(runtime));
-        const mediaUrl = firstAttachmentUrl(content);
-        if (!text.trim() && !mediaUrl) {
-          return;
+        const mediaUrls = attachmentUrls(content);
+        if (!text.trim() && mediaUrls.length === 0) {
+          return {
+            kind: "not_delivered",
+            code: "IMESSAGE_EMPTY_MESSAGE",
+            message:
+              "iMessage send handler requires non-empty text or at least one attachment URL.",
+          };
         }
 
         const resolvedTarget = await resolveIMessageSendTarget(runtime, target);
         if (!resolvedTarget) {
-          throw new Error("iMessage target is missing a phone, email, or chat id");
+          return {
+            kind: "not_delivered",
+            code: "IMESSAGE_TARGET_UNRESOLVED",
+            message: "iMessage target is missing a phone, email, or chat id",
+          };
         }
 
         const result = await service.sendMessage(
           resolvedTarget,
           text,
-          mediaUrl ? { mediaUrl, accountId } : { accountId }
+          mediaUrls.length > 0 ? { mediaUrls, accountId } : { accountId }
         );
         if (!result.success) {
-          throw new Error(result.error ?? "iMessage send failed");
+          const deliveredParts = result.delivered;
+          if (deliveredParts && deliveredParts.effectStamps.length > 0) {
+            // Parts already reached Messages.app before the failure; report
+            // the partial delivery with its local-effect stamps so callers do
+            // not blind-retry and duplicate externally delivered parts.
+            return {
+              kind: "partially_delivered",
+              receipt: {
+                providerMessageIds: deliveredParts.effectStamps as [string, ...string[]],
+                acceptedAt: Date.now(),
+                persistence: {
+                  status: "not_attempted",
+                  reason:
+                    "iMessage AppleScript sends return no provider message ids; effect stamps are local completion markers.",
+                },
+              },
+              memories: [],
+              code: "IMESSAGE_PARTIAL_DELIVERY",
+              message: `iMessage delivered ${deliveredParts.textChunks} text chunk(s) and ${deliveredParts.attachments} attachment(s) before failing: ${result.error ?? "iMessage send failed"}. Do not retry blindly; delivered parts would be duplicated.`,
+            };
+          }
+          return {
+            kind: "not_delivered",
+            code: "IMESSAGE_SEND_FAILED",
+            message: result.error ?? "iMessage send failed",
+          };
         }
+        return {
+          kind: "delivered",
+          receipt: {
+            providerMessageIds: [result.messageId ?? `imessage-effect-${Date.now()}`] as [
+              string,
+              ...string[],
+            ],
+            acceptedAt: Date.now(),
+            persistence: {
+              status: "not_attempted",
+              reason:
+                "iMessage send handler reports effect completion only; outbound memory persistence is owned by the caller.",
+            },
+          },
+          memories: [],
+        };
       },
       resolveTargets: async (query: string) => {
         const candidates: MessageConnectorTarget[] = [];
@@ -1130,17 +1205,22 @@ export class IMessageService extends Service implements IIMessageService {
     // Format phone number if needed
     const target = isPhoneNumber(to) ? formatPhoneNumber(to) : to;
 
-    let media: ResolvedOutboundMedia | null = null;
-    if (options?.mediaUrl) {
+    const mediaList: ResolvedOutboundMedia[] = [];
+    if (options?.mediaUrls?.length) {
       try {
-        // Resolve and bound every byte before the first external send. Invalid,
-        // inaccessible, oversized, or SSRF-blocked media must fail fast instead
-        // of delivering the caption and only then discovering the attachment is
+        // Resolve and bound every byte for EVERY requested attachment before
+        // the first external send. Invalid, inaccessible, oversized, or
+        // SSRF-blocked media must fail fast instead of delivering the caption
+        // (or earlier attachments) and only then discovering a later part is
         // unusable.
-        media = await this.resolveOutboundMedia(options.mediaUrl, options.maxBytes);
+        for (const url of options.mediaUrls) {
+          mediaList.push(await this.resolveOutboundMedia(url, options.maxBytes));
+        }
       } catch (error) {
         // error-policy:J1 Outbound connector boundary translates attachment
-        // resolution failures into an explicit failed delivery.
+        // resolution failures into an explicit failed delivery. Nothing has
+        // been sent yet, so failing the whole send is truthful and safe.
+        await cleanupResolvedMedia(mediaList);
         return {
           success: false,
           error: `iMessage attachment resolution error: ${error instanceof Error ? error.message : String(error)}`,
@@ -1150,23 +1230,45 @@ export class IMessageService extends Service implements IIMessageService {
 
     // Split message if too long
     const chunks = splitMessageForIMessage(text);
+    let deliveredTextChunks = 0;
+    let deliveredAttachments = 0;
+    const effectStamps: string[] = [];
     try {
       for (const chunk of chunks) {
         const result = await this.sendSingleMessage(target, chunk);
         if (!result.success) {
-          return result;
+          return {
+            ...result,
+            delivered: {
+              textChunks: deliveredTextChunks,
+              attachments: deliveredAttachments,
+              effectStamps: [...effectStamps],
+            },
+          };
         }
+        deliveredTextChunks += 1;
+        effectStamps.push(result.messageId ?? `text-${deliveredTextChunks}`);
       }
 
-      // An attachment is one external effect, independent of text chunking.
-      if (media) {
+      // Each attachment is one external effect, independent of text chunking
+      // and of the other attachments; every requested part is attempted.
+      for (const media of mediaList) {
         const mediaResult = await this.sendResolvedAttachment(target, media.path);
         if (!mediaResult.success) {
-          return mediaResult;
+          return {
+            ...mediaResult,
+            delivered: {
+              textChunks: deliveredTextChunks,
+              attachments: deliveredAttachments,
+              effectStamps: [...effectStamps],
+            },
+          };
         }
+        deliveredAttachments += 1;
+        effectStamps.push(mediaResult.messageId ?? `attachment-${deliveredAttachments}`);
       }
     } finally {
-      await media?.cleanup();
+      await cleanupResolvedMedia(mediaList);
     }
 
     // Emit sent events — both the plugin-namespaced form (for iMessage-
@@ -1181,7 +1283,7 @@ export class IMessageService extends Service implements IIMessageService {
         accountId,
         to: target,
         text,
-        hasMedia: Boolean(options?.mediaUrl),
+        hasMedia: (options?.mediaUrls?.length ?? 0) > 0,
       } as EventPayload);
       this.runtime.emitEvent(EventType.MESSAGE_SENT, {
         runtime: this.runtime,

--- a/plugins/plugin-imessage/src/service.ts
+++ b/plugins/plugin-imessage/src/service.ts
@@ -3,7 +3,7 @@
  */
 
 import { execFile } from "node:child_process";
-import crypto from "node:crypto";
+import crypto, { randomUUID } from "node:crypto";
 import { mkdtemp, open, rm, writeFile } from "node:fs/promises";
 import { homedir, platform, tmpdir } from "node:os";
 import { extname, isAbsolute, join } from "node:path";
@@ -857,6 +857,7 @@ export class IMessageService extends Service implements IIMessageService {
                   reason:
                     "iMessage AppleScript sends return no provider message ids; effect stamps are local completion markers.",
                 },
+                evidenceKind: "local-effect",
               },
               memories: [],
               code: "IMESSAGE_PARTIAL_DELIVERY",
@@ -872,16 +873,18 @@ export class IMessageService extends Service implements IIMessageService {
         return {
           kind: "delivered",
           receipt: {
-            providerMessageIds: [result.messageId ?? `imessage-effect-${Date.now()}`] as [
-              string,
-              ...string[],
-            ],
+            // AppleScript provides no provider message id and the service's
+            // synthetic messageId is a repeatable Date.now() echo; the
+            // receipt always carries a freshly generated unique local-effect
+            // stamp instead, honoring the per-send uniqueness contract.
+            providerMessageIds: [`imessage-effect:${randomUUID()}:send`] as [string, ...string[]],
             acceptedAt: Date.now(),
             persistence: {
               status: "not_attempted",
               reason:
                 "iMessage send handler reports effect completion only; outbound memory persistence is owned by the caller.",
             },
+            evidenceKind: "local-effect",
           },
           memories: [],
         };
@@ -1194,7 +1197,7 @@ export class IMessageService extends Service implements IIMessageService {
       return { success: false, error: "Service not initialized" };
     }
 
-    if (this.settings.transport === "blooio" && options?.mediaUrl) {
+    if (this.settings.transport === "blooio" && options?.mediaUrls?.length) {
       return {
         success: false,
         error:
@@ -1233,6 +1236,15 @@ export class IMessageService extends Service implements IIMessageService {
     let deliveredTextChunks = 0;
     let deliveredAttachments = 0;
     const effectStamps: string[] = [];
+    // Local completion markers for parts that reached Messages.app. Stamps
+    // are prefixed with a per-send unique id so they cannot repeat across
+    // sends (#23104 review blocker 3); AppleScript returns no provider ids.
+    const sendStampId = randomUUID();
+    let partIndex = 0;
+    const nextEffectStamp = (kind: "text" | "attachment"): string => {
+      partIndex += 1;
+      return `imessage-effect:${sendStampId}:${kind}:${partIndex}`;
+    };
     try {
       for (const chunk of chunks) {
         const result = await this.sendSingleMessage(target, chunk);
@@ -1247,7 +1259,7 @@ export class IMessageService extends Service implements IIMessageService {
           };
         }
         deliveredTextChunks += 1;
-        effectStamps.push(result.messageId ?? `text-${deliveredTextChunks}`);
+        effectStamps.push(nextEffectStamp("text"));
       }
 
       // Each attachment is one external effect, independent of text chunking
@@ -1265,7 +1277,7 @@ export class IMessageService extends Service implements IIMessageService {
           };
         }
         deliveredAttachments += 1;
-        effectStamps.push(mediaResult.messageId ?? `attachment-${deliveredAttachments}`);
+        effectStamps.push(nextEffectStamp("attachment"));
       }
     } finally {
       await cleanupResolvedMedia(mediaList);

--- a/plugins/plugin-imessage/src/types.ts
+++ b/plugins/plugin-imessage/src/types.ts
@@ -123,9 +123,12 @@ export interface IMessageListMessagesOptions {
 export interface IMessageSendOptions {
   /** Connector account ID. iMessage currently supports only the local default account. */
   accountId?: string;
-  /** Media URL or path to attach */
-  mediaUrl?: string;
-  /** Max bytes for media */
+  /**
+   * Media URL(s) or path(s) to attach. Every requested attachment is resolved
+   * and delivered; there is no first-only selection.
+   */
+  mediaUrls?: string[];
+  /** Max bytes per media attachment */
   maxBytes?: number;
 }
 
@@ -137,6 +140,18 @@ export interface IMessageSendResult {
   messageId?: string;
   chatId?: string;
   error?: string;
+  /**
+   * Evidence about externally delivered parts when the overall send failed
+   * partway (#23104): how many text chunks and attachments reached
+   * Messages.app, plus one local-effect stamp per delivered part. AppleScript
+   * returns no provider ids; stamps are locally generated completion markers,
+   * not provider-backed message ids.
+   */
+  delivered?: {
+    textChunks: number;
+    attachments: number;
+    effectStamps: string[];
+  };
 }
 
 export interface IMessagePermissionAction {

--- a/plugins/plugin-slack/src/handle-send-outcome.test.ts
+++ b/plugins/plugin-slack/src/handle-send-outcome.test.ts
@@ -68,7 +68,7 @@ describe("Slack handleSendMessage delivery outcomes", () => {
   it("returns delivered with ordered ts+fileId provider ids when all parts succeed", async () => {
     const service = createService({
       textReceipts: [
-        { ts: "111.0001", text: "part one " },
+        { ts: "111.000100", text: "part one " },
         { ts: "111.0002", text: "part two" },
       ],
     });
@@ -83,7 +83,7 @@ describe("Slack handleSendMessage delivery outcomes", () => {
     if (outcome.kind !== "delivered") return;
     // Text chunk ts values in send order, then accepted file ids in request order.
     expect(outcome.receipt.providerMessageIds).toEqual([
-      "111.0001",
+      "111.000100",
       "111.0002",
       "F1",
       "F1",
@@ -232,5 +232,100 @@ describe("Slack handleSendMessage delivery outcomes", () => {
     expect(isSendHandlerOutcome(outcome)).toBe(true);
     if (outcome.kind !== "not_delivered") return;
     expect(outcome.code).toBe("SLACK_EMPTY_MESSAGE");
+  });
+
+  // Real sendMessage path (only the Slack client is stubbed): a later text
+  // chunk failing must surface the already-accepted chunk ts evidence as a
+  // partial delivery instead of throwing it away (#23104 review blocker 1).
+  // Structural view of the seams the real path calls; avoids intersecting
+  // the class type (private members collapse such intersections to never).
+  type RealPathService = {
+    runtime: {
+      agentId: string;
+      logger: Record<string, ReturnType<typeof vi.fn>>;
+    };
+    resolveAccountIdForTarget: (
+      runtime: unknown,
+      target: unknown,
+    ) => Promise<string>;
+    getAccountState: (accountId?: string | null) => null;
+    getClientForAccount: (accountId?: string | null) => {
+      chat: { postMessage: ReturnType<typeof vi.fn> };
+    };
+    handleSendMessage: SlackService["handleSendMessage"];
+  };
+
+  function createRealPathService(postMessage: ReturnType<typeof vi.fn>) {
+    const runtime = {
+      agentId: "agent-1",
+      logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() },
+    };
+    const service = Object.create(
+      SlackService.prototype,
+    ) as unknown as RealPathService;
+    service.runtime = runtime;
+    service.resolveAccountIdForTarget = async () => "default";
+    // getOutboundClient falls back to getClientForAccount when no account
+    // state exists, so the real sendMessage loop uses the stubbed client.
+    service.getAccountState = () => null;
+    service.getClientForAccount = () => ({ chat: { postMessage } });
+    return service;
+  }
+
+  // MAX_SLACK_MESSAGE_LENGTH is 40_000 on develop (#28854); 40_001 chars
+  // still exercise the two-chunk partial-delivery path.
+  const TWO_CHUNK_TEXT = "a".repeat(40_001);
+
+  it("returns partially_delivered with accepted chunk ts evidence when a later chunk rejects", async () => {
+    const postMessage = vi
+      .fn()
+      .mockResolvedValueOnce({ ts: "111.000100" })
+      .mockRejectedValueOnce(new Error("slack api down"));
+    const service = createRealPathService(postMessage);
+
+    const outcome: SendOutcome = await service.handleSendMessage(
+      runtimeStub,
+      target,
+      { text: TWO_CHUNK_TEXT },
+    );
+
+    expect(postMessage).toHaveBeenCalledTimes(2);
+    expect(outcome.kind).toBe("partially_delivered");
+    expect(isSendHandlerOutcome(outcome)).toBe(true);
+    if (outcome.kind !== "partially_delivered") return;
+    // Chunk 1 was accepted by Slack: its ts is real provider evidence and
+    // must reach the receipt so an outer retry cannot duplicate it blindly.
+    expect(outcome.receipt.providerMessageIds).toEqual(["111.000100"]);
+    expect(outcome.code).toBe("SLACK_TEXT_PARTIAL_DELIVERY");
+    expect(outcome.message).toContain("slack api down");
+  });
+
+  it("returns partially_delivered when a later chunk resolves without a valid ts", async () => {
+    const postMessage = vi
+      .fn()
+      .mockResolvedValueOnce({ ts: "111.000100" })
+      .mockResolvedValueOnce({ ts: "not-a-ts" });
+    const service = createRealPathService(postMessage);
+
+    const outcome: SendOutcome = await service.handleSendMessage(
+      runtimeStub,
+      target,
+      { text: TWO_CHUNK_TEXT },
+    );
+
+    expect(postMessage).toHaveBeenCalledTimes(2);
+    expect(outcome.kind).toBe("partially_delivered");
+    if (outcome.kind !== "partially_delivered") return;
+    expect(outcome.receipt.providerMessageIds).toEqual(["111.000100"]);
+    expect(outcome.message).toContain("SLACK_POST_MESSAGE_IDENTITY_MISSING");
+  });
+
+  it("still throws the underlying error when the FIRST chunk fails (nothing accepted)", async () => {
+    const postMessage = vi.fn().mockRejectedValue(new Error("no auth"));
+    const service = createRealPathService(postMessage);
+
+    await expect(
+      service.handleSendMessage(runtimeStub, target, { text: TWO_CHUNK_TEXT }),
+    ).rejects.toThrow("no auth");
   });
 });

--- a/plugins/plugin-slack/src/handle-send-outcome.test.ts
+++ b/plugins/plugin-slack/src/handle-send-outcome.test.ts
@@ -1,0 +1,236 @@
+import { Buffer } from "node:buffer";
+import {
+  type Content,
+  isSendHandlerOutcome,
+  type Media,
+  type TargetInfo,
+} from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { SlackService } from "./service";
+
+// Composed delivery-truth coverage for the Slack send handler (#23104):
+// handleSendMessage must derive one structural SendHandlerOutcome from the
+// text chunk receipts plus per-part attachment evidence, so a text-only
+// receipt can never mask requested-but-failed attachments. Runs offline by
+// stubbing the instance seams the production path calls: account resolution,
+// client lookup, channel resolution, text sendMessage, fetch, and upload.
+
+type SendOutcome = Awaited<ReturnType<SlackService["handleSendMessage"]>>;
+
+type TestService = SlackService & {
+  resolveAccountIdForTarget: ReturnType<typeof vi.fn>;
+  getClientForAccount: ReturnType<typeof vi.fn>;
+  sendMessage: ReturnType<typeof vi.fn>;
+  fetchAttachmentBytes: ReturnType<typeof vi.fn>;
+  uploadFile: ReturnType<typeof vi.fn>;
+};
+
+function createService(overrides?: {
+  textReceipts?: Array<{ ts: string; text: string }>;
+}): TestService {
+  const runtime = {
+    agentId: "agent-1",
+    logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() },
+  };
+  const service = Object.create(SlackService.prototype) as TestService;
+  Object.assign(service, { runtime });
+  service.resolveAccountIdForTarget = vi.fn(async () => "default");
+  service.getClientForAccount = vi.fn(() => ({ client: true }));
+  service.sendMessage = vi.fn(async () => ({
+    ts: overrides?.textReceipts?.at(-1)?.ts ?? "1234.0001",
+    channelId: "C1",
+    messages: overrides?.textReceipts ?? [{ ts: "1234.0001", text: "hello" }],
+  }));
+  service.fetchAttachmentBytes = vi.fn(async () => ({
+    buffer: Buffer.from("bytes"),
+    fileName: "fetched.png",
+    contentType: "image/png",
+  }));
+  service.uploadFile = vi.fn(async () => ({ fileId: "F1", permalink: "p" }));
+  return service;
+}
+
+const runtimeStub = {
+  agentId: "agent-1",
+  getRoom: vi.fn(async () => undefined),
+} as unknown as Parameters<SlackService["handleSendMessage"]>[0];
+
+const target: TargetInfo = { source: "slack", channelId: "C1" };
+
+function withAttachments(urls: string[]): Content {
+  const attachments: Media[] = urls.map(
+    (url, index) => ({ id: `m${index}`, url }) as Media,
+  );
+  return { text: "here are the files", attachments };
+}
+
+describe("Slack handleSendMessage delivery outcomes", () => {
+  it("returns delivered with ordered ts+fileId provider ids when all parts succeed", async () => {
+    const service = createService({
+      textReceipts: [
+        { ts: "111.0001", text: "part one " },
+        { ts: "111.0002", text: "part two" },
+      ],
+    });
+    const outcome: SendOutcome = await service.handleSendMessage(
+      runtimeStub,
+      target,
+      withAttachments(["https://x/a.png", "https://x/b.png"]),
+    );
+
+    expect(outcome.kind).toBe("delivered");
+    expect(isSendHandlerOutcome(outcome)).toBe(true);
+    if (outcome.kind !== "delivered") return;
+    // Text chunk ts values in send order, then accepted file ids in request order.
+    expect(outcome.receipt.providerMessageIds).toEqual([
+      "111.0001",
+      "111.0002",
+      "F1",
+      "F1",
+    ]);
+    expect(outcome.receipt.persistence.status).toBe("not_attempted");
+    expect(outcome.memories).toEqual([]);
+  });
+
+  it("returns partially_delivered when text succeeds but every attachment fails", async () => {
+    const service = createService();
+    service.fetchAttachmentBytes = vi
+      .fn()
+      .mockRejectedValue(new Error("ssrf blocked"));
+
+    const outcome = await service.handleSendMessage(
+      runtimeStub,
+      target,
+      withAttachments(["http://169.254.169.254/x"]),
+    );
+
+    expect(outcome.kind).toBe("partially_delivered");
+    expect(isSendHandlerOutcome(outcome)).toBe(true);
+    if (outcome.kind !== "partially_delivered") return;
+    // The text ts is real provider evidence of the partial delivery.
+    expect(outcome.receipt.providerMessageIds).toEqual(["1234.0001"]);
+    expect(outcome.code).toBe("SLACK_ATTACHMENT_PARTIAL_DELIVERY");
+    expect(outcome.message).toContain("169.254.169.254");
+    expect(outcome.message).toContain("SLACK_ATTACHMENT_UPLOAD_FAILED");
+  });
+
+  it("returns partially_delivered enumerating the failed subset when some attachments fail", async () => {
+    const service = createService();
+    service.fetchAttachmentBytes = vi
+      .fn()
+      .mockResolvedValueOnce({ buffer: Buffer.from("ok"), fileName: "ok.png" })
+      .mockRejectedValueOnce(new Error("unreachable host"))
+      .mockResolvedValueOnce({
+        buffer: Buffer.from("ok2"),
+        fileName: "ok2.png",
+      });
+
+    const outcome = await service.handleSendMessage(
+      runtimeStub,
+      target,
+      withAttachments([
+        "https://x/1.png",
+        "https://x/2.png",
+        "https://x/3.png",
+      ]),
+    );
+
+    expect(outcome.kind).toBe("partially_delivered");
+    expect(isSendHandlerOutcome(outcome)).toBe(true);
+    if (outcome.kind !== "partially_delivered") return;
+    // Text ts + the two accepted file ids; the failed part is excluded.
+    expect(outcome.receipt.providerMessageIds).toEqual([
+      "1234.0001",
+      "F1",
+      "F1",
+    ]);
+    expect(outcome.message).toContain("https://x/2.png");
+    expect(outcome.message).toContain("unreachable host");
+  });
+
+  it("returns not_delivered when attachments-only all fail (nothing accepted)", async () => {
+    const service = createService();
+    service.fetchAttachmentBytes = vi
+      .fn()
+      .mockRejectedValue(new Error("oversized"));
+
+    const outcome = await service.handleSendMessage(runtimeStub, target, {
+      text: "",
+      attachments: [
+        { id: "m0", url: "https://x/huge.bin" } as Media,
+        { id: "m1", url: "https://x/huge2.bin" } as Media,
+      ],
+    });
+
+    expect(outcome.kind).toBe("not_delivered");
+    expect(isSendHandlerOutcome(outcome)).toBe(true);
+    if (outcome.kind !== "not_delivered") return;
+    expect(outcome.code).toBe("SLACK_ATTACHMENT_DELIVERY_FAILED");
+    expect(outcome.message).toContain("oversized");
+  });
+
+  it("returns delivered with a file-id-only receipt for attachments-only sends", async () => {
+    const service = createService();
+    const outcome = await service.handleSendMessage(runtimeStub, target, {
+      text: "",
+      attachments: [{ id: "m0", url: "https://x/only.png" } as Media],
+    });
+
+    expect(outcome.kind).toBe("delivered");
+    expect(isSendHandlerOutcome(outcome)).toBe(true);
+    if (outcome.kind !== "delivered") return;
+    expect(outcome.receipt.providerMessageIds).toEqual(["F1"]);
+    expect(service.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("treats an upload resolving without a file id as a failed part, never fabricated success", async () => {
+    const service = createService();
+    service.uploadFile = vi.fn(async () => ({ fileId: "", permalink: "" }));
+
+    const outcome = await service.handleSendMessage(
+      runtimeStub,
+      target,
+      withAttachments(["https://x/ghost.png"]),
+    );
+
+    expect(outcome.kind).toBe("partially_delivered");
+    expect(isSendHandlerOutcome(outcome)).toBe(true);
+    if (outcome.kind !== "partially_delivered") return;
+    // No "" id may appear as provider evidence.
+    expect(outcome.receipt.providerMessageIds).toEqual(["1234.0001"]);
+    expect(outcome.message).toContain("SLACK_FILE_ID_MISSING");
+  });
+
+  it("attempts and reports a whitespace-only attachment URL as a failed part, never silently skipping it", async () => {
+    const service = createService();
+    // A real fetch rejects an unparseable whitespace URL; mirror that here.
+    service.fetchAttachmentBytes = vi.fn(async (url: string) => {
+      if (!url.trim()) throw new Error("Invalid URL");
+      return { buffer: Buffer.from("bytes"), fileName: "fetched.png" };
+    });
+    const outcome = await service.handleSendMessage(runtimeStub, target, {
+      text: "see attached",
+      attachments: [{ id: "m0", url: "   " } as Media],
+    });
+
+    expect(outcome.kind).toBe("partially_delivered");
+    expect(isSendHandlerOutcome(outcome)).toBe(true);
+    if (outcome.kind !== "partially_delivered") return;
+    expect(service.fetchAttachmentBytes).toHaveBeenCalledWith("   ");
+    expect(outcome.receipt.providerMessageIds).toEqual(["1234.0001"]);
+    expect(outcome.message).toContain("   ");
+  });
+
+  it("returns not_delivered with a stable code for empty content instead of throwing", async () => {
+    const service = createService();
+    const outcome = await service.handleSendMessage(runtimeStub, target, {
+      text: "   ",
+      attachments: [],
+    });
+
+    expect(outcome.kind).toBe("not_delivered");
+    expect(isSendHandlerOutcome(outcome)).toBe(true);
+    if (outcome.kind !== "not_delivered") return;
+    expect(outcome.code).toBe("SLACK_EMPTY_MESSAGE");
+  });
+});

--- a/plugins/plugin-slack/src/outbound-attachments.test.ts
+++ b/plugins/plugin-slack/src/outbound-attachments.test.ts
@@ -3,11 +3,17 @@ import type { Media } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { SlackService } from "./service";
 
-// Outbound media coverage for the Slack connector (#8876). Slack's API takes
-// file BYTES (not a URL), so agent `Media` attachments are fetched through the
-// SSRF-guarded fetcher and uploaded via uploadFile. We stub the (instance)
-// fetch wrapper + uploadFile so the test runs offline and exercises only the
-// new send-outbound-attachments logic.
+// Outbound media coverage for the Slack connector (#8876, truthful delivery
+// per #23104). Slack's API takes file BYTES (not a URL), so agent `Media`
+// attachments are fetched through the SSRF-guarded fetcher and uploaded via
+// uploadFile. We stub the (instance) fetch wrapper + uploadFile so the test
+// runs offline and exercises only the send-outbound-attachments logic and the
+// composed handleSendMessage outcome derivation.
+
+type AttachmentDelivery = {
+  delivered: Array<{ url: string; fileId: string; permalink: string }>;
+  failures: Array<{ url: string; code: string; message: string }>;
+};
 
 type TestService = SlackService & {
   sendOutboundAttachments: (
@@ -15,7 +21,7 @@ type TestService = SlackService & {
     attachments: Media[],
     threadTs: string | undefined,
     accountId: string | null,
-  ) => Promise<void>;
+  ) => Promise<AttachmentDelivery>;
   fetchAttachmentBytes: ReturnType<typeof vi.fn>;
   uploadFile: ReturnType<typeof vi.fn>;
 };
@@ -43,7 +49,7 @@ function media(over: Partial<Media>): Media {
 describe("Slack outbound attachments", () => {
   it("fetches each attachment's bytes and uploads it to the channel", async () => {
     const service = createService();
-    await service.sendOutboundAttachments(
+    const delivery = await service.sendOutboundAttachments(
       "C123",
       [media({ id: "img", contentType: "image", title: "cat.png" })],
       "111.222",
@@ -61,11 +67,15 @@ describe("Slack outbound attachments", () => {
       { title: "cat.png", threadTs: "111.222" },
       "default",
     );
+    expect(delivery.delivered).toEqual([
+      { url: "https://cdn.example.com/cat.png", fileId: "F1", permalink: "p" },
+    ]);
+    expect(delivery.failures).toEqual([]);
   });
 
   it("uploads multiple attachments", async () => {
     const service = createService();
-    await service.sendOutboundAttachments(
+    const delivery = await service.sendOutboundAttachments(
       "C1",
       [
         media({ id: "a", url: "https://x/a.png" }),
@@ -75,6 +85,8 @@ describe("Slack outbound attachments", () => {
       null,
     );
     expect(service.uploadFile).toHaveBeenCalledTimes(2);
+    expect(delivery.delivered).toHaveLength(2);
+    expect(delivery.failures).toEqual([]);
   });
 
   it("derives the filename: filename > title > fetched name", async () => {
@@ -110,26 +122,34 @@ describe("Slack outbound attachments", () => {
     );
   });
 
-  it("swallows a fetch failure (warns) and still uploads the rest", async () => {
+  it("records a fetch failure as typed evidence and still uploads the rest", async () => {
     const service = createService();
     service.fetchAttachmentBytes = vi
       .fn()
       .mockRejectedValueOnce(new Error("ssrf blocked"))
       .mockResolvedValueOnce({ buffer: Buffer.from("ok"), fileName: "ok.png" });
 
-    await expect(
-      service.sendOutboundAttachments(
-        "C1",
-        [
-          media({ id: "bad", url: "http://169.254.169.254/x" }),
-          media({ id: "good", url: "https://x/ok.png" }),
-        ],
-        undefined,
-        null,
-      ),
-    ).resolves.toBeUndefined();
+    const delivery = await service.sendOutboundAttachments(
+      "C1",
+      [
+        media({ id: "bad", url: "http://169.254.169.254/x" }),
+        media({ id: "good", url: "https://x/ok.png" }),
+      ],
+      undefined,
+      null,
+    );
 
     expect(service.uploadFile).toHaveBeenCalledTimes(1);
+    expect(delivery.failures).toEqual([
+      {
+        url: "http://169.254.169.254/x",
+        code: "SLACK_ATTACHMENT_UPLOAD_FAILED",
+        message: "ssrf blocked",
+      },
+    ]);
+    expect(delivery.delivered).toEqual([
+      { url: "https://x/ok.png", fileId: "F1", permalink: "p" },
+    ]);
     expect(
       (
         service as unknown as {
@@ -137,5 +157,23 @@ describe("Slack outbound attachments", () => {
         }
       ).runtime.logger.warn,
     ).toHaveBeenCalled();
+  });
+
+  it("treats an upload resolving without a file id as a failed part, not success", async () => {
+    const service = createService();
+    service.uploadFile = vi.fn(async () => ({ fileId: "", permalink: "" }));
+
+    const delivery = await service.sendOutboundAttachments(
+      "C1",
+      [media({ id: "ghost", url: "https://x/ghost.png" })],
+      undefined,
+      null,
+    );
+
+    expect(delivery.delivered).toEqual([]);
+    expect(delivery.failures).toHaveLength(1);
+    expect(delivery.failures[0]?.code).toBe("SLACK_FILE_ID_MISSING");
+    // No fabricated id may ever enter the evidence.
+    expect(JSON.stringify(delivery)).not.toContain('"fileId":""');
   });
 });

--- a/plugins/plugin-slack/src/service.ts
+++ b/plugins/plugin-slack/src/service.ts
@@ -575,6 +575,35 @@ export function compareSlackConnectorTargets(
   );
 }
 
+/**
+ * Raised by {@link SlackService.sendMessage} when a later text chunk fails
+ * after earlier chunks were already accepted by Slack. Carries the accepted
+ * chunk ts evidence so the connector boundary can compose a truthful
+ * `partially_delivered` outcome instead of dropping it (#23104).
+ */
+class SlackTextPartialDeliveryError extends ElizaError {
+  readonly acceptedTs: string[];
+
+  constructor(
+    message: string,
+    options: { accepted: string[]; code?: string },
+    errorOptions?: { cause?: unknown },
+  ) {
+    super(message, {
+      code: options.code ?? "SLACK_TEXT_PARTIAL_DELIVERY",
+      context: { acceptedTs: options.accepted },
+      ...(errorOptions?.cause !== undefined
+        ? { cause: errorOptions.cause }
+        : {}),
+    });
+    this.acceptedTs = options.accepted;
+  }
+
+  static isPartial(value: unknown): value is SlackTextPartialDeliveryError {
+    return value instanceof SlackTextPartialDeliveryError;
+  }
+}
+
 export class SlackService extends Service implements ISlackService {
   static serviceType: string = SLACK_SERVICE_NAME;
   capabilityDescription =
@@ -2684,6 +2713,7 @@ export class SlackService extends Service implements ISlackService {
   private buildSendOutcome(args: {
     acceptedIds: string[];
     attachments: OutboundAttachmentDelivery | null;
+    textFailure?: { message: string; code: string };
   }): SendHandlerOutcome {
     const providerMessageIds = [...args.acceptedIds];
     for (const part of args.attachments?.delivered ?? []) {
@@ -2691,9 +2721,11 @@ export class SlackService extends Service implements ISlackService {
     }
     const failures = args.attachments?.failures ?? [];
     const failureDetail =
-      failures.length > 0
-        ? failures.map((f) => `${f.url} (${f.code}: ${f.message})`).join("; ")
-        : "no per-part failure evidence was recorded";
+      args.textFailure !== undefined
+        ? `text delivery failed (${args.textFailure.code}: ${args.textFailure.message})`
+        : failures.length > 0
+          ? failures.map((f) => `${f.url} (${f.code}: ${f.message})`).join("; ")
+          : "no per-part failure evidence was recorded";
     if (providerMessageIds.length === 0) {
       return {
         kind: "not_delivered",
@@ -2710,6 +2742,15 @@ export class SlackService extends Service implements ISlackService {
           "Slack send handler reports provider receipts only; outbound memory persistence is owned by the caller.",
       },
     };
+    if (args.textFailure !== undefined) {
+      return {
+        kind: "partially_delivered",
+        receipt,
+        memories: [],
+        code: "SLACK_TEXT_PARTIAL_DELIVERY",
+        message: `Slack accepted ${providerMessageIds.length} text chunk${providerMessageIds.length === 1 ? "" : "s"} but a later chunk failed: ${failureDetail}. Do not retry blindly; the accepted chunks would be duplicated.`,
+      };
+    }
     if (failures.length > 0) {
       return {
         kind: "partially_delivered",
@@ -2784,20 +2825,38 @@ export class SlackService extends Service implements ISlackService {
     let textReceipt: Awaited<ReturnType<SlackService["sendMessage"]>> | null =
       null;
     if (text) {
-      textReceipt = await this.sendMessage(
-        channelId,
-        text,
-        {
-          threadTs,
-          replyBroadcast: undefined,
-          unfurlLinks: undefined,
-          unfurlMedia: undefined,
-          mrkdwn: undefined,
-          attachments: undefined,
-          blocks: undefined,
-        },
-        accountId,
-      );
+      try {
+        textReceipt = await this.sendMessage(
+          channelId,
+          text,
+          {
+            threadTs,
+            replyBroadcast: undefined,
+            unfurlLinks: undefined,
+            unfurlMedia: undefined,
+            mrkdwn: undefined,
+            attachments: undefined,
+            blocks: undefined,
+          },
+          accountId,
+        );
+      } catch (error) {
+        // error-policy:J1 connector boundary translation — a mid-text
+        // failure with already-accepted chunks becomes a structural
+        // partially_delivered outcome below; any other error propagates
+        // unchanged.
+        if (!SlackTextPartialDeliveryError.isPartial(error)) {
+          throw error;
+        }
+        return this.buildSendOutcome({
+          acceptedIds: error.acceptedTs,
+          textFailure: {
+            message: error.message,
+            code: error.code,
+          },
+          attachments: null,
+        });
+      }
     }
 
     let attachmentDelivery: OutboundAttachmentDelivery | null = null;
@@ -3901,16 +3960,46 @@ export class SlackService extends Service implements ISlackService {
         messageArgs.blocks = options.blocks;
       }
 
-      const result = await client.chat.postMessage(messageArgs);
+      let result: Awaited<ReturnType<typeof client.chat.postMessage>>;
+      try {
+        result = await client.chat.postMessage(messageArgs);
+      } catch (error) {
+        // error-policy:J2 context-adding rethrow — a later-chunk failure is
+        // wrapped in a typed error carrying the accepted-chunk evidence with
+        // the original error preserved as cause; first-chunk failures
+        // propagate unchanged.
+        // Earlier chunks are already accepted by Slack; surface them with the
+        // failure so the caller composes a partial delivery instead of
+        // dropping the evidence (and blind-retrying into duplicates).
+        if (sentMessages.length > 0) {
+          throw new SlackTextPartialDeliveryError(
+            error instanceof Error ? error.message : String(error),
+            { accepted: sentMessages.map(({ ts }) => ts) },
+            { cause: error },
+          );
+        }
+        throw error;
+      }
 
       if (typeof result.ts !== "string" || !isValidMessageTs(result.ts)) {
-        throw new ElizaError(
+        const identityError = new ElizaError(
           "Slack chat.postMessage returned no message timestamp",
           {
             code: "SLACK_POST_MESSAGE_IDENTITY_MISSING",
             context: { accountId: normalizeAccountId(accountId), channelId },
           },
         );
+        if (sentMessages.length > 0) {
+          throw new SlackTextPartialDeliveryError(
+            identityError.message,
+            {
+              accepted: sentMessages.map(({ ts }) => ts),
+              code: identityError.code,
+            },
+            { cause: identityError },
+          );
+        }
+        throw identityError;
       }
       lastTs = result.ts;
       sentMessages.push({ ts: result.ts, text: msg });

--- a/plugins/plugin-slack/src/service.ts
+++ b/plugins/plugin-slack/src/service.ts
@@ -44,6 +44,8 @@ import {
   type MessagePayload,
   type Room,
   resolveAttachmentBytes,
+  type SendHandlerOutcome,
+  type SendHandlerReceipt,
   Service,
   stringToUuid,
   type TargetInfo,
@@ -55,6 +57,16 @@ import { WebClient as SlackWebClient } from "@slack/web-api";
 
 type WebClient = App["client"];
 type AccountScopedTargetInfo = TargetInfo & { accountId?: string };
+/**
+ * Per-part structural evidence for one outbound attachment upload: successful
+ * parts carry the Slack file id (the provider receipt for files.uploadV2);
+ * failed parts carry a stable code plus message. Consumed by
+ * {@link SlackService.handleSendMessage} to derive complete/partial/not-delivered.
+ */
+type OutboundAttachmentDelivery = {
+  delivered: Array<{ url: string; fileId: string; permalink: string }>;
+  failures: Array<{ url: string; code: string; message: string }>;
+};
 type AccountScopedConnectorContext = MessageConnectorQueryContext & {
   accountId?: string;
   account?: { accountId?: string };
@@ -679,15 +691,14 @@ export class SlackService extends Service implements ISlackService {
         handlerRuntime: IAgentRuntime,
         target: TargetInfo,
         content: Content,
-      ): Promise<void> => {
-        await serviceInstance.handleSendMessage(
+      ): Promise<SendHandlerOutcome> =>
+        serviceInstance.handleSendMessage(
           handlerRuntime,
           normalizedAccountId && !(target as AccountScopedTargetInfo).accountId
             ? ({ ...target, accountId: normalizedAccountId } as TargetInfo)
             : target,
           content,
         );
-      };
 
       const withContextAccount = (
         context: MessageConnectorQueryContext,
@@ -2662,11 +2673,60 @@ export class SlackService extends Service implements ISlackService {
     return channel.id;
   }
 
+  /**
+   * Compose the final delivery outcome for one logical send: provider ids are
+   * ordered text chunk `ts` values first, then accepted upload file ids in
+   * request order (the send order). Attachment failures always downgrade a
+   * send that reached the provider to `partially_delivered`; with nothing
+   * accepted the send is `not_delivered`. `uploadFile` returning no file id
+   * is treated as a failed part, never fabricated evidence.
+   */
+  private buildSendOutcome(args: {
+    acceptedIds: string[];
+    attachments: OutboundAttachmentDelivery | null;
+  }): SendHandlerOutcome {
+    const providerMessageIds = [...args.acceptedIds];
+    for (const part of args.attachments?.delivered ?? []) {
+      providerMessageIds.push(part.fileId);
+    }
+    const failures = args.attachments?.failures ?? [];
+    const failureDetail =
+      failures.length > 0
+        ? failures.map((f) => `${f.url} (${f.code}: ${f.message})`).join("; ")
+        : "no per-part failure evidence was recorded";
+    if (providerMessageIds.length === 0) {
+      return {
+        kind: "not_delivered",
+        code: "SLACK_ATTACHMENT_DELIVERY_FAILED",
+        message: `No Slack part was accepted: ${failureDetail}`,
+      };
+    }
+    const receipt: SendHandlerReceipt = {
+      providerMessageIds: providerMessageIds as [string, ...string[]],
+      acceptedAt: Date.now(),
+      persistence: {
+        status: "not_attempted",
+        reason:
+          "Slack send handler reports provider receipts only; outbound memory persistence is owned by the caller.",
+      },
+    };
+    if (failures.length > 0) {
+      return {
+        kind: "partially_delivered",
+        receipt,
+        memories: [],
+        code: "SLACK_ATTACHMENT_PARTIAL_DELIVERY",
+        message: `Slack accepted ${providerMessageIds.length} part${providerMessageIds.length === 1 ? "" : "s"} but ${failures.length} attachment${failures.length === 1 ? "" : "s"} failed: ${failureDetail}`,
+      };
+    }
+    return { kind: "delivered", receipt, memories: [] };
+  }
+
   async handleSendMessage(
     runtime: IAgentRuntime,
     target: TargetInfo,
     content: Content,
-  ): Promise<void> {
+  ): Promise<SendHandlerOutcome> {
     const accountId = await this.resolveAccountIdForTarget(runtime, target);
     if (!this.getClientForAccount(accountId)) {
       throw new Error("Slack client not initialized");
@@ -2677,9 +2737,12 @@ export class SlackService extends Service implements ISlackService {
       ? content.attachments.filter((media) => Boolean(media?.url))
       : [];
     if (!text && outboundAttachments.length === 0) {
-      throw new Error(
-        "Slack SendHandler requires non-empty text or at least one attachment.",
-      );
+      return {
+        kind: "not_delivered",
+        code: "SLACK_EMPTY_MESSAGE",
+        message:
+          "Slack SendHandler requires non-empty text or at least one attachment.",
+      };
     }
 
     let channelId = target.channelId;
@@ -2718,8 +2781,10 @@ export class SlackService extends Service implements ISlackService {
       );
     }
 
+    let textReceipt: Awaited<ReturnType<SlackService["sendMessage"]>> | null =
+      null;
     if (text) {
-      await this.sendMessage(
+      textReceipt = await this.sendMessage(
         channelId,
         text,
         {
@@ -2735,14 +2800,21 @@ export class SlackService extends Service implements ISlackService {
       );
     }
 
+    let attachmentDelivery: OutboundAttachmentDelivery | null = null;
     if (outboundAttachments.length > 0) {
-      await this.sendOutboundAttachments(
+      attachmentDelivery = await this.sendOutboundAttachments(
         channelId,
         outboundAttachments,
         threadTs,
         accountId,
       );
     }
+
+    return this.buildSendOutcome({
+      // Every accepted text chunk keeps its provider ts, in send order.
+      acceptedIds: (textReceipt?.messages ?? []).map(({ ts }) => ts),
+      attachments: attachmentDelivery,
+    });
   }
 
   /**
@@ -2760,29 +2832,65 @@ export class SlackService extends Service implements ISlackService {
    * Upload agent-generated `Media` attachments to a Slack channel (#8876).
    * Slack's API takes file BYTES (not a URL), so each attachment is fetched
    * through the SSRF-guarded fetcher and uploaded via {@link uploadFile}. Each
-   * upload is isolated in try/catch so a single unreachable/oversized URL logs a
-   * warning and never drops the rest of the reply (the text already went out).
+   * upload is isolated in try/catch so a single unreachable/oversized URL never
+   * drops the rest of the reply; instead of only warning, the failure is
+   * returned as typed per-part evidence so {@link handleSendMessage} can report
+   * a truthful complete/partial/not-delivered outcome.
    */
   private async sendOutboundAttachments(
     channelId: string,
     attachments: Media[],
     threadTs: string | undefined,
     accountId: string | null,
-  ): Promise<void> {
+  ): Promise<OutboundAttachmentDelivery> {
+    const delivered: Array<{ url: string; fileId: string; permalink: string }> =
+      [];
+    const failures: Array<{
+      url: string;
+      code: string;
+      message: string;
+    }> = [];
     for (const media of attachments) {
-      if (!media.url) continue;
+      // Blank/whitespace URLs still pass the caller's Boolean(media?.url)
+      // filter; they are deliberately attempted and reported as per-part
+      // failures rather than silently skipped (#23104 truthfulness).
       try {
         const { buffer, fileName } = await this.fetchAttachmentBytes(media.url);
         const filename =
           media.filename ?? media.title ?? fileName ?? "attachment";
-        await this.uploadFile(
+        const uploaded = await this.uploadFile(
           channelId,
           buffer,
           filename,
           { title: media.title, threadTs },
           accountId,
         );
+        if (!uploaded.fileId?.trim()) {
+          // files.uploadV2 resolving without a file object carries no
+          // structural delivery evidence; an empty id must never enter a
+          // receipt as fabricated success (repo DTO policy).
+          throw new ElizaError(
+            "Slack files.uploadV2 returned no file id for an accepted upload",
+            { code: "SLACK_FILE_ID_MISSING" },
+          );
+        }
+        delivered.push({
+          url: media.url,
+          fileId: uploaded.fileId,
+          permalink: uploaded.permalink,
+        });
       } catch (error) {
+        // error-policy:J1 per-part connector boundary — a fetch/upload failure
+        // becomes typed evidence the composed outcome reports as partial/not
+        // delivered; the remaining attachments are still attempted.
+        failures.push({
+          url: media.url,
+          code:
+            error instanceof ElizaError
+              ? error.code
+              : "SLACK_ATTACHMENT_UPLOAD_FAILED",
+          message: error instanceof Error ? error.message : String(error),
+        });
         this.runtime.logger.warn(
           {
             src: "plugin:slack",
@@ -2794,6 +2902,7 @@ export class SlackService extends Service implements ISlackService {
         );
       }
     }
+    return { delivered, failures };
   }
 
   async resolveConnectorTargets(


### PR DESCRIPTION
Contributes to #23104 (does not close the parent issue) (bounded first delivery-truthfulness slice)

## Summary

First bounded slice of #23104: connector send handlers derive one structural `SendHandlerOutcome` per logical send instead of `void`/throw, and iMessage attempts **every** requested attachment instead of silently selecting only the first. Slack attachment failures are no longer swallowed after text succeeds — they surface as typed per-part evidence.

### Slack (`plugins/plugin-slack`)

- `handleSendMessage` returns a typed `SendHandlerOutcome` (`delivered` / `partially_delivered` / `not_delivered`) composed from text chunk `ts` receipts plus per-attachment upload evidence, in provider send order.
- `sendOutboundAttachments` returns per-part evidence: successful uploads carry the `files.uploadV2` file id; failed parts carry a stable `code` + `message`. An upload resolving without a file id is treated as a failed part — never fabricated into a receipt.
- Empty content → `not_delivered` (`SLACK_EMPTY_MESSAGE`) instead of throwing; nothing accepted → `SLACK_ATTACHMENT_DELIVERY_FAILED`; subset failure → `SLACK_ATTACHMENT_PARTIAL_DELIVERY` with the failed subset enumerated.

### iMessage (`plugins/plugin-imessage`)

- `sendMessage` accepts `mediaUrls: string[]`; the HTTP route still accepts legacy singular `mediaUrl` (ordered first when both are present).
- Every requested attachment is resolved and byte-bounded through the SSRF-guarded fetcher **before** the first external send — unusable parts fail the whole send fast, with all staged dirs cleaned up.
- Mid-send failures return delivered-part evidence (`textChunks`, `attachments`, per-part local effect stamps) so callers do not blind-retry and duplicate externally delivered parts; the sendHandler surfaces it as `partially_delivered` (`IMESSAGE_PARTIAL_DELIVERY`).
- Staged attachment dirs are cleaned best-effort on every exit path (error-policy:J6): a cleanup rejection can never convert a delivered send into a thrown failure.
- Route + sendHandler empty-input paths return `not_delivered` outcomes with stable codes instead of throwing.

### Out of scope (explicitly deferred)

The issue's authorization-bearing Media references and remaining connectors (WhatsApp/Telegram/Discord matrix) are not in this slice; this PR takes the issue-body-sanctioned bounded slice (truthful multi-attachment delivery for two connectors). Follow-up slices will cover authorization + remaining connectors.

## Root-cause verification

Issue author's live-source disposition (2026-08-21) named three symptoms. All three verified against pristine develop before implementing:

1. **Slack swallows attachment failure**: develop's `sendOutboundAttachments` catches fetch/upload errors, logs a warning, returns `void` — a text-then-failed-attachments send reported success with no per-part record.
2. **iMessage first-attachment-only**: develop's outbound selection is `attachments?.find(...)` — one attachment max, silently dropping the rest.
3. **Void/throw handlers**: both `sendHandler`s returned `Promise<void>` or threw, erasing delivered-part evidence on partial failure.

An RP (RepoPrompt) investigation session independently confirmed root cause and files/lines before implementation; RP review r1 (REQUEST_CHANGES, 8 findings) and r2 re-review of the applied fixes returned **APPROVE** with 4 P3 non-blocking notes.

## Evidence

### Test evidence (inline)

Two new suites pin the contract; both fail on pristine develop (RED control: Slack 8/8 fail, iMessage 5/6 fail — the 6th exercises pre-existing resolve-fail-fast behavior that develop already had):

```
plugin-slack   src/handle-send-outcome.test.ts    8 tests — composed outcomes:
  delivered (ordered ts+fileId receipt), partially_delivered (text ok + all
  attachments fail; subset-fail enumeration), not_delivered (attachments-only
  all-fail, nothing accepted), file-id-only receipt for attachments-only
  sends, missing-file-id = failed part never fabricated, whitespace-only URL
  attempted + reported as failure never silently skipped, empty content =
  stable SLACK_EMPTY_MESSAGE code
plugin-imessage src/outbound-multi-attachment.test.ts  6 tests — all parts
  attempted, resolve-before-send (0 text + 0 attachment sends on resolve
  fail), cleanup-after-late-failure (3/3 staged dirs incl. never-sent third),
  delivered-part evidence on mid-send failure
```

Full suites at head `c70072b305`:

```
plugin-slack:   Test Files 8 passed (8)   Tests 180 passed (180)
plugin-imessage: Test Files 20 passed (20) Tests 227 passed (227)
typecheck: plugin-slack ✓ plugin-imessage ✓
biome check (9 changed files): clean, no fixes applied
RED control (pristine develop + new tests only): slack 8/8 FAIL, imessage 5/6 FAIL
```

### Backend log evidence (inline transcript)

RP r2 re-review transcript excerpt (independent reviewer verdict on the exact head bytes):

```
No P1/P2 issues remain: every path through both sendHandlers produces a
contract-valid SendHandlerOutcome (verified against the core type guard,
including the non-blank-id requirement), the J6 teardown cannot convert a
delivered send into a failure, fail-fast staging cleans up earlier
successes, and the suite/RED evidence supports the claimed behavior rather
than merely green automation.
VERDICT: APPROVE — findings 1-4 are recorded follow-ups/PR notes, none blocking.
```

RP r1 verdict (pre-fix, 8 findings) drove the applied fixes: iMessage outcome wiring, best-effort cleanup, intentional whitespace-URL reporting, dead-param removal, `isSendHandlerOutcome` assertions, whitespace + legacy-ordering test cases.

### Reviewer P3 notes carried forward (non-blocking)

1. iMessage success receipts collapse multi-part sends to the single final stamp; the full per-part stamp list is retained internally and could be surfaced on success for symmetry with the failure path (follow-up polish).
2. `splitMessageForIMessage` sits between staging and the `try/finally` (pre-existing ordering; pure string splitter, throw path near-impossible).

### N/A rows

- **Live Slack/iMessage end-to-end transcripts**: N/A - no live workspace credentials/messages.app session available in this environment; suites run the production seams offline (real `fetchAttachmentBytes`/`uploadFile`/AppleScript stubs at the instance boundary), and live-runtime evidence belongs to the follow-up authorization slice.
- **Visual captures**: N/A - no UI surface touched (server-side connector code only).

## Production call path (exact-head caller trace)

`registerSendHandlers` → `messageConnector.sendHandler` (service.ts) → `SlackService.handleSendMessage` / `IMessageService.sendHandler` → `sendMessage` — the same registration path develop already invokes; this PR changes the return contract at that boundary to the core-typed `SendHandlerOutcome` the `MessageConnector` registration consumes.

# Evidence Gate

<!-- evidence-head:f2dd60d35e5c3fae7eaf5018289177c67f44839b -->
<!-- evidence-row:backend-logs -->
- [ ] N/A - rebase-only update 2026-09-10: rebased onto develop tip 25821f1b0f, patch-ids identical 5/5 (delta bytes unchanged). Gates at new head dd7e79f13db: core messaging suites 43/43 pass, plugin-imessage bun suites 23 pass/0 fail, vitest routes-e2e 26/26 pass, core + plugin-imessage typecheck 0 errors, biome clean on all changed files.

```
plugin-slack full suite (vitest run):
Test Files  8 passed (8)
     Tests  180 passed (180)
plugin-imessage full suite (vitest run --config vitest.config.ts):
Test Files  20 passed (20)
     Tests  227 passed (227)
typecheck: plugin-slack tsc --noEmit PASS; plugin-imessage tsc --noEmit PASS
biome check on all 9 changed files: Checked 9 files. No fixes applied.
```
</details>
<!-- evidence-row:domain-artifacts -->
<details><summary>RED control output — new suites vs pristine develop</summary>

```
plugin-slack src/handle-send-outcome.test.ts on pristine develop: 8 tests, 8 failed
  x returns delivered with ordered ts+fileId provider ids when all parts succeed
  x returns partially_delivered when text succeeds but every attachment fails
  x returns partially_delivered enumerating the failed subset when some attachments fail
  x returns not_delivered when attachments-only all fail (nothing accepted)
  x returns delivered with a file-id-only receipt for attachments-only sends
  x treats an upload resolving without a file id as a failed part (no success without a provider id)
  x attempts and reports a whitespace-only attachment URL as a failed part, never silently skipped
  x returns not_delivered with a stable code for empty content instead of throwing
plugin-imessage src/outbound-multi-attachment.test.ts on pristine develop: 6 tests, 5 failed
  develop sends first-attachment-only; resolve-fail-fast pre-existed on develop (1 pass)
At head c70072b305 both suites fully PASS (180/180 and 227/227 with each package).
```
</details>
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend/browser surface touched
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model/trajectory code path touched; connector delivery logic only
<!-- evidence-row:before-screenshots -->
- [ ] N/A - no UI surface touched (server-side connector code only)
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no UI surface touched (server-side connector code only)
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no UI surface touched (server-side connector code only)

---

AI provider/model: zai / glm-5.3
Client / agent tooling: Hermes Agent
Contribution skill revision: elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [hermes-t3rpz]
<!-- eliza-computer-attribution:v1 {"provider":"zai","model":"glm-5.3","client":"Hermes Agent","skill_revision":"elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza"} -->







<!-- evidence-row: backend-logs -->
**Rebase 2026-09-09 (head `2f0a0c204f` (identical tree to my verified `176691dc85` — a sibling lane pushed an equivalent rebase seconds apart), was `afcaf97a10`)** — CI red root-caused and cleared:

- Root cause of the `Subscription authority PostgreSQL` red: branch tree was 1276 commits behind develop; the workflow's `bun test` filter `packages/cloud/shared/src/db/repositories/subscription-authority.postgres.integration.test.ts` matched ZERO files at the old head (file landed on develop in `7153fac213`, 2026-09-06). Not a test failure, not a flake.
- Fix: rebase onto develop tip; `git range-diff` confirms 5/5 commits replayed with identical patches (`=` for all).
- CI proof reproduced locally at the new head: `SUBSCRIPTION_AUTHORITY_POSTGRES_URL=postgresql://...@127.0.0.1:5432/subauth_28074 bun test --config=/dev/null --isolate packages/cloud/shared/src/db/repositories/subscription-authority.postgres.integration.test.ts` → **10 pass / 0 fail / 72 expect() calls** (incl. two real 5s lock-wait concurrency cases).
- Affected suites at new head: plugin-imessage **262/262** (23 files), plugin-slack **188/188** (9 files), core messaging `message.test.ts` + `messaging.test.ts` **43/43**, typecheck clean for core/imessage/slack.

`bun run dev` transcript excerpts at branch heads, incl. local-effect guidance fix (6149538a39) and site-3 coverage commit (9e5df39859):

- `npx vitest run src/features/advanced-capabilities/actions/message.test.ts --root packages/core` → Test Files 1 passed, Tests 35 passed (35)
- `npx vitest run src/features/advanced-capabilities/actions/` → Test Files 11 passed, Tests 127 passed (127)
- `bun run --cwd packages/core typecheck` → exit 0 (Done!)
- `biome check message.ts message.test.ts` → clean
- RED control: `message.ts` swapped to pre-branch 3e0e36623d with the site-3 test kept → "does not direct local-effect sends to provider reconciliation when the outbound record fails" fails (provider reconcile directive interpolates the imessage-effect marker); fixed head restored → 35/35.
- Earlier review-response commit 6149538a39 verified the same way at its head (34/34 + RED control on sites 1-2).



