### PR TITLE
test(anthropic): cover init auth-mode preflight

### DIFF
--- a/plugins/plugin-anthropic/init.test.ts
+++ b/plugins/plugin-anthropic/init.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { logger } from "@elizaos/core";
+
+const configMock = vi.hoisted(() => ({
+  getAuthMode: vi.fn(),
+  getApiKeyOptional: vi.fn(),
+  isBrowser: vi.fn(),
+}));
+vi.mock("./utils/config", () => ({
+  getAuthMode: configMock.getAuthMode,
+  getApiKeyOptional: configMock.getApiKeyOptional,
+  isBrowser: configMock.isBrowser,
+}));
+
+const credMock = vi.hoisted(() => ({
+  getClaudeOAuthToken: vi.fn(),
+  getClaudeOAuthMeta: vi.fn(),
+}));
+vi.mock("./utils/credential-store", () => ({
+  getClaudeOAuthToken: credMock.getClaudeOAuthToken,
+  getClaudeOAuthMeta: credMock.getClaudeOAuthMeta,
+}));
+
+import { initializeAnthropic } from "./init.ts";
+
+// initializeAnthropic fires a detached async IIFE whose body is fully
+// synchronous — one macrotask flush is enough to observe its side effects.
+async function flush() {
+  await new Promise((r) => setTimeout(r, 0));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(logger, "warn").mockImplementation(() => undefined);
+  vi.spyOn(logger, "log").mockImplementation(() => undefined);
+  configMock.getAuthMode.mockReturnValue("apikey");
+  configMock.getApiKeyOptional.mockReturnValue(undefined);
+  configMock.isBrowser.mockReturnValue(false);
+  credMock.getClaudeOAuthToken.mockReturnValue({
+    expiresAt: 1750000000000,
+  });
+  credMock.getClaudeOAuthMeta.mockReturnValue(null);
+});
+
+describe("initializeAnthropic", () => {
+  it("sets the AI_SDK_LOG_WARNINGS default on module load", () => {
+    expect(
+      (globalThis as typeof globalThis & { AI_SDK_LOG_WARNINGS?: boolean })
+        .AI_SDK_LOG_WARNINGS
+    ).toBe(false);
+  });
+
+  it("logs a warning when no API key is set in a non-browser environment", async () => {
+    initializeAnthropic({}, {} as never);
+    await flush();
+    const warn = logger.warn.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(warn).toContain("ANTHROPIC_API_KEY is not set");
+  });
+
+  it("stays silent when no key is set in a browser environment", async () => {
+    configMock.isBrowser.mockReturnValue(true);
+    initializeAnthropic({}, {} as never);
+    await flush();
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.log).not.toHaveBeenCalled();
+  });
+
+  it("logs success when an API key is configured", async () => {
+    configMock.getApiKeyOptional.mockReturnValue("sk-ant-123");
+    initializeAnthropic({}, {} as never);
+    await flush();
+    expect(
+      logger.log.mock.calls.some((c) =>
+        String(c[0]).includes("API key configured successfully")
+      )
+    ).toBe(true);
+  });
+
+  it("preflights the claude CLI and logs the CLI mode", async () => {
+    configMock.getAuthMode.mockReturnValue("cli");
+    (globalThis as typeof globalThis & { Bun?: unknown }).Bun = {
+      spawnSync: () => ({ exitCode: 0 }),
+    };
+    initializeAnthropic({}, {} as never);
+    await flush();
+    expect(
+      logger.log.mock.calls.some((c) =>
+        String(c[0]).includes("CLI mode")
+      )
+    ).toBe(true);
+    delete (globalThis as typeof globalThis & { Bun?: unknown }).Bun;
+  });
+
+  it("warns when the claude CLI preflight fails (missing binary)", async () => {
+    configMock.getAuthMode.mockReturnValue("cli");
+    (globalThis as typeof globalThis & { Bun?: unknown }).Bun = {
+      spawnSync: () => ({ exitCode: 127 }),
+    };
+    initializeAnthropic({}, {} as never);
+    await flush();
+    const warn = logger.warn.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(warn).toContain("claude` command not found");
+    delete (globalThis as typeof globalThis & { Bun?: unknown }).Bun;
+  });
+
+  it("warns when the claude CLI preflight throws", async () => {
+    configMock.getAuthMode.mockReturnValue("cli");
+    (globalThis as typeof globalThis & { Bun?: unknown }).Bun = {
+      spawnSync: () => {
+        throw new Error("spawn ENOENT");
+      },
+    };
+    initializeAnthropic({}, {} as never);
+    await flush();
+    const warn = logger.warn.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(warn).toContain("claude` command not found");
+    delete (globalThis as typeof globalThis & { Bun?: unknown }).Bun;
+  });
+
+  it("logs OAuth subscription details when meta is present", async () => {
+    configMock.getAuthMode.mockReturnValue("oauth");
+    credMock.getClaudeOAuthMeta.mockReturnValue({
+      subscriptionType: "pro",
+      rateLimitTier: "tier-2",
+    });
+    initializeAnthropic({}, {} as never);
+    await flush();
+    const logged = logger.log.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(logged).toContain("OAuth configured");
+    expect(logged).toContain("pro");
+  });
+
+  it("falls back to the env-var notice when no OAuth meta exists", async () => {
+    configMock.getAuthMode.mockReturnValue("oauth");
+    initializeAnthropic({}, {} as never);
+    await flush();
+    expect(
+      logger.log.mock.calls.some((c) =>
+        String(c[0]).includes("CLAUDE_CODE_OAUTH_TOKEN")
+      )
+    ).toBe(true);
+  });
+
+  it("warns without crashing when the OAuth token store is broken", async () => {
+    configMock.getAuthMode.mockReturnValue("oauth");
+    credMock.getClaudeOAuthToken.mockImplementation(() => {
+      throw new Error("token store corrupted");
+    });
+    initializeAnthropic({}, {} as never);
+    await flush();
+    const warn = logger.warn.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(warn).toContain("OAuth credential issue");
+    expect(warn).toContain("token store corrupted");
+  });
+});


### PR DESCRIPTION
## Summary
Adds focused unit tests for `initializeAnthropic`, pinning the plugin boot preflight (no network calls):
- the module sets the `AI_SDK_LOG_WARNINGS` default once at load
- missing `ANTHROPIC_API_KEY` warns in non-browser environments and stays silent in browsers
- a configured key logs success
- `cli` auth mode preflights `claude --version` via `Bun.spawnSync`, logging CLI mode on exit 0 and warning (without crashing boot) when the binary is missing or spawn throws
- `oauth` mode logs subscription details when OAuth meta is present, falls back to the `CLAUDE_CODE_OAUTH_TOKEN` notice otherwise, and turns a broken credential store into a warning — never an unhandled rejection

<!-- contribution-attribution:v1 -->
- <!-- attribution-row:ai-assistance --> AI assistance: `yes`
- <!-- attribution-row:models --> Model(s) used: `deepseek/deepseek-v4-flash`
- <!-- attribution-row:client --> Agent tooling: `Hermes Agent`
- <!-- attribution-row:skill-revision --> Skill path: `N/A - no contribution skill used`
- <!-- attribution-row:status --> Provenance status: `self-reported`

## Test Plan
| Step | Action | Result |
|------|--------|--------|
| 1 | `npx vitest run init.test.ts` | 10 passed |

## Evidence
| Requirement | Evidence |
|-------------|----------|
| Behavioral risk covered | The init preflight runs in a detached async block where an unhandled rejection would be swallowed silently; the warning/error-policy paths (`claude` missing, OAuth store broken, no key) are exactly the failure modes users hit at boot |
| Test isolation | Focused run in clean sandbox, no network, no external services |

## Risks
Low. Tests only; no production code changed.

## Definition of Done
- [x] Rebased on develop
- [x] Tests pass in isolation
- [x] No existing test covers this module
