### PR TITLE
fix(wallet): guard confirmation serialization against cyclic parameters

### DIFF
--- a/plugins/plugin-wallet/src/chains/solana/actions/confirmation.test.ts
+++ b/plugins/plugin-wallet/src/chains/solana/actions/confirmation.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from "vitest";
+import { confirmationRequired, isConfirmed } from "./confirmation";
+
+describe("confirmationRequired (wallet solana)", () => {
+  it("never trusts LLM-supplied confirmed flags (GHSA-rqm7-f4jc-84x3)", () => {
+    expect(isConfirmed({ confirmed: true })).toBe(false);
+    expect(isConfirmed({ confirmed: "yes" })).toBe(false);
+    expect(isConfirmed({ confirmed: 1 })).toBe(false);
+    expect(isConfirmed(undefined)).toBe(false);
+    expect(isConfirmed()).toBe(false);
+  });
+
+  it("normalizes scalar and bigint parameter values to JSON-safe shapes", async () => {
+    const callback = vi.fn();
+    const result = await confirmationRequired({
+      actionName: "swap",
+      preview: "Swap 1 ETH",
+      parameters: {
+        amount: 1n,
+        token: "ETH",
+        extra: undefined,
+        tags: [1, 2n, null, true],
+      },
+      callback,
+    });
+
+    expect(result.success).toBe(false);
+    const data = result.data as {
+      requiresConfirmation: boolean;
+      preview: string;
+      confirmation: {
+        actionName: string;
+        parameters: Record<string, unknown>;
+      };
+    };
+    expect(data.requiresConfirmation).toBe(true);
+    expect(data.preview).toBe("Swap 1 ETH");
+    expect(data.confirmation.actionName).toBe("swap");
+    expect(data.confirmation.parameters).toEqual({
+      amount: "1",
+      token: "ETH",
+      extra: null,
+      tags: [1, "2", null, true],
+    });
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback).toHaveBeenCalledWith(expect.objectContaining({ text: "Swap 1 ETH" }));
+  });
+
+  it("surfaces cyclic parameter graphs as a marker instead of crashing", async () => {
+    const cyclic: Record<string, unknown> = { name: "swap" };
+    cyclic.self = cyclic;
+
+    const result = await confirmationRequired({
+      actionName: "swap",
+      preview: "Swap",
+      parameters: cyclic,
+    });
+
+    // eslint-disable-next-line no-console
+    const data = result.data as {
+      confirmation: { parameters: Record<string, unknown> };
+    };
+    expect(data.confirmation.parameters.self).toBe("[Circular]");
+  });
+
+  it("surfaces shared (diamond) references without false circular markers", async () => {
+    const shared = { address: "0xabc" };
+    const result = await confirmationRequired({
+      actionName: "swap",
+      preview: "Swap",
+      parameters: { from: shared, to: shared },
+    });
+
+    const data = result.data as {
+      confirmation: { parameters: Record<string, unknown> };
+    };
+    expect(data.confirmation.parameters.from).toEqual({ address: "0xabc" });
+    expect(data.confirmation.parameters.to).toEqual({ address: "0xabc" });
+  });
+
+  it("does not collapse non-plain objects (Date, Map) to empty records", async () => {
+    const when = new Date("2026-01-02T03:04:05.000Z");
+    const result = await confirmationRequired({
+      actionName: "swap",
+      preview: "Swap",
+      parameters: { when, tags: new Map([["k", "v"]]) },
+    });
+
+    const data = result.data as {
+      confirmation: { parameters: Record<string, unknown> };
+    };
+    const parameters = data.confirmation.parameters;
+    expect(typeof parameters.when).toBe("string");
+    expect(parameters.when).toContain("2026");
+    expect(typeof parameters.tags).toBe("string");
+    expect(parameters.tags.length).toBeGreaterThan(0);
+  });
+
+  it("omits the callback when none is supplied", async () => {
+    const result = await confirmationRequired({
+      actionName: "swap",
+      preview: "Swap",
+      parameters: {},
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/plugins/plugin-wallet/src/chains/solana/actions/confirmation.ts
+++ b/plugins/plugin-wallet/src/chains/solana/actions/confirmation.ts
@@ -19,11 +19,8 @@ export function isConfirmed(_options?: Record<string, unknown>): boolean {
   return false;
 }
 
-function toConfirmationValue(value: unknown): ConfirmationValue {
-  if (value === undefined) {
-    return null;
-  }
-  if (value === null) {
+function toConfirmationValue(value: unknown, ancestors?: WeakSet<object>): ConfirmationValue {
+  if (value === undefined || value === null) {
     return null;
   }
   if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
@@ -33,19 +30,42 @@ function toConfirmationValue(value: unknown): ConfirmationValue {
     return value.toString();
   }
   if (Array.isArray(value)) {
-    return value.map((item) => toConfirmationValue(item));
+    const chain = ancestors ?? new WeakSet<object>();
+    if (chain.has(value)) {
+      return "[Circular]";
+    }
+    chain.add(value);
+    const result = value.map((item) => toConfirmationValue(item, chain));
+    chain.delete(value);
+    return result;
   }
   if (value && typeof value === "object") {
-    return Object.fromEntries(
-      Object.entries(value).map(([key, item]) => [key, toConfirmationValue(item)])
+    // Non-plain objects (Date, Map, RegExp, class instances) have no
+    // enumerable JSON shape. Surface their string form instead of silently
+    // collapsing them to an empty record in the confirmation preview.
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) {
+      return String(value);
+    }
+    const chain = ancestors ?? new WeakSet<object>();
+    if (chain.has(value)) {
+      return "[Circular]";
+    }
+    chain.add(value);
+    const result = Object.fromEntries(
+      Object.entries(value).map(([key, item]) => [key, toConfirmationValue(item, chain)])
     ) as Record<string, ConfirmationValue>;
+    chain.delete(value);
+    return result;
   }
   return String(value);
 }
 
 function toConfirmationRecord(record: object): Record<string, ConfirmationValue> {
+  const chain = new WeakSet<object>();
+  chain.add(record);
   return Object.fromEntries(
-    Object.entries(record).map(([key, value]) => [key, toConfirmationValue(value)])
+    Object.entries(record).map(([key, value]) => [key, toConfirmationValue(value, chain)])
   ) as Record<string, ConfirmationValue>;
 }
 


### PR DESCRIPTION
# Relates to

No issue; hardening discovered while writing focused coverage for the
Solana confirmation helper (`confirmationRequired` / `isConfirmed`).

## What changed

- `toConfirmationValue` now threads an ancestor chain (`WeakSet`) through
  array/object recursion so a cyclic parameter graph produces a
  `"[Circular]"` marker instead of crashing with a `RangeError: Maximum
  call stack size exceeded` inside the confirmation flow.
- `toConfirmationRecord` seeds that chain with the top-level record, so the
  cycle is detected on the first re-entry (previously the marker only
  appeared one level deep).
- Non-plain objects (`Date`, `Map`, `RegExp`, class instances) now surface
  as their string form instead of being silently collapsed to an empty
  record by `Object.entries` — the confirmation preview previously showed
  `{}` for e.g. a `Date` parameter, losing the value entirely.
- Pinned the security invariant: `isConfirmed` never trusts LLM-supplied
  `confirmed` flags (GHSA-rqm7-f4jc-84x3).

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] Focused vitest run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Minimal production change confined to the confirmation-serialization
helper: an ancestor-tracking cycle guard plus a string fallback for
non-plain objects. All prior shapes (scalars, bigint, arrays, plain
objects, null/undefined) are unchanged; new behavior is covered by the
added tests, including a diamond-reference test proving shared (non-cyclic)
references are not mislabeled.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: 6/6 passed — see log below |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file + minimal source fix in this PR |

```log
Test Files  1 passed (1)
      Tests  6 passed (6)
```

- Command: `npx vitest run src/chains/solana/actions/confirmation.test.ts`
- Result: all passed (cycle guard, non-plain fallback, diamond references,
  bigint/nested normalization, callback contract, `isConfirmed` pin)

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
