### PR TITLE
test(plugin-openai): cover tokenization encoding fallback for unknown models

### DIFF
--- a/plugins/plugin-openai/utils/tokenization.test.ts
+++ b/plugins/plugin-openai/utils/tokenization.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const tiktokenMock = vi.hoisted(() => ({
+  encodingForModel: vi.fn(),
+  getEncoding: vi.fn(),
+}));
+
+const configMock = vi.hoisted(() => ({
+  getLargeModel: vi.fn(),
+  getSmallModel: vi.fn(),
+}));
+
+const coreMock = vi.hoisted(() => ({
+  ModelType: { TEXT_SMALL: "TEXT_SMALL" },
+}));
+
+vi.mock("js-tiktoken", () => tiktokenMock);
+vi.mock("@elizaos/core", () => coreMock);
+vi.mock("./config", () => configMock);
+
+import { countTokens, detokenizeText, tokenizeText } from "./tokenization";
+
+function makeEncoder() {
+  return {
+    encode: vi.fn((text: string) => [...text].map((ch) => ch.charCodeAt(0))),
+    decode: vi.fn((tokens: number[]) => tokens.map((t) => String.fromCharCode(t)).join("")),
+  };
+}
+
+const runtime = { modelProvider: "openai" } as never;
+
+describe("openai tokenization", () => {
+  beforeEach(() => {
+    tiktokenMock.encodingForModel.mockReset();
+    tiktokenMock.getEncoding.mockReset();
+    configMock.getLargeModel.mockReset();
+    configMock.getSmallModel.mockReset();
+  });
+
+  it("tokenizes through the model's registered encoding", () => {
+    const encoder = makeEncoder();
+    tiktokenMock.encodingForModel.mockReturnValue(encoder);
+    configMock.getLargeModel.mockReturnValue("gpt-4o-mini");
+    const tokens = tokenizeText(runtime, "TEXT_LARGE" as never, "hi");
+    expect(tiktokenMock.encodingForModel).toHaveBeenCalledWith("gpt-4o-mini");
+    expect(encoder.encode).toHaveBeenCalledWith("hi");
+    expect(tokens).toEqual([104, 105]);
+  });
+
+  it("resolves the small-model slot for TEXT_SMALL requests", () => {
+    const encoder = makeEncoder();
+    tiktokenMock.encodingForModel.mockReturnValue(encoder);
+    configMock.getSmallModel.mockReturnValue("gpt-4.1-nano");
+    tokenizeText(runtime, "TEXT_SMALL" as never, "x");
+    expect(configMock.getSmallModel).toHaveBeenCalledWith(runtime);
+    expect(configMock.getLargeModel).not.toHaveBeenCalled();
+    expect(tiktokenMock.encodingForModel).toHaveBeenCalledWith("gpt-4.1-nano");
+  });
+
+  it("falls back to o200k_base for unknown 4o-family models instead of throwing", () => {
+    const encoder = makeEncoder();
+    tiktokenMock.encodingForModel.mockImplementation(() => {
+      throw new Error("Unknown model gpt-4o-custom");
+    });
+    tiktokenMock.getEncoding.mockReturnValue(encoder);
+    configMock.getLargeModel.mockReturnValue("gpt-4o-custom");
+    const tokens = tokenizeText(runtime, "TEXT_LARGE" as never, "hi");
+    expect(tiktokenMock.getEncoding).toHaveBeenCalledWith("o200k_base");
+    expect(tokens).toEqual([104, 105]);
+  });
+
+  it("falls back to cl100k_base for unknown non-4o models", () => {
+    const encoder = makeEncoder();
+    tiktokenMock.encodingForModel.mockImplementation(() => {
+      throw new Error("Unknown model claude-3-5-sonnet");
+    });
+    tiktokenMock.getEncoding.mockReturnValue(encoder);
+    configMock.getLargeModel.mockReturnValue("claude-3-5-sonnet");
+    tokenizeText(runtime, "TEXT_LARGE" as never, "hi");
+    expect(tiktokenMock.getEncoding).toHaveBeenCalledWith("cl100k_base");
+  });
+
+  it("detects the 4o family case-insensitively for the fallback choice", () => {
+    const encoder = makeEncoder();
+    tiktokenMock.encodingForModel.mockImplementation(() => {
+      throw new Error("Unknown model GPT-4O-MINI");
+    });
+    tiktokenMock.getEncoding.mockReturnValue(encoder);
+    configMock.getLargeModel.mockReturnValue("GPT-4O-MINI");
+    tokenizeText(runtime, "TEXT_LARGE" as never, "hi");
+    expect(tiktokenMock.getEncoding).toHaveBeenCalledWith("o200k_base");
+  });
+
+  it("counts tokens as the encoded array length", () => {
+    const encoder = makeEncoder();
+    tiktokenMock.encodingForModel.mockReturnValue(encoder);
+    configMock.getLargeModel.mockReturnValue("gpt-4o");
+    expect(countTokens(runtime, "TEXT_LARGE" as never, "hello")).toBe(5);
+  });
+
+  it("detokenizes through the resolved encoding's decoder", () => {
+    const encoder = makeEncoder();
+    tiktokenMock.encodingForModel.mockReturnValue(encoder);
+    configMock.getLargeModel.mockReturnValue("gpt-4o");
+    const out = detokenizeText(runtime, "TEXT_LARGE" as never, [104, 105]);
+    expect(encoder.decode).toHaveBeenCalledWith([104, 105]);
+    expect(out).toBe("hi");
+  });
+
+  it("never falls back for a model that is registered (encoders are cached per model)", () => {
+    const encoder = makeEncoder();
+    tiktokenMock.encodingForModel.mockReturnValue(encoder);
+    configMock.getLargeModel.mockReturnValue("gpt-4.1");
+    tokenizeText(runtime, "TEXT_LARGE" as never, "a");
+    expect(tiktokenMock.getEncoding).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new test file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `Test Files  1 passed (1)
      Tests  8 passed (8)` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
