### PR TITLE
test(plugin-pdf): add unit test coverage for PdfService lifecycle methods

### DIFF
--- a/plugins/plugin-pdf/__tests__/pdf-service.test.ts
+++ b/plugins/plugin-pdf/__tests__/pdf-service.test.ts
@@ -581,4 +581,27 @@ describe("PdfService", () => {
 	it("fails cleanup on malformed caller input instead of returning uncleaned content", () => {
 		expect(() => service().cleanUpContent(null as never)).toThrow();
 	});
+
+	it("initializes and stops service via static lifecycle methods", async () => {
+		const mockInstance = service();
+		const stopSpy = vi.spyOn(mockInstance, "stop");
+		const runtime = {
+			getService: vi.fn((type: string) =>
+				type === "pdf" ? mockInstance : null
+			),
+		} as unknown as IAgentRuntime;
+
+		const started = await PdfService.start(runtime);
+		expect(started).toBeInstanceOf(PdfService);
+
+		await PdfService.stop(runtime);
+		expect(stopSpy).toHaveBeenCalledTimes(1);
+
+		const runtimeWithoutService = {
+			getService: vi.fn(() => null),
+		} as unknown as IAgentRuntime;
+		await expect(
+			PdfService.stop(runtimeWithoutService)
+		).resolves.toBeUndefined();
+	});
 });


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Relates to #28246

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Adds unit tests covering `PdfService.start` and `PdfService.stop` static lifecycle methods in `plugins/plugin-pdf/__tests__/pdf-service.test.ts`.

# Background

## What does this PR do?

Adds a unit test in `plugins/plugin-pdf/__tests__/pdf-service.test.ts` verifying:
- `PdfService.start` instantiates a `PdfService` with the provided runtime.
- `PdfService.stop` gracefully retrieves and stops the registered service instance, or returns gracefully if no service is found.

## What kind of change is this?

Tests (adding missing tests)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

- `plugins/plugin-pdf/__tests__/pdf-service.test.ts`: test asserting lifecycle start and stop methods.

## Detailed testing steps

Run:
```bash
bun run --cwd plugins/plugin-pdf test
bun run --cwd plugins/plugin-pdf typecheck
bun run --cwd plugins/plugin-pdf lint
```

# Evidence Gate

<!-- evidence-head:9ced637fabcc869771e0f9246b2a2f17421e55c5 -->

- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - <reason>`.
  N/A - PDF service lifecycle unit test.
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - <reason>`.
  N/A - PDF service lifecycle unit test.
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - <reason>`.
  N/A - PDF service lifecycle unit test.
- [x] Backend logs show the real code path firing end to end, or are marked `N/A - <reason>`.
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - <reason>`.
  N/A - PDF service lifecycle unit test.
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - <reason>`.
  N/A - PDF service lifecycle unit test.
- [ ] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - <reason>`.
  N/A - PDF service lifecycle unit test.
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - <reason>` when the change has no rendered visual surface.
  N/A - No rendered visual surface.

# Evidence Details

## Backend + frontend logs

```text
$ vitest run

 RUN  v4.1.10 /home/deepanshu/Projects/eliza/plugins/plugin-pdf

 ✓ __tests__/pdf-spec-date.test.ts (7 tests) 8ms
 ✓ __tests__/pdf-service.integration.test.ts (3 tests) 80ms
 ✓ __tests__/pdf-service.test.ts (44 tests) 145ms
 ✓ __tests__/pdf-service.test.ts > PdfService > initializes and stops service via static lifecycle methods

 Test Files  3 passed (3)
      Tests  54 passed (54)
```

## Known gaps / failures

None.

## Maintainer CI exception record

N/A - no exception requested