### PR TITLE
fix(plugin-browser): keep UTF-16 surrogate pairs intact in message adapter summarizePage

### DIFF
--- a/plugins/plugin-browser/src/message-adapter.test.ts
+++ b/plugins/plugin-browser/src/message-adapter.test.ts
@@ -83,4 +83,45 @@ describe("BrowserBridgeAdapter", () => {
       }),
     ).resolves.toEqual([]);
   });
+
+  it("summarizes pages with surrogate pairs safely", async () => {
+    const emojis = "📄".repeat(300); // 600 code units > 500
+    const page = {
+      id: "page-surrogate",
+      agentId: "agent-1",
+      browser: "chrome",
+      profileId: "default",
+      windowId: "window-1",
+      tabId: "tab-1",
+      url: "https://example.com/emojis",
+      title: "Emoji Article",
+      selectionText: null,
+      mainText: emojis,
+      headings: ["Example"],
+      links: [],
+      forms: [],
+      capturedAt: "2026-06-02T12:00:00.000Z",
+      metadata: {},
+    };
+    const routeService = {
+      getCurrentBrowserPage: vi.fn(async () => page),
+    };
+    const runtime = {
+      agentId: "agent-1",
+      getService: vi.fn(() => routeService),
+    } as unknown as IAgentRuntime;
+    const adapter = new BrowserBridgeAdapter();
+
+    const messages = await adapter.listMessages(runtime, { limit: 5 });
+    expect(messages).toHaveLength(1);
+    const snippet = messages[0].snippet;
+    expect(snippet.endsWith("...")).toBe(true);
+    for (const char of snippet) {
+      expect(
+        /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(
+          char,
+        ),
+      ).toBe(false);
+    }
+  });
 });

--- a/plugins/plugin-browser/src/message-adapter.ts
+++ b/plugins/plugin-browser/src/message-adapter.ts
@@ -43,13 +43,25 @@ function browserPageMessageId(page: BrowserBridgePageContext): string {
   ].join(":");
 }
 
+function truncateText(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  let end = maxChars;
+  if (end > 0 && end < text.length) {
+    const code = text.charCodeAt(end - 1);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      end -= 1;
+    }
+  }
+  return text.slice(0, end);
+}
+
 function summarizePage(page: BrowserBridgePageContext): string {
   const text =
     page.selectionText?.trim() ||
     page.mainText?.trim() ||
     page.title.trim() ||
     page.url;
-  return text.length > 500 ? `${text.slice(0, 497)}...` : text;
+  return text.length > 500 ? `${truncateText(text, 497)}...` : text;
 }
 
 function pageToMessageRef(page: BrowserBridgePageContext): MessageRef {


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:f33da7179fcee2f4ba58f4dcf52c67d86d0e6f41 -->

## Summary
In `plugins/plugin-browser/src/message-adapter.ts`, `summarizePage` used raw string slicing `text.slice(0, 497)` when generating triage snippet summaries for pages whose text exceeded 500 characters. Slicing at index 497 can bisect multi-byte UTF-16 surrogate pairs (such as emojis or complex unicode), generating orphaned surrogate characters (`\uFFFD`).

## Proposed Changes
1. Added surrogate-pair safe boundary truncation helper `truncateText`.
2. Applied `truncateText` to `text` in `summarizePage`.
3. Added unit test in `src/message-adapter.test.ts`.

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-browser test src/message-adapter.test.ts` (3/3 passed).

<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-3-5-sonnet","client":"antigravity","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
