### PR TITLE
test(anthropic-proxy): cover SSE rewrite event boundaries

### DIFF
--- a/plugins/plugin-anthropic-proxy/src/proxy/sse-rewrite.test.ts
+++ b/plugins/plugin-anthropic-proxy/src/proxy/sse-rewrite.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi } from "vitest";
+import { createSseStream } from "./sse-rewrite";
+
+function collect() {
+  const emitted: string[] = [];
+  const finished = vi.fn();
+  const stream = createSseStream(
+    (text) => text,
+    (text) => emitted.push(text),
+    finished
+  );
+  return { emitted, finished, stream };
+}
+
+describe("createSseStream", () => {
+  it("buffers an event until its blank-line terminator", () => {
+    const { emitted, stream } = collect();
+    stream.write(Buffer.from("data: hello"));
+    expect(emitted).toEqual([]);
+    stream.write(Buffer.from("\n\n"));
+    expect(emitted).toEqual(["data: hello\n\n"]);
+  });
+
+  it("emits one event per blank-line terminator within a chunk", () => {
+    const { emitted, stream } = collect();
+    stream.write(Buffer.from("data: one\n\ndata: two\n\n"));
+    expect(emitted).toEqual(["data: one\n\n", "data: two\n\n"]);
+  });
+
+  it("splits events on CRLF terminators", () => {
+    const { emitted, stream } = collect();
+    stream.write(Buffer.from("data: a\r\n\r\ndata: b\r\n\r\n"));
+    expect(emitted).toEqual(["data: a\r\n\r\n", "data: b\r\n\r\n"]);
+  });
+
+  it("accepts a bare CR blank line as a terminator", () => {
+    const { emitted, stream } = collect();
+    stream.write(Buffer.from("data: a\r\r"));
+    expect(emitted).toEqual(["data: a\r\r"]);
+  });
+
+  it("does not backtrack a CRLF line ending into CR + LF blank lines", () => {
+    const { emitted, stream } = collect();
+    stream.write(Buffer.from("data: x\r\n\n"));
+    expect(emitted).toEqual(["data: x\r\n\n"]);
+  });
+
+  it("applies the reverse map exactly once per event", () => {
+    const reverseFn = vi.fn((text: string) => text.toUpperCase());
+    const emitted: string[] = [];
+    const stream = createSseStream(
+      reverseFn,
+      (text) => emitted.push(text),
+      () => {}
+    );
+    stream.write(Buffer.from("data: one\n\n"));
+    expect(reverseFn).toHaveBeenCalledTimes(1);
+    expect(emitted).toEqual(["DATA: ONE\n\n"]);
+  });
+
+  it("applies the reverse map per event, not per chunk", () => {
+    const reverseFn = vi.fn((text: string) => text.toUpperCase());
+    const emitted: string[] = [];
+    const stream = createSseStream(
+      reverseFn,
+      (text) => emitted.push(text),
+      () => {}
+    );
+    stream.write(Buffer.from("data: one\n\n"));
+    stream.write(Buffer.from("data: two\n\n"));
+    expect(reverseFn).toHaveBeenCalledTimes(2);
+    expect(emitted).toEqual(["DATA: ONE\n\n", "DATA: TWO\n\n"]);
+  });
+
+  it("never merges a token split across two separate events", () => {
+    const emitted: string[] = [];
+    const stream = createSseStream(
+      (text) => text.replace("secret", "REDACTED"),
+      (text) => emitted.push(text),
+      () => {}
+    );
+    stream.write(Buffer.from("data: se\n\n"));
+    stream.write(Buffer.from("cret\n\n"));
+    expect(emitted).toEqual(["data: se\n\n", "cret\n\n"]);
+  });
+
+  it("decodes multi-byte characters split across chunk boundaries without U+FFFD", () => {
+    const { emitted, stream } = collect();
+    const bytes = Buffer.from("data: 数据\n\n", "utf8");
+    const firstNonAscii = bytes.findIndex((b) => b >= 0x80);
+    // split inside the first multi-byte sequence
+    const first = bytes.subarray(0, firstNonAscii + 1);
+    const second = bytes.subarray(firstNonAscii + 1);
+    stream.write(first);
+    stream.write(second);
+    expect(emitted).toEqual(["data: 数据\n\n"]);
+    expect(emitted[0]).not.toContain("\uFFFD");
+  });
+
+  it("flushes buffered text without a terminator on end()", () => {
+    const { emitted, finished, stream } = collect();
+    stream.write(Buffer.from("data: tail"));
+    stream.end();
+    expect(emitted).toEqual(["data: tail"]);
+    expect(finished).toHaveBeenCalledTimes(1);
+  });
+
+  it("emits nothing and still finishes when end() sees no buffered text", () => {
+    const { emitted, finished, stream } = collect();
+    stream.end();
+    expect(emitted).toEqual([]);
+    expect(finished).toHaveBeenCalledTimes(1);
+  });
+
+  it("maps the pending tail on end() before finishing", () => {
+    const emitted: string[] = [];
+    const stream = createSseStream(
+      (text) => text.replace("raw", "mapped"),
+      (text) => emitted.push(text),
+      () => {}
+    );
+    stream.write(Buffer.from("data: raw"));
+    stream.end();
+    expect(emitted).toEqual(["data: mapped"]);
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new test file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `Test Files  1 passed (1)
      Tests  12 passed (12)` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
