### PR TITLE
fix(zerollama): account for undefined provider responses in token usage estimation

### DIFF
--- a/plugins/plugin-zerollama/utils/modelUsage.test.ts
+++ b/plugins/plugin-zerollama/utils/modelUsage.test.ts
@@ -1,0 +1,199 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  emitModelUsed,
+  estimateEmbeddingUsage,
+  estimateUsage,
+  normalizeTokenUsage,
+} from "./modelUsage";
+
+describe("normalizeTokenUsage", () => {
+  it("returns undefined for non-object input", () => {
+    expect(normalizeTokenUsage(undefined)).toBeUndefined();
+    expect(normalizeTokenUsage(null)).toBeUndefined();
+    expect(normalizeTokenUsage("tokens")).toBeUndefined();
+    expect(normalizeTokenUsage(42)).toBeUndefined();
+  });
+
+  it("returns undefined when no usable token fields exist", () => {
+    expect(normalizeTokenUsage({})).toBeUndefined();
+    expect(normalizeTokenUsage({ promptTokens: "many" })).toBeUndefined();
+  });
+
+  it("maps canonical fields", () => {
+    expect(
+      normalizeTokenUsage({
+        promptTokens: 10,
+        completionTokens: 5,
+        totalTokens: 15,
+      })
+    ).toEqual({ promptTokens: 10, completionTokens: 5, totalTokens: 15 });
+  });
+
+  it("falls back to inputTokens/outputTokens aliases", () => {
+    expect(normalizeTokenUsage({ inputTokens: 7, outputTokens: 3 })).toEqual({
+      promptTokens: 7,
+      completionTokens: 3,
+      totalTokens: 10,
+    });
+  });
+
+  it("derives total from prompt + completion when absent", () => {
+    expect(normalizeTokenUsage({ promptTokens: 2, completionTokens: 3 })).toEqual({
+      promptTokens: 2,
+      completionTokens: 3,
+      totalTokens: 5,
+    });
+  });
+
+  it("rejects NaN, Infinity and negative values as absent", () => {
+    expect(
+      normalizeTokenUsage({
+        promptTokens: NaN,
+        completionTokens: Infinity,
+        totalTokens: -1,
+      })
+    ).toBeUndefined();
+    expect(
+      normalizeTokenUsage({
+        promptTokens: -5,
+        completionTokens: 3,
+      })
+    ).toEqual({ promptTokens: 0, completionTokens: 3, totalTokens: 3 });
+  });
+
+  it("keeps explicit zero totals", () => {
+    expect(normalizeTokenUsage({ promptTokens: 0, completionTokens: 0, totalTokens: 0 })).toEqual({
+      promptTokens: 0,
+      completionTokens: 0,
+      totalTokens: 0,
+    });
+  });
+});
+
+describe("estimateUsage", () => {
+  it("estimates from string responses", () => {
+    const r = estimateUsage("hello", "world");
+    expect(r).toEqual({
+      promptTokens: Math.ceil(5 / 4),
+      completionTokens: Math.ceil(5 / 4),
+      totalTokens: Math.ceil(5 / 4) + Math.ceil(5 / 4),
+      estimated: true,
+    });
+  });
+
+  it("estimates from object responses via JSON serialization", () => {
+    const r = estimateUsage("hi", { ok: true });
+    expect(r.promptTokens).toBe(Math.ceil(2 / 4));
+    expect(r.completionTokens).toBe(Math.ceil(9 / 4));
+    expect(r.estimated).toBe(true);
+  });
+
+  it("serializes unserializable responses instead of crashing", () => {
+    const circular: Record<string, unknown> = { name: "loop" };
+    circular.self = circular;
+    expect(() => estimateUsage("hi", circular)).not.toThrow();
+    const r = estimateUsage("hi", circular);
+    expect(r.completionTokens).toBeGreaterThan(0);
+  });
+
+  it("handles an undefined response instead of crashing", () => {
+    expect(() => estimateUsage("hi", undefined)).not.toThrow();
+    const r = estimateUsage("hi", undefined);
+    expect(r.promptTokens).toBeGreaterThan(0);
+    expect(r.estimated).toBe(true);
+    expect(r.totalTokens).toBe(r.promptTokens + r.completionTokens);
+  });
+
+  it("handles a null response", () => {
+    expect(() => estimateUsage("hi", null)).not.toThrow();
+  });
+
+  it("returns zero for empty prompt and empty response", () => {
+    expect(estimateUsage("", "")).toEqual({
+      promptTokens: 0,
+      completionTokens: 0,
+      totalTokens: 0,
+      estimated: true,
+    });
+  });
+});
+
+describe("estimateEmbeddingUsage", () => {
+  it("counts only prompt tokens", () => {
+    expect(estimateEmbeddingUsage("abcd")).toEqual({
+      promptTokens: 1,
+      completionTokens: 0,
+      totalTokens: 1,
+      estimated: true,
+    });
+  });
+});
+
+describe("emitModelUsed", () => {
+  let runtime: { emitEvent: ReturnType<typeof vi.fn>; reportError: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    runtime = {
+      emitEvent: vi.fn().mockResolvedValue(undefined),
+      reportError: vi.fn(),
+    };
+  });
+
+  it("throws when the model name is blank after trimming", () => {
+    expect(() =>
+      emitModelUsed(runtime, "text", "   ", {
+        promptTokens: 1,
+        completionTokens: 0,
+        totalTokens: 1,
+      })
+    ).toThrow(/MODEL_USED requires the concrete Ollama model name/);
+  });
+
+  it("emits the MODEL_USED event with trimmed model and token accounting", () => {
+    emitModelUsed(runtime, "text", "  llama3  ", {
+      promptTokens: 2,
+      completionTokens: 3,
+      totalTokens: 5,
+    });
+    expect(runtime.emitEvent).toHaveBeenCalledWith(
+      "MODEL_USED",
+      expect.objectContaining({
+        source: "ollama",
+        provider: "ollama",
+        model: "llama3",
+        tokens: { prompt: 2, completion: 3, total: 5 },
+      })
+    );
+  });
+
+  it("flags estimated usage", () => {
+    emitModelUsed(runtime, "text", "llama3", {
+      promptTokens: 1,
+      completionTokens: 1,
+      totalTokens: 2,
+      estimated: true,
+    });
+    const payload = runtime.emitEvent.mock.calls[0][1];
+    expect(payload.tokens.estimated).toBe(true);
+    expect(payload.usageEstimated).toBe(true);
+  });
+
+  it("swallows emission failures and reports them through the runtime diagnostics channel", async () => {
+    const failure = new Error("emit boom");
+    runtime.emitEvent.mockRejectedValue(failure);
+    expect(() =>
+      emitModelUsed(runtime, "text", "llama3", {
+        promptTokens: 1,
+        completionTokens: 0,
+        totalTokens: 1,
+      })
+    ).not.toThrow();
+    await vi.waitFor(() => {
+      expect(runtime.reportError).toHaveBeenCalledWith(
+        "plugin-zerollama.model-usage",
+        failure,
+        expect.objectContaining({ model: "llama3" })
+      );
+    });
+  });
+});

--- a/plugins/plugin-zerollama/utils/modelUsage.ts
+++ b/plugins/plugin-zerollama/utils/modelUsage.ts
@@ -51,6 +51,12 @@ export function estimateUsage(prompt: string, response: unknown): OllamaTokenUsa
       // output; an unserializable value is represented explicitly as text.
       responseText = `[unserializable response: ${error instanceof Error ? error.message : String(error)}]`;
     }
+    // JSON.stringify(undefined) returns undefined rather than a string; a
+    // missing response body is a legitimate provider outcome and must be
+    // accounted for instead of crashing the estimation.
+    if (responseText === undefined) {
+      responseText = "[no response]";
+    }
   }
   const promptTokens = estimateTokenCount(prompt);
   const completionTokens = estimateTokenCount(responseText);


### PR DESCRIPTION
# Relates to

<!-- No issue; defect found while covering token-usage normalization. -->

# What & why

`estimateUsage` in `plugins/plugin-zerollama/utils/modelUsage.ts` crashed on a
missing provider response body:

- `JSON.stringify(undefined)` returns `undefined` rather than a string, and the
  code then called `estimateTokenCount(responseText)` with that `undefined`,
  throwing `TypeError: Cannot read properties of undefined (reading 'length')`.

An absent response body is a legitimate Ollama outcome (a provider that
returns nothing for an embedding or a failed decode), and diagnostic
estimation must never turn a successful model call into a crash — the module
already documents that policy (`error-policy:J3`). The fix represents a
missing body explicitly as `[no response]` and accounts for it in the
estimate, mirroring the existing unserializable-response handling.

The PR also pins the surrounding accounting boundaries: NaN/Infinity/negative
token values are rejected as absent, aliases (`inputTokens`/`outputTokens`)
are honored, totals are derived when missing, and `emitModelUsed` still fails
loudly on blank model names while swallowing emission failures through the
runtime diagnostics channel.

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. The only production change is a two-line guard converting a crash into an
explicit `[no response]` token estimate for `undefined` responses; every other
path is byte-identical and covered by the new tests.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `<TEST_OUTPUT>` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: source fix + test file diff in this PR |
