### PR TITLE
test(vision): cover yolo ffi readiness gate and weight path resolution

### DIFF
--- a/plugins/plugin-vision/src/native/yolo-ffi.test.ts
+++ b/plugins/plugin-vision/src/native/yolo-ffi.test.ts
@@ -1,0 +1,169 @@
+import { promises as fs } from "node:fs";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const h = vi.hoisted(() => {
+  return {
+    logger: { info() {}, warn() {}, error() {}, debug() {} },
+    resolveAliasedEnvValue: (key: string) => process.env[key] ?? null,
+  };
+});
+
+vi.mock("@elizaos/core", () => ({
+  logger: h.logger,
+  resolveAliasedEnvValue: h.resolveAliasedEnvValue,
+}));
+
+vi.mock("node:fs", () => ({
+  promises: { access: vi.fn() },
+}));
+
+const accessMock = vi.mocked(fs.access);
+const warnMock = vi.spyOn(h.logger, "warn").mockImplementation(() => {});
+
+/** Re-import the module fresh so the memoized bindingsPromise is reset. */
+async function loadModule() {
+  vi.resetModules();
+  return await import("./yolo-ffi");
+}
+
+const ORIG_PLATFORM = Object.getOwnPropertyDescriptor(process, "platform");
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.clearAllMocks();
+  if (ORIG_PLATFORM) {
+    Object.defineProperty(process, "platform", ORIG_PLATFORM);
+  }
+});
+
+describe("defaultYoloWeightsPath", () => {
+  it("prefers the ELIZA_YOLO_GGUF override verbatim", async () => {
+    vi.stubEnv("ELIZA_YOLO_GGUF", "/custom/weights/yolov8n.gguf");
+    const { defaultYoloWeightsPath } = await loadModule();
+    expect(defaultYoloWeightsPath()).toBe("/custom/weights/yolov8n.gguf");
+  });
+
+  it("resolves under the aliased ELIZA_STATE_DIR", async () => {
+    vi.stubEnv("ELIZA_STATE_DIR", "/data/eliza");
+    delete process.env.ELIZA_YOLO_GGUF;
+    const { defaultYoloWeightsPath } = await loadModule();
+    expect(defaultYoloWeightsPath()).toBe(
+      "/data/eliza/models/vision/yolov8n.gguf",
+    );
+  });
+
+  it("falls back to ~/.eliza when no state dir or override is set", async () => {
+    delete process.env.ELIZA_STATE_DIR;
+    delete process.env.ELIZA_YOLO_GGUF;
+    const { defaultYoloWeightsPath } = await loadModule();
+    expect(defaultYoloWeightsPath()).toMatch(
+      /(^|\/)\.eliza\/models\/vision\/yolov8n\.gguf$/,
+    );
+  });
+});
+
+describe("isYoloReady", () => {
+  it("fails closed with a diagnostic reason when the GGUF is missing", async () => {
+    vi.stubEnv("ELIZA_YOLO_GGUF", "/missing/model.gguf");
+    accessMock.mockRejectedValue(new Error("ENOENT"));
+    const { isYoloReady } = await loadModule();
+    await expect(isYoloReady()).resolves.toEqual({
+      ready: false,
+      reason: "YOLO GGUF missing: /missing/model.gguf",
+    });
+    expect(accessMock).toHaveBeenCalledWith("/missing/model.gguf");
+  });
+
+  it("respects an explicit weightsPath option", async () => {
+    accessMock.mockRejectedValue(new Error("ENOENT"));
+    const { isYoloReady } = await loadModule();
+    await expect(
+      isYoloReady({ weightsPath: "/opt/weights/yolo.gguf" }),
+    ).resolves.toEqual({
+      ready: false,
+      reason: "YOLO GGUF missing: /opt/weights/yolo.gguf",
+    });
+  });
+
+  it("fails closed when the native library cannot load, reporting the expected .so path on linux", async () => {
+    vi.stubEnv("ELIZA_YOLO_GGUF", "/w/yolov8n.gguf");
+    Object.defineProperty(process, "platform", { value: "linux" });
+    // weights exist, library access fails
+    accessMock.mockImplementation((p: string) => {
+      if (p === "/w/yolov8n.gguf") return Promise.resolve();
+      return Promise.reject(new Error("ENOENT"));
+    });
+    const { isYoloReady } = await loadModule();
+    const result = await isYoloReady();
+    expect(result.ready).toBe(false);
+    expect(result.reason).toMatch(/native library failed to load/);
+    expect(result.reason).toContain("libyolo.so");
+  });
+
+  it("reports a .dll path on win32 and .dylib on darwin", async () => {
+    vi.stubEnv("ELIZA_YOLO_GGUF", "/w/yolov8n.gguf");
+    accessMock.mockImplementation((p: string) => {
+      if (p === "/w/yolov8n.gguf") return Promise.resolve();
+      return Promise.reject(new Error("ENOENT"));
+    });
+    for (const [platform, ext] of [
+      ["win32", "libyolo.dll"],
+      ["darwin", "libyolo.dylib"],
+    ] as const) {
+      Object.defineProperty(process, "platform", { value: platform });
+      const { isYoloReady } = await loadModule();
+      const result = await isYoloReady();
+      expect(result.ready).toBe(false);
+      expect(result.reason).toContain(ext);
+    }
+  });
+
+  it("honors ELIZA_YOLO_LIB when reporting the expected library path", async () => {
+    vi.stubEnv("ELIZA_YOLO_GGUF", "/w/yolov8n.gguf");
+    vi.stubEnv("ELIZA_YOLO_LIB", "/opt/yolo/libyolo-custom.so");
+    accessMock.mockImplementation((p: string) => {
+      if (p === "/w/yolov8n.gguf") return Promise.resolve();
+      return Promise.reject(new Error("ENOENT"));
+    });
+    const { isYoloReady } = await loadModule();
+    const result = await isYoloReady();
+    expect(result.reason).toContain("/opt/yolo/libyolo-custom.so");
+  });
+});
+
+describe("loadYoloBindings", () => {
+  it("returns null and warns when the native library is missing", async () => {
+    accessMock.mockRejectedValue(new Error("ENOENT"));
+    const { loadYoloBindings } = await loadModule();
+    await expect(loadYoloBindings()).resolves.toBeNull();
+    expect(warnMock).toHaveBeenCalledWith(
+      expect.stringContaining("native library not found"),
+    );
+  });
+
+  it("returns null and warns when bun:ffi is unavailable in the runtime", async () => {
+    accessMock.mockResolvedValue(undefined);
+    const { loadYoloBindings } = await loadModule();
+    await expect(loadYoloBindings()).resolves.toBeNull();
+    expect(warnMock).toHaveBeenCalledWith(
+      expect.stringContaining("bun:ffi unavailable"),
+    );
+  });
+
+  it("memoizes the bindings result across calls", async () => {
+    accessMock.mockResolvedValue(undefined);
+    const { loadYoloBindings } = await loadModule();
+    const first = await loadYoloBindings();
+    const second = await loadYoloBindings();
+    expect(first).toBeNull();
+    expect(second).toBe(first);
+  });
+
+  it("does not throw for a missing library — the vision path degrades to unavailable", async () => {
+    accessMock.mockRejectedValue(new Error("ENOENT"));
+    const { loadYoloBindings } = await loadModule();
+    await expect(loadYoloBindings()).resolves.toBeNull();
+    // no unhandled rejection, no throw
+    expect(warnMock).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; focused coverage for the native vision readiness gate. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition pinning the fail-closed native capability gate:
`isYoloReady` must return `{ ready: false }` with a diagnostic reason (never
throw) when the GGUF weights or the native `yolo.cpp` library are missing, and
weight/library path resolution must honor the `ELIZA_YOLO_GGUF`,
`ELIZA_STATE_DIR`, and `ELIZA_YOLO_LIB` overrides with a `~/.eliza` fallback.
The bun:ffi success path cannot be exercised under node/vitest (the source
loads it via a `new Function` dynamic import that bypasses the test module
runner), so those branches are pinned to the documented degrade-to-null
behavior instead.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `12 passed (12)` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
