### PR TITLE
test(wallet): cover wallet backend selection gates and auto fallback

### DIFF
--- a/plugins/plugin-wallet/src/wallet/select-backend.test.ts
+++ b/plugins/plugin-wallet/src/wallet/select-backend.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { LocalEoaBackend } from "./local-eoa-backend.ts";
+import { resolveWalletBackend } from "./select-backend.ts";
+import { StewardBackend } from "./steward-backend.ts";
+
+function makeRuntime(settings = {}) {
+  return {
+    agentId: "agent-1",
+    getSetting: (key) => (key in settings ? settings[key] : null),
+  };
+}
+
+describe("resolveWalletBackend", () => {
+  let localSpy;
+  let stewardSpy;
+
+  beforeEach(() => {
+    localSpy = vi
+      .spyOn(LocalEoaBackend, "create")
+      .mockResolvedValue({ kind: "local" });
+    stewardSpy = vi
+      .spyOn(StewardBackend, "create")
+      .mockResolvedValue({ kind: "steward" });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  it("honors an explicit local mode", async () => {
+    const runtime = makeRuntime({ ELIZA_WALLET_BACKEND: "local" });
+    const backend = await resolveWalletBackend(runtime);
+    expect(backend.kind).toBe("local");
+    expect(localSpy).toHaveBeenCalledWith(runtime);
+    expect(stewardSpy).not.toHaveBeenCalled();
+  });
+
+  it("honors an explicit steward mode", async () => {
+    const runtime = makeRuntime({ ELIZA_WALLET_BACKEND: "steward" });
+    const backend = await resolveWalletBackend(runtime);
+    expect(backend.kind).toBe("steward");
+    expect(stewardSpy).toHaveBeenCalledWith(runtime);
+    expect(localSpy).not.toHaveBeenCalled();
+  });
+
+  it("falls back to auto (local) on an invalid mode value instead of failing open", async () => {
+    const runtime = makeRuntime({ ELIZA_WALLET_BACKEND: "magic-backend" });
+    const backend = await resolveWalletBackend(runtime);
+    expect(backend.kind).toBe("local");
+    expect(stewardSpy).not.toHaveBeenCalled();
+  });
+
+  it("auto prefers steward when ELIZA_WALLET_STEWARD_AUTO=1", async () => {
+    vi.stubEnv("ELIZA_WALLET_STEWARD_AUTO", "1");
+    const runtime = makeRuntime();
+    const backend = await resolveWalletBackend(runtime);
+    expect(backend.kind).toBe("steward");
+    expect(localSpy).not.toHaveBeenCalled();
+  });
+
+  it("auto prefers steward when cloud-provisioned", async () => {
+    vi.stubEnv("ELIZA_CLOUD_PROVISIONED", "1");
+    const runtime = makeRuntime();
+    const backend = await resolveWalletBackend(runtime);
+    expect(backend.kind).toBe("steward");
+  });
+
+  it("auto does NOT prefer steward when cloud-provisioned is 0", async () => {
+    vi.stubEnv("ELIZA_CLOUD_PROVISIONED", "0");
+    const runtime = makeRuntime();
+    const backend = await resolveWalletBackend(runtime);
+    expect(backend.kind).toBe("local");
+    expect(stewardSpy).not.toHaveBeenCalled();
+  });
+
+  it("auto defaults to local when no steward preference is signaled", async () => {
+    const runtime = makeRuntime();
+    const backend = await resolveWalletBackend(runtime);
+    expect(backend.kind).toBe("local");
+  });
+
+  it("runtime setting wins over process env", async () => {
+    vi.stubEnv("ELIZA_WALLET_BACKEND", "local");
+    const runtime = makeRuntime({ ELIZA_WALLET_BACKEND: "steward" });
+    const backend = await resolveWalletBackend(runtime);
+    expect(backend.kind).toBe("steward");
+  });
+
+  it("reads the mode from process env when the runtime setting is absent", async () => {
+    vi.stubEnv("ELIZA_WALLET_BACKEND", "steward");
+    const runtime = makeRuntime();
+    const backend = await resolveWalletBackend(runtime);
+    expect(backend.kind).toBe("steward");
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing decision-gate module. -->

# Summary

Adds focused unit coverage for `resolveWalletBackend`
(`plugins/plugin-wallet/src/wallet/select-backend.ts`), which decides which
signing backend (`local` / `steward` / `auto`) handles wallet operations.
The tests pin the decision gates:

- explicit `local` / `steward` modes are honored and the other backend is
  never constructed,
- an invalid mode value falls back to `auto` (fail-safe, never fails open),
- `auto` prefers Steward only when `ELIZA_WALLET_STEWARD_AUTO=1` or
  `ELIZA_CLOUD_PROVISIONED=1`; `0` does not count, and no signal means local,
- runtime settings take precedence over `process.env`,
- process env is used when the runtime setting is absent.

Backend selection routes which signer is trusted with wallet operations, so
a mis-routed selection (e.g. an invalid mode silently picking the wrong
signer) is a real behavioral risk — this pins the current contract.

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new test file exercising an existing exported
function with mocked backend factories and env. No production code is
modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: see log below |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
