### PR TITLE
test(lifeops): cover continuity probe presence classification; fix bluetooth phone filter

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/continuity-probe.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/continuity-probe.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  type ContinuityShellRunner,
+  probeContinuityDevices,
+} from "./continuity-probe.js";
+
+const realPlatform = process.platform;
+
+function setPlatform(value: string) {
+  Object.defineProperty(process, "platform", { value, configurable: true });
+}
+
+const createActivitySignal = vi.fn(async () => {});
+const listActivitySignals = vi.fn(async () => []);
+const repository = { createActivitySignal, listActivitySignals };
+
+function shellWith(stdout: string): ContinuityShellRunner {
+  return { run: vi.fn(async () => ({ stdout })) };
+}
+
+function bluetoothJson(
+  entries: Array<{
+    name: string;
+    address: string;
+    minorType: string;
+    connected: boolean;
+  }>,
+): string {
+  const connected: Record<string, unknown> = {};
+  const notConnected: Record<string, unknown> = {};
+  for (const entry of entries) {
+    const payload = {
+      device_address: entry.address,
+      device_minorType: entry.minorType,
+    };
+    (entry.connected ? connected : notConnected)[entry.name] = payload;
+  }
+  return JSON.stringify({
+    SPBluetoothDataType: [
+      { device_connected: connected, device_not_connected: notConnected },
+    ],
+  });
+}
+
+beforeEach(() => {
+  createActivitySignal.mockReset();
+  listActivitySignals.mockReset();
+  listActivitySignals.mockResolvedValue([]);
+  setPlatform("darwin");
+});
+
+afterEach(() => {
+  setPlatform(realPlatform);
+});
+
+describe("probeContinuityDevices", () => {
+  it("is a no-op on non-darwin platforms", async () => {
+    setPlatform("linux");
+    await probeContinuityDevices({
+      repository,
+      agentId: "agent-1",
+      now: new Date("2026-08-25T12:00:00Z"),
+    });
+    expect(listActivitySignals).not.toHaveBeenCalled();
+    expect(createActivitySignal).not.toHaveBeenCalled();
+  });
+
+  it("does not run when a recent capacitor mobile signal is authoritative", async () => {
+    listActivitySignals.mockResolvedValue([
+      {
+        source: "mobile_device",
+        platform: "capacitor:ios",
+        state: "active",
+        metadata: {},
+      },
+    ]);
+    const shell = shellWith("{}");
+    await probeContinuityDevices({
+      repository,
+      agentId: "agent-1",
+      now: new Date("2026-08-25T12:00:00Z"),
+      shell,
+    });
+    expect(shell.run).not.toHaveBeenCalled();
+    expect(createActivitySignal).not.toHaveBeenCalled();
+  });
+
+  it("ignores bluetooth headphones even though 'Headphones' contains 'phone'", async () => {
+    const shell = shellWith(
+      bluetoothJson([
+        {
+          name: "Sony WH-1000XM",
+          address: "AA:BB:CC:DD:EE:01",
+          minorType: "Headphones",
+          connected: true,
+        },
+      ]),
+    );
+    await probeContinuityDevices({
+      repository,
+      agentId: "agent-1",
+      now: new Date("2026-08-25T12:00:00Z"),
+      shell,
+    });
+    expect(createActivitySignal).not.toHaveBeenCalled();
+  });
+
+  it("emits a mobile_device signal for a paired connected iPhone", async () => {
+    const shell = shellWith(
+      bluetoothJson([
+        {
+          name: "Owner iPhone",
+          address: "AA:BB:CC:DD:EE:02",
+          minorType: "Phone",
+          connected: true,
+        },
+      ]),
+    );
+    await probeContinuityDevices({
+      repository,
+      agentId: "agent-1",
+      now: new Date("2026-08-25T12:00:00Z"),
+      shell,
+    });
+    expect(createActivitySignal).toHaveBeenCalledTimes(1);
+    const signal = createActivitySignal.mock.calls[0][0];
+    expect(signal.platform).toBe("macos_continuity:system_profiler_bluetooth");
+    expect(signal.state).toBe("active");
+    expect(signal.metadata.deviceId).toBe("AA:BB:CC:DD:EE:02");
+  });
+
+  it("merges devicectl over bluetooth for the same device id and stays idempotent", async () => {
+    const devicectl = JSON.stringify({
+      result: {
+        devices: [
+          {
+            identifier: "00008120-001A1B2C3D4E",
+            deviceProperties: { name: "Owner iPhone", deviceType: "iPhone" },
+            connectionProperties: {
+              pairingState: "paired",
+              tunnelState: "connected",
+            },
+          },
+        ],
+      },
+    });
+    let calls = 0;
+    const shell: ContinuityShellRunner = {
+      run: vi.fn(async () => {
+        calls += 1;
+        return { stdout: calls === 1 ? devicectl : bluetoothJson([]) };
+      }),
+    };
+    await probeContinuityDevices({
+      repository,
+      agentId: "agent-1",
+      now: new Date("2026-08-25T12:00:00Z"),
+      shell,
+    });
+    expect(createActivitySignal).toHaveBeenCalledTimes(1);
+    const signal = createActivitySignal.mock.calls[0][0];
+    expect(signal.platform).toBe("macos_continuity:xcrun_devicectl");
+
+    // Second run with the same observation → no duplicate signal.
+    createActivitySignal.mockReset();
+    listActivitySignals.mockResolvedValue([signal]);
+    await probeContinuityDevices({
+      repository,
+      agentId: "agent-1",
+      now: new Date("2026-08-25T12:01:00Z"),
+      shell,
+    });
+    expect(createActivitySignal).not.toHaveBeenCalled();
+  });
+
+  it("tolerates malformed devicectl output and falls back to bluetooth", async () => {
+    let calls = 0;
+    const shell: ContinuityShellRunner = {
+      run: vi.fn(async () => {
+        calls += 1;
+        return { stdout: calls === 1 ? "not json {" : bluetoothJson([]) };
+      }),
+    };
+    await expect(
+      probeContinuityDevices({
+        repository,
+        agentId: "agent-1",
+        now: new Date("2026-08-25T12:00:00Z"),
+        shell,
+      }),
+    ).resolves.toBeUndefined();
+    expect(createActivitySignal).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/plugin-personal-assistant/src/lifeops/continuity-probe.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/continuity-probe.ts
@@ -193,7 +193,9 @@ async function readBluetoothPairedIphones(
           const entry = rawEntry as BluetoothRawEntry;
           const minorType =
             normalizeString(entry.device_minorType)?.toLowerCase() ?? "";
-          if (!minorType.includes("phone")) continue;
+          // Match the phone device class as a whole word — "Headphones",
+          // "Phone cases" etc. must not be treated as iPhones.
+          if (!/\bphone\b/.test(minorType)) continue;
           const address = normalizeString(entry.device_address);
           if (!address) continue;
           results.push({


### PR DESCRIPTION
# Relates to

No issue; focused test coverage for the macOS continuity probe plus a
one-line behavioral fix it reproduces.

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] Focused vitest was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# What changed

`readBluetoothPairedIphones` in `plugins/plugin-personal-assistant/src/lifeops/continuity-probe.ts`
kept devices whose `device_minorType` **contains** the substring `phone`.
`system_profiler SPBluetoothDataType` reports headphones as
`minorType: "Headphones"`, which contains `phone` — so a paired bluetooth
headset was classified as a paired iPhone and emitted a fake
`mobile_device` presence signal (`macos_continuity:system_profiler_bluetooth`).
The filter now matches the phone class as a whole word (`/\bphone\b/`), so
headsets and other non-phone audio devices are ignored while real iPhones
(`minorType: "Phone"`) still qualify.

# Risks

Low. The production change narrows one device-class predicate; only
substring-only matches (the defect class, e.g. `Headphones`) are excluded.
The probe remains a no-op on non-darwin platforms, skips when a recent
Capacitor mobile signal is authoritative, and stays idempotent per
`(deviceId, connected, observedAt)` — all pinned by the new tests.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: 6 passed (see log below) |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test + fix diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
