### PR TITLE
fix(core): warn when pressure handler does not free space in priority queue

### DIFF
--- a/packages/core/src/utils/batch-queue/priority-queue.test.ts
+++ b/packages/core/src/utils/batch-queue/priority-queue.test.ts
@@ -357,4 +357,26 @@ describe("PriorityQueue", () => {
 		expect(first.stats().normal).toBe(1);
 		expect(second.stats().normal).toBe(1);
 	});
+
+	it("warns when onPressure returns true without freeing space", () => {
+		const onOverflow = vi.fn();
+		const queue = makeQueue({
+			maxSize: 2,
+			onPressure: () => true,
+			onOverflowWarning: onOverflow,
+		});
+		queue.enqueue(item("a", "normal"));
+		queue.enqueue(item("b", "normal"));
+		expect(queue.size).toBe(2);
+		queue.enqueue(item("c", "normal"));
+		expect(queue.size).toBe(3);
+		expect(onOverflow).toHaveBeenCalledWith(3, 2);
+	});
+
+	it("rejects when onPressure returns false", () => {
+		const queue = makeQueue({ maxSize: 1, onPressure: () => false });
+		queue.enqueue(item("a", "normal"));
+		expect(queue.enqueue(item("b", "normal"))).toBe(false);
+		expect(queue.size).toBe(1);
+	});
 });

--- a/packages/core/src/utils/batch-queue/priority-queue.ts
+++ b/packages/core/src/utils/batch-queue/priority-queue.ts
@@ -64,6 +64,9 @@ export class PriorityQueue<T> {
 				if (!this.onPressure(this, item)) {
 					return false;
 				}
+				if (this.size >= max) {
+					this.onOverflowWarning?.(this.size + 1, max);
+				}
 			} else {
 				this.onOverflowWarning?.(this.size + 1, max);
 			}


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

N/A - direct fix for priority queue warning.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Only adds overflow warning when `onPressure` returns true but does not free space. Previously queue silently grew past maxSize without warning; now it warns via `onOverflowWarning`. No change when pressure handler frees space or rejects.

# Background

## What does this PR do?

In `PriorityQueue.enqueue`, after `onPressure` returns true, now checks if `size` is still >= max and if so calls `onOverflowWarning`. This covers the case where pressure handler claims to have made room but didn't.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/core/src/utils/batch-queue/priority-queue.ts` - three-line warning; `packages/core/src/utils/batch-queue/priority-queue.test.ts` - two new tests.

## Detailed testing steps

- Red: `vitest run priority-queue.test.ts` fails on `warns when onPressure returns true without freeing space` (0 calls).
- Green: same passes 25/25.
- Biome clean.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:37675c592faf099b67a7293b6f001f6e35c6bb2a -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - no UI surface, core queue fix`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - no UI surface, core queue fix`.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked `N/A - no UI flow, queue fix`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked `N/A - not a server route, covered by unit test`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend code`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - no LLM path`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - no domain artifact`.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM path.

## Backend + frontend logs

N/A - not a server route, covered by unit test.

## Screenshots (before / after) + video walkthrough

N/A - no UI surface, core queue fix.

### Before

N/A - no UI surface.

### After

N/A - no UI surface.

### Walkthrough video

N/A - no UI flow.

## Audio / voice walkthrough

N/A - no voice path.

## Known gaps / failures

None. Biome clean, tests pass.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

---

### Red -> Green

**Red**:
```
 × warns when onPressure returns true without freeing space
   → expected "vi.fn()" to be called with arguments: [ 3, 2 ]
Number of calls: 0
```

**Green**:
```
 ✓ 25 passed
 Test Files  1 passed (1)
```

