### PR TITLE
fix(plugin-x): keep UTF-16 surrogate pairs intact in message snippet and draft preview

### DIFF
--- a/plugins/plugin-x/src/lifeops-message-adapter.test.ts
+++ b/plugins/plugin-x/src/lifeops-message-adapter.test.ts
@@ -194,4 +194,24 @@ describe("XDmAdapter", () => {
 
     expect(sendDirectMessageForAccount).not.toHaveBeenCalled();
   });
+
+  it("preserves UTF-16 surrogate pairs when creating draft preview and snippet", async () => {
+    const emojis = "🎉".repeat(150); // 300 code units > 200
+    const adapter = new XDmAdapter();
+    const runtime = runtimeWithXService({});
+
+    const draft = await adapter.createDraft(runtime, {
+      to: [{ identifier: "recipient-1" }],
+      body: emojis,
+    });
+
+    expect(draft.preview.endsWith("...")).toBe(true);
+    for (const char of draft.preview) {
+      expect(
+        /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(
+          char,
+        ),
+      ).toBe(false);
+    }
+  });
 });

--- a/plugins/plugin-x/src/lifeops-message-adapter.ts
+++ b/plugins/plugin-x/src/lifeops-message-adapter.ts
@@ -63,6 +63,18 @@ function decodeDraftBody(encoded: string): string {
   return Buffer.from(encoded, "base64url").toString("utf8");
 }
 
+function truncateText(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  let end = maxChars;
+  if (end > 0 && end < text.length) {
+    const code = text.charCodeAt(end - 1);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      end -= 1;
+    }
+  }
+  return text.slice(0, end);
+}
+
 function memoryToMessageRef(memory: Memory): MessageRef {
   const metadata = record(memory.metadata);
   const content = record(memory.content);
@@ -89,7 +101,7 @@ function memoryToMessageRef(memory: Memory): MessageRef {
       displayName: senderHandle,
     },
     to: [],
-    snippet: body.slice(0, 200),
+    snippet: truncateText(body, 200),
     body,
     receivedAtMs: Number.isFinite(receivedAtMs) ? receivedAtMs : Date.now(),
     hasAttachments: false,
@@ -203,7 +215,7 @@ export class XDmAdapter extends BaseMessageAdapter {
     }
     const draftId = `twitter:${encodeURIComponent(recipient)}:${Date.now()}:${encodeDraftBody(draft.body)}`;
     const preview =
-      draft.body.length > 200 ? `${draft.body.slice(0, 197)}...` : draft.body;
+      draft.body.length > 200 ? `${truncateText(draft.body, 197)}...` : draft.body;
     return { draftId, preview };
   }
 


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:8874c8017914c52f76485effd84584a55b457f77 -->

## Summary
In `plugins/plugin-x/src/lifeops-message-adapter.ts`, `memoryToMessageRef` (`body.slice(0, 200)`) and `createDraft` (`draft.body.slice(0, 197)`) used raw string slicing on user direct message bodies, which can bisect multi-byte UTF-16 surrogate pairs (such as emojis or complex unicode characters) at the slice boundary, emitting corrupted surrogate characters (`\uFFFD`).

## Proposed Changes
1. Added surrogate-pair safe boundary truncation helper `truncateText`.
2. Applied `truncateText` to both snippet generation in `memoryToMessageRef` and draft preview generation in `createDraft`.
3. Added unit test in `src/lifeops-message-adapter.test.ts`.

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-x test src/lifeops-message-adapter.test.ts` (8/8 tests passed).

<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-3-5-sonnet","client":"antigravity","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
