### PR TITLE
fix(agent): sweep expired cloud-pair rate-limit buckets

### DIFF
--- a/packages/agent/src/api/cloud-pair-route.test.ts
+++ b/packages/agent/src/api/cloud-pair-route.test.ts
@@ -11,6 +11,7 @@ import {
 } from "@elizaos/shared/contracts";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  __cloudPairRateLimitSizeForTests,
   __resetCloudPairRateLimitForTests,
   handleStandaloneCloudPairRoute,
 } from "./cloud-pair-route.ts";
@@ -151,6 +152,57 @@ afterEach(() => {
   globalThis.fetch = originalFetch;
   vi.unstubAllGlobals();
   restoreManagedEnv();
+});
+
+describe("cloud-pair rate-limit buckets", () => {
+  it("does not retain a bucket for every peer address that never returns", async () => {
+    // Each unique peer mints a bucket. Without a sweep they are only ever
+    // replaced when that same address comes back, so one-off peers accumulate
+    // for the lifetime of the process.
+    const start = Date.parse("2026-08-25T00:00:00.000Z");
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(start);
+
+    for (let i = 0; i < 150; i += 1) {
+      const harness = fakeRes();
+      await handleStandaloneCloudPairRoute(
+        fakeReq({
+          pathname: "/pair",
+          ip: `127.0.${Math.floor(i / 256)}.${i % 256}`,
+        }),
+        harness.res,
+      );
+    }
+    expect(__cloudPairRateLimitSizeForTests()).toBe(150);
+
+    // Every bucket above is now expired. One further request must not leave
+    // the map holding all 150 dead entries.
+    vi.setSystemTime(start + 61_000);
+    const harness = fakeRes();
+    await handleStandaloneCloudPairRoute(
+      fakeReq({ pathname: "/pair", ip: "127.9.9.9" }),
+      harness.res,
+    );
+
+    expect(__cloudPairRateLimitSizeForTests()).toBe(1);
+  });
+
+  it("still rate-limits a repeat caller within the window", async () => {
+    const start = Date.parse("2026-08-25T00:00:00.000Z");
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(start);
+
+    let last = 0;
+    for (let i = 0; i < 21; i += 1) {
+      const harness = fakeRes();
+      await handleStandaloneCloudPairRoute(
+        fakeReq({ pathname: "/pair", ip: "127.1.1.1" }),
+        harness.res,
+      );
+      last = harness.status();
+    }
+    expect(last).toBe(429);
+  });
 });
 
 describe("handleStandaloneCloudPairRoute", () => {

--- a/packages/agent/src/api/cloud-pair-route.ts
+++ b/packages/agent/src/api/cloud-pair-route.ts
@@ -26,6 +26,7 @@ import {
   renderCloudPairHandoffHtml,
   resolveCloudPairAgentIdFromEnv,
 } from "@elizaos/shared/contracts";
+import { sweepExpiredEntries } from "./memory-bounds.js";
 import { resolveDirectRequestOrigin } from "./request-origin.js";
 
 const RELAY_TIMEOUT_MS = 15_000;
@@ -43,9 +44,18 @@ export function __resetCloudPairRateLimitForTests(): void {
   rateBuckets.clear();
 }
 
+/** Retained-bucket count, so tests can assert the map stays bounded. */
+export function __cloudPairRateLimitSizeForTests(): number {
+  return rateBuckets.size;
+}
+
 function rateLimitConsume(key: string | null): boolean {
   const now = Date.now();
   const bucketKey = key || "unknown";
+
+  // Lazy sweep: evict expired entries when map grows beyond 100
+  sweepExpiredEntries(rateBuckets, now, 100);
+
   const current = rateBuckets.get(bucketKey);
   if (!current || current.resetAt <= now) {
     rateBuckets.set(bucketKey, {


### PR DESCRIPTION
# Relates to

Closes #29715.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop`, built directly on the current `origin/develop` tree, zero conflicts.
- [x] Uses the repository's existing helper rather than a new one.
- [x] A reviewer can confirm the behaviour from the mutation output below without reading the code.

# Sync with develop

- [x] Built on the current `origin/develop` tree; zero conflicts.
- [x] Two files differ; the production change is one import and one call.

# Risks

Low. `sweepExpiredEntries` early-returns while the map is at or below its threshold, so the common path is unchanged and the scan is amortized rather than per-request. Only already-expired entries are removed, so no live bucket is dropped and no caller's limit is reset early — pinned by the second test below.

# Background

## What does this PR do?

`rateLimitConsume` in `packages/agent/src/api/cloud-pair-route.ts` mints a bucket per peer address:

```ts
const current = rateBuckets.get(bucketKey);
if (!current || current.resetAt <= now) {
  rateBuckets.set(bucketKey, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
```

An entry is only ever replaced when that same address comes back. A peer that connects once leaves its bucket in the module-level `Map` for the lifetime of the process, long after `resetAt` has passed.

**How wide the key space actually is.** The relay is not open to the internet — `canUseManagedDirectRelay` admits only loopback peers or addresses inside `ELIZA_CLOUD_PAIR_ALLOWED_PEER_CIDRS`. That bounds the leak, and it is worth stating rather than claiming an unbounded remote vector. It does not eliminate it:

- `isLoopbackRemoteAddress` tests `normalized.startsWith("127.")`, so the whole `127.0.0.0/8` is admitted — 16.7M distinct keys reachable by any local process.
- the documented Docker-bridge allowlist example, `172.17.0.0/16`, is 65k keys.

**This is the odd one out.** Both sibling limiters in the same directory already sweep, through a shared helper:

```
server-helpers-auth.ts:534   sweepExpiredEntries(pairingAttempts, now, 100);
bug-report-routes.ts:90      sweepExpiredEntries(bugReportAttempts, now, 100);
```

`cloud-pair-route.ts` did not.

## What is the fix?

Call the existing helper. `RateBucket` is structurally identical to the helper's `RateLimitEntry`, so no type change is needed.

```diff
+import { sweepExpiredEntries } from "./memory-bounds.js";

 function rateLimitConsume(key: string | null): boolean {
   const now = Date.now();
   const bucketKey = key || "unknown";
+
+  // Lazy sweep: evict expired entries when map grows beyond 100
+  sweepExpiredEntries(rateBuckets, now, 100);
+
   const current = rateBuckets.get(bucketKey);
```

A hand-rolled `for` loop would also work, but `sweepExpiredEntries` guards with `if (map.size <= threshold) return;` — so the scan does not run on every request. On a rate-limit hot path that distinction matters: an unguarded sweep would turn each admission check into an O(n) walk precisely when `n` is large.

# Documentation changes needed?

No. No public surface, setting, or documented behaviour changes. `__cloudPairRateLimitSizeForTests` follows the module's existing `__resetCloudPairRateLimitForTests` convention and is test-only.

# Testing

## Where should a reviewer start?

The mutation block. Both tests drive the real exported handler through the file's existing harness — no stubbed rate limiter, no re-implemented logic in the test body.

## Detailed testing steps

| Gate | Result |
| --- | --- |
| `packages/agent/src/api/cloud-pair-route.test.ts` | **24 passed** (22 pre-existing + 2 new) |
| `biome check` (repository-pinned 2.5.8) | `No fixes applied.` |
| production diff vs `develop` | one import, one call, one test-only accessor |

Mutation resistance — reverting **only** the two-line sweep and keeping the tests:

```
× does not retain a bucket for every peer address that never returns
AssertionError: expected 151 to be 1
 Tests  1 failed | 23 passed (24)
```

151 retained buckets versus 1. The second test is the guard in the other direction: a repeat caller from one address still receives `429` after exceeding `RATE_LIMIT_MAX` inside the window, so the sweep cannot be mistaken for a limit reset. It passes in both directions by design.

# Evidence Gate

<!-- evidence-head:3134aea0bb017c276373ac637a6951398be4ea09 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - backend rate-limit bookkeeping; no rendered surface`.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - backend rate-limit bookkeeping; no rendered surface`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough `N/A - the observable behaviour is retained map size, asserted directly in the tests above`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no service is started; the real exported handler is driven directly by the suite above`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no frontend change`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no model call is involved in rate limiting`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - no domain record is produced; the artifact is the retained-bucket count quoted above`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review `N/A - no rendered visual surface`.

# Attribution

- Found by OpenAI `gpt-5.6-sol` via Codex (AgentRouter) during an unbounded-cache sweep of `packages/agent`.
- Independent verification, the correction from a hand-rolled per-request loop to the repository's amortized `sweepExpiredEntries` helper, the peer-gate bound analysis, and the mutation proof by Claude Code (`claude-opus-5`).

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Attribution status: self-reported

