### PR TITLE
fix(voice): recover unspeakable turns and pin callback origin

### DIFF
--- a/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
@@ -1423,6 +1423,32 @@ describe("voice-session WS lifecycle", () => {
     expect(client.controlTypes()).not.toContain("speaking_start");
   });
 
+  test("speaks an explicit recovery prompt for punctuation-only model output", async () => {
+    const client = new FakeClientSocket();
+    await connectSession({
+      client,
+      fetchImpl: makeSseFetch(["?"]),
+    });
+    const ink = FakeInkSocket.instances.at(-1)!;
+    ink.emitTurn("turn.start");
+    ink.emitTurn("turn.end", "answer me");
+    await flush();
+    await flush();
+
+    const cartesia = FakeCartesiaSocket.instances.at(-1)!;
+    expect(cartesia.sentText()).toBe(
+      "Sorry, I couldn't form a response. Could you say that again?",
+    );
+    expect(client.controlFrames).toContainEqual(
+      expect.objectContaining({
+        t: "error",
+        code: "unspeakable_llm_reply",
+        retryable: true,
+      }),
+    );
+    expect(client.controlTypes()).toContain("speaking_start");
+  });
+
   test("starts TTS after 24 chars before an unpunctuated LLM stream completes", async () => {
     let aborted = false;
     const client = new FakeClientSocket();

--- a/packages/cloud/api/v1/voice/session/lib/session.ts
+++ b/packages/cloud/api/v1/voice/session/lib/session.ts
@@ -120,6 +120,8 @@ const CACHE_WARMING_CODES = new Set([
   "conversation_cache_warming",
 ]);
 const SPOKEN_TRANSCRIPT_RE = /[\p{L}\p{N}]/u;
+const UNSPEAKABLE_RESPONSE_FALLBACK =
+  "Sorry, I couldn't form a response. Could you say that again?";
 
 // Cartesia's server buffers streamed transcript for up to 3000ms by default
 // before starting synthesis, which measured ~2.7s of the speaking_start gap on
@@ -1107,6 +1109,8 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
     let modelAudioStarted = false;
     let upstreamServerTiming: ElizaServerTimingReceipt | null = null;
     let ttsTransportReadyAt: number | null = null;
+    let modelOutputChars = 0;
+    let modelSpeakableContentSeen = false;
     const abort = new AbortController();
     this.llmAbort = abort;
     const phrase = new PhraseAggregator({
@@ -1253,6 +1257,10 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
       };
       const onDelta = (delta: string) => {
         if (this.currentVoiceTurnId !== traceId) return;
+        modelOutputChars += delta.length;
+        if (SPOKEN_TRANSCRIPT_RE.test(delta)) {
+          modelSpeakableContentSeen = true;
+        }
         if (!this.firstLlmTextEmitted) {
           this.firstLlmTextEmitted = true;
           firstModelTextAt = this.now();
@@ -1266,6 +1274,7 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
         // the retained suffix with continue:true.
         const phrases = phrase.push(delta);
         for (const p of phrases) {
+          if (!SPOKEN_TRANSCRIPT_RE.test(p)) continue;
           this.turnTtsChars += p.length;
           const stream = ensureTts();
           if (pendingPhrase !== null) {
@@ -1339,7 +1348,7 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
       }
 
       const tail = phrase.flush();
-      if (tail) {
+      if (tail && SPOKEN_TRANSCRIPT_RE.test(tail)) {
         // A trailing phrase remains. Flush any held phrase (continue:true), then
         // send the tail as the terminal phrase with continue:false.
         if (pendingPhrase !== null) {
@@ -1369,6 +1378,21 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
         const fallbackGreeting = options.fallbackGreeting?.trim();
         if (fallbackGreeting) {
           this.speakOpeningGreeting(fallbackGreeting);
+        } else if (modelOutputChars > 0 && !modelSpeakableContentSeen) {
+          // error-policy:J4 punctuation-only or otherwise unspeakable model
+          // output is an expected provider failure shape. Surface it as a
+          // retryable error and speak an explicit recovery prompt so a live
+          // caller never experiences a successful-looking silent turn.
+          logger.warn("[voice-session] Eliza response was not speakable", {
+            traceId,
+            outputChars: modelOutputChars,
+          });
+          this.send({
+            t: "error",
+            code: "unspeakable_llm_reply",
+            retryable: true,
+          });
+          this.speakOpeningGreeting(UNSPEAKABLE_RESPONSE_FALLBACK);
         }
       }
       // If a phrase was sent, its final continue:false closes the context.

--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -526,6 +526,10 @@ binding = "BROWSER"
 
 [env.staging.vars]
 NODE_ENV = "production"
+# Signed Twilio callbacks and media-stream URLs must use the externally routed
+# HTTPS origin, never a request-derived host. Keep this committed so any
+# Wrangler deployment preserves inbound voice instead of failing closed.
+TWILIO_PUBLIC_URL = "https://api-staging.eliza.app"
 # Capture every staging turn while validating voice and cross-channel routing.
 # Rows remain compact and exclude prompt/response text.
 SHARED_TURN_TRACES_ENABLED = "true"
@@ -827,6 +831,10 @@ binding = "BROWSER"
 
 [env.production.vars]
 NODE_ENV = "production"
+# Signed Twilio callbacks and media-stream URLs must use the externally routed
+# HTTPS origin, never a request-derived host. Keep this committed so any
+# Wrangler deployment preserves inbound voice instead of failing closed.
+TWILIO_PUBLIC_URL = "https://api.eliza.app"
 SHARED_TURN_TRACES_ENABLED = "true"
 SHARED_TURN_TRACES_SAMPLE = "0.1"
 # Keep production on the indexed canonical resolver. The Durable Object cannot

--- a/packages/cloud/scripts/__tests__/voice-realtime-deploy-contract.test.ts
+++ b/packages/cloud/scripts/__tests__/voice-realtime-deploy-contract.test.ts
@@ -28,6 +28,11 @@ const workflow = parse(
     "utf8",
   ),
 ) as Workflow;
+const wrangler = Bun.TOML.parse(
+  readFileSync(resolve(repoRoot, "packages/cloud/api/wrangler.toml"), "utf8"),
+) as {
+  env?: Record<string, { vars?: Record<string, string> }>;
+};
 
 function namedStep(name: string): WorkflowStep {
   const step = workflow.jobs["deploy-api"].steps.find(
@@ -81,6 +86,17 @@ describe("realtime staging deploy contract", () => {
     );
     expect(run.indexOf("trap rollback_on_unproven_exit EXIT")).toBeLessThan(
       run.indexOf("requires an authenticated canary credential"),
+    );
+  });
+});
+
+describe("Twilio public callback origin deploy contract", () => {
+  test("pins the externally routed HTTPS origin in every deployed environment", () => {
+    expect(wrangler.env?.staging?.vars?.TWILIO_PUBLIC_URL).toBe(
+      "https://api-staging.eliza.app",
+    );
+    expect(wrangler.env?.production?.vars?.TWILIO_PUBLIC_URL).toBe(
+      "https://api.eliza.app",
     );
   });
 });

--- a/packages/cloud/shared/src/types/cloud-worker-env.ts
+++ b/packages/cloud/shared/src/types/cloud-worker-env.ts
@@ -251,6 +251,8 @@ export interface Bindings {
   VOICE_REALTIME_USER_DAILY_MINUTES?: string;
   /** Max concurrent live voice sessions per worker. */
   VOICE_REALTIME_MAX_SESSIONS?: string;
+  /** Public HTTPS API origin used to construct signed Twilio callback and media URLs. */
+  TWILIO_PUBLIC_URL?: string;
 
   // ---- AI providers ----
   CEREBRAS_API_KEY?: string;


### PR DESCRIPTION
Closes #28220

## What changed
- Pins the public Twilio HTTPS origin in staging and production Wrangler environment vars so exact-source deploys cannot drop signed inbound/media URL construction.
- Treats punctuation-only/otherwise unspeakable model output as a retryable voice failure and speaks an explicit recovery prompt instead of leaving a connected caller in silence.
- Adds deployment-contract and real voice-session lifecycle regression coverage.

## Evidence
- `bun test packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts` — 69/69 pass.
- `bun test packages/cloud/scripts/__tests__/voice-realtime-deploy-contract.test.ts` — pass.
- Biome on all touched TypeScript files — pass.
- `bun run build:core` — 60/60 build tasks pass.
- `bun run --cwd packages/cloud/api typecheck` — pass, including production Worker dry-run. Dry-run inventory explicitly lists `TWILIO_PUBLIC_URL (https://api.eliza.app)`.
- `bun run --cwd packages/cloud/shared typecheck` — pass.
- `git diff --check` — pass.

## Live incident evidence
Production ingress was restored without routing changes by redeploying exact main with `TWILIO_PUBLIC_URL=https://api.eliza.app`. The affected real call remained connected and persisted two late assistant turns containing only `?`; the new boundary converts that precise shape into audible recovery. Provider routing is unchanged.