### PR TITLE
test(plugin-sql): cover connector credential store vault-ref semantics

### DIFF
--- a/plugins/plugin-sql/src/connector-credential-store.test.ts
+++ b/plugins/plugin-sql/src/connector-credential-store.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildConnectorCredentialVaultRef,
+  createConnectorCredentialStore,
+} from "./connector-credential-store";
+
+const baseParams = {
+  agentId: "a1b2c3",
+  provider: "gmail",
+  accountId: "acc-1",
+  credentialType: "oauth",
+} as const;
+
+describe("buildConnectorCredentialVaultRef", () => {
+  it("joins normalized segments with dots", () => {
+    expect(buildConnectorCredentialVaultRef(baseParams)).toBe("connector.a1b2c3.gmail.acc-1.oauth");
+  });
+
+  it("slugifies whitespace and non-alphanumeric characters per segment", () => {
+    expect(
+      buildConnectorCredentialVaultRef({
+        agentId: "agent id",
+        provider: "gmail/oauth",
+        accountId: "acc!1",
+        credentialType: "type",
+      })
+    ).toBe("connector.agent_id.gmail_oauth.acc_1.type");
+  });
+
+  it("trims leading and trailing underscores from segments", () => {
+    expect(
+      buildConnectorCredentialVaultRef({
+        agentId: "_agent_",
+        provider: "gmail",
+        accountId: "acc",
+        credentialType: "oauth",
+      })
+    ).toBe("connector.agent.gmail.acc.oauth");
+  });
+
+  it("falls back to 'unknown' for empty segments", () => {
+    expect(
+      buildConnectorCredentialVaultRef({
+        agentId: "   ",
+        provider: "gmail",
+        accountId: "acc",
+        credentialType: "oauth",
+      })
+    ).toBe("connector.unknown.gmail.acc.oauth");
+  });
+
+  it("caps each normalized segment at 64 characters", () => {
+    const long = "x".repeat(100);
+    const ref = buildConnectorCredentialVaultRef({
+      agentId: long,
+      provider: "gmail",
+      accountId: "acc",
+      credentialType: "oauth",
+    });
+    expect(ref.split(".")[1]).toBe("x".repeat(64));
+  });
+});
+
+describe("createConnectorCredentialStore", () => {
+  it("putSecret stores with sensitive flag and returns the built ref", async () => {
+    const set = vi.fn(async () => {});
+    const store = createConnectorCredentialStore({
+      set,
+      get: vi.fn(),
+      has: vi.fn(),
+      remove: vi.fn(),
+    });
+    const ref = await store.putSecret({ ...baseParams, value: "s3cret" });
+    expect(ref).toBe("connector.a1b2c3.gmail.acc-1.oauth");
+    expect(set).toHaveBeenCalledWith(ref, "s3cret", { sensitive: true });
+  });
+
+  it("putSecret forwards caller and honors an explicit vaultRef", async () => {
+    const set = vi.fn(async () => {});
+    const store = createConnectorCredentialStore({
+      set,
+      get: vi.fn(),
+      has: vi.fn(),
+      remove: vi.fn(),
+    });
+    const ref = await store.putSecret({
+      vaultRef: "custom.ref",
+      ...baseParams,
+      value: "v",
+      caller: "lifeops",
+    });
+    expect(ref).toBe("custom.ref");
+    expect(set).toHaveBeenCalledWith("custom.ref", "v", {
+      sensitive: true,
+      caller: "lifeops",
+    });
+  });
+
+  it("putReference rejects when the vault does not support references", async () => {
+    const store = createConnectorCredentialStore({
+      set: vi.fn(),
+      get: vi.fn(),
+      has: vi.fn(),
+      remove: vi.fn(),
+    });
+    await expect(
+      store.putReference({
+        ...baseParams,
+        reference: { source: "1password", path: "Vault/Item" },
+      })
+    ).rejects.toThrow("does not support password-manager references");
+  });
+
+  it("putReference delegates to vault.setReference and returns the ref", async () => {
+    const setReference = vi.fn(async () => {});
+    const store = createConnectorCredentialStore({
+      set: vi.fn(),
+      setReference,
+      get: vi.fn(),
+      has: vi.fn(),
+      remove: vi.fn(),
+    });
+    const reference = { source: "protonpass", path: "Work/Secrets" } as const;
+    const ref = await store.putReference({ ...baseParams, reference });
+    expect(ref).toBe("connector.a1b2c3.gmail.acc-1.oauth");
+    expect(setReference).toHaveBeenCalledWith(ref, reference);
+  });
+
+  it("get uses reveal(caller) when requested and supported", async () => {
+    const reveal = vi.fn(async () => "revealed");
+    const get = vi.fn(async () => "plain");
+    const store = createConnectorCredentialStore({
+      set: vi.fn(),
+      reveal,
+      get,
+      has: vi.fn(),
+      remove: vi.fn(),
+    });
+    await expect(store.get("ref", { reveal: true, caller: "admin" })).resolves.toBe("revealed");
+    expect(reveal).toHaveBeenCalledWith("ref", "admin");
+    expect(get).not.toHaveBeenCalled();
+  });
+
+  it("get falls back to plain get when reveal is unsupported or not requested", async () => {
+    const get = vi.fn(async () => "plain");
+    const store = createConnectorCredentialStore({
+      set: vi.fn(),
+      get,
+      has: vi.fn(),
+      remove: vi.fn(),
+    });
+    await expect(store.get("ref", { reveal: true })).resolves.toBe("plain");
+    await expect(store.get("ref")).resolves.toBe("plain");
+    expect(get).toHaveBeenCalledTimes(2);
+  });
+
+  it("has and remove delegate to the vault", async () => {
+    const has = vi.fn(async () => true);
+    const remove = vi.fn(async () => {});
+    const store = createConnectorCredentialStore({
+      set: vi.fn(),
+      get: vi.fn(),
+      has,
+      remove,
+    });
+    await expect(store.has("ref")).resolves.toBe(true);
+    await store.remove("ref");
+    expect(has).toHaveBeenCalledWith("ref");
+    expect(remove).toHaveBeenCalledWith("ref");
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new test file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `Test Files 1 passed (1) / Tests 12 passed (12)` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
