### PR TITLE
test(plugin-personal-assistant): cover coding-task-request routing predicate

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/validate/coding-task-request.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/validate/coding-task-request.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  findKeywordTermMatch: vi.fn(),
+  getValidationKeywordTerms: vi.fn(),
+}));
+
+vi.mock("@elizaos/shared", () => mocks);
+
+import { looksLikeCodingTaskRequest } from "./coding-task-request";
+
+describe("looksLikeCodingTaskRequest", () => {
+  it("returns false and skips keyword loading for blank input", () => {
+    expect(looksLikeCodingTaskRequest("")).toBe(false);
+    expect(looksLikeCodingTaskRequest("   ")).toBe(false);
+    expect(mocks.getValidationKeywordTerms).not.toHaveBeenCalled();
+  });
+
+  it("loads the coding-task keyword set with all locales", () => {
+    mocks.getValidationKeywordTerms.mockReturnValue([["app", "build"]]);
+    mocks.findKeywordTermMatch.mockReturnValue(undefined);
+    looksLikeCodingTaskRequest("hello world");
+    expect(mocks.getValidationKeywordTerms).toHaveBeenCalledWith(
+      "validate.codingTaskRequest",
+      { includeAllLocales: true },
+    );
+  });
+
+  it("returns true when a keyword term matches", () => {
+    mocks.getValidationKeywordTerms.mockReturnValue([["build"]]);
+    mocks.findKeywordTermMatch.mockReturnValue("build");
+    expect(looksLikeCodingTaskRequest("build an app")).toBe(true);
+  });
+
+  it("returns false when no keyword term matches", () => {
+    mocks.getValidationKeywordTerms.mockReturnValue([["build", "create"]]);
+    mocks.findKeywordTermMatch.mockReturnValue(undefined);
+    expect(looksLikeCodingTaskRequest("remind me to stretch")).toBe(false);
+  });
+
+  it("passes the trimmed text to the matcher", () => {
+    mocks.getValidationKeywordTerms.mockReturnValue([["build"]]);
+    mocks.findKeywordTermMatch.mockReturnValue(undefined);
+    looksLikeCodingTaskRequest("  build an app  ");
+    expect(mocks.findKeywordTermMatch).toHaveBeenCalledWith("build an app", [
+      ["build"],
+    ]);
+  });
+
+  it("does not match a whitespace-only string after trimming", () => {
+    mocks.getValidationKeywordTerms.mockReset();
+    mocks.findKeywordTermMatch.mockReset();
+    expect(looksLikeCodingTaskRequest("\t\n ")).toBe(false);
+    expect(mocks.getValidationKeywordTerms).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new test file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `Test Files  1 passed (1)
      Tests  6 passed (6)` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
