### PR TITLE
fix(plugin-app-manager): gate relaunch behind OWNER/ADMIN role check (#28144)

### DIFF
--- a/plugins/plugin-app-manager/src/api/apps-routes.test.ts
+++ b/plugins/plugin-app-manager/src/api/apps-routes.test.ts
@@ -293,6 +293,49 @@ describe("handleAppsRoutes", () => {
     },
   );
 
+  it.each([undefined, null, "USER", "GUEST"] as const)(
+    "denies %s actor for relaunch before stop or launch",
+    async (actorRole) => {
+      const appManager = createAppManager();
+
+      const result = await callRoute({
+        method: "POST",
+        pathname: "/api/apps/relaunch",
+        appManager,
+        actorRole,
+        body: { name: "@elizaos/plugin-demo" },
+      });
+
+      expect(result.handled).toBe(true);
+      expect(result.res.status).toBe(403);
+      expect(result.res.body).toEqual({
+        error: "App launch requires OWNER or ADMIN role",
+      });
+      expect(appManager.stop).not.toHaveBeenCalled();
+      expect(appManager.launch).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(["OWNER", "ADMIN"] as const)(
+    "allows %s actor to relaunch apps",
+    async (actorRole) => {
+      const appManager = createAppManager();
+
+      const result = await callRoute({
+        method: "POST",
+        pathname: "/api/apps/relaunch",
+        appManager,
+        actorRole,
+        body: { name: "@elizaos/plugin-demo" },
+      });
+
+      expect(result.handled).toBe(true);
+      expect(result.res.status).toBe(200);
+      expect(appManager.stop).toHaveBeenCalledTimes(1);
+      expect(appManager.launch).toHaveBeenCalledTimes(1);
+    },
+  );
+
   it("rejects illegal percent-encoding in app path segments before service calls", async () => {
     const appManager = createAppManager();
     const refreshRegistry = vi.fn(async () => new Map());

--- a/plugins/plugin-app-manager/src/api/apps-routes.ts
+++ b/plugins/plugin-app-manager/src/api/apps-routes.ts
@@ -1441,6 +1441,10 @@ export async function handleAppsRoutes(
   // -------------------------------------------------------------------------
 
   if (method === "POST" && pathname === "/api/apps/relaunch") {
+    if (!canLaunchApps(actorRole)) {
+      error(res, "App launch requires OWNER or ADMIN role", 403);
+      return true;
+    }
     const rawBody = await readJsonBody<Record<string, unknown>>(req, res);
     if (rawBody === null) return true;
     const parsed = PostRelaunchAppRequestSchema.safeParse(rawBody);


### PR DESCRIPTION
# Relates to

Closes #28144

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Single 3-line guard added to one route handler in `plugins/plugin-app-manager/src/api/apps-routes.ts`, mirroring the existing `canLaunchApps` check on `POST /api/apps/launch`. No new dependencies, no schema change, no migration. The change is deny-by-default: only OWNER/ADMIN were previously allowed via launch; relaunch now matches that contract. Positive path (OWNER/ADMIN) still invokes `stop`+`launch` identically. Risk of regression is isolated to relaunch callers that were previously relying on the missing guard (i.e., exploiting the escalation) — those callers will now correctly receive 403.

# Background

## What does this PR do?

Gates `POST /api/apps/relaunch` behind the same `canLaunchApps(actorRole)` check (OWNER or ADMIN only) that `POST /api/apps/launch` already enforces. Before this fix, relaunch called `appManager.stop()` then `appManager.launch()` with no role check, so any principal that cleared the outer auth gate (e.g., USER/GUEST via `resolveBoundaryRole`) could launch/replace arbitrary apps. After the fix, USER/GUEST/unauthenticated callers receive 403 `"App launch requires OWNER or ADMIN role"` and neither `stop` nor `launch` is invoked.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`plugins/plugin-app-manager/src/api/apps-routes.test.ts` — new `it.each` blocks for relaunch (mirroring launch). `plugins/plugin-app-manager/src/api/apps-routes.ts:1444` — the 3-line guard.

## Detailed testing steps

- `bun run --cwd plugins/plugin-app-manager test --run src/api/apps-routes.test.ts` — 22 tests, 6 new (4 denies + 2 allows for relaunch), all green on this branch, 4 red on `origin/develop` with the new tests (see Evidence).
- `bun run --cwd plugins/plugin-app-manager test` — full suite: 4 files, 42 tests green.
- `bunx @biomejs/biome check plugins/plugin-app-manager/src/api/apps-routes.ts plugins/plugin-app-manager/src/api/apps-routes.test.ts` — clean.
- `bun run --cwd plugins/plugin-app-manager typecheck` — clean.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:a5d7630d42b3b3f20bc0f54a5fd27b87eaf54954 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - non-UI server route change with no rendered surface
<!-- evidence-row:after-screenshots -->
- [ ] N/A - non-UI server route change with no rendered surface
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - non-UI change with no user flow to record
<!-- evidence-row:backend-logs -->
- [ ] N/A - see Evidence Details for red->green vitest logs with full probe output
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend surface for this server route
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no LLM trajectory for this server route fix
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no domain artifacts for this authorization guard
<!-- evidence-row:ocr-review -->
- [ ] N/A - non-UI change with no rendered surface to OCR

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM path.

## Backend + frontend logs

<details><summary>RED — new tests on buggy <code>origin/develop</code> (before fix): 4 failed | 18 passed</summary>

```
$ vitest run --config vitest.config.ts --run src/api/apps-routes.test.ts

 RUN  v4.1.10 /Users/naynaingoo/Downloads/eliza-develop/plugins/plugin-app-manager

 ❯ src/api/apps-routes.test.ts (22 tests | 4 failed) 59ms
     × denies undefined actor for relaunch before stop or launch 3ms
     × denies null actor for relaunch before stop or launch 0ms
     × denies USER actor for relaunch before stop or launch 0ms
     × denies GUEST actor for relaunch before stop or launch 0ms

 FAIL  src/api/apps-routes.test.ts > handleAppsRoutes > denies undefined actor for relaunch before stop or launch
AssertionError: expected 200 to be 403 // Object.is equality
- Expected 403
+ Received 200
 ❯ src/api/apps-routes.test.ts:310:33
      expect(result.res.status).toBe(403);

 Test Files  1 failed (1)
      Tests  4 failed | 18 passed (22)
   Duration  3.40s
```

Verbatim status probes (before fix): each denied actor returned `status=200, launchCalled=1` — the escalation.

</details>

<details><summary>GREEN — after fix (this branch): 22 passed</summary>

```
$ vitest run --config vitest.config.ts --run src/api/apps-routes.test.ts

 RUN  v4.1.10 /Users/naynaingoo/Downloads/eliza-develop/plugins/plugin-app-manager

 Test Files  1 passed (1)
      Tests  22 passed (22)
   Duration  3.31s
```

Full package suite also green:

```
$ vitest run --config vitest.config.ts

 Test Files  4 passed (4)
      Tests  42 passed (42)
   Duration  3.75s
```

</details>

Biome: `Checked 1 file in 51ms. No fixes applied.` for both changed files.
Typecheck: `bun run --cwd plugins/plugin-app-manager typecheck` — clean (no output, exit 0).

## Screenshots (before / after) + video walkthrough

N/A - non-UI change.

### Before

N/A - non-UI change.

### After

N/A - non-UI change.

### Walkthrough video

N/A - non-UI change.

## Audio / voice walkthrough

N/A - no audio/voice path.

## Known gaps / failures

None for this scope. `bun run verify` not run in full (turbo-wide) due to shared checkout time; scoped gates (`typecheck`, `biome check`, `bun run --cwd plugins/plugin-app-manager test`) are green and `git diff --check` is clean. Rebase is conflict-free on `089984beb3`.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`



