### PR TITLE
test(phone): cover web-fallback intent plugin honesty

### DIFF
--- a/plugins/plugin-phone/src/companion/services/eliza-intent.test.ts
+++ b/plugins/plugin-phone/src/companion/services/eliza-intent.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  class MockWebPlugin {
+    unavailable(message: string): Error {
+      return new Error(message);
+    }
+  }
+  return {
+    registerPlugin: vi.fn(() => ({})),
+    MockWebPlugin,
+    logger: {
+      warn: vi.fn(),
+      info: vi.fn(),
+      debug: vi.fn(),
+    },
+  };
+});
+
+vi.mock("@capacitor/core", () => ({
+  registerPlugin: mocks.registerPlugin,
+  WebPlugin: mocks.MockWebPlugin,
+}));
+
+vi.mock("./logger", () => ({ logger: mocks.logger }));
+
+import { ElizaIntent, ElizaIntentWeb } from "./eliza-intent";
+
+describe("ElizaIntentWeb (web fallback)", () => {
+  it("registers the plugin with web and android factories", () => {
+    expect(mocks.registerPlugin).toHaveBeenCalledWith(
+      "ElizaIntent",
+      expect.objectContaining({
+        web: expect.any(Function),
+        android: expect.any(Function),
+      }),
+    );
+    const registration = mocks.registerPlugin.mock.calls[0][1];
+    expect(registration.web()).toBeInstanceOf(ElizaIntentWeb);
+  });
+
+  it("rejects scheduleAlarm on the web fallback instead of faking success", async () => {
+    const web = new ElizaIntentWeb();
+    await expect(
+      web.scheduleAlarm({
+        timeIso: "2026-08-25T10:00:00Z",
+        title: "x",
+        body: "y",
+      }),
+    ).rejects.toThrow(/requires iOS native runtime/);
+    expect(mocks.logger.warn).toHaveBeenCalled();
+  });
+
+  it("reports receiveIntent as not accepted on the web fallback", async () => {
+    const web = new ElizaIntentWeb();
+    const result = await web.receiveIntent({
+      kind: "reminder",
+      payload: {},
+      issuedAtIso: "2026-08-25T10:00:00Z",
+    });
+    expect(result).toEqual({
+      accepted: false,
+      reason: "web-fallback: no native intent bus available",
+    });
+  });
+
+  it("reports the device as unpaired on the web fallback", async () => {
+    const web = new ElizaIntentWeb();
+    await expect(web.getPairingStatus()).resolves.toEqual({
+      paired: false,
+      agentUrl: null,
+      deviceId: null,
+    });
+  });
+
+  it("tolerates an invalid agent url in setPairingStatus logging", async () => {
+    const web = new ElizaIntentWeb();
+    await expect(
+      web.setPairingStatus({ deviceId: "dev-1", agentUrl: "not a url" }),
+    ).resolves.toEqual({ ok: true });
+    expect(mocks.logger.debug).toHaveBeenCalled();
+  });
+
+  it("exposes the registered plugin instance", () => {
+    expect(ElizaIntent).toBeDefined();
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new test file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `Test Files  1 passed (1)
      Tests  6 passed (6)` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
