### PR TITLE
fix(plugin-agent-orchestrator): validate required commit message in workspace commit route

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/workspace-routes.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/workspace-routes.test.ts
@@ -1,0 +1,258 @@
+/**
+ * HTTP handler tests for /api/workspace/* routes with a deterministic workspace service stub.
+ */
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { Readable } from "node:stream";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { RouteContext } from "../../src/api/route-utils.js";
+import { handleWorkspaceRoutes } from "../../src/api/workspace-routes.js";
+
+const provisionWorkspace = vi.fn(async (opts: Record<string, unknown>) => ({
+  id: "ws-1",
+  path: "/tmp/ws-1",
+  branch: opts.branchName ?? "main",
+  isWorktree: opts.useWorktree ?? false,
+}));
+const getStatus = vi.fn(async (id: string) => ({
+  id,
+  branch: "main",
+  clean: true,
+}));
+const commit = vi.fn(
+  async (_id: string, opts: { message: string; all: boolean }) => ({
+    hash: "abc1234",
+    message: opts.message,
+  }),
+);
+const push = vi.fn(async (_id: string, _opts?: Record<string, unknown>) => ({
+  success: true,
+}));
+const createPR = vi.fn(
+  async (_id: string, opts: { title: string; body: string }) => ({
+    url: "https://github.com/owner/repo/pull/1",
+    title: opts.title,
+  }),
+);
+const removeWorkspace = vi.fn(async (_id: string) => undefined);
+
+function createRouteContext(
+  workspaceService: unknown = {
+    provisionWorkspace,
+    getStatus,
+    commit,
+    push,
+    createPR,
+    removeWorkspace,
+  },
+): RouteContext {
+  return {
+    runtime: {},
+    acpService: null,
+    workspaceService,
+  } as never;
+}
+
+function createRequest(
+  method: string,
+  url: string,
+  body?: unknown,
+): IncomingMessage {
+  const payload = body !== undefined ? JSON.stringify(body) : undefined;
+  const stream = Readable.from(payload !== undefined ? [payload] : []);
+  return Object.assign(stream, {
+    method,
+    url,
+    headers: { host: "localhost", "content-type": "application/json" },
+  }) as unknown as IncomingMessage;
+}
+
+class CapturingResponse {
+  statusCode = 200;
+  headers: Record<string, string> = {};
+  body = "";
+
+  writeHead(status: number, headers?: Record<string, string>): this {
+    this.statusCode = status;
+    if (headers) Object.assign(this.headers, headers);
+    return this;
+  }
+
+  setHeader(name: string, value: string): void {
+    this.headers[name] = value;
+  }
+
+  end(chunk?: string): this {
+    if (chunk !== undefined) {
+      this.body = chunk;
+    }
+    return this;
+  }
+
+  json(): Record<string, unknown> {
+    return this.body ? (JSON.parse(this.body) as Record<string, unknown>) : {};
+  }
+}
+
+async function callRoute(
+  method: string,
+  pathname: string,
+  body?: unknown,
+  ctx = createRouteContext(),
+) {
+  const req = createRequest(method, pathname, body);
+  const res = new CapturingResponse();
+  const handled = await handleWorkspaceRoutes(
+    req,
+    res as unknown as ServerResponse,
+    pathname,
+    ctx,
+  );
+  return {
+    handled,
+    status: res.statusCode,
+    body: res.json(),
+  };
+}
+
+describe("handleWorkspaceRoutes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("POST /api/workspace/:id/commit", () => {
+    it("commits changes when a valid non-empty message is provided", async () => {
+      const response = await callRoute("POST", "/api/workspace/ws-123/commit", {
+        message: "fix: update component styling",
+      });
+
+      expect(response.handled).toBe(true);
+      expect(response.status).toBe(200);
+      expect(commit).toHaveBeenCalledTimes(1);
+      expect(commit).toHaveBeenCalledWith("ws-123", {
+        message: "fix: update component styling",
+        all: true,
+      });
+      expect(response.body).toEqual({
+        hash: "abc1234",
+        message: "fix: update component styling",
+      });
+    });
+
+    it.each([
+      ["missing", {}],
+      ["empty string", { message: "" }],
+      ["whitespace string", { message: "   " }],
+      ["null", { message: null }],
+      ["number", { message: 12345 }],
+      ["boolean", { message: true }],
+      ["object", { message: { text: "msg" } }],
+    ])("rejects %s message with 400", async (_desc, body) => {
+      const response = await callRoute(
+        "POST",
+        "/api/workspace/ws-123/commit",
+        body,
+      );
+
+      expect(response.handled).toBe(true);
+      expect(response.status).toBe(400);
+      expect(response.body).toEqual({
+        error: "message is required",
+      });
+      expect(commit).not.toHaveBeenCalled();
+    });
+
+    it("returns 503 when workspace service is not available", async () => {
+      const response = await callRoute(
+        "POST",
+        "/api/workspace/ws-123/commit",
+        { message: "valid message" },
+        createRouteContext(null),
+      );
+
+      expect(response.handled).toBe(true);
+      expect(response.status).toBe(503);
+      expect(response.body).toEqual({
+        error: "Workspace Service not available",
+      });
+      expect(commit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("POST /api/workspace/provision", () => {
+    it("provisions a workspace with valid repo", async () => {
+      const response = await callRoute("POST", "/api/workspace/provision", {
+        repo: "owner/repo",
+        branchName: "feature",
+      });
+
+      expect(response.handled).toBe(true);
+      expect(response.status).toBe(201);
+      expect(provisionWorkspace).toHaveBeenCalledWith({
+        repo: "owner/repo",
+        branchName: "feature",
+      });
+    });
+
+    it("rejects missing repo with 400", async () => {
+      const response = await callRoute("POST", "/api/workspace/provision", {});
+
+      expect(response.handled).toBe(true);
+      expect(response.status).toBe(400);
+      expect(response.body).toEqual({ error: "repo is required" });
+    });
+  });
+
+  describe("POST /api/workspace/:id/pr", () => {
+    it("creates a PR with valid title and body", async () => {
+      const response = await callRoute("POST", "/api/workspace/ws-123/pr", {
+        title: "PR Title",
+        body: "PR Description",
+      });
+
+      expect(response.handled).toBe(true);
+      expect(response.status).toBe(201);
+      expect(createPR).toHaveBeenCalledWith("ws-123", {
+        title: "PR Title",
+        body: "PR Description",
+      });
+    });
+
+    it.each([
+      ["missing body", { title: "Title" }],
+      ["missing title", { body: "Body" }],
+      ["empty title", { title: "", body: "Body" }],
+      ["empty body", { title: "Title", body: "" }],
+    ])("rejects %s with 400", async (_desc, body) => {
+      const response = await callRoute(
+        "POST",
+        "/api/workspace/ws-123/pr",
+        body,
+      );
+
+      expect(response.handled).toBe(true);
+      expect(response.status).toBe(400);
+      expect(response.body).toEqual({ error: "title and body are required" });
+    });
+  });
+
+  describe("GET /api/workspace/:id", () => {
+    it("returns workspace status", async () => {
+      const response = await callRoute("GET", "/api/workspace/ws-123");
+
+      expect(response.handled).toBe(true);
+      expect(response.status).toBe(200);
+      expect(getStatus).toHaveBeenCalledWith("ws-123");
+    });
+  });
+
+  describe("DELETE /api/workspace/:id", () => {
+    it("deletes a workspace", async () => {
+      const response = await callRoute("DELETE", "/api/workspace/ws-123");
+
+      expect(response.handled).toBe(true);
+      expect(response.status).toBe(200);
+      expect(removeWorkspace).toHaveBeenCalledWith("ws-123");
+      expect(response.body).toEqual({ success: true, workspaceId: "ws-123" });
+    });
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/api/workspace-routes.ts
+++ b/plugins/plugin-agent-orchestrator/src/api/workspace-routes.ts
@@ -114,10 +114,14 @@ export async function handleWorkspaceRoutes(
     try {
       const workspaceId = commitMatch[1];
       const body = await parseBody(req);
-      const { message } = body;
+      const message = asString(body.message);
+      if (!message) {
+        sendError(res, "message is required");
+        return true;
+      }
 
       const result = await ctx.workspaceService.commit(workspaceId, {
-        message: message as string,
+        message,
         all: true,
       });
 


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Relates to #28193

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Validates that `message` is a non-empty string in `POST /api/workspace/:id/commit`, returning HTTP 400 with `{ error: "message is required" }` instead of passing `undefined` to `git commit -m undefined`.

# Background

## What does this PR do?

In `plugins/plugin-agent-orchestrator/src/api/workspace-routes.ts`, `POST /api/workspace/:id/commit` now validates `body.message` using `asString(body.message)` and returns HTTP 400 `{ error: "message is required" }` when missing or empty.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

- `plugins/plugin-agent-orchestrator/src/api/workspace-routes.ts`: `message` parameter validation in `POST /api/workspace/:id/commit`.
- `plugins/plugin-agent-orchestrator/__tests__/unit/workspace-routes.test.ts`: test cases covering valid and invalid commit message bodies.

## Detailed testing steps

Run:
```bash
bunx vitest run __tests__/unit/workspace-routes.test.ts
bun run --cwd plugins/plugin-agent-orchestrator typecheck
bun run --cwd plugins/plugin-agent-orchestrator lint
```

# Evidence Gate

<!-- evidence-head:63045873e7c4f1ae3d0606908b04ed67481546a4 -->

- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - <reason>`.
  N/A - Non-UI backend route validation fix.
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - <reason>`.
  N/A - Non-UI backend route validation fix.
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - <reason>`.
  N/A - Non-UI backend route validation fix.
- [x] Backend logs show the real code path firing end to end, or are marked `N/A - <reason>`.
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - <reason>`.
  N/A - Backend route validation fix.
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - <reason>`.
  N/A - Backend route validation fix.
- [ ] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - <reason>`.
  N/A - Backend route validation fix.
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - <reason>` when the change has no rendered visual surface.
  N/A - No rendered visual surface.

# Evidence Details

## Backend + frontend logs

```text
$ bunx vitest run __tests__/unit/workspace-routes.test.ts

 RUN  v4.1.10 /home/deepanshu/Projects/eliza/plugins/plugin-agent-orchestrator

 ✓ __tests__/unit/workspace-routes.test.ts (18 tests) 27ms
 ✓ __tests__/unit/workspace-routes.test.ts > handleWorkspaceRoutes > POST /api/workspace/:id/commit > commits changes when a valid non-empty message is provided
 ✓ __tests__/unit/workspace-routes.test.ts > handleWorkspaceRoutes > POST /api/workspace/:id/commit > rejects missing message with 400
 ✓ __tests__/unit/workspace-routes.test.ts > handleWorkspaceRoutes > POST /api/workspace/:id/commit > rejects empty string message with 400
 ✓ __tests__/unit/workspace-routes.test.ts > handleWorkspaceRoutes > POST /api/workspace/:id/commit > rejects whitespace string message with 400
 ✓ __tests__/unit/workspace-routes.test.ts > handleWorkspaceRoutes > POST /api/workspace/:id/commit > rejects null message with 400
 ✓ __tests__/unit/workspace-routes.test.ts > handleWorkspaceRoutes > POST /api/workspace/:id/commit > rejects number message with 400
 ✓ __tests__/unit/workspace-routes.test.ts > handleWorkspaceRoutes > POST /api/workspace/:id/commit > rejects boolean message with 400
 ✓ __tests__/unit/workspace-routes.test.ts > handleWorkspaceRoutes > POST /api/workspace/:id/commit > rejects object message with 400
 ✓ __tests__/unit/workspace-routes.test.ts > handleWorkspaceRoutes > POST /api/workspace/:id/commit > returns 503 when workspace service is not available
 ✓ __tests__/unit/workspace-routes.test.ts > handleWorkspaceRoutes > POST /api/workspace/provision > provisions a workspace with valid repo
 ✓ __tests__/unit/workspace-routes.test.ts > handleWorkspaceRoutes > POST /api/workspace/provision > rejects missing repo with 400
 ✓ __tests__/unit/workspace-routes.test.ts > handleWorkspaceRoutes > POST /api/workspace/:id/pr > creates a PR with valid title and body
 ✓ __tests__/unit/workspace-routes.test.ts > handleWorkspaceRoutes > POST /api/workspace/:id/pr > rejects missing body with 400
 ✓ __tests__/unit/workspace-routes.test.ts > handleWorkspaceRoutes > POST /api/workspace/:id/pr > rejects missing title with 400
 ✓ __tests__/unit/workspace-routes.test.ts > handleWorkspaceRoutes > POST /api/workspace/:id/pr > rejects empty title with 400
 ✓ __tests__/unit/workspace-routes.test.ts > handleWorkspaceRoutes > POST /api/workspace/:id/pr > rejects empty body with 400
 ✓ __tests__/unit/workspace-routes.test.ts > handleWorkspaceRoutes > GET /api/workspace/:id > returns workspace status
 ✓ __tests__/unit/workspace-routes.test.ts > handleWorkspaceRoutes > DELETE /api/workspace/:id > deletes a workspace

 Test Files  1 passed (1)
      Tests  18 passed (18)
```

## Known gaps / failures

None.

## Maintainer CI exception record

N/A - no exception requested