### PR TITLE
fix(agent): ignore ledger files in media eviction selection

### DIFF
--- a/packages/agent/src/api/media-store.test.ts
+++ b/packages/agent/src/api/media-store.test.ts
@@ -428,30 +428,44 @@ describe("serve-path security headers (stored-XSS defence)", () => {
 describe("selectMediaToEvict", () => {
   it("evicts nothing when within the cap", () => {
     const files = [
-      { name: "a", size: 10, mtimeMs: 1 },
-      { name: "b", size: 20, mtimeMs: 2 },
+      { name: `${"a".repeat(64)}.png`, size: 10, mtimeMs: 1 },
+      { name: `${"b".repeat(64)}.png`, size: 20, mtimeMs: 2 },
     ];
     expect(selectMediaToEvict(files, 100)).toEqual([]);
   });
 
   it("evicts oldest-first down to 90% of the cap", () => {
     const files = [
-      { name: "newest", size: 40, mtimeMs: 300 },
-      { name: "oldest", size: 40, mtimeMs: 100 },
-      { name: "middle", size: 40, mtimeMs: 200 },
+      { name: `${"c".repeat(64)}.png`, size: 40, mtimeMs: 300 },
+      { name: `${"a".repeat(64)}.png`, size: 40, mtimeMs: 100 },
+      { name: `${"b".repeat(64)}.png`, size: 40, mtimeMs: 200 },
     ];
     // total 120 > cap 100, target 90 → drop oldest (80 left), still >90? no, 80<=90 stop
-    expect(selectMediaToEvict(files, 100)).toEqual(["oldest"]);
+    expect(selectMediaToEvict(files, 100)).toEqual([`${"a".repeat(64)}.png`]);
   });
 
   it("evicts multiple oldest files when far over cap", () => {
     const files = [
-      { name: "f1", size: 50, mtimeMs: 1 },
-      { name: "f2", size: 50, mtimeMs: 2 },
-      { name: "f3", size: 50, mtimeMs: 3 },
+      { name: `${"a".repeat(64)}.png`, size: 50, mtimeMs: 1 },
+      { name: `${"b".repeat(64)}.png`, size: 50, mtimeMs: 2 },
+      { name: `${"c".repeat(64)}.png`, size: 50, mtimeMs: 3 },
     ];
     // total 150, cap 60, target 54 → drop f1 (100), f2 (50<=54) stop
-    expect(selectMediaToEvict(files, 60)).toEqual(["f1", "f2"]);
+    expect(selectMediaToEvict(files, 60)).toEqual([
+      `${"a".repeat(64)}.png`,
+      `${"b".repeat(64)}.png`,
+    ]);
+  });
+
+  it("never evicts non-media ledger files (background-pins.json)", () => {
+    const ledger = { name: "background-pins.json", size: 500, mtimeMs: 1 };
+    const mediaOld = { name: `${"a".repeat(64)}.png`, size: 60, mtimeMs: 2 };
+    const mediaNew = { name: `${"b".repeat(64)}.png`, size: 60, mtimeMs: 3 };
+    expect(selectMediaToEvict([ledger, mediaOld, mediaNew], 100)).toEqual([
+      `${"a".repeat(64)}.png`,
+    ]);
+    expect(selectMediaToEvict([ledger], 10)).toEqual([]);
+    expect(selectMediaToEvict([ledger, mediaOld], 100)).toEqual([]);
   });
 });
 

--- a/packages/agent/src/api/media-store.ts
+++ b/packages/agent/src/api/media-store.ts
@@ -251,10 +251,11 @@ export function selectMediaToEvict(
   files: MediaFileStat[],
   cap: number,
 ): string[] {
-  let total = files.reduce((sum, file) => sum + file.size, 0);
+  const mediaFiles = files.filter((file) => MEDIA_FILE_NAME.test(file.name));
+  let total = mediaFiles.reduce((sum, file) => sum + file.size, 0);
   if (total <= cap) return [];
   const target = Math.floor(cap * 0.9);
-  const oldestFirst = [...files].sort((a, b) => a.mtimeMs - b.mtimeMs);
+  const oldestFirst = [...mediaFiles].sort((a, b) => a.mtimeMs - b.mtimeMs);
   const evict: string[] = [];
   for (const file of oldestFirst) {
     if (total <= target) break;


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

N/A - direct fix for media eviction ledger handling.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Only filters `selectMediaToEvict` to ignore non-media files (e.g., `background-pins.json`). Previously ledger files were counted in total and could be selected for eviction/deletion, causing data loss for background tasks. No behavior change for valid media files.

# Background

## What does this PR do?

Filters `files` by `MEDIA_FILE_NAME` (64-hex sha + ext) before calculating total and selecting eviction candidates. Ledger files like `background-pins.json` are now ignored; they are not counted toward cap and never returned for deletion. Updates test fixtures to use valid media names (64-hex).

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/agent/src/api/media-store.ts` - two-line filter; `packages/agent/src/api/media-store.test.ts` - updated fixtures + new ledger test.

## Detailed testing steps

- Red: without filter, `selectMediaToEvict([ledger(500), mediaOld(60), mediaNew(60)], 100)` incorrectly evicts ledger due to total 620 > cap; new test fails.
- Green: with filter, same call correctly returns only `mediaOld`, and ledger-only inputs return `[]`.
- Suite: `vitest run src/api/media-store.test.ts` 73 passed, Biome clean.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:e8b410589da79ef69f5edc5463e312accef8e511 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - no UI surface, agent file store fix`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - no UI surface, agent file store fix`.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked `N/A - no UI flow, background eviction`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked `N/A - not a server route, covered by unit test with file stats`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend code`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - no LLM path`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - no domain artifact`.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM path.

## Backend + frontend logs

N/A - not a server route, covered by unit test.

## Screenshots (before / after) + video walkthrough

N/A - no UI surface, agent file store fix.

### Before

N/A - no UI surface.

### After

N/A - no UI surface.

### Walkthrough video

N/A - no UI flow.

## Audio / voice walkthrough

N/A - no voice path.

## Known gaps / failures

None. Biome clean, tests pass.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

---

### Red -> Green

**Red** (without fix) - ledger file would be evicted:
```
selectMediaToEvict([ledger(500), mediaOld(60), mediaNew(60)], 100)
  → would return ledger as oldest due to total including ledger, causing data loss
```

**Green** (with fix):
```
 ✓ 73 passed including new ledger test
 Test Files  1 passed (1)
```

