### PR TITLE
fix(plugin-messages): support recipient and message parameter aliases in send-sms capability

### DIFF
--- a/plugins/plugin-messages/src/components/messages-interact.test.ts
+++ b/plugins/plugin-messages/src/components/messages-interact.test.ts
@@ -130,6 +130,21 @@ describe("interact view capabilities", () => {
       body: "sent from test",
     });
 
+    await expect(
+      interact("send-sms", {
+        recipient: "+15550400",
+        message: "sent using aliases",
+      }),
+    ).resolves.toEqual({
+      sent: true,
+      address: "+15550400",
+      bodyLength: 18,
+    });
+    expect(bridge.sendSms).toHaveBeenCalledWith({
+      address: "+15550400",
+      body: "sent using aliases",
+    });
+
     await expect(interact("request-sms-role")).resolves.toMatchObject({
       requested: true,
     });

--- a/plugins/plugin-messages/src/components/messages-interact.ts
+++ b/plugins/plugin-messages/src/components/messages-interact.ts
@@ -35,8 +35,23 @@ export async function interact(
 
   if (capability === "send-sms") {
     const address =
-      typeof params?.address === "string" ? params.address.trim() : "";
-    const body = typeof params?.body === "string" ? params.body.trim() : "";
+      typeof params?.address === "string"
+        ? params.address.trim()
+        : typeof params?.recipient === "string"
+          ? params.recipient.trim()
+          : typeof params?.to === "string"
+            ? params.to.trim()
+            : typeof params?.phoneNumber === "string"
+              ? params.phoneNumber.trim()
+              : "";
+    const body =
+      typeof params?.body === "string"
+        ? params.body.trim()
+        : typeof params?.message === "string"
+          ? params.message.trim()
+          : typeof params?.text === "string"
+            ? params.text.trim()
+            : "";
     if (!address) throw new Error("address is required");
     if (!body) throw new Error("body is required");
     await Messages.sendSms({ address, body });


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Relates to #28279

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. In `plugins/plugin-messages/src/components/messages-interact.ts`, `send-sms` capability accepts `recipient`, `to`, `phoneNumber` alongside `address` and `message`, `text` alongside `body`.

# Background

## What does this PR do?

In `plugins/plugin-messages/src/components/messages-interact.ts`:
- Added alias resolution for address (`recipient`, `to`, `phoneNumber`) and body (`message`, `text`).
- Added unit test cases in `plugins/plugin-messages/src/components/messages-interact.test.ts`.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

- `plugins/plugin-messages/src/components/messages-interact.ts`: `send-sms` capability handler.
- `plugins/plugin-messages/src/components/messages-interact.test.ts`: test cases testing aliases.

## Detailed testing steps

Run:
```bash
bun run --cwd plugins/plugin-messages test src/components/messages-interact.test.ts
bun run --cwd plugins/plugin-messages typecheck
bun run --cwd plugins/plugin-messages lint
```

# Evidence Gate

<!-- evidence-head:8e5daaf3e035d97d8f835c4cb17b190b30551415 -->

- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - <reason>`.
  N/A - Messages capability parameter alias fix.
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - <reason>`.
  N/A - Messages capability parameter alias fix.
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - <reason>`.
  N/A - Messages capability parameter alias fix.
- [x] Backend logs show the real code path firing end to end, or are marked `N/A - <reason>`.
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - <reason>`.
  N/A - Messages capability parameter alias fix.
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - <reason>`.
  N/A - Messages capability parameter alias fix.
- [ ] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - <reason>`.
  N/A - Messages capability parameter alias fix.
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - <reason>` when the change has no rendered visual surface.
  N/A - No rendered visual surface.

# Evidence Details

## Backend + frontend logs

```text
$ bunx vitest run --config ./vitest.config.ts src/components/messages-interact.test.ts

 RUN  v4.1.10 /home/deepanshu/Projects/eliza/plugins/plugin-messages

 ✓ src/components/messages-interact.test.ts (3 tests) 27ms
   ✓ interact view capabilities (3)
     ✓ supports capabilities for list, send, and sms role request 9ms

 Test Files  1 passed (1)
      Tests  3 passed (3)
```

## Known gaps / failures

None.

## Maintainer CI exception record

N/A - no exception requested