### PR TITLE
test(cloud-api): cover ballot-id param boundary validation

### DIFF
--- a/packages/cloud/api/v1/ballots/ballot-id.test.ts
+++ b/packages/cloud/api/v1/ballots/ballot-id.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Behavior coverage for ballot-id boundary validation.
+ *
+ * Ballot route `:id` params must be rejected with 400 before any repository
+ * lookup so Postgres UUID casts never surface as internal 500s. This pins the
+ * contract: empty ids and non-UUID strings are typed client errors, and
+ * well-formed UUIDs pass through untouched (misses stay a separate 404).
+ */
+import { describe, expect, test } from "bun:test";
+import { parseBallotIdParam } from "./ballot-id";
+
+describe("parseBallotIdParam", () => {
+  test("rejects a missing id as a client error", () => {
+    expect(parseBallotIdParam(undefined)).toEqual({
+      ok: false,
+      error: "Missing ballot id",
+    });
+  });
+
+  test("rejects an empty id as a client error", () => {
+    expect(parseBallotIdParam("")).toEqual({
+      ok: false,
+      error: "Missing ballot id",
+    });
+  });
+
+  test("rejects a non-UUID string", () => {
+    expect(parseBallotIdParam("not-a-uuid")).toEqual({
+      ok: false,
+      error: "Invalid ballot id",
+    });
+  });
+
+  test("rejects a UUID with trailing garbage", () => {
+    expect(
+      parseBallotIdParam("11111111-1111-4111-8111-111111111111junk"),
+    ).toEqual({
+      ok: false,
+      error: "Invalid ballot id",
+    });
+  });
+
+  test("rejects a UUID with the wrong version nibble", () => {
+    // v6 is outside the [1-5] version range the API accepts.
+    expect(parseBallotIdParam("11111111-1111-6111-8111-111111111111")).toEqual({
+      ok: false,
+      error: "Invalid ballot id",
+    });
+  });
+
+  test("accepts a well-formed UUID", () => {
+    expect(parseBallotIdParam("11111111-1111-4111-8111-111111111111")).toEqual({
+      ok: true,
+      id: "11111111-1111-4111-8111-111111111111",
+    });
+  });
+
+  test("accepts an uppercase well-formed UUID (case-insensitive)", () => {
+    expect(
+      parseBallotIdParam("11111111-1111-4111-8111-111111111111".toUpperCase()),
+    ).toEqual({
+      ok: true,
+      id: "11111111-1111-4111-8111-111111111111".toUpperCase(),
+    });
+  });
+});


### PR DESCRIPTION
## Relates to

Behavior coverage for `ballot-id` boundary validation in the cloud API.

## Background

Ballot route `:id` params must be rejected as typed client errors **before** any repository lookup so Postgres UUID casts never surface as internal 500s on public or authenticated ballot routes. `parseBallotIdParam` was previously untested; this pins the full contract: missing/empty ids → "Missing ballot id", non-UUID or wrong-version strings → "Invalid ballot id", well-formed UUIDs pass through untouched (store misses remain a separate 404).

## Testing

- `7 pass / 0 fail` locally: `cd packages/cloud/api && bun test v1/ballots/ballot-id.test.ts` (76ms)
- Cases: missing id, empty id, non-UUID string, trailing garbage, wrong version nibble (v6 rejected), well-formed UUID, uppercase UUID (case-insensitive regex)

<!-- evidence-row:before-screenshots -->
- [x] before-screenshots: N/A (pure function, no UI)
<!-- evidence-row:after-screenshots -->
- [x] after-screenshots: N/A (pure function, no UI)
<!-- evidence-row:walkthrough-video -->
- [x] walkthrough-video: N/A (pure function, no UI)
<!-- evidence-row:backend-logs -->
- [x] backend-logs: `bun test` output — 7 pass / 0 fail (76ms)
<!-- evidence-row:frontend-logs -->
- [x] frontend-logs: N/A (no frontend change)
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A (test-only PR)
<!-- evidence-row:domain-artifacts -->
- [x] domain-artifacts: N/A (test-only PR)

AI provider/model: deepseek / deepseek-v4-flash
<!-- slop-contribution-attribution:v1 -->
