### PR TITLE
test(meetings): cover google meet leave best-effort contract

### DIFF
--- a/plugins/plugin-meetings/src/platforms/googlemeet/leave.test.ts
+++ b/plugins/plugin-meetings/src/platforms/googlemeet/leave.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./selectors.js", () => ({
+  googleLeaveSelectors: [
+    'button[aria-label*="Leave call"]',
+    'button[aria-label*="Leave meeting"]',
+  ],
+}));
+
+import { leaveGoogleMeet } from "./leave.js";
+
+function fakePage() {
+  return {
+    isClosed: vi.fn(() => false),
+    evaluate: vi.fn(async () => null),
+    waitForTimeout: vi.fn(async () => undefined),
+  };
+}
+
+describe("leaveGoogleMeet", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns immediately when the page is already closed", async () => {
+    const page = fakePage();
+    page.isClosed.mockReturnValue(true);
+    await leaveGoogleMeet(page as never);
+    expect(page.evaluate).not.toHaveBeenCalled();
+    expect(page.waitForTimeout).not.toHaveBeenCalled();
+  });
+
+  it("clicks the first visible leave control and retries for a confirmation dialog", async () => {
+    const page = fakePage();
+    page.evaluate
+      .mockResolvedValueOnce('button[aria-label*="Leave call"]')
+      .mockResolvedValueOnce(undefined);
+    await leaveGoogleMeet(page as never);
+    expect(page.evaluate).toHaveBeenCalledTimes(2);
+    expect(page.waitForTimeout).toHaveBeenCalledWith(500);
+  });
+
+  it("does not retry when no leave control is visible", async () => {
+    const page = fakePage();
+    page.evaluate.mockResolvedValue(null);
+    await leaveGoogleMeet(page as never);
+    expect(page.evaluate).toHaveBeenCalledTimes(1);
+    expect(page.waitForTimeout).not.toHaveBeenCalled();
+  });
+
+  it("never throws when the evaluate call fails", async () => {
+    const page = fakePage();
+    page.evaluate.mockRejectedValue(new Error("context destroyed"));
+    await expect(leaveGoogleMeet(page as never)).resolves.toBeUndefined();
+    expect(page.waitForTimeout).not.toHaveBeenCalled();
+  });
+
+  it("never throws when the confirmation pass fails", async () => {
+    const page = fakePage();
+    page.evaluate
+      .mockResolvedValueOnce('button[aria-label*="Leave call"]')
+      .mockRejectedValueOnce(new Error("dialog vanished"));
+    await expect(leaveGoogleMeet(page as never)).resolves.toBeUndefined();
+    expect(page.evaluate).toHaveBeenCalledTimes(2);
+  });
+
+  it("never throws when isClosed itself reports failure state", async () => {
+    const page = fakePage();
+    page.isClosed.mockReturnValue(false);
+    page.evaluate.mockRejectedValueOnce(new Error("frame detached"));
+    await expect(leaveGoogleMeet(page as never)).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing state-machine module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new test file exercising existing exported
functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `Test Files  1 passed (1)
      Tests  6 passed (6)` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
