### PR TITLE
fix(plugin-app-manager): enforce OWNER/ADMIN role gate on state-changing app routes

### DIFF
--- a/plugins/plugin-app-manager/src/api/apps-routes.test.ts
+++ b/plugins/plugin-app-manager/src/api/apps-routes.test.ts
@@ -87,6 +87,7 @@ async function callRoute(args: {
   favoriteApps?: FavoriteAppsStore;
   getPluginManager?: AppsRouteContext["getPluginManager"];
   actorRole?: AppsRouteActorRole | null;
+  runtime?: unknown;
 }): Promise<{
   handled: boolean;
   res: CapturedResponse;
@@ -105,7 +106,7 @@ async function callRoute(args: {
     appManager,
     favoriteApps: args.favoriteApps,
     actorRole: args.actorRole,
-    runtime: null,
+    runtime: args.runtime ?? null,
     getPluginManager:
       args.getPluginManager ??
       (() =>
@@ -153,6 +154,7 @@ describe("handleAppsRoutes", () => {
     const result = await callRoute({
       method: "POST",
       pathname: "/api/apps/load-from-directory",
+      actorRole: "OWNER",
       body: { directory: "apps" },
     });
 
@@ -516,4 +518,236 @@ describe("handleAppsRoutes", () => {
       await rm(packageDir, { recursive: true, force: true });
     }
   });
+});
+
+describe("app management role gates", () => {
+  const deniedRoles = [undefined, null, "USER", "GUEST"] as const;
+
+  function createPluginManagerWithInstallSpy() {
+    const installPlugin = vi.fn(async () => ({
+      success: true as const,
+      pluginName: "@elizaos/plugin-demo",
+      version: "1.0.0",
+      installPath: "/tmp/plugins/@elizaos/plugin-demo",
+      requiresRestart: false,
+    }));
+    return {
+      installPlugin,
+      asContext: () =>
+        ({
+          installPlugin,
+          getInstalledPlugins: vi.fn(async () => []),
+          searchPlugins: vi.fn(async () => []),
+          refreshRegistry: vi.fn(async () => new Map()),
+        }) as never,
+    };
+  }
+
+  it.each(deniedRoles)(
+    "denies %s actor from installing apps before any side effect",
+    async (actorRole) => {
+      const pluginManager = createPluginManagerWithInstallSpy();
+
+      const result = await callRoute({
+        method: "POST",
+        pathname: "/api/apps/install",
+        getPluginManager: pluginManager.asContext,
+        actorRole,
+        body: { name: "@elizaos/plugin-demo" },
+      });
+
+      expect(result.handled).toBe(true);
+      expect(result.res.status).toBe(403);
+      expect(result.res.body).toEqual({
+        error: "App install requires OWNER or ADMIN role",
+      });
+      expect(pluginManager.installPlugin).not.toHaveBeenCalled();
+    },
+  );
+
+  it("allows an OWNER actor to install apps", async () => {
+    const pluginManager = createPluginManagerWithInstallSpy();
+
+    const result = await callRoute({
+      method: "POST",
+      pathname: "/api/apps/install",
+      getPluginManager: pluginManager.asContext,
+      actorRole: "OWNER",
+      body: { name: "@elizaos/plugin-demo" },
+    });
+
+    expect(result.handled).toBe(true);
+    expect(result.res.status).toBe(200);
+    expect(pluginManager.installPlugin).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(deniedRoles)(
+    "denies %s actor from stopping apps by name before any side effect",
+    async (actorRole) => {
+      const appManager = createAppManager();
+
+      const result = await callRoute({
+        method: "POST",
+        pathname: "/api/apps/stop",
+        appManager,
+        actorRole,
+        body: { name: "@elizaos/plugin-demo" },
+      });
+
+      expect(result.handled).toBe(true);
+      expect(result.res.status).toBe(403);
+      expect(result.res.body).toEqual({
+        error: "App stop requires OWNER or ADMIN role",
+      });
+      expect(appManager.stop).not.toHaveBeenCalled();
+    },
+  );
+
+  it("allows an OWNER actor to stop apps by name", async () => {
+    const appManager = createAppManager();
+
+    const result = await callRoute({
+      method: "POST",
+      pathname: "/api/apps/stop",
+      appManager,
+      actorRole: "OWNER",
+      body: { name: "@elizaos/plugin-demo" },
+    });
+
+    expect(result.handled).toBe(true);
+    expect(result.res.status).toBe(200);
+    expect(appManager.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(deniedRoles)(
+    "denies %s actor from stopping app runs before any side effect",
+    async (actorRole) => {
+      const appManager = createAppManager();
+
+      const result = await callRoute({
+        method: "POST",
+        pathname: "/api/apps/runs/run-123/stop",
+        appManager,
+        actorRole,
+        body: {},
+      });
+
+      expect(result.handled).toBe(true);
+      expect(result.res.status).toBe(403);
+      expect(result.res.body).toEqual({
+        error: "App stop requires OWNER or ADMIN role",
+      });
+      expect(appManager.stop).not.toHaveBeenCalled();
+    },
+  );
+
+  it("allows an OWNER actor to stop app runs", async () => {
+    const appManager = createAppManager();
+
+    const result = await callRoute({
+      method: "POST",
+      pathname: "/api/apps/runs/run-123/stop",
+      appManager,
+      actorRole: "OWNER",
+      body: {},
+    });
+
+    expect(result.handled).toBe(true);
+    expect(result.res.status).toBe(200);
+    expect(appManager.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(deniedRoles)(
+    "denies %s actor from replacing app permission grants",
+    async (actorRole) => {
+      // runtime is null in this harness; without the gate the PUT branch
+      // would fall through to the AppRegistryService lookup and answer 503.
+      // A 403 proves the role gate precedes any registry interaction.
+      const result = await callRoute({
+        method: "PUT",
+        pathname: "/api/apps/permissions/demo-app",
+        actorRole,
+        body: { namespaces: ["fs", "net"] },
+      });
+
+      expect(result.handled).toBe(true);
+      expect(result.res.status).toBe(403);
+      expect(result.res.body).toEqual({
+        error: "App permission changes require OWNER or ADMIN role",
+      });
+    },
+  );
+
+  it("allows an OWNER actor to replace app permission grants through a registered registry", async () => {
+    const setGrantedNamespaces = vi.fn(async () => ({
+      ok: true as const,
+      view: { slug: "demo-app", granted: ["net"] },
+    }));
+    const runtime = {
+      getService: vi.fn((name: string) =>
+        name === "app-registry"
+          ? { getPermissionsView: vi.fn(), setGrantedNamespaces }
+          : null,
+      ),
+    };
+
+    const result = await callRoute({
+      method: "PUT",
+      pathname: "/api/apps/permissions/demo-app",
+      actorRole: "OWNER",
+      runtime,
+      body: { namespaces: ["net"] },
+    });
+
+    expect(result.handled).toBe(true);
+    expect(result.res.status).toBe(200);
+    expect(setGrantedNamespaces).toHaveBeenCalledWith(
+      "demo-app",
+      ["net"],
+      "user",
+    );
+  });
+
+  it.each(deniedRoles)(
+    "denies %s actor from registering host directories as apps",
+    async (actorRole) => {
+      const appManager = createAppManager();
+
+      const result = await callRoute({
+        method: "POST",
+        pathname: "/api/apps/load-from-directory",
+        appManager,
+        actorRole,
+        body: { directory: "/tmp/some-apps-dir" },
+      });
+
+      expect(result.handled).toBe(true);
+      expect(result.res.status).toBe(403);
+      expect(result.res.body).toEqual({
+        error:
+          "App registration from a host directory requires OWNER or ADMIN role",
+      });
+    },
+  );
+
+  it.each(deniedRoles)(
+    "denies %s actor from creating apps before invoking the APP action",
+    async (actorRole) => {
+      // The create branch fabricates an agent-self message so the APP
+      // action's ownership check would pass once invoked; the route-level
+      // gate is what keeps non-owner callers from reaching that point.
+      const result = await callRoute({
+        method: "POST",
+        pathname: "/api/apps/create",
+        actorRole,
+        body: { intent: "build and publish an interactive page" },
+      });
+
+      expect(result.handled).toBe(true);
+      expect(result.res.status).toBe(403);
+      expect(result.res.body).toEqual({
+        error: "App creation requires OWNER or ADMIN role",
+      });
+    },
+  );
 });

--- a/plugins/plugin-app-manager/src/api/apps-routes.test.ts
+++ b/plugins/plugin-app-manager/src/api/apps-routes.test.ts
@@ -750,4 +750,22 @@ describe("app management role gates", () => {
       });
     },
   );
+
+  it.each(deniedRoles)(
+    "denies %s actor from relaunching apps",
+    async (actorRole) => {
+      const result = await callRoute({
+        method: "POST",
+        pathname: "/api/apps/relaunch",
+        actorRole,
+        body: { name: "calculator" },
+      });
+
+      expect(result.handled).toBe(true);
+      expect(result.res.status).toBe(403);
+      expect(result.res.body).toEqual({
+        error: "App relaunch requires OWNER or ADMIN role",
+      });
+    },
+  );
 });

--- a/plugins/plugin-app-manager/src/api/apps-routes.ts
+++ b/plugins/plugin-app-manager/src/api/apps-routes.ts
@@ -1456,6 +1456,10 @@ export async function handleAppsRoutes(
   // -------------------------------------------------------------------------
 
   if (method === "POST" && pathname === "/api/apps/relaunch") {
+    if (!canManageApps(actorRole)) {
+      error(res, "App relaunch requires OWNER or ADMIN role", 403);
+      return true;
+    }
     const rawBody = await readJsonBody<Record<string, unknown>>(req, res);
     if (rawBody === null) return true;
     const parsed = PostRelaunchAppRequestSchema.safeParse(rawBody);

--- a/plugins/plugin-app-manager/src/api/apps-routes.ts
+++ b/plugins/plugin-app-manager/src/api/apps-routes.ts
@@ -11,6 +11,10 @@
  *
  * `/api/apps/hero/:slug` is reachable without an owner role. SVG heroes are
  * XML and can carry script; they must not execute on the dashboard origin.
+ * Every state-changing app operation (launch, install, create, relaunch,
+ * stop, permission grants, directory registration) requires the OWNER or
+ * ADMIN role via canManageApps; run steering and heartbeat stay USER-tier
+ * by design because embedded viewers interact with already-launched apps.
  */
 import type { Dirent } from "node:fs";
 import { promises as fs } from "node:fs";
@@ -579,7 +583,7 @@ function sanitizeFavoriteAppNames(value: unknown): string[] {
   return apps;
 }
 
-function canLaunchApps(
+function canManageApps(
   actorRole: AppsRouteActorRole | null | undefined,
 ): boolean {
   return actorRole === "OWNER" || actorRole === "ADMIN";
@@ -1187,6 +1191,10 @@ export async function handleAppsRoutes(
     }
 
     if (subroute === "stop") {
+      if (!canManageApps(actorRole)) {
+        error(res, "App stop requires OWNER or ADMIN role", 403);
+        return true;
+      }
       const pluginManager = getPluginManager();
       const result = await appManager.stop(pluginManager, "", runId, null);
       json(res, result);
@@ -1215,7 +1223,7 @@ export async function handleAppsRoutes(
 
   if (method === "POST" && pathname === "/api/apps/launch") {
     try {
-      if (!canLaunchApps(actorRole)) {
+      if (!canManageApps(actorRole)) {
         error(res, "App launch requires OWNER or ADMIN role", 403);
         return true;
       }
@@ -1248,6 +1256,10 @@ export async function handleAppsRoutes(
 
   if (method === "POST" && pathname === "/api/apps/install") {
     try {
+      if (!canManageApps(actorRole)) {
+        error(res, "App install requires OWNER or ADMIN role", 403);
+        return true;
+      }
       const rawBody = await readJsonBody<Record<string, unknown>>(req, res);
       if (rawBody === null) return true;
       const parsed = PostInstallAppRequestSchema.safeParse(rawBody);
@@ -1321,6 +1333,10 @@ export async function handleAppsRoutes(
   }
 
   if (method === "POST" && pathname === "/api/apps/stop") {
+    if (!canManageApps(actorRole)) {
+      error(res, "App stop requires OWNER or ADMIN role", 403);
+      return true;
+    }
     const rawBody = await readJsonBody<Record<string, unknown>>(req, res);
     if (rawBody === null) return true;
     const parsed = PostStopAppRequestSchema.safeParse(rawBody);
@@ -1543,6 +1559,12 @@ export async function handleAppsRoutes(
       error(res, "slug is required");
       return true;
     }
+    // GET is a read-only permission view; PUT replaces the owner's grant
+    // decision and must stay behind the same role gate as launch/install.
+    if (method === "PUT" && !canManageApps(actorRole)) {
+      error(res, "App permission changes require OWNER or ADMIN role", 403);
+      return true;
+    }
     const runtimeWithRegistry = runtime as {
       getService?: (type: string) => {
         getPermissionsView?: (slug: string) => Promise<unknown>;
@@ -1604,6 +1626,14 @@ export async function handleAppsRoutes(
   }
 
   if (method === "POST" && pathname === "/api/apps/load-from-directory") {
+    if (!canManageApps(actorRole)) {
+      error(
+        res,
+        "App registration from a host directory requires OWNER or ADMIN role",
+        403,
+      );
+      return true;
+    }
     // Body validation goes through PostLoadFromDirectoryRequestSchema
     // (zod, see @elizaos/shared/contracts/apps-loading-routes.ts).
     // The browser-safe schema handles the structural wire contract. The host
@@ -1748,6 +1778,10 @@ export async function handleAppsRoutes(
   }
 
   if (method === "POST" && pathname === "/api/apps/create") {
+    if (!canManageApps(actorRole)) {
+      error(res, "App creation requires OWNER or ADMIN role", 403);
+      return true;
+    }
     const rawBody = await readJsonBody<Record<string, unknown>>(req, res);
     if (rawBody === null) return true;
     const parsed = PostCreateAppRequestSchema.safeParse(rawBody);


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Closes #28191

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low risk. Confined to role gate authorization checks in `plugins/plugin-app-manager/src/api/apps-routes.ts`.

# Background

## What does this PR do?
Enforces `canManageApps` (OWNER/ADMIN role) on all state-changing app routes in `plugins/plugin-app-manager/src/api/apps-routes.ts` (including `/api/apps/launch`, `/api/apps/install`, `/api/apps/stop`, `/api/apps/relaunch`, `PUT /api/apps/permissions/:slug`, `/api/apps/load-from-directory`, `/api/apps/create`).

## What kind of change is this?
Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?
My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?
Review `plugins/plugin-app-manager/src/api/apps-routes.ts` and `plugins/plugin-app-manager/src/api/apps-routes.test.ts`.

## Detailed testing steps
Run:
```bash
bun run --cwd plugins/plugin-app-manager test
bun run --cwd plugins/plugin-app-manager typecheck
```

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:d686745da556d05f3fc9bf4c062828b8e0586e3f -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots: N/A - HTTP API route role gate.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots: N/A - HTTP API route role gate.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough: N/A - HTTP API route role gate.
<!-- evidence-row:backend-logs -->
- [x] Backend logs:
<details>
<summary>bun run --cwd plugins/plugin-app-manager test output</summary>

```
 Test Files  4 passed (4)
      Tests  68 passed (68)
   Start at  19:13:00
   Duration  6.44s
```
</details>
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs: N/A - Backend route testing without frontend execution.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory: N/A - Deterministic role authorization.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts: N/A - In-memory route testing.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review: N/A - No UI rendered.

# Known gaps / failures
None.

# Maintainer CI exception record
N/A - no exception requested

---

AI provider/model: Google / Gemini 3.7 Flash
Client / agent tooling: Antigravity
Contribution skill revision: elizaOS/eliza@7d55350499b702ec4c979c3dcb6bb5e56d482939:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [antigravity-contrib]
<!-- eliza-computer-attribution:v1 {"provider":"google","model":"gemini-3.7-flash","client":"Antigravity","skill_revision":"elizaOS/eliza@7d55350499b702ec4c979c3dcb6bb5e56d482939:packages/skills/skills/contribute-to-eliza"} -->