### PR TITLE
fix(deploy): keep status-aware diagnostics for non-JSON cloud errors

### DIFF
--- a/packages/elizaos/src/commands/deploy.test.ts
+++ b/packages/elizaos/src/commands/deploy.test.ts
@@ -28,6 +28,14 @@ function jsonResponse(body: unknown, status = 200): Response {
   } as unknown as Response;
 }
 
+function textResponse(body: string, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: vi.fn().mockResolvedValue(body),
+  } as unknown as Response;
+}
+
 describe("runDeploy", () => {
   it("keeps dry-run mode network-free", async () => {
     const fetchMock = vi.fn();
@@ -86,10 +94,45 @@ describe("runDeploy", () => {
     );
   });
 
+  it("reports a non-JSON error body with its HTTP status instead of a JSON SyntaxError", async () => {
+    process.env.ELIZAOS_CLOUD_API_KEY = "eliza_test_key";
+    process.env.ELIZA_CLOUD_API_BASE_URL = "https://cloud.example.test/api/v1";
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(textResponse("<html>502 Bad Gateway</html>", 502));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const code = await runDeploy({ appId: "app-1" });
+
+    expect(code).toBe(1);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "POST /apps/app-1/deploy failed (502): response body was not JSON",
+      ),
+    );
+  });
+
+  it("fails a success response whose body is not JSON instead of returning garbage", async () => {
+    process.env.ELIZAOS_CLOUD_API_KEY = "eliza_test_key";
+    process.env.ELIZA_CLOUD_API_BASE_URL = "https://cloud.example.test/api/v1";
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(textResponse("<html>maintenance</html>", 200));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const code = await runDeploy({ appId: "app-1" });
+
+    expect(code).toBe(1);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("POST /apps/app-1/deploy returned invalid JSON"),
+    );
+  });
+
   it.each(["-1", "1.5", "2147483648"])(
     "rejects malformed poll interval %s before any network call",
     async (interval) => {
-      process.env.ELIZAOS_CLOUD_API_KEY = "eliza_test_key";
       process.env.ELIZAOS_DEPLOY_POLL_INTERVAL_MS = interval;
       const fetchMock = vi.fn();
       globalThis.fetch = fetchMock as unknown as typeof fetch;

--- a/packages/elizaos/src/commands/deploy.ts
+++ b/packages/elizaos/src/commands/deploy.ts
@@ -277,10 +277,26 @@ async function cloudRequest<T>(
     ...(body === undefined ? {} : { body: JSON.stringify(body) }),
   });
   const text = await response.text();
-  const parsed = text ? JSON.parse(text) : {};
+  let parsed: unknown;
+  try {
+    parsed = text ? JSON.parse(text) : {};
+  } catch (err) {
+    if (!response.ok) {
+      // A gateway/proxy error page is not JSON; keep the status-aware
+      // diagnostics instead of surfacing a raw JSON SyntaxError.
+      parsed = undefined;
+    } else {
+      const reason = err instanceof Error ? err.message : String(err);
+      throw new Error(
+        `${method} ${routePath} returned invalid JSON: ${reason}`,
+      );
+    }
+  }
   if (!response.ok) {
+    const summary =
+      parsed === undefined ? "response body was not JSON" : jsonSummary(parsed);
     throw new Error(
-      `${method} ${routePath} failed (${response.status}): ${jsonSummary(parsed)}`,
+      `${method} ${routePath} failed (${response.status}): ${summary}`,
     );
   }
   return parsed as T;


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Closes #28355

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low risk. Confined to error diagnostics for cloud deployment response parsing in `packages/elizaos/src/commands/deploy.ts`.

# Background

## What does this PR do?
Preserves status-aware error diagnostics when the cloud deployment API returns a non-JSON error response, and ensures non-JSON successful responses fail explicitly.

## What kind of change is this?
Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?
My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?
Review `packages/elizaos/src/commands/deploy.ts` and `packages/elizaos/src/commands/deploy.test.ts`.

## Detailed testing steps
Run:
```bash
bun run --cwd packages/elizaos test -- src/commands/deploy.test.ts
bun run --cwd packages/elizaos typecheck
```

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:f3748886ac74719cbb82664aa8e09e1e2cfcba6a -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots: N/A - CLI command error reporting.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots: N/A - CLI command error reporting.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough: N/A - CLI command error reporting.
<!-- evidence-row:backend-logs -->
- [x] Backend logs:
<details>
<summary>bun run --cwd packages/elizaos test -- src/commands/deploy.test.ts output</summary>

```
 Test Files  1 passed (1)
      Tests  41 passed (41)
   Start at  18:57:16
   Duration  361ms
```
</details>
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs: N/A - CLI command without frontend execution.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory: N/A - Deterministic error formatting.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts: N/A - CLI command without persisted storage.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review: N/A - No UI rendered.

# Known gaps / failures
None.

# Maintainer CI exception record
N/A - no exception requested

---

AI provider/model: Google / Gemini 3.7 Flash
Client / agent tooling: Antigravity
Contribution skill revision: elizaOS/eliza@7d55350499b702ec4c979c3dcb6bb5e56d482939:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [antigravity-contrib]
<!-- eliza-computer-attribution:v1 {"provider":"google","model":"gemini-3.7-flash","client":"Antigravity","skill_revision":"elizaOS/eliza@7d55350499b702ec4c979c3dcb6bb5e56d482939:packages/skills/skills/contribute-to-eliza"} -->