### PR TITLE
test(plugin-whatsapp): cover outbound media link SSRF guard

### DIFF
--- a/plugins/plugin-whatsapp/src/media.test.ts
+++ b/plugins/plugin-whatsapp/src/media.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { assertValidWhatsAppMediaLink } from "./media";
+
+describe("assertValidWhatsAppMediaLink", () => {
+  it("accepts a well-formed https URL", () => {
+    expect(assertValidWhatsAppMediaLink("https://cdn.example.com/a.jpg", "image")).toBe(
+      "https://cdn.example.com/a.jpg"
+    );
+  });
+
+  it("accepts an http URL", () => {
+    const out = assertValidWhatsAppMediaLink("http://cdn.example.com/a.jpg", "video");
+    expect(out.startsWith("http://cdn.example.com/a.jpg")).toBe(true);
+  });
+
+  it("trims surrounding whitespace before validation", () => {
+    expect(assertValidWhatsAppMediaLink("  https://cdn.example.com/a.jpg  ", "image")).toBe(
+      "https://cdn.example.com/a.jpg"
+    );
+  });
+
+  it("preserves query strings and paths", () => {
+    const out = assertValidWhatsAppMediaLink(
+      "https://cdn.example.com/path/x.png?token=abc&expires=1",
+      "image"
+    );
+    expect(out).toBe("https://cdn.example.com/path/x.png?token=abc&expires=1");
+  });
+
+  it("rejects non-string inputs", () => {
+    expect(() => assertValidWhatsAppMediaLink(42, "image")).toThrow();
+    expect(() => assertValidWhatsAppMediaLink(null, "image")).toThrow();
+    expect(() => assertValidWhatsAppMediaLink(undefined, "image")).toThrow();
+    expect(() => assertValidWhatsAppMediaLink({ url: "https://x" }, "image")).toThrow();
+  });
+
+  it("rejects empty and whitespace-only strings", () => {
+    expect(() => assertValidWhatsAppMediaLink("", "image")).toThrow();
+    expect(() => assertValidWhatsAppMediaLink("   ", "image")).toThrow();
+  });
+
+  it("rejects non-http(s) protocols (SSRF guard)", () => {
+    expect(() => assertValidWhatsAppMediaLink("file:///etc/passwd", "image")).toThrow();
+    expect(() =>
+      assertValidWhatsAppMediaLink("data:text/plain;base64,SGVsbG8=", "image")
+    ).toThrow();
+    expect(() => assertValidWhatsAppMediaLink("javascript:alert(1)", "image")).toThrow();
+    expect(() => assertValidWhatsAppMediaLink("ftp://cdn.example.com/a.jpg", "image")).toThrow();
+  });
+
+  it("rejects URLs embedding credentials", () => {
+    expect(() =>
+      assertValidWhatsAppMediaLink("https://user:pass@cdn.example.com/a.jpg", "image")
+    ).toThrow();
+    expect(() =>
+      assertValidWhatsAppMediaLink("https://user@cdn.example.com/a.jpg", "image")
+    ).toThrow();
+  });
+
+  it("normalizes scheme-only URLs to a hostname (WHATWG URL parsing)", () => {
+    // "https:///a.jpg" is parsed by WHATWG URL as host "a.jpg" (empty
+    // authority + path), so the guard accepts it — pinned as current behavior.
+    expect(() => assertValidWhatsAppMediaLink("https:///a.jpg", "image")).not.toThrow();
+  });
+
+  it("rejects malformed URL strings", () => {
+    expect(() => assertValidWhatsAppMediaLink("not a url", "image")).toThrow();
+    expect(() => assertValidWhatsAppMediaLink("https://", "image")).toThrow();
+  });
+
+  it("accepts localhost hosts (explicit current behavior)", () => {
+    expect(() =>
+      assertValidWhatsAppMediaLink("http://localhost:3000/a.jpg", "image")
+    ).not.toThrow();
+    expect(() => assertValidWhatsAppMediaLink("http://127.0.0.1/a.jpg", "image")).not.toThrow();
+  });
+
+  it("embeds the media kind in the rejection message", () => {
+    expect(() => assertValidWhatsAppMediaLink("file:///x", "sticker")).toThrow(
+      "sticker message requires a valid http(s) media link"
+    );
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new test file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `Test Files  1 passed (1)
      Tests  12 passed (12)` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
