### PR TITLE
fix(agent): strict positive integer parsing rejects trailing junk

### DIFF
--- a/packages/agent/src/api/chat-routes.test.ts
+++ b/packages/agent/src/api/chat-routes.test.ts
@@ -51,6 +51,7 @@ import {
   persistExactConversationMemoryResult,
   persistInterruptedAssistantReceipt,
   readChatRequestPayload,
+  readPositiveIntegerSetting,
   releaseChatMessageId,
   renderChatSurfaceText,
   resolveChatAdminEntityId,
@@ -1308,6 +1309,128 @@ describe("SSE + delta-v2 token writer", () => {
     expect(sse).toHaveBeenCalledWith(res, {
       type: "token",
       fullText: "done",
+    });
+  });
+
+  describe("readPositiveIntegerSetting", () => {
+    const fallback = 128;
+    function makeRuntime(value: unknown): AgentRuntime {
+      return {
+        getSetting: (key: string) =>
+          key === "ELIZA_MOBILE_LOCAL_DIRECT_REPLY_MAX_TOKENS"
+            ? value
+            : undefined,
+        logger: {
+          info: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+          debug: vi.fn(),
+        },
+      } as unknown as AgentRuntime;
+    }
+
+    it("returns fallback for trailing junk, hex, floats and non-canonical strings", () => {
+      for (const junk of [
+        "10abc",
+        "0x10",
+        "10.5",
+        "1e3",
+        "010",
+        "",
+        "  ",
+        "Infinity",
+        "-5",
+        "0",
+      ]) {
+        const runtime = makeRuntime(junk);
+        expect(
+          readPositiveIntegerSetting(
+            runtime,
+            "ELIZA_MOBILE_LOCAL_DIRECT_REPLY_MAX_TOKENS",
+            fallback,
+          ),
+        ).toBe(fallback);
+      }
+    });
+
+    it("accepts canonical positive integers and trimmed whitespace", () => {
+      expect(
+        readPositiveIntegerSetting(
+          makeRuntime("1"),
+          "ELIZA_MOBILE_LOCAL_DIRECT_REPLY_MAX_TOKENS",
+          fallback,
+        ),
+      ).toBe(1);
+      expect(
+        readPositiveIntegerSetting(
+          makeRuntime("  256  "),
+          "ELIZA_MOBILE_LOCAL_DIRECT_REPLY_MAX_TOKENS",
+          fallback,
+        ),
+      ).toBe(256);
+      expect(
+        readPositiveIntegerSetting(
+          makeRuntime(42),
+          "ELIZA_MOBILE_LOCAL_DIRECT_REPLY_MAX_TOKENS",
+          fallback,
+        ),
+      ).toBe(42);
+      expect(
+        readPositiveIntegerSetting(
+          makeRuntime("999"),
+          "ELIZA_MOBILE_LOCAL_DIRECT_REPLY_MAX_TOKENS",
+          fallback,
+        ),
+      ).toBe(999);
+    });
+
+    it("rejects unsafe and non-integer numbers", () => {
+      expect(
+        readPositiveIntegerSetting(
+          makeRuntime(10.5),
+          "ELIZA_MOBILE_LOCAL_DIRECT_REPLY_MAX_TOKENS",
+          fallback,
+        ),
+      ).toBe(fallback);
+      expect(
+        readPositiveIntegerSetting(
+          makeRuntime(Number.NaN),
+          "ELIZA_MOBILE_LOCAL_DIRECT_REPLY_MAX_TOKENS",
+          fallback,
+        ),
+      ).toBe(fallback);
+      expect(
+        readPositiveIntegerSetting(
+          makeRuntime(Number.POSITIVE_INFINITY),
+          "ELIZA_MOBILE_LOCAL_DIRECT_REPLY_MAX_TOKENS",
+          fallback,
+        ),
+      ).toBe(fallback);
+      expect(
+        readPositiveIntegerSetting(
+          makeRuntime(Number.MAX_SAFE_INTEGER + 1),
+          "ELIZA_MOBILE_LOCAL_DIRECT_REPLY_MAX_TOKENS",
+          fallback,
+        ),
+      ).toBe(fallback);
+    });
+
+    it("returns fallback when setting is missing", () => {
+      const runtime = {
+        getSetting: () => undefined,
+      } as unknown as AgentRuntime;
+      // ensure env not polluted
+      const prev = process.env.ELIZA_MOBILE_LOCAL_DIRECT_REPLY_MAX_TOKENS;
+      delete process.env.ELIZA_MOBILE_LOCAL_DIRECT_REPLY_MAX_TOKENS;
+      expect(
+        readPositiveIntegerSetting(
+          runtime,
+          "ELIZA_MOBILE_LOCAL_DIRECT_REPLY_MAX_TOKENS",
+          fallback,
+        ),
+      ).toBe(fallback);
+      if (prev !== undefined)
+        process.env.ELIZA_MOBILE_LOCAL_DIRECT_REPLY_MAX_TOKENS = prev;
     });
   });
 });

--- a/packages/agent/src/api/chat-routes.ts
+++ b/packages/agent/src/api/chat-routes.ts
@@ -454,14 +454,17 @@ function readRuntimeStringSetting(
   return typeof env === "string" && env.trim().length > 0 ? env.trim() : null;
 }
 
-function readPositiveIntegerSetting(
+export function readPositiveIntegerSetting(
   runtime: AgentRuntime,
   key: string,
   fallback: number,
 ): number {
   const raw = readRuntimeStringSetting(runtime, key);
-  const parsed = raw ? Number.parseInt(raw, 10) : Number.NaN;
-  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : fallback;
+  if (typeof raw !== "string" || raw.trim() === "") return fallback;
+  const trimmed = raw.trim();
+  if (!/^[1-9]\d*$/.test(trimmed)) return fallback;
+  const parsed = Number(trimmed);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback;
 }
 
 function isAndroidLocalDirectChatRuntime(runtime: AgentRuntime): boolean {


### PR DESCRIPTION
# Relates to

N/A - strict positive integer parsing

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Strict integer parsing for chat routes setting.

# Background

## What does this PR do?

Fixes `readPositiveIntegerSetting` in `packages/agent/src/api/chat-routes.ts:457`. `Number.parseInt(raw,10)` accepts `10abc`→10, `0x10`→0, `10.5`→10. Fix exports strict parser with `/^[1-9]\d*$/` and `isSafeInteger`.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/agent/src/api/chat-routes.ts:457` and `packages/agent/src/api/chat-routes.test.ts`

## Detailed testing steps

```bash
node packages/scripts/run-vitest.mjs run chat-routes.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:d42ab9ce51176bfdb60303883ae01f704a78d7d3 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no visual surface`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no visual surface`.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked
      `N/A - no visual surface`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked
      `N/A - verified via unit test`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - no frontend`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - no model`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - unit test`.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked
      `N/A - no rendered visual surface` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A

## Backend + frontend logs

N/A - verified via unit test

Red: `2 fail (10abc→10 vs 128, 10.5→10)`
Green: `70 pass (66+4)` — `node packages/scripts/run-vitest.mjs run chat-routes.test.ts` pass; lint fixed 1 file; typecheck clean on main (worktree plugin errors pre-existing)

## Screenshots (before / after) + video walkthrough

N/A

### Before

N/A

### After

N/A

### Walkthrough video

N/A

## Audio / voice walkthrough

N/A

## Known gaps / failures

None.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
