### PR TITLE
fix(voice): retain deterministic failure provenance

### DIFF
--- a/packages/cloud/api/v1/voice/session/lib/session.ts
+++ b/packages/cloud/api/v1/voice/session/lib/session.ts
@@ -352,7 +352,12 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
             // blip, but sustained inability to verify revocation severs the
             // session within a bounded number of poll windows (SEC-6).
             if (this.revocationPollFailures >= MAX_REVOCATION_POLL_FAILURES) {
-              this.teardown("revoked");
+              logger.error("[voice-session] revocation store unavailable", {
+                sessionId: this.sessionId,
+                traceId: this.currentTraceId,
+                consecutiveFailures: this.revocationPollFailures,
+              });
+              this.teardown("error");
             }
           } finally {
             this.revocationPollInFlight = false;
@@ -558,10 +563,16 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
         // Release the buffered frames now that we are admitted.
         const buffered = this.preAdmissionFrames.splice(0);
         for (const frame of buffered) if (!this.forwardSttFrame(frame)) break;
-      } catch {
+      } catch (error) {
         // error-policy:J4 fail-closed degrade — a metering-store failure must
         // not admit unpaid audio: surface metering_unavailable and sever.
         if (this.closed) return;
+        logger.error("[voice-session] initial metering admission failed", {
+          sessionId: this.sessionId,
+          traceId: this.currentTraceId,
+          errorClass: error instanceof Error ? error.name : typeof error,
+          errorMessage: error instanceof Error ? error.message : String(error),
+        });
         this.meteredExhausted = true;
         this.send({
           t: "error",
@@ -628,12 +639,20 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
       case "connected": {
         // Provider readiness is transport metadata; the client-facing session
         // has already emitted its own authenticated `ready` frame.
+        const reconnectAttempts = this.sttReconnectAttempts;
         this.sttReconnectAttempts = 0;
         this.sttReady = true;
         this.sttBufferOverflowReported = false;
         this.clearSttConnectTimeout();
         const buffered = this.providerPendingFrames.splice(0);
         for (const frame of buffered) if (!this.forwardSttFrame(frame)) break;
+        logger.info("[voice-session] Ink transport connected", {
+          sessionId: this.sessionId,
+          traceId: this.currentTraceId,
+          generation,
+          reconnectAttempts,
+          releasedPendingFrames: buffered.length,
+        });
         break;
       }
       case "start-of-turn": {
@@ -727,6 +746,17 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
         // turn; malformed input must not be reinterpreted as speech.
         this.activeSttTurn = false;
         this.resetSttPartialDelivery();
+        logger.warn("[voice-session] Ink transport error", {
+          sessionId: this.sessionId,
+          traceId: this.currentTraceId,
+          generation,
+          code: event.code,
+          errorClass:
+            event.cause instanceof Error
+              ? event.cause.name
+              : typeof event.cause,
+          messageLength: event.message.length,
+        });
         if (event.code === "transport_error") {
           this.send({ t: "error", code: event.code, retryable: true });
           this.recoverSttTransport("transport_error", generation);
@@ -736,6 +766,14 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
         break;
       }
       case "close": {
+        logger.warn("[voice-session] Ink transport closed", {
+          sessionId: this.sessionId,
+          traceId: this.currentTraceId,
+          generation,
+          code: event.code,
+          wasClean: event.wasClean,
+          reasonLength: event.reason.length,
+        });
         this.send({ t: "error", code: "stt_reconnecting", retryable: true });
         this.recoverSttTransport(`close:${event.code}`, generation);
         break;
@@ -784,6 +822,13 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
     const delay = scheduledDelay ?? Math.max(delays.at(-1) ?? 5_000, 1_000);
     const retryingAtCap = scheduledDelay === undefined;
     this.sttReconnectAttempts += 1;
+    logger.info("[voice-session] Ink reconnect scheduled", {
+      sessionId: this.sessionId,
+      traceId: this.currentTraceId,
+      reason,
+      attempt: this.sttReconnectAttempts,
+      delayMs: delay,
+    });
     if (retryingAtCap) {
       logger.warn(
         "[voice-session] Ink reconnect continuing at capped backoff",
@@ -1471,10 +1516,17 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
         this.send({ t: "error", code: "quota_exhausted", retryable: false });
         this.teardown("quota_exhausted");
       }
-    } catch {
+    } catch (error) {
       this.meterWindowsInFlight = Math.max(0, this.meterWindowsInFlight - 1);
       // error-policy:J4 fail-closed degrade — if we cannot record the cost, we
       // do not keep streaming uncapped paid audio to Cartesia; sever.
+      logger.error("[voice-session] ongoing metering window failed", {
+        sessionId: this.sessionId,
+        traceId: this.currentTraceId,
+        meterWindowsInFlight: this.meterWindowsInFlight,
+        errorClass: error instanceof Error ? error.name : typeof error,
+        errorMessage: error instanceof Error ? error.message : String(error),
+      });
       this.meteredExhausted = true;
       this.send({ t: "error", code: "metering_unavailable", retryable: false });
       this.teardown("error");
@@ -1489,6 +1541,7 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
     this.state = "closed";
     logger.info("[voice-session] session closed", {
       sessionId: this.sessionId,
+      traceId: this.currentTraceId,
       reason,
       durationMs:
         this.startedAtMs === null
@@ -1514,6 +1567,7 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
         // lifecycle marker is idempotent and may be recovered by provider retry.
         logger.warn("[voice-session] lifecycle teardown persistence failed", {
           sessionId: this.sessionId,
+          traceId: this.currentTraceId,
           reason,
           error: error instanceof Error ? error.message : String(error),
         });

--- a/packages/cloud/shared/src/db/schemas/shared-turn-traces.ts
+++ b/packages/cloud/shared/src/db/schemas/shared-turn-traces.ts
@@ -22,12 +22,34 @@ export type SharedTurnTraceStage = {
   tool?: string;
 };
 
+/** Content-free history identity supplied to one model turn. */
+export type SharedTurnTraceHistoryMessage = {
+  id: string | null;
+  role: "system" | "user" | "assistant";
+  createdAt: number | null;
+  interrupted: boolean;
+};
+
+/**
+ * Complete provenance for the history supplied to a turn. Message content is
+ * deliberately excluded; stable ids and transport metadata are sufficient to
+ * diagnose cross-channel or synthetic-test contamination.
+ */
+export type SharedTurnTraceHistoryProvenance = {
+  channelId: string;
+  channelType: string | null;
+  channelSource: string | null;
+  messages: SharedTurnTraceHistoryMessage[];
+};
+
 /** The `stages` jsonb payload: ordered stage list plus the turn's finish reason. */
 export type SharedTurnTraceStages = {
   finishReason: SharedTurnTraceFinishReason;
   stages: SharedTurnTraceStage[];
   /** Content-free terminal runtime receipt captured by the same sampled row. */
   terminalTiming?: SharedRuntimeTimingReceipt;
+  /** Content-free, complete model-history provenance for retained voice traces. */
+  historyProvenance?: SharedTurnTraceHistoryProvenance;
 };
 
 /** Token counts mirrored from `SharedAgentTurnUsage` (numbers only, no text). */

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
@@ -705,6 +705,115 @@ describe("SharedRuntimeChatService", () => {
     }
   });
 
+  test("retains complete content-free history provenance for a voice turn at zero sample", async () => {
+    process.env.SHARED_TURN_TRACES_ENABLED = "true";
+    process.env.SHARED_TURN_TRACES_SAMPLE = "0";
+    const priorContent = "private prior sentence that must never enter diagnostics";
+    const h = harness([
+      {
+        id: "prior-user-id",
+        role: "user",
+        content: priorContent,
+        createdAt: 1_787_860_800_000,
+      },
+      {
+        id: "prior-assistant-id",
+        role: "assistant",
+        content: "private partial reply",
+        createdAt: 1_787_860_800_500,
+        interrupted: true,
+      },
+    ]);
+    await new SharedRuntimeChatService().bridge(agent, rpc, {
+      ...h,
+      channel: {
+        type: ChannelType.VOICE_DM,
+        source: MESSAGE_SOURCE_CLIENT_CHAT,
+      },
+    });
+    await Promise.all(h.background);
+
+    expect(traceRows).toHaveLength(1);
+    const row = traceRows[0] as {
+      channel_id: string;
+      stages: {
+        historyProvenance?: {
+          channelId: string;
+          channelType: string;
+          channelSource: string;
+          messages: Array<Record<string, unknown>>;
+        };
+      };
+    };
+    expect(row.stages.historyProvenance).toEqual({
+      channelId: row.channel_id,
+      channelType: String(ChannelType.VOICE_DM),
+      channelSource: String(MESSAGE_SOURCE_CLIENT_CHAT),
+      messages: [
+        {
+          id: "prior-user-id",
+          role: "user",
+          createdAt: 1_787_860_800_000,
+          interrupted: false,
+        },
+        {
+          id: "prior-assistant-id",
+          role: "assistant",
+          createdAt: 1_787_860_800_500,
+          interrupted: true,
+        },
+      ],
+    });
+    expect(JSON.stringify(row)).not.toContain(priorContent);
+    expect(JSON.stringify(row)).not.toContain("private partial reply");
+  });
+
+  test("retains a voice failure that occurs before the runtime emits terminal timing", async () => {
+    process.env.SHARED_TURN_TRACES_ENABLED = "true";
+    process.env.SHARED_TURN_TRACES_SAMPLE = "0";
+    turnTimingOutcome = null;
+    turnError = new Error("provider failed before timing receipt");
+    const h = harness([
+      {
+        id: "failed-turn-user-id",
+        role: "user",
+        content: "private failed turn",
+        createdAt: 1_787_860_900_000,
+      },
+    ]);
+
+    await expect(
+      new SharedRuntimeChatService().bridge(agent, rpc, {
+        ...h,
+        traceId: "voice-failure-trace",
+        channel: {
+          type: ChannelType.VOICE_DM,
+          source: MESSAGE_SOURCE_CLIENT_CHAT,
+        },
+      }),
+    ).rejects.toThrow("provider failed before timing receipt");
+    await Promise.all(h.background);
+
+    expect(traceRows).toHaveLength(1);
+    expect(traceRows[0]).toMatchObject({
+      trace_id: "voice-failure-trace",
+      stages: {
+        finishReason: "error",
+        historyProvenance: {
+          messages: [
+            {
+              id: "failed-turn-user-id",
+              role: "user",
+              interrupted: false,
+            },
+          ],
+        },
+      },
+    });
+    expect(JSON.stringify(traceRows[0])).not.toContain("private failed turn");
+    expect(JSON.stringify(traceRows[0])).not.toContain("provider failed before timing receipt");
+  });
+
   test("prices the exact projected grounding replay before admission", async () => {
     const service = new SharedRuntimeChatService();
     const h = harness([

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
@@ -119,6 +119,25 @@ import {
   type SharedTurnSummaryResult,
 } from "./shared-turn-trace-recorder";
 
+function retainedVoiceHistoryProvenance(
+  channelId: string,
+  history: readonly SharedTurnMessage[],
+  channel: SharedRuntimeChatOptions["channel"],
+) {
+  if (channel?.type !== ChannelType.VOICE_DM) return undefined;
+  return {
+    channelId,
+    channelType: String(channel.type),
+    channelSource: channel.source === undefined ? null : String(channel.source),
+    messages: history.map((message) => ({
+      id: message.id ?? null,
+      role: message.role,
+      createdAt: message.createdAt ?? null,
+      interrupted: message.interrupted === true,
+    })),
+  };
+}
+
 export { sharedTurnClientMessageId } from "./shared-turn-client-message-id";
 
 const SSE_TRANSPORT_READY_COMMENT = ": ready\n\n";
@@ -166,9 +185,9 @@ export interface SharedRuntimeHistoryStore {
 }
 
 /**
- * P5 sampled turn trace, recorded strictly off the response path. The recorder
- * self-gates on SHARED_TURN_TRACES_ENABLED + deterministic trace-id sampling
- * and never throws, so this adds zero turn latency and zero failure surface.
+ * Turn trace recorded strictly off the response path. The recorder self-gates
+ * on SHARED_TURN_TRACES_ENABLED, samples ordinary chat, and retains
+ * authenticated voice turns so incident diagnosis does not depend on sampling.
  */
 function recordTurnTraceOffPath(
   executionCtx: BridgeExecutionContext | undefined,
@@ -178,7 +197,10 @@ function recordTurnTraceOffPath(
   startedAt: number,
   result: SharedTurnSummaryResult,
   terminalTiming?: SharedRuntimeTimingReceipt,
+  history: readonly SharedTurnMessage[] = [],
+  channel?: SharedRuntimeChatOptions["channel"],
 ): void {
+  const historyProvenance = retainedVoiceHistoryProvenance(channelId, history, channel);
   void settleOffResponsePath(executionCtx, async () => {
     const summary = buildTurnSummary({
       result,
@@ -195,21 +217,29 @@ function recordTurnTraceOffPath(
       {
         ...summary,
         ...(terminalTiming ? { terminalTiming } : {}),
+        ...(historyProvenance ? { historyProvenance } : {}),
       },
+      { forceRecord: channel?.type === ChannelType.VOICE_DM },
     );
   });
 }
 
-/** Persist error/abort receipts through the same durable sampled trace row. */
+/** Persist error/abort receipts through the same durable turn trace row. */
 function recordFailedTurnTraceOffPath(
   executionCtx: BridgeExecutionContext | undefined,
   agent: SharedRuntimeAgent,
   channelId: string,
+  traceId: string,
   model: string,
   startedAt: number,
   terminalTiming: SharedRuntimeTimingReceipt | undefined,
+  history: readonly SharedTurnMessage[] = [],
+  channel?: SharedRuntimeChatOptions["channel"],
+  fallbackFinishReason: "aborted" | "error" = "error",
 ): void {
-  if (!terminalTiming) return;
+  const retainVoiceTrace = channel?.type === ChannelType.VOICE_DM;
+  if (!terminalTiming && !retainVoiceTrace) return;
+  const historyProvenance = retainedVoiceHistoryProvenance(channelId, history, channel);
   void settleOffResponsePath(executionCtx, async () => {
     const completedAt = Date.now();
     await recordSharedTurnTrace(
@@ -219,7 +249,7 @@ function recordFailedTurnTraceOffPath(
         userId: agent.user_id,
         agentId: agent.id,
         channelId,
-        traceId: terminalTiming.traceId,
+        traceId: terminalTiming?.traceId ?? traceId,
         startedAt,
         // The bounded runtime offset can be null when the measurement is
         // unavailable or rejected. The trace row still has an honest wall
@@ -227,10 +257,12 @@ function recordFailedTurnTraceOffPath(
         // failure.
         latencyMs: Math.max(0, Math.round(completedAt - startedAt)),
         model,
-        finishReason: terminalTiming.outcome === "aborted" ? "aborted" : "error",
+        finishReason: terminalTiming?.outcome === "aborted" ? "aborted" : fallbackFinishReason,
         stages: [{ name: "runtime" }],
-        terminalTiming,
+        ...(terminalTiming ? { terminalTiming } : {}),
+        ...(historyProvenance ? { historyProvenance } : {}),
       },
+      { forceRecord: retainVoiceTrace },
     );
   });
 }
@@ -1456,9 +1488,12 @@ export class SharedRuntimeChatService {
         options.executionCtx,
         agent,
         roomId,
+        options.traceId ?? messageIds.assistant,
         character.model?.trim() || "shared-runtime",
         turnStartedAtEpochMs,
         terminalTiming,
+        history,
+        options.channel,
       );
       await settleFailedProviderWorkOffPath(
         agent,
@@ -1478,6 +1513,8 @@ export class SharedRuntimeChatService {
       turnStartedAtEpochMs,
       turn,
       terminalTiming,
+      history,
+      options.channel,
     );
     if (!turn.degraded && turn.responded !== false && messageRole === "user") {
       extractSharedTurnFactsOffPath(options.executionCtx, memoryStore, character, text, turn.reply);
@@ -1686,9 +1723,12 @@ export class SharedRuntimeChatService {
         options.executionCtx,
         agent,
         roomId,
+        options.traceId ?? messageIds.assistant,
         character.model?.trim() || "shared-runtime",
         streamTurnStartedAtEpochMs,
         streamTerminalTiming,
+        history,
+        options.channel,
       );
       detachRequestAbort();
       await settleFailedProviderWorkOffPath(
@@ -1712,6 +1752,8 @@ export class SharedRuntimeChatService {
         streamTurnStartedAtEpochMs,
         turn,
         streamTerminalTiming,
+        history,
+        options.channel,
       );
       const reply = turn.reply?.trim() ?? "";
       if (!reply) return sseError("Shared runtime is unavailable");
@@ -2056,15 +2098,21 @@ export class SharedRuntimeChatService {
                 ...(turn.capabilityWall ? { capabilityWall: turn.capabilityWall } : {}),
               },
               streamTerminalTiming,
+              history,
+              options.channel,
             );
           } else {
             recordFailedTurnTraceOffPath(
               options.executionCtx,
               agent,
               roomId,
+              options.traceId ?? messageIds.assistant,
               turn.model,
               streamTurnStartedAtEpochMs,
               streamTerminalTiming,
+              history,
+              options.channel,
+              consumerCanceled || generationAbort.signal.aborted ? "aborted" : "error",
             );
           }
           detachRequestAbort();

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-turn-trace-recorder.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-turn-trace-recorder.test.ts
@@ -115,6 +115,45 @@ describe("recordSharedTurnTrace gating", () => {
     expect(insertTrace).not.toHaveBeenCalled();
   });
 
+  test("retains authenticated voice diagnostics even when the general sample is zero", async () => {
+    const inserted: NewSharedTurnTraceRow[] = [];
+    const insertTrace = mock(async (trace: NewSharedTurnTraceRow) => {
+      inserted.push(trace);
+    });
+    const historyProvenance = {
+      channelId: "private-room",
+      channelType: "VOICE_DM",
+      channelSource: "client_chat",
+      messages: [
+        {
+          id: "message-1",
+          role: "user" as const,
+          createdAt: 1_787_860_800_000,
+          interrupted: false,
+        },
+      ],
+    };
+    const recorded = await recordSharedTurnTrace(
+      {
+        insertTrace,
+        env: {
+          SHARED_TURN_TRACES_ENABLED: "true",
+          SHARED_TURN_TRACES_SAMPLE: "0",
+        },
+      },
+      summaryFixture({ historyProvenance }),
+      { forceRecord: true },
+    );
+    expect(recorded).toBe(true);
+    expect(inserted).toHaveLength(1);
+    expect(inserted[0].stages).toEqual({
+      finishReason: "reply",
+      stages: [{ name: "model" }],
+      historyProvenance,
+    });
+    expect(JSON.stringify(inserted[0])).not.toContain("message content");
+  });
+
   test("persists a sampled trace with tenant scope, timing, and compact payloads", async () => {
     const inserted: NewSharedTurnTraceRow[] = [];
     const insertTrace = mock(async (trace: NewSharedTurnTraceRow) => {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-turn-trace-recorder.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-turn-trace-recorder.ts
@@ -18,6 +18,7 @@
 import type {
   NewSharedTurnTraceRow,
   SharedTurnTraceFinishReason,
+  SharedTurnTraceHistoryProvenance,
   SharedTurnTraceStage,
   SharedTurnTraceUsage,
 } from "../../../db/schemas/shared-turn-traces";
@@ -48,6 +49,13 @@ export interface SharedTurnSummary {
   stages: SharedTurnTraceStage[];
   /** Terminal runtime receipt persisted under this row's single sample decision. */
   terminalTiming?: SharedRuntimeTimingReceipt;
+  /** Complete content-free history identity retained for voice diagnosis. */
+  historyProvenance?: SharedTurnTraceHistoryProvenance;
+}
+
+export interface RecordSharedTurnTraceOptions {
+  /** Retain authenticated voice turns even when their trace misses the sample. */
+  forceRecord?: boolean;
 }
 
 export interface SharedTurnTraceRecorderDeps {
@@ -178,11 +186,12 @@ export function buildTurnSummary(input: BuildTurnSummaryInput): SharedTurnSummar
 export async function recordSharedTurnTrace(
   deps: SharedTurnTraceRecorderDeps,
   summary: SharedTurnSummary,
+  options: RecordSharedTurnTraceOptions = {},
 ): Promise<boolean> {
   const env = deps.env ?? process.env;
   if (env.SHARED_TURN_TRACES_ENABLED !== "true") return false;
   const sampleRate = resolveSharedTurnTraceSampleRate(env.SHARED_TURN_TRACES_SAMPLE);
-  if (!isSharedTurnTraceSampled(summary.traceId, sampleRate)) return false;
+  if (!options.forceRecord && !isSharedTurnTraceSampled(summary.traceId, sampleRate)) return false;
   const compactedUsage = summary.usage ? compactUsage(summary.usage) : undefined;
   try {
     await deps.insertTrace({
@@ -199,6 +208,7 @@ export async function recordSharedTurnTrace(
         finishReason: summary.finishReason,
         stages: summary.stages,
         ...(summary.terminalTiming ? { terminalTiming: summary.terminalTiming } : {}),
+        ...(summary.historyProvenance ? { historyProvenance: summary.historyProvenance } : {}),
       },
     });
     return true;


### PR DESCRIPTION
Closes #28214.

## Incident

The 77-second human PSTN call stayed carrier-connected and persisted subsequent user turns, but two assistant results were punctuation-only and therefore audibly silent. The same call also exposed a speech-recognition attribution problem and did not persist its close lifecycle. Sampling left no shared turn trace for those failures.

## Change

- retain every authenticated `VOICE_DM` turn when shared turn tracing is enabled, independent of the ordinary chat sample rate
- retain failures that occur before the runtime emits a terminal timing receipt
- persist complete content-free history provenance: channel identity/type/source plus message ids, roles, timestamps, and interruption flags
- add trace-correlated Ink connect/error/close/reconnect, metering, revocation, session-close, and lifecycle-persistence diagnostics
- keep transcript, prompt, response, and provider message text out of trace provenance

This PR is diagnostics only. It does not change Twilio or Blooio routing, prompt/greeting behavior, model output, or punctuation-only voice egress.

## Exact-head verification

Head: `25aa999a3c1bdbffda31069a9342d24ef4cee123`

- shared runtime and trace tests: 61 pass
- voice session lifecycle tests: 67 pass
- `packages/cloud/shared` typecheck: pass
- `packages/cloud/api` typecheck and Worker bundle dry-run: pass
- Biome and `git diff --check`: pass

## Release coordination

The production Worker dry-run on this source does not list `TWILIO_PUBLIC_URL`. The release owner has been notified to include the separately owned permanent binding contract and punctuation-only egress repair before live acceptance.