### PR TITLE
feat(shared): support natural unit names and weeks in parseDurationMs

### DIFF
--- a/packages/shared/src/cli/parse-duration.test.ts
+++ b/packages/shared/src/cli/parse-duration.test.ts
@@ -11,9 +11,17 @@ describe("parseDurationMs", () => {
   it("converts each unit suffix to milliseconds", () => {
     expect(parseDurationMs("500ms")).toBe(500);
     expect(parseDurationMs("2s")).toBe(2000);
+    expect(parseDurationMs("30sec")).toBe(30_000);
+    expect(parseDurationMs("30seconds")).toBe(30_000);
     expect(parseDurationMs("3m")).toBe(180_000);
+    expect(parseDurationMs("5mins")).toBe(300_000);
+    expect(parseDurationMs("5minutes")).toBe(300_000);
     expect(parseDurationMs("1h")).toBe(3_600_000);
+    expect(parseDurationMs("2hours")).toBe(7_200_000);
     expect(parseDurationMs("1d")).toBe(86_400_000);
+    expect(parseDurationMs("3days")).toBe(259_200_000);
+    expect(parseDurationMs("1w")).toBe(604_800_000);
+    expect(parseDurationMs("2weeks")).toBe(1_209_600_000);
     expect(parseDurationMs("1.5s")).toBe(1500);
   });
 

--- a/packages/shared/src/cli/parse-duration.test.ts
+++ b/packages/shared/src/cli/parse-duration.test.ts
@@ -67,4 +67,10 @@ describe("parseDurationMs", () => {
       parseDurationMs(`1${"0".repeat(306)}`, { defaultUnit: "m" }),
     ).toThrow("invalid duration");
   });
+
+  it("throws when a casted-invalid defaultUnit is provided", () => {
+    expect(() => parseDurationMs("5", { defaultUnit: "xyz" as never })).toThrow(
+      "invalid duration",
+    );
+  });
 });

--- a/packages/shared/src/cli/parse-duration.ts
+++ b/packages/shared/src/cli/parse-duration.ts
@@ -4,7 +4,7 @@
  * unparseable input. Used by config zod schemas and CLI flag parsing.
  */
 export type DurationMsParseOptions = {
-  defaultUnit?: "ms" | "s" | "m" | "h" | "d";
+  defaultUnit?: "ms" | "s" | "m" | "h" | "d" | "w";
 };
 
 export function parseDurationMs(
@@ -19,7 +19,10 @@ export function parseDurationMs(
     throw new Error("invalid duration (empty)");
   }
 
-  const m = /^(\d+(?:\.\d+)?)(ms|s|m|h|d)?$/.exec(trimmed);
+  const m =
+    /^(\d+(?:\.\d+)?)(ms|millisecond|milliseconds|s|sec|secs|second|seconds|m|min|mins|minute|minutes|h|hr|hrs|hour|hours|d|day|days|w|week|weeks)?$/.exec(
+      trimmed,
+    );
   if (!m) {
     throw new Error(`invalid duration: ${raw}`);
   }
@@ -29,22 +32,43 @@ export function parseDurationMs(
     throw new Error(`invalid duration: ${raw}`);
   }
 
-  const unit = (m[2] ?? opts?.defaultUnit ?? "ms") as
-    | "ms"
-    | "s"
-    | "m"
-    | "h"
-    | "d";
-  const multiplier =
-    unit === "ms"
-      ? 1
-      : unit === "s"
-        ? 1000
-        : unit === "m"
-          ? 60_000
-          : unit === "h"
-            ? 3_600_000
-            : 86_400_000;
+  const rawUnit = m[2] ?? opts?.defaultUnit ?? "ms";
+  const multiplier = (() => {
+    switch (rawUnit) {
+      case "ms":
+      case "millisecond":
+      case "milliseconds":
+        return 1;
+      case "s":
+      case "sec":
+      case "secs":
+      case "second":
+      case "seconds":
+        return 1000;
+      case "m":
+      case "min":
+      case "mins":
+      case "minute":
+      case "minutes":
+        return 60_000;
+      case "h":
+      case "hr":
+      case "hrs":
+      case "hour":
+      case "hours":
+        return 3_600_000;
+      case "d":
+      case "day":
+      case "days":
+        return 86_400_000;
+      case "w":
+      case "week":
+      case "weeks":
+        return 604_800_000;
+      default:
+        throw new Error(`invalid duration: ${raw}`);
+    }
+  })();
   const milliseconds = value * multiplier;
   if (
     !Number.isFinite(milliseconds) ||


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Closes #28237

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low risk. Confined to duration string parsing in `packages/shared/src/cli/parse-duration.ts`.

# Background

## What does this PR do?
Adds support for natural unit names (`sec`, `seconds`, `mins`, `minutes`, `hours`, `days`, `weeks`) and weeks (`w`) in `parseDurationMs`, while strictly throwing on invalid units and invalid `defaultUnit` options.

## What kind of change is this?
Features (non-breaking change which adds functionality)

# Documentation changes needed?
My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?
Review `packages/shared/src/cli/parse-duration.ts` and `packages/shared/src/cli/parse-duration.test.ts`.

## Detailed testing steps
Run:
```bash
bun test packages/shared/src/cli/parse-duration.test.ts
bun run --cwd packages/shared typecheck
```

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:97e40e3815b51dc3fdb89a99723ecdbf56641870 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots: N/A - Shared duration parser utility.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots: N/A - Shared duration parser utility.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough: N/A - Shared duration parser utility.
<!-- evidence-row:backend-logs -->
- [x] Backend logs:
<details>
<summary>bun test packages/shared/src/cli/parse-duration.test.ts output</summary>

```
 10 pass
 0 fail
 33 expect() calls
Ran 10 tests across 1 file. [248.00ms]
```
</details>
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs: N/A - Shared library utility without frontend execution.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory: N/A - Deterministic duration parsing function.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts: N/A - In-memory computation without persistent storage.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review: N/A - No UI rendered.

# Known gaps / failures
None.

# Maintainer CI exception record
N/A - no exception requested

---

AI provider/model: Google / Gemini 3.7 Flash
Client / agent tooling: Antigravity
Contribution skill revision: elizaOS/eliza@7d55350499b702ec4c979c3dcb6bb5e56d482939:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [antigravity-contrib]
<!-- eliza-computer-attribution:v1 {"provider":"google","model":"gemini-3.7-flash","client":"Antigravity","skill_revision":"elizaOS/eliza@7d55350499b702ec4c979c3dcb6bb5e56d482939:packages/skills/skills/contribute-to-eliza"} -->