### PR TITLE
test(auth): cover built-in subscription auth providers discovery and idempotency

### DIFF
--- a/packages/auth/src/subscription-auth/builtin-providers.test.ts
+++ b/packages/auth/src/subscription-auth/builtin-providers.test.ts
@@ -132,3 +132,121 @@ describe("built-in Codex CLI credential discovery", () => {
     },
   );
 });
+
+describe("built-in Gemini CLI credential discovery", () => {
+  beforeEach(() => {
+    resetSubscriptionAuthProviders();
+  });
+
+  afterEach(() => {
+    resetSubscriptionAuthProviders();
+  });
+
+  it("reports Gemini CLI as configured when the binary is present on PATH", () => {
+    const tempBin = fs.mkdtempSync(
+      path.join(process.cwd(), ".gemini-bin-test-"),
+    );
+    const originalPath = process.env.PATH;
+    try {
+      const geminiScript = path.join(tempBin, "gemini");
+      fs.writeFileSync(geminiScript, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+      process.env.PATH = `${tempBin}:${originalPath ?? ""}`;
+
+      ensureBuiltinSubscriptionAuthProviders();
+      const detected =
+        getSubscriptionAuthProvider(
+          "gemini-cli",
+        )?.detectExternalCredentials?.();
+
+      expect(detected).toEqual({
+        accountId: "gemini-cli",
+        label: "Gemini CLI",
+        source: "gemini-cli",
+        configured: true,
+        valid: true,
+        expiresAt: null,
+      });
+    } finally {
+      process.env.PATH = originalPath;
+      fs.rmSync(tempBin, { recursive: true, force: true });
+    }
+  });
+
+  it("reports Gemini CLI as unconfigured when the binary is absent from PATH", () => {
+    const originalPath = process.env.PATH;
+    try {
+      process.env.PATH = "/nonexistent-path-for-gemini-test";
+
+      ensureBuiltinSubscriptionAuthProviders();
+      const detected =
+        getSubscriptionAuthProvider(
+          "gemini-cli",
+        )?.detectExternalCredentials?.();
+
+      expect(detected).toEqual({
+        accountId: "gemini-cli",
+        label: "Gemini CLI",
+        source: null,
+        configured: false,
+        valid: false,
+        expiresAt: null,
+      });
+    } finally {
+      process.env.PATH = originalPath;
+    }
+  });
+});
+
+describe("built-in DeepSeek Coding Plan provider descriptor", () => {
+  beforeEach(() => {
+    resetSubscriptionAuthProviders();
+  });
+
+  afterEach(() => {
+    resetSubscriptionAuthProviders();
+  });
+
+  it("surfaces a static unavailable credential record", () => {
+    ensureBuiltinSubscriptionAuthProviders();
+    const descriptor = getSubscriptionAuthProvider("deepseek-coding");
+
+    expect(descriptor).toBeDefined();
+    expect(descriptor?.id).toBe("deepseek-coding");
+    expect(descriptor?.detectExternalCredentials?.()).toEqual({
+      accountId: "deepseek-coding",
+      label: "DeepSeek Coding Plan",
+      source: "unavailable",
+      configured: false,
+      valid: false,
+      expiresAt: null,
+    });
+  });
+});
+
+describe("ensureBuiltinSubscriptionAuthProviders registration idempotency", () => {
+  beforeEach(() => {
+    resetSubscriptionAuthProviders();
+  });
+
+  afterEach(() => {
+    resetSubscriptionAuthProviders();
+  });
+
+  it("registers all three built-in providers and does not overwrite custom registrations", () => {
+    expect(getSubscriptionAuthProvider("openai-codex")).toBeUndefined();
+    expect(getSubscriptionAuthProvider("gemini-cli")).toBeUndefined();
+    expect(getSubscriptionAuthProvider("deepseek-coding")).toBeUndefined();
+
+    ensureBuiltinSubscriptionAuthProviders();
+
+    expect(getSubscriptionAuthProvider("openai-codex")).toBeDefined();
+    expect(getSubscriptionAuthProvider("gemini-cli")).toBeDefined();
+    expect(getSubscriptionAuthProvider("deepseek-coding")).toBeDefined();
+
+    // Calling again does not throw or mutate registry state
+    ensureBuiltinSubscriptionAuthProviders();
+    expect(getSubscriptionAuthProvider("openai-codex")?.id).toBe(
+      "openai-codex",
+    );
+  });
+});


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Test-only change: adds behavioral unit test coverage to the canonical suite `packages/auth/src/subscription-auth/builtin-providers.test.ts` for Gemini CLI detection, DeepSeek Coding Plan descriptor state, and `ensureBuiltinSubscriptionAuthProviders` registration idempotency.

# Background

## What does this PR do?

Extends `packages/auth/src/subscription-auth/builtin-providers.test.ts` to test:
- Gemini CLI discovery when binary is present on PATH vs absent.
- DeepSeek Coding Plan static unavailable descriptor structure.
- `ensureBuiltinSubscriptionAuthProviders()` registration idempotency across resets.

## What kind of change is this?

Improvements (misc. changes to existing features)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

[`packages/auth/src/subscription-auth/builtin-providers.test.ts`](packages/auth/src/subscription-auth/builtin-providers.test.ts)

## Detailed testing steps

Run:
```bash
node packages/scripts/run-vitest.mjs run packages/auth/src/subscription-auth/builtin-providers.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:02b25d19da06459d455c703b72d00da82a702751 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - non-UI test-only change`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - non-UI test-only change`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - non-UI test-only change`.
<!-- evidence-row:backend-logs -->
- [ ] N/A - test runner output provided below
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - no frontend components touched`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - deterministic auth discovery unit tests`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - test runner output only`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory
N/A - deterministic auth discovery unit tests.

## Backend + frontend logs
```text
$ node packages/scripts/run-vitest.mjs run packages/auth/src/subscription-auth/builtin-providers.test.ts

 RUN  v4.1.10 /Users/naynaingoo/Downloads/eliza-develop

 ✓ packages/auth/src/subscription-auth/builtin-providers.test.ts (13 tests) 32ms

 Test Files  1 passed (1)
      Tests  13 passed (13)
```

## Screenshots (before / after) + video walkthrough
N/A - non-UI test-only change.

## Audio / voice walkthrough
N/A - no audio components touched.

## Known gaps / failures
None.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

— [lane-naysmacbookpro4-1787628875]

