### PR TITLE
test(sql): cover deterministic string-to-uuid derivation and pass-through

### DIFF
--- a/plugins/plugin-sql/src/utils/string-to-uuid.test.ts
+++ b/plugins/plugin-sql/src/utils/string-to-uuid.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { stringToUuid } from "./string-to-uuid";
+
+const UUID_SHAPE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+describe("stringToUuid", () => {
+  it("passes an already-valid lowercase UUID through unchanged", () => {
+    const uuid = "123e4567-e89b-42d3-a456-426614174000";
+    expect(stringToUuid(uuid)).toBe(uuid);
+  });
+
+  it("passes an already-valid uppercase UUID through unchanged", () => {
+    const uuid = "123E4567-E89B-42D3-A456-426614174000";
+    expect(stringToUuid(uuid)).toBe(uuid);
+  });
+
+  it("derives a deterministic UUID for a number input", () => {
+    const first = stringToUuid(12345);
+    const second = stringToUuid(12345);
+    expect(first).toBe(second);
+    expect(first).toMatch(UUID_SHAPE);
+  });
+
+  it("maps the same string to the same UUID", () => {
+    const first = stringToUuid("room:alice-bob");
+    const second = stringToUuid("room:alice-bob");
+    expect(first).toBe(second);
+  });
+
+  it("maps distinct strings to distinct UUIDs", () => {
+    const a = stringToUuid("room:alice-bob");
+    const b = stringToUuid("room:alice-carol");
+    expect(a).not.toBe(b);
+  });
+
+  it("produces v4-shaped UUIDs with a variant nibble in 8-b", () => {
+    for (const input of ["a", "hello world", "中文输入", "x".repeat(100)]) {
+      const uuid = stringToUuid(input);
+      expect(uuid).toMatch(UUID_SHAPE);
+      const variantNibble = uuid[19];
+      expect("89ab").toContain(variantNibble);
+    }
+  });
+
+  it("handles characters that change under encodeURIComponent", () => {
+    const uuid = stringToUuid("a b%c/d?e=f&g#h");
+    expect(uuid).toMatch(UUID_SHAPE);
+    expect(stringToUuid("a b%c/d?e=f&g#h")).toBe(uuid);
+  });
+
+  it("handles an empty string deterministically", () => {
+    const uuid = stringToUuid("");
+    expect(uuid).toMatch(UUID_SHAPE);
+    expect(stringToUuid("")).toBe(uuid);
+  });
+
+  it("does not collide between the number 12 and the string '12'", () => {
+    // The number is stringified before hashing, so both forms derive the
+    // same synthetic id — this pins the canonical (non-surprising) mapping.
+    expect(stringToUuid(12)).toBe(stringToUuid("12"));
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new test file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `Test Files  1 passed (1)
      Tests  9 passed (9)` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
