### PR TITLE
fix(core): harden code-fence language prefix match to require delimiter

### DIFF
--- a/packages/core/src/utils/code-fence.test.ts
+++ b/packages/core/src/utils/code-fence.test.ts
@@ -28,4 +28,20 @@ describe("unwrapWholeCodeFence", () => {
 			"x",
 		);
 	});
+
+	it("rejects prefix-overmatched languages without a delimiter", () => {
+		expect(unwrapWholeCodeFence("```jsonata\nhello\n```", ["json"])).toBeNull();
+		expect(unwrapWholeCodeFence("```jsonATA\nhello\n```", ["json"])).toBeNull();
+		expect(unwrapWholeCodeFence("```js\nhello\n```", ["json"])).toBeNull();
+		expect(unwrapWholeCodeFence("```json\nhello\n```", ["json"])).toBe("hello");
+		expect(
+			unwrapWholeCodeFence("```jsonata\nhello\n```", ["json", "jsonata"]),
+		).toBe("hello");
+		expect(
+			unwrapWholeCodeFence("```json\nhello\n```", ["json", "jsonata"]),
+		).toBe("hello");
+		expect(unwrapWholeCodeFence("```json \nhello\n```", ["json"])).toBe(
+			"hello",
+		);
+	});
 });

--- a/packages/core/src/utils/code-fence.ts
+++ b/packages/core/src/utils/code-fence.ts
@@ -8,9 +8,22 @@ export function unwrapWholeCodeFence(
 		return null;
 	}
 	const lowerValue = value.toLowerCase();
-	const acceptedLanguage = [...languages]
-		.sort((left, right) => right.length - left.length)
-		.find((language) => lowerValue.startsWith(language.toLowerCase(), 3));
+	const sorted = [...languages].sort(
+		(left, right) => right.length - left.length,
+	);
+	let acceptedLanguage: string | undefined;
+	for (const language of sorted) {
+		const lowerLang = language.toLowerCase();
+		if (!lowerValue.startsWith(lowerLang, 3)) continue;
+		const afterIdx = 3 + language.length;
+		let extEnd = afterIdx;
+		while (extEnd < value.length && /[A-Za-z0-9]/.test(value[extEnd])) {
+			extEnd += 1;
+		}
+		if (extEnd > afterIdx && /\s/u.test(value[extEnd] ?? "")) continue;
+		acceptedLanguage = language;
+		break;
+	}
 	let cursor = acceptedLanguage ? 3 + acceptedLanguage.length : 3;
 	if (!acceptedLanguage) {
 		while (cursor < value.length && /[A-Za-z0-9]/.test(value[cursor]))


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

N/A - direct fix for code-fence prefix matching.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Fixes prefix matching to require delimiter; only affects cases where language list contains a prefix of another language (e.g., json vs jsonata). Without fix, ` ```jsonata` incorrectly matches `json` and returns `ata` as content.

# Background

## What does this PR do?

Hardens `unwrapWholeCodeFence` language detection: when checking `lowerValue.startsWith(language, 3)`, now verifies that the character after the matched prefix is not alphanumeric without whitespace delimiter. If `json` matches but the next chars are `ata` followed by newline (not whitespace delimiter), it continues searching.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/core/src/utils/code-fence.ts` - loop replacing `find`; `packages/core/src/utils/code-fence.test.ts` - new prefix test.

## Detailed testing steps

- Red: `vitest run packages/core/src/utils/code-fence.test.ts` fails with `expected 'ata\nhello' to be null`.
- Green: same passes 4/4.
- Biome clean.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:8055ec08d1a264273447e248975688356929e647 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - no UI surface, core parser fix`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - no UI surface, core parser fix`.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked `N/A - no UI flow, parser fix`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked `N/A - not a server route, covered by unit test`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend code`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - no LLM path`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - no domain artifact`.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM path.

## Backend + frontend logs

N/A - not a server route, covered by unit test.

## Screenshots (before / after) + video walkthrough

N/A - no UI surface, core parser fix.

### Before

N/A - no UI surface.

### After

N/A - no UI surface.

### Walkthrough video

N/A - no UI flow.

## Audio / voice walkthrough

N/A - no voice path.

## Known gaps / failures

None. Biome clean, tests pass.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

---

### Red -> Green

**Red**:
```
 × rejects prefix-overmatched languages without a delimiter
   → expected 'ata\nhello' to be null
```

**Green**:
```
 ✓ 4 passed
 Test Files  1 passed (1)
```

