### PR TITLE
fix(plugin-documents): keep UTF-16 surrogate pairs intact in search hit snippet truncation

### DIFF
--- a/plugins/plugin-documents/src/components/documents/DocumentsView.test.tsx
+++ b/plugins/plugin-documents/src/components/documents/DocumentsView.test.tsx
@@ -258,3 +258,44 @@ describe("DocumentsView — open affordance", () => {
     expect(sendChatMessage).toHaveBeenCalledTimes(1);
   });
 });
+describe("DocumentsView — search hit snippet surrogate safety", () => {
+  it("renders search hit snippets without broken surrogate pairs", async () => {
+    const emojis = "📄".repeat(80); // 160 code units > 100
+    const fetchSearch = vi.fn(async (query: string) => ({
+      query,
+      threshold: 0.3,
+      results: [
+        {
+          id: "frag-1",
+          text: emojis,
+          similarity: 0.9,
+          documentId: "doc-1",
+          documentTitle: "Doc With Emojis",
+          position: 0,
+        },
+      ],
+      count: 1,
+    }));
+    render(
+      React.createElement(DocumentsView, {
+        fetchers: makeFetchers({ fetchSearch }),
+      }),
+    );
+    await screen.findByText("Quarterly Plan.md");
+
+    const input = agent("documents-search") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "emojis" } });
+
+    await screen.findByText("Results (1)");
+    const hitEl = screen.getByText(/…$/);
+    const snippetText = hitEl.textContent ?? "";
+    expect(snippetText.endsWith("…")).toBe(true);
+    for (const char of snippetText) {
+      expect(
+        /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(
+          char,
+        ),
+      ).toBe(false);
+    }
+  });
+});

--- a/plugins/plugin-documents/src/components/documents/DocumentsView.tsx
+++ b/plugins/plugin-documents/src/components/documents/DocumentsView.tsx
@@ -197,9 +197,16 @@ const SNIPPET_MAX = 100;
 
 function toHit(result: DocumentSearchResultWire): DocumentSearchHit {
   const trimmed = result.text.trim();
+  let end = SNIPPET_MAX - 1;
+  if (end > 0 && end < trimmed.length) {
+    const code = trimmed.charCodeAt(end - 1);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      end -= 1;
+    }
+  }
   const snippet =
     trimmed.length > SNIPPET_MAX
-      ? `${trimmed.slice(0, SNIPPET_MAX - 1)}…`
+      ? `${trimmed.slice(0, end)}…`
       : trimmed;
   return {
     id: result.id,


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:99f303eff3062077e87594c2dfb8ca8ededc19a2 -->

## Summary
In `plugins/plugin-documents/src/components/documents/DocumentsView.tsx`, `toHit` used raw string slicing `trimmed.slice(0, SNIPPET_MAX - 1)` when generating search result snippets for documents whose text exceeded `SNIPPET_MAX` (100 characters). This can bisect multi-byte UTF-16 surrogate pairs (e.g. emojis or complex characters) at index 99, creating orphaned surrogate characters (`\uFFFD`).

## Proposed Changes
1. Added surrogate-pair safe boundary back-off check before slicing in `toHit`.
2. Added unit test in `src/components/documents/DocumentsView.test.tsx`.

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-documents test src/components/documents/DocumentsView.test.tsx` (10/10 tests passed).

<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-3-5-sonnet","client":"antigravity","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
