### PR TITLE
fix(plugin-mcp): require non-empty server name in DELETE /api/mcp/config/server/:name

### DIFF
--- a/plugins/plugin-mcp/__tests__/routes-mcp.test.ts
+++ b/plugins/plugin-mcp/__tests__/routes-mcp.test.ts
@@ -362,6 +362,24 @@ describe("handleMcpRoutes", () => {
     expect(ctx.saveElizaConfig).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ["empty string", "/api/mcp/config/server/"],
+    ["whitespace string", "/api/mcp/config/server/%20%20"],
+  ])("rejects %s on DELETE /api/mcp/config/server/:name with 400", async (_desc, path) => {
+    const config = { mcp: { servers: { remote: { type: "http", url: "https://example.com" } } } };
+    const ctx = makeCtx("DELETE", path, { config });
+
+    await expect(handleMcpRoutes(ctx)).resolves.toBe(true);
+
+    expect(ctx.response.status).toBe(400);
+    expect(ctx.response.body).toEqual({
+      ok: false,
+      error: "Server name is required",
+    });
+    expect(config.mcp.servers.remote).toBeDefined();
+    expect(ctx.saveElizaConfig).not.toHaveBeenCalled();
+  });
+
   it("returns empty status when the MCP service lookup fails", async () => {
     const ctx = makeCtx("GET", "/api/mcp/status", {
       runtime: {

--- a/plugins/plugin-mcp/src/routes-mcp.ts
+++ b/plugins/plugin-mcp/src/routes-mcp.ts
@@ -363,7 +363,12 @@ export async function handleMcpRoutes(ctx: McpRouteContext): Promise<boolean> {
       "server name"
     );
     if (serverName === null) return true;
-    if (ctx.isBlockedObjectKey(serverName)) {
+    const normalizedServerName = serverName.trim();
+    if (!normalizedServerName) {
+      error(res, "Server name is required", 400);
+      return true;
+    }
+    if (ctx.isBlockedObjectKey(normalizedServerName)) {
       error(
         res,
         'Invalid server name: "__proto__", "constructor", and "prototype" are reserved',
@@ -372,8 +377,8 @@ export async function handleMcpRoutes(ctx: McpRouteContext): Promise<boolean> {
       return true;
     }
 
-    if (state.config.mcp?.servers?.[serverName]) {
-      delete state.config.mcp.servers[serverName];
+    if (state.config.mcp?.servers?.[normalizedServerName]) {
+      delete state.config.mcp.servers[normalizedServerName];
       // error-policy:J4 a config write failure is visible in logs while the in-memory update remains usable.
       try {
         ctx.saveElizaConfig(state.config);


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Closes #28203

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low risk. Confined to MCP route parameter validation in `plugins/plugin-mcp/src/routes-mcp.ts`.

# Background

## What does this PR do?
Requires non-empty, trimmed server name in `DELETE /api/mcp/config/server/:name`, returning HTTP 400 when empty or whitespace-only.

## What kind of change is this?
Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?
My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?
Review `plugins/plugin-mcp/src/routes-mcp.ts` and `plugins/plugin-mcp/__tests__/routes-mcp.test.ts`.

## Detailed testing steps
Run:
```bash
bun run --cwd plugins/plugin-mcp test -- routes-mcp
bun run --cwd plugins/plugin-mcp typecheck
```

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:e4329a3cb5a07c3a088cefc4aa3b29c9ef652a22 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots: N/A - HTTP API route validation.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots: N/A - HTTP API route validation.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough: N/A - HTTP API route validation.
<!-- evidence-row:backend-logs -->
- [x] Backend logs:
<details>
<summary>bun run --cwd plugins/plugin-mcp test -- routes-mcp output</summary>

```
 Test Files  1 passed (1)
      Tests  18 passed (18)
   Start at  19:09:32
   Duration  4.81s
```
</details>
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs: N/A - Backend HTTP endpoint without frontend execution.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory: N/A - Deterministic route parameter handling.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts: N/A - In-memory route testing.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review: N/A - No UI rendered.

# Known gaps / failures
None.

# Maintainer CI exception record
N/A - no exception requested

---

AI provider/model: Google / Gemini 3.7 Flash
Client / agent tooling: Antigravity
Contribution skill revision: elizaOS/eliza@7d55350499b702ec4c979c3dcb6bb5e56d482939:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [antigravity-contrib]
<!-- eliza-computer-attribution:v1 {"provider":"google","model":"gemini-3.7-flash","client":"Antigravity","skill_revision":"elizaOS/eliza@7d55350499b702ec4c979c3dcb6bb5e56d482939:packages/skills/skills/contribute-to-eliza"} -->