### PR TITLE
test(workflow): cover /api/automations route boundary

### DIFF
--- a/plugins/plugin-workflow/src/routes/automations.test.ts
+++ b/plugins/plugin-workflow/src/routes/automations.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from 'vitest';
+import { handleAutomationsRoutes } from './automations.js';
+
+vi.mock('../lib/automations-builder', () => ({
+  buildAutomationListResponse: vi.fn(),
+}));
+
+vi.mock('./_helpers', () => ({
+  getRouteOwnerEntityId: vi.fn(() => 'owner-1'),
+}));
+
+import { buildAutomationListResponse } from '../lib/automations-builder';
+
+function ctx(overrides: Record<string, unknown> = {}) {
+  return {
+    req: {},
+    res: {},
+    method: 'GET',
+    pathname: '/api/automations',
+    runtime: {},
+    json: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('handleAutomationsRoutes', () => {
+  it('declines non-GET methods so other routers can handle them', async () => {
+    const c = ctx({ method: 'POST' });
+    expect(await handleAutomationsRoutes(c as never)).toBe(false);
+    expect(c.json).not.toHaveBeenCalled();
+  });
+
+  it('declines unknown paths', async () => {
+    const c = ctx({ pathname: '/api/other' });
+    expect(await handleAutomationsRoutes(c as never)).toBe(false);
+    expect(c.json).not.toHaveBeenCalled();
+  });
+
+  it('answers 503 when the agent runtime is unavailable', async () => {
+    const c = ctx({ runtime: null });
+    expect(await handleAutomationsRoutes(c as never)).toBe(true);
+    expect(c.json).toHaveBeenCalledWith(c.res, { error: 'Agent runtime is not available' }, 503);
+  });
+
+  it('answers 200 with the builder payload, scoped to the trimmed principal', async () => {
+    vi.mocked(buildAutomationListResponse).mockResolvedValue({
+      automations: [],
+    });
+    const c = ctx({ principalId: '  principal-7 ' });
+    expect(await handleAutomationsRoutes(c as never)).toBe(true);
+    expect(buildAutomationListResponse).toHaveBeenCalledWith(c.runtime, 'principal-7');
+    expect(c.json).toHaveBeenCalledWith(c.res, { automations: [] }, 200);
+  });
+
+  it('falls back to the route owner entity when no principal is supplied', async () => {
+    vi.mocked(buildAutomationListResponse).mockResolvedValue({
+      automations: [],
+    });
+    const c = ctx();
+    await handleAutomationsRoutes(c as never);
+    expect(buildAutomationListResponse).toHaveBeenCalledWith(c.runtime, 'owner-1');
+  });
+
+  it('translates builder failures to a 500 with the message only (no stack leak)', async () => {
+    vi.mocked(buildAutomationListResponse).mockRejectedValue(new Error('boom'));
+    const c = ctx();
+    expect(await handleAutomationsRoutes(c as never)).toBe(true);
+    expect(c.json).toHaveBeenCalledWith(c.res, { error: 'boom' }, 500);
+  });
+
+  it('handles non-Error throws from the builder', async () => {
+    vi.mocked(buildAutomationListResponse).mockRejectedValue('string failure');
+    const c = ctx();
+    expect(await handleAutomationsRoutes(c as never)).toBe(true);
+    expect(c.json).toHaveBeenCalledWith(c.res, { error: 'string failure' }, 500);
+  });
+});


### PR DESCRIPTION
# Relates to

No open issue. `handleAutomationsRoutes` in `plugins/plugin-workflow/src/routes/automations.ts`
is the request boundary for `/api/automations`; this PR pins its gate
behavior (method/path/runtime checks, 503 on unavailable runtime, 500
error translation) with the builder and owner-resolution helpers mocked.

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new test file exercising existing exported
functions with the builder and owner-resolution helpers mocked. No
production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: see log below |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

```log
Test Files  1 passed (1)
      Tests  7 passed (7)
```

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used