### PR TITLE
fix(cloud): strict embedding sidecar host port parsing rejects trailing junk

### DIFF
--- a/packages/cloud/shared/src/lib/config/containers-env-disk.test.ts
+++ b/packages/cloud/shared/src/lib/config/containers-env-disk.test.ts
@@ -126,3 +126,72 @@ describe("nodeDiskAgentImagePruneMaxAgeHours", () => {
     expect(containersEnv.nodeDiskAgentImagePruneMaxAgeHours()).toBe(90 * 24);
   });
 });
+
+describe("embeddingSidecarHostPort", () => {
+  const hostPortKeys = [
+    "CONTAINERS_EMBEDDING_SIDECAR_HOST_PORT",
+    "ELIZA_EMBEDDING_SIDECAR_HOST_PORT",
+  ] as const;
+  const savedHost = new Map<string, string | undefined>();
+  function setHostPort(
+    value: string | undefined,
+    key: (typeof hostPortKeys)[number] = "CONTAINERS_EMBEDDING_SIDECAR_HOST_PORT",
+  ): void {
+    for (const k of hostPortKeys) {
+      if (!savedHost.has(k)) savedHost.set(k, process.env[k]);
+      delete process.env[k];
+    }
+    if (value !== undefined) process.env[key] = value;
+  }
+  afterEach(() => {
+    for (const [k, v] of savedHost) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+    savedHost.clear();
+  });
+
+  test("defaults to 8290 when unset", () => {
+    setHostPort(undefined);
+    expect(containersEnv.embeddingSidecarHostPort()).toBe(8290);
+  });
+
+  test("accepts canonical port", () => {
+    setHostPort("8080");
+    expect(containersEnv.embeddingSidecarHostPort()).toBe(8080);
+    setHostPort("  9000  ");
+    expect(containersEnv.embeddingSidecarHostPort()).toBe(9000);
+  });
+
+  test("rejects trailing junk, hex, floats and out-of-range", () => {
+    for (const junk of [
+      "8080abc",
+      "0x10",
+      "8080.5",
+      "1e3",
+      "010",
+      "0",
+      "70000",
+      "-1",
+      "Infinity",
+      "",
+    ]) {
+      setHostPort(junk);
+      expect(containersEnv.embeddingSidecarHostPort(), `junk ${junk}`).toBe(8290);
+    }
+  });
+
+  test("falls back to legacy key when primary unset", () => {
+    setHostPort("9090", "ELIZA_EMBEDDING_SIDECAR_HOST_PORT");
+    expect(containersEnv.embeddingSidecarHostPort()).toBe(9090);
+  });
+
+  test("clamps to [1, 65535] even for canonical", () => {
+    setHostPort("65535");
+    expect(containersEnv.embeddingSidecarHostPort()).toBe(65535);
+    setHostPort("65536");
+    expect(containersEnv.embeddingSidecarHostPort()).toBe(8290);
+    setHostPort("1");
+    expect(containersEnv.embeddingSidecarHostPort()).toBe(1);
+  });
+});

--- a/packages/cloud/shared/src/lib/config/containers-env.ts
+++ b/packages/cloud/shared/src/lib/config/containers-env.ts
@@ -168,8 +168,11 @@ export const containersEnv = {
       env.CONTAINERS_EMBEDDING_SIDECAR_HOST_PORT,
       env.ELIZA_EMBEDDING_SIDECAR_HOST_PORT,
     );
-    const parsed = raw ? Number.parseInt(raw, 10) : Number.NaN;
-    return Number.isFinite(parsed) && parsed >= 1 && parsed <= 65535 ? parsed : 8290;
+    if (typeof raw !== "string" || raw.trim() === "") return 8290;
+    const trimmed = raw.trim();
+    if (!/^[1-9]\d*$/.test(trimmed)) return 8290;
+    const parsed = Number(trimmed);
+    return Number.isSafeInteger(parsed) && parsed >= 1 && parsed <= 65535 ? parsed : 8290;
   },
 
   /**


### PR DESCRIPTION
# Relates to

N/A - strict host port parsing

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Host port parsing for embedding sidecar.

# Background

## What does this PR do?

Fixes `embeddingSidecarHostPort` in `packages/cloud/shared/src/lib/config/containers-env.ts:165`. `Number.parseInt(raw,10)` accepts `8080abc`→8080 etc. Fix uses strict regex + isSafeInteger 1-65535 fallback 8290.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/shared/src/lib/config/containers-env.ts:165` and `packages/cloud/shared/src/lib/config/containers-env-disk.test.ts`

## Detailed testing steps

```bash
bun test containers-env-disk.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:b8e02b5af5cc262eff06ea3bb64b04f2cc50c1c8 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no visual surface`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no visual surface`.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked
      `N/A - no visual surface`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked
      `N/A - verified via unit test`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - no frontend`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - no model`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - unit test`.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked
      `N/A - no rendered visual surface` when the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A

## Backend + frontend logs

N/A - verified via unit test

Red: `1 fail (8080abc→8080 vs 8290)`
Green: `18 pass` — `bun test containers-env-disk.test.ts` pass; lint + typecheck clean on main

## Screenshots (before / after) + video walkthrough

N/A

### Before

N/A

### After

N/A

### Walkthrough video

N/A

## Audio / voice walkthrough

N/A

## Known gaps / failures

None.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
