### PR TITLE
fix(orchestrator): gate aggregate task completion

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/__tests__/aggregate-completion-barrier.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/aggregate-completion-barrier.test.ts
@@ -1,0 +1,477 @@
+/**
+ * Exercises the durable aggregate-completion barrier through the real task
+ * service and in-memory store. ACP transport is deterministic: it records
+ * coordinator-review prompts and can inject delivery failures, while every
+ * task/session transition remains production code.
+ */
+
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { AcpService } from "../services/acp-service.js";
+import { OrchestratorTaskService } from "../services/orchestrator-task-service.js";
+import { OrchestratorTaskStore } from "../services/orchestrator-task-store.js";
+import type {
+  OrchestratorTaskSession,
+  TaskCompletionRole,
+} from "../services/orchestrator-task-types.js";
+
+type EventHandler = (
+  sessionId: string,
+  event: string,
+  data: unknown,
+  sessionSnapshot?: Record<string, unknown>,
+) => void | Promise<void>;
+
+class BarrierAcp {
+  private handler: EventHandler | undefined;
+  readonly sent: Array<{ sessionId: string; text: string }> = [];
+  deliveryError: Error | undefined;
+  emitCoordinatorCompletionOnSend = false;
+
+  onSessionEvent(handler: EventHandler): () => void {
+    this.handler = handler;
+    return () => {
+      this.handler = undefined;
+    };
+  }
+
+  async sendToSession(sessionId: string, text: string): Promise<object> {
+    if (this.deliveryError) throw this.deliveryError;
+    this.sent.push({ sessionId, text });
+    if (this.emitCoordinatorCompletionOnSend) {
+      void this.handler?.(sessionId, "task_complete", {
+        response: "reviewed receipts and verified aggregate work",
+      });
+    }
+    return { stopReason: "end_turn", finalText: "reviewed" };
+  }
+
+  getOrchestratorOwnedArtifacts(): [] {
+    return [];
+  }
+
+  async emit(sessionId: string, event: string, data: unknown): Promise<void> {
+    await this.handler?.(sessionId, event, data);
+  }
+
+  async emitSuccessor(
+    sessionId: string,
+    event: string,
+    data: unknown,
+    metadata: Record<string, unknown>,
+  ): Promise<void> {
+    await this.handler?.(sessionId, event, data, {
+      id: sessionId,
+      agentType: "elizaos",
+      workdir: process.cwd(),
+      status: "ready",
+      metadata,
+    });
+  }
+}
+
+const previousAutoVerify = process.env.ELIZA_ORCHESTRATOR_AUTO_GOAL_VERIFY;
+const previousResiduals = process.env.ELIZA_ORCHESTRATOR_RESIDUALS_GATE;
+
+beforeAll(() => {
+  process.env.ELIZA_ORCHESTRATOR_AUTO_GOAL_VERIFY = "0";
+  process.env.ELIZA_ORCHESTRATOR_RESIDUALS_GATE = "0";
+});
+
+afterAll(() => {
+  if (previousAutoVerify === undefined) {
+    delete process.env.ELIZA_ORCHESTRATOR_AUTO_GOAL_VERIFY;
+  } else {
+    process.env.ELIZA_ORCHESTRATOR_AUTO_GOAL_VERIFY = previousAutoVerify;
+  }
+  if (previousResiduals === undefined) {
+    delete process.env.ELIZA_ORCHESTRATOR_RESIDUALS_GATE;
+  } else {
+    process.env.ELIZA_ORCHESTRATOR_RESIDUALS_GATE = previousResiduals;
+  }
+});
+
+function runtime(acp: BarrierAcp) {
+  return {
+    character: { name: "Coordinator" },
+    logger: {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
+    reportError: vi.fn(),
+    getSetting: () => undefined,
+    getService: (type: string) =>
+      type === AcpService.serviceType ? acp : undefined,
+    useModel: vi.fn(async () => "{}"),
+  };
+}
+
+function session(input: {
+  taskId: string;
+  sessionId: string;
+  role?: TaskCompletionRole;
+  parentSessionId?: string;
+  required?: boolean;
+}): OrchestratorTaskSession {
+  const now = Date.now();
+  return {
+    id: `row-${input.sessionId}`,
+    taskId: input.taskId,
+    sessionId: input.sessionId,
+    framework: "elizaos",
+    label: input.sessionId,
+    originalTask: "finish the aggregate goal",
+    workdir: process.cwd(),
+    status: "ready",
+    decisionCount: 0,
+    autoResolvedCount: 0,
+    registeredAt: now,
+    lastActivityAt: now,
+    idleCheckCount: 0,
+    taskDelivered: false,
+    lastSeenDecisionIndex: 0,
+    spawnedAt: now,
+    retryCount: 0,
+    inputTokens: 0,
+    outputTokens: 0,
+    reasoningTokens: 0,
+    cacheTokens: 0,
+    costUsd: 0,
+    usageState: "unavailable",
+    ...(input.role ? { completionRole: input.role } : {}),
+    ...(input.parentSessionId
+      ? { parentSessionId: input.parentSessionId }
+      : {}),
+    ...(input.required === undefined
+      ? {}
+      : { requiredForTaskCompletion: input.required }),
+    metadata: {},
+    createdAt: new Date(now).toISOString(),
+    updatedAt: new Date(now).toISOString(),
+  };
+}
+
+async function harness(options: { legacySingle?: boolean } = {}) {
+  const acp = new BarrierAcp();
+  const store = new OrchestratorTaskStore({ backend: "memory" });
+  const created = await store.createTask({
+    title: "aggregate completion",
+    goal: "finish the aggregate goal",
+    acceptanceCriteria: [],
+  });
+  const taskId = created.task.id;
+  await store.addSession(
+    session({
+      taskId,
+      sessionId: "coordinator",
+      ...(options.legacySingle ? {} : { role: "coordinator", required: false }),
+    }),
+  );
+  if (!options.legacySingle) {
+    await store.addSession(
+      session({
+        taskId,
+        sessionId: "contributor",
+        role: "contributor",
+        parentSessionId: "coordinator",
+        required: true,
+      }),
+    );
+    await store.updateTask(taskId, {
+      completionCoordinatorSessionId: "coordinator",
+    });
+  }
+  await store.updateTask(taskId, { status: "active" });
+  const service = new OrchestratorTaskService(runtime(acp) as never, { store });
+  await service.start();
+  return { acp, store, service, taskId };
+}
+
+describe("aggregate completion barrier", () => {
+  it("keeps contributor-first evidence provisional", async () => {
+    const h = await harness();
+    await h.acp.emit("contributor", "task_complete", {
+      response: "contributor result in full",
+    });
+    const doc = await h.store.getTask(h.taskId);
+    expect(doc?.task.status).toBe("active");
+    expect(h.acp.sent).toEqual([]);
+    await h.service.stop();
+  });
+
+  it("waits when the coordinator completes while a required child is busy", async () => {
+    const h = await harness();
+    await h.acp.emit("coordinator", "task_complete", {
+      response: "my part is done",
+    });
+    const doc = await h.store.getTask(h.taskId);
+    expect(doc?.task.status).toBe("active");
+    expect(
+      doc?.sessions.find((row) => row.sessionId === "coordinator")
+        ?.aggregateCompletionRequestedAt,
+    ).toBeTruthy();
+    expect(h.acp.sent).toEqual([]);
+    await h.service.stop();
+  });
+
+  it("delivers the final contributor receipt and requires a second coordinator completion", async () => {
+    const h = await harness();
+    await h.acp.emit("coordinator", "task_complete", {
+      response: "my part is done",
+    });
+    await h.acp.emit("contributor", "task_complete", {
+      response: "full child result",
+    });
+    await vi.waitFor(() => expect(h.acp.sent).toHaveLength(1));
+    expect(h.acp.sent[0]).toMatchObject({ sessionId: "coordinator" });
+    expect(h.acp.sent[0]?.text).toContain("full child result");
+    expect((await h.store.getTask(h.taskId))?.task.status).toBe("active");
+
+    await h.acp.emit("coordinator", "task_complete", {
+      response: "reviewed and aggregate verified",
+    });
+    await vi.waitFor(async () => {
+      expect((await h.store.getTask(h.taskId))?.task.status).toBe("validating");
+    });
+    const final = await h.store.getTask(h.taskId);
+    expect(
+      final?.sessions.find((row) => row.sessionId === "contributor")
+        ?.contributionReviewedAt,
+    ).toBeTruthy();
+    await h.service.stop();
+  });
+
+  it("serializes simultaneous sibling completions and sends one review", async () => {
+    const h = await harness();
+    await Promise.all([
+      h.acp.emit("coordinator", "task_complete", { response: "coord" }),
+      h.acp.emit("contributor", "task_complete", { response: "child" }),
+    ]);
+    await vi.waitFor(() => expect(h.acp.sent).toHaveLength(1));
+    expect((await h.store.getTask(h.taskId))?.task.status).toBe("active");
+    await h.service.stop();
+  });
+
+  it("authorizes the production-like completion emitted by the review turn", async () => {
+    const h = await harness();
+    h.acp.emitCoordinatorCompletionOnSend = true;
+    await h.acp.emit("coordinator", "task_complete", { response: "coord" });
+    await h.acp.emit("contributor", "task_complete", { response: "child" });
+    await vi.waitFor(async () => {
+      expect((await h.store.getTask(h.taskId))?.task.status).toBe("validating");
+    });
+    expect(h.acp.sent).toHaveLength(1);
+    await h.service.stop();
+  });
+
+  it("does not settle through a blocked required child", async () => {
+    const h = await harness();
+    await h.acp.emit("contributor", "blocked", { message: "need API key" });
+    await h.acp.emit("coordinator", "task_complete", { response: "coord" });
+    expect((await h.store.getTask(h.taskId))?.task.status).toBe("blocked");
+    expect(h.acp.sent).toEqual([]);
+    await h.service.stop();
+  });
+
+  it("persists receipt delivery failure without authorizing completion", async () => {
+    const h = await harness();
+    h.acp.deliveryError = new Error("coordinator transport unavailable");
+    await h.acp.emit("coordinator", "task_complete", { response: "coord" });
+    await h.acp.emit("contributor", "task_complete", { response: "child" });
+    await vi.waitFor(async () => {
+      const contributor = (await h.store.getTask(h.taskId))?.sessions.find(
+        (row) => row.sessionId === "contributor",
+      );
+      expect(contributor?.completionReceiptDeliveryError).toContain(
+        "transport unavailable",
+      );
+    });
+    const doc = await h.store.getTask(h.taskId);
+    expect(doc?.task.status).toBe("waiting_on_user");
+    expect(
+      doc?.sessions.find((row) => row.sessionId === "contributor")
+        ?.completionReceiptDeliveredAt,
+    ).toBeUndefined();
+    expect(
+      doc?.events.some(
+        (event) => event.eventType === "completion_review_delivery_failed",
+      ),
+    ).toBe(true);
+
+    h.acp.deliveryError = undefined;
+    await h.service.recoverCompletionBarriers();
+    await vi.waitFor(() => expect(h.acp.sent).toHaveLength(1));
+    expect(
+      (await h.store.getTask(h.taskId))?.sessions.find(
+        (row) => row.sessionId === "contributor",
+      )?.completionReceiptDeliveredAt,
+    ).toBeTruthy();
+    await h.service.stop();
+  });
+
+  it("recovers a pending receipt delivery after service restart", async () => {
+    const h = await harness();
+    h.acp.deliveryError = new Error("offline");
+    await h.acp.emit("coordinator", "task_complete", { response: "coord" });
+    await h.acp.emit("contributor", "task_complete", { response: "child" });
+    await vi.waitFor(async () => {
+      const contributor = (await h.store.getTask(h.taskId))?.sessions.find(
+        (row) => row.sessionId === "contributor",
+      );
+      expect(contributor?.completionReceiptDeliveryError).toBe("offline");
+    });
+    await h.service.stop();
+
+    const recoveredAcp = new BarrierAcp();
+    const recovered = new OrchestratorTaskService(
+      runtime(recoveredAcp) as never,
+      { store: h.store },
+    );
+    await recovered.start();
+    await recovered.recoverCompletionBarriers();
+    await vi.waitFor(() => expect(recoveredAcp.sent).toHaveLength(1));
+    const doc = await h.store.getTask(h.taskId);
+    expect(
+      doc?.sessions.find((row) => row.sessionId === "contributor")
+        ?.completionReceiptDeliveredAt,
+    ).toBeTruthy();
+    await recovered.stop();
+  });
+
+  it("transfers authority explicitly and preserves one elected coordinator", async () => {
+    const h = await harness();
+    await h.store.updateSession(
+      "coordinator",
+      { status: "errored", stoppedAt: Date.now() },
+      h.taskId,
+    );
+    await h.service.transferCompletionCoordinator(h.taskId, "contributor");
+    const doc = await h.store.getTask(h.taskId);
+    expect(doc?.task.completionCoordinatorSessionId).toBe("contributor");
+    expect(
+      doc?.sessions.find((row) => row.sessionId === "coordinator"),
+    ).toMatchObject({
+      completionRole: "contributor",
+      requiredForTaskCompletion: false,
+    });
+    expect(
+      doc?.sessions.find((row) => row.sessionId === "contributor"),
+    ).toMatchObject({
+      completionRole: "coordinator",
+      requiredForTaskCompletion: false,
+    });
+    await h.service.stop();
+  });
+
+  it("lets a completing legacy retry elect itself without requiring old attempts", async () => {
+    const h = await harness({ legacySingle: true });
+    await h.store.updateSession(
+      "coordinator",
+      { status: "errored", stoppedAt: Date.now() },
+      h.taskId,
+    );
+    await h.store.addSession(
+      session({ taskId: h.taskId, sessionId: "legacy-retry" }),
+    );
+    await h.store.updateTask(h.taskId, { status: "active" });
+    await h.acp.emit("legacy-retry", "task_complete", { response: "fixed" });
+    await vi.waitFor(async () => {
+      expect((await h.store.getTask(h.taskId))?.task.status).toBe("validating");
+    });
+    expect(
+      (await h.store.getTask(h.taskId))?.task.completionCoordinatorSessionId,
+    ).toBe("legacy-retry");
+    await h.service.stop();
+  });
+
+  it("transfers coordinator authority to an automatic state-lost successor", async () => {
+    const h = await harness();
+    await h.store.updateSession(
+      "coordinator",
+      { status: "errored", stoppedAt: Date.now() },
+      h.taskId,
+    );
+    await h.store.updateSession(
+      "contributor",
+      { requiredForTaskCompletion: false },
+      h.taskId,
+    );
+    const metadata = {
+      taskId: h.taskId,
+      retryOfSessionId: "coordinator",
+      completionRole: "coordinator",
+      requiredForTaskCompletion: false,
+      initialTask: "resume coordinator work",
+    };
+    await h.acp.emitSuccessor("coordinator-retry", "ready", {}, metadata);
+    await h.acp.emitSuccessor(
+      "coordinator-retry",
+      "task_complete",
+      { response: "recovered and done" },
+      metadata,
+    );
+    await vi.waitFor(async () => {
+      expect((await h.store.getTask(h.taskId))?.task.status).toBe("validating");
+    });
+    const doc = await h.store.getTask(h.taskId);
+    expect(doc?.task.completionCoordinatorSessionId).toBe("coordinator-retry");
+    expect(
+      doc?.sessions.find((row) => row.sessionId === "coordinator")
+        ?.requiredForTaskCompletion,
+    ).toBe(false);
+    await h.service.stop();
+  });
+
+  it("transfers a required contribution to an automatic failover successor", async () => {
+    const h = await harness();
+    await h.acp.emit("coordinator", "task_complete", { response: "coord" });
+    await h.store.updateSession(
+      "contributor",
+      { status: "errored", stoppedAt: Date.now() },
+      h.taskId,
+    );
+    const metadata = {
+      taskId: h.taskId,
+      retryOfSessionId: "contributor",
+      completionRole: "contributor",
+      requiredForTaskCompletion: true,
+      parentSessionId: "coordinator",
+      initialTask: "resume contributor work",
+    };
+    await h.acp.emitSuccessor("contributor-retry", "ready", {}, metadata);
+    await h.acp.emitSuccessor(
+      "contributor-retry",
+      "task_complete",
+      { response: "recovered contribution" },
+      metadata,
+    );
+    await vi.waitFor(() => expect(h.acp.sent).toHaveLength(1));
+    const doc = await h.store.getTask(h.taskId);
+    expect(
+      doc?.sessions.find((row) => row.sessionId === "contributor")
+        ?.requiredForTaskCompletion,
+    ).toBe(false);
+    expect(
+      doc?.sessions.find((row) => row.sessionId === "contributor-retry"),
+    ).toMatchObject({
+      completionRole: "contributor",
+      requiredForTaskCompletion: true,
+      parentSessionId: "coordinator",
+    });
+    expect(h.acp.sent[0]?.text).toContain("recovered contribution");
+    await h.service.stop();
+  });
+
+  it("keeps persisted single-session tasks backward compatible", async () => {
+    const h = await harness({ legacySingle: true });
+    await h.acp.emit("coordinator", "task_complete", { response: "done" });
+    await vi.waitFor(async () => {
+      expect((await h.store.getTask(h.taskId))?.task.status).toBe("validating");
+    });
+    expect(
+      (await h.store.getTask(h.taskId))?.task.completionCoordinatorSessionId,
+    ).toBe("coordinator");
+    await h.service.stop();
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/__tests__/parent-agent-broker-spawn.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/parent-agent-broker-spawn.test.ts
@@ -44,6 +44,7 @@ describe("parent-agent broker — spawn-sub-agent (nesting)", () => {
   it("spawns a child for the parent task at parent depth + 1", async () => {
     const spawnAgentForTask = vi.fn<SpawnFn>(async () => ({
       task: { id: "task-1" },
+      sessions: [{ sessionId: "child-1", parentSessionId: "sess-1" }],
     }));
     const res = await runParentAgentBroker(
       makeRequest({
@@ -64,7 +65,11 @@ describe("parent-agent broker — spawn-sub-agent (nesting)", () => {
       task: "write tests",
       label: "tester",
       nestingDepth: 1,
+      completionRole: "contributor",
+      parentSessionId: "sess-1",
+      requiredForTaskCompletion: true,
     });
+    expect(res.data).toMatchObject({ childSessionId: "child-1" });
   });
 
   it("computes child depth from the parent session's nestingDepth", async () => {

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-mapper.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-mapper.ts
@@ -58,6 +58,7 @@ export interface TaskThreadDto {
   latestAccountId: string | null;
   latestAccountLabel: string | null;
   parentTaskId: string | null;
+  completionCoordinatorSessionId: string | null;
   /**
    * The task's stable workdir/repo. Prefers the durable binding pinned at first
    * spawn (`task.boundWorkdir`/`boundRepo`) over the most-recent session's
@@ -104,6 +105,13 @@ export interface TaskSessionDto {
   idleCheckCount: number;
   taskDelivered: boolean;
   completionSummary: string | null;
+  completionRole: "coordinator" | "contributor" | null;
+  parentSessionId: string | null;
+  requiredForTaskCompletion: boolean | null;
+  aggregateCompletionRequestedAt: string | null;
+  completionReceiptDeliveredAt: string | null;
+  completionReceiptDeliveryError: string | null;
+  contributionReviewedAt: string | null;
   lastSeenDecisionIndex: number;
   lastInputSentAt: number | null;
   stoppedAt: number | null;
@@ -436,6 +444,8 @@ export function toTaskThread(doc: OrchestratorTaskDocument): TaskThreadDto {
     latestAccountId: latest?.accountId ?? null,
     latestAccountLabel: latest?.accountLabel ?? null,
     parentTaskId: doc.task.parentTaskId ?? null,
+    completionCoordinatorSessionId:
+      doc.task.completionCoordinatorSessionId ?? null,
     latestWorkdir: doc.task.boundWorkdir ?? latest?.workdir ?? null,
     latestRepo,
     projectId: doc.task.projectId ?? null,
@@ -513,6 +523,16 @@ export function toTaskThreadDetail(
       idleCheckCount: session.idleCheckCount,
       taskDelivered: session.taskDelivered,
       completionSummary: session.completionSummary ?? null,
+      completionRole: session.completionRole ?? null,
+      parentSessionId: session.parentSessionId ?? null,
+      requiredForTaskCompletion: session.requiredForTaskCompletion ?? null,
+      aggregateCompletionRequestedAt:
+        session.aggregateCompletionRequestedAt ?? null,
+      completionReceiptDeliveredAt:
+        session.completionReceiptDeliveredAt ?? null,
+      completionReceiptDeliveryError:
+        session.completionReceiptDeliveryError ?? null,
+      contributionReviewedAt: session.contributionReviewedAt ?? null,
       lastSeenDecisionIndex: session.lastSeenDecisionIndex,
       lastInputSentAt: session.lastInputSentAt ?? null,
       stoppedAt: session.stoppedAt ?? null,

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -7,9 +7,10 @@
  *
  * 1. **Event bridge.** Subscribes to {@link AcpService} session events and
  *    records them against the owning task — status, tool activity, messages,
- *    token usage. A sub-agent's `task_complete` moves the task to `validating`,
- *    never straight to `done`; promotion to `done` requires an explicit
- *    {@link OrchestratorTaskService.validateTask} call.
+ *    token usage. Session completion is evidence; only the elected coordinator
+ *    may move the aggregate task to `validating` after required contributor
+ *    receipts are delivered and reviewed. Promotion to `done` requires an
+ *    explicit {@link OrchestratorTaskService.validateTask} call.
  * 2. **Lifecycle API.** Create / list / inspect / update / pause / resume /
  *    archive / reopen / delete / fork tasks, spawn and steer sub-agents through
  *    the mandatory goal wrapper, and aggregate cross-task status.
@@ -175,6 +176,7 @@ import {
   resolveStateLostRespawnCap,
   resolveTaskTransition,
   stateLostRespawnUnderCap,
+  type TaskCompletionRole,
   type TaskLifecycleTrigger,
   type TaskListFilter,
   type TaskMessageDirection,
@@ -400,6 +402,12 @@ export interface SpawnAgentForTaskOptions {
    * the max-nesting-depth cap so self-spawning can't run away.
    */
   nestingDepth?: number;
+  /** Internal completion authority; ordinary callers rely on first-session election. */
+  completionRole?: TaskCompletionRole;
+  /** Internal lineage for a contributor spawned by another coding session. */
+  parentSessionId?: string;
+  /** Internal barrier membership; contributors are required by default. */
+  requiredForTaskCompletion?: boolean;
   /**
    * Internal: the admission-queue drain sets this false so a cap race during a
    * replayed dispatch RETHROWS SessionCapError instead of self-parking. The
@@ -1049,6 +1057,8 @@ export class OrchestratorTaskService extends Service {
   // from two sites for one turn; without this guard both runs read the same
   // attempt counter across the model `await` and double-send a correction.
   private readonly autoVerifyInFlight = new Set<string>();
+  /** Tasks currently handing contributor receipts to their elected coordinator. */
+  private readonly completionReviewDispatchInFlight = new Set<string>();
 
   /** Per-task async mutex serializing the two completion-metadata writers
    * (autoVerifyCompletion and validateTask). Both replace `task.metadata`
@@ -1181,6 +1191,7 @@ export class OrchestratorTaskService extends Service {
     if (acp) {
       this.subscribeToAcp(acp);
       this.queueSmithersRecovery(acp);
+      this.queueCompletionBarrierRecovery();
       return;
     }
     // ACP may not be registered yet — service start order during boot isn't
@@ -1220,6 +1231,7 @@ export class OrchestratorTaskService extends Service {
       if (this.started && !this.unsubscribe) {
         this.subscribeToAcp(acp);
         this.queueSmithersRecovery(acp);
+        this.queueCompletionBarrierRecovery();
       }
     } catch (error) {
       // error-policy:J7 background ACP bind; the failure is warned and observable
@@ -1266,6 +1278,35 @@ export class OrchestratorTaskService extends Service {
         {},
       );
     });
+  }
+
+  private queueCompletionBarrierRecovery(): void {
+    void this.recoverCompletionBarriers().catch((err) => {
+      // error-policy:J7 persisted receipt delivery is retried on the next boot
+      // or terminal event; a recovery failure cannot prevent service startup.
+      this.runtime.reportError?.(
+        "OrchestratorTask.recoverCompletionBarriers",
+        err,
+        {},
+      );
+    });
+  }
+
+  /** Retry persisted coordinator-review deliveries after a runtime restart. */
+  async recoverCompletionBarriers(): Promise<number> {
+    const tasks = await this.store.listTasks();
+    let recovered = 0;
+    for (const task of tasks) {
+      if (!task.completionCoordinatorSessionId) continue;
+      const doc = await this.store.getTask(task.id);
+      const coordinator = doc?.sessions.find(
+        (session) => session.sessionId === task.completionCoordinatorSessionId,
+      );
+      if (!coordinator?.aggregateCompletionRequestedAt) continue;
+      await this.dispatchContributionReview(task.id);
+      recovered++;
+    }
+    return recovered;
   }
 
   /**
@@ -1626,6 +1667,26 @@ export class OrchestratorTaskService extends Service {
           ? snapshotTaskId
           : await this.resolveTaskId(sessionId);
       if (!taskId) return;
+      if (
+        sessionSnapshot &&
+        !(await this.store.findSession(sessionId, taskId))
+      ) {
+        await this.attachSession(taskId, {
+          sessionId,
+          agentType: sessionSnapshot.agentType,
+          workdir: sessionSnapshot.workdir,
+          status: sessionSnapshot.status,
+          metadata: sessionSnapshot.metadata,
+          ...(typeof sessionSnapshot.metadata?.label === "string"
+            ? { label: sessionSnapshot.metadata.label }
+            : sessionSnapshot.name
+              ? { label: sessionSnapshot.name }
+              : {}),
+          ...(typeof sessionSnapshot.metadata?.initialTask === "string"
+            ? { originalTask: sessionSnapshot.metadata.initialTask }
+            : {}),
+        });
+      }
       const rawData = isRecord(data) ? data : { value: data };
       const taskDoc = await this.store.getTask(taskId);
       const childTerminalResult = taskDoc
@@ -1676,6 +1737,279 @@ export class OrchestratorTaskService extends Service {
       // consumer before exposing failover credentials to a child. Other
       // telemetry events retain their established diagnostics-only behavior.
       if (event === "account_switched") throw err;
+    }
+  }
+
+  /**
+   * Resolve legacy rows into one durable completion authority. The task-level
+   * id is authoritative; pre-rollout documents elect their explicit
+   * coordinator-role row or, failing that, the earliest registered session.
+   */
+  private async completionCoordinatorLocked(
+    taskId: string,
+    doc: OrchestratorTaskDocument,
+    preferredLegacySessionId?: string,
+  ): Promise<OrchestratorTaskSession | undefined> {
+    const durable = doc.task.completionCoordinatorSessionId;
+    const candidate =
+      (durable
+        ? doc.sessions.find((session) => session.sessionId === durable)
+        : undefined) ??
+      doc.sessions.find(
+        (session) => session.completionRole === "coordinator",
+      ) ??
+      (preferredLegacySessionId
+        ? doc.sessions.find(
+            (session) => session.sessionId === preferredLegacySessionId,
+          )
+        : undefined) ??
+      [...doc.sessions].sort(
+        (left, right) => left.registeredAt - right.registeredAt,
+      )[0];
+    if (!candidate) return undefined;
+    if (durable !== candidate.sessionId) {
+      await this.store.updateTask(taskId, {
+        completionCoordinatorSessionId: candidate.sessionId,
+      });
+    }
+    if (candidate.completionRole !== "coordinator") {
+      await this.store.updateSession(
+        candidate.sessionId,
+        { completionRole: "coordinator", requiredForTaskCompletion: false },
+        taskId,
+      );
+      return {
+        ...candidate,
+        completionRole: "coordinator",
+        requiredForTaskCompletion: false,
+      };
+    }
+    return candidate;
+  }
+
+  private requiredContributors(
+    doc: OrchestratorTaskDocument,
+    coordinatorSessionId: string,
+  ): OrchestratorTaskSession[] {
+    return doc.sessions.filter((session) => {
+      if (session.sessionId === coordinatorSessionId) return false;
+      return (
+        session.completionRole === "contributor" &&
+        session.requiredForTaskCompletion === true
+      );
+    });
+  }
+
+  /**
+   * Session completion is evidence, not aggregate completion. This method runs
+   * only under the per-task write lock, so simultaneous sibling completions
+   * observe one coordinator, one required set, and one review state.
+   */
+  private async aggregateCompletionGateLocked(
+    taskId: string,
+    completingSessionId: string,
+  ): Promise<{ authorized: boolean; dispatchReview: boolean }> {
+    const doc = await this.store.getTask(taskId);
+    if (!doc) return { authorized: false, dispatchReview: false };
+    const coordinator = await this.completionCoordinatorLocked(
+      taskId,
+      doc,
+      completingSessionId,
+    );
+    if (!coordinator) return { authorized: false, dispatchReview: false };
+    const refreshed = (await this.store.getTask(taskId)) ?? doc;
+    const contributors = this.requiredContributors(
+      refreshed,
+      coordinator.sessionId,
+    );
+    const completingCoordinator = completingSessionId === coordinator.sessionId;
+    if (contributors.length === 0) {
+      return {
+        authorized: completingCoordinator,
+        dispatchReview: false,
+      };
+    }
+
+    if (completingCoordinator) {
+      await this.store.updateSession(
+        coordinator.sessionId,
+        { aggregateCompletionRequestedAt: nowIso() },
+        taskId,
+      );
+    }
+    const allCompleted = contributors.every(
+      (session) => session.status === "completed" && session.taskDelivered,
+    );
+    if (!allCompleted) {
+      return { authorized: false, dispatchReview: false };
+    }
+
+    const latestCoordinator = (
+      await this.store.findSession(coordinator.sessionId, taskId)
+    )?.session;
+    const coordinatorRequested = Boolean(
+      latestCoordinator?.aggregateCompletionRequestedAt,
+    );
+    const undelivered = contributors.filter(
+      (session) => !session.completionReceiptDeliveredAt,
+    );
+    if (undelivered.length > 0) {
+      return {
+        authorized: false,
+        dispatchReview: coordinatorRequested,
+      };
+    }
+    if (!completingCoordinator) {
+      return { authorized: false, dispatchReview: false };
+    }
+
+    const reviewedAt = nowIso();
+    for (const contributor of contributors) {
+      if (!contributor.contributionReviewedAt) {
+        await this.store.updateSession(
+          contributor.sessionId,
+          { contributionReviewedAt: reviewedAt },
+          taskId,
+        );
+      }
+    }
+    return { authorized: true, dispatchReview: false };
+  }
+
+  private completionReviewPrompt(
+    task: OrchestratorTaskRecord,
+    contributors: readonly OrchestratorTaskSession[],
+  ): string {
+    const receipts = contributors
+      .map(
+        (session) =>
+          `- ${session.label} (${session.sessionId}): ${session.completionSummary ?? "Completed without a textual summary."}`,
+      )
+      .join("\n");
+    return [
+      "[System] Required contributor receipts are now settled for this coding task.",
+      `Goal: ${task.goal}`,
+      "Review every receipt and the shared workspace state. Resolve any conflicts or missing work, run the appropriate verification, then report completion again only if the aggregate goal is genuinely finished.",
+      "Contributor receipts:",
+      receipts,
+    ].join("\n\n");
+  }
+
+  /** Deliver pending required receipts and persist success/failure atomically. */
+  private async dispatchContributionReview(taskId: string): Promise<void> {
+    if (this.completionReviewDispatchInFlight.has(taskId)) return;
+    this.completionReviewDispatchInFlight.add(taskId);
+    try {
+      await this.withTaskWriteLock(taskId, async () => {
+        const doc = await this.store.getTask(taskId);
+        if (!doc) return;
+        const coordinator = await this.completionCoordinatorLocked(taskId, doc);
+        if (!coordinator?.aggregateCompletionRequestedAt) return;
+        const refreshed = (await this.store.getTask(taskId)) ?? doc;
+        const contributors = this.requiredContributors(
+          refreshed,
+          coordinator.sessionId,
+        );
+        if (
+          contributors.length === 0 ||
+          contributors.some(
+            (session) =>
+              session.status !== "completed" || !session.taskDelivered,
+          )
+        ) {
+          return;
+        }
+        const undelivered = contributors.filter(
+          (session) => !session.completionReceiptDeliveredAt,
+        );
+        if (undelivered.length === 0) return;
+        const acp = this.acp();
+        if (!acp) throw new Error("ACP service unavailable");
+        try {
+          const delivery = await acp.sendToSession(
+            coordinator.sessionId,
+            this.completionReviewPrompt(refreshed.task, undelivered),
+          );
+          const stopReason = delivery.stopReason.toLowerCase();
+          if (
+            delivery.terminalFailure ||
+            delivery.error ||
+            stopReason === "cancelled" ||
+            stopReason === "stopped" ||
+            stopReason === "error" ||
+            /max|length|interrupt/.test(stopReason)
+          ) {
+            throw new Error(
+              delivery.terminalFailure?.message ??
+                delivery.error ??
+                `Coordinator review prompt did not settle: ${delivery.stopReason}`,
+            );
+          }
+          const deliveredAt = nowIso();
+          for (const contributor of undelivered) {
+            await this.store.updateSession(
+              contributor.sessionId,
+              {
+                completionReceiptDeliveredAt: deliveredAt,
+                completionReceiptDeliveryError: null,
+              },
+              taskId,
+            );
+          }
+          await this.store.addEvent({
+            id: randomUUID(),
+            taskId,
+            sessionId: coordinator.sessionId,
+            eventType: "completion_review_delivered",
+            summary:
+              "Required contributor receipts delivered for coordinator review",
+            data: {
+              coordinatorSessionId: coordinator.sessionId,
+              contributorSessionIds: undelivered.map(
+                (session) => session.sessionId,
+              ),
+            },
+            timestamp: Date.now(),
+            createdAt: nowIso(),
+          });
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          for (const contributor of undelivered) {
+            await this.store.updateSession(
+              contributor.sessionId,
+              { completionReceiptDeliveryError: message },
+              taskId,
+            );
+          }
+          await this.store.addEvent({
+            id: randomUUID(),
+            taskId,
+            sessionId: coordinator.sessionId,
+            eventType: "completion_review_delivery_failed",
+            summary: `Could not deliver contributor receipts to the completion coordinator: ${message}`,
+            data: {
+              coordinatorSessionId: coordinator.sessionId,
+              contributorSessionIds: undelivered.map(
+                (session) => session.sessionId,
+              ),
+              retryable: true,
+              retryMethod: "recoverCompletionBarriers",
+              error: message,
+            },
+            timestamp: Date.now(),
+            createdAt: nowIso(),
+          });
+          await this.advanceTaskStatus(taskId, "awaiting_user");
+          this.emitChange(taskId);
+          this.runtime.reportError?.(
+            "OrchestratorTask.dispatchContributionReview",
+            err,
+            { taskId, coordinatorSessionId: coordinator.sessionId },
+          );
+        }
+      });
+    } finally {
+      this.completionReviewDispatchInFlight.delete(taskId);
     }
   }
 
@@ -1758,35 +2092,48 @@ export class OrchestratorTaskService extends Service {
         );
         break;
       case "task_complete": {
-        const summary = str(record.response);
-        await this.store.updateSession(
-          sessionId,
-          {
-            status: "completed",
-            taskDelivered: true,
-            completionSummary: summary,
-            stoppedAt: Date.now(),
-          },
-          taskId,
-        );
-        await this.mirrorChangeSetToStore(taskId, sessionId);
-        // Completion metadata is written before validation advances so clients
-        // never observe a successful completion without its associated PR.
-        await this.mirrorPullRequestToStore(taskId, summary ?? "");
-        // Attach the sub-agent's own recorded trajectories (its inner model
-        // prompts/responses) as task artifacts under the shared traceId (#13775).
-        // error-policy:J7 diagnostics-must-not-kill-the-loop — trace ingest is
-        // observability; a failure is reported but must not block task validation.
-        try {
-          await this.ingestChildTrajectories(taskId, sessionId);
-        } catch (err) {
-          this.runtime.reportError?.(
-            "OrchestratorTaskService.ingestChildTrajectories",
-            err,
-            { taskId, sessionId },
+        const summary = str(record.response) ?? "";
+        const gate = await this.withTaskWriteLock(taskId, async () => {
+          await this.store.updateSession(
+            sessionId,
+            {
+              status: "completed",
+              taskDelivered: true,
+              completionSummary: summary,
+              stoppedAt: Date.now(),
+            },
+            taskId,
           );
+          await this.mirrorChangeSetToStore(taskId, sessionId);
+          // Completion metadata is written before validation advances so clients
+          // never observe a successful completion without its associated PR.
+          await this.mirrorPullRequestToStore(taskId, summary);
+          // Attach the sub-agent's own recorded trajectories (its inner model
+          // prompts/responses) as task artifacts under the shared traceId (#13775).
+          // error-policy:J7 diagnostics-must-not-kill-the-loop — trace ingest is
+          // observability; a failure is reported but must not block task validation.
+          try {
+            await this.ingestChildTrajectories(taskId, sessionId);
+          } catch (err) {
+            this.runtime.reportError?.(
+              "OrchestratorTaskService.ingestChildTrajectories",
+              err,
+              { taskId, sessionId },
+            );
+          }
+          const decision = await this.aggregateCompletionGateLocked(
+            taskId,
+            sessionId,
+          );
+          if (decision.authorized) {
+            await this.advanceTaskStatus(taskId, "completion_reported");
+          }
+          return decision;
+        });
+        if (gate.dispatchReview) {
+          void this.dispatchContributionReview(taskId);
         }
-        await this.advanceTaskStatus(taskId, "completion_reported");
+        if (!gate.authorized) break;
         // Cross-surface arbitration for the digest emitter: stamp this
         // completion on the supervisor BEFORE its next tick, so the room's
         // status digest yields to the completion relay the router posts for
@@ -1809,7 +2156,7 @@ export class OrchestratorTaskService extends Service {
         // stays fast; the verifier gates itself on the flag + criteria presence,
         // and evidence assembly never throws into this path.
         const { evidence: completionEvidence, bundle: completionBundle } =
-          await this.buildCompletionEvidence(taskId, sessionId, summary ?? "");
+          await this.buildCompletionEvidence(taskId, sessionId, summary);
         // Thread the RAW final message (record.response) through alongside the
         // reworded evidence bundle: the #8895 CompletionEnvelope lives verbatim in
         // the sub-agent's last message, not in the prose evidence, so the structural
@@ -1818,7 +2165,7 @@ export class OrchestratorTaskService extends Service {
           taskId,
           sessionId,
           completionEvidence,
-          summary ?? "",
+          summary,
           completionBundle,
         );
         break;
@@ -3416,6 +3763,7 @@ export class OrchestratorTaskService extends Service {
         createdAt: nowIso(),
       });
       await this.spawnAgentForTask(taskId, {
+        completionRole: "coordinator",
         task: "Resume this task from its current durable context. Reinspect the task timeline and any partial work, then continue until the goal is met or you are blocked.",
       });
     }
@@ -4865,6 +5213,7 @@ export class OrchestratorTaskService extends Service {
       // the default framework (opencode + Cerebras) into a per-task workdir.
       try {
         await this.spawnAgentForTask(taskId, {
+          completionRole: "coordinator",
           task: content,
           workdir: await ensureTaskWorkdir(taskId),
         });
@@ -4958,6 +5307,7 @@ export class OrchestratorTaskService extends Service {
     if (mode === "new-session") {
       await this.spawnAgentForTask(taskId, {
         ...input.agent,
+        completionRole: "coordinator",
         task: instruction,
       });
       if (planRevision) {
@@ -5077,6 +5427,7 @@ export class OrchestratorTaskService extends Service {
     await this.advanceTaskStatus(taskId, "retrying");
     await this.spawnAgentForTask(taskId, {
       ...input.agent,
+      completionRole: "coordinator",
       task: withPlanRevisionContext(
         rerunInstruction(event, input.instruction),
         planRevision,
@@ -5113,6 +5464,7 @@ export class OrchestratorTaskService extends Service {
     });
     const restartedDetail = await this.spawnAgentForTask(taskId, {
       ...input.agent,
+      completionRole: "coordinator",
       task: instruction,
     });
     const firstRestartedSessionId = restartedDetail?.sessions.at(-1)?.sessionId;
@@ -5307,6 +5659,74 @@ export class OrchestratorTaskService extends Service {
 
   // ---- sub-agent control -------------------------------------------------
 
+  /**
+   * Explicitly transfer aggregate-completion authority to another session.
+   * The task-level id remains the source of truth across partial legacy rows;
+   * role fields are maintained for inspection and future reloads.
+   */
+  async transferCompletionCoordinator(
+    taskId: string,
+    nextSessionId: string,
+  ): Promise<TaskThreadDetailDto | null> {
+    return this.withTaskWriteLock(taskId, async () => {
+      const doc = await this.store.getTask(taskId);
+      if (!doc) return null;
+      await this.transferCompletionCoordinatorLocked(
+        taskId,
+        doc,
+        nextSessionId,
+      );
+      return this.getTask(taskId);
+    });
+  }
+
+  private async transferCompletionCoordinatorLocked(
+    taskId: string,
+    doc: OrchestratorTaskDocument,
+    nextSessionId: string,
+  ): Promise<void> {
+    const next = doc.sessions.find(
+      (session) => session.sessionId === nextSessionId,
+    );
+    if (!next) {
+      throw new Error(
+        `Cannot transfer completion authority: session ${nextSessionId} is not attached to task ${taskId}`,
+      );
+    }
+    const previousId = doc.task.completionCoordinatorSessionId;
+    if (previousId && previousId !== nextSessionId) {
+      await this.store.updateSession(
+        previousId,
+        {
+          completionRole: "contributor",
+          requiredForTaskCompletion: false,
+        },
+        taskId,
+      );
+    }
+    await this.store.updateSession(
+      nextSessionId,
+      {
+        completionRole: "coordinator",
+        requiredForTaskCompletion: false,
+      },
+      taskId,
+    );
+    await this.store.updateTask(taskId, {
+      completionCoordinatorSessionId: nextSessionId,
+    });
+    await this.store.addEvent({
+      id: randomUUID(),
+      taskId,
+      sessionId: nextSessionId,
+      eventType: "completion_authority_transferred",
+      summary: "Aggregate completion authority transferred",
+      data: { previousSessionId: previousId, nextSessionId },
+      timestamp: Date.now(),
+      createdAt: nowIso(),
+    });
+  }
+
   async spawnAgentForTask(
     taskId: string,
     opts: SpawnAgentForTaskOptions = {},
@@ -5438,6 +5858,13 @@ export class OrchestratorTaskService extends Service {
       opts.framework ??
       policy.preferredFramework ??
       configuredDefaultAgentType(this.runtime);
+    const intendedCompletionRole: TaskCompletionRole =
+      opts.completionRole ??
+      (opts.parentSessionId || nestingDepth > 0
+        ? "contributor"
+        : doc.task.completionCoordinatorSessionId
+          ? "contributor"
+          : "coordinator");
 
     // W3 wave cap layers on top of the existing global ACP admission queue.
     // Default-OFF supervisor means this lookup is behavior-neutral. When the
@@ -5522,6 +5949,13 @@ export class OrchestratorTaskService extends Service {
           // Carried so a child this sub-agent spawns can compute its own depth
           // (parent depth + 1) and the nesting guard above can enforce the cap.
           nestingDepth,
+          completionRole: intendedCompletionRole,
+          ...(opts.parentSessionId
+            ? { parentSessionId: opts.parentSessionId }
+            : {}),
+          requiredForTaskCompletion:
+            opts.requiredForTaskCompletion ??
+            intendedCompletionRole === "contributor",
         },
       });
     } catch (err) {
@@ -5562,7 +5996,7 @@ export class OrchestratorTaskService extends Service {
     const orchestratorOwnedArtifacts =
       readOwnedArtifactsFromMetadata(resultMetadata);
     const ts = nowIso();
-    const session: OrchestratorTaskSession = {
+    let session: OrchestratorTaskSession = {
       id: randomUUID(),
       taskId,
       sessionId: result.sessionId,
@@ -5589,6 +6023,13 @@ export class OrchestratorTaskService extends Service {
       lastActivityAt: Date.now(),
       idleCheckCount: 0,
       taskDelivered: false,
+      completionRole: intendedCompletionRole,
+      ...(opts.parentSessionId
+        ? { parentSessionId: opts.parentSessionId }
+        : {}),
+      requiredForTaskCompletion:
+        opts.requiredForTaskCompletion ??
+        intendedCompletionRole === "contributor",
       lastSeenDecisionIndex: 0,
       spawnedAt: Date.now(),
       retryCount: 0,
@@ -5634,7 +6075,33 @@ export class OrchestratorTaskService extends Service {
       // next drain would replay the stale admission record and dispatch a
       // DUPLICATE agent for the same goal. No-op for non-parked tasks.
       await this.dequeueAdmission(taskId);
-      await this.store.addSession(session);
+      await this.withTaskWriteLock(taskId, async () => {
+        const latest = await this.store.getTask(taskId);
+        const elected = latest?.task.completionCoordinatorSessionId;
+        const explicitTransfer = opts.completionRole === "coordinator";
+        const role: TaskCompletionRole =
+          explicitTransfer ||
+          (!elected && intendedCompletionRole === "coordinator")
+            ? "coordinator"
+            : "contributor";
+        session = {
+          ...session,
+          completionRole: role,
+          requiredForTaskCompletion:
+            opts.requiredForTaskCompletion ?? role === "contributor",
+        };
+        await this.store.addSession(session);
+        if (role === "coordinator" && elected !== session.sessionId) {
+          const withSession = await this.store.getTask(taskId);
+          if (withSession) {
+            await this.transferCompletionCoordinatorLocked(
+              taskId,
+              withSession,
+              session.sessionId,
+            );
+          }
+        }
+      });
       // Pin (or re-pin, on explicit override) the durable workdir/repo binding
       // from the workdir the session actually landed in, so subsequent
       // follow-up spawns of this task reuse it deterministically (#13776).
@@ -5769,6 +6236,19 @@ export class OrchestratorTaskService extends Service {
       if (existing) return true;
     }
     const account = accountMetaFromSessionMetadata(input.metadata);
+    const metadataRole = input.metadata?.completionRole;
+    const completionRole: TaskCompletionRole | undefined =
+      metadataRole === "coordinator" || metadataRole === "contributor"
+        ? metadataRole
+        : undefined;
+    const metadataParentSessionId = input.metadata?.parentSessionId;
+    const parentSessionId =
+      typeof metadataParentSessionId === "string" && metadataParentSessionId
+        ? metadataParentSessionId
+        : undefined;
+    const metadataRequired = input.metadata?.requiredForTaskCompletion;
+    const requiredForTaskCompletion =
+      typeof metadataRequired === "boolean" ? metadataRequired : undefined;
     const ts = nowIso();
     const now = Date.now();
     const originalTask = input.originalTask ?? doc.task.goal;
@@ -5799,6 +6279,11 @@ export class OrchestratorTaskService extends Service {
       lastActivityAt: now,
       idleCheckCount: 0,
       taskDelivered: false,
+      ...(completionRole ? { completionRole } : {}),
+      ...(parentSessionId ? { parentSessionId } : {}),
+      ...(requiredForTaskCompletion === undefined
+        ? {}
+        : { requiredForTaskCompletion }),
       lastSeenDecisionIndex: 0,
       spawnedAt: now,
       ...(TERMINAL_TASK_SESSION_STATUSES.has(input.status)
@@ -5828,7 +6313,65 @@ export class OrchestratorTaskService extends Service {
         previousOwner.taskId,
       );
     }
-    await this.store.addSession(session);
+    await this.withTaskWriteLock(taskId, async () => {
+      const latest = (await this.store.getTask(taskId)) ?? doc;
+      const retryOfSessionId =
+        typeof input.metadata?.retryOfSessionId === "string"
+          ? input.metadata.retryOfSessionId
+          : undefined;
+      const predecessor = retryOfSessionId
+        ? latest.sessions.find(
+            (candidate) => candidate.sessionId === retryOfSessionId,
+          )
+        : undefined;
+      if (predecessor) {
+        session.parentSessionId ??= predecessor.parentSessionId;
+        if (
+          latest.task.completionCoordinatorSessionId === predecessor.sessionId
+        ) {
+          session.completionRole = "coordinator";
+          session.requiredForTaskCompletion = false;
+        } else if (
+          predecessor.completionRole === "contributor" &&
+          predecessor.requiredForTaskCompletion === true
+        ) {
+          session.completionRole = "contributor";
+          session.requiredForTaskCompletion = true;
+        }
+      }
+      await this.store.addSession(session);
+      if (session.completionRole === "coordinator") {
+        const withSession = (await this.store.getTask(taskId)) ?? latest;
+        await this.transferCompletionCoordinatorLocked(
+          taskId,
+          withSession,
+          session.sessionId,
+        );
+      } else if (
+        predecessor &&
+        session.completionRole === "contributor" &&
+        session.requiredForTaskCompletion === true
+      ) {
+        await this.store.updateSession(
+          predecessor.sessionId,
+          { requiredForTaskCompletion: false },
+          taskId,
+        );
+        await this.store.addEvent({
+          id: randomUUID(),
+          taskId,
+          sessionId: session.sessionId,
+          eventType: "completion_contribution_transferred",
+          summary: "Required contribution transferred to successor session",
+          data: {
+            previousSessionId: predecessor.sessionId,
+            nextSessionId: session.sessionId,
+          },
+          timestamp: Date.now(),
+          createdAt: nowIso(),
+        });
+      }
+    });
     this.sessionTaskIndex.set(input.sessionId, taskId);
     // Pin the durable workdir/repo binding at first spawn so follow-up spawns of
     // this task reuse it instead of re-resolving from routing env (#13776).

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-types.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-types.ts
@@ -10,8 +10,8 @@
  * @module services/orchestrator-task-types
  */
 
-/** Lifecycle states. `validating` gates `done`: a sub-agent's `task_complete`
- * moves the task to `validating`, never straight to `done`. */
+/** Lifecycle states. `validating` gates `done`: only the elected coordinator's
+ * aggregate completion may enter validation, never a contributor receipt. */
 export type OrchestratorTaskStatus =
   | "open"
   | "active"
@@ -29,6 +29,9 @@ export type OrchestratorTaskPriority = "low" | "normal" | "high" | "urgent";
  * the provider. The UI renders these three cases distinctly so an operator is
  * never misled by a confident-looking `0`. */
 export type UsageState = "measured" | "estimated" | "unavailable";
+
+/** Durable authority a coding-task session holds in aggregate completion. */
+export type TaskCompletionRole = "coordinator" | "contributor";
 
 export type TaskMessageSenderKind =
   | "user"
@@ -72,6 +75,8 @@ export interface OrchestratorTaskRecord {
   /** Lineage: the task this one was forked from, if any. */
   parentTaskId?: string;
   forkSource?: string;
+  /** The only session authorized to request aggregate coding-task completion. */
+  completionCoordinatorSessionId?: string;
   /**
    * Durable workdir/repo binding, pinned at the task's FIRST successful spawn
    * and reused for every follow-up spawn of the same task. Without it,
@@ -256,6 +261,20 @@ export interface OrchestratorTaskSession {
   idleCheckCount: number;
   taskDelivered: boolean;
   completionSummary?: string;
+  /** Completion authority. Optional for rows persisted before this contract. */
+  completionRole?: TaskCompletionRole;
+  /** Immediate spawning-session lineage for nested/parallel contributors. */
+  parentSessionId?: string;
+  /** Whether this contribution must be reviewed before aggregate completion. */
+  requiredForTaskCompletion?: boolean;
+  /** Coordinator requested completion while this task still had contributors. */
+  aggregateCompletionRequestedAt?: string;
+  /** The contributor's terminal receipt reached the elected coordinator. */
+  completionReceiptDeliveredAt?: string;
+  /** Last delivery failure; cleared only after a successful receipt handoff. */
+  completionReceiptDeliveryError?: string | null;
+  /** The coordinator subsequently completed after receiving this receipt. */
+  contributionReviewedAt?: string;
   lastSeenDecisionIndex: number;
   lastInputSentAt?: number;
   spawnedAt: number;

--- a/plugins/plugin-agent-orchestrator/src/services/parent-agent-broker.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/parent-agent-broker.ts
@@ -1531,8 +1531,13 @@ interface SpawnCapableTaskService {
       framework?: string;
       workdir?: string;
       nestingDepth?: number;
+      completionRole?: "coordinator" | "contributor";
+      parentSessionId?: string;
+      requiredForTaskCompletion?: boolean;
     },
-  ): Promise<unknown>;
+  ): Promise<{
+    sessions?: Array<{ sessionId: string; parentSessionId?: string | null }>;
+  } | null>;
 }
 
 /**
@@ -1598,6 +1603,9 @@ async function runSpawnSubAgent(request: {
       framework: request.framework,
       workdir: request.workdir,
       nestingDepth: childDepth,
+      completionRole: "contributor",
+      parentSessionId: request.sessionId,
+      requiredForTaskCompletion: true,
     });
     if (!result) {
       return {
@@ -1616,10 +1624,18 @@ async function runSpawnSubAgent(request: {
       },
       `${LOG_PREFIX} spawned nested sub-agent at depth ${childDepth}`,
     );
+    const childSessionId = result.sessions
+      ?.filter((session) => session.parentSessionId === request.sessionId)
+      .at(-1)?.sessionId;
     return {
       success: true,
-      text: `Spawned a sub-agent (depth ${childDepth}) on task ${parentTaskId}${request.label ? ` named "${request.label}"` : ""}. It runs in parallel on: ${normalizePromptText(prompt)}. Its progress appears in this task's thread — check back rather than blocking on it.`,
-      data: { ...data, parentTaskId, nestingDepth: childDepth },
+      text: `Spawned a sub-agent${childSessionId ? ` ${childSessionId}` : ""} (depth ${childDepth}) on task ${parentTaskId}${request.label ? ` named "${request.label}"` : ""}. It runs in parallel on: ${normalizePromptText(prompt)}. Its progress appears in this task's thread — check back rather than blocking on it.`,
+      data: {
+        ...data,
+        parentTaskId,
+        ...(childSessionId ? { childSessionId } : {}),
+        nestingDepth: childDepth,
+      },
     };
   } catch (error) {
     // error-policy:J1 boundary — translates a spawn failure into the structured {success:false} result the child sub-agent reads.


### PR DESCRIPTION
## Invariant

> A session completion is evidence, not task completion. Only the coding task’s elected coordinator may request aggregate completion, and only after every explicitly required contributor has settled and its terminal receipt has been delivered back for coordinator review.

## What changed

- elects and persists one completion coordinator while preserving legacy single-session and multi-attempt tasks
- records contributor completion without advancing the aggregate coding task
- requires a coordinator review turn after all required contributor receipts are delivered
- serializes completion-gate evaluation per coding task to prevent sibling races
- carries coordinator/contributor lineage through parent-broker nested spawns
- substitutes barrier membership for router-created state-lost and account-failover successors via `retryOfSessionId`
- transfers authority on resume, auto-spawn, new-session retry, rerun, and restart; superseded attempts remain non-required history
- persists review delivery success/failure, surfaces failures as `waiting_on_user`, and supports live/startup retry
- exposes additive typed authority/review fields in task DTOs

## Acceptance coverage

The real task service + durable in-memory store cover:

- contributor completes first
- coordinator completes while a required contributor is busy
- final contributor triggers a complete receipt-review prompt
- a second coordinator completion is required for aggregate validation
- simultaneous sibling completions send exactly one review
- production-like ACP review turn emits the authorizing completion
- blocked required contributor cannot settle the coding task
- delivery failure is durable/user-visible and retries without restart
- pending receipt delivery recovers after restart
- explicit authority transfer from a terminal coordinator
- legacy multi-attempt compatibility
- automatic coordinator state-lost successor handoff
- automatic required-contributor failover handoff
- legacy single-session compatibility
- parent broker propagates contributor role, parent session, required membership, and child session handle

## Exact local evidence

Validated at head `2672fb2b5f7dec74780e008b6a1d0ed14bd54f52` on base `089984beb3db5aab32b486b874a90cb320f4a3a0`:

- `bunx vitest run --config vitest.config.ts src/__tests__/aggregate-completion-barrier.test.ts src/__tests__/parent-agent-broker-spawn.test.ts src/__tests__/auto-goal-verify.test.ts src/__tests__/concurrency-lifecycle-integration.test.ts src/__tests__/stuck-task-reaper.test.ts` — 5 files, 75 tests passed
- `bun run typecheck` — passed
- Biome check on all six changed files — passed
- `git diff --check origin/develop...HEAD` — passed
- independent read-only review after successor-handoff fixes — no remaining blockers

No live provider claim is made by this PR; it changes the deterministic durable orchestration contract.

Refs #24299