### PR TITLE
test(agent-skills): cover skill execution env sanitizer and process isolation boundaries

### DIFF
--- a/plugins/plugin-agent-skills/src/security/skill-execution-env.test.ts
+++ b/plugins/plugin-agent-skills/src/security/skill-execution-env.test.ts
@@ -60,6 +60,67 @@ describe("buildSkillExecutionEnv", () => {
     expect(() => buildSkillExecutionEnv({ HOME: "/root" }, {})).toThrow(
       /no PATH/,
     );
+    expect(() =>
+      buildSkillExecutionEnv({ PATH: "   ", HOME: "/root" }, {}),
+    ).toThrow(/no PATH/);
+    expect(() =>
+      buildSkillExecutionEnv({ PATH: "\t\n", HOME: "/root" }, {}),
+    ).toThrow(/no PATH/);
+  });
+
+  it("passes all authorized host environment keys through", () => {
+    const hostEnv = {
+      PATH: "/usr/bin",
+      HOME: "/home/user",
+      TMPDIR: "/tmp/custom",
+      TMP: "/tmp/custom",
+      TEMP: "/tmp/custom",
+      SHELL: "/bin/zsh",
+      TERM: "xterm-256color",
+      USER: "eliza",
+      LOGNAME: "eliza",
+      LANG: "en_US.UTF-8",
+      LC_ALL: "en_US.UTF-8",
+      LC_CTYPE: "en_US.UTF-8",
+      TZ: "UTC",
+    };
+    const env = buildSkillExecutionEnv(hostEnv, {});
+    for (const [key, value] of Object.entries(hostEnv)) {
+      expect(env[key]).toBe(value);
+    }
+  });
+
+  it("passes all agent-scoped and skill-declared keys through", () => {
+    const authorizedKeys = {
+      PATH: "/usr/bin",
+      ELIZAOS_CLOUD_API_KEY: "cloud-key",
+      ELIZAOS_CLOUD_BASE_URL: "https://api.eliza.app",
+      ELIZA_CLOUD_BASE_URL: "https://api.eliza.app",
+      ELIZA_CLOUD_PUBLIC_URL: "https://public.eliza.app",
+      ELIZA_CLOUD_URL: "https://cloud.eliza.app",
+      ELIZA_APP_ID: "app-uuid-123",
+      GEMINI_API_KEY: "gemini-key",
+      OTTO_TMUX_SOCKET_DIR: "/tmp/otto-tmux",
+      NOTION_API_KEY: "notion-key",
+      TRELLO_API_KEY: "trello-key",
+      TRELLO_TOKEN: "trello-token",
+      THINGS_AUTH_TOKEN: "things-token",
+    };
+    const env = buildSkillExecutionEnv(authorizedKeys, {});
+    for (const [key, value] of Object.entries(authorizedKeys)) {
+      expect(env[key]).toBe(value);
+    }
+  });
+
+  it("ignores undefined values in processEnv and overlay", () => {
+    const env = buildSkillExecutionEnv(
+      { PATH: "/usr/bin", HOME: undefined, GEMINI_API_KEY: "valid" },
+      { NOTION_API_KEY: undefined as unknown as string, TRELLO_KEY: "set" },
+    );
+    expect(env.PATH).toBe("/usr/bin");
+    expect(env.GEMINI_API_KEY).toBe("valid");
+    expect(env).not.toHaveProperty("HOME");
+    expect(env).not.toHaveProperty("NOTION_API_KEY");
   });
 
   it("drops an unrecognised ambient key rather than passing it through", () => {
@@ -102,15 +163,21 @@ describe("buildSkillExecutionEnv", () => {
     // ship both, and a child reading the documented uppercase spelling would
     // still get the ambient value — silently using the wrong credential.
     const env = buildSkillExecutionEnv(
-      { PATH: "/usr/bin", GEMINI_API_KEY: "ambient" },
-      { Gemini_Api_Key: "from-skill-config" },
+      { PATH: "/usr/bin", GEMINI_API_KEY: "ambient", TRELLO_TOKEN: "ambient-token" },
+      { Gemini_Api_Key: "from-skill-config", trello_token: "overlay-token" },
     );
 
-    const spellings = Object.keys(env).filter(
+    const geminiKeys = Object.keys(env).filter(
       (key) => key.toUpperCase() === "GEMINI_API_KEY",
     );
-    expect(spellings).toHaveLength(1);
-    expect(env[spellings[0]]).toBe("from-skill-config");
+    expect(geminiKeys).toHaveLength(1);
+    expect(env[geminiKeys[0]]).toBe("from-skill-config");
+
+    const trelloKeys = Object.keys(env).filter(
+      (key) => key.toUpperCase() === "TRELLO_TOKEN",
+    );
+    expect(trelloKeys).toHaveLength(1);
+    expect(env[trelloKeys[0]]).toBe("overlay-token");
   });
 });
 
@@ -120,6 +187,10 @@ describe("isInheritableSkillEnvKey", () => {
     // reported ready and then spawned without the variable it declared.
     expect(isInheritableSkillEnvKey("GEMINI_API_KEY")).toBe(true);
     expect(isInheritableSkillEnvKey("gemini_api_key")).toBe(true);
+    expect(isInheritableSkillEnvKey("ELIZA_APP_ID")).toBe(true);
+    expect(isInheritableSkillEnvKey("eliza_app_id")).toBe(true);
+    expect(isInheritableSkillEnvKey("THINGS_AUTH_TOKEN")).toBe(true);
+    expect(isInheritableSkillEnvKey("things_auth_token")).toBe(true);
     expect(isInheritableSkillEnvKey("AGENT_SERVER_SHARED_SECRET")).toBe(false);
     expect(isInheritableSkillEnvKey("SOME_THIRD_PARTY_KEY")).toBe(false);
   });


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Test-only suite expansion covering process environment sanitization logic and inheritable key allowlist behavior.

# Background

## What does this PR do?

Expands test coverage for `plugins/plugin-agent-skills/src/security/skill-execution-env.ts` by adding granular boundary checks for `buildSkillExecutionEnv` and `isInheritableSkillEnvKey`. Specifically tests:
- Refusal when PATH contains only whitespace (`"   "`, `"\t\n"`), ensuring fail-closed behavior against bare command resolution.
- Pass-through of all authorized host environment variables (`TMPDIR`, `TMP`, `TEMP`, `SHELL`, `TERM`, `USER`, `LOGNAME`, `LANG`, `LC_ALL`, `LC_CTYPE`, `TZ`).
- Pass-through of agent-scoped cloud tokens and skill-declared credentials (`ELIZA_CLOUD_PUBLIC_URL`, `ELIZA_CLOUD_URL`, `ELIZA_APP_ID`, `OTTO_TMUX_SOCKET_DIR`, `NOTION_API_KEY`, `TRELLO_API_KEY`, `TRELLO_TOKEN`, `THINGS_AUTH_TOKEN`).
- Graceful handling of `undefined` entries in ambient `processEnv` and overlay dictionaries.
- Correct case-collision resolution where overlay properties overwrite ambient variables regardless of casing.
- Contract agreement in `isInheritableSkillEnvKey` across lowercase, uppercase, and unauthorized identifiers.

## What kind of change is this?

Improvements (misc. changes to existing features)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Review `plugins/plugin-agent-skills/src/security/skill-execution-env.test.ts`.

## Detailed testing steps

Run:
```bash
bun run --cwd plugins/plugin-agent-skills test src/security/skill-execution-env.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows` sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:21d3759a87f7eb042397f3c3030e3251d14576c7 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only change with no rendered UI surface
<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only change with no rendered UI surface
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - test-only change has no user flow to record
<!-- evidence-row:backend-logs -->
- [ ] N/A - pure unit test does not exercise a server path
<!-- evidence-row:frontend-logs -->
- [ ] N/A - pure unit test does not exercise a browser path
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent model or prompt path is touched
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database rows or generated files produced
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface in this change

# Evidence Details

## Real LLM-call trajectory

N/A - pure unit test change.

## Backend + frontend logs

```
RED (behavior mutated by commenting out NOTION_API_KEY):
  src/security/skill-execution-env.test.ts (12 tests | 1 failed)
  FAIL src/security/skill-execution-env.test.ts > buildSkillExecutionEnv > passes all agent-scoped and skill-declared keys through
  AssertionError: expected undefined to be 'notion-key'

GREEN (restored):
  src/security/skill-execution-env.test.ts (12 tests | 12 passed)
  Test Files: 1 passed (1)
  Tests: 12 passed (12)
```

## Screenshots (before / after) + video walkthrough

N/A - test-only change with no UI surfaces.

## Audio / voice walkthrough

N/A - test-only change with no voice components.

## Known gaps / failures

None. All 34 test files (392 tests) in `plugin-agent-skills` pass clean.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: Claude Code
— [lane-byt61-7381]
