### PR TITLE
fix(ci): build core before extended UI fixtures

### DIFF
--- a/.github/workflows/ui-fixture-e2e.yml
+++ b/.github/workflows/ui-fixture-e2e.yml
@@ -64,6 +64,12 @@ jobs:
       - name: Ensure generated shared i18n data
         run: node packages/app-core/scripts/ensure-shared-i18n-data.mjs
 
+      # Fixture bundlers consume @elizaos/core through its package exports. A
+      # clean install does not guarantee that dist exists, so build the core
+      # contract before esbuild traverses those exports in browser mode.
+      - name: Build core contract
+        run: bun run build:core
+
       # Settings page sections and persisted local state.
       - name: Settings page e2e
         run: bun run --cwd packages/ui test:settings-e2e

--- a/packages/scripts/__tests__/github-action-pinning.test.ts
+++ b/packages/scripts/__tests__/github-action-pinning.test.ts
@@ -291,6 +291,28 @@ describe("GitHub action supply-chain references", () => {
     );
   });
 
+  test("builds core before extended UI fixtures bundle workspace exports", () => {
+    const source = readFileSync(
+      join(githubRoot, "workflows", "ui-fixture-e2e.yml"),
+      "utf8",
+    );
+    const workflow = Bun.YAML.parse(source) as {
+      jobs?: { "fixture-e2e"?: { steps?: WorkflowStep[] } };
+    };
+    const steps = workflow.jobs?.["fixture-e2e"]?.steps ?? [];
+    const buildIndex = steps.findIndex(
+      (step) =>
+        step.name === "Build core contract" &&
+        step.run === "bun run build:core",
+    );
+    const walletIndex = steps.findIndex(
+      (step) => step.run === "bun run --cwd packages/ui test:wallet-widget-e2e",
+    );
+
+    expect(buildIndex).toBeGreaterThanOrEqual(0);
+    expect(walletIndex).toBeGreaterThan(buildIndex);
+  });
+
   test("keeps the WebKit fixture lane on a provisionable hosted runner", () => {
     const source = readFileSync(
       join(githubRoot, "workflows", "ui-fixture-e2e.yml"),


### PR DESCRIPTION
Closes #28329.

## Problem

Develop Full run 32822502277 reaches the wallet widget fixture with no built `@elizaos/core` package contract. esbuild then traverses core source as a browser bundle and fails on 81 Node built-ins.

## Fix

- build the core contract after generated i18n setup and before every extended UI fixture
- add a parsed-workflow regression proving the build precedes the wallet fixture

## Verification

- `bun test packages/scripts/__tests__/github-action-pinning.test.ts` — 17 passed
- targeted Biome — passed
- actionlint on `ui-fixture-e2e.yml` — passed

Exact head: `fde108f8bae72edc8500c3b283698f7f0d231d5a`