### PR TITLE
fix(mcp): reject array toolArguments in selection guard

### DIFF
--- a/plugins/plugin-mcp/src/utils/schemas.test.ts
+++ b/plugins/plugin-mcp/src/utils/schemas.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { isResourceSelection, isToolSelectionArgument, isToolSelectionName } from "./schemas";
+
+describe("isToolSelectionName", () => {
+  it("accepts a selection with non-empty server and tool names", () => {
+    expect(isToolSelectionName({ serverName: "mcp-server", toolName: "read" })).toBe(true);
+  });
+
+  it("rejects non-objects and null", () => {
+    expect(isToolSelectionName(null)).toBe(false);
+    expect(isToolSelectionName("mcp-server")).toBe(false);
+    expect(isToolSelectionName(undefined)).toBe(false);
+    expect(isToolSelectionName([1])).toBe(false);
+  });
+
+  it("rejects empty or missing required names", () => {
+    expect(isToolSelectionName({ serverName: "", toolName: "read" })).toBe(false);
+    expect(isToolSelectionName({ serverName: "srv", toolName: "" })).toBe(false);
+    expect(isToolSelectionName({ serverName: "srv" })).toBe(false);
+    expect(isToolSelectionName({ toolName: "read" })).toBe(false);
+    expect(isToolSelectionName({})).toBe(false);
+  });
+
+  it("ignores optional reasoning/noToolAvailable fields", () => {
+    expect(
+      isToolSelectionName({
+        serverName: "srv",
+        toolName: "read",
+        reasoning: "because",
+        noToolAvailable: false,
+      })
+    ).toBe(true);
+  });
+});
+
+describe("isToolSelectionArgument", () => {
+  it("accepts a plain object toolArguments", () => {
+    expect(isToolSelectionArgument({ toolArguments: { query: "x", limit: 5 } })).toBe(true);
+    expect(isToolSelectionArgument({ toolArguments: {} })).toBe(true);
+  });
+
+  it("rejects null, missing, and non-object toolArguments", () => {
+    expect(isToolSelectionArgument({ toolArguments: null })).toBe(false);
+    expect(isToolSelectionArgument({})).toBe(false);
+    expect(isToolSelectionArgument({ toolArguments: "query" })).toBe(false);
+    expect(isToolSelectionArgument({ toolArguments: 42 })).toBe(false);
+  });
+
+  it("rejects array toolArguments despite typeof object", () => {
+    // The declared JSON schema types toolArguments as { "type": "object" },
+    // which excludes arrays; the guard must match the schema.
+    expect(isToolSelectionArgument({ toolArguments: [1, 2] })).toBe(false);
+  });
+
+  it("rejects non-object frames", () => {
+    expect(isToolSelectionArgument(null)).toBe(false);
+    expect(isToolSelectionArgument([{ toolArguments: {} }])).toBe(false);
+    expect(isToolSelectionArgument("x")).toBe(false);
+  });
+});
+
+describe("isResourceSelection", () => {
+  it("accepts a selection with non-empty server name and uri", () => {
+    expect(isResourceSelection({ serverName: "mcp-server", uri: "mem://topic/1" })).toBe(true);
+  });
+
+  it("rejects empty or missing required fields", () => {
+    expect(isResourceSelection({ serverName: "", uri: "mem://x" })).toBe(false);
+    expect(isResourceSelection({ serverName: "srv", uri: "" })).toBe(false);
+    expect(isResourceSelection({ serverName: "srv" })).toBe(false);
+    expect(isResourceSelection({})).toBe(false);
+    expect(isResourceSelection(null)).toBe(false);
+  });
+
+  it("ignores optional fields", () => {
+    expect(
+      isResourceSelection({
+        serverName: "srv",
+        uri: "mem://x",
+        reasoning: "r",
+        noResourceAvailable: true,
+      })
+    ).toBe(true);
+  });
+});

--- a/plugins/plugin-mcp/src/utils/schemas.ts
+++ b/plugins/plugin-mcp/src/utils/schemas.ts
@@ -91,7 +91,13 @@ export function isToolSelectionArgument(value: unknown): value is ToolSelectionA
     return false;
   }
   const obj = value as Record<string, unknown>;
-  return typeof obj.toolArguments === "object" && obj.toolArguments !== null;
+  // The declared JSON schema types toolArguments as { "type": "object" },
+  // which excludes arrays — typeof alone would accept them.
+  return (
+    typeof obj.toolArguments === "object" &&
+    obj.toolArguments !== null &&
+    !Array.isArray(obj.toolArguments)
+  );
 }
 
 export function isResourceSelection(value: unknown): value is ResourceSelection {


### PR DESCRIPTION
# Relates to

No issue; hardening discovered while writing focused coverage for the MCP
selection type guards.

## What changed

- `isToolSelectionArgument` now rejects array values for `toolArguments`.
  The declared JSON schema types `toolArguments` as `{ "type": "object" }`,
  which excludes arrays, but the guard only checked `typeof === "object"` —
  so an array (e.g. `{ toolArguments: [1, 2] }`) passed the guard while
  failing the schema. Model-produced selection shapes cross this guard, so
  the mismatch let structurally invalid selections through to validators.
- Added focused unit coverage for all three selection guards
  (`isToolSelectionName`, `isToolSelectionArgument`, `isResourceSelection`):
  required-field validation, empty-string rejection, non-object rejection,
  and optional-field tolerance.

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] Focused vitest run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. One guard now matches the schema it declares: array `toolArguments`
are rejected instead of accepted. No valid selection shape changes
behavior; covered by the added tests.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: 11/11 passed — see log below |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file + minimal source fix in this PR |

```log
Test Files  1 passed (1)
      Tests  11 passed (11)
```

- Command: `npx vitest run src/utils/schemas.test.ts`
- Result: all passed (required-field validation, empty-string rejection,
  non-object rejection, array-`toolArguments` rejection, optional-field
  tolerance)

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
