### PR TITLE
fix(core): reset confirmRegex.lastIndex before matching user reply

### DIFF
--- a/packages/core/src/utils/confirmation.test.ts
+++ b/packages/core/src/utils/confirmation.test.ts
@@ -229,4 +229,64 @@ describe("confirmation utilities", () => {
 		expect(llmConfirmedFlagIsAuthoritative(1)).toBe(false);
 		expect(llmConfirmedFlagIsAuthoritative({})).toBe(false);
 	});
+
+	it("handles global-flag confirmRegex without lastIndex alternation", async () => {
+		const globalRegex = /yes/gi;
+		const runtime = createMockRuntime();
+
+		// First pending + confirm: should be confirmed
+		const m1: Memory = {
+			entityId: "user-1",
+			content: { text: "delete" },
+		} as unknown as Memory;
+		await requireConfirmation({
+			runtime,
+			message: m1,
+			actionName: "DELETE_ITEM",
+			pendingKey: "item:g1",
+			prompt: "Delete?",
+			confirmRegex: globalRegex,
+		});
+		const m2: Memory = {
+			entityId: "user-1",
+			content: { text: "yes" },
+		} as unknown as Memory;
+		const d1 = await requireConfirmation({
+			runtime,
+			message: m2,
+			actionName: "DELETE_ITEM",
+			pendingKey: "item:g1",
+			prompt: "Delete?",
+			confirmRegex: globalRegex,
+		});
+		expect(d1.status).toBe("confirmed");
+
+		// Reuse same regex object for a second independent confirmation:
+		// without lastIndex reset it would alternate to cancelled.
+		const m3: Memory = {
+			entityId: "user-1",
+			content: { text: "delete again" },
+		} as unknown as Memory;
+		await requireConfirmation({
+			runtime,
+			message: m3,
+			actionName: "DELETE_ITEM",
+			pendingKey: "item:g2",
+			prompt: "Delete?",
+			confirmRegex: globalRegex,
+		});
+		const m4: Memory = {
+			entityId: "user-1",
+			content: { text: "yes" },
+		} as unknown as Memory;
+		const d2 = await requireConfirmation({
+			runtime,
+			message: m4,
+			actionName: "DELETE_ITEM",
+			pendingKey: "item:g2",
+			prompt: "Delete?",
+			confirmRegex: globalRegex,
+		});
+		expect(d2.status).toBe("confirmed");
+	});
 });

--- a/packages/core/src/utils/confirmation.ts
+++ b/packages/core/src/utils/confirmation.ts
@@ -160,6 +160,7 @@ export async function requireConfirmation(
 	// Existing pending record found — interpret the user's reply.
 	await args.runtime.deleteCache(cacheKey);
 
+	confirmRegex.lastIndex = 0;
 	const status: ConfirmationStatus = confirmRegex.test(userText)
 		? "confirmed"
 		: "cancelled";


### PR DESCRIPTION
## Relates to

Fixes a stateful-regex bug in `packages/core/src/utils/confirmation.ts` (`requireConfirmation`).

## Background

`requireConfirmation` accepts a caller-supplied `confirmRegex`. When the caller passes a global-flag regex (`/yes/gi`), `RegExp.prototype.test` advances `lastIndex` on every successful match. Because `requireConfirmation` keeps reusing the same regex object across independent confirmation flows (e.g. a long-lived action handler holding one regex constant), the second confirmation alternates: the first `test()` succeeds and advances `lastIndex`, the next call starts matching mid-string and returns `false` — silently flipping a "confirmed" user reply into "cancelled". The reply was already consumed (`deleteCache` ran before the test), so the user's confirmation is lost and the action is aborted.

The fix resets `confirmRegex.lastIndex = 0` immediately before the status test, making the match deterministic regardless of prior uses of the same regex object. This is a behavior contract fix: identical user input now yields identical confirmation status on every call.

## Testing

```bash
cd packages/core
bun x vitest run src/utils/confirmation.test.ts
# 8 passed (26ms)
```

New regression test reproduces the exact failure: a shared `/yes/gi` regex, two independent confirmation flows — without the fix the second `test()` matches at a stale offset and returns `cancelled`. Verified locally: 8/8 pass with fix, fails (second flow `cancelled`) without it. `bun x biome check` clean.

<!-- evidence-row:after-screenshots -->
- [x] after-screenshots: N/A (pure unit test — no UI)
<!-- evidence-row:backend-logs -->
- [x] backend-logs: vitest 8 passed, see Testing section
<!-- evidence-row:walkthrough-video -->
- [x] walkthrough-video: N/A
<!-- evidence-row:frontend-logs -->
- [x] frontend-logs: N/A
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A (unit test run)

AI provider/model: deepseek / deepseek-v4-flash
<!-- slop-contribution-attribution:v1 -->
