### PR TITLE
fix(plugin-personal-assistant): keep connector status crash-safe for hostile rejections

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/connectors/x.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/connectors/x.test.ts
@@ -1,0 +1,248 @@
+/**
+ * X (Twitter) LifeOps connector contribution.
+ *
+ * Behavioral contracts pinned here:
+ *  - `send()` rejects malformed payloads BEFORE touching the service (empty /
+ *    whitespace targets, missing message, non-objects).
+ *  - `send()` maps transport failures to typed DispatchResults and NEVER
+ *    throws to the caller (429 -> rate_limited with retryAfterMinutes, etc.).
+ *  - `status()` is crash-safe: even a hostile rejection value (e.g. a
+ *    null-prototype object whose String() coercion throws) must yield a
+ *    `disconnected` status instead of rejecting.
+ */
+
+import { LifeOpsServiceError } from "@elizaos/shared";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createXConnectorContribution } from "./x";
+
+const serviceState = vi.hoisted(() => ({
+  getXConnectorStatus: vi.fn(),
+  sendXDirectMessage: vi.fn(),
+}));
+
+vi.mock("../service.js", () => ({
+  LifeOpsService: class {
+    constructor(_runtime: unknown) {}
+    getXConnectorStatus(...args: unknown[]) {
+      return serviceState.getXConnectorStatus(...args);
+    }
+    sendXDirectMessage(...args: unknown[]) {
+      return serviceState.sendXDirectMessage(...args);
+    }
+  },
+}));
+
+const RUNTIME = { agentId: "agent-1" };
+
+describe("createXConnectorContribution", () => {
+  let connector: ReturnType<typeof createXConnectorContribution>;
+
+  beforeEach(() => {
+    serviceState.getXConnectorStatus.mockReset();
+    serviceState.sendXDirectMessage.mockReset();
+    connector = createXConnectorContribution(RUNTIME as never);
+  });
+
+  describe("static surface", () => {
+    it("declares x capabilities and local/cloud modes", () => {
+      expect(connector.kind).toBe("x");
+      expect(connector.capabilities).toEqual([
+        "x.read",
+        "x.write",
+        "x.dm.read",
+        "x.dm.write",
+      ]);
+      expect(connector.modes).toEqual(["local", "cloud"]);
+    });
+
+    it("start/disconnect are no-ops that resolve", async () => {
+      await expect(connector.start()).resolves.toBeUndefined();
+      await expect(connector.disconnect()).resolves.toBeUndefined();
+    });
+  });
+
+  describe("verify", () => {
+    it("resolves true when the service reports connected", async () => {
+      serviceState.getXConnectorStatus.mockResolvedValue({ connected: true });
+      await expect(connector.verify()).resolves.toBe(true);
+      expect(serviceState.getXConnectorStatus).toHaveBeenCalledWith(
+        undefined,
+        "owner",
+      );
+    });
+
+    it("resolves false when the service reports disconnected", async () => {
+      serviceState.getXConnectorStatus.mockResolvedValue({ connected: false });
+      await expect(connector.verify()).resolves.toBe(false);
+    });
+  });
+
+  describe("status", () => {
+    it("maps connected=true to ok", async () => {
+      serviceState.getXConnectorStatus.mockResolvedValue({ connected: true });
+      await expect(connector.status()).resolves.toMatchObject({
+        state: "ok",
+        observedAt: expect.any(String),
+      });
+    });
+
+    it("maps connected with degradations to degraded", async () => {
+      serviceState.getXConnectorStatus.mockResolvedValue({
+        connected: true,
+        degradations: [{ message: "X API degraded" }],
+      });
+      await expect(connector.status()).resolves.toMatchObject({
+        state: "degraded",
+        message: "X API degraded",
+      });
+    });
+
+    it("maps connected=false to disconnected with the reason", async () => {
+      serviceState.getXConnectorStatus.mockResolvedValue({
+        connected: false,
+        reason: "not linked",
+      });
+      await expect(connector.status()).resolves.toMatchObject({
+        state: "disconnected",
+        message: "not linked",
+      });
+    });
+
+    it("never throws when the service throws a typed error", async () => {
+      serviceState.getXConnectorStatus.mockRejectedValue(
+        new LifeOpsServiceError("X unreachable", 503),
+      );
+      await expect(connector.status()).resolves.toMatchObject({
+        state: "disconnected",
+        message: "X unreachable",
+      });
+    });
+
+    it("never throws when the service rejects with a hostile non-Error value", async () => {
+      // Regression: the catch branch used formatError() directly, whose
+      // String() coercion throws on null-prototype objects — turning a
+      // status probe into a rejected promise instead of disconnected.
+      const hostile = Object.create(null);
+      serviceState.getXConnectorStatus.mockRejectedValue(hostile);
+      await expect(connector.status()).resolves.toMatchObject({
+        state: "disconnected",
+        message: "[object Object]",
+      });
+    });
+  });
+
+  describe("send payload gate", () => {
+    it.each([
+      ["null", null],
+      ["number", 42],
+      ["empty object", {}],
+      ["missing message", { target: "user-1" }],
+      ["empty target", { target: "", message: "hi" }],
+      ["whitespace target", { target: "   ", message: "hi" }],
+      ["non-string target", { target: 7, message: "hi" }],
+    ])("rejects %s before touching the service", async (_label, payload) => {
+      const result = await connector.send(payload);
+      expect(result.ok).toBe(false);
+      expect(result.reason).toBe("transport_error");
+      expect(serviceState.sendXDirectMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("send success/failure mapping", () => {
+    it("forwards a valid payload to the service and reports ok", async () => {
+      serviceState.sendXDirectMessage.mockResolvedValue({ ok: true });
+      const result = await connector.send({
+        target: "user-1",
+        message: "hello",
+      });
+      expect(result).toEqual({ ok: true });
+      expect(serviceState.sendXDirectMessage).toHaveBeenCalledWith({
+        participantId: "user-1",
+        text: "hello",
+        confirmSend: true,
+        side: "owner",
+      });
+    });
+
+    it("forwards an empty-string message per the current gate contract", async () => {
+      // The payload gate requires target to be non-empty but only requires
+      // message to be a string; an empty message is forwarded as-is.
+      serviceState.sendXDirectMessage.mockResolvedValue({ ok: true });
+      const result = await connector.send({
+        target: "user-1",
+        message: "",
+      });
+      expect(result).toEqual({ ok: true });
+      expect(serviceState.sendXDirectMessage).toHaveBeenCalledWith({
+        participantId: "user-1",
+        text: "",
+        confirmSend: true,
+        side: "owner",
+      });
+    });
+
+    it("maps a non-ok service response to transport_error", async () => {
+      serviceState.sendXDirectMessage.mockResolvedValue({
+        ok: false,
+        error: "X DM send returned a non-ok response.",
+      });
+      const result = await connector.send({
+        target: "user-1",
+        message: "hello",
+      });
+      expect(result).toEqual({
+        ok: false,
+        reason: "transport_error",
+        userActionable: false,
+        message: "X DM send returned a non-ok response.",
+      });
+    });
+
+    it("maps a 429 service error to rate_limited with retryAfterMinutes", async () => {
+      serviceState.sendXDirectMessage.mockRejectedValue(
+        new LifeOpsServiceError("rate limited", 429),
+      );
+      const result = await connector.send({
+        target: "user-1",
+        message: "hello",
+      });
+      expect(result).toMatchObject({
+        ok: false,
+        reason: "rate_limited",
+        retryAfterMinutes: 5,
+        userActionable: false,
+      });
+    });
+
+    it("maps a 401 service error to auth_expired and user-actionable", async () => {
+      serviceState.sendXDirectMessage.mockRejectedValue(
+        new LifeOpsServiceError("token expired", 401),
+      );
+      const result = await connector.send({
+        target: "user-1",
+        message: "hello",
+      });
+      expect(result).toMatchObject({
+        ok: false,
+        reason: "auth_expired",
+        userActionable: true,
+      });
+    });
+
+    it("maps a generic service error to transport_error", async () => {
+      serviceState.sendXDirectMessage.mockRejectedValue(
+        new Error("socket hang up"),
+      );
+      const result = await connector.send({
+        target: "user-1",
+        message: "hello",
+      });
+      expect(result).toMatchObject({
+        ok: false,
+        reason: "transport_error",
+        userActionable: false,
+        message: "socket hang up",
+      });
+    });
+  });
+});

--- a/plugins/plugin-personal-assistant/src/lifeops/connectors/x.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/connectors/x.ts
@@ -3,13 +3,13 @@
  * (`service-mixin-x.ts`).
  */
 import type { IAgentRuntime } from "@elizaos/core";
-import { formatError } from "@elizaos/core";
 import { LifeOpsService } from "../service.js";
 import {
   errorToDispatchResult,
   isConnectorSendPayload,
   legacyStatusToConnectorStatus,
   rejectInvalidPayload,
+  safeFormatError,
 } from "./_helpers.js";
 import type {
   ConnectorContribution,
@@ -39,7 +39,7 @@ export function createXConnectorContribution(
       } catch (error) {
         return {
           state: "disconnected",
-          message: formatError(error),
+          message: safeFormatError(error),
           observedAt: new Date().toISOString(),
         };
       }


### PR DESCRIPTION
# Relates to

No issue; behavioral fix + regression test for the LifeOps X connector's
`status()` probe.

**Defect:** `createXConnectorContribution().status()` catches service
failures and formats the rejection with `formatError()`. `formatError`
coerces non-Error values via `String(value)`, which **throws** on
null-prototype objects (no `toString` on the prototype chain) and on
objects whose coercion hooks throw. A hostile rejection value therefore
escapes the `try/catch` and the status probe rejects instead of
returning `{ state: "disconnected" }` — the exact failure mode
`safeFormatError` in `_helpers.ts` was written to prevent (it falls back
to `Object.prototype.toString.call`).

**Fix:** use `safeFormatError` in the `status()` catch branch, matching
the crash-safe formatting the dispatch path already uses. Regression test
rejects `getXConnectorStatus` with `Object.create(null)` and asserts the
probe resolves to `disconnected` with `"[object Object]"`.

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. One-line behavior change inside the `status()` error path; happy
paths (ok/degraded/disconnected mappings) are untouched and covered by
the test suite. The fix only widens the set of rejection values that
yield a typed `disconnected` status instead of a rejected promise.

# Evidence

| Row | Status |
|---|---|
| Focused test run (22 tests: payload gate, error mapping, status, verify) | `Test Files 1 passed (1)`, `Tests 22 passed (22)` |
| Prior behavior (hostile-rejection test against unfixed source) | 1 failure: `status()` rejected on `Object.create(null)` |
| Command | `npx vitest run xconn/x.test.ts` (isolated) |
| Biome | `biome check --write` clean on both files |
