### PR TITLE
fix(android): retain background runner JNI bridge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -404,6 +404,7 @@ jobs:
       - name: Build mobile package dependencies
         if: steps.selection.outputs.selected == 'true'
         run: |
+          bun run --cwd packages/prompts build:package
           bun run build:core
           bun run --cwd packages/ui build
           bun run --cwd packages/vault build

--- a/.github/workflows/device-e2e.yml
+++ b/.github/workflows/device-e2e.yml
@@ -39,6 +39,11 @@ on:
           - ios
           - linux
           - windows
+      android_release_minify_smoke:
+        description: Build, install, and launch a debug-signed minified Android release APK
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: device-e2e-${{ github.event_name == 'workflow_dispatch' && format('dispatch-{0}', github.run_id) || github.ref }}
@@ -71,6 +76,7 @@ jobs:
       # self-hosted device runners.
       ELIZA_ANDROID_BACKEND: "host"
       ELIZA_DEVICE_BUNDLE_ROOT: ${{ github.workspace }}/device-e2e-artifacts
+      ELIZA_ANDROID_RELEASE_MINIFY_SMOKE: ${{ github.event_name == 'workflow_dispatch' && inputs.android_release_minify_smoke && '1' || '0' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
@@ -117,7 +123,9 @@ jobs:
           ram-size: 6144M
           # avx2/fma passthrough so the (x86) on-device agent doesn't SIGILL.
           emulator-options: -no-window -no-snapshot -no-boot-anim -gpu swiftshader_indirect -qemu -cpu qemu64,+avx,+avx2,+f16c,+fma
-          script: node packages/app/scripts/android-e2e.mjs --build --skip-local-chat --no-emulator-boot --start-host-agent --host-emulator-probes --output "$ELIZA_DEVICE_BUNDLE_ROOT/android"
+          # The runner invokes each physical line separately, so keep the
+          # branch on one line and delegate the focused proof to a script.
+          script: if [ "$ELIZA_ANDROID_RELEASE_MINIFY_SMOKE" = "1" ]; then bash packages/app/scripts/android-release-minify-smoke.sh; else node packages/app/scripts/android-e2e.mjs --build --skip-local-chat --no-emulator-boot --start-host-agent --host-emulator-probes --output "$ELIZA_DEVICE_BUNDLE_ROOT/android"; fi
 
       - name: Upload Android device bundle
         if: always()

--- a/packages/app-core/platforms/android/app/proguard-rules.pro
+++ b/packages/app-core/platforms/android/app/proguard-rules.pro
@@ -6,6 +6,10 @@
 -keep @com.getcapacitor.annotation.CapacitorPlugin class * { *; }
 -keep class com.getcapacitor.community.** { *; }
 
+# Background Runner's bundled JS engine resolves this namespace from native
+# code, so R8 cannot discover the references from Java bytecode.
+-keep class io.ionic.android_js_engine.** { *; }
+
 # elizaOS custom Capacitor plugins.
 #
 # Two package roots are in play and BOTH must be kept:

--- a/packages/app-core/scripts/run-mobile-build-android-aab-audit.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-android-aab-audit.test.mjs
@@ -34,6 +34,7 @@ import {
 import { ElizaError as ScriptElizaError } from "./lib/eliza-error.mjs";
 import {
   assertAndroidArtifactOmitsLp3ManifestMarkers,
+  assertAndroidArtifactRetainsBackgroundRunnerJniBridge,
   assertAndroidArtifactShipsWebPayload,
   assertAndroidArtifactSnapshotUnchanged,
   auditAndroidArtifactDexLp3Policy,
@@ -281,7 +282,10 @@ function writeSyntheticCloudAab(
   { extraEntries = {}, includeWebPayload = true } = {},
 ) {
   const entries = {
-    "base/dex/classes.dex": Buffer.from("clean synthetic DEX", "utf8"),
+    "base/dex/classes.dex": Buffer.from(
+      "clean synthetic DEX io/ionic/android_js_engine/NativeWebAPI",
+      "utf8",
+    ),
     "base/manifest/AndroidManifest.xml": Buffer.from(
       "compiled manifest placeholder",
       "utf8",
@@ -1425,7 +1429,7 @@ describe("Android Cloud outer audit boundary", () => {
       const inspectAndroidAppBundleImpl = vi.fn((options) => {
         expect(
           options.readDexEntries(["base/dex/classes.dex"])[0].toString("utf8"),
-        ).toBe("clean synthetic DEX");
+        ).toBe("clean synthetic DEX io/ionic/android_js_engine/NativeWebAPI");
         expect(fs.realpathSync(options.artifact)).not.toBe(
           fs.realpathSync(artifact),
         );
@@ -1443,6 +1447,39 @@ describe("Android Cloud outer audit boundary", () => {
         /android-cloud AAB attestation .*"sha256":"[a-f0-9]{64}"/,
       );
       expect(log.mock.calls.at(-1)?.[0]).toContain("artifact audit passed");
+    } finally {
+      fs.rmSync(temporaryDir, { force: true, recursive: true });
+    }
+  });
+
+  it("rejects a release AAB missing the Background Runner JNI bridge before inspection", () => {
+    const temporaryDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "eliza-outer-aab-no-background-runner-jni-"),
+    );
+    const inspectAndroidAppBundleImpl = vi.fn();
+    const log = vi.fn();
+    try {
+      const artifact = writeSyntheticCloudAab(temporaryDir, {
+        extraEntries: {
+          "base/dex/classes.dex": Buffer.from("clean synthetic DEX", "utf8"),
+        },
+      });
+
+      expect(() =>
+        auditAndroidCloudArtifact(
+          { artifact, env: {}, javaHome: JAVA_HOME },
+          { inspectAndroidAppBundleImpl, log },
+        ),
+      ).toThrow(
+        expect.objectContaining({
+          code: "ANDROID_BACKGROUND_RUNNER_JNI_CLASS_MISSING",
+          context: expect.objectContaining({
+            label: "android-cloud release AAB",
+          }),
+        }),
+      );
+      expect(inspectAndroidAppBundleImpl).not.toHaveBeenCalled();
+      expect(log).not.toHaveBeenCalled();
     } finally {
       fs.rmSync(temporaryDir, { force: true, recursive: true });
     }
@@ -1614,6 +1651,46 @@ describe("Android APK audit regression contract", () => {
       ["classes.dex"],
       JAVA_HOME,
       { label: "LP3 policy DEX audit" },
+    );
+  });
+
+  it("requires the Background Runner class resolved through JNI", () => {
+    const readEntryBuffers = vi
+      .fn()
+      .mockReturnValueOnce([
+        Buffer.from("io/ionic/android_js_engine/NativeWebAPI", "utf8"),
+      ])
+      .mockReturnValueOnce([Buffer.from("unrelated classes", "utf8")]);
+    const entries = ["classes.dex", "classes2.dex"];
+
+    expect(() =>
+      assertAndroidArtifactRetainsBackgroundRunnerJniBridge(
+        "/artifacts/app-release.apk",
+        entries,
+        JAVA_HOME,
+        { label: "android-system" },
+        { readEntryBuffers },
+      ),
+    ).not.toThrow();
+    expect(() =>
+      assertAndroidArtifactRetainsBackgroundRunnerJniBridge(
+        "/artifacts/app-release.apk",
+        entries,
+        JAVA_HOME,
+        { label: "android-system" },
+        { readEntryBuffers },
+      ),
+    ).toThrow(
+      expect.objectContaining({
+        code: "ANDROID_BACKGROUND_RUNNER_JNI_CLASS_MISSING",
+        context: expect.objectContaining({ label: "android-system" }),
+      }),
+    );
+    expect(readEntryBuffers).toHaveBeenCalledWith(
+      "/artifacts/app-release.apk",
+      entries,
+      JAVA_HOME,
+      { label: "Background Runner JNI DEX audit" },
     );
   });
 

--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -7888,6 +7888,12 @@ function auditAndroidSideloadArtifact({ javaHome } = {}) {
     );
   }
   const entries = listAndroidArtifactEntries(artifact, javaHome);
+  assertAndroidArtifactRetainsBackgroundRunnerJniBridge(
+    artifact,
+    entries,
+    javaHome,
+    { label: "android sideload" },
+  );
   assertAndroidArtifactShipsWebPayload(artifact, entries, {
     requireAgent: true,
     label: "android",
@@ -7947,6 +7953,12 @@ function auditAndroidHostE2eArtifact({ javaHome } = {}) {
     );
   }
   const entries = listAndroidArtifactEntries(artifact, javaHome);
+  assertAndroidArtifactRetainsBackgroundRunnerJniBridge(
+    artifact,
+    entries,
+    javaHome,
+    { label: "android host-e2e" },
+  );
   assertAndroidArtifactShipsWebPayload(artifact, entries, {
     requireAgent: false,
     label: "android-host-e2e",
@@ -7982,6 +7994,12 @@ function auditAndroidSystemArtifact({ androidSdkRoot, javaHome } = {}) {
     );
   }
   const entries = listAndroidArtifactEntries(artifact, javaHome);
+  assertAndroidArtifactRetainsBackgroundRunnerJniBridge(
+    artifact,
+    entries,
+    javaHome,
+    { label: "android-system" },
+  );
   const aapt = resolveAndroidBuildTool(androidSdkRoot, "aapt");
   if (!aapt) {
     throw mobileBuildError(
@@ -8669,6 +8687,48 @@ export function auditAndroidArtifactDexLp3Policy(
   }
 }
 
+/**
+ * Require the Background Runner Java class that its native JS engine resolves
+ * through JNI. R8 cannot infer this edge from Java bytecode, so a missing class
+ * is a release-startup crash rather than a safely unused implementation detail.
+ */
+export function assertAndroidArtifactRetainsBackgroundRunnerJniBridge(
+  artifact,
+  entries,
+  javaHome,
+  { label = "Android" } = {},
+  { readEntryBuffers = readAndroidArtifactEntryBuffers } = {},
+) {
+  const dexEntries = entries.filter((entry) =>
+    /(^|\/)classes\d*\.dex$/.test(entry),
+  );
+  if (dexEntries.length === 0) {
+    throw mobileBuildError(
+      `[mobile-build] Android artifact has no classes*.dex entries: ${artifact}`,
+      {
+        code: "ANDROID_ARTIFACT_DEX_MISSING",
+        context: { artifact, label },
+      },
+    );
+  }
+
+  const marker = "io/ionic/android_js_engine/NativeWebAPI";
+  const dexBuffers = readEntryBuffers(artifact, dexEntries, javaHome, {
+    label: "Background Runner JNI DEX audit",
+  });
+  if (dexBuffers.some((dex) => dex.includes(Buffer.from(marker, "utf8")))) {
+    return;
+  }
+
+  throw mobileBuildError(
+    `[mobile-build] ${label} artifact DEX is missing the Background Runner JNI class ${marker.replaceAll("/", ".")}.`,
+    {
+      code: "ANDROID_BACKGROUND_RUNNER_JNI_CLASS_MISSING",
+      context: { artifact, label, marker },
+    },
+  );
+}
+
 function findAndroidManifestElementBlock(
   manifestText,
   elementName,
@@ -8968,6 +9028,31 @@ export function auditAndroidCloudArtifact(
   }
   let evidence;
   try {
+    assertAndroidArtifactRetainsBackgroundRunnerJniBridge(
+      inspectedArtifact,
+      entries,
+      javaHome,
+      {
+        label: debug ? "android-cloud debug" : "android-cloud release AAB",
+      },
+      {
+        readEntryBuffers: (
+          selectedArtifact,
+          selectedEntries,
+          selectedJavaHome,
+          options,
+        ) =>
+          readAndroidArtifactEntryBuffers(
+            selectedArtifact,
+            selectedEntries,
+            selectedJavaHome,
+            {
+              ...options,
+              artifactBytes: initialSnapshot.bytes,
+            },
+          ),
+      },
+    );
     if (artifactKind === "apk") {
       // APK inspection deliberately retains the existing AAPT badging/xmltree
       // behavior. bundletool is only valid for the release App Bundle path.

--- a/packages/app/scripts/android-release-minify-smoke.sh
+++ b/packages/app/scripts/android-release-minify-smoke.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+artifact_root="${ELIZA_DEVICE_BUNDLE_ROOT:?}/android"
+release_apk="${GITHUB_WORKSPACE:?}/packages/app-core/platforms/android/app/build/outputs/apk/release/app-release.apk"
+package_id="ai.elizaos.app"
+
+mkdir -p "$artifact_root/inline" "$artifact_root/logs"
+# The production Vite graph resolves @elizaos/prompts through its dist export.
+# A clean workflow checkout has no dist until this package boundary is built.
+bun run --cwd packages/prompts build:package
+bun run --cwd packages/app build:android:host-e2e
+
+# The release signing contract reads these variables. Generate a disposable
+# debug identity so this fork-safe proof does not require a repository secret.
+export ELIZAOS_KEYSTORE_PATH="${RUNNER_TEMP:?}/eliza-release-smoke.jks"
+export ELIZAOS_KEYSTORE_PASSWORD=android
+export ELIZAOS_KEY_ALIAS=androiddebugkey
+export ELIZAOS_KEY_PASSWORD=android
+keytool -genkeypair \
+  -keystore "$ELIZAOS_KEYSTORE_PATH" \
+  -storepass "$ELIZAOS_KEYSTORE_PASSWORD" \
+  -alias "$ELIZAOS_KEY_ALIAS" \
+  -keypass "$ELIZAOS_KEY_PASSWORD" \
+  -dname "CN=Eliza Android Release Smoke,O=elizaOS,C=US" \
+  -keyalg RSA \
+  -keysize 2048 \
+  -validity 1 \
+  -noprompt
+test -s "$ELIZAOS_KEYSTORE_PATH"
+(
+  cd packages/app-core/platforms/android
+  ./gradlew -PelizaStripAgentAssets=true :app:assembleRelease
+)
+test -s "$release_apk"
+
+unzip -p "$release_apk" 'classes*.dex' \
+  | strings \
+  | grep -F 'io/ionic/android_js_engine/NativeWebAPI' \
+    > "$artifact_root/logs/release-minify-dex.txt"
+
+adb install -r "$release_apk"
+local_sha="$(sha256sum "$release_apk" | cut -d ' ' -f 1)"
+device_apk="$(adb shell pm path "$package_id" | sed -n 's/^package://p' | head -n 1)"
+device_sha="$(adb shell sha256sum "$device_apk" | cut -d ' ' -f 1)"
+test "$local_sha" = "$device_sha"
+printf 'local_sha256=%s\ndevice_sha256=%s\ndevice_apk=%s\n' \
+  "$local_sha" "$device_sha" "$device_apk" \
+  > "$artifact_root/logs/release-minify-install.txt"
+
+adb shell am force-stop "$package_id"
+adb logcat -c
+adb shell am start -W -n "$package_id/.MainActivity" \
+  | tee "$artifact_root/logs/release-minify-launch.txt"
+sleep 8
+adb shell pidof "$package_id" \
+  | tee "$artifact_root/logs/release-minify-pid.txt"
+adb logcat -d > "$artifact_root/logs/release-minify-logcat.txt"
+if grep -E 'ClassNotFoundException: io\.ionic\.android_js_engine\.NativeWebAPI|FATAL EXCEPTION|SIGABRT' "$artifact_root/logs/release-minify-logcat.txt"; then
+  echo 'minified release launch emitted a fatal startup signature' >&2
+  exit 1
+fi
+
+adb exec-out screencap -p > "$artifact_root/inline/release-minify-launch.png"
+adb shell screenrecord --time-limit 8 /sdcard/eliza-release-minify-launch.mp4
+adb pull /sdcard/eliza-release-minify-launch.mp4 "$artifact_root/inline/release-minify-launch.mp4"

--- a/packages/scripts/__tests__/ci-android-aab-workflow.test.ts
+++ b/packages/scripts/__tests__/ci-android-aab-workflow.test.ts
@@ -157,6 +157,24 @@ describe("consolidated Android release AAB authority", () => {
     ).toContain("needs.android_aab.result");
   });
 
+  test("builds the prompts package before the clean-checkout mobile app bundle", () => {
+    const android = requireJob("android_aab");
+    const dependencies = requireStep(
+      android,
+      "Build mobile package dependencies",
+    );
+    const build = requireStep(
+      android,
+      "Build and audit canonical Android Cloud release AAB",
+    );
+    const steps = android.steps ?? [];
+
+    expect(dependencies.run).toContain(
+      "bun run --cwd packages/prompts build:package",
+    );
+    expect(steps.indexOf(dependencies)).toBeLessThan(steps.indexOf(build));
+  });
+
   test("accepts exact booleans and rejects failed, missing, or malformed selectors", () => {
     const source = requireStep(
       requireJob("android_aab"),


### PR DESCRIPTION
# Relates to

Fixes #27907.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [ ] Hosted Quality, canonical Android release AAB, and device-smoke reruns are in progress for the refreshed head.
- [x] A reviewer can confirm the original runtime fix from the minified APK device evidence and the review repair from the refreshed-head AAB regression below.

# Sync with develop

- [x] Final preflight: `origin/develop` = `43b4e75fc64b1baa573c36d820ff8dbb6bf8c7b9`; PR head = `958914cc2e8b99be6ee01f6d2e68a69d4136f20d`; zero upstream-only commits and two contribution commits.
- [ ] Refreshed-head hosted checks are running. The predecessor head's Quality, gitleaks, Android release AAB, and installed release APK evidence remains linked below.

# Risks

Low. The keep rule increases release DEX size by retaining the Background Runner JS-engine namespace. The artifact audit now fails closed if the JNI-resolved class disappears from any supported Android build path. The new hosted release smoke is opt-in and does not change the default device workflow.

# Background

## What does this PR do?

- keeps `io.ionic.android_js_engine.**` through R8 so native `FindClass` can resolve `NativeWebAPI` during Background Runner registration;
- audits every Android sideload, host-E2E, system APK, and release AAB DEX for that JNI bridge with a typed failure;
- adds present/missing-marker regression coverage; and
- adds an opt-in, fork-safe workflow dispatch that builds, minifies, signs, installs, cold-launches, and captures the release APK on an emulator.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No user-facing documentation change is needed. The build/audit comments document the JNI reachability contract at its enforcement points.

# Testing

## Where should a reviewer start?

1. `packages/app-core/platforms/android/app/proguard-rules.pro`
2. `assertAndroidArtifactRetainsBackgroundRunnerJniBridge` and its regression test
3. [Exact-head Android device proof](https://github.com/0takuc0mrade/eliza/actions/runs/32796566984)

## Detailed testing steps

- Product-head `vitest ...run-mobile-build-android-aab-audit.test.mjs`: 93 passed, 7 skipped under repository-pinned Bun 1.3.14 and Vitest 4.1.10.
- The new release-AAB boundary test removes `NativeWebAPI` from `base/dex/classes.dex` and proves `ANDROID_BACKGROUND_RUNNER_JNI_CLASS_MISSING` is thrown before bundle inspection or attestation.
- Current-head AAB workflow contract: the focused clean-checkout prompts-bootstrap test passes under repository-pinned Bun 1.3.14.
- Workflow trigger policy: 61 workflows verified; one `develop` push surface.
- Shell syntax, YAML parse, Biome, and `git diff --check`: passed.
- [Quality](https://github.com/0takuc0mrade/eliza/actions/runs/32796551829/job/97648951661): passed on predecessor head `4ce76886a22aeb697db64c46f00388c008f91921`.
- [gitleaks](https://github.com/0takuc0mrade/eliza/actions/runs/32796551829/job/97648951867): passed on predecessor head `4ce76886a22aeb697db64c46f00388c008f91921`.
- [Canonical Android release AAB](https://github.com/0takuc0mrade/eliza/actions/runs/32796551829/job/97649144728): minified build and artifact audit passed on predecessor head `4ce76886a22aeb697db64c46f00388c008f91921`.
- [Android emulator release APK](https://github.com/0takuc0mrade/eliza/actions/runs/32796566984): passed on predecessor head `4ce76886a22aeb697db64c46f00388c008f91921`.
  - DEX contains `NativeWebAPI` and `NativeWebAPI$Companion` descriptors.
  - local and installed APK SHA-256 both equal `830e427f810a90b1715ab464e3df8138a6b193dfd500da06c6d87b9e14e6ad53`.
  - cold launch returned `Status: ok`, `LaunchState: COLD`, activity `ai.elizaos.app/.MainActivity`, total time 808 ms.
  - PID `2363` remained alive after the startup window.
  - logcat contained no matching `NativeWebAPI` `ClassNotFoundException`, `FATAL EXCEPTION`, or `SIGABRT`.
  - the captured screen renders the Eliza onboarding UI.

# Evidence Gate

<!-- evidence-head:958914cc2e8b99be6ee01f6d2e68a69d4136f20d -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - the archived build crashes before rendering a frame; #27907 contains the native crash buffer, official APK digest, and missing-DEX-class reproduction.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI source changed; the screenshot linked in Evidence Details is supplied only as native startup proof.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no UI source or multi-step user flow changed; the acceptance condition is native startup, evidenced by DEX identity, install hash, cold-launch status, surviving PID, logcat, and screenshot.
<!-- evidence-row:backend-logs -->
- [x] N/A - the reported failure occurs during Android plugin registration before any backend request.
<!-- evidence-row:frontend-logs -->
- [x] N/A - the reported failure occurs before WebView renderer startup; native launch and logcat evidence is supplied instead.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Refreshed-head AAB audit output plus predecessor release-startup output:
  <details>
  <summary>Android release startup log output</summary>

  ```text
  product_revision=6d5e4ab3293e52f550a556245e1c855bbed03ef9
  workflow_revision=958914cc2e8b99be6ee01f6d2e68a69d4136f20d
  focused_suite=93_passed,7_skipped
  missing_release_aab_bridge_error=ANDROID_BACKGROUND_RUNNER_JNI_CLASS_MISSING
  missing_release_aab_inspector_calls=0
  missing_release_aab_attestation_logs=0

  predecessor_device_revision=4ce76886a22aeb697db64c46f00388c008f91921
  dex=Lio/ionic/android_js_engine/NativeWebAPI;
  local_sha256=830e427f810a90b1715ab464e3df8138a6b193dfd500da06c6d87b9e14e6ad53
  device_sha256=830e427f810a90b1715ab464e3df8138a6b193dfd500da06c6d87b9e14e6ad53
  launch_status=ok
  launch_state=COLD
  activity=ai.elizaos.app/.MainActivity
  total_time_ms=808
  surviving_pid=2363
  nativewebapi_classnotfound_matches=0
  fatal_exception_matches=0
  sigabrt_matches=0
  ```

  </details>
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered UI text or layout source changed; the screenshot only proves that native startup reaches the existing onboarding UI.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - this is an Android native startup crash before backend or renderer traffic. The domain bundle contains native launch output and full logcat.

## Screenshots (before / after) + video walkthrough

### Before

N/A - the affected archived APK aborts before its first frame; see #27907.

### After

![Predecessor-head Android minified release cold launch](https://github.com/0takuc0mrade/eliza/releases/download/pr-28099-evidence/28099-eliza27907-release-minify-launch.jpg)

The screenshot is bound to predecessor commit `4ce76886a22aeb697db64c46f00388c008f91921` by the accompanying [workflow bootstrap and startup evidence](https://github.com/0takuc0mrade/eliza/releases/download/pr-28099-evidence/28099-eliza27907-android-release-evidence.txt). The refreshed-head device rerun is in progress.

### Walkthrough video

N/A - no UI flow changed; the exact-head native startup proof is described above.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, TTS, STT, or omnivoice behavior changed.

## Known gaps / failures

The predecessor-head manually dispatched aggregate CI run includes existing failures outside this patch's seven-file Android packaging/proof scope:

- `Tests (scripts)`: stale cloud/workflow contract expectations and missing prebuilt workspace packages in unrelated tests.
- `Tests (client)`: 18 unrelated app test files fail, including browser overlay/source-contract and API expectation drift.
- smoke shards: unrelated voice STT shim, cloud lifecycle/deep-link readiness, onboarding expectation, Android phone mock, and settings bridge inventory failures.

These do not overlap the changed R8 rule, Android artifact audit, regression test, or opt-in proof script. Refreshed-head hosted results will replace this note when terminal.

## Maintainer CI exception record

N/A - no exception requested.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-eliza
Attribution status: self-reported
— [otakucomrade-issue27907-fix]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0V2V5TF7YWDHA8PGS1TKV3M","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-24T23:49:12.655Z","completed_at":"2026-08-25T01:45:52.840Z","skill_sha256":"7d4db0c19ef1171c18744a11ec1aceb613e3f779a9c49953ef1a0018aa80e4fd","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-24T23:49:18.265Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"024c405f891fa435ffea464b8348c9e9626ecd5b42e034d792d5297ede262879","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"06a5e808-25e8-4954-a58c-d2034f1f95df","object_id":"sha256:024c405f891fa435ffea464b8348c9e9626ecd5b42e034d792d5297ede262879","sha256":"024c405f891fa435ffea464b8348c9e9626ecd5b42e034d792d5297ede262879"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAflM8PoTR9ODo1eyirHaPX5A5wyYTcz--adY0c87h5N0","device_key_id":"38ff88641eac1ef721754364b87c73e2df36dc2b4dac70d9efab272041f0340c","device_signature":"ibVlglk-gjbsTbHEeB-CtxjzjXjecMt_Tu6aC0rH15DPJq9fRa_fJJYSIMSem59x7hRn3aK12W5q1YshsBkLBQ"}} -->
