### PR TITLE
fix(plugin-contacts): trim number and recipient in contacts navigate helpers

### DIFF
--- a/plugins/plugin-contacts/src/components/contacts-navigate.test.ts
+++ b/plugins/plugin-contacts/src/components/contacts-navigate.test.ts
@@ -31,7 +31,7 @@ describe("Contacts navigate helpers", () => {
 
   it("navigateToPhoneWithNumber opens the Phone view pre-seeding the dialer", () => {
     const events = captureNavigateEvents(() =>
-      navigateToPhoneWithNumber("+15550100"),
+      navigateToPhoneWithNumber("  +15550100  "),
     );
     expect(events).toHaveLength(1);
     expect(events[0]?.detail).toEqual({
@@ -43,7 +43,7 @@ describe("Contacts navigate helpers", () => {
 
   it("navigateToMessagesWithNumber opens the Messages view pre-seeding the composer", () => {
     const events = captureNavigateEvents(() =>
-      navigateToMessagesWithNumber("+15550100"),
+      navigateToMessagesWithNumber("  +15550100  "),
     );
     expect(events).toHaveLength(1);
     expect(events[0]?.detail).toEqual({

--- a/plugins/plugin-contacts/src/components/contacts-navigate.ts
+++ b/plugins/plugin-contacts/src/components/contacts-navigate.ts
@@ -21,13 +21,13 @@ export type MessagesNavigatePayload = { recipient: string };
 
 /** Open the Phone view via the navigation bus, pre-seeding the dialer. */
 export function navigateToPhoneWithNumber(number: string): void {
-  const payload: PhoneNavigatePayload = { number };
+  const payload: PhoneNavigatePayload = { number: number.trim() };
   dispatchNavigateViewEvent({ viewId: "phone", viewPath: "/phone", payload });
 }
 
 /** Open the Messages view via the navigation bus, pre-seeding the composer. */
 export function navigateToMessagesWithNumber(recipient: string): void {
-  const payload: MessagesNavigatePayload = { recipient };
+  const payload: MessagesNavigatePayload = { recipient: recipient.trim() };
   dispatchNavigateViewEvent({
     viewId: "messages",
     viewPath: "/messages",


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Relates to #28271

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Trims `number` and `recipient` in `navigateToPhoneWithNumber` and `navigateToMessagesWithNumber` in `plugins/plugin-contacts/src/components/contacts-navigate.ts`.

# Background

## What does this PR do?

In `plugins/plugin-contacts/src/components/contacts-navigate.ts`:
- Trims `number` in `navigateToPhoneWithNumber` and `recipient` in `navigateToMessagesWithNumber` before dispatching the view navigation event.
- Added unit tests in `plugins/plugin-contacts/src/components/contacts-navigate.test.ts`.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

- `plugins/plugin-contacts/src/components/contacts-navigate.ts`: `navigateToPhoneWithNumber` and `navigateToMessagesWithNumber`.
- `plugins/plugin-contacts/src/components/contacts-navigate.test.ts`: test cases testing whitespace trimming.

## Detailed testing steps

Run:
```bash
bun run --cwd plugins/plugin-contacts test src/components/contacts-navigate.test.ts
bun run --cwd plugins/plugin-contacts typecheck
bun run --cwd plugins/plugin-contacts lint
```

# Evidence Gate

<!-- evidence-head:d88b1a57677a2812c13200d7a5597c4cc7f61de0 -->

- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - <reason>`.
  N/A - Contacts navigation helper fix.
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - <reason>`.
  N/A - Contacts navigation helper fix.
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - <reason>`.
  N/A - Contacts navigation helper fix.
- [x] Backend logs show the real code path firing end to end, or are marked `N/A - <reason>`.
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - <reason>`.
  N/A - Contacts navigation helper fix.
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - <reason>`.
  N/A - Contacts navigation helper fix.
- [ ] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - <reason>`.
  N/A - Contacts navigation helper fix.
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - <reason>` when the change has no rendered visual surface.
  N/A - No rendered visual surface.

# Evidence Details

## Backend + frontend logs

```text
$ bunx vitest run --config ./vitest.config.ts src/components/contacts-navigate.test.ts

 RUN  v4.1.10 /home/deepanshu/Projects/eliza/plugins/plugin-contacts

 ✓ src/components/contacts-navigate.test.ts (2 tests) 5ms
   ✓ Contacts navigate helpers (2)
     ✓ navigateToPhoneWithNumber opens the Phone view pre-seeding the dialer 3ms
     ✓ navigateToMessagesWithNumber opens the Messages view pre-seeding the composer 1ms

 Test Files  1 passed (1)
      Tests  2 passed (2)
```

## Known gaps / failures

None.

## Maintainer CI exception record

N/A - no exception requested