### PR TITLE
test(agent-orchestrator): cover trajectory context set/clear and leak-free wrap

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/services/trajectory-context.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/trajectory-context.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  clearTrajectoryContext,
+  setTrajectoryContext,
+  withTrajectoryContext,
+} from "./trajectory-context";
+
+const CTX_KEY = "__orchestratorTrajectoryCtx";
+
+describe("trajectory-context", () => {
+  it("sets the context on the runtime object", () => {
+    const runtime = {};
+    const ctx = {
+      source: "orchestrator" as const,
+      decisionType: "skill-context-generation" as const,
+      sessionId: "sess-1",
+    };
+    setTrajectoryContext(runtime, ctx);
+    expect((runtime as Record<string, unknown>)[CTX_KEY]).toBe(ctx);
+  });
+
+  it("clears the context to undefined", () => {
+    const runtime = { [CTX_KEY]: { source: "orchestrator" } };
+    clearTrajectoryContext(runtime);
+    expect((runtime as Record<string, unknown>)[CTX_KEY]).toBeUndefined();
+  });
+
+  it("sets context before the wrapped call and clears it after", async () => {
+    const runtime = {};
+    const ctx = {
+      source: "orchestrator" as const,
+      decisionType: "launch-failure-message" as const,
+    };
+    let seenDuringCall: unknown;
+    const result = await withTrajectoryContext(runtime, ctx, async () => {
+      seenDuringCall = (runtime as Record<string, unknown>)[CTX_KEY];
+      return 42;
+    });
+    expect(seenDuringCall).toBe(ctx);
+    expect(result).toBe(42);
+    expect((runtime as Record<string, unknown>)[CTX_KEY]).toBeUndefined();
+  });
+
+  it("clears the context even when the wrapped call throws", async () => {
+    const runtime = {};
+    const ctx = {
+      source: "orchestrator" as const,
+      decisionType: "skill-context-generation" as const,
+    };
+    await expect(
+      withTrajectoryContext(runtime, ctx, async () => {
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+    // The finally block must prevent a leaked context from tagging
+    // unrelated follow-up LLM calls.
+    expect((runtime as Record<string, unknown>)[CTX_KEY]).toBeUndefined();
+  });
+
+  it("clears the context when the wrapped call rejects", async () => {
+    const runtime = {};
+    await expect(
+      withTrajectoryContext(
+        runtime,
+        { source: "orchestrator", decisionType: "launch-failure-message" },
+        async () => Promise.reject(new Error("rejected")),
+      ),
+    ).rejects.toThrow("rejected");
+    expect((runtime as Record<string, unknown>)[CTX_KEY]).toBeUndefined();
+  });
+
+  it("preserves task metadata in the stored context", () => {
+    const runtime = {};
+    const ctx = {
+      source: "orchestrator" as const,
+      decisionType: "skill-context-generation" as const,
+      sessionId: "sess-9",
+      taskLabel: "fix login",
+      repo: "acme/app",
+    };
+    setTrajectoryContext(runtime, ctx);
+    const stored = (runtime as Record<string, unknown>)[CTX_KEY] as {
+      sessionId?: string;
+      taskLabel?: string;
+      repo?: string;
+    };
+    expect(stored.sessionId).toBe("sess-9");
+    expect(stored.taskLabel).toBe("fix login");
+    expect(stored.repo).toBe("acme/app");
+  });
+
+  it("does not require a promise-returning call", async () => {
+    const runtime = {};
+    const fn = vi.fn(() => Promise.resolve("ok"));
+    await withTrajectoryContext(
+      runtime,
+      { source: "orchestrator", decisionType: "launch-failure-message" },
+      fn,
+    );
+    expect(fn).toHaveBeenCalledOnce();
+    expect((runtime as Record<string, unknown>)[CTX_KEY]).toBeUndefined();
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new test file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `Test Files  1 passed (1)
      Tests  7 passed (7)` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
