### PR TITLE
test(plugin-personal-assistant): cover overdue followups threshold coercion and slicing

### DIFF
--- a/plugins/plugin-personal-assistant/src/followup/actions/listOverdueFollowups.test.ts
+++ b/plugins/plugin-personal-assistant/src/followup/actions/listOverdueFollowups.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  computeOverdueFollowups: vi.fn(),
+  FOLLOWUP_DEFAULT_THRESHOLD_DAYS: 30,
+}));
+
+vi.mock("../followup-tracker.js", () => ({
+  computeOverdueFollowups: mocks.computeOverdueFollowups,
+  FOLLOWUP_DEFAULT_THRESHOLD_DAYS: mocks.FOLLOWUP_DEFAULT_THRESHOLD_DAYS,
+}));
+
+import { listOverdueFollowupsAction } from "./listOverdueFollowups";
+
+const runtime = {};
+
+function overdueEntries(count: number) {
+  return Array.from({ length: count }, (_, i) => ({
+    displayName: `Contact ${i + 1}`,
+    lastContactedAt: "2026-07-01T10:00:00.000Z",
+    daysOverdue: i + 1,
+    thresholdDays: 30,
+  }));
+}
+
+function digest(overdue: unknown[]) {
+  return { generatedAt: "2026-08-01T00:00:00.000Z", overdue };
+}
+
+async function run(params: Record<string, unknown> | undefined) {
+  return listOverdueFollowupsAction.handler(
+    runtime,
+    {},
+    {},
+    {
+      parameters: params,
+    },
+  );
+}
+
+describe("listOverdueFollowupsAction", () => {
+  it("is an OWNER-gated read-only action", () => {
+    expect(listOverdueFollowupsAction.name).toBe("LIST_OVERDUE_FOLLOWUPS");
+    expect(listOverdueFollowupsAction.roleGate).toEqual({ minRole: "OWNER" });
+  });
+
+  it("uses the default threshold when no override is provided", async () => {
+    mocks.computeOverdueFollowups.mockResolvedValue(digest([]));
+    await run(undefined);
+    expect(mocks.computeOverdueFollowups).toHaveBeenCalledWith(
+      runtime,
+      expect.any(Number),
+      30,
+    );
+  });
+
+  it("accepts a numeric string threshold override", async () => {
+    mocks.computeOverdueFollowups.mockResolvedValue(digest([]));
+    await run({ thresholdDays: "7" });
+    expect(mocks.computeOverdueFollowups).toHaveBeenCalledWith(
+      runtime,
+      expect.any(Number),
+      7,
+    );
+  });
+
+  it("falls back to the default for zero, negative, and non-numeric thresholds", async () => {
+    mocks.computeOverdueFollowups.mockResolvedValue(digest([]));
+    for (const bad of ["0", "-3", "abc", "   ", 0]) {
+      await run({ thresholdDays: bad });
+      expect(mocks.computeOverdueFollowups).toHaveBeenLastCalledWith(
+        runtime,
+        expect.any(Number),
+        30,
+      );
+    }
+  });
+
+  it("reports when nothing is overdue", async () => {
+    mocks.computeOverdueFollowups.mockResolvedValue(digest([]));
+    const result = await run(undefined);
+    expect(result.success).toBe(true);
+    expect(result.text).toBe("No overdue follow-ups.");
+  });
+
+  it("formats one line per overdue contact", async () => {
+    mocks.computeOverdueFollowups.mockResolvedValue(
+      digest([
+        {
+          displayName: "Carol Patel",
+          lastContactedAt: "2026-06-01T09:00:00.000Z",
+          daysOverdue: 30,
+          thresholdDays: 30,
+        },
+      ]),
+    );
+    const result = await run(undefined);
+    expect(result.text).toBe(
+      "Carol Patel: last contacted 2026-06-01T09:00:00.000Z (+30d over 30d threshold)",
+    );
+    expect(result.data.digest.overdue).toHaveLength(1);
+  });
+
+  it("slices the overdue list when a limit override is provided", async () => {
+    mocks.computeOverdueFollowups.mockResolvedValue(digest(overdueEntries(3)));
+    const result = await run({ limit: "2" });
+    expect(
+      result.data.digest.overdue.map(
+        (e: { displayName: string }) => e.displayName,
+      ),
+    ).toEqual(["Contact 1", "Contact 2"]);
+  });
+
+  it("floors fractional limits", async () => {
+    mocks.computeOverdueFollowups.mockResolvedValue(digest(overdueEntries(3)));
+    const result = await run({ limit: "1.9" });
+    expect(result.data.digest.overdue).toHaveLength(1);
+  });
+
+  it("treats a zero or invalid limit as no limit", async () => {
+    mocks.computeOverdueFollowups.mockResolvedValue(digest(overdueEntries(3)));
+    const zero = await run({ limit: "0" });
+    expect(zero.data.digest.overdue).toHaveLength(3);
+    const invalid = await run({ limit: "nope" });
+    expect(invalid.data.digest.overdue).toHaveLength(3);
+  });
+
+  it("preserves the rest of the digest alongside the sliced overdue list", async () => {
+    mocks.computeOverdueFollowups.mockResolvedValue(digest(overdueEntries(2)));
+    const result = await run({ limit: "1" });
+    expect(result.data.digest.generatedAt).toBe("2026-08-01T00:00:00.000Z");
+    expect(result.data.digest.overdue).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing action module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new test file exercising the action handler with
the followup tracker mocked. No production code is modified, no runtime
behavior changes. The test pins threshold coercion (default fallback for
zero/negative/non-numeric), limit slicing, and output formatting.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `Test Files 1 passed (1) / Tests 10 passed (10)` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
