### PR TITLE
fix(ui): define env in Settings fixture

### DIFF
--- a/packages/ui/src/components/pages/__e2e__/run-settings-e2e.mjs
+++ b/packages/ui/src/components/pages/__e2e__/run-settings-e2e.mjs
@@ -147,7 +147,15 @@ const bundle = await build({
   conditions: ["eliza-source", "browser"],
   jsx: "automatic",
   loader: { ".tsx": "tsx", ".ts": "ts", ".css": "empty", ".svg": "dataurl", ".png": "dataurl" },
-  define: { "process.env.NODE_ENV": '"production"' },
+  define: {
+    "process.env.NODE_ENV": '"production"',
+    "import.meta.env": JSON.stringify({
+      DEV: false,
+      MODE: "production",
+      PROD: true,
+      SSR: false,
+    }),
+  },
   plugins: [stubBarrels, stubElizaCore, stubNodeBuiltins],
   write: false,
   absWorkingDir: repoRoot,


### PR DESCRIPTION
Refs #28105

## What changed

- define the complete Vite `import.meta.env` object in the Settings IIFE fixture
- allow cloud route registration to read `import.meta.env.DEV` before React mounts

## Root cause

The Settings E2E fixture bundles an IIFE outside Vite, but only defined `process.env.NODE_ENV`. Cloud route registration reads `import.meta.env.DEV`, so the fixture crashed before React mounted.

The Zero-Key coverage half of #28105 was independently removed from the workflow by #28109 while this branch was being rebased, so this PR deliberately preserves that removal and contains only the remaining Settings fixture fix.

## Verification at exact head 1fe35bc746b2d

- `bun install`
- `bun run --cwd packages/ui test:settings-e2e` — passed; 13 desktop/mobile captures, walkthrough, 0 uncaught page errors
- `bun run --cwd packages/ui typecheck` — passed
- `bun run verify` — passed; 375/375 workspace tasks, all repository audits, and 11,003-file anti-focused-test scan green
- `git diff --check origin/develop...HEAD`

This removes the remaining observed Develop Full blocker for the exact-head iMessage media/Seedance release candidate.