### PR TITLE
test(plugin-wallet): cover x402 fetch middleware 402 retry flow

### DIFF
--- a/plugins/plugin-wallet/src/sdk/x402/middleware.test.ts
+++ b/plugins/plugin-wallet/src/sdk/x402/middleware.test.ts
@@ -1,0 +1,186 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const instances: Array<{
+    wallet: unknown;
+    config: unknown;
+    fetch: ReturnType<typeof vi.fn>;
+    parse402Response: ReturnType<typeof vi.fn>;
+    selectPaymentOption: ReturnType<typeof vi.fn>;
+  }> = [];
+
+  class FakeX402Client {
+    wallet: unknown;
+    config: unknown;
+    fetch = vi.fn(async () => new Response(null, { status: 200 }));
+    parse402Response = vi.fn(async () => null);
+    selectPaymentOption = vi.fn(() => null);
+
+    constructor(wallet: unknown, config?: unknown) {
+      this.wallet = wallet;
+      this.config = config;
+      instances.push(this);
+    }
+  }
+
+  return { FakeX402Client, instances };
+});
+
+vi.mock("./client.js", () => ({
+  X402Client: mocks.FakeX402Client,
+}));
+
+import { createX402Client, createX402Fetch, wrapWithX402 } from "./middleware";
+
+describe("createX402Client", () => {
+  it("constructs an X402Client with the wallet and config", () => {
+    const wallet = { address: "0xabc" };
+    const config = { globalDailyLimit: 10_000_000n };
+    const client = createX402Client(wallet as never, config as never);
+    expect(mocks.instances).toHaveLength(1);
+    expect(mocks.instances[0].wallet).toBe(wallet);
+    expect(mocks.instances[0].config).toBe(config);
+    expect(client).toBeInstanceOf(mocks.FakeX402Client);
+  });
+});
+
+describe("createX402Fetch", () => {
+  beforeEach(() => {
+    mocks.instances.length = 0;
+  });
+
+  it("returns a fetch-compatible function that delegates to the client", async () => {
+    const x402Fetch = createX402Fetch({ address: "0xabc" } as never);
+    const expected = new Response("ok", { status: 200 });
+    mocks.instances[0].fetch.mockResolvedValueOnce(expected);
+    const result = await x402Fetch("https://api.example.com/data");
+    expect(result).toBe(expected);
+    expect(mocks.instances[0].fetch).toHaveBeenCalledWith(
+      "https://api.example.com/data",
+      undefined,
+    );
+  });
+
+  it("stringifies URL objects before delegating", async () => {
+    const x402Fetch = createX402Fetch({ address: "0xabc" } as never);
+    await x402Fetch(new URL("https://api.example.com/v2"));
+    expect(mocks.instances[0].fetch).toHaveBeenCalledWith(
+      "https://api.example.com/v2",
+      undefined,
+    );
+  });
+
+  it("extracts .url from Request inputs", async () => {
+    const x402Fetch = createX402Fetch({ address: "0xabc" } as never);
+    await x402Fetch(
+      new Request("https://api.example.com/upload", { method: "POST" }),
+    );
+    expect(mocks.instances[0].fetch).toHaveBeenCalledWith(
+      "https://api.example.com/upload",
+      undefined,
+    );
+  });
+
+  it("forwards init options to the client fetch", async () => {
+    const x402Fetch = createX402Fetch({ address: "0xabc" } as never);
+    const init = {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+    };
+    await x402Fetch("https://api.example.com/data", init);
+    expect(mocks.instances[0].fetch).toHaveBeenCalledWith(
+      "https://api.example.com/data",
+      init,
+    );
+  });
+});
+
+describe("wrapWithX402", () => {
+  beforeEach(() => {
+    mocks.instances.length = 0;
+  });
+
+  const okResponse = () => new Response("ok", { status: 200 });
+
+  it("passes through non-402 responses untouched", async () => {
+    const fetchFn = vi.fn(async () => okResponse());
+    const wrapped = wrapWithX402(
+      fetchFn as never,
+      { address: "0xabc" } as never,
+    );
+    const response = await wrapped("https://api.example.com/data");
+    expect(response.status).toBe(200);
+    expect(fetchFn).toHaveBeenCalledWith(
+      "https://api.example.com/data",
+      undefined,
+    );
+    const client = mocks.instances[0];
+    expect(client.parse402Response).not.toHaveBeenCalled();
+    expect(client.fetch).not.toHaveBeenCalled();
+  });
+
+  it("passes through when a 402 response carries no parseable payment requirements", async () => {
+    const fetchFn = vi.fn(async () => new Response(null, { status: 402 }));
+    const wrapped = wrapWithX402(
+      fetchFn as never,
+      { address: "0xabc" } as never,
+    );
+    const client = mocks.instances[0];
+    client.parse402Response.mockResolvedValueOnce(null);
+    const response = await wrapped("https://api.example.com/data");
+    expect(response.status).toBe(402);
+    expect(client.selectPaymentOption).not.toHaveBeenCalled();
+    expect(client.fetch).not.toHaveBeenCalled();
+  });
+
+  it("passes through when no payment option is selected", async () => {
+    const fetchFn = vi.fn(async () => new Response(null, { status: 402 }));
+    const wrapped = wrapWithX402(
+      fetchFn as never,
+      { address: "0xabc" } as never,
+    );
+    const client = mocks.instances[0];
+    client.parse402Response.mockResolvedValueOnce({ accepts: ["USDC"] });
+    client.selectPaymentOption.mockReturnValueOnce(null);
+    const response = await wrapped("https://api.example.com/data");
+    expect(response.status).toBe(402);
+    expect(client.fetch).not.toHaveBeenCalled();
+  });
+
+  it("retries through the client when a payment option is selected", async () => {
+    const fetchFn = vi.fn(async () => new Response(null, { status: 402 }));
+    const wrapped = wrapWithX402(
+      fetchFn as never,
+      { address: "0xabc" } as never,
+    );
+    const client = mocks.instances[0];
+    client.parse402Response.mockResolvedValueOnce({ accepts: ["USDC"] });
+    client.selectPaymentOption.mockReturnValueOnce("USDC");
+    const retried = new Response("paid", { status: 200 });
+    client.fetch.mockResolvedValueOnce(retried);
+    const response = await wrapped("https://api.example.com/data", {
+      method: "GET",
+    });
+    expect(response).toBe(retried);
+    expect(client.fetch).toHaveBeenCalledWith("https://api.example.com/data", {
+      method: "GET",
+    });
+  });
+
+  it("extracts .url from Request inputs before retrying", async () => {
+    const fetchFn = vi.fn(async () => new Response(null, { status: 402 }));
+    const wrapped = wrapWithX402(
+      fetchFn as never,
+      { address: "0xabc" } as never,
+    );
+    const client = mocks.instances[0];
+    client.parse402Response.mockResolvedValueOnce({ accepts: ["USDC"] });
+    client.selectPaymentOption.mockReturnValueOnce("USDC");
+    client.fetch.mockResolvedValueOnce(new Response("paid", { status: 200 }));
+    await wrapped(new Request("https://api.example.com/pay"));
+    expect(client.fetch).toHaveBeenCalledWith(
+      "https://api.example.com/pay",
+      undefined,
+    );
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new test file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `Test Files  1 passed (1)
      Tests  10 passed (10)` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
