### PR TITLE
test(lifeops): cover FDA probe status classification; fix blank IMESSAGE_DB_PATH

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/fda-probe.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/fda-probe.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { probeFullDiskAccess } from "./fda-probe.js";
+
+const realPlatform = process.platform;
+const realEnv = { ...process.env };
+
+function setPlatform(value: string) {
+  Object.defineProperty(process, "platform", { value, configurable: true });
+}
+
+beforeEach(() => {
+  setPlatform("darwin");
+  delete process.env.IMESSAGE_DB_PATH;
+});
+
+afterEach(() => {
+  setPlatform(realPlatform);
+  process.env = { ...realEnv };
+});
+
+describe("probeFullDiskAccess", () => {
+  it("is not applicable on non-darwin platforms", async () => {
+    setPlatform("linux");
+    const result = await probeFullDiskAccess();
+    expect(result.status).toBe("not_applicable");
+    expect(result.reason).toContain("macOS");
+  });
+
+  it("reports granted when the chat.db file opens", async () => {
+    const fs = await import("node:fs");
+    const openSpy = vi
+      .spyOn(fs.promises, "open")
+      .mockResolvedValue({ close: vi.fn(async () => {}) } as never);
+    try {
+      const result = await probeFullDiskAccess({ chatDbPath: "/tmp/chat.db" });
+      expect(result.status).toBe("granted");
+      expect(result.chatDbPath).toBe("/tmp/chat.db");
+      expect(result.reason).toBeNull();
+    } finally {
+      openSpy.mockRestore();
+    }
+  });
+
+  it("reports not_applicable when the file is missing (ENOENT)", async () => {
+    const fs = await import("node:fs");
+    const error = Object.assign(new Error("no such file"), { code: "ENOENT" });
+    const openSpy = vi.spyOn(fs.promises, "open").mockRejectedValue(error);
+    try {
+      const result = await probeFullDiskAccess({
+        chatDbPath: "/tmp/missing.db",
+      });
+      expect(result.status).toBe("not_applicable");
+      expect(result.reason).toContain("not present");
+    } finally {
+      openSpy.mockRestore();
+    }
+  });
+
+  it("reports revoked on EPERM/EACCES", async () => {
+    const fs = await import("node:fs");
+    const error = Object.assign(new Error("permission denied"), {
+      code: "EPERM",
+    });
+    const openSpy = vi.spyOn(fs.promises, "open").mockRejectedValue(error);
+    try {
+      const result = await probeFullDiskAccess({
+        chatDbPath: "/tmp/denied.db",
+      });
+      expect(result.status).toBe("revoked");
+      expect(result.reason).toContain("Full Disk Access");
+    } finally {
+      openSpy.mockRestore();
+    }
+  });
+
+  it("reports unknown for unclassified errno errors", async () => {
+    const fs = await import("node:fs");
+    const error = Object.assign(new Error("disk on fire"), { code: "EIO" });
+    const openSpy = vi.spyOn(fs.promises, "open").mockRejectedValue(error);
+    try {
+      const result = await probeFullDiskAccess({ chatDbPath: "/tmp/eio.db" });
+      expect(result.status).toBe("unknown");
+      expect(result.reason).toContain("EIO");
+    } finally {
+      openSpy.mockRestore();
+    }
+  });
+
+  it("falls back to the default path when IMESSAGE_DB_PATH is an empty string", async () => {
+    process.env.IMESSAGE_DB_PATH = "   ";
+    const fs = await import("node:fs");
+    const openSpy = vi
+      .spyOn(fs.promises, "open")
+      .mockResolvedValue({ close: vi.fn(async () => {}) } as never);
+    try {
+      const result = await probeFullDiskAccess();
+      // A blank env override must not make us open an empty path — the
+      // default chat.db location is probed instead.
+      expect(result.chatDbPath.length).toBeGreaterThan(0);
+      expect(result.status).toBe("granted");
+    } finally {
+      openSpy.mockRestore();
+    }
+  });
+
+  it("prefers an explicit override over the environment variable", async () => {
+    process.env.IMESSAGE_DB_PATH = "/env/chat.db";
+    const fs = await import("node:fs");
+    const openSpy = vi
+      .spyOn(fs.promises, "open")
+      .mockResolvedValue({ close: vi.fn(async () => {}) } as never);
+    try {
+      const result = await probeFullDiskAccess({
+        chatDbPath: "/override/chat.db",
+      });
+      expect(result.chatDbPath).toBe("/override/chat.db");
+    } finally {
+      openSpy.mockRestore();
+    }
+  });
+});

--- a/plugins/plugin-personal-assistant/src/lifeops/fda-probe.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/fda-probe.ts
@@ -54,7 +54,7 @@ export async function probeFullDiskAccess(overrides?: {
   }
   const chatDbPath =
     (overrides?.chatDbPath?.trim() || null) ??
-    process.env.IMESSAGE_DB_PATH?.trim() ??
+    (process.env.IMESSAGE_DB_PATH?.trim() || null) ??
     DEFAULT_CHAT_DB_PATH;
   try {
     const handle = await fs.open(chatDbPath, "r");


### PR DESCRIPTION
# Relates to

No issue; focused test coverage for the Full Disk Access probe plus a
one-line behavioral fix it reproduces.

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] Focused vitest was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# What changed

`probeFullDiskAccess` in `plugins/plugin-personal-assistant/src/lifeops/fda-probe.ts`
chose the probe path as
`override ?? env ?? default`. When `IMESSAGE_DB_PATH` was set to an empty or
whitespace string, the nullish coalescing kept the blank value, so the probe
called `fs.open("")`, got `ENOENT`, and reported FDA as `not_applicable`
("chat.db not present") even though chat.db exists at the default location —
the permissions panel would show the wrong permission state. Blank env values
are now treated as unset, matching the explicit-override handling directly
above; the probe falls back to the default `~/Library/Messages/chat.db`.

# Risks

Low. The production change only affects blank `IMESSAGE_DB_PATH` values
(now falling back to the default path instead of opening an empty path).
All status classifications (granted/revoked/not_applicable/unknown) are
unchanged and pinned by the new tests.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: 7 passed (see log below) |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test + fix diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
