### PR TITLE
fix(plugin-personal-assistant): keep UTF-16 surrogate pairs intact in approvalSafeLabel

### DIFF
--- a/plugins/plugin-personal-assistant/src/actions/calendar-label-surrogates.test.ts
+++ b/plugins/plugin-personal-assistant/src/actions/calendar-label-surrogates.test.ts
@@ -1,27 +1,19 @@
+/**
+ * Tests for calendar action approvalSafeLabel surrogate pair preservation.
+ */
+
 import { describe, expect, it } from "vitest";
+import { approvalSafeLabel } from "./calendar.ts";
 
 describe("approvalSafeLabel surrogate safety", () => {
   it("truncates approval labels without bisecting surrogate pairs", () => {
-    function approvalSafeLabel(value: string): string {
-      const sanitized = value
-        .replace(/[\r\n\t]+/g, " ")
-        .replace(/[[\]]/g, "")
-        .replace(/\s+/g, " ")
-        .trim();
-      if (sanitized.length <= 160) return sanitized;
-      let end = 160;
-      if (end > 0 && end < sanitized.length) {
-        const code = sanitized.charCodeAt(end - 1);
-        if (code >= 0xd800 && code <= 0xdbff) {
-          end -= 1;
-        }
-      }
-      return sanitized.slice(0, end);
-    }
+    // "x" (1 char) + "📅" (2 chars each * 120 = 240 chars).
+    // Index 160 lands right between high and low surrogate of the 80th emoji.
+    const bisectingInput = "x" + "📅".repeat(120);
+    const label = approvalSafeLabel(bisectingInput);
 
-    const emojis = "📅".repeat(100); // 200 code units > 160
-    const label = approvalSafeLabel(emojis);
-    expect(label.length).toBe(160);
+    // Backs off by 1 to avoid orphan high surrogate at index 159.
+    expect(label.length).toBe(159);
     for (const char of label) {
       expect(
         /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(
@@ -29,5 +21,12 @@ describe("approvalSafeLabel surrogate safety", () => {
         ),
       ).toBe(false);
     }
+  });
+
+  it("preserves non-bisecting unicode strings up to length limit", () => {
+    const input = "📅".repeat(80); // exactly 160 code units
+    const label = approvalSafeLabel(input);
+    expect(label.length).toBe(160);
+    expect(label).toBe(input);
   });
 });

--- a/plugins/plugin-personal-assistant/src/actions/calendar-label-surrogates.test.ts
+++ b/plugins/plugin-personal-assistant/src/actions/calendar-label-surrogates.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+describe("approvalSafeLabel surrogate safety", () => {
+  it("truncates approval labels without bisecting surrogate pairs", () => {
+    function approvalSafeLabel(value: string): string {
+      const sanitized = value
+        .replace(/[\r\n\t]+/g, " ")
+        .replace(/[[\]]/g, "")
+        .replace(/\s+/g, " ")
+        .trim();
+      if (sanitized.length <= 160) return sanitized;
+      let end = 160;
+      if (end > 0 && end < sanitized.length) {
+        const code = sanitized.charCodeAt(end - 1);
+        if (code >= 0xd800 && code <= 0xdbff) {
+          end -= 1;
+        }
+      }
+      return sanitized.slice(0, end);
+    }
+
+    const emojis = "📅".repeat(100); // 200 code units > 160
+    const label = approvalSafeLabel(emojis);
+    expect(label.length).toBe(160);
+    for (const char of label) {
+      expect(
+        /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(
+          char,
+        ),
+      ).toBe(false);
+    }
+  });
+});

--- a/plugins/plugin-personal-assistant/src/actions/calendar.ts
+++ b/plugins/plugin-personal-assistant/src/actions/calendar.ts
@@ -131,14 +131,21 @@ interface CalendarApprovalQueue {
 }
 
 function approvalSafeLabel(value: string): string {
-  return value
+  const sanitized = value
     .replace(/[\r\n\t]+/g, " ")
-    .replace(/[[\]]/g, "")
+    .replace(/[\[\]]/g, "")
     .replace(/\s+/g, " ")
-    .trim()
-    .slice(0, 160);
+    .trim();
+  if (sanitized.length <= 160) return sanitized;
+  let end = 160;
+  if (end > 0 && end < sanitized.length) {
+    const code = sanitized.charCodeAt(end - 1);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      end -= 1;
+    }
+  }
+  return sanitized.slice(0, end);
 }
-
 function requireApprovalMessageIdentity(message: Memory): {
   messageId: string;
   createdAt: number;

--- a/plugins/plugin-personal-assistant/src/actions/calendar.ts
+++ b/plugins/plugin-personal-assistant/src/actions/calendar.ts
@@ -130,7 +130,7 @@ interface CalendarApprovalQueue {
   ): Promise<ApprovalEnqueueResult>;
 }
 
-function approvalSafeLabel(value: string): string {
+export function approvalSafeLabel(value: string): string {
   const sanitized = value
     .replace(/[\r\n\t]+/g, " ")
     .replace(/[\[\]]/g, "")


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:e10a488ede55ce60d4aec44cef9f24d8826f9829 -->

## Summary
In `plugins/plugin-personal-assistant/src/actions/calendar.ts`, `approvalSafeLabel` used raw string slicing `.slice(0, 160)` on sanitized calendar approval descriptions. Slicing at index 160 can bisect multi-byte UTF-16 surrogate pairs (e.g. emojis in event descriptions), producing orphaned surrogate characters (`\uFFFD`).

## Proposed Changes
1. Added surrogate-pair safe boundary back-off check before slicing in `approvalSafeLabel`.
2. Added unit test in `src/actions/calendar-label-surrogates.test.ts`.

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-personal-assistant test src/actions/calendar-label-surrogates.test.ts` (passed).

<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-3-5-sonnet","client":"antigravity","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
