### PR TITLE
fix(whatsapp): fail closed on empty-string Cloud API credentials in auth method detection

### DIFF
--- a/plugins/plugin-whatsapp/src/utils/config-detector.test.ts
+++ b/plugins/plugin-whatsapp/src/utils/config-detector.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { detectAuthMethod } from "./config-detector";
+
+describe("detectAuthMethod", () => {
+  it("honors an explicit known authMethod", () => {
+    expect(detectAuthMethod({ authMethod: "baileys" })).toBe("baileys");
+    expect(detectAuthMethod({ authMethod: "cloudapi" })).toBe("cloudapi");
+  });
+
+  it("rejects unknown explicit authMethod values instead of guessing", () => {
+    expect(() => detectAuthMethod({ authMethod: "matrix" })).toThrow(
+      /Invalid authMethod: "matrix"/
+    );
+    expect(() => detectAuthMethod({ authMethod: "" })).toThrow(/Invalid authMethod/);
+    expect(() => detectAuthMethod({ authMethod: " " })).toThrow(/Invalid authMethod/);
+    expect(() => detectAuthMethod({ authMethod: "BAILEYS" })).toThrow(/Invalid authMethod/);
+  });
+
+  it("prefers baileys when an authDir is present even alongside cloud fields", () => {
+    expect(
+      detectAuthMethod({
+        authDir: "/data/whatsapp",
+        accessToken: "tok",
+        phoneNumberId: "123",
+      })
+    ).toBe("baileys");
+  });
+
+  it("chooses baileys when authDir is present", () => {
+    expect(detectAuthMethod({ authDir: "/data/whatsapp" })).toBe("baileys");
+  });
+
+  it("chooses cloudapi when accessToken and phoneNumberId are present", () => {
+    expect(detectAuthMethod({ accessToken: "tok", phoneNumberId: "123" })).toBe("cloudapi");
+  });
+
+  it("fails closed when neither transport has usable credentials", () => {
+    expect(() => detectAuthMethod({})).toThrow(/Cannot detect auth method/);
+    expect(() => detectAuthMethod({ authDir: "" })).toThrow(/Cannot detect auth method/);
+    expect(() => detectAuthMethod({ authDir: 0 })).toThrow(/Cannot detect auth method/);
+  });
+
+  it("fails closed on empty-string cloud credentials instead of selecting a broken transport", () => {
+    // Empty accessToken would select cloudapi and then fail downstream at
+    // auth time with a confusing error; it must be rejected here.
+    expect(() => detectAuthMethod({ accessToken: "", phoneNumberId: "123" })).toThrow(
+      /Cannot detect auth method/
+    );
+    expect(() => detectAuthMethod({ accessToken: "tok", phoneNumberId: "" })).toThrow(
+      /Cannot detect auth method/
+    );
+    expect(() => detectAuthMethod({ accessToken: "", phoneNumberId: "" })).toThrow(
+      /Cannot detect auth method/
+    );
+  });
+
+  it("requires both cloudapi credentials together", () => {
+    expect(() => detectAuthMethod({ accessToken: "tok" })).toThrow(/Cannot detect auth method/);
+    expect(() => detectAuthMethod({ phoneNumberId: "123" })).toThrow(/Cannot detect auth method/);
+  });
+});

--- a/plugins/plugin-whatsapp/src/utils/config-detector.ts
+++ b/plugins/plugin-whatsapp/src/utils/config-detector.ts
@@ -22,7 +22,14 @@ export function detectAuthMethod(
     return "baileys";
   }
 
-  if ("accessToken" in config && "phoneNumberId" in config) {
+  // Cloud API credentials must be present and non-empty: an empty
+  // accessToken/phoneNumberId would select cloudapi and then fail downstream
+  // at auth time with a confusing error. Mirrors the authDir truthiness check
+  // above (an empty authDir already falls through to the error below).
+  if (
+    (config as { accessToken?: unknown }).accessToken &&
+    (config as { phoneNumberId?: unknown }).phoneNumberId
+  ) {
     return "cloudapi";
   }
 


### PR DESCRIPTION
# Relates to

<!-- No issue; defect found while covering auth-transport selection behavior. -->

# What & why

`detectAuthMethod` in `plugins/plugin-whatsapp/src/utils/config-detector.ts`
selected the Cloud API transport whenever the `accessToken` and
`phoneNumberId` **keys were present** — even when both were empty strings.
That picked a transport that cannot authenticate, deferring the failure to a
confusing runtime auth error. The Baileys branch already used a truthiness
check on `authDir`, so an empty `authDir` correctly fell through to the
"cannot detect" error while empty Cloud credentials did not.

This change makes the Cloud API branch fail closed the same way: both
credentials must be present **and non-empty** before `cloudapi` is selected,
otherwise `detectAuthMethod` throws the same `Cannot detect auth method`
error.

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. The fix tightens validation on the auth-method resolution path: configs
with empty-string Cloud credentials now fail fast with a clear error instead
of selecting a broken transport. Configs with non-empty credentials behave
identically (covered by existing and new tests).

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `<TEST_OUTPUT>` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: source fix + test file diff in this PR |
