### PR TITLE
fix(cloud): pin inbound media vision to one provider attempt per claim

### DIFF
--- a/packages/cloud/shared/src/lib/services/eliza-app/describe-inbound-media.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/describe-inbound-media.test.ts
@@ -176,6 +176,7 @@ describe("describeInboundImageMedia — enrichment path", () => {
         >;
       }>;
       abortSignal: AbortSignal;
+      maxRetries?: number;
     };
     expect(options.messages).toHaveLength(1);
     const [textPart, imageA, imageB] = options.messages[0].content;
@@ -191,6 +192,20 @@ describe("describeInboundImageMedia — enrichment path", () => {
       mediaType: "image/png",
     });
     expect(options.abortSignal).toBeInstanceOf(AbortSignal);
+  });
+
+  test("the provider call is pinned to one attempt per claim (maxRetries 0)", async () => {
+    safeFetch.mockImplementation(async () => imageResponse(new Uint8Array([1, 2, 3])));
+
+    await describeInboundImageMedia(ENABLED, [URL_A]);
+
+    // The AI SDK default (maxRetries 2) permits up to three billed provider
+    // attempts for one admitted claim while the quota ledger charges only the
+    // admitted image count — retry spend would be unaccounted. The call must
+    // opt out so exactly one billable attempt happens per claim; a later
+    // redelivery is separately admitted and attempt-counted.
+    const options = generateText.mock.calls[0]?.[0] as { maxRetries?: number };
+    expect(options.maxRetries).toBe(0);
   });
 
   test("every media fetch forbids redirects so hops cannot leave the allowlist", async () => {

--- a/packages/cloud/shared/src/lib/services/eliza-app/describe-inbound-media.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/describe-inbound-media.ts
@@ -280,6 +280,14 @@ export async function describeInboundImageMedia(
   );
   let completion: Awaited<ReturnType<typeof generateText>>;
   try {
+    // Exactly one billable provider attempt per admitted claim (issue #25127:
+    // "define and test the AI SDK provider-attempt/retry policy"). The AI SDK
+    // default (maxRetries 2) would let one admission spend up to three provider
+    // attempts while the daily quota accounting charges only the admitted
+    // image count, so retry spend would be unaccounted. The caller's
+    // AbortSignal.timeout is shared across attempts, so retries add no wall
+    // clock beyond it; a later redelivery is separately admitted and
+    // attempt-counted, and a recorded terminal failure is never retried.
     completion = await generateText({
       model,
       messages: [
@@ -295,6 +303,7 @@ export async function describeInboundImageMedia(
           ],
         },
       ],
+      maxRetries: 0,
       abortSignal: AbortSignal.timeout(INBOUND_MEDIA_VISION_TIMEOUT_MS),
     });
   } catch (error) {


### PR DESCRIPTION
# fix(cloud): pin inbound media vision to one provider attempt per claim

Contributes to #25127 — residual provider-attempt control only. **Does not close #25127**: the isolated Blooio staging evidence and the documented deployment owner + controlled rollout/rollback procedure remain unmet and stay tracked on the open issue (per the issue status comment: keep #25127 open or move those gates to an explicitly owned deploy-gate child). See "what was already on develop" below.

## What changed

`describeInboundImageMedia`'s `generateText` call now passes `maxRetries: 0`, pinning the AI SDK provider-attempt policy to **exactly one billable provider attempt per admitted claim**. The AI SDK default (`maxRetries: 2`) would let a single admission ledger claim spend up to **three** provider attempts while the daily quota accounting charges only the admitted image count — retry spend would be unaccounted. The caller's `AbortSignal.timeout(45s)` is shared across attempts (verified against `ai@6.0.174`'s `_retryWithExponentialBackoff`), so retries add no wall clock beyond it; a later redelivery is separately admitted and attempt-counted by the ledger, and a recorded terminal failure is never retried.

One new test pins the policy: it asserts the mocked `generateText` options carry `maxRetries: 0`, protecting against silently restoring the SDK default.

## What was already on develop (issue context)

#25127's core criteria were implemented by #25359 + #25485 (merged 2026-08-23, before this PR): the durable admission ledger (`personal_shared_inbound_media_descriptions` keyed by platform+project+connectorAccount+sourceMessageId, claim tokens, 120s lease, attempt counts, per-sender/per-connector daily image quotas, media-digest mismatch), error retyping of fetch/body-read/timeout/cancel failures as `InboundMediaDescriptionError` with raw-text degradation, and redelivery/reuse/in-flight/terminal-failure semantics. #25359's body explicitly deferred the retry posture ("the media retry posture is intentionally unchanged"), leaving the issue's "Define and test the AI SDK provider-attempt/retry policy" + "one bounded billable enrichment attempt" criterion open. This PR closes that residual.

## Verification (exact head 6147ea2e06)

- **RED control** (test fails on develop behavior): stashed the production change, ran the new test → `1 fail` (`maxRetries` undefined ≠ 0); restored → passes.
- **GREEN**: `bun test --isolate` on all four inbound-media suites → **58 pass / 0 fail** (enrichment orchestrator, describe module, admission migration, API route).
- `bun run --cwd packages/cloud/shared typecheck` → exit 0.
- `npx biome check` on both changed files → clean.
- Independent verification of the shared-AbortSignal claim against `ai@6.0.174` dist source (`_retryWithExponentialBackoff(f, {maxRetries, ..., abortSignal})`; `isAbortError` never retried).

## Definition of Done

- [x] This PR targets `develop` and is based on the latest `origin/develop` (`089984beb3`, 0 behind at publish).
- [x] Focused gates run on the exact head (test/typecheck/lint above); the repository-wide `bun run verify` lane was not run this session.
- [x] A reviewer can confirm the change works without reading the code: the new test's RED-control note above shows it fails when the fix is absent.

Staging-environment evidence rows (isolated Blooio staging webhook/fetch/ledger artifacts) are **N/A - the isolated Blooio staging environment (#22787) does not exist yet; the flag remains off in every deployment, and the code-path behavior is covered by the deterministic suites above**.

<!-- evidence-head:45cc1f07c36350c276467cb43a52b1808b7e6600 -->

<!-- evidence-row:backend-logs -->
```text
$ bun test packages/cloud/shared/src/lib/services/eliza-app/describe-inbound-media.test.ts
 22 pass
 0 fail
Ran 22 tests across 1 file. [624.00ms]

$ biome check describe-inbound-media.test.ts describe-inbound-media.ts
Checked 2 files in 15ms. No fixes applied. (exit 0)

Rebase 2026-09-01T01:02Z: fix/issue-25127-inbound-vision-spend-gate fa1048123 -> 1d31eaa90

Rebase 2026-09-09T21:10Z: 625d579e21 -> 005622d42b onto develop 3a7f438a9e (fast-forward base advance; PR delta unchanged: +24 lines / 2 files, maxRetries: 0 pin intact). Gates at exact head 005622d42b:

$ bun test packages/cloud/shared/src/lib/services/eliza-app/describe-inbound-media.test.ts
 22 pass
 0 fail
 72 expect() calls
Ran 22 tests across 1 file. [271.00ms]

$ bun run --cwd packages/cloud/shared typecheck
Done! (exit 0)

$ biome check describe-inbound-media.ts describe-inbound-media.test.ts
Checked 2 files in 50ms. No fixes applied. (exit 0)
onto develop tip 3821d43f57 with zero conflicts. cloud/shared typecheck error-delta vs develop
control = identical pre-existing failures only (doordash-browser-run.ts TS7006 x2,
cloud-worker-env.ts TS2307 @cloudflare/playwright) — no new errors.
```

<!-- evidence-row:before-screenshots -->
- [ ] N/A - cloud Worker backend change, no UI surface touched

<!-- evidence-row:after-screenshots -->
- [ ] N/A - cloud Worker backend change, no UI surface touched

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - one-line retry-policy pin with deterministic test proof, no interactive surface

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code touched (cloud/shared service module)

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - provider-attempt policy is enforced client-side on the generateText call options; no agent-runtime model routing changed

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no on-chain or external domain system touched; ledger behavior covered by checked-in PGlite suites

AI provider/model: zai / glm-5.3
Client / agent tooling: Hermes Agent
Skill revision: elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [hermes-t3rpz]
<!-- eliza-computer-attribution:v1 {"provider":"zai","model":"glm-5.3","client":"Hermes Agent","skill_revision":"elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza"} -->

## Review update (head `625d579e`, unchanged code)

Per review: the closing linkage is withdrawn — this PR is narrowed to the residual provider-attempt control it actually implements (`maxRetries: 0` pinning the admitted claim to one AI SDK provider attempt). The staging-evidence and rollout-ownership acceptance criteria of #25127 remain open on the issue; the feature flag stays intentionally dark in production until those gates are met by their owner. Evidence marker restamped to the exact current head `625d579e21`. No code changed; the reviewer's exact-head verification (describe-inbound-media suite 22/22, cloud-shared typecheck, Biome — all passed at this head in a network-disabled container) still binds.

