### PR TITLE
fix(ci): cover Vault route with a complete desktop test host

### DIFF
--- a/packages/app/test/ui-smoke/all-pages-clicksafe.spec.ts
+++ b/packages/app/test/ui-smoke/all-pages-clicksafe.spec.ts
@@ -370,6 +370,7 @@ const APP_TOOL_ROUTE_PROBES: readonly RouteProbe[] = DIRECT_ROUTE_CASES.map(
   (routeCase) => ({
     name: `app tool ${routeCase.name}`,
     path: routeCase.path,
+    expectedUrl: routeCase.expectedUrl,
     readyChecks:
       "readyChecks" in routeCase
         ? routeCase.readyChecks
@@ -505,6 +506,7 @@ function installPageIssueGuards(page: Page): string[] {
 
 async function installDesktopPermissionsBridge(page: Page): Promise<void> {
   await page.addInitScript((permissions) => {
+    const secureStore = new Map<string, string>();
     const existing = window.__ELIZA_ELECTROBUN_RPC__;
     window.__ELIZA_ELECTROBUN_RPC__ = {
       request: {
@@ -529,6 +531,28 @@ async function installDesktopPermissionsBridge(page: Page): Promise<void> {
         permissionsGetAll: async () => permissions,
         permissionsIsShellEnabled: async () => false,
         permissionsGetPlatform: async () => "linux",
+        // The injected RPC marker declares a complete desktop host, so its
+        // protected-storage boundary must exist too. Keep credentials inside
+        // this native-boundary stand-in rather than letting the renderer's
+        // fail-closed storage bridge report the deliberately incomplete host.
+        secureStoreGet: async (params) => {
+          const { kind } = params as { kind: string };
+          return secureStore.has(kind)
+            ? { ok: true, value: secureStore.get(kind) }
+            : { ok: false, reason: "not_found" };
+        },
+        secureStoreSet: async (params) => {
+          const { kind, value } = params as { kind: string; value: string };
+          secureStore.set(kind, value);
+          return { ok: true };
+        },
+        secureStoreDelete: async (params) => {
+          const { kind } = params as { kind: string };
+          const deleted = secureStore.delete(kind);
+          return deleted
+            ? { ok: true, deleted: true }
+            : { ok: false, reason: "not_found" };
+        },
       },
       onMessage: existing?.onMessage ?? (() => {}),
       offMessage: existing?.offMessage ?? (() => {}),

--- a/packages/app/test/ui-smoke/apps-session-route-cases.ts
+++ b/packages/app/test/ui-smoke/apps-session-route-cases.ts
@@ -6,7 +6,7 @@ export function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-type DirectRouteCase =
+type DirectRouteCase = (
   | {
       name: string;
       path: string;
@@ -18,7 +18,8 @@ type DirectRouteCase =
       path: string;
       readyChecks: readonly ReadyCheck[];
       timeoutMs?: number;
-    };
+    }
+) & { expectedUrl?: RegExp };
 
 type ReadyCheck =
   | { selector: string; text?: never }
@@ -195,6 +196,13 @@ export const DIRECT_ROUTE_CASES: readonly DirectRouteCase[] = [
     name: "automations / workflows view",
     path: "/automations",
     selector: '[data-testid="automations-shell"]',
+    timeoutMs: 90_000,
+  },
+  {
+    name: "vault view",
+    path: "/vault",
+    expectedUrl: /\/vault#vault\/overview$/,
+    selector: '[data-testid="vault-page"]',
     timeoutMs: 90_000,
   },
   {


### PR DESCRIPTION
Closes #27302

## Summary

- add `/vault` to the canonical click-safe desktop/mobile route matrix and assert its shipped hash route
- model the injected Electrobun test host completely by providing in-memory secure-store get/set/delete RPCs
- preserve production fail-closed credential storage and the strict console/page issue gate

## Evidence

- `bun run verify` — PASS on the pre-rebase exact patch head (375/375 Turbo tasks plus repository audits); the three newer `develop` commits were then rebased and the focused owning gates rerun
- `bun test packages/app/test/route-coverage.test.ts` — 10/10 PASS on `e0958c51a`
- `bunx biome check packages/app/test/ui-smoke/all-pages-clicksafe.spec.ts packages/app/test/ui-smoke/apps-session-route-cases.ts` — PASS
- `git diff --check` — PASS
- desktop/mobile Vault Playwright probes — running; result will be posted before merge

The null-export source-alias failure originally mentioned in #27302 was independently repaired upstream by #27299 and is not duplicated here.