### PR TITLE
feat(core): add Pi-default coding action profile

### DIFF
--- a/packages/core/src/__tests__/planner-happy-path.test.ts
+++ b/packages/core/src/__tests__/planner-happy-path.test.ts
@@ -16,6 +16,7 @@ import {
 	runV5MessageRuntimeStage1,
 	wrapSingleTurnVisibleCallback,
 } from "../services/message";
+import { PI_CODING_ACTION_PROFILE } from "../types/coding";
 import type {
 	Action,
 	ActionResult,
@@ -377,6 +378,107 @@ describe("v5 happy path — message handler → planner → executor → evaluat
 		expect(firstPlannerMessages?.[0]?.content).not.toContain(
 			"Owner life-management side effects",
 		);
+	});
+
+	it("applies the Pi coding profile while retaining planner protocol terminals", async () => {
+		const actions = [
+			"FILE",
+			"READ",
+			"WRITE",
+			"EDIT",
+			"SHELL",
+			"WORKTREE",
+			"ATTACHMENT",
+			"GENERATE_MEDIA",
+			"WEB_FETCH",
+			"WEB_SEARCH",
+		].map((name) =>
+			makeMockAction({
+				name,
+				contexts: ["code", "files", "terminal"],
+				handler: async () => ({ success: true, text: `${name} complete` }),
+			}),
+		);
+		const runtime = makeRuntime({
+			actions,
+			owner: true,
+			responses: [
+				{
+					expectModelType: ModelType.ACTION_PLANNER,
+					body: {
+						text: "",
+						completed: true,
+						toolCalls: [{ id: "read-1", name: "READ", args: {} }],
+					},
+				},
+				{
+					expectModelType: ModelType.ACTION_PLANNER,
+					body: {
+						text: "",
+						toolCalls: [
+							{ id: "reply-1", name: "REPLY", args: { text: "Done." } },
+						],
+					},
+				},
+			],
+		});
+
+		await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage("read the repository"),
+			state: makeState(),
+			responseId: RESPONSE_ID,
+			codingMode: true,
+			codingActionProfile: PI_CODING_ACTION_PROFILE,
+		});
+
+		const plannerTools = new Set(
+			getCalls(runtime).flatMap((call) =>
+				(
+					(call.params as { tools?: Array<{ name?: string }> }).tools ?? []
+				).flatMap((tool) => (tool.name ? [tool.name] : [])),
+			),
+		);
+		for (const name of ["READ", "SHELL", "EDIT", "WRITE"]) {
+			expect(plannerTools).toContain(name);
+		}
+		for (const name of ["REPLY", "IGNORE", "STOP"]) {
+			expect(plannerTools).toContain(name);
+		}
+		for (const name of [
+			"FILE",
+			"WORKTREE",
+			"ATTACHMENT",
+			"GENERATE_MEDIA",
+			"WEB_FETCH",
+			"WEB_SEARCH",
+		]) {
+			expect(plannerTools).not.toContain(name);
+		}
+		const nonterminalTools = [...plannerTools]
+			.filter((name) => !["REPLY", "IGNORE", "STOP"].includes(name))
+			.sort();
+		expect(nonterminalTools).toEqual(["EDIT", "READ", "SHELL", "WRITE"]);
+		expect(runtime.actions).toHaveLength(actions.length);
+		expect(runtime.logger.debug).toHaveBeenCalledWith(
+			expect.objectContaining({
+				actionSurface: expect.objectContaining({
+					tierAParents: ["EDIT", "READ", "SHELL", "WRITE"],
+					codingActionProfile: {
+						kind: "pi",
+						includeWorktree: false,
+					},
+				}),
+			}),
+			"Built v5 planner action surface",
+		);
+		const recordedTrajectory = readRecordedTrajectories(String(AGENT_ID))[0] as
+			| { codingActionProfile?: { kind: string; includeWorktree: boolean } }
+			| undefined;
+		expect(recordedTrajectory?.codingActionProfile).toEqual({
+			kind: "pi",
+			includeWorktree: false,
+		});
 	});
 
 	it("does not leak coding mode into the next ordinary turn", async () => {

--- a/packages/core/src/runtime/__tests__/trajectory-recorder.test.ts
+++ b/packages/core/src/runtime/__tests__/trajectory-recorder.test.ts
@@ -124,6 +124,7 @@ describe("JsonFileTrajectoryRecorder", () => {
 		const id = recorder.startTrajectory({
 			agentId: "agent-test",
 			roomId: "room-1",
+			codingActionProfile: { kind: "pi", includeWorktree: true },
 			rootMessage: { id: "msg-1", text: "hello", sender: "user-1" },
 		});
 
@@ -229,6 +230,10 @@ describe("JsonFileTrajectoryRecorder", () => {
 		expect(parsed.trajectoryId).toBe(id);
 		expect(parsed.agentId).toBe("agent-test");
 		expect(parsed.roomId).toBe("room-1");
+		expect(parsed.codingActionProfile).toEqual({
+			kind: "pi",
+			includeWorktree: true,
+		});
 		expect(parsed.rootMessage).toEqual({
 			id: "msg-1",
 			text: "hello",

--- a/packages/core/src/runtime/coding-action-profile.test.ts
+++ b/packages/core/src/runtime/coding-action-profile.test.ts
@@ -1,0 +1,80 @@
+/** Verifies per-turn coding profiles filter authorized actions without mutating the runtime catalog. */
+
+import { describe, expect, it } from "vitest";
+import { PI_CODING_ACTION_PROFILE } from "../types/coding";
+import type { Action } from "../types/components";
+import {
+	applyCodingActionProfile,
+	parseCodingActionProfile,
+} from "./coding-action-profile";
+
+function action(name: string): Action {
+	return {
+		name,
+		description: name,
+		examples: [],
+		validate: async () => true,
+		handler: async () => ({ success: true }),
+	};
+}
+
+describe("applyCodingActionProfile", () => {
+	it("keeps the complete authorized surface when no profile is selected", () => {
+		const actions = [action("READ"), action("WEB_SEARCH")];
+
+		expect(applyCodingActionProfile(actions, undefined)).toEqual(actions);
+		expect(actions.map(({ name }) => name)).toEqual(["READ", "WEB_SEARCH"]);
+	});
+
+	it("uses Pi's action surface and makes WORKTREE explicitly configurable", () => {
+		const actions = [
+			action("FILE"),
+			action("READ"),
+			action("WRITE"),
+			action("EDIT"),
+			action("SHELL"),
+			action("WORKTREE"),
+			action("ATTACHMENT"),
+			action("GENERATE_MEDIA"),
+			action("WEB_FETCH"),
+			action("WEB_SEARCH"),
+		];
+
+		expect(
+			applyCodingActionProfile(actions, PI_CODING_ACTION_PROFILE).map(
+				({ name }) => name,
+			),
+		).toEqual(["READ", "WRITE", "EDIT", "SHELL"]);
+		expect(
+			applyCodingActionProfile(actions, {
+				kind: "pi",
+				includeWorktree: true,
+			}).map(({ name }) => name),
+		).toEqual(["READ", "WRITE", "EDIT", "SHELL", "WORKTREE"]);
+		expect(actions).toHaveLength(10);
+	});
+
+	it("can only narrow the actions that ordinary authorization already allowed", () => {
+		const authorizedActions = [action("SHELL"), action("WEB_SEARCH")];
+
+		expect(
+			applyCodingActionProfile(authorizedActions, {
+				kind: "pi",
+				includeWorktree: true,
+			}).map(({ name }) => name),
+		).toEqual(["SHELL"]);
+	});
+
+	it.each([
+		null,
+		"pi",
+		{},
+		{ kind: "other" },
+		{ kind: "pi", includeWorktree: "yes" },
+		{ kind: "pi", includeWorktree: false, extra: true },
+	])("rejects an invalid runtime profile shape: %j", (profile) => {
+		expect(() => parseCodingActionProfile(profile)).toThrowError(
+			expect.objectContaining({ code: "INVALID_CODING_ACTION_PROFILE" }),
+		);
+	});
+});

--- a/packages/core/src/runtime/coding-action-profile.ts
+++ b/packages/core/src/runtime/coding-action-profile.ts
@@ -1,0 +1,72 @@
+/** Resolves explicit coding profiles against already-authorized runtime actions. */
+
+import { ElizaError } from "../errors";
+import type { CodingActionProfile } from "../types/coding";
+import type { Action } from "../types/components";
+import { normalizeActionName } from "./action-catalog";
+
+const PI_ACTION_NAMES = new Set(["READ", "SHELL", "EDIT", "WRITE"]);
+
+/**
+ * Validates the runtime value before it reaches action selection or telemetry.
+ * Hosts normally pass the typed value, but JavaScript and transport adapters can
+ * still supply an arbitrary shape at runtime.
+ */
+export function parseCodingActionProfile(
+	value: unknown,
+): CodingActionProfile | undefined {
+	if (value === undefined) return undefined;
+	if (value === null || typeof value !== "object" || Array.isArray(value)) {
+		throw new ElizaError("Coding action profile must be an object", {
+			code: "INVALID_CODING_ACTION_PROFILE",
+			context: { receivedType: value === null ? "null" : typeof value },
+		});
+	}
+
+	const profile = value as Record<string, unknown>;
+	const unknownKeys = Object.keys(profile).filter(
+		(key) => key !== "kind" && key !== "includeWorktree",
+	);
+	if (
+		profile.kind !== "pi" ||
+		(profile.includeWorktree !== undefined &&
+			typeof profile.includeWorktree !== "boolean") ||
+		unknownKeys.length > 0
+	) {
+		throw new ElizaError("Invalid coding action profile", {
+			code: "INVALID_CODING_ACTION_PROFILE",
+			context: {
+				kind: typeof profile.kind === "string" ? profile.kind : undefined,
+				includeWorktreeType: typeof profile.includeWorktree,
+				unknownKeys,
+			},
+		});
+	}
+
+	return profile.includeWorktree === true
+		? { kind: "pi", includeWorktree: true }
+		: { kind: "pi" };
+}
+
+/**
+ * Applies a host-selected coding profile after ordinary action authorization.
+ * The input array and runtime action registry remain untouched.
+ */
+export function applyCodingActionProfile(
+	actions: ReadonlyArray<Action>,
+	profileValue: CodingActionProfile | undefined,
+): Action[] {
+	const profile = parseCodingActionProfile(profileValue);
+	if (!profile) return [...actions];
+
+	switch (profile.kind) {
+		case "pi": {
+			const allowedNames = profile.includeWorktree
+				? new Set([...PI_ACTION_NAMES, "WORKTREE"])
+				: PI_ACTION_NAMES;
+			return actions.filter((action) =>
+				allowedNames.has(normalizeActionName(action.name)),
+			);
+		}
+	}
+}

--- a/packages/core/src/runtime/trajectory-recorder.ts
+++ b/packages/core/src/runtime/trajectory-recorder.ts
@@ -321,6 +321,10 @@ export interface RecordedTrajectory {
 	taskId?: string;
 	sessionId?: string;
 	parentStepId?: string;
+	codingActionProfile?: {
+		kind: "pi";
+		includeWorktree: boolean;
+	};
 	rootMessage: { id: string; text: string; sender?: string };
 	startedAt: number;
 	endedAt?: number;
@@ -351,6 +355,11 @@ export interface StartTrajectoryInput {
 	taskId?: string;
 	sessionId?: string;
 	parentStepId?: string;
+	/** Normalized trusted coding policy selected for this recorded turn. */
+	codingActionProfile?: {
+		kind: "pi";
+		includeWorktree: boolean;
+	};
 }
 
 export interface ListTrajectoriesOptions {
@@ -1205,6 +1214,7 @@ class JsonFileTrajectoryRecorder implements TrajectoryRecorder {
 			taskId: correlation.taskId,
 			sessionId: correlation.sessionId,
 			parentStepId: correlation.parentStepId,
+			codingActionProfile: input.codingActionProfile,
 			rootMessage: cloneRootMessageForRecord(input.rootMessage),
 			startedAt: Date.now(),
 			status: "running",

--- a/packages/core/src/services/message.coding-action-profile.test.ts
+++ b/packages/core/src/services/message.coding-action-profile.test.ts
@@ -1,0 +1,58 @@
+/** Verifies coding action profiles fail closed before the message lifecycle has side effects. */
+
+import { describe, expect, it, vi } from "vitest";
+import type { IAgentRuntime, Memory, MessageProcessingOptions } from "../types";
+import { DefaultMessageService } from "./message";
+
+function inertMessage(): Memory {
+	return {
+		id: "00000000-0000-0000-0000-000000000001",
+		agentId: "00000000-0000-0000-0000-000000000002",
+		entityId: "00000000-0000-0000-0000-000000000003",
+		roomId: "00000000-0000-0000-0000-000000000004",
+		content: { text: "work" },
+	} as Memory;
+}
+
+function untouchedRuntime(): IAgentRuntime {
+	return new Proxy({} as IAgentRuntime, {
+		get(_target, property) {
+			throw new Error(`runtime side effect: ${String(property)}`);
+		},
+	});
+}
+
+describe("DefaultMessageService coding action profile boundary", () => {
+	it.each([
+		{
+			label: "invalid shape",
+			options: {
+				codingMode: true,
+				codingActionProfile: { kind: "pi", includeWorktree: "yes" },
+			} as unknown as MessageProcessingOptions,
+			code: "INVALID_CODING_ACTION_PROFILE",
+		},
+		{
+			label: "profile without coding mode",
+			options: { codingActionProfile: { kind: "pi" } },
+			code: "CODING_ACTION_PROFILE_REQUIRES_CODING_MODE",
+		},
+	])(
+		"rejects $label before events, actions, or callbacks",
+		async ({ options, code }) => {
+			const message = inertMessage();
+			const callback = vi.fn();
+
+			await expect(
+				new DefaultMessageService().handleMessage(
+					untouchedRuntime(),
+					message,
+					callback,
+					options,
+				),
+			).rejects.toMatchObject({ code });
+			expect(callback).not.toHaveBeenCalled();
+			expect(message.metadata).toBeUndefined();
+		},
+	);
+});

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -92,6 +92,10 @@ import {
 	getCandidateActionBackstopRules,
 } from "../runtime/candidate-action-backstop";
 import { isCanonicalModelCapabilityDisabled } from "../runtime/canonical-model-capabilities.ts";
+import {
+	applyCodingActionProfile,
+	parseCodingActionProfile,
+} from "../runtime/coding-action-profile";
 import { filterProvidersByContextGate } from "../runtime/context-gates.ts";
 import { computePrefixHashes, hashString } from "../runtime/context-hash";
 import {
@@ -243,6 +247,7 @@ import {
 } from "../trajectory-context";
 import { withEvaluatorStep } from "../trajectory-utils";
 import type { CharacterSettings } from "../types/agent";
+import type { CodingActionProfile } from "../types/coding";
 import type {
 	Action,
 	ActionResult,
@@ -1532,6 +1537,7 @@ function _resolvePromptAttachments(
 type ResolvedMessageOptions = {
 	maxRetries: number;
 	codingMode: boolean;
+	codingActionProfile?: CodingActionProfile;
 	continueAfterActions: boolean;
 	keepExistingResponses: boolean;
 	onStreamChunk?: StreamChunkCallback;
@@ -3130,6 +3136,10 @@ type V5PlannerActionSurfaceSummary = {
 	queryTokens: string[];
 	candidateActions: string[];
 	parentActionHints: string[];
+	codingActionProfile?: {
+		kind: "pi";
+		includeWorktree: boolean;
+	};
 	fallback?: string;
 };
 
@@ -3534,6 +3544,7 @@ function buildFullV5PlannerActionSurface(params: {
 	actions: readonly Action[];
 	candidateActions?: readonly string[];
 	parentActionHints?: readonly string[];
+	codingActionProfile?: CodingActionProfile;
 }): V5PlannerActionSurface {
 	const exposedActionNames = new Set(
 		params.actions.map((action) => normalizeActionIdentifier(action.name)),
@@ -3553,6 +3564,15 @@ function buildFullV5PlannerActionSurface(params: {
 			queryTokens: [],
 			candidateActions: [...(params.candidateActions ?? [])],
 			parentActionHints: [...(params.parentActionHints ?? [])],
+			...(params.codingActionProfile
+				? {
+						codingActionProfile: {
+							kind: params.codingActionProfile.kind,
+							includeWorktree:
+								params.codingActionProfile.includeWorktree === true,
+						},
+					}
+				: {}),
 		},
 	};
 }
@@ -3603,6 +3623,7 @@ export function getCachedActionCatalog(
 function buildV5PlannerActionSurface(params: {
 	actions: readonly Action[];
 	forceFullSurface?: boolean;
+	codingActionProfile?: CodingActionProfile;
 	message: Memory;
 	state?: State;
 	messageHandler: MessageHandlerResult;
@@ -3661,6 +3682,15 @@ function buildV5PlannerActionSurface(params: {
 				queryTokens: [],
 				candidateActions: [],
 				parentActionHints: [],
+				...(params.codingActionProfile
+					? {
+							codingActionProfile: {
+								kind: params.codingActionProfile.kind,
+								includeWorktree:
+									params.codingActionProfile.includeWorktree === true,
+							},
+						}
+					: {}),
 			},
 		};
 	}
@@ -3671,6 +3701,7 @@ function buildV5PlannerActionSurface(params: {
 			actions: params.actions,
 			candidateActions,
 			parentActionHints,
+			codingActionProfile: params.codingActionProfile,
 		});
 	}
 
@@ -3817,6 +3848,15 @@ function buildV5PlannerActionSurface(params: {
 			queryTokens: retrieval.query.tokens,
 			candidateActions,
 			parentActionHints,
+			...(params.codingActionProfile
+				? {
+						codingActionProfile: {
+							kind: params.codingActionProfile.kind,
+							includeWorktree:
+								params.codingActionProfile.includeWorktree === true,
+						},
+					}
+				: {}),
 		},
 	};
 }
@@ -8152,6 +8192,8 @@ export async function runV5MessageRuntimeStage1(args: {
 	responseId: UUID;
 	/** Trusted per-turn direct coding-loop selection. */
 	codingMode?: boolean;
+	/** Optional model-facing action policy for this trusted coding turn. */
+	codingActionProfile?: CodingActionProfile;
 	callback?: HandlerCallback;
 	deliveredVisibleTexts?: Set<string>;
 	plannerLoopConfig?: PlannerLoopParams["config"];
@@ -8180,6 +8222,18 @@ export async function runV5MessageRuntimeStage1(args: {
 	/** Stops after Stage-1 routing, before reply generation, planning, or tools. */
 	stage1DecisionOnly?: boolean;
 }): Promise<V5MessageRuntimeStage1Result> {
+	const codingActionProfile = parseCodingActionProfile(
+		args.codingActionProfile,
+	);
+	if (codingActionProfile && args.codingMode !== true) {
+		throw new ElizaError(
+			"Coding action profile requires codingMode to be enabled",
+			{
+				code: "CODING_ACTION_PROFILE_REQUIRES_CODING_MODE",
+				context: { kind: codingActionProfile.kind },
+			},
+		);
+	}
 	const senderRole =
 		getTrajectoryContext()?.userRole ??
 		(await resolveStage1SenderRole(args.runtime, args.message));
@@ -8261,6 +8315,14 @@ export async function runV5MessageRuntimeStage1(args: {
 				// (#13775). Threading it here makes the file trajectory join the DB
 				// row and any spawned sub-agent trajectory on one traceId.
 				traceId: getTrajectoryContext()?.traceId,
+				...(codingActionProfile
+					? {
+							codingActionProfile: {
+								kind: codingActionProfile.kind,
+								includeWorktree: codingActionProfile.includeWorktree === true,
+							},
+						}
+					: {}),
 				rootMessage: {
 					id: String(args.message.id ?? args.responseId),
 					text: getUserMessageText(args.message) ?? "",
@@ -9224,14 +9286,14 @@ export async function runV5MessageRuntimeStage1(args: {
 			};
 		}
 		// A focused coding turn receives every action whose ordinary execution gates
-		// pass for the coding contexts. Relevance or a fixed name list may order or
-		// describe the tools, but cannot hide a newly registered authorized action.
+		// pass for the coding contexts unless its trusted host selected an explicit
+		// per-turn profile. Generic coding mode keeps the complete authorized surface.
 		const useFullSurface = args.codingMode === true;
-		const plannerCandidateActions = useFullSurface
+		const authorizedCodingActions = useFullSurface
 			? (args.runtime.actions ?? []).filter((action) =>
 					// The execution gates are the authority for a focused coding turn.
-					// Names may rank tools but cannot form a second fixed allowlist that
-					// silently hides newly registered coding capabilities.
+					// Absent an explicit profile, names cannot form a second fixed allowlist
+					// that silently hides newly registered coding capabilities.
 					canActionRun(action, {
 						activeContexts: CODING_SUB_AGENT_CONTEXTS,
 						userRoles: [senderRole],
@@ -9240,6 +9302,9 @@ export async function runV5MessageRuntimeStage1(args: {
 						skipPrivateGate: true,
 					}),
 				)
+			: undefined;
+		const plannerCandidateActions = authorizedCodingActions
+			? applyCodingActionProfile(authorizedCodingActions, codingActionProfile)
 			: await collectV5PlannerCandidateActions({
 					runtime: args.runtime,
 					message: args.message,
@@ -9393,6 +9458,7 @@ export async function runV5MessageRuntimeStage1(args: {
 		const actionSurface = buildV5PlannerActionSurface({
 			actions: plannerCandidateActions,
 			forceFullSurface: args.codingMode === true,
+			codingActionProfile,
 			message: args.message,
 			state: plannerState,
 			messageHandler,
@@ -12863,6 +12929,22 @@ export class DefaultMessageService implements IMessageService {
 		callback?: HandlerCallback,
 		options?: MessageProcessingOptions,
 	): Promise<MessageProcessingResult> {
+		// Validate trusted host policy before touching the message, runtime events,
+		// action hooks, or callbacks. A profile is meaningful only on the explicit
+		// direct coding path; accepting it elsewhere would make telemetry claim a
+		// restriction that ordinary routing never applied.
+		const codingActionProfile = parseCodingActionProfile(
+			options?.codingActionProfile,
+		);
+		if (codingActionProfile && options?.codingMode !== true) {
+			throw new ElizaError(
+				"Coding action profile requires codingMode to be enabled",
+				{
+					code: "CODING_ACTION_PROFILE_REQUIRES_CODING_MODE",
+					context: { kind: codingActionProfile.kind },
+				},
+			);
+		}
 		// Analysis-mode token detection runs BEFORE any planner work so the
 		// agent never hallucinates a "performing an analysis" reply. Gated by
 		// `ELIZA_ENABLE_ANALYSIS_MODE` / `NODE_ENV=development`. See
@@ -13191,6 +13273,7 @@ export class DefaultMessageService implements IMessageService {
 				const opts: ResolvedMessageOptions = {
 					maxRetries: options?.maxRetries ?? 3,
 					codingMode: options?.codingMode === true,
+					...(codingActionProfile ? { codingActionProfile } : {}),
 					continueAfterActions:
 						options?.continueAfterActions ??
 						parseBooleanFromText(
@@ -14216,6 +14299,9 @@ export class DefaultMessageService implements IMessageService {
 							state,
 							responseId,
 							codingMode: opts.codingMode,
+							...(opts.codingActionProfile
+								? { codingActionProfile: opts.codingActionProfile }
+								: {}),
 							...(callback ? { callback } : {}),
 							deliveredVisibleTexts,
 							...(opts.roomHandlerLease

--- a/packages/core/src/types/coding.ts
+++ b/packages/core/src/types/coding.ts
@@ -1,0 +1,18 @@
+/** Defines trusted per-turn coding action profiles without changing runtime plugin composition. */
+
+/**
+ * Restricts a coding turn to the native action families exposed by Pi.
+ * WORKTREE is opt-in because Pi's default tool surface has no worktree tool.
+ */
+export interface PiCodingActionProfile {
+	readonly kind: "pi";
+	readonly includeWorktree?: boolean;
+}
+
+/** Model-facing action policy selected by a trusted coding host for one turn. */
+export type CodingActionProfile = PiCodingActionProfile;
+
+/** Pi 0.84.2 default active tools mapped to Eliza: READ, SHELL, EDIT, and WRITE. */
+export const PI_CODING_ACTION_PROFILE: PiCodingActionProfile = Object.freeze({
+	kind: "pi",
+});

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -23,6 +23,7 @@ export * from "./channel-config";
 // Chat pre-handler contract (generic pre-action dispatch extension point);
 // the concrete registry lives in ../runtime/chat-pre-handler-registry.
 export * from "./chat-pre-handler";
+export * from "./coding";
 // Chat-command contract (CommandDefinition + CommandRegistryService); the
 // concrete registry lives in @elizaos/plugin-commands and re-exports these.
 export * from "./commands";

--- a/packages/core/src/types/message-service.ts
+++ b/packages/core/src/types/message-service.ts
@@ -6,6 +6,7 @@
 
 import type { InferenceTurnSummary } from "../inference-timing";
 import type { RoomHandlerLease } from "../runtime/room-handler-queue";
+import type { CodingActionProfile } from "./coding";
 import type {
 	ActionResult,
 	AgentContext,
@@ -33,6 +34,11 @@ export interface MessageProcessingOptions {
 	 * an authorization signal; normal role and action gates still apply.
 	 */
 	codingMode?: boolean;
+	/**
+	 * Optional trusted host policy for the model-facing action set of this coding
+	 * turn. Omission preserves the complete authorized coding surface.
+	 */
+	codingActionProfile?: CodingActionProfile;
 	shouldRespondModel?: ShouldRespondModelType;
 	onStreamChunk?: StreamChunkCallback;
 	/**

--- a/packages/examples/code/src/App.ts
+++ b/packages/examples/code/src/App.ts
@@ -20,6 +20,7 @@ import { osc52 } from "./lib/clipboard.js";
 import { getCwd, setCwd } from "./lib/cwd.js";
 import { FilteringTerminal } from "./lib/filtering-terminal.js";
 import { getCodeTaskService } from "./lib/get-code-task-service.js";
+import { sendInteractiveCodingTurn } from "./lib/interactive-coding-turn.js";
 import { useStore } from "./lib/store.js";
 import {
   actionNameFromPayload,
@@ -1222,11 +1223,10 @@ During a turn: Enter queues the message, Esc/Ctrl+C aborts (queued messages are 
       const agentClient = getAgentClient();
       const placeholder = state.addMessage(roomId, "assistant", "", undefined);
       placeholderId = placeholder.id;
-      const response = await agentClient.sendMessage({
+      const response = await sendInteractiveCodingTurn(agentClient, {
         room,
         text,
         identity: state.identity,
-        codingMode: true,
         abortSignal: turnAbortController.signal,
         onDelta: (delta) => {
           if (turnAbortController.signal.aborted) return;

--- a/packages/examples/code/src/acp-preamble.test.ts
+++ b/packages/examples/code/src/acp-preamble.test.ts
@@ -1,0 +1,14 @@
+/** Verifies ACP first-turn instructions name only tools available through the Pi profile. */
+
+import { expect, it } from "bun:test";
+import { buildAcpCodingPreamble } from "./acp-preamble.js";
+
+it("instructs the ACP agent to use the exact Pi-shaped coding surface", () => {
+  const text = buildAcpCodingPreamble("/workspace/project").join("\n");
+
+  for (const tool of ["READ", "WRITE", "EDIT", "SHELL"]) {
+    expect(text).toContain(tool);
+  }
+  expect(text).not.toMatch(/\bFILE\b/);
+  expect(text).toContain("/workspace/project/<filename>");
+});

--- a/packages/examples/code/src/acp-preamble.ts
+++ b/packages/examples/code/src/acp-preamble.ts
@@ -1,0 +1,14 @@
+/** Builds the ACP first-turn coding contract from the tools the Pi profile actually exposes. */
+
+/** Returns the non-interactive execution instructions injected before an ACP task. */
+export function buildAcpCodingPreamble(workspace?: string): string[] {
+  const preamble = [
+    'Execution contract: DO the work by calling tools. Use READ to inspect files, WRITE to create or intentionally replace complete files, EDIT for exact localized changes, and SHELL to run commands and verification. Do NOT reply with a description of what you are about to do; a turn that only says "I\'ll create..." or "Creating the app now" without an accompanying WRITE, EDIT, or SHELL tool call is a failure. For a multi-file or large build, perform each mutation with WRITE or EDIT, verify it, and only then report what you did. Never claim a file exists unless you wrote it this session.',
+  ];
+  if (workspace) {
+    preamble.push(
+      `Your workspace directory is: ${workspace}\nAll file paths MUST be absolute — create and edit files under this directory (e.g. ${workspace}/<filename>) and run shell commands from here.`,
+    );
+  }
+  return preamble;
+}

--- a/packages/examples/code/src/acp-tool-ledger.test.ts
+++ b/packages/examples/code/src/acp-tool-ledger.test.ts
@@ -1,11 +1,18 @@
 /**
  * The tool ledger bridge is tested on the runtime's ACTION_COMPLETED content
- * shape: SHELL runs and FILE writes become verifiable ACP tool calls, reads and
- * non-coding actions contribute nothing.
+ * shape: shell and direct or umbrella file mutations become verifiable ACP
+ * tool calls, while reads and non-coding actions contribute nothing.
  */
 
 import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
 import type { Content } from "@elizaos/core";
+import { setupEnv } from "@elizaos/plugin-coding-tools/actions/_test-helpers";
+import {
+  editAction,
+  writeAction,
+} from "@elizaos/plugin-coding-tools/actions/index";
 import { toolCallUpdateFromAction } from "./acp-tool-ledger.js";
 
 function completed(
@@ -79,6 +86,98 @@ describe("ACP tool ledger bridge", () => {
     expect(toolCallUpdateFromAction("s1", content, "c")?.update.status).toBe(
       "failed",
     );
+  });
+
+  it.each(["WRITE", "EDIT"])(
+    "turns %s success and failure into located edit receipts",
+    (action) => {
+      const path = `/ws/${action.toLowerCase()}.ts`;
+      for (const actionStatus of ["completed", "failed"] as const) {
+        const content = {
+          ...completed(action, `${action} result for ${path}`, { path }),
+          actionStatus,
+          actionResult: {
+            success: actionStatus === "completed",
+            text: `${action} result for ${path}`,
+            data: { path },
+          },
+        } as unknown as Content;
+
+        expect(
+          toolCallUpdateFromAction("s1", content, `${action}-${actionStatus}`),
+        ).toMatchObject({
+          update: {
+            title: `${action} ${path}`,
+            kind: "edit",
+            status: actionStatus,
+            rawInput: { path },
+            locations: [{ path }],
+            rawOutput: `${action} result for ${path}`,
+          },
+        });
+      }
+    },
+  );
+
+  it("preserves real failed WRITE and EDIT paths through completion receipts", async () => {
+    const env = await setupEnv("acp-ledger-failure");
+    try {
+      const file = path.join(env.tmpDir, "existing.ts");
+      await fs.writeFile(file, "const value = 1;\n", "utf8");
+      await env.fileState.recordRead("test-room", file);
+
+      const cases = [
+        {
+          action: writeAction,
+          name: "WRITE",
+          parameters: { file_path: file, content: "replacement" },
+        },
+        {
+          action: editAction,
+          name: "EDIT",
+          parameters: {
+            file_path: file,
+            old_string: "missing text",
+            new_string: "replacement",
+          },
+        },
+      ] as const;
+
+      for (const entry of cases) {
+        const result = await entry.action.handler(
+          env.runtime,
+          env.message,
+          undefined,
+          { parameters: entry.parameters },
+          undefined,
+          undefined,
+        );
+        if (!result) throw new Error(`${entry.name} returned no ActionResult`);
+        expect(result.success).toBe(false);
+        expect(result.data).toMatchObject({ path: file });
+
+        const completion = {
+          text: result.text,
+          actions: [entry.name],
+          actionStatus: "failed",
+          actionResult: result,
+        } as unknown as Content;
+        expect(
+          toolCallUpdateFromAction(
+            "s1",
+            completion,
+            `${entry.name}-actual-failure`,
+          ),
+        ).toMatchObject({
+          update: {
+            status: "failed",
+            locations: [{ path: file }],
+          },
+        });
+      }
+    } finally {
+      await env.cleanup();
+    }
   });
 
   it("ignores reads, listings, and non-coding actions", () => {

--- a/packages/examples/code/src/acp-tool-ledger.ts
+++ b/packages/examples/code/src/acp-tool-ledger.ts
@@ -2,7 +2,7 @@
  * Bridges the child runtime's completed coding actions onto ACP `tool_call`
  * updates. The orchestrator's write ledger, deterministic verifier, and
  * deliverable capture read only ACP tool events; this runtime executes
- * FILE/SHELL in-process, so without the bridge every tool call was invisible
+ * coding tools in-process, so without the bridge every tool call was invisible
  * to the parent and the verifier judged prose alone (live 2026-08-21: a script
  * that ran with exit 0 failed verification for "no execution logs", costing a
  * coaching lap on every build).
@@ -100,6 +100,23 @@ export function toolCallUpdateFromAction(
         kind,
         status,
         rawInput: { path, ...(operation ? { operation } : {}) },
+        locations: [{ path }],
+        ...(output ? { rawOutput: output } : {}),
+      },
+    };
+  }
+  if (name === "WRITE" || name === "EDIT") {
+    const path = str(data?.path);
+    if (!path) return undefined;
+    return {
+      sessionId,
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId,
+        title: `${name} ${path}`,
+        kind: "edit",
+        status,
+        rawInput: { path },
         locations: [{ path }],
         ...(output ? { rawOutput: output } : {}),
       },

--- a/packages/examples/code/src/acp.ts
+++ b/packages/examples/code/src/acp.ts
@@ -50,9 +50,10 @@ import {
   type AcpToolCallUpdate,
   toolCallUpdateFromAction,
 } from "./acp-tool-ledger.js";
+import { buildAcpCodingPreamble } from "./acp-preamble.js";
 import { AcpWarmSessionClaim } from "./acp-session-claim.js";
 import { initializeAgent } from "./lib/agent.js";
-import { getAgentClient } from "./lib/agent-client.js";
+import { getAgentClient, sendPiCodingTurn } from "./lib/agent-client.js";
 import {
   ensureSessionIdentity,
   getMainRoomElizaId,
@@ -120,7 +121,7 @@ async function ensureRuntime(cwd?: string): Promise<AgentRuntime> {
     process.env.POSTGRES_URL = "";
     runtimePromise = (async () => {
       // Resolve the session identity FIRST and mark its user as the runtime OWNER
-      // — the coding tools are role-gated (FILE=ADMIN, SHELL=OWNER), so without
+      // — the coding tools are role-gated (file actions=ADMIN, SHELL=OWNER), so without
       // this the sub-agent runs as GUEST and every tool is denied ("I don't have
       // permission… role (GUEST)"). A spawned coding sub-agent IS the operator in
       // its sandbox, so it gets full rights. Must be set before initializeAgent so
@@ -135,13 +136,13 @@ async function ensureRuntime(cwd?: string): Promise<AgentRuntime> {
       });
       // Mark the session user as OWNER via the RUNTIME SETTING the role resolver
       // actually reads (getConfiguredOwnerEntityIds → runtime.getSetting), not just
-      // process.env — otherwise the sender stays GUEST and FILE/SHELL are gated off.
+      // process.env — otherwise the sender stays GUEST and coding tools are gated off.
       const rt = runtime as unknown as {
         setSetting?: (k: string, v: unknown) => void;
       };
       rt.setSetting?.("ELIZA_ADMIN_ENTITY_ID", identity.userId);
       getAgentClient().setRuntime(runtime);
-      // Tool ledger: mirror each completed FILE/SHELL call onto the ACP stream
+      // Tool ledger: mirror each completed coding mutation or shell call onto ACP
       // so the orchestrator's write ledger and verifier see what actually ran
       // (see acp-tool-ledger.ts).
       runtime.registerEvent(
@@ -292,7 +293,7 @@ const _connection = new AgentSideConnection(
       // SessionCwdService otherwise defaults the conversation cwd to
       // process.cwd() — the monorepo — making `pwd`, relative-path resolution,
       // and the sandbox roots all point at the wrong directory. Set it
-      // explicitly to the build workspace so FILE/SHELL/LS operate there.
+      // explicitly to the build workspace so coding tools operate there.
       // conversationId == message.roomId == room.elizaRoomId (see agent-client).
       if (params.cwd) {
         const conversationId = String(room.elizaRoomId);
@@ -324,33 +325,9 @@ const _connection = new AgentSideConnection(
         const preamble: string[] = [];
         const manual = await readWorkspaceManual(session.cwd);
         if (manual) preamble.push(manual);
-        // Execution contract: weaker coding models (e.g. Cerebras glm-4.7) tend
-        // to NARRATE a plan ("I'll create the app...") and end the turn instead
-        // of emitting the FILE/SHELL action, especially on larger tasks — which
-        // leaves nothing on disk. Make the act-don't-describe requirement
-        // explicit so a build actually happens before the agent reports done.
-        preamble.push(
-          "Execution contract: DO the work by calling tools — use the FILE " +
-            "action to actually write/edit each file and the SHELL action to run " +
-            "commands. Do NOT reply with a description of what you are about to " +
-            'do; a turn that only says "I\'ll create..." or "Creating the app ' +
-            'now" without an accompanying FILE/SHELL tool call is a failure. For ' +
-            "a multi-file or large build, write the full content of each file " +
-            "with a FILE action first, then verify, and only then report what you " +
-            "did. Never claim a file exists unless you wrote it this session.",
-        );
-        if (session.cwd) {
-          // The coding tools (FILE/EDIT) require ABSOLUTE paths. Tell the agent
-          // its workspace root up front so it writes absolute paths directly
-          // instead of emitting a relative path, having it rejected, and
-          // round-tripping through `pwd` to rediscover the directory.
-          preamble.push(
-            `Your workspace directory is: ${session.cwd}\n` +
-              `All file paths MUST be absolute — create and edit files under ` +
-              `this directory (e.g. ${session.cwd}/<filename>) and run shell ` +
-              `commands from here.`,
-          );
-        }
+        // Make the act-don't-describe requirement explicit using only tools
+        // exposed by the selected Pi profile.
+        preamble.push(...buildAcpCodingPreamble(session.cwd));
         if (preamble.length > 0) {
           text = `${preamble.join("\n\n---\n\n")}\n\n---\n\nTask:\n${text}`;
           log("injected workspace preamble", {
@@ -381,12 +358,11 @@ const _connection = new AgentSideConnection(
       };
       try {
         const response = await activePrompts.run(promptContext, (abortSignal) =>
-          getAgentClient().sendMessage({
+          sendPiCodingTurn(getAgentClient(), {
             room,
             text,
             identity: sessionIdentity,
             source: "acp",
-            codingMode: true,
             abortSignal,
           }),
         );

--- a/packages/examples/code/src/cli-coding-profile.test.ts
+++ b/packages/examples/code/src/cli-coding-profile.test.ts
@@ -1,0 +1,39 @@
+/** Verifies the one-shot CLI selects the Pi action profile at the agent-client boundary. */
+
+import { expect, it } from "bun:test";
+import { sendCliCodingTurn } from "./cli.js";
+import type { SendMessageParams } from "./lib/agent-client.js";
+
+it("sends coding turns with the Pi profile", async () => {
+  let sentOptions: SendMessageParams | undefined;
+  const client = {
+    sendMessage: async (options: SendMessageParams) => {
+      sentOptions = options;
+      return "done";
+    },
+  };
+
+  await expect(
+    sendCliCodingTurn(client, {
+      room: {
+        id: "room",
+        name: "Room",
+        messages: [],
+        createdAt: new Date(),
+        taskIds: [],
+        elizaRoomId: "00000000-0000-0000-0000-000000000001",
+      },
+      text: "inspect the repository",
+      identity: {
+        projectId: "00000000-0000-0000-0000-000000000002",
+        userId: "00000000-0000-0000-0000-000000000003",
+        worldId: "00000000-0000-0000-0000-000000000004",
+        messageServerId: "00000000-0000-0000-0000-000000000005",
+      },
+    }),
+  ).resolves.toBe("done");
+  expect(sentOptions).toMatchObject({
+    codingMode: true,
+    codingActionProfile: { kind: "pi" },
+  });
+});

--- a/packages/examples/code/src/cli.ts
+++ b/packages/examples/code/src/cli.ts
@@ -17,7 +17,11 @@ import * as fs from "node:fs/promises";
 import * as readline from "node:readline";
 import { type AgentRuntime, ElizaError } from "@elizaos/core";
 import { v4 as uuidv4 } from "uuid";
-import { getAgentClient } from "./lib/agent-client.js";
+import {
+  getAgentClient,
+  type SendMessageParams,
+  sendPiCodingTurn,
+} from "./lib/agent-client.js";
 import { getCwd, setCwd } from "./lib/cwd.js";
 import { loadEnv } from "./lib/load-env.js";
 import { resolveModelProvider } from "./lib/model-provider.js";
@@ -54,6 +58,14 @@ interface CLIResult {
     completedAt: number;
     durationMs: number;
   };
+}
+
+/** Applies the CLI's trusted coding policy at its agent-client boundary. */
+function sendCliCodingTurn(
+  client: { sendMessage(params: SendMessageParams): Promise<string> },
+  params: Omit<SendMessageParams, "codingMode" | "codingActionProfile">,
+): Promise<string> {
+  return sendPiCodingTurn(client, params);
 }
 
 // ============================================================================
@@ -353,11 +365,10 @@ async function runCLI(options: CLIOptions): Promise<CLIResult> {
     let didPrintStreaming = false;
 
     // Send message and get response
-    const response = await agentClient.sendMessage({
+    const response = await sendCliCodingTurn(agentClient, {
       room,
       text: message,
       identity: session.identity,
-      codingMode: true,
       onDelta: shouldStream
         ? (delta) => {
             // Write deltas directly for real-time streaming.
@@ -507,4 +518,5 @@ export {
   getMessage,
   parseArgs,
   runCLI,
+  sendCliCodingTurn,
 };

--- a/packages/examples/code/src/lib/agent-client.streaming.test.ts
+++ b/packages/examples/code/src/lib/agent-client.streaming.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it } from "bun:test";
 */
 import {
   ChannelType,
+  type CodingActionProfile,
   type Content,
   ElizaError,
   FAILED_TOOL_FALLBACK_MESSAGE,
@@ -30,6 +31,7 @@ const { beforeEach, describe, expect, it } = runnerApi as unknown as TestApi;
 
 interface HandleMessageOptions {
   codingMode?: boolean;
+  codingActionProfile?: CodingActionProfile;
   abortSignal?: AbortSignal;
   onStreamChunk?: StreamChunkCallback;
 }
@@ -102,6 +104,7 @@ describe("AgentClient streaming", () => {
       text: "say hello",
       identity: makeIdentity(),
       codingMode: true,
+      codingActionProfile: { kind: "pi" },
       abortSignal: abortController.signal,
       onDelta: (delta) => deltas.push(delta),
     });
@@ -109,6 +112,7 @@ describe("AgentClient streaming", () => {
     expect(response).toBe("hello");
     expect(deltas).toEqual(["hel", "lo"]);
     expect(seenOptions?.codingMode).toBe(true);
+    expect(seenOptions?.codingActionProfile).toEqual({ kind: "pi" });
     expect(seenOptions?.abortSignal).toBe(abortController.signal);
     expect(typeof seenOptions?.onStreamChunk).toBe("function");
   });

--- a/packages/examples/code/src/lib/agent-client.ts
+++ b/packages/examples/code/src/lib/agent-client.ts
@@ -1,12 +1,14 @@
 // Provides shared support logic for the Code example.
 import {
   ChannelType,
+  type CodingActionProfile,
   type Content,
   createMessageMemory,
   ElizaError,
   FAILED_TOOL_FALLBACK_MESSAGE,
   type IAgentRuntime,
   type Memory,
+  PI_CODING_ACTION_PROFILE,
   type StreamChunkCallback,
   type UUID,
 } from "@elizaos/core";
@@ -21,12 +23,14 @@ const STREAM_EVENT_TYPES = new Set([
   "context_event",
 ]);
 
-interface SendMessageParams {
+export interface SendMessageParams {
   room: ChatRoom;
   text: string;
   identity: SessionIdentity;
   /** Enter the runtime's trusted direct coding loop for this turn. */
   codingMode?: boolean;
+  /** Optional trusted model-facing action profile for this coding turn. */
+  codingActionProfile?: CodingActionProfile;
   userName?: string;
   source?: string;
   channelType?: ChannelType;
@@ -37,6 +41,27 @@ interface SendMessageParams {
   onDelta?: (delta: string) => void;
   /** Optional caller-controlled cancellation signal for in-flight turns. */
   abortSignal?: AbortSignal;
+}
+
+export type PiCodingTurnParams = Omit<
+  SendMessageParams,
+  "codingMode" | "codingActionProfile"
+>;
+
+export interface AgentClientSendBoundary {
+  sendMessage(params: SendMessageParams): Promise<string>;
+}
+
+/** Applies the example host's shared Pi policy to any coding turn boundary. */
+export function sendPiCodingTurn(
+  client: AgentClientSendBoundary,
+  params: PiCodingTurnParams,
+): Promise<string> {
+  return client.sendMessage({
+    ...params,
+    codingMode: true,
+    codingActionProfile: PI_CODING_ACTION_PROFILE,
+  });
 }
 
 function hasStreamingEventType(value: unknown): value is { type: string } {
@@ -170,9 +195,15 @@ class AgentClient {
     }
 
     const options =
-      params.codingMode || params.abortSignal || onDelta
+      params.codingMode ||
+      params.codingActionProfile ||
+      params.abortSignal ||
+      onDelta
         ? {
             ...(params.codingMode ? { codingMode: true } : {}),
+            ...(params.codingActionProfile
+              ? { codingActionProfile: params.codingActionProfile }
+              : {}),
             ...(params.abortSignal ? { abortSignal: params.abortSignal } : {}),
             ...(onDelta ? { onStreamChunk: handleStreamChunk } : {}),
           }

--- a/packages/examples/code/src/lib/interactive-coding-turn.test.ts
+++ b/packages/examples/code/src/lib/interactive-coding-turn.test.ts
@@ -1,0 +1,38 @@
+/** Verifies the interactive TUI send boundary applies the shared Pi coding policy. */
+
+import { expect, it } from "bun:test";
+import type { SendMessageParams } from "./agent-client.js";
+import { sendInteractiveCodingTurn } from "./interactive-coding-turn.js";
+
+it("sends interactive turns with the Pi profile", async () => {
+  let sentOptions: SendMessageParams | undefined;
+  const client = {
+    sendMessage: async (options: SendMessageParams) => {
+      sentOptions = options;
+      return "done";
+    },
+  };
+
+  await sendInteractiveCodingTurn(client, {
+    room: {
+      id: "room",
+      name: "Room",
+      messages: [],
+      createdAt: new Date(),
+      taskIds: [],
+      elizaRoomId: "00000000-0000-0000-0000-000000000001",
+    },
+    text: "inspect the repository",
+    identity: {
+      projectId: "00000000-0000-0000-0000-000000000002",
+      userId: "00000000-0000-0000-0000-000000000003",
+      worldId: "00000000-0000-0000-0000-000000000004",
+      messageServerId: "00000000-0000-0000-0000-000000000005",
+    },
+  });
+
+  expect(sentOptions).toMatchObject({
+    codingMode: true,
+    codingActionProfile: { kind: "pi" },
+  });
+});

--- a/packages/examples/code/src/lib/interactive-coding-turn.ts
+++ b/packages/examples/code/src/lib/interactive-coding-turn.ts
@@ -1,0 +1,15 @@
+/** Applies the shared Pi coding policy at the interactive TUI send boundary. */
+
+import {
+  type AgentClientSendBoundary,
+  type PiCodingTurnParams,
+  sendPiCodingTurn,
+} from "./agent-client.js";
+
+/** Sends one interactive App turn through the same profile as CLI and ACP. */
+export function sendInteractiveCodingTurn(
+  client: AgentClientSendBoundary,
+  params: PiCodingTurnParams,
+): Promise<string> {
+  return sendPiCodingTurn(client, params);
+}

--- a/plugins/plugin-coding-tools/src/actions/edit.ts
+++ b/plugins/plugin-coding-tools/src/actions/edit.ts
@@ -108,13 +108,10 @@ export async function editFileHandler(
   const sandbox = runtime.getService(SANDBOX_SERVICE) as InstanceType<
     typeof SandboxService
   > | null;
-  const fileState = runtime.getService(FILE_STATE_SERVICE) as InstanceType<
-    typeof FileStateService
-  > | null;
-  if (!sandbox || !fileState) {
+  if (!sandbox) {
     return failureToActionResult({
       reason: "internal",
-      message: "coding-tools services unavailable",
+      message: "coding-tools sandbox service unavailable",
     });
   }
 
@@ -126,12 +123,24 @@ export async function editFileHandler(
   }
 
   const resolved = validated.resolved;
+  const failAtPath = (
+    failure: Parameters<typeof failureToActionResult>[0],
+  ): ActionResult => failureToActionResult(failure, { path: resolved });
+  const fileState = runtime.getService(FILE_STATE_SERVICE) as InstanceType<
+    typeof FileStateService
+  > | null;
+  if (!fileState) {
+    return failAtPath({
+      reason: "internal",
+      message: "coding-tools file-state service unavailable",
+    });
+  }
 
   const gate = await fileState.assertWritable(conversationId, resolved);
   if (gate.ok === false) {
     const reason =
       gate.reason === "stale_read" ? "stale_read" : "invalid_param";
-    return failureToActionResult({ reason, message: gate.message });
+    return failAtPath({ reason, message: gate.message });
   }
 
   let original: string;
@@ -141,7 +150,7 @@ export async function editFileHandler(
     // error-policy:J1 action boundary; a read failure becomes a success:false
     // ActionResult carrying the real message, surfaced to the model.
     const msg = err instanceof Error ? err.message : String(err);
-    return failureToActionResult({
+    return failAtPath({
       reason: "io_error",
       message: `read failed: ${msg}`,
     });
@@ -149,13 +158,13 @@ export async function editFileHandler(
 
   const occurrences = countOccurrences(original, oldStr);
   if (occurrences === 0) {
-    return failureToActionResult({
+    return failAtPath({
       reason: "no_match",
       message: `old_string not found in ${resolved}`,
     });
   }
   if (!replaceAll && occurrences > 1) {
-    return failureToActionResult({
+    return failAtPath({
       reason: "invalid_param",
       message: `ambiguous: ${occurrences} matches; pass replace_all=true or extend old_string`,
     });
@@ -174,7 +183,7 @@ export async function editFileHandler(
   const secrets = detectSecrets(newStr);
   if (secrets.length > 0) {
     const names = secrets.map((s) => s.name).join(", ");
-    return failureToActionResult({
+    return failAtPath({
       reason: "invalid_param",
       message: `refusing to introduce content matching secret patterns: ${names}`,
     });
@@ -186,7 +195,7 @@ export async function editFileHandler(
     // error-policy:J1 action boundary; a write failure becomes a success:false
     // ActionResult carrying the real message, surfaced to the model.
     const msg = err instanceof Error ? err.message : String(err);
-    return failureToActionResult({
+    return failAtPath({
       reason: "io_error",
       message: `write failed: ${msg}`,
     });

--- a/plugins/plugin-coding-tools/src/actions/write.ts
+++ b/plugins/plugin-coding-tools/src/actions/write.ts
@@ -105,13 +105,10 @@ export async function writeFileHandler(
   const sandbox = runtime.getService(SANDBOX_SERVICE) as InstanceType<
     typeof SandboxService
   > | null;
-  const fileState = runtime.getService(FILE_STATE_SERVICE) as InstanceType<
-    typeof FileStateService
-  > | null;
-  if (!sandbox || !fileState) {
+  if (!sandbox) {
     return failureToActionResult({
       reason: "internal",
-      message: "coding-tools services unavailable",
+      message: "coding-tools sandbox service unavailable",
     });
   }
 
@@ -123,15 +120,27 @@ export async function writeFileHandler(
   }
 
   const resolved = validated.resolved;
+  const failAtPath = (
+    failure: Parameters<typeof failureToActionResult>[0],
+  ): ActionResult => failureToActionResult(failure, { path: resolved });
+  const fileState = runtime.getService(FILE_STATE_SERVICE) as InstanceType<
+    typeof FileStateService
+  > | null;
+  if (!fileState) {
+    return failAtPath({
+      reason: "internal",
+      message: "coding-tools file-state service unavailable",
+    });
+  }
 
   const gate = await fileState.assertWritable(conversationId, resolved);
   if (gate.ok === false) {
     const reason =
       gate.reason === "stale_read" ? "stale_read" : "invalid_param";
-    return failureToActionResult({ reason, message: gate.message });
+    return failAtPath({ reason, message: gate.message });
   }
   if (gate.exists && readBoolParam(options, "overwrite") !== true) {
-    return failureToActionResult({
+    return failAtPath({
       reason: "invalid_param",
       message:
         "WRITE would replace the entire existing file. Use EDIT for a localized change, or set overwrite=true only after reading the complete file and intentionally supplying its complete replacement.",
@@ -141,7 +150,7 @@ export async function writeFileHandler(
   const secrets = detectSecrets(content);
   if (secrets.length > 0) {
     const names = secrets.map((s) => s.name).join(", ");
-    return failureToActionResult({
+    return failAtPath({
       reason: "invalid_param",
       message: `refusing to write content containing detected secret patterns: ${names}`,
     });
@@ -153,7 +162,7 @@ export async function writeFileHandler(
     content,
   });
   if (routed.ok === false && routed.reason === "failed") {
-    return failureToActionResult({
+    return failAtPath({
       reason: "io_error",
       message: `write failed: ${routed.message}`,
     });
@@ -167,7 +176,7 @@ export async function writeFileHandler(
       // error-policy:J1 action boundary; the direct-write failure becomes a
       // success:false ActionResult carrying the real message for the model.
       const msg = err instanceof Error ? err.message : String(err);
-      return failureToActionResult({
+      return failAtPath({
         reason: "io_error",
         message: `write failed: ${msg}`,
       });


### PR DESCRIPTION
Closes #28285

## Summary
- adds a typed, explicit Pi 0.84.2 coding profile exposing exactly READ, SHELL, EDIT, and WRITE, with WORKTREE opt-in
- applies the profile only after ordinary authorization while preserving generic codingMode full-surface compatibility and planner terminals
- rejects invalid or profile-only calls before events, hooks, callbacks, runtime access, or message mutation
- persists normalized profile identity in trajectory JSON and action-surface telemetry
- makes eliza-code CLI, ACP, and interactive TUI share one Pi turn-policy source
- emits located ACP receipts for real WRITE and EDIT successes and applicable post-validation failures

## Exact revision
Head: ffd421a8f487cd45d48240ccf9bd9c226be436cc
Parent develop: ade260957ce1c0c341d657d9baa149ff3901ae43

## Verification
- core focused profile/planner/trajectory contracts: 97 passed
- eliza-code affected boundary/ACP suite: 31 passed
- plugin-coding-tools WRITE/EDIT tests: 22 passed
- core, packages/examples/code, and plugin-coding-tools typechecks passed
- packages/examples/code lint:check passed across 89 files
- scoped Biome checks passed
- core Node build, plugin-coding-tools build, and eliza-code CLI/ACP build passed

## Behavioral evidence
- planner contract observes exact nonterminal tools EDIT, READ, SHELL, WRITE plus REPLY, IGNORE, STOP
- persisted JSON is read back with codingActionProfile kind pi and normalized includeWorktree
- actual filesystem WRITE overwrite refusal and EDIT no-match results retain canonical paths and become failed ACP tool receipts with locations
- CLI, ACP, and interactive TUI boundaries all delegate to the same shared Pi policy