### PR TITLE
test(plugin-notion): add unit test coverage for NotionService lifecycle and delegation

### DIFF
--- a/plugins/plugin-notion/src/__tests__/service.test.ts
+++ b/plugins/plugin-notion/src/__tests__/service.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Unit tests for NotionService lifecycle and client delegation.
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { NotionService } from "../service.js";
+import type { NotionCredentialResolver } from "../types.js";
+
+const resolver: NotionCredentialResolver = {
+  getCredential: async () => ({ accessToken: "secret_service_test_token" }),
+};
+
+interface RecordedRequest {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body: unknown;
+}
+
+function fakeNotion(
+  handler: (request: RecordedRequest) => {
+    status: number;
+    body: unknown;
+    headers?: Record<string, string>;
+  }
+): { fetchImpl: typeof fetch; requests: RecordedRequest[] } {
+  const requests: RecordedRequest[] = [];
+  const fetchImpl: typeof fetch = async (input, init) => {
+    const request: RecordedRequest = {
+      url: String(input),
+      method: init?.method ?? "GET",
+      headers: Object.fromEntries(
+        Object.entries((init?.headers as Record<string, string>) ?? {}).map(([k, v]) => [
+          k.toLowerCase(),
+          v,
+        ])
+      ),
+      body: typeof init?.body === "string" ? JSON.parse(init.body) : undefined,
+    };
+    requests.push(request);
+    const result = handler(request);
+    return new Response(JSON.stringify(result.body), {
+      status: result.status,
+      headers: { "Content-Type": "application/json", ...result.headers },
+    });
+  };
+  return { fetchImpl, requests };
+}
+
+function page(id: string, title: string): Record<string, unknown> {
+  return {
+    object: "page",
+    id,
+    created_time: "2026-08-01T00:00:00.000Z",
+    last_edited_time: "2026-08-02T00:00:00.000Z",
+    archived: false,
+    url: `https://www.notion.so/${title.replace(/\s/g, "-")}-${id.replace(/-/g, "")}`,
+    parent: { type: "workspace", workspace: true },
+    properties: {
+      Name: {
+        id: "title",
+        type: "title",
+        title: [{ type: "text", plain_text: title, text: { content: title } }],
+      },
+    },
+  };
+}
+
+describe("NotionService", () => {
+  it("initializes and reports capability description", () => {
+    const service = new NotionService(undefined, { credentialResolver: resolver });
+    expect(service.capabilityDescription).toContain("Notion workspace service");
+  });
+
+  it("starts and stops service lifecycle", async () => {
+    const runtime = {} as unknown as IAgentRuntime;
+    const service = await NotionService.start(runtime);
+    expect(service).toBeInstanceOf(NotionService);
+    await expect(service.stop()).resolves.toBeUndefined();
+  });
+
+  it("updates credential resolver via setCredentialResolver", async () => {
+    const { fetchImpl, requests } = fakeNotion(() => ({
+      status: 200,
+      body: { object: "list", results: [], has_more: false, next_cursor: null },
+    }));
+
+    const service = new NotionService(undefined, {
+      credentialResolver: resolver,
+      clientOptions: { baseUrl: "https://notion.test", fetchImpl },
+    });
+
+    const updatedResolver: NotionCredentialResolver = {
+      getCredential: async () => ({ accessToken: "updated_token_456" }),
+    };
+
+    service.setCredentialResolver(updatedResolver);
+
+    await service.search({ accountId: "default", query: "roadmap" });
+    expect(requests[0].headers.authorization).toBe("Bearer updated_token_456");
+  });
+
+  it("delegates search, getPage, getPageContent, createPage, and appendToPage to client", async () => {
+    const samplePage = page("page-123", "Project Plan");
+    const { fetchImpl } = fakeNotion((req) => {
+      if (req.method === "POST" && req.url.endsWith("/v1/search")) {
+        return {
+          status: 200,
+          body: { object: "list", results: [samplePage], has_more: false, next_cursor: null },
+        };
+      }
+      if (req.method === "GET" && req.url.includes("/v1/pages/page-123")) {
+        return {
+          status: 200,
+          body: samplePage,
+        };
+      }
+      if (req.method === "GET" && req.url.includes("/v1/blocks/page-123/children")) {
+        return {
+          status: 200,
+          body: {
+            object: "list",
+            results: [
+              {
+                object: "block",
+                type: "paragraph",
+                paragraph: {
+                  rich_text: [{ plain_text: "Line 1" }],
+                },
+              },
+            ],
+            has_more: false,
+            next_cursor: null,
+          },
+        };
+      }
+      if (req.method === "POST" && req.url.endsWith("/v1/pages")) {
+        return {
+          status: 200,
+          body: page("page-456", "New Page"),
+        };
+      }
+      if (req.method === "PATCH" && req.url.includes("/children")) {
+        return {
+          status: 200,
+          body: { object: "list", results: [] },
+        };
+      }
+      return { status: 404, body: {} };
+    });
+
+    const service = new NotionService(undefined, {
+      credentialResolver: resolver,
+      clientOptions: { baseUrl: "https://notion.test", fetchImpl },
+    });
+
+    const searchRes = await service.search({ accountId: "default", query: "Project" });
+    expect(searchRes.results).toHaveLength(1);
+    expect(searchRes.results[0].title).toBe("Project Plan");
+
+    const pageRes = await service.getPage({ accountId: "default", pageId: "page-123" });
+    expect(pageRes.id).toBe("page-123");
+    expect(pageRes.title).toBe("Project Plan");
+
+    const contentRes = await service.getPageContent({ accountId: "default", pageId: "page-123" });
+    expect(contentRes.plainText).toBe("Line 1");
+
+    const createRes = await service.createPage({
+      accountId: "default",
+      parentPageId: "page-123",
+      title: "New Page",
+      content: "Content",
+    });
+    expect(createRes.id).toBe("page-456");
+
+    await expect(
+      service.appendToPage({
+        accountId: "default",
+        pageId: "page-123",
+        content: "Appended",
+      })
+    ).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Relates to #28291

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Adds unit tests for `NotionService` covering lifecycle methods (`start`, `stop`, `setCredentialResolver`) and method delegations (`search`, `getPage`, `getPageContent`, `createPage`, `appendToPage`).

# Background

## What does this PR do?

Adds unit test suite `plugins/plugin-notion/src/__tests__/service.test.ts` verifying:
- Service initialization and capability description.
- Lifecycle methods `NotionService.start` and `stop`.
- Swapping credential resolver via `setCredentialResolver`.
- Delegation of `search`, `getPage`, `getPageContent`, `createPage`, and `appendToPage` methods to the underlying client.

## What kind of change is this?

Tests (adding missing tests)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

- `plugins/plugin-notion/src/__tests__/service.test.ts`: test cases covering `NotionService`.

## Detailed testing steps

Run:
```bash
bun run --cwd plugins/plugin-notion test src/__tests__/service.test.ts
bun run --cwd plugins/plugin-notion typecheck
bun run --cwd plugins/plugin-notion lint
```

# Evidence Gate

<!-- evidence-head:db31c51e1cef51189be9060d02f69def555dcb04 -->

- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - <reason>`.
  N/A - Notion service unit test.
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - <reason>`.
  N/A - Notion service unit test.
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - <reason>`.
  N/A - Notion service unit test.
- [x] Backend logs show the real code path firing end to end, or are marked `N/A - <reason>`.
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - <reason>`.
  N/A - Notion service unit test.
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - <reason>`.
  N/A - Notion service unit test.
- [ ] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - <reason>`.
  N/A - Notion service unit test.
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - <reason>` when the change has no rendered visual surface.
  N/A - No rendered visual surface.

# Evidence Details

## Backend + frontend logs

```text
$ vitest run src/__tests__/service.test.ts

 RUN  v4.1.10 /home/deepanshu/Projects/eliza/plugins/plugin-notion

 ✓ src/__tests__/service.test.ts (4 tests) 23ms
   ✓ NotionService (4)
     ✓ initializes and reports capability description 2ms
     ✓ starts and stops service lifecycle 4ms
     ✓ updates credential resolver via setCredentialResolver 8ms
     ✓ delegates search, getPage, getPageContent, createPage, and appendToPage to client 7ms

 Test Files  1 passed (1)
      Tests  4 passed (4)
```

## Known gaps / failures

None.

## Maintainer CI exception record

N/A - no exception requested