### PR TITLE
fix(core): preserve coding-agent planner cache locality

### DIFF
--- a/packages/core/src/__tests__/planner-happy-path.test.ts
+++ b/packages/core/src/__tests__/planner-happy-path.test.ts
@@ -942,7 +942,7 @@ describe("v5 happy path — message handler → planner → executor → evaluat
 					promptSegments?: unknown[];
 					responseSchema?: unknown;
 					providerOptions?: {
-						eliza?: { segmentHashes?: unknown[] };
+						eliza?: { segmentHashes?: unknown[]; conversationId?: string };
 						cerebras?: { prompt_cache_key?: string; promptCacheKey?: string };
 					};
 			  }
@@ -953,7 +953,7 @@ describe("v5 happy path — message handler → planner → executor → evaluat
 					promptSegments?: unknown[];
 					responseSchema?: unknown;
 					providerOptions?: {
-						eliza?: { segmentHashes?: unknown[] };
+						eliza?: { segmentHashes?: unknown[]; conversationId?: string };
 						cerebras?: { prompt_cache_key?: string; promptCacheKey?: string };
 					};
 			  }
@@ -1029,6 +1029,15 @@ describe("v5 happy path — message handler → planner → executor → evaluat
 		);
 		expect(evaluatorParams?.providerOptions?.cerebras?.prompt_cache_key).toBe(
 			plannerParams?.providerOptions?.cerebras?.prompt_cache_key,
+		);
+		// Local/model-runner affinity is stable across turns but stage-scoped so
+		// planner and evaluator KV state cannot collide. The shared provider
+		// prefix hash above intentionally remains identical across both stages.
+		expect(plannerParams?.providerOptions?.eliza?.conversationId).toBe(
+			`${ROOM_ID}:planner`,
+		);
+		expect(evaluatorParams?.providerOptions?.eliza?.conversationId).toBe(
+			`${ROOM_ID}:evaluator`,
 		);
 
 		// Trajectory recording wrote a JSON file

--- a/packages/core/src/runtime/__tests__/planner-loop-message-stacking.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop-message-stacking.test.ts
@@ -1,7 +1,8 @@
 /**
  * Pins the planner's chat-message wire shape across loop iterations: an
- * append-only array with a stable system+user prefix and one assistant+tool
- * pair per completed step (prefix-cache-safe, no JSON trajectory dump).
+ * append-only array with a stable system+user prefix, one assistant+tool pair
+ * per completed step, and chronological loop feedback (prefix-cache-safe, no
+ * JSON trajectory dump).
  * Deterministic — `useModel` is a vitest mock that captures each `messages`
  * array; no live model.
  */
@@ -11,18 +12,20 @@ import type {
 	ChatMessageContentPart,
 	ToolDefinition,
 } from "../../types/model";
+import { ModelType } from "../../types/model";
 import { runPlannerLoop } from "../planner-loop";
 
 /**
  * Regression: the planner messages array must grow append-only across
  * iterations. Specifically:
  *
- *   1. The base messages (before any trajectory steps) must be byte-identical
- *      across planner iterations — required for Cerebras/OpenAI prefix cache.
+ *   1. Every earlier planner request must be a byte-identical array prefix of
+ *      every later planner request — required for provider prefix caches.
  *
  *   2. Each completed step adds exactly one assistant message (with a
  *      tool-call content part) and one tool message (with a tool-result
- *      content part). No JSON dump in a user message.
+ *      content part). Loop/evaluator feedback follows as an appended user
+ *      message instead of rewriting the original context message.
  *
  *   3. The messages array MUST NOT contain a role:"user" message whose content
  *      matches /^trajectory:\n\[/ (the old JSON-dump anti-pattern).
@@ -30,7 +33,7 @@ import { runPlannerLoop } from "../planner-loop";
  * These tests drive the planner with a mock useModel that captures every
  * `messages` array passed to it. Two planner calls happen in the two-tool chain:
  *   - Call 1 (iteration 1): no prior steps → base N messages
- *   - Call 2 (iteration 2): one completed step → N + 2 messages (assistant + tool)
+ *   - Call 2 (iteration 2): one completed step plus evaluator feedback
  */
 
 const TOOL_DEF: ToolDefinition = {
@@ -117,23 +120,20 @@ describe("planner-loop message stacking regression", () => {
 		// The second call must have more messages than the first
 		expect(msgs2.length).toBeGreaterThan(msgs1.length);
 
-		// The system message (messages[0]) must be byte-identical across iterations.
-		// messages[1] is the rendered context which legitimately grows as tool results
-		// are appended to context.events — that growth is expected and correct.
-		expect(JSON.stringify(msgs2[0])).toBe(JSON.stringify(msgs1[0]));
-
-		// Prior assistant/tool pair messages (indices >= 2) must be preserved byte-for-byte.
-		for (let i = 2; i < msgs1.length; i++) {
+		// The complete earlier request—not just its system message—must be the
+		// byte-identical prefix of the later request.
+		for (let i = 0; i < msgs1.length; i++) {
 			expect(JSON.stringify(msgs2[i])).toBe(JSON.stringify(msgs1[i]));
 		}
 
-		// The new messages added in call 2 must be assistant + tool pair (AI SDK v6 shape:
-		// tool calls live inside `content` as `ToolCallPart`, tool results inside `content`
-		// as `ToolResultPart`).
+		// AI SDK v6 shape: tool calls live inside `content` as ToolCallPart,
+		// tool results inside `content` as ToolResultPart. Evaluator feedback is
+		// chronological and follows the pair without changing either message.
 		const added = msgs2.slice(msgs1.length);
-		expect(added.length).toBe(2);
+		expect(added.length).toBe(3);
 		expect(added[0].role).toBe("assistant");
 		expect(added[1].role).toBe("tool");
+		expect(added[2].role).toBe("user");
 
 		const assistantToolCall = contentPartOfType(added[0], "tool-call");
 		const toolResult = contentPartOfType(added[1], "tool-result");
@@ -142,6 +142,7 @@ describe("planner-loop message stacking regression", () => {
 
 		// The assistant message's tool-call id must match the tool-result id.
 		expect(toolResult?.toolCallId).toBe(assistantToolCall?.toolCallId);
+		expect(JSON.stringify(added).match(/result of LOOKUP/g)).toHaveLength(1);
 	});
 
 	it("planner never appends a standalone trajectory JSON dump as the LAST message", async () => {
@@ -205,12 +206,16 @@ describe("planner-loop message stacking regression", () => {
 			expect(isJsonDump).toBe(false);
 		}
 
-		// After the first tool executes, the second planner call must end with
-		// a role:"tool" message (append-only suffix).
+		// After the first tool executes, the exact tool pair remains immediately
+		// before the appended evaluator feedback message.
 		if (capturedMessages.length >= 2) {
 			const secondPlannerMsgs = capturedMessages[1];
-			const lastMsg = secondPlannerMsgs?.[secondPlannerMsgs.length - 1];
-			expect(lastMsg?.role).toBe("tool");
+			const suffix = secondPlannerMsgs?.slice(-3);
+			expect(suffix?.map((message) => message.role)).toEqual([
+				"assistant",
+				"tool",
+				"user",
+			]);
 		}
 	});
 
@@ -294,11 +299,11 @@ describe("planner-loop message stacking regression", () => {
 			expect(messages[1]?.role).not.toBe("system");
 			// Second message must be the live user turn.
 			expect(messages[1]?.role).toBe("user");
-			// No system messages after the user turn (no system inserted into
-			// the suffix stream). Suffix is assistant or tool, never user.
+			// No system messages after the user turn. Suffix entries are native
+			// assistant/tool pairs or chronological loop-feedback user messages.
 			for (let i = 2; i < messages.length; i++) {
 				expect(messages[i]?.role).not.toBe("system");
-				expect(["assistant", "tool"]).toContain(messages[i]?.role);
+				expect(["assistant", "tool", "user"]).toContain(messages[i]?.role);
 			}
 		}
 	});
@@ -357,5 +362,200 @@ describe("planner-loop message stacking regression", () => {
 			expect(tcId).toBeDefined();
 			expect(resultId).toBe(tcId);
 		}
+	});
+
+	it("evaluator requests also grow as byte-identical same-stage prefixes", async () => {
+		const evaluatorMessages: ChatMessage[][] = [];
+		let plannerCalls = 0;
+		let evaluatorCalls = 0;
+		const runtime = {
+			useModel: vi.fn(async (modelType: string, params: unknown) => {
+				const messages = (params as { messages?: ChatMessage[] }).messages;
+				if (modelType === ModelType.RESPONSE_HANDLER) {
+					if (messages) {
+						evaluatorMessages.push(JSON.parse(JSON.stringify(messages)));
+					}
+					evaluatorCalls++;
+					return JSON.stringify({
+						success: true,
+						decision: evaluatorCalls === 1 ? "CONTINUE" : "FINISH",
+						thought: evaluatorCalls === 1 ? "Run the second lookup." : "Done.",
+						...(evaluatorCalls === 2 ? { messageToUser: "complete" } : {}),
+					});
+				}
+				plannerCalls++;
+				return plannerCalls === 1
+					? {
+							text: "",
+							toolCalls: [
+								{ id: "tc-first", name: "LOOKUP", arguments: { q: "first" } },
+							],
+						}
+					: {
+							text: "",
+							toolCalls: [
+								{ id: "tc-second", name: "LOOKUP", arguments: { q: "second" } },
+							],
+						};
+			}),
+		};
+
+		await runPlannerLoop({
+			runtime,
+			context: { id: "ctx-evaluator-prefix" },
+			tools: [TOOL_DEF],
+			executeToolCall: vi.fn(async (toolCall) => ({
+				success: true,
+				text: `result:${String(toolCall.params?.q)}`,
+			})),
+		});
+
+		expect(evaluatorMessages).toHaveLength(2);
+		const first = evaluatorMessages[0] ?? [];
+		const second = evaluatorMessages[1] ?? [];
+		expect(second.length).toBeGreaterThan(first.length);
+		for (let i = 0; i < first.length; i++) {
+			expect(JSON.stringify(second[i])).toBe(JSON.stringify(first[i]));
+		}
+		expect(JSON.stringify(second).match(/result:first/g)).toHaveLength(1);
+		expect(JSON.stringify(second).match(/result:second/g)).toHaveLength(1);
+	});
+
+	it("keeps local cache affinity stable across trajectories and separated by stage", async () => {
+		type CacheCapture = {
+			modelType: string;
+			conversationId?: string;
+			promptCacheKey?: string;
+		};
+		const captures: CacheCapture[] = [];
+
+		for (const trajectoryId of ["trajectory-a", "trajectory-b"]) {
+			const runtime = {
+				useModel: vi.fn(async (modelType: string, params: unknown) => {
+					const providerOptions = (
+						params as {
+							providerOptions?: {
+								eliza?: { conversationId?: string };
+								cerebras?: { prompt_cache_key?: string };
+							};
+						}
+					).providerOptions;
+					captures.push({
+						modelType,
+						conversationId: providerOptions?.eliza?.conversationId,
+						promptCacheKey: providerOptions?.cerebras?.prompt_cache_key,
+					});
+					if (modelType === ModelType.RESPONSE_HANDLER) {
+						return JSON.stringify({
+							success: true,
+							decision: "FINISH",
+							thought: "Done.",
+							messageToUser: "complete",
+						});
+					}
+					return {
+						text: "",
+						toolCalls: [
+							{ id: `tc-${trajectoryId}`, name: "LOOKUP", arguments: {} },
+						],
+					};
+				}),
+			};
+
+			await runPlannerLoop({
+				runtime,
+				context: { id: "same-context" },
+				tools: [TOOL_DEF],
+				trajectoryId,
+				cacheConversationId: "room-stable",
+				executeToolCall: vi.fn(async () => ({ success: true, text: "ok" })),
+			});
+		}
+
+		const planners = captures.filter(
+			(capture) => capture.modelType === ModelType.ACTION_PLANNER,
+		);
+		const evaluators = captures.filter(
+			(capture) => capture.modelType === ModelType.RESPONSE_HANDLER,
+		);
+		expect(planners.map((capture) => capture.conversationId)).toEqual([
+			"room-stable:planner",
+			"room-stable:planner",
+		]);
+		expect(evaluators.map((capture) => capture.conversationId)).toEqual([
+			"room-stable:evaluator",
+			"room-stable:evaluator",
+		]);
+		expect(planners[0]?.conversationId).not.toBe(evaluators[0]?.conversationId);
+		expect(planners[1]?.promptCacheKey).toBe(planners[0]?.promptCacheKey);
+		expect(evaluators[1]?.promptCacheKey).toBe(evaluators[0]?.promptCacheKey);
+	});
+
+	it("shows the evaluator complete pending calls and executes its recommendation", async () => {
+		const evaluatorMessages: ChatMessage[][] = [];
+		let evaluatorCalls = 0;
+		const runtime = {
+			useModel: vi.fn(async (modelType: string, params: unknown) => {
+				if (modelType === ModelType.RESPONSE_HANDLER) {
+					const messages =
+						(params as { messages?: ChatMessage[] }).messages ?? [];
+					evaluatorMessages.push(JSON.parse(JSON.stringify(messages)));
+					evaluatorCalls++;
+					return JSON.stringify(
+						evaluatorCalls === 1
+							? {
+									success: true,
+									decision: "NEXT_RECOMMENDED",
+									thought: "Execute the remaining planned lookup.",
+									recommendedToolCallId: "tc-second",
+								}
+							: {
+									success: true,
+									decision: "FINISH",
+									thought: "Both lookups completed.",
+									messageToUser: "complete",
+								},
+					);
+				}
+				return {
+					text: "",
+					toolCalls: [
+						{ id: "tc-first", name: "LOOKUP", arguments: { q: "first" } },
+						{
+							id: "tc-second",
+							name: "LOOKUP",
+							arguments: { q: "second", nested: { full: "arguments" } },
+						},
+					],
+				};
+			}),
+		};
+		const executeToolCall = vi.fn(async (toolCall) => ({
+			success: true,
+			text: `result:${String(toolCall.params?.q)}`,
+		}));
+
+		await runPlannerLoop({
+			runtime,
+			context: { id: "ctx-pending-queue" },
+			tools: [TOOL_DEF],
+			executeToolCall,
+		});
+
+		expect(executeToolCall).toHaveBeenCalledTimes(2);
+		expect(executeToolCall.mock.calls.map((call) => call[0]?.id)).toEqual([
+			"tc-first",
+			"tc-second",
+		]);
+		const firstEvaluatorPrompt = JSON.stringify(evaluatorMessages[0]);
+		expect(firstEvaluatorPrompt).toContain("pending_tool_calls");
+		expect(firstEvaluatorPrompt).toContain('\\"id\\": \\"tc-second\\"');
+		expect(firstEvaluatorPrompt).toContain('\\"nested\\": {');
+		expect(firstEvaluatorPrompt).toContain('\\"full\\": \\"arguments\\"');
+		expect(
+			firstEvaluatorPrompt.match(/tc-second/g)?.length,
+		).toBeGreaterThanOrEqual(1);
+		expect(firstEvaluatorPrompt).not.toContain("result:second");
+		expect(JSON.stringify(evaluatorMessages[1])).toContain("result:second");
 	});
 });

--- a/packages/core/src/runtime/__tests__/planner-loop.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop.test.ts
@@ -28,6 +28,18 @@ import {
 } from "../planner-loop";
 import type { RecordedStage, TrajectoryRecorder } from "../trajectory-recorder";
 
+function renderedMessagePrompt(
+	messages: Array<{ role?: string; content?: unknown }> | undefined,
+): string {
+	return (messages ?? [])
+		.map((message) =>
+			typeof message.content === "string"
+				? message.content
+				: JSON.stringify(message.content ?? null),
+		)
+		.join("\n\n");
+}
+
 describe("v5 planner loop skeleton", () => {
 	it("parses planner tool calls", () => {
 		const output = parsePlannerOutput(`{
@@ -2939,12 +2951,11 @@ describe("v5 planner loop skeleton", () => {
 
 		expect(runtime.useModel).toHaveBeenCalledTimes(2);
 		const retryParams = runtime.useModel.mock.calls[1]?.[1] as {
-			messages?: Array<{ role?: string; content?: string | null }>;
+			messages?: Array<{ role?: string; content?: unknown }>;
 		};
-		expect(retryParams.messages?.[1]?.content).toContain(
-			"previous planner response was not valid",
-		);
-		expect(retryParams.messages?.[1]?.content).toContain(
+		const retryPrompt = renderedMessagePrompt(retryParams.messages);
+		expect(retryPrompt).toContain("previous planner response was not valid");
+		expect(retryPrompt).toContain(
 			'do not answer with "saved", "done", or similar prose unless a tool call result proves the side effect happened',
 		);
 		expect(executeToolCall).toHaveBeenCalledWith(
@@ -4480,13 +4491,12 @@ describe("v5 planner loop skeleton", () => {
 
 		expect(runtime.useModel).toHaveBeenCalledTimes(2);
 		const retryParams = runtime.useModel.mock.calls[1]?.[1] as {
-			messages?: Array<{ role?: string; content?: string | null }>;
+			messages?: Array<{ role?: string; content?: unknown }>;
 		};
-		expect(retryParams.messages?.[1]?.content).toContain(
-			"unavailable_tool_calls",
-		);
-		expect(retryParams.messages?.[1]?.content).toContain("GET_PRICE");
-		expect(retryParams.messages?.[1]?.content).toContain("SHELL");
+		const retryPrompt = renderedMessagePrompt(retryParams.messages);
+		expect(retryPrompt).toContain("unavailable_tool_calls");
+		expect(retryPrompt).toContain("GET_PRICE");
+		expect(retryPrompt).toContain("SHELL");
 		expect(executeToolCall).toHaveBeenCalledTimes(1);
 		expect(executeToolCall).toHaveBeenCalledWith(
 			{
@@ -4623,9 +4633,9 @@ describe("v5 planner loop skeleton", () => {
 
 		expect(runtime.useModel).toHaveBeenCalledTimes(3);
 		const retryParams = runtime.useModel.mock.calls[1]?.[1] as {
-			messages?: Array<{ role?: string; content?: string | null }>;
+			messages?: Array<{ role?: string; content?: unknown }>;
 		};
-		expect(retryParams.messages?.[1]?.content).toContain(
+		expect(renderedMessagePrompt(retryParams.messages)).toContain(
 			"silent_failed_finish",
 		);
 		expect(executeToolCall).toHaveBeenCalledTimes(2);

--- a/packages/core/src/runtime/evaluator.ts
+++ b/packages/core/src/runtime/evaluator.ts
@@ -335,7 +335,9 @@ export async function runEvaluator(
 				segmentHashes: prefixHashes.map((entry) => entry.segmentHash),
 				promptSegments: input.promptSegments,
 				provider,
-				conversationId: params.trajectoryId,
+				conversationId: params.cacheConversationId
+					? `${params.cacheConversationId}:evaluator`
+					: params.trajectoryId,
 			}),
 			budget,
 		) as Record<string, unknown> & { eliza?: Record<string, unknown> };
@@ -771,14 +773,18 @@ function renderEvaluatorModelInput(params: {
 	promptSegments: PromptSegment[];
 	cacheKeySegments: PromptSegment[];
 } {
-	const renderedContext = renderContextObject(params.context);
+	const renderedContext = renderContextObject(
+		params.trajectory.modelBaseContext ?? params.context,
+	);
 	const template = params.template ?? evaluatorTemplate;
 	const instructions = (
 		template.split("context_object:")[0] ?? template
 	).trim();
-	const stepMessages = trajectoryStepsToMessages(params.trajectory.steps, {
-		redactText: params.redactText,
-	});
+	const stepMessages =
+		params.trajectory.modelHistory ??
+		trajectoryStepsToMessages(params.trajectory.steps, {
+			redactText: params.redactText,
+		});
 	// Mirrors planner-loop: the evaluator stage instructions are template-derived
 	// (`evaluatorTemplate`) and structurally identical across calls. Marking
 	// the segment `stable: true` makes them cacheable on Anthropic's wire path.

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -21,6 +21,7 @@ import { parseInteractionBlocks } from "../messaging/interactions/parse";
 import { plannerSchema, plannerTemplate } from "../prompts/planner";
 import {
 	composeToolDiagnosticRedactor,
+	projectCompleteToolArgsForModel,
 	projectToolDiagnosticArgs,
 	projectToolDiagnosticValue,
 	type ToolDiagnosticTextRedactor,
@@ -76,6 +77,7 @@ import {
 	buildStageChatMessages,
 	normalizePromptSegments,
 	renderContextObject,
+	segmentBlock,
 } from "./context-renderer";
 import { runEvaluator } from "./evaluator";
 import {
@@ -381,6 +383,7 @@ async function runPlannerLoopIterations(
 		: plannerContext;
 	const trajectory: PlannerTrajectory = {
 		context: trajectoryContext,
+		modelBaseContext: trajectoryContext,
 		codingMode,
 		steps: postToolReplySeed
 			? [
@@ -395,6 +398,9 @@ async function runPlannerLoopIterations(
 		plannedQueue: [],
 		evaluatorOutputs: [],
 	};
+	trajectory.modelHistory = trajectoryStepsToMessages(trajectory.steps, {
+		redactText: redactDiagnosticText,
+	});
 	const failures: FailureLike[] = [];
 	let terminalOnlyContinuations = 0;
 	let codingVerificationDeferrals = 0;
@@ -682,6 +688,7 @@ async function runPlannerLoopIterations(
 							: params.toolChoice,
 					recorder: params.recorder,
 					trajectoryId: params.trajectoryId,
+					cacheConversationId: params.cacheConversationId,
 					parentStageId: params.parentStageId,
 					providerAttributionState: params.providerAttributionState,
 					iteration,
@@ -867,8 +874,8 @@ async function runPlannerLoopIterations(
 					terminalMessage: finalMessage,
 					terminalOnly: true,
 				});
-				trajectory.context = appendTerminalPlannerOutputEvent({
-					context: trajectory.context,
+				appendTerminalPlannerOutputEvent({
+					trajectory,
 					iteration,
 					message: finalMessage,
 				});
@@ -884,12 +891,12 @@ async function runPlannerLoopIterations(
 						redactDiagnosticText,
 					) as EvaluatorOutput,
 				);
-				trajectory.context = appendEvaluationEvent({
-					context: trajectory.context,
+				appendEvaluatorContextEvent(
+					trajectory,
+					gated,
 					iteration,
-					evaluator: gated,
 					redactDiagnosticText,
-				});
+				);
 				const gateStartedAt = Date.now();
 				await recordGatedEvaluationStage({
 					runtime: params.runtime,
@@ -1016,8 +1023,8 @@ async function runPlannerLoopIterations(
 					terminalMessage: plannerOutput.messageToUser,
 					terminalOnly: true,
 				});
-				trajectory.context = appendTerminalPlannerOutputEvent({
-					context: trajectory.context,
+				appendTerminalPlannerOutputEvent({
+					trajectory,
 					iteration,
 					message: plannerOutput.messageToUser,
 				});
@@ -1052,12 +1059,12 @@ async function runPlannerLoopIterations(
 							redactDiagnosticText,
 						) as EvaluatorOutput,
 					);
-					trajectory.context = appendEvaluationEvent({
-						context: trajectory.context,
-						iteration,
+					appendEvaluatorContextEvent(
+						trajectory,
 						evaluator,
+						iteration,
 						redactDiagnosticText,
-					});
+					);
 					const protocolFailureRelay =
 						deterministicEvaluatorProtocolFailureRelay(evaluator, trajectory);
 					if (protocolFailureRelay) {
@@ -1168,8 +1175,8 @@ async function runPlannerLoopIterations(
 						observed: terminalOnlyContinuations,
 					});
 					trajectory.plannedQueue.length = 0;
-					trajectory.context = appendTerminalContinuationEvent({
-						context: trajectory.context,
+					appendTerminalContinuationEvent({
+						trajectory,
 						iteration,
 						terminalOnlyContinuations,
 						message: plannerOutput.messageToUser,
@@ -1330,12 +1337,12 @@ async function runPlannerLoopIterations(
 						redactDiagnosticText,
 					) as EvaluatorOutput,
 				);
-				trajectory.context = appendEvaluationEvent({
-					context: trajectory.context,
+				appendEvaluatorContextEvent(
+					trajectory,
+					terminalEvaluator,
 					iteration,
-					evaluator: terminalEvaluator,
 					redactDiagnosticText,
-				});
+				);
 				if (shouldRecordTerminalEvaluation) {
 					const terminalEvalStartedAt = Date.now();
 					await recordGatedEvaluationStage({
@@ -1427,8 +1434,8 @@ async function runPlannerLoopIterations(
 					},
 					"Planner called unavailable tools; retrying without executing them",
 				);
-				trajectory.context = appendUnavailableToolCallEvent({
-					context: trajectory.context,
+				appendUnavailableToolCallEvent({
+					trajectory,
 					iteration,
 					invalidToolCalls: unavailable.invalid,
 					tools: params.tools,
@@ -1476,7 +1483,7 @@ async function runPlannerLoopIterations(
 							"different tool or different arguments.",
 					);
 				}
-				trajectory.context = appendContextEvent(trajectory.context, {
+				appendPlannerModelFeedbackEvent(trajectory, {
 					id: `redundant-tool-call:${iteration}`,
 					type: "instruction",
 					source: "planner-loop",
@@ -1548,7 +1555,7 @@ async function runPlannerLoopIterations(
 						`The per-turn memory search budget (${config.maxMemorySearchRounds}) is spent.`,
 					);
 				}
-				trajectory.context = appendContextEvent(trajectory.context, {
+				appendPlannerModelFeedbackEvent(trajectory, {
 					id: `memory-search-budget:${iteration}`,
 					type: "instruction",
 					source: "planner-loop",
@@ -1694,6 +1701,14 @@ async function runPlannerLoopIterations(
 			continue;
 		}
 
+		if (trajectory.plannedQueue.length > 0) {
+			appendPendingToolQueueFeedbackEvent(
+				trajectory,
+				iteration,
+				redactDiagnosticText,
+			);
+		}
+
 		if (
 			latestResult?.success === true &&
 			latestResult.modelReplyRequired === true &&
@@ -1726,12 +1741,12 @@ async function runPlannerLoopIterations(
 					redactDiagnosticText,
 				) as EvaluatorOutput,
 			);
-			trajectory.context = appendEvaluationEvent({
-				context: trajectory.context,
+			appendEvaluatorContextEvent(
+				trajectory,
+				gated,
 				iteration,
-				evaluator: gated,
 				redactDiagnosticText,
-			});
+			);
 			await recordGatedEvaluationStage({
 				runtime: params.runtime,
 				recorder: params.recorder,
@@ -1845,11 +1860,10 @@ async function runPlannerLoopIterations(
 				})
 			) {
 				silentFailedFinishRecoveries++;
-				trajectory.context = appendSilentFailedFinishRecoveryEvent({
-					context: trajectory.context,
+				appendSilentFailedFinishRecoveryEvent({
+					trajectory,
 					iteration,
 					evaluator,
-					trajectory,
 				});
 				continue;
 			}
@@ -1908,6 +1922,71 @@ function normalizePlannerContext(context: ContextObject): ContextObject {
 			};
 }
 
+/**
+ * Retains a loop-generated event for observability and appends its complete
+ * model representation after the existing assistant/tool suffix. The initial
+ * turn context stays immutable, so every later request within the same model
+ * stage has the preceding same-stage request as a byte-identical prefix.
+ */
+function appendPlannerModelFeedbackEvent(
+	trajectory: PlannerTrajectory,
+	event: ContextEvent,
+): void {
+	trajectory.context = appendContextEvent(trajectory.context, event);
+	if (!trajectory.modelHistory) return;
+	const rendered = renderContextObject({
+		id: `model-feedback:${event.id}`,
+		events: [event],
+	});
+	const content = rendered.promptSegments
+		.map(segmentBlock)
+		.filter((block) => block.length > 0)
+		.join("\n\n");
+	if (content.length > 0) {
+		trajectory.modelHistory.push({ role: "user", content });
+	}
+}
+
+function appendPlannerToolStepToModelHistory(
+	trajectory: PlannerTrajectory,
+	step: PlannerStep,
+	redactText: ToolDiagnosticTextRedactor,
+): void {
+	if (!trajectory.modelHistory) return;
+	trajectory.modelHistory.push(
+		...trajectoryStepsToMessages([step], { redactText }),
+	);
+}
+
+function appendPendingToolQueueFeedbackEvent(
+	trajectory: PlannerTrajectory,
+	iteration: number,
+	redactText: ToolDiagnosticTextRedactor,
+): void {
+	const pendingCalls = trajectory.plannedQueue.map((toolCall) => ({
+		id: toolCall.id ?? toolCall.name,
+		name: toolCall.name,
+		params:
+			projectCompleteToolArgsForModel(toolCall.params ?? {}, redactText) ?? {},
+		status: "queued" as const,
+	}));
+	appendPlannerModelFeedbackEvent(trajectory, {
+		id: `pending-tool-queue:${iteration}`,
+		type: "instruction",
+		source: "planner-loop",
+		createdAt: Date.now(),
+		content: [
+			"pending_tool_calls:",
+			stringifyForModel(pendingCalls),
+			"The listed calls came from the same planner response and have not executed yet. Decide NEXT_RECOMMENDED with the selected call id to execute one, FINISH only if every pending call is unnecessary, or CONTINUE to discard this queue and replan.",
+		].join("\n"),
+		metadata: {
+			iteration,
+			pendingToolCallIds: pendingCalls.map((call) => call.id),
+		},
+	});
+}
+
 function renderPlannerModelInput(params: {
 	context: ContextObject;
 	trajectory: PlannerTrajectory;
@@ -1919,7 +1998,9 @@ function renderPlannerModelInput(params: {
 	promptSegments: PromptSegment[];
 	cacheKeySegments: PromptSegment[];
 } {
-	const renderedContext = renderContextObject(params.context);
+	const renderedContext = renderContextObject(
+		params.trajectory.modelBaseContext ?? params.context,
+	);
 	const template = params.template ?? plannerTemplate;
 	const instructions = (
 		params.codingMode
@@ -1928,9 +2009,11 @@ function renderPlannerModelInput(params: {
 					template.split("context_object:")[0] ?? template,
 				)
 	).trim();
-	const stepMessages = trajectoryStepsToMessages(params.trajectory.steps, {
-		redactText: composeToolDiagnosticRedactor(params.runtime),
-	});
+	const stepMessages =
+		params.trajectory.modelHistory ??
+		trajectoryStepsToMessages(params.trajectory.steps, {
+			redactText: composeToolDiagnosticRedactor(params.runtime),
+		});
 	// Action names + parameter schemas now ride directly on the tools array
 	// (each Action is exposed as its own native tool), so there is no separate
 	// available_actions block rendered into the prompt. Routing hints stay as a
@@ -2456,6 +2539,7 @@ async function callPlanner(params: {
 	toolChoice?: ToolChoice;
 	recorder?: TrajectoryRecorder;
 	trajectoryId?: string;
+	cacheConversationId?: string;
 	parentStageId?: string;
 	providerAttributionState?: PlannerLoopParams["providerAttributionState"];
 	iteration?: number;
@@ -2512,7 +2596,9 @@ async function callPlanner(params: {
 			promptSegments: renderedInput.promptSegments,
 			provider: params.provider,
 			hasTools,
-			conversationId: params.trajectoryId,
+			conversationId: params.cacheConversationId
+				? `${params.cacheConversationId}:planner`
+				: params.trajectoryId,
 		}),
 	};
 	const configuredMaxTokens = resolvePlannerMaxTokens(
@@ -2906,24 +2992,24 @@ async function evaluateTrajectory(
 		effects: params.evaluatorEffects,
 		recorder: params.recorder,
 		trajectoryId: params.trajectoryId,
+		cacheConversationId: params.cacheConversationId,
 		parentStageId: params.parentStageId,
 		iteration,
 		onUsage: params.onModelUsage,
 	});
 }
 
-function appendEvaluationEvent(args: {
-	context: ContextObject;
+function evaluationContextEvent(args: {
 	iteration: number;
 	evaluator: EvaluatorOutput;
 	redactDiagnosticText?: ToolDiagnosticTextRedactor;
-}): ContextObject {
+}): ContextEvent {
 	const createdAt = Date.now();
 	const evaluator = projectToolDiagnosticValue(
 		args.evaluator,
 		args.redactDiagnosticText ?? composeToolDiagnosticRedactor(),
 	) as EvaluatorOutput;
-	return appendContextEvent(args.context, {
+	return {
 		id: `evaluation:${args.iteration}:${createdAt}`,
 		type: "evaluation",
 		source: "planner-loop",
@@ -2938,7 +3024,7 @@ function appendEvaluationEvent(args: {
 			protocolFailure: evaluator.protocolFailure,
 			parseError: evaluator.parseError,
 		},
-	});
+	};
 }
 
 function appendEvaluatorContextEvent(
@@ -2947,19 +3033,21 @@ function appendEvaluatorContextEvent(
 	iteration: number,
 	redactDiagnosticText?: ToolDiagnosticTextRedactor,
 ): void {
-	trajectory.context = appendEvaluationEvent({
-		context: trajectory.context,
-		iteration,
-		evaluator,
-		redactDiagnosticText,
-	});
+	appendPlannerModelFeedbackEvent(
+		trajectory,
+		evaluationContextEvent({
+			iteration,
+			evaluator,
+			redactDiagnosticText,
+		}),
+	);
 }
 
 function appendTerminalPlannerOutputEvent(args: {
-	context: ContextObject;
+	trajectory: PlannerTrajectory;
 	iteration: number;
 	message?: string;
-}): ContextObject {
+}): void {
 	const createdAt = Date.now();
 	const unsafe = isUnsafeUserVisibleText(args.message);
 	const content = [
@@ -2970,7 +3058,7 @@ function appendTerminalPlannerOutputEvent(args: {
 			? "note: This output looked like internal planning or attempted tool-call text. It must not be shown directly to the user."
 			: "note: Evaluate whether this user-visible output actually completes the request.",
 	].join("\n");
-	return appendContextEvent(args.context, {
+	appendPlannerModelFeedbackEvent(args.trajectory, {
 		id: `terminal-planner-output:${args.iteration}:${createdAt}`,
 		type: "segment",
 		source: "planner-loop",
@@ -2993,11 +3081,11 @@ function appendTerminalPlannerOutputEvent(args: {
 }
 
 function appendTerminalContinuationEvent(args: {
-	context: ContextObject;
+	trajectory: PlannerTrajectory;
 	iteration: number;
 	terminalOnlyContinuations: number;
 	message?: string;
-}): ContextObject {
+}): void {
 	const createdAt = Date.now();
 	const unsafe = isUnsafeUserVisibleText(args.message);
 	const content = [
@@ -3008,7 +3096,7 @@ function appendTerminalContinuationEvent(args: {
 			: "The evaluator found the previous terminal planner output partial. Emit native toolCalls for remaining work.",
 		'If the user asked you to save, schedule, send, update, remember, or complete something, do not answer with "saved", "done", or similar prose unless a tool call result proves the side effect happened.',
 	].join("\n");
-	return appendContextEvent(args.context, {
+	appendPlannerModelFeedbackEvent(args.trajectory, {
 		id: `terminal-planner-retry:${args.iteration}:${createdAt}`,
 		type: "segment",
 		source: "planner-loop",
@@ -3033,11 +3121,11 @@ function appendTerminalContinuationEvent(args: {
 }
 
 function appendUnavailableToolCallEvent(args: {
-	context: ContextObject;
+	trajectory: PlannerTrajectory;
 	iteration: number;
 	invalidToolCalls: readonly PlannerToolCall[];
 	tools?: ToolDefinition[];
-}): ContextObject {
+}): void {
 	const createdAt = Date.now();
 	const exposed = Array.from(exposedToolNameSet(args.tools) ?? []).sort();
 	const invalid = args.invalidToolCalls.map((toolCall) => toolCall.name);
@@ -3047,7 +3135,7 @@ function appendUnavailableToolCallEvent(args: {
 		`available_tools: ${JSON.stringify(exposed)}`,
 		"The previous planner output called tools that were not exposed for this turn. Retry using only available_tools, or return a terminal REPLY if no exposed tool fits.",
 	].join("\n");
-	return appendContextEvent(args.context, {
+	appendPlannerModelFeedbackEvent(args.trajectory, {
 		id: `unavailable-tool-call-retry:${args.iteration}:${createdAt}`,
 		type: "instruction",
 		source: "planner-loop",
@@ -3062,11 +3150,10 @@ function appendUnavailableToolCallEvent(args: {
 }
 
 function appendSilentFailedFinishRecoveryEvent(args: {
-	context: ContextObject;
+	trajectory: PlannerTrajectory;
 	iteration: number;
 	evaluator: EvaluatorOutput;
-	trajectory: PlannerTrajectory;
-}): ContextObject {
+}): void {
 	const createdAt = Date.now();
 	const failedStep = latestFailedToolStep(args.trajectory);
 	const failedToolName = failedStep?.toolCall?.name;
@@ -3085,7 +3172,7 @@ function appendSilentFailedFinishRecoveryEvent(args: {
 	]
 		.filter((line): line is string => line !== null)
 		.join("\n");
-	return appendContextEvent(args.context, {
+	appendPlannerModelFeedbackEvent(args.trajectory, {
 		id: `silent-failed-finish-retry:${args.iteration}:${createdAt}`,
 		type: "instruction",
 		source: "planner-loop",
@@ -3210,11 +3297,17 @@ async function executeQueuedToolCall(params: {
 		});
 	}
 
-	params.trajectory.steps.push({
+	const completedStep: PlannerStep = {
 		iteration: params.iteration,
 		toolCall: params.toolCall,
 		result,
-	});
+	};
+	params.trajectory.steps.push(completedStep);
+	appendPlannerToolStepToModelHistory(
+		params.trajectory,
+		completedStep,
+		redactDiagnosticText,
+	);
 	params.trajectory.context = {
 		...params.trajectory.context,
 		plannedQueue: (params.trajectory.context.plannedQueue ?? []).map((entry) =>
@@ -4568,7 +4661,7 @@ function handleRequiredToolPlannerMiss(params: {
 		},
 		"Planner returned terminal output before satisfying a required tool call; retrying",
 	);
-	params.trajectory.context = appendContextEvent(params.trajectory.context, {
+	appendPlannerModelFeedbackEvent(params.trajectory, {
 		id: `required-tool-retry:${params.iteration}:${params.reason}`,
 		type: "instruction",
 		source: "planner-loop",
@@ -4908,7 +5001,7 @@ async function finishWithForcedSynthesis(params: {
 			},
 		};
 	}
-	trajectory.context = appendContextEvent(trajectory.context, {
+	appendPlannerModelFeedbackEvent(trajectory, {
 		id: `force-synthesis:${iteration}`,
 		type: "instruction",
 		source: "planner-loop",
@@ -4941,6 +5034,7 @@ async function finishWithForcedSynthesis(params: {
 		tools: undefined,
 		recorder: loop.recorder,
 		trajectoryId: loop.trajectoryId,
+		cacheConversationId: loop.cacheConversationId,
 		parentStageId: loop.parentStageId,
 		providerAttributionState: loop.providerAttributionState,
 		iteration,
@@ -6167,7 +6261,7 @@ function failedStepCauseForPrompt(step: PlannerStep): string | undefined {
  *
  * On any single ambiguity the function returns `null` and the caller falls
  * through to the full evaluator path. Returning a synthesized `EvaluatorOutput`
- * preserves trajectory observability: `appendEvaluationEvent` still records
+ * preserves trajectory observability: the evaluator event still records
  * the decision in the context event stream, `trajectory.evaluatorOutputs` still
  * gets the entry, and the loop's return value still carries `evaluator` in the
  * shape consumers (`subPlannerResultToPlannerToolResult` in `services/message.ts`)

--- a/packages/core/src/runtime/planner-types.ts
+++ b/packages/core/src/runtime/planner-types.ts
@@ -229,6 +229,10 @@ export interface PlannerStep {
 
 export interface PlannerTrajectory {
 	context: ContextObject;
+	/** Immutable turn context used as the byte-stable model prefix. */
+	modelBaseContext?: ContextObject;
+	/** Complete append-only assistant/tool/feedback suffix sent to the model. */
+	modelHistory?: ChatMessage[];
 	/** Internal execution-mode provenance for mode-specific terminal handling. */
 	codingMode?: boolean;
 	steps: PlannerStep[];
@@ -383,6 +387,8 @@ export interface PlannerLoopParams {
 	 */
 	recorder?: TrajectoryRecorder;
 	trajectoryId?: string;
+	/** Stable room/session identity used only for provider prompt-cache affinity. */
+	cacheConversationId?: string;
 	parentStageId?: string;
 	providerAttributionState?: State;
 }
@@ -396,6 +402,8 @@ export interface RunEvaluatorParams {
 	provider?: string;
 	recorder?: TrajectoryRecorder;
 	trajectoryId?: string;
+	/** Stable room/session identity used only for provider prompt-cache affinity. */
+	cacheConversationId?: string;
 	parentStageId?: string;
 	iteration?: number;
 	onUsage?: (usage: { promptTokens: number; completionTokens: number }) => void;

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -9795,10 +9795,12 @@ export async function runV5MessageRuntimeStage1(args: {
 								effects: evaluatorEffects,
 								recorder,
 								trajectoryId,
+								cacheConversationId: String(args.message.roomId),
 							}),
 						evaluatorEffects,
 						recorder,
 						trajectoryId,
+						cacheConversationId: String(args.message.roomId),
 						providerAttributionState: plannerState,
 					});
 				}
@@ -9895,6 +9897,7 @@ export async function runV5MessageRuntimeStage1(args: {
 					evaluatorEffects,
 					recorder,
 					trajectoryId,
+					cacheConversationId: String(args.message.roomId),
 					providerAttributionState: plannerState,
 					executeToolCall: (toolCall, ctx) =>
 						timeInferenceSpan(
@@ -9953,6 +9956,7 @@ export async function runV5MessageRuntimeStage1(args: {
 								effects: evaluatorEffects,
 								recorder,
 								trajectoryId,
+								cacheConversationId: String(args.message.roomId),
 							}),
 						),
 				}),

--- a/plugins/plugin-local-inference/__tests__/text-handler.test.ts
+++ b/plugins/plugin-local-inference/__tests__/text-handler.test.ts
@@ -115,6 +115,53 @@ describe("provider TEXT_SMALL / TEXT_LARGE dispatch", () => {
 		);
 	});
 
+	it("prefers complete chat history over prompt segments and preserves native tool parts", async () => {
+		const generate = vi.fn(async () => "ok");
+		const handlers = createLocalInferenceModelHandlers();
+		const runtime = runtimeWithService({ generate });
+
+		await handlers[ModelType.TEXT_LARGE]?.(runtime as never, {
+			messages: [
+				{ role: "system", content: "You are a coding agent." },
+				{
+					role: "assistant",
+					content: [
+						{
+							type: "tool-call",
+							toolCallId: "call-1",
+							toolName: "SHELL",
+							input: { command: "go test ./..." },
+						},
+					],
+				},
+				{
+					role: "tool",
+					content: [
+						{
+							type: "tool-result",
+							toolCallId: "call-1",
+							toolName: "SHELL",
+							output: { type: "text", value: "PASS\nok package" },
+						},
+					],
+				},
+				{ role: "user", content: "verification_feedback: continue" },
+			],
+			promptSegments: [{ content: "STALE_SEGMENT_SENTINEL" }],
+		} as never);
+
+		const prompt = String(generate.mock.calls[0]?.[0]?.prompt);
+		expect(prompt).not.toContain("STALE_SEGMENT_SENTINEL");
+		expect(prompt).toContain(
+			'assistant:\n[{"type":"tool-call","toolCallId":"call-1","toolName":"SHELL","input":{"command":"go test ./..."}}]',
+		);
+		expect(prompt).toContain(
+			'tool:\n[{"type":"tool-result","toolCallId":"call-1","toolName":"SHELL","output":{"type":"text","value":"PASS\\nok package"}}]',
+		);
+		expect(prompt.match(/PASS\\nok package/g)).toHaveLength(1);
+		expect(prompt).toContain("user:\nverification_feedback: continue");
+	});
+
 	it("emits a typed LOCAL_INFERENCE_UNAVAILABLE error when no loader is registered (runtime then falls through to next provider)", async () => {
 		const handlers = createLocalInferenceModelHandlers();
 		let caught: unknown;

--- a/plugins/plugin-local-inference/src/provider.ts
+++ b/plugins/plugin-local-inference/src/provider.ts
@@ -17,6 +17,7 @@
 import {
 	type AudioStreamResult,
 	applyBackgroundInferenceBudget,
+	canonicalPromptForModelCall,
 	EventType,
 	type GenerateTextParams,
 	getInferencePriorityGate,
@@ -288,21 +289,6 @@ function renderPromptContent(content: unknown): string {
 	return "";
 }
 
-function promptFromMessages(messages: readonly MessageLike[]): string {
-	return messages
-		.map((message) => {
-			const content = renderPromptContent(message.content);
-			if (!content) return "";
-			const role =
-				typeof message.role === "string" && message.role.trim()
-					? message.role.trim()
-					: "message";
-			return `${role}:\n${content}`;
-		})
-		.filter(Boolean)
-		.join("\n\n");
-}
-
 function promptFromParams(params: GenerateTextParams): string {
 	const record = params as GenerateTextParams & {
 		messages?: readonly MessageLike[];
@@ -311,12 +297,13 @@ function promptFromParams(params: GenerateTextParams): string {
 	const prompt =
 		typeof params.prompt === "string" && params.prompt.length > 0
 			? params.prompt
-			: Array.isArray(record.promptSegments) && record.promptSegments.length > 0
-				? record.promptSegments
-						.map((segment) => renderPromptContent(segment.content))
-						.join("")
-				: Array.isArray(record.messages) && record.messages.length > 0
-					? promptFromMessages(record.messages)
+			: Array.isArray(record.messages) && record.messages.length > 0
+				? canonicalPromptForModelCall({ messages: record.messages })
+				: Array.isArray(record.promptSegments) &&
+						record.promptSegments.length > 0
+					? record.promptSegments
+							.map((segment) => renderPromptContent(segment.content))
+							.join("")
 					: "";
 	if (typeof prompt !== "string" || prompt.trim().length === 0) {
 		throw unavailable(

--- a/plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.test.ts
+++ b/plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.test.ts
@@ -437,6 +437,50 @@ describe("ensureLocalInferenceHandler", () => {
 		);
 	});
 
+	it("uses the complete native tool history when prompt segments are also present", async () => {
+		const { registrations, runtime } = makeRuntime();
+		engineState.hasLoadedModel.mockReturnValue(true);
+
+		await ensureLocalInferenceHandler(runtime);
+		const handler = findRegisteredHandler(registrations, ModelType.TEXT_SMALL);
+
+		await handler(runtime, {
+			messages: [
+				{ role: "system", content: "You are Eliza." },
+				{
+					role: "assistant",
+					content: [
+						{
+							type: "tool-call",
+							toolCallId: "call-2",
+							toolName: "READ_FILE",
+							input: { path: "README.md" },
+						},
+					],
+				},
+				{
+					role: "tool",
+					content: [
+						{
+							type: "tool-result",
+							toolCallId: "call-2",
+							toolName: "READ_FILE",
+							output: { type: "text", value: "complete file bytes" },
+						},
+					],
+				},
+			],
+			promptSegments: [{ content: "STALE_SEGMENT_SENTINEL" }],
+		});
+
+		const prompt = String(engineState.generate.mock.calls.at(-1)?.[0]?.prompt);
+		expect(prompt).not.toContain("STALE_SEGMENT_SENTINEL");
+		expect(prompt).toContain('"type":"tool-call"');
+		expect(prompt).toContain('"input":{"path":"README.md"}');
+		expect(prompt).toContain('"type":"tool-result"');
+		expect(prompt.match(/complete file bytes/g)).toHaveLength(1);
+	});
+
 	it("uses a fine-grained maxTokensPerStep for user-visible streaming, coarse for internal calls", async () => {
 		const prior = process.env.ELIZA_LOCAL_STREAM_TOKENS_PER_STEP;
 		delete process.env.ELIZA_LOCAL_STREAM_TOKENS_PER_STEP;

--- a/plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.ts
+++ b/plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.ts
@@ -24,6 +24,7 @@
 import {
 	type AgentRuntime,
 	applyBackgroundInferenceBudget,
+	canonicalPromptForModelCall,
 	fetchRemoteMedia,
 	type GenerateTextParams,
 	getInferencePriorityGate,
@@ -412,39 +413,13 @@ function engineGenerateArgsFromParams(
 	maxTokensPerStep?: number;
 	voiceOutput?: "user-visible" | "internal";
 } {
-	const renderContent = (content: unknown): string => {
-		if (typeof content === "string") return content;
-		if (Array.isArray(content)) {
-			return content
-				.map((part) => {
-					if (typeof part === "string") return part;
-					if (
-						part &&
-						typeof part === "object" &&
-						typeof (part as { text?: unknown }).text === "string"
-					) {
-						return (part as { text: string }).text;
-					}
-					return "";
-				})
-				.filter(Boolean)
-				.join("\n");
-		}
-		return "";
-	};
+	const promptFromMessages =
+		params.messages && params.messages.length > 0
+			? canonicalPromptForModelCall({ messages: params.messages })
+			: "";
 	const promptFromSegments =
 		params.promptSegments && params.promptSegments.length > 0
 			? params.promptSegments.map((segment) => segment.content).join("")
-			: "";
-	const promptFromMessages =
-		!promptFromSegments && params.messages && params.messages.length > 0
-			? params.messages
-					.map((message) => {
-						const content = renderContent(message.content);
-						return content ? `${message.role}:\n${content}` : "";
-					})
-					.filter(Boolean)
-					.join("\n\n")
 			: "";
 	const streamStructured = params.streamStructured === true;
 	// Surface per-token chunks to the caller only when it requested streaming.
@@ -456,7 +431,7 @@ function engineGenerateArgsFromParams(
 			? (chunk: string) => params.onStreamChunk?.(chunk)
 			: undefined;
 	return {
-		prompt: params.prompt ?? (promptFromSegments || promptFromMessages),
+		prompt: params.prompt ?? (promptFromMessages || promptFromSegments),
 		stopSequences: mergeElizaTurnStopSequences(params.stopSequences),
 		cacheKey,
 		signal: params.signal,


### PR DESCRIPTION
## Summary

Closes the planner/evaluator context-locality portion of #24299.

- keeps each turn's rendered base context immutable and appends complete assistant/tool/evaluator/retry history instead of rewriting the second chat message on every iteration
- assigns stable room-scoped, stage-separated local cache identities (`<room>:planner` / `<room>:evaluator`) while preserving the shared provider prefix key
- preserves pending multi-tool calls as complete redacted append-only feedback before ordinary-chat evaluation, so `NEXT_RECOMMENDED` can execute the remaining call
- makes both local-inference text adapters prefer the complete chat-message ledger over duplicate prompt segments and losslessly serialize native tool-call/tool-result parts
- retains the evolving context event stream for trajectory observability; no truncation, compaction, slicing, or tool-result omission

## Consumer-visible failure fixed

Previously, evaluator/tool/retry events were appended into the context object and the entire context user message was re-rendered. That changed bytes before the existing assistant/tool suffix, destroying prefix-cache locality. The local-inference adapters compounded this by selecting `promptSegments`, which do not carry the assistant/tool history, whenever both representations were present.

A multi-tool ordinary-chat response also needs its still-queued calls in the evaluator input. The new ledger records the pending call IDs, names, complete non-secret arguments, and status before evaluation; the default-evaluator regression proves the recommended second call executes.

## Exact-head verification

Head: `12d13e83f1c81`
Base at verification: `78a866181f481`

- `bunx vitest run src/runtime/__tests__/planner-loop.test.ts src/runtime/__tests__/planner-loop-message-stacking.test.ts src/__tests__/planner-happy-path.test.ts` from `packages/core`: 257 passed
- `bun run typecheck` from `packages/core`: passed
- `bun run typecheck` from `plugins/plugin-local-inference`: passed
- `NODE_OPTIONS='--experimental-sqlite' bunx vitest run __tests__/text-handler.test.ts src/runtime/ensure-local-inference-handler.test.ts` from `plugins/plugin-local-inference`: 38 passed
- changed-file Biome check: passed
- `git diff --check`: passed
- independent read-only review: no blocking findings after the pending-queue repair

## Evidence boundary

These deterministic tests prove byte-prefix stability, stage-scoped affinity, exact-once tool-result serialization, full pending arguments, and recommended-call execution. Post-merge controlled-model benchmark traces are still required before attributing a live cache-hit or task-quality improvement to this change.
