### PR TITLE
fix(core): strip UTF-8 BOM in atomic-json reads

### DIFF
--- a/packages/core/src/utils/atomic-json.test.ts
+++ b/packages/core/src/utils/atomic-json.test.ts
@@ -117,6 +117,15 @@ describe("atomic-json", () => {
 			expect((await fsp.readdir(tempDir)).sort()).toEqual(["concurrent.json"]);
 		});
 
+		it("strips UTF-8 BOM before parsing JSON", async () => {
+			const bomFile = path.join(tempDir, "bom.json");
+			await fsp.writeFile(bomFile, '\uFEFF{"a":1}', "utf-8");
+			expect(await readJsonFile<{ a: number }>(bomFile)).toEqual({ a: 1 });
+			const bomSync = path.join(tempDir, "bom-sync.json");
+			fs.writeFileSync(bomSync, '\uFEFF{"b":2}', "utf-8");
+			expect(readJsonFileSync<{ b: number }>(bomSync)).toEqual({ b: 2 });
+		});
+
 		it("rejects non-string or empty file paths", async () => {
 			await expect(
 				writeJsonAtomic("" as unknown as string, {}),

--- a/packages/core/src/utils/atomic-json.ts
+++ b/packages/core/src/utils/atomic-json.ts
@@ -153,7 +153,7 @@ export async function readJsonFile<T>(filePath: string): Promise<T | null> {
 	assertFilePath(filePath);
 	try {
 		const raw = await fsp.readFile(filePath, "utf-8");
-		return JSON.parse(raw) as T;
+		return JSON.parse(raw.replace(/^\uFEFF/, "")) as T;
 	} catch (error) {
 		if ((error as NodeJS.ErrnoException).code === "ENOENT") {
 			// error-policy:J4 an absent optional JSON file is an explicit not-found
@@ -172,7 +172,7 @@ export function readJsonFileSync<T>(filePath: string): T | null {
 	assertFilePath(filePath);
 	try {
 		const raw = fs.readFileSync(filePath, "utf-8");
-		return JSON.parse(raw) as T;
+		return JSON.parse(raw.replace(/^\uFEFF/, "")) as T;
 	} catch (error) {
 		if ((error as NodeJS.ErrnoException).code === "ENOENT") {
 			// error-policy:J4 an absent optional JSON file is an explicit not-found


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

N/A - direct fix for atomic-json BOM handling, no linked issue.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Only affects JSON file reads that start with UTF-8 BOM (`\uFEFF`). Without fix, BOM files throw SyntaxError; with fix, BOM is stripped before parse. No behavior change for normal JSON. No new dependencies.

# Background

## What does this PR do?

Strips leading UTF-8 BOM (`\uFEFF`) before `JSON.parse` in both `readJsonFile` (async) and `readJsonFileSync` (sync). BOM-prefixed files (common from Windows editors) previously threw `SyntaxError: Unexpected token`. Now they parse correctly.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/core/src/utils/atomic-json.ts` - two one-line changes stripping BOM; `packages/core/src/utils/atomic-json.test.ts` - new test case.

## Detailed testing steps

- Red (reverted): `vitest run packages/core/src/utils/atomic-json.test.ts` fails on BOM test with SyntaxError.
- Green (restored): same command passes (11 passed).
- Existing suite passes: `vitest run packages/core/src/utils/atomic-json.test.ts` 11/11.
- Biome check clean on changed files.
- Typecheck via `bun run --cwd packages/core typecheck` passes (no new errors).

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:593e836a9e9a7c46ead69e29f72847f38a054d23 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - no UI surface, core file utility fix`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - no UI surface, core file utility fix`.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked `N/A - no UI flow, file read helper`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked `N/A - not a server route, covered by unit test with file I/O`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend code, core utils`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - no LLM path, file parsing fix`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - no domain artifact, file read`.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM path, file parsing fix.

## Backend + frontend logs

N/A - not a server route, covered by unit test with file I/O. Test output below shows file read path.

## Screenshots (before / after) + video walkthrough

N/A - no UI surface, core file utility fix.

### Before

N/A - no UI surface, core file utility fix.

### After

N/A - no UI surface, core file utility fix.

### Walkthrough video

N/A - no UI flow, file read helper.

## Audio / voice walkthrough

N/A - no voice path.

## Known gaps / failures

None. `bun run --cwd packages/core typecheck` passes on main checkout; fresh worktree typecheck shows pre-existing missing optional peer deps when run without workspace generation, not related to this diff. Biome clean. No UI evidence needed.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

---

### Red (reverted) -> Green (restored)

**Red** (without fix) - `vitest run packages/core/src/utils/atomic-json.test.ts`:
```
 ✓ 10 passed
 × 1 failed > strips UTF-8 BOM before parsing JSON 5ms
   → SyntaxError: Unexpected token '﻿', "﻿{"a":1}" is not valid JSON
     at JSON.parse (<anonymous>)
     at readJsonFile packages/core/src/utils/atomic-json.ts:156:15
```

**Green** (with fix):
```
 ✓ 11 passed
 Test Files  1 passed (1)
      Tests  11 passed (11)
   Duration  251ms
```

Existing suite: `bun --cwd packages/core` typecheck clean, biome clean.

