### PR TITLE
test(cloud-shared): cover shared-runtime error types

### DIFF
--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-errors.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-errors.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Behavior coverage for shared-runtime error types.
+ *
+ * These classes are deliberately dependency-free: coordinator and route
+ * boundaries need real class identity for these errors without dragging the
+ * billing/runtime module graph into their own graphs. Several catch sites
+ * additionally match on `error.name` because the class cannot survive the
+ * Durable Object fetch boundary — so name identity is part of the contract.
+ */
+import { describe, expect, test } from "bun:test";
+import { SharedRuntimeCacheWarmingError, SharedTurnConflictError } from "./shared-runtime-errors";
+
+describe("SharedRuntimeCacheWarmingError", () => {
+  test("is an Error with the stable class name", () => {
+    const error = new SharedRuntimeCacheWarmingError("warming failed");
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(SharedRuntimeCacheWarmingError);
+    expect(error.name).toBe("SharedRuntimeCacheWarmingError");
+  });
+
+  test("carries the message through", () => {
+    const error = new SharedRuntimeCacheWarmingError("cache warm aborted");
+    expect(error.message).toBe("cache warm aborted");
+  });
+});
+
+describe("SharedTurnConflictError", () => {
+  test("is an Error with the stable class name", () => {
+    const error = new SharedTurnConflictError();
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(SharedTurnConflictError);
+    expect(error.name).toBe("SharedTurnConflictError");
+  });
+
+  test("defaults to the clientMessageId-reuse message", () => {
+    const error = new SharedTurnConflictError();
+    expect(error.message).toBe("clientMessageId was already used with a different message.");
+  });
+
+  test("accepts a custom message", () => {
+    const error = new SharedTurnConflictError("duplicate id");
+    expect(error.message).toBe("duplicate id");
+  });
+});


### PR DESCRIPTION
## Relates to

Behavior coverage for shared-runtime error types in cloud-shared.

## Background

`SharedRuntimeCacheWarmingError` and `SharedTurnConflictError` are deliberately dependency-free: coordinator and route boundaries need real class identity for these errors without dragging the billing/runtime module graph into their own graphs. Several catch sites additionally match on `error.name` because the class cannot survive the Durable Object fetch boundary — so name identity is part of the contract and was previously untested. This pins name/message/instanceof behavior for both classes.

## Testing

- `5 pass / 0 fail` locally: `cd packages/cloud/shared && bun test lib/services/shared-runtime/shared-runtime-errors.test.ts`
- Cases: instanceof Error + stable class name, message passthrough, default conflict message, custom message override

<!-- evidence-row:before-screenshots -->
- [x] before-screenshots: N/A (pure error types, no UI)
<!-- evidence-row:after-screenshots -->
- [x] after-screenshots: N/A (pure error types, no UI)
<!-- evidence-row:walkthrough-video -->
- [x] walkthrough-video: N/A (pure error types, no UI)
<!-- evidence-row:backend-logs -->
- [x] backend-logs: `bun test` output — 5 pass / 0 fail
<!-- evidence-row:frontend-logs -->
- [x] frontend-logs: N/A (no frontend change)
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A (test-only PR)
<!-- evidence-row:domain-artifacts -->
- [x] domain-artifacts: N/A (test-only PR)

AI provider/model: deepseek / deepseek-v4-flash
<!-- slop-contribution-attribution:v1 -->
