### PR TITLE
fix(plugin-web-search): validate freshness parameter in searchNews

### DIFF
--- a/plugins/plugin-web-search/src/services/webSearchService.test.ts
+++ b/plugins/plugin-web-search/src/services/webSearchService.test.ts
@@ -199,6 +199,28 @@ describe("WebSearchService", () => {
                 days: 14,
             })
         );
+
+        await service.searchNews("funding", { freshness: "day" });
+        expect(searchMock).toHaveBeenLastCalledWith(
+            "funding",
+            expect.objectContaining({
+                topic: "news",
+                days: 1,
+            })
+        );
+
+        await service.searchNews("funding", { freshness: "month" });
+        expect(searchMock).toHaveBeenLastCalledWith(
+            "funding",
+            expect.objectContaining({
+                topic: "news",
+                days: 30,
+            })
+        );
+
+        await expect(service.searchNews("funding", { freshness: "year" as never })).rejects.toThrow(
+            'Invalid freshness: expected "day", "week", or "month", got "year"'
+        );
     });
 
     it("derives suggestions and trending searches from Tavily result titles", async () => {

--- a/plugins/plugin-web-search/src/services/webSearchService.ts
+++ b/plugins/plugin-web-search/src/services/webSearchService.ts
@@ -202,7 +202,9 @@ function freshnessToDays(freshness: NewsSearchOptions["freshness"]): number {
         case "month":
             return 30;
         default:
-            return 3;
+            throw new TypeError(
+                `Invalid freshness: expected "day", "week", or "month", got "${freshness}"`
+            );
     }
 }
 


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Relates to #28217

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Throws `TypeError` when an unsupported/unrecognized `freshness` option is passed to `searchNews` in `plugins/plugin-web-search/src/services/webSearchService.ts` instead of silently defaulting to 3 days.

# Background

## What does this PR do?

In `plugins/plugin-web-search/src/services/webSearchService.ts`, `freshnessToDays` now throws a `TypeError` for unrecognized freshness values rather than silently defaulting to 3 days, providing immediate actionable feedback to callers when invalid freshness options are supplied.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

- `plugins/plugin-web-search/src/services/webSearchService.ts`: `freshnessToDays` error throwing on invalid freshness values.
- `plugins/plugin-web-search/src/services/webSearchService.test.ts`: test cases verifying freshness mapping for "day", "week", "month", and rejection of invalid values.

## Detailed testing steps

Run:
```bash
bun run --cwd plugins/plugin-web-search test
bun run --cwd plugins/plugin-web-search typecheck
bun run --cwd plugins/plugin-web-search lint
```

# Evidence Gate

<!-- evidence-head:5f8b3f199ab526847479c5dd30e68c328b261e72 -->

- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - <reason>`.
  N/A - Web search service option validation fix.
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - <reason>`.
  N/A - Web search service option validation fix.
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - <reason>`.
  N/A - Web search service option validation fix.
- [x] Backend logs show the real code path firing end to end, or are marked `N/A - <reason>`.
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - <reason>`.
  N/A - Web search service option validation fix.
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - <reason>`.
  N/A - Web search service option validation fix.
- [ ] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - <reason>`.
  N/A - Web search service option validation fix.
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - <reason>` when the change has no rendered visual surface.
  N/A - No rendered visual surface.

# Evidence Details

## Backend + frontend logs

```text
$ vitest run --config ./vitest.config.ts

 RUN  v4.1.10 /home/deepanshu/Projects/eliza/plugins/plugin-web-search

 ✓ src/services/webSearchService.test.ts (19 tests) 413ms
 ✓ src/services/webSearchService.test.ts > WebSearchService > maps news freshness and image searches through the shared search path

 Test Files  4 passed | 1 skipped (5)
      Tests  35 passed | 1 skipped (36)
```

## Known gaps / failures

None.

## Maintainer CI exception record

N/A - no exception requested