### PR TITLE
fix(plugin-personal-assistant): keep UTF-16 surrogate pairs intact in policyProvenance note truncation

### DIFF
--- a/plugins/plugin-personal-assistant/src/actions/lib/owner-policy-surrogates.test.ts
+++ b/plugins/plugin-personal-assistant/src/actions/lib/owner-policy-surrogates.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+describe("owner policy writes surrogate safety", () => {
+  it("truncates policy intent note without bisecting surrogate pairs", () => {
+    function truncateText(text: string, maxChars: number): string {
+      if (text.length <= maxChars) return text;
+      let end = maxChars;
+      if (end > 0 && end < text.length) {
+        const code = text.charCodeAt(end - 1);
+        if (code >= 0xd800 && code <= 0xdbff) {
+          end -= 1;
+        }
+      }
+      return text.slice(0, end);
+    }
+
+    const emojis = "🛡️".repeat(100);
+    const result = truncateText(emojis, 201);
+    for (const char of result) {
+      expect(
+        /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(
+          char,
+        ),
+      ).toBe(false);
+    }
+  });
+});

--- a/plugins/plugin-personal-assistant/src/actions/lib/owner-policy-writes.ts
+++ b/plugins/plugin-personal-assistant/src/actions/lib/owner-policy-writes.ts
@@ -65,13 +65,25 @@ export interface OwnerPolicyConfigureEscalationInput {
   details?: OwnerPolicyDetails;
 }
 
+function truncateText(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  let end = maxChars;
+  if (end > 0 && end < text.length) {
+    const code = text.charCodeAt(end - 1);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      end -= 1;
+    }
+  }
+  return text.slice(0, end);
+}
+
 function policyProvenance(intent: string): OwnerFactProvenance {
   const provenance: OwnerFactProvenance = {
     source: "policy_action",
     recordedAt: new Date().toISOString(),
   };
   if (intent.length > 0) {
-    provenance.note = intent.slice(0, 200);
+    provenance.note = truncateText(intent, 200);
   }
   return provenance;
 }


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:b16002ce423d45b27979c3f06e62ffa4e5a7ddd0 -->

## Summary
In `plugins/plugin-personal-assistant/src/actions/lib/owner-policy-writes.ts`, `policyProvenance` used raw string slicing `intent.slice(0, 200)` to truncate intent descriptions attached as provenance notes. When the intent text contains multi-byte UTF-16 surrogate pairs (such as emojis or complex unicode characters), slicing at index 200 can split surrogate pairs, creating orphaned surrogate characters (`\uFFFD`).

## Proposed Changes
1. Added surrogate-pair safe boundary truncation helper `truncateText`.
2. Applied `truncateText` to `provenance.note` in `policyProvenance`.
3. Added unit test in `src/actions/lib/owner-policy-surrogates.test.ts`.

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-personal-assistant test src/actions/lib/owner-policy-surrogates.test.ts` (passed).

<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-3-5-sonnet","client":"antigravity","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
