### PR TITLE
fix(plugin-github): validate review body before confirmation in GITHUB_PR_OP

### DIFF
--- a/plugins/plugin-github/src/actions/pr-op.test.ts
+++ b/plugins/plugin-github/src/actions/pr-op.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Verifies GITHUB_PR_OP action validation, confirmation gating, and review execution.
+ */
+import type { IAgentRuntime, Memory } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+
+import { prOpAction } from "./pr-op.js";
+
+function makeRuntime(): IAgentRuntime {
+  return {
+    getSetting: vi.fn(() => undefined),
+  } as unknown as IAgentRuntime;
+}
+
+function makeMessage(): Memory {
+  return {
+    id: "msg-123",
+    agentId: "agent-123",
+    roomId: "room-123",
+    entityId: "user-123",
+    content: { text: "review pr" },
+  } as unknown as Memory;
+}
+
+describe("GITHUB_PR_OP review validation", () => {
+  it("rejects request-changes without a body before initiating confirmation", async () => {
+    const runtime = makeRuntime();
+    const message = makeMessage();
+    const callback = vi.fn();
+
+    const result = await prOpAction.handler(
+      runtime,
+      message,
+      undefined,
+      {
+        op: "review",
+        repo: "owner/repo",
+        number: 42,
+        action: "request-changes",
+      },
+      callback,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe(
+      "request-changes review requires a body explaining the changes",
+    );
+    expect(callback).toHaveBeenCalledWith({
+      text: "request-changes review requires a body explaining the changes",
+    });
+  });
+
+  it("rejects invalid repo format before initiating confirmation", async () => {
+    const runtime = makeRuntime();
+    const message = makeMessage();
+    const callback = vi.fn();
+
+    const result = await prOpAction.handler(
+      runtime,
+      message,
+      undefined,
+      {
+        op: "review",
+        repo: "invalid-repo",
+        number: 42,
+        action: "approve",
+      },
+      callback,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Invalid repo "invalid-repo"');
+  });
+
+  it("rejects missing parameters before initiating confirmation", async () => {
+    const runtime = makeRuntime();
+    const message = makeMessage();
+    const callback = vi.fn();
+
+    const result = await prOpAction.handler(
+      runtime,
+      message,
+      undefined,
+      {
+        op: "review",
+        repo: "owner/repo",
+      },
+      callback,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("GITHUB_PR_OP review requires repo");
+  });
+});

--- a/plugins/plugin-github/src/actions/pr-op.ts
+++ b/plugins/plugin-github/src/actions/pr-op.ts
@@ -193,6 +193,11 @@ async function runReview(
     await callback?.({ text: err });
     return { success: false, error: err };
   }
+  if (action === "request-changes" && !body) {
+    const err = "request-changes review requires a body explaining the changes";
+    await callback?.({ text: err });
+    return { success: false, error: err };
+  }
 
   const preview = buildReviewPreview(
     action,
@@ -222,12 +227,6 @@ async function runReview(
     const text = "GitHub PR review cancelled.";
     await callback?.({ text });
     return { success: true, text, data: { cancelled: true } };
-  }
-
-  if (action === "request-changes" && !body) {
-    const err = "request-changes review requires a body explaining the changes";
-    await callback?.({ text: err });
-    return { success: false, error: err };
   }
 
   const resolved = buildResolvedClient(runtime, selection);


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Relates to #28195

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Moves the preflight check ensuring `request-changes` reviews supply a non-empty `body` before `requireConfirmation` in `plugins/plugin-github/src/actions/pr-op.ts`.

# Background

## What does this PR do?

In `plugins/plugin-github/src/actions/pr-op.ts`, `runReview` now validates `if (action === "request-changes" && !body)` before invoking `requireConfirmation`, failing fast with `{ success: false, error: "request-changes review requires a body explaining the changes" }` instead of prompting the user for confirmation first.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

- `plugins/plugin-github/src/actions/pr-op.ts`: ordering of `action === "request-changes" && !body` check relative to `requireConfirmation`.
- `plugins/plugin-github/src/actions/pr-op.test.ts`: test cases verifying preflight parameter validation.

## Detailed testing steps

Run:
```bash
bunx vitest run src/actions/pr-op.test.ts
bun run --cwd plugins/plugin-github typecheck
bun run --cwd plugins/plugin-github lint
```

# Evidence Gate

<!-- evidence-head:d5a6c4641d3ced918f46198c0f63c915641ae844 -->

- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - <reason>`.
  N/A - Action preflight parameter validation fix.
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - <reason>`.
  N/A - Action preflight parameter validation fix.
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - <reason>`.
  N/A - Action preflight parameter validation fix.
- [x] Backend logs show the real code path firing end to end, or are marked `N/A - <reason>`.
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - <reason>`.
  N/A - Action preflight parameter validation fix.
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - <reason>`.
  N/A - Action preflight parameter validation fix.
- [ ] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - <reason>`.
  N/A - Action preflight parameter validation fix.
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - <reason>` when the change has no rendered visual surface.
  N/A - No rendered visual surface.

# Evidence Details

## Backend + frontend logs

```text
$ vitest run src/actions/pr-op.test.ts

 RUN  v4.1.10 /home/deepanshu/Projects/eliza/plugins/plugin-github

 ✓ src/actions/pr-op.test.ts (3 tests) 6ms
 ✓ src/actions/pr-op.test.ts > GITHUB_PR_OP review validation > rejects request-changes without a body before initiating confirmation
 ✓ src/actions/pr-op.test.ts > GITHUB_PR_OP review validation > rejects invalid repo format before initiating confirmation
 ✓ src/actions/pr-op.test.ts > GITHUB_PR_OP review validation > rejects missing parameters before initiating confirmation

 Test Files  1 passed (1)
      Tests  3 passed (3)
```

## Known gaps / failures

None.

## Maintainer CI exception record

N/A - no exception requested