### PR TITLE
fix(voice): release buffered bridge queue before body pull

### DIFF
--- a/packages/cloud/api/src/shared-runtime-conversation.test.ts
+++ b/packages/cloud/api/src/shared-runtime-conversation.test.ts
@@ -419,6 +419,43 @@ function makeInvoke(object: { fetch(request: Request): Promise<Response> }) {
   };
 }
 
+test("buffered bridge releases the room before its response body is consumed", async () => {
+  repositoryReads = 0;
+  repositoryWrites = 0;
+  repositoryRow = [];
+  const object = new SharedRuntimeConversation(
+    makeState(new Map<string, unknown>(), []) as never,
+    {} as never,
+  );
+
+  const firstResponse = await object.fetch(
+    new Request("https://shared-runtime.internal/bridge", {
+      method: "POST",
+      body: JSON.stringify({
+        operation: "bridge",
+        agent: AGENT_FIXTURE,
+        rpc: {
+          jsonrpc: "2.0",
+          id: "buffered-first",
+          method: "message.send",
+          params: { text: "hi", roomId: "room-1" },
+        },
+      }),
+    }),
+  );
+
+  const second = makeInvoke(object)("buffered-second");
+  await expect(
+    Promise.race([
+      second,
+      new Promise<"queue-blocked">((resolve) =>
+        setTimeout(() => resolve("queue-blocked"), 100),
+      ),
+    ]),
+  ).resolves.not.toBe("queue-blocked");
+  await firstResponse.arrayBuffer();
+});
+
 async function pushOperation(
   object: { fetch(request: Request): Promise<Response> },
   body: Record<string, unknown>,

--- a/packages/cloud/api/src/shared-runtime-conversation.ts
+++ b/packages/cloud/api/src/shared-runtime-conversation.ts
@@ -1909,7 +1909,13 @@ export class SharedRuntimeConversation {
             }
           : undefined,
       });
-      return Response.json(result);
+      const response = Response.json(result);
+      // A bridge result is complete before this response exists. Releasing the
+      // room here avoids coupling later turns to whether a nested Worker fetch
+      // happens to pull the small JSON body promptly; only live SSE streams
+      // need to retain serialization until their body is consumed.
+      response.headers.set(RELEASE_QUEUE_BEFORE_BODY_HEADER, "before-body");
+      return response;
     });
   }
 


### PR DESCRIPTION
Closes #28220

Production recorded acceptance after #28318 proved the complete bridge result still held the conversation room for the 120-second body-consumption watchdog: model turns completed in 464–849 ms, but the next admitted turn arrived 127 seconds later.

A bridge result is fully computed before `Response.json` exists, so this marks only buffered bridge responses for immediate coordinator queue release. SSE responses retain consume-through serialization.

Regression: start a second buffered bridge turn without consuming the first JSON body and prove it is admitted within 100 ms.

Verification:
- conversation DO 37/37
- real Workerd eviction 2/2
- cloud API typecheck + production Worker dry-run
- Biome exact files

No provider routing changes.