### PR TITLE
fix(plugin-browser): keep UTF-16 surrogate pairs intact in autofill fillReason truncation

### DIFF
--- a/plugins/plugin-browser/src/actions/browser-autofill-login.test.ts
+++ b/plugins/plugin-browser/src/actions/browser-autofill-login.test.ts
@@ -126,4 +126,28 @@ describe("executeBrowserAutofillLogin", () => {
     expect(result.text).toContain("Filled login on example.com");
     expect(JSON.stringify(result)).not.toContain("vault-password");
   });
+
+  it("truncates fillReason without bisecting surrogate pairs", async () => {
+    const emojis = "🔐".repeat(200); // 400 code units > 256
+    mocks.evaluateBrowserWorkspaceTab.mockResolvedValue({
+      ok: false,
+      reason: emojis,
+    });
+
+    const result = await executeBrowserAutofillLogin({} as never, undefined, {
+      parameters: { domain: "example.com", username: "alice" },
+    } as never);
+
+    expect(result.success).toBe(false);
+    expect(result.data).toBeDefined();
+    const data = result.data as { fillReason?: string | null };
+    expect(data.fillReason).toBeDefined();
+    for (const char of data.fillReason ?? "") {
+      expect(
+        /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(
+          char,
+        ),
+      ).toBe(false);
+    }
+  });
 });

--- a/plugins/plugin-browser/src/actions/browser-autofill-login.ts
+++ b/plugins/plugin-browser/src/actions/browser-autofill-login.ts
@@ -161,6 +161,18 @@ function buildAutofillScript(args: {
 `;
 }
 
+function truncateText(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  let end = maxChars;
+  if (end > 0 && end < text.length) {
+    const code = text.charCodeAt(end - 1);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      end -= 1;
+    }
+  }
+  return text.slice(0, end);
+}
+
 function narrowSnippetResult(raw: unknown): {
   filled: boolean;
   fillReason: string | null;
@@ -176,7 +188,7 @@ function narrowSnippetResult(raw: unknown): {
   let fillReason: string | null = null;
   const reasonVal = "reason" in obj ? obj.reason : undefined;
   if (typeof reasonVal === "string") {
-    fillReason = reasonVal.slice(0, MAX_FILL_REASON_CHARS);
+    fillReason = truncateText(reasonVal, MAX_FILL_REASON_CHARS);
   }
   return { filled, fillReason };
 }


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:c5463d5e4f95b696ab99c1728c823607baf60e80 -->

## Summary
In `plugins/plugin-browser/src/actions/browser-autofill-login.ts`, `narrowSnippetResult` used raw string slicing `reasonVal.slice(0, MAX_FILL_REASON_CHARS)` to truncate autofill failure reasons returned from evaluated tabs. When the reason message contains multi-byte UTF-16 surrogate pairs (such as emojis or complex characters), slicing at index `MAX_FILL_REASON_CHARS` can bisect surrogate pairs, generating orphaned surrogate characters (`\uFFFD`).

## Proposed Changes
1. Added surrogate-pair safe boundary truncation helper `truncateText`.
2. Applied `truncateText` to `reasonVal` in `narrowSnippetResult`.
3. Added unit test in `src/actions/browser-autofill-login.test.ts`.

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-browser test src/actions/browser-autofill-login.test.ts` (7/7 passed).

<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-3-5-sonnet","client":"antigravity","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
