### PR TITLE
test(elizacloud): cover state-paths config resolution precedence

### DIFF
--- a/plugins/plugin-elizacloud/src/lib/state-paths.test.ts
+++ b/plugins/plugin-elizacloud/src/lib/state-paths.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	existsSync: vi.fn(),
+	join: vi.fn((...parts: string[]) => parts.join("/")),
+	getElizaNamespace: vi.fn(() => "eliza"),
+	resolveStateDir: vi.fn(() => "/state"),
+	resolveUserPath: vi.fn((p: string) => `/user/${p}`),
+}));
+
+vi.mock("node:fs", () => ({
+	default: { existsSync: mocks.existsSync },
+	existsSync: mocks.existsSync,
+}));
+vi.mock("node:path", () => ({ join: mocks.join, default: { join: mocks.join } }));
+vi.mock("@elizaos/core", () => ({
+	getElizaNamespace: mocks.getElizaNamespace,
+	resolveStateDir: mocks.resolveStateDir,
+	resolveUserPath: mocks.resolveUserPath,
+}));
+
+import { resolveConfigPath } from "./state-paths";
+
+describe("resolveConfigPath", () => {
+	beforeEach(() => {
+		mocks.existsSync.mockReset().mockReturnValue(false);
+		mocks.getElizaNamespace.mockReset().mockReturnValue("eliza");
+		mocks.resolveUserPath.mockReset().mockImplementation(
+			(p: string) => `/user/${p}`,
+		);
+	});
+
+	it("uses the ELIZA_CONFIG_PATH override when set", () => {
+		expect(resolveConfigPath({ ELIZA_CONFIG_PATH: "/custom/config.json" })).toBe(
+			"/user//custom/config.json",
+		);
+		expect(mocks.resolveUserPath).toHaveBeenCalledWith("/custom/config.json");
+	});
+
+	it("trims the ELIZA_CONFIG_PATH override", () => {
+		expect(
+			resolveConfigPath({ ELIZA_CONFIG_PATH: "  /trimmed/config.json  " }),
+		).toBe("/user//trimmed/config.json");
+		expect(mocks.resolveUserPath).toHaveBeenCalledWith("/trimmed/config.json");
+	});
+
+	it("treats a blank override as absent and uses the primary path", () => {
+		mocks.existsSync.mockReturnValue(false);
+		const result = resolveConfigPath({ ELIZA_CONFIG_PATH: "   " });
+		expect(result).toBe("/state/eliza.json");
+	});
+
+	it("returns the primary namespaced path when it exists", () => {
+		mocks.existsSync.mockReturnValue(true);
+		expect(resolveConfigPath({})).toBe("/state/eliza.json");
+	});
+
+	it("falls back to the legacy eliza.json when the namespace differs", () => {
+		mocks.getElizaNamespace.mockReturnValue("myapp");
+		mocks.existsSync.mockImplementation((p: string) => p === "/state/eliza.json");
+		expect(resolveConfigPath({})).toBe("/state/eliza.json");
+	});
+
+	it("does not consult legacy eliza.json for the default namespace", () => {
+		mocks.existsSync.mockReturnValue(false);
+		expect(resolveConfigPath({})).toBe("/state/eliza.json");
+		// eliza.json was never probed for the default namespace
+		expect(mocks.existsSync).toHaveBeenCalledTimes(1);
+	});
+
+	it("returns the primary path when neither file exists", () => {
+		expect(resolveConfigPath({})).toBe("/state/eliza.json");
+	});
+
+	it("defaults the state dir to resolveStateDir(env)", () => {
+		mocks.resolveStateDir.mockReturnValue("/derived");
+		mocks.existsSync.mockReturnValue(false);
+		expect(resolveConfigPath({ FOO: "bar" })).toBe("/derived/eliza.json");
+		expect(mocks.resolveStateDir).toHaveBeenCalledWith({ FOO: "bar" });
+	});
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new test file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `Test Files  1 passed (1)
      Tests  8 passed (8)` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
