### PR TITLE
fix(core): guard deterministic helpers against non-finite and non-integer counts

### DIFF
--- a/packages/core/src/utils/deterministic.test.ts
+++ b/packages/core/src/utils/deterministic.test.ts
@@ -67,6 +67,17 @@ describe("shuffle / sample / pick", () => {
 		expect(deterministicSample(items, 2, "s")).toEqual(two);
 	});
 
+	it("guards deterministicSample against non-finite and non-integer counts", () => {
+		expect(deterministicSample(items, Number.NaN, "s")).toEqual([]);
+		expect(deterministicSample(items, Number.POSITIVE_INFINITY, "s")).toEqual(
+			[],
+		);
+		expect(deterministicSample(items, 1.5, "s")).toEqual([]);
+		expect(deterministicSample(items, -1, "s")).toEqual([]);
+		expect(getDeterministicNames(Number.NaN, "s")).toEqual([]);
+		expect(getDeterministicNames(2.7, "s")).toEqual([]);
+	});
+
 	it("deterministicPick returns one reproducible element", () => {
 		const p = deterministicPick(items, "s");
 		expect(items).toContain(p);

--- a/packages/core/src/utils/deterministic.ts
+++ b/packages/core/src/utils/deterministic.ts
@@ -69,7 +69,12 @@ export function deterministicSample<T>(
 	count: number,
 	seed: string | number,
 ): T[] {
-	if (count <= 0 || items.length === 0) {
+	if (
+		!Number.isFinite(count) ||
+		!Number.isInteger(count) ||
+		count <= 0 ||
+		items.length === 0
+	) {
 		return [];
 	}
 
@@ -90,7 +95,7 @@ export function getDeterministicNames(
 	count: number,
 	seed: string | number,
 ): string[] {
-	if (count <= 0) {
+	if (!Number.isFinite(count) || !Number.isInteger(count) || count <= 0) {
 		return [];
 	}
 


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

N/A - direct fix for deterministic helpers guard.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Only tightens validation of `count` in `deterministicSample` and `getDeterministicNames` to reject NaN, Infinity, non-integer, and negative. Previously Infinity returned full array via shuffle, and 1.5 truncated to 1 via floor. Now correctly returns [] for invalid counts.

# Background

## What does this PR do?

Adds `Number.isFinite` and `Number.isInteger` checks to `deterministicSample` and `getDeterministicNames`. Invalid counts now return `[]` instead of shuffled results or truncated arrays.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/core/src/utils/deterministic.ts` - two guards; `packages/core/src/utils/deterministic.test.ts` - new guard test.

## Detailed testing steps

- Red: `vitest run deterministic.test.ts` fails on `guards deterministicSample` (expected [] got shuffled array for Infinity).
- Green: same passes 13/13.
- Biome clean.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:db546366df59cf31e66711839a13ed42af96deee -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - no UI surface, core util fix`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - no UI surface, core util fix`.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked `N/A - no UI flow, util fix`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked `N/A - not a server route, covered by unit test`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend code`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - no LLM path`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - no domain artifact`.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM path.

## Backend + frontend logs

N/A - not a server route, covered by unit test.

## Screenshots (before / after) + video walkthrough

N/A - no UI surface, core util fix.

### Before

N/A - no UI surface.

### After

N/A - no UI surface.

### Walkthrough video

N/A - no UI flow.

## Audio / voice walkthrough

N/A - no voice path.

## Known gaps / failures

None. Biome clean, tests pass.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

---

### Red -> Green

**Red**:
```
 × guards deterministicSample against non-finite and non-integer counts
   → expected [ 2, 3, 5, 1, 4 ] to deeply equal []
```

**Green**:
```
 ✓ 13 passed
 Test Files  1 passed (1)
```

