### PR TITLE
test(plugin-google-genai): cover MODEL_USED event emission and token mapping

### DIFF
--- a/plugins/plugin-google-genai/utils/events.test.ts
+++ b/plugins/plugin-google-genai/utils/events.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { emitModelUsageEvent } from "./events";
+
+describe("emitModelUsageEvent", () => {
+  const runtime = {
+    emitEvent: vi.fn().mockResolvedValue(undefined),
+  };
+
+  beforeEach(() => {
+    runtime.emitEvent.mockClear();
+  });
+
+  it("emits the MODEL_USED event with the plugin as source", async () => {
+    await emitModelUsageEvent(
+      runtime as never,
+      "TEXT_EMBEDDING" as never,
+      "prompt text",
+      { promptTokens: 10, completionTokens: 20, totalTokens: 30 },
+    );
+    expect(runtime.emitEvent).toHaveBeenCalledTimes(1);
+    const [eventName, payload] = runtime.emitEvent.mock.calls[0] as [
+      string,
+      Record<string, unknown>,
+    ];
+    expect(eventName).toBe("MODEL_USED");
+    expect(payload.source).toBe("plugin-google-genai");
+  });
+
+  it("carries the model type through to the payload", async () => {
+    await emitModelUsageEvent(
+      runtime as never,
+      "TEXT_GENERATION" as never,
+      "prompt",
+      { promptTokens: 1, completionTokens: 2, totalTokens: 3 },
+    );
+    const payload = runtime.emitEvent.mock.calls[0][1] as Record<
+      string,
+      unknown
+    >;
+    expect(payload.type).toBe("TEXT_GENERATION");
+  });
+
+  it("maps prompt/completion/total token counts into the tokens object", async () => {
+    await emitModelUsageEvent(
+      runtime as never,
+      "TEXT_GENERATION" as never,
+      "prompt",
+      { promptTokens: 123, completionTokens: 456, totalTokens: 579 },
+    );
+    const payload = runtime.emitEvent.mock.calls[0][1] as {
+      tokens: { prompt: number; completion: number; total: number };
+    };
+    expect(payload.tokens.prompt).toBe(123);
+    expect(payload.tokens.completion).toBe(456);
+    expect(payload.tokens.total).toBe(579);
+  });
+
+  it("preserves zero and large token counts exactly", async () => {
+    await emitModelUsageEvent(
+      runtime as never,
+      "TEXT_GENERATION" as never,
+      "prompt",
+      { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+    );
+    const payload = runtime.emitEvent.mock.calls[0][1] as {
+      tokens: { prompt: number; completion: number; total: number };
+    };
+    expect(payload.tokens).toEqual({ prompt: 0, completion: 0, total: 0 });
+
+    await emitModelUsageEvent(
+      runtime as never,
+      "TEXT_GENERATION" as never,
+      "prompt",
+      { promptTokens: 999999999, completionTokens: 1, totalTokens: 1000000000 },
+    );
+    const payload2 = runtime.emitEvent.mock.calls[1][1] as {
+      tokens: { prompt: number; completion: number; total: number };
+    };
+    expect(payload2.tokens.total).toBe(1000000000);
+  });
+
+  it("does not leak the raw prompt into the event payload", async () => {
+    await emitModelUsageEvent(
+      runtime as never,
+      "TEXT_GENERATION" as never,
+      "sensitive prompt text",
+      { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+    );
+    const payload = runtime.emitEvent.mock.calls[0][1] as Record<
+      string,
+      unknown
+    >;
+    expect(payload.prompt).toBeUndefined();
+    expect(JSON.stringify(payload)).not.toContain("sensitive prompt text");
+  });
+
+  it("resolves when emitEvent resolves", async () => {
+    await expect(
+      emitModelUsageEvent(runtime as never, "TEXT_GENERATION" as never, "p", {
+        promptTokens: 1,
+        completionTokens: 1,
+        totalTokens: 2,
+      }),
+    ).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new test file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `Test Files  1 passed (1)
      Tests  6 passed (6)` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
