### PR TITLE
fix(plugin-calendar): fix attendee anyOf schema contradiction and add notifyAttendees aliases

### DIFF
--- a/plugins/plugin-calendar/src/actions/calendar-attendees.test.ts
+++ b/plugins/plugin-calendar/src/actions/calendar-attendees.test.ts
@@ -33,4 +33,19 @@ describe("normalizeCalendarAttendees (planner-arg sanitization)", () => {
     expect(normalizeCalendarAttendees({})).toBeUndefined();
     expect(normalizeCalendarAttendees(undefined)).toBeUndefined();
   });
+
+  it("CALENDAR_DETAILS_PARAMETER_SCHEMA attendees.items has no conflicting type above anyOf", async () => {
+    const { CALENDAR_DETAILS_PARAMETER_SCHEMA } = await import(
+      "../calendar-action-schema.ts"
+    );
+    const attendees = CALENDAR_DETAILS_PARAMETER_SCHEMA.properties
+      ?.attendees as {
+      items?: { type?: string; anyOf?: unknown[] };
+    };
+    expect(attendees?.items?.type).toBeUndefined();
+    expect(Array.isArray(attendees?.items?.anyOf)).toBe(true);
+    expect(
+      CALENDAR_DETAILS_PARAMETER_SCHEMA.properties?.notify_attendees,
+    ).toEqual({ type: "boolean" });
+  });
 });

--- a/plugins/plugin-calendar/src/calendar-action-schema.ts
+++ b/plugins/plugin-calendar/src/calendar-action-schema.ts
@@ -96,6 +96,8 @@ const CALENDAR_DETAIL_BOOLEAN_KEYS = [
   "forcesync",
   "force_sync",
   "notifyAttendees",
+  "notifyattendees",
+  "notify_attendees",
 ] as const;
 
 const CALENDAR_DETAIL_RECURRENCE_KEYS = [
@@ -142,7 +144,6 @@ export const CALENDAR_DETAILS_PARAMETER_SCHEMA: ActionParameterSchema = {
     attendees: {
       type: "array",
       items: {
-        type: "object",
         anyOf: [
           { type: "string" },
           {


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Relates to #28228

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Refines JSON action schema in `plugins/plugin-calendar/src/calendar-action-schema.ts` by removing a redundant and contradicting parent `type: "object"` declaration above `anyOf: [{ type: "string" }, ...]` for `attendees.items`, and adds `"notifyattendees"` and `"notify_attendees"` boolean aliases.

# Background

## What does this PR do?

In `plugins/plugin-calendar/src/calendar-action-schema.ts`:
1. Removed contradicting `type: "object"` wrapper above `anyOf` in `CALENDAR_DETAILS_PARAMETER_SCHEMA.properties.attendees.items` so strict provider grammars accept either string or object attendee declarations.
2. Added `"notifyattendees"` and `"notify_attendees"` to `CALENDAR_DETAIL_BOOLEAN_KEYS`.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

- `plugins/plugin-calendar/src/calendar-action-schema.ts`: `CALENDAR_DETAILS_PARAMETER_SCHEMA` definition.
- `plugins/plugin-calendar/src/actions/calendar-attendees.test.ts`: test case verifying schema structure and boolean key properties.

## Detailed testing steps

Run:
```bash
bun run --cwd plugins/plugin-calendar test src/actions/calendar-attendees.test.ts
bun run --cwd plugins/plugin-calendar typecheck
bun run --cwd plugins/plugin-calendar lint
```

# Evidence Gate

<!-- evidence-head:f418b83c208de5ef1e03b9e0847c39ccba786d83 -->

- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - <reason>`.
  N/A - Calendar action schema fix.
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - <reason>`.
  N/A - Calendar action schema fix.
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - <reason>`.
  N/A - Calendar action schema fix.
- [x] Backend logs show the real code path firing end to end, or are marked `N/A - <reason>`.
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - <reason>`.
  N/A - Calendar action schema fix.
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - <reason>`.
  N/A - Calendar action schema fix.
- [ ] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - <reason>`.
  N/A - Calendar action schema fix.
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - <reason>` when the change has no rendered visual surface.
  N/A - No rendered visual surface.

# Evidence Details

## Backend + frontend logs

```text
$ vitest run --config vitest.config.ts src/actions/calendar-attendees.test.ts

 RUN  v4.1.10 /home/deepanshu/Projects/eliza/plugins/plugin-calendar

 ✓ src/actions/calendar-attendees.test.ts (4 tests) 5ms
   ✓ normalizeCalendarAttendees (planner-arg sanitization) (4)
     ✓ drops a planner-invented bare-name attendee instead of failing the create (live regression) 2ms
     ✓ keeps valid-email attendees and drops invalid ones from a mixed list 1ms
     ✓ returns undefined when the details carry no attendees 0ms
     ✓ CALENDAR_DETAILS_PARAMETER_SCHEMA attendees.items has no conflicting type above anyOf 0ms

 Test Files  1 passed (1)
      Tests  4 passed (4)
```

## Known gaps / failures

None.

## Maintainer CI exception record

N/A - no exception requested