### PR TITLE
feat(core): durable per-principal capability grants, slice 1 (#23102)

### DIFF
--- a/packages/core/src/features/capabilities/CapabilityGrantStore.test.ts
+++ b/packages/core/src/features/capabilities/CapabilityGrantStore.test.ts
@@ -4,11 +4,14 @@
  * itself), grant CRUD with vocabulary validation, live-grant filtering
  * (expiry + revocation in SQL), deny-wins over simultaneous allows and over
  * the role tier, constraints intersection with incompatible→deny, fail-closed
- * `authorizeCapability` semantics, per-decision audit rows with redaction by
- * construction, optimistic-version conflicts, revocation-epoch bumps,
- * quarantined legacy selectors, and restart survival — the store is opened,
- * closed, and reopened on the SAME disk data dir with grants created in the
- * first process authoritative in the second.
+ * `authorizeCapability` semantics (malformed resources and world ids,
+ * store-unavailable, audit-failure reporting through the injected hook),
+ * audit sanitization of malformed inputs, per-decision audit rows,
+ * optimistic-version conflicts, revocation-epoch bumps, typed constraint
+ * intersection, quarantined legacy vocabulary rows, world-aware active-policy
+ * uniqueness, and restart survival — the store is opened, closed, and
+ * reopened on the SAME disk data dir with grants created in the first
+ * process authoritative in the second.
  */
 
 import fs from "node:fs";
@@ -34,6 +37,7 @@ import {
 	CAPABILITY_REASON_CODES,
 	canonicalizeCapabilitySubject,
 	canonicalizeResourceSelector,
+	intersectGrantConstraints,
 	selectorMatchesResource,
 	validateCapabilityName,
 } from "./types.ts";
@@ -809,5 +813,286 @@ describe("enforcement inventory", () => {
 			expect(typeof entry.description).toBe("string");
 			expect(entry.description.length).toBeGreaterThan(10);
 		}
+	});
+});
+
+describe("RP review round-2 coverage", () => {
+	it("selector charset rejects whitespace, quotes, backslashes, non-ASCII", () => {
+		expect(canonicalizeResourceSelector("media/ file").ok).toBe(false);
+		expect(canonicalizeResourceSelector('media/"x"').ok).toBe(false);
+		expect(canonicalizeResourceSelector("media/\\x").ok).toBe(false);
+		expect(canonicalizeResourceSelector("media/файл").ok).toBe(false);
+		expect(canonicalizeResourceSelector("media/a\tb").ok).toBe(false);
+		expect(canonicalizeResourceSelector("media:general/id-1.2_x").ok).toBe(
+			true,
+		);
+	});
+
+	it("malformed resource and worldId deny as INVALID_REQUEST with sanitized audit rows", async () => {
+		const badResource = await authorizeCapability(store.db, {
+			subject: SUBJECT_ENTITY,
+			agentId: AGENT,
+			capability: "media.read",
+			resource: 42 as unknown as string,
+		});
+		expect(badResource.reasonCode).toBe(
+			CAPABILITY_REASON_CODES.INVALID_REQUEST,
+		);
+		const badWorld = await authorizeCapability(store.db, {
+			subject: SUBJECT_ENTITY,
+			agentId: AGENT,
+			worldId: "not-a-uuid" as UUID,
+			capability: "media.read",
+			resource: "media/abc",
+		});
+		expect(badWorld.reasonCode).toBe(CAPABILITY_REASON_CODES.INVALID_REQUEST);
+		const audit = await listCapabilityAudit(store.db, { limit: 50 });
+		const row = audit.find((r) => r.id === badResource.auditId);
+		expect(row?.resource).toBe("<non-string>");
+	});
+
+	it("truncates over-long audit resources at the 512-char cap", async () => {
+		const truncSubject = "entity:00000000-0000-4000-8000-00000000e804";
+		const longResource = `media/${"x".repeat(600)}`;
+		const result = await authorizeCapability(store.db, {
+			subject: truncSubject,
+			agentId: AGENT,
+			capability: "media.read",
+			resource: longResource,
+		});
+		expect(result.reasonCode).toBe(CAPABILITY_REASON_CODES.NO_MATCHING_GRANT);
+		const audit = await listCapabilityAudit(store.db, { limit: 50 });
+		const row = audit.find((r) => r.id === result.auditId);
+		expect(row?.resource.length).toBeLessThanOrEqual(512);
+		expect(row?.resource.endsWith("...")).toBe(true);
+	});
+
+	it("store-unavailable denies fail-closed", async () => {
+		const broken: CapabilityStoreDb = {
+			execute: () => {
+				throw new Error("ddl down");
+			},
+			select: () => {
+				throw new Error("read down");
+			},
+			insert: () => {
+				throw new Error("write down");
+			},
+			update: () => {
+				throw new Error("update down");
+			},
+			transaction: () => {
+				throw new Error("tx down");
+			},
+		};
+		const result = await authorizeCapability(broken, {
+			subject: SUBJECT_ENTITY,
+			agentId: AGENT,
+			capability: "media.read",
+			resource: "media/abc",
+		});
+		expect(result.decision).toBe("deny");
+		expect(result.reasonCode).toBe(CAPABILITY_REASON_CODES.STORE_UNAVAILABLE);
+	});
+
+	it("audit-write failure is reported through onAuditFailure and the decision stands", async () => {
+		const failures: unknown[] = [];
+		// Reads delegate (preserving drizzle's receiver); inserts throw —
+		// exactly the audit-sink failure shape.
+		const wrapped: CapabilityStoreDb = {
+			execute: (query) => store.db.execute(query),
+			select: (...args) => store.db.select(...args),
+			insert: () => {
+				throw new Error("audit insert down");
+			},
+			update: (table) => store.db.update(table),
+			transaction: (cb) => store.db.transaction(cb),
+		};
+		const grant = await createCapabilityGrant(store.db, {
+			subject: SUBJECT_ENTITY,
+			agentId: AGENT,
+			worldId: null,
+			capability: "media.read",
+			resourceSelector: "*",
+			effect: "allow",
+			issuer: ISSUER,
+			provenance: "api",
+		});
+		expect(grant.id).toBeTruthy();
+		const result = await authorizeCapability(wrapped, {
+			subject: SUBJECT_ENTITY,
+			agentId: AGENT,
+			capability: "media.read",
+			resource: "media/abc",
+			onAuditFailure: (error) => failures.push(error),
+		});
+		expect(result.decision).toBe("allow");
+		expect(result.auditId).toBeTruthy();
+		expect(failures.length).toBeGreaterThan(0);
+		const row = await listCapabilityAudit(store.db, { limit: 200 });
+		expect(row.find((r) => r.id === result.auditId)).toBeUndefined();
+	});
+
+	it("nearest expiry across multiple matching allows governs the decision", async () => {
+		const s = "entity:00000000-0000-4000-8000-00000000e801";
+		const now = Date.now();
+		await createCapabilityGrant(store.db, {
+			subject: s,
+			agentId: AGENT,
+			worldId: null,
+			capability: "api.route.admin",
+			resourceSelector: "*",
+			effect: "allow",
+			issuer: ISSUER,
+			expiresAt: new Date(now + 10 * MINUTE),
+			provenance: "api",
+		});
+		const near = await createCapabilityGrant(store.db, {
+			subject: s,
+			agentId: AGENT,
+			worldId: null,
+			capability: "api.route.admin",
+			resourceSelector: "route:admin/*",
+			effect: "allow",
+			issuer: ISSUER,
+			expiresAt: new Date(now + 2 * MINUTE),
+			provenance: "api",
+		});
+		const result = await authorizeCapability(store.db, {
+			subject: s,
+			agentId: AGENT,
+			capability: "api.route.admin",
+			resource: "route:admin/x",
+			now,
+		});
+		expect(result.decision).toBe("allow");
+		expect(result.expiresAt?.getTime()).toBe(near.expiresAt?.getTime());
+	});
+
+	it("typed array intersection keeps values type-separate and deduplicates", () => {
+		const merged = intersectGrantConstraints([
+			{ constraints: { channels: ["a", 1, true] } },
+			{ constraints: { channels: [1, "a", "b", true, 2] } },
+		]);
+		expect(merged.ok).toBe(true);
+		if (merged.ok) {
+			expect(merged.constraints.channels).toEqual([1, "a", true]);
+		}
+		const incompatible = intersectGrantConstraints([
+			{ constraints: { shape: { a: 1 } } },
+			{ constraints: { shape: { a: 2 } } },
+		]);
+		expect(incompatible.ok).toBe(false);
+		const structuralOk = intersectGrantConstraints([
+			{ constraints: { shape: { a: 1, b: [1, 2] } } },
+			{ constraints: { shape: { b: [1, 2], a: 1 } } },
+		]);
+		expect(structuralOk.ok).toBe(true);
+	});
+
+	it("quarantines legacy rows with malformed issuer or capability vocabulary", async () => {
+		const s = "entity:00000000-0000-4000-8000-00000000e802";
+		await store.client.exec(
+			`INSERT INTO capabilities.capability_grants (subject, agent_id, capability, resource_selector, effect, issuer, provenance)
+			 VALUES ('${s}', '${AGENT}', 'media.read', '*', 'allow', 'not-an-issuer', 'api')`,
+		);
+		await store.client.exec(
+			`INSERT INTO capabilities.capability_grants (subject, agent_id, capability, resource_selector, effect, issuer, provenance)
+			 VALUES ('${s}', '${AGENT}', 'NOT A CAPABILITY', '*', 'allow', '${ISSUER}', 'api')`,
+		);
+		const live = await listLiveGrantsFor(store.db, {
+			subject: s,
+			agentId: AGENT,
+			capability: "media.read",
+		});
+		expect(live.length).toBe(0);
+	});
+
+	it("concurrent first store calls share one bootstrap (promise memoization)", async () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "capgrants-race-"));
+		try {
+			const client = new PGlite(dir);
+			const db = drizzle(client) as unknown as CapabilityStoreDb;
+			const reads = await Promise.all([
+				getCapabilityEpoch(db),
+				getCapabilityEpoch(db),
+				getCapabilityEpoch(db),
+			]);
+			expect(reads).toEqual([1, 1, 1]);
+			await client.close();
+		} finally {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("epoch read fails loudly when the singleton row is missing", async () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "capgrants-epoch-"));
+		try {
+			const client = new PGlite(dir);
+			const db = drizzle(client) as unknown as CapabilityStoreDb;
+			await getCapabilityEpoch(db);
+			await client.exec("DELETE FROM capabilities.capability_epoch");
+			await expect(getCapabilityEpoch(db)).rejects.toThrow(/missing/);
+			await client.close();
+		} finally {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("identical policies in distinct worlds and global+world coexistence are both legal", async () => {
+		const s = "entity:00000000-0000-4000-8000-00000000e803";
+		const base = {
+			subject: s,
+			agentId: AGENT,
+			capability: "device.command",
+			resourceSelector: "home/*",
+			effect: "allow" as const,
+			issuer: ISSUER,
+			provenance: "api" as const,
+		};
+		const w1 = await createCapabilityGrant(store.db, {
+			...base,
+			worldId: WORLD_1,
+		});
+		const w2 = await createCapabilityGrant(store.db, {
+			...base,
+			worldId: WORLD_2,
+		});
+		expect(w1.id).not.toBe(w2.id);
+		const global = await createCapabilityGrant(store.db, {
+			...base,
+			worldId: null,
+		});
+		expect(global.id).toBeTruthy();
+		await expect(
+			createCapabilityGrant(store.db, { ...base, worldId: WORLD_1 }),
+		).rejects.toThrow();
+	});
+
+	it("createCapabilityGrant validates agentId and worldId uuids", async () => {
+		await expect(
+			createCapabilityGrant(store.db, {
+				subject: SUBJECT_ENTITY,
+				agentId: "nope" as UUID,
+				worldId: null,
+				capability: "media.read",
+				resourceSelector: "*",
+				effect: "allow",
+				issuer: ISSUER,
+				provenance: "api",
+			}),
+		).rejects.toThrow(/agentId/);
+		await expect(
+			createCapabilityGrant(store.db, {
+				subject: SUBJECT_ENTITY,
+				agentId: AGENT,
+				worldId: "bad" as UUID,
+				capability: "media.read",
+				resourceSelector: "*",
+				effect: "allow",
+				issuer: ISSUER,
+				provenance: "api",
+			}),
+		).rejects.toThrow(/worldId/);
 	});
 });

--- a/packages/core/src/features/capabilities/CapabilityGrantStore.test.ts
+++ b/packages/core/src/features/capabilities/CapabilityGrantStore.test.ts
@@ -730,7 +730,7 @@ describe("selector + subject + capability canonicalization", () => {
 });
 
 describe("restart survival (real PGlite, disk data dir)", () => {
-	it("grants created in one process are authoritative after close + reopen", async () => {
+	it("grants created under one store handle are authoritative after close + reopen", async () => {
 		const restartDir = fs.mkdtempSync(
 			path.join(os.tmpdir(), "capgrants-restart-"),
 		);
@@ -1122,7 +1122,18 @@ describe("RP review round-3 coverage", () => {
 		expect(okScalars.ok).toBe(true);
 	});
 
-	it("a throwing onAuditFailure reporter cannot abort the decision", async () => {
+	it("a throwing onAuditFailure reporter cannot abort the decision (forced invocation)", async () => {
+		// Force the audit write itself to fail so the reporter IS invoked,
+		// and make the reporter throw — the decision must still return.
+		const brokenInsert: CapabilityStoreDb = {
+			execute: (query) => store.db.execute(query),
+			select: (...args) => store.db.select(...args),
+			insert: () => {
+				throw new Error("audit insert down");
+			},
+			update: (table) => store.db.update(table),
+			transaction: (cb) => store.db.transaction(cb),
+		};
 		const grant = await createCapabilityGrant(store.db, {
 			subject: "entity:00000000-0000-4000-8000-00000000e805",
 			agentId: AGENT,
@@ -1134,7 +1145,7 @@ describe("RP review round-3 coverage", () => {
 			provenance: "api",
 		});
 		expect(grant.id).toBeTruthy();
-		const result = await authorizeCapability(store.db, {
+		const result = await authorizeCapability(brokenInsert, {
 			subject: "entity:00000000-0000-4000-8000-00000000e805",
 			agentId: AGENT,
 			capability: "media.read",
@@ -1144,6 +1155,51 @@ describe("RP review round-3 coverage", () => {
 			},
 		});
 		expect(result.decision).toBe("allow");
+	});
+
+	it("store-unavailable reports through the hook and a throwing hook still returns the denial", async () => {
+		const seen: unknown[] = [];
+		const broken: CapabilityStoreDb = {
+			execute: () => {
+				throw new Error("ddl down");
+			},
+			select: () => {
+				throw new Error("read down");
+			},
+			insert: () => {
+				throw new Error("write down");
+			},
+			update: () => {
+				throw new Error("update down");
+			},
+			transaction: () => {
+				throw new Error("tx down");
+			},
+		};
+		const result = await authorizeCapability(broken, {
+			subject: SUBJECT_ENTITY,
+			agentId: AGENT,
+			capability: "media.read",
+			resource: "media/abc",
+			onAuditFailure: (error) => {
+				seen.push(error);
+			},
+		});
+		expect(result.decision).toBe("deny");
+		expect(result.reasonCode).toBe(CAPABILITY_REASON_CODES.STORE_UNAVAILABLE);
+		expect(seen.length).toBeGreaterThan(0);
+		// Now the hook itself throws — the denial must still come back.
+		const survived = await authorizeCapability(broken, {
+			subject: SUBJECT_ENTITY,
+			agentId: AGENT,
+			capability: "media.read",
+			resource: "media/abc",
+			onAuditFailure: () => {
+				throw new Error("reporter exploded");
+			},
+		});
+		expect(survived.decision).toBe("deny");
+		expect(survived.reasonCode).toBe(CAPABILITY_REASON_CODES.STORE_UNAVAILABLE);
 	});
 
 	it("invalid-request audit details carry categorical text, not raw values", async () => {

--- a/packages/core/src/features/capabilities/CapabilityGrantStore.test.ts
+++ b/packages/core/src/features/capabilities/CapabilityGrantStore.test.ts
@@ -9,9 +9,9 @@
  * audit sanitization of malformed inputs, per-decision audit rows,
  * optimistic-version conflicts, revocation-epoch bumps, typed constraint
  * intersection, quarantined legacy vocabulary rows, world-aware active-policy
- * uniqueness, and restart survival — the store is opened, closed, and
- * reopened on the SAME disk data dir with grants created in the first
- * process authoritative in the second.
+ * uniqueness, and restart survival — the store handle is closed and a fresh
+ * handle opened on the SAME disk data dir, with grants created under the
+ * first handle authoritative for the second.
  */
 
 import fs from "node:fs";

--- a/packages/core/src/features/capabilities/CapabilityGrantStore.test.ts
+++ b/packages/core/src/features/capabilities/CapabilityGrantStore.test.ts
@@ -1096,3 +1096,96 @@ describe("RP review round-2 coverage", () => {
 		).rejects.toThrow(/worldId/);
 	});
 });
+
+describe("RP review round-3 coverage", () => {
+	it("rejects leading-slash wildcard selectors like /foo/*", () => {
+		expect(canonicalizeResourceSelector("/foo/*").ok).toBe(false);
+		expect(canonicalizeResourceSelector("foo/*").ok).toBe(true);
+		expect(canonicalizeResourceSelector("a/b/*").ok).toBe(true);
+	});
+
+	it("non-scalar array members make constraints incompatible, never silently dropped", () => {
+		const bad = intersectGrantConstraints([
+			{ constraints: { channels: [{ id: "a" }] } },
+			{ constraints: { channels: [{ id: "a" }] } },
+		]);
+		expect(bad.ok).toBe(false);
+		const mixed = intersectGrantConstraints([
+			{ constraints: { channels: ["a", { id: 1 }] } },
+			{ constraints: { channels: ["a"] } },
+		]);
+		expect(mixed.ok).toBe(false);
+		const okScalars = intersectGrantConstraints([
+			{ constraints: { channels: ["a", "b"] } },
+			{ constraints: { channels: ["b", "a"] } },
+		]);
+		expect(okScalars.ok).toBe(true);
+	});
+
+	it("a throwing onAuditFailure reporter cannot abort the decision", async () => {
+		const grant = await createCapabilityGrant(store.db, {
+			subject: "entity:00000000-0000-4000-8000-00000000e805",
+			agentId: AGENT,
+			worldId: null,
+			capability: "media.read",
+			resourceSelector: "*",
+			effect: "allow",
+			issuer: ISSUER,
+			provenance: "api",
+		});
+		expect(grant.id).toBeTruthy();
+		const result = await authorizeCapability(store.db, {
+			subject: "entity:00000000-0000-4000-8000-00000000e805",
+			agentId: AGENT,
+			capability: "media.read",
+			resource: "media/ok",
+			onAuditFailure: () => {
+				throw new Error("reporter exploded");
+			},
+		});
+		expect(result.decision).toBe("allow");
+	});
+
+	it("invalid-request audit details carry categorical text, not raw values", async () => {
+		const result = await authorizeCapability(store.db, {
+			subject: "garbage-subject-with-secrets",
+			agentId: AGENT,
+			capability: "media.read",
+			resource: "media/abc",
+		});
+		expect(result.reasonCode).toBe(CAPABILITY_REASON_CODES.INVALID_REQUEST);
+		const audit = await listCapabilityAudit(store.db, { limit: 30 });
+		const row = audit.find((r) => r.id === result.auditId);
+		expect(row?.details).toContain("raw value withheld");
+		expect(row?.details).not.toContain("garbage-subject-with-secrets");
+	});
+
+	it("grant mutation rolls back when the epoch singleton is missing", async () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "capgrants-rollback-"));
+		try {
+			const client = new PGlite(dir);
+			const db = drizzle(client) as unknown as CapabilityStoreDb;
+			await getCapabilityEpoch(db);
+			await client.exec("DELETE FROM capabilities.capability_epoch");
+			await expect(
+				createCapabilityGrant(db, {
+					subject: "entity:00000000-0000-4000-8000-00000000e806",
+					agentId: AGENT,
+					worldId: null,
+					capability: "media.read",
+					resourceSelector: "*",
+					effect: "allow",
+					issuer: ISSUER,
+					provenance: "api",
+				}),
+			).rejects.toThrow(/missing/);
+			const after = await client.query(
+				"SELECT count(*)::int AS n FROM capabilities.capability_grants",
+			);
+			expect((after.rows[0] as { n: number }).n).toBe(0);
+			await client.close();
+		} finally {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/core/src/features/capabilities/CapabilityGrantStore.test.ts
+++ b/packages/core/src/features/capabilities/CapabilityGrantStore.test.ts
@@ -1,0 +1,813 @@
+/**
+ * Real-PGlite coverage for the durable capability-grant feature (#23102
+ * slice 1). Proves: self-migration (tables created from empty by the store
+ * itself), grant CRUD with vocabulary validation, live-grant filtering
+ * (expiry + revocation in SQL), deny-wins over simultaneous allows and over
+ * the role tier, constraints intersection with incompatible→deny, fail-closed
+ * `authorizeCapability` semantics, per-decision audit rows with redaction by
+ * construction, optimistic-version conflicts, revocation-epoch bumps,
+ * quarantined legacy selectors, and restart survival — the store is opened,
+ * closed, and reopened on the SAME disk data dir with grants created in the
+ * first process authoritative in the second.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { PGlite } from "@electric-sql/pglite";
+import { drizzle } from "drizzle-orm/pglite";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { UUID } from "../../types/index.ts";
+import { authorizeCapability } from "./authorizeCapability.ts";
+import type { CapabilityStoreDb } from "./CapabilityGrantStore.ts";
+import {
+	createCapabilityGrant,
+	getCapabilityEpoch,
+	getCapabilityGrant,
+	listCapabilityAudit,
+	listLiveGrantsFor,
+	revokeCapabilityGrant,
+	updateCapabilityGrant,
+} from "./CapabilityGrantStore.ts";
+import { CAPABILITY_BOUNDARY_INVENTORY } from "./capability-boundary-inventory.ts";
+import {
+	CAPABILITY_REASON_CODES,
+	canonicalizeCapabilitySubject,
+	canonicalizeResourceSelector,
+	selectorMatchesResource,
+	validateCapabilityName,
+} from "./types.ts";
+
+const MINUTE = 60_000;
+
+const AGENT = "00000000-0000-4000-8000-00000000a111" as UUID;
+const WORLD_1 = "00000000-0000-4000-8000-00000000b222" as UUID;
+const WORLD_2 = "00000000-0000-4000-8000-00000000b333" as UUID;
+const SUBJECT_ENTITY = "entity:00000000-0000-4000-8000-00000000c444";
+const SUBJECT_ENTITY_2 = "entity:00000000-0000-4000-8000-00000000c445";
+const ISSUER = "entity:00000000-0000-4000-8000-00000000d555";
+
+interface Harness {
+	client: PGlite;
+	db: CapabilityStoreDb;
+	close: () => Promise<void>;
+}
+
+/**
+ * Opens a store WITHOUT pre-running the DDL: the store must self-migrate.
+ * This is the real-boot proof — nothing registers these tables externally.
+ */
+async function openStore(dataDir: string): Promise<Harness> {
+	const client = new PGlite(dataDir);
+	const db = drizzle(client) as unknown as CapabilityStoreDb;
+	return {
+		client,
+		db,
+		close: async () => {
+			await client.close();
+		},
+	};
+}
+
+let dataDir: string;
+let store: Harness;
+
+beforeAll(async () => {
+	dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "capgrants-"));
+	store = await openStore(dataDir);
+}, 120_000);
+
+afterAll(async () => {
+	await store?.close();
+	fs.rmSync(dataDir, { recursive: true, force: true });
+});
+
+describe("self-migration", () => {
+	it("store calls create the tables from an empty database", async () => {
+		// Any store call triggers ensureCapabilityGrantTables; the epoch read
+		// is the cheapest probe that the table exists.
+		const epoch = await getCapabilityEpoch(store.db);
+		expect(epoch).toBe(1);
+		const grant = await createCapabilityGrant(store.db, {
+			subject: SUBJECT_ENTITY,
+			agentId: AGENT,
+			worldId: null,
+			capability: "connector.account.read",
+			resourceSelector: "*",
+			effect: "allow",
+			issuer: ISSUER,
+			provenance: "api",
+		});
+		expect(grant.id).toBeTruthy();
+	});
+});
+
+describe("capability grant store (real PGlite)", () => {
+	it("creates a grant and reads it back", async () => {
+		const grant = await createCapabilityGrant(store.db, {
+			subject: SUBJECT_ENTITY,
+			agentId: AGENT,
+			worldId: null,
+			capability: "connector.message.send",
+			resourceSelector: "*",
+			effect: "allow",
+			issuer: ISSUER,
+			provenance: "api",
+		});
+		expect(grant.subject).toBe(SUBJECT_ENTITY);
+		expect(grant.effect).toBe("allow");
+		expect(grant.version).toBe(1);
+		expect(grant.revokedAt).toBeNull();
+		expect(grant.issuer).toBe(ISSUER);
+		const fetched = await getCapabilityGrant(store.db, grant.id);
+		expect(fetched?.id).toBe(grant.id);
+	});
+
+	it("rejects malformed subjects, issuers, capabilities, selectors, effects, provenance", async () => {
+		const base = {
+			agentId: AGENT,
+			worldId: null as UUID | null,
+			capability: "connector.message.send",
+			resourceSelector: "*",
+			effect: "allow" as const,
+			issuer: ISSUER,
+			provenance: "api" as const,
+		};
+		await expect(
+			createCapabilityGrant(store.db, { ...base, subject: "garbage" }),
+		).rejects.toThrow(/subject/);
+		await expect(
+			createCapabilityGrant(store.db, {
+				...base,
+				subject: SUBJECT_ENTITY,
+				issuer: "nonsense",
+			}),
+		).rejects.toThrow(/issuer/);
+		await expect(
+			createCapabilityGrant(store.db, {
+				...base,
+				subject: SUBJECT_ENTITY,
+				capability: "Not A Capability",
+			}),
+		).rejects.toThrow(/capability/);
+		await expect(
+			createCapabilityGrant(store.db, {
+				...base,
+				subject: SUBJECT_ENTITY,
+				resourceSelector: "media/*/extra",
+			}),
+		).rejects.toThrow(/selector/);
+		await expect(
+			createCapabilityGrant(store.db, {
+				...base,
+				subject: SUBJECT_ENTITY,
+				resourceSelector: "media//",
+			}),
+		).rejects.toThrow(/selector/);
+		await expect(
+			createCapabilityGrant(store.db, {
+				...base,
+				subject: SUBJECT_ENTITY,
+				effect: "maybe" as "allow",
+			}),
+		).rejects.toThrow(/effect/);
+		await expect(
+			createCapabilityGrant(store.db, {
+				...base,
+				subject: SUBJECT_ENTITY,
+				provenance: "telepathy" as "api",
+			}),
+		).rejects.toThrow(/provenance/);
+	});
+
+	it("expires grants at the boundary: expiresAt <= now never matches", async () => {
+		const now = Date.now();
+		const grant = await createCapabilityGrant(store.db, {
+			subject: SUBJECT_ENTITY,
+			agentId: AGENT,
+			worldId: null,
+			capability: "media.read",
+			resourceSelector: "media/*",
+			effect: "allow",
+			issuer: ISSUER,
+			expiresAt: new Date(now + MINUTE),
+			provenance: "api",
+		});
+		const liveBefore = await listLiveGrantsFor(store.db, {
+			subject: SUBJECT_ENTITY,
+			agentId: AGENT,
+			capability: "media.read",
+			now: now,
+		});
+		expect(liveBefore.map((g) => g.id)).toContain(grant.id);
+		const atBoundary = await listLiveGrantsFor(store.db, {
+			subject: SUBJECT_ENTITY,
+			agentId: AGENT,
+			capability: "media.read",
+			now: now + MINUTE,
+		});
+		expect(atBoundary.map((g) => g.id)).not.toContain(grant.id);
+	});
+
+	it("revocation is visible to the very next live-grant read and bumps the epoch", async () => {
+		const epochBefore = await getCapabilityEpoch(store.db);
+		const grant = await createCapabilityGrant(store.db, {
+			subject: SUBJECT_ENTITY,
+			agentId: AGENT,
+			worldId: null,
+			capability: "shell.execute",
+			resourceSelector: "*",
+			effect: "allow",
+			issuer: ISSUER,
+			provenance: "settings",
+		});
+		const epochAfterCreate = await getCapabilityEpoch(store.db);
+		expect(epochAfterCreate).toBeGreaterThan(epochBefore);
+		const before = await listLiveGrantsFor(store.db, {
+			subject: SUBJECT_ENTITY,
+			agentId: AGENT,
+			capability: "shell.execute",
+		});
+		expect(before.map((g) => g.id)).toContain(grant.id);
+		const revoked = await revokeCapabilityGrant(store.db, {
+			id: grant.id,
+			reason: "user revoked",
+		});
+		expect(revoked.ok).toBe(true);
+		if (revoked.ok) {
+			expect(revoked.grant.version).toBe(grant.version + 1);
+			expect(revoked.grant.revokedAt).not.toBeNull();
+		}
+		const epochAfterRevoke = await getCapabilityEpoch(store.db);
+		expect(epochAfterRevoke).toBeGreaterThan(epochAfterCreate);
+		const after = await listLiveGrantsFor(store.db, {
+			subject: SUBJECT_ENTITY,
+			agentId: AGENT,
+			capability: "shell.execute",
+		});
+		expect(after.map((g) => g.id)).not.toContain(grant.id);
+		// Idempotent revoke returns the already-revoked row.
+		const again = await revokeCapabilityGrant(store.db, { id: grant.id });
+		expect(again.ok).toBe(true);
+	});
+
+	it("update is version-checked and bumps version + epoch", async () => {
+		const grant = await createCapabilityGrant(store.db, {
+			subject: SUBJECT_ENTITY,
+			agentId: AGENT,
+			worldId: null,
+			capability: "git.operation",
+			resourceSelector: "*",
+			effect: "allow",
+			issuer: ISSUER,
+			provenance: "natural-language",
+		});
+		const stale = await updateCapabilityGrant(store.db, {
+			id: grant.id,
+			expectedVersion: 99,
+			patch: { expiresAt: null },
+		});
+		expect(stale.ok).toBe(false);
+		if (!stale.ok) {
+			expect(stale.conflict).toBe(true);
+		}
+		const epochBefore = await getCapabilityEpoch(store.db);
+		const good = await updateCapabilityGrant(store.db, {
+			id: grant.id,
+			expectedVersion: grant.version,
+			patch: { expiresAt: new Date(Date.now() + 60 * MINUTE) },
+		});
+		expect(good.ok).toBe(true);
+		if (good.ok) {
+			expect(good.grant.version).toBe(grant.version + 1);
+			expect(good.grant.expiresAt).not.toBeNull();
+		}
+		const epochAfter = await getCapabilityEpoch(store.db);
+		expect(epochAfter).toBeGreaterThan(epochBefore);
+	});
+
+	it("world-scoped grants only match inside their world; global grants match everywhere", async () => {
+		const grant = await createCapabilityGrant(store.db, {
+			subject: SUBJECT_ENTITY,
+			agentId: AGENT,
+			worldId: WORLD_1,
+			capability: "device.command",
+			resourceSelector: "*",
+			effect: "allow",
+			issuer: ISSUER,
+			provenance: "api",
+		});
+		const inWorld = await listLiveGrantsFor(store.db, {
+			subject: SUBJECT_ENTITY,
+			agentId: AGENT,
+			worldId: WORLD_1,
+			capability: "device.command",
+		});
+		expect(inWorld.map((g) => g.id)).toContain(grant.id);
+		const otherWorld = await listLiveGrantsFor(store.db, {
+			subject: SUBJECT_ENTITY,
+			agentId: AGENT,
+			worldId: WORLD_2,
+			capability: "device.command",
+		});
+		expect(otherWorld.map((g) => g.id)).not.toContain(grant.id);
+		const global = await createCapabilityGrant(store.db, {
+			subject: SUBJECT_ENTITY,
+			agentId: AGENT,
+			worldId: null,
+			capability: "device.command",
+			resourceSelector: "home/*",
+			effect: "allow",
+			issuer: ISSUER,
+			provenance: "api",
+		});
+		const anyWorld = await listLiveGrantsFor(store.db, {
+			subject: SUBJECT_ENTITY,
+			agentId: AGENT,
+			worldId: WORLD_2,
+			capability: "device.command",
+		});
+		expect(anyWorld.map((g) => g.id)).toContain(global.id);
+	});
+
+	it("the partial unique index blocks duplicate active policies", async () => {
+		const dup = {
+			subject: SUBJECT_ENTITY_2,
+			agentId: AGENT,
+			worldId: null as UUID | null,
+			capability: "api.route.admin",
+			resourceSelector: "*",
+			effect: "deny" as const,
+			issuer: ISSUER,
+			provenance: "api" as const,
+		};
+		const first = await createCapabilityGrant(store.db, dup);
+		await expect(createCapabilityGrant(store.db, dup)).rejects.toThrow();
+		// Revoking the first frees the policy slot for re-grant.
+		await revokeCapabilityGrant(store.db, { id: first.id });
+		const third = await createCapabilityGrant(store.db, dup);
+		expect(third.id).not.toBe(first.id);
+	});
+
+	it("quarantines legacy rows with selectors that no longer canonicalize", async () => {
+		// Insert a pre-validation row directly, bypassing the store's guard.
+		await store.client.exec(
+			`INSERT INTO capabilities.capability_grants (subject, agent_id, capability, resource_selector, effect, issuer, provenance)
+			 VALUES ('${SUBJECT_ENTITY}', '${AGENT}', 'coding.environment.use', 'env:local//bad', 'allow', '${ISSUER}', 'api')`,
+		);
+		const live = await listLiveGrantsFor(store.db, {
+			subject: SUBJECT_ENTITY,
+			agentId: AGENT,
+			capability: "coding.environment.use",
+		});
+		// The quarantined row is visible for management via getCapabilityGrant
+		// only through the store's own reads; live-grant listing must exclude it.
+		expect(live.some((g) => g.resourceSelector === "env:local//bad")).toBe(
+			false,
+		);
+		const result = await authorizeCapability(store.db, {
+			subject: SUBJECT_ENTITY,
+			agentId: AGENT,
+			capability: "coding.environment.use",
+			resource: "env:local//bad",
+		});
+		expect(result.decision).toBe("deny");
+	});
+});
+
+describe("authorizeCapability decision semantics (real PGlite)", () => {
+	it("allows via matching live allow grants and writes an audit row", async () => {
+		const grant = await createCapabilityGrant(store.db, {
+			subject: SUBJECT_ENTITY,
+			agentId: AGENT,
+			worldId: null,
+			capability: "connector.message.send",
+			resourceSelector: "channel:general/*",
+			effect: "allow",
+			issuer: ISSUER,
+			constraints: { maxMessagesPerMinute: 10 },
+			provenance: "api",
+		});
+		const result = await authorizeCapability(store.db, {
+			subject: SUBJECT_ENTITY,
+			agentId: AGENT,
+			capability: "connector.message.send",
+			resource: "channel:general/msg-1",
+		});
+		expect(result.decision).toBe("allow");
+		expect(result.reasonCode).toBe(CAPABILITY_REASON_CODES.ALLOW_GRANT_MATCHED);
+		expect(result.matchedGrantId).toBe(grant.id);
+		expect(result.constraints).toEqual({ maxMessagesPerMinute: 10 });
+		expect(result.layer).toBe("allow-grant");
+		const audit = await listCapabilityAudit(store.db, { limit: 100 });
+		const row = audit.find((row) => row.id === result.auditId);
+		expect(row).toBeDefined();
+		expect(row?.decision).toBe("allow");
+		expect(row?.matchedGrantId).toBe(grant.id);
+		expect(row?.grantVersion).toBe(grant.version);
+	});
+
+	it("deny-wins: a simultaneous explicit deny outranks the allow", async () => {
+		const allow = await createCapabilityGrant(store.db, {
+			subject: SUBJECT_ENTITY,
+			agentId: AGENT,
+			worldId: null,
+			capability: "filesystem.write",
+			resourceSelector: "*",
+			effect: "allow",
+			issuer: ISSUER,
+			provenance: "api",
+		});
+		const deny = await createCapabilityGrant(store.db, {
+			subject: SUBJECT_ENTITY,
+			agentId: AGENT,
+			worldId: null,
+			capability: "filesystem.write",
+			resourceSelector: "secrets/*",
+			effect: "deny",
+			issuer: ISSUER,
+			provenance: "api",
+		});
+		const okResult = await authorizeCapability(store.db, {
+			subject: SUBJECT_ENTITY,
+			agentId: AGENT,
+			capability: "filesystem.write",
+			resource: "notes/todo.md",
+		});
+		expect(okResult.decision).toBe("allow");
+		const denied = await authorizeCapability(store.db, {
+			subject: SUBJECT_ENTITY,
+			agentId: AGENT,
+			capability: "filesystem.write",
+			resource: "secrets/private-key.pem",
+		});
+		expect(denied.decision).toBe("deny");
+		expect(denied.reasonCode).toBe(CAPABILITY_REASON_CODES.DENY_GRANT_MATCHED);
+		expect(denied.matchedGrantId).toBe(deny.id);
+		expect(denied.layer).toBe("deny-grant");
+		expect(allow.id).not.toBe(deny.id);
+	});
+
+	it("revocation is effective before the next authorize returns", async () => {
+		const grant = await createCapabilityGrant(store.db, {
+			subject: SUBJECT_ENTITY,
+			agentId: AGENT,
+			worldId: null,
+			capability: "provider.model.invoke",
+			resourceSelector: "*",
+			effect: "allow",
+			issuer: ISSUER,
+			provenance: "api",
+		});
+		const before = await authorizeCapability(store.db, {
+			subject: SUBJECT_ENTITY,
+			agentId: AGENT,
+			capability: "provider.model.invoke",
+			resource: "model:glm",
+		});
+		expect(before.decision).toBe("allow");
+		const revoked = await revokeCapabilityGrant(store.db, {
+			id: grant.id,
+			reason: "rotation",
+		});
+		expect(revoked.ok).toBe(true);
+		const after = await authorizeCapability(store.db, {
+			subject: SUBJECT_ENTITY,
+			agentId: AGENT,
+			capability: "provider.model.invoke",
+			resource: "model:glm",
+		});
+		expect(after.decision).toBe("deny");
+		expect(after.reasonCode).toBe(CAPABILITY_REASON_CODES.NO_MATCHING_GRANT);
+	});
+
+	it("fails closed on malformed requests with audit rows", async () => {
+		const badSubject = await authorizeCapability(store.db, {
+			subject: "not-a-subject",
+			agentId: AGENT,
+			capability: "media.read",
+			resource: "media/abc",
+		});
+		expect(badSubject.decision).toBe("deny");
+		expect(badSubject.reasonCode).toBe(CAPABILITY_REASON_CODES.INVALID_REQUEST);
+		const badCapability = await authorizeCapability(store.db, {
+			subject: SUBJECT_ENTITY,
+			agentId: AGENT,
+			capability: "NOPE",
+			resource: "media/abc",
+		});
+		expect(badCapability.reasonCode).toBe(
+			CAPABILITY_REASON_CODES.INVALID_REQUEST,
+		);
+		const badAgent = await authorizeCapability(store.db, {
+			subject: SUBJECT_ENTITY,
+			agentId: "zzz" as UUID,
+			capability: "media.read",
+			resource: "media/abc",
+		});
+		expect(badAgent.reasonCode).toBe(CAPABILITY_REASON_CODES.INVALID_REQUEST);
+		const audit = await listCapabilityAudit(store.db, { limit: 200 });
+		for (const result of [badSubject, badCapability, badAgent]) {
+			const row = audit.find((row) => row.id === result.auditId);
+			expect(row).toBeDefined();
+			expect(row?.decision).toBe("deny");
+			expect(row?.reasonCode).toBe(CAPABILITY_REASON_CODES.INVALID_REQUEST);
+		}
+	});
+
+	it("no matching grant denies (no implicit allow)", async () => {
+		const result = await authorizeCapability(store.db, {
+			subject: SUBJECT_ENTITY,
+			agentId: AGENT,
+			capability: "coding.environment.use",
+			resource: "env:local",
+		});
+		expect(result.decision).toBe("deny");
+		expect(result.reasonCode).toBe(CAPABILITY_REASON_CODES.NO_MATCHING_GRANT);
+		expect(result.layer).toBe("no-match");
+	});
+
+	it("expired grants never authorize even mid-window", async () => {
+		const grant = await createCapabilityGrant(store.db, {
+			subject: SUBJECT_ENTITY,
+			agentId: AGENT,
+			worldId: null,
+			capability: "api.route.admin",
+			resourceSelector: "*",
+			effect: "allow",
+			issuer: ISSUER,
+			expiresAt: new Date(Date.now() + 5 * MINUTE),
+			provenance: "api",
+		});
+		const before = await authorizeCapability(store.db, {
+			subject: SUBJECT_ENTITY,
+			agentId: AGENT,
+			capability: "api.route.admin",
+			resource: "route:/api/settings",
+			now: Date.now() + MINUTE,
+		});
+		expect(before.decision).toBe("allow");
+		const after = await authorizeCapability(store.db, {
+			subject: SUBJECT_ENTITY,
+			agentId: AGENT,
+			capability: "api.route.admin",
+			resource: "route:/api/settings",
+			now: Date.now() + 10 * MINUTE,
+		});
+		expect(after.decision).toBe("deny");
+		expect(grant.expiresAt).not.toBeNull();
+	});
+
+	it("intersects constraints across matching allows; incompatibility denies", async () => {
+		// Two overlapping canonical allows on the same resource: numeric mins
+		// intersect to the smaller (most-restrictive) value. Distinct subjects
+		// from every other test so the partial unique active-policy index
+		// (subject, agent, capability, selector, effect) sees fresh rows.
+		const constraintSubject = "entity:00000000-0000-4000-8000-00000000e701";
+		const a = await createCapabilityGrant(store.db, {
+			subject: constraintSubject,
+			agentId: AGENT,
+			worldId: null,
+			capability: "connector.message.send",
+			resourceSelector: "channel:hot/*",
+			effect: "allow",
+			issuer: ISSUER,
+			constraints: { maxMessagesPerMinute: 30 },
+			provenance: "api",
+		});
+		const b = await createCapabilityGrant(store.db, {
+			subject: constraintSubject,
+			agentId: AGENT,
+			worldId: null,
+			capability: "connector.message.send",
+			resourceSelector: "*",
+			effect: "allow",
+			issuer: ISSUER,
+			constraints: { maxMessagesPerMinute: 5 },
+			provenance: "api",
+		});
+		const result = await authorizeCapability(store.db, {
+			subject: constraintSubject,
+			agentId: AGENT,
+			capability: "connector.message.send",
+			resource: "channel:hot/x",
+		});
+		expect(result.decision).toBe("allow");
+		expect(result.constraints).toEqual({ maxMessagesPerMinute: 5 });
+		expect(a.id).not.toBe(b.id);
+		// Incompatible scalar values for the same key deny.
+		const conflictSubject = "entity:00000000-0000-4000-8000-00000000e702";
+		const c1 = await createCapabilityGrant(store.db, {
+			subject: conflictSubject,
+			agentId: AGENT,
+			worldId: null,
+			capability: "media.write",
+			resourceSelector: "media/*",
+			effect: "allow",
+			issuer: ISSUER,
+			constraints: { visibility: "private" },
+			provenance: "api",
+		});
+		const c2 = await createCapabilityGrant(store.db, {
+			subject: conflictSubject,
+			agentId: AGENT,
+			worldId: null,
+			capability: "media.write",
+			resourceSelector: "*",
+			effect: "allow",
+			issuer: ISSUER,
+			constraints: { visibility: "public" },
+			provenance: "api",
+		});
+		const conflicted = await authorizeCapability(store.db, {
+			subject: conflictSubject,
+			agentId: AGENT,
+			capability: "media.write",
+			resource: "media/abc",
+		});
+		expect(conflicted.decision).toBe("deny");
+		expect(conflicted.reasonCode).toBe(
+			CAPABILITY_REASON_CODES.INCOMPATIBLE_CONSTRAINTS,
+		);
+		expect(c1.id).not.toBe(c2.id);
+	});
+
+	it("role tier evaluates after grants and cannot rescue a deny grant", async () => {
+		const denyGrant = await createCapabilityGrant(store.db, {
+			subject: SUBJECT_ENTITY_2,
+			agentId: AGENT,
+			worldId: null,
+			capability: "device.command",
+			resourceSelector: "danger/*",
+			effect: "deny",
+			issuer: ISSUER,
+			provenance: "api",
+		});
+		const resolverCalls: string[] = [];
+		const result = await authorizeCapability(store.db, {
+			subject: SUBJECT_ENTITY_2,
+			agentId: AGENT,
+			capability: "device.command",
+			resource: "danger/nuke",
+			roleResolver: async (subject) => {
+				resolverCalls.push(subject);
+				return ["admin"];
+			},
+		});
+		expect(result.decision).toBe("deny");
+		expect(result.reasonCode).toBe(CAPABILITY_REASON_CODES.DENY_GRANT_MATCHED);
+		// The deny grant short-circuited before the role tier ran.
+		expect(resolverCalls).toEqual([]);
+		expect(denyGrant.id).toBeTruthy();
+		// No-grant case: the resolver runs and the layer names it.
+		const noGrant = await authorizeCapability(store.db, {
+			subject: SUBJECT_ENTITY_2,
+			agentId: AGENT,
+			capability: "device.command",
+			resource: "danger2/other",
+			roleResolver: async () => ["member"],
+		});
+		expect(noGrant.decision).toBe("deny");
+		expect(noGrant.layer).toBe("role-tier");
+		// A throwing resolver degrades to no-match, never widens access.
+		const broken = await authorizeCapability(store.db, {
+			subject: SUBJECT_ENTITY_2,
+			agentId: AGENT,
+			capability: "device.command",
+			resource: "danger3/x",
+			roleResolver: async () => {
+				throw new Error("resolver down");
+			},
+		});
+		expect(broken.decision).toBe("deny");
+		expect(broken.reasonCode).toBe(CAPABILITY_REASON_CODES.NO_MATCHING_GRANT);
+	});
+});
+
+describe("selector + subject + capability canonicalization", () => {
+	it("selector matching follows prefix and exact semantics", () => {
+		expect(selectorMatchesResource("media/*", "media/abc")).toBe(true);
+		expect(selectorMatchesResource("media/*", "media/abc/def")).toBe(true);
+		expect(selectorMatchesResource("media/*", "mediaroot")).toBe(false);
+		expect(selectorMatchesResource("media/*", "media")).toBe(false);
+		expect(selectorMatchesResource("*", "anything")).toBe(true);
+		expect(selectorMatchesResource("exact:one", "exact:one")).toBe(true);
+		expect(selectorMatchesResource("exact:one", "exact:two")).toBe(false);
+	});
+
+	it("subject canonicalization validates kinds and uuids", () => {
+		expect(canonicalizeCapabilitySubject(SUBJECT_ENTITY).ok).toBe(true);
+		expect(canonicalizeCapabilitySubject("entity:not-a-uuid").ok).toBe(false);
+		expect(canonicalizeCapabilitySubject("role:admin").ok).toBe(true);
+		const up = canonicalizeCapabilitySubject(
+			"entity:00000000-0000-4000-8000-00000000C444",
+		);
+		expect(up.ok && up.subject).toBe(SUBJECT_ENTITY);
+		expect(canonicalizeCapabilitySubject("cosmic:abc").ok).toBe(false);
+		expect(canonicalizeCapabilitySubject("").ok).toBe(false);
+	});
+
+	it("capability names must be dot-separated lowercase", () => {
+		expect(validateCapabilityName("connector.message.send").ok).toBe(true);
+		expect(validateCapabilityName("send").ok).toBe(false);
+		expect(validateCapabilityName("Connector.Message").ok).toBe(false);
+		expect(validateCapabilityName("conn..send").ok).toBe(false);
+		expect(validateCapabilityName("conn .send").ok).toBe(false);
+	});
+
+	it("selectors canonicalize wildcards strictly", () => {
+		expect(canonicalizeResourceSelector("*").ok).toBe(true);
+		expect(canonicalizeResourceSelector("media/*").ok).toBe(true);
+		expect(canonicalizeResourceSelector("media//").ok).toBe(false);
+		expect(canonicalizeResourceSelector("*media").ok).toBe(false);
+		expect(canonicalizeResourceSelector("me*dia/x").ok).toBe(false);
+		expect(canonicalizeResourceSelector(`${"a".repeat(513)}/*`).ok).toBe(false);
+	});
+});
+
+describe("restart survival (real PGlite, disk data dir)", () => {
+	it("grants created in one process are authoritative after close + reopen", async () => {
+		const restartDir = fs.mkdtempSync(
+			path.join(os.tmpdir(), "capgrants-restart-"),
+		);
+		try {
+			const first = await openStore(restartDir);
+			const grant = await createCapabilityGrant(first.db, {
+				subject: SUBJECT_ENTITY,
+				agentId: AGENT,
+				worldId: WORLD_1,
+				capability: "connector.message.send",
+				resourceSelector: "*",
+				effect: "allow",
+				issuer: ISSUER,
+				constraints: { survives: true },
+				provenance: "settings",
+			});
+			const denyGrant = await createCapabilityGrant(first.db, {
+				subject: SUBJECT_ENTITY,
+				agentId: AGENT,
+				worldId: WORLD_1,
+				capability: "connector.message.send",
+				resourceSelector: "channel:spam/*",
+				effect: "deny",
+				issuer: ISSUER,
+				provenance: "settings",
+			});
+			const epochFirst = await getCapabilityEpoch(first.db);
+			await first.close();
+
+			const second = await openStore(restartDir);
+			const live = await listLiveGrantsFor(second.db, {
+				subject: SUBJECT_ENTITY,
+				agentId: AGENT,
+				worldId: WORLD_1,
+				capability: "connector.message.send",
+			});
+			expect(live.map((g) => g.id)).toContain(grant.id);
+			expect(live.map((g) => g.id)).toContain(denyGrant.id);
+			const epochSecond = await getCapabilityEpoch(second.db);
+			expect(epochSecond).toBe(epochFirst);
+			const allowed = await authorizeCapability(second.db, {
+				subject: SUBJECT_ENTITY,
+				agentId: AGENT,
+				worldId: WORLD_1,
+				capability: "connector.message.send",
+				resource: "channel:general/x",
+			});
+			expect(allowed.decision).toBe("allow");
+			expect(allowed.constraints).toEqual({ survives: true });
+			const denied = await authorizeCapability(second.db, {
+				subject: SUBJECT_ENTITY,
+				agentId: AGENT,
+				worldId: WORLD_1,
+				capability: "connector.message.send",
+				resource: "channel:spam/y",
+			});
+			expect(denied.decision).toBe("deny");
+			expect(denied.reasonCode).toBe(
+				CAPABILITY_REASON_CODES.DENY_GRANT_MATCHED,
+			);
+			await second.close();
+		} finally {
+			fs.rmSync(restartDir, { recursive: true, force: true });
+		}
+	}, 180_000);
+});
+
+describe("enforcement inventory", () => {
+	it("every boundary id is a valid capability name and status is classified", () => {
+		expect(CAPABILITY_BOUNDARY_INVENTORY.length).toBeGreaterThanOrEqual(12);
+		for (const entry of CAPABILITY_BOUNDARY_INVENTORY) {
+			const capability = validateCapabilityName(entry.id);
+			expect({ id: entry.id, ok: capability.ok }).toEqual({
+				id: entry.id,
+				ok: true,
+			});
+			expect(
+				["enforced", "inventory-only", "planned"].includes(entry.status),
+			).toBe(true);
+			expect(typeof entry.description).toBe("string");
+			expect(entry.description.length).toBeGreaterThan(10);
+		}
+	});
+});

--- a/packages/core/src/features/capabilities/CapabilityGrantStore.ts
+++ b/packages/core/src/features/capabilities/CapabilityGrantStore.ts
@@ -1,0 +1,567 @@
+/**
+ * Data-access layer for durable per-principal capability grants (#23102).
+ * Wraps the `capabilities` schema tables: validated insert, version-checked
+ * update and revoke (both bump the global `capability_epoch` and the row's
+ * `version`), live-grant lookup that filters expired and revoked rows in
+ * SQL, and the append-only audit append used by `authorizeCapability`.
+ * `ensureCapabilityGrantTables` self-migrates with idempotent DDL on first
+ * use per process (TrajectoriesService pattern), so the tables exist
+ * whenever any SQL database is attached — no plugin registration needed.
+ * Reads through `listLiveGrantsFor` are authoritative; a revocation is
+ * visible to the very next decision because there is no decision cache.
+ */
+
+import { and, desc, eq, gt, isNull, or, sql } from "drizzle-orm";
+import type { UUID } from "../../types/index.ts";
+import {
+	capabilityAuditLog,
+	capabilityEpoch,
+	capabilityGrants,
+} from "./schema.ts";
+import type {
+	CapabilityGrant,
+	CreateCapabilityGrantInput,
+	UpdateCapabilityGrantInput,
+} from "./types.ts";
+import {
+	canonicalizeCapabilitySubject,
+	canonicalizeResourceSelector,
+	parseCapabilityGrantEffect,
+	parseCapabilityProvenance,
+	truncateAuditResource,
+	validateCapabilityName,
+} from "./types.ts";
+
+/** Row shape as Drizzle returns it (dates as Date, jsonb as unknown). */
+type GrantRow = {
+	id: string;
+	subject: string;
+	agentId: string;
+	worldId: string | null;
+	capability: string;
+	resourceSelector: string;
+	effect: string;
+	issuer: string;
+	issuedAt: Date;
+	expiresAt: Date | null;
+	revokedAt: Date | null;
+	revocationReason: string | null;
+	constraints: unknown;
+	provenance: string;
+	version: number;
+};
+
+/**
+ * Rejects rows whose enum-like columns drifted out of vocabulary, and
+ * quarantines rows whose selector pre-dates strict validation: a selector
+ * that no longer canonicalizes never matches (the grant stays visible for
+ * management but stops authorizing).
+ */
+function rowToGrant(row: GrantRow): CapabilityGrant | null {
+	const effect = parseCapabilityGrantEffect(row.effect);
+	const provenance = parseCapabilityProvenance(row.provenance);
+	if (effect === null || provenance === null) {
+		return null;
+	}
+	const constraints =
+		row.constraints !== null &&
+		typeof row.constraints === "object" &&
+		!Array.isArray(row.constraints)
+			? (row.constraints as Record<string, unknown>)
+			: null;
+	return {
+		id: row.id as UUID,
+		subject: row.subject,
+		agentId: row.agentId as UUID,
+		worldId: (row.worldId as UUID | null) ?? null,
+		capability: row.capability,
+		resourceSelector: row.resourceSelector,
+		effect,
+		issuer: row.issuer,
+		issuedAt: row.issuedAt,
+		expiresAt: row.expiresAt,
+		revokedAt: row.revokedAt,
+		revocationReason: row.revocationReason,
+		constraints,
+		provenance,
+		version: row.version,
+	};
+}
+
+/** True when the row's selector still passes canonicalization. */
+function selectorIsTrusted(grant: CapabilityGrant): boolean {
+	return canonicalizeResourceSelector(grant.resourceSelector).ok;
+}
+
+/**
+ * Idempotent DDL materializing the capability tables. Runs once per process
+ * per database handle (memoized by the client identity); safe to call
+ * concurrently because every statement is IF NOT EXISTS.
+ */
+const CAPABILITY_DDL = [
+	`CREATE SCHEMA IF NOT EXISTS capabilities`,
+	`CREATE TABLE IF NOT EXISTS capabilities.capability_grants (
+		id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+		subject text NOT NULL,
+		agent_id uuid NOT NULL,
+		world_id uuid,
+		capability text NOT NULL,
+		resource_selector text NOT NULL,
+		effect text NOT NULL CHECK (effect IN ('allow','deny')),
+		issuer text NOT NULL,
+		issued_at timestamptz DEFAULT now() NOT NULL,
+		expires_at timestamptz,
+		revoked_at timestamptz,
+		revocation_reason text,
+		constraints jsonb DEFAULT '{}'::jsonb,
+		provenance text NOT NULL CHECK (provenance IN ('api','natural-language','settings')),
+		version integer DEFAULT 1 NOT NULL
+	)`,
+	`CREATE INDEX IF NOT EXISTS capability_grants_subject_idx ON capabilities.capability_grants (subject)`,
+	`CREATE INDEX IF NOT EXISTS capability_grants_agent_idx ON capabilities.capability_grants (agent_id)`,
+	`CREATE INDEX IF NOT EXISTS capability_grants_capability_idx ON capabilities.capability_grants (capability)`,
+	`CREATE UNIQUE INDEX IF NOT EXISTS capability_grants_active_uniq ON capabilities.capability_grants (subject, agent_id, capability, resource_selector, effect) WHERE revoked_at IS NULL`,
+	`CREATE TABLE IF NOT EXISTS capabilities.capability_audit_log (
+		id uuid PRIMARY KEY,
+		agent_id uuid NOT NULL,
+		subject text NOT NULL,
+		capability text NOT NULL,
+		resource text NOT NULL,
+		decision text NOT NULL CHECK (decision IN ('allow','deny')),
+		reason_code text NOT NULL,
+		details text,
+		matched_grant_id uuid,
+		constraints jsonb,
+		grant_expires_at timestamptz,
+		approval_required boolean DEFAULT false NOT NULL,
+		grant_version integer,
+		created_at timestamptz DEFAULT now() NOT NULL
+	)`,
+	`CREATE INDEX IF NOT EXISTS capability_audit_subject_idx ON capabilities.capability_audit_log (subject)`,
+	`CREATE INDEX IF NOT EXISTS capability_audit_created_idx ON capabilities.capability_audit_log (created_at)`,
+	`CREATE TABLE IF NOT EXISTS capabilities.capability_epoch (
+		id integer PRIMARY KEY DEFAULT 1,
+		epoch integer DEFAULT 1 NOT NULL,
+		updated_at timestamptz DEFAULT now() NOT NULL
+	)`,
+	`INSERT INTO capabilities.capability_epoch (id, epoch) VALUES (1, 1) ON CONFLICT (id) DO NOTHING`,
+];
+
+const ensuredClients = new WeakSet<object>();
+
+/**
+ * Minimal Drizzle-compatible DB shape this store uses. Mirrors the trust
+ * feature's `DrizzleDB`: a chainable any-typed query-builder surface plus the
+ * raw `execute` used by the idempotent DDL bootstrap.
+ */
+export interface CapabilityStoreDb {
+	// biome-ignore lint/suspicious/noExplicitAny: raw execute result varies by driver (rows/rowCount); consumers treat it as opaque
+	execute(query: unknown): Promise<any>;
+	// biome-ignore lint/suspicious/noExplicitAny: chainable drizzle builder
+	select: (...args: any[]) => any;
+	// biome-ignore lint/suspicious/noExplicitAny: chainable drizzle builder
+	insert: (table: any) => any;
+	// biome-ignore lint/suspicious/noExplicitAny: chainable drizzle builder
+	update: (table: any) => any;
+}
+
+/**
+ * Ensures the capability tables exist on the attached database. Memoized per
+ * client object so repeated calls are one WeakSet lookup.
+ */
+export async function ensureCapabilityGrantTables(
+	db: CapabilityStoreDb,
+	client?: object,
+): Promise<void> {
+	const key = client ?? (db as unknown as object);
+	if (ensuredClients.has(key)) {
+		return;
+	}
+	for (const statement of CAPABILITY_DDL) {
+		await db.execute(sql.raw(statement));
+	}
+	ensuredClients.add(key);
+}
+
+/** Reads the current revocation epoch (cache-invalidation watermark). */
+export async function getCapabilityEpoch(
+	db: CapabilityStoreDb,
+): Promise<number> {
+	await ensureCapabilityGrantTables(db);
+	const rows = (await db
+		.select()
+		.from(capabilityEpoch)
+		.where(eq(capabilityEpoch.id, 1))
+		.limit(1)) as Array<{ epoch: number }>;
+	return rows[0]?.epoch ?? 1;
+}
+
+/** Bumps the revocation epoch; every grant mutation calls this. */
+async function bumpEpoch(db: CapabilityStoreDb): Promise<void> {
+	await db
+		.update(capabilityEpoch)
+		.set({ epoch: sql`${capabilityEpoch.epoch} + 1`, updatedAt: new Date() })
+		.where(eq(capabilityEpoch.id, 1));
+}
+
+export type RevokeGrantResult =
+	| { ok: true; grant: CapabilityGrant }
+	| { ok: false; error: string };
+
+export type UpdateGrantResult =
+	| { ok: true; grant: CapabilityGrant }
+	| { ok: false; error: string; conflict?: true; grant?: CapabilityGrant };
+
+export interface AuditAppendInput {
+	auditId: UUID;
+	agentId: UUID;
+	subject: string;
+	capability: string;
+	resource: string;
+	decision: "allow" | "deny";
+	reasonCode: string;
+	details?: string | null;
+	matchedGrantId?: UUID | null;
+	constraints?: Record<string, unknown> | null;
+	grantExpiresAt?: Date | null;
+	approvalRequired?: boolean;
+	grantVersion?: number | null;
+}
+
+export interface AuditRow {
+	id: UUID;
+	agentId: UUID;
+	subject: string;
+	capability: string;
+	resource: string;
+	decision: string;
+	reasonCode: string;
+	details: string | null;
+	matchedGrantId: UUID | null;
+	grantExpiresAt: Date | null;
+	approvalRequired: boolean;
+	grantVersion: number | null;
+	createdAt: Date;
+}
+
+/** Creates a durable grant after validating every vocabulary field. */
+export async function createCapabilityGrant(
+	db: CapabilityStoreDb,
+	input: CreateCapabilityGrantInput,
+): Promise<CapabilityGrant> {
+	await ensureCapabilityGrantTables(db);
+	const subject = canonicalizeCapabilitySubject(input.subject);
+	if (!subject.ok) {
+		throw new Error(`[capability-grants] ${subject.error}`);
+	}
+	const issuer = canonicalizeCapabilitySubject(input.issuer);
+	if (!issuer.ok) {
+		throw new Error(`[capability-grants] issuer: ${issuer.error}`);
+	}
+	const capability = validateCapabilityName(input.capability);
+	if (!capability.ok) {
+		throw new Error(`[capability-grants] ${capability.error}`);
+	}
+	const selector = canonicalizeResourceSelector(input.resourceSelector);
+	if (!selector.ok) {
+		throw new Error(`[capability-grants] ${selector.error}`);
+	}
+	if (input.effect !== "allow" && input.effect !== "deny") {
+		throw new Error(
+			`[capability-grants] effect must be "allow" or "deny", got ${JSON.stringify(input.effect)}`,
+		);
+	}
+	if (parseCapabilityProvenance(input.provenance) === null) {
+		throw new Error(
+			`[capability-grants] unknown provenance ${JSON.stringify(input.provenance)}`,
+		);
+	}
+
+	const inserted = (await db
+		.insert(capabilityGrants)
+		.values({
+			subject: subject.subject,
+			agentId: input.agentId,
+			worldId: input.worldId ?? null,
+			capability: capability.capability,
+			resourceSelector: selector.selector,
+			effect: input.effect,
+			issuer: issuer.subject,
+			expiresAt: input.expiresAt ?? null,
+			constraints: input.constraints ?? {},
+			provenance: input.provenance,
+		})
+		.returning()) as GrantRow[];
+	const row = inserted[0];
+	if (!row) {
+		throw new Error(
+			"[capability-grants] insert returned no row (store misbehavior)",
+		);
+	}
+	const grant = rowToGrant(row);
+	if (!grant) {
+		throw new Error(
+			`[capability-grants] inserted row failed vocabulary re-parse: ${JSON.stringify({ effect: row.effect, provenance: row.provenance })}`,
+		);
+	}
+	await bumpEpoch(db);
+	return grant;
+}
+
+/**
+ * Live grants for a subject × capability, ordered newest-issued first.
+ * Expired (expiresAt <= now) and revoked rows are excluded in SQL; rows with
+ * selectors that no longer canonicalize are quarantined after the read
+ * (visible for management, never authoritative).
+ */
+export async function listLiveGrantsFor(
+	db: CapabilityStoreDb,
+	params: {
+		subject: string;
+		agentId: UUID;
+		worldId?: UUID | null;
+		capability: string;
+		now?: number;
+	},
+): Promise<CapabilityGrant[]> {
+	await ensureCapabilityGrantTables(db);
+	const now = new Date(params.now ?? Date.now());
+	const worldMatch = or(
+		isNull(capabilityGrants.worldId),
+		params.worldId !== undefined && params.worldId !== null
+			? eq(capabilityGrants.worldId, params.worldId)
+			: sql`false`,
+	);
+	const rows = (await db
+		.select()
+		.from(capabilityGrants)
+		.where(
+			and(
+				eq(capabilityGrants.subject, params.subject),
+				eq(capabilityGrants.agentId, params.agentId),
+				eq(capabilityGrants.capability, params.capability),
+				worldMatch,
+				isNull(capabilityGrants.revokedAt),
+				or(
+					isNull(capabilityGrants.expiresAt),
+					gt(capabilityGrants.expiresAt, now),
+				),
+			),
+		)
+		.orderBy(desc(capabilityGrants.issuedAt), desc(capabilityGrants.id))
+		.limit(500)) as GrantRow[];
+	return rows
+		.map(rowToGrant)
+		.filter((grant): grant is CapabilityGrant => grant !== null)
+		.filter((grant) => selectorIsTrusted(grant));
+}
+
+/** Version-checked update of expiry/constraints; bumps `version` + epoch. */
+export async function updateCapabilityGrant(
+	db: CapabilityStoreDb,
+	input: UpdateCapabilityGrantInput,
+): Promise<UpdateGrantResult> {
+	await ensureCapabilityGrantTables(db);
+	const patch: Record<string, unknown> = {};
+	if (Object.hasOwn(input.patch, "expiresAt")) {
+		patch.expiresAt = input.patch.expiresAt ?? null;
+	}
+	if (Object.hasOwn(input.patch, "constraints")) {
+		patch.constraints = input.patch.constraints ?? {};
+	}
+	if (Object.keys(patch).length === 0) {
+		return {
+			ok: false,
+			error: "[capability-grants] update patch must set at least one field",
+		};
+	}
+	const updated = (await db
+		.update(capabilityGrants)
+		.set({
+			...patch,
+			version: sql`${capabilityGrants.version} + 1`,
+		})
+		.where(
+			and(
+				eq(capabilityGrants.id, input.id),
+				eq(capabilityGrants.version, input.expectedVersion),
+			),
+		)
+		.returning()) as GrantRow[];
+	const row = updated[0];
+	if (!row) {
+		const existing = (await db
+			.select()
+			.from(capabilityGrants)
+			.where(eq(capabilityGrants.id, input.id))
+			.limit(1)) as GrantRow[];
+		if (!existing[0]) {
+			return {
+				ok: false,
+				error: `[capability-grants] grant ${input.id} not found`,
+			};
+		}
+		const current = rowToGrant(existing[0]);
+		return {
+			ok: false,
+			error: `[capability-grants] version conflict on ${input.id}: expected ${input.expectedVersion}, current ${existing[0].version}`,
+			conflict: true,
+			grant: current ?? undefined,
+		};
+	}
+	const grant = rowToGrant(row);
+	if (!grant) {
+		return {
+			ok: false,
+			error: "[capability-grants] updated row failed vocabulary re-parse",
+		};
+	}
+	await bumpEpoch(db);
+	return { ok: true, grant };
+}
+
+/**
+ * Revokes a grant: sets revokedAt/reason and bumps `version` + the global
+ * epoch. Idempotent for an already-revoked grant (returns it unchanged).
+ * The next `listLiveGrantsFor` after this returns cannot include the
+ * revoked row.
+ */
+export async function revokeCapabilityGrant(
+	db: CapabilityStoreDb,
+	params: { id: UUID; reason?: string; now?: number },
+): Promise<RevokeGrantResult> {
+	await ensureCapabilityGrantTables(db);
+	const revokedAt = new Date(params.now ?? Date.now());
+	const updated = (await db
+		.update(capabilityGrants)
+		.set({
+			revokedAt,
+			revocationReason: params.reason ?? null,
+			version: sql`${capabilityGrants.version} + 1`,
+		})
+		.where(
+			and(
+				eq(capabilityGrants.id, params.id),
+				isNull(capabilityGrants.revokedAt),
+			),
+		)
+		.returning()) as GrantRow[];
+	const row = updated[0];
+	if (!row) {
+		const existing = (await db
+			.select()
+			.from(capabilityGrants)
+			.where(eq(capabilityGrants.id, params.id))
+			.limit(1)) as GrantRow[];
+		if (!existing[0]) {
+			return {
+				ok: false,
+				error: `[capability-grants] grant ${params.id} not found`,
+			};
+		}
+		const already = rowToGrant(existing[0]);
+		if (already && already.revokedAt !== null) {
+			return { ok: true, grant: already };
+		}
+		return {
+			ok: false,
+			error: `[capability-grants] revoke of ${params.id} matched no row and row is not revoked`,
+		};
+	}
+	const grant = rowToGrant(row);
+	if (!grant) {
+		return {
+			ok: false,
+			error: "[capability-grants] revoked row failed vocabulary re-parse",
+		};
+	}
+	await bumpEpoch(db);
+	return { ok: true, grant };
+}
+
+/** Fetch one grant by id (any state) for management surfaces. */
+export async function getCapabilityGrant(
+	db: CapabilityStoreDb,
+	id: UUID,
+): Promise<CapabilityGrant | null> {
+	await ensureCapabilityGrantTables(db);
+	const rows = (await db
+		.select()
+		.from(capabilityGrants)
+		.where(eq(capabilityGrants.id, id))
+		.limit(1)) as GrantRow[];
+	const row = rows[0];
+	if (!row) return null;
+	return rowToGrant(row);
+}
+
+/** Appends one audit row; every authorizeCapability decision writes one. */
+export async function appendCapabilityAudit(
+	db: CapabilityStoreDb,
+	input: AuditAppendInput,
+): Promise<void> {
+	await ensureCapabilityGrantTables(db);
+	await db.insert(capabilityAuditLog).values({
+		id: input.auditId,
+		agentId: input.agentId,
+		subject: input.subject,
+		capability: input.capability,
+		resource: truncateAuditResource(input.resource),
+		decision: input.decision,
+		reasonCode: input.reasonCode,
+		details: input.details ?? null,
+		matchedGrantId: input.matchedGrantId ?? null,
+		constraints: input.constraints ?? null,
+		grantExpiresAt: input.grantExpiresAt ?? null,
+		approvalRequired: input.approvalRequired ?? false,
+		grantVersion: input.grantVersion ?? null,
+	});
+}
+
+/** Lists audit rows newest-first, optionally narrowed by subject. */
+export async function listCapabilityAudit(
+	db: CapabilityStoreDb,
+	params?: { subject?: string; limit?: number },
+): Promise<AuditRow[]> {
+	await ensureCapabilityGrantTables(db);
+	const rows = (await db
+		.select()
+		.from(capabilityAuditLog)
+		.where(
+			params?.subject
+				? eq(capabilityAuditLog.subject, params.subject)
+				: undefined,
+		)
+		.orderBy(desc(capabilityAuditLog.createdAt), desc(capabilityAuditLog.id))
+		.limit(Math.min(params?.limit ?? 100, 500))) as Array<{
+		id: string;
+		agentId: string;
+		subject: string;
+		capability: string;
+		resource: string;
+		decision: string;
+		reasonCode: string;
+		details: string | null;
+		matchedGrantId: string | null;
+		constraints: unknown;
+		grantExpiresAt: Date | null;
+		approvalRequired: boolean;
+		grantVersion: number | null;
+		createdAt: Date;
+	}>;
+	return rows.map((row) => ({
+		id: row.id as UUID,
+		agentId: row.agentId as UUID,
+		subject: row.subject,
+		capability: row.capability,
+		resource: row.resource,
+		decision: row.decision,
+		reasonCode: row.reasonCode,
+		details: row.details,
+		matchedGrantId: (row.matchedGrantId as UUID | null) ?? null,
+		grantExpiresAt: row.grantExpiresAt,
+		approvalRequired: row.approvalRequired,
+		grantVersion: row.grantVersion,
+		createdAt: row.createdAt,
+	}));
+}

--- a/packages/core/src/features/capabilities/CapabilityGrantStore.ts
+++ b/packages/core/src/features/capabilities/CapabilityGrantStore.ts
@@ -171,8 +171,8 @@ export function ensureCapabilityGrantTables(
 	let pending = ensuredClients.get(key);
 	if (!pending) {
 		pending = runCapabilityDdl(db).catch((error: unknown) => {
-			// A failed bootstrap must be retried by the next call, not cached
-			// as "done" — drop the memo only on failure; success is permanent.
+			// error-policy:J2 — evict the memo so the next call retries the
+			// bootstrap, then rethrow unchanged; callers see the raw failure.
 			if (ensuredClients.get(key) === pending) {
 				ensuredClients.delete(key);
 			}
@@ -228,12 +228,23 @@ export async function getCapabilityEpoch(
 	return row.epoch;
 }
 
-/** Bumps the revocation epoch; every grant mutation calls this. */
+/**
+ * Bumps the revocation epoch inside the caller's transaction; every grant
+ * mutation calls this. A zero-row update means the singleton is missing
+ * (corrupt store state) — throwing here rolls the whole mutation back
+ * rather than committing a grant whose invalidation watermark never moved.
+ */
 async function bumpEpoch(db: CapabilityStoreDb): Promise<void> {
-	await db
+	const rows = (await db
 		.update(capabilityEpoch)
 		.set({ epoch: sql`${capabilityEpoch.epoch} + 1`, updatedAt: new Date() })
-		.where(eq(capabilityEpoch.id, 1));
+		.where(eq(capabilityEpoch.id, 1))
+		.returning()) as Array<{ id: number }>;
+	if (rows.length === 0) {
+		throw new Error(
+			"[capability-grants] capability_epoch row 1 is missing; mutation rolled back (corrupt store state)",
+		);
+	}
 }
 
 export type RevokeGrantResult =

--- a/packages/core/src/features/capabilities/CapabilityGrantStore.ts
+++ b/packages/core/src/features/capabilities/CapabilityGrantStore.ts
@@ -1,14 +1,15 @@
 /**
  * Data-access layer for durable per-principal capability grants (#23102).
  * Wraps the `capabilities` schema tables: validated insert, version-checked
- * update and revoke (both bump the global `capability_epoch` and the row's
- * `version`), live-grant lookup that filters expired and revoked rows in
- * SQL, and the append-only audit append used by `authorizeCapability`.
- * `ensureCapabilityGrantTables` self-migrates with idempotent DDL on first
- * use per process (TrajectoriesService pattern), so the tables exist
- * whenever any SQL database is attached — no plugin registration needed.
- * Reads through `listLiveGrantsFor` are authoritative; a revocation is
- * visible to the very next decision because there is no decision cache.
+ * update and revoke — each mutation and its `capability_epoch` bump commit
+ * in ONE transaction — uncapped live-grant lookup that filters expired and
+ * revoked rows in SQL, and the append-only audit append used by
+ * `authorizeCapability`. `ensureCapabilityGrantTables` self-migrates with
+ * idempotent DDL, memoizing the in-flight promise per client so concurrent
+ * first calls share one bootstrap, and the tables exist whenever any SQL
+ * database is attached — no plugin registration needed. Reads through
+ * `listLiveGrantsFor` are authoritative; a revocation is visible to the
+ * very next decision because there is no decision cache.
  */
 
 import { and, desc, eq, gt, isNull, or, sql } from "drizzle-orm";
@@ -26,6 +27,7 @@ import type {
 import {
 	canonicalizeCapabilitySubject,
 	canonicalizeResourceSelector,
+	isValidUuid,
 	parseCapabilityGrantEffect,
 	parseCapabilityProvenance,
 	truncateAuditResource,
@@ -61,6 +63,18 @@ function rowToGrant(row: GrantRow): CapabilityGrant | null {
 	const effect = parseCapabilityGrantEffect(row.effect);
 	const provenance = parseCapabilityProvenance(row.provenance);
 	if (effect === null || provenance === null) {
+		return null;
+	}
+	const subject = canonicalizeCapabilitySubject(row.subject);
+	if (!subject.ok) {
+		return null;
+	}
+	const issuer = canonicalizeCapabilitySubject(row.issuer);
+	if (!issuer.ok) {
+		return null;
+	}
+	const capability = validateCapabilityName(row.capability);
+	if (!capability.ok) {
 		return null;
 	}
 	const constraints =
@@ -120,7 +134,7 @@ const CAPABILITY_DDL = [
 	`CREATE INDEX IF NOT EXISTS capability_grants_subject_idx ON capabilities.capability_grants (subject)`,
 	`CREATE INDEX IF NOT EXISTS capability_grants_agent_idx ON capabilities.capability_grants (agent_id)`,
 	`CREATE INDEX IF NOT EXISTS capability_grants_capability_idx ON capabilities.capability_grants (capability)`,
-	`CREATE UNIQUE INDEX IF NOT EXISTS capability_grants_active_uniq ON capabilities.capability_grants (subject, agent_id, capability, resource_selector, effect) WHERE revoked_at IS NULL`,
+	`CREATE UNIQUE INDEX IF NOT EXISTS capability_grants_active_uniq ON capabilities.capability_grants (subject, agent_id, coalesce(world_id, '00000000-0000-0000-0000-000000000000'::uuid), capability, resource_selector, effect) WHERE revoked_at IS NULL`,
 	`CREATE TABLE IF NOT EXISTS capabilities.capability_audit_log (
 		id uuid PRIMARY KEY,
 		agent_id uuid NOT NULL,
@@ -147,7 +161,33 @@ const CAPABILITY_DDL = [
 	`INSERT INTO capabilities.capability_epoch (id, epoch) VALUES (1, 1) ON CONFLICT (id) DO NOTHING`,
 ];
 
-const ensuredClients = new WeakSet<object>();
+const ensuredClients = new WeakMap<object, Promise<void>>();
+
+export function ensureCapabilityGrantTables(
+	db: CapabilityStoreDb,
+	client?: object,
+): Promise<void> {
+	const key = client ?? (db as unknown as object);
+	let pending = ensuredClients.get(key);
+	if (!pending) {
+		pending = runCapabilityDdl(db).catch((error: unknown) => {
+			// A failed bootstrap must be retried by the next call, not cached
+			// as "done" — drop the memo only on failure; success is permanent.
+			if (ensuredClients.get(key) === pending) {
+				ensuredClients.delete(key);
+			}
+			throw error;
+		});
+		ensuredClients.set(key, pending);
+	}
+	return pending;
+}
+
+async function runCapabilityDdl(db: CapabilityStoreDb): Promise<void> {
+	for (const statement of CAPABILITY_DDL) {
+		await db.execute(sql.raw(statement));
+	}
+}
 
 /**
  * Minimal Drizzle-compatible DB shape this store uses. Mirrors the trust
@@ -163,24 +203,7 @@ export interface CapabilityStoreDb {
 	insert: (table: any) => any;
 	// biome-ignore lint/suspicious/noExplicitAny: chainable drizzle builder
 	update: (table: any) => any;
-}
-
-/**
- * Ensures the capability tables exist on the attached database. Memoized per
- * client object so repeated calls are one WeakSet lookup.
- */
-export async function ensureCapabilityGrantTables(
-	db: CapabilityStoreDb,
-	client?: object,
-): Promise<void> {
-	const key = client ?? (db as unknown as object);
-	if (ensuredClients.has(key)) {
-		return;
-	}
-	for (const statement of CAPABILITY_DDL) {
-		await db.execute(sql.raw(statement));
-	}
-	ensuredClients.add(key);
+	transaction: (cb: (tx: CapabilityStoreDb) => Promise<void>) => Promise<void>;
 }
 
 /** Reads the current revocation epoch (cache-invalidation watermark). */
@@ -193,7 +216,16 @@ export async function getCapabilityEpoch(
 		.from(capabilityEpoch)
 		.where(eq(capabilityEpoch.id, 1))
 		.limit(1)) as Array<{ epoch: number }>;
-	return rows[0]?.epoch ?? 1;
+	const row = rows[0];
+	if (!row) {
+		// The DDL bootstrap inserts this singleton; a missing row means the
+		// table was truncated or corrupted. Fail rather than fabricate an
+		// epoch that would falsely validate every cached decision.
+		throw new Error(
+			"[capability-grants] capability_epoch row 1 is missing (corrupt store state); refusing to fabricate an epoch",
+		);
+	}
+	return row.epoch;
 }
 
 /** Bumps the revocation epoch; every grant mutation calls this. */
@@ -244,6 +276,20 @@ export interface AuditRow {
 	createdAt: Date;
 }
 
+/**
+ * Runs `work` and the epoch bump in ONE transaction so a mutation and its
+ * cache-invalidation watermark commit atomically (RP must-fix 4).
+ */
+async function withEpochBump(
+	db: CapabilityStoreDb,
+	work: (tx: CapabilityStoreDb) => Promise<void>,
+): Promise<void> {
+	await db.transaction(async (tx) => {
+		await work(tx);
+		await bumpEpoch(tx);
+	});
+}
+
 /** Creates a durable grant after validating every vocabulary field. */
 export async function createCapabilityGrant(
 	db: CapabilityStoreDb,
@@ -262,6 +308,20 @@ export async function createCapabilityGrant(
 	if (!capability.ok) {
 		throw new Error(`[capability-grants] ${capability.error}`);
 	}
+	if (!isValidUuid(input.agentId)) {
+		throw new Error(
+			`[capability-grants] agentId must be a UUID, got ${JSON.stringify(input.agentId)}`,
+		);
+	}
+	if (
+		input.worldId !== undefined &&
+		input.worldId !== null &&
+		!isValidUuid(input.worldId)
+	) {
+		throw new Error(
+			`[capability-grants] worldId must be a UUID when provided, got ${JSON.stringify(input.worldId)}`,
+		);
+	}
 	const selector = canonicalizeResourceSelector(input.resourceSelector);
 	if (!selector.ok) {
 		throw new Error(`[capability-grants] ${selector.error}`);
@@ -277,22 +337,25 @@ export async function createCapabilityGrant(
 		);
 	}
 
-	const inserted = (await db
-		.insert(capabilityGrants)
-		.values({
-			subject: subject.subject,
-			agentId: input.agentId,
-			worldId: input.worldId ?? null,
-			capability: capability.capability,
-			resourceSelector: selector.selector,
-			effect: input.effect,
-			issuer: issuer.subject,
-			expiresAt: input.expiresAt ?? null,
-			constraints: input.constraints ?? {},
-			provenance: input.provenance,
-		})
-		.returning()) as GrantRow[];
-	const row = inserted[0];
+	let row: GrantRow | undefined;
+	await withEpochBump(db, async (tx) => {
+		const inserted = (await tx
+			.insert(capabilityGrants)
+			.values({
+				subject: subject.subject,
+				agentId: input.agentId.toLowerCase() as UUID,
+				worldId: input.worldId ? (input.worldId.toLowerCase() as UUID) : null,
+				capability: capability.capability,
+				resourceSelector: selector.selector,
+				effect: input.effect,
+				issuer: issuer.subject,
+				expiresAt: input.expiresAt ?? null,
+				constraints: input.constraints ?? {},
+				provenance: input.provenance,
+			})
+			.returning()) as GrantRow[];
+		row = inserted[0];
+	});
 	if (!row) {
 		throw new Error(
 			"[capability-grants] insert returned no row (store misbehavior)",
@@ -304,15 +367,16 @@ export async function createCapabilityGrant(
 			`[capability-grants] inserted row failed vocabulary re-parse: ${JSON.stringify({ effect: row.effect, provenance: row.provenance })}`,
 		);
 	}
-	await bumpEpoch(db);
 	return grant;
 }
 
 /**
- * Live grants for a subject × capability, ordered newest-issued first.
- * Expired (expiresAt <= now) and revoked rows are excluded in SQL; rows with
- * selectors that no longer canonicalize are quarantined after the read
- * (visible for management, never authoritative).
+ * Live grants for a subject × capability, ordered newest-issued first. The
+ * read is uncapped so deny-wins and full constraint intersection always see
+ * every live policy. Expired (expiresAt <= now) and revoked rows are
+ * excluded in SQL; rows whose subject/issuer/capability/selector no longer
+ * canonicalize are quarantined after the read (visible for management via
+ * getCapabilityGrant, never authoritative).
  */
 export async function listLiveGrantsFor(
 	db: CapabilityStoreDb,
@@ -348,8 +412,10 @@ export async function listLiveGrantsFor(
 				),
 			),
 		)
-		.orderBy(desc(capabilityGrants.issuedAt), desc(capabilityGrants.id))
-		.limit(500)) as GrantRow[];
+		.orderBy(
+			desc(capabilityGrants.issuedAt),
+			desc(capabilityGrants.id),
+		)) as GrantRow[];
 	return rows
 		.map(rowToGrant)
 		.filter((grant): grant is CapabilityGrant => grant !== null)
@@ -375,20 +441,23 @@ export async function updateCapabilityGrant(
 			error: "[capability-grants] update patch must set at least one field",
 		};
 	}
-	const updated = (await db
-		.update(capabilityGrants)
-		.set({
-			...patch,
-			version: sql`${capabilityGrants.version} + 1`,
-		})
-		.where(
-			and(
-				eq(capabilityGrants.id, input.id),
-				eq(capabilityGrants.version, input.expectedVersion),
-			),
-		)
-		.returning()) as GrantRow[];
-	const row = updated[0];
+	let row: GrantRow | undefined;
+	await withEpochBump(db, async (tx) => {
+		const updated = (await tx
+			.update(capabilityGrants)
+			.set({
+				...patch,
+				version: sql`${capabilityGrants.version} + 1`,
+			})
+			.where(
+				and(
+					eq(capabilityGrants.id, input.id),
+					eq(capabilityGrants.version, input.expectedVersion),
+				),
+			)
+			.returning()) as GrantRow[];
+		row = updated[0];
+	});
 	if (!row) {
 		const existing = (await db
 			.select()
@@ -416,7 +485,6 @@ export async function updateCapabilityGrant(
 			error: "[capability-grants] updated row failed vocabulary re-parse",
 		};
 	}
-	await bumpEpoch(db);
 	return { ok: true, grant };
 }
 
@@ -432,21 +500,24 @@ export async function revokeCapabilityGrant(
 ): Promise<RevokeGrantResult> {
 	await ensureCapabilityGrantTables(db);
 	const revokedAt = new Date(params.now ?? Date.now());
-	const updated = (await db
-		.update(capabilityGrants)
-		.set({
-			revokedAt,
-			revocationReason: params.reason ?? null,
-			version: sql`${capabilityGrants.version} + 1`,
-		})
-		.where(
-			and(
-				eq(capabilityGrants.id, params.id),
-				isNull(capabilityGrants.revokedAt),
-			),
-		)
-		.returning()) as GrantRow[];
-	const row = updated[0];
+	let row: GrantRow | undefined;
+	await withEpochBump(db, async (tx) => {
+		const updated = (await tx
+			.update(capabilityGrants)
+			.set({
+				revokedAt,
+				revocationReason: params.reason ?? null,
+				version: sql`${capabilityGrants.version} + 1`,
+			})
+			.where(
+				and(
+					eq(capabilityGrants.id, params.id),
+					isNull(capabilityGrants.revokedAt),
+				),
+			)
+			.returning()) as GrantRow[];
+		row = updated[0];
+	});
 	if (!row) {
 		const existing = (await db
 			.select()
@@ -475,7 +546,6 @@ export async function revokeCapabilityGrant(
 			error: "[capability-grants] revoked row failed vocabulary re-parse",
 		};
 	}
-	await bumpEpoch(db);
 	return { ok: true, grant };
 }
 

--- a/packages/core/src/features/capabilities/authorizeCapability.ts
+++ b/packages/core/src/features/capabilities/authorizeCapability.ts
@@ -55,8 +55,13 @@ async function writeAudit(
 	} catch (error) {
 		// error-policy:J7 — audit-sink failure is reported to the injected
 		// hook (runtime.reportError at the boundary), never blocks the
-		// decision, and never converts a denial into an allow.
-		onAuditFailure?.(error);
+		// decision, and never converts a denial into an allow. A throwing
+		// reporter is swallowed here for the same reason.
+		try {
+			onAuditFailure?.(error);
+		} catch {
+			// The decision already stands; reporter failures must not abort it.
+		}
 	}
 }
 
@@ -175,7 +180,7 @@ export async function authorizeCapability(
 			db,
 			request,
 			CAPABILITY_REASON_CODES.INVALID_REQUEST,
-			`Invalid subject: ${subject.error}`,
+			"Invalid subject: failed canonical-form validation (raw value withheld from audit)",
 			"invalid",
 		);
 	}
@@ -185,7 +190,7 @@ export async function authorizeCapability(
 			db,
 			request,
 			CAPABILITY_REASON_CODES.INVALID_REQUEST,
-			`Invalid capability: ${capability.error}`,
+			"Invalid capability: failed vocabulary validation (raw value withheld from audit)",
 			"invalid",
 		);
 	}
@@ -194,7 +199,7 @@ export async function authorizeCapability(
 			db,
 			request,
 			CAPABILITY_REASON_CODES.INVALID_REQUEST,
-			`Invalid agentId: ${JSON.stringify(request.agentId)}`,
+			"Invalid agentId: not a UUID (raw value withheld from audit)",
 			"invalid",
 		);
 	}
@@ -216,7 +221,7 @@ export async function authorizeCapability(
 			db,
 			request,
 			CAPABILITY_REASON_CODES.INVALID_REQUEST,
-			`Invalid worldId: ${JSON.stringify(request.worldId)}`,
+			"Invalid worldId: not a UUID (raw value withheld from audit)",
 			"invalid",
 		);
 	}
@@ -233,12 +238,14 @@ export async function authorizeCapability(
 	} catch (error) {
 		// error-policy:J4 — a store read failure becomes the structured
 		// STORE_UNAVAILABLE denial (fail closed); the boundary logs it via
-		// runtime.reportError from the decision record.
+		// runtime.reportError from the decision record, and the hook gets
+		// the raw driver error here (J7).
+		request.onAuditFailure?.(error);
 		return denyWithAudit(
 			db,
 			request,
 			CAPABILITY_REASON_CODES.STORE_UNAVAILABLE,
-			`Grant store unavailable: ${error instanceof Error ? error.message : String(error)}`,
+			"Grant store unavailable (driver error message withheld from audit)",
 			"store-unavailable",
 		);
 	}

--- a/packages/core/src/features/capabilities/authorizeCapability.ts
+++ b/packages/core/src/features/capabilities/authorizeCapability.ts
@@ -4,12 +4,13 @@
  * validate (fail closed) → deny grants → allow grants (constraints
  * intersected; incompatible → deny) → role tier (composition hook, only if a
  * resolver is provided and no grant matched) → deny NO_MATCHING_GRANT. Every
- * decision writes exactly one audit row whose id is generated UP FRONT so it
- * can be returned synchronously even when the audit write itself fails (that
- * failure is reported, never swallowed into an allow). There is deliberately
- * no decision cache — revocation is effective before the next call returns —
- * and no implicit allow. Boundaries that enforce call this function; nothing
- * reads `capabilities.capability_grants` directly.
+ * decision attempts exactly one audit row whose id is generated up front and
+ * returned even when the audit write itself fails; that failure is reported
+ * through the injected `onAuditFailure` hook (J7) and never converts a
+ * denial into an allow. There is deliberately no decision cache — revocation
+ * is effective before the next call returns — and no implicit allow.
+ * Boundaries that enforce call this function; nothing reads
+ * `capabilities.capability_grants` directly.
  */
 
 import type { UUID } from "../../types/index.ts";
@@ -29,33 +30,46 @@ import {
 	intersectGrantConstraints,
 	isValidUuid,
 	selectorMatchesResource,
+	truncateAuditResource,
 	validateCapabilityName,
 } from "./types.ts";
 
 /** Null-agent sentinel for auditing malformed requests safely. */
 const NIL_AGENT = "00000000-0000-0000-0000-000000000000" as UUID;
 
-/** Best-effort audit write; returns true when the row landed. */
+/**
+ * Optional sink for audit-write failures. Production callers wire this to
+ * `runtime.reportError(scope, error, context)`; the decision itself is
+ * unaffected (J7: diagnostics must not kill the loop).
+ */
+export type CapabilityAuditFailureReporter = (error: unknown) => void;
+
+/** Best-effort audit write; reports failures through `onAuditFailure`. */
 async function writeAudit(
 	db: CapabilityStoreDb,
 	input: Parameters<typeof appendCapabilityAudit>[1],
-): Promise<boolean> {
+	onAuditFailure?: CapabilityAuditFailureReporter,
+): Promise<void> {
 	try {
 		await appendCapabilityAudit(db, input);
-		return true;
 	} catch (error) {
-		// error-policy:J7 — audit-sink failure is reported (the caller's
-		// boundary logs it via runtime.reportError), never blocks the
+		// error-policy:J7 — audit-sink failure is reported to the injected
+		// hook (runtime.reportError at the boundary), never blocks the
 		// decision, and never converts a denial into an allow.
-		loggerAuditFailure(error);
-		return false;
+		onAuditFailure?.(error);
 	}
 }
 
-/** Isolated so tests can observe audit-failure reporting. */
-export const auditFailureReports: unknown[] = [];
-function loggerAuditFailure(error: unknown): void {
-	auditFailureReports.push(error);
+/**
+ * Sanitizes a raw request field for the audit row: non-strings become the
+ * literal marker, and strings are truncated to the audit resource cap so a
+ * malformed payload cannot smuggle unbounded bytes into the audit log.
+ */
+function auditSafeField(value: unknown): string {
+	if (typeof value !== "string") {
+		return "<non-string>";
+	}
+	return truncateAuditResource(value);
 }
 
 /**
@@ -76,18 +90,21 @@ async function denyWithAudit(
 	const auditedAgentId = isValidUuid(request.agentId)
 		? request.agentId
 		: NIL_AGENT;
-	await writeAudit(db, {
-		auditId,
-		agentId: auditedAgentId,
-		subject: typeof request.subject === "string" ? request.subject : "",
-		capability:
-			typeof request.capability === "string" ? request.capability : "",
-		resource: typeof request.resource === "string" ? request.resource : "",
-		decision: "deny",
-		reasonCode,
-		details: reason,
-		approvalRequired: options?.approvalRequired ?? false,
-	});
+	await writeAudit(
+		db,
+		{
+			auditId,
+			agentId: auditedAgentId,
+			subject: auditSafeField(request.subject),
+			capability: auditSafeField(request.capability),
+			resource: auditSafeField(request.resource),
+			decision: "deny",
+			reasonCode,
+			details: reason,
+			approvalRequired: options?.approvalRequired ?? false,
+		},
+		request.onAuditFailure,
+	);
 	return {
 		decision: "deny",
 		reasonCode: reasonCode as CapabilityAuthorizationResult["reasonCode"],
@@ -214,6 +231,9 @@ export async function authorizeCapability(
 			now: request.now,
 		});
 	} catch (error) {
+		// error-policy:J4 — a store read failure becomes the structured
+		// STORE_UNAVAILABLE denial (fail closed); the boundary logs it via
+		// runtime.reportError from the decision record.
 		return denyWithAudit(
 			db,
 			request,
@@ -229,21 +249,25 @@ export async function authorizeCapability(
 		if (grant.effect !== "deny") continue;
 		if (selectorMatchesResource(grant.resourceSelector, request.resource)) {
 			const auditId = newAuditId();
-			await writeAudit(db, {
-				auditId,
-				agentId: request.agentId,
-				subject: subject.subject,
-				capability: capability.capability,
-				resource: request.resource,
-				decision: "deny",
-				reasonCode: CAPABILITY_REASON_CODES.DENY_GRANT_MATCHED,
-				details: `Denied by grant ${grant.id} (explicit deny outranks allow and role tiers)`,
-				matchedGrantId: grant.id,
-				constraints: grant.constraints ?? null,
-				grantExpiresAt: grant.expiresAt,
-				approvalRequired: false,
-				grantVersion: grant.version,
-			});
+			await writeAudit(
+				db,
+				{
+					auditId,
+					agentId: request.agentId,
+					subject: subject.subject,
+					capability: capability.capability,
+					resource: request.resource,
+					decision: "deny",
+					reasonCode: CAPABILITY_REASON_CODES.DENY_GRANT_MATCHED,
+					details: `Denied by grant ${grant.id} (explicit deny outranks allow and role tiers)`,
+					matchedGrantId: grant.id,
+					constraints: grant.constraints ?? null,
+					grantExpiresAt: grant.expiresAt,
+					approvalRequired: false,
+					grantVersion: grant.version,
+				},
+				request.onAuditFailure,
+			);
 			return {
 				decision: "deny",
 				reasonCode: CAPABILITY_REASON_CODES.DENY_GRANT_MATCHED,
@@ -271,17 +295,21 @@ export async function authorizeCapability(
 		const intersection = intersectGrantConstraints(matching);
 		if (!intersection.ok) {
 			const auditId = newAuditId();
-			await writeAudit(db, {
-				auditId,
-				agentId: request.agentId,
-				subject: subject.subject,
-				capability: capability.capability,
-				resource: request.resource,
-				decision: "deny",
-				reasonCode: CAPABILITY_REASON_CODES.INCOMPATIBLE_CONSTRAINTS,
-				details: `Matching allow grants ${matching.map((g) => g.id).join(", ")} carry incompatible constraints`,
-				approvalRequired: false,
-			});
+			await writeAudit(
+				db,
+				{
+					auditId,
+					agentId: request.agentId,
+					subject: subject.subject,
+					capability: capability.capability,
+					resource: request.resource,
+					decision: "deny",
+					reasonCode: CAPABILITY_REASON_CODES.INCOMPATIBLE_CONSTRAINTS,
+					details: `Matching allow grants ${matching.map((g) => g.id).join(", ")} carry incompatible constraints`,
+					approvalRequired: false,
+				},
+				request.onAuditFailure,
+			);
 			return {
 				decision: "deny",
 				reasonCode: CAPABILITY_REASON_CODES.INCOMPATIBLE_CONSTRAINTS,
@@ -297,25 +325,29 @@ export async function authorizeCapability(
 			};
 		}
 		const auditId = newAuditId();
-		await writeAudit(db, {
-			auditId,
-			agentId: request.agentId,
-			subject: subject.subject,
-			capability: capability.capability,
-			resource: request.resource,
-			decision: "allow",
-			reasonCode: CAPABILITY_REASON_CODES.ALLOW_GRANT_MATCHED,
-			details: `Allowed by ${matching.length} matching live allow grant(s)`,
-			matchedGrantId: matching[0].id,
-			constraints: intersection.constraints,
-			grantExpiresAt:
-				matching
-					.map((g) => g.expiresAt)
-					.filter((v): v is Date => v !== null)
-					.sort((a, b) => a.getTime() - b.getTime())[0] ?? null,
-			approvalRequired: false,
-			grantVersion: matching[0].version,
-		});
+		await writeAudit(
+			db,
+			{
+				auditId,
+				agentId: request.agentId,
+				subject: subject.subject,
+				capability: capability.capability,
+				resource: request.resource,
+				decision: "allow",
+				reasonCode: CAPABILITY_REASON_CODES.ALLOW_GRANT_MATCHED,
+				details: `Allowed by ${matching.length} matching live allow grant(s)`,
+				matchedGrantId: matching[0].id,
+				constraints: intersection.constraints,
+				grantExpiresAt:
+					matching
+						.map((g) => g.expiresAt)
+						.filter((v): v is Date => v !== null)
+						.sort((a, b) => a.getTime() - b.getTime())[0] ?? null,
+				approvalRequired: false,
+				grantVersion: matching[0].version,
+			},
+			request.onAuditFailure,
+		);
 		return allowFromGrants(matching, auditId, intersection.constraints);
 	}
 
@@ -330,9 +362,10 @@ export async function authorizeCapability(
 			});
 		} catch (error) {
 			// error-policy:J4 — a broken role resolver degrades to the plain
-			// no-match denial; it must never widen access.
+			// no-match denial; it must never widen access. The failure itself
+			// is reported through the injected hook (J7).
 			roles = null;
-			loggerAuditFailure(error);
+			request.onAuditFailure?.(error);
 		}
 		if (roles && roles.length > 0) {
 			// Slice 1 models the NONE floor only: roles present means the
@@ -342,17 +375,21 @@ export async function authorizeCapability(
 			// beyond what grants already said (no match), so record the layer
 			// and fall through to the no-match denial naming it.
 			const auditId = newAuditId();
-			await writeAudit(db, {
-				auditId,
-				agentId: request.agentId,
-				subject: subject.subject,
-				capability: capability.capability,
-				resource: request.resource,
-				decision: "deny",
-				reasonCode: CAPABILITY_REASON_CODES.NO_MATCHING_GRANT,
-				details: `Role tier evaluated (roles: ${roles.join(", ")}) but grants no floor capability in slice 1`,
-				approvalRequired: false,
-			});
+			await writeAudit(
+				db,
+				{
+					auditId,
+					agentId: request.agentId,
+					subject: subject.subject,
+					capability: capability.capability,
+					resource: request.resource,
+					decision: "deny",
+					reasonCode: CAPABILITY_REASON_CODES.NO_MATCHING_GRANT,
+					details: `Role tier evaluated (roles: ${roles.join(", ")}) but grants no floor capability in slice 1`,
+					approvalRequired: false,
+				},
+				request.onAuditFailure,
+			);
 			return {
 				decision: "deny",
 				reasonCode: CAPABILITY_REASON_CODES.NO_MATCHING_GRANT,

--- a/packages/core/src/features/capabilities/authorizeCapability.ts
+++ b/packages/core/src/features/capabilities/authorizeCapability.ts
@@ -1,0 +1,382 @@
+/**
+ * Canonical capability-authorization entry point (#23102). `authorizeCapability`
+ * is the single decision path for durable grants. Evaluation order is fixed:
+ * validate (fail closed) → deny grants → allow grants (constraints
+ * intersected; incompatible → deny) → role tier (composition hook, only if a
+ * resolver is provided and no grant matched) → deny NO_MATCHING_GRANT. Every
+ * decision writes exactly one audit row whose id is generated UP FRONT so it
+ * can be returned synchronously even when the audit write itself fails (that
+ * failure is reported, never swallowed into an allow). There is deliberately
+ * no decision cache — revocation is effective before the next call returns —
+ * and no implicit allow. Boundaries that enforce call this function; nothing
+ * reads `capabilities.capability_grants` directly.
+ */
+
+import type { UUID } from "../../types/index.ts";
+import type { CapabilityStoreDb } from "./CapabilityGrantStore.ts";
+import {
+	appendCapabilityAudit,
+	listLiveGrantsFor,
+} from "./CapabilityGrantStore.ts";
+import type {
+	CapabilityAuthorizationRequest,
+	CapabilityAuthorizationResult,
+	CapabilityGrant,
+} from "./types.ts";
+import {
+	CAPABILITY_REASON_CODES,
+	canonicalizeCapabilitySubject,
+	intersectGrantConstraints,
+	isValidUuid,
+	selectorMatchesResource,
+	validateCapabilityName,
+} from "./types.ts";
+
+/** Null-agent sentinel for auditing malformed requests safely. */
+const NIL_AGENT = "00000000-0000-0000-0000-000000000000" as UUID;
+
+/** Best-effort audit write; returns true when the row landed. */
+async function writeAudit(
+	db: CapabilityStoreDb,
+	input: Parameters<typeof appendCapabilityAudit>[1],
+): Promise<boolean> {
+	try {
+		await appendCapabilityAudit(db, input);
+		return true;
+	} catch (error) {
+		// error-policy:J7 — audit-sink failure is reported (the caller's
+		// boundary logs it via runtime.reportError), never blocks the
+		// decision, and never converts a denial into an allow.
+		loggerAuditFailure(error);
+		return false;
+	}
+}
+
+/** Isolated so tests can observe audit-failure reporting. */
+export const auditFailureReports: unknown[] = [];
+function loggerAuditFailure(error: unknown): void {
+	auditFailureReports.push(error);
+}
+
+/**
+ * Denial result helper shared by every fail-closed path. The audit row must
+ * still land for malformed requests, but raw malformed field values (e.g. a
+ * non-uuid agentId) would violate column constraints, so each audited field
+ * is sanitized to its string form with a deterministic null-agent sentinel.
+ */
+async function denyWithAudit(
+	db: CapabilityStoreDb,
+	request: CapabilityAuthorizationRequest,
+	reasonCode: string,
+	reason: string,
+	layer: string,
+	options?: { approvalRequired?: boolean },
+): Promise<CapabilityAuthorizationResult> {
+	const auditId = crypto.randomUUID() as UUID;
+	const auditedAgentId = isValidUuid(request.agentId)
+		? request.agentId
+		: NIL_AGENT;
+	await writeAudit(db, {
+		auditId,
+		agentId: auditedAgentId,
+		subject: typeof request.subject === "string" ? request.subject : "",
+		capability:
+			typeof request.capability === "string" ? request.capability : "",
+		resource: typeof request.resource === "string" ? request.resource : "",
+		decision: "deny",
+		reasonCode,
+		details: reason,
+		approvalRequired: options?.approvalRequired ?? false,
+	});
+	return {
+		decision: "deny",
+		reasonCode: reasonCode as CapabilityAuthorizationResult["reasonCode"],
+		reason,
+		matchedGrantId: null,
+		effect: null,
+		constraints: {},
+		expiresAt: null,
+		approvalRequired: options?.approvalRequired ?? false,
+		auditId,
+		layer,
+	};
+}
+
+/** Mints the decision's audit id up front (returned even if the write fails). */
+function newAuditId(): UUID {
+	return crypto.randomUUID() as UUID;
+}
+
+/** Allow result from the winning grant set (constraints intersected). */
+function allowFromGrants(
+	grants: CapabilityGrant[],
+	auditId: UUID,
+	constraints: Record<string, unknown>,
+): CapabilityAuthorizationResult {
+	// The nearest expiry across matching allows governs the decision.
+	const expiring = grants
+		.map((grant) => grant.expiresAt)
+		.filter((value): value is Date => value !== null)
+		.sort((a, b) => a.getTime() - b.getTime());
+	const primary = grants[0];
+	return {
+		decision: "allow",
+		reasonCode: CAPABILITY_REASON_CODES.ALLOW_GRANT_MATCHED,
+		reason: `Allowed by grant ${primary.id} (${grants.length} matching live allow${grants.length === 1 ? "" : "s"}, constraints intersected)`,
+		matchedGrantId: primary.id,
+		effect: primary.effect,
+		constraints,
+		expiresAt: expiring[0] ?? null,
+		approvalRequired: false,
+		auditId,
+		layer: "allow-grant",
+	};
+}
+
+/**
+ * Evaluate one authorization request against the durable grant store.
+ * Semantics (per #23102 + RP investigation findings):
+ * - malformed subject/capability/agentId/resource/worldId → deny INVALID_REQUEST
+ * - store failure → deny STORE_UNAVAILABLE (fail closed, audit attempted)
+ * - expired or revoked grants never match (filtered in SQL)
+ * - rows with quarantined (non-canonicalizable) selectors never match
+ * - an explicit deny matching the resource outranks any allow and any role
+ * - matching allows intersect constraints; incompatible values → deny
+ * - role tier (when a resolver is provided) evaluates only when no grant
+ *   matched, so grants always override the role floor, and the decision
+ *   names the layer that matched
+ * - no matching grant or role → deny NO_MATCHING_GRANT (no implicit allow)
+ * - every decision writes exactly one audit row (id returned up front)
+ */
+export async function authorizeCapability(
+	db: CapabilityStoreDb,
+	request: CapabilityAuthorizationRequest,
+): Promise<CapabilityAuthorizationResult> {
+	const subject = canonicalizeCapabilitySubject(request.subject);
+	if (!subject.ok) {
+		return denyWithAudit(
+			db,
+			request,
+			CAPABILITY_REASON_CODES.INVALID_REQUEST,
+			`Invalid subject: ${subject.error}`,
+			"invalid",
+		);
+	}
+	const capability = validateCapabilityName(request.capability);
+	if (!capability.ok) {
+		return denyWithAudit(
+			db,
+			request,
+			CAPABILITY_REASON_CODES.INVALID_REQUEST,
+			`Invalid capability: ${capability.error}`,
+			"invalid",
+		);
+	}
+	if (!isValidUuid(request.agentId)) {
+		return denyWithAudit(
+			db,
+			request,
+			CAPABILITY_REASON_CODES.INVALID_REQUEST,
+			`Invalid agentId: ${JSON.stringify(request.agentId)}`,
+			"invalid",
+		);
+	}
+	if (typeof request.resource !== "string" || request.resource.length === 0) {
+		return denyWithAudit(
+			db,
+			request,
+			CAPABILITY_REASON_CODES.INVALID_REQUEST,
+			"resource must be a non-empty string",
+			"invalid",
+		);
+	}
+	if (
+		request.worldId !== undefined &&
+		request.worldId !== null &&
+		!isValidUuid(request.worldId)
+	) {
+		return denyWithAudit(
+			db,
+			request,
+			CAPABILITY_REASON_CODES.INVALID_REQUEST,
+			`Invalid worldId: ${JSON.stringify(request.worldId)}`,
+			"invalid",
+		);
+	}
+
+	let grants: CapabilityGrant[];
+	try {
+		grants = await listLiveGrantsFor(db, {
+			subject: subject.subject,
+			agentId: request.agentId,
+			worldId: request.worldId ?? null,
+			capability: capability.capability,
+			now: request.now,
+		});
+	} catch (error) {
+		return denyWithAudit(
+			db,
+			request,
+			CAPABILITY_REASON_CODES.STORE_UNAVAILABLE,
+			`Grant store unavailable: ${error instanceof Error ? error.message : String(error)}`,
+			"store-unavailable",
+		);
+	}
+
+	// Explicit deny wins: any live deny grant whose selector matches the
+	// resource ends evaluation. Denies outrank allows AND the role tier.
+	for (const grant of grants) {
+		if (grant.effect !== "deny") continue;
+		if (selectorMatchesResource(grant.resourceSelector, request.resource)) {
+			const auditId = newAuditId();
+			await writeAudit(db, {
+				auditId,
+				agentId: request.agentId,
+				subject: subject.subject,
+				capability: capability.capability,
+				resource: request.resource,
+				decision: "deny",
+				reasonCode: CAPABILITY_REASON_CODES.DENY_GRANT_MATCHED,
+				details: `Denied by grant ${grant.id} (explicit deny outranks allow and role tiers)`,
+				matchedGrantId: grant.id,
+				constraints: grant.constraints ?? null,
+				grantExpiresAt: grant.expiresAt,
+				approvalRequired: false,
+				grantVersion: grant.version,
+			});
+			return {
+				decision: "deny",
+				reasonCode: CAPABILITY_REASON_CODES.DENY_GRANT_MATCHED,
+				reason: `Denied by explicit deny grant ${grant.id}`,
+				matchedGrantId: grant.id,
+				effect: grant.effect,
+				constraints: grant.constraints ?? {},
+				expiresAt: grant.expiresAt,
+				approvalRequired: false,
+				auditId,
+				layer: "deny-grant",
+			};
+		}
+	}
+
+	// Allow scan: collect every matching live allow, intersect constraints.
+	const matching: CapabilityGrant[] = [];
+	for (const grant of grants) {
+		if (grant.effect !== "allow") continue;
+		if (selectorMatchesResource(grant.resourceSelector, request.resource)) {
+			matching.push(grant);
+		}
+	}
+	if (matching.length > 0) {
+		const intersection = intersectGrantConstraints(matching);
+		if (!intersection.ok) {
+			const auditId = newAuditId();
+			await writeAudit(db, {
+				auditId,
+				agentId: request.agentId,
+				subject: subject.subject,
+				capability: capability.capability,
+				resource: request.resource,
+				decision: "deny",
+				reasonCode: CAPABILITY_REASON_CODES.INCOMPATIBLE_CONSTRAINTS,
+				details: `Matching allow grants ${matching.map((g) => g.id).join(", ")} carry incompatible constraints`,
+				approvalRequired: false,
+			});
+			return {
+				decision: "deny",
+				reasonCode: CAPABILITY_REASON_CODES.INCOMPATIBLE_CONSTRAINTS,
+				reason:
+					"Matching allow grants carry incompatible constraints; denying rather than picking one",
+				matchedGrantId: matching[0].id,
+				effect: null,
+				constraints: {},
+				expiresAt: null,
+				approvalRequired: false,
+				auditId,
+				layer: "allow-grant",
+			};
+		}
+		const auditId = newAuditId();
+		await writeAudit(db, {
+			auditId,
+			agentId: request.agentId,
+			subject: subject.subject,
+			capability: capability.capability,
+			resource: request.resource,
+			decision: "allow",
+			reasonCode: CAPABILITY_REASON_CODES.ALLOW_GRANT_MATCHED,
+			details: `Allowed by ${matching.length} matching live allow grant(s)`,
+			matchedGrantId: matching[0].id,
+			constraints: intersection.constraints,
+			grantExpiresAt:
+				matching
+					.map((g) => g.expiresAt)
+					.filter((v): v is Date => v !== null)
+					.sort((a, b) => a.getTime() - b.getTime())[0] ?? null,
+			approvalRequired: false,
+			grantVersion: matching[0].version,
+		});
+		return allowFromGrants(matching, auditId, intersection.constraints);
+	}
+
+	// Role tier (composition hook): evaluated only when no grant matched, so
+	// an explicit deny grant beats any role floor and grants override roles.
+	if (request.roleResolver) {
+		let roles: string[] | null = null;
+		try {
+			roles = await request.roleResolver(subject.subject, {
+				agentId: request.agentId,
+				worldId: request.worldId ?? null,
+			});
+		} catch (error) {
+			// error-policy:J4 — a broken role resolver degrades to the plain
+			// no-match denial; it must never widen access.
+			roles = null;
+			loggerAuditFailure(error);
+		}
+		if (roles && roles.length > 0) {
+			// Slice 1 models the NONE floor only: roles present means the
+			// role-tier layer vouches for the subject's base actions. The
+			// full role→capability mapping is slice 2+; here the tier says
+			// "allow what the floor grants", which for this slice is nothing
+			// beyond what grants already said (no match), so record the layer
+			// and fall through to the no-match denial naming it.
+			const auditId = newAuditId();
+			await writeAudit(db, {
+				auditId,
+				agentId: request.agentId,
+				subject: subject.subject,
+				capability: capability.capability,
+				resource: request.resource,
+				decision: "deny",
+				reasonCode: CAPABILITY_REASON_CODES.NO_MATCHING_GRANT,
+				details: `Role tier evaluated (roles: ${roles.join(", ")}) but grants no floor capability in slice 1`,
+				approvalRequired: false,
+			});
+			return {
+				decision: "deny",
+				reasonCode: CAPABILITY_REASON_CODES.NO_MATCHING_GRANT,
+				reason:
+					"No matching live grant; role tier evaluated but grants no additional capability in slice 1",
+				matchedGrantId: null,
+				effect: null,
+				constraints: {},
+				expiresAt: null,
+				approvalRequired: false,
+				auditId,
+				layer: "role-tier",
+			};
+		}
+	}
+
+	// No live grant matched and no role tier vouched: deny (no implicit
+	// allow). Approval flows for governed capabilities are a follow-up slice;
+	// approvalRequired stays false and the decision is a plain denial.
+	return denyWithAudit(
+		db,
+		request,
+		CAPABILITY_REASON_CODES.NO_MATCHING_GRANT,
+		"No matching live grant",
+		"no-match",
+	);
+}

--- a/packages/core/src/features/capabilities/authorizeCapability.ts
+++ b/packages/core/src/features/capabilities/authorizeCapability.ts
@@ -44,6 +44,25 @@ const NIL_AGENT = "00000000-0000-0000-0000-000000000000" as UUID;
  */
 export type CapabilityAuditFailureReporter = (error: unknown) => void;
 
+/**
+ * Reports a diagnostic failure through the injected hook. The decision
+ * already stands when this runs, so a throwing reporter is swallowed —
+ * diagnostics must never abort authorization.
+ */
+function safeReport(
+	onAuditFailure: CapabilityAuditFailureReporter | undefined,
+	error: unknown,
+): void {
+	// error-policy:J7 — diagnostic failures (audit sink, store reads, role
+	// resolvers) are reported best-effort and can never change or block the
+	// decision, including when the reporter itself throws.
+	try {
+		onAuditFailure?.(error);
+	} catch {
+		// The reporter is itself broken; nothing further to do safely.
+	}
+}
+
 /** Best-effort audit write; reports failures through `onAuditFailure`. */
 async function writeAudit(
 	db: CapabilityStoreDb,
@@ -53,15 +72,7 @@ async function writeAudit(
 	try {
 		await appendCapabilityAudit(db, input);
 	} catch (error) {
-		// error-policy:J7 — audit-sink failure is reported to the injected
-		// hook (runtime.reportError at the boundary), never blocks the
-		// decision, and never converts a denial into an allow. A throwing
-		// reporter is swallowed here for the same reason.
-		try {
-			onAuditFailure?.(error);
-		} catch {
-			// The decision already stands; reporter failures must not abort it.
-		}
+		safeReport(onAuditFailure, error);
 	}
 }
 
@@ -240,7 +251,7 @@ export async function authorizeCapability(
 		// STORE_UNAVAILABLE denial (fail closed); the boundary logs it via
 		// runtime.reportError from the decision record, and the hook gets
 		// the raw driver error here (J7).
-		request.onAuditFailure?.(error);
+		safeReport(request.onAuditFailure, error);
 		return denyWithAudit(
 			db,
 			request,
@@ -372,7 +383,7 @@ export async function authorizeCapability(
 			// no-match denial; it must never widen access. The failure itself
 			// is reported through the injected hook (J7).
 			roles = null;
-			request.onAuditFailure?.(error);
+			safeReport(request.onAuditFailure, error);
 		}
 		if (roles && roles.length > 0) {
 			// Slice 1 models the NONE floor only: roles present means the

--- a/packages/core/src/features/capabilities/capability-boundary-inventory.ts
+++ b/packages/core/src/features/capabilities/capability-boundary-inventory.ts
@@ -1,11 +1,11 @@
 /**
- * Checked-in enforcement inventory for #23102 slice 1: the authoritative list
- * of privileged boundaries that the capability-grant system must eventually
- * enforce, with per-boundary status and owner. Slice 1 ships the inventory as
- * data; enforcement wiring (slices 2+) updates statuses here as boundaries
- * are connected to `authorizeCapability`. A test walks this list and fails
- * when a boundary is left unclassified, so no privileged boundary can
- * silently appear outside the inventory.
+ * Checked-in enforcement inventory for #23102 slice 1: the tracked list of
+ * privileged boundaries the capability-grant system must eventually enforce,
+ * with per-boundary status and owner. Slice 1 ships the inventory as data;
+ * enforcement wiring (slices 2+) updates statuses here as boundaries are
+ * connected to `authorizeCapability`. A test validates every entry's shape;
+ * completeness against newly added repo boundaries is a human review
+ * obligation until a codebase-wide classifier lands (slice 2+).
  */
 
 import type { CapabilityBoundaryInventoryEntry } from "./types.ts";

--- a/packages/core/src/features/capabilities/capability-boundary-inventory.ts
+++ b/packages/core/src/features/capabilities/capability-boundary-inventory.ts
@@ -1,0 +1,97 @@
+/**
+ * Checked-in enforcement inventory for #23102 slice 1: the authoritative list
+ * of privileged boundaries that the capability-grant system must eventually
+ * enforce, with per-boundary status and owner. Slice 1 ships the inventory as
+ * data; enforcement wiring (slices 2+) updates statuses here as boundaries
+ * are connected to `authorizeCapability`. A test walks this list and fails
+ * when a boundary is left unclassified, so no privileged boundary can
+ * silently appear outside the inventory.
+ */
+
+import type { CapabilityBoundaryInventoryEntry } from "./types.ts";
+
+export const CAPABILITY_BOUNDARY_INVENTORY: CapabilityBoundaryInventoryEntry[] =
+	[
+		{
+			id: "connector.message.send",
+			description:
+				"Sending any outbound message through a connector account (channel/DM post).",
+			status: "inventory-only",
+			owner: null,
+		},
+		{
+			id: "connector.account.read",
+			description:
+				"Reading a connector account's messages, presence, or membership.",
+			status: "inventory-only",
+			owner: null,
+		},
+		{
+			id: "device.command",
+			description:
+				"Issuing a command to a paired device (smart home, remote runtime).",
+			status: "inventory-only",
+			owner: null,
+		},
+		{
+			id: "filesystem.read",
+			description: "Reading files from the host filesystem.",
+			status: "inventory-only",
+			owner: null,
+		},
+		{
+			id: "filesystem.write",
+			description: "Writing or deleting files on the host filesystem.",
+			status: "inventory-only",
+			owner: null,
+		},
+		{
+			id: "shell.execute",
+			description:
+				"Executing a shell command (PTY) on the host or in a workspace sandbox.",
+			status: "inventory-only",
+			owner: null,
+		},
+		{
+			id: "git.operation",
+			description:
+				"Running git mutations (commit, push, merge) on behalf of a principal.",
+			status: "inventory-only",
+			owner: null,
+		},
+		{
+			id: "media.read",
+			description:
+				"Fetching or reading media/attachment bytes (content-addressed store).",
+			status: "inventory-only",
+			owner: null,
+		},
+		{
+			id: "media.write",
+			description:
+				"Ingesting media/attachment bytes into the content-addressed store.",
+			status: "inventory-only",
+			owner: null,
+		},
+		{
+			id: "provider.model.invoke",
+			description:
+				"Invoking a model/inference provider on behalf of a principal.",
+			status: "inventory-only",
+			owner: null,
+		},
+		{
+			id: "api.route.admin",
+			description:
+				"Calling an administrative API route (settings, plugin, world management).",
+			status: "inventory-only",
+			owner: null,
+		},
+		{
+			id: "coding.environment.use",
+			description:
+				"Using a coding environment or tool bridge (Claude Code, Codex) as the principal.",
+			status: "inventory-only",
+			owner: null,
+		},
+	];

--- a/packages/core/src/features/capabilities/index.ts
+++ b/packages/core/src/features/capabilities/index.ts
@@ -1,0 +1,29 @@
+/**
+ * Public barrel for the durable capability-grant feature (#23102): the typed
+ * vocabulary and decision contracts, the self-migrating grant/audit store,
+ * the canonical `authorizeCapability` decision path, and the checked-in
+ * enforcement-boundary inventory. Authorization data is intentionally kept
+ * separate from the trust feature; nothing here imports trust code.
+ */
+
+export { authorizeCapability } from "./authorizeCapability.ts";
+export type {
+	AuditAppendInput,
+	AuditRow,
+	CapabilityStoreDb,
+	RevokeGrantResult,
+	UpdateGrantResult,
+} from "./CapabilityGrantStore.ts";
+export {
+	appendCapabilityAudit,
+	createCapabilityGrant,
+	ensureCapabilityGrantTables,
+	getCapabilityEpoch,
+	getCapabilityGrant,
+	listCapabilityAudit,
+	listLiveGrantsFor,
+	revokeCapabilityGrant,
+	updateCapabilityGrant,
+} from "./CapabilityGrantStore.ts";
+export { CAPABILITY_BOUNDARY_INVENTORY } from "./capability-boundary-inventory.ts";
+export * from "./types.ts";

--- a/packages/core/src/features/capabilities/schema.ts
+++ b/packages/core/src/features/capabilities/schema.ts
@@ -1,0 +1,143 @@
+/**
+ * Drizzle table definitions for the durable capability-grant feature
+ * (#23102), in a dedicated `capabilities` Postgres schema — authorization
+ * data kept out of the trust feature so enforcement boundaries never reach
+ * sideways into trust tables. `ensureCapabilityGrantTables` materializes
+ * both tables with idempotent raw DDL at first store use (the
+ * TrajectoriesService pattern), because nothing in the runtime registers a
+ * schema-bearing trust plugin and relying on plugin-schema migration would
+ * leave these tables uncreated in real deployments.
+ */
+
+import { sql } from "drizzle-orm";
+import {
+	boolean,
+	index,
+	integer,
+	jsonb,
+	pgSchema,
+	text,
+	timestamp,
+	uniqueIndex,
+	uuid,
+} from "drizzle-orm/pg-core";
+
+export const capabilitiesSchema = pgSchema("capabilities");
+
+/**
+ * Durable per-principal capability grants. Each row is one subject ×
+ * capability × resource-selector policy with allow/deny effect, issuer
+ * provenance, expiry, revocation, constraints, and an optimistic-concurrency
+ * version. A partial unique index enforces one active row per exact policy;
+ * superseding a policy revokes the old row first.
+ */
+export const capabilityGrants = capabilitiesSchema.table(
+	"capability_grants",
+	{
+		id: uuid("id").primaryKey().default(sql`gen_random_uuid()`),
+		/** Canonical subject string, e.g. `entity:<uuid>` or `role:admin`. */
+		subject: text("subject").notNull(),
+		/** The agent whose authority this grant applies under. */
+		agentId: uuid("agent_id").notNull(),
+		/** Optional world scoping; null grants apply in every world. */
+		worldId: uuid("world_id"),
+		/** Typed capability name, e.g. `connector.message.send`. */
+		capability: text("capability").notNull(),
+		/**
+		 * Resource selector: `*`, an exact resource id, or `<prefix>/*` matching
+		 * the prefix's descendants at any depth.
+		 */
+		resourceSelector: text("resource_selector").notNull(),
+		/** 'allow' | 'deny'; an explicit deny outranks any allow. */
+		effect: text("effect").notNull(),
+		/** Canonical issuer subject string, e.g. `entity:<uuid>`. */
+		issuer: text("issuer").notNull(),
+		issuedAt: timestamp("issued_at", { withTimezone: true })
+			.defaultNow()
+			.notNull(),
+		/** Null expires never. */
+		expiresAt: timestamp("expires_at", { withTimezone: true }),
+		/** Null means not revoked; set by revoke(). */
+		revokedAt: timestamp("revoked_at", { withTimezone: true }),
+		revocationReason: text("revocation_reason"),
+		/** Free-form constraints surfaced (intersected) on allow decisions. */
+		constraints: jsonb("constraints").default({}),
+		/** Where this grant came from: 'api' | 'natural-language' | 'settings'. */
+		provenance: text("provenance").notNull(),
+		/** Optimistic-concurrency version, bumped on every mutation. */
+		version: integer("version").default(1).notNull(),
+	},
+	(table) => [
+		index("capability_grants_subject_idx").on(table.subject),
+		index("capability_grants_agent_idx").on(table.agentId),
+		index("capability_grants_capability_idx").on(table.capability),
+		uniqueIndex("capability_grants_active_uniq")
+			.on(
+				table.subject,
+				table.agentId,
+				table.capability,
+				table.resourceSelector,
+				table.effect,
+			)
+			.where(sql`revoked_at IS NULL`),
+	],
+);
+
+/**
+ * Append-only audit trail for capability authorization decisions. Every
+ * `authorizeCapability` call — allow or deny — writes exactly one row
+ * carrying the decision's audit id so denials are as traceable as grants.
+ * Audits carry ids and outcomes only — never credentials, prompts, message
+ * bodies, or file bytes (#23102 acceptance criterion 8).
+ */
+export const capabilityAuditLog = capabilitiesSchema.table(
+	"capability_audit_log",
+	{
+		id: uuid("id").primaryKey(),
+		agentId: uuid("agent_id").notNull(),
+		subject: text("subject").notNull(),
+		capability: text("capability").notNull(),
+		/** Resource id, truncated; identifies the target, never its contents. */
+		resource: text("resource").notNull(),
+		decision: text("decision").notNull(), // 'allow' | 'deny'
+		/** Machine-readable denial/deny-wins reason code. */
+		reasonCode: text("reason_code").notNull(),
+		/** Human-readable explanation. */
+		details: text("details"),
+		/** Grant the decision matched; null when nothing matched. */
+		matchedGrantId: uuid("matched_grant_id"),
+		/** Intersected grant constraints echoed on allow decisions. */
+		constraints: jsonb("constraints"),
+		/** Matched grant expiry echoed when the decision matched a live grant. */
+		grantExpiresAt: timestamp("grant_expires_at", { withTimezone: true }),
+		/** True when the request must be re-run through an approval flow. */
+		approvalRequired: boolean("approval_required").default(false).notNull(),
+		/** Matched grant version at decision time. */
+		grantVersion: integer("grant_version"),
+		createdAt: timestamp("created_at", { withTimezone: true })
+			.defaultNow()
+			.notNull(),
+	},
+	(table) => [
+		index("capability_audit_subject_idx").on(table.subject),
+		index("capability_audit_created_idx").on(table.createdAt),
+	],
+);
+
+/**
+ * Single-row revocation epoch (RP Q4): every grant mutation bumps
+ * `capability_epoch`, and any future decision cache must record the epoch it
+ * read; a mismatch is a cache miss. Slice 1 ships no cache — revocation is
+ * effective before return by construction (one indexed read per decision) —
+ * but the epoch is part of the store API from day one so the first cache
+ * implementation cannot reintroduce the stale-allow bug.
+ */
+export const capabilityEpoch = capabilitiesSchema.table("capability_epoch", {
+	/** Fixed row id; only row 1 exists. */
+	id: integer("id").primaryKey().default(1),
+	/** Monotonic counter bumped on every grant create/revoke/update. */
+	epoch: integer("epoch").default(1).notNull(),
+	updatedAt: timestamp("updated_at", { withTimezone: true })
+		.defaultNow()
+		.notNull(),
+});

--- a/packages/core/src/features/capabilities/schema.ts
+++ b/packages/core/src/features/capabilities/schema.ts
@@ -28,8 +28,9 @@ export const capabilitiesSchema = pgSchema("capabilities");
  * Durable per-principal capability grants. Each row is one subject ×
  * capability × resource-selector policy with allow/deny effect, issuer
  * provenance, expiry, revocation, constraints, and an optimistic-concurrency
- * version. A partial unique index enforces one active row per exact policy;
- * superseding a policy revokes the old row first.
+ * version. A partial unique index (world-aware via nil-uuid coalescing)
+ * enforces one active row per exact policy per world; superseding a policy
+ * revokes the old row first.
  */
 export const capabilityGrants = capabilitiesSchema.table(
 	"capability_grants",
@@ -75,6 +76,9 @@ export const capabilityGrants = capabilitiesSchema.table(
 			.on(
 				table.subject,
 				table.agentId,
+				// Null (global) world coalesces to the nil uuid so global and
+				// world-scoped rows never collide in the unique index.
+				sql`coalesce(${table.worldId}, '00000000-0000-0000-0000-000000000000'::uuid)`,
 				table.capability,
 				table.resourceSelector,
 				table.effect,
@@ -85,7 +89,7 @@ export const capabilityGrants = capabilitiesSchema.table(
 
 /**
  * Append-only audit trail for capability authorization decisions. Every
- * `authorizeCapability` call — allow or deny — writes exactly one row
+ * `authorizeCapability` call — allow or deny — attempts exactly one row
  * carrying the decision's audit id so denials are as traceable as grants.
  * Audits carry ids and outcomes only — never credentials, prompts, message
  * bodies, or file bytes (#23102 acceptance criterion 8).

--- a/packages/core/src/features/capabilities/schema.ts
+++ b/packages/core/src/features/capabilities/schema.ts
@@ -3,10 +3,11 @@
  * (#23102), in a dedicated `capabilities` Postgres schema — authorization
  * data kept out of the trust feature so enforcement boundaries never reach
  * sideways into trust tables. `ensureCapabilityGrantTables` materializes
- * both tables with idempotent raw DDL at first store use (the
- * TrajectoriesService pattern), because nothing in the runtime registers a
- * schema-bearing trust plugin and relying on plugin-schema migration would
- * leave these tables uncreated in real deployments.
+ * all three tables (grants, audit log, epoch singleton) with idempotent
+ * raw DDL at first store use (the TrajectoriesService pattern), because
+ * nothing in the runtime registers a schema-bearing trust plugin and
+ * relying on plugin-schema migration would leave these tables uncreated
+ * in real deployments.
  */
 
 import { sql } from "drizzle-orm";

--- a/packages/core/src/features/capabilities/types.ts
+++ b/packages/core/src/features/capabilities/types.ts
@@ -133,6 +133,12 @@ export interface CapabilityAuthorizationRequest {
 	now?: number;
 	/** Optional role-tier composition hook (evaluated after grants). */
 	roleResolver?: CapabilityRoleResolver;
+	/**
+	 * Optional sink for audit-write and role-resolver failures. Production
+	 * boundaries wire this to `runtime.reportError`; without it the failures
+	 * are silent to the caller (the decision itself is already fail-closed).
+	 */
+	onAuditFailure?: (error: unknown) => void;
 }
 
 /** Canonical authorization decision returned by `authorizeCapability`. */
@@ -251,6 +257,14 @@ export function validateCapabilityName(
 }
 
 /**
+ * Allowlist for selector characters: printable ASCII letters, digits, `-`,
+ * `_`, `:`, `.`, `/`, the bare `*` (everything), or an optional trailing
+ * `/*` wildcard. Rejects whitespace, control characters, quotes,
+ * backslashes, and non-ASCII input.
+ */
+const SELECTOR_CHARSET = /^(?:\*|[A-Za-z0-9\-_:./]+(?:\/\*)?)$/;
+
+/**
  * Validates and canonicalizes a resource selector: `*`, an exact resource id
  * (non-empty, no `*`, no leading/trailing/double slashes), or `<prefix>/*`
  * matching the prefix's descendants. Validation runs at grant-creation time
@@ -271,6 +285,14 @@ export function canonicalizeResourceSelector(
 		return {
 			ok: false,
 			error: `resource selector exceeds 512 characters, got ${value.length}`,
+		};
+	}
+	// Strict charset (RP must-fix 3): printable ASCII only; star is legal
+	// solely as the trailing `/*` wildcard (checked below).
+	if (!SELECTOR_CHARSET.test(value)) {
+		return {
+			ok: false,
+			error: `selector characters must be printable ASCII letters, digits, or - _ : . / (no spaces, quotes, backslashes, or non-ASCII); got ${JSON.stringify(value)}`,
 		};
 	}
 	if (value === "*") {
@@ -351,6 +373,45 @@ export function parseCapabilityProvenance(
 		: null;
 }
 
+/** Scalar constraint values comparable by Set identity. */
+function isScalarConstraintValue(
+	value: unknown,
+): value is string | number | boolean | null {
+	return (
+		typeof value === "string" ||
+		typeof value === "number" ||
+		typeof value === "boolean" ||
+		value === null
+	);
+}
+
+/** Structural equality over JSON-shaped constraint values. */
+export function jsonValuesEqual(a: unknown, b: unknown): boolean {
+	if (a === b) return true;
+	if (typeof a !== typeof b) return false;
+	if (a === null || b === null) return false;
+	if (Array.isArray(a) && Array.isArray(b)) {
+		return (
+			a.length === b.length && a.every((item, i) => jsonValuesEqual(item, b[i]))
+		);
+	}
+	if (typeof a === "object" && typeof b === "object") {
+		if (Array.isArray(a) || Array.isArray(b)) return false;
+		const ak = Object.keys(a as Record<string, unknown>);
+		const bk = Object.keys(b as Record<string, unknown>);
+		if (ak.length !== bk.length) return false;
+		return ak.every((key) =>
+			key in (b as Record<string, unknown>)
+				? jsonValuesEqual(
+						(a as Record<string, unknown>)[key],
+						(b as Record<string, unknown>)[key],
+					)
+				: false,
+		);
+	}
+	return false;
+}
+
 /**
  * Intersects the constraints of multiple matching allow grants:
  * most-restrictive wins per key (min for numbers, set intersection for
@@ -381,11 +442,22 @@ export function intersectGrantConstraints(
 				continue;
 			}
 			if (Array.isArray(existing) && Array.isArray(value)) {
-				const set = new Set(existing.map(String));
-				merged[key] = value.filter((item) => set.has(String(item)));
+				// Type-preserving intersection: identical scalars collapse to
+				// one entry; non-scalar items make the combination
+				// incompatible rather than guessed at.
+				const seen = new Set(existing.filter(isScalarConstraintValue));
+				const kept: unknown[] = [];
+				for (const item of value) {
+					if (isScalarConstraintValue(item) && seen.has(item)) {
+						if (!kept.includes(item)) {
+							kept.push(item);
+						}
+					}
+				}
+				merged[key] = kept;
 				continue;
 			}
-			if (existing !== value) {
+			if (!jsonValuesEqual(existing, value)) {
 				return { ok: false };
 			}
 		}

--- a/packages/core/src/features/capabilities/types.ts
+++ b/packages/core/src/features/capabilities/types.ts
@@ -1,0 +1,403 @@
+/**
+ * Typed contract for the durable capability-grant subsystem (#23102): the
+ * versioned capability vocabulary, the grant record shape mirrored by
+ * `capabilities.capability_grants`, the canonical `authorizeCapability`
+ * request and decision (with audit id), and the fail-closed validation
+ * helpers that canonicalize subjects, selectors, and capabilities before
+ * they reach the store. Unknown or malformed input is rejected explicitly —
+ * never coerced into a healthy-looking default grant.
+ */
+
+import type { UUID } from "../../types/index.ts";
+
+/** Schema version of the capability vocabulary itself. */
+export const CAPABILITY_VOCABULARY_VERSION = 1;
+
+/** Canonical subject kinds understood by the grant store. */
+export const CAPABILITY_SUBJECT_KINDS = ["entity", "role", "world"] as const;
+
+export type CapabilitySubjectKind = (typeof CAPABILITY_SUBJECT_KINDS)[number];
+
+/** Grant effects; an explicit deny outranks any number of allows. */
+export const CAPABILITY_GRANT_EFFECTS = ["allow", "deny"] as const;
+
+export type CapabilityGrantEffect = (typeof CAPABILITY_GRANT_EFFECTS)[number];
+
+/** Where a grant may be issued from. */
+export const CAPABILITY_PROVENANCES = [
+	"api",
+	"natural-language",
+	"settings",
+] as const;
+
+export type CapabilityProvenance = (typeof CAPABILITY_PROVENANCES)[number];
+
+/** Machine-readable decision outcome. */
+export type CapabilityDecision = "allow" | "deny";
+
+/** Machine-readable reason codes carried on decisions and audit rows. */
+export const CAPABILITY_REASON_CODES = {
+	/** A live deny grant matched; it outranks every allow. */
+	DENY_GRANT_MATCHED: "DENY_GRANT_MATCHED",
+	/** A live allow grant matched. */
+	ALLOW_GRANT_MATCHED: "ALLOW_GRANT_MATCHED",
+	/** No live grant matched the subject × capability × resource. */
+	NO_MATCHING_GRANT: "NO_MATCHING_GRANT",
+	/** The request was malformed; evaluation could not proceed. */
+	INVALID_REQUEST: "INVALID_REQUEST",
+	/** Grant-store access failed; fail closed. */
+	STORE_UNAVAILABLE: "STORE_UNAVAILABLE",
+	/** Matching allow grants had incompatible constraints. */
+	INCOMPATIBLE_CONSTRAINTS: "INCOMPATIBLE_CONSTRAINTS",
+	/** A synthesized role-tier allow matched (composition hook). */
+	ROLE_TIER_MATCHED: "ROLE_TIER_MATCHED",
+	/** A role-tier resolver denied the request (composition hook). */
+	ROLE_TIER_DENIED: "ROLE_TIER_DENIED",
+} as const;
+
+export type CapabilityReasonCode =
+	(typeof CAPABILITY_REASON_CODES)[keyof typeof CAPABILITY_REASON_CODES];
+
+/**
+ * A durable capability grant as returned by the store. Field names mirror the
+ * `capabilities.capability_grants` columns so rows translate without renames.
+ */
+export interface CapabilityGrant {
+	id: UUID;
+	subject: string;
+	agentId: UUID;
+	worldId: UUID | null;
+	capability: string;
+	resourceSelector: string;
+	effect: CapabilityGrantEffect;
+	issuer: string;
+	issuedAt: Date;
+	expiresAt: Date | null;
+	revokedAt: Date | null;
+	revocationReason: string | null;
+	constraints: Record<string, unknown> | null;
+	provenance: CapabilityProvenance;
+	version: number;
+}
+
+/** Input for creating a grant; id/version are store-assigned. */
+export interface CreateCapabilityGrantInput {
+	subject: string;
+	agentId: UUID;
+	worldId?: UUID | null;
+	capability: string;
+	resourceSelector: string;
+	effect: CapabilityGrantEffect;
+	issuer: string;
+	expiresAt?: Date | null;
+	constraints?: Record<string, unknown> | null;
+	provenance: CapabilityProvenance;
+}
+
+/** Input for version-checked grant mutation. */
+export interface UpdateCapabilityGrantInput {
+	id: UUID;
+	/** Must equal the row's current version or the update is rejected. */
+	expectedVersion: number;
+	patch: {
+		expiresAt?: Date | null;
+		constraints?: Record<string, unknown> | null;
+	};
+}
+
+/**
+ * Resolves a canonical subject to the roles that apply for one evaluation.
+ * Slice 1 ships the hook so composition order is fixed and testable; role
+ * data itself is provided by the caller (trust feature / roles module in
+ * slice 2+).
+ */
+/** Roles held by the subject for this evaluation, if any. */
+export type CapabilityRoleResolver = (
+	subject: string,
+	context: { agentId: UUID; worldId?: UUID | null },
+) => Promise<string[] | null>;
+
+/**
+ * Canonical authorization request evaluated by `authorizeCapability`.
+ * `roleResolver` is the composition hook (RP Q3 gap 1): when provided, role
+ * tiers evaluate AFTER explicit grants, so a deny grant still wins over any
+ * role floor, and the decision names the layer that matched.
+ */
+export interface CapabilityAuthorizationRequest {
+	subject: string;
+	agentId: UUID;
+	worldId?: UUID | null;
+	capability: string;
+	resource: string;
+	/** Trusted clock override for tests; defaults to Date.now(). */
+	now?: number;
+	/** Optional role-tier composition hook (evaluated after grants). */
+	roleResolver?: CapabilityRoleResolver;
+}
+
+/** Canonical authorization decision returned by `authorizeCapability`. */
+export interface CapabilityAuthorizationResult {
+	decision: CapabilityDecision;
+	reasonCode: CapabilityReasonCode;
+	/** Human-readable explanation. */
+	reason: string;
+	/** Grant the decision matched; null when nothing matched. */
+	matchedGrantId: UUID | null;
+	/** Matched grant's effect, echoed for callers. */
+	effect: CapabilityGrantEffect | null;
+	/** Intersected constraints of every matching allow grant. */
+	constraints: Record<string, unknown>;
+	/** Nearest expiry across matching allows; null when none expire. */
+	expiresAt: Date | null;
+	/**
+	 * True when no grant matched and the capability is governed by an
+	 * approval flow; the request must then be re-run through that flow
+	 * instead of being treated as a plain denial.
+	 */
+	approvalRequired: boolean;
+	/** Audit-row id for this decision (every decision writes one). */
+	auditId: UUID;
+	/**
+	 * Evaluation layer that produced the decision, so one record names the
+	 * winning layer: 'deny-grant' | 'allow-grant' | 'role-tier' | 'invalid' |
+	 * 'no-match' | 'store-unavailable'.
+	 */
+	layer: string;
+}
+
+/** One enforcement-boundary row in the checked-in inventory. */
+export interface CapabilityBoundaryInventoryEntry {
+	/** Stable boundary id, e.g. `connector.message.send`. */
+	id: string;
+	/** Free-text description of what crossing this boundary does. */
+	description: string;
+	/** Enforcement status of this boundary in the current slice. */
+	status: "enforced" | "inventory-only" | "planned";
+	/** Where enforcement lives once wired; null until then. */
+	owner: string | null;
+}
+
+const UUID_PATTERN =
+	/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
+/**
+ * Validates and canonicalizes a subject string. Accepts `entity:<uuid>`,
+ * `role:<name>`, and `world:<uuid>`; rejects empty, unknown-kind, and
+ * malformed-uuid subjects. Returns an explicit invalid result instead of a
+ * default subject.
+ */
+export function canonicalizeCapabilitySubject(
+	value: unknown,
+): { ok: true; subject: string } | { ok: false; error: string } {
+	if (typeof value !== "string" || value.length === 0) {
+		return { ok: false, error: "subject must be a non-empty string" };
+	}
+	const separator = value.indexOf(":");
+	if (separator <= 0 || separator === value.length - 1) {
+		return {
+			ok: false,
+			error: `subject must be "<kind>:<id>", got ${JSON.stringify(value)}`,
+		};
+	}
+	const kind = value.slice(0, separator);
+	const id = value.slice(separator + 1);
+	if (!(CAPABILITY_SUBJECT_KINDS as readonly string[]).includes(kind)) {
+		return {
+			ok: false,
+			error: `unknown subject kind ${JSON.stringify(kind)} (expected one of ${CAPABILITY_SUBJECT_KINDS.join(", ")})`,
+		};
+	}
+	if (id.length === 0) {
+		return { ok: false, error: "subject id must be non-empty" };
+	}
+	if (kind === "entity" || kind === "world") {
+		if (!UUID_PATTERN.test(id)) {
+			return {
+				ok: false,
+				error: `subject id for kind "${kind}" must be a UUID, got ${JSON.stringify(id)}`,
+			};
+		}
+		return { ok: true, subject: `${kind}:${id.toLowerCase()}` };
+	}
+	if (!/^[a-z0-9-]+$/.test(id)) {
+		return {
+			ok: false,
+			error: `role subject id must be lowercase alphanumeric/dash, got ${JSON.stringify(id)}`,
+		};
+	}
+	return { ok: true, subject: value };
+}
+
+/**
+ * Validates a capability name: dot-separated lowercase segments, at least
+ * two segments, no wildcard anywhere.
+ */
+export function validateCapabilityName(
+	value: unknown,
+): { ok: true; capability: string } | { ok: false; error: string } {
+	if (typeof value !== "string" || value.length < 3) {
+		return {
+			ok: false,
+			error: "capability must be a string of at least 3 characters",
+		};
+	}
+	if (!/^[a-z0-9-]+(?:\.[a-z0-9-]+)+$/.test(value)) {
+		return {
+			ok: false,
+			error: `capability must be dot-separated lowercase segments (e.g. "connector.message.send"), got ${JSON.stringify(value)}`,
+		};
+	}
+	return { ok: true, capability: value };
+}
+
+/**
+ * Validates and canonicalizes a resource selector: `*`, an exact resource id
+ * (non-empty, no `*`, no leading/trailing/double slashes), or `<prefix>/*`
+ * matching the prefix's descendants. Validation runs at grant-creation time
+ * so malformed selectors are rejected by the write, not discovered at
+ * evaluation; rows that pre-date stricter validation are quarantined (never
+ * match, always audit) rather than trusted.
+ */
+export function canonicalizeResourceSelector(
+	value: unknown,
+): { ok: true; selector: string } | { ok: false; error: string } {
+	if (typeof value !== "string" || value.length === 0) {
+		return {
+			ok: false,
+			error: "resource selector must be a non-empty string",
+		};
+	}
+	if (value.length > 512) {
+		return {
+			ok: false,
+			error: `resource selector exceeds 512 characters, got ${value.length}`,
+		};
+	}
+	if (value === "*") {
+		return { ok: true, selector: "*" };
+	}
+	if (value.endsWith("/*")) {
+		const prefix = value.slice(0, -2);
+		if (
+			prefix.length === 0 ||
+			prefix.endsWith("/") ||
+			prefix.includes("*") ||
+			prefix.includes("//")
+		) {
+			return {
+				ok: false,
+				error: `wildcard selector prefix must be non-empty and slash-trimmed, got ${JSON.stringify(value)}`,
+			};
+		}
+		return { ok: true, selector: value };
+	}
+	if (value.includes("*")) {
+		return {
+			ok: false,
+			error: `selector wildcards are only allowed as a trailing "/*", got ${JSON.stringify(value)}`,
+		};
+	}
+	if (value.includes("//") || value.startsWith("/") || value.endsWith("/")) {
+		return {
+			ok: false,
+			error: `exact selectors must be slash-trimmed with non-empty segments, got ${JSON.stringify(value)}`,
+		};
+	}
+	return { ok: true, selector: value };
+}
+
+/**
+ * True when `selector` (already canonicalized) authorizes `resource`.
+ * `*` matches everything; `<prefix>/*` matches the prefix's descendants
+ * (the slash boundary is included in the prefix); otherwise the selector
+ * must equal the resource exactly.
+ */
+export function selectorMatchesResource(
+	selector: string,
+	resource: string,
+): boolean {
+	if (selector === "*") {
+		return true;
+	}
+	if (selector.endsWith("/*")) {
+		const prefix = selector.slice(0, -1); // keep the trailing slash
+		return resource.startsWith(prefix);
+	}
+	return selector === resource;
+}
+
+/** Validates a UUID-typed field without coercing. */
+export function isValidUuid(value: unknown): value is UUID {
+	return typeof value === "string" && UUID_PATTERN.test(value);
+}
+
+/** Parses a stored effect column value, failing closed on anything else. */
+export function parseCapabilityGrantEffect(
+	value: unknown,
+): CapabilityGrantEffect | null {
+	return (CAPABILITY_GRANT_EFFECTS as readonly string[]).includes(
+		value as string,
+	)
+		? (value as CapabilityGrantEffect)
+		: null;
+}
+
+/** Parses a stored provenance column value, failing closed on anything else. */
+export function parseCapabilityProvenance(
+	value: unknown,
+): CapabilityProvenance | null {
+	return (CAPABILITY_PROVENANCES as readonly string[]).includes(value as string)
+		? (value as CapabilityProvenance)
+		: null;
+}
+
+/**
+ * Intersects the constraints of multiple matching allow grants:
+ * most-restrictive wins per key (min for numbers, set intersection for
+ * arrays, exact equality for everything else). Returns null when two grants
+ * demand incompatible values for the same key — the decision must then deny
+ * (INCOMPATIBLE_CONSTRAINTS), never silently pick one.
+ */
+export function intersectGrantConstraints(
+	grants: Array<{ constraints: Record<string, unknown> | null }>,
+): { ok: true; constraints: Record<string, unknown> } | { ok: false } {
+	const merged: Record<string, unknown> = {};
+	for (const grant of grants) {
+		const constraints = grant.constraints;
+		if (!constraints) continue;
+		for (const [key, value] of Object.entries(constraints)) {
+			const existing = merged[key];
+			if (existing === undefined) {
+				merged[key] = value;
+				continue;
+			}
+			if (
+				typeof existing === "number" &&
+				typeof value === "number" &&
+				Number.isFinite(existing) &&
+				Number.isFinite(value)
+			) {
+				merged[key] = Math.min(existing, value);
+				continue;
+			}
+			if (Array.isArray(existing) && Array.isArray(value)) {
+				const set = new Set(existing.map(String));
+				merged[key] = value.filter((item) => set.has(String(item)));
+				continue;
+			}
+			if (existing !== value) {
+				return { ok: false };
+			}
+		}
+	}
+	return { ok: true, constraints: merged };
+}
+
+/** Truncates an audit resource id to the column cap, suffixing on cut. */
+export function truncateAuditResource(resource: string): string {
+	const MAX_AUDIT_RESOURCE = 512;
+	if (resource.length <= MAX_AUDIT_RESOURCE) {
+		return resource;
+	}
+	return `${resource.slice(0, MAX_AUDIT_RESOURCE - 3)}...`;
+}

--- a/packages/core/src/features/capabilities/types.ts
+++ b/packages/core/src/features/capabilities/types.ts
@@ -302,6 +302,7 @@ export function canonicalizeResourceSelector(
 		const prefix = value.slice(0, -2);
 		if (
 			prefix.length === 0 ||
+			prefix.startsWith("/") ||
 			prefix.endsWith("/") ||
 			prefix.includes("*") ||
 			prefix.includes("//")
@@ -442,16 +443,20 @@ export function intersectGrantConstraints(
 				continue;
 			}
 			if (Array.isArray(existing) && Array.isArray(value)) {
-				// Type-preserving intersection: identical scalars collapse to
-				// one entry; non-scalar items make the combination
-				// incompatible rather than guessed at.
-				const seen = new Set(existing.filter(isScalarConstraintValue));
+				// Type-preserving intersection of scalars only: any
+				// non-scalar member in EITHER array makes the combination
+				// incompatible (deny) — never silently dropped.
+				if (
+					existing.some((item) => !isScalarConstraintValue(item)) ||
+					value.some((item) => !isScalarConstraintValue(item))
+				) {
+					return { ok: false };
+				}
+				const seen = new Set(existing);
 				const kept: unknown[] = [];
 				for (const item of value) {
-					if (isScalarConstraintValue(item) && seen.has(item)) {
-						if (!kept.includes(item)) {
-							kept.push(item);
-						}
+					if (seen.has(item) && !kept.includes(item)) {
+						kept.push(item);
 					}
 				}
 				merged[key] = kept;

--- a/packages/core/src/index.node.ts
+++ b/packages/core/src/index.node.ts
@@ -128,6 +128,7 @@ export {
 } from "./features/autonomy";
 // Export capabilities and plugin creation
 export * from "./features/basic-capabilities/index";
+export * from "./features/capabilities/index.ts";
 export * from "./features/credential-proxy/index.ts";
 export * from "./features/documents/index";
 export type {


### PR DESCRIPTION
feat(core): durable per-principal capability grants, slice 1 (#23102)

## Summary

First implementation slice for #23102 per the issue's own slicing guidance: a durable subject × capability × resource grant store and the canonical fail-closed `authorizeCapability` decision path, in a new `packages/core/src/features/capabilities/` module. Storage lives in a dedicated `capabilities` Postgres schema, self-materialized through idempotent DDL on first store use (the TrajectoriesService pattern) because no registered plugin carries a schema-bearing entry — relying on plugin-schema migration would leave the tables uncreated in real deployments.

- **Typed, versioned vocabulary** (`types.ts`): canonical subjects (`entity:<uuid>`, `role:<name>`, `world:<uuid>`, case-folded), dot-separated lowercase capabilities, strict selector grammar (`*`, exact ids, trailing `/*` only — printable ASCII allowlist, no leading/trailing/double slashes, length cap). Malformed input is rejected at the write (error-policy J3); legacy rows that drift are quarantined — visible for management, never authoritative.
- **Store** (`CapabilityGrantStore.ts`): validated create, version-checked update, idempotent revoke — each mutation and its global `capability_epoch` bump commit in ONE transaction; a missing epoch singleton rolls the mutation back instead of fabricating progress. Uncapped live-grant reads filtered (expiry `> now`, non-revoked) in SQL. Concurrent-safe promise-memoized DDL bootstrap.
- **Decision path** (`authorizeCapability.ts`): fixed evaluation order — validate (fail closed) → explicit deny grants → allow grants (constraints intersected: numeric min, typed scalar array intersection, structural equality; incompatible → deny) → role-tier composition hook → deny `NO_MATCHING_GRANT` (no implicit allow). No decision cache, so revocation is effective before the next call returns by construction. Every decision attempts exactly one audit row (id generated up front); audit failures are reported through an injected `onAuditFailure` hook (J7; wire to `runtime.reportError` at the boundary) and can never block or flip a decision. Audit rows carry categorical/sanitized fields only — raw malformed values and driver errors never enter the log.
- **Enforcement inventory** (`capability-boundary-inventory.ts`): 12 privileged boundaries (message send/read, device, fs read/write, PTy, git, media read/write, provider invoke, admin API, coding environments) with per-boundary status; the shape is test-validated. Completeness against future repo boundaries is a human-review obligation until the slice-2 classifier.
- Exported node-only from `index.node.ts` (SQL-bound; browser/edge untouched).

## Test evidence

`bun run --cwd packages/core test` scope: **41/41 passing** real-PGlite tests in `CapabilityGrantStore.test.ts` (default vitest lane; PGlite disk data dirs, real Drizzle queries, no mocks of the system under test):

- Self-migration from an empty database; concurrent first calls share one bootstrap
- Restart survival: handle closed, fresh handle opened on the SAME disk dir — grants (and deny grants) created under the first handle remain authoritative; epoch identical
- Revocation visible to the very next decision; expiry boundary `expiresAt <= now` never matches
- Deny-wins over simultaneous allows and over the role tier; role tier never rescues a deny; broken resolver degrades to deny
- Fail-closed: malformed subject/capability/agentId/resource/worldId → `INVALID_REQUEST`; store down → `STORE_UNAVAILABLE`; no grant → `NO_MATCHING_GRANT`
- Audit: per-decision rows, categorical details (raw values withheld), 512-char resource truncation, failure reported through the hook, throwing reporter cannot abort any decision path
- Optimistic-version conflicts; partial unique index (world-aware via nil-uuid coalescing) blocks duplicate active policies and frees on revoke; identical policies legal in distinct worlds and alongside global
- Typed constraint intersection incl. non-scalar arrays → incompatible; nearest expiry across multiple allows
- Quarantine of legacy rows with malformed selector/issuer/capability/subject/effect/provenance
- Mutation rollback when the epoch singleton is missing (zero grant rows survive)
- Boundary inventory shape validation

Typecheck clean (`bun run --cwd packages/core typecheck`), Biome clean, `bun run --cwd packages/core build` succeeds and the built barrel exports `authorizeCapability` + store API (verified by import probe against the built output).

## Review evidence

Independently reviewed by a second agent (RepoPrompt CE, gpt-5.6-sol) over the full embedded diff across **5 rounds**: 16 must-fix findings raised, all fixed with direct test coverage — including removal of a 500-row live-grant cap that could break deny-wins, audit sanitization + injected failure reporting, selector charset grammar, transactional epoch bumps with rollback, promise-memoized concurrent migration, world-aware uniqueness, typed/structural constraint semantics, and forced-invocation reporter tests. Final round passed all six checklist areas; the sole residual (a header wording nit) is fixed in 87a4f61.

## Out of scope (follow-up slices, per the issue)

Boundary-by-boundary enforcement wiring, Settings UI explain surface, management API + natural-language grant path, approval flows, role→capability floor mapping, PostgreSQL-lane CI evidence, disposition of legacy in-memory elevations/delegations.

Closes #23102 (slice 1 of the tracked follow-ups).

<!-- evidence-head:d568ac18b13395e7d16aea063168d01e42c5b42e -->

<!-- evidence-row:backend-logs -->
- [x] <details><summary>Exact-head suite verification at e3178835cc (2026-09-01, lane A)</summary>

```text
$ bun test packages/core/src/features/capabilities/
 41 pass
 0 fail
 221 expect() calls
Ran 41 tests across 1 file. [4.41s]
```
The PR's new CapabilityGrantStore suite re-run at the current PR head (worktree eliza-rebase-28130, symlinked node_modules, core dist pre-built).</details>


<!-- evidence-row:before-screenshots -->
- [ ] N/A - core-only durable grant store + authorizeCapability decision path; no UI surface touched

<!-- evidence-row:after-screenshots -->
- [ ] N/A - core-only durable grant store + authorizeCapability decision path; no UI surface touched

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - backend-only change, no user-visible surface to demonstrate

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend package touched; packages/core only

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, provider, prompt, or trajectory-recording path changed; authorization store + decision logic only

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - boundary inventory checked in as real test (inventory shape validation, cited in body); no external domain artifact produced

AI provider/model: zai / glm-5.3
Client / agent tooling: Hermes Agent
Contribution skill revision: elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [hermes-t3rpz]
<!-- eliza-computer-attribution:v1 {"provider":"zai","model":"glm-5.3","client":"Hermes Agent","skill_revision":"elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza"} -->







