### PR TITLE
fix(logger): preserve error name in pretty-format log extras

### DIFF
--- a/packages/logger/src/logger.test.ts
+++ b/packages/logger/src/logger.test.ts
@@ -35,6 +35,19 @@ describe("logger", () => {
     expect(recentLogs()).toContain("info [LOGGER-TEST] hello (requestId=abc)");
   });
 
+  it("formats custom error with error name in pretty extras", () => {
+    const logger = bufferLogger();
+
+    logger.error(
+      { src: "logger-test", err: new TypeError("bad type") },
+      "failed",
+    );
+
+    expect(recentLogs()).toContain(
+      "error [LOGGER-TEST] failed (err=TypeError: bad type)",
+    );
+  });
+
   it("removes log listeners through the unsubscribe function", () => {
     const logger = bufferLogger();
     const listener = vi.fn<(entry: LogEntry) => void>();

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -253,7 +253,11 @@ function formatExtraValue(value: unknown): string {
   if (typeof value === "string") return value;
   if (typeof value === "number" || typeof value === "boolean")
     return String(value);
-  if (value instanceof Error) return value.message;
+  if (value instanceof Error) {
+    return value.name && value.name !== "Error"
+      ? `${value.name}: ${value.message}`
+      : value.message;
+  }
   return safeStringify(value);
 }
 


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Relates to #28234

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. In `packages/logger/src/logger.ts`, `formatExtraValue` formats non-generic `Error` instances as `${error.name}: ${error.message}` instead of dropping the error name.

# Background

## What does this PR do?

In `packages/logger/src/logger.ts`:
When `formatExtraValue` encounters an `Error` instance where `error.name` is distinct from `"Error"` (such as `TypeError`, `RangeError`, `ElizaError`), it includes the error name in the pretty log extras formatting (`(err=TypeError: bad type)`), providing essential diagnostic context in pretty logs.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

- `packages/logger/src/logger.ts`: `formatExtraValue` implementation.
- `packages/logger/src/logger.test.ts`: test case verifying custom error formatting in pretty extras.

## Detailed testing steps

Run:
```bash
bun run --cwd packages/logger test
bun run --cwd packages/logger typecheck
bun run --cwd packages/logger lint
```

# Evidence Gate

<!-- evidence-head:d7a4f42a0787924d19aed3e9de9b185acb07397a -->

- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - <reason>`.
  N/A - Logger formatting fix.
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - <reason>`.
  N/A - Logger formatting fix.
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - <reason>`.
  N/A - Logger formatting fix.
- [x] Backend logs show the real code path firing end to end, or are marked `N/A - <reason>`.
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - <reason>`.
  N/A - Logger formatting fix.
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - <reason>`.
  N/A - Logger formatting fix.
- [ ] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - <reason>`.
  N/A - Logger formatting fix.
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - <reason>` when the change has no rendered visual surface.
  N/A - No rendered visual surface.

# Evidence Details

## Backend + frontend logs

```text
$ vitest run --config vitest.config.ts

 RUN  v4.1.10 /home/deepanshu/Projects/eliza/packages/logger

 ✓ src/logger.test.ts (57 tests) 72ms
 ✓ src/logger.test.ts > logger > formats custom error with error name in pretty extras

 Test Files  2 passed (2)
      Tests  61 passed (61)
```

## Known gaps / failures

None.

## Maintainer CI exception record

N/A - no exception requested