### PR TITLE
test(plugin-scheduling): add unit test coverage for validateScheduledTaskInput

### DIFF
--- a/plugins/plugin-scheduling/src/scheduled-task/validation.test.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/validation.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Unit tests for validateScheduledTaskInput and ScheduledTaskValidationError.
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  createCompletionCheckRegistry,
+  registerBuiltInCompletionChecks,
+} from "./completion-check-registry.js";
+import { createEscalationLadderRegistry } from "./escalation.js";
+import {
+  createTaskGateRegistry,
+  registerBuiltInGates,
+} from "./gate-registry.js";
+import type { ScheduledTaskInput } from "./types.js";
+import {
+  type ScheduledTaskValidationDeps,
+  ScheduledTaskValidationError,
+  validateScheduledTaskInput,
+} from "./validation.js";
+
+describe("validateScheduledTaskInput", () => {
+  let deps: ScheduledTaskValidationDeps;
+
+  beforeEach(() => {
+    const gates = createTaskGateRegistry();
+    registerBuiltInGates(gates);
+
+    const completionChecks = createCompletionCheckRegistry();
+    registerBuiltInCompletionChecks(completionChecks);
+
+    const ladders = createEscalationLadderRegistry();
+
+    deps = { gates, completionChecks, ladders };
+  });
+
+  const minimalValidTask: ScheduledTaskInput = {
+    kind: "reminder",
+    promptInstructions: "Drink water",
+    priority: "medium",
+    source: "user_chat",
+    createdBy: "user-123",
+    ownerVisible: true,
+    respectsGlobalPause: true,
+    trigger: {
+      kind: "once",
+      atIso: "2026-10-01T10:00:00.000Z",
+    },
+  };
+
+  it("returns no issues for a minimal valid task", () => {
+    const issues = validateScheduledTaskInput(minimalValidTask, deps);
+    expect(issues).toEqual([]);
+  });
+
+  it("validates enums and non-empty strings on root fields", () => {
+    const invalidTask = {
+      ...minimalValidTask,
+      kind: "invalid_kind" as never,
+      promptInstructions: "   ",
+      priority: "urgent" as never,
+      source: "unknown" as never,
+      createdBy: "",
+      ownerVisible: "yes" as never,
+      respectsGlobalPause: 1 as never,
+    };
+
+    const issues = validateScheduledTaskInput(invalidTask, deps);
+    expect(issues).toContain("task.kind is invalid");
+    expect(issues).toContain(
+      "task.promptInstructions must be a non-empty string",
+    );
+    expect(issues).toContain("task.priority is invalid");
+    expect(issues).toContain("task.source is invalid");
+    expect(issues).toContain("task.createdBy must be a non-empty string");
+    expect(issues).toContain("task.ownerVisible must be boolean");
+    expect(issues).toContain("task.respectsGlobalPause must be boolean");
+  });
+
+  it("validates triggers: once, cron, interval, relative_to_anchor, and after_task", () => {
+    expect(
+      validateScheduledTaskInput(
+        { ...minimalValidTask, trigger: { kind: "once", atIso: "not-a-date" } },
+        deps,
+      ),
+    ).toContain("task.trigger.atIso must be an ISO timestamp");
+
+    expect(
+      validateScheduledTaskInput(
+        {
+          ...minimalValidTask,
+          trigger: { kind: "cron", expression: "", tz: "UTC" },
+        },
+        deps,
+      ),
+    ).toContain("task.trigger.expression must be a non-empty string");
+
+    expect(
+      validateScheduledTaskInput(
+        {
+          ...minimalValidTask,
+          trigger: { kind: "interval", everyMinutes: -5 },
+        },
+        deps,
+      ),
+    ).toContain("task.trigger.everyMinutes must be a positive integer");
+
+    expect(
+      validateScheduledTaskInput(
+        {
+          ...minimalValidTask,
+          trigger: {
+            kind: "relative_to_anchor",
+            anchorKey: "",
+            offsetMinutes: 10,
+          },
+        },
+        deps,
+      ),
+    ).toContain("task.trigger.anchorKey must be a non-empty string");
+
+    expect(
+      validateScheduledTaskInput(
+        {
+          ...minimalValidTask,
+          trigger: { kind: "after_task", taskId: "", outcome: "completed" },
+        },
+        deps,
+      ),
+    ).toContain(
+      "task.trigger.after_task requires a non-empty taskId and terminal outcome",
+    );
+  });
+
+  it("validates registered gates and parameters", () => {
+    const taskWithGates: ScheduledTaskInput = {
+      ...minimalValidTask,
+      shouldFire: {
+        compose: "all",
+        gates: [
+          { kind: "weekday_only", params: { weekdays: [1, 2, 3] } },
+          { kind: "unregistered_gate" },
+        ],
+      },
+    };
+
+    const issues = validateScheduledTaskInput(taskWithGates, deps);
+    expect(issues).toContain(
+      'task.shouldFire.gates[1].kind "unregistered_gate" is not registered',
+    );
+  });
+
+  it("validates registered completion checks", () => {
+    const taskWithCheck: ScheduledTaskInput = {
+      ...minimalValidTask,
+      completionCheck: {
+        kind: "unknown_check",
+      },
+    };
+
+    const issues = validateScheduledTaskInput(taskWithCheck, deps);
+    expect(issues).toContain(
+      'task.completionCheck.kind "unknown_check" is not registered',
+    );
+  });
+
+  it("detects cyclic pipeline task references", () => {
+    const taskWithCycle: ScheduledTaskInput = {
+      ...minimalValidTask,
+    };
+    taskWithCycle.pipeline = {
+      onComplete: [taskWithCycle as never],
+    };
+
+    const issues = validateScheduledTaskInput(taskWithCycle, deps);
+    expect(issues).toContain(
+      "task.pipeline.onComplete[0] must not contain a cyclic task ref",
+    );
+  });
+
+  it("ScheduledTaskValidationError formats issue message", () => {
+    const err = new ScheduledTaskValidationError(
+      ["issue 1", "issue 2"],
+      "customTask",
+    );
+    expect(err.message).toBe("customTask: issue 1; issue 2");
+    expect(err.code).toBe("scheduled_task_validation_failed");
+    expect(err.name).toBe("ScheduledTaskValidationError");
+  });
+});


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Relates to #28265

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Adds unit tests covering `validateScheduledTaskInput` and `ScheduledTaskValidationError` in `plugins/plugin-scheduling/src/scheduled-task/validation.test.ts`.

# Background

## What does this PR do?

Adds unit test coverage in `plugins/plugin-scheduling/src/scheduled-task/validation.test.ts` verifying:
- Valid minimal scheduled task returns no issues.
- Enums (`kind`, `priority`, `source`), non-empty strings, and boolean invariants on root fields.
- Trigger validation for `once`, `cron`, `interval`, `relative_to_anchor`, and `after_task`.
- Gate registry and completion check registry lookup validation.
- Cycle detection on nested pipeline references.
- `ScheduledTaskValidationError` error properties.

## What kind of change is this?

Tests (adding missing tests)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

- `plugins/plugin-scheduling/src/scheduled-task/validation.test.ts`: test suite exercising `validateScheduledTaskInput`.

## Detailed testing steps

Run:
```bash
bun run --cwd plugins/plugin-scheduling test src/scheduled-task/validation.test.ts
bun run --cwd plugins/plugin-scheduling typecheck
bun run --cwd plugins/plugin-scheduling lint
```

# Evidence Gate

<!-- evidence-head:89a99dfb6def35139540ff81dba38725ec04faf7 -->

- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - <reason>`.
  N/A - Scheduling task validation unit test.
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - <reason>`.
  N/A - Scheduling task validation unit test.
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - <reason>`.
  N/A - Scheduling task validation unit test.
- [x] Backend logs show the real code path firing end to end, or are marked `N/A - <reason>`.
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - <reason>`.
  N/A - Scheduling task validation unit test.
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - <reason>`.
  N/A - Scheduling task validation unit test.
- [ ] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - <reason>`.
  N/A - Scheduling task validation unit test.
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - <reason>` when the change has no rendered visual surface.
  N/A - No rendered visual surface.

# Evidence Details

## Backend + frontend logs

```text
$ bunx vitest run --config ./vitest.config.ts src/scheduled-task/validation.test.ts

 RUN  v4.1.10 /home/deepanshu/Projects/eliza/plugins/plugin-scheduling

 ✓ src/scheduled-task/validation.test.ts (7 tests) 7ms
   ✓ validateScheduledTaskInput (7)
     ✓ returns no issues for a minimal valid task 2ms
     ✓ validates enums and non-empty strings on root fields 1ms
     ✓ validates triggers: once, cron, interval, relative_to_anchor, and after_task 0ms
     ✓ validates registered gates and parameters 0ms
     ✓ validates registered completion checks 0ms
     ✓ detects cyclic pipeline task references 0ms
     ✓ ScheduledTaskValidationError formats issue message 0ms

 Test Files  1 passed (1)
      Tests  7 passed (7)
```

## Known gaps / failures

None.

## Maintainer CI exception record

N/A - no exception requested