### PR TITLE
test(plugin-personal-assistant): cover lifeops grounded reply wrapper defaults

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/voice/grounded-reply.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/voice/grounded-reply.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  renderGroundedActionReply: vi.fn(async () => "rewritten reply"),
+}));
+
+vi.mock("@elizaos/agent", () => ({
+  renderGroundedActionReply: mocks.renderGroundedActionReply,
+}));
+
+import { messageText, renderLifeOpsActionReply } from "./grounded-reply";
+
+const baseArgs = {
+  runtime: {},
+  message: { content: { text: "show my screen time" } },
+  state: undefined,
+  intent: "show my screen time",
+  scenario: "screen_time_summary",
+  fallback: "Here is your screen time summary.",
+};
+
+describe("renderLifeOpsActionReply", () => {
+  it("passes all args through with the lifeops domain and character voice defaults", async () => {
+    await renderLifeOpsActionReply({
+      ...baseArgs,
+      context: { totalSeconds: 3600 },
+      additionalRules: ["keep it short"],
+    });
+    expect(mocks.renderGroundedActionReply).toHaveBeenCalledWith({
+      runtime: baseArgs.runtime,
+      message: baseArgs.message,
+      state: baseArgs.state,
+      intent: baseArgs.intent,
+      domain: "lifeops",
+      scenario: baseArgs.scenario,
+      fallback: baseArgs.fallback,
+      context: { totalSeconds: 3600 },
+      additionalRules: ["keep it short"],
+      preferCharacterVoice: true,
+    });
+  });
+
+  it("defaults context and additionalRules to undefined when omitted", async () => {
+    await renderLifeOpsActionReply(baseArgs);
+    expect(mocks.renderGroundedActionReply).toHaveBeenCalledWith({
+      runtime: baseArgs.runtime,
+      message: baseArgs.message,
+      state: baseArgs.state,
+      intent: baseArgs.intent,
+      domain: "lifeops",
+      scenario: baseArgs.scenario,
+      fallback: baseArgs.fallback,
+      context: undefined,
+      additionalRules: undefined,
+      preferCharacterVoice: true,
+    });
+  });
+
+  it("returns whatever the underlying rewriter produces", async () => {
+    await expect(renderLifeOpsActionReply(baseArgs)).resolves.toBe(
+      "rewritten reply",
+    );
+  });
+});
+
+describe("messageText", () => {
+  it("returns the text verbatim for string content", () => {
+    expect(messageText({ content: { text: "hello" } })).toBe("hello");
+  });
+
+  it("returns an empty string when content text is missing", () => {
+    expect(messageText({ content: {} })).toBe("");
+  });
+
+  it("returns an empty string when content text is not a string", () => {
+    expect(messageText({ content: { text: 42 } })).toBe("");
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new test file exercising the existing wrapper
(with `@elizaos/agent` rewriter mocked) and the `messageText` coercion
helper. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `Test Files 1 passed (1) / Tests 6 passed (6)` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
