### PR TITLE
fix: require grounded media action for Personal Shared requests

### DIFF
--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.error-policy.test.ts
@@ -139,6 +139,105 @@ describe("Shared turn AgentRuntime boundary", () => {
     expect(result.reply).toBe("runtime reply");
   });
 
+  test("requires a grounded media action result instead of accepting a model-invented tool failure", async () => {
+    const mediaInput = {
+      character: { name: "Eliza", system: "You are Eliza." },
+      history: [
+        {
+          role: "assistant" as const,
+          content: "The image tool had a billing problem earlier.",
+        },
+      ],
+      message: "Generate an image of a golden retriever puppy",
+      execution: {
+        agentKey: "personal:user-1",
+        authenticatedPersonalSharedUser: true as const,
+        channel: { type: ChannelType.GROUP, source: "blooio" },
+        media: {
+          canGenerateMedia: async () => true,
+          generateMedia: async () => ({ mediaType: "image" as const }),
+        },
+      },
+    };
+
+    const error = await runSharedAgentTurn(mediaInput).catch((caught) => caught as Error);
+    expect(error.message).toContain("AgentRuntime turn failed");
+    expect((error.cause as Error).message).toContain(
+      "executable GENERATE_MEDIA request without an action result",
+    );
+    expect(JSON.stringify(runtimeInputs[0])).toContain(
+      "Call GENERATE_MEDIA before any terminal answer",
+    );
+    expect(JSON.stringify(runtimeInputs[0])).toContain(
+      "generation was attempted, unavailable, or failed is not an execution result",
+    );
+
+    runtimeActionResults = [
+      {
+        success: false,
+        error: "provider rejected request",
+        data: { actionName: "GENERATE_MEDIA", mediaType: "image" },
+      },
+    ];
+    const groundedFailure = await runSharedAgentTurn(mediaInput);
+    expect(groundedFailure.actionResults).toEqual(runtimeActionResults);
+  });
+
+  test("buffers explicit media streams so the required action receipt cannot be bypassed", async () => {
+    runtimeActionResults = [
+      {
+        success: true,
+        data: { actionName: "GENERATE_MEDIA", mediaType: "video" },
+      },
+    ];
+    const result = await runSharedAgentTurnStream({
+      character: { name: "Eliza", system: "You are Eliza." },
+      history: [],
+      message: "Create a video from this attached image",
+      execution: {
+        agentKey: "personal:user-1",
+        authenticatedPersonalSharedUser: true,
+        channel: { type: ChannelType.GROUP, source: "blooio" },
+        media: {
+          canGenerateMedia: async () => true,
+          generateMedia: async () => ({ mediaType: "video" }),
+        },
+      },
+    });
+
+    expect(runtimeInputs).toHaveLength(1);
+    expect(streamInputs).toHaveLength(0);
+    const parts = [];
+    if (!result.parts) throw new Error("Expected buffered media parts");
+    for await (const part of result.parts) parts.push(part);
+    expect(parts.at(-1)).toMatchObject({
+      type: "finish",
+      actionResults: runtimeActionResults,
+    });
+  });
+
+  test("does not force generation for an image-description request", async () => {
+    const result = await runSharedAgentTurn({
+      character: { name: "Eliza", system: "You are Eliza." },
+      history: [],
+      message: "Can you describe the image I attached?",
+      execution: {
+        agentKey: "personal:user-1",
+        authenticatedPersonalSharedUser: true,
+        channel: { type: ChannelType.GROUP, source: "blooio" },
+        media: {
+          canGenerateMedia: async () => true,
+          generateMedia: async () => ({ mediaType: "image" }),
+        },
+      },
+    });
+
+    expect(result.reply).toBe("runtime reply");
+    expect(JSON.stringify(runtimeInputs[0])).not.toContain(
+      "Call GENERATE_MEDIA before any terminal answer",
+    );
+  });
+
   test("routes unsupported capabilities through the model with a truthful constraint", async () => {
     let dispatches = 0;
     const result = await runSharedAgentTurn({

--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
@@ -319,12 +319,14 @@ export function resolveSharedAgentTurnModel(preferred?: string): string | null {
  * from `@elizaos/core`'s prompt builder; the Shared runtime receives the
  * already-projected edge character, so this is the renderer on this side.
  */
+type RequiredSharedAction = "REMINDERS" | "TODO" | "GENERATE_MEDIA";
+
 function buildSharedRuntimeSystem(
   character: SharedAgentCharacter,
   capabilities: SharedCapabilityFlags,
   recallContext?: string,
   blockedCapabilities: SharedCapabilityWall[] = [],
-  requiredAction?: "REMINDERS" | "TODO",
+  requiredAction?: RequiredSharedAction,
   realtimeGrounding?: SharedRuntimePublicGrounding,
 ): string {
   const parts: string[] = [];
@@ -348,10 +350,20 @@ function buildSharedRuntimeSystem(
     );
   }
   if (requiredAction) {
+    const requestLabel =
+      requiredAction === "REMINDERS"
+        ? "reminder"
+        : requiredAction === "TODO"
+          ? "todo"
+          : "image or video generation";
+    const ungroundedClaim =
+      requiredAction === "GENERATE_MEDIA"
+        ? "A plain-text claim that generation was attempted, unavailable, or failed is not an execution result."
+        : 'A plain-text acknowledgement such as "done", "saved", or "scheduled" is not an execution result.';
     parts.push(
       "Current-turn execution requirement:\n" +
-        `- The user's current message is an executable ${requiredAction === "REMINDERS" ? "reminder" : "todo"} request, and ${requiredAction} is available for this verified account.\n` +
-        `- Call ${requiredAction} before any terminal answer. A plain-text acknowledgement such as "done", "saved", or "scheduled" is not an execution result.\n` +
+        `- The user's current message is an executable ${requestLabel} request, and ${requiredAction} is available for this verified account.\n` +
+        `- Call ${requiredAction} before any terminal answer. ${ungroundedClaim}\n` +
         `- If the request is incomplete or cannot be applied, call ${requiredAction} anyway and use its grounded clarification or failure result; never invent success.`,
     );
   }
@@ -362,16 +374,50 @@ function buildSharedRuntimeSystem(
 
 function requiredActionForResolution(
   resolution: SharedCapabilityResolution | null,
-): "REMINDERS" | "TODO" | undefined {
+): Exclude<RequiredSharedAction, "GENERATE_MEDIA"> | undefined {
   if (resolution?.kind !== "enabled-primary") return undefined;
   if (resolution.primary.capability === "reminders") return "REMINDERS";
   if (resolution.primary.capability === "todos") return "TODO";
   return undefined;
 }
 
+function isExplicitSharedMediaGenerationRequest(text: string): boolean {
+  const normalized = text.toLowerCase().replace(/\s+/gu, " ").trim();
+  if (!normalized) return false;
+  const mediaNoun =
+    "(?:image|picture|photo|art(?:work)?|illustration|logo|sticker|wallpaper|drawing|painting|meme|gif|video|animation|clip)";
+  return (
+    new RegExp(
+      `\\b(?:generate|make|draw|create|render|paint|produce|design|animate)\\b[^.!?]{0,160}\\b${mediaNoun}s?\\b`,
+      "iu",
+    ).test(normalized) ||
+    /\b(?:turn|convert|transform)\b[^.!?]{0,160}\b(?:image|picture|photo|attachment)\b[^.!?]{0,80}\b(?:into|to)\b[^.!?]{0,40}\b(?:video|animation|clip)\b/iu.test(
+      normalized,
+    )
+  );
+}
+
+function requiredActionForTurn(
+  input: RunSharedAgentTurnInput,
+  resolution: SharedCapabilityResolution | null,
+  actionsEnabled: boolean,
+): RequiredSharedAction | undefined {
+  const capabilityAction = requiredActionForResolution(resolution);
+  if (capabilityAction) return capabilityAction;
+  const intentText = input.capabilityText ?? input.message;
+  if (
+    actionsEnabled &&
+    input.execution?.media &&
+    isExplicitSharedMediaGenerationRequest(intentText)
+  ) {
+    return "GENERATE_MEDIA";
+  }
+  return undefined;
+}
+
 function hasRequiredActionResult(
   turn: RunSharedAgentTurnResult,
-  actionName: "REMINDERS" | "TODO",
+  actionName: RequiredSharedAction,
 ): boolean {
   return Boolean(turn.actionResults?.some((result) => result.data?.actionName === actionName));
 }
@@ -531,7 +577,7 @@ export async function runSharedAgentTurn(
     todos: todosEnabled,
   };
   const resolution = capabilityResolution(input, capabilities);
-  const requiredAction = requiredActionForResolution(resolution);
+  const requiredAction = requiredActionForTurn(input, resolution, actionsEnabled);
   const capabilityWall = resolution?.kind === "blocked-primary" ? resolution.blocked : undefined;
   const blockedSecondary =
     resolution?.kind === "enabled-primary" ? resolution.blockedSecondary : [];
@@ -721,7 +767,7 @@ export async function runSharedAgentTurnStream(
     todos: todosEnabled,
   };
   const resolution = capabilityResolution(input, capabilities);
-  const requiredAction = requiredActionForResolution(resolution);
+  const requiredAction = requiredActionForTurn(input, resolution, actionsEnabled);
   const capabilityWall = resolution?.kind === "blocked-primary" ? resolution.blocked : undefined;
   const blockedSecondary =
     resolution?.kind === "enabled-primary" ? resolution.blockedSecondary : [];
@@ -740,9 +786,10 @@ export async function runSharedAgentTurnStream(
   // Current-data answers are buffered until their complete grounded reply has
   // passed validation; streaming an unverified numeric claim cannot be undone.
   if (
-    actionsEnabled &&
-    ((publicSearchText && hasSharedRealtimeIntent(publicSearchText, input.history)) ||
-      (!publicSearchText && hasSharedRealtimeIntent(message, input.history)))
+    requiredAction === "GENERATE_MEDIA" ||
+    (actionsEnabled &&
+      ((publicSearchText && hasSharedRealtimeIntent(publicSearchText, input.history)) ||
+        (!publicSearchText && hasSharedRealtimeIntent(message, input.history))))
   ) {
     const turn = await runSharedAgentTurn(input);
     const parts = (async function* (): AsyncIterable<SharedAgentTurnStreamPart> {

--- a/packages/core/src/features/advanced-capabilities/actions/generateMedia.test.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/generateMedia.test.ts
@@ -1,11 +1,12 @@
 /**
  * Covers the GENERATE_MEDIA action's validate/handler: provider gating (media
- * service vs IMAGE-model fallback), missing-URL failure, attachment delivery,
- * and i18n-safe media-kind routing (#10471). Runs against a deterministic mock
- * runtime (vi.fn media service, no live model).
+ * service vs IMAGE-model fallback), model-facing Seedance controls, missing-URL
+ * failure, attachment delivery, and i18n-safe media-kind routing (#10471). Runs
+ * against a deterministic mock runtime (vi.fn media service, no live model).
  */
 
 import { describe, expect, it, vi } from "vitest";
+import { actionToTool } from "../../../actions/to-tool.ts";
 import { ModelType, ServiceType } from "../../../types/index.ts";
 import { generateMediaAction } from "./generateMedia.ts";
 
@@ -34,6 +35,24 @@ function runtimeWithMediaService(
 }
 
 describe("generateMediaAction availability", () => {
+	it("publishes every Seedance and attachment input in the planner tool schema", () => {
+		const tool = actionToTool(generateMediaAction);
+		expect(tool.function.parameters).toMatchObject({
+			type: "object",
+			properties: {
+				duration: { type: "number" },
+				aspectRatio: {
+					type: "string",
+					enum: ["auto", "21:9", "16:9", "4:3", "1:1", "3:4", "9:16"],
+				},
+				resolution: { type: "string", enum: ["480p", "720p"] },
+				audio: { type: "boolean" },
+				seed: { type: "number" },
+				imageUrl: { type: "string" },
+			},
+		});
+	});
+
 	it("is hidden when the media service reports no configured provider", async () => {
 		await expect(
 			generateMediaAction.validate?.(

--- a/packages/core/src/features/advanced-capabilities/actions/generateMedia.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/generateMedia.ts
@@ -710,19 +710,52 @@ export const generateMediaAction = {
 		},
 		{
 			name: "duration",
-			description: "Target duration seconds for video/audio.",
+			description:
+				"Optional target duration in seconds for video or audio. Seedance 2.5 video accepts whole seconds from 4 through 30; omit it for a short inferred default.",
 			required: false,
 			schema: { type: "number" as const },
 		},
 		{
 			name: "aspectRatio",
-			description: "Video aspect ratio, e.g. 16:9, 9:16, 1:1.",
+			description:
+				"Optional video aspect ratio. Seedance 2.5 supports auto, 21:9, 16:9, 4:3, 1:1, 3:4, and 9:16; omit it to infer framing.",
 			required: false,
-			schema: { type: "string" as const },
+			schema: {
+				type: "string" as const,
+				enum: ["auto", "21:9", "16:9", "4:3", "1:1", "3:4", "9:16"],
+			},
+		},
+		{
+			name: "resolution",
+			description:
+				"Optional video resolution. Seedance 2.5 supports 480p and 720p; omit it for 720p.",
+			required: false,
+			schema: { type: "string" as const, enum: ["480p", "720p"] },
+		},
+		{
+			name: "audio",
+			description:
+				"Whether video generation should include synchronized audio. Omit it to include audio.",
+			required: false,
+			schema: { type: "boolean" as const },
+		},
+		{
+			name: "seed",
+			description:
+				"Optional non-negative integer seed for reproducible media generation.",
+			required: false,
+			schema: { type: "number" as const },
 		},
 		{
 			name: "size",
 			description: "Image size/provider preset.",
+			required: false,
+			schema: { type: "string" as const },
+		},
+		{
+			name: "imageUrl",
+			description:
+				"Optional source image URL for image editing or image-to-video generation. Use the exact trusted attachment URL supplied in the turn context.",
 			required: false,
 			schema: { type: "string" as const },
 		},


### PR DESCRIPTION
Closes #28315

## Root cause
The Personal Shared runtime did not require an execution receipt for explicit image/video generation requests. The model could therefore emit a plausible tool-failure sentence from conversation history without invoking `GENERATE_MEDIA`; correlated production logs confirmed no fal request occurred.

## Fix
- require a `GENERATE_MEDIA` action result for explicit image/video creation and image-to-video requests when trusted media authority is present
- buffer streamed media turns until that receipt is validated
- expose duration, aspect ratio, resolution, audio, seed, and source image URL to the planner schema
- preserve description-only image requests without forcing generation

## Verification
- 25 focused grounding and planner-schema tests pass
- 48 Personal Shared Seedance/chat tests pass
- 2 genuine runtime media tests pass
- `packages/core` and `packages/cloud/shared` typechecks pass
- Biome check and `git diff --check` pass

## Live evidence plan
After merge/deploy: verify native iMessage image generation, Cerebras image recognition, Seedance 2.5 text-to-video, and attachment-driven image-to-video with correlated Railway/Cloudflare logs.