### PR TITLE
test(sql): cover extension manager allowlist and failure isolation

### DIFF
--- a/plugins/plugin-sql/src/runtime-migrator/extension-manager.test.ts
+++ b/plugins/plugin-sql/src/runtime-migrator/extension-manager.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { sql } = vi.hoisted(() => {
+  const sqlTag = (strings: TemplateStringsArray, ...values: unknown[]) => ({
+    strings,
+    values,
+  });
+  sqlTag.identifier = (name: string) => ({ identifier: name });
+  return { sql: sqlTag };
+});
+
+vi.mock("drizzle-orm", () => ({ sql }));
+
+import { ExtensionManager } from "./extension-manager";
+
+function createFakeDb() {
+  return { execute: vi.fn().mockResolvedValue(undefined) };
+}
+
+describe("ExtensionManager", () => {
+  let db: ReturnType<typeof createFakeDb>;
+
+  beforeEach(() => {
+    db = createFakeDb();
+  });
+
+  it("installs every allowlisted extension name", async () => {
+    const manager = new ExtensionManager(db as never);
+    await manager.installRequiredExtensions(["vector", "pg_trgm", "fuzzystrmatch", "ext_1-2"]);
+    expect(db.execute).toHaveBeenCalledTimes(4);
+    for (const call of db.execute.mock.calls) {
+      const [arg] = call;
+      const identifier = (arg as { strings: string[]; values: unknown[] }).values[0];
+      expect(identifier).toMatchObject({ identifier: expect.any(String) });
+      expect((identifier as { identifier: string }).identifier).toMatch(/^[a-zA-Z0-9_-]+$/);
+    }
+  });
+
+  it("skips invalid extension names and never hands them to the database", async () => {
+    const manager = new ExtensionManager(db as never);
+    await manager.installRequiredExtensions([
+      "vector",
+      "vector; DROP TABLE users",
+      "vec tor",
+      "x'y",
+      "",
+      "pg_trgm",
+    ]);
+    expect(db.execute).toHaveBeenCalledTimes(2);
+    for (const call of db.execute.mock.calls) {
+      const [arg] = call;
+      const identifier = (arg as { strings: string[]; values: unknown[] }).values[0];
+      expect((identifier as { identifier: string }).identifier).not.toMatch(/[^a-zA-Z0-9_-]/);
+    }
+  });
+
+  it("interpolates the validated name into the CREATE EXTENSION statement", async () => {
+    const manager = new ExtensionManager(db as never);
+    await manager.installRequiredExtensions(["vector"]);
+    const [arg] = db.execute.mock.calls[0];
+    const { strings, values } = arg as {
+      strings: string[];
+      values: unknown[];
+    };
+    expect(strings.join("${}")).toContain("CREATE EXTENSION IF NOT EXISTS");
+    expect(values[0]).toMatchObject({ identifier: "vector" });
+  });
+
+  it("continues with remaining extensions when one install fails", async () => {
+    db.execute.mockRejectedValueOnce(new Error("extension unavailable"));
+    const manager = new ExtensionManager(db as never);
+    await expect(manager.installRequiredExtensions(["vector", "pg_trgm"])).resolves.toBeUndefined();
+    expect(db.execute).toHaveBeenCalledTimes(2);
+  });
+
+  it("fails only the failing extension when several are installed", async () => {
+    db.execute.mockRejectedValueOnce(new Error("boom")).mockResolvedValueOnce(undefined);
+    const manager = new ExtensionManager(db as never);
+    await manager.installRequiredExtensions(["bad_ok", "good"]);
+    expect(db.execute).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new test file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `5 passed (5)` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
