### PR TITLE
fix(local-inference): strip BOS/EOS framing in phonemizePhrase like the streaming path

### DIFF
--- a/plugins/plugin-local-inference/src/services/voice/kokoro/phoneme-stream.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/kokoro/phoneme-stream.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Behavioral tests for the Kokoro phoneme stream seam.
+ *
+ * Materiality: the module owns the boundary between the phonemizer and the
+ * model input tensor. `streamPhonemes` deliberately strips BOS/EOS framing so
+ * the model sees one BOS at the head and one EOS at the tail; `phonemizePhrase`
+ * documents itself as equivalent to draining the stream — but did not strip
+ * framing, so a whole-phrase caller fed the model BOS/EOS on every phrase.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { phonemizePhrase, streamPhonemes } from "./phoneme-stream";
+
+/** Phonemizer mock: returns queued id arrays in call order, framed like the
+ *  real espeak-ng output (BOS=1 ... EOS=2). */
+function makePhonemizer(seqs: number[][]) {
+	const queue = seqs.map((ids) => ({
+		ids: Int32Array.from(ids),
+		phonemes: "",
+	}));
+	const phonemize = vi.fn(
+		async () => queue.shift() ?? { ids: new Int32Array(0), phonemes: "" },
+	);
+	return { phonemizer: { phonemize, lang: "en-us" }, phonemize };
+}
+
+function drainStream(
+	chunks: string[],
+	seqs: number[][],
+	opts: Record<string, unknown> = {},
+) {
+	const { phonemizer, phonemize } = makePhonemizer(seqs);
+	return {
+		phonemize,
+		windows: streamPhonemes(chunks, { ...opts, phonemizer }),
+	};
+}
+
+describe("streamPhonemes", () => {
+	it("strips BOS/EOS framing so the model sees one BOS at head and one EOS at tail", async () => {
+		const { windows } = drainStream(["hello"], [[1, 5, 6, 2]]);
+		const final = await windows.next();
+		expect(final.done).toBe(false);
+		expect(Array.from(final.value.ids)).toEqual([5, 6]);
+		expect(final.value.isFinal).toBe(true);
+		const done = await windows.next();
+		expect(done.done).toBe(true);
+	});
+
+	it("keeps raw ids when the phonemizer emits no framing", async () => {
+		const { windows } = drainStream(["hello"], [[5, 6]]);
+		const final = await windows.next();
+		expect(Array.from(final.value.ids)).toEqual([5, 6]);
+		expect(final.value.isFinal).toBe(true);
+	});
+
+	it("yields a cumulative window once flushAt new ids have accumulated", async () => {
+		// chunk "one two" → head "one" (3 ids); then leftover "two" + " three" →
+		// head "two three" (2 ids) → 5 accumulated ≥ flushAt 4.
+		const { windows } = drainStream(
+			["one two", " three"],
+			[
+				[10, 11, 12],
+				[13, 14],
+				[15, 16],
+			],
+			{ flushAt: 4 },
+		);
+		const first = await windows.next();
+		expect(first.done).toBe(false);
+		expect(Array.from(first.value.ids)).toEqual([10, 11, 12, 13, 14]);
+		expect(first.value.isFinal).toBe(false);
+		const final = await windows.next();
+		expect(Array.from(final.value.ids)).toEqual([10, 11, 12, 13, 14, 15, 16]);
+		expect(final.value.isFinal).toBe(true);
+	});
+
+	it("clamps degenerate flushAt values to 1", async () => {
+		for (const flushAt of [0, -3]) {
+			const { windows } = drainStream(
+				["hello world"],
+				[
+					[1, 10, 11, 2],
+					[12, 13],
+				],
+				{ flushAt },
+			);
+			const first = await windows.next();
+			// flushAt 1 → flush after the first phonemize call.
+			expect(Array.from(first.value.ids)).toEqual([10, 11]);
+		}
+	});
+
+	it("skips empty chunks without calling the phonemizer", async () => {
+		const { windows, phonemize } = drainStream(
+			["", "", "hello"],
+			[[1, 5, 6, 2]],
+		);
+		await windows.next();
+		expect(phonemize).toHaveBeenCalledTimes(1);
+	});
+
+	it("accumulates the phoneme string across windows", async () => {
+		const { phonemizer } = makePhonemizer([[1, 10, 11, 2]]);
+		phonemizer.phonemize.mockResolvedValueOnce({
+			ids: Int32Array.from([1, 10, 11, 2]),
+			phonemes: "hello",
+		});
+		const windows = streamPhonemes(["hello"], { phonemizer });
+		const final = await windows.next();
+		expect(final.value.phonemes).toBe("hello");
+	});
+});
+
+describe("phonemizePhrase", () => {
+	it("strips BOS/EOS framing — matches draining streamPhonemes on a single item", async () => {
+		// Documented equivalence: phonemizePhrase "returns the full id array —
+		// equivalent to draining streamPhonemes on a single-item iterator and
+		// taking the last window." A whole-phrase caller must not feed the model
+		// a BOS/EOS pair per phrase.
+		const { phonemizer } = makePhonemizer([[1, 5, 6, 2]]);
+		const window = await phonemizePhrase("hello", { phonemizer });
+		expect(Array.from(window.ids)).toEqual([5, 6]);
+		expect(window.isFinal).toBe(true);
+	});
+
+	it("keeps ids unchanged when the phonemizer omits framing", async () => {
+		const { phonemizer } = makePhonemizer([[5, 6]]);
+		const window = await phonemizePhrase("hello", { phonemizer });
+		expect(Array.from(window.ids)).toEqual([5, 6]);
+	});
+});

--- a/plugins/plugin-local-inference/src/services/voice/kokoro/phoneme-stream.ts
+++ b/plugins/plugin-local-inference/src/services/voice/kokoro/phoneme-stream.ts
@@ -91,12 +91,10 @@ export async function* streamPhonemes(
 	};
 }
 
-function appendSeq(seq: KokoroPhonemeSequence, target: number[]): void {
-	// The phonemizer emits a sequence framed with BOS/EOS — strip both when
-	// accumulating windows so the model sees one BOS at the head and one EOS
-	// at the tail. Defensive against phonemizers that omit framing (the
-	// accumulator simply appends raw ids in that case).
-	const ids = seq.ids;
+function stripFraming(ids: Int32Array): Int32Array {
+	// The phonemizer emits a sequence framed with BOS/EOS — strip both so the
+	// model sees one BOS at the head and one EOS at the tail. Defensive
+	// against phonemizers that omit framing (we simply keep the raw ids).
 	let start = 0;
 	let end = ids.length;
 	if (ids.length >= 2) {
@@ -104,7 +102,16 @@ function appendSeq(seq: KokoroPhonemeSequence, target: number[]): void {
 		if (ids[0] !== undefined && ids[0] <= 2) start = 1;
 		if (ids[end - 1] !== undefined && (ids[end - 1] as number) <= 2) end -= 1;
 	}
-	for (let i = start; i < end; i++) {
+	return ids.slice(start, end);
+}
+
+function appendSeq(seq: KokoroPhonemeSequence, target: number[]): void {
+	// The phonemizer emits a sequence framed with BOS/EOS — strip both when
+	// accumulating windows so the model sees one BOS at the head and one EOS
+	// at the tail. Defensive against phonemizers that omit framing (the
+	// accumulator simply appends raw ids in that case).
+	const ids = stripFraming(seq.ids);
+	for (let i = 0; i < ids.length; i++) {
 		const id = ids[i];
 		if (id !== undefined) target.push(id);
 	}
@@ -119,5 +126,8 @@ export async function phonemizePhrase(
 	opts: StreamPhonemesOptions,
 ): Promise<PhonemeStreamWindow> {
 	const seq = await opts.phonemizer.phonemize(text, opts.lang);
-	return { ids: seq.ids, phonemes: seq.phonemes, isFinal: true };
+	// Same framing rule as the streaming path: strip BOS/EOS so a whole-phrase
+	// caller feeds the model one BOS at the head and one EOS at the tail —
+	// equivalent to draining streamPhonemes on a single-item iterator.
+	return { ids: stripFraming(seq.ids), phonemes: seq.phonemes, isFinal: true };
 }


### PR DESCRIPTION
# What

`phonemizePhrase` documented itself as *equivalent to draining `streamPhonemes` on a single-item iterator and taking the last window* — but returned the phonemizer's raw ids **including BOS/EOS framing**, while the streaming path strips both. A whole-phrase caller therefore fed the model a BOS/EOS pair on **every phrase**, violating the module's stated model-input invariant (one BOS at the head, one EOS at the tail).

Extract the framing-strip heuristic into `stripFraming`, reuse it in `appendSeq` (behavior unchanged there), and apply it in `phonemizePhrase`. New tests reproduce the divergence (test failed before the fix: `expected [ 1, 5, 6, 2 ] to deeply equal [ 5, 6 ]`) and pin the windowing/clamp/empty-chunk behavior of the stream.

# Relates to

No issue; found while pinning the phoneme-stream seam between the phonemizer and the model input tensor.

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. The strip heuristic is extracted verbatim from `appendSeq` (no behavior change to the streaming path); `phonemizePhrase` now matches its documented equivalence to the drained stream. Only whole-phrase callers see a change, and it aligns them with the model-input invariant.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: 8 passed (8) |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test + fix diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
