### PR TITLE
test(anthropic-proxy): cover status route sensitive-field redaction

### DIFF
--- a/plugins/plugin-anthropic-proxy/__tests__/status-route.test.ts
+++ b/plugins/plugin-anthropic-proxy/__tests__/status-route.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/services/proxy-service.js", () => ({
+  ANTHROPIC_PROXY_SERVICE_NAME: "anthropic_proxy_service",
+}));
+
+import { anthropicProxyRoutes } from "../src/routes/status-route";
+
+interface CapturedResponse {
+  statusCode: number;
+  body: unknown;
+}
+
+function mockResponse(): { res: Record<string, unknown>; captured: CapturedResponse } {
+  const captured: CapturedResponse = { statusCode: 0, body: undefined };
+  const res = {
+    status(code: number) {
+      captured.statusCode = code;
+      return {
+        json(body: unknown) {
+          captured.body = body;
+        },
+      };
+    },
+  };
+  return { res, captured };
+}
+
+function mockRuntime(service: unknown) {
+  return { getService: vi.fn(() => service) };
+}
+
+describe("anthropicProxyRoutes", () => {
+  it("declares the GET status route with raw path handling", () => {
+    expect(anthropicProxyRoutes).toHaveLength(1);
+    expect(anthropicProxyRoutes[0]).toMatchObject({
+      type: "GET",
+      path: "/api/anthropic-proxy/status",
+      rawPath: true,
+    });
+  });
+
+  it("returns 503 when the proxy service is not loaded", async () => {
+    const { res, captured } = mockResponse();
+    await anthropicProxyRoutes[0].handler({}, res, mockRuntime(null));
+    expect(captured.statusCode).toBe(503);
+    expect(captured.body).toEqual({ error: "AnthropicProxyService not loaded" });
+  });
+
+  it("returns 200 with the service status when loaded", async () => {
+    const { res, captured } = mockResponse();
+    const service = {
+      getStatus: vi.fn(async () => ({ mode: "relay", stats: null })),
+    };
+    await anthropicProxyRoutes[0].handler({}, res, mockRuntime(service));
+    expect(captured.statusCode).toBe(200);
+    expect(captured.body).toEqual({ mode: "relay", stats: null });
+  });
+
+  it("strips sensitive credential fields from stats on the health surface", async () => {
+    const { res, captured } = mockResponse();
+    const service = {
+      getStatus: vi.fn(async () => ({
+        mode: "direct",
+        upstream: "claude",
+        stats: {
+          tokensIn: 12,
+          tokensOut: 34,
+          credsPath: "/var/secrets/creds.json",
+          subscriptionType: "pro",
+        },
+      })),
+    };
+    await anthropicProxyRoutes[0].handler({}, res, mockRuntime(service));
+    expect(captured.statusCode).toBe(200);
+    const stats = (captured.body as { stats: Record<string, unknown> }).stats;
+    expect(stats.tokensIn).toBe(12);
+    expect(stats.tokensOut).toBe(34);
+    expect(stats.credsPath).toBeUndefined();
+    expect(stats.subscriptionType).toBeUndefined();
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing route module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new test file exercising the status route handler
with mocked runtime and service. No production code is modified, no runtime
behavior changes. The test asserts the handler's 503/200 branches and that
sensitive fields (`credsPath`, `subscriptionType`) are redacted from the
public health surface.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `Test Files 1 passed (1) / Tests 4 passed (4)` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
