### PR TITLE
fix(discord): secure guild management reconciliation

### DIFF
--- a/packages/core/src/connection.test.ts
+++ b/packages/core/src/connection.test.ts
@@ -9,7 +9,7 @@ import { recordOwnerGrant, recordRoleGrant } from "./roles";
 import { stringToUuid } from "./utils";
 
 describe("ensureConnection", () => {
-	it("persists an exact Discord server and account binding on the room", async () => {
+	it("persists an exact Discord server binding on the room", async () => {
 		const adapter = new InMemoryDatabaseAdapter();
 		const agentId = stringToUuid("discord-binding-agent");
 		const entityId = stringToUuid("discord-binding-requester");
@@ -28,7 +28,6 @@ describe("ensureConnection", () => {
 			source: "discord",
 			channelId: "323456789012345678",
 			metadata: { accountId: "primary" },
-			roomMetadata: { accountId: "primary" },
 		});
 
 		const [room] = await adapter.getRoomsByIds([roomId]);
@@ -38,7 +37,6 @@ describe("ensureConnection", () => {
 			source: "discord",
 			serverId,
 			messageServerId,
-			metadata: { accountId: "primary" },
 		});
 	});
 

--- a/packages/core/src/connection.test.ts
+++ b/packages/core/src/connection.test.ts
@@ -9,6 +9,39 @@ import { recordOwnerGrant, recordRoleGrant } from "./roles";
 import { stringToUuid } from "./utils";
 
 describe("ensureConnection", () => {
+	it("persists an exact Discord server and account binding on the room", async () => {
+		const adapter = new InMemoryDatabaseAdapter();
+		const agentId = stringToUuid("discord-binding-agent");
+		const entityId = stringToUuid("discord-binding-requester");
+		const roomId = stringToUuid("discord-binding-room");
+		const worldId = stringToUuid("discord-binding-world");
+		const serverId = "223456789012345678";
+		const messageServerId = stringToUuid(serverId);
+
+		await ensureConnection(adapter, {
+			agentId,
+			entityId,
+			roomId,
+			worldId,
+			messageServerId,
+			serverId,
+			source: "discord",
+			channelId: "323456789012345678",
+			metadata: { accountId: "primary" },
+			roomMetadata: { accountId: "primary" },
+		});
+
+		const [room] = await adapter.getRoomsByIds([roomId]);
+		expect(room).toMatchObject({
+			id: roomId,
+			worldId,
+			source: "discord",
+			serverId,
+			messageServerId,
+			metadata: { accountId: "primary" },
+		});
+	});
+
 	it("preserves existing role grants when another caller reconciles", async () => {
 		const adapter = new InMemoryDatabaseAdapter();
 		const agentId = stringToUuid("connection-role-agent");

--- a/packages/core/src/connection.ts
+++ b/packages/core/src/connection.ts
@@ -32,8 +32,6 @@ export interface EnsureConnectionParams {
 	messageServerId?: UUID;
 	userId?: UUID;
 	metadata?: Record<string, JsonValue>;
-	/** Room-scoped connector metadata such as the selected account id. */
-	roomMetadata?: Record<string, JsonValue>;
 }
 
 export interface EnsureConnectionsParams {
@@ -285,7 +283,6 @@ export async function ensureConnections(
 			serverId: c.serverId,
 			messageServerId: c.messageServerId,
 			worldId,
-			metadata: c.roomMetadata,
 		};
 		roomMap.set(c.roomId, room);
 

--- a/packages/core/src/connection.ts
+++ b/packages/core/src/connection.ts
@@ -27,9 +27,13 @@ export interface EnsureConnectionParams {
 	source: string;
 	type?: ChannelType | string;
 	channelId?: string;
+	/** Raw connector server/guild id retained for exact destination binding. */
+	serverId?: string;
 	messageServerId?: UUID;
 	userId?: UUID;
 	metadata?: Record<string, JsonValue>;
+	/** Room-scoped connector metadata such as the selected account id. */
+	roomMetadata?: Record<string, JsonValue>;
 }
 
 export interface EnsureConnectionsParams {
@@ -278,8 +282,10 @@ export async function ensureConnections(
 			source,
 			type: roomType,
 			channelId: c.channelId ?? c.roomId,
+			serverId: c.serverId,
 			messageServerId: c.messageServerId,
 			worldId,
+			metadata: c.roomMetadata,
 		};
 		roomMap.set(c.roomId, room);
 

--- a/packages/core/src/features/advanced-capabilities/actions/message.manage-server.test.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/message.manage-server.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Covers MESSAGE op=manage_server routing: operation normalization from the
+ * action-alias surface, connector selection by manageServerHandler hook,
+ * bounded param forwarding, NOT_SUPPORTED / missing-operation failures, and
+ * connector-thrown gate errors surfacing as structured action failures.
+ * Deterministic mock runtime and connectors — no live model, no DB.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { createMockRuntime } from "../../../testing/mock-runtime";
+import type {
+	ActionResult,
+	IAgentRuntime,
+	Memory,
+} from "../../../types/index.ts";
+import { inferOp, messageAction } from "./message.ts";
+
+const AGENT_ID = "00000000-0000-0000-0000-000000000001";
+const ROOM_ID = "00000000-0000-0000-0000-0000000000bb";
+const SENDER_ID = "00000000-0000-0000-0000-0000000000cc";
+
+const baseMessage = {
+	id: "00000000-0000-0000-0000-0000000000aa",
+	roomId: ROOM_ID,
+	entityId: SENDER_ID,
+	agentId: AGENT_ID,
+	content: { text: "set up the server", source: "discord" },
+	createdAt: 1,
+} as unknown as Memory;
+
+type ManageCall = {
+	operation: string;
+	serverId?: string;
+	params?: Record<string, unknown>;
+};
+
+function harness(options?: {
+	handler?: (
+		params: ManageCall,
+	) => Promise<{ summary: string; data?: Record<string, unknown> }>;
+	omitHandler?: boolean;
+}) {
+	const calls: ManageCall[] = [];
+	const manageServerHandler = options?.omitHandler
+		? undefined
+		: vi.fn(
+				async (
+					_runtime: IAgentRuntime,
+					params: {
+						operation: string;
+						serverId?: string;
+						params?: Record<string, unknown>;
+					},
+				) => {
+					const call = {
+						operation: params.operation,
+						serverId: params.serverId,
+						params: params.params,
+					};
+					calls.push(call);
+					if (options?.handler) return options.handler(call);
+					return { summary: `did ${params.operation}` };
+				},
+			);
+	const runtime = createMockRuntime({
+		agentId: AGENT_ID,
+		logger: { debug() {}, info() {}, warn() {}, error() {} },
+		getMessageConnectors: () => [
+			{
+				source: "discord",
+				label: "Discord",
+				capabilities: ["manage_server"],
+				supportedTargetKinds: ["channel"],
+				contexts: [],
+				...(manageServerHandler ? { manageServerHandler } : {}),
+			},
+		],
+		reportError: () => undefined,
+	});
+	return { runtime, calls, manageServerHandler };
+}
+
+async function invoke(
+	runtime: IAgentRuntime,
+	params: Record<string, unknown>,
+): Promise<ActionResult> {
+	const result = await messageAction.handler(
+		runtime,
+		baseMessage,
+		undefined,
+		{ parameters: params },
+		undefined,
+		undefined,
+	);
+	if (!result) throw new Error("handler returned no result");
+	return result as ActionResult;
+}
+
+describe("MESSAGE op inference for manage_server", () => {
+	it("maps the manage_server op and its verb aliases", () => {
+		expect(inferOp({ action: "manage_server" })).toBe("manage_server");
+		expect(inferOp({ action: "create_channel" })).toBe("manage_server");
+		expect(inferOp({ action: "create_role" })).toBe("manage_server");
+		expect(inferOp({ action: "apply_template" })).toBe("manage_server");
+		expect(inferOp({ action: "kick_member" })).toBe("manage_server");
+		expect(inferOp({ action: "guild_management" })).toBe("manage_server");
+	});
+
+	it("does not shadow existing ops", () => {
+		expect(inferOp({ action: "send" })).toBe("send");
+		expect(inferOp({ action: "manage" })).toBe("manage");
+		expect(inferOp({ action: "react" })).toBe("react");
+	});
+});
+
+describe("MESSAGE op=manage_server routing", () => {
+	it("forwards an explicit operation with bounded params to the connector", async () => {
+		const { runtime, calls } = harness();
+		const result = await invoke(runtime, {
+			action: "manage_server",
+			source: "discord",
+			operation: "create_channel",
+			serverId: "1234567890",
+			name: "alerts",
+			topic: "CI alerts",
+			channelType: "text",
+			parentId: "999",
+			dryRun: false,
+			// Unknown params must NOT be forwarded.
+			token: "should-not-forward",
+		});
+		expect(result.success).toBe(true);
+		expect(calls).toHaveLength(1);
+		expect(calls[0]?.operation).toBe("create_channel");
+		expect(calls[0]?.serverId).toBe("1234567890");
+		expect(calls[0]?.params).toMatchObject({
+			name: "alerts",
+			topic: "CI alerts",
+			channelType: "text",
+			parentId: "999",
+		});
+		expect(calls[0]?.params).not.toHaveProperty("token");
+		expect(result.text).toBe("did create_channel");
+	});
+
+	it("derives the operation from an aliased action string", async () => {
+		const { runtime, calls } = harness();
+		const result = await invoke(runtime, {
+			action: "create_role",
+			source: "discord",
+			serverId: "1234567890",
+			name: "Dev",
+			permissions: ["ViewChannel", "SendMessages"],
+		});
+		expect(result.success).toBe(true);
+		expect(calls[0]?.operation).toBe("create_role");
+		expect(calls[0]?.params?.permissions).toEqual([
+			"ViewChannel",
+			"SendMessages",
+		]);
+	});
+
+	it("renames moderation aliases to the connector verbs", async () => {
+		const { runtime, calls } = harness();
+		await invoke(runtime, {
+			action: "kick_member",
+			source: "discord",
+			serverId: "1234567890",
+			userId: "555",
+		});
+		expect(calls[0]?.operation).toBe("kick");
+	});
+
+	it("fails with INVALID_PARAMETERS when no operation can be derived", async () => {
+		const { runtime, calls } = harness();
+		const result = await invoke(runtime, {
+			action: "manage_server",
+			source: "discord",
+		});
+		expect(result.success).toBe(false);
+		expect(result.data?.error).toBe("INVALID_PARAMETERS");
+		expect(calls).toHaveLength(0);
+	});
+
+	it("fails when no connector supports server management", async () => {
+		const { runtime } = harness({ omitHandler: true });
+		const result = await invoke(runtime, {
+			action: "manage_server",
+			source: "discord",
+			operation: "create_channel",
+			name: "general",
+		});
+		expect(result.success).toBe(false);
+		expect(result.data?.error).toBe("NO_CONNECTORS_REGISTERED");
+	});
+
+	it("surfaces connector gate denials as structured failures", async () => {
+		const { runtime } = harness({
+			handler: async () => {
+				throw new Error(
+					"Discord create_channel is disabled: config gate actions.channels must be explicitly enabled in the Discord connector settings.",
+				);
+			},
+		});
+		const result = await invoke(runtime, {
+			action: "manage_server",
+			source: "discord",
+			operation: "create_channel",
+			serverId: "1234567890",
+			name: "general",
+		});
+		expect(result.success).toBe(false);
+		expect(result.data?.error).toBe("MESSAGE_MANAGE_SERVER_FAILED");
+		expect(result.text).toContain("actions.channels");
+	});
+
+	it("returns the connector receipt in the action result data", async () => {
+		const { runtime } = harness({
+			handler: async () => ({
+				summary: "Applied template",
+				data: {
+					entries: [{ kind: "channel", action: "created", name: "general" }],
+				},
+			}),
+		});
+		const result = await invoke(runtime, {
+			action: "apply_template",
+			source: "discord",
+			serverId: "1234567890",
+			template: "project-team",
+		});
+		expect(result.success).toBe(true);
+		expect(result.data?.receipt).toMatchObject({
+			entries: [{ kind: "channel", action: "created", name: "general" }],
+		});
+		expect(result.data?.operation).toBe("apply_template");
+	});
+});

--- a/packages/core/src/features/advanced-capabilities/actions/message.manage-server.test.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/message.manage-server.test.ts
@@ -49,7 +49,6 @@ function harness(options?: {
 	omitHandler?: boolean;
 	authorizedEntityId?: UUID | null;
 	includeBinding?: boolean;
-	bindingAccountId?: string;
 	resolverAccountId?: string;
 	verifiedRelatedEntityIds?: UUID[];
 }) {
@@ -137,9 +136,6 @@ function harness(options?: {
 							type: "GROUP",
 							serverId: activeServerId,
 							messageServerId: stringToUuid(activeServerId),
-							metadata: {
-								accountId: options?.bindingAccountId ?? ACCOUNT_ID,
-							},
 						},
 					]
 				: [],
@@ -365,21 +361,6 @@ describe("MESSAGE op=manage_server routing", () => {
 		});
 		expect(result.success).toBe(false);
 		expect(result.data?.error).toBe("MANAGE_SERVER_DESTINATION_UNBOUND");
-		expect(calls).toHaveLength(0);
-	});
-
-	it("fails closed when the exact room belongs to another connector account", async () => {
-		const { runtime, calls } = harness({ bindingAccountId: "secondary" });
-		const result = await invoke(runtime, {
-			action: "create_invite",
-			source: "discord",
-			accountId: ACCOUNT_ID,
-			serverId: "223456789012345678",
-		});
-		expect(result.success).toBe(false);
-		expect(result.data?.error).toBe(
-			"MANAGE_SERVER_DESTINATION_ACCOUNT_MISMATCH",
-		);
 		expect(calls).toHaveLength(0);
 	});
 

--- a/packages/core/src/features/advanced-capabilities/actions/message.manage-server.test.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/message.manage-server.test.ts
@@ -12,12 +12,19 @@ import type {
 	ActionResult,
 	IAgentRuntime,
 	Memory,
+	MessageConnectorManageServerAuthorization,
+	UUID,
 } from "../../../types/index.ts";
+import { stringToUuid } from "../../../utils.ts";
 import { inferOp, messageAction } from "./message.ts";
 
 const AGENT_ID = "00000000-0000-0000-0000-000000000001";
 const ROOM_ID = "00000000-0000-0000-0000-0000000000bb";
 const SENDER_ID = "00000000-0000-0000-0000-0000000000cc";
+const LINKED_ID = "00000000-0000-0000-0000-0000000000dd";
+const DESTINATION_WORLD_ID = "00000000-0000-0000-0000-0000000000ee";
+const DESTINATION_ROOM_ID = "00000000-0000-0000-0000-0000000000ff";
+const ACCOUNT_ID = "primary";
 
 const baseMessage = {
 	id: "00000000-0000-0000-0000-0000000000aa",
@@ -31,6 +38,7 @@ const baseMessage = {
 type ManageCall = {
 	operation: string;
 	serverId?: string;
+	authorization: MessageConnectorManageServerAuthorization;
 	params?: Record<string, unknown>;
 };
 
@@ -39,7 +47,17 @@ function harness(options?: {
 		params: ManageCall,
 	) => Promise<{ summary: string; data?: Record<string, unknown> }>;
 	omitHandler?: boolean;
+	authorizedEntityId?: UUID | null;
+	includeBinding?: boolean;
+	bindingAccountId?: string;
+	resolverAccountId?: string;
+	verifiedRelatedEntityIds?: UUID[];
 }) {
+	let activeServerId = "123456789012345678";
+	const authorizedEntityId =
+		options?.authorizedEntityId === undefined
+			? (SENDER_ID as UUID)
+			: options.authorizedEntityId;
 	const calls: ManageCall[] = [];
 	const manageServerHandler = options?.omitHandler
 		? undefined
@@ -49,12 +67,14 @@ function harness(options?: {
 					params: {
 						operation: string;
 						serverId?: string;
+						authorization: MessageConnectorManageServerAuthorization;
 						params?: Record<string, unknown>;
 					},
 				) => {
 					const call = {
 						operation: params.operation,
 						serverId: params.serverId,
+						authorization: params.authorization,
 						params: params.params,
 					};
 					calls.push(call);
@@ -68,13 +88,72 @@ function harness(options?: {
 		getMessageConnectors: () => [
 			{
 				source: "discord",
+				accountId: ACCOUNT_ID,
 				label: "Discord",
 				capabilities: ["manage_server"],
 				supportedTargetKinds: ["channel"],
 				contexts: [],
+				resolveManageServerDestination: async (_runtime, params) => {
+					activeServerId = params.serverId;
+					const accountId = options?.resolverAccountId ?? ACCOUNT_ID;
+					return {
+						source: "discord",
+						accountId,
+						serverId: activeServerId,
+						messageServerId: stringToUuid(activeServerId),
+						destinationWorldId: DESTINATION_WORLD_ID as UUID,
+						target: {
+							source: "discord",
+							accountId,
+							serverId: activeServerId,
+						},
+					};
+				},
 				...(manageServerHandler ? { manageServerHandler } : {}),
 			},
 		],
+		getWorld: async (worldId: UUID) =>
+			worldId === DESTINATION_WORLD_ID
+				? {
+						id: DESTINATION_WORLD_ID as UUID,
+						agentId: AGENT_ID as UUID,
+						messageServerId: stringToUuid(activeServerId),
+						metadata: authorizedEntityId
+							? {
+									roles: { [authorizedEntityId]: "ADMIN" },
+									roleSources: { [authorizedEntityId]: "manual" },
+								}
+							: {},
+					}
+				: null,
+		getRooms: async (worldId: UUID) =>
+			worldId === DESTINATION_WORLD_ID && options?.includeBinding !== false
+				? [
+						{
+							id: DESTINATION_ROOM_ID as UUID,
+							worldId: DESTINATION_WORLD_ID as UUID,
+							agentId: AGENT_ID as UUID,
+							source: "discord",
+							type: "GROUP",
+							serverId: activeServerId,
+							messageServerId: stringToUuid(activeServerId),
+							metadata: {
+								accountId: options?.bindingAccountId ?? ACCOUNT_ID,
+							},
+						},
+					]
+				: [],
+		getRoomsForParticipant: async (entityId: UUID) =>
+			entityId === AGENT_ID || entityId === authorizedEntityId
+				? [DESTINATION_ROOM_ID as UUID]
+				: [],
+		getService: (serviceType: string) =>
+			serviceType === "relationships" && options?.verifiedRelatedEntityIds
+				? ({
+						getVerifiedMemberEntityIds: async () =>
+							options.verifiedRelatedEntityIds ?? [],
+					} as never)
+				: null,
 		reportError: () => undefined,
 	});
 	return { runtime, calls, manageServerHandler };
@@ -234,5 +313,87 @@ describe("MESSAGE op=manage_server routing", () => {
 			entries: [{ kind: "channel", action: "created", name: "general" }],
 		});
 		expect(result.data?.operation).toBe("apply_template");
+	});
+
+	it("denies a source-world ADMIN turn targeting an unauthorized world B", async () => {
+		// The outer MESSAGE action role gate has already admitted this turn as an
+		// ADMIN in world A. This contract test starts at its manage_server handler
+		// and proves that source authority is not reused for destination world B.
+		const { runtime, calls } = harness({ authorizedEntityId: null });
+		const result = await invoke(runtime, {
+			action: "delete_channel",
+			source: "discord",
+			accountId: ACCOUNT_ID,
+			serverId: "223456789012345678",
+			channelId: "323456789012345678",
+		});
+		expect(result.success).toBe(false);
+		expect(result.data?.error).toBe("MANAGE_SERVER_DESTINATION_NOT_AUTHORIZED");
+		expect(calls).toHaveLength(0);
+	});
+
+	it("allows a verified linked identity that is ADMIN and a member in world B", async () => {
+		const { runtime, calls } = harness({
+			authorizedEntityId: LINKED_ID as UUID,
+			verifiedRelatedEntityIds: [LINKED_ID as UUID],
+		});
+		const result = await invoke(runtime, {
+			action: "create_channel",
+			source: "discord",
+			accountId: ACCOUNT_ID,
+			serverId: "223456789012345678",
+			name: "linked-admin",
+		});
+		expect(result.success).toBe(true);
+		expect(calls).toHaveLength(1);
+		expect(calls[0]?.authorization).toMatchObject({
+			requesterEntityId: SENDER_ID,
+			authorizedEntityId: LINKED_ID,
+			role: "ADMIN",
+			destinationWorldId: DESTINATION_WORLD_ID,
+		});
+	});
+
+	it("fails closed when the exact destination room binding is missing", async () => {
+		const { runtime, calls } = harness({ includeBinding: false });
+		const result = await invoke(runtime, {
+			action: "create_role",
+			source: "discord",
+			accountId: ACCOUNT_ID,
+			serverId: "223456789012345678",
+			name: "ops",
+		});
+		expect(result.success).toBe(false);
+		expect(result.data?.error).toBe("MANAGE_SERVER_DESTINATION_UNBOUND");
+		expect(calls).toHaveLength(0);
+	});
+
+	it("fails closed when the exact room belongs to another connector account", async () => {
+		const { runtime, calls } = harness({ bindingAccountId: "secondary" });
+		const result = await invoke(runtime, {
+			action: "create_invite",
+			source: "discord",
+			accountId: ACCOUNT_ID,
+			serverId: "223456789012345678",
+		});
+		expect(result.success).toBe(false);
+		expect(result.data?.error).toBe(
+			"MANAGE_SERVER_DESTINATION_ACCOUNT_MISMATCH",
+		);
+		expect(calls).toHaveLength(0);
+	});
+
+	it("rejects a resolver result for a different selected account", async () => {
+		const { runtime, calls } = harness({ resolverAccountId: "secondary" });
+		const result = await invoke(runtime, {
+			action: "create_channel",
+			source: "discord",
+			accountId: ACCOUNT_ID,
+			serverId: "223456789012345678",
+			name: "wrong-account",
+		});
+		expect(result.success).toBe(false);
+		expect(result.data?.error).toBe("DESTINATION_CONNECTOR_MISMATCH");
+		expect(calls).toHaveLength(0);
 	});
 });

--- a/packages/core/src/features/advanced-capabilities/actions/message.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/message.ts
@@ -15,9 +15,11 @@
 import { searchCanonicalConversationMemories } from "../../../access-control/provenance-envelope.ts";
 import { getConnectorAccountManager } from "../../../connectors/account-manager.ts";
 import { createUniqueUuid, findEntityByName } from "../../../entities.ts";
+import { ElizaError } from "../../../errors.ts";
 import { getActionSpec } from "../../../generated/spec-helpers.ts";
 import { getVerifiedRelatedEntityIds } from "../../../identity-clusters.ts";
 import { logger } from "../../../logger.ts";
+import { authorizeManageServerDestination } from "../../../messaging/manage-server-authorization.ts";
 import {
 	deterministicOwnerEntityId,
 	resolveCanonicalOwnerIdForMessage,
@@ -43,6 +45,8 @@ import type {
 	Media,
 	Memory,
 	MessageConnector,
+	MessageConnectorManageServerAuthorization,
+	MessageConnectorManageServerDestination,
 	MessageConnectorQueryContext,
 	MessageConnectorTarget,
 	MessageTargetKind,
@@ -432,12 +436,19 @@ type ConnectorWithHooks = MessageConnector & {
 		runtime: IAgentRuntime,
 		query: { userId?: string; username?: string; handle?: string },
 	) => Promise<unknown> | unknown;
+	resolveManageServerDestination?: (
+		runtime: IAgentRuntime,
+		params: { target?: TargetInfo; serverId: string },
+	) =>
+		| Promise<MessageConnectorManageServerDestination>
+		| MessageConnectorManageServerDestination;
 	manageServerHandler?: (
 		runtime: IAgentRuntime,
 		payload: {
 			target?: TargetInfo;
 			operation: string;
 			serverId?: string;
+			authorization: MessageConnectorManageServerAuthorization;
 			params?: Record<string, unknown>;
 		},
 	) =>
@@ -4718,8 +4729,20 @@ async function handleManageServer(
 	);
 	if ("error" in selection) return selection.error;
 	const connector = selection.connector;
+	if (!connector.accountId) {
+		return opFailure(
+			op,
+			"ACCOUNT_ID_REQUIRED",
+			"Server management requires an explicitly account-scoped connector.",
+		);
+	}
+	const selectedAccountId = connector.accountId;
 	const handler = connector.manageServerHandler;
-	if (typeof handler !== "function") {
+	const resolveDestination = connector.resolveManageServerDestination;
+	if (
+		typeof handler !== "function" ||
+		typeof resolveDestination !== "function"
+	) {
 		return opFailure(
 			op,
 			"NOT_SUPPORTED",
@@ -4739,16 +4762,51 @@ async function handleManageServer(
 	for (const key of MANAGE_SERVER_FORWARDED_PARAMS) {
 		if (params[key] !== undefined) forwarded[key] = params[key];
 	}
-	const serverId =
+	let serverId =
 		textParam(params.serverId) ??
 		textParam(params.server) ??
 		textParam(params.guildId) ??
 		resolved.target?.serverId;
+	if (!serverId) {
+		const currentRoom = await runtime.getRoom(message.roomId);
+		serverId =
+			currentRoom?.source === connector.source
+				? currentRoom.serverId
+				: undefined;
+	}
+	if (!serverId) {
+		return opFailure(
+			op,
+			"SERVER_ID_REQUIRED",
+			"MESSAGE op=manage_server requires an exact platform serverId or a current room with an exact persisted server binding.",
+		);
+	}
 	try {
-		const result = await handler(runtime, {
+		const destination = await resolveDestination(runtime, {
 			target: resolved.target,
-			operation,
 			serverId,
+		});
+		if (
+			destination.source !== connector.source ||
+			destination.accountId !== selectedAccountId ||
+			destination.target.accountId !== selectedAccountId
+		) {
+			return opFailure(
+				op,
+				"DESTINATION_CONNECTOR_MISMATCH",
+				"The resolved server destination does not match the selected connector source and account.",
+			);
+		}
+		const authorization = await authorizeManageServerDestination(
+			runtime,
+			message.entityId,
+			destination,
+		);
+		const result = await handler(runtime, {
+			target: destination.target,
+			operation,
+			serverId: destination.serverId,
+			authorization,
 			params: forwarded,
 		});
 		return opSuccess(op, result.summary, {
@@ -4758,6 +4816,14 @@ async function handleManageServer(
 		});
 	} catch (error) {
 		// error-policy:J1 Connector failures become structured action failures.
+		if (error instanceof ElizaError) {
+			logger.error(`[MESSAGE/${op}] ${error.message}`);
+			return opFailure(
+				op,
+				error.code,
+				`MESSAGE op=${op} failed: ${error.message}`,
+			);
+		}
 		return opErrorWrap(op, error);
 	}
 }

--- a/packages/core/src/features/advanced-capabilities/actions/message.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/message.ts
@@ -112,6 +112,7 @@ export const MESSAGE_OPS = [
 	"delete",
 	"pin",
 	"get_user",
+	"manage_server",
 	// Inbox / triage / draft ops (delegated to triage actions)
 	"triage",
 	"list_inbox",
@@ -135,9 +136,9 @@ const MESSAGE_CONTEXTS = [
 ];
 
 const MESSAGE_DESCRIPTION =
-	"Addressed messaging action: DMs, groups, channels, rooms, threads, servers, users, inboxes, drafts, and authorized cross-world continuity. Use list_worlds to discover durable worlds shared by the verified requester and this agent, list_rooms to inspect the current or an authorized worldId, and read_message to page an exact provider message or email body. Public feed publishing uses POST.";
+	"Addressed messaging action: DMs, groups, channels, rooms, threads, servers, users, inboxes, drafts, and authorized cross-world continuity. Use list_worlds to discover durable worlds shared by the verified requester and this agent, list_rooms to inspect the current or an authorized worldId, and read_message to page an exact provider message or email body. Use manage_server for structural server administration on a connector that supports it (create/edit/delete channels, categories, and roles, permission overwrites, member roles, invites, moderation, guild templates) — gated by connector configuration. Public feed publishing uses POST.";
 const MESSAGE_COMPRESSED =
-	"primary message action send read_channel read_with_contact read_message search list_channels list_servers list_connections list_worlds list_rooms join leave react edit delete pin get_user triage list_inbox search_inbox draft_reply draft_followup respond send_draft schedule_draft_send manage dm group channel room thread user server world inbox draft connections platforms reachable";
+	"primary message action send read_channel read_with_contact read_message search list_channels list_servers list_connections list_worlds list_rooms join leave react edit delete pin get_user manage_server triage list_inbox search_inbox draft_reply draft_followup respond send_draft schedule_draft_send manage dm group channel room thread user server world inbox draft connections platforms reachable";
 
 // ---------------------------------------------------------------------------
 // Param coercion / op normalization
@@ -283,6 +284,31 @@ const OP_ALIASES: Record<string, MessageOperation> = {
 	unsubscribe: "manage",
 	block_sender: "manage",
 	mark_read: "manage",
+	// Structural server management verbs route to manage_server; the concrete
+	// verb is preserved via params.operation (or the raw action string).
+	manage_guild: "manage_server",
+	server_management: "manage_server",
+	guild_management: "manage_server",
+	create_channel: "manage_server",
+	create_category: "manage_server",
+	edit_channel: "manage_server",
+	delete_channel: "manage_server",
+	create_role: "manage_server",
+	edit_role: "manage_server",
+	delete_role: "manage_server",
+	edit_permissions: "manage_server",
+	edit_channel_permissions: "manage_server",
+	assign_role: "manage_server",
+	remove_role: "manage_server",
+	create_invite: "manage_server",
+	kick_member: "manage_server",
+	ban_member: "manage_server",
+	unban_member: "manage_server",
+	timeout_member: "manage_server",
+	apply_template: "manage_server",
+	apply_server_template: "manage_server",
+	list_templates: "manage_server",
+	list_server_templates: "manage_server",
 };
 
 function normalizeOp(value: unknown): MessageOperation | undefined {
@@ -406,6 +432,17 @@ type ConnectorWithHooks = MessageConnector & {
 		runtime: IAgentRuntime,
 		query: { userId?: string; username?: string; handle?: string },
 	) => Promise<unknown> | unknown;
+	manageServerHandler?: (
+		runtime: IAgentRuntime,
+		payload: {
+			target?: TargetInfo;
+			operation: string;
+			serverId?: string;
+			params?: Record<string, unknown>;
+		},
+	) =>
+		| Promise<{ summary: string; data?: Record<string, unknown> }>
+		| { summary: string; data?: Record<string, unknown> };
 	contentShaping?: {
 		postProcess?: (text: string) => string;
 		constraints?: { maxLength?: number };
@@ -4590,6 +4627,142 @@ async function handleMessageMutation(
 }
 
 // ---------------------------------------------------------------------------
+// op=manage_server
+// ---------------------------------------------------------------------------
+
+/**
+ * Raw `action` strings that alias to manage_server while naming a concrete
+ * management verb. Preserved as the connector operation so `action:
+ * "create_channel"` works without a separate `operation` param.
+ */
+const MANAGE_SERVER_GENERIC_ALIASES = new Set([
+	"manage_server",
+	"manage_guild",
+	"server_management",
+	"guild_management",
+]);
+
+const MANAGE_SERVER_OPERATION_RENAMES: Record<string, string> = {
+	kick_member: "kick",
+	ban_member: "ban",
+	unban_member: "unban",
+	timeout_member: "timeout",
+	edit_channel_permissions: "edit_permissions",
+	apply_server_template: "apply_template",
+	list_server_templates: "list_templates",
+};
+
+function manageServerOperation(params: ParamRecord): string | undefined {
+	const explicit = textParam(params.operation) ?? textParam(params.op);
+	if (explicit) {
+		const normalized = explicit.toLowerCase().replace(/[-\s]+/g, "_");
+		return MANAGE_SERVER_OPERATION_RENAMES[normalized] ?? normalized;
+	}
+	const raw = textParam(params.action);
+	if (!raw) return undefined;
+	const normalized = raw.toLowerCase().replace(/[-\s]+/g, "_");
+	if (MANAGE_SERVER_GENERIC_ALIASES.has(normalized)) return undefined;
+	return MANAGE_SERVER_OPERATION_RENAMES[normalized] ?? normalized;
+}
+
+/** Bounded param names forwarded verbatim to the connector. */
+const MANAGE_SERVER_FORWARDED_PARAMS = [
+	"channelId",
+	"parentId",
+	"roleId",
+	"userId",
+	"name",
+	"topic",
+	"channelType",
+	"color",
+	"hoist",
+	"mentionable",
+	"permissions",
+	"allow",
+	"deny",
+	"overwriteId",
+	"reason",
+	"durationMinutes",
+	"deleteMessageSeconds",
+	"maxAgeSeconds",
+	"maxUses",
+	"unique",
+	"template",
+	"templateSpec",
+	"variables",
+	"dryRun",
+] as const;
+
+async function handleManageServer(
+	runtime: IAgentRuntime,
+	message: Memory,
+	state: State | undefined,
+	params: ParamRecord,
+): Promise<ActionResult> {
+	const op: MessageOperation = "manage_server";
+	const operation = manageServerOperation(params);
+	if (!operation) {
+		return opFailure(
+			op,
+			"INVALID_PARAMETERS",
+			'MESSAGE op=manage_server requires an operation (e.g. operation: "create_channel").',
+		);
+	}
+	const connectors = connectorsWithHook(runtime, "manageServerHandler");
+	const selection = selectConnectorForOp(
+		connectors,
+		sourceFromParams(params, message),
+		trustedConnectorSource(message),
+		op,
+		accountIdFromParams(params, message),
+	);
+	if ("error" in selection) return selection.error;
+	const connector = selection.connector;
+	const handler = connector.manageServerHandler;
+	if (typeof handler !== "function") {
+		return opFailure(
+			op,
+			"NOT_SUPPORTED",
+			`Server management is not supported for ${connector.label}.`,
+		);
+	}
+	const resolved = await resolveOptionalTarget(
+		connector,
+		runtime,
+		message,
+		state,
+		params,
+		op,
+	);
+	if (resolved.error) return resolved.error;
+	const forwarded: Record<string, unknown> = {};
+	for (const key of MANAGE_SERVER_FORWARDED_PARAMS) {
+		if (params[key] !== undefined) forwarded[key] = params[key];
+	}
+	const serverId =
+		textParam(params.serverId) ??
+		textParam(params.server) ??
+		textParam(params.guildId) ??
+		resolved.target?.serverId;
+	try {
+		const result = await handler(runtime, {
+			target: resolved.target,
+			operation,
+			serverId,
+			params: forwarded,
+		});
+		return opSuccess(op, result.summary, {
+			source: connector.source,
+			operation,
+			...(result.data ? { receipt: result.data } : {}),
+		});
+	} catch (error) {
+		// error-policy:J1 Connector failures become structured action failures.
+		return opErrorWrap(op, error);
+	}
+}
+
+// ---------------------------------------------------------------------------
 // op=get_user
 // ---------------------------------------------------------------------------
 
@@ -4820,6 +4993,7 @@ export const MESSAGE_PARAMETERS: ActionParameter[] = [
 			"delete",
 			"pin",
 			"get_user",
+			"manage_server",
 			"triage",
 			"list_inbox",
 			"search_inbox",
@@ -4967,6 +5141,7 @@ export const MESSAGE_PARAMETERS: ActionParameter[] = [
 			"delete",
 			"pin",
 			"draft_followup",
+			"manage_server",
 		],
 		schema: { type: "string" },
 	},
@@ -4999,6 +5174,7 @@ export const MESSAGE_PARAMETERS: ActionParameter[] = [
 			"edit",
 			"delete",
 			"pin",
+			"manage_server",
 		],
 		schema: { type: "string" },
 	},
@@ -5016,6 +5192,7 @@ export const MESSAGE_PARAMETERS: ActionParameter[] = [
 			"delete",
 			"pin",
 			"get_user",
+			"manage_server",
 		],
 		schema: { type: "string" },
 	},
@@ -5513,6 +5690,108 @@ export const MESSAGE_PARAMETERS: ActionParameter[] = [
 		subactions: ["read_channel", "search"],
 		schema: { type: "string" },
 	},
+	{
+		name: "operation",
+		description:
+			"Server-management verb for op=manage_server: create_category, create_channel, edit_channel, delete_channel, create_role, edit_role, delete_role, edit_permissions, assign_role, remove_role, create_invite, kick, ban, unban, timeout, list_templates, apply_template. Connector configuration gates every write (fail closed).",
+		required: false,
+		subactions: ["manage_server"],
+		schema: { type: "string" },
+	},
+	{
+		name: "name",
+		description:
+			"Name for created/edited channels, categories, and roles (manage_server).",
+		required: false,
+		subactions: ["manage_server"],
+		schema: { type: "string" },
+	},
+	{
+		name: "topic",
+		description: "Channel topic for manage_server create/edit channel.",
+		required: false,
+		subactions: ["manage_server"],
+		schema: { type: "string" },
+	},
+	{
+		name: "channelType",
+		description:
+			"Channel type for manage_server create_channel: text, voice, announcement, forum, stage.",
+		required: false,
+		subactions: ["manage_server"],
+		schema: { type: "string" },
+	},
+	{
+		name: "parentId",
+		description:
+			"Parent category channel id for manage_server create/edit channel.",
+		required: false,
+		subactions: ["manage_server"],
+		schema: { type: "string" },
+	},
+	{
+		name: "roleId",
+		description:
+			"Role id for manage_server edit_role, delete_role, assign_role, remove_role.",
+		required: false,
+		subactions: ["manage_server"],
+		schema: { type: "string" },
+	},
+	{
+		name: "permissions",
+		description:
+			"Named permission list for manage_server create_role/edit_role (Administrator is always rejected).",
+		required: false,
+		subactions: ["manage_server"],
+		schema: { type: "array", items: { type: "string" } },
+	},
+	{
+		name: "allow",
+		description:
+			"Permissions to allow in a manage_server edit_permissions overwrite.",
+		required: false,
+		subactions: ["manage_server"],
+		schema: { type: "array", items: { type: "string" } },
+	},
+	{
+		name: "deny",
+		description:
+			"Permissions to deny in a manage_server edit_permissions overwrite.",
+		required: false,
+		subactions: ["manage_server"],
+		schema: { type: "array", items: { type: "string" } },
+	},
+	{
+		name: "overwriteId",
+		description:
+			'Overwrite subject for manage_server edit_permissions: a role id, user id, or "@everyone".',
+		required: false,
+		subactions: ["manage_server"],
+		schema: { type: "string" },
+	},
+	{
+		name: "template",
+		description:
+			"Registered template id for manage_server apply_template (see list_templates).",
+		required: false,
+		subactions: ["manage_server"],
+		schema: { type: "string" },
+	},
+	{
+		name: "dryRun",
+		description:
+			"For manage_server: report the plan (would_create/would_update) without writing.",
+		required: false,
+		subactions: ["manage_server"],
+		schema: { type: "boolean" },
+	},
+	{
+		name: "reason",
+		description: "Audit-log reason for manage_server writes.",
+		required: false,
+		subactions: ["manage_server"],
+		schema: { type: "string" },
+	},
 ];
 
 // ---------------------------------------------------------------------------
@@ -5633,6 +5912,8 @@ export const messageAction: Action = {
 				return handleMessageMutation(runtime, message, state, params, op);
 			case "get_user":
 				return handleGetUser(runtime, message, state, params);
+			case "manage_server":
+				return handleManageServer(runtime, message, state, params);
 			case "triage":
 			case "list_inbox":
 			case "search_inbox":

--- a/packages/core/src/index.node.ts
+++ b/packages/core/src/index.node.ts
@@ -217,6 +217,7 @@ export * from "./markdown";
 export * from "./media";
 export * from "./memory";
 export * from "./messaging/interactions";
+export * from "./messaging/manage-server-authorization";
 export * from "./mobile-device-bridge-service";
 export * from "./model-gateway";
 export * from "./name-tokens";

--- a/packages/core/src/messaging/manage-server-authorization.ts
+++ b/packages/core/src/messaging/manage-server-authorization.ts
@@ -22,16 +22,6 @@ import type {
 	UUID,
 } from "../types/index.ts";
 
-function metadataAccountId(metadata: unknown): string | undefined {
-	if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
-		return undefined;
-	}
-	const accountId = (metadata as Record<string, unknown>).accountId;
-	return typeof accountId === "string" && accountId.length > 0
-		? accountId
-		: undefined;
-}
-
 function deny(
 	code: string,
 	message: string,
@@ -76,20 +66,10 @@ export async function authorizeManageServerDestination(
 			room.serverId === destination.serverId &&
 			room.messageServerId === destination.messageServerId,
 	);
-	const destinationRooms = serverRooms.filter(
-		(room) => metadataAccountId(room.metadata) === destination.accountId,
-	);
-	if (destinationRooms.length === 0) {
-		if (serverRooms.length > 0) {
-			deny(
-				"MANAGE_SERVER_DESTINATION_ACCOUNT_MISMATCH",
-				"The requested server room binding does not belong to the selected connector account.",
-				destination,
-			);
-		}
+	if (serverRooms.length === 0) {
 		deny(
 			"MANAGE_SERVER_DESTINATION_UNBOUND",
-			"The requested server has no exact persisted room binding for the selected connector account.",
+			"The requested server has no exact persisted room binding.",
 			destination,
 		);
 	}
@@ -111,7 +91,7 @@ export async function authorizeManageServerDestination(
 		runtime.getRoomsForParticipant(runtime.agentId),
 	]);
 	const agentRooms = new Set(agentRoomIds);
-	const destinationRoomIds = new Set(destinationRooms.map((room) => room.id));
+	const destinationRoomIds = new Set(serverRooms.map((room) => room.id));
 
 	for (let index = 0; index < requesterEntityIds.length; index += 1) {
 		const entityId = requesterEntityIds[index];

--- a/packages/core/src/messaging/manage-server-authorization.ts
+++ b/packages/core/src/messaging/manage-server-authorization.ts
@@ -1,0 +1,146 @@
+/**
+ * Revalidates structural server-management authority against one exact durable
+ * room/world binding. Both core dispatch and connector mutation boundaries call
+ * this function; no display name, live provider enumeration, or source-world
+ * role can authorize a different destination.
+ */
+
+import { ElizaError } from "../errors.ts";
+import {
+	getVerifiedRelatedEntityIds,
+	invalidateRelatedEntityIds,
+} from "../identity-clusters.ts";
+import {
+	hasAtLeastRole,
+	type RolesWorldMetadata,
+	resolveEntityRole,
+} from "../roles.ts";
+import type {
+	IAgentRuntime,
+	MessageConnectorManageServerAuthorization,
+	MessageConnectorManageServerDestination,
+	UUID,
+} from "../types/index.ts";
+
+function metadataAccountId(metadata: unknown): string | undefined {
+	if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+		return undefined;
+	}
+	const accountId = (metadata as Record<string, unknown>).accountId;
+	return typeof accountId === "string" && accountId.length > 0
+		? accountId
+		: undefined;
+}
+
+function deny(
+	code: string,
+	message: string,
+	destination: MessageConnectorManageServerDestination,
+): never {
+	throw new ElizaError(message, {
+		code,
+		context: {
+			source: destination.source,
+			accountId: destination.accountId,
+			serverId: destination.serverId,
+			destinationWorldId: destination.destinationWorldId,
+		},
+	});
+}
+
+/**
+ * Resolve the requester's verified identity cluster afresh, intersect its rooms
+ * with the agent's rooms, and require ADMIN+ in the exact destination world.
+ */
+export async function authorizeManageServerDestination(
+	runtime: IAgentRuntime,
+	requesterEntityId: UUID,
+	destination: MessageConnectorManageServerDestination,
+): Promise<MessageConnectorManageServerAuthorization> {
+	const world = await runtime.getWorld(destination.destinationWorldId);
+	if (
+		!world ||
+		world.agentId !== runtime.agentId ||
+		world.messageServerId !== destination.messageServerId
+	) {
+		deny(
+			"MANAGE_SERVER_DESTINATION_UNBOUND",
+			"The requested server is not bound to a durable world for this agent.",
+			destination,
+		);
+	}
+	const serverRooms = (await runtime.getRooms(world.id)).filter(
+		(room) =>
+			room.worldId === world.id &&
+			room.source === destination.source &&
+			room.serverId === destination.serverId &&
+			room.messageServerId === destination.messageServerId,
+	);
+	const destinationRooms = serverRooms.filter(
+		(room) => metadataAccountId(room.metadata) === destination.accountId,
+	);
+	if (destinationRooms.length === 0) {
+		if (serverRooms.length > 0) {
+			deny(
+				"MANAGE_SERVER_DESTINATION_ACCOUNT_MISMATCH",
+				"The requested server room binding does not belong to the selected connector account.",
+				destination,
+			);
+		}
+		deny(
+			"MANAGE_SERVER_DESTINATION_UNBOUND",
+			"The requested server has no exact persisted room binding for the selected connector account.",
+			destination,
+		);
+	}
+
+	// The connector boundary calls this after the planner-side check. Drop the
+	// turn memo so revocation or identity-link changes cannot inherit the earlier
+	// identity-cluster snapshot.
+	invalidateRelatedEntityIds(runtime, requesterEntityId);
+	const requesterEntityIds = await getVerifiedRelatedEntityIds(
+		runtime,
+		requesterEntityId,
+	);
+	const [requesterRoomLists, agentRoomIds] = await Promise.all([
+		Promise.all(
+			requesterEntityIds.map((entityId) =>
+				runtime.getRoomsForParticipant(entityId),
+			),
+		),
+		runtime.getRoomsForParticipant(runtime.agentId),
+	]);
+	const agentRooms = new Set(agentRoomIds);
+	const destinationRoomIds = new Set(destinationRooms.map((room) => room.id));
+
+	for (let index = 0; index < requesterEntityIds.length; index += 1) {
+		const entityId = requesterEntityIds[index];
+		if (!entityId) continue;
+		const sharedDestinationRoomIds = Array.from(
+			new Set(requesterRoomLists[index] ?? []),
+		).filter(
+			(roomId) => agentRooms.has(roomId) && destinationRoomIds.has(roomId),
+		);
+		if (sharedDestinationRoomIds.length === 0) continue;
+		const role = await resolveEntityRole(
+			runtime,
+			world,
+			world.metadata as RolesWorldMetadata | undefined,
+			entityId,
+		);
+		if (!hasAtLeastRole(role, "ADMIN")) continue;
+		return {
+			...destination,
+			requesterEntityId,
+			authorizedEntityId: entityId,
+			role: role === "OWNER" ? "OWNER" : "ADMIN",
+			bindingRoomIds: sharedDestinationRoomIds,
+		};
+	}
+
+	deny(
+		"MANAGE_SERVER_DESTINATION_NOT_AUTHORIZED",
+		"The verified requester is not an ADMIN or OWNER member of the requested server world.",
+		destination,
+	);
+}

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -4769,7 +4769,6 @@ export class AgentRuntime implements IAgentRuntime {
 		messageServerId?: UUID;
 		userId?: UUID;
 		metadata?: Record<string, JsonValue>;
-		roomMetadata?: Record<string, JsonValue>;
 	}) {
 		const result = await ensureConnectionStandalone(this.adapter, {
 			agentId: this.agentId,

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -1139,6 +1139,8 @@ function normalizeMessageConnector(
 		connector.createThreadHandler = metadata.createThreadHandler;
 	if (metadata.postToThreadHandler)
 		connector.postToThreadHandler = metadata.postToThreadHandler;
+	if (metadata.manageServerHandler)
+		connector.manageServerHandler = metadata.manageServerHandler;
 	if (metadata.contentShaping)
 		connector.contentShaping = {
 			...metadata.contentShaping,

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -4765,9 +4765,11 @@ export class AgentRuntime implements IAgentRuntime {
 		source?: string;
 		type?: ChannelType | string;
 		channelId?: string;
+		serverId?: string;
 		messageServerId?: UUID;
 		userId?: UUID;
 		metadata?: Record<string, JsonValue>;
+		roomMetadata?: Record<string, JsonValue>;
 	}) {
 		const result = await ensureConnectionStandalone(this.adapter, {
 			agentId: this.agentId,

--- a/packages/core/src/types/runtime.ts
+++ b/packages/core/src/types/runtime.ts
@@ -939,7 +939,6 @@ export interface IAgentRuntime extends RuntimeDatabaseAdapterSurface {
 		type,
 		worldId,
 		userId,
-		roomMetadata,
 	}: {
 		entityId: UUID;
 		roomId: UUID;
@@ -955,7 +954,6 @@ export interface IAgentRuntime extends RuntimeDatabaseAdapterSurface {
 		worldId?: UUID;
 		userId?: UUID;
 		metadata?: Record<string, JsonValue>;
-		roomMetadata?: Record<string, JsonValue>;
 	}): Promise<void>;
 
 	ensureParticipantInRoom(entityId: UUID, roomId: UUID): Promise<void>;

--- a/packages/core/src/types/runtime.ts
+++ b/packages/core/src/types/runtime.ts
@@ -137,6 +137,7 @@ export type MessageConnectorCapability =
 	| "webhook_identity"
 	| "rich_components"
 	| "rich_embed"
+	| "manage_server"
 	| (string & {});
 
 export type PostConnectorCapability =
@@ -366,6 +367,31 @@ export interface MessageConnectorPostToThreadParams {
 	identity?: ConnectorPostIdentity;
 }
 
+/**
+ * Structural server/guild management request forwarded to a connector
+ * (create/edit/delete channels and roles, permission overwrites, member role
+ * assignment, invites, moderation, template reconcile). The connector owns
+ * validation, its own configuration gating (fail closed), and platform
+ * hierarchy checks; `operation` and `params` are treated as untrusted input.
+ */
+export interface MessageConnectorManageServerParams {
+	target?: TargetInfo;
+	/** Connector-defined management verb, e.g. "create_channel". */
+	operation: string;
+	/** Platform server/guild id the operation applies to. */
+	serverId?: string;
+	/** Bounded operation arguments; the connector validates every field. */
+	params?: Record<string, unknown>;
+}
+
+/** Structured result of a connector server-management operation. */
+export interface MessageConnectorManageServerResult {
+	/** Human-readable receipt line for the acting agent. */
+	summary: string;
+	/** Structured receipt (created/updated/unchanged/skipped entities). */
+	data?: Record<string, unknown>;
+}
+
 export interface MessageConnector {
 	source: string;
 	accountId?: string;
@@ -468,6 +494,10 @@ export interface MessageConnector {
 		runtime: IAgentRuntime,
 		params: MessageConnectorPostToThreadParams,
 	) => Promise<Memory | undefined>;
+	manageServerHandler?: (
+		runtime: IAgentRuntime,
+		params: MessageConnectorManageServerParams,
+	) => Promise<MessageConnectorManageServerResult>;
 	contentShaping?: ConnectorContentShaping;
 }
 

--- a/packages/core/src/types/runtime.ts
+++ b/packages/core/src/types/runtime.ts
@@ -380,8 +380,33 @@ export interface MessageConnectorManageServerParams {
 	operation: string;
 	/** Platform server/guild id the operation applies to. */
 	serverId?: string;
+	/** Trusted authorization minted by core for the exact destination binding. */
+	authorization: MessageConnectorManageServerAuthorization;
 	/** Bounded operation arguments; the connector validates every field. */
 	params?: Record<string, unknown>;
+}
+
+/** Exact connector destination resolved before any server-management write. */
+export interface MessageConnectorManageServerDestination {
+	source: string;
+	accountId: string;
+	serverId: string;
+	messageServerId: UUID;
+	destinationWorldId: UUID;
+	target: TargetInfo;
+}
+
+/**
+ * Trusted destination authorization carried from core to the connector. The
+ * connector must independently revalidate this envelope immediately before
+ * mutation; it is provenance, not a reusable capability grant.
+ */
+export interface MessageConnectorManageServerAuthorization
+	extends MessageConnectorManageServerDestination {
+	requesterEntityId: UUID;
+	authorizedEntityId: UUID;
+	role: "ADMIN" | "OWNER";
+	bindingRoomIds: UUID[];
 }
 
 /** Structured result of a connector server-management operation. */
@@ -494,6 +519,12 @@ export interface MessageConnector {
 		runtime: IAgentRuntime,
 		params: MessageConnectorPostToThreadParams,
 	) => Promise<Memory | undefined>;
+	resolveManageServerDestination?: (
+		runtime: IAgentRuntime,
+		params: { target?: TargetInfo; serverId: string },
+	) =>
+		| Promise<MessageConnectorManageServerDestination>
+		| MessageConnectorManageServerDestination;
 	manageServerHandler?: (
 		runtime: IAgentRuntime,
 		params: MessageConnectorManageServerParams,
@@ -903,10 +934,12 @@ export interface IAgentRuntime extends RuntimeDatabaseAdapterSurface {
 		name,
 		source,
 		channelId,
+		serverId,
 		messageServerId,
 		type,
 		worldId,
 		userId,
+		roomMetadata,
 	}: {
 		entityId: UUID;
 		roomId: UUID;
@@ -916,11 +949,13 @@ export interface IAgentRuntime extends RuntimeDatabaseAdapterSurface {
 		worldName?: string;
 		source?: string;
 		channelId?: string;
+		serverId?: string;
 		messageServerId?: UUID;
 		type?: ChannelType | string;
 		worldId?: UUID;
 		userId?: UUID;
 		metadata?: Record<string, JsonValue>;
+		roomMetadata?: Record<string, JsonValue>;
 	}): Promise<void>;
 
 	ensureParticipantInRoom(entityId: UUID, roomId: UUID): Promise<void>;

--- a/plugins/plugin-discord/README.md
+++ b/plugins/plugin-discord/README.md
@@ -259,10 +259,13 @@ authorization or lookup key. For example:
 Before Discord is queried or changed, core requires a verified identity related
 to the requester to be both a member and `ADMIN` or `OWNER` in that exact
 destination world. The destination must also have an exact Discord room binding
-for the selected connector account (`room.source`, raw guild `room.serverId`,
-and `room.metadata.accountId`). The Discord connector independently revalidates
-the same binding, membership, and role immediately before mutation, so revoked,
-unbound, cross-account, and cross-guild requests fail closed.
+(`room.source`, raw guild `room.serverId`, and `room.messageServerId`). The
+selected account's Discord client must then fetch that exact guild before any
+write. The connector independently revalidates the same world binding,
+membership, role, account provenance, and live guild id immediately before
+mutation, so revoked, unbound, cross-account, and cross-guild requests fail
+closed. Shared guild rooms remain valid when more than one configured Discord
+account can access the same guild.
 
 **Every structural write fails closed.** The `actions.channels`,
 `actions.roles`, `actions.permissions`, and `actions.moderation` gates all

--- a/plugins/plugin-discord/README.md
+++ b/plugins/plugin-discord/README.md
@@ -242,6 +242,28 @@ operations:
 - `list_templates`, `apply_template` (idempotent, non-destructive guild
   template reconcile)
 
+Management requests must identify the destination with the exact Discord guild
+snowflake persisted as the room's `serverId`; guild display names are never an
+authorization or lookup key. For example:
+
+```json
+{
+  "action": "create_channel",
+  "source": "discord",
+  "accountId": "primary",
+  "serverId": "123456789012345678",
+  "name": "release-status"
+}
+```
+
+Before Discord is queried or changed, core requires a verified identity related
+to the requester to be both a member and `ADMIN` or `OWNER` in that exact
+destination world. The destination must also have an exact Discord room binding
+for the selected connector account (`room.source`, raw guild `room.serverId`,
+and `room.metadata.accountId`). The Discord connector independently revalidates
+the same binding, membership, and role immediately before mutation, so revoked,
+unbound, cross-account, and cross-guild requests fail closed.
+
 **Every structural write fails closed.** The `actions.channels`,
 `actions.roles`, `actions.permissions`, and `actions.moderation` gates all
 default to OFF and must be explicitly enabled:

--- a/plugins/plugin-discord/README.md
+++ b/plugins/plugin-discord/README.md
@@ -227,6 +227,105 @@ From Discord.js `PermissionFlagsBits`:
 
 No actions or providers are registered. The plugin operates entirely through services and events. Credential pairing is handled by connector account providers and owner-only slash commands.
 
+### Server Management (structural guild operations)
+
+The connector exposes structural server management through the platform
+`MESSAGE` action (`op=manage_server`, `source=discord`). Supported
+operations:
+
+- `create_category`, `create_channel`, `edit_channel`, `delete_channel`
+- `create_role`, `edit_role`, `delete_role`
+- `edit_permissions` (channel permission overwrites)
+- `assign_role`, `remove_role`
+- `create_invite`
+- `kick`, `ban`, `unban`, `timeout`
+- `list_templates`, `apply_template` (idempotent, non-destructive guild
+  template reconcile)
+
+**Every structural write fails closed.** The `actions.channels`,
+`actions.roles`, `actions.permissions`, and `actions.moderation` gates all
+default to OFF and must be explicitly enabled:
+
+```json
+{
+  "settings": {
+    "discord": {
+      "token": "<bot token>",
+      "actions": {
+        "channels": true,
+        "roles": true,
+        "permissions": true,
+        "moderation": false
+      }
+    }
+  }
+}
+```
+
+Environment fallbacks: `DISCORD_ACTIONS_CHANNELS`, `DISCORD_ACTIONS_ROLES`,
+`DISCORD_ACTIONS_PERMISSIONS`, `DISCORD_ACTIONS_MODERATION` (only consulted
+when the config key is absent).
+
+Additional guardrails, independent of the gates:
+
+- The bot must actually hold the Discord-side permission (`ManageChannels`,
+  `ManageRoles`, `CreateInstantInvite`, `KickMembers`, `BanMembers`,
+  `ModerateMembers`) for the verb, or the operation fails with an actionable
+  error.
+- Role and member-role writes enforce Discord role hierarchy: only roles
+  strictly below the bot's highest role can be created against, edited,
+  deleted, or assigned. Integration-managed roles and `@everyone` are
+  refused.
+- Granting the `Administrator` permission through any role or overwrite is
+  always rejected, and requested role permissions must be a subset of the
+  bot's own permissions (no escalation).
+- Moderation refuses to target the guild owner and honors
+  `kickable`/`bannable`/`moderatable`.
+- Every operation accepts `dryRun: true` and returns a structured receipt
+  listing created/updated/unchanged/skipped entities.
+
+#### Guild templates
+
+`apply_template` reconciles a declarative guild spec (roles, categories,
+channels, permission overwrites) against the live guild:
+
+- Objects are matched by stable template `key` via a persisted
+  key-to-snowflake map (runtime cache), with exact-name fallback, so
+  re-applying converges (`unchanged`) instead of duplicating.
+- Reconcile creates missing objects and updates explicitly managed fields
+  (name, topic, parent, color, hoist, mentionable, permissions, overwrites).
+- It NEVER deletes channels or roles it does not manage; manual channels
+  and roles are untouched. Deletion only happens through the explicit
+  `delete_channel` / `delete_role` verbs.
+- `dryRun: true` returns the full plan (`would_create` / `would_update`)
+  without touching Discord.
+
+Built-in vendor-neutral templates: `companion-private`, `friends-casual`,
+`project-team`, `community-public`. Deployments can add or override
+templates via `settings.discord.guildTemplates` (per-account:
+`settings.discord.accounts.<id>.guildTemplates`):
+
+```json
+{
+  "settings": {
+    "discord": {
+      "guildTemplates": {
+        "my-workspace": {
+          "id": "my-workspace",
+          "categories": [{ "key": "ops", "name": "OPS" }],
+          "channels": [
+            { "key": "receipts", "name": "receipts", "parent": "ops" }
+          ]
+        }
+      }
+    }
+  }
+}
+```
+
+`{{agent}}` in template names renders the character name; custom variables
+can be supplied per apply via `variables`.
+
 ### Event Types
 
 The plugin emits the following Discord-specific events:

--- a/plugins/plugin-discord/__tests__/guild-management-authorization.test.ts
+++ b/plugins/plugin-discord/__tests__/guild-management-authorization.test.ts
@@ -1,0 +1,367 @@
+/**
+ * Exercises Discord guild-management destination binding and connector-boundary
+ * revalidation with the production authorization helpers over a mutable
+ * deterministic runtime. No Discord API calls are made.
+ */
+
+import {
+	authorizeManageServerDestination,
+	createUniqueUuid,
+	ElizaError,
+	stringToUuid,
+	type UUID,
+} from "@elizaos/core";
+import { createMockRuntime } from "@elizaos/core/testing";
+import { describe, expect, it } from "vitest";
+import type { ManageableGuild } from "../guild-management";
+import {
+	resolveDiscordManageServerDestination,
+	revalidateDiscordManageServerAuthorization,
+} from "../guild-management-authorization";
+import { DiscordService } from "../service";
+
+const AGENT_ID = "00000000-0000-0000-0000-000000000001" as UUID;
+const REQUESTER_ID = "00000000-0000-0000-0000-000000000002" as UUID;
+const LINKED_ID = "00000000-0000-0000-0000-000000000003" as UUID;
+const ROOM_ID = "00000000-0000-0000-0000-000000000004" as UUID;
+const GUILD_ID = "223456789012345678";
+const ACCOUNT_ID = "primary";
+
+function authorizationHarness() {
+	let member = true;
+	let role: "ADMIN" | "GUEST" = "ADMIN";
+	let worldId: UUID;
+	const runtime = createMockRuntime({
+		agentId: AGENT_ID,
+		logger: { debug() {}, info() {}, warn() {}, error() {} },
+		getWorld: async (requestedWorldId: UUID) =>
+			requestedWorldId === worldId
+				? {
+						id: worldId,
+						agentId: AGENT_ID,
+						messageServerId: stringToUuid(GUILD_ID),
+						metadata: {
+							roles: { [LINKED_ID]: role },
+							roleSources: { [LINKED_ID]: "manual" },
+						},
+					}
+				: null,
+		getRooms: async (requestedWorldId: UUID) =>
+			requestedWorldId === worldId
+				? [
+						{
+							id: ROOM_ID,
+							worldId,
+							agentId: AGENT_ID,
+							source: "discord",
+							type: "GROUP",
+							serverId: GUILD_ID,
+							messageServerId: stringToUuid(GUILD_ID),
+							metadata: { accountId: ACCOUNT_ID },
+						},
+					]
+				: [],
+		getRoomsForParticipant: async (entityId: UUID) =>
+			entityId === AGENT_ID || (entityId === LINKED_ID && member)
+				? [ROOM_ID]
+				: [],
+		getService: (serviceType: string) =>
+			serviceType === "relationships"
+				? ({
+						getVerifiedMemberEntityIds: async () => [LINKED_ID],
+					} as never)
+				: null,
+		reportError: () => undefined,
+	});
+	worldId = createUniqueUuid(runtime, GUILD_ID);
+	return {
+		runtime,
+		revokeMembership: () => {
+			member = false;
+		},
+		revokeRole: () => {
+			role = "GUEST";
+		},
+	};
+}
+
+async function errorCode(run: () => Promise<unknown>): Promise<string> {
+	try {
+		await run();
+		throw new Error("expected authorization failure");
+	} catch (error) {
+		if (!(error instanceof ElizaError)) throw error;
+		return error.code;
+	}
+}
+
+describe("Discord guild-management authorization", () => {
+	it("rejects display names instead of resolving them from the live guild cache", () => {
+		const { runtime } = authorizationHarness();
+		expect(() =>
+			resolveDiscordManageServerDestination(
+				runtime,
+				{ serverId: "Production Guild" },
+				ACCOUNT_ID,
+			),
+		).toThrowError(
+			expect.objectContaining({ code: "DISCORD_MANAGE_SERVER_ID_REQUIRED" }),
+		);
+	});
+
+	it("revalidates a verified linked ADMIN member at the connector boundary", async () => {
+		const { runtime } = authorizationHarness();
+		const destination = resolveDiscordManageServerDestination(
+			runtime,
+			{ serverId: GUILD_ID },
+			ACCOUNT_ID,
+		);
+		const authorization = await authorizeManageServerDestination(
+			runtime,
+			REQUESTER_ID,
+			destination,
+		);
+		const fresh = await revalidateDiscordManageServerAuthorization(
+			runtime,
+			authorization,
+			ACCOUNT_ID,
+			GUILD_ID,
+		);
+		expect(fresh).toMatchObject({
+			requesterEntityId: REQUESTER_ID,
+			authorizedEntityId: LINKED_ID,
+			role: "ADMIN",
+			accountId: ACCOUNT_ID,
+			serverId: GUILD_ID,
+		});
+	});
+
+	it("fails when membership is revoked between core authorization and mutation", async () => {
+		const { runtime, revokeMembership } = authorizationHarness();
+		const destination = resolveDiscordManageServerDestination(
+			runtime,
+			{ serverId: GUILD_ID },
+			ACCOUNT_ID,
+		);
+		const authorization = await authorizeManageServerDestination(
+			runtime,
+			REQUESTER_ID,
+			destination,
+		);
+		revokeMembership();
+		expect(
+			await errorCode(() =>
+				revalidateDiscordManageServerAuthorization(
+					runtime,
+					authorization,
+					ACCOUNT_ID,
+					GUILD_ID,
+				),
+			),
+		).toBe("MANAGE_SERVER_DESTINATION_NOT_AUTHORIZED");
+	});
+
+	it("fails when the destination role is revoked before mutation", async () => {
+		const { runtime, revokeRole } = authorizationHarness();
+		const destination = resolveDiscordManageServerDestination(
+			runtime,
+			{ serverId: GUILD_ID },
+			ACCOUNT_ID,
+		);
+		const authorization = await authorizeManageServerDestination(
+			runtime,
+			REQUESTER_ID,
+			destination,
+		);
+		revokeRole();
+		expect(
+			await errorCode(() =>
+				revalidateDiscordManageServerAuthorization(
+					runtime,
+					authorization,
+					ACCOUNT_ID,
+					GUILD_ID,
+				),
+			),
+		).toBe("MANAGE_SERVER_DESTINATION_NOT_AUTHORIZED");
+	});
+
+	it("revalidates membership through the real service before provider discovery", async () => {
+		const { runtime, revokeMembership } = authorizationHarness();
+		const destination = resolveDiscordManageServerDestination(
+			runtime,
+			{ serverId: GUILD_ID },
+			ACCOUNT_ID,
+		);
+		const authorization = await authorizeManageServerDestination(
+			runtime,
+			REQUESTER_ID,
+			destination,
+		);
+		revokeMembership();
+		let fetchCount = 0;
+		const service = Object.assign(Object.create(DiscordService.prototype), {
+			runtime,
+			defaultAccountId: ACCOUNT_ID,
+			getClient: () => ({
+				isReady: () => true,
+				guilds: {
+					fetch: async () => {
+						fetchCount += 1;
+						return { id: GUILD_ID };
+					},
+				},
+			}),
+		}) as unknown as DiscordService;
+
+		expect(
+			await errorCode(() =>
+				service.manageConnectorServer(runtime, {
+					target: destination.target,
+					operation: "create_channel",
+					serverId: GUILD_ID,
+					authorization,
+					params: { name: "must-not-exist" },
+					accountId: ACCOUNT_ID,
+				}),
+			),
+		).toBe("MANAGE_SERVER_DESTINATION_NOT_AUTHORIZED");
+		expect(fetchCount).toBe(0);
+	});
+
+	it("revalidates again after guild fetch so a race cannot mutate Discord", async () => {
+		const { runtime, revokeRole } = authorizationHarness();
+		const destination = resolveDiscordManageServerDestination(
+			runtime,
+			{ serverId: GUILD_ID },
+			ACCOUNT_ID,
+		);
+		const authorization = await authorizeManageServerDestination(
+			runtime,
+			REQUESTER_ID,
+			destination,
+		);
+		let mutationCount = 0;
+		const empty = new Map();
+		const guild = {
+			id: GUILD_ID,
+			name: "Destination B",
+			members: {
+				me: {
+					id: "bot",
+					permissions: { has: () => true },
+					roles: {
+						highest: { position: 100 },
+						cache: empty,
+						add: async () => undefined,
+						remove: async () => undefined,
+					},
+					kick: async () => undefined,
+					timeout: async () => undefined,
+				},
+				fetch: async () => {
+					throw new Error("unexpected member lookup");
+				},
+			},
+			roles: {
+				everyone: { id: GUILD_ID },
+				cache: empty,
+				fetch: async () => null,
+				create: async () => {
+					throw new Error("unexpected role mutation");
+				},
+			},
+			channels: {
+				cache: empty,
+				fetch: async () => null,
+				create: async (options: Record<string, unknown>) => {
+					mutationCount += 1;
+					return {
+						id: "423456789012345678",
+						name: String(options.name),
+					};
+				},
+			},
+			bans: {
+				create: async () => undefined,
+				remove: async () => undefined,
+			},
+		} as unknown as ManageableGuild;
+		const service = Object.assign(Object.create(DiscordService.prototype), {
+			runtime: {
+				...runtime,
+				character: {
+					...runtime.character,
+					settings: {
+						...runtime.character.settings,
+						discord: { actions: { channels: true } },
+					},
+				},
+			},
+			defaultAccountId: ACCOUNT_ID,
+			getClient: () => ({
+				isReady: () => true,
+				guilds: {
+					fetch: async () => {
+						revokeRole();
+						return guild;
+					},
+				},
+			}),
+		}) as unknown as DiscordService;
+
+		expect(
+			await errorCode(() =>
+				service.manageConnectorServer(runtime, {
+					target: destination.target,
+					operation: "create_channel",
+					serverId: GUILD_ID,
+					authorization,
+					params: { name: "must-not-exist" },
+					accountId: ACCOUNT_ID,
+				}),
+			),
+		).toBe("MANAGE_SERVER_DESTINATION_NOT_AUTHORIZED");
+		expect(mutationCount).toBe(0);
+	});
+
+	it("rejects source, account, and guild provenance mismatches", async () => {
+		const { runtime } = authorizationHarness();
+		const destination = resolveDiscordManageServerDestination(
+			runtime,
+			{ serverId: GUILD_ID },
+			ACCOUNT_ID,
+		);
+		const authorization = await authorizeManageServerDestination(
+			runtime,
+			REQUESTER_ID,
+			destination,
+		);
+		for (const [accountId, guildId] of [
+			["secondary", GUILD_ID],
+			[ACCOUNT_ID, "323456789012345678"],
+		] as const) {
+			expect(
+				await errorCode(() =>
+					revalidateDiscordManageServerAuthorization(
+						runtime,
+						authorization,
+						accountId,
+						guildId,
+					),
+				),
+			).toBe("DISCORD_MANAGE_SERVER_PROVENANCE_MISMATCH");
+		}
+		expect(() =>
+			resolveDiscordManageServerDestination(
+				runtime,
+				{ target: { source: "telegram" }, serverId: GUILD_ID },
+				ACCOUNT_ID,
+			),
+		).toThrowError(
+			expect.objectContaining({
+				code: "DISCORD_MANAGE_SERVER_SOURCE_MISMATCH",
+			}),
+		);
+	});
+});

--- a/plugins/plugin-discord/__tests__/guild-management-authorization.test.ts
+++ b/plugins/plugin-discord/__tests__/guild-management-authorization.test.ts
@@ -57,7 +57,6 @@ function authorizationHarness() {
 							type: "GROUP",
 							serverId: GUILD_ID,
 							messageServerId: stringToUuid(GUILD_ID),
-							metadata: { accountId: ACCOUNT_ID },
 						},
 					]
 				: [],
@@ -134,6 +133,29 @@ describe("Discord guild-management authorization", () => {
 			accountId: ACCOUNT_ID,
 			serverId: GUILD_ID,
 		});
+	});
+
+	it("allows either configured account to use one shared durable guild room", async () => {
+		const { runtime } = authorizationHarness();
+		for (const accountId of [ACCOUNT_ID, "secondary"]) {
+			const destination = resolveDiscordManageServerDestination(
+				runtime,
+				{ serverId: GUILD_ID },
+				accountId,
+			);
+			const authorization = await authorizeManageServerDestination(
+				runtime,
+				REQUESTER_ID,
+				destination,
+			);
+			const fresh = await revalidateDiscordManageServerAuthorization(
+				runtime,
+				authorization,
+				accountId,
+				GUILD_ID,
+			);
+			expect(fresh.accountId).toBe(accountId);
+		}
 	});
 
 	it("fails when membership is revoked between core authorization and mutation", async () => {

--- a/plugins/plugin-discord/__tests__/guild-management.test.ts
+++ b/plugins/plugin-discord/__tests__/guild-management.test.ts
@@ -130,9 +130,11 @@ function makeChannel(
 			async edit(target: string, options: Record<string, boolean | null>) {
 				const allow: string[] = [];
 				const deny: string[] = [];
+				const reset: string[] = [];
 				for (const [name, value] of Object.entries(options)) {
 					if (value === true) allow.push(name);
 					if (value === false) deny.push(name);
+					if (value === null) reset.push(name);
 				}
 				const existing = overwrites.get(target);
 				const mergedAllow = new Set([
@@ -145,6 +147,10 @@ function makeChannel(
 				]);
 				for (const name of allow) mergedDeny.delete(name);
 				for (const name of deny) mergedAllow.delete(name);
+				for (const name of reset) {
+					mergedAllow.delete(name);
+					mergedDeny.delete(name);
+				}
 				overwrites.set(target, {
 					id: target,
 					allow: permissionSet([...mergedAllow]),
@@ -774,6 +780,19 @@ describe("guild management verbs", () => {
 		expect(guild.channelsMap.size).toBe(0);
 	});
 
+	it("rejects direct channel topics beyond Discord's limit before writing", async () => {
+		const guild = makeGuild();
+		await expectError(
+			run(guild, {
+				operation: "create_channel",
+				name: "general",
+				topic: "x".repeat(1025),
+			}),
+			"TOPIC_TOO_LONG",
+		);
+		expect(guild.log).toHaveLength(0);
+	});
+
 	it("assign_role is idempotent (already-assigned reports unchanged)", async () => {
 		const guild = makeGuild();
 		const role = makeRole(guild, { name: "Dev", position: 2 });
@@ -905,6 +924,53 @@ describe("apply_template reconcile", () => {
 		expect(lounge?.name).toBe("lounge");
 	});
 
+	it("reconcile removes stale extra permissions from managed overwrites", async () => {
+		const guild = makeGuild();
+		const stateStore = memoryStateStore();
+		await run(
+			guild,
+			{ operation: "apply_template", template: "project-team" },
+			{ stateStore },
+		);
+		const dev = [...guild.channelsMap.values()].find(
+			(channel) => channel.name === "dev",
+		) as
+			| (ManageableChannel & {
+					__overwrites: Map<
+						string,
+						{
+							id: string;
+							allow: ReturnType<typeof permissionSet>;
+							deny: ReturnType<typeof permissionSet>;
+						}
+					>;
+			  })
+			| undefined;
+		expect(dev).toBeDefined();
+		const everyone = dev?.__overwrites.get(guild.roles.everyone.id);
+		expect(everyone).toBeDefined();
+		if (dev && everyone) {
+			dev.__overwrites.set(everyone.id, {
+				...everyone,
+				allow: permissionSet(["ManageChannels"]),
+			});
+		}
+
+		const second = await run(
+			guild,
+			{ operation: "apply_template", template: "project-team" },
+			{ stateStore },
+		);
+		expect(
+			second.entries.find((entry) => entry.key === "dev/@everyone")?.action,
+		).toBe("updated");
+		expect(
+			dev?.__overwrites
+				.get(guild.roles.everyone.id)
+				?.allow.has("ManageChannels"),
+		).toBe(false);
+	});
+
 	it("NEVER deletes unmanaged channels or roles", async () => {
 		const guild = makeGuild();
 		const manualChannel = makeChannel(guild, {
@@ -970,6 +1036,37 @@ describe("apply_template reconcile", () => {
 			}),
 			"TEMPLATE_INVALID",
 		);
+	});
+
+	it("rejects malformed inline template collections without entering reconcile", async () => {
+		const guild = makeGuild();
+		await expectError(
+			run(guild, {
+				operation: "apply_template",
+				templateSpec: {
+					id: "malformed",
+					roles: {} as never,
+				},
+			}),
+			"TEMPLATE_INVALID",
+		);
+		expect(guild.log).toHaveLength(0);
+	});
+
+	it("rejects template variables that render names beyond Discord's limit", async () => {
+		const guild = makeGuild();
+		await expectError(
+			run(guild, {
+				operation: "apply_template",
+				templateSpec: {
+					id: "render-bound",
+					roles: [{ key: "agent", name: "{{agent}}" }],
+				},
+				variables: { agent: "x".repeat(101) },
+			}),
+			"TEMPLATE_RENDER_INVALID",
+		);
+		expect(guild.log).toHaveLength(0);
 	});
 
 	it("rejects inline template specs that request Administrator", async () => {

--- a/plugins/plugin-discord/__tests__/guild-management.test.ts
+++ b/plugins/plugin-discord/__tests__/guild-management.test.ts
@@ -1,0 +1,1019 @@
+/**
+ * Unit tests for the structural guild-management module: fail-closed config
+ * gates, role-hierarchy denial, Administrator/permission-escalation rejection,
+ * malformed-input errors, idempotent template reconcile (second apply is all
+ * "unchanged"), non-destruction of unmanaged channels/roles, dry-run planning,
+ * and moderation guardrails. Driven entirely by plain fakes of the
+ * `Manageable*` structural interfaces — no live Discord client.
+ */
+import { describe, expect, it } from "vitest";
+import {
+	executeGuildManagement,
+	GuildManagementError,
+	type GuildManagementGates,
+	type GuildManagementRequest,
+	type ManageableBotMember,
+	type ManageableChannel,
+	type ManageableGuild,
+	type ManageableMember,
+	type ManageableRole,
+	normalizePermissionList,
+	resolveGuildManagementGates,
+	type TemplateStateStore,
+} from "../guild-management";
+import { BUILT_IN_GUILD_TEMPLATES } from "../guild-templates";
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+let idCounter = 1000;
+function nextId(): string {
+	idCounter += 1;
+	return String(idCounter);
+}
+
+function permissionSet(names: string[]) {
+	const set = new Set(names);
+	return {
+		has: (name: string) => set.has(name) || set.has("Administrator"),
+		toArray: () => [...set].sort(),
+	};
+}
+
+interface FakeRoleInit {
+	id?: string;
+	name: string;
+	position?: number;
+	managed?: boolean;
+	color?: number;
+	hoist?: boolean;
+	mentionable?: boolean;
+	permissions?: string[];
+}
+
+function makeRole(guild: FakeGuild, init: FakeRoleInit): ManageableRole {
+	const role: ManageableRole = {
+		id: init.id ?? nextId(),
+		name: init.name,
+		position: init.position ?? 1,
+		managed: init.managed ?? false,
+		color: init.color ?? 0,
+		hoist: init.hoist ?? false,
+		mentionable: init.mentionable ?? false,
+		permissions: permissionSet(init.permissions ?? []),
+		async edit(options: Record<string, unknown>) {
+			if (typeof options.name === "string") role.name = options.name;
+			if (typeof options.color === "number") role.color = options.color;
+			if (typeof options.hoist === "boolean") role.hoist = options.hoist;
+			if (typeof options.mentionable === "boolean")
+				role.mentionable = options.mentionable;
+			if (Array.isArray(options.permissions)) {
+				role.permissions = permissionSet(options.permissions as string[]);
+			}
+			guild.log.push({ op: "role.edit", id: role.id, options });
+			return role;
+		},
+		async delete(reason?: string) {
+			guild.rolesMap.delete(role.id);
+			guild.log.push({ op: "role.delete", id: role.id, reason });
+			return undefined;
+		},
+	};
+	return role;
+}
+
+interface FakeChannelInit {
+	id?: string;
+	name: string;
+	type: number;
+	parentId?: string | null;
+	topic?: string | null;
+}
+
+function makeChannel(
+	guild: FakeGuild,
+	init: FakeChannelInit,
+): ManageableChannel {
+	const overwrites = new Map<
+		string,
+		{
+			id: string;
+			allow: ReturnType<typeof permissionSet>;
+			deny: ReturnType<typeof permissionSet>;
+		}
+	>();
+	const channel: ManageableChannel & {
+		__overwrites: typeof overwrites;
+	} = {
+		id: init.id ?? nextId(),
+		name: init.name,
+		type: init.type,
+		parentId: init.parentId ?? null,
+		topic: init.topic ?? null,
+		guildId: guild.id,
+		__overwrites: overwrites,
+		async edit(options: Record<string, unknown>) {
+			if (typeof options.name === "string") channel.name = options.name;
+			if (typeof options.topic === "string") channel.topic = options.topic;
+			if (typeof options.parent === "string") channel.parentId = options.parent;
+			guild.log.push({ op: "channel.edit", id: channel.id, options });
+			return channel;
+		},
+		async delete(reason?: string) {
+			guild.channelsMap.delete(channel.id);
+			guild.log.push({ op: "channel.delete", id: channel.id, reason });
+			return undefined;
+		},
+		permissionOverwrites: {
+			cache: overwrites,
+			async edit(target: string, options: Record<string, boolean | null>) {
+				const allow: string[] = [];
+				const deny: string[] = [];
+				for (const [name, value] of Object.entries(options)) {
+					if (value === true) allow.push(name);
+					if (value === false) deny.push(name);
+				}
+				const existing = overwrites.get(target);
+				const mergedAllow = new Set([
+					...(existing ? existing.allow.toArray() : []),
+					...allow,
+				]);
+				const mergedDeny = new Set([
+					...(existing ? existing.deny.toArray() : []),
+					...deny,
+				]);
+				for (const name of allow) mergedDeny.delete(name);
+				for (const name of deny) mergedAllow.delete(name);
+				overwrites.set(target, {
+					id: target,
+					allow: permissionSet([...mergedAllow]),
+					deny: permissionSet([...mergedDeny]),
+				});
+				guild.log.push({
+					op: "overwrite.edit",
+					id: channel.id,
+					target,
+					options,
+				});
+				return undefined;
+			},
+		},
+		async createInvite(options) {
+			guild.log.push({ op: "invite.create", id: channel.id, options });
+			return { code: "abc123", url: "https://discord.gg/abc123" };
+		},
+	};
+	return channel;
+}
+
+interface FakeGuild extends ManageableGuild {
+	rolesMap: Map<string, ManageableRole>;
+	channelsMap: Map<string, ManageableChannel>;
+	membersMap: Map<string, ManageableMember>;
+	log: Array<Record<string, unknown>>;
+	bans_: Set<string>;
+}
+
+function makeGuild(options?: {
+	botPermissions?: string[];
+	botRolePosition?: number;
+}): FakeGuild {
+	const rolesMap = new Map<string, ManageableRole>();
+	const channelsMap = new Map<string, ManageableChannel>();
+	const membersMap = new Map<string, ManageableMember>();
+	const log: Array<Record<string, unknown>> = [];
+	const bans_ = new Set<string>();
+	const everyoneId = "1";
+	const botPermissions = options?.botPermissions ?? [
+		"ManageChannels",
+		"ManageRoles",
+		"CreateInstantInvite",
+		"KickMembers",
+		"BanMembers",
+		"ModerateMembers",
+		"ViewChannel",
+		"SendMessages",
+		"ManageMessages",
+		"ReadMessageHistory",
+		"AddReactions",
+		"AttachFiles",
+		"EmbedLinks",
+		"Connect",
+		"Speak",
+		"ManageThreads",
+		"CreatePublicThreads",
+		"SendMessagesInThreads",
+		"UseApplicationCommands",
+		"MentionEveryone",
+		"ManageNicknames",
+		"ModerateMembers",
+	];
+	const bot: ManageableBotMember = {
+		id: "bot",
+		permissions: permissionSet(botPermissions),
+		roles: {
+			highest: { position: options?.botRolePosition ?? 100 },
+			cache: new Map(),
+			add: async () => undefined,
+			remove: async () => undefined,
+		},
+		kick: async () => undefined,
+		timeout: async () => undefined,
+	};
+	const guild: FakeGuild = {
+		id: "guild-1",
+		name: "Test Guild",
+		ownerId: "owner-1",
+		rolesMap,
+		channelsMap,
+		membersMap,
+		log,
+		bans_,
+		members: {
+			me: bot,
+			async fetch(userId: string) {
+				const member = membersMap.get(userId);
+				if (!member) throw new Error("Unknown Member");
+				return member;
+			},
+		},
+		roles: {
+			everyone: { id: everyoneId },
+			cache: rolesMap,
+			async fetch(roleId: string) {
+				return rolesMap.get(roleId) ?? null;
+			},
+			async create(createOptions: Record<string, unknown>) {
+				const role = makeRole(guild, {
+					name: String(createOptions.name),
+					position: 1,
+					color:
+						typeof createOptions.color === "number"
+							? createOptions.color
+							: undefined,
+					hoist:
+						typeof createOptions.hoist === "boolean"
+							? createOptions.hoist
+							: undefined,
+					mentionable:
+						typeof createOptions.mentionable === "boolean"
+							? createOptions.mentionable
+							: undefined,
+					permissions: Array.isArray(createOptions.permissions)
+						? (createOptions.permissions as string[])
+						: [],
+				});
+				rolesMap.set(role.id, role);
+				log.push({ op: "role.create", id: role.id, options: createOptions });
+				return role;
+			},
+		},
+		channels: {
+			cache: channelsMap,
+			async fetch(channelId: string) {
+				return channelsMap.get(channelId) ?? null;
+			},
+			async create(createOptions: Record<string, unknown>) {
+				const channel = makeChannel(guild, {
+					name: String(createOptions.name),
+					type: Number(createOptions.type),
+					parentId:
+						typeof createOptions.parent === "string"
+							? createOptions.parent
+							: null,
+					topic:
+						typeof createOptions.topic === "string"
+							? createOptions.topic
+							: null,
+				});
+				channelsMap.set(channel.id, channel);
+				log.push({
+					op: "channel.create",
+					id: channel.id,
+					options: createOptions,
+				});
+				return channel;
+			},
+		},
+		bans: {
+			async create(userId: string, banOptions?: Record<string, unknown>) {
+				bans_.add(userId);
+				log.push({ op: "ban.create", id: userId, options: banOptions });
+				return undefined;
+			},
+			async remove(userId: string, reason?: string) {
+				bans_.delete(userId);
+				log.push({ op: "ban.remove", id: userId, reason });
+				return undefined;
+			},
+		},
+	};
+	// @everyone role present in cache.
+	rolesMap.set(
+		everyoneId,
+		makeRole(guild, { id: everyoneId, name: "@everyone", position: 0 }),
+	);
+	return guild;
+}
+
+function makeMember(
+	guild: FakeGuild,
+	init: {
+		id: string;
+		roles?: string[];
+		kickable?: boolean;
+		bannable?: boolean;
+		moderatable?: boolean;
+	},
+): ManageableMember {
+	const roleCache = new Map<string, { id: string }>();
+	for (const roleId of init.roles ?? []) roleCache.set(roleId, { id: roleId });
+	const member: ManageableMember = {
+		id: init.id,
+		kickable: init.kickable,
+		bannable: init.bannable,
+		moderatable: init.moderatable,
+		roles: {
+			highest: { position: 1 },
+			cache: roleCache,
+			async add(roleId: string) {
+				roleCache.set(roleId, { id: roleId });
+				guild.log.push({ op: "member.role.add", id: init.id, roleId });
+				return undefined;
+			},
+			async remove(roleId: string) {
+				roleCache.delete(roleId);
+				guild.log.push({ op: "member.role.remove", id: init.id, roleId });
+				return undefined;
+			},
+		},
+		async kick(reason?: string) {
+			guild.log.push({ op: "member.kick", id: init.id, reason });
+			return undefined;
+		},
+		async timeout(durationMs: number | null, reason?: string) {
+			guild.log.push({ op: "member.timeout", id: init.id, durationMs, reason });
+			return undefined;
+		},
+	};
+	guild.membersMap.set(init.id, member);
+	return member;
+}
+
+function memoryStateStore(): TemplateStateStore & {
+	stateMap: Map<string, Record<string, string>>;
+} {
+	const stateMap = new Map<string, Record<string, string>>();
+	return {
+		stateMap,
+		async get(guildId, templateId) {
+			return stateMap.get(`${guildId}:${templateId}`);
+		},
+		async set(guildId, templateId, state) {
+			stateMap.set(`${guildId}:${templateId}`, state);
+		},
+	};
+}
+
+const ALL_GATES: GuildManagementGates = {
+	channels: true,
+	roles: true,
+	permissions: true,
+	moderation: true,
+};
+
+function run(
+	guild: FakeGuild,
+	request: GuildManagementRequest,
+	overrides?: {
+		gates?: Partial<GuildManagementGates>;
+		stateStore?: TemplateStateStore;
+	},
+) {
+	return executeGuildManagement(
+		{
+			guild,
+			gates: { ...ALL_GATES, ...(overrides?.gates ?? {}) },
+			stateStore: overrides?.stateStore ?? memoryStateStore(),
+			agentName: "Soliza",
+		},
+		request,
+	);
+}
+
+async function expectError(
+	promise: Promise<unknown>,
+	code: string,
+): Promise<GuildManagementError> {
+	try {
+		await promise;
+	} catch (error) {
+		expect(error).toBeInstanceOf(GuildManagementError);
+		const managementError = error as GuildManagementError;
+		expect(managementError.code).toBe(code);
+		return managementError;
+	}
+	throw new Error(`expected GuildManagementError ${code}, got success`);
+}
+
+// ---------------------------------------------------------------------------
+// Gate behavior (fail closed)
+// ---------------------------------------------------------------------------
+
+describe("guild management gates", () => {
+	it("resolves absent config to every structural gate OFF", () => {
+		expect(resolveGuildManagementGates(undefined)).toEqual({
+			channels: false,
+			roles: false,
+			permissions: false,
+			moderation: false,
+		});
+	});
+
+	it("only an explicit true opens a gate (truthy strings stay closed)", () => {
+		expect(
+			resolveGuildManagementGates({
+				channels: "true",
+				roles: 1,
+				permissions: true,
+				moderation: false,
+			}),
+		).toEqual({
+			channels: false,
+			roles: false,
+			permissions: true,
+			moderation: false,
+		});
+	});
+
+	it("denies create_channel when actions.channels is off", async () => {
+		const guild = makeGuild();
+		const error = await expectError(
+			run(
+				guild,
+				{ operation: "create_channel", name: "general" },
+				{
+					gates: { channels: false },
+				},
+			),
+			"GATE_DISABLED",
+		);
+		expect(error.message).toContain("actions.channels");
+		expect(guild.log).toHaveLength(0);
+	});
+
+	it("denies create_role when actions.roles is off", async () => {
+		const guild = makeGuild();
+		await expectError(
+			run(
+				guild,
+				{ operation: "create_role", name: "Dev" },
+				{
+					gates: { roles: false },
+				},
+			),
+			"GATE_DISABLED",
+		);
+		expect(guild.log).toHaveLength(0);
+	});
+
+	it("denies edit_permissions when actions.permissions is off", async () => {
+		const guild = makeGuild();
+		await expectError(
+			run(
+				guild,
+				{
+					operation: "edit_permissions",
+					channelId: "123",
+					overwriteId: "@everyone",
+					deny: ["ViewChannel"],
+				},
+				{ gates: { permissions: false } },
+			),
+			"GATE_DISABLED",
+		);
+		expect(guild.log).toHaveLength(0);
+	});
+
+	it("denies kick when actions.moderation is off", async () => {
+		const guild = makeGuild();
+		await expectError(
+			run(
+				guild,
+				{ operation: "kick", userId: "12345678" },
+				{
+					gates: { moderation: false },
+				},
+			),
+			"GATE_DISABLED",
+		);
+		expect(guild.log).toHaveLength(0);
+	});
+
+	it("apply_template requires channels + roles + permissions gates", async () => {
+		const guild = makeGuild();
+		const error = await expectError(
+			run(
+				guild,
+				{ operation: "apply_template", template: "project-team" },
+				{
+					gates: { permissions: false },
+				},
+			),
+			"GATE_DISABLED",
+		);
+		expect(error.message).toContain("actions.permissions");
+	});
+
+	it("list_templates requires no gates", async () => {
+		const guild = makeGuild();
+		const result = await run(
+			guild,
+			{ operation: "list_templates" },
+			{
+				gates: {
+					channels: false,
+					roles: false,
+					permissions: false,
+					moderation: false,
+				},
+			},
+		);
+		expect(result.templates?.map((template) => template.id)).toEqual(
+			Object.keys(BUILT_IN_GUILD_TEMPLATES).sort(),
+		);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Input validation
+// ---------------------------------------------------------------------------
+
+describe("guild management input validation", () => {
+	it("rejects unknown operations", async () => {
+		const guild = makeGuild();
+		await expectError(
+			run(guild, { operation: "nuke_guild" as never }),
+			"OPERATION_UNKNOWN",
+		);
+	});
+
+	it("rejects Administrator in role permissions", async () => {
+		const guild = makeGuild();
+		await expectError(
+			run(guild, {
+				operation: "create_role",
+				name: "Sneaky",
+				permissions: ["ADMINISTRATOR"],
+			}),
+			"PERMISSION_ADMINISTRATOR_FORBIDDEN",
+		);
+		expect(guild.log).toHaveLength(0);
+	});
+
+	it("rejects unknown permission names with the offending name", async () => {
+		const guild = makeGuild();
+		const error = await expectError(
+			run(guild, {
+				operation: "create_role",
+				name: "Dev",
+				permissions: ["TotallyRealPerm"],
+			}),
+			"PERMISSION_UNKNOWN",
+		);
+		expect(error.message).toContain("TotallyRealPerm");
+	});
+
+	it("accepts SCREAMING_SNAKE and camelCase permission spellings", () => {
+		expect(
+			normalizePermissionList(["MANAGE_CHANNELS", "sendMessages"], "test"),
+		).toEqual(["ManageChannels", "SendMessages"]);
+	});
+
+	it("rejects a permission listed in both allow and deny", async () => {
+		const guild = makeGuild();
+		const channel = makeChannel(guild, { name: "general", type: 0 });
+		guild.channelsMap.set(channel.id, channel);
+		await expectError(
+			run(guild, {
+				operation: "edit_permissions",
+				channelId: channel.id,
+				overwriteId: "@everyone",
+				allow: ["SendMessages"],
+				deny: ["SendMessages"],
+			}),
+			"PERMISSION_CONFLICT",
+		);
+	});
+
+	it("rejects invalid colors", async () => {
+		const guild = makeGuild();
+		await expectError(
+			run(guild, { operation: "create_role", name: "Dev", color: "red" }),
+			"COLOR_INVALID",
+		);
+	});
+
+	it("requires channelId for edit_channel", async () => {
+		const guild = makeGuild();
+		await expectError(
+			run(guild, { operation: "edit_channel", name: "renamed" }),
+			"CHANNEL_ID_REQUIRED",
+		);
+	});
+
+	it("fails on channels that do not exist in the guild", async () => {
+		const guild = makeGuild();
+		await expectError(
+			run(guild, { operation: "delete_channel", channelId: "404404" }),
+			"CHANNEL_NOT_FOUND",
+		);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Permission escalation + hierarchy
+// ---------------------------------------------------------------------------
+
+describe("guild management hierarchy and escalation guards", () => {
+	it("refuses to grant role permissions the bot does not hold", async () => {
+		const guild = makeGuild({
+			botPermissions: ["ManageRoles", "ViewChannel", "SendMessages"],
+		});
+		const error = await expectError(
+			run(guild, {
+				operation: "create_role",
+				name: "Overreach",
+				permissions: ["BanMembers"],
+			}),
+			"PERMISSION_ESCALATION",
+		);
+		expect(error.message).toContain("BanMembers");
+	});
+
+	it("refuses to edit a role at or above the bot's highest role", async () => {
+		const guild = makeGuild({ botRolePosition: 5 });
+		const high = makeRole(guild, { name: "Above", position: 9 });
+		guild.rolesMap.set(high.id, high);
+		await expectError(
+			run(guild, { operation: "edit_role", roleId: high.id, name: "Renamed" }),
+			"ROLE_HIERARCHY",
+		);
+	});
+
+	it("refuses to delete integration-managed roles", async () => {
+		const guild = makeGuild();
+		const managed = makeRole(guild, {
+			name: "SomeBot",
+			position: 2,
+			managed: true,
+		});
+		guild.rolesMap.set(managed.id, managed);
+		await expectError(
+			run(guild, { operation: "delete_role", roleId: managed.id }),
+			"ROLE_MANAGED",
+		);
+	});
+
+	it("refuses direct writes against @everyone via role verbs", async () => {
+		const guild = makeGuild();
+		await expectError(
+			run(guild, { operation: "delete_role", roleId: "1" }),
+			"ROLE_EVERYONE",
+		);
+	});
+
+	it("refuses assign_role when the role is above the bot", async () => {
+		const guild = makeGuild({ botRolePosition: 3 });
+		const high = makeRole(guild, { name: "Admin", position: 8 });
+		guild.rolesMap.set(high.id, high);
+		makeMember(guild, { id: "555555" });
+		await expectError(
+			run(guild, {
+				operation: "assign_role",
+				roleId: high.id,
+				userId: "555555",
+			}),
+			"ROLE_HIERARCHY",
+		);
+	});
+
+	it("refuses moderation against the guild owner", async () => {
+		const guild = makeGuild();
+		makeMember(guild, { id: "owner-1" });
+		await expectError(
+			run(guild, { operation: "kick", userId: "owner-1" }),
+			"USER_ID_INVALID",
+		);
+		// With a snowflake-shaped owner id the owner guard fires.
+		guild.ownerId = "99999999";
+		makeMember(guild, { id: "99999999" });
+		await expectError(
+			run(guild, { operation: "kick", userId: "99999999" }),
+			"MODERATION_OWNER",
+		);
+	});
+
+	it("refuses kick when Discord reports the member is not kickable", async () => {
+		const guild = makeGuild();
+		makeMember(guild, { id: "424242", kickable: false });
+		await expectError(
+			run(guild, { operation: "kick", userId: "424242" }),
+			"MODERATION_HIERARCHY",
+		);
+	});
+
+	it("refuses writes when the bot lacks the Discord-side permission", async () => {
+		const guild = makeGuild({ botPermissions: ["SendMessages"] });
+		const error = await expectError(
+			run(guild, { operation: "create_channel", name: "general" }),
+			"BOT_MISSING_PERMISSION",
+		);
+		expect(error.message).toContain("ManageChannels");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Individual verbs
+// ---------------------------------------------------------------------------
+
+describe("guild management verbs", () => {
+	it("creates a category and a channel under it", async () => {
+		const guild = makeGuild();
+		const categoryReceipt = await run(guild, {
+			operation: "create_category",
+			name: "OPS",
+		});
+		expect(categoryReceipt.entries[0]?.action).toBe("created");
+		const categoryId = categoryReceipt.entries[0]?.id as string;
+		const channelReceipt = await run(guild, {
+			operation: "create_channel",
+			name: "alerts",
+			parentId: categoryId,
+			topic: "CI alerts",
+		});
+		expect(channelReceipt.entries[0]?.action).toBe("created");
+		const created = guild.channelsMap.get(
+			channelReceipt.entries[0]?.id as string,
+		);
+		expect(created?.parentId).toBe(categoryId);
+		expect(created?.topic).toBe("CI alerts");
+	});
+
+	it("dry-run create reports the plan without writing", async () => {
+		const guild = makeGuild();
+		const receipt = await run(guild, {
+			operation: "create_channel",
+			name: "general",
+			dryRun: true,
+		});
+		expect(receipt.dryRun).toBe(true);
+		expect(receipt.entries[0]?.action).toBe("would_create");
+		expect(guild.log).toHaveLength(0);
+		expect(guild.channelsMap.size).toBe(0);
+	});
+
+	it("assign_role is idempotent (already-assigned reports unchanged)", async () => {
+		const guild = makeGuild();
+		const role = makeRole(guild, { name: "Dev", position: 2 });
+		guild.rolesMap.set(role.id, role);
+		makeMember(guild, { id: "777777" });
+		const first = await run(guild, {
+			operation: "assign_role",
+			roleId: role.id,
+			userId: "777777",
+		});
+		expect(first.entries[0]?.action).toBe("updated");
+		const second = await run(guild, {
+			operation: "assign_role",
+			roleId: role.id,
+			userId: "777777",
+		});
+		expect(second.entries[0]?.action).toBe("unchanged");
+		const writes = guild.log.filter((entry) => entry.op === "member.role.add");
+		expect(writes).toHaveLength(1);
+	});
+
+	it("creates invites with bounded age and never echoes tokens", async () => {
+		const guild = makeGuild();
+		const channel = makeChannel(guild, { name: "general", type: 0 });
+		guild.channelsMap.set(channel.id, channel);
+		const receipt = await run(guild, {
+			operation: "create_invite",
+			channelId: channel.id,
+			maxAgeSeconds: 99999999,
+		});
+		expect(receipt.invite?.code).toBe("abc123");
+		const logged = guild.log.find((entry) => entry.op === "invite.create");
+		expect(logged).toBeDefined();
+		expect(
+			(logged as { options: { maxAge: number } }).options.maxAge,
+		).toBeLessThanOrEqual(7 * 24 * 60 * 60);
+	});
+
+	it("timeout clamps duration and moderatable=false denies", async () => {
+		const guild = makeGuild();
+		makeMember(guild, { id: "888888", moderatable: true });
+		const receipt = await run(guild, {
+			operation: "timeout",
+			userId: "888888",
+			durationMinutes: 10_000_000,
+		});
+		expect(receipt.entries[0]?.action).toBe("updated");
+		const logged = guild.log.find((entry) => entry.op === "member.timeout");
+		expect((logged as { durationMs: number }).durationMs).toBeLessThanOrEqual(
+			28 * 24 * 60 * 60 * 1000,
+		);
+	});
+
+	it("ban then unban round-trips through guild.bans", async () => {
+		const guild = makeGuild();
+		await run(guild, { operation: "ban", userId: "654321" });
+		expect(guild.bans_.has("654321")).toBe(true);
+		await run(guild, { operation: "unban", userId: "654321" });
+		expect(guild.bans_.has("654321")).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Template reconcile
+// ---------------------------------------------------------------------------
+
+describe("apply_template reconcile", () => {
+	it("first apply creates roles, categories, channels, and overwrites", async () => {
+		const guild = makeGuild();
+		const stateStore = memoryStateStore();
+		const receipt = await run(
+			guild,
+			{ operation: "apply_template", template: "project-team" },
+			{ stateStore },
+		);
+		expect(
+			receipt.entries.filter((entry) => entry.action === "created").length,
+		).toBeGreaterThanOrEqual(4 + 3 + 4); // roles + categories + channels
+		// Agent placeholder rendered.
+		const agentRole = [...guild.rolesMap.values()].find(
+			(role) => role.name === "Soliza",
+		);
+		expect(agentRole).toBeDefined();
+		// State persisted for idempotency.
+		expect(stateStore.stateMap.get("guild-1:project-team")).toBeDefined();
+	});
+
+	it("second apply converges: everything unchanged, zero writes", async () => {
+		const guild = makeGuild();
+		const stateStore = memoryStateStore();
+		await run(
+			guild,
+			{ operation: "apply_template", template: "project-team" },
+			{ stateStore },
+		);
+		const writesAfterFirst = guild.log.length;
+		const second = await run(
+			guild,
+			{ operation: "apply_template", template: "project-team" },
+			{ stateStore },
+		);
+		expect(second.entries.every((entry) => entry.action === "unchanged")).toBe(
+			true,
+		);
+		expect(guild.log.length).toBe(writesAfterFirst);
+	});
+
+	it("re-apply after manual rename converges the managed channel back", async () => {
+		const guild = makeGuild();
+		const stateStore = memoryStateStore();
+		await run(
+			guild,
+			{ operation: "apply_template", template: "friends-casual" },
+			{ stateStore },
+		);
+		const lounge = [...guild.channelsMap.values()].find(
+			(channel) => channel.name === "lounge",
+		);
+		expect(lounge).toBeDefined();
+		// Manual drift.
+		if (lounge) lounge.name = "renamed-by-human";
+		const second = await run(
+			guild,
+			{ operation: "apply_template", template: "friends-casual" },
+			{ stateStore },
+		);
+		const loungeEntry = second.entries.find((entry) => entry.key === "lounge");
+		expect(loungeEntry?.action).toBe("updated");
+		expect(lounge?.name).toBe("lounge");
+	});
+
+	it("NEVER deletes unmanaged channels or roles", async () => {
+		const guild = makeGuild();
+		const manualChannel = makeChannel(guild, {
+			name: "hand-made-channel",
+			type: 0,
+		});
+		guild.channelsMap.set(manualChannel.id, manualChannel);
+		const manualRole = makeRole(guild, { name: "Hand Made Role", position: 2 });
+		guild.rolesMap.set(manualRole.id, manualRole);
+		await run(guild, { operation: "apply_template", template: "project-team" });
+		await run(guild, { operation: "apply_template", template: "project-team" });
+		expect(guild.channelsMap.get(manualChannel.id)).toBeDefined();
+		expect(guild.rolesMap.get(manualRole.id)).toBeDefined();
+		expect(
+			guild.log.some(
+				(entry) => entry.op === "channel.delete" || entry.op === "role.delete",
+			),
+		).toBe(false);
+	});
+
+	it("dry-run apply plans without writing and without persisting state", async () => {
+		const guild = makeGuild();
+		const stateStore = memoryStateStore();
+		const receipt = await run(
+			guild,
+			{
+				operation: "apply_template",
+				template: "companion-private",
+				dryRun: true,
+			},
+			{ stateStore },
+		);
+		expect(receipt.dryRun).toBe(true);
+		expect(
+			receipt.entries.every((entry) =>
+				["would_create", "would_update", "unchanged", "skipped"].includes(
+					entry.action,
+				),
+			),
+		).toBe(true);
+		expect(guild.log).toHaveLength(0);
+		expect(stateStore.stateMap.size).toBe(0);
+	});
+
+	it("rejects unknown template ids with the available list", async () => {
+		const guild = makeGuild();
+		const error = await expectError(
+			run(guild, { operation: "apply_template", template: "does-not-exist" }),
+			"TEMPLATE_NOT_FOUND",
+		);
+		expect(error.message).toContain("project-team");
+	});
+
+	it("rejects inline template specs that fail validation", async () => {
+		const guild = makeGuild();
+		await expectError(
+			run(guild, {
+				operation: "apply_template",
+				templateSpec: {
+					id: "broken",
+					channels: [{ key: "a", name: "a", parent: "missing-category" }],
+				},
+			}),
+			"TEMPLATE_INVALID",
+		);
+	});
+
+	it("rejects inline template specs that request Administrator", async () => {
+		const guild = makeGuild();
+		await expectError(
+			run(guild, {
+				operation: "apply_template",
+				templateSpec: {
+					id: "sneaky",
+					roles: [
+						{ key: "boss", name: "Boss", permissions: ["Administrator"] },
+					],
+				},
+			}),
+			"PERMISSION_ADMINISTRATOR_FORBIDDEN",
+		);
+	});
+
+	it("supports custom tenant templates through the registry override", async () => {
+		const guild = makeGuild();
+		const receipt = await executeGuildManagement(
+			{
+				guild,
+				gates: ALL_GATES,
+				stateStore: memoryStateStore(),
+				agentName: "Soliza",
+				templateRegistry: {
+					"code-ops": {
+						id: "code-ops",
+						categories: [{ key: "cat", name: "CODE OPS" }],
+						channels: [
+							{ key: "builds", name: "builds", parent: "cat" },
+							{ key: "prs", name: "prs", parent: "cat" },
+						],
+					},
+				},
+			},
+			{ operation: "apply_template", template: "code-ops" },
+		);
+		expect(
+			receipt.entries.filter((entry) => entry.action === "created"),
+		).toHaveLength(3);
+		expect(
+			[...guild.channelsMap.values()].map((channel) => channel.name).sort(),
+		).toEqual(["CODE OPS", "builds", "prs"]);
+	});
+});

--- a/plugins/plugin-discord/__tests__/guild-management.test.ts
+++ b/plugins/plugin-discord/__tests__/guild-management.test.ts
@@ -240,7 +240,9 @@ function makeGuild(options?: {
 			me: bot,
 			async fetch(userId: string) {
 				const member = membersMap.get(userId);
-				if (!member) throw new Error("Unknown Member");
+				if (!member) {
+					throw Object.assign(new Error("Unknown Member"), { code: 10007 });
+				}
 				return member;
 			},
 		},
@@ -852,6 +854,20 @@ describe("guild management verbs", () => {
 		expect(guild.bans_.has("654321")).toBe(true);
 		await run(guild, { operation: "unban", userId: "654321" });
 		expect(guild.bans_.has("654321")).toBe(false);
+	});
+
+	it("does not ban when member lookup fails for a reason other than absence", async () => {
+		const guild = makeGuild();
+		guild.members.fetch = async () => {
+			throw new Error("Discord gateway unavailable");
+		};
+		const error = await expectError(
+			run(guild, { operation: "ban", userId: "654321" }),
+			"MEMBER_FETCH_FAILED",
+		);
+		expect(error.cause).toBeInstanceOf(Error);
+		expect(guild.bans_.has("654321")).toBe(false);
+		expect(guild.log).toHaveLength(0);
 	});
 });
 

--- a/plugins/plugin-discord/__tests__/messages-durable-turn.test.ts
+++ b/plugins/plugin-discord/__tests__/messages-durable-turn.test.ts
@@ -17,6 +17,7 @@ import {
 	type Content,
 	createUniqueUuid,
 	type Memory,
+	stringToUuid,
 	type UUID,
 } from "@elizaos/core";
 import type { Message as DiscordMessage } from "discord.js";
@@ -74,7 +75,16 @@ function makeDurableHarness(): DurableHarness {
 	// Canonical room state backing the delivery-audience attestation: the
 	// manager calls ensureConnection before attesting, so the store mirrors
 	// what the connector declared and survives simulated restarts.
-	const rooms = new Map<UUID, { id: UUID; type?: string }>();
+	const rooms = new Map<
+		UUID,
+		{
+			id: UUID;
+			type?: string;
+			serverId?: string;
+			messageServerId?: UUID;
+			metadata?: Record<string, unknown>;
+		}
+	>();
 	const participantsByRoom = new Map<UUID, UUID[]>();
 
 	const indexMemory = (memory: Memory, id: UUID, tableName: string) => {
@@ -100,8 +110,21 @@ function makeDurableHarness(): DurableHarness {
 			key === "ELIZA_LIFEOPS_PASSIVE_CONNECTORS" ? "false" : undefined,
 		getService: () => null,
 		ensureConnection: vi.fn(
-			async (params: { entityId: UUID; roomId: UUID; type?: string }) => {
-				rooms.set(params.roomId, { id: params.roomId, type: params.type });
+			async (params: {
+				entityId: UUID;
+				roomId: UUID;
+				type?: string;
+				serverId?: string;
+				messageServerId?: UUID;
+				roomMetadata?: Record<string, unknown>;
+			}) => {
+				rooms.set(params.roomId, {
+					id: params.roomId,
+					type: params.type,
+					serverId: params.serverId,
+					messageServerId: params.messageServerId,
+					metadata: params.roomMetadata,
+				});
 				participantsByRoom.set(params.roomId, [params.entityId, AGENT_ID]);
 			},
 		),
@@ -202,7 +225,10 @@ function makeDiscordService(
 	return {
 		client,
 		accountId: "default",
-		getChannelType: async () => ChannelType.DM,
+		getChannelType: async (channel: { type?: number }) =>
+			channel.type === DiscordChannelType.DM
+				? ChannelType.DM
+				: ChannelType.GROUP,
 		discordSettings: {
 			autoReply: true,
 			dmPolicy: "open",
@@ -218,7 +244,11 @@ function makeDiscordService(
 	};
 }
 
-function makeInbound(channel: unknown, messageId: string): DiscordMessage {
+function makeInbound(
+	channel: unknown,
+	messageId: string,
+	guild?: { id: string; name: string; ownerId: string },
+): DiscordMessage {
 	return {
 		id: messageId,
 		content: "hello",
@@ -233,7 +263,7 @@ function makeInbound(channel: unknown, messageId: string): DiscordMessage {
 		},
 		member: null,
 		channel,
-		guild: undefined,
+		guild,
 		interaction: null,
 		reference: undefined,
 		embeds: [],
@@ -270,6 +300,33 @@ async function turnState(
 }
 
 describe("Discord durable turn / outbox state machine", () => {
+	it("persists the inbound guild and connector-account room binding", async () => {
+		const messageId = "666000000000000999";
+		const guildId = "999000000000000000";
+		const harness = makeDurableHarness();
+		const channel = {
+			...makeDmChannel(harness.sends),
+			name: "release-status",
+			type: DiscordChannelType.GuildText,
+		};
+
+		await restartManager(harness).handleMessage(
+			makeInbound(channel, messageId, {
+				id: guildId,
+				name: "Destination B",
+				ownerId: "444000000000000000",
+			}),
+		);
+
+		await expect(
+			harness.runtime.getRoom(roomIdFor(CHANNEL_ID)),
+		).resolves.toMatchObject({
+			serverId: guildId,
+			messageServerId: stringToUuid(guildId),
+			metadata: { accountId: "default" },
+		});
+	});
+
 	it("(a) crash after inbound persist before dispatch: redelivery resumes and replies exactly once", async () => {
 		const messageId = "666000000000001000";
 		const harness = makeDurableHarness();

--- a/plugins/plugin-discord/__tests__/messages-durable-turn.test.ts
+++ b/plugins/plugin-discord/__tests__/messages-durable-turn.test.ts
@@ -82,7 +82,6 @@ function makeDurableHarness(): DurableHarness {
 			type?: string;
 			serverId?: string;
 			messageServerId?: UUID;
-			metadata?: Record<string, unknown>;
 		}
 	>();
 	const participantsByRoom = new Map<UUID, UUID[]>();
@@ -116,14 +115,12 @@ function makeDurableHarness(): DurableHarness {
 				type?: string;
 				serverId?: string;
 				messageServerId?: UUID;
-				roomMetadata?: Record<string, unknown>;
 			}) => {
 				rooms.set(params.roomId, {
 					id: params.roomId,
 					type: params.type,
 					serverId: params.serverId,
 					messageServerId: params.messageServerId,
-					metadata: params.roomMetadata,
 				});
 				participantsByRoom.set(params.roomId, [params.entityId, AGENT_ID]);
 			},
@@ -300,7 +297,7 @@ async function turnState(
 }
 
 describe("Discord durable turn / outbox state machine", () => {
-	it("persists the inbound guild and connector-account room binding", async () => {
+	it("persists the inbound guild room binding", async () => {
 		const messageId = "666000000000000999";
 		const guildId = "999000000000000000";
 		const harness = makeDurableHarness();
@@ -323,7 +320,6 @@ describe("Discord durable turn / outbox state machine", () => {
 		).resolves.toMatchObject({
 			serverId: guildId,
 			messageServerId: stringToUuid(guildId),
-			metadata: { accountId: "default" },
 		});
 	});
 

--- a/plugins/plugin-discord/compat.ts
+++ b/plugins/plugin-discord/compat.ts
@@ -38,6 +38,7 @@ export interface EnsureConnectionParams {
 	worldId?: UUID;
 	userId?: UUID;
 	metadata?: Metadata;
+	roomMetadata?: Metadata;
 }
 
 export interface ICompatRuntime

--- a/plugins/plugin-discord/compat.ts
+++ b/plugins/plugin-discord/compat.ts
@@ -38,7 +38,6 @@ export interface EnsureConnectionParams {
 	worldId?: UUID;
 	userId?: UUID;
 	metadata?: Metadata;
-	roomMetadata?: Metadata;
 }
 
 export interface ICompatRuntime

--- a/plugins/plugin-discord/config.ts
+++ b/plugins/plugin-discord/config.ts
@@ -92,6 +92,11 @@ export type DiscordActionConfig = {
 	reactions?: boolean;
 	stickers?: boolean;
 	polls?: boolean;
+	/**
+	 * Enable channel permission-overwrite editing (manage_server
+	 * edit_permissions and template overwrite reconcile). Default: false —
+	 * structural writes fail closed.
+	 */
 	permissions?: boolean;
 	messages?: boolean;
 	threads?: boolean;
@@ -99,13 +104,25 @@ export type DiscordActionConfig = {
 	search?: boolean;
 	memberInfo?: boolean;
 	roleInfo?: boolean;
+	/**
+	 * Enable role management (create/edit/delete role, assign/remove member
+	 * role) via manage_server. Default: false — fail closed.
+	 */
 	roles?: boolean;
 	channelInfo?: boolean;
 	voiceStatus?: boolean;
 	events?: boolean;
+	/**
+	 * Enable moderation verbs (kick/ban/unban/timeout) via manage_server.
+	 * Default: false — fail closed.
+	 */
 	moderation?: boolean;
 	emojiUploads?: boolean;
 	stickerUploads?: boolean;
+	/**
+	 * Enable structural channel management (create/edit/delete channel and
+	 * category, create_invite) via manage_server. Default: false — fail closed.
+	 */
 	channels?: boolean;
 	/** Enable bot presence/activity changes (default: false). */
 	presence?: boolean;
@@ -186,8 +203,19 @@ export type DiscordAccountConfig = {
 	dms?: Record<string, DmConfig>;
 	/** Retry policy for outbound Discord API calls. */
 	retry?: OutboundRetryConfig;
-	/** Per-action tool gating (default: true for all). */
+	/**
+	 * Per-action tool gating. Lightweight messaging toggles default to true;
+	 * the structural server-management gates (`channels`, `roles`,
+	 * `permissions`, `moderation`) default to FALSE and must be explicitly
+	 * enabled before manage_server writes are allowed.
+	 */
 	actions?: DiscordActionConfig;
+	/**
+	 * Additional guild templates for manage_server apply_template, keyed by
+	 * template id. Merged over the plugin's built-in registry
+	 * (companion-private, friends-casual, project-team, community-public).
+	 */
+	guildTemplates?: Record<string, unknown>;
 	/** Control reply threading when reply tags are present (off|first|all). */
 	replyToMode?: ReplyToMode;
 	dm?: DiscordDmConfig;

--- a/plugins/plugin-discord/discord-events.ts
+++ b/plugins/plugin-discord/discord-events.ts
@@ -901,6 +901,7 @@ export function setupDiscordEventListeners(service: DiscordServiceInternals): {
 				await handleBuiltinSlashCommand(interaction, service.runtime, {
 					entityId,
 					roomId,
+					accountId,
 				});
 			}
 		} catch (error) {

--- a/plugins/plugin-discord/discord-history.ts
+++ b/plugins/plugin-discord/discord-history.ts
@@ -575,6 +575,9 @@ export async function ensureConnectionsForMessages(
 			{
 				id: createUniqueUuid(service.runtime, firstMessage.channel.id),
 				channelId: firstMessage.channel.id,
+				serverId,
+				messageServerId: stringToUuid(serverId),
+				worldId,
 				type: channelType,
 				source: "discord",
 				metadata: {

--- a/plugins/plugin-discord/discord-interactions.ts
+++ b/plugins/plugin-discord/discord-interactions.ts
@@ -153,6 +153,7 @@ export async function handleInteractionCreate(
 		name,
 		source: "discord",
 		channelId: interactionChannelId,
+		serverId,
 		messageServerId: serverId ? stringToUuid(serverId) : undefined,
 		type,
 		worldId: createUniqueUuid(service.runtime, serverId ?? roomId) as UUID,
@@ -162,6 +163,7 @@ export async function handleInteractionCreate(
 			...buildDiscordWorldMetadata(service.runtime, interaction.guild?.ownerId),
 			accountId,
 		},
+		roomMetadata: { accountId },
 	});
 
 	if (interaction.isCommand()) {
@@ -356,7 +358,7 @@ export async function handleInteractionCreate(
 export async function buildStandardizedRooms(
 	service: InteractionServiceInternals,
 	guild: Guild,
-	_worldId: UUID,
+	worldId: UUID,
 ): Promise<Room[]> {
 	const accountId = service.accountId ?? "default";
 	const rooms: Room[] = [];
@@ -415,6 +417,9 @@ export async function buildStandardizedRooms(
 				type: channelType,
 				channelId: channel.id,
 				source: "discord",
+				serverId: guild.id,
+				messageServerId: stringToUuid(guild.id),
+				worldId,
 				/**
 				 * Channel topic exposed via metadata for plugin-content-seeder
 				 */
@@ -697,7 +702,7 @@ export async function onReady(
 						id: worldId,
 						name: fullGuild.name,
 						agentId: service.runtime.agentId,
-						serverId: fullGuild.id,
+						messageServerId: stringToUuid(fullGuild.id),
 						metadata: {
 							...buildDiscordWorldMetadata(service.runtime, fullGuild.ownerId),
 							accountId,

--- a/plugins/plugin-discord/discord-interactions.ts
+++ b/plugins/plugin-discord/discord-interactions.ts
@@ -163,7 +163,6 @@ export async function handleInteractionCreate(
 			...buildDiscordWorldMetadata(service.runtime, interaction.guild?.ownerId),
 			accountId,
 		},
-		roomMetadata: { accountId },
 	});
 
 	if (interaction.isCommand()) {

--- a/plugins/plugin-discord/discord-local-service.ts
+++ b/plugins/plugin-discord/discord-local-service.ts
@@ -1209,6 +1209,7 @@ export class DiscordLocalService extends Service {
 			source: DISCORD_LOCAL_SERVICE_NAME,
 			type: roomType,
 			channelId,
+			serverId: serverKey,
 			messageServerId: stringToUuid(
 				`discord-local-server:${serverKey}`,
 			) as UUID,
@@ -1217,6 +1218,7 @@ export class DiscordLocalService extends Service {
 				discordChannelId: channelId,
 				...(guildId ? { discordServerId: guildId } : {}),
 			},
+			roomMetadata: { accountId: this.accountId },
 		} as EnsureConnectionArg);
 
 		const attachments: Media[] = (message.attachments ?? []).flatMap(

--- a/plugins/plugin-discord/discord-local-service.ts
+++ b/plugins/plugin-discord/discord-local-service.ts
@@ -1218,7 +1218,6 @@ export class DiscordLocalService extends Service {
 				discordChannelId: channelId,
 				...(guildId ? { discordServerId: guildId } : {}),
 			},
-			roomMetadata: { accountId: this.accountId },
 		} as EnsureConnectionArg);
 
 		const attachments: Media[] = (message.attachments ?? []).flatMap(

--- a/plugins/plugin-discord/discord-reactions.ts
+++ b/plugins/plugin-discord/discord-reactions.ts
@@ -154,6 +154,7 @@ export async function handleReaction(
 			name,
 			source: "discord",
 			channelId: reaction.message.channel.id,
+			serverId: reaction.message.guild?.id,
 			messageServerId: reaction.message.guild?.id
 				? stringToUuid(reaction.message.guild.id)
 				: undefined,
@@ -166,6 +167,7 @@ export async function handleReaction(
 				),
 				accountId,
 			},
+			roomMetadata: { accountId },
 		});
 
 		const inReplyTo = createUniqueUuid(service.runtime, reaction.message.id);

--- a/plugins/plugin-discord/discord-reactions.ts
+++ b/plugins/plugin-discord/discord-reactions.ts
@@ -167,7 +167,6 @@ export async function handleReaction(
 				),
 				accountId,
 			},
-			roomMetadata: { accountId },
 		});
 
 		const inReplyTo = createUniqueUuid(service.runtime, reaction.message.id);

--- a/plugins/plugin-discord/guild-management-authorization.ts
+++ b/plugins/plugin-discord/guild-management-authorization.ts
@@ -1,0 +1,127 @@
+/**
+ * Binds Discord structural management to an exact persisted guild world and
+ * revalidates requester authority at the connector mutation boundary. Guild
+ * names and live cache enumeration never participate in authorization.
+ */
+
+import {
+	authorizeManageServerDestination,
+	createUniqueUuid,
+	ElizaError,
+	type IAgentRuntime,
+	type MessageConnectorManageServerAuthorization,
+	type MessageConnectorManageServerDestination,
+	stringToUuid,
+	type TargetInfo,
+} from "@elizaos/core";
+
+const DISCORD_SNOWFLAKE_PATTERN = /^\d{15,20}$/;
+
+function authorizationError(
+	code: string,
+	message: string,
+	context: Record<string, unknown>,
+): never {
+	throw new ElizaError(message, { code, context });
+}
+
+/** Resolve only an exact Discord snowflake into its deterministic durable ids. */
+export function resolveDiscordManageServerDestination(
+	runtime: IAgentRuntime,
+	params: { target?: TargetInfo; serverId: string },
+	accountId: string,
+): MessageConnectorManageServerDestination {
+	const serverId = params.serverId.trim();
+	if (!DISCORD_SNOWFLAKE_PATTERN.test(serverId)) {
+		authorizationError(
+			"DISCORD_MANAGE_SERVER_ID_REQUIRED",
+			"Discord server management requires an exact guild snowflake; display names are not authorized.",
+			{ accountId },
+		);
+	}
+	if (params.target?.source && params.target.source !== "discord") {
+		authorizationError(
+			"DISCORD_MANAGE_SERVER_SOURCE_MISMATCH",
+			"Discord server management received a target from another connector source.",
+			{ accountId, targetSource: params.target.source },
+		);
+	}
+	if (params.target?.accountId && params.target.accountId !== accountId) {
+		authorizationError(
+			"DISCORD_MANAGE_SERVER_ACCOUNT_MISMATCH",
+			"Discord server management target account does not match the selected connector account.",
+			{ accountId, targetAccountId: params.target.accountId },
+		);
+	}
+	if (params.target?.serverId && params.target.serverId !== serverId) {
+		authorizationError(
+			"DISCORD_MANAGE_SERVER_BINDING_MISMATCH",
+			"Discord server management target does not match the requested guild.",
+			{ accountId, serverId },
+		);
+	}
+
+	return {
+		source: "discord",
+		accountId,
+		serverId,
+		messageServerId: stringToUuid(serverId),
+		destinationWorldId: createUniqueUuid(runtime, serverId),
+		target: {
+			...params.target,
+			source: "discord",
+			accountId,
+			serverId,
+		},
+	};
+}
+
+/**
+ * Check that core's provenance still names this exact guild/account, then
+ * repeat the durable binding, verified-cluster membership, and ADMIN+ checks.
+ */
+export async function revalidateDiscordManageServerAuthorization(
+	runtime: IAgentRuntime,
+	authorization: MessageConnectorManageServerAuthorization,
+	accountId: string,
+	guildId: string,
+): Promise<MessageConnectorManageServerAuthorization> {
+	if (
+		authorization.source !== "discord" ||
+		authorization.accountId !== accountId ||
+		authorization.target.source !== "discord" ||
+		authorization.target.accountId !== accountId ||
+		authorization.serverId !== guildId ||
+		authorization.target.serverId !== guildId
+	) {
+		authorizationError(
+			"DISCORD_MANAGE_SERVER_PROVENANCE_MISMATCH",
+			"Discord server management authorization does not match the live mutation destination.",
+			{ accountId, guildId },
+		);
+	}
+	const expected = resolveDiscordManageServerDestination(
+		runtime,
+		{ target: authorization.target, serverId: guildId },
+		accountId,
+	);
+	if (
+		authorization.source !== expected.source ||
+		authorization.accountId !== expected.accountId ||
+		authorization.serverId !== expected.serverId ||
+		authorization.messageServerId !== expected.messageServerId ||
+		authorization.destinationWorldId !== expected.destinationWorldId
+	) {
+		authorizationError(
+			"DISCORD_MANAGE_SERVER_PROVENANCE_MISMATCH",
+			"Discord server management authorization does not match the live mutation destination.",
+			{ accountId, guildId },
+		);
+	}
+
+	return authorizeManageServerDestination(
+		runtime,
+		authorization.requesterEntityId,
+		expected,
+	);
+}

--- a/plugins/plugin-discord/guild-management.ts
+++ b/plugins/plugin-discord/guild-management.ts
@@ -1,0 +1,1987 @@
+/**
+ * Structural guild management for the Discord connector: create/edit/delete
+ * channels, categories, and roles, permission-overwrite editing, member role
+ * assignment, invites, moderation verbs, and an idempotent non-destructive
+ * template reconcile (`apply_template`).
+ *
+ * Security model (fail closed):
+ * - Every write sits behind the `actions.channels`, `actions.roles`,
+ *   `actions.permissions`, or `actions.moderation` config gates. For these
+ *   STRUCTURAL operations an absent gate means OFF — the deployment must
+ *   explicitly opt in.
+ * - Role and member operations validate Discord role hierarchy: the bot can
+ *   only touch roles strictly below its own highest role, and only members it
+ *   can manage.
+ * - The `Administrator` permission can never be granted through this surface,
+ *   in any role or overwrite, and requested role permissions must be a subset
+ *   of what the bot itself holds.
+ * - Template reconcile matches objects by stable template key (persisted
+ *   key->snowflake map, exact-name fallback), converges on re-apply, and
+ *   NEVER deletes channels or roles it does not manage. Deletion only happens
+ *   through the explicit, gated `delete_channel` / `delete_role` verbs.
+ *
+ * The module operates on narrow structural interfaces (`ManageableGuild` et
+ * al) so unit tests can drive it with plain fakes; `service.ts` adapts the
+ * live discord.js `Guild` to it.
+ */
+
+import { ChannelType, PermissionsBitField } from "discord.js";
+import {
+	BUILT_IN_GUILD_TEMPLATES,
+	GUILD_TEMPLATE_LIMITS,
+	type GuildTemplate,
+	type GuildTemplateChannel,
+	type GuildTemplateChannelType,
+	type GuildTemplateOverwrite,
+	renderTemplateString,
+	validateGuildTemplate,
+} from "./guild-templates";
+
+// ---------------------------------------------------------------------------
+// Gates
+// ---------------------------------------------------------------------------
+
+export interface GuildManagementGates {
+	channels: boolean;
+	roles: boolean;
+	permissions: boolean;
+	moderation: boolean;
+}
+
+/**
+ * Structural management gates fail closed: only an explicit `true` opens a
+ * gate. (`DiscordActionConfig` documents `default: true` for the lightweight
+ * messaging toggles; the structural surface is deliberately stricter.)
+ */
+export function resolveGuildManagementGates(
+	actions: Record<string, unknown> | undefined,
+): GuildManagementGates {
+	return {
+		channels: actions?.channels === true,
+		roles: actions?.roles === true,
+		permissions: actions?.permissions === true,
+		moderation: actions?.moderation === true,
+	};
+}
+
+export const GUILD_MANAGEMENT_OPERATIONS = [
+	"create_category",
+	"create_channel",
+	"edit_channel",
+	"delete_channel",
+	"create_role",
+	"edit_role",
+	"delete_role",
+	"edit_permissions",
+	"assign_role",
+	"remove_role",
+	"create_invite",
+	"kick",
+	"ban",
+	"unban",
+	"timeout",
+	"list_templates",
+	"apply_template",
+] as const;
+
+export type GuildManagementOperation =
+	(typeof GUILD_MANAGEMENT_OPERATIONS)[number];
+
+/** Gates each operation requires. ALL listed gates must be open. */
+export const OPERATION_GATES: Record<
+	GuildManagementOperation,
+	Array<keyof GuildManagementGates>
+> = {
+	create_category: ["channels"],
+	create_channel: ["channels"],
+	edit_channel: ["channels"],
+	delete_channel: ["channels"],
+	create_role: ["roles"],
+	edit_role: ["roles"],
+	delete_role: ["roles"],
+	edit_permissions: ["permissions"],
+	assign_role: ["roles"],
+	remove_role: ["roles"],
+	create_invite: ["channels"],
+	kick: ["moderation"],
+	ban: ["moderation"],
+	unban: ["moderation"],
+	timeout: ["moderation"],
+	list_templates: [],
+	apply_template: ["channels", "roles", "permissions"],
+};
+
+export function normalizeGuildManagementOperation(
+	value: unknown,
+): GuildManagementOperation | undefined {
+	if (typeof value !== "string") return undefined;
+	const normalized = value
+		.trim()
+		.toLowerCase()
+		.replace(/[-\s]+/g, "_");
+	return (GUILD_MANAGEMENT_OPERATIONS as readonly string[]).includes(normalized)
+		? (normalized as GuildManagementOperation)
+		: undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Structural interfaces (fake-able subset of discord.js)
+// ---------------------------------------------------------------------------
+
+export interface ManageablePermissionSet {
+	has(permission: string): boolean;
+}
+
+export interface ManageableRole {
+	id: string;
+	name: string;
+	position: number;
+	/** Integration-managed roles (bot roles, boosts) are never touched. */
+	managed?: boolean;
+	color?: number;
+	hoist?: boolean;
+	mentionable?: boolean;
+	permissions: ManageablePermissionSet & { toArray?(): string[] };
+	/** discord.js style: audit-log `reason` travels inside options. */
+	edit(options: Record<string, unknown>): Promise<ManageableRole>;
+	delete(reason?: string): Promise<unknown>;
+}
+
+export interface ManageableOverwrite {
+	id: string;
+	allow: ManageablePermissionSet;
+	deny: ManageablePermissionSet;
+}
+
+export interface ManageableChannel {
+	id: string;
+	name: string;
+	type: number;
+	parentId?: string | null;
+	topic?: string | null;
+	guildId?: string;
+	/** discord.js style: audit-log `reason` travels inside options. */
+	edit(options: Record<string, unknown>): Promise<ManageableChannel>;
+	delete(reason?: string): Promise<unknown>;
+	permissionOverwrites?: {
+		cache: ReadonlyMap<string, ManageableOverwrite>;
+		edit(
+			target: string,
+			options: Record<string, boolean | null>,
+			extra?: Record<string, unknown>,
+		): Promise<unknown>;
+	};
+	createInvite?(options: {
+		maxAge?: number;
+		maxUses?: number;
+		unique?: boolean;
+		reason?: string;
+	}): Promise<{ code: string; url?: string }>;
+}
+
+export interface ManageableMember {
+	id: string;
+	kickable?: boolean;
+	bannable?: boolean;
+	moderatable?: boolean;
+	roles: {
+		highest: { position: number };
+		cache: ReadonlyMap<string, { id: string }>;
+		add(roleId: string, reason?: string): Promise<unknown>;
+		remove(roleId: string, reason?: string): Promise<unknown>;
+	};
+	kick(reason?: string): Promise<unknown>;
+	timeout(durationMs: number | null, reason?: string): Promise<unknown>;
+}
+
+export interface ManageableBotMember extends ManageableMember {
+	permissions: ManageablePermissionSet;
+}
+
+export interface ManageableGuild {
+	id: string;
+	name: string;
+	ownerId?: string;
+	members: {
+		me: ManageableBotMember | null;
+		fetch(userId: string): Promise<ManageableMember>;
+	};
+	roles: {
+		everyone: { id: string };
+		cache: ReadonlyMap<string, ManageableRole>;
+		fetch(roleId: string): Promise<ManageableRole | null>;
+		create(options: Record<string, unknown>): Promise<ManageableRole>;
+	};
+	channels: {
+		cache: ReadonlyMap<string, ManageableChannel>;
+		fetch(channelId: string): Promise<ManageableChannel | null>;
+		create(options: Record<string, unknown>): Promise<ManageableChannel>;
+	};
+	bans: {
+		create(userId: string, options?: Record<string, unknown>): Promise<unknown>;
+		remove(userId: string, reason?: string): Promise<unknown>;
+	};
+}
+
+/** Persisted template key->snowflake map, one record per guild+template. */
+export interface TemplateStateStore {
+	get(
+		guildId: string,
+		templateId: string,
+	): Promise<Record<string, string> | undefined>;
+	set(
+		guildId: string,
+		templateId: string,
+		state: Record<string, string>,
+	): Promise<void>;
+}
+
+export interface GuildManagementContext {
+	guild: ManageableGuild;
+	gates: GuildManagementGates;
+	stateStore: TemplateStateStore;
+	templateRegistry?: Record<string, GuildTemplate>;
+	/** Rendered into `{{agent}}` template placeholders. */
+	agentName?: string;
+	/** Audit-log reason prefix for every write. */
+	reasonPrefix?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Request / receipt shapes
+// ---------------------------------------------------------------------------
+
+export interface GuildManagementRequest {
+	operation: GuildManagementOperation;
+	guildId?: string;
+	channelId?: string;
+	/** Category (parent) channel id or template category name for creation. */
+	parentId?: string;
+	roleId?: string;
+	userId?: string;
+	name?: string;
+	topic?: string;
+	channelType?: string;
+	color?: string;
+	hoist?: boolean;
+	mentionable?: boolean;
+	permissions?: string[];
+	allow?: string[];
+	deny?: string[];
+	/** Overwrite subject for edit_permissions: role id, user id, or "@everyone". */
+	overwriteId?: string;
+	reason?: string;
+	durationMinutes?: number;
+	deleteMessageSeconds?: number;
+	maxAgeSeconds?: number;
+	maxUses?: number;
+	unique?: boolean;
+	template?: string;
+	templateSpec?: GuildTemplate;
+	variables?: Record<string, string>;
+	dryRun?: boolean;
+}
+
+export type ReceiptAction =
+	| "created"
+	| "updated"
+	| "deleted"
+	| "unchanged"
+	| "would_create"
+	| "would_update"
+	| "skipped";
+
+export interface ReceiptEntry {
+	kind:
+		| "role"
+		| "category"
+		| "channel"
+		| "overwrite"
+		| "member_role"
+		| "invite"
+		| "member";
+	action: ReceiptAction;
+	name?: string;
+	key?: string;
+	id?: string;
+	reason?: string;
+}
+
+export interface GuildManagementReceipt {
+	operation: GuildManagementOperation;
+	guildId: string;
+	guildName?: string;
+	dryRun: boolean;
+	entries: ReceiptEntry[];
+	invite?: { code: string; url?: string };
+	templates?: Array<{ id: string; description?: string }>;
+	summary: string;
+}
+
+export class GuildManagementError extends Error {
+	public readonly code: string;
+	constructor(code: string, message: string) {
+		super(message);
+		this.name = "GuildManagementError";
+		this.code = code;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Permission-name handling
+// ---------------------------------------------------------------------------
+
+const PERMISSION_FLAG_NAMES = new Set(Object.keys(PermissionsBitField.Flags));
+
+/** "MANAGE_CHANNELS" | "manageChannels" | "ManageChannels" -> "ManageChannels". */
+export function normalizePermissionName(raw: string): string | undefined {
+	const trimmed = raw.trim();
+	if (!trimmed) return undefined;
+	if (PERMISSION_FLAG_NAMES.has(trimmed)) return trimmed;
+	const pascal = trimmed
+		.toLowerCase()
+		.split(/[_\s-]+/)
+		.map((part) => (part ? part.charAt(0).toUpperCase() + part.slice(1) : part))
+		.join("");
+	if (PERMISSION_FLAG_NAMES.has(pascal)) return pascal;
+	// Allow camelCase input ("manageChannels").
+	const upperFirst = trimmed.charAt(0).toUpperCase() + trimmed.slice(1);
+	if (PERMISSION_FLAG_NAMES.has(upperFirst)) return upperFirst;
+	return undefined;
+}
+
+/**
+ * Normalizes a permission list, rejecting unknown names and the Administrator
+ * bypass. Deterministic (sorted) output.
+ */
+export function normalizePermissionList(
+	values: string[] | undefined,
+	label: string,
+): string[] {
+	if (!values || values.length === 0) return [];
+	if (values.length > GUILD_TEMPLATE_LIMITS.maxPermissionEntries) {
+		throw new GuildManagementError(
+			"PERMISSIONS_TOO_MANY",
+			`${label} lists ${values.length} permissions; the maximum is ${GUILD_TEMPLATE_LIMITS.maxPermissionEntries}.`,
+		);
+	}
+	const normalized = new Set<string>();
+	for (const value of values) {
+		if (typeof value !== "string") {
+			throw new GuildManagementError(
+				"PERMISSION_INVALID",
+				`${label} contains a non-string permission entry.`,
+			);
+		}
+		const name = normalizePermissionName(value);
+		if (!name) {
+			throw new GuildManagementError(
+				"PERMISSION_UNKNOWN",
+				`${label} contains unknown Discord permission "${value}".`,
+			);
+		}
+		if (name === "Administrator") {
+			throw new GuildManagementError(
+				"PERMISSION_ADMINISTRATOR_FORBIDDEN",
+				`${label} requests Administrator; granting the Administrator bypass through guild management is not allowed.`,
+			);
+		}
+		normalized.add(name);
+	}
+	return [...normalized].sort();
+}
+
+// ---------------------------------------------------------------------------
+// Shared guards
+// ---------------------------------------------------------------------------
+
+function requireGates(
+	gates: GuildManagementGates,
+	operation: GuildManagementOperation,
+): void {
+	const required = OPERATION_GATES[operation];
+	const closed = required.filter((gate) => gates[gate] !== true);
+	if (closed.length > 0) {
+		throw new GuildManagementError(
+			"GATE_DISABLED",
+			`Discord ${operation} is disabled: config gate${closed.length > 1 ? "s" : ""} ` +
+				`${closed.map((gate) => `actions.${gate}`).join(", ")} ` +
+				"must be explicitly enabled in the Discord connector settings.",
+		);
+	}
+}
+
+function requireBotMember(guild: ManageableGuild): ManageableBotMember {
+	const me = guild.members.me;
+	if (!me) {
+		throw new GuildManagementError(
+			"BOT_MEMBER_UNAVAILABLE",
+			`The bot's own member record for guild ${guild.id} is unavailable.`,
+		);
+	}
+	return me;
+}
+
+function requireBotPermission(
+	guild: ManageableGuild,
+	permission: string,
+	operation: string,
+): ManageableBotMember {
+	const me = requireBotMember(guild);
+	if (!me.permissions.has(permission)) {
+		throw new GuildManagementError(
+			"BOT_MISSING_PERMISSION",
+			`The bot lacks the ${permission} permission in guild "${guild.name}" required for ${operation}. Re-invite the bot with a permission set that includes ${permission}.`,
+		);
+	}
+	return me;
+}
+
+/** Bot may only manage roles strictly below its own highest role. */
+function requireRoleBelowBot(
+	guild: ManageableGuild,
+	role: ManageableRole,
+	operation: string,
+): void {
+	const me = requireBotMember(guild);
+	if (role.managed) {
+		throw new GuildManagementError(
+			"ROLE_MANAGED",
+			`Role "${role.name}" is integration-managed and cannot be modified.`,
+		);
+	}
+	if (role.id === guild.roles.everyone.id) {
+		throw new GuildManagementError(
+			"ROLE_EVERYONE",
+			`The @everyone role cannot be targeted by ${operation}; use edit_permissions channel overwrites instead.`,
+		);
+	}
+	if (role.position >= me.roles.highest.position) {
+		throw new GuildManagementError(
+			"ROLE_HIERARCHY",
+			`Role "${role.name}" (position ${role.position}) is not below the bot's highest role (position ${me.roles.highest.position}); Discord role hierarchy forbids this ${operation}.`,
+		);
+	}
+}
+
+/** Requested permissions must be a subset of what the bot itself holds. */
+function requirePermissionSubset(
+	guild: ManageableGuild,
+	permissions: string[],
+	label: string,
+): void {
+	const me = requireBotMember(guild);
+	if (me.permissions.has("Administrator")) return;
+	const missing = permissions.filter((name) => !me.permissions.has(name));
+	if (missing.length > 0) {
+		throw new GuildManagementError(
+			"PERMISSION_ESCALATION",
+			`${label} grants permissions the bot itself does not hold (${missing.join(", ")}); refusing the escalation.`,
+		);
+	}
+}
+
+async function fetchRole(
+	guild: ManageableGuild,
+	roleId: string,
+): Promise<ManageableRole> {
+	const cached = guild.roles.cache.get(roleId);
+	if (cached) return cached;
+	let fetched: ManageableRole | null = null;
+	try {
+		fetched = await guild.roles.fetch(roleId);
+	} catch {
+		fetched = null;
+	}
+	if (!fetched) {
+		throw new GuildManagementError(
+			"ROLE_NOT_FOUND",
+			`Role ${roleId} was not found in guild "${guild.name}".`,
+		);
+	}
+	return fetched;
+}
+
+async function fetchChannel(
+	guild: ManageableGuild,
+	channelId: string,
+): Promise<ManageableChannel> {
+	const cached = guild.channels.cache.get(channelId);
+	if (cached) return cached;
+	let fetched: ManageableChannel | null = null;
+	try {
+		fetched = await guild.channels.fetch(channelId);
+	} catch {
+		fetched = null;
+	}
+	if (!fetched) {
+		throw new GuildManagementError(
+			"CHANNEL_NOT_FOUND",
+			`Channel ${channelId} was not found in guild "${guild.name}".`,
+		);
+	}
+	if (fetched.guildId && fetched.guildId !== guild.id) {
+		throw new GuildManagementError(
+			"CHANNEL_WRONG_GUILD",
+			`Channel ${channelId} does not belong to guild "${guild.name}".`,
+		);
+	}
+	return fetched;
+}
+
+async function fetchMember(
+	guild: ManageableGuild,
+	userId: string,
+): Promise<ManageableMember> {
+	try {
+		return await guild.members.fetch(userId);
+	} catch {
+		throw new GuildManagementError(
+			"MEMBER_NOT_FOUND",
+			`Member ${userId} was not found in guild "${guild.name}".`,
+		);
+	}
+}
+
+function requireName(request: GuildManagementRequest): string {
+	const name = request.name?.trim();
+	if (!name) {
+		throw new GuildManagementError(
+			"NAME_REQUIRED",
+			`${request.operation} requires a non-empty name.`,
+		);
+	}
+	if (name.length > GUILD_TEMPLATE_LIMITS.maxNameLength) {
+		throw new GuildManagementError(
+			"NAME_TOO_LONG",
+			`Names are limited to ${GUILD_TEMPLATE_LIMITS.maxNameLength} characters.`,
+		);
+	}
+	return name;
+}
+
+function parseColor(raw: string | undefined): number | undefined {
+	if (!raw) return undefined;
+	const match = /^#?([0-9a-fA-F]{6})$/.exec(raw.trim());
+	if (!match) {
+		throw new GuildManagementError(
+			"COLOR_INVALID",
+			`Color "${raw}" is not a #RRGGBB hex color.`,
+		);
+	}
+	return Number.parseInt(match[1], 16);
+}
+
+const CHANNEL_TYPE_MAP: Record<GuildTemplateChannelType, number> = {
+	text: ChannelType.GuildText,
+	voice: ChannelType.GuildVoice,
+	announcement: ChannelType.GuildAnnouncement,
+	forum: ChannelType.GuildForum,
+	stage: ChannelType.GuildStageVoice,
+};
+
+function resolveChannelType(raw: string | undefined): number {
+	if (!raw) return ChannelType.GuildText;
+	const normalized = raw.trim().toLowerCase() as GuildTemplateChannelType;
+	const mapped = CHANNEL_TYPE_MAP[normalized];
+	if (mapped === undefined) {
+		throw new GuildManagementError(
+			"CHANNEL_TYPE_INVALID",
+			`Channel type "${raw}" is not one of: ${Object.keys(CHANNEL_TYPE_MAP).join(", ")}.`,
+		);
+	}
+	return mapped;
+}
+
+function auditReason(
+	context: GuildManagementContext,
+	request: GuildManagementRequest,
+): string {
+	const prefix = context.reasonPrefix ?? "eliza guild management";
+	const extra = request.reason?.trim();
+	return extra ? `${prefix}: ${extra}`.slice(0, 512) : prefix;
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+export async function executeGuildManagement(
+	context: GuildManagementContext,
+	request: GuildManagementRequest,
+): Promise<GuildManagementReceipt> {
+	const operation = normalizeGuildManagementOperation(request.operation);
+	if (!operation) {
+		throw new GuildManagementError(
+			"OPERATION_UNKNOWN",
+			`Unknown guild management operation "${String(request.operation)}". Supported: ${GUILD_MANAGEMENT_OPERATIONS.join(", ")}.`,
+		);
+	}
+	requireGates(context.gates, operation);
+	const normalizedRequest = { ...request, operation };
+
+	switch (operation) {
+		case "list_templates":
+			return listTemplates(context, normalizedRequest);
+		case "create_category":
+			return createChannelOp(context, normalizedRequest, true);
+		case "create_channel":
+			return createChannelOp(context, normalizedRequest, false);
+		case "edit_channel":
+			return editChannelOp(context, normalizedRequest);
+		case "delete_channel":
+			return deleteChannelOp(context, normalizedRequest);
+		case "create_role":
+			return createRoleOp(context, normalizedRequest);
+		case "edit_role":
+			return editRoleOp(context, normalizedRequest);
+		case "delete_role":
+			return deleteRoleOp(context, normalizedRequest);
+		case "edit_permissions":
+			return editPermissionsOp(context, normalizedRequest);
+		case "assign_role":
+		case "remove_role":
+			return memberRoleOp(context, normalizedRequest, operation);
+		case "create_invite":
+			return createInviteOp(context, normalizedRequest);
+		case "kick":
+		case "ban":
+		case "unban":
+		case "timeout":
+			return moderationOp(context, normalizedRequest, operation);
+		case "apply_template":
+			return applyTemplateOp(context, normalizedRequest);
+		default: {
+			const unreachable: never = operation;
+			throw new GuildManagementError(
+				"OPERATION_UNKNOWN",
+				`Unhandled operation ${String(unreachable)}.`,
+			);
+		}
+	}
+}
+
+function receipt(
+	context: GuildManagementContext,
+	request: GuildManagementRequest,
+	entries: ReceiptEntry[],
+	summary: string,
+	extra?: Partial<GuildManagementReceipt>,
+): GuildManagementReceipt {
+	return {
+		operation: request.operation,
+		guildId: context.guild.id,
+		guildName: context.guild.name,
+		dryRun: request.dryRun === true,
+		entries,
+		summary,
+		...extra,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Templates listing
+// ---------------------------------------------------------------------------
+
+function templateRegistry(
+	context: GuildManagementContext,
+): Record<string, GuildTemplate> {
+	return {
+		...BUILT_IN_GUILD_TEMPLATES,
+		...(context.templateRegistry ?? {}),
+	};
+}
+
+function listTemplates(
+	context: GuildManagementContext,
+	request: GuildManagementRequest,
+): GuildManagementReceipt {
+	const registry = templateRegistry(context);
+	const templates = Object.values(registry)
+		.map((template) => ({
+			id: template.id,
+			description: template.description,
+		}))
+		.sort((a, b) => a.id.localeCompare(b.id));
+	return receipt(
+		context,
+		request,
+		[],
+		`${templates.length} guild templates available: ${templates.map((t) => t.id).join(", ")}.`,
+		{ templates },
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Channel verbs
+// ---------------------------------------------------------------------------
+
+async function createChannelOp(
+	context: GuildManagementContext,
+	request: GuildManagementRequest,
+	isCategory: boolean,
+): Promise<GuildManagementReceipt> {
+	const { guild } = context;
+	requireBotPermission(guild, "ManageChannels", request.operation);
+	const name = requireName(request);
+	const type = isCategory
+		? ChannelType.GuildCategory
+		: resolveChannelType(request.channelType);
+	let parentId: string | undefined;
+	if (!isCategory && request.parentId) {
+		const parent = await fetchChannel(guild, request.parentId);
+		if (parent.type !== ChannelType.GuildCategory) {
+			throw new GuildManagementError(
+				"PARENT_NOT_CATEGORY",
+				`Parent channel ${parent.id} ("${parent.name}") is not a category.`,
+			);
+		}
+		parentId = parent.id;
+	}
+	const kind = isCategory ? "category" : "channel";
+	if (request.dryRun) {
+		return receipt(
+			context,
+			request,
+			[{ kind, action: "would_create", name }],
+			`Dry run: would create ${kind} "${name}" in "${guild.name}".`,
+		);
+	}
+	const created = await guild.channels.create({
+		name,
+		type,
+		...(parentId ? { parent: parentId } : {}),
+		...(request.topic ? { topic: request.topic.trim() } : {}),
+		reason: auditReason(context, request),
+	});
+	return receipt(
+		context,
+		request,
+		[{ kind, action: "created", name: created.name, id: created.id }],
+		`Created ${kind} "${created.name}" (${created.id}) in "${guild.name}".`,
+	);
+}
+
+async function editChannelOp(
+	context: GuildManagementContext,
+	request: GuildManagementRequest,
+): Promise<GuildManagementReceipt> {
+	const { guild } = context;
+	requireBotPermission(guild, "ManageChannels", request.operation);
+	if (!request.channelId) {
+		throw new GuildManagementError(
+			"CHANNEL_ID_REQUIRED",
+			"edit_channel requires channelId.",
+		);
+	}
+	const channel = await fetchChannel(guild, request.channelId);
+	const changes: Record<string, unknown> = {};
+	if (request.name?.trim()) changes.name = requireName(request);
+	if (request.topic !== undefined) changes.topic = request.topic;
+	if (request.parentId) {
+		const parent = await fetchChannel(guild, request.parentId);
+		if (parent.type !== ChannelType.GuildCategory) {
+			throw new GuildManagementError(
+				"PARENT_NOT_CATEGORY",
+				`Parent channel ${parent.id} ("${parent.name}") is not a category.`,
+			);
+		}
+		changes.parent = parent.id;
+	}
+	if (Object.keys(changes).length === 0) {
+		throw new GuildManagementError(
+			"NO_CHANGES",
+			"edit_channel requires at least one of name, topic, or parentId.",
+		);
+	}
+	if (request.dryRun) {
+		return receipt(
+			context,
+			request,
+			[
+				{
+					kind: "channel",
+					action: "would_update",
+					name: channel.name,
+					id: channel.id,
+				},
+			],
+			`Dry run: would update channel "${channel.name}" (${Object.keys(changes).join(", ")}).`,
+		);
+	}
+	const updated = await channel.edit({
+		...changes,
+		reason: auditReason(context, request),
+	});
+	return receipt(
+		context,
+		request,
+		[
+			{
+				kind: "channel",
+				action: "updated",
+				name: updated.name ?? channel.name,
+				id: channel.id,
+			},
+		],
+		`Updated channel "${updated.name ?? channel.name}" (${Object.keys(changes).join(", ")}).`,
+	);
+}
+
+async function deleteChannelOp(
+	context: GuildManagementContext,
+	request: GuildManagementRequest,
+): Promise<GuildManagementReceipt> {
+	const { guild } = context;
+	requireBotPermission(guild, "ManageChannels", request.operation);
+	if (!request.channelId) {
+		throw new GuildManagementError(
+			"CHANNEL_ID_REQUIRED",
+			"delete_channel requires channelId.",
+		);
+	}
+	const channel = await fetchChannel(guild, request.channelId);
+	if (request.dryRun) {
+		return receipt(
+			context,
+			request,
+			[
+				{
+					kind: "channel",
+					action: "skipped",
+					name: channel.name,
+					id: channel.id,
+					reason: "dry run",
+				},
+			],
+			`Dry run: would delete channel "${channel.name}" (${channel.id}).`,
+		);
+	}
+	await channel.delete(auditReason(context, request));
+	return receipt(
+		context,
+		request,
+		[
+			{
+				kind: "channel",
+				action: "deleted",
+				name: channel.name,
+				id: channel.id,
+			},
+		],
+		`Deleted channel "${channel.name}" (${channel.id}) from "${guild.name}".`,
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Role verbs
+// ---------------------------------------------------------------------------
+
+async function createRoleOp(
+	context: GuildManagementContext,
+	request: GuildManagementRequest,
+): Promise<GuildManagementReceipt> {
+	const { guild } = context;
+	requireBotPermission(guild, "ManageRoles", request.operation);
+	const name = requireName(request);
+	const permissions = normalizePermissionList(
+		request.permissions,
+		`create_role "${name}"`,
+	);
+	requirePermissionSubset(guild, permissions, `create_role "${name}"`);
+	const color = parseColor(request.color);
+	if (request.dryRun) {
+		return receipt(
+			context,
+			request,
+			[{ kind: "role", action: "would_create", name }],
+			`Dry run: would create role "${name}" in "${guild.name}".`,
+		);
+	}
+	const created = await guild.roles.create({
+		name,
+		...(color !== undefined ? { color } : {}),
+		...(request.hoist !== undefined ? { hoist: request.hoist } : {}),
+		...(request.mentionable !== undefined
+			? { mentionable: request.mentionable }
+			: {}),
+		permissions,
+		reason: auditReason(context, request),
+	});
+	return receipt(
+		context,
+		request,
+		[{ kind: "role", action: "created", name: created.name, id: created.id }],
+		`Created role "${created.name}" (${created.id}) in "${guild.name}".`,
+	);
+}
+
+async function editRoleOp(
+	context: GuildManagementContext,
+	request: GuildManagementRequest,
+): Promise<GuildManagementReceipt> {
+	const { guild } = context;
+	requireBotPermission(guild, "ManageRoles", request.operation);
+	if (!request.roleId) {
+		throw new GuildManagementError(
+			"ROLE_ID_REQUIRED",
+			"edit_role requires roleId.",
+		);
+	}
+	const role = await fetchRole(guild, request.roleId);
+	requireRoleBelowBot(guild, role, "edit_role");
+	const changes: Record<string, unknown> = {};
+	if (request.name?.trim()) changes.name = requireName(request);
+	const color = parseColor(request.color);
+	if (color !== undefined) changes.color = color;
+	if (request.hoist !== undefined) changes.hoist = request.hoist;
+	if (request.mentionable !== undefined)
+		changes.mentionable = request.mentionable;
+	if (request.permissions !== undefined) {
+		const permissions = normalizePermissionList(
+			request.permissions,
+			`edit_role "${role.name}"`,
+		);
+		requirePermissionSubset(guild, permissions, `edit_role "${role.name}"`);
+		changes.permissions = permissions;
+	}
+	if (Object.keys(changes).length === 0) {
+		throw new GuildManagementError(
+			"NO_CHANGES",
+			"edit_role requires at least one of name, color, hoist, mentionable, or permissions.",
+		);
+	}
+	if (request.dryRun) {
+		return receipt(
+			context,
+			request,
+			[
+				{
+					kind: "role",
+					action: "would_update",
+					name: role.name,
+					id: role.id,
+				},
+			],
+			`Dry run: would update role "${role.name}" (${Object.keys(changes).join(", ")}).`,
+		);
+	}
+	const updated = await role.edit({
+		...changes,
+		reason: auditReason(context, request),
+	});
+	return receipt(
+		context,
+		request,
+		[
+			{
+				kind: "role",
+				action: "updated",
+				name: updated.name ?? role.name,
+				id: role.id,
+			},
+		],
+		`Updated role "${updated.name ?? role.name}" (${Object.keys(changes).join(", ")}).`,
+	);
+}
+
+async function deleteRoleOp(
+	context: GuildManagementContext,
+	request: GuildManagementRequest,
+): Promise<GuildManagementReceipt> {
+	const { guild } = context;
+	requireBotPermission(guild, "ManageRoles", request.operation);
+	if (!request.roleId) {
+		throw new GuildManagementError(
+			"ROLE_ID_REQUIRED",
+			"delete_role requires roleId.",
+		);
+	}
+	const role = await fetchRole(guild, request.roleId);
+	requireRoleBelowBot(guild, role, "delete_role");
+	if (request.dryRun) {
+		return receipt(
+			context,
+			request,
+			[
+				{
+					kind: "role",
+					action: "skipped",
+					name: role.name,
+					id: role.id,
+					reason: "dry run",
+				},
+			],
+			`Dry run: would delete role "${role.name}" (${role.id}).`,
+		);
+	}
+	await role.delete(auditReason(context, request));
+	return receipt(
+		context,
+		request,
+		[{ kind: "role", action: "deleted", name: role.name, id: role.id }],
+		`Deleted role "${role.name}" (${role.id}) from "${guild.name}".`,
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Permission overwrites
+// ---------------------------------------------------------------------------
+
+async function editPermissionsOp(
+	context: GuildManagementContext,
+	request: GuildManagementRequest,
+): Promise<GuildManagementReceipt> {
+	const { guild } = context;
+	requireBotPermission(guild, "ManageRoles", request.operation);
+	if (!request.channelId) {
+		throw new GuildManagementError(
+			"CHANNEL_ID_REQUIRED",
+			"edit_permissions requires channelId.",
+		);
+	}
+	if (!request.overwriteId?.trim()) {
+		throw new GuildManagementError(
+			"OVERWRITE_TARGET_REQUIRED",
+			'edit_permissions requires overwriteId (a role id, user id, or "@everyone").',
+		);
+	}
+	const allow = normalizePermissionList(
+		request.allow,
+		"edit_permissions allow",
+	);
+	const deny = normalizePermissionList(request.deny, "edit_permissions deny");
+	if (allow.length === 0 && deny.length === 0) {
+		throw new GuildManagementError(
+			"NO_CHANGES",
+			"edit_permissions requires at least one allow or deny permission.",
+		);
+	}
+	const overlap = allow.filter((name) => deny.includes(name));
+	if (overlap.length > 0) {
+		throw new GuildManagementError(
+			"PERMISSION_CONFLICT",
+			`edit_permissions lists ${overlap.join(", ")} in both allow and deny.`,
+		);
+	}
+	requirePermissionSubset(guild, allow, "edit_permissions allow");
+	const channel = await fetchChannel(guild, request.channelId);
+	if (!channel.permissionOverwrites) {
+		throw new GuildManagementError(
+			"OVERWRITES_UNSUPPORTED",
+			`Channel "${channel.name}" does not support permission overwrites.`,
+		);
+	}
+	const subject =
+		request.overwriteId.trim() === "@everyone"
+			? guild.roles.everyone.id
+			: request.overwriteId.trim();
+	if (!/^\d{5,22}$/.test(subject)) {
+		throw new GuildManagementError(
+			"OVERWRITE_TARGET_INVALID",
+			`edit_permissions overwriteId "${request.overwriteId}" is not a Discord id or "@everyone".`,
+		);
+	}
+	// If the subject is a role, hierarchy still applies.
+	const subjectRole = guild.roles.cache.get(subject);
+	if (subjectRole && subjectRole.id !== guild.roles.everyone.id) {
+		requireRoleBelowBot(guild, subjectRole, "edit_permissions");
+	}
+	if (request.dryRun) {
+		return receipt(
+			context,
+			request,
+			[
+				{
+					kind: "overwrite",
+					action: "would_update",
+					name: channel.name,
+					id: subject,
+				},
+			],
+			`Dry run: would edit overwrites for ${subject} on "${channel.name}" (allow: ${allow.join(", ") || "none"}; deny: ${deny.join(", ") || "none"}).`,
+		);
+	}
+	const options: Record<string, boolean | null> = {};
+	for (const name of allow) options[name] = true;
+	for (const name of deny) options[name] = false;
+	await channel.permissionOverwrites.edit(subject, options, {
+		reason: auditReason(context, request),
+	});
+	return receipt(
+		context,
+		request,
+		[
+			{
+				kind: "overwrite",
+				action: "updated",
+				name: channel.name,
+				id: subject,
+			},
+		],
+		`Edited permission overwrites for ${subject} on "${channel.name}" (allow: ${allow.join(", ") || "none"}; deny: ${deny.join(", ") || "none"}).`,
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Member role assignment
+// ---------------------------------------------------------------------------
+
+async function memberRoleOp(
+	context: GuildManagementContext,
+	request: GuildManagementRequest,
+	operation: "assign_role" | "remove_role",
+): Promise<GuildManagementReceipt> {
+	const { guild } = context;
+	requireBotPermission(guild, "ManageRoles", operation);
+	if (!request.userId) {
+		throw new GuildManagementError(
+			"USER_ID_REQUIRED",
+			`${operation} requires userId.`,
+		);
+	}
+	if (!request.roleId) {
+		throw new GuildManagementError(
+			"ROLE_ID_REQUIRED",
+			`${operation} requires roleId.`,
+		);
+	}
+	const role = await fetchRole(guild, request.roleId);
+	requireRoleBelowBot(guild, role, operation);
+	const member = await fetchMember(guild, request.userId);
+	const hasRole = member.roles.cache.has(role.id);
+	if (operation === "assign_role" && hasRole) {
+		return receipt(
+			context,
+			request,
+			[
+				{
+					kind: "member_role",
+					action: "unchanged",
+					name: role.name,
+					id: role.id,
+				},
+			],
+			`Member ${member.id} already has role "${role.name}".`,
+		);
+	}
+	if (operation === "remove_role" && !hasRole) {
+		return receipt(
+			context,
+			request,
+			[
+				{
+					kind: "member_role",
+					action: "unchanged",
+					name: role.name,
+					id: role.id,
+				},
+			],
+			`Member ${member.id} does not have role "${role.name}".`,
+		);
+	}
+	if (request.dryRun) {
+		return receipt(
+			context,
+			request,
+			[
+				{
+					kind: "member_role",
+					action: "would_update",
+					name: role.name,
+					id: role.id,
+				},
+			],
+			`Dry run: would ${operation === "assign_role" ? "assign" : "remove"} role "${role.name}" ${operation === "assign_role" ? "to" : "from"} member ${member.id}.`,
+		);
+	}
+	if (operation === "assign_role") {
+		await member.roles.add(role.id, auditReason(context, request));
+	} else {
+		await member.roles.remove(role.id, auditReason(context, request));
+	}
+	return receipt(
+		context,
+		request,
+		[
+			{
+				kind: "member_role",
+				action: "updated",
+				name: role.name,
+				id: role.id,
+			},
+		],
+		`${operation === "assign_role" ? "Assigned" : "Removed"} role "${role.name}" ${operation === "assign_role" ? "to" : "from"} member ${member.id}.`,
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Invites
+// ---------------------------------------------------------------------------
+
+const MAX_INVITE_AGE_SECONDS = 7 * 24 * 60 * 60;
+
+async function createInviteOp(
+	context: GuildManagementContext,
+	request: GuildManagementRequest,
+): Promise<GuildManagementReceipt> {
+	const { guild } = context;
+	requireBotPermission(guild, "CreateInstantInvite", request.operation);
+	if (!request.channelId) {
+		throw new GuildManagementError(
+			"CHANNEL_ID_REQUIRED",
+			"create_invite requires channelId.",
+		);
+	}
+	const channel = await fetchChannel(guild, request.channelId);
+	if (typeof channel.createInvite !== "function") {
+		throw new GuildManagementError(
+			"INVITES_UNSUPPORTED",
+			`Channel "${channel.name}" does not support invites.`,
+		);
+	}
+	const maxAge = Math.min(
+		Math.max(Math.floor(request.maxAgeSeconds ?? 86400), 0),
+		MAX_INVITE_AGE_SECONDS,
+	);
+	const maxUses = Math.min(Math.max(Math.floor(request.maxUses ?? 0), 0), 100);
+	if (request.dryRun) {
+		return receipt(
+			context,
+			request,
+			[
+				{
+					kind: "invite",
+					action: "skipped",
+					name: channel.name,
+					id: channel.id,
+					reason: "dry run",
+				},
+			],
+			`Dry run: would create an invite for "${channel.name}" (maxAge ${maxAge}s, maxUses ${maxUses || "unlimited"}).`,
+		);
+	}
+	const invite = await channel.createInvite({
+		maxAge,
+		maxUses,
+		unique: request.unique !== false,
+		reason: auditReason(context, request),
+	});
+	const url = invite.url ?? `https://discord.gg/${invite.code}`;
+	return receipt(
+		context,
+		request,
+		[
+			{
+				kind: "invite",
+				action: "created",
+				name: channel.name,
+				id: invite.code,
+			},
+		],
+		`Created invite ${url} for "${channel.name}" (expires ${maxAge ? `${maxAge}s` : "never"}, uses ${maxUses || "unlimited"}).`,
+		{ invite: { code: invite.code, url } },
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Moderation
+// ---------------------------------------------------------------------------
+
+const MAX_TIMEOUT_MINUTES = 28 * 24 * 60;
+
+async function moderationOp(
+	context: GuildManagementContext,
+	request: GuildManagementRequest,
+	operation: "kick" | "ban" | "unban" | "timeout",
+): Promise<GuildManagementReceipt> {
+	const { guild } = context;
+	const permissionByOp: Record<typeof operation, string> = {
+		kick: "KickMembers",
+		ban: "BanMembers",
+		unban: "BanMembers",
+		timeout: "ModerateMembers",
+	};
+	requireBotPermission(guild, permissionByOp[operation], operation);
+	if (!request.userId) {
+		throw new GuildManagementError(
+			"USER_ID_REQUIRED",
+			`${operation} requires userId.`,
+		);
+	}
+	if (!/^\d{5,22}$/.test(request.userId.trim())) {
+		throw new GuildManagementError(
+			"USER_ID_INVALID",
+			`${operation} userId "${request.userId}" is not a Discord user id.`,
+		);
+	}
+	const userId = request.userId.trim();
+	if (guild.ownerId && userId === guild.ownerId) {
+		throw new GuildManagementError(
+			"MODERATION_OWNER",
+			`Refusing ${operation} against the guild owner.`,
+		);
+	}
+	if (request.dryRun) {
+		return receipt(
+			context,
+			request,
+			[
+				{
+					kind: "member",
+					action: "skipped",
+					id: userId,
+					reason: "dry run",
+				},
+			],
+			`Dry run: would ${operation} member ${userId}.`,
+		);
+	}
+	const reason = auditReason(context, request);
+	if (operation === "unban") {
+		await guild.bans.remove(userId, reason);
+		return receipt(
+			context,
+			request,
+			[{ kind: "member", action: "updated", id: userId }],
+			`Unbanned ${userId} from "${guild.name}".`,
+		);
+	}
+	if (operation === "ban") {
+		// Hierarchy check when the member is present; bans of absent users pass
+		// straight to the API.
+		let member: ManageableMember | null = null;
+		try {
+			member = await guild.members.fetch(userId);
+		} catch {
+			member = null;
+		}
+		if (member && member.bannable === false) {
+			throw new GuildManagementError(
+				"MODERATION_HIERARCHY",
+				`Member ${userId} is not bannable by the bot (role hierarchy).`,
+			);
+		}
+		const deleteMessageSeconds = Math.min(
+			Math.max(Math.floor(request.deleteMessageSeconds ?? 0), 0),
+			7 * 24 * 60 * 60,
+		);
+		await guild.bans.create(userId, {
+			reason,
+			...(deleteMessageSeconds ? { deleteMessageSeconds } : {}),
+		});
+		return receipt(
+			context,
+			request,
+			[{ kind: "member", action: "updated", id: userId }],
+			`Banned ${userId} from "${guild.name}".`,
+		);
+	}
+	const member = await fetchMember(guild, userId);
+	if (operation === "kick") {
+		if (member.kickable === false) {
+			throw new GuildManagementError(
+				"MODERATION_HIERARCHY",
+				`Member ${userId} is not kickable by the bot (role hierarchy).`,
+			);
+		}
+		await member.kick(reason);
+		return receipt(
+			context,
+			request,
+			[{ kind: "member", action: "updated", id: userId }],
+			`Kicked ${userId} from "${guild.name}".`,
+		);
+	}
+	if (member.moderatable === false) {
+		throw new GuildManagementError(
+			"MODERATION_HIERARCHY",
+			`Member ${userId} is not moderatable by the bot (role hierarchy).`,
+		);
+	}
+	const minutes = Math.min(
+		Math.max(Math.floor(request.durationMinutes ?? 10), 1),
+		MAX_TIMEOUT_MINUTES,
+	);
+	await member.timeout(minutes * 60 * 1000, reason);
+	return receipt(
+		context,
+		request,
+		[{ kind: "member", action: "updated", id: userId }],
+		`Timed out ${userId} for ${minutes} minute${minutes === 1 ? "" : "s"}.`,
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Template reconcile
+// ---------------------------------------------------------------------------
+
+interface ReconcileMaps {
+	state: Record<string, string>;
+	roleIdByKey: Map<string, string>;
+	channelIdByKey: Map<string, string>;
+}
+
+function renderVars(
+	context: GuildManagementContext,
+	request: GuildManagementRequest,
+): Record<string, string> {
+	return {
+		agent: context.agentName ?? "Agent",
+		guild: context.guild.name,
+		...(request.variables ?? {}),
+	};
+}
+
+async function applyTemplateOp(
+	context: GuildManagementContext,
+	request: GuildManagementRequest,
+): Promise<GuildManagementReceipt> {
+	const { guild } = context;
+	requireBotPermission(guild, "ManageChannels", "apply_template");
+	requireBotPermission(guild, "ManageRoles", "apply_template");
+
+	const registry = templateRegistry(context);
+	let template: GuildTemplate | undefined;
+	if (request.templateSpec) {
+		template = request.templateSpec;
+	} else if (request.template) {
+		template = registry[request.template.trim()];
+		if (!template) {
+			throw new GuildManagementError(
+				"TEMPLATE_NOT_FOUND",
+				`Template "${request.template}" is not registered. Available: ${Object.keys(
+					registry,
+				)
+					.sort()
+					.join(", ")}.`,
+			);
+		}
+	} else {
+		throw new GuildManagementError(
+			"TEMPLATE_REQUIRED",
+			"apply_template requires template (registered id) or templateSpec (inline spec).",
+		);
+	}
+	const validationErrors = validateGuildTemplate(template);
+	if (validationErrors.length > 0) {
+		throw new GuildManagementError(
+			"TEMPLATE_INVALID",
+			`Template "${template.id}" failed validation: ${validationErrors.join("; ")}.`,
+		);
+	}
+	const variables = renderVars(context, request);
+	const dryRun = request.dryRun === true;
+	const entries: ReceiptEntry[] = [];
+	const maps: ReconcileMaps = {
+		state:
+			(await context.stateStore.get(guild.id, template.id)) ??
+			({} as Record<string, string>),
+		roleIdByKey: new Map(),
+		channelIdByKey: new Map(),
+	};
+	const reason = auditReason(context, request);
+
+	await reconcileRoles(context, template, variables, maps, entries, {
+		dryRun,
+		reason,
+	});
+	await reconcileCategories(context, template, variables, maps, entries, {
+		dryRun,
+		reason,
+	});
+	await reconcileChannels(context, template, variables, maps, entries, {
+		dryRun,
+		reason,
+	});
+	await reconcileOverwrites(context, template, maps, entries, {
+		dryRun,
+		reason,
+	});
+
+	if (!dryRun) {
+		await context.stateStore.set(guild.id, template.id, maps.state);
+	}
+	const counts: Record<string, number> = {};
+	for (const entry of entries) {
+		counts[entry.action] = (counts[entry.action] ?? 0) + 1;
+	}
+	const countText = Object.entries(counts)
+		.sort(([a], [b]) => a.localeCompare(b))
+		.map(([action, count]) => `${action}: ${count}`)
+		.join(", ");
+	return receipt(
+		context,
+		request,
+		entries,
+		`${dryRun ? "Dry run of" : "Applied"} template "${template.id}" on "${guild.name}" (${countText || "no objects"}). Unmanaged channels and roles were left untouched.`,
+	);
+}
+
+interface ReconcileOptions {
+	dryRun: boolean;
+	reason: string;
+}
+
+async function resolveTrackedRole(
+	guild: ManageableGuild,
+	stateId: string | undefined,
+	renderedName: string,
+): Promise<ManageableRole | undefined> {
+	if (stateId) {
+		const byId =
+			guild.roles.cache.get(stateId) ??
+			(await guild.roles.fetch(stateId).catch(() => null));
+		if (byId) return byId;
+	}
+	for (const role of guild.roles.cache.values()) {
+		if (
+			!role.managed &&
+			role.id !== guild.roles.everyone.id &&
+			role.name === renderedName
+		) {
+			return role;
+		}
+	}
+	return undefined;
+}
+
+async function reconcileRoles(
+	context: GuildManagementContext,
+	template: GuildTemplate,
+	variables: Record<string, string>,
+	maps: ReconcileMaps,
+	entries: ReceiptEntry[],
+	options: ReconcileOptions,
+): Promise<void> {
+	const { guild } = context;
+	for (const spec of template.roles ?? []) {
+		const stateKey = `role:${spec.key}`;
+		const renderedName = renderTemplateString(spec.name, variables);
+		const permissions = normalizePermissionList(
+			spec.permissions,
+			`template role "${spec.key}"`,
+		);
+		requirePermissionSubset(guild, permissions, `template role "${spec.key}"`);
+		const color = parseColor(spec.color);
+		const existing = await resolveTrackedRole(
+			guild,
+			maps.state[stateKey],
+			renderedName,
+		);
+		if (!existing) {
+			if (options.dryRun) {
+				entries.push({
+					kind: "role",
+					key: spec.key,
+					name: renderedName,
+					action: "would_create",
+				});
+				continue;
+			}
+			const created = await guild.roles.create({
+				name: renderedName,
+				...(color !== undefined ? { color } : {}),
+				...(spec.hoist !== undefined ? { hoist: spec.hoist } : {}),
+				...(spec.mentionable !== undefined
+					? { mentionable: spec.mentionable }
+					: {}),
+				permissions,
+				reason: options.reason,
+			});
+			maps.state[stateKey] = created.id;
+			maps.roleIdByKey.set(spec.key, created.id);
+			entries.push({
+				kind: "role",
+				key: spec.key,
+				name: renderedName,
+				id: created.id,
+				action: "created",
+			});
+			continue;
+		}
+		maps.roleIdByKey.set(spec.key, existing.id);
+		maps.state[stateKey] = existing.id;
+		const drift: Record<string, unknown> = {};
+		if (existing.name !== renderedName) drift.name = renderedName;
+		if (color !== undefined && existing.color !== color) drift.color = color;
+		if (spec.hoist !== undefined && existing.hoist !== spec.hoist)
+			drift.hoist = spec.hoist;
+		if (
+			spec.mentionable !== undefined &&
+			existing.mentionable !== spec.mentionable
+		)
+			drift.mentionable = spec.mentionable;
+		if (spec.permissions !== undefined) {
+			const current = existing.permissions.toArray
+				? [...existing.permissions.toArray()].sort()
+				: undefined;
+			if (current && current.join("|") !== permissions.join("|")) {
+				drift.permissions = permissions;
+			}
+		}
+		if (Object.keys(drift).length === 0) {
+			entries.push({
+				kind: "role",
+				key: spec.key,
+				name: existing.name,
+				id: existing.id,
+				action: "unchanged",
+			});
+			continue;
+		}
+		if (options.dryRun) {
+			entries.push({
+				kind: "role",
+				key: spec.key,
+				name: existing.name,
+				id: existing.id,
+				action: "would_update",
+			});
+			continue;
+		}
+		requireRoleBelowBot(guild, existing, "apply_template role update");
+		await existing.edit({ ...drift, reason: options.reason });
+		entries.push({
+			kind: "role",
+			key: spec.key,
+			name: renderedName,
+			id: existing.id,
+			action: "updated",
+		});
+	}
+}
+
+async function resolveTrackedChannel(
+	guild: ManageableGuild,
+	stateId: string | undefined,
+	renderedName: string,
+	type: number,
+	parentId?: string,
+): Promise<ManageableChannel | undefined> {
+	if (stateId) {
+		const byId =
+			guild.channels.cache.get(stateId) ??
+			(await guild.channels.fetch(stateId).catch(() => null));
+		if (byId) return byId;
+	}
+	for (const channel of guild.channels.cache.values()) {
+		if (channel.type !== type) continue;
+		if (channel.name !== renderedName) continue;
+		if (parentId !== undefined && (channel.parentId ?? undefined) !== parentId)
+			continue;
+		return channel;
+	}
+	// Second pass without the parent constraint so a manually-moved managed
+	// channel is adopted (and re-parented) instead of duplicated.
+	for (const channel of guild.channels.cache.values()) {
+		if (channel.type === type && channel.name === renderedName) return channel;
+	}
+	return undefined;
+}
+
+async function reconcileCategories(
+	context: GuildManagementContext,
+	template: GuildTemplate,
+	variables: Record<string, string>,
+	maps: ReconcileMaps,
+	entries: ReceiptEntry[],
+	options: ReconcileOptions,
+): Promise<void> {
+	const { guild } = context;
+	for (const spec of template.categories ?? []) {
+		const stateKey = `category:${spec.key}`;
+		const renderedName = renderTemplateString(spec.name, variables);
+		const existing = await resolveTrackedChannel(
+			guild,
+			maps.state[stateKey],
+			renderedName,
+			ChannelType.GuildCategory,
+		);
+		if (!existing) {
+			if (options.dryRun) {
+				entries.push({
+					kind: "category",
+					key: spec.key,
+					name: renderedName,
+					action: "would_create",
+				});
+				continue;
+			}
+			const created = await guild.channels.create({
+				name: renderedName,
+				type: ChannelType.GuildCategory,
+				reason: options.reason,
+			});
+			maps.state[stateKey] = created.id;
+			maps.channelIdByKey.set(spec.key, created.id);
+			entries.push({
+				kind: "category",
+				key: spec.key,
+				name: renderedName,
+				id: created.id,
+				action: "created",
+			});
+			continue;
+		}
+		maps.channelIdByKey.set(spec.key, existing.id);
+		maps.state[stateKey] = existing.id;
+		if (existing.name !== renderedName) {
+			if (options.dryRun) {
+				entries.push({
+					kind: "category",
+					key: spec.key,
+					name: existing.name,
+					id: existing.id,
+					action: "would_update",
+				});
+				continue;
+			}
+			await existing.edit({ name: renderedName, reason: options.reason });
+			entries.push({
+				kind: "category",
+				key: spec.key,
+				name: renderedName,
+				id: existing.id,
+				action: "updated",
+			});
+			continue;
+		}
+		entries.push({
+			kind: "category",
+			key: spec.key,
+			name: existing.name,
+			id: existing.id,
+			action: "unchanged",
+		});
+	}
+}
+
+async function reconcileChannels(
+	context: GuildManagementContext,
+	template: GuildTemplate,
+	variables: Record<string, string>,
+	maps: ReconcileMaps,
+	entries: ReceiptEntry[],
+	options: ReconcileOptions,
+): Promise<void> {
+	const { guild } = context;
+	for (const spec of template.channels ?? []) {
+		const stateKey = `channel:${spec.key}`;
+		const renderedName = renderTemplateString(spec.name, variables);
+		const renderedTopic =
+			spec.topic !== undefined
+				? renderTemplateString(spec.topic, variables)
+				: undefined;
+		const type = CHANNEL_TYPE_MAP[spec.type ?? "text"];
+		const parentId = spec.parent
+			? maps.channelIdByKey.get(spec.parent)
+			: undefined;
+		if (spec.parent && !parentId && !options.dryRun) {
+			entries.push({
+				kind: "channel",
+				key: spec.key,
+				name: renderedName,
+				action: "skipped",
+				reason: `parent category "${spec.parent}" was not resolved`,
+			});
+			continue;
+		}
+		const existing = await resolveTrackedChannel(
+			guild,
+			maps.state[stateKey],
+			renderedName,
+			type,
+			parentId,
+		);
+		if (!existing) {
+			if (options.dryRun) {
+				entries.push({
+					kind: "channel",
+					key: spec.key,
+					name: renderedName,
+					action: "would_create",
+				});
+				continue;
+			}
+			const created = await guild.channels.create({
+				name: renderedName,
+				type,
+				...(parentId ? { parent: parentId } : {}),
+				...(renderedTopic !== undefined && type === ChannelType.GuildText
+					? { topic: renderedTopic }
+					: {}),
+				reason: options.reason,
+			});
+			maps.state[stateKey] = created.id;
+			maps.channelIdByKey.set(spec.key, created.id);
+			entries.push({
+				kind: "channel",
+				key: spec.key,
+				name: renderedName,
+				id: created.id,
+				action: "created",
+			});
+			continue;
+		}
+		maps.channelIdByKey.set(spec.key, existing.id);
+		maps.state[stateKey] = existing.id;
+		const drift: Record<string, unknown> = {};
+		if (existing.name !== renderedName) drift.name = renderedName;
+		if (
+			renderedTopic !== undefined &&
+			type === ChannelType.GuildText &&
+			(existing.topic ?? "") !== renderedTopic
+		) {
+			drift.topic = renderedTopic;
+		}
+		if (
+			parentId !== undefined &&
+			(existing.parentId ?? undefined) !== parentId
+		) {
+			drift.parent = parentId;
+		}
+		if (Object.keys(drift).length === 0) {
+			entries.push({
+				kind: "channel",
+				key: spec.key,
+				name: existing.name,
+				id: existing.id,
+				action: "unchanged",
+			});
+			continue;
+		}
+		if (options.dryRun) {
+			entries.push({
+				kind: "channel",
+				key: spec.key,
+				name: existing.name,
+				id: existing.id,
+				action: "would_update",
+			});
+			continue;
+		}
+		await existing.edit({ ...drift, reason: options.reason });
+		entries.push({
+			kind: "channel",
+			key: spec.key,
+			name: renderedName,
+			id: existing.id,
+			action: "updated",
+		});
+	}
+}
+
+function overwriteSatisfied(
+	existing: ManageableOverwrite | undefined,
+	allow: string[],
+	deny: string[],
+): boolean {
+	if (!existing) return allow.length === 0 && deny.length === 0;
+	for (const name of allow) {
+		if (!existing.allow.has(name)) return false;
+	}
+	for (const name of deny) {
+		if (!existing.deny.has(name)) return false;
+	}
+	return true;
+}
+
+async function reconcileOverwrites(
+	context: GuildManagementContext,
+	template: GuildTemplate,
+	maps: ReconcileMaps,
+	entries: ReceiptEntry[],
+	options: ReconcileOptions,
+): Promise<void> {
+	const { guild } = context;
+	const channelSpecs: GuildTemplateChannel[] = template.channels ?? [];
+	for (const spec of channelSpecs) {
+		const overwrites: GuildTemplateOverwrite[] = spec.overwrites ?? [];
+		if (overwrites.length === 0) continue;
+		const channelId = maps.channelIdByKey.get(spec.key);
+		if (!channelId) {
+			if (!options.dryRun) {
+				entries.push({
+					kind: "overwrite",
+					key: spec.key,
+					action: "skipped",
+					reason: "channel was not resolved",
+				});
+			}
+			continue;
+		}
+		const channel =
+			guild.channels.cache.get(channelId) ??
+			(await guild.channels.fetch(channelId).catch(() => null));
+		if (!channel?.permissionOverwrites) {
+			entries.push({
+				kind: "overwrite",
+				key: spec.key,
+				action: "skipped",
+				reason: "channel does not support overwrites",
+			});
+			continue;
+		}
+		for (const overwrite of overwrites) {
+			const subjectId =
+				overwrite.role === "@everyone"
+					? guild.roles.everyone.id
+					: maps.roleIdByKey.get(overwrite.role);
+			const subjectLabel = `${spec.key}/${overwrite.role}`;
+			if (!subjectId) {
+				entries.push({
+					kind: "overwrite",
+					key: subjectLabel,
+					action: "skipped",
+					reason: `role key "${overwrite.role}" was not resolved`,
+				});
+				continue;
+			}
+			const allow = normalizePermissionList(
+				overwrite.allow,
+				`template overwrite ${subjectLabel} allow`,
+			);
+			const deny = normalizePermissionList(
+				overwrite.deny,
+				`template overwrite ${subjectLabel} deny`,
+			);
+			requirePermissionSubset(
+				guild,
+				allow,
+				`template overwrite ${subjectLabel} allow`,
+			);
+			const existing = channel.permissionOverwrites.cache.get(subjectId);
+			if (overwriteSatisfied(existing, allow, deny)) {
+				entries.push({
+					kind: "overwrite",
+					key: subjectLabel,
+					id: subjectId,
+					action: "unchanged",
+				});
+				continue;
+			}
+			if (options.dryRun) {
+				entries.push({
+					kind: "overwrite",
+					key: subjectLabel,
+					id: subjectId,
+					action: "would_update",
+				});
+				continue;
+			}
+			const optionsMap: Record<string, boolean | null> = {};
+			for (const name of allow) optionsMap[name] = true;
+			for (const name of deny) optionsMap[name] = false;
+			await channel.permissionOverwrites.edit(subjectId, optionsMap, {
+				reason: options.reason,
+			});
+			entries.push({
+				kind: "overwrite",
+				key: subjectLabel,
+				id: subjectId,
+				action: "updated",
+			});
+		}
+	}
+}

--- a/plugins/plugin-discord/guild-management.ts
+++ b/plugins/plugin-discord/guild-management.ts
@@ -25,6 +25,7 @@
  * live discord.js `Guild` to it.
  */
 
+import { ElizaError } from "@elizaos/core";
 import { ChannelType, PermissionsBitField } from "discord.js";
 import {
 	BUILT_IN_GUILD_TEMPLATES,
@@ -319,12 +320,13 @@ export interface GuildManagementReceipt {
 	summary: string;
 }
 
-export class GuildManagementError extends Error {
-	public readonly code: string;
-	constructor(code: string, message: string) {
-		super(message);
-		this.name = "GuildManagementError";
-		this.code = code;
+export class GuildManagementError extends ElizaError {
+	override readonly name = "GuildManagementError";
+	constructor(code: string, message: string, cause?: unknown) {
+		super(message, {
+			code,
+			...(cause !== undefined ? { cause } : {}),
+		});
 	}
 }
 
@@ -486,14 +488,7 @@ async function fetchRole(
 	guild: ManageableGuild,
 	roleId: string,
 ): Promise<ManageableRole> {
-	const cached = guild.roles.cache.get(roleId);
-	if (cached) return cached;
-	let fetched: ManageableRole | null = null;
-	try {
-		fetched = await guild.roles.fetch(roleId);
-	} catch {
-		fetched = null;
-	}
+	const fetched = await fetchOptionalRole(guild, roleId);
 	if (!fetched) {
 		throw new GuildManagementError(
 			"ROLE_NOT_FOUND",
@@ -503,18 +498,39 @@ async function fetchRole(
 	return fetched;
 }
 
+function discordErrorCode(error: unknown): string | undefined {
+	if (!error || typeof error !== "object") return undefined;
+	const code = (error as { code?: unknown }).code;
+	return typeof code === "string" || typeof code === "number"
+		? String(code)
+		: undefined;
+}
+
+async function fetchOptionalRole(
+	guild: ManageableGuild,
+	roleId: string,
+): Promise<ManageableRole | null> {
+	const cached = guild.roles.cache.get(roleId);
+	if (cached) return cached;
+	try {
+		return await guild.roles.fetch(roleId);
+	} catch (error) {
+		// error-policy:J4 Discord's exact Unknown Role response is a designed
+		// missing state; every other provider failure remains a typed error.
+		if (discordErrorCode(error) === "10011") return null;
+		throw new GuildManagementError(
+			"ROLE_FETCH_FAILED",
+			`Discord failed to fetch role ${roleId} from guild "${guild.name}".`,
+			error,
+		);
+	}
+}
+
 async function fetchChannel(
 	guild: ManageableGuild,
 	channelId: string,
 ): Promise<ManageableChannel> {
-	const cached = guild.channels.cache.get(channelId);
-	if (cached) return cached;
-	let fetched: ManageableChannel | null = null;
-	try {
-		fetched = await guild.channels.fetch(channelId);
-	} catch {
-		fetched = null;
-	}
+	const fetched = await fetchOptionalChannel(guild, channelId);
 	if (!fetched) {
 		throw new GuildManagementError(
 			"CHANNEL_NOT_FOUND",
@@ -530,18 +546,56 @@ async function fetchChannel(
 	return fetched;
 }
 
+async function fetchOptionalChannel(
+	guild: ManageableGuild,
+	channelId: string,
+): Promise<ManageableChannel | null> {
+	const cached = guild.channels.cache.get(channelId);
+	if (cached) return cached;
+	try {
+		return await guild.channels.fetch(channelId);
+	} catch (error) {
+		// error-policy:J4 Discord's exact Unknown Channel response is a designed
+		// missing state; every other provider failure remains a typed error.
+		if (discordErrorCode(error) === "10003") return null;
+		throw new GuildManagementError(
+			"CHANNEL_FETCH_FAILED",
+			`Discord failed to fetch channel ${channelId} from guild "${guild.name}".`,
+			error,
+		);
+	}
+}
+
+async function fetchOptionalMember(
+	guild: ManageableGuild,
+	userId: string,
+): Promise<ManageableMember | null> {
+	try {
+		return await guild.members.fetch(userId);
+	} catch (error) {
+		// error-policy:J4 Discord's exact Unknown Member response is a designed
+		// missing state; every other provider failure remains a typed error.
+		if (discordErrorCode(error) === "10007") return null;
+		throw new GuildManagementError(
+			"MEMBER_FETCH_FAILED",
+			`Discord failed to fetch member ${userId} from guild "${guild.name}".`,
+			error,
+		);
+	}
+}
+
 async function fetchMember(
 	guild: ManageableGuild,
 	userId: string,
 ): Promise<ManageableMember> {
-	try {
-		return await guild.members.fetch(userId);
-	} catch {
+	const member = await fetchOptionalMember(guild, userId);
+	if (!member) {
 		throw new GuildManagementError(
 			"MEMBER_NOT_FOUND",
 			`Member ${userId} was not found in guild "${guild.name}".`,
 		);
 	}
+	return member;
 }
 
 function requireName(request: GuildManagementRequest): string {
@@ -1365,12 +1419,7 @@ async function moderationOp(
 	if (operation === "ban") {
 		// Hierarchy check when the member is present; bans of absent users pass
 		// straight to the API.
-		let member: ManageableMember | null = null;
-		try {
-			member = await guild.members.fetch(userId);
-		} catch {
-			member = null;
-		}
+		const member = await fetchOptionalMember(guild, userId);
 		if (member && member.bannable === false) {
 			throw new GuildManagementError(
 				"MODERATION_HIERARCHY",
@@ -1580,9 +1629,7 @@ async function resolveTrackedRole(
 	renderedName: string,
 ): Promise<ManageableRole | undefined> {
 	if (stateId) {
-		const byId =
-			guild.roles.cache.get(stateId) ??
-			(await guild.roles.fetch(stateId).catch(() => null));
+		const byId = await fetchOptionalRole(guild, stateId);
 		if (byId) return byId;
 	}
 	for (const role of guild.roles.cache.values()) {
@@ -1715,9 +1762,7 @@ async function resolveTrackedChannel(
 	parentId?: string,
 ): Promise<ManageableChannel | undefined> {
 	if (stateId) {
-		const byId =
-			guild.channels.cache.get(stateId) ??
-			(await guild.channels.fetch(stateId).catch(() => null));
+		const byId = await fetchOptionalChannel(guild, stateId);
 		if (byId) return byId;
 	}
 	for (const channel of guild.channels.cache.values()) {
@@ -1991,9 +2036,7 @@ async function reconcileOverwrites(
 			}
 			continue;
 		}
-		const channel =
-			guild.channels.cache.get(channelId) ??
-			(await guild.channels.fetch(channelId).catch(() => null));
+		const channel = await fetchOptionalChannel(guild, channelId);
 		if (!channel?.permissionOverwrites) {
 			entries.push({
 				kind: "overwrite",

--- a/plugins/plugin-discord/guild-management.ts
+++ b/plugins/plugin-discord/guild-management.ts
@@ -130,6 +130,7 @@ export function normalizeGuildManagementOperation(
 
 export interface ManageablePermissionSet {
 	has(permission: string): boolean;
+	toArray?(): string[];
 }
 
 export interface ManageableRole {
@@ -560,6 +561,18 @@ function requireName(request: GuildManagementRequest): string {
 	return name;
 }
 
+function normalizeTopic(topic: string | undefined): string | undefined {
+	if (topic === undefined) return undefined;
+	const normalized = topic.trim();
+	if (normalized.length > GUILD_TEMPLATE_LIMITS.maxTopicLength) {
+		throw new GuildManagementError(
+			"TOPIC_TOO_LONG",
+			`Channel topics are limited to ${GUILD_TEMPLATE_LIMITS.maxTopicLength} characters.`,
+		);
+	}
+	return normalized;
+}
+
 function parseColor(raw: string | undefined): number | undefined {
 	if (!raw) return undefined;
 	const match = /^#?([0-9a-fA-F]{6})$/.exec(raw.trim());
@@ -727,6 +740,7 @@ async function createChannelOp(
 	const type = isCategory
 		? ChannelType.GuildCategory
 		: resolveChannelType(request.channelType);
+	const topic = normalizeTopic(request.topic);
 	let parentId: string | undefined;
 	if (!isCategory && request.parentId) {
 		const parent = await fetchChannel(guild, request.parentId);
@@ -751,7 +765,7 @@ async function createChannelOp(
 		name,
 		type,
 		...(parentId ? { parent: parentId } : {}),
-		...(request.topic ? { topic: request.topic.trim() } : {}),
+		...(topic ? { topic } : {}),
 		reason: auditReason(context, request),
 	});
 	return receipt(
@@ -777,7 +791,8 @@ async function editChannelOp(
 	const channel = await fetchChannel(guild, request.channelId);
 	const changes: Record<string, unknown> = {};
 	if (request.name?.trim()) changes.name = requireName(request);
-	if (request.topic !== undefined) changes.topic = request.topic;
+	if (request.topic !== undefined)
+		changes.topic = normalizeTopic(request.topic);
 	if (request.parentId) {
 		const parent = await fetchChannel(guild, request.parentId);
 		if (parent.type !== ChannelType.GuildCategory) {
@@ -1433,6 +1448,42 @@ function renderVars(
 	};
 }
 
+function renderTemplateName(
+	value: string,
+	variables: Record<string, string>,
+	label: string,
+): string {
+	const rendered = renderTemplateString(value, variables).trim();
+	if (!rendered) {
+		throw new GuildManagementError(
+			"TEMPLATE_RENDER_INVALID",
+			`${label} rendered to an empty name.`,
+		);
+	}
+	if (rendered.length > GUILD_TEMPLATE_LIMITS.maxNameLength) {
+		throw new GuildManagementError(
+			"TEMPLATE_RENDER_INVALID",
+			`${label} rendered beyond the ${GUILD_TEMPLATE_LIMITS.maxNameLength}-character name limit.`,
+		);
+	}
+	return rendered;
+}
+
+function renderTemplateTopic(
+	value: string,
+	variables: Record<string, string>,
+	label: string,
+): string {
+	const rendered = renderTemplateString(value, variables).trim();
+	if (rendered.length > GUILD_TEMPLATE_LIMITS.maxTopicLength) {
+		throw new GuildManagementError(
+			"TEMPLATE_RENDER_INVALID",
+			`${label} rendered beyond the ${GUILD_TEMPLATE_LIMITS.maxTopicLength}-character topic limit.`,
+		);
+	}
+	return rendered;
+}
+
 async function applyTemplateOp(
 	context: GuildManagementContext,
 	request: GuildManagementRequest,
@@ -1557,7 +1608,11 @@ async function reconcileRoles(
 	const { guild } = context;
 	for (const spec of template.roles ?? []) {
 		const stateKey = `role:${spec.key}`;
-		const renderedName = renderTemplateString(spec.name, variables);
+		const renderedName = renderTemplateName(
+			spec.name,
+			variables,
+			`template role "${spec.key}"`,
+		);
 		const permissions = normalizePermissionList(
 			spec.permissions,
 			`template role "${spec.key}"`,
@@ -1691,7 +1746,11 @@ async function reconcileCategories(
 	const { guild } = context;
 	for (const spec of template.categories ?? []) {
 		const stateKey = `category:${spec.key}`;
-		const renderedName = renderTemplateString(spec.name, variables);
+		const renderedName = renderTemplateName(
+			spec.name,
+			variables,
+			`template category "${spec.key}"`,
+		);
 		const existing = await resolveTrackedChannel(
 			guild,
 			maps.state[stateKey],
@@ -1768,10 +1827,18 @@ async function reconcileChannels(
 	const { guild } = context;
 	for (const spec of template.channels ?? []) {
 		const stateKey = `channel:${spec.key}`;
-		const renderedName = renderTemplateString(spec.name, variables);
+		const renderedName = renderTemplateName(
+			spec.name,
+			variables,
+			`template channel "${spec.key}"`,
+		);
 		const renderedTopic =
 			spec.topic !== undefined
-				? renderTemplateString(spec.topic, variables)
+				? renderTemplateTopic(
+						spec.topic,
+						variables,
+						`template channel "${spec.key}"`,
+					)
 				: undefined;
 		const type = CHANNEL_TYPE_MAP[spec.type ?? "text"];
 		const parentId = spec.parent
@@ -1878,13 +1945,26 @@ function overwriteSatisfied(
 	deny: string[],
 ): boolean {
 	if (!existing) return allow.length === 0 && deny.length === 0;
-	for (const name of allow) {
-		if (!existing.allow.has(name)) return false;
-	}
-	for (const name of deny) {
-		if (!existing.deny.has(name)) return false;
-	}
-	return true;
+	const existingAllow = existing.allow.toArray?.().sort();
+	const existingDeny = existing.deny.toArray?.().sort();
+	if (!existingAllow || !existingDeny) return false;
+	return (
+		existingAllow.join("|") === allow.join("|") &&
+		existingDeny.join("|") === deny.join("|")
+	);
+}
+
+function exactOverwriteOptions(
+	existing: ManageableOverwrite | undefined,
+	allow: string[],
+	deny: string[],
+): Record<string, boolean | null> {
+	const options: Record<string, boolean | null> = {};
+	for (const name of existing?.allow.toArray?.() ?? []) options[name] = null;
+	for (const name of existing?.deny.toArray?.() ?? []) options[name] = null;
+	for (const name of allow) options[name] = true;
+	for (const name of deny) options[name] = false;
+	return options;
 }
 
 async function reconcileOverwrites(
@@ -1970,9 +2050,7 @@ async function reconcileOverwrites(
 				});
 				continue;
 			}
-			const optionsMap: Record<string, boolean | null> = {};
-			for (const name of allow) optionsMap[name] = true;
-			for (const name of deny) optionsMap[name] = false;
+			const optionsMap = exactOverwriteOptions(existing, allow, deny);
 			await channel.permissionOverwrites.edit(subjectId, optionsMap, {
 				reason: options.reason,
 			});

--- a/plugins/plugin-discord/guild-templates.ts
+++ b/plugins/plugin-discord/guild-templates.ts
@@ -1,0 +1,565 @@
+/**
+ * Declarative guild templates for the Discord connector's structural
+ * management surface (`guild-management.ts`).
+ *
+ * A template is a vendor-neutral, idempotent guild spec: roles first (so
+ * permission overwrites can reference them), then categories, then channels.
+ * Objects are matched by stable `key` (via a persisted key->snowflake map)
+ * with an exact-name fallback, so re-applying a template converges instead of
+ * duplicating, and NEVER deletes anything it does not manage.
+ *
+ * Deployments can extend or override the built-in registry through
+ * `settings.discord.guildTemplates` (per-account override via
+ * `settings.discord.accounts.<id>.guildTemplates`).
+ */
+
+export interface GuildTemplateRole {
+	/** Stable identity for reconcile. Never rendered to Discord. */
+	key: string;
+	name: string;
+	/** Hex color, e.g. "#E4C340". */
+	color?: string;
+	hoist?: boolean;
+	mentionable?: boolean;
+	/**
+	 * Named Discord permissions (PascalCase or SCREAMING_SNAKE). Administrator
+	 * is always rejected — templates cannot mint an admin bypass.
+	 */
+	permissions?: string[];
+}
+
+export interface GuildTemplateCategory {
+	key: string;
+	name: string;
+}
+
+export interface GuildTemplateOverwrite {
+	/** Role `key` from this template, or the literal "@everyone". */
+	role: string;
+	allow?: string[];
+	deny?: string[];
+}
+
+export type GuildTemplateChannelType =
+	| "text"
+	| "voice"
+	| "announcement"
+	| "forum"
+	| "stage";
+
+export interface GuildTemplateChannel {
+	key: string;
+	name: string;
+	/** Defaults to "text". */
+	type?: GuildTemplateChannelType;
+	/** Category `key` from this template. */
+	parent?: string;
+	topic?: string;
+	overwrites?: GuildTemplateOverwrite[];
+}
+
+export interface GuildTemplate {
+	id: string;
+	version?: number;
+	description?: string;
+	roles?: GuildTemplateRole[];
+	categories?: GuildTemplateCategory[];
+	channels?: GuildTemplateChannel[];
+}
+
+/** Bounded template sizes — reject anything larger before touching Discord. */
+export const GUILD_TEMPLATE_LIMITS = {
+	maxRoles: 50,
+	maxCategories: 50,
+	maxChannels: 200,
+	maxOverwritesPerChannel: 25,
+	maxNameLength: 100,
+	maxTopicLength: 1024,
+	maxPermissionEntries: 40,
+} as const;
+
+const AGENT_ROLE_PERMISSIONS = [
+	"ViewChannel",
+	"SendMessages",
+	"ManageMessages",
+	"EmbedLinks",
+	"AttachFiles",
+	"ReadMessageHistory",
+	"AddReactions",
+	"ManageThreads",
+	"CreatePublicThreads",
+	"SendMessagesInThreads",
+	"UseApplicationCommands",
+];
+
+/**
+ * Strong management set WITHOUT Administrator. Templates never grant the
+ * Administrator bypass; guild owners can escalate manually if they want it.
+ */
+const ADMIN_ROLE_PERMISSIONS = [
+	"ViewChannel",
+	"SendMessages",
+	"ReadMessageHistory",
+	"AddReactions",
+	"AttachFiles",
+	"EmbedLinks",
+	"ManageChannels",
+	"ManageRoles",
+	"ManageMessages",
+	"ManageThreads",
+	"ManageNicknames",
+	"KickMembers",
+	"BanMembers",
+	"ModerateMembers",
+	"MentionEveryone",
+	"CreateInstantInvite",
+];
+
+const MEMBER_ROLE_PERMISSIONS = [
+	"ViewChannel",
+	"SendMessages",
+	"ReadMessageHistory",
+	"AddReactions",
+];
+
+const companionPrivate: GuildTemplate = {
+	id: "companion-private",
+	version: 1,
+	description:
+		"Single owner + agent private space: locked-down chat, voice, and an agent log channel.",
+	roles: [
+		{
+			key: "agent",
+			name: "{{agent}}",
+			color: "#E4C340",
+			hoist: true,
+			mentionable: true,
+			permissions: [...AGENT_ROLE_PERMISSIONS, "Connect", "Speak"],
+		},
+		{
+			key: "owner",
+			name: "Owner",
+			color: "#FFFFFF",
+			hoist: true,
+			permissions: ADMIN_ROLE_PERMISSIONS,
+		},
+	],
+	categories: [{ key: "cat-home", name: "HOME" }],
+	channels: [
+		{
+			key: "chat",
+			name: "chat",
+			type: "text",
+			parent: "cat-home",
+			topic: "private channel for the owner and the agent",
+			overwrites: [
+				{ role: "@everyone", deny: ["ViewChannel"] },
+				{ role: "owner", allow: ["ViewChannel", "SendMessages"] },
+				{
+					role: "agent",
+					allow: ["ViewChannel", "SendMessages", "ManageMessages"],
+				},
+			],
+		},
+		{
+			key: "voice",
+			name: "voice",
+			type: "voice",
+			parent: "cat-home",
+			overwrites: [
+				{ role: "@everyone", deny: ["ViewChannel"] },
+				{ role: "owner", allow: ["ViewChannel", "Connect", "Speak"] },
+				{ role: "agent", allow: ["ViewChannel", "Connect", "Speak"] },
+			],
+		},
+		{
+			key: "log",
+			name: "agent-log",
+			type: "text",
+			parent: "cat-home",
+			topic: "agent journals and receipts",
+			overwrites: [
+				{ role: "@everyone", deny: ["ViewChannel"] },
+				{ role: "owner", allow: ["ViewChannel"] },
+				{
+					role: "agent",
+					allow: ["ViewChannel", "SendMessages", "ManageMessages"],
+				},
+			],
+		},
+	],
+};
+
+const friendsCasual: GuildTemplate = {
+	id: "friends-casual",
+	version: 1,
+	description:
+		"Small friends server with a shared agent: open lounge, media, and a hang voice channel.",
+	roles: [
+		{
+			key: "agent",
+			name: "{{agent}}",
+			color: "#E4C340",
+			hoist: true,
+			mentionable: true,
+			permissions: [...AGENT_ROLE_PERMISSIONS, "Connect", "Speak"],
+		},
+		{
+			key: "friend",
+			name: "Friend",
+			color: "#9B59B6",
+			permissions: [
+				...MEMBER_ROLE_PERMISSIONS,
+				"AttachFiles",
+				"EmbedLinks",
+				"Connect",
+				"Speak",
+			],
+		},
+	],
+	categories: [{ key: "cat-hang", name: "HANG" }],
+	channels: [
+		{
+			key: "lounge",
+			name: "lounge",
+			type: "text",
+			parent: "cat-hang",
+			topic: "whatever",
+		},
+		{
+			key: "media",
+			name: "media",
+			type: "text",
+			parent: "cat-hang",
+			topic: "pics and links",
+		},
+		{ key: "vc", name: "hang-vc", type: "voice", parent: "cat-hang" },
+	],
+};
+
+const projectTeam: GuildTemplate = {
+	id: "project-team",
+	version: 1,
+	description:
+		"Work team server: general, role-gated dev, agent-write receipts and alerts channels.",
+	roles: [
+		{
+			key: "agent",
+			name: "{{agent}}",
+			color: "#E4C340",
+			hoist: true,
+			mentionable: true,
+			permissions: AGENT_ROLE_PERMISSIONS,
+		},
+		{
+			key: "admin",
+			name: "Admin",
+			color: "#E74C3C",
+			hoist: true,
+			permissions: ADMIN_ROLE_PERMISSIONS,
+		},
+		{
+			key: "dev",
+			name: "Dev",
+			color: "#1ABC9C",
+			permissions: [
+				...MEMBER_ROLE_PERMISSIONS,
+				"AttachFiles",
+				"EmbedLinks",
+				"CreatePublicThreads",
+				"SendMessagesInThreads",
+			],
+		},
+		{
+			key: "member",
+			name: "Member",
+			color: "#3498DB",
+			permissions: MEMBER_ROLE_PERMISSIONS,
+		},
+	],
+	categories: [
+		{ key: "cat-team", name: "TEAM" },
+		{ key: "cat-dev", name: "DEV" },
+		{ key: "cat-ops", name: "OPS" },
+	],
+	channels: [
+		{
+			key: "general",
+			name: "general",
+			type: "text",
+			parent: "cat-team",
+			topic: "team-wide",
+		},
+		{
+			key: "dev",
+			name: "dev",
+			type: "text",
+			parent: "cat-dev",
+			topic: "engineering",
+			overwrites: [
+				{ role: "@everyone", deny: ["ViewChannel"] },
+				{ role: "dev", allow: ["ViewChannel", "SendMessages"] },
+				{ role: "admin", allow: ["ViewChannel", "SendMessages"] },
+				{
+					role: "agent",
+					allow: ["ViewChannel", "SendMessages", "ManageMessages"],
+				},
+			],
+		},
+		{
+			key: "receipts",
+			name: "receipts",
+			type: "text",
+			parent: "cat-ops",
+			topic: "agent posts build and PR receipts here",
+			overwrites: [
+				{
+					role: "@everyone",
+					allow: ["ViewChannel", "ReadMessageHistory"],
+					deny: ["SendMessages"],
+				},
+				{ role: "agent", allow: ["SendMessages", "ManageMessages"] },
+			],
+		},
+		{
+			key: "alerts",
+			name: "alerts",
+			type: "text",
+			parent: "cat-ops",
+			topic: "CI, uptime, incidents",
+			overwrites: [
+				{
+					role: "@everyone",
+					allow: ["ViewChannel", "ReadMessageHistory"],
+					deny: ["SendMessages"],
+				},
+				{ role: "agent", allow: ["SendMessages"] },
+			],
+		},
+	],
+};
+
+const communityPublic: GuildTemplate = {
+	id: "community-public",
+	version: 1,
+	description:
+		"Public community: locked landing (rules + welcome), verified-gated general, mod log.",
+	roles: [
+		{
+			key: "agent",
+			name: "{{agent}}",
+			color: "#E4C340",
+			hoist: true,
+			mentionable: true,
+			permissions: [...AGENT_ROLE_PERMISSIONS, "ModerateMembers"],
+		},
+		{
+			key: "admin",
+			name: "Admin",
+			color: "#E74C3C",
+			hoist: true,
+			permissions: ADMIN_ROLE_PERMISSIONS,
+		},
+		{
+			key: "mod",
+			name: "Mod",
+			color: "#E67E22",
+			hoist: true,
+			permissions: [
+				...MEMBER_ROLE_PERMISSIONS,
+				"ManageMessages",
+				"ManageThreads",
+				"KickMembers",
+				"ModerateMembers",
+			],
+		},
+		{
+			key: "verified",
+			name: "Verified",
+			color: "#2ECC71",
+			permissions: [...MEMBER_ROLE_PERMISSIONS, "AttachFiles", "EmbedLinks"],
+		},
+	],
+	categories: [
+		{ key: "cat-welcome", name: "WELCOME" },
+		{ key: "cat-community", name: "COMMUNITY" },
+	],
+	channels: [
+		{
+			key: "rules",
+			name: "rules",
+			type: "text",
+			parent: "cat-welcome",
+			topic: "read and react to verify",
+			overwrites: [
+				{
+					role: "@everyone",
+					allow: ["ViewChannel", "ReadMessageHistory", "AddReactions"],
+					deny: ["SendMessages"],
+				},
+				{ role: "agent", allow: ["SendMessages", "ManageMessages"] },
+			],
+		},
+		{
+			key: "welcome",
+			name: "welcome",
+			type: "text",
+			parent: "cat-welcome",
+			topic: "greetings",
+			overwrites: [
+				{
+					role: "@everyone",
+					allow: ["ViewChannel", "ReadMessageHistory"],
+					deny: ["SendMessages"],
+				},
+				{ role: "agent", allow: ["SendMessages"] },
+			],
+		},
+		{
+			key: "general",
+			name: "general",
+			type: "text",
+			parent: "cat-community",
+			topic: "verified members only",
+			overwrites: [
+				{ role: "@everyone", deny: ["ViewChannel"] },
+				{ role: "verified", allow: ["ViewChannel", "SendMessages"] },
+				{
+					role: "agent",
+					allow: ["ViewChannel", "SendMessages", "ManageMessages"],
+				},
+			],
+		},
+		{
+			key: "modlog",
+			name: "mod-log",
+			type: "text",
+			parent: "cat-community",
+			topic: "moderation audit",
+			overwrites: [
+				{ role: "@everyone", deny: ["ViewChannel"] },
+				{ role: "mod", allow: ["ViewChannel"] },
+				{ role: "admin", allow: ["ViewChannel"] },
+				{ role: "agent", allow: ["ViewChannel", "SendMessages"] },
+			],
+		},
+	],
+};
+
+export const BUILT_IN_GUILD_TEMPLATES: Readonly<Record<string, GuildTemplate>> =
+	Object.freeze({
+		[companionPrivate.id]: companionPrivate,
+		[friendsCasual.id]: friendsCasual,
+		[projectTeam.id]: projectTeam,
+		[communityPublic.id]: communityPublic,
+	});
+
+/**
+ * Renders `{{variable}}` placeholders in template names/topics. Unknown
+ * variables render their default when provided (`agent` -> "Agent") and are
+ * otherwise left intact so the drift is visible instead of silently blank.
+ */
+export function renderTemplateString(
+	value: string,
+	variables: Record<string, string>,
+): string {
+	return value.replace(/\{\{\s*([\w-]+)\s*\}\}/g, (whole, name: string) => {
+		const provided = variables[name];
+		if (typeof provided === "string" && provided.trim()) {
+			return provided.trim();
+		}
+		if (name === "agent") return "Agent";
+		return whole;
+	});
+}
+
+/** Validates template shape and bounds. Returns human-actionable errors. */
+export function validateGuildTemplate(template: GuildTemplate): string[] {
+	const errors: string[] = [];
+	const limits = GUILD_TEMPLATE_LIMITS;
+	if (!template || typeof template !== "object") {
+		return ["template must be an object"];
+	}
+	if (typeof template.id !== "string" || !template.id.trim()) {
+		errors.push("template.id is required");
+	}
+	const roles = template.roles ?? [];
+	const categories = template.categories ?? [];
+	const channels = template.channels ?? [];
+	if (roles.length > limits.maxRoles) {
+		errors.push(`template.roles exceeds ${limits.maxRoles} entries`);
+	}
+	if (categories.length > limits.maxCategories) {
+		errors.push(`template.categories exceeds ${limits.maxCategories} entries`);
+	}
+	if (channels.length > limits.maxChannels) {
+		errors.push(`template.channels exceeds ${limits.maxChannels} entries`);
+	}
+	const seenKeys = new Set<string>();
+	const checkKeyedName = (
+		kind: string,
+		entry: { key?: unknown; name?: unknown },
+		index: number,
+	): void => {
+		const key = typeof entry.key === "string" ? entry.key.trim() : "";
+		const name = typeof entry.name === "string" ? entry.name.trim() : "";
+		if (!key) errors.push(`${kind}[${index}].key is required`);
+		if (!name) errors.push(`${kind}[${index}].name is required`);
+		if (name.length > limits.maxNameLength) {
+			errors.push(
+				`${kind}[${index}].name exceeds ${limits.maxNameLength} characters`,
+			);
+		}
+		const qualified = `${kind}:${key}`;
+		if (key && seenKeys.has(qualified)) {
+			errors.push(`duplicate ${kind} key "${key}"`);
+		}
+		seenKeys.add(qualified);
+	};
+	roles.forEach((role, index) => {
+		checkKeyedName("roles", role, index);
+		if (
+			role.permissions &&
+			role.permissions.length > limits.maxPermissionEntries
+		) {
+			errors.push(
+				`roles[${index}].permissions exceeds ${limits.maxPermissionEntries} entries`,
+			);
+		}
+	});
+	categories.forEach((category, index) => {
+		checkKeyedName("categories", category, index);
+	});
+	const categoryKeys = new Set(categories.map((category) => category.key));
+	const roleKeys = new Set(roles.map((role) => role.key));
+	channels.forEach((channel, index) => {
+		checkKeyedName("channels", channel, index);
+		if (channel.parent && !categoryKeys.has(channel.parent)) {
+			errors.push(
+				`channels[${index}].parent "${channel.parent}" is not a category key in this template`,
+			);
+		}
+		if (
+			typeof channel.topic === "string" &&
+			channel.topic.length > limits.maxTopicLength
+		) {
+			errors.push(
+				`channels[${index}].topic exceeds ${limits.maxTopicLength} characters`,
+			);
+		}
+		const overwrites = channel.overwrites ?? [];
+		if (overwrites.length > limits.maxOverwritesPerChannel) {
+			errors.push(
+				`channels[${index}].overwrites exceeds ${limits.maxOverwritesPerChannel} entries`,
+			);
+		}
+		overwrites.forEach((overwrite, overwriteIndex) => {
+			if (overwrite.role !== "@everyone" && !roleKeys.has(overwrite.role)) {
+				errors.push(
+					`channels[${index}].overwrites[${overwriteIndex}].role "${overwrite.role}" is not a role key in this template`,
+				);
+			}
+		});
+	});
+	return errors;
+}

--- a/plugins/plugin-discord/guild-templates.ts
+++ b/plugins/plugin-discord/guild-templates.ts
@@ -477,15 +477,29 @@ export function renderTemplateString(
 export function validateGuildTemplate(template: GuildTemplate): string[] {
 	const errors: string[] = [];
 	const limits = GUILD_TEMPLATE_LIMITS;
-	if (!template || typeof template !== "object") {
+	if (!template || typeof template !== "object" || Array.isArray(template)) {
 		return ["template must be an object"];
 	}
 	if (typeof template.id !== "string" || !template.id.trim()) {
 		errors.push("template.id is required");
 	}
-	const roles = template.roles ?? [];
-	const categories = template.categories ?? [];
-	const channels = template.channels ?? [];
+	if (template.roles !== undefined && !Array.isArray(template.roles)) {
+		errors.push("template.roles must be an array");
+	}
+	if (
+		template.categories !== undefined &&
+		!Array.isArray(template.categories)
+	) {
+		errors.push("template.categories must be an array");
+	}
+	if (template.channels !== undefined && !Array.isArray(template.channels)) {
+		errors.push("template.channels must be an array");
+	}
+	const roles = Array.isArray(template.roles) ? template.roles : [];
+	const categories = Array.isArray(template.categories)
+		? template.categories
+		: [];
+	const channels = Array.isArray(template.channels) ? template.channels : [];
 	if (roles.length > limits.maxRoles) {
 		errors.push(`template.roles exceeds ${limits.maxRoles} entries`);
 	}
@@ -498,11 +512,16 @@ export function validateGuildTemplate(template: GuildTemplate): string[] {
 	const seenKeys = new Set<string>();
 	const checkKeyedName = (
 		kind: string,
-		entry: { key?: unknown; name?: unknown },
+		entry: unknown,
 		index: number,
-	): void => {
-		const key = typeof entry.key === "string" ? entry.key.trim() : "";
-		const name = typeof entry.name === "string" ? entry.name.trim() : "";
+	): entry is { key: string; name: string } & Record<string, unknown> => {
+		if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+			errors.push(`${kind}[${index}] must be an object`);
+			return false;
+		}
+		const record = entry as Record<string, unknown>;
+		const key = typeof record.key === "string" ? record.key.trim() : "";
+		const name = typeof record.name === "string" ? record.name.trim() : "";
 		if (!key) errors.push(`${kind}[${index}].key is required`);
 		if (!name) errors.push(`${kind}[${index}].name is required`);
 		if (name.length > limits.maxNameLength) {
@@ -515,26 +534,53 @@ export function validateGuildTemplate(template: GuildTemplate): string[] {
 			errors.push(`duplicate ${kind} key "${key}"`);
 		}
 		seenKeys.add(qualified);
+		return Boolean(key && name);
 	};
 	roles.forEach((role, index) => {
-		checkKeyedName("roles", role, index);
-		if (
-			role.permissions &&
+		if (!checkKeyedName("roles", role, index)) return;
+		if (role.permissions !== undefined && !Array.isArray(role.permissions)) {
+			errors.push(`roles[${index}].permissions must be an array`);
+		} else if (
+			Array.isArray(role.permissions) &&
 			role.permissions.length > limits.maxPermissionEntries
 		) {
 			errors.push(
 				`roles[${index}].permissions exceeds ${limits.maxPermissionEntries} entries`,
 			);
 		}
+		if (
+			Array.isArray(role.permissions) &&
+			role.permissions.some((permission) => typeof permission !== "string")
+		) {
+			errors.push(`roles[${index}].permissions must contain only strings`);
+		}
 	});
 	categories.forEach((category, index) => {
 		checkKeyedName("categories", category, index);
 	});
-	const categoryKeys = new Set(categories.map((category) => category.key));
-	const roleKeys = new Set(roles.map((role) => role.key));
+	const categoryKeys = new Set(
+		categories.flatMap((category) =>
+			category &&
+			typeof category === "object" &&
+			typeof category.key === "string"
+				? [category.key]
+				: [],
+		),
+	);
+	const roleKeys = new Set(
+		roles.flatMap((role) =>
+			role && typeof role === "object" && typeof role.key === "string"
+				? [role.key]
+				: [],
+		),
+	);
 	channels.forEach((channel, index) => {
-		checkKeyedName("channels", channel, index);
-		if (channel.parent && !categoryKeys.has(channel.parent)) {
+		if (!checkKeyedName("channels", channel, index)) return;
+		if (
+			typeof channel.parent === "string" &&
+			channel.parent &&
+			!categoryKeys.has(channel.parent)
+		) {
 			errors.push(
 				`channels[${index}].parent "${channel.parent}" is not a category key in this template`,
 			);
@@ -547,17 +593,65 @@ export function validateGuildTemplate(template: GuildTemplate): string[] {
 				`channels[${index}].topic exceeds ${limits.maxTopicLength} characters`,
 			);
 		}
-		const overwrites = channel.overwrites ?? [];
+		if (
+			channel.type !== undefined &&
+			!["text", "voice", "announcement", "forum", "stage"].includes(
+				String(channel.type),
+			)
+		) {
+			errors.push(`channels[${index}].type is not supported`);
+		}
+		if (
+			channel.overwrites !== undefined &&
+			!Array.isArray(channel.overwrites)
+		) {
+			errors.push(`channels[${index}].overwrites must be an array`);
+		}
+		const overwrites = Array.isArray(channel.overwrites)
+			? channel.overwrites
+			: [];
 		if (overwrites.length > limits.maxOverwritesPerChannel) {
 			errors.push(
 				`channels[${index}].overwrites exceeds ${limits.maxOverwritesPerChannel} entries`,
 			);
 		}
 		overwrites.forEach((overwrite, overwriteIndex) => {
+			if (
+				!overwrite ||
+				typeof overwrite !== "object" ||
+				Array.isArray(overwrite)
+			) {
+				errors.push(
+					`channels[${index}].overwrites[${overwriteIndex}] must be an object`,
+				);
+				return;
+			}
+			if (typeof overwrite.role !== "string" || !overwrite.role.trim()) {
+				errors.push(
+					`channels[${index}].overwrites[${overwriteIndex}].role is required`,
+				);
+				return;
+			}
 			if (overwrite.role !== "@everyone" && !roleKeys.has(overwrite.role)) {
 				errors.push(
 					`channels[${index}].overwrites[${overwriteIndex}].role "${overwrite.role}" is not a role key in this template`,
 				);
+			}
+			for (const field of ["allow", "deny"] as const) {
+				const permissions = overwrite[field];
+				if (permissions !== undefined && !Array.isArray(permissions)) {
+					errors.push(
+						`channels[${index}].overwrites[${overwriteIndex}].${field} must be an array`,
+					);
+				} else if (
+					Array.isArray(permissions) &&
+					(permissions.length > limits.maxPermissionEntries ||
+						permissions.some((permission) => typeof permission !== "string"))
+				) {
+					errors.push(
+						`channels[${index}].overwrites[${overwriteIndex}].${field} must contain at most ${limits.maxPermissionEntries} strings`,
+					);
+				}
 			}
 		});
 	});

--- a/plugins/plugin-discord/index.ts
+++ b/plugins/plugin-discord/index.ts
@@ -269,6 +269,24 @@ export {
 	resolveDiscordUserProfile,
 	resolveStoredDiscordEntityProfile,
 } from "./discord-profiles";
+export {
+	executeGuildManagement,
+	GUILD_MANAGEMENT_OPERATIONS,
+	GuildManagementError,
+	type GuildManagementGates,
+	type GuildManagementOperation,
+	type GuildManagementReceipt,
+	type GuildManagementRequest,
+	normalizeGuildManagementOperation,
+	resolveGuildManagementGates,
+} from "./guild-management";
+export {
+	BUILT_IN_GUILD_TEMPLATES,
+	type GuildTemplate,
+	type GuildTemplateChannel,
+	type GuildTemplateRole,
+	validateGuildTemplate,
+} from "./guild-templates";
 // Messaging utilities exports
 export {
 	buildChannelLink,

--- a/plugins/plugin-discord/messages.ts
+++ b/plugins/plugin-discord/messages.ts
@@ -1746,7 +1746,6 @@ export class MessageManager {
 					),
 					accountId: this.accountId,
 				},
-				roomMetadata: { accountId: this.accountId },
 			});
 			try {
 				await attestDeliveryAudienceFromCanonicalRoom(this.runtime, newMessage);

--- a/plugins/plugin-discord/messages.ts
+++ b/plugins/plugin-discord/messages.ts
@@ -1728,6 +1728,7 @@ export class MessageManager {
 				...(aliasedAuthor ? {} : { userName, name }),
 				source: "discord",
 				channelId: message.channel.id,
+				serverId: messageServerId,
 				// Convert Discord snowflake to UUID (see service.ts header for why stringToUuid not asUUID)
 				messageServerId: messageServerId
 					? stringToUuid(messageServerId)
@@ -1745,6 +1746,7 @@ export class MessageManager {
 					),
 					accountId: this.accountId,
 				},
+				roomMetadata: { accountId: this.accountId },
 			});
 			try {
 				await attestDeliveryAudienceFromCanonicalRoom(this.runtime, newMessage);

--- a/plugins/plugin-discord/service.ts
+++ b/plugins/plugin-discord/service.ts
@@ -2112,7 +2112,6 @@ export class DiscordService extends Service implements IDiscordService {
 								metadata: {
 									accountId,
 								},
-								roomMetadata: { accountId },
 							});
 						}
 						const dedupeParams = {
@@ -2277,7 +2276,6 @@ export class DiscordService extends Service implements IDiscordService {
 							metadata: {
 								accountId,
 							},
-							roomMetadata: { accountId },
 						});
 					} catch (error) {
 						// error-policy:J1 local persistence boundary keeps provider

--- a/plugins/plugin-discord/service.ts
+++ b/plugins/plugin-discord/service.ts
@@ -144,6 +144,15 @@ import {
 import { DmChannelRegistry } from "./dm-channel-registry";
 import { getDiscordSettings } from "./environment";
 import {
+	executeGuildManagement,
+	type GuildManagementReceipt,
+	type GuildManagementRequest,
+	type ManageableGuild,
+	resolveGuildManagementGates,
+	type TemplateStateStore,
+} from "./guild-management";
+import type { GuildTemplate } from "./guild-templates";
+import {
 	extractDiscordOwnerUserIds,
 	extractDiscordTeamAdminUserIds,
 	isAliasedDiscordEntityId,
@@ -198,6 +207,48 @@ import {
 } from "./voice-target-registry";
 
 const DISCORD_SNOWFLAKE_PATTERN = /^\d{15,20}$/;
+
+// Loose coercion for planner-supplied manage_server params: unknown shapes
+// collapse to undefined so the management module's own validation reports
+// missing fields instead of type errors leaking through.
+function stringOrUndefined(value: unknown): string | undefined {
+	return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+function booleanOrUndefined(value: unknown): boolean | undefined {
+	if (typeof value === "boolean") return value;
+	if (typeof value === "string") {
+		const normalized = value.trim().toLowerCase();
+		if (["true", "yes", "1", "on"].includes(normalized)) return true;
+		if (["false", "no", "0", "off"].includes(normalized)) return false;
+	}
+	return undefined;
+}
+
+function numberOrUndefined(value: unknown): number | undefined {
+	if (typeof value === "number" && Number.isFinite(value)) return value;
+	if (typeof value === "string" && value.trim()) {
+		const parsed = Number(value.trim());
+		if (Number.isFinite(parsed)) return parsed;
+	}
+	return undefined;
+}
+
+function stringArrayOrUndefined(value: unknown): string[] | undefined {
+	if (!Array.isArray(value)) {
+		if (typeof value === "string" && value.trim()) {
+			return value
+				.split(",")
+				.map((entry) => entry.trim())
+				.filter(Boolean);
+		}
+		return undefined;
+	}
+	return value.filter(
+		(entry): entry is string =>
+			typeof entry === "string" && Boolean(entry.trim()),
+	);
+}
 type MessageConnectorRegistration = Parameters<
 	IAgentRuntime["registerMessageConnector"]
 >[0];
@@ -457,6 +508,15 @@ type ExtendedMessageConnectorRegistration = MessageConnectorRegistration & {
 		runtime: IAgentRuntime,
 		params: ConnectorUserLookupParams,
 	) => Promise<unknown>;
+	manageServerHandler?: (
+		runtime: IAgentRuntime,
+		params: {
+			target?: TargetInfo;
+			operation: string;
+			serverId?: string;
+			params?: Record<string, unknown>;
+		},
+	) => Promise<{ summary: string; data?: Record<string, unknown> }>;
 };
 
 const DISCORD_CONNECTOR_CONTEXTS = ["social", "connectors"];
@@ -482,6 +542,7 @@ const DISCORD_CONNECTOR_CAPABILITIES = [
 	"webhook_identity",
 	"rich_components",
 	"rich_embed",
+	"manage_server",
 ];
 
 function normalizeDiscordConnectorQuery(value: string): string {
@@ -3553,6 +3614,187 @@ export class DiscordService extends Service implements IDiscordService {
 		this.removeAllowedChannel(channel.id, accountId);
 	}
 
+	/**
+	 * Structural guild management entry point for the message tool
+	 * (`MESSAGE op=manage_server source=discord`). Fail-closed: every write
+	 * requires the corresponding `actions.channels|roles|permissions|moderation`
+	 * gate to be explicitly enabled for this account, and role/member writes
+	 * validate Discord role hierarchy inside `executeGuildManagement`.
+	 */
+	public async manageConnectorServer(
+		runtime: IAgentRuntime,
+		params: {
+			target?: TargetInfo;
+			operation: string;
+			serverId?: string;
+			params?: Record<string, unknown>;
+			accountId?: string;
+		},
+	): Promise<{ summary: string; data?: Record<string, unknown> }> {
+		const accountId = this.resolveAccountIdFromTarget(params.target, params);
+		const client = this.getClient(accountId);
+		if (!client?.isReady()) {
+			throw new Error(`Discord client is not ready for account ${accountId}.`);
+		}
+		const guild = await this.resolveManagementGuild(client, params);
+		const gates = this.getGuildManagementGates(accountId);
+		const raw = params.params ?? {};
+		const request: GuildManagementRequest = {
+			operation: params.operation as GuildManagementRequest["operation"],
+			guildId: guild.id,
+			channelId: stringOrUndefined(raw.channelId ?? params.target?.channelId),
+			parentId: stringOrUndefined(raw.parentId),
+			roleId: stringOrUndefined(raw.roleId),
+			userId: stringOrUndefined(raw.userId),
+			name: stringOrUndefined(raw.name),
+			topic: stringOrUndefined(raw.topic),
+			channelType: stringOrUndefined(raw.channelType),
+			color: stringOrUndefined(raw.color),
+			hoist: booleanOrUndefined(raw.hoist),
+			mentionable: booleanOrUndefined(raw.mentionable),
+			permissions: stringArrayOrUndefined(raw.permissions),
+			allow: stringArrayOrUndefined(raw.allow),
+			deny: stringArrayOrUndefined(raw.deny),
+			overwriteId: stringOrUndefined(raw.overwriteId),
+			reason: stringOrUndefined(raw.reason),
+			durationMinutes: numberOrUndefined(raw.durationMinutes),
+			deleteMessageSeconds: numberOrUndefined(raw.deleteMessageSeconds),
+			maxAgeSeconds: numberOrUndefined(raw.maxAgeSeconds),
+			maxUses: numberOrUndefined(raw.maxUses),
+			unique: booleanOrUndefined(raw.unique),
+			template: stringOrUndefined(raw.template),
+			templateSpec:
+				raw.templateSpec && typeof raw.templateSpec === "object"
+					? (raw.templateSpec as GuildTemplate)
+					: undefined,
+			variables:
+				raw.variables && typeof raw.variables === "object"
+					? (raw.variables as Record<string, string>)
+					: undefined,
+			dryRun: booleanOrUndefined(raw.dryRun),
+		};
+		const stateStore: TemplateStateStore = {
+			get: async (guildId, templateId) =>
+				(await runtime.getCache<Record<string, string>>(
+					`discord:guild-template:${accountId}:${guildId}:${templateId}`,
+				)) ?? undefined,
+			set: async (guildId, templateId, state) => {
+				await runtime.setCache(
+					`discord:guild-template:${accountId}:${guildId}:${templateId}`,
+					state,
+				);
+			},
+		};
+		const receipt: GuildManagementReceipt = await executeGuildManagement(
+			{
+				guild: guild as unknown as ManageableGuild,
+				gates,
+				stateStore,
+				templateRegistry: this.getGuildTemplateRegistry(accountId),
+				agentName: this.runtime.character?.name,
+				reasonPrefix: `eliza:${this.runtime.character?.name ?? "agent"} guild management`,
+			},
+			request,
+		);
+		return {
+			summary: receipt.summary,
+			data: receipt as unknown as Record<string, unknown>,
+		};
+	}
+
+	private async resolveManagementGuild(
+		client: DiscordJsClient,
+		params: {
+			target?: TargetInfo;
+			serverId?: string;
+			params?: Record<string, unknown>;
+		},
+	): Promise<Guild> {
+		const requested =
+			params.serverId?.trim() || params.target?.serverId?.trim() || undefined;
+		if (requested) {
+			if (DISCORD_SNOWFLAKE_PATTERN.test(requested)) {
+				const byId = await client.guilds.fetch(requested).catch(() => null);
+				if (byId) return byId;
+			}
+			const normalized = normalizeDiscordConnectorQuery(requested);
+			const byName = client.guilds.cache.find(
+				(guild) => guild.name.toLowerCase() === normalized,
+			);
+			if (byName) return byName;
+			throw new Error(
+				`Discord server "${requested}" was not found among the bot's guilds.`,
+			);
+		}
+		const channelId =
+			params.target?.channelId ?? stringOrUndefined(params.params?.channelId);
+		if (channelId) {
+			const channel = await client.channels.fetch(channelId).catch(() => null);
+			const guild =
+				channel && "guild" in channel ? (channel.guild as Guild) : null;
+			if (guild) return guild;
+		}
+		if (client.guilds.cache.size === 1) {
+			const only = client.guilds.cache.first();
+			if (only) return only;
+		}
+		throw new Error(
+			"Discord server management requires a serverId (guild id or exact name) when the bot is in multiple guilds.",
+		);
+	}
+
+	/**
+	 * Structural-management gates for one account. Reads
+	 * `settings.discord.actions` with per-account overrides and env fallbacks
+	 * (`DISCORD_ACTIONS_CHANNELS|ROLES|PERMISSIONS|MODERATION`). Absent means
+	 * OFF — structural writes are opt-in.
+	 */
+	private getGuildManagementGates(accountId: string) {
+		const settings = this.runtime.character?.settings?.discord as
+			| {
+					actions?: Record<string, unknown>;
+					accounts?: Record<string, { actions?: Record<string, unknown> }>;
+			  }
+			| undefined;
+		const merged: Record<string, unknown> = {
+			...(settings?.actions ?? {}),
+			...(settings?.accounts?.[accountId]?.actions ?? {}),
+		};
+		for (const [envKey, gateKey] of [
+			["DISCORD_ACTIONS_CHANNELS", "channels"],
+			["DISCORD_ACTIONS_ROLES", "roles"],
+			["DISCORD_ACTIONS_PERMISSIONS", "permissions"],
+			["DISCORD_ACTIONS_MODERATION", "moderation"],
+		] as const) {
+			if (merged[gateKey] === undefined) {
+				const rawSetting = this.runtime.getSetting(envKey);
+				if (rawSetting !== undefined && rawSetting !== null) {
+					merged[gateKey] = parseBooleanFromText(String(rawSetting));
+				}
+			}
+		}
+		return resolveGuildManagementGates(merged);
+	}
+
+	/** Deployment-supplied template registry (merged over the built-ins). */
+	private getGuildTemplateRegistry(
+		accountId: string,
+	): Record<string, GuildTemplate> | undefined {
+		const settings = this.runtime.character?.settings?.discord as
+			| {
+					guildTemplates?: Record<string, GuildTemplate>;
+					accounts?: Record<
+						string,
+						{ guildTemplates?: Record<string, GuildTemplate> }
+					>;
+			  }
+			| undefined;
+		const base = settings?.guildTemplates;
+		const account = settings?.accounts?.[accountId]?.guildTemplates;
+		if (!base && !account) return undefined;
+		return { ...(base ?? {}), ...(account ?? {}) };
+	}
+
 	public async getConnectorUser(
 		_runtime: IAgentRuntime,
 		params: ConnectorUserLookupParams,
@@ -3808,7 +4050,7 @@ export class DiscordService extends Service implements IDiscordService {
 							: {}),
 						label,
 						description:
-							"Discord connector for sending, reading, searching, reacting to, editing, deleting, pinning, joining, and leaving messages/channels.",
+							"Discord connector for sending, reading, searching, reacting to, editing, deleting, pinning, joining, and leaving messages/channels, plus gated structural server management (channels, categories, roles, permissions, invites, moderation, guild templates).",
 						capabilities: [...DISCORD_CONNECTOR_CAPABILITIES],
 						supportedTargetKinds: ["channel", "thread", "user"],
 						contexts: [...DISCORD_CONNECTOR_CONTEXTS],
@@ -3908,6 +4150,12 @@ export class DiscordService extends Service implements IDiscordService {
 								runtime,
 								scopedFetchParams(params),
 							),
+						manageServerHandler: (runtime, params) =>
+							serviceInstance.manageConnectorServer(runtime, {
+								...params,
+								accountId: accountIdFromRecord(params.target) ?? accountId,
+								target: params.target ? scopedTarget(params.target) : undefined,
+							}),
 					};
 					runtime.registerMessageConnector(registration);
 					runtime.logger.info(

--- a/plugins/plugin-discord/service.ts
+++ b/plugins/plugin-discord/service.ts
@@ -16,6 +16,7 @@ import {
 	type Character,
 	type Content,
 	createUniqueUuid,
+	ElizaError,
 	type EventPayload,
 	getConnectorAdminWhitelist,
 	type IAgentRuntime,
@@ -25,6 +26,8 @@ import {
 	MemoryType,
 	type MessageConnectorChatContext,
 	type MessageConnectorCreateThreadParams,
+	type MessageConnectorManageServerAuthorization,
+	type MessageConnectorManageServerDestination,
 	type MessageConnectorPostToThreadParams,
 	type MessageConnectorQueryContext,
 	type MessageConnectorTarget,
@@ -151,6 +154,10 @@ import {
 	resolveGuildManagementGates,
 	type TemplateStateStore,
 } from "./guild-management";
+import {
+	resolveDiscordManageServerDestination,
+	revalidateDiscordManageServerAuthorization,
+} from "./guild-management-authorization";
 import type { GuildTemplate } from "./guild-templates";
 import {
 	extractDiscordOwnerUserIds,
@@ -508,12 +515,19 @@ type ExtendedMessageConnectorRegistration = MessageConnectorRegistration & {
 		runtime: IAgentRuntime,
 		params: ConnectorUserLookupParams,
 	) => Promise<unknown>;
+	resolveManageServerDestination?: (
+		runtime: IAgentRuntime,
+		params: { target?: TargetInfo; serverId: string },
+	) =>
+		| Promise<MessageConnectorManageServerDestination>
+		| MessageConnectorManageServerDestination;
 	manageServerHandler?: (
 		runtime: IAgentRuntime,
 		params: {
 			target?: TargetInfo;
 			operation: string;
 			serverId?: string;
+			authorization: MessageConnectorManageServerAuthorization;
 			params?: Record<string, unknown>;
 		},
 	) => Promise<{ summary: string; data?: Record<string, unknown> }>;
@@ -2090,6 +2104,7 @@ export class DiscordService extends Service implements IDiscordService {
 								name: dmRecipient.name,
 								source: "discord",
 								channelId: targetChannel.id,
+								serverId,
 								messageServerId: stringToUuid(serverId),
 								type: channelType,
 								worldId,
@@ -2097,6 +2112,7 @@ export class DiscordService extends Service implements IDiscordService {
 								metadata: {
 									accountId,
 								},
+								roomMetadata: { accountId },
 							});
 						}
 						const dedupeParams = {
@@ -2253,6 +2269,7 @@ export class DiscordService extends Service implements IDiscordService {
 							name: clientUser.displayName || clientUser.username || undefined,
 							source: "discord",
 							channelId: targetChannel.id,
+							serverId,
 							messageServerId: stringToUuid(serverId),
 							type: channelType,
 							worldId,
@@ -2260,6 +2277,7 @@ export class DiscordService extends Service implements IDiscordService {
 							metadata: {
 								accountId,
 							},
+							roomMetadata: { accountId },
 						});
 					} catch (error) {
 						// error-policy:J1 local persistence boundary keeps provider
@@ -3578,6 +3596,7 @@ export class DiscordService extends Service implements IDiscordService {
 			channelId: channel.id,
 			worldId,
 			serverId: guild?.id,
+			messageServerId: guild?.id ? stringToUuid(guild.id) : undefined,
 			metadata: {
 				accountId,
 				discordChannelId: channel.id,
@@ -3614,6 +3633,14 @@ export class DiscordService extends Service implements IDiscordService {
 		this.removeAllowedChannel(channel.id, accountId);
 	}
 
+	public resolveManageConnectorServerDestination(
+		runtime: IAgentRuntime,
+		params: { target?: TargetInfo; serverId: string; accountId?: string },
+	): MessageConnectorManageServerDestination {
+		const accountId = this.resolveAccountIdFromTarget(params.target, params);
+		return resolveDiscordManageServerDestination(runtime, params, accountId);
+	}
+
 	/**
 	 * Structural guild management entry point for the message tool
 	 * (`MESSAGE op=manage_server source=discord`). Fail-closed: every write
@@ -3627,6 +3654,7 @@ export class DiscordService extends Service implements IDiscordService {
 			target?: TargetInfo;
 			operation: string;
 			serverId?: string;
+			authorization: MessageConnectorManageServerAuthorization;
 			params?: Record<string, unknown>;
 			accountId?: string;
 		},
@@ -3636,7 +3664,31 @@ export class DiscordService extends Service implements IDiscordService {
 		if (!client?.isReady()) {
 			throw new Error(`Discord client is not ready for account ${accountId}.`);
 		}
-		const guild = await this.resolveManagementGuild(client, params);
+		if (
+			params.serverId !== params.authorization.serverId ||
+			params.target?.serverId !== params.authorization.serverId
+		) {
+			throw new ElizaError(
+				"Discord guild-management parameters do not match the trusted destination authorization.",
+				{
+					code: "DISCORD_MANAGE_SERVER_PROVENANCE_MISMATCH",
+					context: { accountId },
+				},
+			);
+		}
+		await revalidateDiscordManageServerAuthorization(
+			runtime,
+			params.authorization,
+			accountId,
+			params.authorization.serverId,
+		);
+		const guild = await client.guilds.fetch(params.authorization.serverId);
+		await revalidateDiscordManageServerAuthorization(
+			runtime,
+			params.authorization,
+			accountId,
+			guild.id,
+		);
 		const gates = this.getGuildManagementGates(accountId);
 		const raw = params.params ?? {};
 		const request: GuildManagementRequest = {
@@ -3700,47 +3752,6 @@ export class DiscordService extends Service implements IDiscordService {
 			summary: receipt.summary,
 			data: receipt as unknown as Record<string, unknown>,
 		};
-	}
-
-	private async resolveManagementGuild(
-		client: DiscordJsClient,
-		params: {
-			target?: TargetInfo;
-			serverId?: string;
-			params?: Record<string, unknown>;
-		},
-	): Promise<Guild> {
-		const requested =
-			params.serverId?.trim() || params.target?.serverId?.trim() || undefined;
-		if (requested) {
-			if (DISCORD_SNOWFLAKE_PATTERN.test(requested)) {
-				const byId = await client.guilds.fetch(requested).catch(() => null);
-				if (byId) return byId;
-			}
-			const normalized = normalizeDiscordConnectorQuery(requested);
-			const byName = client.guilds.cache.find(
-				(guild) => guild.name.toLowerCase() === normalized,
-			);
-			if (byName) return byName;
-			throw new Error(
-				`Discord server "${requested}" was not found among the bot's guilds.`,
-			);
-		}
-		const channelId =
-			params.target?.channelId ?? stringOrUndefined(params.params?.channelId);
-		if (channelId) {
-			const channel = await client.channels.fetch(channelId).catch(() => null);
-			const guild =
-				channel && "guild" in channel ? (channel.guild as Guild) : null;
-			if (guild) return guild;
-		}
-		if (client.guilds.cache.size === 1) {
-			const only = client.guilds.cache.first();
-			if (only) return only;
-		}
-		throw new Error(
-			"Discord server management requires a serverId (guild id or exact name) when the bot is in multiple guilds.",
-		);
 	}
 
 	/**
@@ -4150,6 +4161,15 @@ export class DiscordService extends Service implements IDiscordService {
 								runtime,
 								scopedFetchParams(params),
 							),
+						resolveManageServerDestination: (runtime, params) =>
+							serviceInstance.resolveManageConnectorServerDestination(runtime, {
+								...params,
+								accountId:
+									accountIdFromRecord(params.target) ??
+									accountId ??
+									defaultAccountId,
+								target: params.target ? scopedTarget(params.target) : undefined,
+							}),
 						manageServerHandler: (runtime, params) =>
 							serviceInstance.manageConnectorServer(runtime, {
 								...params,

--- a/plugins/plugin-discord/slash-commands.ts
+++ b/plugins/plugin-discord/slash-commands.ts
@@ -12,6 +12,7 @@ import {
 	hasRoleAccess,
 	type IAgentRuntime,
 	type Memory,
+	stringToUuid,
 	type UUID,
 } from "@elizaos/core";
 import type {
@@ -50,6 +51,7 @@ export interface SlashCommand {
 	execute: (
 		interaction: ChatInputCommandInteraction,
 		runtime: IAgentRuntime,
+		context?: SlashCommandContext,
 	) => Promise<void>;
 	autocomplete?: (interaction: AutocompleteInteraction) => Promise<void>;
 }
@@ -58,6 +60,7 @@ export interface SlashCommand {
 export interface SlashCommandContext {
 	entityId: string;
 	roomId: string;
+	accountId?: string;
 }
 
 async function replyEphemeral(
@@ -699,7 +702,7 @@ const askCommand: SlashCommand = {
 			required: true,
 		},
 	],
-	async execute(interaction, runtime) {
+	async execute(interaction, runtime, context) {
 		const text = interaction.options.getString("message", true).trim();
 		if (!text) {
 			await interaction.reply({
@@ -757,6 +760,8 @@ const askCommand: SlashCommand = {
 			name: interaction.user.displayName ?? interaction.user.username,
 			source: "discord",
 			channelId,
+			serverId: interaction.guildId ?? channelId,
+			messageServerId: stringToUuid(interaction.guildId ?? channelId),
 			type: channelType,
 			worldId: createUniqueUuid(runtime, interaction.guildId ?? channelId),
 			worldName: interaction.guild?.name,
@@ -764,6 +769,12 @@ const askCommand: SlashCommand = {
 			// allowlist checks (see the "Discord ID Handling" note in service.ts and
 			// the matching cast in messages.ts's ensureConnection call).
 			userId: interaction.user.id as UUID,
+			...(context?.accountId
+				? {
+						metadata: { accountId: context.accountId },
+						roomMetadata: { accountId: context.accountId },
+					}
+				: {}),
 		});
 
 		const message: Memory = {
@@ -1005,7 +1016,7 @@ export async function handleSlashCommand(
 	}
 
 	try {
-		await command.execute(interaction, runtime);
+		await command.execute(interaction, runtime, context);
 	} catch (error) {
 		const content = `An error occurred while running \`/${command.name}\`: ${error instanceof Error ? error.message : String(error)}`;
 		runtime.logger.error(

--- a/plugins/plugin-discord/slash-commands.ts
+++ b/plugins/plugin-discord/slash-commands.ts
@@ -772,7 +772,6 @@ const askCommand: SlashCommand = {
 			...(context?.accountId
 				? {
 						metadata: { accountId: context.accountId },
-						roomMetadata: { accountId: context.accountId },
 					}
 				: {}),
 		});

--- a/plugins/plugin-discord/voice.ts
+++ b/plugins/plugin-discord/voice.ts
@@ -1593,7 +1593,6 @@ export class VoiceManager extends EventEmitter {
 				metadata: {
 					accountId: this.accountId,
 				},
-				roomMetadata: { accountId: this.accountId },
 			});
 
 			const memory: Memory = {

--- a/plugins/plugin-discord/voice.ts
+++ b/plugins/plugin-discord/voice.ts
@@ -1584,6 +1584,7 @@ export class VoiceManager extends EventEmitter {
 				name,
 				source: "discord",
 				channelId,
+				serverId: channel.guild.id,
 				// Convert Discord snowflake to UUID (see service.ts header for why stringToUuid not asUUID)
 				messageServerId: stringToUuid(channel.guild.id),
 				type,
@@ -1592,6 +1593,7 @@ export class VoiceManager extends EventEmitter {
 				metadata: {
 					accountId: this.accountId,
 				},
+				roomMetadata: { accountId: this.accountId },
 			});
 
 			const memory: Memory = {


### PR DESCRIPTION
Supersedes #27399 because the reviewed repair could not be pushed to the contributors fork.

This keeps the gated Discord guild-management and idempotent template reconciliation feature while closing the authorization and reconciliation gaps found in review.

Key corrections:
- authorize the exact destination guild from durable world, room, membership, role, and identity bindings
- reject display-name destination resolution and require the raw Discord guild snowflake
- revalidate membership and ADMIN or OWNER authority at the connector boundary, including after the live guild fetch
- preserve correct behavior when multiple configured Discord accounts share one durable guild room
- distinguish Discord missing-object responses from transient fetch failures and never continue moderation after a failed lookup
- validate rendered template limits and malformed inline collections before mutation
- remove stale managed overwrite permissions during reconciliation without touching unmanaged channels or roles
- use typed ElizaError failures with preserved causes

Exact local head: 93994d16d4cd94bd56d2b7c6cf52397454d6db18

Verification on this exact head:
- core authorization and durable binding tests: 18 passed
- Discord guild management, authorization, and durable-turn tests: 59 passed
- packages/core typecheck: passed
- plugins/plugin-discord typecheck: passed
- touched-file Biome check and git diff --check: passed

A full repository verify also passed before the final develop refresh; the refresh only incorporated merged test and documentation cleanup. Hosted checks on this PR are the authoritative exact-head gate.