### PR TITLE
fix(shared): avoid spread stack overflow in transcriptKnowledgeFragments

### DIFF
--- a/packages/shared/src/transcripts.test.ts
+++ b/packages/shared/src/transcripts.test.ts
@@ -116,6 +116,21 @@ describe("transcriptKnowledgeFragments", () => {
       transcriptKnowledgeFragments([{ ...segs[0], endMs: -1 }]),
     ).toThrow(/invalid timing/);
   });
+
+  it("handles large groups without spread stack overflow", () => {
+    const large = Array.from({ length: 200000 }, (_, i) => ({
+      id: `s${i}`,
+      speakerLabel: "Alice",
+      startMs: i * 10,
+      endMs: i * 10 + 5,
+      text: "word",
+      words: [],
+    }));
+    const fragments = transcriptKnowledgeFragments(large, 5_000_000);
+    expect(fragments).toHaveLength(1);
+    expect(fragments[0]?.metadata.startMs).toBe(0);
+    expect(fragments[0]?.metadata.endMs).toBe(200000 * 10 - 5);
+  });
 });
 
 describe("transcriptPreview", () => {

--- a/packages/shared/src/transcripts.ts
+++ b/packages/shared/src/transcripts.ts
@@ -324,12 +324,22 @@ export function transcriptKnowledgeFragments(
           .filter((label): label is string => Boolean(label)),
       ),
     ];
+    let startMs = group[0]?.startMs ?? 0;
+    let endMs = group[0]?.endMs ?? 0;
+    for (let i = 1; i < group.length; i += 1) {
+      const seg = group[i];
+      if (!seg) continue;
+      const s = seg.startMs;
+      const e = seg.endMs;
+      if (s < startMs) startMs = s;
+      if (e > endMs) endMs = e;
+    }
     fragments.push({
       text: lines.join("\n"),
       metadata: {
         segmentIds: group.map((segment) => segment.id),
-        startMs: Math.min(...group.map((segment) => segment.startMs)),
-        endMs: Math.max(...group.map((segment) => segment.endMs)),
+        startMs,
+        endMs,
         ...(speakerLabels.length > 0 ? { speakerLabels } : {}),
       },
     });


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

N/A - direct fix for transcriptKnowledgeFragments stack overflow.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Only changes the min/max calculation inside `flush()` from spread (`Math.min(...array)`) to iterative loop. No behavior change for normal sizes; fixes stack overflow for very large groups (200k segments). No new deps.

# Background

## What does this PR do?

Replaces `Math.min(...group.map(s=>s.startMs))` and `Math.max(...group.map(s=>s.endMs))` with a manual loop to avoid `RangeError: Maximum call stack size exceeded` when `group` contains many segments (e.g., 200k). The spread operator pushes each element onto the call stack as an argument.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/shared/src/transcripts.ts` - two-line loop replacing spread; `packages/shared/src/transcripts.test.ts` - new large-group test.

## Detailed testing steps

- Red (reverted): `bun run --cwd packages/shared test --run src/transcripts.test.ts` fails with `RangeError: Maximum call stack size exceeded` at `Math.min(...group.map)`.
- Green (restored): same command passes 33/33.
- Existing suite passes, Biome clean.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:8a0e2d0f696b477d1fde56534f32e73e5b8a176e -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - no UI surface, shared transcript utility`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - no UI surface, shared transcript utility`.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked `N/A - no UI flow, data processing fix`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked `N/A - not a server route, covered by unit test`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend code`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - no LLM path`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - no domain artifact, transcript fragments`.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM path.

## Backend + frontend logs

N/A - not a server route, covered by unit test.

## Screenshots (before / after) + video walkthrough

N/A - no UI surface, shared transcript utility.

### Before

N/A - no UI surface.

### After

N/A - no UI surface.

### Walkthrough video

N/A - no UI flow, data processing fix.

## Audio / voice walkthrough

N/A - no voice path.

## Known gaps / failures

None. Biome clean, tests pass. Typecheck passes in main checkout.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

---

### Red -> Green

**Red** (without fix):
```
 FAIL  src/transcripts.test.ts > handles large groups without spread stack overflow
RangeError: Maximum call stack size exceeded
   at flush src/transcripts.ts:331:23
   at transcriptKnowledgeFragments
```

**Green** (with fix):
```
 Test Files  1 passed (1)
      Tests  33 passed (33)
```

