### PR TITLE
fix(meetings): terminate xdotool options before absolute coordinates

### DIFF
--- a/plugins/plugin-meetings/src/platforms/humanized/x11-input.test.ts
+++ b/plugins/plugin-meetings/src/platforms/humanized/x11-input.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { X11Input } from "./x11-input";
+
+vi.mock("node:child_process", () => ({
+  execFile: vi.fn(),
+  default: { execFile: vi.fn() },
+}));
+
+describe("X11Input (dryRun command recording)", () => {
+  it("defaults the display to :99 when neither option nor env is set", () => {
+    delete process.env.DISPLAY;
+    const input = new X11Input({ dryRun: true });
+    // Exercise isAvailable (dryRun short-circuits to true) and moveAbs to
+    // confirm the recorded argv carries the defaulted display-independent
+    // command shape.
+    expect(input.isAvailable()).resolves.toBe(true);
+    return input.moveAbs(1, 1);
+  });
+
+  it("records argv lines and tracks the simulated pointer in dryRun", async () => {
+    const input = new X11Input({ dryRun: true, display: ":9" });
+    await input.moveAbs(100, 200);
+    await input.moveRel(-30, 40);
+    const pointer = await input.getPointer();
+
+    expect(input.log).toEqual([
+      ["xdotool", "mousemove", "--sync", "--", "100", "200"],
+      ["xdotool", "mousemove_relative", "--sync", "--", "-30", "40"],
+    ]);
+    expect(pointer).toEqual({ x: 70, y: 240 });
+  });
+
+  it("uses an option terminator before negative absolute coordinates", async () => {
+    // Without the "--" terminator, xdotool would parse "-100" as an option
+    // and fail the move; moveRel already terminates, moveAbs must too.
+    const input = new X11Input({ dryRun: true, display: ":9" });
+    await input.moveAbs(-100, -50);
+    expect(input.log[0]).toEqual([
+      "xdotool",
+      "mousemove",
+      "--sync",
+      "--",
+      "-100",
+      "-50",
+    ]);
+  });
+
+  it("does not let getPointer mutate the simulated pointer", async () => {
+    const input = new X11Input({ dryRun: true, display: ":9" });
+    await input.moveAbs(5, 6);
+    const first = await input.getPointer();
+    first.x = 999;
+    expect(await input.getPointer()).toEqual({ x: 5, y: 6 });
+  });
+
+  it("records mouse button presses with default and explicit buttons", async () => {
+    const input = new X11Input({ dryRun: true, display: ":9" });
+    await input.buttonDown();
+    await input.buttonUp(3);
+    expect(input.log).toEqual([
+      ["xdotool", "mousedown", "1"],
+      ["xdotool", "mouseup", "3"],
+    ]);
+  });
+
+  it("records typeText with delay and clear-modifiers flags", async () => {
+    const input = new X11Input({ dryRun: true, display: ":9" });
+    await input.typeText("hello world", 120);
+    expect(input.log[0]).toEqual([
+      "xdotool",
+      "type",
+      "--clearmodifiers",
+      "--delay",
+      "120",
+      "--",
+      "hello world",
+    ]);
+  });
+
+  it("short-circuits isAvailable to true in dryRun", async () => {
+    const input = new X11Input({ dryRun: true, display: ":9" });
+    await expect(input.isAvailable()).resolves.toBe(true);
+    expect(input.log).toEqual([]);
+  });
+
+  it("returns false from isAvailable when no display is configured", async () => {
+    delete process.env.DISPLAY;
+    const input = new X11Input({ dryRun: false, display: "" });
+    await expect(input.isAvailable()).resolves.toBe(false);
+  });
+});
+
+describe("X11Input (live execFile path)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("rejects when xdotool is missing", async () => {
+    const { execFile } = await import("node:child_process");
+    vi.mocked(execFile).mockImplementation((_cmd, _args, _opts, cb) => {
+      cb?.(new Error("xdotool not found"), "");
+    });
+    const input = new X11Input({ dryRun: false, display: ":9" });
+    await expect(input.isAvailable()).resolves.toBe(false);
+  });
+
+  it("parses getmouselocation --shell output", async () => {
+    const { execFile } = await import("node:child_process");
+    vi.mocked(execFile).mockImplementation((_cmd, _args, _opts, cb) => {
+      cb?.(null, "X=1200\nY=800\nSCREEN=0");
+    });
+    const input = new X11Input({ dryRun: false, display: ":9" });
+    await expect(input.getPointer()).resolves.toEqual({ x: 1200, y: 800 });
+  });
+
+  it("passes the display override through the execFile env", async () => {
+    const { execFile } = await import("node:child_process");
+    let capturedEnv: NodeJS.ProcessEnv | undefined;
+    vi.mocked(execFile).mockImplementation((_cmd, _args, opts, cb) => {
+      capturedEnv = (opts as { env: NodeJS.ProcessEnv }).env;
+      cb?.(null, "");
+    });
+    const input = new X11Input({ dryRun: false, display: ":77" });
+    await input.moveAbs(1, 2);
+    expect(capturedEnv?.DISPLAY).toBe(":77");
+    expect(vi.mocked(execFile)).toHaveBeenCalledWith(
+      "xdotool",
+      ["mousemove", "--sync", "--", "1", "2"],
+      expect.objectContaining({ env: expect.any(Object) }),
+      expect.any(Function),
+    );
+  });
+});

--- a/plugins/plugin-meetings/src/platforms/humanized/x11-input.ts
+++ b/plugins/plugin-meetings/src/platforms/humanized/x11-input.ts
@@ -73,7 +73,17 @@ export class X11Input {
 
   async moveAbs(x: number, y: number): Promise<void> {
     if (this.dryRun) this.simPointer = { x, y };
-    await this.run(["xdotool", "mousemove", "--sync", String(x), String(y)]);
+    // Terminate option parsing before the coordinates so negative values
+    // (offscreen moves) are not interpreted as xdotool options; moveRel
+    // already terminates with "--".
+    await this.run([
+      "xdotool",
+      "mousemove",
+      "--sync",
+      "--",
+      String(x),
+      String(y),
+    ]);
   }
 
   async moveRel(dx: number, dy: number): Promise<void> {


### PR DESCRIPTION
# Relates to

No issue; hardening discovered while writing focused coverage for the
X11 input driver (`X11Input`).

## What changed

- `moveAbs` now terminates xdotool option parsing with `--` before the
  coordinates, matching `moveRel`'s existing argv shape. Without the
  terminator, negative coordinates (offscreen/corner moves) are parsed by
  xdotool as options and the move fails; `moveRel` already used `--`, so
  this makes absolute and relative moves consistent.
- Added focused unit coverage for the dryRun command-recording contract
  (argv shape, simulated pointer tracking, button/type commands) and the
  live `execFile` path (display env override, `getmouselocation --shell`
  parsing, missing-xdotool fallback).

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] Focused vitest run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. One-argument change to a command construction (`--` terminator before
absolute coordinates) with no behavior change for non-negative coordinates;
all paths are covered by the added tests, including negative-coordinate
moves.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: 11/11 passed — see log below |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file + minimal source fix in this PR |

```log
Test Files  1 passed (1)
      Tests  11 passed (11)
```

- Command: `npx vitest run src/platforms/humanized/x11-input.test.ts`
- Result: all passed (argv recording, `--` terminator for negative
  coordinates, simulated pointer tracking, button/type commands, display
  env override, shell-output parsing, missing-xdotool fallback)

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
