### PR TITLE
test(coding-tools): cover worktree umbrella dispatch and alias routing

### DIFF
--- a/plugins/plugin-coding-tools/src/actions/worktree.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/worktree.test.ts
@@ -1,0 +1,227 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { worktreeAction } from "./worktree";
+
+const h = vi.hoisted(() => ({
+  format: {
+    failureToActionResult: vi.fn(),
+    readStringParam: vi.fn(),
+  },
+  enter: { enterWorktreeHandler: vi.fn() },
+  exit: { exitWorktreeHandler: vi.fn() },
+}));
+
+vi.mock("../lib/format.js", () => ({
+  failureToActionResult: h.format.failureToActionResult,
+  readStringParam: h.format.readStringParam,
+}));
+
+vi.mock("../types.js", () => ({
+  CODING_TOOLS_CONTEXTS: ["coding", "terminal"],
+}));
+
+vi.mock("./enter-worktree.js", () => ({
+  enterWorktreeHandler: h.enter.enterWorktreeHandler,
+}));
+
+vi.mock("./exit-worktree.js", () => ({
+  exitWorktreeHandler: h.exit.exitWorktreeHandler,
+}));
+
+const runtime = {} as never;
+const message = { id: "m1" } as never;
+const callback = vi.fn() as never;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.enter.enterWorktreeHandler.mockResolvedValue({
+    success: true,
+    action: "enter",
+  });
+  h.exit.exitWorktreeHandler.mockResolvedValue({
+    success: true,
+    action: "exit",
+  });
+});
+
+describe("worktreeAction metadata", () => {
+  it("declares the WORKTREE umbrella with an ADMIN role gate", () => {
+    expect(worktreeAction.name).toBe("WORKTREE");
+    expect(worktreeAction.similes).toContain("GIT_WORKTREE");
+    expect(worktreeAction.roleGate).toEqual({ minRole: "ADMIN" });
+    expect(worktreeAction.contexts).toEqual(["coding", "terminal"]);
+    expect(worktreeAction.contextGate).toEqual({
+      anyOf: ["coding", "terminal"],
+    });
+    expect(worktreeAction.parameters?.[0]?.name).toBe("action");
+  });
+});
+
+describe("worktreeAction.handler dispatch", () => {
+  it("routes action=enter to the enter handler and returns its result", async () => {
+    h.format.readStringParam.mockReturnValue("enter");
+    const options = { action: "enter", name: "feat/login" };
+    const result = await worktreeAction.handler(
+      runtime,
+      message,
+      undefined,
+      options,
+      callback,
+    );
+    expect(h.format.readStringParam).toHaveBeenCalledWith(options, "action");
+    expect(h.enter.enterWorktreeHandler).toHaveBeenCalledWith(
+      runtime,
+      message,
+      undefined,
+      options,
+      callback,
+    );
+    expect(result).toEqual({ success: true, action: "enter" });
+  });
+
+  it("routes action=exit to the exit handler", async () => {
+    h.format.readStringParam.mockReturnValue("exit");
+    const options = { action: "exit", cleanup: true };
+    const result = await worktreeAction.handler(
+      runtime,
+      message,
+      undefined,
+      options,
+      callback,
+    );
+    expect(h.exit.exitWorktreeHandler).toHaveBeenCalledWith(
+      runtime,
+      message,
+      undefined,
+      options,
+      callback,
+    );
+    expect(result).toEqual({ success: true, action: "exit" });
+  });
+
+  it.each(["add", "open", "create"])(
+    "normalizes the %s alias to action=enter",
+    async (alias) => {
+      h.format.readStringParam.mockReturnValue(alias);
+      await worktreeAction.handler(
+        runtime,
+        message,
+        undefined,
+        { action: alias },
+        callback,
+      );
+      expect(h.enter.enterWorktreeHandler).toHaveBeenCalledTimes(1);
+      expect(h.exit.exitWorktreeHandler).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(["leave", "pop", "remove"])(
+    "normalizes the %s alias to action=exit",
+    async (alias) => {
+      h.format.readStringParam.mockReturnValue(alias);
+      await worktreeAction.handler(
+        runtime,
+        message,
+        undefined,
+        { action: alias },
+        callback,
+      );
+      expect(h.exit.exitWorktreeHandler).toHaveBeenCalledTimes(1);
+      expect(h.enter.enterWorktreeHandler).not.toHaveBeenCalled();
+    },
+  );
+
+  it("case-normalizes and hyphen-normalizes the raw action", async () => {
+    h.format.readStringParam.mockReturnValue("  ADD  ");
+    await worktreeAction.handler(
+      runtime,
+      message,
+      undefined,
+      { action: "  ADD  " },
+      callback,
+    );
+    expect(h.enter.enterWorktreeHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails closed with missing_param for an unknown operation", async () => {
+    h.format.readStringParam.mockReturnValue("fly");
+    h.format.failureToActionResult.mockReturnValue({
+      success: false,
+      reason: "missing_param",
+      message: "WORKTREE requires action=enter/exit",
+    });
+    const result = await worktreeAction.handler(
+      runtime,
+      message,
+      undefined,
+      { action: "fly" },
+      callback,
+    );
+    expect(h.format.failureToActionResult).toHaveBeenCalledWith({
+      reason: "missing_param",
+      message: "WORKTREE requires action=enter/exit",
+    });
+    expect(result).toEqual({
+      success: false,
+      reason: "missing_param",
+      message: "WORKTREE requires action=enter/exit",
+    });
+    expect(h.enter.enterWorktreeHandler).not.toHaveBeenCalled();
+    expect(h.exit.exitWorktreeHandler).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when the action parameter is absent", async () => {
+    h.format.readStringParam.mockReturnValue(undefined);
+    await worktreeAction.handler(runtime, message, undefined, {}, callback);
+    expect(h.format.failureToActionResult).toHaveBeenCalled();
+    expect(h.enter.enterWorktreeHandler).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when the action parameter is an empty string", async () => {
+    h.format.readStringParam.mockReturnValue("");
+    await worktreeAction.handler(
+      runtime,
+      message,
+      undefined,
+      { action: "   " },
+      callback,
+    );
+    expect(h.format.failureToActionResult).toHaveBeenCalled();
+    expect(h.exit.exitWorktreeHandler).not.toHaveBeenCalled();
+  });
+
+  it("propagates handler failures to the caller", async () => {
+    h.format.readStringParam.mockReturnValue("enter");
+    h.enter.enterWorktreeHandler.mockRejectedValue(
+      new Error("worktree exists"),
+    );
+    await expect(
+      worktreeAction.handler(
+        runtime,
+        message,
+        undefined,
+        { action: "enter" },
+        callback,
+      ),
+    ).rejects.toThrow("worktree exists");
+  });
+});
+
+describe("worktreeAction.summarize", () => {
+  it("summarizes successful worktree management", () => {
+    expect(
+      worktreeAction.summarize?.({ success: true, action: "enter" } as never),
+    ).toBe("managed a git worktree");
+  });
+
+  it("returns undefined for failed results", () => {
+    expect(
+      worktreeAction.summarize?.({ success: false } as never),
+    ).toBeUndefined();
+  });
+});
+
+describe("worktreeAction.validate", () => {
+  it("accepts the action", async () => {
+    await expect(worktreeAction.validate?.({} as never)).resolves.toBe(true);
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; focused coverage for the WORKTREE umbrella dispatcher. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition pinning the WORKTREE umbrella's input-validation and
dispatch boundary: the action must fail closed with `missing_param` for absent,
empty, or unknown operations, route the documented aliases (`add`/`open`/
`create` → enter, `leave`/`pop`/`remove` → exit) to the correct handler, and
pass the caller's options through unchanged. The role gate (`ADMIN`) and
context gating are pinned from the action metadata. Handler modules are mocked,
so no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `17 passed (17)` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
