### PR TITLE
fix(orchestrator): opt parent broker into coding mode

### DIFF
--- a/plugins/plugin-agent-orchestrator/docs/default-eliza-skills-and-agent-bridge-plan.md
+++ b/plugins/plugin-agent-orchestrator/docs/default-eliza-skills-and-agent-bridge-plan.md
@@ -82,7 +82,7 @@ A new virtual broker skill, `parent-agent`, lets a child ask the running parent 
 USE_SKILL parent-agent {"request":"Find the next open 30 minute slot on my calendar tomorrow afternoon"}
 ```
 
-The broker builds a synthetic message memory and sends it through the parent's normal `messageService.handleMessage(...)` pipeline with `continueAfterActions: true`. This means the parent can use the same actions, providers, services, connectors, model handlers, confirmation policies, and user approval flow it already uses for normal chat.
+The broker builds a synthetic message memory and sends it through the parent's normal `messageService.handleMessage(...)` pipeline with `continueAfterActions: true`. This means the parent can use the same actions, providers, services, connectors, model handlers, confirmation policies, and user approval flow it already uses for normal chat. A repository-editing request may explicitly add `"executionMode":"coding"` to select the parent coding planner and its mutation-verification contract. The option changes planning behavior only: it grants no authority and does not bypass action validation, role gates, connector policy, or confirmation.
 
 It also supports action discovery:
 

--- a/plugins/plugin-agent-orchestrator/src/__tests__/parent-agent-broker-coding-conformance.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/parent-agent-broker-coding-conformance.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Exercises the child-to-parent broker failure path through a real PGLite-backed
+ * DefaultMessageService, AcpService event stream, and SubAgentRouter. Model I/O
+ * is deterministic and local; only the final child-delivery transport is a probe.
+ */
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  type Action,
+  ChannelType,
+  type IAgentRuntime,
+  type Memory,
+  ModelType,
+  stringToUuid,
+  type UUID,
+} from "@elizaos/core";
+import { createTestRuntimeWithModelProvider } from "@elizaos/core/testing";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AcpService } from "../services/acp-service.js";
+import {
+  PARENT_AGENT_FAILURE_RECEIPT_PREFIX,
+  parseParentAgentFailureReceipt,
+} from "../services/parent-agent-dispatch.js";
+import { SubAgentRouter } from "../services/sub-agent-router.js";
+
+const cleanups: Array<() => Promise<void> | void> = [];
+
+afterEach(async () => {
+  while (cleanups.length > 0) await cleanups.pop()?.();
+});
+
+describe("parent-agent explicit coding-mode negative conformance", () => {
+  it("preserves an unverified real workspace mutation as a typed child receipt", async () => {
+    const workdir = mkdtempSync(join(tmpdir(), "parent-broker-coding-"));
+    cleanups.push(() => rmSync(workdir, { recursive: true, force: true }));
+    const mutatedFile = join(workdir, "parent-mutation.txt");
+    let plannerCalls = 0;
+    const writeAction: Action = {
+      name: "WRITE",
+      override: true,
+      description: "Write exact text to a file in the isolated test workspace.",
+      contexts: ["code", "files"],
+      parameters: [
+        {
+          name: "file_path",
+          description: "Workspace-relative file path.",
+          required: true,
+          schema: { type: "string" },
+        },
+        {
+          name: "content",
+          description: "Exact file content.",
+          required: true,
+          schema: { type: "string" },
+        },
+      ],
+      validate: async () => true,
+      handler: async (
+        _runtime: IAgentRuntime,
+        _message: Memory,
+        _state: unknown,
+        options: { parameters?: Record<string, unknown> },
+      ) => {
+        const filePath = String(options.parameters?.file_path ?? "");
+        const content = String(options.parameters?.content ?? "");
+        if (filePath !== "parent-mutation.txt") {
+          throw new Error(`unexpected write path: ${filePath}`);
+        }
+        writeFileSync(mutatedFile, content, "utf8");
+        return {
+          success: true,
+          text: `wrote ${filePath}`,
+          modelReplyRequired: true,
+          data: {
+            workspaceDeltaReceipt: {
+              version: 1,
+              kind: "workspace_delta",
+              scope: {
+                kind: "git_worktree",
+                root: workdir,
+                rootId: "a".repeat(64),
+                executionDomainId: "b".repeat(64),
+                coverage: "tracked_and_untracked_nonignored",
+              },
+              outcome: "changed",
+              observedAt: new Date().toISOString(),
+            },
+          },
+        };
+      },
+    };
+    const harness = await createTestRuntimeWithModelProvider({
+      characterName: "ParentBrokerConformanceAgent",
+      resolve: (call) => {
+        if (call.modelType !== ModelType.ACTION_PLANNER) return undefined;
+        plannerCalls += 1;
+        if (plannerCalls === 1) {
+          expect(call.toolNames).toContain("WRITE");
+          return {
+            text: "",
+            toolCalls: [
+              {
+                id: "write-parent-mutation",
+                name: "WRITE",
+                args: {
+                  file_path: "parent-mutation.txt",
+                  content: "mutated but unverified\n",
+                },
+              },
+            ],
+          };
+        }
+        return {
+          text: "",
+          toolCalls: [
+            {
+              id: `premature-reply-${plannerCalls}`,
+              name: "REPLY",
+              args: { text: "The parent coding change is complete." },
+            },
+          ],
+        };
+      },
+    });
+    cleanups.push(harness.cleanup);
+    await harness.runtime.disableTrajectories();
+    harness.runtime.registerAction(writeAction);
+    expect(harness.runtime.actions).toContain(writeAction);
+
+    const roomId = stringToUuid("parent-broker-conformance-room") as UUID;
+    const userId = stringToUuid("parent-broker-conformance-user") as UUID;
+    const worldId = stringToUuid("parent-broker-conformance-world") as UUID;
+    await harness.runtime.createWorld({
+      id: worldId,
+      name: "Parent broker conformance world",
+      agentId: harness.runtime.agentId,
+      metadata: { roles: { [userId]: "ADMIN" } },
+    });
+    await harness.runtime.ensureConnection({
+      entityId: userId,
+      roomId,
+      worldId,
+      userName: "Parent broker child",
+      source: "parent-agent-broker",
+      channelId: roomId,
+      type: ChannelType.DM,
+    });
+
+    const session = {
+      id: "parent-broker-conformance-session",
+      status: "running",
+      workdir,
+      metadata: { userId, roomId, worldId, source: "parent-agent-broker" },
+    };
+    const acp = new AcpService(harness.runtime);
+    const sent: string[] = [];
+    acp.getSession = vi.fn(async () => session as never);
+    acp.sendToSession = vi.fn(async (_sessionId: string, input: string) => {
+      sent.push(input);
+      return {} as never;
+    });
+    harness.runtime.services.set(AcpService.serviceType, [acp]);
+    const router = await SubAgentRouter.start(harness.runtime);
+    cleanups.push(() => router.stop());
+
+    const receipts: unknown[] = [];
+    acp.onSessionEvent((_sessionId, event, data) => {
+      if (event === "parent_agent_failure") receipts.push(data);
+    });
+    acp.emitSessionEvent(session.id, "message", {
+      text: `USE_SKILL parent-agent ${JSON.stringify({
+        request:
+          "Write parent-mutation.txt with the requested content, then finish without running shell verification.",
+        executionMode: "coding",
+      })}`,
+    });
+
+    await vi.waitFor(
+      () => {
+        expect(sent).toHaveLength(1);
+      },
+      { timeout: 20_000 },
+    );
+    expect(plannerCalls).toBe(4);
+    const expectedFailure = {
+      kind: "coding_mutation_unverified",
+      transient: false,
+      message:
+        "I changed files but could not complete the required command verification. The coding task is incomplete.",
+    };
+    expect(readFileSync(mutatedFile, "utf8")).toBe("mutated but unverified\n");
+    expect(sent).toHaveLength(1);
+    expect(sent[0].startsWith(PARENT_AGENT_FAILURE_RECEIPT_PREFIX)).toBe(true);
+    expect(receipts).toHaveLength(1);
+    expect(parseParentAgentFailureReceipt(sent[0])).toEqual({
+      type: "parent_agent_failure",
+      version: 1,
+      brokerSuccess: false,
+      terminalFailure: expectedFailure,
+    });
+    expect(receipts[0]).toEqual({
+      type: "parent_agent_failure",
+      version: 1,
+      brokerSuccess: false,
+      delivered: true,
+      terminalFailure: expectedFailure,
+    });
+  }, 60_000);
+});

--- a/plugins/plugin-agent-orchestrator/src/__tests__/parent-agent-broker.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/parent-agent-broker.test.ts
@@ -92,8 +92,9 @@ describe("runParentAgentBroker", () => {
 
   it("routes ask mode through the parent message service", async () => {
     const createMemory = vi.fn().mockResolvedValue(undefined);
-    const handleMessage = vi.fn(async (_runtime, memory, callback) => {
+    const handleMessage = vi.fn(async (_runtime, memory, callback, options) => {
       expect(memory.content.text).toContain("Use my calendar");
+      expect(options).toEqual({ continueAfterActions: true });
       await callback({ text: "Calendar says tomorrow at 2pm works." });
       return { responseContent: { text: "" } };
     });
@@ -122,6 +123,44 @@ describe("runParentAgentBroker", () => {
     expect(handleMessage).toHaveBeenCalledTimes(1);
     expect(result.success).toBe(true);
     expect(result.text).toContain("Calendar says tomorrow at 2pm works.");
+  });
+
+  it("opts into coding mode only for an explicit executionMode coding request", async () => {
+    const observedOptions: unknown[] = [];
+    const handleMessage = vi.fn(
+      async (_runtime, _memory, _callback, options) => {
+        observedOptions.push(options);
+        return {
+          didRespond: true,
+          responseContent: { text: "Parent turn complete." },
+          responseMessages: [],
+        };
+      },
+    );
+    const runtime = createRuntime({
+      createMemory: vi.fn().mockResolvedValue(undefined),
+      messageService: { handleMessage },
+    } as Partial<IAgentRuntime>);
+
+    for (const args of [
+      { request: "Use the normal parent pipeline." },
+      { request: "Remain normal.", executionMode: "normal" },
+      { request: "Reject unknown profiles.", executionMode: "privileged" },
+      { request: "Use the coding planner.", executionMode: "coding" },
+    ]) {
+      await runParentAgentBroker({
+        runtime,
+        sessionId: `session-${observedOptions.length}`,
+        args,
+      });
+    }
+
+    expect(observedOptions).toEqual([
+      { continueAfterActions: true },
+      { continueAfterActions: true },
+      { continueAfterActions: true },
+      { continueAfterActions: true, codingMode: true },
+    ]);
   });
 
   it("returns callback-delivered null-content terminal failures as typed failures", async () => {

--- a/plugins/plugin-agent-orchestrator/src/services/parent-agent-broker.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/parent-agent-broker.ts
@@ -46,7 +46,7 @@ export const PARENT_AGENT_BROKER_MANIFEST_ENTRY = {
   description:
     "Task-scoped bridge for asking the running parent Eliza agent to use its loaded capabilities, actions, providers, connectors, and confirmation flow.",
   guidance:
-    'Use when workspace context is not enough and the parent agent should do something with its own capabilities. Examples: `USE_SKILL parent-agent {"request":"Find the next free 30 minute slot on my calendar"}`, `USE_SKILL parent-agent {"mode":"list-actions","query":"github"}`, `USE_SKILL parent-agent {"mode":"list-cloud-commands"}`, or `USE_SKILL parent-agent {"mode":"cloud-command","command":"apps.list"}`. Mutating, paid, or destructive Cloud commands require an explicit user yes on a follow-up turn (not LLM `confirmed`). Fixed-cost self-spend commands such as `containers.create` may auto-authorize within the configured agent spend cap; variable-cost self-spend commands such as `domains.buy`, `media.*`, `promote.*`, and `advertising.*` always require human confirmation because the server-quoted price cannot be trusted from child-declared `params.spendEstimateUsd`. To delegate part of your work to a NEW parallel sub-agent on this same task, use `USE_SKILL parent-agent {"mode":"spawn-sub-agent","task":"<instruction for the child>","label":"<optional name>"}` — it spawns a child sub-agent (bounded nesting depth) whose progress shows in this task\'s thread; keep working, do not block waiting on it.',
+    'Use when workspace context is not enough and the parent agent should do something with its own capabilities. Examples: `USE_SKILL parent-agent {"request":"Find the next free 30 minute slot on my calendar"}`, `USE_SKILL parent-agent {"mode":"list-actions","query":"github"}`, `USE_SKILL parent-agent {"mode":"list-cloud-commands"}`, or `USE_SKILL parent-agent {"mode":"cloud-command","command":"apps.list"}`. For a repository-editing request that needs the parent coding planner and its mutation-verification contract, explicitly add `"executionMode":"coding"`; this selects planning behavior only and never grants authorization or bypasses role, confirmation, connector, or action gates. Mutating, paid, or destructive Cloud commands require an explicit user yes on a follow-up turn (not LLM `confirmed`). Fixed-cost self-spend commands such as `containers.create` may auto-authorize within the configured agent spend cap; variable-cost self-spend commands such as `domains.buy`, `media.*`, `promote.*`, and `advertising.*` always require human confirmation because the server-quoted price cannot be trusted from child-declared `params.spendEstimateUsd`. To delegate part of your work to a NEW parallel sub-agent on this same task, use `USE_SKILL parent-agent {"mode":"spawn-sub-agent","task":"<instruction for the child>","label":"<optional name>"}` — it spawns a child sub-agent (bounded nesting depth) whose progress shows in this task\'s thread; keep working, do not block waiting on it.',
 } as const;
 
 /**
@@ -97,6 +97,8 @@ interface CloudCommandDefinition {
 
 interface ParentAgentBrokerArgs {
   mode: ParentAgentMode;
+  /** Planner execution profile only; never an authorization signal. */
+  executionMode: "normal" | "coding";
   request?: string;
   query?: string;
   limit: number;
@@ -753,6 +755,7 @@ function normalizeArgs(raw: unknown): ParentAgentBrokerArgs {
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
     return {
       mode: "ask",
+      executionMode: "normal",
       limit: ACTION_LIST_LIMIT_DEFAULT,
     };
   }
@@ -769,6 +772,10 @@ function normalizeArgs(raw: unknown): ParentAgentBrokerArgs {
       : undefined;
   return {
     mode: normalizeMode(record.mode),
+    executionMode:
+      normalizeString(record.executionMode)?.toLowerCase() === "coding"
+        ? "coding"
+        : "normal",
     request,
     query: normalizeString(record.query),
     limit: normalizeLimit(record.limit),
@@ -1436,6 +1443,7 @@ async function askParentAgent(request: {
   sessionId: string;
   session?: SessionInfo;
   text: string;
+  executionMode: "normal" | "coding";
 }): Promise<{
   text: string;
   terminalFailure?: NonNullable<
@@ -1481,6 +1489,9 @@ async function askParentAgent(request: {
     callback,
     {
       continueAfterActions: true,
+      // This changes planner/tool behavior only. The normal action validation,
+      // role gates, confirmation policy, and connector authority still apply.
+      ...(request.executionMode === "coding" ? { codingMode: true } : {}),
     },
   );
 
@@ -1739,6 +1750,7 @@ export async function runParentAgentBroker(
       sessionId: request.sessionId,
       session: request.session,
       text: requestText,
+      executionMode: args.executionMode,
     });
     if (parentResult.terminalFailure) {
       return {


### PR DESCRIPTION
Closes a live conformance gap tracked under #24299.

## What changed
- adds an explicit `executionMode: "coding"` parent-broker directive option
- leaves omitted, normal, and unknown modes on the normal parent pipeline
- threads coding mode without bypassing roles, authorization, confirmation, connector, or action gates
- adds deterministic real-runtime conformance across PGLite AgentRuntime, DefaultMessageService, ParentAgentBroker, AcpService events, and SubAgentRouter
- proves a real workspace WRITE, typed unverified-mutation failure, authoritative first-line receipt, and delivered router event

## Exact-head local evidence
- `parent-agent-broker-coding-conformance.test.ts`: 1/1
- `parent-agent-broker.test.ts`: 22/22
- focused Biome: pass
- `git diff --check`: pass

No paid provider was invoked. The conformance model is deterministic and local.