### PR TITLE
fix(cli): normalize ported SSH and tree/blob GitHub repo URLs in plugins submit

### DIFF
--- a/packages/elizaos/src/commands/plugins.test.ts
+++ b/packages/elizaos/src/commands/plugins.test.ts
@@ -49,7 +49,10 @@ describe("submitPluginToRegistry", () => {
   it.each([
     ["git+ssh://git@github.com/acme/plugin-weather.git"],
     ["ssh://git@github.com/acme/plugin-weather.git"],
+    ["git+ssh://git@github.com:22/acme/plugin-weather.git"],
     ["git://github.com/acme/plugin-weather.git"],
+    ["https://github.com/acme/plugin-weather.git/tree/main"],
+    ["https://github.com/acme/plugin-weather.git/blob/develop#readme"],
   ])("normalizes the npm repository url form %s", async (repositoryUrl) => {
     const dir = makePluginPackage({
       name: "@acme/plugin-weather",

--- a/packages/elizaos/src/commands/plugins.ts
+++ b/packages/elizaos/src/commands/plugins.ts
@@ -271,13 +271,12 @@ function normalizeGithubRepo(value: string | null | undefined): string | null {
   }
   input = input
     .replace(/^https?:\/\/github\.com\//, "")
-    .replace(/^ssh:\/\/git@github\.com[:/]/, "")
+    .replace(/^ssh:\/\/git@github\.com(?::\d+)?[:\/]/, "")
     .replace(/^git:\/\/github\.com\//, "")
     .replace(/^git@github\.com:/, "")
-    .replace(/\.git$/, "")
-    .replace(/\/tree\/.*$/, "")
-    .replace(/\/blob\/.*$/, "")
-    .replace(/#.*$/, "");
+    .replace(/\/(?:tree|blob)\/.*$/, "")
+    .replace(/#.*$/, "")
+    .replace(/\.git$/, "");
   const [owner, repo] = input.split("/");
   return owner && repo ? `${owner}/${repo}` : null;
 }


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Closes #28344

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low risk. Confined to repository URL normalization in `packages/elizaos/src/commands/plugins.ts`.

# Background

## What does this PR do?
Normalizes ported SSH (`git+ssh://git@github.com:22/owner/repo.git`) and `/tree` or `/blob` GitHub repo URLs to the canonical `github:owner/repo` form during `elizaos plugins submit`.

## What kind of change is this?
Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?
My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?
Review `packages/elizaos/src/commands/plugins.ts` and `packages/elizaos/src/commands/plugins.test.ts`.

## Detailed testing steps
Run:
```bash
bun run --cwd packages/elizaos test -- src/commands/plugins.test.ts
bun run --cwd packages/elizaos typecheck
```

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:b036b84e013a776e27a6f95c8ba0e2518e957ca1 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots: N/A - CLI command metadata generation.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots: N/A - CLI command metadata generation.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough: N/A - CLI command metadata generation.
<!-- evidence-row:backend-logs -->
- [x] Backend logs:
<details>
<summary>bun run --cwd packages/elizaos test -- src/commands/plugins.test.ts output</summary>

```
 Test Files  1 passed (1)
      Tests  11 passed (11)
   Start at  18:58:11
   Duration  267ms
```
</details>
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs: N/A - CLI command without frontend execution.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory: N/A - Deterministic URL normalization.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts: N/A - In-memory metadata transformation.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review: N/A - No UI rendered.

# Known gaps / failures
None.

# Maintainer CI exception record
N/A - no exception requested

---

AI provider/model: Google / Gemini 3.7 Flash
Client / agent tooling: Antigravity
Contribution skill revision: elizaOS/eliza@7d55350499b702ec4c979c3dcb6bb5e56d482939:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [antigravity-contrib]
<!-- eliza-computer-attribution:v1 {"provider":"google","model":"gemini-3.7-flash","client":"Antigravity","skill_revision":"elizaOS/eliza@7d55350499b702ec4c979c3dcb6bb5e56d482939:packages/skills/skills/contribute-to-eliza"} -->