### PR TITLE
test(openai): cover tokenizer model-resolution fallback

### DIFF
--- a/plugins/plugin-openai/utils/tokenization.test.ts
+++ b/plugins/plugin-openai/utils/tokenization.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockEncoder = {
+  encode: vi.fn((text: string) => Array.from(text).map((_, i) => i)),
+  decode: vi.fn((tokens: number[]) => String.fromCharCode(...tokens)),
+};
+
+vi.mock("js-tiktoken", () => ({
+  encodingForModel: vi.fn(),
+  getEncoding: vi.fn(() => mockEncoder),
+}));
+
+vi.mock("./config", () => ({
+  getLargeModel: vi.fn(() => "gpt-4o"),
+  getSmallModel: vi.fn(() => "gpt-4o-mini"),
+}));
+
+import { ModelType } from "@elizaos/core";
+import { encodingForModel, getEncoding } from "js-tiktoken";
+import { getLargeModel, getSmallModel } from "./config";
+import { countTokens, detokenizeText, tokenizeText } from "./tokenization.js";
+
+const runtime = {} as never;
+
+describe("tokenizeText", () => {
+  beforeEach(() => {
+    vi.mocked(encodingForModel).mockReset();
+    vi.mocked(getEncoding).mockReset().mockReturnValue(mockEncoder);
+    vi.mocked(getLargeModel).mockReset().mockReturnValue("gpt-4o");
+    vi.mocked(getSmallModel).mockReset().mockReturnValue("gpt-4o-mini");
+  });
+
+  it("uses the tiktoken registry encoding for a known model name", () => {
+    vi.mocked(encodingForModel).mockReturnValue(mockEncoder);
+    const tokens = tokenizeText(runtime, ModelType.TEXT_LARGE as never, "hello");
+    expect(vi.mocked(encodingForModel)).toHaveBeenCalledWith("gpt-4o");
+    expect(tokens).toEqual([0, 1, 2, 3, 4]);
+  });
+
+  it("falls back to o200k_base for an unknown 4o-family model name", () => {
+    vi.mocked(getLargeModel).mockReturnValue("gpt-4o-custom");
+    vi.mocked(encodingForModel).mockImplementation(() => {
+      throw new Error("Unknown model gpt-4o-custom");
+    });
+    const tokens = tokenizeText(runtime, ModelType.TEXT_LARGE as never, "hi");
+    expect(tokens).toEqual([0, 1]);
+    expect(vi.mocked(getEncoding)).toHaveBeenCalledWith("o200k_base");
+  });
+
+  it("falls back to cl100k_base for an unknown model without the 4o marker", () => {
+    vi.mocked(getLargeModel).mockReturnValue("my-private-llm");
+    vi.mocked(encodingForModel).mockImplementation(() => {
+      throw new Error("Unknown model");
+    });
+    const tokens = tokenizeText(runtime, ModelType.TEXT_LARGE as never, "hi");
+    expect(tokens).toEqual([0, 1]);
+    expect(vi.mocked(getEncoding)).toHaveBeenCalledWith("cl100k_base");
+  });
+
+  it("routes TEXT_SMALL through the small model setting", () => {
+    vi.mocked(encodingForModel).mockReturnValue(mockEncoder);
+    tokenizeText(runtime, ModelType.TEXT_SMALL as never, "hi");
+    expect(vi.mocked(getSmallModel)).toHaveBeenCalled();
+    expect(vi.mocked(encodingForModel)).toHaveBeenCalledWith("gpt-4o-mini");
+    expect(vi.mocked(getLargeModel)).not.toHaveBeenCalled();
+  });
+});
+
+describe("countTokens", () => {
+  it("returns the encoded length", () => {
+    vi.mocked(encodingForModel).mockReturnValue(mockEncoder);
+    expect(countTokens(runtime, ModelType.TEXT_LARGE as never, "hello")).toBe(5);
+  });
+});
+
+describe("detokenizeText", () => {
+  it("decodes through the resolved encoder", () => {
+    vi.mocked(encodingForModel).mockReturnValue(mockEncoder);
+    expect(detokenizeText(runtime, ModelType.TEXT_LARGE as never, [72, 105])).toBe(
+      String.fromCharCode(72, 105)
+    );
+  });
+});


### PR DESCRIPTION
# Relates to

No open issue. `resolveTokenizerEncoding` in `plugins/plugin-openai/utils/tokenization.ts`
falls back to a base encoding when js-tiktoken throws on an unknown model
name (error-policy:J3 untrusted-input sanitizing). This PR pins that
boundary so a future regression in the fallback selection cannot silently
change token counts used for budgets/limits.

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new test file exercising existing exported
functions with mocked tiktoken/config modules. No production code is
modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: see log below |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

```log
Test Files  1 passed (1)
      Tests  6 passed (6)
```

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used