### PR TITLE
test(plugin-sql): cover migration tracker schema and parameterized history

### DIFF
--- a/plugins/plugin-sql/src/runtime-migrator/storage/migration-tracker.test.ts
+++ b/plugins/plugin-sql/src/runtime-migrator/storage/migration-tracker.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../types", () => ({
+  getRow: (result: { rows: unknown[] }, index = 0) => result.rows[index],
+}));
+
+import { MigrationTracker } from "./migration-tracker";
+
+function sqlText(sqlLike: unknown): string {
+  const s = sqlLike as { strings: string[]; values: unknown[] };
+  let out = s.strings[0] ?? "";
+  for (let i = 0; i < (s.values?.length ?? 0); i += 1) {
+    out += `?${s.strings[i + 1] ?? ""}`;
+  }
+  return out;
+}
+
+describe("MigrationTracker", () => {
+  let db: { execute: ReturnType<typeof vi.fn> };
+  let tracker: MigrationTracker;
+
+  beforeEach(() => {
+    db = { execute: vi.fn(async () => ({ rows: [] })) };
+    tracker = new MigrationTracker(db as never);
+  });
+
+  it("creates the migrations schema on demand", async () => {
+    await tracker.ensureSchema();
+    expect(db.execute).toHaveBeenCalledTimes(1);
+    expect(sqlText(db.execute.mock.calls[0][0])).toContain(
+      "CREATE SCHEMA IF NOT EXISTS migrations"
+    );
+  });
+
+  it("creates all three bookkeeping tables with IF NOT EXISTS semantics", async () => {
+    await tracker.ensureTables();
+    expect(db.execute).toHaveBeenCalledTimes(4); // schema + 3 tables
+    const ddl = db.execute.mock.calls.map((c) => sqlText(c[0])).join("\n");
+    expect(ddl).toContain("migrations._migrations");
+    expect(ddl).toContain("migrations._journal");
+    expect(ddl).toContain("migrations._snapshots");
+    expect(ddl.match(/CREATE TABLE IF NOT EXISTS/g)).toHaveLength(3);
+  });
+
+  it("reads the newest migration row for a plugin", async () => {
+    db.execute.mockResolvedValue({
+      rows: [{ id: 7, hash: "abc123", created_at: "2026-01-01" }],
+    });
+    await expect(tracker.getLastMigration("plugin-a")).resolves.toEqual({
+      id: 7,
+      hash: "abc123",
+      created_at: "2026-01-01",
+    });
+    const q = sqlText(db.execute.mock.calls[0][0]);
+    expect(q).toContain("plugin_name = ?");
+    expect(q).toContain("ORDER BY created_at DESC");
+    expect(q).toContain("LIMIT 1");
+    expect(db.execute.mock.calls[0][0].values).toEqual(["plugin-a"]);
+  });
+
+  it("returns null when no migration has been recorded yet", async () => {
+    await expect(tracker.getLastMigration("plugin-a")).resolves.toBeNull();
+  });
+
+  it("records a migration with parameterized values (no string interpolation)", async () => {
+    await tracker.recordMigration("plugin-a", "deadbeef", 1700000000000);
+    expect(db.execute).toHaveBeenCalledTimes(1);
+    const call = db.execute.mock.calls[0][0];
+    expect(sqlText(call)).toContain(
+      "INSERT INTO migrations._migrations (plugin_name, hash, created_at)"
+    );
+    expect(call.values).toEqual(["plugin-a", "deadbeef", 1700000000000]);
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new test file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `Test Files  1 passed (1)
      Tests  5 passed (5)` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
