### PR TITLE
fix(core): guard truncateToCompleteSentence against non-finite maxLength

### DIFF
--- a/packages/core/src/utils.parsing.test.ts
+++ b/packages/core/src/utils.parsing.test.ts
@@ -137,4 +137,34 @@ describe("truncateToCompleteSentence", () => {
 	it("returns text unchanged when it already fits", () => {
 		expect(truncateToCompleteSentence("short", 280)).toBe("short");
 	});
+
+	it("guards non-finite and out-of-range maxLength", () => {
+		const text = "One. Two. Three is longer than limit.";
+		// NaN / Infinity must not bypass the budget — they return empty
+		expect(truncateToCompleteSentence(text, Number.NaN)).toBe("");
+		expect(truncateToCompleteSentence(text, Number.POSITIVE_INFINITY)).toBe("");
+		expect(truncateToCompleteSentence(text, Number.NEGATIVE_INFINITY)).toBe("");
+		// Negative and zero are already guarded but re-assert
+		expect(truncateToCompleteSentence(text, -1)).toBe("");
+		expect(truncateToCompleteSentence(text, -100)).toBe("");
+		// Fractional caps floor to integer
+		expect(
+			truncateToCompleteSentence("alpha beta gamma delta", 12.9).length,
+		).toBeLessThanOrEqual(12);
+		expect(
+			truncateToCompleteSentence("alpha beta gamma delta", 10.1).length,
+		).toBeLessThanOrEqual(10);
+		// Infinity text bypass check: long text must not be returned unchanged
+		const long = "word ".repeat(100).trim();
+		expect(long.length).toBeGreaterThan(100);
+		expect(truncateToCompleteSentence(long, Number.POSITIVE_INFINITY)).toBe("");
+		expect(truncateToCompleteSentence(long, Number.NaN)).toBe("");
+	});
+
+	it("caps output strictly at fractional and small limits", () => {
+		expect(
+			truncateToCompleteSentence("Hello world. Extra.", 5.7).length,
+		).toBeLessThanOrEqual(5);
+		expect(truncateToCompleteSentence("abcdef", 3.9)).toBe("abc");
+	});
 });

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1006,16 +1006,17 @@ export function truncateToCompleteSentence(
 	text: string,
 	maxLength: number,
 ): string {
-	if (maxLength <= 0) return "";
-	if (text.length <= maxLength) {
+	if (!Number.isFinite(maxLength) || maxLength <= 0) return "";
+	const cap = Math.floor(maxLength);
+	if (text.length <= cap) {
 		return text;
 	}
-	if (maxLength <= 3) {
-		return truncateWellFormed(text, maxLength);
+	if (cap <= 3) {
+		return truncateWellFormed(text, cap);
 	}
 
 	// Attempt to truncate at the last period within the limit
-	const lastPeriodIndex = text.lastIndexOf(".", maxLength - 1);
+	const lastPeriodIndex = text.lastIndexOf(".", cap - 1);
 	if (lastPeriodIndex !== -1) {
 		const truncatedAtPeriod = text.slice(0, lastPeriodIndex + 1).trim();
 		if (truncatedAtPeriod.length > 0) {
@@ -1024,9 +1025,9 @@ export function truncateToCompleteSentence(
 	}
 
 	// If no period, truncate to the nearest whitespace within the limit.
-	// Search from maxLength - 3 so the appended ellipsis still fits the cap,
+	// Search from cap - 3 so the appended ellipsis still fits the cap,
 	// matching the hard-truncate fallback below.
-	const lastSpaceIndex = text.lastIndexOf(" ", maxLength - 3);
+	const lastSpaceIndex = text.lastIndexOf(" ", cap - 3);
 	if (lastSpaceIndex !== -1) {
 		const truncatedAtSpace = text.slice(0, lastSpaceIndex).trim();
 		if (truncatedAtSpace.length > 0) {
@@ -1035,7 +1036,7 @@ export function truncateToCompleteSentence(
 	}
 
 	// Fallback: Hard truncate (surrogate-safe) and add ellipsis
-	const hardTruncated = truncateWellFormed(text, maxLength - 3).trim();
+	const hardTruncated = truncateWellFormed(text, cap - 3).trim();
 	return `${hardTruncated}...`;
 }
 


### PR DESCRIPTION
# Relates to

N/A - guard truncateToCompleteSentence

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Pure guard for non-finite maxLength; no behavior change for valid inputs.

# Background

## What does this PR do?

Fixes `truncateToCompleteSentence` in `packages/core/src/utils.ts:1005`. `maxLength <=0` is false for `NaN`, `Infinity` bypasses budget, fractional not floored. Fix adds `!Number.isFinite` check and floors via `cap=Math.floor(maxLength)`.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/core/src/utils.ts:1005` and `packages/core/src/utils.parsing.test.ts`

## Detailed testing steps

```bash
bun test packages/core/src/utils.parsing.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:0d3a3687db2ffc547eaf6af4cb3f1e02b1af8a48 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no visual surface`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no visual surface`.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked
      `N/A - no visual surface`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked
      `N/A - verified via unit test`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - no frontend`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - no model`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - unit test`.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked
      `N/A - no rendered visual surface` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A

## Backend + frontend logs

N/A - verified via unit test

Red (reverted): `15 pass 2 fail (NaN→One... not "", 3.9→... not abc)`
Green (restored): `17 pass 60 expects` — `bun test packages/core/src/utils.parsing.test.ts` pass; typecheck/lint clean

## Screenshots (before / after) + video walkthrough

N/A

### Before

N/A

### After

N/A

### Walkthrough video

N/A

## Audio / voice walkthrough

N/A

## Known gaps / failures

None.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
