### PR TITLE
test(scheduling): cover dispatch channel registry guards

### DIFF
--- a/plugins/plugin-scheduling/src/scheduled-task/channel-dispatcher-registry.test.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/channel-dispatcher-registry.test.ts
@@ -1,0 +1,195 @@
+import { ElizaError } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import {
+  getScheduledTaskChannelDispatcher,
+  listScheduledTaskChannelDispatcherKeys,
+  registerScheduledTaskChannelDispatcher,
+  unregisterScheduledTaskChannelDispatcher,
+} from "./channel-dispatcher-registry.ts";
+
+function makeContribution(channelKey: string) {
+  return { channelKey, dispatch: vi.fn(async () => undefined) };
+}
+
+describe("registerScheduledTaskChannelDispatcher", () => {
+  it("rejects a missing channelKey", () => {
+    const runtime = {};
+    expect(() =>
+      registerScheduledTaskChannelDispatcher(runtime as never, {
+        channelKey: "",
+        dispatch: async () => undefined,
+      }),
+    ).toThrow("channelKey required");
+  });
+
+  it("rejects a non-string channelKey", () => {
+    const runtime = {};
+    expect(() =>
+      registerScheduledTaskChannelDispatcher(
+        runtime as never,
+        { channelKey: 42, dispatch: async () => undefined } as never,
+      ),
+    ).toThrow("channelKey required");
+  });
+
+  it("rejects a contribution without a dispatch function", () => {
+    const runtime = {};
+    expect(() =>
+      registerScheduledTaskChannelDispatcher(
+        runtime as never,
+        { channelKey: "my_channel" } as never,
+      ),
+    ).toThrow('dispatch function required for channel "my_channel"');
+  });
+
+  it("rejects a reserved built-in channel key to prevent silent hijack", () => {
+    const runtime = {};
+    expect(() =>
+      registerScheduledTaskChannelDispatcher(
+        runtime as never,
+        makeContribution("coding_agent_pr_shepherd"),
+      ),
+    ).toThrow(ElizaError);
+    try {
+      registerScheduledTaskChannelDispatcher(
+        runtime as never,
+        makeContribution("coding_agent_pr_shepherd"),
+      );
+    } catch (error) {
+      const e = error as ElizaError;
+      expect(e.code).toBe("SCHEDULED_TASK_CHANNEL_KEY_RESERVED");
+      expect(e.context).toEqual({ channelKey: "coding_agent_pr_shepherd" });
+    }
+  });
+
+  it("rejects every literal reserved host channel key", () => {
+    const runtime = {};
+    for (const key of [
+      "in_app",
+      "push",
+      "browser",
+      "email",
+      "imessage",
+      "telegram",
+      "discord",
+      "whatsapp",
+      "x",
+      "x_dm",
+      "sms",
+      "voice",
+      "twilio_voice",
+    ]) {
+      expect(() =>
+        registerScheduledTaskChannelDispatcher(
+          runtime as never,
+          makeContribution(key),
+        ),
+      ).toThrow(`channel key "${key}" is reserved`);
+    }
+  });
+
+  it("rejects a duplicate channel key on the same runtime", () => {
+    const runtime = {};
+    registerScheduledTaskChannelDispatcher(
+      runtime as never,
+      makeContribution("wallet_balance_delta"),
+    );
+    expect(() =>
+      registerScheduledTaskChannelDispatcher(
+        runtime as never,
+        makeContribution("wallet_balance_delta"),
+      ),
+    ).toThrow('duplicate channel "wallet_balance_delta"');
+  });
+
+  it("allows the same channel key on a different runtime", () => {
+    registerScheduledTaskChannelDispatcher(
+      {} as never,
+      makeContribution("shared_channel"),
+    );
+    expect(() =>
+      registerScheduledTaskChannelDispatcher(
+        {} as never,
+        makeContribution("shared_channel"),
+      ),
+    ).not.toThrow();
+  });
+});
+
+describe("getScheduledTaskChannelDispatcher", () => {
+  it("returns null for an unknown key", () => {
+    expect(getScheduledTaskChannelDispatcher({} as never, "nope")).toBeNull();
+  });
+
+  it("returns the registered contribution for a known key", () => {
+    const runtime = {};
+    const contribution = makeContribution("my_channel");
+    registerScheduledTaskChannelDispatcher(runtime as never, contribution);
+    expect(
+      getScheduledTaskChannelDispatcher(runtime as never, "my_channel"),
+    ).toBe(contribution);
+  });
+});
+
+describe("listScheduledTaskChannelDispatcherKeys", () => {
+  it("lists registered keys in registration order", () => {
+    const runtime = {};
+    registerScheduledTaskChannelDispatcher(
+      runtime as never,
+      makeContribution("a_channel"),
+    );
+    registerScheduledTaskChannelDispatcher(
+      runtime as never,
+      makeContribution("b_channel"),
+    );
+    expect(listScheduledTaskChannelDispatcherKeys(runtime as never)).toEqual([
+      "a_channel",
+      "b_channel",
+    ]);
+  });
+
+  it("returns [] for a runtime with no contributions", () => {
+    expect(listScheduledTaskChannelDispatcherKeys({} as never)).toEqual([]);
+  });
+});
+
+describe("unregisterScheduledTaskChannelDispatcher", () => {
+  it("returns false for an unknown key", () => {
+    expect(
+      unregisterScheduledTaskChannelDispatcher({} as never, "missing"),
+    ).toBe(false);
+  });
+
+  it("refuses to remove when the identity guard does not match", () => {
+    const runtime = {};
+    const registered = makeContribution("my_channel");
+    registerScheduledTaskChannelDispatcher(runtime as never, registered);
+    const impostor = makeContribution("my_channel");
+    expect(
+      unregisterScheduledTaskChannelDispatcher(
+        runtime as never,
+        "my_channel",
+        impostor,
+      ),
+    ).toBe(false);
+    expect(
+      getScheduledTaskChannelDispatcher(runtime as never, "my_channel"),
+    ).toBe(registered);
+  });
+
+  it("removes the contribution when the identity matches", () => {
+    const runtime = {};
+    const contribution = makeContribution("my_channel");
+    registerScheduledTaskChannelDispatcher(runtime as never, contribution);
+    expect(
+      unregisterScheduledTaskChannelDispatcher(
+        runtime as never,
+        "my_channel",
+        contribution,
+      ),
+    ).toBe(true);
+    expect(
+      getScheduledTaskChannelDispatcher(runtime as never, "my_channel"),
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
Adds focused unit tests for the scheduled-task dispatch channel registry (`registerScheduledTaskChannelDispatcher` and friends), pinning the guards that prevent cross-plugin dispatch hijack:
- a missing/non-string `channelKey` and a missing `dispatch` function are rejected
- registering under any reserved built-in channel key (`coding_agent_pr_shepherd`, `telegram`, `discord`, `x`, …) throws an `ElizaError` with code `SCHEDULED_TASK_CHANNEL_KEY_RESERVED` and the offending key in `context` — a contribution under a built-in key would silently reroute that channel's dispatches
- duplicate keys on the same runtime throw; the same key on a different runtime is isolated (WeakMap per runtime)
- `unregister` refuses to remove a contribution when the identity guard does not match, preventing an older plugin instance from deleting a newer registration

<!-- contribution-attribution:v1 -->
- <!-- attribution-row:ai-assistance --> AI assistance: `yes`
- <!-- attribution-row:models --> Model(s) used: `deepseek/deepseek-v4-flash`
- <!-- attribution-row:client --> Agent tooling: `Hermes Agent`
- <!-- attribution-row:skill-revision --> Skill path: `N/A - no contribution skill used`
- <!-- attribution-row:status --> Provenance status: `self-reported`

## Test Plan
| Step | Action | Result |
|------|--------|--------|
| 1 | `npx vitest run scheduled-task/channel-dispatcher-registry.test.ts` | 14 passed |

## Evidence
| Requirement | Evidence |
|-------------|----------|
| Behavioral risk covered | A contribution registered under a built-in channel key would silently hijack that channel's dispatches (lookup runs before built-ins); silent duplicate override is a cross-plugin hazard; identity-less unregister can delete a newer registration |
| Test isolation | Focused run in clean sandbox, no network, no external services |

## Risks
Low. Tests only; no production code changed.

## Definition of Done
- [x] Rebased on develop
- [x] Tests pass in isolation
- [x] No existing test covers this module
