### PR TITLE
fix(plugin-google-workspace): keep UTF-16 surrogate pairs intact in message chunking and text clipping

### DIFF
--- a/plugins/plugin-google-workspace/src/chat/types.ts
+++ b/plugins/plugin-google-workspace/src/chat/types.ts
@@ -340,6 +340,13 @@ export function splitMessageForGoogleChat(
       }
     }
 
+    if (breakPoint > 0 && breakPoint < remaining.length) {
+      const code = remaining.charCodeAt(breakPoint - 1);
+      if (code >= 0xd800 && code <= 0xdbff) {
+        breakPoint -= 1;
+      }
+    }
+
     chunks.push(remaining.slice(0, breakPoint).trimEnd());
     remaining = remaining.slice(breakPoint).trimStart();
   }

--- a/plugins/plugin-google-workspace/src/gmail-message-connector.test.ts
+++ b/plugins/plugin-google-workspace/src/gmail-message-connector.test.ts
@@ -349,6 +349,34 @@ describe("gmail send handler", () => {
   });
 });
 
+
+  it("preserves UTF-16 surrogate pairs when deriving subject from long first line", async () => {
+    const { runtime, sendGmailMessage } = runtimeStub({
+      accounts: [CONNECTED_ACCOUNT],
+    });
+    const registration = createGmailMessageConnector(runtime);
+
+    const emojis = "🎉".repeat(100); // 200 code units > SUBJECT_MAX_LENGTH (120)
+    await invokeSend(
+      registration,
+      runtime,
+      { channelId: "shadow@example.com" },
+      { text: emojis }
+    );
+
+    expect(sendGmailMessage).toHaveBeenCalledTimes(1);
+    const callArg = sendGmailMessage.mock.calls[0][0];
+    const subject = callArg.subject;
+    expect(subject.endsWith("...")).toBe(true);
+    for (const char of subject) {
+      expect(
+        /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(
+          char,
+        ),
+      ).toBe(false);
+    }
+  });
+
 describe("isEmailAddress", () => {
   it("accepts literal addresses and rejects names/handles", () => {
     expect(isEmailAddress("shadow@example.com")).toBe(true);

--- a/plugins/plugin-google-workspace/src/gmail-message-connector.ts
+++ b/plugins/plugin-google-workspace/src/gmail-message-connector.ts
@@ -168,9 +168,17 @@ function subjectFromContent(content: Content): string {
   const firstLine = String(content.text ?? "")
     .split("\n", 1)[0]
     .trim();
-  return firstLine.length <= SUBJECT_MAX_LENGTH
-    ? firstLine
-    : `${firstLine.slice(0, SUBJECT_MAX_LENGTH - 3)}...`;
+  if (firstLine.length <= SUBJECT_MAX_LENGTH) {
+    return firstLine;
+  }
+  let end = SUBJECT_MAX_LENGTH - 3;
+  if (end > 0 && end < firstLine.length) {
+    const code = firstLine.charCodeAt(end - 1);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      end -= 1;
+    }
+  }
+  return `${firstLine.slice(0, end)}...`;
 }
 
 async function sendGmailFromTarget(

--- a/plugins/plugin-google-workspace/src/lifeops-message-adapter.ts
+++ b/plugins/plugin-google-workspace/src/lifeops-message-adapter.ts
@@ -46,7 +46,15 @@ interface GmailDraftContext {
 }
 
 function clip(value: string, maxLength: number): string {
-  return value.length > maxLength ? `${value.slice(0, maxLength - 3)}...` : value;
+  if (value.length <= maxLength) return value;
+  let end = maxLength - 3;
+  if (end > 0 && end < value.length) {
+    const code = value.charCodeAt(end - 1);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      end -= 1;
+    }
+  }
+  return `${value.slice(0, end)}...`;
 }
 
 function refId(messageId: string): string {


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:88692014c443c5738731a1058dfb01d886eee3fb -->

## Summary
In `plugins/plugin-google-workspace`:
1. `splitMessageForGoogleChat` in `src/chat/types.ts` used raw string slicing `remaining.slice(0, breakPoint)` without verifying if `breakPoint` landed between high and low surrogate code units.
2. `clip` in `src/lifeops-message-adapter.ts` and `subjectFromContent` in `src/gmail-message-connector.ts` used raw slicing `value.slice(0, maxLength - 3)` which could bisect surrogate pairs at the truncation boundary.

## Proposed Changes
1. Added surrogate-pair safe boundary back-off check to `splitMessageForGoogleChat`, `clip`, and `subjectFromContent`.
2. Added unit tests in `src/gmail-message-connector.test.ts`.

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-google-workspace test src/gmail-message-connector.test.ts` (13/13 tests passed).

<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-3-5-sonnet","client":"antigravity","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
