### PR TITLE
fix(install): build startup runtime prerequisites

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "node": "24.15.0"
   },
   "scripts": {
-    "postinstall": "bun packages/scripts/patch-nested-core-dist.mjs && bun packages/scripts/patch-punycode-deprecation.mjs && bun packages/scripts/patch-llama-cpp-capacitor.mjs && bun packages/scripts/ensure-workspace-symlinks.mjs && bun packages/scripts/build-private-workspace-packages.mjs",
+    "postinstall": "node packages/app-core/scripts/ensure-shared-i18n-data.mjs && bun packages/scripts/patch-nested-core-dist.mjs && bun packages/scripts/patch-punycode-deprecation.mjs && bun packages/scripts/patch-llama-cpp-capacitor.mjs && bun packages/scripts/ensure-workspace-symlinks.mjs && bun packages/scripts/build-private-workspace-packages.mjs",
     "install:light": "bun install",
     "cloud:mock": "bun scripts/cloud/mock-stack-up.mjs",
     "cloud:mock:fresh": "bun scripts/cloud/mock-stack-up.mjs --reset",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -252,6 +252,10 @@
 	"elizaos": {
 		"scripts": {
 			"coreBuild": true,
+			"buildOnInstall": {
+				"sentinel": "dist/edge/index.edge.js",
+				"order": 3
+			},
 			"testLanes": [
 				"server"
 			],

--- a/packages/scripts/__tests__/plugin-discovery-zero-edit.test.ts
+++ b/packages/scripts/__tests__/plugin-discovery-zero-edit.test.ts
@@ -16,6 +16,7 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
+  resolveBuildOnInstallPackages,
   resolveCoreBuildPackages,
   resolveDevAllSkipPlugins,
   resolveTestLaneDirs,
@@ -126,6 +127,41 @@ function snapshotScriptSources(): Map<string, string> {
 }
 
 describe("plugin discovery is zero-edit", () => {
+  test("build-on-install packages are discovered and dependency ordered", () => {
+    const root = makeRepo();
+    writePackage(root, "packages/dependent", {
+      name: "@fixture/dependent",
+      elizaos: {
+        scripts: {
+          buildOnInstall: { sentinel: "dist/edge.js", order: 20 },
+        },
+      },
+    });
+    writePackage(root, "packages/dependency", {
+      name: "@fixture/dependency",
+      elizaos: {
+        scripts: {
+          buildOnInstall: { sentinel: "dist/index.js", order: 10 },
+        },
+      },
+    });
+
+    expect(resolveBuildOnInstallPackages({ repoRoot: root })).toEqual([
+      {
+        dir: "packages/dependency",
+        name: "@fixture/dependency",
+        order: 10,
+        sentinel: "dist/index.js",
+      },
+      {
+        dir: "packages/dependent",
+        name: "@fixture/dependent",
+        order: 20,
+        sentinel: "dist/edge.js",
+      },
+    ]);
+  });
+
   test("adding then removing a plugin flips every resolved set with no script edit", async () => {
     const before = snapshotScriptSources();
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -557,6 +557,10 @@
   "elizaos": {
     "scripts": {
       "coreBuild": true,
+      "buildOnInstall": {
+        "sentinel": "dist/brand/index.js",
+        "order": 2
+      },
       "testLanes": [
         "server"
       ]


### PR DESCRIPTION
Closes #28078

## Summary
- generate the gitignored shared/core i18n keyword modules during root postinstall
- opt the compiled shared and core runtime boundaries into the existing metadata-driven build-on-install orchestration
- verify build-on-install discovery and dependency ordering with a real workspace fixture

## Exact-head evidence
- removed shared/core dist and generated keyword artifacts, then ran `bun install`; it regenerated i18n, built shared brand and core edge, reported 3721 installs across 3997 packages with no changes, and left the tracked tree clean
- `bun test packages/scripts/__tests__/plugin-discovery-zero-edit.test.ts` (3 passed)
- `bunx vitest run packages/app-core/scripts/ensure-shared-i18n-data.test.mjs` (3 passed)
- Biome check for all four touched files passed
- `bun run verify` passed, including 375/375 Turbo typecheck/lint tasks and the final anti-larp audit
- `bun run start` reached `ready: true`, `agentState: running`, and `startup.phase: running` on `/api/health`

## Live dev note
The API and Vite UI now bind successfully after a fresh install. Final agent readiness validation on this Mac is pending a manual screen unlock because macOS Keychain access blocks while the machine is locked.