### PR TITLE
test(secure-store): pin the fail-closed web fallback contract

### DIFF
--- a/plugins/plugin-native-secure-store/src/web.test.ts
+++ b/plugins/plugin-native-secure-store/src/web.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Fail-closed contract tests for the browser fallback of the native secure
+ * store.
+ *
+ * Materiality: this module is the security boundary for secrets on web
+ * surfaces. The documented contract is that the web fallback NEVER degrades
+ * to localStorage/IndexedDB ("stored in the clear") — every operation reports
+ * `unavailable`. These tests pin that contract so a future "helpful" fallback
+ * that starts persisting via web storage fails CI instead of silently
+ * weakening the secrets guarantee.
+ */
+import { describe, expect, it } from "vitest";
+import { ElizaSecureStoreWeb } from "./web";
+
+describe("ElizaSecureStoreWeb (fail-closed fallback)", () => {
+  it("get() never reads from web storage — reports unavailable", async () => {
+    const result = await new ElizaSecureStoreWeb().get();
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("unavailable");
+  });
+
+  it("set() never writes to web storage — reports unavailable", async () => {
+    const result = await new ElizaSecureStoreWeb().set();
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("unavailable");
+  });
+
+  it("remove() reports unavailable", async () => {
+    const result = await new ElizaSecureStoreWeb().remove();
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("unavailable");
+  });
+
+  it("status() reports the backend as unavailable", async () => {
+    const status = await new ElizaSecureStoreWeb().status();
+    expect(status.ok).toBe(false);
+    expect(status.available).toBe(false);
+    expect(status.backend).toBe("unavailable");
+    expect(status.accessibility).toBe("unavailable");
+    expect(status.synchronized).toBe(false);
+  });
+
+  it("explains the absence of secure storage in the message", async () => {
+    const result = await new ElizaSecureStoreWeb().get();
+    expect(result.message).toMatch(/native Eliza app/);
+    const status = await new ElizaSecureStoreWeb().status();
+    expect(status.message).toMatch(/native Eliza app/);
+  });
+});


### PR DESCRIPTION
# What

Test-only PR pinning the fail-closed contract of `ElizaSecureStoreWeb`, the browser fallback for the native secure store.

The module's documented security contract: the web fallback **never** degrades to web storage — localStorage/IndexedDB are readable by any script on the origin, so silently persisting there would turn "stored in the Keychain/Keystore" into "stored in the clear" without the caller ever learning the guarantee changed. Every operation must report `ok: false, error: "unavailable"` and `status()` must report `available: false, backend: "unavailable"`.

These tests pin that contract so a future "helpful" fallback that starts persisting via web storage fails CI instead of silently weakening the secrets guarantee.

# Relates to

No issue; security-boundary coverage for the secure-store plugin's web surface.

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition; no production code modified.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: 5 passed (5) |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
