### PR TITLE
test(wallet): cover x402 multi-asset resolution; fix decimals fallback on malformed network

### DIFF
--- a/plugins/plugin-wallet/src/sdk/x402/multi-asset.test.ts
+++ b/plugins/plugin-wallet/src/sdk/x402/multi-asset.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  buildSupportedAssets,
+  isStablecoin,
+  parseNetworkChainId,
+  resolveAssetAddress,
+  resolveAssetDecimals,
+} from "./multi-asset.js";
+
+const { getToken, getTokenByAddress, USDC_BASE, WETH_BASE } = vi.hoisted(
+  () => ({
+    getToken: vi.fn(),
+    getTokenByAddress: vi.fn(),
+    USDC_BASE: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    WETH_BASE: "0x4200000000000000000000000000000000000006",
+  }),
+);
+
+vi.mock("../tokens/registry.js", () => ({
+  getGlobalRegistry: () => ({ getToken, getTokenByAddress }),
+}));
+
+vi.mock("./types.js", () => ({
+  USDC_ADDRESSES: { "base:8453": USDC_BASE },
+}));
+
+beforeEach(() => {
+  getToken.mockReset();
+  getTokenByAddress.mockReset();
+});
+
+describe("parseNetworkChainId", () => {
+  it("extracts the trailing chain id", () => {
+    expect(parseNetworkChainId("base:8453")).toBe(8453);
+    expect(parseNetworkChainId("arbitrum:42161")).toBe(42161);
+  });
+
+  it("rejects non-numeric ids and malformed networks", () => {
+    expect(parseNetworkChainId("base:not-a-number")).toBeNull();
+    expect(parseNetworkChainId("base:8453:extra")).toBeNull();
+    expect(parseNetworkChainId("base")).toBeNull();
+    expect(parseNetworkChainId("base:")).toBeNull();
+    expect(parseNetworkChainId("")).toBeNull();
+  });
+});
+
+describe("resolveAssetAddress", () => {
+  it("resolves a symbol via the registry", () => {
+    getToken.mockReturnValue({ address: WETH_BASE });
+    expect(resolveAssetAddress("weth", "base:8453")).toBe(WETH_BASE);
+    expect(getToken).toHaveBeenCalledWith("WETH", 8453);
+  });
+
+  it("rejects unknown hex addresses for safety", () => {
+    getTokenByAddress.mockReturnValue(null);
+    expect(
+      resolveAssetAddress(
+        "0x1111111111111111111111111111111111111111",
+        "base:8453",
+      ),
+    ).toBeNull();
+  });
+
+  it("accepts a registered hex address", () => {
+    getTokenByAddress.mockReturnValue({ address: WETH_BASE });
+    expect(resolveAssetAddress(WETH_BASE, "base:8453")).toBe(WETH_BASE);
+  });
+
+  it("returns null for an unparseable network", () => {
+    expect(resolveAssetAddress("USDC", "garbage")).toBeNull();
+  });
+});
+
+describe("resolveAssetDecimals", () => {
+  it("returns registered decimals by address", () => {
+    getTokenByAddress.mockReturnValue({ address: WETH_BASE, decimals: 18 });
+    expect(resolveAssetDecimals(WETH_BASE, "base:8453")).toBe(18);
+  });
+
+  it("defaults to 18 for unknown tokens", () => {
+    getTokenByAddress.mockReturnValue(null);
+    getToken.mockReturnValue(null);
+    expect(
+      resolveAssetDecimals(
+        "0x9999999999999999999999999999999999999999",
+        "base:8453",
+      ),
+    ).toBe(18);
+    expect(resolveAssetDecimals("UNKNOWN_SYMBOL", "base:8453")).toBe(18);
+  });
+
+  it("does not default a non-USDC asset to 6 decimals when the network is unparseable", () => {
+    // A malformed network string (e.g. from an untrusted 402 response) must
+    // not be treated as a stablecoin: the documented fallback for unknown
+    // assets is 18 decimals, otherwise payment amounts are mis-formatted.
+    expect(resolveAssetDecimals(WETH_BASE, "base")).toBe(18);
+    expect(resolveAssetDecimals(WETH_BASE, "base:not-a-number")).toBe(18);
+  });
+
+  it("keeps 6 for assets the registry confirms are 6-decimal", () => {
+    getTokenByAddress.mockReturnValue({ address: USDC_BASE, decimals: 6 });
+    expect(resolveAssetDecimals(USDC_BASE, "base:8453")).toBe(6);
+  });
+});
+
+describe("buildSupportedAssets", () => {
+  it("populates registered non-native symbols per network", () => {
+    getToken.mockImplementation((symbol: string) =>
+      symbol === "WETH" ? { address: WETH_BASE, isNative: false } : null,
+    );
+    const result = buildSupportedAssets(["base:8453"], ["WETH"]);
+    expect(result["base:8453"]).toContain(WETH_BASE);
+  });
+
+  it("skips native tokens and unparseable networks", () => {
+    getToken.mockReturnValue({ address: "0xeth", isNative: true });
+    const result = buildSupportedAssets(["base:8453", "garbage"], ["ETH"]);
+    expect(result.garbage).toBeUndefined();
+  });
+
+  it("appends the USDC fallback when not already present", () => {
+    getToken.mockReturnValue(null);
+    const result = buildSupportedAssets(["base:8453"], ["WETH"]);
+    expect(result["base:8453"]).toContain(USDC_BASE);
+  });
+});
+
+describe("isStablecoin", () => {
+  it("classifies by resolved decimals", () => {
+    getTokenByAddress.mockReturnValue({ address: USDC_BASE, decimals: 6 });
+    expect(isStablecoin(USDC_BASE, "base:8453")).toBe(true);
+    getTokenByAddress.mockReturnValue({ address: WETH_BASE, decimals: 18 });
+    expect(isStablecoin(WETH_BASE, "base:8453")).toBe(false);
+  });
+});

--- a/plugins/plugin-wallet/src/sdk/x402/multi-asset.ts
+++ b/plugins/plugin-wallet/src/sdk/x402/multi-asset.ts
@@ -71,7 +71,10 @@ export function resolveAssetAddress(
  */
 export function resolveAssetDecimals(asset: string, network: string): number {
   const chainId = parseNetworkChainId(network);
-  if (chainId == null) return 6;
+  // An unparseable network string (e.g. from an untrusted 402 response)
+  // carries no asset context — fall back to the documented default for
+  // unknown assets (18) instead of assuming a 6-decimal stablecoin.
+  if (chainId == null) return 18;
 
   const registry = getGlobalRegistry();
 


### PR DESCRIPTION
# Relates to

No issue; focused test coverage for the x402 multi-asset helpers plus a
one-line behavioral fix it reproduces.

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] Focused vitest was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# What changed

`resolveAssetDecimals` in `plugins/plugin-wallet/src/sdk/x402/multi-asset.ts`
returned `6` whenever the network string did not parse to a chain id. The
documented fallback for unknown assets is `18` ("defaults to 6 for USDC-like
stable, 18 for everything else"); a malformed network (e.g. from an
untrusted 402 response) carries no asset context, so a WETH payment would
have been formatted with 6 decimals instead of 18 — mis-formatting the
payment amount at a trust boundary. The unparseable-network branch now
returns the documented 18-decimal default, consistent with the
unknown-token branches below it.

# Risks

Low. The production change only alters the malformed-network branch of one
pure helper; registered 6-decimal stablecoins still resolve to 6, unknown
tokens still resolve to 18, and `resolveAssetAddress`/`buildSupportedAssets`
behavior is unchanged — all pinned by the new tests.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: 14 passed (see log below) |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test + fix diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
