### PR TITLE
test(plugin-vision): cover file bridge camera trust boundary and single-flight capture

### DIFF
--- a/plugins/plugin-vision/src/mobile/file-bridge-camera.test.ts
+++ b/plugins/plugin-vision/src/mobile/file-bridge-camera.test.ts
@@ -1,0 +1,232 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const fsMock = vi.hoisted(() => ({
+  promises: {
+    mkdir: vi.fn(async () => undefined),
+    rm: vi.fn(async () => undefined),
+    writeFile: vi.fn(async () => undefined),
+    readFile: vi.fn(),
+  },
+}));
+
+vi.mock("node:fs", () => ({
+  default: { promises: fsMock.promises },
+  promises: fsMock.promises,
+}));
+vi.mock("node:path", async () => {
+  const actual = await vi.importActual<typeof import("node:path")>("node:path");
+  return { default: actual, ...actual };
+});
+
+import { FileBridgeCameraSource } from "./file-bridge-camera";
+
+const ORIGINAL_ROOT = process.env.AGENT_ROOT;
+
+function bridgeReads(
+  overrides: {
+    ack?: () => Promise<string>;
+    error?: () => Promise<string>;
+    frame?: () => Promise<Buffer>;
+  } = {},
+) {
+  let requestId = "";
+  fsMock.promises.writeFile.mockImplementation((p: string, content: string) => {
+    if (String(p).endsWith("capture.req")) requestId = String(content);
+    return Promise.resolve();
+  });
+  fsMock.promises.readFile.mockImplementation((p: string) => {
+    const path = String(p);
+    if (path.endsWith("capture.ack")) {
+      if (overrides.ack) return overrides.ack();
+      return Promise.resolve(requestId);
+    }
+    if (path.endsWith("capture.err")) {
+      if (overrides.error) return overrides.error();
+      return Promise.reject(new Error("ENOENT"));
+    }
+    if (path.endsWith("capture.jpg")) {
+      if (overrides.frame) return overrides.frame();
+      return Promise.resolve(Buffer.from("jpeg-bytes"));
+    }
+    return Promise.reject(new Error("ENOENT"));
+  });
+  return () => requestId;
+}
+
+describe("file bridge camera", () => {
+  let dateNowSpy: ReturnType<typeof vi.spyOn> | undefined;
+
+  function fixedClock(): void {
+    dateNowSpy?.mockRestore();
+    dateNowSpy = vi.spyOn(Date, "now").mockReturnValue(1700000000000);
+  }
+
+  beforeEach(() => {
+    process.env.AGENT_ROOT = "/agent";
+    fsMock.promises.mkdir.mockClear();
+    fsMock.promises.rm.mockClear();
+    fsMock.promises.writeFile.mockClear();
+    fsMock.promises.readFile.mockReset();
+    vi.useRealTimers();
+  });
+
+  afterEach(() => {
+    dateNowSpy?.mockRestore();
+    dateNowSpy = undefined;
+    if (ORIGINAL_ROOT === undefined) delete process.env.AGENT_ROOT;
+    else process.env.AGENT_ROOT = ORIGINAL_ROOT;
+  });
+
+  describe("parseBridgeError", () => {
+    it("parses a well-formed error ack", async () => {
+      // via capture: error sidecar with matching shape must fail the capture
+      const source = new FileBridgeCameraSource();
+      const getRequestId = bridgeReads({
+        error: () =>
+          Promise.resolve(
+            JSON.stringify({
+              id: getRequestId(),
+              code: "NO_CAMERA",
+              message: "camera busy",
+            }),
+          ),
+        ack: () => Promise.reject(new Error("ENOENT")),
+      });
+      // id is `${Date.now()}-1` — force a fixed clock so we can name the request
+      fixedClock();
+      const err = await source.captureJpeg().catch((e: Error) => e);
+      expect(err.message).toBe(
+        `Camera bridge failed (NO_CAMERA) for request ${getRequestId()}: camera busy`,
+      );
+    });
+
+    it("ignores an error ack whose id does not match the in-flight request", async () => {
+      const source = new FileBridgeCameraSource();
+      bridgeReads({
+        error: () =>
+          Promise.resolve(
+            JSON.stringify({
+              id: "stale-9",
+              code: "NO_CAMERA",
+              message: "old",
+            }),
+          ),
+      });
+      const frame = await source.captureJpeg();
+      expect(frame.toString()).toBe("jpeg-bytes");
+    });
+
+    it("ignores a malformed error sidecar (untrusted WebView input) and still succeeds", async () => {
+      const source = new FileBridgeCameraSource();
+      bridgeReads({
+        error: () => Promise.resolve("{not json"),
+      });
+      const frame = await source.captureJpeg();
+      expect(frame.toString()).toBe("jpeg-bytes");
+    });
+
+    it("ignores an error sidecar with a non-string code", async () => {
+      const source = new FileBridgeCameraSource();
+      bridgeReads({
+        error: () =>
+          Promise.resolve(
+            JSON.stringify({ id: "x", code: 42, message: "nope" }),
+          ),
+      });
+      const frame = await source.captureJpeg();
+      expect(frame.toString()).toBe("jpeg-bytes");
+    });
+  });
+
+  describe("captureJpeg", () => {
+    it("returns the frame when the ack matches the in-flight request id", async () => {
+      const source = new FileBridgeCameraSource();
+      bridgeReads();
+      const frame = await source.captureJpeg();
+      expect(frame.toString()).toBe("jpeg-bytes");
+      // the request id is written before polling starts
+      expect(fsMock.promises.writeFile).toHaveBeenCalledWith(
+        "/agent/vision-bridge/capture.req",
+        expect.stringMatching(/^\d+-\d+$/),
+        "utf8",
+      );
+    });
+
+    it("ignores a stale ack from a previous request (single-flight by id)", async () => {
+      const source = new FileBridgeCameraSource();
+      let ackReads = 0;
+      const getRequestId = bridgeReads({
+        ack: () => {
+          // first read returns the previous request's ack, then the real one
+          ackReads += 1;
+          return Promise.resolve(ackReads === 1 ? "stale-7" : getRequestId());
+        },
+      });
+      const frame = await source.captureJpeg();
+      expect(frame.toString()).toBe("jpeg-bytes");
+      expect(ackReads).toBeGreaterThan(1);
+    });
+
+    it("fails fast on a matching error ack without waiting for the deadline", async () => {
+      const source = new FileBridgeCameraSource();
+      let errReads = 0;
+      const getRequestId = bridgeReads({
+        ack: () => Promise.reject(new Error("ENOENT")),
+        error: () => {
+          errReads += 1;
+          return Promise.resolve(
+            JSON.stringify({
+              id: getRequestId(),
+              code: "DENIED",
+              message: "permission",
+            }),
+          );
+        },
+      });
+      fixedClock();
+      const err = await source.captureJpeg().catch((e: Error) => e);
+      expect(err.message).toMatch(/Camera bridge failed \(DENIED\)/);
+      expect(errReads).toBe(1);
+    });
+
+    it("clears stale ack/error sidecars before issuing a new request", async () => {
+      const source = new FileBridgeCameraSource();
+      bridgeReads();
+      await source.captureJpeg();
+      expect(fsMock.promises.rm).toHaveBeenCalledWith(
+        "/agent/vision-bridge/capture.ack",
+        { force: true },
+      );
+      expect(fsMock.promises.rm).toHaveBeenCalledWith(
+        "/agent/vision-bridge/capture.err",
+        { force: true },
+      );
+    });
+
+    it("times out with a descriptive error when the responder never answers", async () => {
+      vi.useFakeTimers();
+      const source = new FileBridgeCameraSource();
+      bridgeReads({
+        ack: () => Promise.reject(new Error("ENOENT")),
+      });
+      const promise = source.captureJpeg();
+      const assertion = expect(promise).rejects.toThrow(
+        /Camera bridge timed out after 12000ms/,
+      );
+      await vi.advanceTimersByTimeAsync(13_000);
+      await assertion;
+    });
+
+    it("monotonic seq gives each capture a distinct request id", async () => {
+      fixedClock();
+      const source = new FileBridgeCameraSource();
+      bridgeReads();
+      await source.captureJpeg();
+      await source.captureJpeg();
+      const writes = fsMock.promises.writeFile.mock.calls
+        .filter((c) => String(c[0]).endsWith("capture.req"))
+        .map((c) => String(c[1]));
+      expect(writes).toEqual(["1700000000000-1", "1700000000000-2"]);
+    });
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new test file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `Test Files  1 passed (1)
      Tests  10 passed (10)` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
