### PR TITLE
test(plugin-browser): add unit test coverage for assertBrowserWorkspaceUrl and inferBrowserWorkspaceTitle

### DIFF
--- a/plugins/plugin-browser/src/workspace/browser-workspace-helpers.test.ts
+++ b/plugins/plugin-browser/src/workspace/browser-workspace-helpers.test.ts
@@ -4,6 +4,8 @@
 
 import { describe, expect, it } from "vitest";
 import {
+  assertBrowserWorkspaceUrl,
+  inferBrowserWorkspaceTitle,
   normalizeBrowserWorkspaceText,
   parseBrowserWorkspaceNumberLike,
 } from "./browser-workspace-helpers";
@@ -49,5 +51,61 @@ describe("normalizeBrowserWorkspaceText", () => {
     expect(normalizeBrowserWorkspaceText(null)).toBe("");
     expect(normalizeBrowserWorkspaceText(undefined)).toBe("");
     expect(normalizeBrowserWorkspaceText(42)).toBe("42");
+  });
+});
+
+describe("assertBrowserWorkspaceUrl", () => {
+  it("accepts about:blank without modification", () => {
+    expect(assertBrowserWorkspaceUrl("about:blank")).toBe("about:blank");
+    expect(assertBrowserWorkspaceUrl("  about:blank  ")).toBe("about:blank");
+  });
+
+  it("accepts valid http and https URLs and normalizes them", () => {
+    expect(assertBrowserWorkspaceUrl("https://example.com")).toBe(
+      "https://example.com/",
+    );
+    expect(assertBrowserWorkspaceUrl("http://localhost:3000/app")).toBe(
+      "http://localhost:3000/app",
+    );
+  });
+
+  it("rejects non-http/https protocols", () => {
+    expect(() => assertBrowserWorkspaceUrl("javascript:alert(1)")).toThrow(
+      /only supports http\/https URLs/,
+    );
+    expect(() => assertBrowserWorkspaceUrl("file:///etc/passwd")).toThrow(
+      /only supports http\/https URLs/,
+    );
+    expect(() =>
+      assertBrowserWorkspaceUrl("data:text/html,<h1>hi</h1>"),
+    ).toThrow(/only supports http\/https URLs/);
+  });
+
+  it("rejects malformed URLs", () => {
+    expect(() => assertBrowserWorkspaceUrl("not a url")).toThrow(
+      /rejected invalid URL/,
+    );
+    expect(() => assertBrowserWorkspaceUrl("://missing-scheme")).toThrow(
+      /rejected invalid URL/,
+    );
+  });
+});
+
+describe("inferBrowserWorkspaceTitle", () => {
+  it("infers New Tab for about:blank", () => {
+    expect(inferBrowserWorkspaceTitle("about:blank")).toBe("New Tab");
+  });
+
+  it("infers hostname stripped of leading www for web URLs", () => {
+    expect(inferBrowserWorkspaceTitle("https://www.google.com/search")).toBe(
+      "google.com",
+    );
+    expect(inferBrowserWorkspaceTitle("https://github.com/elizaOS/eliza")).toBe(
+      "github.com",
+    );
+  });
+
+  it("falls back to default title on invalid URLs", () => {
+    expect(inferBrowserWorkspaceTitle("invalid url")).toBe("Eliza Browser");
   });
 });


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Relates to #28244

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Adds unit tests covering `assertBrowserWorkspaceUrl` and `inferBrowserWorkspaceTitle` in `plugins/plugin-browser/src/workspace/browser-workspace-helpers.test.ts`.

# Background

## What does this PR do?

Adds unit test suites in `plugins/plugin-browser/src/workspace/browser-workspace-helpers.test.ts` for:
- `assertBrowserWorkspaceUrl`: validating `about:blank`, `http:`, and `https:` URLs, and ensuring disallowed protocols (`javascript:`, `file:`, `data:`) and malformed URLs throw `invalid_url`.
- `inferBrowserWorkspaceTitle`: verifying hostname derivation, stripping leading `www.`, handling `about:blank`, and fallback behavior.

## What kind of change is this?

Tests (adding missing tests)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

- `plugins/plugin-browser/src/workspace/browser-workspace-helpers.test.ts`: newly added test blocks for `assertBrowserWorkspaceUrl` and `inferBrowserWorkspaceTitle`.

## Detailed testing steps

Run:
```bash
bun run --cwd plugins/plugin-browser test src/workspace/browser-workspace-helpers.test.ts
bun run --cwd plugins/plugin-browser typecheck
bun run --cwd plugins/plugin-browser lint
```

# Evidence Gate

<!-- evidence-head:22c1c4b3dc781003080187427f3977309c32bed7 -->

- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - <reason>`.
  N/A - Browser helper unit tests.
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - <reason>`.
  N/A - Browser helper unit tests.
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - <reason>`.
  N/A - Browser helper unit tests.
- [x] Backend logs show the real code path firing end to end, or are marked `N/A - <reason>`.
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - <reason>`.
  N/A - Browser helper unit tests.
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - <reason>`.
  N/A - Browser helper unit tests.
- [ ] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - <reason>`.
  N/A - Browser helper unit tests.
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - <reason>` when the change has no rendered visual surface.
  N/A - No rendered visual surface.

# Evidence Details

## Backend + frontend logs

```text
$ vitest run src/workspace/browser-workspace-helpers.test.ts

 RUN  v4.1.10 /home/deepanshu/Projects/eliza/plugins/plugin-browser

 ✓ src/workspace/browser-workspace-helpers.test.ts (12 tests) 9ms
   ✓ parseBrowserWorkspaceNumberLike (3)
   ✓ normalizeBrowserWorkspaceText (2)
   ✓ assertBrowserWorkspaceUrl (4)
     ✓ accepts about:blank without modification 0ms
     ✓ accepts valid http and https URLs and normalizes them 0ms
     ✓ rejects non-http/https protocols 2ms
     ✓ rejects malformed URLs 0ms
   ✓ inferBrowserWorkspaceTitle (3)
     ✓ infers New Tab for about:blank 0ms
     ✓ infers hostname stripped of leading www for web URLs 0ms
     ✓ falls back to default title on invalid URLs 0ms

 Test Files  1 passed (1)
      Tests  12 passed (12)
```

## Known gaps / failures

None.

## Maintainer CI exception record

N/A - no exception requested