### PR TITLE
fix(core): validate minItems and maxItems on array schemas in validateToolArgs

### DIFF
--- a/packages/core/src/actions/action-schema.ts
+++ b/packages/core/src/actions/action-schema.ts
@@ -28,6 +28,8 @@ export interface JsonSchema {
 	properties?: Record<string, JsonSchema>;
 	required?: string[];
 	items?: JsonSchema;
+	minItems?: number;
+	maxItems?: number;
 	additionalProperties?: boolean | JsonSchema;
 	minimum?: number;
 	maximum?: number;
@@ -264,6 +266,12 @@ export function actionParameterSchemaToJsonSchema(
 	}
 
 	if (schema.type === "array") {
+		if (schema.minItems !== undefined) {
+			jsonSchema.minItems = schema.minItems;
+		}
+		if (schema.maxItems !== undefined) {
+			jsonSchema.maxItems = schema.maxItems;
+		}
 		jsonSchema.items = schema.items
 			? actionParameterSchemaToJsonSchema(schema.items, {
 					path: `${path}[]`,

--- a/packages/core/src/actions/validate-tool-args.test.ts
+++ b/packages/core/src/actions/validate-tool-args.test.ts
@@ -108,6 +108,36 @@ describe("validate-tool-args", () => {
 			expect(errors).toHaveLength(0);
 			expect(result).toEqual({ id: "item-1", enabled: true });
 		});
+
+		it("validates array minItems and maxItems bounds", () => {
+			const errors: string[] = [];
+			const arraySchema = {
+				type: "array" as const,
+				minItems: 2,
+				maxItems: 4,
+				items: { type: "string" as const },
+			};
+
+			const valid = validateSchema(
+				arraySchema,
+				["a", "b", "c"],
+				"tags",
+				errors,
+			);
+			expect(valid).toEqual(["a", "b", "c"]);
+			expect(errors).toHaveLength(0);
+
+			validateSchema(arraySchema, ["a"], "tags", errors);
+			expect(errors).toContain(
+				"Argument 'tags' must contain at least 2 items, got 1",
+			);
+
+			errors.length = 0;
+			validateSchema(arraySchema, ["a", "b", "c", "d", "e"], "tags", errors);
+			expect(errors).toContain(
+				"Argument 'tags' must contain at most 4 items, got 5",
+			);
+		});
 	});
 
 	describe("validateToolArgs", () => {

--- a/packages/core/src/actions/validate-tool-args.ts
+++ b/packages/core/src/actions/validate-tool-args.ts
@@ -338,6 +338,16 @@ export function validateSchema(
 				);
 				return value;
 			}
+			if (schema.minItems !== undefined && value.length < schema.minItems) {
+				errors.push(
+					`Argument '${formatPath(path)}' must contain at least ${schema.minItems} items, got ${value.length}`,
+				);
+			}
+			if (schema.maxItems !== undefined && value.length > schema.maxItems) {
+				errors.push(
+					`Argument '${formatPath(path)}' must contain at most ${schema.maxItems} items, got ${value.length}`,
+				);
+			}
 			return value.map((entry, index) =>
 				validateSchema(
 					schema.items ?? { type: "string" },

--- a/packages/core/src/types/components.ts
+++ b/packages/core/src/types/components.ts
@@ -50,6 +50,10 @@ export interface ActionParameterSchema {
 	additionalProperties?: boolean | ActionParameterSchema;
 	/** For array types, define the item schema */
 	items?: ActionParameterSchema;
+	/** Minimum number of items for array-valued parameters */
+	minItems?: number;
+	/** Maximum number of items for array-valued parameters */
+	maxItems?: number;
 	/** Enumerated allowed values (schema-compatible) */
 	enumValues?: string[];
 	/** Enumerated allowed values */


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Closes #28211

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low risk. Confined to array parameter schema bounds validation in `packages/core/src/actions/validate-tool-args.ts`.

# Background

## What does this PR do?
Validates `minItems` and `maxItems` on array parameter schemas during tool argument validation in `packages/core/src/actions/validate-tool-args.ts`.

## What kind of change is this?
Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?
My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?
Review `packages/core/src/actions/validate-tool-args.ts` and `packages/core/src/actions/validate-tool-args.test.ts`.

## Detailed testing steps
Run:
```bash
bun test packages/core/src/actions/validate-tool-args.test.ts
bun run --cwd packages/core typecheck
```

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:837a48affa3858a2edffd94b69823c274d2f92f4 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots: N/A - Core tool argument validator.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots: N/A - Core tool argument validator.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough: N/A - Core tool argument validator.
<!-- evidence-row:backend-logs -->
- [x] Backend logs:
<details>
<summary>bun test packages/core/src/actions/validate-tool-args.test.ts output</summary>

```
 15 pass
 0 fail
 48 expect() calls
Ran 15 tests across 1 file. [117.00ms]
```
</details>
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs: N/A - Backend runtime validation without frontend execution.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory: N/A - Deterministic schema validation.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts: N/A - In-memory schema checks.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review: N/A - No UI rendered.

# Known gaps / failures
None.

# Maintainer CI exception record
N/A - no exception requested

---

AI provider/model: Google / Gemini 3.7 Flash
Client / agent tooling: Antigravity
Contribution skill revision: elizaOS/eliza@7d55350499b702ec4c979c3dcb6bb5e56d482939:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [antigravity-contrib]
<!-- eliza-computer-attribution:v1 {"provider":"google","model":"gemini-3.7-flash","client":"Antigravity","skill_revision":"elizaOS/eliza@7d55350499b702ec4c979c3dcb6bb5e56d482939:packages/skills/skills/contribute-to-eliza"} -->