### PR TITLE
fix(coding): preserve trusted Go caches in sanitized shells

### DIFF
--- a/packages/examples/code/src/acp-bootstrap.test.ts
+++ b/packages/examples/code/src/acp-bootstrap.test.ts
@@ -3,6 +3,23 @@
  * so process-global authority state cannot leak between test cases.
  */
 import { expect, it } from "bun:test";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { HOST_EXECUTION_BASELINE_ENV_MIRROR_KEYS } from "@elizaos/shared/host-execution-env";
+
+function cleanHostAuthorityEnv(): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+  const denied = new Set([
+    "GOPATH",
+    "GOMODCACHE",
+    "GOCACHE",
+    ...HOST_EXECUTION_BASELINE_ENV_MIRROR_KEYS,
+  ]);
+  for (const key of Object.keys(env)) {
+    if (denied.has(key.toUpperCase())) delete env[key];
+  }
+  return env;
+}
 
 it("deletes the warm token before imports and captures only claimed PATH", () => {
   const bootstrapUrl = new URL("./acp-bootstrap.ts", import.meta.url).href;
@@ -26,10 +43,9 @@ it("deletes the warm token before imports and captures only claimed PATH", () =>
     }));
   `;
   const childEnv: NodeJS.ProcessEnv = {
-    ...process.env,
+    ...cleanHostAuthorityEnv(),
     ELIZA_ACP_WARM_CLAIM_TOKEN: "single-use-secret",
   };
-  delete childEnv.ELIZA_HOST_EXECUTION_BASELINE_PATH;
   const result = Bun.spawnSync(
     [process.execPath, "--conditions=eliza-source", "-e", script],
     {
@@ -43,5 +59,98 @@ it("deletes the warm token before imports and captures only claimed PATH", () =>
   expect(JSON.parse(result.stdout.toString())).toEqual({
     before: { token: "single-use-secret" },
     after: "/claimed/wrapper:/usr/bin",
+  });
+});
+
+it("cold bootstrap captures only parent-canonical Go authority", () => {
+  const bootstrapUrl = new URL("./acp-bootstrap.ts", import.meta.url).href;
+  const sharedUrl = new URL(
+    "../../../shared/src/host-execution-env.ts",
+    import.meta.url,
+  ).href;
+  const script = `
+    await import(${JSON.stringify(bootstrapUrl)});
+    const shared = await import(${JSON.stringify(sharedUrl)});
+    process.stdout.write(JSON.stringify(shared.getHostExecutionBaseline()));
+  `;
+  const goPath = join(tmpdir(), "parent-go");
+  const goModCache = join(tmpdir(), "parent-go-mod");
+  const goCache = join(tmpdir(), "parent-go-build");
+  const childEnv: NodeJS.ProcessEnv = {
+    ...cleanHostAuthorityEnv(),
+    HOME: join(tmpdir(), "caller-home-must-not-win"),
+    GOPATH: goPath,
+    GOMODCACHE: goModCache,
+    GOCACHE: goCache,
+    ELIZA_HOST_EXECUTION_BASELINE_GOPATH: join(tmpdir(), "caller-mirror"),
+  };
+  delete childEnv.ELIZA_ACP_WARM_CLAIM_TOKEN;
+  const result = Bun.spawnSync(
+    [process.execPath, "--conditions=eliza-source", "-e", script],
+    { env: childEnv, stdout: "pipe", stderr: "pipe" },
+  );
+
+  expect(result.exitCode, result.stderr.toString()).toBe(0);
+  expect(JSON.parse(result.stdout.toString())).toMatchObject({
+    goPath,
+    goModCache,
+    goCache,
+  });
+});
+
+it("warm bootstrap captures authenticated Go authority over bootstrap values", () => {
+  const bootstrapUrl = new URL("./acp-bootstrap.ts", import.meta.url).href;
+  const claimUrl = new URL("./acp-session-claim.ts", import.meta.url).href;
+  const sharedUrl = new URL(
+    "../../../shared/src/host-execution-env.ts",
+    import.meta.url,
+  ).href;
+  const goPath = join(tmpdir(), "claimed-go");
+  const goModCache = join(tmpdir(), "claimed-go-mod");
+  const goCache = join(tmpdir(), "claimed-go-build");
+  const executionPath =
+    process.platform === "win32" ? "C:\\Windows\\System32" : "/usr/bin:/bin";
+  const script = `
+    const bootstrap = await import(${JSON.stringify(bootstrapUrl)});
+    const { AcpWarmSessionClaim } = await import(${JSON.stringify(claimUrl)});
+    const shared = await import(${JSON.stringify(sharedUrl)});
+    const claim = new AcpWarmSessionClaim(bootstrap.consumeWarmClaimToken());
+    claim.apply({ elizaSessionClaim: {
+      token: "single-use-secret",
+      env: ${JSON.stringify({ GOPATH: goPath, GOMODCACHE: goModCache, GOCACHE: goCache })},
+      executionPath: ${JSON.stringify(executionPath)}
+    }});
+    const baseline = shared.captureHostExecutionBaseline();
+    const applied = shared.applyHostExecutionBaseline({
+      PATH: "/caller/bin",
+      GOPATH: "/caller/go",
+      GOMODCACHE: "/caller/mod",
+      GOCACHE: "/caller/build"
+    });
+    process.stdout.write(JSON.stringify({ baseline, applied }));
+  `;
+  const childEnv = {
+    ...cleanHostAuthorityEnv(),
+    ELIZA_ACP_WARM_CLAIM_TOKEN: "single-use-secret",
+    HOME: join(tmpdir(), "bootstrap-home-must-not-win"),
+    GOPATH: join(tmpdir(), "bootstrap-go-must-not-win"),
+    GOMODCACHE: join(tmpdir(), "bootstrap-mod-must-not-win"),
+    GOCACHE: join(tmpdir(), "bootstrap-build-must-not-win"),
+  };
+  const result = Bun.spawnSync(
+    [process.execPath, "--conditions=eliza-source", "-e", script],
+    { env: childEnv, stdout: "pipe", stderr: "pipe" },
+  );
+
+  expect(result.exitCode, result.stderr.toString()).toBe(0);
+  const parsed = JSON.parse(result.stdout.toString()) as {
+    baseline: Record<string, string>;
+    applied: Record<string, string>;
+  };
+  expect(parsed.baseline).toMatchObject({ goPath, goModCache, goCache });
+  expect(parsed.applied).toMatchObject({
+    GOPATH: goPath,
+    GOMODCACHE: goModCache,
+    GOCACHE: goCache,
   });
 });

--- a/packages/examples/code/src/acp-session-claim.test.ts
+++ b/packages/examples/code/src/acp-session-claim.test.ts
@@ -2,6 +2,7 @@
 
 import { describe, expect, it } from "bun:test";
 import { delimiter } from "node:path";
+import { HOST_EXECUTION_BASELINE_ENV_MIRROR_KEYS } from "@elizaos/shared/host-execution-env";
 import { AcpWarmSessionClaim } from "./acp-session-claim";
 
 describe("AcpWarmSessionClaim", () => {
@@ -68,6 +69,11 @@ describe("AcpWarmSessionClaim", () => {
         env: { OPENAI_API_KEY: "lease-b" },
         executionPath: "relative/bin",
       },
+      ...HOST_EXECUTION_BASELINE_ENV_MIRROR_KEYS.map((key) => ({
+        token: "claim-secret",
+        env: { [key]: "/caller-controlled" },
+        executionPath: "/usr/bin",
+      })),
     ]) {
       const target = { EXISTING: "preserved" };
       const claim = new AcpWarmSessionClaim("claim-secret");

--- a/packages/examples/code/src/acp-session-claim.ts
+++ b/packages/examples/code/src/acp-session-claim.ts
@@ -5,6 +5,7 @@
  */
 import { timingSafeEqual } from "node:crypto";
 import { delimiter, isAbsolute } from "node:path";
+import { isHostExecutionBaselineMirrorKey } from "@elizaos/shared/host-execution-env";
 
 export type AcpSessionClaimMeta = {
   elizaSessionClaim?: {
@@ -61,6 +62,7 @@ export class AcpWarmSessionClaim {
       if (
         !/^[A-Z_][A-Z0-9_]*$/.test(key) ||
         key === "ELIZA_ACP_WARM_CLAIM_TOKEN" ||
+        isHostExecutionBaselineMirrorKey(key) ||
         typeof value !== "string"
       ) {
         throw new Error("invalid warm-session environment entry");

--- a/packages/shared/src/host-execution-env.test.ts
+++ b/packages/shared/src/host-execution-env.test.ts
@@ -12,12 +12,29 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import {
   applyHostExecutionBaseline,
+  applyHostToolchainExecutionBaseline,
   captureHostExecutionBaseline,
   createHostExecutionBaseline,
   getHostExecutionBaseline,
+  isHostExecutionBaselineMirrorKey,
+  isHostExecutionToolchainEnvKey,
   resolveHostExecutable,
+  validateHostExecutionDirectory,
   validateHostExecutionPath,
 } from "./host-execution-env.ts";
+
+const BASELINE_MIRROR_KEYS = [
+  "ELIZA_HOST_EXECUTION_BASELINE_PATH",
+  "ELIZA_HOST_EXECUTION_BASELINE_GOPATH",
+  "ELIZA_HOST_EXECUTION_BASELINE_GOMODCACHE",
+  "ELIZA_HOST_EXECUTION_BASELINE_GOCACHE",
+] as const;
+
+function withoutBaselineMirrors(): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+  for (const key of BASELINE_MIRROR_KEYS) delete env[key];
+  return env;
+}
 
 describe("host execution boot baseline", () => {
   it("captures before a later PATH write in a fresh process", () => {
@@ -26,15 +43,24 @@ describe("host execution boot baseline", () => {
     const fixture = fileURLToPath(
       new URL("./host-execution-env.fixture.ts", import.meta.url),
     );
+    const childEnv: NodeJS.ProcessEnv = {
+      ...process.env,
+      PATH: bootPath,
+      ELIZA_TEST_MUTATED_PATH: "/tmp/plugin-controlled-bin",
+    };
+    delete childEnv.GOPATH;
+    delete childEnv.GOMODCACHE;
+    delete childEnv.GOCACHE;
     const stdout = execFileSync(process.execPath, [fixture], {
       encoding: "utf8",
-      env: {
-        ...process.env,
-        PATH: bootPath,
-        ELIZA_TEST_MUTATED_PATH: "/tmp/plugin-controlled-bin",
-      },
+      env: childEnv,
     });
-    expect(JSON.parse(stdout)).toEqual({ path: bootPath });
+    expect(JSON.parse(stdout)).toMatchObject({
+      path: bootPath,
+      goPath: expect.stringMatching(/[/\\]go$/),
+      goModCache: expect.stringMatching(/[/\\]go[/\\]pkg[/\\]mod$/),
+      goCache: expect.stringMatching(/[/\\]go-build$/),
+    });
   });
 
   it("keeps a fresh process capture after later environment mutation", () => {
@@ -68,11 +94,150 @@ describe("host execution boot baseline", () => {
     ).toBeUndefined();
   });
 
-  it("adds only PATH to an already-sanitized environment", () => {
-    const bootPath = getHostExecutionBaseline().path;
+  it("handles Windows Go path lists, cache defaults, and duplicate casing", () => {
     expect(
-      applyHostExecutionBaseline({ Path: "/tmp/late", SAFE: "yes" }),
-    ).toEqual({ PATH: bootPath, SAFE: "yes" });
+      createHostExecutionBaseline(
+        {
+          Path: "C:\\Windows\\System32",
+          GOPATH: "C:\\go-one;D:\\go-two",
+          LOCALAPPDATA: "C:\\Users\\coder\\AppData\\Local",
+        },
+        "win32",
+        "C:\\Users\\coder",
+      ),
+    ).toEqual({
+      path: "C:\\Windows\\System32",
+      goPath: "C:\\go-one;D:\\go-two",
+      goModCache: "C:\\go-one\\pkg\\mod",
+      goCache: "C:\\Users\\coder\\AppData\\Local\\go-build",
+    });
+    expect(
+      createHostExecutionBaseline(
+        {
+          Path: "C:\\Windows\\System32",
+          GOPATH: "C:\\caller-a",
+          GoPath: "C:\\caller-b",
+        },
+        "win32",
+        "C:\\Users\\coder",
+      ).goPath,
+    ).toBe("C:\\Users\\coder\\go");
+  });
+
+  it("derives complete Go defaults without HOME or Go variables", () => {
+    expect(
+      createHostExecutionBaseline(
+        { PATH: "/usr/bin:/bin" },
+        "darwin",
+        "/Users/coder",
+      ),
+    ).toEqual({
+      path: "/usr/bin:/bin",
+      goPath: "/Users/coder/go",
+      goModCache: "/Users/coder/go/pkg/mod",
+      goCache: "/Users/coder/Library/Caches/go-build",
+    });
+  });
+
+  it("preserves explicit absolute Go workspace and cache directories", () => {
+    expect(
+      createHostExecutionBaseline(
+        {
+          PATH: "/usr/bin:/bin",
+          GOPATH: "/opt/go-work:/srv/go-work",
+          GOMODCACHE: "/var/cache/go-mod",
+          GOCACHE: "/var/cache/go-build",
+        },
+        "linux",
+        "/home/coder",
+      ),
+    ).toEqual({
+      path: "/usr/bin:/bin",
+      goPath: "/opt/go-work:/srv/go-work",
+      goModCache: "/var/cache/go-mod",
+      goCache: "/var/cache/go-build",
+    });
+  });
+
+  it("derives safe defaults instead of accepting relative Go paths", () => {
+    expect(
+      createHostExecutionBaseline(
+        {
+          PATH: "/usr/bin:/bin",
+          GOPATH: "runtime/go",
+          GOMODCACHE: "runtime/go-mod",
+          GOCACHE: "off",
+        },
+        "linux",
+        "/home/coder",
+      ),
+    ).toEqual({
+      path: "/usr/bin:/bin",
+      goPath: "/home/coder/go",
+      goModCache: "/home/coder/go/pkg/mod",
+      goCache: "/home/coder/.cache/go-build",
+    });
+  });
+
+  it("rejects relative and NUL-bearing cache directories", () => {
+    expect(validateHostExecutionDirectory("relative/cache")).toBeUndefined();
+    expect(
+      validateHostExecutionDirectory("/tmp/cache\0/escape"),
+    ).toBeUndefined();
+  });
+
+  it("replaces mutable Go and PATH values with the captured baseline", () => {
+    const baseline = getHostExecutionBaseline();
+    const applied = applyHostExecutionBaseline({
+      Path: "/tmp/late",
+      gopath: "/tmp/runtime-go",
+      GoModCache: "/tmp/runtime-mod",
+      gocache: "/tmp/runtime-build",
+      eliza_host_execution_baseline_path: "/tmp/runtime-path-mirror",
+      eliza_host_execution_baseline_gopath: "/tmp/runtime-go-mirror",
+      Eliza_Host_Execution_Baseline_Gomodcache: "/tmp/runtime-mod-mirror",
+      ELIZA_HOST_EXECUTION_BASELINE_GOCACHE: "/tmp/runtime-cache-mirror",
+      SAFE: "yes",
+    });
+
+    expect(applied).toMatchObject({
+      PATH: baseline.path,
+      GOPATH: baseline.goPath,
+      GOMODCACHE: baseline.goModCache,
+      GOCACHE: baseline.goCache,
+      SAFE: "yes",
+    });
+    expect(applied.gopath).toBeUndefined();
+    expect(applied.GoModCache).toBeUndefined();
+    expect(applied.gocache).toBeUndefined();
+    expect(applied.eliza_host_execution_baseline_path).toBeUndefined();
+    expect(applied.ELIZA_HOST_EXECUTION_BASELINE_GOPATH).toBe(baseline.goPath);
+  });
+
+  it("replaces only toolchain authority when a validated session owns PATH", () => {
+    const baseline = getHostExecutionBaseline();
+    const applied = applyHostToolchainExecutionBaseline({
+      PATH: "/trusted/session-wrapper:/usr/bin",
+      GOPATH: "/caller/go",
+      GOMODCACHE: "/caller/mod",
+      GOCACHE: "/caller/build",
+    });
+    expect(applied).toMatchObject({
+      PATH: "/trusted/session-wrapper:/usr/bin",
+      GOPATH: baseline.goPath,
+      GOMODCACHE: baseline.goModCache,
+      GOCACHE: baseline.goCache,
+    });
+  });
+
+  it("classifies Go variables and mirror aliases as host-only authority", () => {
+    expect(isHostExecutionToolchainEnvKey("gopath")).toBe(true);
+    expect(isHostExecutionToolchainEnvKey("GoModCache")).toBe(true);
+    expect(isHostExecutionToolchainEnvKey("GOCACHE")).toBe(true);
+    expect(
+      isHostExecutionBaselineMirrorKey("eliza_host_execution_baseline_gocache"),
+    ).toBe(true);
+    expect(isHostExecutionToolchainEnvKey("GOFLAGS")).toBe(false);
   });
 
   it("rejects executable paths outside the captured PATH directories", () => {
@@ -98,11 +263,19 @@ describe("host execution baseline env mirror", () => {
     const stdout = execFileSync(process.execPath, [fixture], {
       encoding: "utf8",
       env: {
-        ...process.env,
+        ...withoutBaselineMirrors(),
         ELIZA_HOST_EXECUTION_BASELINE_PATH: "/usr/bin:/bin",
+        ELIZA_HOST_EXECUTION_BASELINE_GOPATH: "/home/coder/go",
+        ELIZA_HOST_EXECUTION_BASELINE_GOMODCACHE: "/home/coder/go/pkg/mod",
+        ELIZA_HOST_EXECUTION_BASELINE_GOCACHE: "/home/coder/.cache/go-build",
       },
     });
-    expect(JSON.parse(stdout)).toEqual({ path: "/usr/bin:/bin" });
+    expect(JSON.parse(stdout)).toEqual({
+      path: "/usr/bin:/bin",
+      goPath: "/home/coder/go",
+      goModCache: "/home/coder/go/pkg/mod",
+      goCache: "/home/coder/.cache/go-build",
+    });
   });
 
   it("rejects an invalid mirrored value instead of trusting it", () => {
@@ -112,19 +285,39 @@ describe("host execution baseline env mirror", () => {
     const stdout = execFileSync(process.execPath, [fixture], {
       encoding: "utf8",
       env: {
-        ...process.env,
+        ...withoutBaselineMirrors(),
         ELIZA_HOST_EXECUTION_BASELINE_PATH: "relative/entry:/bin",
       },
     });
     expect(JSON.parse(stdout)).toEqual({});
   });
 
+  it("fills missing cross-version Go mirrors from the OS account home", () => {
+    const fixture = fileURLToPath(
+      new URL("./host-execution-env.bridge.fixture.ts", import.meta.url),
+    );
+    const stdout = execFileSync(process.execPath, [fixture], {
+      encoding: "utf8",
+      env: {
+        ...withoutBaselineMirrors(),
+        HOME: "/caller-controlled-home",
+        ELIZA_HOST_EXECUTION_BASELINE_PATH: "/usr/bin:/bin",
+      },
+    });
+    expect(JSON.parse(stdout)).toEqual(
+      createHostExecutionBaseline(
+        { PATH: "/usr/bin:/bin" },
+        process.platform,
+        os.userInfo().homedir,
+      ),
+    );
+  });
+
   it("stays empty when no capture ran and no mirror is set", () => {
     const fixture = fileURLToPath(
       new URL("./host-execution-env.bridge.fixture.ts", import.meta.url),
     );
-    const env = { ...process.env };
-    delete env.ELIZA_HOST_EXECUTION_BASELINE_PATH;
+    const env = withoutBaselineMirrors();
     const stdout = execFileSync(process.execPath, [fixture], {
       encoding: "utf8",
       env,

--- a/packages/shared/src/host-execution-env.ts
+++ b/packages/shared/src/host-execution-env.ts
@@ -1,27 +1,32 @@
 /**
- * Owns the process-wide executable-search authority captured by a Node host
- * before runtime configuration or plugins can mutate `process.env`. Host
- * process launchers consume this narrow PATH baseline; sandbox launchers do
+ * Owns the process-wide executable-search and Go-cache authority captured by a
+ * Node host before runtime configuration or plugins can mutate `process.env`.
+ * Host process launchers consume this narrow baseline; sandbox launchers do
  * not, because containers must retain their image-native environment.
  */
 
 import { accessSync, constants } from "node:fs";
+import { userInfo } from "node:os";
 import path from "node:path";
 import process from "node:process";
 
 export interface HostExecutionBaseline {
   readonly path?: string;
+  readonly goPath?: string;
+  readonly goModCache?: string;
+  readonly goCache?: string;
 }
 
 let capturedBaseline: HostExecutionBaseline | undefined;
 
-function pathValueForPlatform(
+function envValueForPlatform(
   env: NodeJS.ProcessEnv,
+  name: string,
   platform: NodeJS.Platform,
 ): string | undefined {
-  if (platform !== "win32") return env.PATH;
+  if (platform !== "win32") return env[name];
   const entries = Object.entries(env).filter(
-    ([key, value]) => key.toUpperCase() === "PATH" && value !== undefined,
+    ([key, value]) => key.toUpperCase() === name && value !== undefined,
   );
   return entries.length === 1 ? entries[0]?.[1] : undefined;
 }
@@ -42,64 +47,209 @@ export function validateHostExecutionPath(
   return value;
 }
 
+export function validateHostExecutionDirectory(
+  value: string | undefined,
+  platform: NodeJS.Platform = process.platform,
+): string | undefined {
+  if (!value || value.includes("\0")) return undefined;
+  const pathApi = platform === "win32" ? path.win32 : path.posix;
+  return pathApi.isAbsolute(value) ? pathApi.normalize(value) : undefined;
+}
+
 export function createHostExecutionBaseline(
   env: NodeJS.ProcessEnv,
   platform: NodeJS.Platform = process.platform,
+  homeDirectory: string | undefined = trustedHostHomeDirectory(),
 ): HostExecutionBaseline {
+  const pathApi = platform === "win32" ? path.win32 : path.posix;
+  const trustedHome = validateHostExecutionDirectory(homeDirectory, platform);
+  const goPath =
+    validateHostExecutionPath(
+      envValueForPlatform(env, "GOPATH", platform),
+      platform,
+    ) ?? (trustedHome ? pathApi.join(trustedHome, "go") : undefined);
+  const firstGoPath = goPath?.split(pathApi.delimiter)[0];
+  const goModCache =
+    validateHostExecutionDirectory(
+      envValueForPlatform(env, "GOMODCACHE", platform),
+      platform,
+    ) ?? (firstGoPath ? pathApi.join(firstGoPath, "pkg", "mod") : undefined);
+  const explicitGoCache = validateHostExecutionDirectory(
+    envValueForPlatform(env, "GOCACHE", platform),
+    platform,
+  );
+  const xdgCacheHome = validateHostExecutionDirectory(
+    envValueForPlatform(env, "XDG_CACHE_HOME", platform),
+    platform,
+  );
+  const localAppData = validateHostExecutionDirectory(
+    envValueForPlatform(env, "LOCALAPPDATA", platform),
+    platform,
+  );
+  const defaultGoCache = trustedHome
+    ? platform === "darwin"
+      ? pathApi.join(trustedHome, "Library", "Caches", "go-build")
+      : platform === "win32"
+        ? pathApi.join(
+            localAppData ?? pathApi.join(trustedHome, "AppData", "Local"),
+            "go-build",
+          )
+        : pathApi.join(
+            xdgCacheHome ?? pathApi.join(trustedHome, ".cache"),
+            "go-build",
+          )
+    : undefined;
   return Object.freeze({
     path: validateHostExecutionPath(
-      pathValueForPlatform(env, platform),
+      envValueForPlatform(env, "PATH", platform),
       platform,
     ),
+    goPath,
+    goModCache,
+    goCache: explicitGoCache ?? defaultGoCache,
   });
 }
 
+function trustedHostHomeDirectory(): string | undefined {
+  try {
+    return userInfo().homedir;
+  } catch {
+    // error-policy:J3 hosts without an OS account fail closed instead of
+    // treating mutable HOME/USERPROFILE values as execution authority.
+    return undefined;
+  }
+}
+
 /**
- * Process-global mirror of the captured PATH authority. Module state alone is
+ * Process-global mirrors of the captured host authority. Module state alone is
  * NOT process-global under bundling: an entrypoint that bundles this module
  * captures into ITS copy, while an externalized package (plugin-coding-tools
  * in the eliza-code ACP child) resolves a second instance from node_modules
- * whose `capturedBaseline` stays empty — live 2026-08-17, every sub-agent
- * SHELL died "No boot-authorized shell" with a fully valid child PATH. The
- * env mirror bridges instances; it is validated on every read and grants no
- * new authority (whoever sets a child's env already controls its PATH).
+ * whose `capturedBaseline` stays empty. The validated mirrors bridge those
+ * instances and are replaced from the trusted baseline at every host spawn.
  */
-const BASELINE_ENV_MIRROR = "ELIZA_HOST_EXECUTION_BASELINE_PATH";
+const BASELINE_ENV_MIRRORS = {
+  path: "ELIZA_HOST_EXECUTION_BASELINE_PATH",
+  goPath: "ELIZA_HOST_EXECUTION_BASELINE_GOPATH",
+  goModCache: "ELIZA_HOST_EXECUTION_BASELINE_GOMODCACHE",
+  goCache: "ELIZA_HOST_EXECUTION_BASELINE_GOCACHE",
+} as const;
+
+export const HOST_EXECUTION_BASELINE_ENV_MIRROR_KEYS = Object.freeze(
+  Object.values(BASELINE_ENV_MIRRORS),
+);
+
+const HOST_EXECUTION_GO_ENV_KEYS = new Set(["GOPATH", "GOMODCACHE", "GOCACHE"]);
+
+export function isHostExecutionBaselineMirrorKey(key: string): boolean {
+  const upper = key.toUpperCase();
+  return HOST_EXECUTION_BASELINE_ENV_MIRROR_KEYS.some(
+    (candidate) => candidate === upper,
+  );
+}
+
+/** Go values and their internal mirrors are host-only spawn authority. */
+export function isHostExecutionToolchainEnvKey(key: string): boolean {
+  return (
+    HOST_EXECUTION_GO_ENV_KEYS.has(key.toUpperCase()) ||
+    isHostExecutionBaselineMirrorKey(key)
+  );
+}
+
+function publishBaselineMirrors(baseline: HostExecutionBaseline): void {
+  for (const [key, mirror] of Object.entries(BASELINE_ENV_MIRRORS) as Array<
+    [keyof HostExecutionBaseline, string]
+  >) {
+    const value = baseline[key];
+    if (value) process.env[mirror] = value;
+    else delete process.env[mirror];
+  }
+}
 
 /** Capture once. Later calls cannot replace the boot authority. */
 export function captureHostExecutionBaseline(): HostExecutionBaseline {
   if (capturedBaseline) return capturedBaseline;
   capturedBaseline = createHostExecutionBaseline(process.env);
-  if (capturedBaseline.path) {
-    process.env[BASELINE_ENV_MIRROR] = capturedBaseline.path;
-  }
+  publishBaselineMirrors(capturedBaseline);
   return capturedBaseline;
 }
 
 export function getHostExecutionBaseline(): HostExecutionBaseline {
   if (capturedBaseline) return capturedBaseline;
-  const mirrored = validateHostExecutionPath(process.env[BASELINE_ENV_MIRROR]);
-  if (mirrored) {
-    capturedBaseline = Object.freeze({ path: mirrored });
+  const mirrored = {
+    path: validateHostExecutionPath(process.env[BASELINE_ENV_MIRRORS.path]),
+    goPath: validateHostExecutionPath(process.env[BASELINE_ENV_MIRRORS.goPath]),
+    goModCache: validateHostExecutionDirectory(
+      process.env[BASELINE_ENV_MIRRORS.goModCache],
+    ),
+    goCache: validateHostExecutionDirectory(
+      process.env[BASELINE_ENV_MIRRORS.goCache],
+    ),
+  };
+  if (Object.values(mirrored).some((value) => value !== undefined)) {
+    capturedBaseline = createHostExecutionBaseline(
+      {
+        PATH: mirrored.path,
+        GOPATH: mirrored.goPath,
+        GOMODCACHE: mirrored.goModCache,
+        GOCACHE: mirrored.goCache,
+      },
+      process.platform,
+      trustedHostHomeDirectory(),
+    );
     return capturedBaseline;
   }
   return Object.freeze({});
 }
 
 /**
- * Add only the captured PATH to an already-sanitized host child environment.
- * Case variants are removed so Windows cannot retain a second mutable value.
+ * Add only captured host authority to an already-sanitized child environment.
+ * Case variants and caller-provided mirror values are removed so a mutable
+ * runtime overlay cannot replace PATH or Go's workspace/cache locations.
  */
+function applyBaseline(
+  env: NodeJS.ProcessEnv,
+  replacePath: boolean,
+): NodeJS.ProcessEnv {
+  const out: NodeJS.ProcessEnv = {};
+  const replacedKeys = new Set([
+    "GOPATH",
+    "GOMODCACHE",
+    "GOCACHE",
+    ...Object.values(BASELINE_ENV_MIRRORS),
+  ]);
+  if (replacePath) replacedKeys.add("PATH");
+  for (const [key, value] of Object.entries(env)) {
+    if (!replacedKeys.has(key.toUpperCase())) out[key] = value;
+  }
+  const baseline = getHostExecutionBaseline();
+  if (replacePath && baseline.path) out.PATH = baseline.path;
+  if (baseline.goPath) out.GOPATH = baseline.goPath;
+  if (baseline.goModCache) out.GOMODCACHE = baseline.goModCache;
+  if (baseline.goCache) out.GOCACHE = baseline.goCache;
+  for (const [key, mirror] of Object.entries(BASELINE_ENV_MIRRORS) as Array<
+    [keyof HostExecutionBaseline, string]
+  >) {
+    const value = baseline[key];
+    if (value) out[mirror] = value;
+  }
+  return out;
+}
+
+/**
+ * Replace caller-controlled Go values and every internal mirror while leaving
+ * PATH itself intact for a separately validated per-session wrapper.
+ */
+export function applyHostToolchainExecutionBaseline(
+  env: NodeJS.ProcessEnv,
+): NodeJS.ProcessEnv {
+  return applyBaseline(env, false);
+}
+
 export function applyHostExecutionBaseline(
   env: NodeJS.ProcessEnv,
 ): NodeJS.ProcessEnv {
-  const out: NodeJS.ProcessEnv = {};
-  for (const [key, value] of Object.entries(env)) {
-    if (key.toUpperCase() !== "PATH") out[key] = value;
-  }
-  const baseline = getHostExecutionBaseline();
-  if (baseline.path) out.PATH = baseline.path;
-  return out;
+  return applyBaseline(env, true);
 }
 
 export function resolveHostExecutable(nameOrPath: string): string | undefined {

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
@@ -18,6 +18,7 @@ import {
 import {
   captureHostExecutionBaseline,
   getHostExecutionBaseline,
+  HOST_EXECUTION_BASELINE_ENV_MIRROR_KEYS,
 } from "@elizaos/shared/host-execution-env";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -1069,6 +1070,7 @@ describe("AcpService", () => {
   });
 
   it("uses the native TypeScript transport by default", async () => {
+    const baseline = getHostExecutionBaseline();
     const service = new AcpService(
       runtime({
         ELIZA_ACP_TRANSPORT: undefined,
@@ -1081,6 +1083,16 @@ describe("AcpService", () => {
       name: "default-native",
       agentType: "codex",
       workdir: "/tmp/acp-test",
+      env: {
+        gopath: "/caller/go",
+        GOMODCACHE: "/caller/go-mod",
+        ELIZA_HOST_EXECUTION_BASELINE_GOCACHE: "/caller/go-build-mirror",
+      },
+      customCredentials: {
+        GoCache: "/caller/go-build",
+        eliza_host_execution_baseline_gopath: "/caller/go-mirror",
+        ELIZA_HOST_EXECUTION_BASELINE_GOMODCACHE: "/caller/go-mod-mirror",
+      },
     });
 
     expect(spawned.status).toBe("ready");
@@ -1092,6 +1104,17 @@ describe("AcpService", () => {
     expect(
       nativeClientMock.instances[0]?.opts.env?.ORCHESTRATOR_SESSION_ID,
     ).toBe(spawned.sessionId);
+    expect(nativeClientMock.instances[0]?.opts.env).toMatchObject({
+      GOPATH: baseline.goPath,
+      GOMODCACHE: baseline.goModCache,
+      GOCACHE: baseline.goCache,
+      ELIZA_HOST_EXECUTION_BASELINE_PATH: baseline.path,
+      ELIZA_HOST_EXECUTION_BASELINE_GOPATH: baseline.goPath,
+      ELIZA_HOST_EXECUTION_BASELINE_GOMODCACHE: baseline.goModCache,
+      ELIZA_HOST_EXECUTION_BASELINE_GOCACHE: baseline.goCache,
+    });
+    expect(nativeClientMock.instances[0]?.opts.env?.gopath).toBeUndefined();
+    expect(nativeClientMock.instances[0]?.opts.env?.GoCache).toBeUndefined();
   });
 
   it("single-claims warm elizaos children without credentials at process spawn", async () => {
@@ -1124,6 +1147,12 @@ describe("AcpService", () => {
           OPENAI_API_KEY: "lease-a",
           ELIZA_ACP_WARM_CLAIM_TOKEN: "caller-injected-token",
           PATH: "/caller-controlled/bin",
+          GOPATH: "/caller/go",
+          GOMODCACHE: "/caller/go-mod",
+          GOCACHE: "/caller/go-build",
+          ELIZA_HOST_EXECUTION_BASELINE_GOPATH: "/caller/go-mirror",
+          ELIZA_HOST_EXECUTION_BASELINE_GOMODCACHE: "/caller/go-mod-mirror",
+          ELIZA_HOST_EXECUTION_BASELINE_GOCACHE: "/caller/go-build-mirror",
         },
       });
       expect(firstWarm?.createSession).toHaveBeenCalledTimes(1);
@@ -1140,9 +1169,14 @@ describe("AcpService", () => {
       const firstClaim = firstWarm?.createSession.mock.calls[0]?.[1];
       expect(firstClaim?.env?.ELIZA_ACP_WARM_CLAIM_TOKEN).toBeUndefined();
       expect(firstClaim?.env?.PATH).toBeUndefined();
-      expect(
-        firstClaim?.env?.ELIZA_HOST_EXECUTION_BASELINE_PATH,
-      ).toBeUndefined();
+      for (const key of HOST_EXECUTION_BASELINE_ENV_MIRROR_KEYS) {
+        expect(firstClaim?.env?.[key]).toBeUndefined();
+      }
+      expect(firstClaim?.env).toMatchObject({
+        GOPATH: getHostExecutionBaseline().goPath,
+        GOMODCACHE: getHostExecutionBaseline().goModCache,
+        GOCACHE: getHostExecutionBaseline().goCache,
+      });
       expect(firstClaim?.executionPath).toBe(getHostExecutionBaseline().path);
 
       await waitForNativeClients(2);

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-env-deny.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-env-deny.test.ts
@@ -18,6 +18,13 @@ describe("isDeniedSubAgentEnvKey (customCredentials deny-list)", () => {
       "TERMINAL_RUN_TOKEN",
       "ELIZA_TERMINAL_RUN_TOKEN",
       "ELIZA_ACP_WARM_CLAIM_TOKEN",
+      "GOPATH",
+      "gomodcache",
+      "GoCache",
+      "ELIZA_HOST_EXECUTION_BASELINE_PATH",
+      "eliza_host_execution_baseline_gopath",
+      "ELIZA_HOST_EXECUTION_BASELINE_GOMODCACHE",
+      "Eliza_Host_Execution_Baseline_Gocache",
     ]) {
       expect(isDeniedSubAgentEnvKey(key)).toBe(true);
     }

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -50,7 +50,11 @@ import {
   isAndroidMobile,
   isCodingAgentBackend,
 } from "@elizaos/shared";
-import { getHostExecutionBaseline } from "@elizaos/shared/host-execution-env";
+import {
+  applyHostToolchainExecutionBaseline,
+  getHostExecutionBaseline,
+  HOST_EXECUTION_BASELINE_ENV_MIRROR_KEYS,
+} from "@elizaos/shared/host-execution-env";
 import { NativeAcpClient, splitCommandLine } from "./acp-native-transport.js";
 import { augmentTaskWithDeployGuidance } from "./app-deploy-guidance.js";
 import {
@@ -3529,7 +3533,9 @@ export class AcpService extends Service {
           opts.session,
         );
         builtEnv.PATH = trustedExecutionPath;
-        delete builtEnv.ELIZA_HOST_EXECUTION_BASELINE_PATH;
+        for (const key of HOST_EXECUTION_BASELINE_ENV_MIRROR_KEYS) {
+          delete builtEnv[key];
+        }
         this.configureNativeClientForSession(warm.client, opts.session, {
           env: builtEnv,
           timeoutMs: opts.timeoutMs,
@@ -3542,7 +3548,9 @@ export class AcpService extends Service {
         // PATH is separate claim authority: the child never accepts an
         // arbitrary environment entry as executable-search authority.
         delete claimEnv.PATH;
-        delete claimEnv.ELIZA_HOST_EXECUTION_BASELINE_PATH;
+        for (const key of HOST_EXECUTION_BASELINE_ENV_MIRROR_KEYS) {
+          delete claimEnv[key];
+        }
         const nativeSession = await warm.client.createSession(
           opts.session.workdir,
           {
@@ -5069,7 +5077,7 @@ export class AcpService extends Service {
     // forwardableSubAgentEnv / canonicalForwardedEnvKey — Bun on Windows reports
     // OS vars like `Path` with native casing, which a child must not inherit
     // alongside an uppercase duplicate).
-    const env: NodeJS.ProcessEnv = forwardableSubAgentEnv(process.env);
+    let env: NodeJS.ProcessEnv = forwardableSubAgentEnv(process.env);
     // #14118: the raw owner cloud key is broker-gated by default. When an
     // operator opts INTO forwarding it and a key actually landed in the child
     // env, surface it — an autonomous child now holds the owner's Cloud bearer,
@@ -5113,6 +5121,10 @@ export class AcpService extends Service {
       }
       env[canonicalForwardedEnvKey(key)] = value;
     }
+    // Runtime/caller inputs may name Go's cache variables or the internal
+    // cross-module mirrors. Rebuild those values only from the boot-captured
+    // authority, while preserving the separately validated session PATH.
+    env = applyHostToolchainExecutionBaseline(env);
     if (model) {
       const normalizedModel =
         agentType === "claude" ? normalizeClaudeAcpModelId(model) : model;

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-env-policy.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-env-policy.ts
@@ -3,6 +3,8 @@
  * consumes this as the single host-env projection before adding per-session
  * model gateway, credential bridge, and adapter-specific overrides.
  */
+import { isHostExecutionToolchainEnvKey } from "@elizaos/shared/host-execution-env";
+
 const DENY_ENV_PATTERNS = [
   /DISCORD.*TOKEN/i,
   /TELEGRAM.*TOKEN/i,
@@ -26,6 +28,7 @@ const DENY_ENV_PATTERNS = [
   // AFTER this filter runs). A caller- or host-supplied value would let the
   // spawner inject arbitrary provider config into the child, so it is denied at
   // both intake paths.
+  /^OPENCODE_CONFIG_CONTENT$/i,
 ];
 
 /**
@@ -35,7 +38,10 @@ const DENY_ENV_PATTERNS = [
  * vault passphrase) the deny-list exists to keep out of sub-agents.
  */
 export function isDeniedSubAgentEnvKey(key: string): boolean {
-  return DENY_ENV_PATTERNS.some((pattern) => pattern.test(key));
+  return (
+    isHostExecutionToolchainEnvKey(key) ||
+    DENY_ENV_PATTERNS.some((pattern) => pattern.test(key))
+  );
 }
 
 /**

--- a/plugins/plugin-coding-tools/src/lib/run-shell.test.ts
+++ b/plugins/plugin-coding-tools/src/lib/run-shell.test.ts
@@ -5,7 +5,10 @@ import {
   type IAgentRuntime,
   UnavailableCapabilityRouter,
 } from "@elizaos/core";
-import { captureHostExecutionBaseline } from "@elizaos/shared/host-execution-env";
+import {
+  captureHostExecutionBaseline,
+  getHostExecutionBaseline,
+} from "@elizaos/shared/host-execution-env";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { runShell } from "./run-shell.js";
 
@@ -18,6 +21,13 @@ const ENV_KEYS = [
   "PATH",
   "HOME",
   "SHELL",
+  "GOPATH",
+  "GOMODCACHE",
+  "GOCACHE",
+  "NODE_OPTIONS",
+  "LD_PRELOAD",
+  "GIT_CONFIG_KEY_0",
+  "GIT_CONFIG_VALUE_0",
 ] as const;
 
 let savedEnv: Record<string, string | undefined>;
@@ -278,5 +288,43 @@ describe("plugin-coding-tools host execution authority", () => {
     expect(result.stdout.split("|")[0]).toBe(bootPath);
     expect(result.stdout).not.toContain("/tmp/runtime-home");
     expect(result.stdout).not.toContain("/tmp/runtime-shell");
+  });
+
+  it("provides trusted Go caches while stripping runtime overlays and injection keys", async () => {
+    const baseline = getHostExecutionBaseline();
+    process.env.ELIZA_RUNTIME_MODE = "local-yolo";
+    process.env.GOPATH = "/tmp/runtime-go";
+    process.env.GOMODCACHE = "/tmp/runtime-go-mod";
+    process.env.GOCACHE = "/tmp/runtime-go-build";
+    process.env.NODE_OPTIONS = "--require=/tmp/runtime-hook.cjs";
+    process.env.LD_PRELOAD = "/tmp/runtime-hook.dylib";
+    process.env.GIT_CONFIG_KEY_0 = "core.sshCommand";
+    process.env.GIT_CONFIG_VALUE_0 = "/tmp/runtime-git-hook";
+    const script =
+      "process.stdout.write(JSON.stringify({" +
+      "goPath:process.env.GOPATH??null," +
+      "goModCache:process.env.GOMODCACHE??null," +
+      "goCache:process.env.GOCACHE??null," +
+      "nodeOptions:process.env.NODE_OPTIONS??null," +
+      "ldPreload:process.env.LD_PRELOAD??null," +
+      "gitConfigKey:process.env.GIT_CONFIG_KEY_0??null," +
+      "gitConfigValue:process.env.GIT_CONFIG_VALUE_0??null}))";
+
+    const result = await runShell({ getService: () => null } as IAgentRuntime, {
+      command: `${JSON.stringify(process.execPath)} -e ${JSON.stringify(script)}`,
+      cwd: process.cwd(),
+      timeoutMs: 10_000,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual({
+      goPath: baseline.goPath,
+      goModCache: baseline.goModCache,
+      goCache: baseline.goCache,
+      nodeOptions: null,
+      ldPreload: null,
+      gitConfigKey: null,
+      gitConfigValue: null,
+    });
   });
 });


### PR DESCRIPTION
Closes #28270

## Summary

- capture validated host GOPATH, GOMODCACHE, and GOCACHE alongside executable-search authority, deriving platform-safe defaults from the OS account when Go relies on HOME
- preserve HOME sanitization and rebuild Go execution values only from the boot-captured parent baseline
- close ACP cold/warm trust boundaries by denying caller Go values and internal mirrors, stripping mirrors from warm claims, and rejecting mirror claims in the child
- preserve existing runtime-loader and Git-config spawn filtering

## Security boundary

Caller spawn env and custom credentials are untrusted. Raw Go cache variables, casing variants, and internal cross-module mirrors are denied at intake. Cold children receive parent-canonical values. Warm children receive canonical raw values through the authenticated one-shot claim, never internal mirrors; the child validates the claim before capturing its execution baseline. Missing cross-version mirror fields derive from the OS account home rather than mutable HOME or USERPROFILE.

## Local evidence

Exact tested head: 17e53cefa7309d2f985a93e531d50e12eab87433
Exact base: 49f190e29bd4b8c56dc9ff6c65fbf9ce21ff1473

- packages/shared host-execution-env: 17/17 passed
- plugin-coding-tools run-shell: 8/8 passed
- plugin-agent-orchestrator ACP/env: 101/101 passed
- example-code real cold/warm subprocess tests: 6/6 passed
- typecheck passed for shared, plugin-coding-tools, plugin-agent-orchestrator, and example-code after normal prerequisite builds
- exact Biome check passed for all ten changed files
- git diff --check passed
- independent security re-review found no remaining blocker
- real sanitized host runShell go env returned valid GOPATH, GOMODCACHE, and GOCACHE with HOME and runtime Go overlays removed
- real go test -mod=readonly ./internal/config passed in the retained Flipt benchmark workspace

## Scope

No UI changes. No committed evidence artifacts.