### PR TITLE
fix(voice): bypass nested response stream stalls

### DIFF
--- a/packages/cloud/api/__tests__/shared-agent-messages-stream.test.ts
+++ b/packages/cloud/api/__tests__/shared-agent-messages-stream.test.ts
@@ -236,11 +236,24 @@ describe("shared agent messages/stream", () => {
 
   function voiceWorkerRuntime(sseText = "adapter ok") {
     const fetch = mock(
-      async (_input: RequestInfo | URL, _init?: RequestInit) =>
-        new Response(
-          `event: chunk\ndata: ${JSON.stringify({ chunk: sseText })}\n\nevent: done\ndata: {}\n\n`,
-          { headers: { "Content-Type": "text/event-stream" } },
-        ),
+      async (_input: RequestInfo | URL, init?: RequestInit) => {
+        const request = JSON.parse(String(init?.body)) as {
+          operation?: string;
+          rpc?: { id?: string };
+        };
+        if (request.operation === "prewarm") {
+          return Response.json({ success: true });
+        }
+        return Response.json({
+          jsonrpc: "2.0",
+          id: request.rpc?.id ?? "voice-buffered",
+          result: {
+            text: sseText,
+            messageId: "assistant-message",
+            userMessageId: "user-message",
+          },
+        });
+      },
     );
     const namespace = {
       getByName: mock(() => ({ fetch })),
@@ -367,7 +380,7 @@ describe("shared agent messages/stream", () => {
     });
   });
 
-  test("internal voice fetch adapter dispatches cached scope through the conversation Durable Object", async () => {
+  test("internal voice fetch adapter buffers cached scope through the conversation Durable Object", async () => {
     await seedVoiceScope();
     const runtime = voiceWorkerRuntime();
 
@@ -404,7 +417,7 @@ describe("shared agent messages/stream", () => {
       String(runtime.fetch.mock.calls[0]?.[1]?.body),
     ) as Record<string, unknown>;
     expect(operation).toMatchObject({
-      operation: "stream",
+      operation: "bridge",
       agent: cachedVoiceAgent(),
       rpc: {
         method: "message.send",
@@ -447,16 +460,26 @@ describe("shared agent messages/stream", () => {
     expect(hasCloudBindingsContext()).toBe(false);
     expect(hasDbCacheContext()).toBe(false);
 
-    runtime.fetch.mockImplementation(async () => {
+    runtime.fetch.mockImplementation(async (_input, init) => {
       expect(hasCloudBindingsContext()).toBe(true);
       expect(hasDbCacheContext()).toBe(false);
       expect(getCloudAwareEnv().DATABASE_URL).toBe(env.DATABASE_URL);
-      return new Response(
-        'event: chunk\ndata: {"chunk":"late callback ok"}\n\nevent: done\ndata: {}\n\n',
-        {
-          headers: { "Content-Type": "text/event-stream" },
+      const request = JSON.parse(String(init?.body)) as {
+        operation?: string;
+        rpc?: { id?: string };
+      };
+      if (request.operation === "prewarm") {
+        return Response.json({ success: true });
+      }
+      return Response.json({
+        jsonrpc: "2.0",
+        id: request.rpc?.id ?? "voice-buffered",
+        result: {
+          text: "late callback ok",
+          messageId: "assistant-message",
+          userMessageId: "user-message",
         },
-      );
+      });
     });
 
     const fetchImpl = createLateFetch({
@@ -483,7 +506,7 @@ describe("shared agent messages/stream", () => {
     ) as Array<{ operation: string }>;
     expect(operations.map(({ operation }) => operation)).toEqual([
       "prewarm",
-      "stream",
+      "bridge",
     ]);
   });
 
@@ -554,7 +577,7 @@ describe("shared agent messages/stream", () => {
     ) as Array<{ operation: string }>;
     expect(operations.map(({ operation }) => operation)).toEqual([
       "prewarm",
-      "stream",
+      "bridge",
     ]);
     expect(bridgeStream).not.toHaveBeenCalled();
   });

--- a/packages/cloud/api/v1/voice/session/lib/internal-eliza-conversation-fetch.ts
+++ b/packages/cloud/api/v1/voice/session/lib/internal-eliza-conversation-fetch.ts
@@ -353,6 +353,7 @@ async function dispatchInternalElizaConversationFetch(
     },
     body,
     origin: headers.get("origin"),
+    responseMode: "buffered",
     namespace: runtime.namespace,
     executionCtx: runtime.executionCtx,
   });

--- a/packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.test.ts
@@ -16,9 +16,19 @@ const coordinateSharedStream = mock(
       headers: { "Content-Type": "text/event-stream; charset=utf-8" },
     }),
 );
+const coordinateSharedBridge = mock(async () => ({
+  jsonrpc: "2.0" as const,
+  id: "voice-buffered",
+  result: {
+    text: "complete buffered reply",
+    messageId: "assistant-message",
+    userMessageId: "user-message",
+  },
+}));
 
 mock.module("./conversation-coordinator", () => ({
   ...coordinatorActual,
+  coordinateSharedBridge,
   coordinateSharedStream,
 }));
 
@@ -57,6 +67,16 @@ const BASE = {
 
 describe("handleCanonicalScopedAgentStream", () => {
   beforeEach(() => {
+    coordinateSharedBridge.mockReset();
+    coordinateSharedBridge.mockResolvedValue({
+      jsonrpc: "2.0",
+      id: "voice-buffered",
+      result: {
+        text: "complete buffered reply",
+        messageId: "assistant-message",
+        userMessageId: "user-message",
+      },
+    });
     coordinateSharedStream.mockReset();
     coordinateSharedStream.mockResolvedValue(
       new Response("event: done\ndata: {}\n\n", {
@@ -97,6 +117,35 @@ describe("handleCanonicalScopedAgentStream", () => {
     ];
     expect(rpc.params).not.toHaveProperty("channel");
     expect(options.channel).toEqual(channel);
+  });
+
+  test("buffers a voice coordinator turn before exposing its complete reply as SSE", async () => {
+    const channel = {
+      type: ChannelType.VOICE_DM,
+      source: MESSAGE_SOURCE_CLIENT_CHAT,
+    };
+    const response = await handleCanonicalScopedAgentStream({
+      ...BASE,
+      channel,
+      responseMode: "buffered",
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("text/event-stream");
+    const body = await response.text();
+    expect(body).toContain("event: chunk");
+    expect(body).toContain('"chunk":"complete buffered reply"');
+    expect(body).toContain("event: done");
+    expect(coordinateSharedBridge).toHaveBeenCalledTimes(1);
+    expect(coordinateSharedStream).not.toHaveBeenCalled();
+    const [, rpc, options] = coordinateSharedBridge.mock.calls[0] as unknown as [
+      unknown,
+      { params: Record<string, unknown> },
+      Record<string, unknown>,
+    ];
+    expect(rpc.params).not.toHaveProperty("responseMode");
+    expect(options.channel).toEqual(channel);
+    expect(options.abortSignal).toBe(ABORT_SIGNAL);
   });
 
   test("preserves coordinator phase timings beside route timings", async () => {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.ts
@@ -10,9 +10,13 @@ import type { RuntimeDurableObjectNamespace } from "../../../types/cloud-worker-
 import { InsufficientCreditsError, RateLimitError } from "../../api/errors";
 import { logger } from "../../utils/logger";
 import { chatSseFrame } from "../chat-sse-frames";
-import type { BridgeRequest } from "../eliza-sandbox-bridge";
+import type { BridgeRequest, BridgeResponse } from "../eliza-sandbox-bridge";
 import { applyCorsHeaders } from "../proxy/cors";
-import { coordinateSharedStream } from "./conversation-coordinator";
+import {
+  coordinateSharedBridge,
+  coordinateSharedStream,
+  type SharedConversationCoordinatorOptions,
+} from "./conversation-coordinator";
 import type { SharedRuntimeChannel } from "./run-shared-agent-turn";
 import type { SharedRuntimeAgent } from "./shared-runtime-agent";
 import type { BridgeExecutionContext } from "./shared-runtime-chat";
@@ -54,6 +58,64 @@ export interface CanonicalScopedStreamRequest {
   body: unknown;
   origin?: string | null;
   timings?: Record<string, number>;
+  /**
+   * Realtime phone sessions buffer the fast model turn inside the coordinator,
+   * then expose the complete result as SSE. This avoids making the phone's
+   * response path depend on a second, nested Durable Object response stream.
+   */
+  responseMode?: "stream" | "buffered";
+}
+
+function bufferedBridgeSse(response: BridgeResponse): Response {
+  if (response.error) {
+    return new Response(
+      chatSseFrame("error", {
+        message: response.error.message || "Shared runtime turn failed",
+      }),
+      { headers: STREAM_HEADERS },
+    );
+  }
+  const result = (response.result ?? {}) as {
+    text?: unknown;
+    responded?: unknown;
+    messageId?: unknown;
+    userMessageId?: unknown;
+    actionResults?: unknown;
+    timing?: unknown;
+  };
+  const text = typeof result.text === "string" ? result.text : "";
+  const responded = result.responded !== false;
+  if (!text && responded) {
+    return new Response(
+      chatSseFrame("error", {
+        message: "Shared runtime produced no response",
+      }),
+      { headers: STREAM_HEADERS },
+    );
+  }
+  const messageId = typeof result.messageId === "string" ? result.messageId : crypto.randomUUID();
+  const userMessageId =
+    typeof result.userMessageId === "string" ? result.userMessageId : crypto.randomUUID();
+  const done = {
+    messageId,
+    userMessageId,
+    text,
+    fullText: text,
+    ...(responded ? {} : { responded: false }),
+    ...(Array.isArray(result.actionResults) ? { actionResults: result.actionResults } : {}),
+    ...(result.timing && typeof result.timing === "object" ? { timing: result.timing } : {}),
+  };
+  const body = text
+    ? chatSseFrame("chunk", {
+        messageId,
+        userMessageId,
+        chunk: text,
+        text,
+        fullText: text,
+        timestamp: Date.now(),
+      }) + chatSseFrame("done", done)
+    : chatSseFrame("done", done);
+  return new Response(body, { headers: STREAM_HEADERS });
 }
 
 function nowMs(): number {
@@ -150,7 +212,7 @@ export async function handleCanonicalScopedAgentStream(
   let upstream: Response;
   const bridgeStartedAt = nowMs();
   try {
-    upstream = await coordinateSharedStream(request.agent, rpc, {
+    const coordinatorOptions: SharedConversationCoordinatorOptions = {
       abortSignal: request.abortSignal,
       namespace: request.namespace,
       executionCtx: request.executionCtx,
@@ -164,7 +226,11 @@ export async function handleCanonicalScopedAgentStream(
       traceId: request.traceId,
       trustedHistoryCutoffAt,
       transientInput,
-    });
+    };
+    upstream =
+      request.responseMode === "buffered"
+        ? bufferedBridgeSse(await coordinateSharedBridge(request.agent, rpc, coordinatorOptions))
+        : await coordinateSharedStream(request.agent, rpc, coordinatorOptions);
     timings.bridge = elapsedMs(bridgeStartedAt);
   } catch (error) {
     timings.bridge = elapsedMs(bridgeStartedAt);

--- a/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.ts
@@ -317,6 +317,7 @@ export async function coordinateSharedBridge(
           : {}),
         ...(options.channel ? { channel: options.channel } : {}),
       }),
+      ...(options.abortSignal ? { signal: options.abortSignal } : {}),
     },
   );
   await requireCoordinatorResponse(response, "conversation");


### PR DESCRIPTION
Closes #28220

## What changed
- route authenticated realtime phone turns through the conversation coordinator buffered bridge
- convert the complete, untruncated bridge result back to the existing SSE contract for the voice adapter
- preserve public web/chat streaming unchanged
- propagate caller cancellation to buffered coordinator fetches

## Why
Recorded production acceptance showed Twilio media remained connected while nested Durable Object response streams stalled for 120 seconds. Deterministic production traces showed the underlying model turns completed successfully in 400–761 ms. This removes the nested streamed-body dependency only for authenticated phone turns.

## Verification
- canonical scoped stream tests: 12/12
- coordinator tests: 15/15
- internal voice/public stream tests: 31/31
- cloud/shared typecheck
- cloud/api typecheck + production Worker dry-run
- Biome exact-file check

No provider routing changes.