### PR TITLE
test(plugin-personal-assistant): cover first-run replay defaults projection

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/first-run/replay.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/first-run/replay.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildReplayContext,
+  partialAnswersFromFacts,
+  relationshipsFallbackForReplay,
+} from "./replay";
+
+const fullFacts = {
+  preferredName: { value: "Alex", provenance: "owner" },
+  timezone: { value: "America/New_York", provenance: "owner" },
+  morningWindow: {
+    value: {
+      startLocal: "06:30",
+      endLocal: "10:00",
+      timezone: "America/New_York",
+    },
+    provenance: "owner",
+  },
+  eveningWindow: {
+    value: {
+      startLocal: "19:00",
+      endLocal: "23:00",
+      timezone: "America/New_York",
+    },
+    provenance: "owner",
+  },
+  preferredNotificationChannel: { value: "push", provenance: "owner" },
+};
+
+describe("partialAnswersFromFacts", () => {
+  it("projects every known fact into the partial answers shape", () => {
+    const partial = partialAnswersFromFacts(fullFacts);
+    expect(partial).toEqual({
+      preferredName: "Alex",
+      timezone: "America/New_York",
+      morningWindow: { startLocal: "06:30", endLocal: "10:00" },
+      eveningWindow: { startLocal: "19:00", endLocal: "23:00" },
+      channel: "push",
+    });
+  });
+
+  it("keeps missing facts missing instead of inventing defaults", () => {
+    const partial = partialAnswersFromFacts({});
+    expect(partial).toEqual({});
+    expect(partial.preferredName).toBeUndefined();
+    expect(partial.timezone).toBeUndefined();
+    expect(partial.morningWindow).toBeUndefined();
+    expect(partial.channel).toBeUndefined();
+  });
+
+  it("maps windows to local start/end only, dropping the timezone field", () => {
+    const partial = partialAnswersFromFacts({
+      morningWindow: fullFacts.morningWindow,
+    });
+    expect(partial.morningWindow).toEqual({
+      startLocal: "06:30",
+      endLocal: "10:00",
+    });
+    expect(partial.morningWindow?.timezone).toBeUndefined();
+  });
+
+  it("maps only the facts that are present in a sparse fact set", () => {
+    const partial = partialAnswersFromFacts({
+      preferredName: fullFacts.preferredName,
+      eveningWindow: fullFacts.eveningWindow,
+    });
+    expect(partial.preferredName).toBe("Alex");
+    expect(partial.eveningWindow).toEqual({
+      startLocal: "19:00",
+      endLocal: "23:00",
+    });
+    expect(partial.timezone).toBeUndefined();
+    expect(partial.channel).toBeUndefined();
+  });
+});
+
+describe("relationshipsFallbackForReplay", () => {
+  it("starts the relationship question as a fresh round", () => {
+    expect(relationshipsFallbackForReplay()).toEqual([]);
+  });
+});
+
+describe("buildReplayContext", () => {
+  it("surfaces current facts as the replay defaults payload", async () => {
+    const store = { read: vi.fn(async () => fullFacts) };
+    await expect(buildReplayContext(store)).resolves.toEqual({
+      currentFacts: fullFacts,
+    });
+    expect(store.read).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new test file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `Test Files 1 passed (1) / Tests 6 passed (6)` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
