### PR TITLE
test(personal-assistant): cover activity signal publisher mapping

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/signals/activity-signal-publisher.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/signals/activity-signal-publisher.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from "vitest";
+import { publishActivitySignalToBus } from "./activity-signal-publisher";
+
+function makeBus() {
+  return { publish: vi.fn() };
+}
+
+function makeRegistry(get: (source: string) => unknown) {
+  return { get };
+}
+
+const signal = {
+  id: "signal-1",
+  source: "chat:123",
+  observedAt: "2026-08-25T00:00:00.000Z",
+  platform: "telegram",
+};
+
+describe("publishActivitySignalToBus", () => {
+  it("publishes a mapped message-activity signal and reports published: 1", () => {
+    const bus = makeBus();
+    const registry = makeRegistry(() => ({
+      family: "message_activity_event",
+      telemetryMapper: (s: typeof signal) => ({
+        family: "message_activity_event",
+        source: s.source,
+      }),
+    }));
+    const result = publishActivitySignalToBus(
+      bus as never,
+      signal as never,
+      registry as never,
+    );
+    expect(result).toEqual({ published: 1, unmapped: 0 });
+    expect(bus.publish).toHaveBeenCalledTimes(1);
+    expect(bus.publish).toHaveBeenCalledWith({
+      family: "message_activity_event",
+      occurredAt: signal.observedAt,
+      payload: { family: "message_activity_event", source: signal.source },
+      metadata: {
+        source: "lifeops-activity-signal",
+        signalId: signal.id,
+        signalSource: signal.source,
+        signalPlatform: signal.platform,
+      },
+    });
+  });
+
+  it("reports unmapped when the registry has no mapping for the source", () => {
+    const bus = makeBus();
+    const registry = makeRegistry(() => null);
+    const result = publishActivitySignalToBus(
+      bus as never,
+      signal as never,
+      registry as never,
+    );
+    expect(result).toEqual({ published: 0, unmapped: 1 });
+    expect(bus.publish).not.toHaveBeenCalled();
+  });
+
+  it("does not publish signals mapped to a non-message family", () => {
+    const bus = makeBus();
+    const registry = makeRegistry(() => ({
+      family: "health_metric",
+      telemetryMapper: (s: typeof signal) => ({
+        family: "health_metric",
+        source: s.source,
+      }),
+    }));
+    const result = publishActivitySignalToBus(
+      bus as never,
+      signal as never,
+      registry as never,
+    );
+    expect(result).toEqual({ published: 0, unmapped: 1 });
+    expect(bus.publish).not.toHaveBeenCalled();
+  });
+
+  it("carries the mapped payload through to the bus envelope", () => {
+    const bus = makeBus();
+    const payload = { family: "message_activity_event", value: 7 };
+    const registry = makeRegistry(() => ({
+      family: "message_activity_event",
+      telemetryMapper: () => payload,
+    }));
+    publishActivitySignalToBus(
+      bus as never,
+      signal as never,
+      registry as never,
+    );
+    expect(bus.publish).toHaveBeenCalledWith(
+      expect.objectContaining({ payload, family: "message_activity_event" }),
+    );
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new test file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `Test Files  1 passed (1)
      Tests  4 passed (4)` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
