### PR TITLE
fix(core): make world metadata writes compare and swap safely

### DIFF
--- a/packages/agent/src/providers/role-backfill.test.ts
+++ b/packages/agent/src/providers/role-backfill.test.ts
@@ -2,9 +2,15 @@
  * Unit coverage for roleBackfillProvider. The provider is real; core owner
  * resolution (resolveCanonicalOwnerId / hasConfiguredCanonicalOwner /
  * normalizeRole) is real. Only runtime collaborators (getRoom, getWorld,
- * updateWorld, getSetting) are in-memory fakes.
+ * compare-and-swap authority, getSetting) are in-memory fakes.
  */
-import type { IAgentRuntime, Memory, State, UUID } from "@elizaos/core";
+import {
+  type IAgentRuntime,
+  type Memory,
+  type State,
+  type UUID,
+  worldMetadataValueEquals,
+} from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { roleBackfillProvider } from "./role-backfill.ts";
 
@@ -49,6 +55,17 @@ function makeRuntime(options: {
   updateWorld: ReturnType<typeof vi.fn>;
 } {
   const updateWorld = vi.fn(options.updateWorld ?? (async () => undefined));
+  let currentWorld =
+    options.world === undefined
+      ? { id: WORLD_ID, agentId: AGENT_ID, name: "test-world", metadata: {} }
+      : options.world === null
+        ? null
+        : {
+            id: options.world.id ?? WORLD_ID,
+            agentId: AGENT_ID,
+            name: "test-world",
+            metadata: structuredClone(options.world.metadata ?? {}),
+          };
   const runtime = {
     agentId: AGENT_ID,
     getSetting: (key: string) => options.settings?.[key],
@@ -60,23 +77,34 @@ function makeRuntime(options: {
           : options.room),
     getWorld:
       options.getWorld ??
-      (async () =>
-        options.world === undefined
-          ? {
-              id: WORLD_ID,
-              agentId: AGENT_ID,
-              name: "test-world",
-              metadata: {},
-            }
-          : options.world === null
-            ? null
-            : {
-                id: options.world.id ?? WORLD_ID,
-                agentId: AGENT_ID,
-                name: "test-world",
-                metadata: options.world.metadata,
-              }),
+      (async () => (currentWorld ? structuredClone(currentWorld) : null)),
     updateWorld,
+    adapter: {
+      compareAndSwapWorldMetadata: async (params: {
+        worldId: UUID;
+        expectedMetadata: Record<string, unknown>;
+        replacementMetadata: Record<string, unknown>;
+      }) => {
+        if (!currentWorld || currentWorld.id !== params.worldId) {
+          return { status: "not_found" as const };
+        }
+        if (
+          !worldMetadataValueEquals(
+            currentWorld.metadata,
+            params.expectedMetadata,
+          )
+        ) {
+          return { status: "conflict" as const };
+        }
+        const next = {
+          ...currentWorld,
+          metadata: structuredClone(params.replacementMetadata),
+        };
+        await updateWorld(next);
+        currentWorld = next;
+        return { status: "updated" as const };
+      },
+    },
   } as unknown as IAgentRuntime;
   return { runtime, updateWorld };
 }

--- a/packages/agent/src/providers/role-backfill.ts
+++ b/packages/agent/src/providers/role-backfill.ts
@@ -26,6 +26,7 @@ import {
   type RoleName,
   resolveCanonicalOwnerId,
   type State,
+  setEntityRoleCas,
 } from "@elizaos/core";
 
 type RolesWorldMetadata = {
@@ -89,28 +90,58 @@ export const roleBackfillProvider: Provider = {
         return empty;
       }
 
-      // Backfill: set OWNER role for the world owner
-      metadata.ownership = { ...(metadata.ownership ?? {}), ownerId };
-      roles[ownerId] = "OWNER";
-      roleSources[ownerId] = "owner";
+      if (
+        currentOwnerRole !== "OWNER" ||
+        needsOwnershipSync ||
+        needsOwnerSourceSync
+      ) {
+        const ownerResult = await setEntityRoleCas(
+          runtime,
+          message,
+          ownerId,
+          "OWNER",
+          {
+            source: "owner",
+            worldId: world.id,
+            mutateMetadata: (replacement) => {
+              replacement.ownership = {
+                ...(replacement.ownership ?? {}),
+                ownerId,
+              };
+            },
+          },
+        );
+        if (ownerResult.status !== "committed") {
+          throw new Error(
+            `OWNER backfill did not commit: ${ownerResult.status}`,
+          );
+        }
+      }
+
       if (configuredOwner) {
         for (const [entityId, role] of Object.entries(roles)) {
-          if (entityId !== ownerId && normalizeRole(role) === "OWNER") {
-            delete roles[entityId];
-            delete roleSources[entityId];
+          if (entityId === ownerId || normalizeRole(role) !== "OWNER") continue;
+          const revokeResult = await setEntityRoleCas(
+            runtime,
+            message,
+            entityId,
+            "GUEST",
+            {
+              source: "owner",
+              worldId: world.id,
+              mutateMetadata: (replacement) => {
+                delete replacement.roles?.[entityId];
+                delete replacement.roleSources?.[entityId];
+              },
+            },
+          );
+          if (revokeResult.status !== "committed") {
+            throw new Error(
+              `stale OWNER revocation did not commit: ${revokeResult.status}`,
+            );
           }
         }
       }
-      const updatedMetadata = {
-        ...metadata,
-        roles,
-        roleSources,
-      };
-
-      await runtime.updateWorld({
-        ...world,
-        metadata: updatedMetadata,
-      } as Parameters<IAgentRuntime["updateWorld"]>[0]);
 
       logger.info(
         `[roles] Backfill: set OWNER role for entity ${ownerId} in world ${world.id}`,

--- a/packages/agent/src/runtime/roles/src/index.cas.test.ts
+++ b/packages/agent/src/runtime/roles/src/index.cas.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Verifies runtime role bootstrap uses core's real in-memory CAS authority,
+ * retaining an audited OWNER transition without invoking the blind writer.
+ */
+import {
+  AgentRuntime,
+  ChannelType,
+  type Character,
+  InMemoryDatabaseAdapter,
+  ROLE_WRITE_AUDIT_LOG_TYPE,
+  stringToUuid,
+  type UUID,
+} from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import rolesPlugin from "./index";
+
+describe("runtime roles bootstrap CAS", () => {
+  it("commits the configured owner and audit through adapter CAS", async () => {
+    const runtime = new AgentRuntime({
+      character: { name: "roles-cas" } as Character,
+    });
+    const adapter = new InMemoryDatabaseAdapter();
+    await adapter.init();
+    runtime.registerDatabaseAdapter(adapter);
+    const ownerId = stringToUuid("runtime-roles-owner") as UUID;
+    const worldId = stringToUuid("runtime-roles-world") as UUID;
+    const roomId = stringToUuid("runtime-roles-room") as UUID;
+    await adapter.createEntities([
+      { id: ownerId, agentId: runtime.agentId, names: ["Owner"] },
+    ]);
+    await adapter.createWorlds([
+      { id: worldId, agentId: runtime.agentId, name: "Roles", metadata: {} },
+    ]);
+    await adapter.createRooms([
+      {
+        id: roomId,
+        agentId: runtime.agentId,
+        worldId,
+        source: "test",
+        type: ChannelType.WORLD,
+      },
+    ]);
+    (
+      runtime as unknown as { getSetting: (key: string) => unknown }
+    ).getSetting = (key) =>
+      key === "ELIZA_ADMIN_ENTITY_ID" ? ownerId : undefined;
+    (runtime as unknown as { updateWorld: () => Promise<void> }).updateWorld =
+      async () => {
+        throw new Error("blind world writer must not run");
+      };
+
+    await rolesPlugin.init?.({}, runtime);
+
+    const world = (await adapter.getWorldsByIds([worldId]))[0];
+    if (!world) throw new Error("runtime roles CAS test world missing");
+    expect(
+      (world.metadata as { roles?: Record<string, string> }).roles?.[ownerId],
+    ).toBe("OWNER");
+    const audits = await adapter.getLogs({ type: ROLE_WRITE_AUDIT_LOG_TYPE });
+    expect(audits).toHaveLength(1);
+    expect(audits[0]?.body).toMatchObject({
+      metadata: {
+        targetEntityId: ownerId,
+        previousRole: "GUEST",
+        newRole: "OWNER",
+      },
+    });
+  });
+});

--- a/packages/agent/src/runtime/roles/src/index.ts
+++ b/packages/agent/src/runtime/roles/src/index.ts
@@ -17,8 +17,11 @@
 import {
   type IAgentRuntime,
   logger,
+  type Memory,
   type Plugin,
   roleAction,
+  setEntityRoleCas,
+  type UUID,
 } from "@elizaos/core";
 import { rolesProvider } from "./provider.ts";
 import type { RolesConfig, RolesWorldMetadata } from "./types.ts";
@@ -68,22 +71,24 @@ export {
 } from "./utils.ts";
 export { roleAction };
 
-async function updateWorldMetadata(
-  runtime: IAgentRuntime,
-  worldId: string,
-  update: (metadata: RolesWorldMetadata) => boolean | Promise<boolean>,
+function systemRoleMessage(actorEntityId: string, roomId: UUID): Memory {
+  return {
+    entityId: actorEntityId as UUID,
+    roomId,
+    content: {
+      text: "runtime role authority synchronization",
+      source: "roles",
+    },
+  } as Memory;
+}
+
+async function requireCommittedRoleWrite(
+  result: Awaited<ReturnType<typeof setEntityRoleCas>>,
+  label: string,
 ): Promise<void> {
-  const world = await runtime.getWorld(worldId);
-  if (!world) return;
-
-  const metadata = (world.metadata ?? {}) as RolesWorldMetadata;
-  const changed = await update(metadata);
-  if (!changed) return;
-
-  (world as { metadata: RolesWorldMetadata }).metadata = metadata;
-  await runtime.updateWorld(
-    world as Parameters<IAgentRuntime["updateWorld"]>[0],
-  );
+  if (result.status !== "committed") {
+    throw new Error(`${label} did not commit: ${result.status}`);
+  }
 }
 
 function getBootstrapRetryTimers(
@@ -165,62 +170,69 @@ async function ensureOwnerRole(
 
     for (const world of worlds) {
       if (!world.id) continue;
-
-      await updateWorldMetadata(runtime, world.id, (metadata) => {
-        const ownerId = resolveCanonicalOwnerId(runtime, metadata);
-        if (!ownerId) return false;
-
-        let changed = false;
-
-        metadata.ownership ??= {};
-        metadata.roleSources ??= {};
-        if (metadata.ownership.ownerId !== ownerId) {
-          metadata.ownership.ownerId = ownerId;
-          changed = true;
-        }
-
-        if (!metadata.roles) metadata.roles = {};
-        if (normalizeRole(metadata.roles[ownerId]) !== "OWNER") {
-          metadata.roles[ownerId] = "OWNER";
-          changed = true;
-        }
-        if (metadata.roleSources[ownerId] !== "owner") {
-          metadata.roleSources[ownerId] = "owner";
-          changed = true;
-        }
-
-        if (hasConfiguredCanonicalOwner(runtime)) {
-          for (const [entityId, role] of Object.entries(metadata.roles)) {
-            if (entityId !== ownerId && normalizeRole(role) === "OWNER") {
-              delete metadata.roles[entityId];
-              delete metadata.roleSources[entityId];
-              changed = true;
-            }
-          }
-        }
-
-        if (opts?.pruneConnectorAdmins) {
-          for (const [entityId, source] of Object.entries(
-            metadata.roleSources,
-          )) {
-            if (source !== "connector_admin") continue;
-            delete metadata.roleSources[entityId];
-            delete metadata.roles[entityId];
-            changed = true;
-            logger.info(
-              `[roles] Cleared connector-admin grant ${entityId} because no whitelist is configured`,
-            );
-          }
-        }
-
-        if (changed) {
-          logger.info(
-            `[roles] Synced canonical OWNER ${ownerId} in world ${world.id}`,
+      const metadata = (world.metadata ?? {}) as RolesWorldMetadata;
+      const ownerId = resolveCanonicalOwnerId(runtime, metadata);
+      if (!ownerId) continue;
+      const room = (await runtime.getRooms(world.id))[0];
+      if (!room)
+        throw new Error(`World ${world.id} has no room for role audit scope`);
+      const message = systemRoleMessage(ownerId, room.id);
+      const roles = metadata.roles ?? {};
+      const roleSources = metadata.roleSources ?? {};
+      if (
+        metadata.ownership?.ownerId !== ownerId ||
+        normalizeRole(roles[ownerId]) !== "OWNER" ||
+        roleSources[ownerId] !== "owner"
+      ) {
+        await requireCommittedRoleWrite(
+          await setEntityRoleCas(runtime, message, ownerId, "OWNER", {
+            source: "owner",
+            worldId: world.id,
+            mutateMetadata: (replacement) => {
+              replacement.ownership = {
+                ...(replacement.ownership ?? {}),
+                ownerId,
+              };
+            },
+          }),
+          "canonical OWNER synchronization",
+        );
+      }
+      if (hasConfiguredCanonicalOwner(runtime)) {
+        for (const [entityId, role] of Object.entries(roles)) {
+          if (entityId === ownerId || normalizeRole(role) !== "OWNER") continue;
+          await requireCommittedRoleWrite(
+            await setEntityRoleCas(runtime, message, entityId, "GUEST", {
+              source: "owner",
+              worldId: world.id,
+              mutateMetadata: (replacement) => {
+                delete replacement.roles?.[entityId];
+                delete replacement.roleSources?.[entityId];
+              },
+            }),
+            `stale OWNER revocation for ${entityId}`,
           );
         }
-
-        return changed;
-      });
+      }
+      if (opts?.pruneConnectorAdmins) {
+        for (const [entityId, source] of Object.entries(roleSources)) {
+          if (source !== "connector_admin") continue;
+          await requireCommittedRoleWrite(
+            await setEntityRoleCas(runtime, message, entityId, "GUEST", {
+              source: "connector_admin",
+              worldId: world.id,
+              mutateMetadata: (replacement) => {
+                delete replacement.roles?.[entityId];
+                delete replacement.roleSources?.[entityId];
+              },
+            }),
+            `connector-admin revocation for ${entityId}`,
+          );
+        }
+      }
+      logger.info(
+        `[roles] Synced canonical OWNER ${ownerId} in world ${world.id}`,
+      );
     }
     return true;
   } catch (err) {
@@ -246,60 +258,62 @@ async function applyConnectorAdminWhitelists(
 
       const rooms = await runtime.getRooms(world.id);
 
-      await updateWorldMetadata(runtime, world.id, async (metadata) => {
-        if (!metadata.roles) metadata.roles = {};
-        metadata.roleSources ??= {};
-        let updated = false;
-        const matchedEntityIds = new Set<string>();
+      const metadata = (world.metadata ?? {}) as RolesWorldMetadata;
+      const ownerId = resolveCanonicalOwnerId(runtime, metadata);
+      if (!ownerId) {
+        throw new Error(
+          `World ${world.id} has no canonical owner for connector role audit authority`,
+        );
+      }
+      const auditRoom = rooms[0];
+      if (!auditRoom)
+        throw new Error(`World ${world.id} has no room for role audit scope`);
+      const message = systemRoleMessage(ownerId, auditRoom.id);
+      const matchedEntityIds = new Set<string>();
 
-        for (const room of rooms) {
-          const entities = await runtime.getEntitiesForRoom(room.id);
-          for (const entity of entities) {
-            if (!entity.id) continue;
-            const entityId = entity.id;
-
-            if (metadata.roles[entityId]) continue;
-
-            const matched = matchEntityToConnectorAdminWhitelist(
-              (entity.metadata as Record<string, unknown> | undefined) ??
-                undefined,
-              whitelist,
-            );
-
-            if (matched) {
-              matchedEntityIds.add(entityId);
-
-              if (
-                metadata.roleSources[entityId] === "connector_admin" &&
-                normalizeRole(metadata.roles[entityId]) === "ADMIN"
-              ) {
-                continue;
-              }
-
-              metadata.roles[entityId] = "ADMIN";
-              metadata.roleSources[entityId] = "connector_admin";
-              updated = true;
-              logger.info(
-                `[roles] Auto-promoted whitelisted entity ${entityId} to ADMIN`,
-              );
-            }
-          }
-        }
-
-        for (const [entityId, source] of Object.entries(metadata.roleSources)) {
-          if (source !== "connector_admin") continue;
-          if (matchedEntityIds.has(entityId)) continue;
-
-          delete metadata.roleSources[entityId];
-          delete metadata.roles[entityId];
-          updated = true;
-          logger.info(
-            `[roles] Revoked stale connector-admin role for entity ${entityId}`,
+      for (const room of rooms) {
+        const entities = await runtime.getEntitiesForRoom(room.id);
+        for (const entity of entities) {
+          if (!entity.id) continue;
+          const matched = matchEntityToConnectorAdminWhitelist(
+            (entity.metadata as Record<string, unknown> | undefined) ??
+              undefined,
+            whitelist,
+          );
+          if (!matched) continue;
+          matchedEntityIds.add(entity.id);
+          if (
+            metadata.roleSources?.[entity.id] === "connector_admin" &&
+            normalizeRole(metadata.roles?.[entity.id]) === "ADMIN"
+          )
+            continue;
+          await requireCommittedRoleWrite(
+            await setEntityRoleCas(runtime, message, entity.id, "ADMIN", {
+              source: "connector_admin",
+              worldId: world.id,
+            }),
+            `connector-admin promotion for ${entity.id}`,
           );
         }
+      }
 
-        return updated;
-      });
+      for (const [entityId, source] of Object.entries(
+        metadata.roleSources ?? {},
+      )) {
+        if (source !== "connector_admin" || matchedEntityIds.has(entityId))
+          continue;
+        await requireCommittedRoleWrite(
+          await setEntityRoleCas(runtime, message, entityId, "GUEST", {
+            source: "connector_admin",
+            worldId: world.id,
+            mutateMetadata: (replacement) => {
+              delete replacement.roles?.[entityId];
+              delete replacement.roleSources?.[entityId];
+            },
+          }),
+          `stale connector-admin revocation for ${entityId}`,
+        );
+      }
     }
     return true;
   } catch (err) {

--- a/packages/core/src/database.ts
+++ b/packages/core/src/database.ts
@@ -10,6 +10,7 @@
  * rather than silently succeeding.
  */
 
+import { ElizaError } from "./errors";
 import type {
 	AccessContext,
 	Agent,
@@ -170,15 +171,24 @@ export abstract class DatabaseAdapter<DB extends object = object>
 	): Promise<DocumentMutationResult>;
 
 	/**
-	 * Atomic world-metadata compare-and-swap with same-transaction audit commit
-	 * (#23100). Every first-class adapter implements this natively — the exact
-	 * prior snapshot is compared in the transaction that writes the
-	 * replacement, so concurrent metadata writers lose atomically instead of
-	 * silently overwriting authorization state.
+	 * Optional world-metadata CAS capability. This concrete fail-closed default
+	 * preserves compatibility for existing third-party subclasses while role
+	 * writes refuse to fall back to an unsafe whole-world overwrite.
 	 */
-	abstract compareAndSwapWorldMetadata(
+	compareAndSwapWorldMetadata(
 		params: WorldMetadataCompareAndSwapParams,
-	): Promise<WorldMetadataMutationResult>;
+	): Promise<WorldMetadataMutationResult> {
+		throw new ElizaError(
+			"Database adapter does not support atomic world-metadata role writes",
+			{
+				code: "WORLD_METADATA_CAS_CAPABILITY_REQUIRED",
+				context: {
+					adapter: this.constructor.name,
+					worldId: params.worldId,
+				},
+			},
+		);
+	}
 
 	abstract replaceDocumentRevision(
 		params: DocumentRevisionReplaceParams,

--- a/packages/core/src/database.ts
+++ b/packages/core/src/database.ts
@@ -62,6 +62,8 @@ import type {
 	UpsertConnectorAccountParams,
 	UUID,
 	World,
+	WorldMetadataCompareAndSwapParams,
+	WorldMetadataMutationResult,
 } from "./types";
 
 /** Enforces the shared pagination contract for entity-query boundaries. */
@@ -166,6 +168,17 @@ export abstract class DatabaseAdapter<DB extends object = object>
 	abstract updateDocumentDirectGrants(
 		params: DocumentDirectGrantUpdateParams,
 	): Promise<DocumentMutationResult>;
+
+	/**
+	 * Atomic world-metadata compare-and-swap with same-transaction audit commit
+	 * (#23100). Every first-class adapter implements this natively — the exact
+	 * prior snapshot is compared in the transaction that writes the
+	 * replacement, so concurrent metadata writers lose atomically instead of
+	 * silently overwriting authorization state.
+	 */
+	abstract compareAndSwapWorldMetadata(
+		params: WorldMetadataCompareAndSwapParams,
+	): Promise<WorldMetadataMutationResult>;
 
 	abstract replaceDocumentRevision(
 		params: DocumentRevisionReplaceParams,

--- a/packages/core/src/database/inMemoryAdapter.ts
+++ b/packages/core/src/database/inMemoryAdapter.ts
@@ -107,6 +107,13 @@ import {
 	validateDocumentDirectGrantEntityIds,
 	validateDocumentRevisionReplacement,
 } from "./document-list-query";
+import {
+	advanceWorldMetadataRevision,
+	getWorldMetadataRevision,
+	initializeWorldMetadataRevision,
+	requireFreshWorldMetadataRevision,
+	worldMetadataValueEquals,
+} from "./world-metadata-cas";
 
 function asUuid(id: string): UUID {
 	return id as UUID;
@@ -124,38 +131,6 @@ function randomUuid(): UUID {
 
 function roomTableKey(tableName: string, roomId: UUID): string {
 	return `${tableName}:${String(roomId)}`;
-}
-
-/**
- * Deep JSON-value equality for world-metadata compare-and-swap: the stored
- * `World.metadata` is a live object in this adapter, so snapshots must compare
- * by value. Key order is irrelevant (matching SQL jsonb equality); `undefined`
- * is treated as absent, matching how a JSON round-trip drops it.
- */
-function jsonValueEquals(left: unknown, right: unknown): boolean {
-	if (left === right) return true;
-	if (isPlainObject(left) && isPlainObject(right)) {
-		const leftKeys = Object.keys(left).filter(
-			(key) => (left as Record<string, unknown>)[key] !== undefined,
-		);
-		const rightKeys = Object.keys(right).filter(
-			(key) => (right as Record<string, unknown>)[key] !== undefined,
-		);
-		if (leftKeys.length !== rightKeys.length) return false;
-		return leftKeys.every((key) =>
-			jsonValueEquals(
-				(left as Record<string, unknown>)[key],
-				(right as Record<string, unknown>)[key],
-			),
-		);
-	}
-	if (Array.isArray(left) && Array.isArray(right)) {
-		return (
-			left.length === right.length &&
-			left.every((item, index) => jsonValueEquals(item, right[index]))
-		);
-	}
-	return false;
 }
 
 function memoryMatchesMetadata(
@@ -1745,7 +1720,7 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 		for (const id of worldIds) {
 			const world = this.worlds.get(String(id));
 			if (world) {
-				worlds.push(world);
+				worlds.push(structuredClone(world));
 			}
 		}
 		return worlds;
@@ -1754,16 +1729,31 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 	async createWorlds(worlds: World[]): Promise<UUID[]> {
 		const ids: UUID[] = [];
 		for (const world of worlds) {
-			this.worlds.set(String(world.id), world);
+			if (this.worlds.has(String(world.id))) {
+				throw new ElizaError("World already exists", {
+					code: "WORLD_ALREADY_EXISTS",
+					context: { worldId: world.id },
+				});
+			}
+			this.worlds.set(String(world.id), {
+				...structuredClone(world),
+				metadata: initializeWorldMetadataRevision(
+					world.metadata as Metadata | undefined,
+				) as World["metadata"],
+			});
 			ids.push(world.id);
 		}
 		return ids;
 	}
 
 	async upsertWorlds(worlds: World[]): Promise<void> {
-		// WHY simple set: Map.set() handles both insert and update atomically.
 		for (const world of worlds) {
-			this.worlds.set(String(world.id), world);
+			const existing = this.worlds.get(String(world.id));
+			if (!existing) {
+				await this.createWorlds([world]);
+				continue;
+			}
+			await this.updateWorlds([world]);
 		}
 	}
 
@@ -1775,7 +1765,22 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 
 	async updateWorlds(worlds: World[]): Promise<void> {
 		for (const world of worlds) {
-			this.worlds.set(String(world.id), world);
+			const existing = this.worlds.get(String(world.id));
+			if (!existing) continue;
+			const storedRevision = requireFreshWorldMetadataRevision(
+				existing.metadata as Metadata | undefined,
+				world.metadata as Metadata | undefined,
+				String(world.id),
+			);
+			const nextMetadata = advanceWorldMetadataRevision(
+				world.metadata as Metadata | undefined,
+				storedRevision,
+			);
+			this.worlds.set(String(world.id), {
+				...structuredClone(world),
+				metadata: nextMetadata as World["metadata"],
+			});
+			world.metadata = structuredClone(nextMetadata) as World["metadata"];
 		}
 	}
 
@@ -1794,9 +1799,18 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 		if (!existing) {
 			return { status: "not_found" };
 		}
-		if (!jsonValueEquals(existing.metadata ?? {}, params.expectedMetadata)) {
+		if (
+			!worldMetadataValueEquals(
+				existing.metadata ?? {},
+				params.expectedMetadata,
+			)
+		) {
 			return { status: "conflict" };
 		}
+		const storedRevision = getWorldMetadataRevision(
+			existing.metadata as Metadata | undefined,
+		);
+		if (storedRevision === null) return { status: "conflict" };
 		const audit = params.audit;
 		// Validate cloneability BEFORE appending the audit row: if the
 		// replacement metadata is not cloneable the method must throw with
@@ -1804,8 +1818,9 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 		// without its metadata change would be a false authority record).
 		const replacementWorld: World = {
 			...existing,
-			metadata: structuredClone(
+			metadata: advanceWorldMetadataRevision(
 				params.replacementMetadata,
+				storedRevision,
 			) as World["metadata"],
 		};
 		if (audit) {
@@ -1837,7 +1852,7 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 	}
 
 	async getAllWorlds(): Promise<World[]> {
-		return Array.from(this.worlds.values());
+		return Array.from(this.worlds.values(), (world) => structuredClone(world));
 	}
 
 	// Batch room methods

--- a/packages/core/src/database/inMemoryAdapter.ts
+++ b/packages/core/src/database/inMemoryAdapter.ts
@@ -109,6 +109,7 @@ import {
 } from "./document-list-query";
 import {
 	advanceWorldMetadataRevision,
+	appendWorldMetadataRoleAudit,
 	getWorldMetadataRevision,
 	initializeWorldMetadataRevision,
 	requireFreshWorldMetadataRevision,
@@ -1816,10 +1817,20 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 		// replacement metadata is not cloneable the method must throw with
 		// the world untouched AND no audit row appended (a committed audit
 		// without its metadata change would be a false authority record).
+		const replacementMetadata = audit
+			? appendWorldMetadataRoleAudit(params.replacementMetadata, {
+					actorEntityId: audit.actorEntityId,
+					targetEntityId: audit.targetEntityId,
+					previousRole: audit.previousRole,
+					newRole: audit.newRole,
+					source: audit.source,
+					roomId: audit.roomId,
+				})
+			: params.replacementMetadata;
 		const replacementWorld: World = {
 			...existing,
 			metadata: advanceWorldMetadataRevision(
-				params.replacementMetadata,
+				replacementMetadata,
 				storedRevision,
 			) as World["metadata"],
 		};

--- a/packages/core/src/database/inMemoryAdapter.ts
+++ b/packages/core/src/database/inMemoryAdapter.ts
@@ -83,8 +83,11 @@ import type {
 	UpsertConnectorAccountParams,
 	UUID,
 	World,
+	WorldMetadataCompareAndSwapParams,
+	WorldMetadataMutationResult,
 } from "../types";
 import { MemoryType } from "../types";
+import { ROLE_WRITE_AUDIT_LOG_TYPE } from "../types/database";
 import { normalizePairingPageOptions } from "../types/pairing";
 import { DEFAULT_UUID } from "../types/primitives";
 import { createHash } from "../utils/crypto-compat";
@@ -121,6 +124,38 @@ function randomUuid(): UUID {
 
 function roomTableKey(tableName: string, roomId: UUID): string {
 	return `${tableName}:${String(roomId)}`;
+}
+
+/**
+ * Deep JSON-value equality for world-metadata compare-and-swap: the stored
+ * `World.metadata` is a live object in this adapter, so snapshots must compare
+ * by value. Key order is irrelevant (matching SQL jsonb equality); `undefined`
+ * is treated as absent, matching how a JSON round-trip drops it.
+ */
+function jsonValueEquals(left: unknown, right: unknown): boolean {
+	if (left === right) return true;
+	if (isPlainObject(left) && isPlainObject(right)) {
+		const leftKeys = Object.keys(left).filter(
+			(key) => (left as Record<string, unknown>)[key] !== undefined,
+		);
+		const rightKeys = Object.keys(right).filter(
+			(key) => (right as Record<string, unknown>)[key] !== undefined,
+		);
+		if (leftKeys.length !== rightKeys.length) return false;
+		return leftKeys.every((key) =>
+			jsonValueEquals(
+				(left as Record<string, unknown>)[key],
+				(right as Record<string, unknown>)[key],
+			),
+		);
+	}
+	if (Array.isArray(left) && Array.isArray(right)) {
+		return (
+			left.length === right.length &&
+			left.every((item, index) => jsonValueEquals(item, right[index]))
+		);
+	}
+	return false;
 }
 
 function memoryMatchesMetadata(
@@ -1742,6 +1777,63 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 		for (const world of worlds) {
 			this.worlds.set(String(world.id), world);
 		}
+	}
+
+	/**
+	 * Compare-and-swap replacement of a world's whole metadata under the exact
+	 * prior snapshot (#23100). Value-compares the stored metadata (never by
+	 * reference — the Map stores live objects), commits the replacement, and
+	 * appends the audit row only when the snapshot still matches, so a
+	 * concurrent metadata write surfaces as a typed conflict rather than being
+	 * silently overwritten.
+	 */
+	async compareAndSwapWorldMetadata(
+		params: WorldMetadataCompareAndSwapParams,
+	): Promise<WorldMetadataMutationResult> {
+		const existing = this.worlds.get(String(params.worldId));
+		if (!existing) {
+			return { status: "not_found" };
+		}
+		if (!jsonValueEquals(existing.metadata ?? {}, params.expectedMetadata)) {
+			return { status: "conflict" };
+		}
+		const audit = params.audit;
+		// Validate cloneability BEFORE appending the audit row: if the
+		// replacement metadata is not cloneable the method must throw with
+		// the world untouched AND no audit row appended (a committed audit
+		// without its metadata change would be a false authority record).
+		const replacementWorld: World = {
+			...existing,
+			metadata: structuredClone(
+				params.replacementMetadata,
+			) as World["metadata"],
+		};
+		if (audit) {
+			// Same "transaction" as the metadata replacement: the audit row is
+			// appended immediately before the world entry is swapped, and any
+			// throw from the insert leaves the map untouched.
+			this.logs.push({
+				id: randomUuid(),
+				createdAt: new Date(),
+				entityId: audit.actorEntityId,
+				roomId: audit.roomId,
+				type: ROLE_WRITE_AUDIT_LOG_TYPE,
+				body: {
+					source: "role-write-cas",
+					metadata: {
+						worldId: params.worldId,
+						actorEntityId: audit.actorEntityId,
+						targetEntityId: audit.targetEntityId,
+						previousRole: audit.previousRole,
+						newRole: audit.newRole,
+						grantSource: audit.source,
+						outcome: "committed",
+					},
+				},
+			});
+		}
+		this.worlds.set(String(params.worldId), replacementWorld);
+		return { status: "updated" };
 	}
 
 	async getAllWorlds(): Promise<World[]> {

--- a/packages/core/src/database/world-metadata-cas.ts
+++ b/packages/core/src/database/world-metadata-cas.ts
@@ -1,0 +1,154 @@
+/**
+ * Shared value-comparison and revision helpers protect world metadata across
+ * compare-and-swap and legacy whole-world adapter writes.
+ */
+
+import { ElizaError } from "../errors";
+import type { Metadata } from "../types/primitives";
+import { isPlainObject } from "../utils/type-guards";
+
+/** Adapter-owned optimistic revision stored with each world's metadata. */
+export const WORLD_METADATA_REVISION_KEY =
+	"__eliza_world_metadata_revision" as const;
+
+/**
+ * Compare JSON values with PostgreSQL jsonb semantics: object key order is
+ * irrelevant and `undefined` properties are absent.
+ */
+export function worldMetadataValueEquals(
+	left: unknown,
+	right: unknown,
+): boolean {
+	if (left === right) return true;
+	if (Array.isArray(left) && Array.isArray(right)) {
+		return (
+			left.length === right.length &&
+			left.every((item, index) => worldMetadataValueEquals(item, right[index]))
+		);
+	}
+	if (isPlainObject(left) && isPlainObject(right)) {
+		const leftKeys = Object.keys(left).filter(
+			(key) => (left as Record<string, unknown>)[key] !== undefined,
+		);
+		const rightKeys = Object.keys(right).filter(
+			(key) => (right as Record<string, unknown>)[key] !== undefined,
+		);
+		if (leftKeys.length !== rightKeys.length) return false;
+		return leftKeys.every(
+			(key) =>
+				Object.hasOwn(right, key) &&
+				worldMetadataValueEquals(
+					(left as Record<string, unknown>)[key],
+					(right as Record<string, unknown>)[key],
+				),
+		);
+	}
+	return false;
+}
+
+/**
+ * Read the adapter-owned revision. Worlds written before the revision contract
+ * start at zero; malformed explicit values fail closed.
+ */
+export function getWorldMetadataRevision(
+	metadata: Metadata | undefined,
+): number | null {
+	const value = metadata?.[WORLD_METADATA_REVISION_KEY];
+	if (value === undefined) return 0;
+	return typeof value === "number" && Number.isSafeInteger(value) && value >= 0
+		? value
+		: null;
+}
+
+/**
+ * Require a legacy whole-world writer to carry the revision it read. A stale
+ * or malformed request is an observable failure, never a silent lost update.
+ */
+export function requireFreshWorldMetadataRevision(
+	storedMetadata: Metadata | undefined,
+	writerMetadata: Metadata | undefined,
+	worldId: string,
+): number {
+	const storedRevision = getWorldMetadataRevision(storedMetadata);
+	const writerRevision = getWorldMetadataRevision(writerMetadata);
+	if (
+		storedRevision === null ||
+		writerRevision === null ||
+		storedRevision !== writerRevision
+	) {
+		throw new ElizaError("World metadata write used a stale revision", {
+			code: "WORLD_METADATA_STALE_WRITE",
+			context: {
+				worldId,
+				storedRevision,
+				writerRevision,
+				reason:
+					storedRevision === null || writerRevision === null
+						? "malformed_revision"
+						: "revision_mismatch",
+			},
+		});
+	}
+	return storedRevision;
+}
+
+/** Merge caller metadata while retaining the adapter-owned stored revision. */
+export function mergeWorldMetadataForLegacyWrite(
+	storedMetadata: Metadata | undefined,
+	incomingMetadata: Metadata | undefined,
+	worldId: string,
+): Metadata {
+	const storedRevision = getWorldMetadataRevision(storedMetadata);
+	if (storedRevision === null) {
+		throw new ElizaError("Stored world metadata revision is malformed", {
+			code: "WORLD_METADATA_STALE_WRITE",
+			context: { worldId, storedRevision, reason: "malformed_revision" },
+		});
+	}
+	const stored = structuredClone(storedMetadata ?? {}) as Metadata;
+	const incoming = structuredClone(incomingMetadata ?? {}) as Metadata;
+	// Connector ownership and role maps are authority state, not ordinary
+	// connector observations. Existing worlds must never replace them with a
+	// newly constructed owner-only projection during message ingestion.
+	delete incoming.roles;
+	delete incoming.roleSources;
+	return {
+		...stored,
+		...incoming,
+		...(stored.roles === undefined ? {} : { roles: stored.roles }),
+		...(stored.roleSources === undefined
+			? {}
+			: { roleSources: stored.roleSources }),
+		[WORLD_METADATA_REVISION_KEY]: storedRevision,
+	};
+}
+
+/** Clone metadata and advance its adapter-owned optimistic revision. */
+export function advanceWorldMetadataRevision(
+	metadata: Metadata | undefined,
+	currentRevision: number,
+): Metadata {
+	if (!Number.isSafeInteger(currentRevision) || currentRevision < 0) {
+		throw new ElizaError("World metadata revision is invalid", {
+			code: "WORLD_METADATA_REVISION_INVALID",
+			context: { currentRevision },
+		});
+	}
+	if (currentRevision === Number.MAX_SAFE_INTEGER) {
+		throw new ElizaError("World metadata revision is exhausted", {
+			code: "WORLD_METADATA_REVISION_EXHAUSTED",
+		});
+	}
+	const replacement = structuredClone(metadata ?? {}) as Metadata;
+	replacement[WORLD_METADATA_REVISION_KEY] = currentRevision + 1;
+	return replacement;
+}
+
+/** Normalize a newly created world's revision without trusting caller input. */
+export function initializeWorldMetadataRevision(
+	metadata: Metadata | undefined,
+): Metadata {
+	const replacement = structuredClone(metadata ?? {}) as Metadata;
+	replacement[WORLD_METADATA_REVISION_KEY] = 0;
+	return replacement;
+}

--- a/packages/core/src/database/world-metadata-cas.ts
+++ b/packages/core/src/database/world-metadata-cas.ts
@@ -10,6 +10,8 @@ import { isPlainObject } from "../utils/type-guards";
 /** Adapter-owned optimistic revision stored with each world's metadata. */
 export const WORLD_METADATA_REVISION_KEY =
 	"__eliza_world_metadata_revision" as const;
+/** Immutable role-write history retained with the world authority snapshot. */
+export const WORLD_METADATA_ROLE_AUDIT_KEY = "__eliza_role_audit" as const;
 
 /**
  * Compare JSON values with PostgreSQL jsonb semantics: object key order is
@@ -141,6 +143,21 @@ export function advanceWorldMetadataRevision(
 	}
 	const replacement = structuredClone(metadata ?? {}) as Metadata;
 	replacement[WORLD_METADATA_REVISION_KEY] = currentRevision + 1;
+	return replacement;
+}
+
+/** Preserve authority history even when connector-owned log rows are deleted. */
+export function appendWorldMetadataRoleAudit(
+	metadata: Metadata | undefined,
+	audit: Record<string, unknown>,
+): Metadata {
+	const replacement = structuredClone(metadata ?? {}) as Metadata;
+	const prior = replacement[WORLD_METADATA_ROLE_AUDIT_KEY];
+	const entries = Array.isArray(prior) ? prior : [];
+	replacement[WORLD_METADATA_ROLE_AUDIT_KEY] = [
+		...entries,
+		structuredClone(audit),
+	] as never;
 	return replacement;
 }
 

--- a/packages/core/src/features/advanced-capabilities/actions/role.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/role.ts
@@ -21,7 +21,7 @@ import {
 	resolveCanonicalOwnerId,
 	resolveEntityRole,
 	resolveWorldForMessage,
-	setEntityRole,
+	setEntityRoleCas,
 } from "../../../roles.ts";
 import type {
 	Action,
@@ -524,18 +524,80 @@ async function applyAssignments(args: {
 			continue;
 		}
 
-		await setEntityRole(runtime, message, entityId, newRole);
-		successes.push({ entityId, newRole });
-		logger.info(
+		// #23100: commit through the atomic compare-and-swap path. The checks
+		// above are fast-fail filters against the initial snapshot; the SAME
+		// rules are re-enforced per CAS attempt against freshly resolved state
+		// (inside `authorize`), so a concurrent revocation of the requester or
+		// target cannot be outrun by a retry, and the write itself is an
+		// atomic snapshot compare — never a blind whole-world overwrite.
+		const casResult = await setEntityRoleCas(
+			runtime,
+			message,
+			entityId,
+			newRole,
 			{
-				src: "advanced-capabilities:action:role",
-				agentId: runtime.agentId,
-				op,
-				entityId,
-				newRole,
+				authorize: async (fresh) => {
+					if (!fresh) return false;
+					const freshRequesterRole = await resolveEntityRole(
+						runtime,
+						fresh.world,
+						fresh.metadata,
+						message.entityId,
+						{ liveEntityMetadata: getLiveEntityMetadataFromMessage(message) },
+					);
+					if (freshRequesterRole !== "OWNER") return false;
+					const freshTargetRole = await resolveEntityRole(
+						runtime,
+						fresh.world,
+						fresh.metadata,
+						entityId,
+					);
+					if (newRole === "OWNER") {
+						const canonicalOwnerId = resolveCanonicalOwnerId(
+							runtime,
+							fresh.metadata,
+						);
+						if (!canonicalOwnerId || entityId !== canonicalOwnerId)
+							return false;
+					}
+					if (entityId === message.entityId && newRole !== "OWNER") {
+						const otherOwners = Object.entries(
+							fresh.metadata.roles ?? {},
+						).filter(
+							([id, r]) =>
+								id !== message.entityId && normalizeRole(r) === "OWNER",
+						);
+						if (otherOwners.length === 0) return false;
+					}
+					return canModifyRole(freshRequesterRole, freshTargetRole, newRole);
+				},
 			},
-			`[role] ${message.entityId} ${op === "revoke" ? "revoked" : "set"} ${entityId} to ${newRole}`,
 		);
+		if (casResult.status === "committed") {
+			successes.push({ entityId, newRole });
+			logger.info(
+				{
+					src: "advanced-capabilities:action:role",
+					agentId: runtime.agentId,
+					op,
+					entityId,
+					newRole,
+				},
+				`[role] ${message.entityId} ${op === "revoke" ? "revoked" : "set"} ${entityId} to ${newRole}`,
+			);
+		} else if (casResult.status === "world_not_found") {
+			failures.push({ entityId, reason: "World removed during role update" });
+		} else if (casResult.status === "unauthorized") {
+			failures.push({
+				entityId,
+				reason: "Permission changed during role update; retry the request",
+			});
+		} else {
+			failures.push({
+				entityId,
+				reason: "Concurrent role change; retry the update",
+			});
+		}
 	}
 
 	const summary = `${op === "revoke" ? "Revoked" : "Updated"} ${successes.length} role${successes.length === 1 ? "" : "s"}${failures.length > 0 ? `; ${failures.length} failed` : ""}.`;

--- a/packages/core/src/features/trust/actions/roles.cas.test.ts
+++ b/packages/core/src/features/trust/actions/roles.cas.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Exercises the trust update_role handler's #23100 CAS integration against
+ * the real core in-memory adapter: writes land on the handler's resolved
+ * (configured WORLD_ID) world, no trailing whole-world `updateWorld`
+ * clobbers concurrent metadata writers, per-attempt reauthorization turns a
+ * mid-flight requester revocation into an explicit denial line (not a
+ * phantom concurrency message), and exhaustion yields a typed retry line.
+ * Deterministic unit harness — real adapter, stub runtime around it, no
+ * model or network (the LLM extraction step is bypassed by supplying the
+ * parsed assignments directly through `options.parameters`).
+ */
+import { describe, expect, it } from "vitest";
+import { InMemoryDatabaseAdapter } from "../../../database/inMemoryAdapter.ts";
+import type { IAgentRuntime, Memory, UUID, World } from "../../../types";
+import { ChannelType } from "../../../types/index.ts";
+import { stringToUuid } from "../../../utils.ts";
+import { updateRoleHandler } from "./roles.ts";
+
+const AGENT_ID = stringToUuid("trust-role-test-agent") as UUID;
+const ROOM_ID = stringToUuid("trust-role-test-room") as UUID;
+// A world DIFFERENT from the room's world — proving the handler writes the
+// configured WORLD_ID world, not the message room's.
+const CONFIG_WORLD_ID = stringToUuid("trust-role-test-config-world") as UUID;
+const OWNER_ID = stringToUuid("trust-role-test-owner") as UUID;
+const TARGET_ID = stringToUuid("trust-role-test-target") as UUID;
+
+function baseRoles(): Record<string, string> {
+	return {
+		[OWNER_ID]: "OWNER",
+		[TARGET_ID]: "USER",
+	};
+}
+
+async function buildAdapter(): Promise<InMemoryDatabaseAdapter> {
+	const adapter = new InMemoryDatabaseAdapter();
+	await adapter.init();
+	await adapter.createWorlds([
+		{
+			id: CONFIG_WORLD_ID,
+			agentId: AGENT_ID,
+			name: "trust-config-world",
+			metadata: {
+				ownership: { ownerId: OWNER_ID },
+				roles: baseRoles(),
+			} as unknown as World["metadata"],
+		},
+	]);
+	await adapter.createRooms([
+		{
+			id: ROOM_ID,
+			agentId: AGENT_ID,
+			// Deliberately NO worldId: the room does not resolve to the
+			// configured world, so a room-world write would target nothing.
+			source: "test",
+			type: ChannelType.GROUP,
+		},
+	]);
+	return adapter;
+}
+
+function buildRuntime(
+	adapter: InMemoryDatabaseAdapter,
+	over: Partial<IAgentRuntime> = {},
+): IAgentRuntime {
+	return {
+		agentId: AGENT_ID,
+		adapter,
+		getSetting: (key: string) =>
+			key === "WORLD_ID" ? String(CONFIG_WORLD_ID) : null,
+		getWorld: async (worldId: UUID) => {
+			const rows = await adapter.getWorldsByIds([worldId]);
+			return rows[0] ?? null;
+		},
+		getEntitiesForRoom: async () => [
+			{
+				id: OWNER_ID,
+				agentId: AGENT_ID,
+				names: ["Owner Entity"],
+			},
+			{
+				id: TARGET_ID,
+				agentId: AGENT_ID,
+				names: ["Target Entity"],
+			},
+		],
+		updateWorld: async (_world: World) => {
+			// The handler must NEVER call this after the CAS loop — record
+			// any invocation so the test can fail on it.
+			updateWorldCalls.push(_world);
+		},
+		// The LLM extraction step always runs; explicit assignments supplied
+		// through `options.parameters` take precedence over its output, so a
+		// deterministic empty extraction keeps the harness model-free.
+		dynamicPromptExecFromState: async () => ({ roleAssignments: [] }),
+		...over,
+	} as unknown as IAgentRuntime;
+}
+
+const updateWorldCalls: World[] = [];
+
+function buildMessage(): Memory {
+	return {
+		id: stringToUuid("trust-role-message"),
+		entityId: OWNER_ID,
+		roomId: ROOM_ID,
+		agentId: AGENT_ID,
+		content: {
+			text: "promote target to admin",
+			channelType: ChannelType.GROUP,
+			serverId: "trust-role-test-server",
+		},
+	} as Memory;
+}
+
+async function storedRoles(adapter: InMemoryDatabaseAdapter) {
+	const rows = await adapter.getWorldsByIds([CONFIG_WORLD_ID]);
+	return (rows[0]?.metadata as { roles?: Record<string, string> })?.roles ?? {};
+}
+
+async function runHandler(
+	runtime: IAgentRuntime,
+	message: Memory,
+	assignments: Array<{ entityId: string; newRole: string }>,
+) {
+	return updateRoleHandler(runtime, message, {} as never, {
+		parameters: { roleAssignments: assignments },
+	});
+}
+
+describe("updateRoleHandler CAS integration (#23100)", () => {
+	it("commits on the configured WORLD_ID world, not the message room's world", async () => {
+		const adapter = await buildAdapter();
+		const runtime = buildRuntime(adapter);
+		const result = await runHandler(runtime, buildMessage(), [
+			{ entityId: String(TARGET_ID), newRole: "ADMIN" },
+		]);
+		expect(result.success).toBe(true);
+		expect(await storedRoles(adapter)).toMatchObject({ [TARGET_ID]: "ADMIN" });
+		// The durable audit row rides the CAS commit.
+		const logs = await adapter.getLogs({ type: "role_audit" });
+		expect(logs).toHaveLength(1);
+	});
+
+	it("does not issue a trailing whole-world updateWorld after the CAS loop", async () => {
+		updateWorldCalls.length = 0;
+		const adapter = await buildAdapter();
+		const runtime = buildRuntime(adapter);
+		await runHandler(runtime, buildMessage(), [
+			{ entityId: String(TARGET_ID), newRole: "ADMIN" },
+		]);
+		// The pre-loop world object is stale after the CAS commits; writing
+		// it back would resurrect the pre-CAS roles and drop the audit
+		// evidence of the concurrent state. The handler must not do it.
+		expect(updateWorldCalls).toHaveLength(0);
+		expect(await storedRoles(adapter)).toMatchObject({ [TARGET_ID]: "ADMIN" });
+	});
+
+	it("reports permission revoked — not a concurrent change — when fresh-state authorization denies", async () => {
+		const adapter = await buildAdapter();
+		const runtime = buildRuntime(adapter);
+		const message = buildMessage();
+		// Revoke the requester AFTER initial authorization but BEFORE the
+		// CAS attempt: the per-attempt authorize predicate must surface
+		// `unauthorized`, and the denial must name the permission loss.
+		const realGetWorld = runtime.getWorld.bind(runtime);
+		let firstCall = true;
+		runtime.getWorld = async (worldId: UUID) => {
+			const world = await realGetWorld(worldId);
+			if (world && firstCall) {
+				firstCall = false;
+				// Handler's initial resolution still sees the requester as
+				// OWNER (initial gate passes), but subsequent per-attempt
+				// resolutions see them demoted.
+				return world;
+			}
+			if (world) {
+				const mutated = structuredClone(world);
+				(mutated.metadata as { roles: Record<string, string> }).roles[
+					String(OWNER_ID)
+				] = "USER";
+				return mutated;
+			}
+			return null;
+		};
+		const result = await runHandler(runtime, message, [
+			{ entityId: String(TARGET_ID), newRole: "ADMIN" },
+		]);
+		expect(result.success).toBe(false);
+		const text = (result as { text?: string }).text ?? "";
+		expect(text).toContain("permission was revoked");
+		expect(text).not.toContain("concurrent change");
+		// No write, no audit row.
+		expect(await storedRoles(adapter)).toMatchObject({ [TARGET_ID]: "USER" });
+		expect(await adapter.getLogs({ type: "role_audit" })).toHaveLength(0);
+	});
+
+	it("returns a typed retry line and no audit row when every CAS attempt conflicts", async () => {
+		const adapter = await buildAdapter();
+		const runtime = buildRuntime(adapter);
+		// A writer keeps racing ahead of every CAS commit so the snapshot is
+		// always stale: resolve → authorize → [RACE] → compare fails → retry.
+		const realCas = adapter.compareAndSwapWorldMetadata.bind(adapter);
+		let races = 0;
+		adapter.compareAndSwapWorldMetadata = async (params) => {
+			const world = (await adapter.getWorldsByIds([CONFIG_WORLD_ID]))[0];
+			if (world) {
+				races += 1;
+				await adapter.updateWorlds([
+					{
+						...world,
+						metadata: {
+							...(world.metadata as object),
+							raceCounter: races,
+						},
+					},
+				]);
+			}
+			return realCas(params);
+		};
+		const result = await runHandler(runtime, buildMessage(), [
+			{ entityId: String(TARGET_ID), newRole: "ADMIN" },
+		]);
+		expect(result.success).toBe(false);
+		const text = (result as { text?: string }).text ?? "";
+		expect(text).toContain("concurrent change");
+		expect(await storedRoles(adapter)).toMatchObject({ [TARGET_ID]: "USER" });
+		expect(await adapter.getLogs({ type: "role_audit" })).toHaveLength(0);
+	});
+
+	it("keeps GUEST as the stored representation for a NONE assignment", async () => {
+		const adapter = await buildAdapter();
+		const runtime = buildRuntime(adapter);
+		const result = await runHandler(runtime, buildMessage(), [
+			{ entityId: String(TARGET_ID), newRole: "NONE" },
+		]);
+		expect(result.success).toBe(true);
+		expect(await storedRoles(adapter)).toMatchObject({ [TARGET_ID]: "GUEST" });
+	});
+});

--- a/packages/core/src/features/trust/actions/roles.test.ts
+++ b/packages/core/src/features/trust/actions/roles.test.ts
@@ -7,14 +7,18 @@
  */
 
 import { describe, expect, it, vi } from "vitest";
-import { ChannelType, Role } from "../../../types/index.ts";
+import { ChannelType, type UUID, Role } from "../../../types/index.ts";
+import { stringToUuid } from "../../../utils.ts";
 import { updateRoleHandler } from "./roles.ts";
 
-const ROOM_ID = "room-role-test";
-const WORLD_ID = "world-role-test";
-const REQUESTER_ID = "requester-entity";
-const BOB_ID = "bob-entity";
-const ALICE_ID = "alice-entity";
+// Real UUIDs: the #23100 CAS path fails closed on non-UUID target ids, and
+// role writes now commit through adapter.compareAndSwapWorldMetadata
+// instead of a whole-world updateWorld overwrite.
+const ROOM_ID = stringToUuid("room-role-test") as UUID;
+const WORLD_ID = stringToUuid("world-role-test") as UUID;
+const REQUESTER_ID = stringToUuid("requester-entity") as UUID;
+const BOB_ID = stringToUuid("bob-entity") as UUID;
+const ALICE_ID = stringToUuid("alice-entity") as UUID;
 
 function buildEntity(id: string, names: string[]) {
 	return { id, names };
@@ -40,7 +44,31 @@ function buildFixtures(options: FixtureOptions = {}) {
 		...(options.extraEntities ?? []),
 	];
 
+	// #23100: role writes commit through the adapter's world-metadata CAS.
+	// This stub applies the replacement to the fixture world in place when
+	// the expected snapshot still matches, preserving the suite's original
+	// observable-state semantics while exercising the real commit path.
+	const worldRecord = world as unknown as { metadata?: Record<string, unknown> };
+	const casCommits = { count: 0 };
+	const adapter = {
+		compareAndSwapWorldMetadata: vi.fn(async (params: {
+			expectedMetadata?: Record<string, unknown>;
+			replacementMetadata: Record<string, unknown>;
+		}) => {
+			const current = (worldRecord.metadata ?? {}) as Record<string, unknown>;
+			if (
+				JSON.stringify(current ?? {}) !== JSON.stringify(params.expectedMetadata ?? {})
+			) {
+				return { status: "conflict" as const };
+			}
+			worldRecord.metadata = params.replacementMetadata;
+			casCommits.count += 1;
+			return { status: "updated" as const };
+		}),
+	};
+
 	const runtime = {
+		adapter,
 		getSetting: vi.fn((key: string) =>
 			key === "WORLD_ID" ? WORLD_ID : undefined,
 		),
@@ -71,6 +99,7 @@ function buildFixtures(options: FixtureOptions = {}) {
 		message,
 		state,
 		callback,
+		casCommits,
 		run: (extraOptions?: Record<string, unknown>) =>
 			updateRoleHandler(
 				runtime as never,
@@ -225,8 +254,8 @@ describe("TRUST update_role", () => {
 			(fixtures.world as { metadata: { roles: Record<string, string> } })
 				.metadata.roles,
 		).toEqual({ [REQUESTER_ID]: Role.OWNER, [BOB_ID]: Role.ADMIN });
-		expect(fixtures.runtime.updateWorld).toHaveBeenCalledTimes(1);
-		expect(fixtures.runtime.updateWorld).toHaveBeenCalledWith(fixtures.world);
+		expect(fixtures.runtime.updateWorld).not.toHaveBeenCalled();
+		expect(fixtures.casCommits.count).toBe(1);
 		expect(fixtures.runtime.dynamicPromptExecFromState).toHaveBeenCalledTimes(
 			1,
 		);
@@ -449,7 +478,8 @@ describe("TRUST update_role", () => {
 			totalUpdated: 1,
 		});
 		expect(fixtures.world.metadata?.roles?.[BOB_ID]).toBe(Role.ADMIN);
-		expect(fixtures.runtime.updateWorld).toHaveBeenCalledTimes(1);
+		expect(fixtures.runtime.updateWorld).not.toHaveBeenCalled();
+		expect(fixtures.casCommits.count).toBe(1);
 	});
 
 	it("persists an OWNER-granted role, fires one aggregated callback, and reports counts", async () => {
@@ -482,8 +512,8 @@ describe("TRUST update_role", () => {
 			totalUpdated: 1,
 		});
 		expect(fixtures.world.metadata?.roles?.[BOB_ID]).toBe(Role.ADMIN);
-		expect(fixtures.runtime.updateWorld).toHaveBeenCalledTimes(1);
-		expect(fixtures.runtime.updateWorld).toHaveBeenCalledWith(fixtures.world);
+		expect(fixtures.runtime.updateWorld).not.toHaveBeenCalled();
+		expect(fixtures.casCommits.count).toBe(1);
 		expect(fixtures.callback).toHaveBeenCalledTimes(1);
 		expect(fixtures.callback).toHaveBeenCalledWith({
 			text: "Updated Bob's role to ADMIN.",
@@ -519,6 +549,7 @@ describe("TRUST update_role", () => {
 			updatedRoles: [{ entityId: BOB_ID, newRole: Role.ADMIN }],
 		});
 		expect(fixtures.world.metadata?.roles?.[ALICE_ID]).toBe(Role.OWNER);
-		expect(fixtures.runtime.updateWorld).toHaveBeenCalledTimes(1);
+		expect(fixtures.runtime.updateWorld).not.toHaveBeenCalled();
+		expect(fixtures.casCommits.count).toBe(1);
 	});
 });

--- a/packages/core/src/features/trust/actions/roles.test.ts
+++ b/packages/core/src/features/trust/actions/roles.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, expect, it, vi } from "vitest";
-import { ChannelType, type UUID, Role } from "../../../types/index.ts";
+import { ChannelType, Role, type UUID } from "../../../types/index.ts";
 import { stringToUuid } from "../../../utils.ts";
 import { updateRoleHandler } from "./roles.ts";
 
@@ -48,23 +48,28 @@ function buildFixtures(options: FixtureOptions = {}) {
 	// This stub applies the replacement to the fixture world in place when
 	// the expected snapshot still matches, preserving the suite's original
 	// observable-state semantics while exercising the real commit path.
-	const worldRecord = world as unknown as { metadata?: Record<string, unknown> };
+	const worldRecord = world as unknown as {
+		metadata?: Record<string, unknown>;
+	};
 	const casCommits = { count: 0 };
 	const adapter = {
-		compareAndSwapWorldMetadata: vi.fn(async (params: {
-			expectedMetadata?: Record<string, unknown>;
-			replacementMetadata: Record<string, unknown>;
-		}) => {
-			const current = (worldRecord.metadata ?? {}) as Record<string, unknown>;
-			if (
-				JSON.stringify(current ?? {}) !== JSON.stringify(params.expectedMetadata ?? {})
-			) {
-				return { status: "conflict" as const };
-			}
-			worldRecord.metadata = params.replacementMetadata;
-			casCommits.count += 1;
-			return { status: "updated" as const };
-		}),
+		compareAndSwapWorldMetadata: vi.fn(
+			async (params: {
+				expectedMetadata?: Record<string, unknown>;
+				replacementMetadata: Record<string, unknown>;
+			}) => {
+				const current = (worldRecord.metadata ?? {}) as Record<string, unknown>;
+				if (
+					JSON.stringify(current ?? {}) !==
+					JSON.stringify(params.expectedMetadata ?? {})
+				) {
+					return { status: "conflict" as const };
+				}
+				worldRecord.metadata = params.replacementMetadata;
+				casCommits.count += 1;
+				return { status: "updated" as const };
+			},
+		),
 	};
 
 	const runtime = {

--- a/packages/core/src/features/trust/actions/roles.ts
+++ b/packages/core/src/features/trust/actions/roles.ts
@@ -11,6 +11,7 @@
 
 import dedent from "dedent";
 import { logger } from "../../../logger.ts";
+import { type RoleName, setEntityRoleCas } from "../../../roles.ts";
 import {
 	type ActionResult,
 	ChannelType,
@@ -282,22 +283,69 @@ export async function updateRoleHandler(
 			continue;
 		}
 
-		world.metadata.roles[assignment.entityId] = assignment.newRole;
-
-		worldUpdated = true;
-		updatedRoles.push({
-			entityName: targetEntity.names[0] || "Unknown",
-			entityId: assignment.entityId,
-			newRole: assignment.newRole,
-		});
-
-		summaryLines.push(
-			`Updated ${targetEntity.names[0]}'s role to ${assignment.newRole}.`,
+		// #23100: commit through the atomic compare-and-swap path instead of
+		// the former whole-world blind write — a concurrent metadata writer
+		// becomes a typed conflict (re-read + re-check per attempt inside the
+		// CAS loop) rather than being silently overwritten. The write targets
+		// THIS handler's resolved world (the configured WORLD_ID setting may
+		// differ from the message room's world), and there is deliberately NO
+		// trailing runtime.updateWorld(world): the handler's pre-loop world
+		// object is stale by then and a blind overwrite would clobber the
+		// committed CAS results it is reporting success for.
+		const casResult = await setEntityRoleCas(
+			runtime,
+			message,
+			assignment.entityId,
+			assignment.newRole === Role.NONE
+				? "GUEST"
+				: (assignment.newRole as RoleName),
+			{
+				worldId: world.id as UUID,
+				authorize: (fresh) => {
+					if (!fresh) return false;
+					const freshRoles = fresh.metadata.roles ?? {};
+					// The local canModifyRole is typed on the message-loop Role
+					// vocabulary; the metadata stores RoleName strings whose
+					// ranks agree (MEMBER ≡ USER), so compare normalized.
+					const freshRequesterRole = normalizeRole(
+						freshRoles[message.entityId],
+					);
+					const freshTargetRole = normalizeRole(
+						freshRoles[assignment.entityId],
+					);
+					if (freshRequesterRole === freshTargetRole) return false;
+					return freshRequesterRole === "OWNER";
+				},
+			},
 		);
+		if (casResult.status === "committed") {
+			worldUpdated = true;
+			updatedRoles.push({
+				entityName: targetEntity.names[0] || "Unknown",
+				entityId: assignment.entityId,
+				newRole: assignment.newRole,
+			});
+			summaryLines.push(
+				`Updated ${targetEntity.names[0]}'s role to ${assignment.newRole}.`,
+			);
+		} else if (casResult.status === "world_not_found") {
+			summaryLines.push(
+				`Could not update ${targetEntity.names[0]}'s role; the world is gone.`,
+			);
+		} else if (casResult.status === "unauthorized") {
+			// Authorization was re-checked against fresh state and denied —
+			// report the permission loss, not a phantom concurrency retry.
+			summaryLines.push(
+				`Could not update ${targetEntity.names[0]}'s role; permission was revoked while processing. Ask an OWNER to retry.`,
+			);
+		} else {
+			summaryLines.push(
+				`Could not update ${targetEntity.names[0]}'s role due to a concurrent change; retry.`,
+			);
+		}
 	}
 
 	if (worldUpdated) {
-		await runtime.updateWorld(world);
 		logger.info(`Updated roles in world metadata for server ${serverId}`);
 	}
 

--- a/packages/core/src/features/trust/index.cas.test.ts
+++ b/packages/core/src/features/trust/index.cas.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Verifies trust bootstrap writes ADMIN through the real in-memory world CAS,
+ * producing the same committed authority audit as interactive role changes.
+ */
+import { describe, expect, it } from "vitest";
+import { InMemoryDatabaseAdapter } from "../../database/inMemoryAdapter";
+import { AgentRuntime } from "../../runtime";
+import { ChannelType, type Character, type UUID } from "../../types";
+import { ROLE_WRITE_AUDIT_LOG_TYPE } from "../../types/database";
+import { stringToUuid } from "../../utils";
+import { ensureAdminRoleOnInit } from "./index";
+
+describe("trust admin role bootstrap CAS", () => {
+	it("commits ADMIN and its authority audit without runtime.updateWorld", async () => {
+		const runtime = new AgentRuntime({
+			character: { name: "trust-cas" } as Character,
+		});
+		const adapter = new InMemoryDatabaseAdapter();
+		await adapter.init();
+		runtime.registerDatabaseAdapter(adapter);
+		const ownerId = stringToUuid("trust-cas-owner") as UUID;
+		const worldId = stringToUuid("trust-cas-world") as UUID;
+		const roomId = stringToUuid("trust-cas-room") as UUID;
+		await adapter.createEntities([
+			{ id: ownerId, agentId: runtime.agentId, names: ["Owner"] },
+		]);
+		await adapter.createWorlds([
+			{ id: worldId, agentId: runtime.agentId, name: "Trust", metadata: {} },
+		]);
+		await adapter.createRooms([
+			{
+				id: roomId,
+				agentId: runtime.agentId,
+				worldId,
+				source: "test",
+				type: ChannelType.WORLD,
+			},
+		]);
+		(
+			runtime as unknown as { getSetting: (key: string) => unknown }
+		).getSetting = (key) =>
+			key === "OWNER_ENTITY_ID"
+				? ownerId
+				: key === "WORLD_ID"
+					? worldId
+					: undefined;
+		(runtime as unknown as { updateWorld: () => Promise<void> }).updateWorld =
+			async () => {
+				throw new Error("blind world writer must not run");
+			};
+
+		await ensureAdminRoleOnInit(runtime);
+
+		const world = (await adapter.getWorldsByIds([worldId]))[0];
+		if (!world) throw new Error("trust CAS test world missing");
+		expect(
+			(world.metadata as { roles?: Record<string, string> }).roles?.[ownerId],
+		).toBe("ADMIN");
+		const audits = await adapter.getLogs({ type: ROLE_WRITE_AUDIT_LOG_TYPE });
+		expect(audits).toHaveLength(1);
+		expect(audits[0]?.body).toMatchObject({
+			metadata: {
+				targetEntityId: ownerId,
+				previousRole: "GUEST",
+				newRole: "ADMIN",
+			},
+		});
+	});
+});

--- a/packages/core/src/features/trust/index.ts
+++ b/packages/core/src/features/trust/index.ts
@@ -11,9 +11,11 @@
  */
 import { promoteSubactionsToActions } from "../../actions/promote-subactions.ts";
 import { logger } from "../../logger.ts";
+import { setEntityRoleCas } from "../../roles.ts";
 import {
 	type Action,
 	type IAgentRuntime,
+	type Memory,
 	type Plugin,
 	Role,
 	type UUID,
@@ -107,10 +109,7 @@ async function ensureAdminRoleOnInit(runtime: IAgentRuntime): Promise<void> {
 			return;
 		}
 
-		const metadata = world.metadata ?? {};
-		world.metadata = metadata;
-
-		const metadataRecord = metadata as Record<string, unknown>;
+		const metadataRecord = (world.metadata ?? {}) as Record<string, unknown>;
 		const roles =
 			(metadataRecord.roles as Record<string, Role> | undefined) ?? {};
 		metadataRecord.roles = roles;
@@ -120,8 +119,27 @@ async function ensureAdminRoleOnInit(runtime: IAgentRuntime): Promise<void> {
 			return;
 		}
 
-		roles[adminEntityId] = Role.ADMIN;
-		await runtime.updateWorld(world);
+		const room = (await runtime.getRooms(world.id))[0];
+		if (!room) {
+			throw new Error(
+				"Trust admin bootstrap requires a real room for its audit scope",
+			);
+		}
+		const bootstrapMessage = {
+			entityId: adminEntityId as UUID,
+			roomId: room.id,
+			content: { text: "trust admin bootstrap", source: "trust" },
+		} as Memory;
+		const result = await setEntityRoleCas(
+			runtime,
+			bootstrapMessage,
+			adminEntityId,
+			"ADMIN",
+			{ source: "owner", worldId: world.id },
+		);
+		if (result.status !== "committed") {
+			throw new Error(`Trust admin bootstrap did not commit: ${result.status}`);
+		}
 		logger.info(
 			{ adminEntityId, worldId },
 			"[Trust] Bootstrapped admin role for app user",

--- a/packages/core/src/index.browser.ts
+++ b/packages/core/src/index.browser.ts
@@ -46,6 +46,7 @@ export * from "./database";
 export * from "./database/connector-json";
 export * from "./database/document-list-query";
 export * from "./database/inMemoryAdapter";
+export * from "./database/world-metadata-cas";
 export * from "./entities";
 // `isTruthyEnvValue` is pure string logic (no Node deps), so it is browser-safe
 // and exported from both barrels. @elizaos/shared re-exports it from the core

--- a/packages/core/src/index.edge.ts
+++ b/packages/core/src/index.edge.ts
@@ -42,6 +42,7 @@ export * from "./database";
 export * from "./database/connector-json";
 export * from "./database/document-list-query";
 export * from "./database/inMemoryAdapter";
+export * from "./database/world-metadata-cas";
 export * from "./entities";
 export * from "./errors";
 export { generateMediaAction } from "./features/advanced-capabilities/actions/generateMedia";

--- a/packages/core/src/index.node.ts
+++ b/packages/core/src/index.node.ts
@@ -103,6 +103,7 @@ export * from "./database";
 export * from "./database/connector-json";
 export * from "./database/document-list-query";
 export * from "./database/inMemoryAdapter";
+export * from "./database/world-metadata-cas";
 export * from "./entities";
 export * from "./env-utils";
 export * from "./errors";

--- a/packages/core/src/markdown/chunk.test.ts
+++ b/packages/core/src/markdown/chunk.test.ts
@@ -165,7 +165,7 @@ describe("chunkMarkdownText", () => {
 	});
 
 	it("closes and reopens a code fence split across chunks", () => {
-		const code = "```js\n" + "const x = 1;\n".repeat(20) + "```";
+		const code = `\`\`\`js\n${"const x = 1;\n".repeat(20)}\`\`\``;
 		const chunks = chunkMarkdownText(code, 30);
 		expect(chunks.length).toBeGreaterThan(1);
 		// Every non-final chunk that started inside a fence must end with a close line.

--- a/packages/core/src/roles.role-write-cas.test.ts
+++ b/packages/core/src/roles.role-write-cas.test.ts
@@ -1,0 +1,324 @@
+/**
+ * Exercises the #23100 atomic role-write path end-to-end against the real
+ * in-memory adapter: `setEntityRoleCas` resolving the world through the
+ * runtime, enforcing the per-attempt `authorize` predicate, committing via
+ * `compareAndSwapWorldMetadata`, and the typed conflict / unauthorized /
+ * world-not-found / malformed-target / missing-capability outcomes.
+ * Deterministic unit harness — real adapter, fake runtime object, no model
+ * or network.
+ */
+import { describe, expect, it } from "vitest";
+import { InMemoryDatabaseAdapter } from "./database/inMemoryAdapter.ts";
+import {
+	ROLE_WRITE_CAS_MAX_ATTEMPTS,
+	type RolesWorldMetadata,
+	setEntityRoleCas,
+} from "./roles.ts";
+import type { IAgentRuntime, Memory, UUID, World } from "./types";
+import { ChannelType } from "./types/index.ts";
+import { stringToUuid } from "./utils.ts";
+
+const AGENT_ID = stringToUuid("roles-cas-test-agent") as UUID;
+const WORLD_ID = stringToUuid("roles-cas-test-world") as UUID;
+const ROOM_ID = stringToUuid("roles-cas-test-room") as UUID;
+const OWNER_ID = stringToUuid("roles-cas-test-owner") as UUID;
+const TARGET_ID = stringToUuid("roles-cas-test-target") as UUID;
+
+function baseMetadata(): RolesWorldMetadata {
+	return {
+		ownership: { ownerId: OWNER_ID },
+		roles: { [OWNER_ID]: "OWNER", [TARGET_ID]: "USER" },
+	};
+}
+
+/** Read the world back through the adapter so assertions use stored truth. */
+async function storedWorld(
+	adapter: InMemoryDatabaseAdapter,
+): Promise<World | undefined> {
+	const rows = await adapter.getWorldsByIds([WORLD_ID]);
+	return rows[0];
+}
+
+async function storedRoles(
+	adapter: InMemoryDatabaseAdapter,
+): Promise<Record<string, string>> {
+	const world = await storedWorld(adapter);
+	return ((world?.metadata as RolesWorldMetadata | undefined)?.roles ??
+		{}) as Record<string, string>;
+}
+
+function buildRuntime(adapter: InMemoryDatabaseAdapter): IAgentRuntime {
+	return {
+		agentId: AGENT_ID,
+		adapter,
+		getRoom: async (roomId: UUID) =>
+			roomId === ROOM_ID
+				? {
+						id: ROOM_ID,
+						agentId: AGENT_ID,
+						worldId: WORLD_ID,
+						source: "test",
+						type: ChannelType.WORLD,
+					}
+				: null,
+		getWorld: async (worldId: UUID) => {
+			if (worldId !== WORLD_ID) return null;
+			const rows = await adapter.getWorldsByIds([WORLD_ID]);
+			return rows[0] ?? null;
+		},
+	} as unknown as IAgentRuntime;
+}
+
+function buildMessage(): Memory {
+	return {
+		id: stringToUuid("roles-cas-message"),
+		entityId: OWNER_ID,
+		roomId: ROOM_ID,
+		agentId: AGENT_ID,
+		content: { text: "promote target" },
+	} as Memory;
+}
+
+async function setup() {
+	const adapter = new InMemoryDatabaseAdapter();
+	await adapter.init();
+	await adapter.createWorlds([
+		{
+			id: WORLD_ID,
+			agentId: AGENT_ID,
+			name: "cas-test-world",
+			metadata: baseMetadata() as unknown as World["metadata"],
+		},
+	]);
+	await adapter.createRooms([
+		{
+			id: ROOM_ID,
+			agentId: AGENT_ID,
+			worldId: WORLD_ID,
+			source: "test",
+			type: ChannelType.WORLD,
+		},
+	]);
+	const runtime = buildRuntime(adapter);
+	const message = buildMessage();
+	return { adapter, runtime, message };
+}
+
+describe("setEntityRoleCas against the real in-memory adapter", () => {
+	it("commits a role change with a durable audit row and typed result", async () => {
+		const { adapter, runtime, message } = await setup();
+		const result = await setEntityRoleCas(
+			runtime,
+			message,
+			TARGET_ID,
+			"ADMIN",
+			{
+				authorize: () => true,
+			},
+		);
+		expect(result.status).toBe("committed");
+		if (result.status === "committed") {
+			expect(result.roles[TARGET_ID]).toBe("ADMIN");
+		}
+		expect(await storedRoles(adapter)).toMatchObject({ [TARGET_ID]: "ADMIN" });
+		const logs = await adapter.getLogs({ type: "role_audit" });
+		expect(logs).toHaveLength(1);
+		const body = logs[0]?.body as {
+			source: string;
+			metadata?: Record<string, unknown>;
+		};
+		expect(body?.source).toBe("role-write-cas");
+		expect(body?.metadata?.targetEntityId).toBe(TARGET_ID);
+		expect(body?.metadata?.previousRole).toBe("USER");
+		expect(body?.metadata?.newRole).toBe("ADMIN");
+		expect(body?.metadata?.outcome).toBe("committed");
+	});
+
+	it("returns unauthorized when the per-attempt authorize predicate denies on fresh state", async () => {
+		const { adapter, runtime, message } = await setup();
+		const result = await setEntityRoleCas(
+			runtime,
+			message,
+			TARGET_ID,
+			"ADMIN",
+			{
+				authorize: () => false,
+			},
+		);
+		expect(result.status).toBe("unauthorized");
+		expect(await storedRoles(adapter)).toMatchObject({ [TARGET_ID]: "USER" });
+		expect(await adapter.getLogs({ type: "role_audit" })).toHaveLength(0);
+	});
+
+	it("recovers from a lost race by re-reading and re-authorizing on the next attempt", async () => {
+		const { adapter, runtime, message } = await setup();
+		// A concurrent writer mutates metadata after the caller's read but
+		// before the CAS commit on the FIRST attempt only; the retry must
+		// re-resolve fresh state and still commit.
+		let authorizeCalls = 0;
+		const result = await setEntityRoleCas(
+			runtime,
+			message,
+			TARGET_ID,
+			"ADMIN",
+			{
+				authorize: async (fresh) => {
+					authorizeCalls += 1;
+					if (authorizeCalls === 1 && fresh) {
+						await adapter.updateWorlds([
+							{
+								id: WORLD_ID,
+								agentId: AGENT_ID,
+								metadata: {
+									...baseMetadata(),
+									roles: { [OWNER_ID]: "OWNER", [TARGET_ID]: "GUEST" },
+								} as unknown as World["metadata"],
+							},
+						]);
+					}
+					return Boolean(fresh);
+				},
+			},
+		);
+		expect(result.status).toBe("committed");
+		expect(authorizeCalls).toBe(2);
+		expect(await storedRoles(adapter)).toMatchObject({ [TARGET_ID]: "ADMIN" });
+		// Only the committed attempt's audit row exists — the lost race left none.
+		expect(await adapter.getLogs({ type: "role_audit" })).toHaveLength(1);
+	});
+
+	it("surfaces conflict exhaustion after bounded attempts without writing or auditing", async () => {
+		const { adapter, runtime, message } = await setup();
+		let casCalls = 0;
+		const realCas = adapter.compareAndSwapWorldMetadata.bind(adapter);
+		// A writer keeps racing ahead of every CAS commit so the caller's
+		// snapshot is always stale: attempt → conflict → re-read → attempt.
+		const result = await setEntityRoleCas(
+			runtime,
+			message,
+			TARGET_ID,
+			"ADMIN",
+			{
+				maxAttempts: ROLE_WRITE_CAS_MAX_ATTEMPTS,
+				authorize: async () => {
+					casCalls += 1;
+					const world = (await adapter.getWorldsByIds([WORLD_ID]))[0];
+					if (world) {
+						await adapter.updateWorlds([
+							{
+								id: WORLD_ID,
+								agentId: AGENT_ID,
+								metadata: { ...world.metadata, raceCounter: casCalls },
+							},
+						]);
+					}
+					return true;
+				},
+			},
+		);
+		void realCas;
+		expect(result.status).toBe("conflict");
+		expect(casCalls).toBe(CEILING());
+		expect(await storedRoles(adapter)).toMatchObject({ [TARGET_ID]: "USER" });
+		expect(await adapter.getLogs({ type: "role_audit" })).toHaveLength(0);
+	});
+
+	it("fails closed with a typed error when the target id is not a UUID", async () => {
+		const { runtime, message } = await setup();
+		await expect(
+			setEntityRoleCas(runtime, message, "not-a-uuid", "ADMIN", {
+				authorize: () => true,
+			}),
+		).rejects.toMatchObject({ code: "INVALID_ROLE_TARGET_ENTITY_ID" });
+	});
+
+	it("fails closed when the adapter lacks the CAS capability", async () => {
+		const { runtime, message } = await setup();
+		const noCap = { ...runtime, adapter: {} } as unknown as IAgentRuntime;
+		await expect(
+			setEntityRoleCas(noCap, message, TARGET_ID, "ADMIN", {
+				authorize: () => true,
+			}),
+		).rejects.toMatchObject({ code: "WORLD_METADATA_CAS_CAPABILITY_REQUIRED" });
+	});
+
+	it("reports world_not_found when the world vanished", async () => {
+		const { adapter, runtime, message } = await setup();
+		await adapter.deleteWorlds([WORLD_ID]);
+		const result = await setEntityRoleCas(
+			runtime,
+			message,
+			TARGET_ID,
+			"ADMIN",
+			{
+				authorize: () => true,
+			},
+		);
+		expect(result.status).toBe("world_not_found");
+	});
+
+	it("conflicts when a legacy writer mutates the live stored metadata during authorization", async () => {
+		const { adapter, runtime, message } = await setup();
+		// The memory store returns LIVE stored objects. A legacy whole-world
+		// writer (plain updateWorlds holding the same reference) mutates the
+		// world's metadata IN PLACE while our authorize predicate awaits:
+		// the helper's frozen snapshot must diverge from the stored state and
+		// the CAS must retry/conflict instead of comparing two aliases of
+		// the same mutated object and committing over the concurrent write.
+		let attempts = 0;
+		let firstViewTargetRole: string | undefined;
+		const result = await setEntityRoleCas(
+			runtime,
+			message,
+			TARGET_ID,
+			"ADMIN",
+			{
+				maxAttempts: 2,
+				authorize: (fresh) => {
+					attempts += 1;
+					if (attempts === 1) {
+						firstViewTargetRole = fresh?.metadata?.roles?.[String(TARGET_ID)];
+						// Mutate the LIVE stored world object in place — exactly
+						// what a legacy blind writer holding the getWorldsByIds
+						// reference would do between our read and our write.
+						const world = (
+							adapter as unknown as {
+								worlds: Map<
+									string,
+									{ metadata: { roles: Record<string, string> } }
+								>;
+							}
+						).worlds.get(String(WORLD_ID));
+						if (world) {
+							world.metadata.roles[String(TARGET_ID)] = "GUEST";
+						}
+					}
+					return true;
+				},
+			},
+		);
+		// The mutation happened on attempt 1's authorize; attempt 2 re-reads,
+		// re-freezes, and can commit the intended grant on the mutated state
+		// — the point is the helper never compared aliased objects: it
+		// either conflicts or re-reads. Assert the final state carries OUR
+		// write only if a commit actually happened, and that no silent
+		// merge lost the concurrent GUEST write without a fresh attempt.
+		expect(firstViewTargetRole).toBe("USER");
+		expect(attempts).toBe(2);
+		expect(["committed", "conflict"]).toContain(result.status);
+		if (result.status === "committed") {
+			const world = (
+				adapter as unknown as {
+					worlds: Map<string, { metadata: { roles: Record<string, string> } }>;
+				}
+			).worlds.get(String(WORLD_ID));
+			// The committed replacement was built from the POST-mutation
+			// snapshot (roles include whatever the legacy writer set).
+			expect(world?.metadata.roles[String(TARGET_ID)]).toBe("ADMIN");
+		}
+	});
+});
+
+function CEILING() {
+	return ROLE_WRITE_CAS_MAX_ATTEMPTS;
+}

--- a/packages/core/src/roles.role-write-cas.test.ts
+++ b/packages/core/src/roles.role-write-cas.test.ts
@@ -9,6 +9,7 @@
  */
 import { describe, expect, it } from "vitest";
 import { InMemoryDatabaseAdapter } from "./database/inMemoryAdapter.ts";
+import { WORLD_METADATA_REVISION_KEY } from "./database/world-metadata-cas.ts";
 import {
 	ROLE_WRITE_CAS_MAX_ATTEMPTS,
 	type RolesWorldMetadata,
@@ -256,6 +257,65 @@ describe("setEntityRoleCas against the real in-memory adapter", () => {
 		);
 		expect(result.status).toBe("world_not_found");
 	});
+
+	it.each(["updateWorlds", "upsertWorlds"] as const)(
+		"keeps a stale legacy %s writer from overwriting a committed role CAS",
+		async (legacyMethod) => {
+			const { adapter, runtime, message } = await setup();
+			let signalRead!: () => void;
+			let releaseWriter!: () => void;
+			const readComplete = new Promise<void>((resolve) => {
+				signalRead = resolve;
+			});
+			const writerGate = new Promise<void>((resolve) => {
+				releaseWriter = resolve;
+			});
+			const legacyWriter = (async () => {
+				const staleWorld = await storedWorld(adapter);
+				signalRead();
+				await writerGate;
+				if (!staleWorld) throw new Error("test world missing");
+				const staleMetadata = staleWorld.metadata as RolesWorldMetadata;
+				if (!staleMetadata.roles) throw new Error("test roles missing");
+				staleMetadata.roles[TARGET_ID] = "GUEST";
+				await adapter[legacyMethod]([staleWorld]);
+			})();
+			await readComplete;
+
+			const result = await setEntityRoleCas(
+				runtime,
+				message,
+				TARGET_ID,
+				"ADMIN",
+				{ authorize: () => true },
+			);
+			releaseWriter();
+			await expect(legacyWriter).rejects.toMatchObject({
+				code: "WORLD_METADATA_STALE_WRITE",
+			});
+
+			expect(result.status).toBe("committed");
+			expect(await storedRoles(adapter)).toMatchObject({
+				[TARGET_ID]: "ADMIN",
+			});
+		},
+	);
+
+	it.each(["updateWorlds", "upsertWorlds"] as const)(
+		"rejects a malformed revision from legacy %s",
+		async (legacyMethod) => {
+			const { adapter } = await setup();
+			const world = await storedWorld(adapter);
+			if (!world?.metadata) throw new Error("test world metadata missing");
+			(world.metadata as Record<string, unknown>)[WORLD_METADATA_REVISION_KEY] =
+				"invalid";
+
+			await expect(adapter[legacyMethod]([world])).rejects.toMatchObject({
+				code: "WORLD_METADATA_STALE_WRITE",
+			});
+			expect(await storedRoles(adapter)).toMatchObject({ [TARGET_ID]: "USER" });
+		},
+	);
 
 	it("conflicts when a legacy writer mutates the live stored metadata during authorization", async () => {
 		const { adapter, runtime, message } = await setup();

--- a/packages/core/src/roles.ts
+++ b/packages/core/src/roles.ts
@@ -1452,6 +1452,8 @@ export async function setEntityRoleCas(
 		authorize?: (
 			fresh: Awaited<ReturnType<typeof resolveWorldForMessage>>,
 		) => boolean | Promise<boolean>;
+		/** Additional authority metadata committed in the same audited CAS. */
+		mutateMetadata?: (replacement: RolesWorldMetadata) => void;
 	} = {},
 ): Promise<EntityRoleCasResult> {
 	const source = options.source ?? "manual";
@@ -1511,6 +1513,7 @@ export async function setEntityRoleCas(
 		);
 		const replacement: RolesWorldMetadata = structuredClone(expectedSnapshot);
 		recordRoleGrant(replacement, targetEntityId, newRole, source);
+		options.mutateMetadata?.(replacement);
 
 		const result = await runtime.adapter.compareAndSwapWorldMetadata({
 			worldId: world.id,

--- a/packages/core/src/roles.ts
+++ b/packages/core/src/roles.ts
@@ -30,6 +30,11 @@ import { createUniqueUuid } from "./entities";
 import { ElizaError } from "./errors.ts";
 import { logger } from "./logger";
 import type { IAgentRuntime, Memory, UUID, World } from "./types";
+import type {
+	IDatabaseAdapter,
+	WorldMetadataCompareAndSwapParams,
+	WorldMetadataMutationResult,
+} from "./types/database";
 import type { PrincipalService } from "./types/identity";
 import {
 	MESSAGE_SOURCE_AGENT_GREETING,
@@ -37,6 +42,7 @@ import {
 	MESSAGE_SOURCE_CODING_AGENT,
 	MESSAGE_SOURCE_SUB_AGENT,
 } from "./types/message-source";
+import type { Metadata } from "./types/primitives";
 import { ServiceType } from "./types/service";
 import { formatError } from "./utils/format-error";
 import { asRecordOrUndefined as asRecord } from "./utils/type-guards";
@@ -1009,6 +1015,19 @@ export function canModifyRole(
 	return false;
 }
 
+export async function resolveWorldById(
+	runtime: IAgentRuntime,
+	worldId: UUID,
+): Promise<{
+	world: Awaited<ReturnType<IAgentRuntime["getWorld"]>>;
+	metadata: RolesWorldMetadata;
+} | null> {
+	const world = await runtime.getWorld(worldId);
+	if (!world) return null;
+	const metadata = (world.metadata ?? {}) as RolesWorldMetadata;
+	return { world, metadata };
+}
+
 export async function resolveWorldForMessage(
 	runtime: IAgentRuntime,
 	message: Memory,
@@ -1335,4 +1354,185 @@ export async function setEntityRole(
 		world as Parameters<IAgentRuntime["updateWorld"]>[0],
 	);
 	return { ...metadata.roles };
+}
+
+/**
+ * Typed outcome of one atomic role-write attempt (#23100). `conflict` means a
+ * concurrent metadata write landed between the caller's authorized read and
+ * the compare-and-swap; the caller must re-resolve and re-authorize before
+ * retrying — never retry with the original snapshot.
+ */
+export type EntityRoleCasResult =
+	| {
+			status: "committed";
+			roles: Record<string, RoleName>;
+	  }
+	| { status: "conflict" }
+	| { status: "world_not_found" }
+	| { status: "unauthorized" };
+
+/** Bounded retries before a persistently contended role write gives up. */
+export const ROLE_WRITE_CAS_MAX_ATTEMPTS = 3;
+
+function requireWorldMetadataCasCapability(
+	adapter: IAgentRuntime["adapter"],
+): asserts adapter is IAgentRuntime["adapter"] & {
+	compareAndSwapWorldMetadata: (
+		params: WorldMetadataCompareAndSwapParams,
+	) => Promise<WorldMetadataMutationResult>;
+} {
+	if (
+		typeof (
+			adapter as Partial<IDatabaseAdapter> & {
+				compareAndSwapWorldMetadata?: unknown;
+			}
+		).compareAndSwapWorldMetadata === "function"
+	) {
+		return;
+	}
+	// Fail closed: authorization writes never fall back to the blind
+	// whole-world overwrite, which can resurrect revoked authority.
+	throw new ElizaError(
+		"Database adapter must implement compareAndSwapWorldMetadata for atomic role writes",
+		{
+			code: "WORLD_METADATA_CAS_CAPABILITY_REQUIRED",
+			context: {
+				adapter: adapter?.constructor?.name ?? "unknown",
+				migrationGuide:
+					"Implement IDatabaseAdapter.compareAndSwapWorldMetadata on every adapter that persists worlds; role writes fail closed until then.",
+			},
+			severity: "fatal",
+		},
+	);
+}
+
+/**
+ * Atomically set one entity's world role under compare-and-swap (#23100).
+ *
+ * Unlike {@link setEntityRole} (a blind read-merge-write of whole-world
+ * metadata), this resolves the world fresh on EVERY attempt, re-invokes the
+ * caller's `authorize` predicate against that fresh state, applies the grant
+ * via {@link recordRoleGrant}, and commits through
+ * `adapter.compareAndSwapWorldMetadata`, which compares the exact prior
+ * metadata snapshot in the same transaction that writes the replacement and
+ * inserts the durable `role_audit` log row. A concurrent writer therefore
+ * turns into a typed `conflict` the caller can retry after re-authorizing,
+ * instead of being silently overwritten (the revoked-ADMIN resurrection
+ * hazard named in #23100 and the #24243 review).
+ *
+ * The `authorize` predicate is re-evaluated on every attempt against the
+ * freshly resolved world — never trust an authorization verdict computed
+ * against an earlier snapshot. The audit row uses the originating
+ * `message.roomId` — a real room the request came from — and is committed in
+ * the same adapter transaction as the metadata replacement, so a committed
+ * authority change is never separable from its audit record.
+ */
+export async function setEntityRoleCas(
+	runtime: IAgentRuntime,
+	message: Memory,
+	targetEntityId: string,
+	newRole: RoleName,
+	options: {
+		source?: RoleGrantSource;
+		/**
+		 * Resolve this explicit world instead of the message room's world.
+		 * The trust ROLE handler resolves the configured `WORLD_ID` setting,
+		 * which may differ from the room the message arrived in — its CAS
+		 * must write that world, not the room's.
+		 */
+		worldId?: UUID;
+		/** Max CAS attempts before reporting conflict exhaustion. */
+		maxAttempts?: number;
+		/**
+		 * Per-attempt authorization against the FRESH world state. Re-checked
+		 * before every CAS write, so a concurrent revocation of the requester
+		 * cannot be outrun by a retry. Deny surfaces as
+		 * {@link EntityRoleCasOutcome} `unauthorized` — never a write.
+		 */
+		authorize?: (
+			fresh: Awaited<ReturnType<typeof resolveWorldForMessage>>,
+		) => boolean | Promise<boolean>;
+	} = {},
+): Promise<EntityRoleCasResult> {
+	const source = options.source ?? "manual";
+	const maxAttempts = options.maxAttempts ?? ROLE_WRITE_CAS_MAX_ATTEMPTS;
+	if (!Number.isInteger(maxAttempts) || maxAttempts < 1) {
+		// Fail closed: a zero/negative/fractional bound would turn the
+		// documented bounded-retry contract into "never attempt" or an
+		// unbounded loop.
+		throw new ElizaError("Role write CAS maxAttempts must be an integer >= 1", {
+			code: "INVALID_ROLE_CAS_MAX_ATTEMPTS",
+			context: { maxAttempts },
+		});
+	}
+	requireWorldMetadataCasCapability(runtime.adapter);
+	// Fail closed on malformed target ids BEFORE any attempt: an audit row
+	// must never carry a null targetEntityId silently smuggled through the
+	// `as UUID` casts on caller-supplied action params.
+	const targetUuid = validateUuid(targetEntityId);
+	if (!targetUuid) {
+		throw new ElizaError("Role write target is not a valid entity UUID", {
+			code: "INVALID_ROLE_TARGET_ENTITY_ID",
+			context: { targetEntityId },
+		});
+	}
+
+	for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+		// Re-resolve per attempt: every retry re-reads the world and re-runs
+		// the caller's authorization against CURRENT state, never the
+		// original possibly-stale read.
+		const resolved = options.worldId
+			? await resolveWorldById(runtime, options.worldId)
+			: await resolveWorldForMessage(runtime, message);
+		if (!resolved?.world) return { status: "world_not_found" };
+		const { world } = resolved;
+		// Freeze an independent snapshot the moment the world is resolved:
+		// the memory adapters return LIVE stored objects, so a legacy
+		// whole-world writer mutating metadata in place during the awaited
+		// authorize predicate would otherwise change both sides of the CAS
+		// comparison together and the concurrent write would go undetected.
+		// Authorization evaluates against this SAME frozen view — the
+		// authorize predicate and the CAS comparison must never observe
+		// different metadata states for one attempt.
+		const resolvedWorld = structuredClone(world);
+		const expectedSnapshot = (resolvedWorld.metadata ??
+			{}) as RolesWorldMetadata;
+		const authorizeView: typeof resolved = {
+			world: resolvedWorld,
+			metadata: expectedSnapshot,
+		};
+
+		if (options.authorize && !(await options.authorize(authorizeView))) {
+			return { status: "unauthorized" };
+		}
+
+		const previousRole = normalizeRole(
+			expectedSnapshot.roles?.[targetEntityId],
+		);
+		const replacement: RolesWorldMetadata = structuredClone(expectedSnapshot);
+		recordRoleGrant(replacement, targetEntityId, newRole, source);
+
+		const result = await runtime.adapter.compareAndSwapWorldMetadata({
+			worldId: world.id,
+			expectedMetadata: expectedSnapshot as unknown as Metadata,
+			replacementMetadata: replacement as unknown as Metadata,
+			audit: {
+				actorEntityId: message.entityId,
+				targetEntityId: targetUuid,
+				previousRole,
+				newRole,
+				source,
+				roomId: message.roomId,
+			},
+		});
+		if (result.status === "updated") {
+			return { status: "committed", roles: { ...replacement.roles } };
+		}
+		if (result.status === "not_found") return { status: "world_not_found" };
+		// conflict: loop to re-read, re-authorize, and re-apply
+	}
+	// Persistently contended: surface conflict exhaustion to the caller; the
+	// batch caller reports it as an explicit skipped failure, never a silent
+	// success or overwrite.
+	return { status: "conflict" };
 }

--- a/packages/core/src/runtime.ensure-world.test.ts
+++ b/packages/core/src/runtime.ensure-world.test.ts
@@ -5,11 +5,92 @@
 
 import { describe, expect, it } from "vitest";
 import { InMemoryDatabaseAdapter } from "./database/inMemoryAdapter";
+import { ElizaError } from "./errors";
 import { AgentRuntime } from "./runtime";
 import type { Character, UUID, World } from "./types";
 import { stringToUuid } from "./utils";
 
 describe("AgentRuntime.ensureWorldExists", () => {
+	it("rereads and merges after a concurrent creator wins the unique insert", async () => {
+		class CreateRaceAdapter extends InMemoryDatabaseAdapter {
+			private arrivals = 0;
+			private release!: () => void;
+			private readonly bothArrived = new Promise<void>((resolve) => {
+				this.release = resolve;
+			});
+
+			override async upsertWorlds(worlds: World[]): Promise<void> {
+				this.arrivals += 1;
+				const arrival = this.arrivals;
+				if (arrival > 2) {
+					await super.upsertWorlds(worlds);
+					return;
+				}
+				if (this.arrivals === 2) this.release();
+				await this.bothArrived;
+				if (arrival === 1) {
+					await this.createWorlds(worlds);
+					return;
+				}
+				throw new ElizaError("World already exists", {
+					code: "WORLD_ALREADY_EXISTS",
+					context: { worldId: worlds[0]?.id },
+				});
+			}
+		}
+
+		const runtime = new AgentRuntime({
+			character: { name: "ensure-world-create-race" } as Character,
+		});
+		const adapter = new CreateRaceAdapter();
+		await adapter.init();
+		runtime.registerDatabaseAdapter(adapter);
+		const worldId = stringToUuid("ensure-world-create-race") as UUID;
+
+		await Promise.all([
+			runtime.ensureWorldExists({
+				id: worldId,
+				agentId: runtime.agentId,
+				name: "raced",
+				metadata: { first: "one" },
+			}),
+			runtime.ensureWorldExists({
+				id: worldId,
+				agentId: runtime.agentId,
+				name: "raced",
+				metadata: { second: "two" },
+			}),
+		]);
+
+		const stored = (await adapter.getWorldsByIds([worldId]))[0];
+		expect(stored?.metadata).toMatchObject({ first: "one", second: "two" });
+	});
+
+	it("reports a typed failure after bounded create-race retries", async () => {
+		class PermanentlyRacedAdapter extends InMemoryDatabaseAdapter {
+			override async upsertWorlds(worlds: World[]): Promise<void> {
+				throw new ElizaError("World already exists", {
+					code: "WORLD_ALREADY_EXISTS",
+					context: { worldId: worlds[0]?.id },
+				});
+			}
+		}
+		const runtime = new AgentRuntime({
+			character: { name: "ensure-world-create-race-exhausted" } as Character,
+		});
+		const adapter = new PermanentlyRacedAdapter();
+		await adapter.init();
+		runtime.registerDatabaseAdapter(adapter);
+
+		await expect(
+			runtime.ensureWorldExists({
+				id: stringToUuid("ensure-world-create-race-exhausted") as UUID,
+				agentId: runtime.agentId,
+				name: "never-created",
+			}),
+		).rejects.toMatchObject({ code: "WORLD_ENSURE_CONFLICT_EXHAUSTED" });
+	});
+
 	it("merges repeated constructed-world updates with the persisted revision", async () => {
 		const runtime = new AgentRuntime({
 			character: { name: "ensure-world-test" } as Character,

--- a/packages/core/src/runtime.ensure-world.test.ts
+++ b/packages/core/src/runtime.ensure-world.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Exercises merge-aware world ensure behavior against the real core in-memory
+ * adapter, including repeated updates after the persisted revision advances.
+ */
+
+import { describe, expect, it } from "vitest";
+import { InMemoryDatabaseAdapter } from "./database/inMemoryAdapter";
+import { AgentRuntime } from "./runtime";
+import type { Character, UUID, World } from "./types";
+import { stringToUuid } from "./utils";
+
+describe("AgentRuntime.ensureWorldExists", () => {
+	it("merges repeated constructed-world updates with the persisted revision", async () => {
+		const runtime = new AgentRuntime({
+			character: { name: "ensure-world-test" } as Character,
+		});
+		const adapter = new InMemoryDatabaseAdapter();
+		await adapter.init();
+		runtime.registerDatabaseAdapter(adapter);
+		const worldId = stringToUuid("ensure-world-revision") as UUID;
+		const serverId = stringToUuid("ensure-world-server") as UUID;
+
+		await runtime.ensureWorldExists({
+			id: worldId,
+			agentId: runtime.agentId,
+			name: "first",
+			messageServerId: serverId,
+			metadata: { first: "one" },
+		});
+		await runtime.ensureWorldExists({
+			id: worldId,
+			agentId: runtime.agentId,
+			metadata: { second: "two" },
+		});
+		await runtime.ensureWorldExists({
+			id: worldId,
+			agentId: runtime.agentId,
+			name: "third",
+			metadata: { third: "three" },
+		});
+
+		const stored = (await adapter.getWorldsByIds([worldId]))[0] as World;
+		expect(stored.name).toBe("third");
+		expect(stored.messageServerId).toBe(serverId);
+		expect(stored.metadata).toMatchObject({
+			first: "one",
+			second: "two",
+			third: "three",
+		});
+	});
+
+	it("preserves CAS-managed authority maps during connector-style ensure", async () => {
+		const runtime = new AgentRuntime({
+			character: { name: "ensure-world-authority-test" } as Character,
+		});
+		const adapter = new InMemoryDatabaseAdapter();
+		await adapter.init();
+		runtime.registerDatabaseAdapter(adapter);
+		const worldId = stringToUuid("ensure-world-authority") as UUID;
+		await runtime.ensureWorldExists({
+			id: worldId,
+			agentId: runtime.agentId,
+			name: "authority",
+			metadata: {
+				roles: { admin: "ADMIN" },
+				roleSources: { admin: "manual" },
+			},
+		});
+		const before = (await adapter.getWorldsByIds([worldId]))[0] as World;
+		await adapter.compareAndSwapWorldMetadata({
+			worldId,
+			expectedMetadata: before.metadata as never,
+			replacementMetadata: structuredClone(before.metadata ?? {}) as never,
+		});
+		await runtime.ensureWorldExists({
+			id: worldId,
+			agentId: runtime.agentId,
+			metadata: {
+				roles: { owner: "OWNER" },
+				roleSources: { owner: "connector" },
+			},
+		});
+		const after = (await adapter.getWorldsByIds([worldId]))[0] as World;
+		expect(after.metadata).toMatchObject({
+			roles: { admin: "ADMIN" },
+			roleSources: { admin: "manual" },
+		});
+	});
+});

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -40,6 +40,10 @@ import {
 	validateTaskQueryPagination,
 } from "./database";
 import { InMemoryDatabaseAdapter } from "./database/inMemoryAdapter";
+import {
+	mergeWorldMetadataForLegacyWrite,
+	worldMetadataValueEquals,
+} from "./database/world-metadata-cas";
 import { ElizaError, type ReportedError, toElizaError } from "./errors";
 import {
 	type CapabilityConfig,
@@ -4892,26 +4896,50 @@ export class AgentRuntime implements IAgentRuntime {
 		return ids;
 	}
 
-	/**
-	 * Ensure the existence of a world.
-	 *
-	 * WHY upsert: Eliminates race condition where concurrent agent basic-capabilitiess
-	 * could both try to create the same world. Upsert is atomic.
-	 */
+	/** Ensures a world exists while preserving persisted metadata and revision. */
 	async ensureWorldExists({ id, name, messageServerId, metadata }: World) {
-		// Check if world exists (for logging only)
-		const world = (await this.adapter.getWorldsByIds([id]))[0] ?? null;
-
-		// Atomic upsert - handles both insert and update
-		await this.adapter.upsertWorlds([
-			{
-				id,
-				name,
-				agentId: this.agentId,
-				messageServerId,
-				metadata,
-			},
-		]);
+		let world: World | null = null;
+		for (let attempt = 0; attempt < 3; attempt += 1) {
+			world = (await this.adapter.getWorldsByIds([id]))[0] ?? null;
+			const mergedMetadata = world
+				? mergeWorldMetadataForLegacyWrite(
+						world.metadata as Metadata | undefined,
+						metadata as Metadata | undefined,
+						String(id),
+					)
+				: metadata;
+			if (
+				world &&
+				worldMetadataValueEquals(world.metadata ?? {}, mergedMetadata ?? {}) &&
+				world.name === (name ?? world.name) &&
+				world.messageServerId === (messageServerId ?? world.messageServerId)
+			) {
+				break;
+			}
+			try {
+				await this.adapter.upsertWorlds([
+					{
+						...world,
+						id,
+						name: name ?? world?.name,
+						agentId: this.agentId,
+						messageServerId: messageServerId ?? world?.messageServerId,
+						metadata: mergedMetadata as World["metadata"],
+					},
+				]);
+				break;
+			} catch (error) {
+				if (
+					!(error instanceof ElizaError) ||
+					error.code !== "WORLD_METADATA_STALE_WRITE" ||
+					attempt === 2
+				) {
+					throw error;
+				}
+				// error-policy:J2 — retry against a fresh snapshot after a
+				// concurrent legacy writer advances the metadata revision.
+			}
+		}
 
 		this.logger.debug(
 			{ src: "agent", agentId: this.agentId, worldId: id, messageServerId },

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -4899,6 +4899,7 @@ export class AgentRuntime implements IAgentRuntime {
 	/** Ensures a world exists while preserving persisted metadata and revision. */
 	async ensureWorldExists({ id, name, messageServerId, metadata }: World) {
 		let world: World | null = null;
+		let completed = false;
 		for (let attempt = 0; attempt < 3; attempt += 1) {
 			world = (await this.adapter.getWorldsByIds([id]))[0] ?? null;
 			const mergedMetadata = world
@@ -4914,6 +4915,7 @@ export class AgentRuntime implements IAgentRuntime {
 				world.name === (name ?? world.name) &&
 				world.messageServerId === (messageServerId ?? world.messageServerId)
 			) {
+				completed = true;
 				break;
 			}
 			try {
@@ -4927,18 +4929,28 @@ export class AgentRuntime implements IAgentRuntime {
 						metadata: mergedMetadata as World["metadata"],
 					},
 				]);
+				completed = true;
 				break;
 			} catch (error) {
 				if (
 					!(error instanceof ElizaError) ||
-					error.code !== "WORLD_METADATA_STALE_WRITE" ||
-					attempt === 2
+					!(
+						["WORLD_METADATA_STALE_WRITE", "WORLD_ALREADY_EXISTS"] as const
+					).includes(
+						error.code as "WORLD_METADATA_STALE_WRITE" | "WORLD_ALREADY_EXISTS",
+					)
 				) {
 					throw error;
 				}
-				// error-policy:J2 — retry against a fresh snapshot after a
-				// concurrent legacy writer advances the metadata revision.
+				// error-policy:J2 — retry against a fresh snapshot after a concurrent
+				// creator wins the unique insert or a legacy writer advances revision.
 			}
+		}
+		if (!completed) {
+			throw new ElizaError("World ensure retries were exhausted", {
+				code: "WORLD_ENSURE_CONFLICT_EXHAUSTED",
+				context: { worldId: id, attempts: 3 },
+			});
 		}
 
 		this.logger.debug(

--- a/packages/core/src/types/database.ts
+++ b/packages/core/src/types/database.ts
@@ -195,6 +195,56 @@ export interface DocumentDeleteParams extends DocumentRequesterContext {
 	expected: DocumentMutationSnapshot;
 }
 
+/**
+ * Durable audit row committed in the SAME adapter transaction as an
+ * authorization-role write (#23100). A committed role change must never be
+ * separable from its audit record, so the audit insert rides the CAS
+ * transaction rather than a follow-up `createLogs` call.
+ */
+export interface RoleWriteAuditRecord {
+	/** Originating actor whose authority produced the write. */
+	actorEntityId: UUID;
+	/** Entity whose world role changed. */
+	targetEntityId: UUID;
+	/** Role held by the target immediately before the write. */
+	previousRole: string;
+	/** Role after the write (same as previousRole when nothing changed). */
+	newRole: string;
+	/** Grant provenance recorded alongside the role. */
+	source: string;
+	/** Real room the mutation request originated from — audit scope. */
+	roomId: UUID;
+}
+
+/**
+ * Compare-and-swap replacement of a world's whole `metadata` JSON under the
+ * exact prior snapshot (#23100 role-write atomicity). Mirrors the document
+ * mutation contract: the adapter compares `expectedMetadata` against the
+ * stored value in the same transaction that writes `replacementMetadata`,
+ * commits the audit row only on success, and reports a typed conflict so a
+ * concurrent writer can never be silently overwritten.
+ */
+export interface WorldMetadataCompareAndSwapParams {
+	worldId: UUID;
+	/** Exact prior metadata snapshot the caller read and authorized against. */
+	expectedMetadata: Metadata;
+	/** Whole replacement metadata; role grants are embedded within. */
+	replacementMetadata: Metadata;
+	/** Committed atomically with the metadata replacement. */
+	audit?: RoleWriteAuditRecord;
+}
+
+export type WorldMetadataMutationResult =
+	| { status: "updated" }
+	| { status: "not_found" | "conflict" };
+
+/**
+ * Canonical `logs.type` tag for durable role-write audit rows committed by
+ * {@link IDatabaseAdapter.compareAndSwapWorldMetadata}. Queried as
+ * `getLogs({ type: "role_audit" })`.
+ */
+export const ROLE_WRITE_AUDIT_LOG_TYPE = "role_audit";
+
 export type DocumentMutationResult =
 	| { status: "updated"; document: Memory }
 	| { status: "deleted"; document: Memory }
@@ -1187,6 +1237,17 @@ export interface IDatabaseAdapter<DB extends object = object> {
 	deleteDocumentWithSnapshot(
 		params: DocumentDeleteParams,
 	): Promise<DocumentMutationResult>;
+
+	/**
+	 * Atomic compare-and-swap replacement of a world's whole metadata under the
+	 * exact prior snapshot, committing the audit row in the same transaction
+	 * (#23100 role-write atomicity). Authorization role writes MUST go through
+	 * this operation — a blind `updateWorlds` overwrite can resurrect revoked
+	 * authority when racing a concurrent writer.
+	 */
+	compareAndSwapWorldMetadata(
+		params: WorldMetadataCompareAndSwapParams,
+	): Promise<WorldMetadataMutationResult>;
 
 	getMemoriesByIds(ids: UUID[], tableName?: string): Promise<Memory[]>;
 

--- a/packages/core/src/types/database.ts
+++ b/packages/core/src/types/database.ts
@@ -1242,10 +1242,10 @@ export interface IDatabaseAdapter<DB extends object = object> {
 	 * Atomic compare-and-swap replacement of a world's whole metadata under the
 	 * exact prior snapshot, committing the audit row in the same transaction
 	 * (#23100 role-write atomicity). Authorization role writes MUST go through
-	 * this operation — a blind `updateWorlds` overwrite can resurrect revoked
-	 * authority when racing a concurrent writer.
+	 * this operation and fail closed when an adapter omits the optional
+	 * capability; they never fall back to a blind `updateWorlds` overwrite.
 	 */
-	compareAndSwapWorldMetadata(
+	compareAndSwapWorldMetadata?(
 		params: WorldMetadataCompareAndSwapParams,
 	): Promise<WorldMetadataMutationResult>;
 

--- a/packages/core/src/types/runtime.ts
+++ b/packages/core/src/types/runtime.ts
@@ -627,6 +627,7 @@ type RuntimeDatabaseAdapterSurface = Omit<
 	| "updateDocumentDirectGrants"
 	| "replaceDocumentRevision"
 	| "deleteDocumentWithSnapshot"
+	| "compareAndSwapWorldMetadata"
 >;
 
 export interface IAgentRuntime extends RuntimeDatabaseAdapterSurface {

--- a/plugins/plugin-inmemorydb/adapter.ts
+++ b/plugins/plugin-inmemorydb/adapter.ts
@@ -65,6 +65,7 @@ import {
   queryDocumentFragmentsInMemory,
   queryDocumentsInMemory,
   type Relationship,
+  ROLE_WRITE_AUDIT_LOG_TYPE,
   type Room,
   rankMessageSearch,
   type Task,
@@ -74,6 +75,8 @@ import {
   validateQueryEntitiesPagination,
   validateTaskQueryPagination,
   type World,
+  type WorldMetadataCompareAndSwapParams,
+  type WorldMetadataMutationResult,
   withinCreatedAtWindow,
 } from "@elizaos/core";
 import { dataContainsFilter } from "./data-contains-filter";
@@ -263,6 +266,30 @@ function storedMemoryTableName(memory: StoredMemory): string | undefined {
   return memory.tableName ?? memory.metadata?.type;
 }
 
+/**
+ * Serialization tail for world-metadata writes, keyed by STORAGE INSTANCE
+ * (#23100). The plugin shares one `MemoryStorage` singleton across adapter
+ * instances in a process, and the storage itself has no transaction
+ * isolation — an adapter-local tail would let two adapters (or a legacy
+ * `updateWorlds` writer racing a CAS) both compare the same snapshot and
+ * both "win". Attaching the tail to the shared storage object closes both
+ * holes: every adapter over that storage, and every world write path that
+ * goes through this helper, serializes on the same chain.
+ */
+const worldMetadataTails = new WeakMap<IStorage, Promise<void>>();
+
+function withWorldMetadataTail<T>(storage: IStorage, operation: () => Promise<T>): Promise<T> {
+  const run = (worldMetadataTails.get(storage) ?? Promise.resolve()).then(operation, operation);
+  worldMetadataTails.set(
+    storage,
+    run.then(
+      () => undefined,
+      () => undefined
+    )
+  );
+  return run;
+}
+
 function relationshipFromStored(r: StoredRelationship, fallbackAgentId: UUID): Relationship {
   return {
     id: r.id as UUID,
@@ -382,6 +409,42 @@ function compareStoredMemoriesNewestFirst(a: StoredMemory, b: StoredMemory): num
   const aId = typeof a.id === "string" ? a.id : "";
   const bId = typeof b.id === "string" ? b.id : "";
   return compareMemoryIds(bId, aId);
+}
+
+/**
+ * Deep JSON-value equality for world-metadata compare-and-swap. The stored
+ * `World.metadata` is a live object in this adapter, so snapshots must compare
+ * by value; key order is irrelevant (matching SQL jsonb equality) and
+ * `undefined` is treated as absent, matching how a JSON round-trip drops it.
+ */
+function worldMetadataValueEquals(left: unknown, right: unknown): boolean {
+  if (left === right) return true;
+  if (Array.isArray(left) && Array.isArray(right)) {
+    return (
+      left.length === right.length &&
+      left.every((item, index) => worldMetadataValueEquals(item, right[index]))
+    );
+  }
+  if (
+    typeof left === "object" &&
+    left !== null &&
+    typeof right === "object" &&
+    right !== null &&
+    !Array.isArray(left) &&
+    !Array.isArray(right)
+  ) {
+    const leftRecord = left as Record<string, unknown>;
+    const rightRecord = right as Record<string, unknown>;
+    const leftKeys = Object.keys(leftRecord).filter((key) => leftRecord[key] !== undefined);
+    const rightKeys = Object.keys(rightRecord).filter((key) => rightRecord[key] !== undefined);
+    if (leftKeys.length !== rightKeys.length) return false;
+    return leftKeys.every(
+      (key) =>
+        Object.hasOwn(rightRecord, key) &&
+        worldMetadataValueEquals(leftRecord[key], rightRecord[key])
+    );
+  }
+  return false;
 }
 
 export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
@@ -1555,43 +1618,150 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
   }
 
   async createWorlds(worlds: World[]): Promise<UUID[]> {
-    const ids: UUID[] = [];
-    for (const world of worlds) {
-      const id = world.id as UUID;
-      await this.storage.set(COLLECTIONS.WORLDS, id, { ...world, id });
-      ids.push(id);
-    }
-    return ids;
+    // World-collection mutations share the CAS serialization tail (#23100):
+    // a create or delete interleaving between a CAS read and its write
+    // could resurrect a deleted world or clobber a fresh one.
+    return withWorldMetadataTail(this.storage, async () => {
+      const ids: UUID[] = [];
+      for (const world of worlds) {
+        const id = world.id as UUID;
+        await this.storage.set(COLLECTIONS.WORLDS, id, { ...world, id });
+        ids.push(id);
+      }
+      return ids;
+    });
   }
 
   async deleteWorlds(worldIds: UUID[]): Promise<void> {
-    for (const id of worldIds) {
-      await this.storage.delete(COLLECTIONS.WORLDS, id);
-    }
+    return withWorldMetadataTail(this.storage, async () => {
+      for (const id of worldIds) {
+        await this.storage.delete(COLLECTIONS.WORLDS, id);
+      }
+    });
   }
 
   async updateWorlds(worlds: World[]): Promise<void> {
-    for (const world of worlds) {
-      if (!world.id) continue;
-      const existing = await this.storage.get<World>(COLLECTIONS.WORLDS, world.id);
-      if (!existing) continue;
-      await this.storage.set(COLLECTIONS.WORLDS, world.id, {
-        ...existing,
-        ...world,
-      });
-    }
+    // World writes share the CAS serialization tail so a legacy whole-world
+    // writer cannot interleave between a CAS read/compare and its write
+    // (#23100): the blind write still happens, but never INSIDE another
+    // world-metadata mutation's critical section.
+    return withWorldMetadataTail(this.storage, async () => {
+      for (const world of worlds) {
+        if (!world.id) continue;
+        const existing = await this.storage.get<World>(COLLECTIONS.WORLDS, world.id);
+        if (!existing) continue;
+        await this.storage.set(COLLECTIONS.WORLDS, world.id, {
+          ...existing,
+          ...world,
+        });
+      }
+    });
   }
 
   async upsertWorlds(worlds: World[]): Promise<void> {
-    for (const world of worlds) {
-      const id = world.id as UUID;
-      const existing = await this.storage.get<World>(COLLECTIONS.WORLDS, id);
-      await this.storage.set(COLLECTIONS.WORLDS, id, {
-        ...(existing ?? {}),
-        ...world,
-        id,
-      });
+    return withWorldMetadataTail(this.storage, async () => {
+      for (const world of worlds) {
+        const id = world.id as UUID;
+        const existing = await this.storage.get<World>(COLLECTIONS.WORLDS, id);
+        await this.storage.set(COLLECTIONS.WORLDS, id, {
+          ...(existing ?? {}),
+          ...world,
+          id,
+        });
+      }
+    });
+  }
+
+  /**
+   * Compare-and-swap replacement of a world's whole metadata under the exact
+   * prior snapshot (#23100 role-write atomicity). The whole operation —
+   * read, compare, audit insert, world replacement — runs on the
+   * world-metadata mutation tail so concurrent CAS calls serialize and
+   * exactly one wins per snapshot. If the world write fails after the audit
+   * row was inserted, the audit row is deleted back (best-effort
+   * compensation — the storage has no transactions) so a failed attempt
+   * does not leave a false committed audit record behind.
+   */
+  async compareAndSwapWorldMetadata(
+    params: WorldMetadataCompareAndSwapParams
+  ): Promise<WorldMetadataMutationResult> {
+    // Storage-scoped serialization (see withWorldMetadataTail): this races
+    // correctly against other adapter instances over the same shared
+    // storage AND against the updateWorlds/upsertWorlds writers below,
+    // which route through the same tail.
+    return withWorldMetadataTail(this.storage, () =>
+      this.compareAndSwapWorldMetadataSerialized(params)
+    );
+  }
+
+  private async compareAndSwapWorldMetadataSerialized(
+    params: WorldMetadataCompareAndSwapParams
+  ): Promise<WorldMetadataMutationResult> {
+    const stored = await this.storage.get<World>(COLLECTIONS.WORLDS, params.worldId);
+    if (!stored) return { status: "not_found" };
+    const storedMetadata = (stored.metadata ?? {}) as Record<string, unknown>;
+    if (
+      !worldMetadataValueEquals(storedMetadata, params.expectedMetadata as Record<string, unknown>)
+    ) {
+      return { status: "conflict" };
     }
+    const audit = params.audit;
+    // Validate cloneability BEFORE inserting the audit row: a non-cloneable
+    // replacement must throw with the world untouched and NO audit row left
+    // behind (a committed audit without its metadata change would be a false
+    // authority record).
+    const replacementWorld: World = {
+      ...stored,
+      metadata: structuredClone(params.replacementMetadata) as World["metadata"],
+    };
+    if (audit) {
+      const id = randomUUID() as UUID;
+      await this.storage.set(COLLECTIONS.LOGS, id, {
+        id,
+        entityId: audit.actorEntityId,
+        roomId: audit.roomId,
+        type: ROLE_WRITE_AUDIT_LOG_TYPE,
+        body: {
+          source: "role-write-cas",
+          metadata: {
+            worldId: params.worldId,
+            actorEntityId: audit.actorEntityId,
+            targetEntityId: audit.targetEntityId,
+            previousRole: audit.previousRole,
+            newRole: audit.newRole,
+            grantSource: audit.source,
+            outcome: "committed",
+          },
+        },
+        createdAt: new Date(),
+      } as Log);
+      try {
+        await this.storage.set(COLLECTIONS.WORLDS, params.worldId, replacementWorld);
+      } catch (error) {
+        // error-policy:J6 best-effort teardown: the world write failed after
+        // the audit insert; compensate by deleting the audit row so the
+        // failed attempt leaves no false committed record, then surface the
+        // original storage failure. Compensation failure is warned (and
+        // reported below) — never silently swallowed.
+        try {
+          await this.storage.delete(COLLECTIONS.LOGS, id);
+        } catch (compensationError) {
+          logger.warn(
+            {
+              src: "plugin-inmemorydb:adapter",
+              worldId: params.worldId,
+              auditLogId: id,
+              err: compensationError,
+            },
+            "Failed to roll back the role_audit row after a failed world-metadata write; a stale committed audit row may remain"
+          );
+        }
+        throw error;
+      }
+      return { status: "updated" };
+    }
+    await this.storage.set(COLLECTIONS.WORLDS, params.worldId, replacementWorld);
+    return { status: "updated" };
   }
 
   // ── Room CRUD ─────────────────────────────────────────────────────────

--- a/plugins/plugin-inmemorydb/adapter.ts
+++ b/plugins/plugin-inmemorydb/adapter.ts
@@ -18,6 +18,7 @@ import {
   type AccessContext,
   type Agent,
   advanceWorldMetadataRevision,
+  appendWorldMetadataRoleAudit,
   type Component,
   type Content,
   canRequesterManageDocumentDirectGrants,
@@ -1722,10 +1723,20 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
     // replacement must throw with the world untouched and NO audit row left
     // behind (a committed audit without its metadata change would be a false
     // authority record).
+    const replacementMetadata = audit
+      ? appendWorldMetadataRoleAudit(params.replacementMetadata, {
+          actorEntityId: audit.actorEntityId,
+          targetEntityId: audit.targetEntityId,
+          previousRole: audit.previousRole,
+          newRole: audit.newRole,
+          source: audit.source,
+          roomId: audit.roomId,
+        })
+      : params.replacementMetadata;
     const replacementWorld: World = {
       ...stored,
       metadata: advanceWorldMetadataRevision(
-        params.replacementMetadata,
+        replacementMetadata,
         storedRevision
       ) as World["metadata"],
     };

--- a/plugins/plugin-inmemorydb/adapter.ts
+++ b/plugins/plugin-inmemorydb/adapter.ts
@@ -17,6 +17,7 @@ import { randomUUID } from "node:crypto";
 import {
   type AccessContext,
   type Agent,
+  advanceWorldMetadataRevision,
   type Component,
   type Content,
   canRequesterManageDocumentDirectGrants,
@@ -39,7 +40,9 @@ import {
   type EntitiesForRoomsResult,
   type Entity,
   filterMemoryReadByAccessContext,
+  getWorldMetadataRevision,
   type IDatabaseAdapter,
+  initializeWorldMetadataRevision,
   isDocumentVisibleToRequester,
   type JsonValue,
   type Log,
@@ -68,6 +71,7 @@ import {
   ROLE_WRITE_AUDIT_LOG_TYPE,
   type Room,
   rankMessageSearch,
+  requireFreshWorldMetadataRevision,
   type Task,
   type UUID,
   validateDocumentDirectGrantEntityIds,
@@ -78,6 +82,7 @@ import {
   type WorldMetadataCompareAndSwapParams,
   type WorldMetadataMutationResult,
   withinCreatedAtWindow,
+  worldMetadataValueEquals,
 } from "@elizaos/core";
 import { dataContainsFilter } from "./data-contains-filter";
 import { EphemeralHNSW } from "./hnsw";
@@ -409,42 +414,6 @@ function compareStoredMemoriesNewestFirst(a: StoredMemory, b: StoredMemory): num
   const aId = typeof a.id === "string" ? a.id : "";
   const bId = typeof b.id === "string" ? b.id : "";
   return compareMemoryIds(bId, aId);
-}
-
-/**
- * Deep JSON-value equality for world-metadata compare-and-swap. The stored
- * `World.metadata` is a live object in this adapter, so snapshots must compare
- * by value; key order is irrelevant (matching SQL jsonb equality) and
- * `undefined` is treated as absent, matching how a JSON round-trip drops it.
- */
-function worldMetadataValueEquals(left: unknown, right: unknown): boolean {
-  if (left === right) return true;
-  if (Array.isArray(left) && Array.isArray(right)) {
-    return (
-      left.length === right.length &&
-      left.every((item, index) => worldMetadataValueEquals(item, right[index]))
-    );
-  }
-  if (
-    typeof left === "object" &&
-    left !== null &&
-    typeof right === "object" &&
-    right !== null &&
-    !Array.isArray(left) &&
-    !Array.isArray(right)
-  ) {
-    const leftRecord = left as Record<string, unknown>;
-    const rightRecord = right as Record<string, unknown>;
-    const leftKeys = Object.keys(leftRecord).filter((key) => leftRecord[key] !== undefined);
-    const rightKeys = Object.keys(rightRecord).filter((key) => rightRecord[key] !== undefined);
-    if (leftKeys.length !== rightKeys.length) return false;
-    return leftKeys.every(
-      (key) =>
-        Object.hasOwn(rightRecord, key) &&
-        worldMetadataValueEquals(leftRecord[key], rightRecord[key])
-    );
-  }
-  return false;
 }
 
 export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
@@ -1605,14 +1574,15 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
   // ── World CRUD ────────────────────────────────────────────────────────
 
   async getAllWorlds(): Promise<World[]> {
-    return this.storage.getAll<World>(COLLECTIONS.WORLDS);
+    const worlds = await this.storage.getAll<World>(COLLECTIONS.WORLDS);
+    return worlds.map((world) => structuredClone(world));
   }
 
   async getWorldsByIds(worldIds: UUID[]): Promise<World[]> {
     const worlds: World[] = [];
     for (const id of worldIds) {
       const w = await this.storage.get<World>(COLLECTIONS.WORLDS, id);
-      if (w) worlds.push(w);
+      if (w) worlds.push(structuredClone(w));
     }
     return worlds;
   }
@@ -1625,7 +1595,17 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
       const ids: UUID[] = [];
       for (const world of worlds) {
         const id = world.id as UUID;
-        await this.storage.set(COLLECTIONS.WORLDS, id, { ...world, id });
+        if (await this.storage.get<World>(COLLECTIONS.WORLDS, id)) {
+          throw new ElizaError("World already exists", {
+            code: "WORLD_ALREADY_EXISTS",
+            context: { worldId: id },
+          });
+        }
+        await this.storage.set(COLLECTIONS.WORLDS, id, {
+          ...structuredClone(world),
+          id,
+          metadata: initializeWorldMetadataRevision(world.metadata as Metadata | undefined),
+        });
         ids.push(id);
       }
       return ids;
@@ -1641,19 +1621,30 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
   }
 
   async updateWorlds(worlds: World[]): Promise<void> {
-    // World writes share the CAS serialization tail so a legacy whole-world
-    // writer cannot interleave between a CAS read/compare and its write
-    // (#23100): the blind write still happens, but never INSIDE another
-    // world-metadata mutation's critical section.
+    // World writes share the CAS serialization tail and compare the revision
+    // carried by their read snapshot. A writer that resumes after a CAS has
+    // advanced storage therefore fails with a typed stale-write error instead
+    // of overwriting authority.
     return withWorldMetadataTail(this.storage, async () => {
       for (const world of worlds) {
         if (!world.id) continue;
         const existing = await this.storage.get<World>(COLLECTIONS.WORLDS, world.id);
         if (!existing) continue;
+        const storedRevision = requireFreshWorldMetadataRevision(
+          existing.metadata as Metadata | undefined,
+          world.metadata as Metadata | undefined,
+          String(world.id)
+        );
+        const nextMetadata = advanceWorldMetadataRevision(
+          world.metadata as Metadata | undefined,
+          storedRevision
+        );
         await this.storage.set(COLLECTIONS.WORLDS, world.id, {
           ...existing,
-          ...world,
+          ...structuredClone(world),
+          metadata: nextMetadata,
         });
+        world.metadata = structuredClone(nextMetadata) as World["metadata"];
       }
     });
   }
@@ -1663,11 +1654,30 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
       for (const world of worlds) {
         const id = world.id as UUID;
         const existing = await this.storage.get<World>(COLLECTIONS.WORLDS, id);
+        if (!existing) {
+          await this.storage.set(COLLECTIONS.WORLDS, id, {
+            ...structuredClone(world),
+            id,
+            metadata: initializeWorldMetadataRevision(world.metadata as Metadata | undefined),
+          });
+          continue;
+        }
+        const storedRevision = requireFreshWorldMetadataRevision(
+          existing.metadata as Metadata | undefined,
+          world.metadata as Metadata | undefined,
+          String(id)
+        );
+        const nextMetadata = advanceWorldMetadataRevision(
+          world.metadata as Metadata | undefined,
+          storedRevision
+        );
         await this.storage.set(COLLECTIONS.WORLDS, id, {
-          ...(existing ?? {}),
-          ...world,
+          ...existing,
+          ...structuredClone(world),
           id,
+          metadata: nextMetadata,
         });
+        world.metadata = structuredClone(nextMetadata) as World["metadata"];
       }
     });
   }
@@ -1705,6 +1715,8 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
     ) {
       return { status: "conflict" };
     }
+    const storedRevision = getWorldMetadataRevision(stored.metadata as Metadata | undefined);
+    if (storedRevision === null) return { status: "conflict" };
     const audit = params.audit;
     // Validate cloneability BEFORE inserting the audit row: a non-cloneable
     // replacement must throw with the world untouched and NO audit row left
@@ -1712,7 +1724,10 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
     // authority record).
     const replacementWorld: World = {
       ...stored,
-      metadata: structuredClone(params.replacementMetadata) as World["metadata"],
+      metadata: advanceWorldMetadataRevision(
+        params.replacementMetadata,
+        storedRevision
+      ) as World["metadata"],
     };
     if (audit) {
       const id = randomUUID() as UUID;

--- a/plugins/plugin-inmemorydb/world-metadata-cas.test.ts
+++ b/plugins/plugin-inmemorydb/world-metadata-cas.test.ts
@@ -1,0 +1,446 @@
+/**
+ * Exercises the #23100 world-metadata compare-and-swap against the first-party
+ * ephemeral adapter: snapshot match/mismatch, value equality with key-order
+ * differences, audit-row placement (inserted before the swap so a storage
+ * throw leaves the world untouched), and world-not-found. Real adapter over
+ * real storage, no mocks.
+ */
+import { ROLE_WRITE_AUDIT_LOG_TYPE, type UUID, type World } from "@elizaos/core";
+import { v4 } from "uuid";
+import { describe, expect, it } from "vitest";
+import { InMemoryDatabaseAdapter } from "./adapter";
+import { MemoryStorage } from "./storage-memory";
+
+const AGENT_ID = "70000000-0000-0000-0000-000000000001" as UUID;
+const ACTOR_ID = "70000000-0000-0000-0000-000000000002" as UUID;
+const TARGET_ID = "70000000-0000-0000-0000-000000000003" as UUID;
+const ROOM_ID = v4() as UUID;
+const WORLD_ID = v4() as UUID;
+
+const BASE_METADATA = {
+  ownership: { ownerId: String(ACTOR_ID) },
+  roles: { [String(ACTOR_ID)]: "OWNER", [String(TARGET_ID)]: "USER" },
+};
+
+async function buildAdapter() {
+  const adapter = new InMemoryDatabaseAdapter(new MemoryStorage(), AGENT_ID);
+  await adapter.init();
+  await adapter.createWorlds([
+    {
+      id: WORLD_ID,
+      agentId: AGENT_ID,
+      name: "cas-world",
+      // Deep-clone per adapter: the memory store keeps the object by
+      // reference, and the live-mutation test below edits a world's
+      // metadata in place — a shared module-level fixture would leak that
+      // edit into every subsequently built adapter.
+      metadata: structuredClone(BASE_METADATA) as unknown as World["metadata"],
+    },
+  ]);
+  return adapter;
+}
+
+async function storedMetadata(adapter: InMemoryDatabaseAdapter) {
+  const rows = await adapter.getWorldsByIds([WORLD_ID]);
+  return (rows[0]?.metadata ?? {}) as Record<string, unknown>;
+}
+
+describe("InMemoryDatabaseAdapter.compareAndSwapWorldMetadata", () => {
+  it("commits when the snapshot matches, updating metadata and audit together", async () => {
+    const adapter = await buildAdapter();
+    const before = await storedMetadata(adapter);
+    const replacement = structuredClone(before);
+    (replacement as { roles: Record<string, string> }).roles[String(TARGET_ID)] = "ADMIN";
+
+    const result = await adapter.compareAndSwapWorldMetadata({
+      worldId: WORLD_ID,
+      expectedMetadata: before as never,
+      replacementMetadata: replacement as never,
+      audit: {
+        actorEntityId: ACTOR_ID,
+        targetEntityId: TARGET_ID,
+        previousRole: "USER",
+        newRole: "ADMIN",
+        source: "manual",
+        roomId: ROOM_ID,
+      },
+    });
+
+    expect(result).toEqual({ status: "updated" });
+    const after = await storedMetadata(adapter);
+    expect((after as { roles: Record<string, string> }).roles[String(TARGET_ID)]).toBe("ADMIN");
+    const logs = await adapter.getLogs({ type: ROLE_WRITE_AUDIT_LOG_TYPE });
+    expect(logs).toHaveLength(1);
+    const body = logs[0]?.body as { source: string; metadata?: Record<string, unknown> };
+    expect(body?.source).toBe("role-write-cas");
+    expect(body?.metadata?.newRole).toBe("ADMIN");
+    expect(body?.metadata?.outcome).toBe("committed");
+  });
+
+  it("conflicts when the stored metadata drifted from the snapshot", async () => {
+    const adapter = await buildAdapter();
+    const before = await storedMetadata(adapter);
+    // A concurrent writer lands first.
+    const raced = structuredClone(before);
+    (raced as { roles: Record<string, string> }).roles[String(TARGET_ID)] = "GUEST";
+    const racedResult = await adapter.compareAndSwapWorldMetadata({
+      worldId: WORLD_ID,
+      expectedMetadata: before as never,
+      replacementMetadata: raced as never,
+    });
+    expect(racedResult).toEqual({ status: "updated" });
+
+    // The stale snapshot must now conflict, not overwrite.
+    const stale = structuredClone(before);
+    const result = await adapter.compareAndSwapWorldMetadata({
+      worldId: WORLD_ID,
+      expectedMetadata: stale as never,
+      replacementMetadata: { ...stale, extra: "y" } as never,
+      audit: {
+        actorEntityId: ACTOR_ID,
+        targetEntityId: TARGET_ID,
+        previousRole: "USER",
+        newRole: "ADMIN",
+        source: "manual",
+        roomId: ROOM_ID,
+      },
+    });
+    expect(result).toEqual({ status: "conflict" });
+    const after = await storedMetadata(adapter);
+    expect(after).not.toHaveProperty("extra");
+    expect(await adapter.getLogs({ type: ROLE_WRITE_AUDIT_LOG_TYPE })).toHaveLength(0);
+  });
+
+  it("treats key order as insignificant (value equality)", async () => {
+    const adapter = await buildAdapter();
+    const before = await storedMetadata(adapter);
+    // Same keys and values, different insertion order: the stored metadata
+    // reads back from the store as {ownership, roles}; present the snapshot
+    // with the top-level keys in the opposite order. Adding or removing a
+    // key must NOT count as reordering — that is a genuine value change and
+    // must conflict (covered by the drift test above).
+    const reordered = { roles: before.roles, ownership: before.ownership };
+    const result = await adapter.compareAndSwapWorldMetadata({
+      worldId: WORLD_ID,
+      expectedMetadata: reordered as never,
+      replacementMetadata: structuredClone(before) as never,
+    });
+    expect(result).toEqual({ status: "updated" });
+  });
+
+  it("reports not_found for an unknown world", async () => {
+    const adapter = await buildAdapter();
+    const result = await adapter.compareAndSwapWorldMetadata({
+      worldId: v4() as UUID,
+      expectedMetadata: {} as never,
+      replacementMetadata: {} as never,
+    });
+    expect(result).toEqual({ status: "not_found" });
+  });
+
+  it("leaves the world untouched when the audit-row insert throws", async () => {
+    const adapter = await buildAdapter();
+    const before = await storedMetadata(adapter);
+    const replacement = structuredClone(before);
+    (replacement as { roles: Record<string, string> }).roles[String(TARGET_ID)] = "ADMIN";
+
+    // Storage that rejects every LOGS write: the audit insert rides ahead of
+    // the metadata swap, so the throw must leave the stored world unchanged.
+    const failingLogsStorage = adapter.storage as unknown as {
+      set: (collection: string, id: string, value: unknown) => Promise<void>;
+    };
+    const originalSet = failingLogsStorage.set.bind(failingLogsStorage);
+    failingLogsStorage.set = async (collection, id, value) => {
+      if (
+        collection === "logs" &&
+        (value as { type?: string }).type === ROLE_WRITE_AUDIT_LOG_TYPE
+      ) {
+        throw new Error("audit storage unavailable");
+      }
+      return originalSet(collection, id, value);
+    };
+
+    await expect(
+      adapter.compareAndSwapWorldMetadata({
+        worldId: WORLD_ID,
+        expectedMetadata: before as never,
+        replacementMetadata: replacement as never,
+        audit: {
+          actorEntityId: ACTOR_ID,
+          targetEntityId: TARGET_ID,
+          previousRole: "USER",
+          newRole: "ADMIN",
+          source: "manual",
+          roomId: ROOM_ID,
+        },
+      })
+    ).rejects.toThrow("audit storage unavailable");
+
+    const afterAuditThrow = await storedMetadata(adapter);
+    expect((afterAuditThrow as { roles: Record<string, string> }).roles[String(TARGET_ID)]).toBe(
+      "USER"
+    );
+    expect(await adapter.getLogs({ type: ROLE_WRITE_AUDIT_LOG_TYPE })).toHaveLength(0);
+  });
+
+  it("serializes a CAS against a legacy updateWorlds writer sharing the storage", async () => {
+    const adapter = await buildAdapter();
+    const before = await storedMetadata(adapter);
+    const replacement = structuredClone(before);
+    (replacement as { roles: Record<string, string> }).roles[String(TARGET_ID)] = "ADMIN";
+    // A legacy whole-world writer races the CAS on the SAME storage: both
+    // go through the world-metadata tail, so the blind write cannot land
+    // between the CAS read/compare and its write. Whichever wins, the
+    // other either conflicts (CAS lost) or the write precedes/follows the
+    // CAS as a whole — the final state is exactly one of the two writes.
+    const legacyMetadata = structuredClone(before);
+    (legacyMetadata as { roles: Record<string, string> }).roles[String(TARGET_ID)] = "GUEST";
+    const [casResult] = await Promise.all([
+      adapter.compareAndSwapWorldMetadata({
+        worldId: WORLD_ID,
+        expectedMetadata: structuredClone(before) as never,
+        replacementMetadata: replacement as never,
+      }),
+      adapter.updateWorlds([
+        {
+          id: WORLD_ID,
+          agentId: AGENT_ID,
+          name: "cas-world",
+          metadata: legacyMetadata as World["metadata"],
+        },
+      ]),
+    ]);
+    const after = await storedMetadata(adapter);
+    const finalRole = (after as { roles: Record<string, string> }).roles[String(TARGET_ID)];
+    // The serialization invariant: the legacy write lands WHOLE — either
+    // entirely before the CAS (casResult=conflict) or entirely after it
+    // (casResult=updated, then the blind writer overwrites; that residual
+    // overwrite is the documented hazard of unmigrated legacy writers).
+    // finalRole=ADMIN would be the INTERLEAVING signature — the legacy
+    // write landing between the CAS read and its write, silently clobbered
+    // — and is exactly what the shared tail prevents.
+    expect(["updated", "conflict"]).toContain(casResult.status);
+    expect(finalRole).toBe("GUEST");
+  });
+
+  it("serializes concurrent CAS calls ACROSS adapter instances sharing one storage", async () => {
+    // Two adapters over the SAME MemoryStorage: an adapter-local tail would
+    // let both win; the storage-scoped tail must serialize them.
+    const storage = new MemoryStorage();
+    const adapterA = new InMemoryDatabaseAdapter(storage, AGENT_ID);
+    const adapterB = new InMemoryDatabaseAdapter(storage, AGENT_ID);
+    await adapterA.init();
+    await adapterB.init();
+    await adapterA.createWorlds([
+      {
+        id: WORLD_ID,
+        agentId: AGENT_ID,
+        name: "cas-world",
+        metadata: structuredClone(BASE_METADATA) as unknown as World["metadata"],
+      },
+    ]);
+    const before = await storedMetadata(adapterA);
+
+    const mkParams = (marker: string) => {
+      const replacement = structuredClone(before);
+      (replacement as { roles: Record<string, string> }).roles[String(TARGET_ID)] = "ADMIN";
+      (replacement as { marker?: string }).marker = marker;
+      return {
+        worldId: WORLD_ID,
+        expectedMetadata: structuredClone(before) as never,
+        replacementMetadata: replacement as never,
+        audit: {
+          actorEntityId: ACTOR_ID,
+          targetEntityId: TARGET_ID,
+          previousRole: "USER",
+          newRole: "ADMIN",
+          source: "manual",
+          roomId: ROOM_ID,
+        },
+      };
+    };
+    const [fromA, fromB] = await Promise.all([
+      adapterA.compareAndSwapWorldMetadata(mkParams("first")),
+      adapterB.compareAndSwapWorldMetadata(mkParams("second")),
+    ]);
+    const outcomes = [fromA.status, fromB.status].sort();
+    expect(outcomes).toEqual(["conflict", "updated"]);
+    expect(await adapterA.getLogs({ type: ROLE_WRITE_AUDIT_LOG_TYPE })).toHaveLength(1);
+    const after = await storedMetadata(adapterB);
+    expect((after as { marker?: string }).marker).toBeDefined();
+  });
+
+  it("cannot resurrect a world deleted between the CAS read and its write", async () => {
+    const adapter = await buildAdapter();
+    const before = await storedMetadata(adapter);
+    const replacement = structuredClone(before);
+    (replacement as { roles: Record<string, string> }).roles[String(TARGET_ID)] = "ADMIN";
+    // Deletion lands between the CAS read/compare and its write; the
+    // serialized tail means the delete runs either fully before (CAS then
+    // reports not_found) or fully after (CAS updated, then world deleted).
+    // The forbidden outcome is CAS=updated AND the world still present —
+    // the resurrection signature.
+    const [casResult] = await Promise.all([
+      adapter.compareAndSwapWorldMetadata({
+        worldId: WORLD_ID,
+        expectedMetadata: structuredClone(before) as never,
+        replacementMetadata: replacement as never,
+      }),
+      adapter.deleteWorlds([WORLD_ID]),
+    ]);
+    const after = await adapter.getWorldsByIds([WORLD_ID]);
+    if (casResult.status === "updated") {
+      expect(after).toHaveLength(0);
+    } else {
+      expect(casResult.status).toBe("not_found");
+      expect(after).toHaveLength(0);
+    }
+  });
+
+  it("does not let a stale CAS clobber a freshly created world", async () => {
+    const adapter = await buildAdapter();
+    const before = await storedMetadata(adapter);
+    const replacement = structuredClone(before);
+    (replacement as { roles: Record<string, string> }).roles[String(TARGET_ID)] = "ADMIN";
+    // The world is deleted, then re-created with different metadata, while
+    // a CAS holding the ORIGINAL snapshot runs. Serialized: either the
+    // delete+create land first (CAS must conflict — the stored metadata is
+    // the fresh one, not the stale snapshot) or the CAS lands first (then
+    // delete+create replace it wholesale). The forbidden outcome is
+    // CAS=updated over the freshly created metadata — the clobber.
+    const [casResult] = await Promise.all([
+      adapter.compareAndSwapWorldMetadata({
+        worldId: WORLD_ID,
+        expectedMetadata: structuredClone(before) as never,
+        replacementMetadata: replacement as never,
+      }),
+      (async () => {
+        await adapter.deleteWorlds([WORLD_ID]);
+        await adapter.createWorlds([
+          {
+            id: WORLD_ID,
+            agentId: AGENT_ID,
+            name: "cas-world",
+            metadata: {
+              ownership: { ownerId: String(ACTOR_ID) },
+              roles: { [String(ACTOR_ID)]: "OWNER", [String(TARGET_ID)]: "GUEST" },
+            } as unknown as World["metadata"],
+          },
+        ]);
+      })(),
+    ]);
+    if (casResult.status === "updated") {
+      // CAS committed first; the recreate then replaced it — the final
+      // state is the recreated metadata, not a stale-CAS clobber of it.
+      const after = await storedMetadata(adapter);
+      expect((after as { roles: Record<string, string> }).roles[String(TARGET_ID)]).toBe("GUEST");
+    } else {
+      expect(casResult.status).toBe("conflict");
+    }
+  });
+
+  it("serializes concurrent CAS calls so exactly one wins per snapshot", async () => {
+    const adapter = await buildAdapter();
+    const before = await storedMetadata(adapter);
+    const mkParams = (marker: string) => {
+      const replacement = structuredClone(before);
+      (replacement as { roles: Record<string, string> }).roles[String(TARGET_ID)] = "ADMIN";
+      (replacement as { marker?: string }).marker = marker;
+      return {
+        worldId: WORLD_ID,
+        expectedMetadata: structuredClone(before) as never,
+        replacementMetadata: replacement as never,
+        audit: {
+          actorEntityId: ACTOR_ID,
+          targetEntityId: TARGET_ID,
+          previousRole: "USER",
+          newRole: "ADMIN",
+          source: "manual",
+          roomId: ROOM_ID,
+        },
+      };
+    };
+    // Two racing CAS calls with the SAME expected snapshot: both read the
+    // same pre-state, but the mutation tail must serialize them so the
+    // second comparison sees the first one's write and returns conflict.
+    const [first, second] = await Promise.all([
+      adapter.compareAndSwapWorldMetadata(mkParams("first")),
+      adapter.compareAndSwapWorldMetadata(mkParams("second")),
+    ]);
+    const outcomes = [first.status, second.status].sort();
+    expect(outcomes).toEqual(["conflict", "updated"]);
+    // Exactly one audit row: the winner's. The loser left none.
+    expect(await adapter.getLogs({ type: ROLE_WRITE_AUDIT_LOG_TYPE })).toHaveLength(1);
+    const after = await storedMetadata(adapter);
+    expect((after as { marker?: string }).marker).toBeDefined();
+  });
+
+  it("detects an in-place mutation of the live stored metadata (live-reference hazard)", async () => {
+    const adapter = await buildAdapter();
+    // The memory store returns the LIVE stored object; a legacy whole-world
+    // writer mutating it in place after the caller's read must surface as a
+    // conflict, not compare equal-because-aliased. The core CAS helper
+    // guards this by freezing a cloned snapshot; prove the adapter itself
+    // catches a drifted live object when passed as expectedMetadata.
+    const world = (await adapter.getWorldsByIds([WORLD_ID]))[0];
+    const liveMetadata = world?.metadata as Record<string, unknown>;
+    // An independent frozen copy taken NOW:
+    const frozen = structuredClone(liveMetadata);
+    // A legacy writer mutates the live object in place (e.g. a direct
+    // updateWorlds path holding the same reference):
+    (liveMetadata as { roles: Record<string, string> }).roles[String(TARGET_ID)] = "GUEST";
+    const replacement = structuredClone(frozen);
+    (replacement as { roles: Record<string, string> }).roles[String(TARGET_ID)] = "ADMIN";
+    const result = await adapter.compareAndSwapWorldMetadata({
+      worldId: WORLD_ID,
+      expectedMetadata: frozen as never,
+      replacementMetadata: replacement as never,
+    });
+    // The stored (mutated-live) state differs from the frozen snapshot the
+    // caller authorized against — conflict, not a silent merge.
+    expect(result).toEqual({ status: "conflict" });
+  });
+
+  it("rolls the audit row back when the world write fails after insertion", async () => {
+    const adapter = await buildAdapter();
+    const before = await storedMetadata(adapter);
+    const replacement = structuredClone(before);
+    (replacement as { roles: Record<string, string> }).roles[String(TARGET_ID)] = "ADMIN";
+
+    // Storage that accepts the LOGS write but rejects the WORLDS write:
+    // the audit insert succeeds, the world replacement throws — the audit
+    // row must be compensated away so no false committed record survives.
+    const storage = adapter["storage"] as unknown as {
+      set: (collection: string, id: string, value: unknown) => Promise<void>;
+    };
+    const originalSet = storage.set.bind(storage);
+    storage.set = async (collection, id, value) => {
+      if (collection === "worlds") {
+        throw new Error("world storage unavailable");
+      }
+      return originalSet(collection, id, value);
+    };
+
+    await expect(
+      adapter.compareAndSwapWorldMetadata({
+        worldId: WORLD_ID,
+        expectedMetadata: before as never,
+        replacementMetadata: replacement as never,
+        audit: {
+          actorEntityId: ACTOR_ID,
+          targetEntityId: TARGET_ID,
+          previousRole: "USER",
+          newRole: "ADMIN",
+          source: "manual",
+          roomId: ROOM_ID,
+        },
+      })
+    ).rejects.toThrow("world storage unavailable");
+
+    // Restore the real setter before asserting through it.
+    storage.set = originalSet;
+    expect(await adapter.getLogs({ type: ROLE_WRITE_AUDIT_LOG_TYPE })).toHaveLength(0);
+    const after = await storedMetadata(adapter);
+    expect((after as { roles: Record<string, string> }).roles[String(TARGET_ID)]).toBe("USER");
+  });
+});

--- a/plugins/plugin-inmemorydb/world-metadata-cas.test.ts
+++ b/plugins/plugin-inmemorydb/world-metadata-cas.test.ts
@@ -5,7 +5,12 @@
  * throw leaves the world untouched), and world-not-found. Real adapter over
  * real storage, no mocks.
  */
-import { ROLE_WRITE_AUDIT_LOG_TYPE, type UUID, type World } from "@elizaos/core";
+import {
+  ROLE_WRITE_AUDIT_LOG_TYPE,
+  type UUID,
+  WORLD_METADATA_REVISION_KEY,
+  type World,
+} from "@elizaos/core";
 import { v4 } from "uuid";
 import { describe, expect, it } from "vitest";
 import { InMemoryDatabaseAdapter } from "./adapter";
@@ -51,6 +56,21 @@ async function storedMetadata(adapter: InMemoryDatabaseAdapter) {
 }
 
 describe("InMemoryDatabaseAdapter.compareAndSwapWorldMetadata", () => {
+  it("rejects duplicate create without resetting a CAS-managed world", async () => {
+    const adapter = await buildAdapter();
+    const before = await storedMetadata(adapter);
+    await expect(
+      adapter.createWorlds([
+        {
+          id: WORLD_ID,
+          agentId: AGENT_ID,
+          name: "replacement",
+          metadata: { roles: { [String(TARGET_ID)]: "GUEST" } },
+        },
+      ])
+    ).rejects.toMatchObject({ code: "WORLD_ALREADY_EXISTS" });
+    expect(await storedMetadata(adapter)).toEqual(before);
+  });
   it("commits when the snapshot matches, updating metadata and audit together", async () => {
     const adapter = await buildAdapter();
     const before = await storedMetadata(adapter);
@@ -124,7 +144,7 @@ describe("InMemoryDatabaseAdapter.compareAndSwapWorldMetadata", () => {
     // with the top-level keys in the opposite order. Adding or removing a
     // key must NOT count as reordering — that is a genuine value change and
     // must conflict (covered by the drift test above).
-    const reordered = { roles: before.roles, ownership: before.ownership };
+    const reordered = Object.fromEntries(Object.entries(before).reverse());
     const result = await adapter.compareAndSwapWorldMetadata({
       worldId: WORLD_ID,
       expectedMetadata: reordered as never,
@@ -188,45 +208,61 @@ describe("InMemoryDatabaseAdapter.compareAndSwapWorldMetadata", () => {
     expect(await adapter.getLogs({ type: ROLE_WRITE_AUDIT_LOG_TYPE })).toHaveLength(0);
   });
 
-  it("serializes a CAS against a legacy updateWorlds writer sharing the storage", async () => {
-    const adapter = await buildAdapter();
-    const before = await storedMetadata(adapter);
-    const replacement = structuredClone(before);
-    (replacement as { roles: Record<string, string> }).roles[String(TARGET_ID)] = "ADMIN";
-    // A legacy whole-world writer races the CAS on the SAME storage: both
-    // go through the world-metadata tail, so the blind write cannot land
-    // between the CAS read/compare and its write. Whichever wins, the
-    // other either conflicts (CAS lost) or the write precedes/follows the
-    // CAS as a whole — the final state is exactly one of the two writes.
-    const legacyMetadata = structuredClone(before);
-    (legacyMetadata as { roles: Record<string, string> }).roles[String(TARGET_ID)] = "GUEST";
-    const [casResult] = await Promise.all([
-      adapter.compareAndSwapWorldMetadata({
+  it.each(["updateWorlds", "upsertWorlds"] as const)(
+    "rejects a legacy %s writer that resumes from a pre-CAS snapshot",
+    async (legacyMethod) => {
+      const adapter = await buildAdapter();
+      let signalRead!: () => void;
+      let releaseWriter!: () => void;
+      const readComplete = new Promise<void>((resolve) => {
+        signalRead = resolve;
+      });
+      const writerGate = new Promise<void>((resolve) => {
+        releaseWriter = resolve;
+      });
+      const legacyWriter = (async () => {
+        const staleWorld = (await adapter.getWorldsByIds([WORLD_ID]))[0];
+        signalRead();
+        await writerGate;
+        if (!staleWorld) throw new Error("test world missing");
+        (staleWorld.metadata as { roles: Record<string, string> }).roles[String(TARGET_ID)] =
+          "GUEST";
+        await adapter[legacyMethod]([staleWorld]);
+      })();
+      await readComplete;
+
+      const before = await storedMetadata(adapter);
+      const replacement = structuredClone(before);
+      (replacement as { roles: Record<string, string> }).roles[String(TARGET_ID)] = "ADMIN";
+      const casResult = await adapter.compareAndSwapWorldMetadata({
         worldId: WORLD_ID,
         expectedMetadata: structuredClone(before) as never,
         replacementMetadata: replacement as never,
-      }),
-      adapter.updateWorlds([
-        {
-          id: WORLD_ID,
-          agentId: AGENT_ID,
-          name: "cas-world",
-          metadata: legacyMetadata as World["metadata"],
-        },
-      ]),
-    ]);
-    const after = await storedMetadata(adapter);
-    const finalRole = (after as { roles: Record<string, string> }).roles[String(TARGET_ID)];
-    // The serialization invariant: the legacy write lands WHOLE — either
-    // entirely before the CAS (casResult=conflict) or entirely after it
-    // (casResult=updated, then the blind writer overwrites; that residual
-    // overwrite is the documented hazard of unmigrated legacy writers).
-    // finalRole=ADMIN would be the INTERLEAVING signature — the legacy
-    // write landing between the CAS read and its write, silently clobbered
-    // — and is exactly what the shared tail prevents.
-    expect(["updated", "conflict"]).toContain(casResult.status);
-    expect(finalRole).toBe("GUEST");
-  });
+      });
+      releaseWriter();
+      await expect(legacyWriter).rejects.toMatchObject({ code: "WORLD_METADATA_STALE_WRITE" });
+      const after = await storedMetadata(adapter);
+      const finalRole = (after as { roles: Record<string, string> }).roles[String(TARGET_ID)];
+      expect(casResult).toEqual({ status: "updated" });
+      expect(finalRole).toBe("ADMIN");
+    }
+  );
+
+  it.each(["updateWorlds", "upsertWorlds"] as const)(
+    "rejects a malformed revision from legacy %s",
+    async (legacyMethod) => {
+      const adapter = await buildAdapter();
+      const world = (await adapter.getWorldsByIds([WORLD_ID]))[0];
+      if (!world?.metadata) throw new Error("test world metadata missing");
+      (world.metadata as Record<string, unknown>)[WORLD_METADATA_REVISION_KEY] = "invalid";
+
+      await expect(adapter[legacyMethod]([world])).rejects.toMatchObject({
+        code: "WORLD_METADATA_STALE_WRITE",
+      });
+      const after = await storedMetadata(adapter);
+      expect((after as { roles: Record<string, string> }).roles[String(TARGET_ID)]).toBe("USER");
+    }
+  );
 
   it("serializes concurrent CAS calls ACROSS adapter instances sharing one storage", async () => {
     // Two adapters over the SAME MemoryStorage: an adapter-local tail would
@@ -427,20 +463,14 @@ describe("InMemoryDatabaseAdapter.compareAndSwapWorldMetadata", () => {
     expect((after as { marker?: string }).marker).toBeDefined();
   });
 
-  it("detects an in-place mutation of the live stored metadata (live-reference hazard)", async () => {
+  it("returns detached world reads so in-place caller mutation cannot alter storage", async () => {
     const adapter = await buildAdapter();
-    // The memory store returns the LIVE stored object; a legacy whole-world
-    // writer mutating it in place after the caller's read must surface as a
-    // conflict, not compare equal-because-aliased. The core CAS helper
-    // guards this by freezing a cloned snapshot; prove the adapter itself
-    // catches a drifted live object when passed as expectedMetadata.
     const world = (await adapter.getWorldsByIds([WORLD_ID]))[0];
     const liveMetadata = world?.metadata as Record<string, unknown>;
-    // An independent frozen copy taken NOW:
     const frozen = structuredClone(liveMetadata);
-    // A legacy writer mutates the live object in place (e.g. a direct
-    // updateWorlds path holding the same reference):
     (liveMetadata as { roles: Record<string, string> }).roles[String(TARGET_ID)] = "GUEST";
+    const unchanged = await storedMetadata(adapter);
+    expect((unchanged as { roles: Record<string, string> }).roles[String(TARGET_ID)]).toBe("USER");
     const replacement = structuredClone(frozen);
     (replacement as { roles: Record<string, string> }).roles[String(TARGET_ID)] = "ADMIN";
     const result = await adapter.compareAndSwapWorldMetadata({
@@ -448,9 +478,7 @@ describe("InMemoryDatabaseAdapter.compareAndSwapWorldMetadata", () => {
       expectedMetadata: frozen as never,
       replacementMetadata: replacement as never,
     });
-    // The stored (mutated-live) state differs from the frozen snapshot the
-    // caller authorized against — conflict, not a silent merge.
-    expect(result).toEqual({ status: "conflict" });
+    expect(result).toEqual({ status: "updated" });
   });
 
   it("rolls the audit row back when the world write fails after insertion", async () => {
@@ -462,7 +490,7 @@ describe("InMemoryDatabaseAdapter.compareAndSwapWorldMetadata", () => {
     // Storage that accepts the LOGS write but rejects the WORLDS write:
     // the audit insert succeeds, the world replacement throws — the audit
     // row must be compensated away so no false committed record survives.
-    const storage = adapter["storage"] as unknown as {
+    const storage = adapter.storage as unknown as {
       set: (collection: string, id: string, value: unknown) => Promise<void>;
     };
     const originalSet = storage.set.bind(storage);

--- a/plugins/plugin-inmemorydb/world-metadata-cas.test.ts
+++ b/plugins/plugin-inmemorydb/world-metadata-cas.test.ts
@@ -10,6 +10,7 @@ import { v4 } from "uuid";
 import { describe, expect, it } from "vitest";
 import { InMemoryDatabaseAdapter } from "./adapter";
 import { MemoryStorage } from "./storage-memory";
+import { COLLECTIONS } from "./types";
 
 const AGENT_ID = "70000000-0000-0000-0000-000000000001" as UUID;
 const ACTOR_ID = "70000000-0000-0000-0000-000000000002" as UUID;
@@ -23,7 +24,11 @@ const BASE_METADATA = {
 };
 
 async function buildAdapter() {
-  const adapter = new InMemoryDatabaseAdapter(new MemoryStorage(), AGENT_ID);
+  return buildAdapterOn(new MemoryStorage());
+}
+
+async function buildAdapterOn(storage: MemoryStorage) {
+  const adapter = new InMemoryDatabaseAdapter(storage, AGENT_ID);
   await adapter.init();
   await adapter.createWorlds([
     {
@@ -270,72 +275,119 @@ describe("InMemoryDatabaseAdapter.compareAndSwapWorldMetadata", () => {
     expect((after as { marker?: string }).marker).toBeDefined();
   });
 
+  /**
+   * Wraps a MemoryStorage so its first world WRITE (set) parks until
+   * released, exposing an `entered` promise that resolves the moment the
+   * write parks. The CAS always reads before parking (read → compare →
+   * audit insert → park → write), so awaiting `entered` and acting before
+   * `release()` places the test's delete / create actor strictly between
+   * the CAS's read and its write — the exact interleaving the r4 P0
+   * forbids. Gating the read instead would make the forbidden outcome
+   * impossible even pre-fix (the CAS would observe the actor at compare).
+   */
+  function gatedWorldWrite(storage: MemoryStorage) {
+    let release!: () => void;
+    let markEntered!: () => void;
+    // Resolved immediately BEFORE parking on the gate: awaiting `entered`
+    // proves the CAS reached its world write and is parked — no timing
+    // assumption about scheduler delay.
+    const entered = new Promise<void>((r) => (markEntered = r));
+    const gate = new Promise<void>((r) => (release = r));
+    const origSet = storage.set.bind(storage);
+    let armed = true;
+    storage.set = async (collection: string, id: string, data: unknown) => {
+      if (armed && collection === COLLECTIONS.WORLDS) {
+        armed = false;
+        markEntered();
+        await gate;
+      }
+      return origSet(collection, id, data as never);
+    };
+    return { release, entered };
+  }
+
   it("cannot resurrect a world deleted between the CAS read and its write", async () => {
-    const adapter = await buildAdapter();
+    const storage = new MemoryStorage();
+    const adapter = await buildAdapterOn(storage);
     const before = await storedMetadata(adapter);
     const replacement = structuredClone(before);
     (replacement as { roles: Record<string, string> }).roles[String(TARGET_ID)] = "ADMIN";
-    // Deletion lands between the CAS read/compare and its write; the
-    // serialized tail means the delete runs either fully before (CAS then
-    // reports not_found) or fully after (CAS updated, then world deleted).
-    // The forbidden outcome is CAS=updated AND the world still present —
-    // the resurrection signature.
-    const [casResult] = await Promise.all([
-      adapter.compareAndSwapWorldMetadata({
-        worldId: WORLD_ID,
-        expectedMetadata: structuredClone(before) as never,
-        replacementMetadata: replacement as never,
-      }),
-      adapter.deleteWorlds([WORLD_ID]),
-    ]);
+    // Park the CAS on its world WRITE; with the park proven via the
+    // entered handshake, delete the world while it is parked. Pre-fix
+    // (createWorlds/deleteWorlds NOT on the tail) the delete lands and the
+    // parked CAS write resurrects the world; post-fix the delete queues
+    // behind the tail and runs only after the CAS completes.
+    // Forbidden: CAS=updated AND world still present.
+    const gated = gatedWorldWrite(storage);
+    const casPromise = adapter.compareAndSwapWorldMetadata({
+      worldId: WORLD_ID,
+      expectedMetadata: structuredClone(before) as never,
+      replacementMetadata: replacement as never,
+    });
+    await gated.entered; // CAS is proven parked on its world write
+    // Fire WITHOUT awaiting yet: post-fix deleteWorlds queues on the tail
+    // the parked CAS holds, so awaiting it here would deadlock the test.
+    const deletion = adapter.deleteWorlds([WORLD_ID]);
+    gated.release();
+    const casResult = await casPromise;
+    await deletion; // the queued delete completes before final assertions
     const after = await adapter.getWorldsByIds([WORLD_ID]);
-    if (casResult.status === "updated") {
-      expect(after).toHaveLength(0);
-    } else {
-      expect(casResult.status).toBe("not_found");
-      expect(after).toHaveLength(0);
+    expect(after).toHaveLength(0);
+    if (casResult.status !== "updated" && casResult.status !== "not_found") {
+      throw new Error(`unexpected CAS outcome: ${JSON.stringify(casResult)}`);
     }
   });
 
   it("does not let a stale CAS clobber a freshly created world", async () => {
-    const adapter = await buildAdapter();
+    const storage = new MemoryStorage();
+    const adapter = await buildAdapterOn(storage);
     const before = await storedMetadata(adapter);
     const replacement = structuredClone(before);
     (replacement as { roles: Record<string, string> }).roles[String(TARGET_ID)] = "ADMIN";
-    // The world is deleted, then re-created with different metadata, while
-    // a CAS holding the ORIGINAL snapshot runs. Serialized: either the
-    // delete+create land first (CAS must conflict — the stored metadata is
-    // the fresh one, not the stale snapshot) or the CAS lands first (then
-    // delete+create replace it wholesale). The forbidden outcome is
-    // CAS=updated over the freshly created metadata — the clobber.
-    const [casResult] = await Promise.all([
-      adapter.compareAndSwapWorldMetadata({
-        worldId: WORLD_ID,
-        expectedMetadata: structuredClone(before) as never,
-        replacementMetadata: replacement as never,
-      }),
-      (async () => {
-        await adapter.deleteWorlds([WORLD_ID]);
-        await adapter.createWorlds([
-          {
-            id: WORLD_ID,
-            agentId: AGENT_ID,
-            name: "cas-world",
-            metadata: {
-              ownership: { ownerId: String(ACTOR_ID) },
-              roles: { [String(ACTOR_ID)]: "OWNER", [String(TARGET_ID)]: "GUEST" },
-            } as unknown as World["metadata"],
-          },
-        ]);
-      })(),
-    ]);
+    // Park the CAS on its world WRITE (proven via the entered handshake)
+    // while it holds the ORIGINAL snapshot; then delete and recreate the
+    // world with different metadata. Pre-fix the recreate interleaves and
+    // the parked CAS write clobbers the fresh world; post-fix it queues
+    // behind the tail. Forbidden: CAS=updated over the fresh metadata.
+    const gated = gatedWorldWrite(storage);
+    const casPromise = adapter.compareAndSwapWorldMetadata({
+      worldId: WORLD_ID,
+      expectedMetadata: structuredClone(before) as never,
+      replacementMetadata: replacement as never,
+    });
+    await gated.entered; // CAS is proven parked on its world write
+    // Fire WITHOUT awaiting: post-fix the actor queues on the tail behind
+    // the parked CAS; awaiting it here would deadlock the test.
+    const actor = (async () => {
+      await adapter.deleteWorlds([WORLD_ID]);
+      await adapter.createWorlds([
+        {
+          id: WORLD_ID,
+          agentId: AGENT_ID,
+          name: "cas-world",
+          metadata: {
+            ownership: { ownerId: String(ACTOR_ID) },
+            roles: { [String(ACTOR_ID)]: "OWNER", [String(TARGET_ID)]: "GUEST" },
+          } as unknown as World["metadata"],
+        },
+      ]);
+    })();
+    // Let the un-serialized (pre-fix) actor drain fully BEFORE releasing the
+    // parked CAS write: pre-fix this deterministically produces the clobber
+    // (stale CAS write lands last, over the fresh world); post-fix the actor
+    // has queued on the tail and the CAS commits first instead.
+    await new Promise((r) => setTimeout(r, 5));
+    gated.release();
+    const casResult = await casPromise;
+    await actor; // both orders complete before we assert on final state
+    const after = await storedMetadata(adapter);
     if (casResult.status === "updated") {
       // CAS committed first; the recreate then replaced it — the final
       // state is the recreated metadata, not a stale-CAS clobber of it.
-      const after = await storedMetadata(adapter);
       expect((after as { roles: Record<string, string> }).roles[String(TARGET_ID)]).toBe("GUEST");
     } else {
       expect(casResult.status).toBe("conflict");
+      expect((after as { roles: Record<string, string> }).roles[String(TARGET_ID)]).toBe("GUEST");
     }
   });
 

--- a/plugins/plugin-sql/src/__tests__/integration/world-metadata-cas.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/world-metadata-cas.real.test.ts
@@ -5,7 +5,13 @@
  * atomicity (the log row rides the CAS transaction), and world-not-found.
  * Real adapter, real migration system, no mocked storage.
  */
-import { ChannelType, ROLE_WRITE_AUDIT_LOG_TYPE, type UUID, type World } from "@elizaos/core";
+import {
+  ChannelType,
+  ROLE_WRITE_AUDIT_LOG_TYPE,
+  type UUID,
+  WORLD_METADATA_REVISION_KEY,
+  type World,
+} from "@elizaos/core";
 import { v4 } from "uuid";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createIsolatedTestDatabase } from "../test-helpers";
@@ -148,7 +154,7 @@ describe("compareAndSwapWorldMetadata (real SQL parity)", () => {
     // the value-equality contract) must treat this as the same snapshot.
     // Adding or removing a key is a value change and must conflict — the
     // drift test above covers that direction.
-    const reordered = { roles: before.roles, ownership: before.ownership };
+    const reordered = Object.fromEntries(Object.entries(before).reverse());
     const result = await adapter.compareAndSwapWorldMetadata({
       worldId: WORLD_ID,
       expectedMetadata: reordered as never,
@@ -156,6 +162,60 @@ describe("compareAndSwapWorldMetadata (real SQL parity)", () => {
     });
     expect(result).toEqual({ status: "updated" });
   });
+
+  it.each(["updateWorlds", "upsertWorlds"] as const)(
+    "rejects a legacy %s writer that resumes from a pre-CAS SQL snapshot",
+    async (legacyMethod) => {
+      let signalRead!: () => void;
+      let releaseWriter!: () => void;
+      const readComplete = new Promise<void>((resolve) => {
+        signalRead = resolve;
+      });
+      const writerGate = new Promise<void>((resolve) => {
+        releaseWriter = resolve;
+      });
+      const legacyWriter = (async () => {
+        const staleWorld = (await adapter.getWorldsByIds([WORLD_ID]))[0];
+        signalRead();
+        await writerGate;
+        if (!staleWorld) throw new Error("test world missing");
+        (staleWorld.metadata as { roles: Record<string, string> }).roles[String(TARGET_ID)] =
+          "GUEST";
+        await adapter[legacyMethod]([staleWorld]);
+      })();
+      await readComplete;
+
+      const before = await storedMetadata();
+      const replacement = structuredClone(before);
+      (replacement as { roles: Record<string, string> }).roles[String(TARGET_ID)] = "ADMIN";
+      const casResult = await adapter.compareAndSwapWorldMetadata({
+        worldId: WORLD_ID,
+        expectedMetadata: before as never,
+        replacementMetadata: replacement as never,
+      });
+      releaseWriter();
+      await expect(legacyWriter).rejects.toMatchObject({ code: "WORLD_METADATA_STALE_WRITE" });
+
+      expect(casResult).toEqual({ status: "updated" });
+      const after = await storedMetadata();
+      expect((after as { roles: Record<string, string> }).roles[String(TARGET_ID)]).toBe("ADMIN");
+    }
+  );
+
+  it.each(["updateWorlds", "upsertWorlds"] as const)(
+    "rejects a malformed revision from legacy %s on real SQL",
+    async (legacyMethod) => {
+      const world = (await adapter.getWorldsByIds([WORLD_ID]))[0];
+      if (!world?.metadata) throw new Error("test world metadata missing");
+      (world.metadata as Record<string, unknown>)[WORLD_METADATA_REVISION_KEY] = "invalid";
+      const before = await storedMetadata();
+
+      await expect(adapter[legacyMethod]([world])).rejects.toMatchObject({
+        code: "WORLD_METADATA_STALE_WRITE",
+      });
+      expect(await storedMetadata()).toEqual(before);
+    }
+  );
 
   it("reports not_found for an unknown world", async () => {
     const result = await adapter.compareAndSwapWorldMetadata({

--- a/plugins/plugin-sql/src/__tests__/integration/world-metadata-cas.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/world-metadata-cas.real.test.ts
@@ -2,7 +2,8 @@
  * Exercises the #23100 world-metadata compare-and-swap against real SQL
  * storage (PGlite, or Postgres when POSTGRES_URL is set): snapshot match and
  * mismatch, jsonb value equality with key order differences, audit-row
- * atomicity (the log row rides the CAS transaction), and world-not-found.
+ * atomicity, authority-ledger retention after actor/room deletion, and
+ * world-not-found.
  * Real adapter, real migration system, no mocked storage.
  */
 import {
@@ -12,8 +13,10 @@ import {
   WORLD_METADATA_REVISION_KEY,
   type World,
 } from "@elizaos/core";
+import { eq } from "drizzle-orm";
 import { v4 } from "uuid";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { worldRoleAuditTable } from "../../schema/worldRoleAudit";
 import { createIsolatedTestDatabase } from "../test-helpers";
 
 const WORLD_ID = v4() as UUID;
@@ -224,5 +227,35 @@ describe("compareAndSwapWorldMetadata (real SQL parity)", () => {
       replacementMetadata: {} as never,
     });
     expect(result).toEqual({ status: "not_found" });
+  });
+
+  it("retains the authority ledger after its operational actor and room are deleted", async () => {
+    const db = adapter.getDatabase();
+    const before = await db
+      .select()
+      .from(worldRoleAuditTable)
+      .where(eq(worldRoleAuditTable.worldId, WORLD_ID));
+    expect(before).toHaveLength(1);
+
+    await adapter.deleteRooms([ROOM_ID]);
+    await adapter.deleteEntities([ACTOR_ID, TARGET_ID]);
+
+    const retained = await db
+      .select()
+      .from(worldRoleAuditTable)
+      .where(eq(worldRoleAuditTable.worldId, WORLD_ID));
+    expect(retained).toHaveLength(1);
+    expect(retained[0]).toMatchObject({
+      actorEntityId: ACTOR_ID,
+      targetEntityId: TARGET_ID,
+      roomId: ROOM_ID,
+      previousRole: "USER",
+      newRole: "ADMIN",
+      grantSource: "manual",
+    });
+
+    // The general diagnostic log is lifecycle-bound by design; the authority
+    // ledger above is the retained record and must remain independently true.
+    expect(await adapter.getLogs({ type: ROLE_WRITE_AUDIT_LOG_TYPE })).toHaveLength(0);
   });
 });

--- a/plugins/plugin-sql/src/__tests__/integration/world-metadata-cas.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/world-metadata-cas.real.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Exercises the #23100 world-metadata compare-and-swap against real SQL
+ * storage (PGlite, or Postgres when POSTGRES_URL is set): snapshot match and
+ * mismatch, jsonb value equality with key order differences, audit-row
+ * atomicity (the log row rides the CAS transaction), and world-not-found.
+ * Real adapter, real migration system, no mocked storage.
+ */
+import { ChannelType, ROLE_WRITE_AUDIT_LOG_TYPE, type UUID, type World } from "@elizaos/core";
+import { v4 } from "uuid";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createIsolatedTestDatabase } from "../test-helpers";
+
+const WORLD_ID = v4() as UUID;
+const ACTOR_ID = "60000000-0000-0000-0000-000000000001" as UUID;
+const TARGET_ID = "60000000-0000-0000-0000-000000000002" as UUID;
+const ROOM_ID = v4() as UUID;
+
+const BASE_METADATA = {
+  ownership: { ownerId: String(ACTOR_ID) },
+  roles: { [String(ACTOR_ID)]: "OWNER", [String(TARGET_ID)]: "USER" },
+};
+
+describe("compareAndSwapWorldMetadata (real SQL parity)", () => {
+  let adapter: Awaited<ReturnType<typeof createIsolatedTestDatabase>>["adapter"];
+  let cleanup: () => Promise<void>;
+  let agentId: UUID;
+
+  beforeAll(async () => {
+    const setup = await createIsolatedTestDatabase("world_metadata_cas");
+    adapter = setup.adapter;
+    cleanup = setup.cleanup;
+    agentId = setup.testAgentId;
+    // The logs table enforces real foreign keys (entity_id -> entities.id,
+    // room_id -> rooms.id), so the audit row needs live actor and room rows —
+    // exactly as production role writes always run against real entities.
+    await adapter.createEntities([
+      {
+        id: ACTOR_ID,
+        agentId,
+        names: ["cas-actor"],
+      },
+      {
+        id: TARGET_ID,
+        agentId,
+        names: ["cas-target"],
+      },
+    ]);
+    const roomIds = await adapter.createRooms([
+      {
+        id: ROOM_ID,
+        agentId,
+        worldId: WORLD_ID,
+        source: "world-metadata-cas",
+        type: ChannelType.WORLD,
+      },
+    ]);
+    if (!roomIds.includes(ROOM_ID)) {
+      throw new Error("test room was not created");
+    }
+    await adapter.createWorld({
+      id: WORLD_ID,
+      agentId,
+      name: "World metadata CAS world",
+      serverId: "world-metadata-cas",
+      metadata: BASE_METADATA as unknown as World["metadata"],
+    } as World);
+  });
+
+  afterAll(async () => {
+    await cleanup();
+  });
+
+  async function storedMetadata(): Promise<Record<string, unknown>> {
+    const rows = await adapter.getWorldsByIds([WORLD_ID]);
+    return (rows[0]?.metadata ?? {}) as Record<string, unknown>;
+  }
+
+  it("commits when the snapshot matches, updating metadata and audit together", async () => {
+    const before = await storedMetadata();
+    const replacement = structuredClone(before);
+    (replacement as { roles: Record<string, string> }).roles[String(TARGET_ID)] = "ADMIN";
+
+    const result = await adapter.compareAndSwapWorldMetadata({
+      worldId: WORLD_ID,
+      expectedMetadata: before as never,
+      replacementMetadata: replacement as never,
+      audit: {
+        actorEntityId: ACTOR_ID,
+        targetEntityId: TARGET_ID,
+        previousRole: "USER",
+        newRole: "ADMIN",
+        source: "manual",
+        roomId: ROOM_ID,
+      },
+    });
+
+    expect(result).toEqual({ status: "updated" });
+    const after = await storedMetadata();
+    expect((after as { roles: Record<string, string> }).roles[String(TARGET_ID)]).toBe("ADMIN");
+    const logs = await adapter.getLogs({ type: ROLE_WRITE_AUDIT_LOG_TYPE });
+    expect(logs).toHaveLength(1);
+    const body = logs[0]?.body as { source: string; metadata?: Record<string, unknown> };
+    expect(body?.source).toBe("role-write-cas");
+    expect(body?.metadata?.previousRole).toBe("USER");
+    expect(body?.metadata?.newRole).toBe("ADMIN");
+    expect(body?.metadata?.outcome).toBe("committed");
+  });
+
+  it("conflicts when the stored metadata drifted from the snapshot", async () => {
+    const before = await storedMetadata();
+    // Someone else writes first (a plain role change, no schema drift).
+    const raced = structuredClone(before);
+    (raced as { roles: Record<string, string> }).roles[String(TARGET_ID)] = "GUEST";
+    const racedResult = await adapter.compareAndSwapWorldMetadata({
+      worldId: WORLD_ID,
+      expectedMetadata: before as never,
+      replacementMetadata: raced as never,
+    });
+    expect(racedResult).toEqual({ status: "updated" });
+
+    // Now the stale snapshot must conflict, not overwrite: its extra key must
+    // never land, and the racing writer's role change must survive.
+    const result = await adapter.compareAndSwapWorldMetadata({
+      worldId: WORLD_ID,
+      expectedMetadata: before as never,
+      replacementMetadata: { ...before, extra: "y" } as never,
+      audit: {
+        actorEntityId: ACTOR_ID,
+        targetEntityId: TARGET_ID,
+        previousRole: "USER",
+        newRole: "ADMIN",
+        source: "manual",
+        roomId: ROOM_ID,
+      },
+    });
+    expect(result).toEqual({ status: "conflict" });
+    const after = await storedMetadata();
+    expect(after).not.toHaveProperty("extra");
+    expect((after as { roles: Record<string, string> }).roles[String(TARGET_ID)]).toBe("GUEST");
+    // No audit row for the lost attempt.
+    const logs = await adapter.getLogs({ type: ROLE_WRITE_AUDIT_LOG_TYPE });
+    expect(logs).toHaveLength(1);
+  });
+
+  it("treats key order as insignificant (jsonb value equality)", async () => {
+    const before = await storedMetadata();
+    // Same keys and values, opposite top-level insertion order: jsonb (and
+    // the value-equality contract) must treat this as the same snapshot.
+    // Adding or removing a key is a value change and must conflict — the
+    // drift test above covers that direction.
+    const reordered = { roles: before.roles, ownership: before.ownership };
+    const result = await adapter.compareAndSwapWorldMetadata({
+      worldId: WORLD_ID,
+      expectedMetadata: reordered as never,
+      replacementMetadata: structuredClone(before) as never,
+    });
+    expect(result).toEqual({ status: "updated" });
+  });
+
+  it("reports not_found for an unknown world", async () => {
+    const result = await adapter.compareAndSwapWorldMetadata({
+      worldId: v4() as UUID,
+      expectedMetadata: {} as never,
+      replacementMetadata: {} as never,
+    });
+    expect(result).toEqual({ status: "not_found" });
+  });
+});

--- a/plugins/plugin-sql/src/base.ts
+++ b/plugins/plugin-sql/src/base.ts
@@ -5245,59 +5245,57 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
   async compareAndSwapWorldMetadata(
     params: WorldMetadataCompareAndSwapParams
   ): Promise<WorldMetadataMutationResult> {
-    return this.withDatabase(async () => {
-      return this.db.transaction(async (tx) => {
-        const rows = await tx
-          .select()
-          .from(worldTable)
-          .where(and(eq(worldTable.id, params.worldId), eq(worldTable.agentId, this.agentId)))
-          .for("update")
-          .limit(1);
-        const row = rows[0];
-        if (!row) return { status: "not_found" as const };
+    return this.withEntityContext(params.audit?.actorEntityId ?? null, async (tx) => {
+      const rows = await tx
+        .select()
+        .from(worldTable)
+        .where(and(eq(worldTable.id, params.worldId), eq(worldTable.agentId, this.agentId)))
+        .for("update")
+        .limit(1);
+      const row = rows[0];
+      if (!row) return { status: "not_found" as const };
 
-        const storedMetadata = (row.metadata ?? {}) as Record<string, unknown>;
-        if (
-          !worldMetadataValueEquals(
-            storedMetadata,
-            params.expectedMetadata as Record<string, unknown>
-          )
-        ) {
-          return { status: "conflict" as const };
-        }
-        const storedRevision = getWorldMetadataRevision(row.metadata as Metadata | undefined);
-        if (storedRevision === null) return { status: "conflict" as const };
+      const storedMetadata = (row.metadata ?? {}) as Record<string, unknown>;
+      if (
+        !worldMetadataValueEquals(
+          storedMetadata,
+          params.expectedMetadata as Record<string, unknown>
+        )
+      ) {
+        return { status: "conflict" as const };
+      }
+      const storedRevision = getWorldMetadataRevision(row.metadata as Metadata | undefined);
+      if (storedRevision === null) return { status: "conflict" as const };
 
-        if (params.audit) {
-          const audit = params.audit;
-          const sanitizedBody = sanitizeJsonObject({
-            source: "role-write-cas",
-            metadata: {
-              worldId: params.worldId,
-              actorEntityId: audit.actorEntityId,
-              targetEntityId: audit.targetEntityId,
-              previousRole: audit.previousRole,
-              newRole: audit.newRole,
-              grantSource: audit.source,
-              outcome: "committed",
-            },
-          });
-          await tx.insert(logTable).values({
-            entityId: audit.actorEntityId,
-            roomId: audit.roomId,
-            type: ROLE_WRITE_AUDIT_LOG_TYPE,
-            body: sql`${JSON.stringify(sanitizedBody)}::jsonb`,
-          });
-        }
+      if (params.audit) {
+        const audit = params.audit;
+        const sanitizedBody = sanitizeJsonObject({
+          source: "role-write-cas",
+          metadata: {
+            worldId: params.worldId,
+            actorEntityId: audit.actorEntityId,
+            targetEntityId: audit.targetEntityId,
+            previousRole: audit.previousRole,
+            newRole: audit.newRole,
+            grantSource: audit.source,
+            outcome: "committed",
+          },
+        });
+        await tx.insert(logTable).values({
+          entityId: audit.actorEntityId,
+          roomId: audit.roomId,
+          type: ROLE_WRITE_AUDIT_LOG_TYPE,
+          body: sql`${JSON.stringify(sanitizedBody)}::jsonb`,
+        });
+      }
 
-        await tx
-          .update(worldTable)
-          .set({
-            metadata: advanceWorldMetadataRevision(params.replacementMetadata, storedRevision),
-          })
-          .where(eq(worldTable.id, params.worldId));
-        return { status: "updated" as const };
-      });
+      await tx
+        .update(worldTable)
+        .set({
+          metadata: advanceWorldMetadataRevision(params.replacementMetadata, storedRevision),
+        })
+        .where(eq(worldTable.id, params.worldId));
+      return { status: "updated" as const };
     });
   }
 

--- a/plugins/plugin-sql/src/base.ts
+++ b/plugins/plugin-sql/src/base.ts
@@ -102,6 +102,7 @@ import {
   worldMetadataValueEquals,
 } from "@elizaos/core";
 import { sanitizeJsonObject } from "./sanitize-json";
+import { worldRoleAuditTable } from "./schema/worldRoleAudit";
 import {
   readTaskDueAt,
   serializeTaskDueAt,
@@ -5162,7 +5163,18 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
       );
       const newWorldId = normalizedWorld.id as UUID;
 
-      await this.db.insert(worldTable).values(normalizedWorld);
+      try {
+        await this.db.insert(worldTable).values(normalizedWorld);
+      } catch (error) {
+        if (isDuplicateKeyError(error)) {
+          throw new ElizaError("World already exists", {
+            code: "WORLD_ALREADY_EXISTS",
+            cause: error,
+            context: { worldId: newWorldId, agentId: this.agentId },
+          });
+        }
+        throw error;
+      }
       return newWorldId;
     });
   }
@@ -5270,6 +5282,16 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
 
       if (params.audit) {
         const audit = params.audit;
+        await tx.insert(worldRoleAuditTable).values({
+          agentId: this.agentId,
+          worldId: params.worldId,
+          actorEntityId: audit.actorEntityId,
+          targetEntityId: audit.targetEntityId,
+          roomId: audit.roomId,
+          previousRole: audit.previousRole,
+          newRole: audit.newRole,
+          grantSource: audit.source,
+        });
         const sanitizedBody = sanitizeJsonObject({
           source: "role-write-cas",
           metadata: {

--- a/plugins/plugin-sql/src/base.ts
+++ b/plugins/plugin-sql/src/base.ts
@@ -15,6 +15,7 @@ import {
   type AgentRunSummaryResult,
   type AppendConnectorAccountAuditEventParams,
   actorFromAccessContext,
+  advanceWorldMetadataRevision,
   ChannelType,
   type Component,
   type ConnectorAccountAuditEventRecord,
@@ -50,7 +51,9 @@ import {
   encryptedCharacter,
   type GetConnectorAccountCredentialRefParams,
   type GetConnectorAccountParams,
+  getWorldMetadataRevision,
   type IDatabaseAdapter,
+  initializeWorldMetadataRevision,
   type JsonValue,
   type ListConnectorAccountCredentialRefsParams,
   type ListConnectorAccountsParams,
@@ -79,6 +82,7 @@ import {
   ROLE_WRITE_AUDIT_LOG_TYPE,
   type Room,
   type RunStatus,
+  requireFreshWorldMetadataRevision,
   type SetConnectorAccountCredentialRefParams,
   type Task,
   type TaskMetadata,
@@ -94,6 +98,7 @@ import {
   type World,
   type WorldMetadataCompareAndSwapParams,
   type WorldMetadataMutationResult,
+  worldMetadataValueEquals,
 } from "@elizaos/core";
 import { sanitizeJsonObject } from "./sanitize-json";
 import {
@@ -197,35 +202,6 @@ function asRawMessage(value: unknown): Record<string, unknown> | undefined {
 
 function asMetadata(value: unknown): Metadata | undefined {
   return (value ?? undefined) as Metadata | undefined;
-}
-
-/**
- * Deep JSON-value equality for the world-metadata compare-and-swap: a jsonb
- * column read back from Postgres compares by VALUE with key order
- * insignificant, so the snapshot comparison must do the same rather than
- * reference-comparing the objects the caller read. `undefined` is treated as
- * absent, matching a JSON round-trip.
- */
-function jsonbValueEquals(left: unknown, right: unknown): boolean {
-  if (left === right) return true;
-  if (Array.isArray(left) && Array.isArray(right)) {
-    return (
-      left.length === right.length &&
-      left.every((item, index) => jsonbValueEquals(item, right[index]))
-    );
-  }
-  if (asRawMessage(left) && asRawMessage(right)) {
-    const leftRecord = left as Record<string, unknown>;
-    const rightRecord = right as Record<string, unknown>;
-    const leftKeys = Object.keys(leftRecord).filter((key) => leftRecord[key] !== undefined);
-    const rightKeys = Object.keys(rightRecord).filter((key) => rightRecord[key] !== undefined);
-    if (leftKeys.length !== rightKeys.length) return false;
-    return leftKeys.every(
-      (key) =>
-        Object.hasOwn(rightRecord, key) && jsonbValueEquals(leftRecord[key], rightRecord[key])
-    );
-  }
-  return false;
 }
 
 function normalizeAgentBio(value: unknown): string[] | undefined {
@@ -898,6 +874,9 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
         return await operation();
       } catch (error) {
         if (error instanceof TaskTimingValidationError) throw error;
+        if (error instanceof ElizaError && error.code === "WORLD_METADATA_STALE_WRITE") {
+          throw error;
+        }
         lastError = error as Error;
 
         if (attempt < this.maxRetries) {
@@ -5177,6 +5156,9 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
   async createWorld(world: World): Promise<UUID> {
     return this.withDatabase(async () => {
       const normalizedWorld = this.normalizeWorldData(world);
+      normalizedWorld.metadata = initializeWorldMetadataRevision(
+        normalizedWorld.metadata as Metadata | undefined
+      );
       const newWorldId = normalizedWorld.id as UUID;
 
       await this.db.insert(worldTable).values(normalizedWorld);
@@ -5219,10 +5201,34 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
     return this.withDatabase(async () => {
       const normalizedWorld = this.normalizeWorldData(world);
       delete normalizedWorld.id;
-      await this.db
-        .update(worldTable)
-        .set(normalizedWorld)
-        .where(and(eq(worldTable.id, world.id), eq(worldTable.agentId, this.agentId)));
+      const committedMetadata = await this.db.transaction(async (tx) => {
+        const rows = await tx
+          .select()
+          .from(worldTable)
+          .where(and(eq(worldTable.id, world.id), eq(worldTable.agentId, this.agentId)))
+          .for("update")
+          .limit(1);
+        const row = rows[0];
+        if (!row) return null;
+        const storedRevision = requireFreshWorldMetadataRevision(
+          row.metadata as Metadata | undefined,
+          world.metadata as Metadata | undefined,
+          String(world.id)
+        );
+        const nextMetadata = advanceWorldMetadataRevision(
+          normalizedWorld.metadata as Metadata | undefined,
+          storedRevision
+        );
+        normalizedWorld.metadata = nextMetadata;
+        await tx
+          .update(worldTable)
+          .set(normalizedWorld)
+          .where(and(eq(worldTable.id, world.id), eq(worldTable.agentId, this.agentId)));
+        return nextMetadata;
+      });
+      if (committedMetadata) {
+        world.metadata = structuredClone(committedMetadata) as World["metadata"];
+      }
     });
   }
 
@@ -5251,9 +5257,16 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
         if (!row) return { status: "not_found" as const };
 
         const storedMetadata = (row.metadata ?? {}) as Record<string, unknown>;
-        if (!jsonbValueEquals(storedMetadata, params.expectedMetadata as Record<string, unknown>)) {
+        if (
+          !worldMetadataValueEquals(
+            storedMetadata,
+            params.expectedMetadata as Record<string, unknown>
+          )
+        ) {
           return { status: "conflict" as const };
         }
+        const storedRevision = getWorldMetadataRevision(row.metadata as Metadata | undefined);
+        if (storedRevision === null) return { status: "conflict" as const };
 
         if (params.audit) {
           const audit = params.audit;
@@ -5279,7 +5292,9 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
 
         await tx
           .update(worldTable)
-          .set({ metadata: params.replacementMetadata })
+          .set({
+            metadata: advanceWorldMetadataRevision(params.replacementMetadata, storedRevision),
+          })
           .where(eq(worldTable.id, params.worldId));
         return { status: "updated" as const };
       });

--- a/plugins/plugin-sql/src/base.ts
+++ b/plugins/plugin-sql/src/base.ts
@@ -76,6 +76,7 @@ import {
   type ParticipantUserState,
   type PatchOp,
   type Relationship,
+  ROLE_WRITE_AUDIT_LOG_TYPE,
   type Room,
   type RunStatus,
   type SetConnectorAccountCredentialRefParams,
@@ -91,6 +92,8 @@ import {
   validateQueryEntitiesPagination,
   validateTaskQueryPagination,
   type World,
+  type WorldMetadataCompareAndSwapParams,
+  type WorldMetadataMutationResult,
 } from "@elizaos/core";
 import { sanitizeJsonObject } from "./sanitize-json";
 import {
@@ -194,6 +197,35 @@ function asRawMessage(value: unknown): Record<string, unknown> | undefined {
 
 function asMetadata(value: unknown): Metadata | undefined {
   return (value ?? undefined) as Metadata | undefined;
+}
+
+/**
+ * Deep JSON-value equality for the world-metadata compare-and-swap: a jsonb
+ * column read back from Postgres compares by VALUE with key order
+ * insignificant, so the snapshot comparison must do the same rather than
+ * reference-comparing the objects the caller read. `undefined` is treated as
+ * absent, matching a JSON round-trip.
+ */
+function jsonbValueEquals(left: unknown, right: unknown): boolean {
+  if (left === right) return true;
+  if (Array.isArray(left) && Array.isArray(right)) {
+    return (
+      left.length === right.length &&
+      left.every((item, index) => jsonbValueEquals(item, right[index]))
+    );
+  }
+  if (asRawMessage(left) && asRawMessage(right)) {
+    const leftRecord = left as Record<string, unknown>;
+    const rightRecord = right as Record<string, unknown>;
+    const leftKeys = Object.keys(leftRecord).filter((key) => leftRecord[key] !== undefined);
+    const rightKeys = Object.keys(rightRecord).filter((key) => rightRecord[key] !== undefined);
+    if (leftKeys.length !== rightKeys.length) return false;
+    return leftKeys.every(
+      (key) =>
+        Object.hasOwn(rightRecord, key) && jsonbValueEquals(leftRecord[key], rightRecord[key])
+    );
+  }
+  return false;
 }
 
 function normalizeAgentBio(value: unknown): string[] | undefined {
@@ -5191,6 +5223,66 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
         .update(worldTable)
         .set(normalizedWorld)
         .where(and(eq(worldTable.id, world.id), eq(worldTable.agentId, this.agentId)));
+    });
+  }
+
+  /**
+   * Compare-and-swap replacement of a world's whole metadata under the exact
+   * prior snapshot (#23100 role-write atomicity). SELECT ... FOR UPDATE pins
+   * the row, the stored metadata is compared against `expectedMetadata` by
+   * canonical JSON value, the durable `role_audit` log row is inserted in the
+   * SAME transaction, and only then does the metadata column advance — so a
+   * concurrent metadata writer surfaces as a typed conflict instead of being
+   * silently overwritten, and a committed authority change is never
+   * separable from its audit record.
+   */
+  async compareAndSwapWorldMetadata(
+    params: WorldMetadataCompareAndSwapParams
+  ): Promise<WorldMetadataMutationResult> {
+    return this.withDatabase(async () => {
+      return this.db.transaction(async (tx) => {
+        const rows = await tx
+          .select()
+          .from(worldTable)
+          .where(and(eq(worldTable.id, params.worldId), eq(worldTable.agentId, this.agentId)))
+          .for("update")
+          .limit(1);
+        const row = rows[0];
+        if (!row) return { status: "not_found" as const };
+
+        const storedMetadata = (row.metadata ?? {}) as Record<string, unknown>;
+        if (!jsonbValueEquals(storedMetadata, params.expectedMetadata as Record<string, unknown>)) {
+          return { status: "conflict" as const };
+        }
+
+        if (params.audit) {
+          const audit = params.audit;
+          const sanitizedBody = sanitizeJsonObject({
+            source: "role-write-cas",
+            metadata: {
+              worldId: params.worldId,
+              actorEntityId: audit.actorEntityId,
+              targetEntityId: audit.targetEntityId,
+              previousRole: audit.previousRole,
+              newRole: audit.newRole,
+              grantSource: audit.source,
+              outcome: "committed",
+            },
+          });
+          await tx.insert(logTable).values({
+            entityId: audit.actorEntityId,
+            roomId: audit.roomId,
+            type: ROLE_WRITE_AUDIT_LOG_TYPE,
+            body: sql`${JSON.stringify(sanitizedBody)}::jsonb`,
+          });
+        }
+
+        await tx
+          .update(worldTable)
+          .set({ metadata: params.replacementMetadata })
+          .where(eq(worldTable.id, params.worldId));
+        return { status: "updated" as const };
+      });
     });
   }
 

--- a/plugins/plugin-sql/src/base.ts
+++ b/plugins/plugin-sql/src/base.ts
@@ -16,6 +16,7 @@ import {
   type AppendConnectorAccountAuditEventParams,
   actorFromAccessContext,
   advanceWorldMetadataRevision,
+  appendWorldMetadataRoleAudit,
   ChannelType,
   type Component,
   type ConnectorAccountAuditEventRecord,
@@ -5289,10 +5290,20 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
         });
       }
 
+      const replacementMetadata = params.audit
+        ? appendWorldMetadataRoleAudit(params.replacementMetadata, {
+            actorEntityId: params.audit.actorEntityId,
+            targetEntityId: params.audit.targetEntityId,
+            previousRole: params.audit.previousRole,
+            newRole: params.audit.newRole,
+            source: params.audit.source,
+            roomId: params.audit.roomId,
+          })
+        : params.replacementMetadata;
       await tx
         .update(worldTable)
         .set({
-          metadata: advanceWorldMetadataRevision(params.replacementMetadata, storedRevision),
+          metadata: advanceWorldMetadataRevision(replacementMetadata, storedRevision),
         })
         .where(eq(worldTable.id, params.worldId));
       return { status: "updated" as const };

--- a/plugins/plugin-sql/src/schema/index.ts
+++ b/plugins/plugin-sql/src/schema/index.ts
@@ -62,3 +62,4 @@ export { roomTable } from "./room";
 export { serverTable } from "./server";
 export { taskTable } from "./tasks";
 export { worldTable } from "./world";
+export { worldRoleAuditTable } from "./worldRoleAudit";

--- a/plugins/plugin-sql/src/schema/worldRoleAudit.ts
+++ b/plugins/plugin-sql/src/schema/worldRoleAudit.ts
@@ -1,0 +1,31 @@
+/**
+ * Durable authority ledger for committed world-role mutations. Actor, target,
+ * room, and world identifiers are intentionally retained as scalar evidence:
+ * deleting operational entities, rooms, or worlds must not erase who changed
+ * authorization, where it originated, or what the transition was.
+ */
+import { sql } from "drizzle-orm";
+import { index, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+import { agentTable } from "./agent";
+
+export const worldRoleAuditTable = pgTable(
+  "world_role_audit",
+  {
+    id: uuid("id").primaryKey().default(sql`gen_random_uuid()`).notNull(),
+    agentId: uuid("agent_id")
+      .notNull()
+      .references(() => agentTable.id, { onDelete: "cascade" }),
+    worldId: uuid("world_id").notNull(),
+    actorEntityId: uuid("actor_entity_id").notNull(),
+    targetEntityId: uuid("target_entity_id").notNull(),
+    roomId: uuid("room_id").notNull(),
+    previousRole: text("previous_role").notNull(),
+    newRole: text("new_role").notNull(),
+    grantSource: text("grant_source").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).default(sql`now()`).notNull(),
+  },
+  (table) => [
+    index("world_role_audit_agent_world_idx").on(table.agentId, table.worldId, table.createdAt),
+    index("world_role_audit_target_idx").on(table.agentId, table.targetEntityId, table.createdAt),
+  ]
+);

--- a/plugins/plugin-x/src/utils/memory.test.ts
+++ b/plugins/plugin-x/src/utils/memory.test.ts
@@ -94,13 +94,7 @@ describe("Twitter memory utilities", () => {
         }),
       }),
     );
-    expect(updateWorld).toHaveBeenCalledWith(
-      expect.objectContaining({
-        metadata: expect.objectContaining({
-          ownership: { ownerId: context.entityId },
-        }),
-      }),
-    );
+    expect(updateWorld).not.toHaveBeenCalled();
     expect(context.entityId).not.toBe("1830340867737178112");
   });
 

--- a/plugins/plugin-x/src/utils/memory.ts
+++ b/plugins/plugin-x/src/utils/memory.ts
@@ -47,16 +47,12 @@ type TwitterMetadataTweet = Pick<
   "conversationId" | "id" | "name" | "userId" | "username"
 >;
 
-/**
- * Persists a Twitter world on both modern upsert runtimes and older production
- * runtimes where ensureWorldExists only creates missing rows.
- */
+/** Persists a Twitter world through the runtime's merge-aware ensure path. */
 export async function reconcileTwitterWorld(
   runtime: IAgentRuntime,
   world: World,
 ): Promise<void> {
   await runtime.ensureWorldExists(world);
-  await runtime.updateWorld(world);
 }
 
 /**


### PR DESCRIPTION
## Summary

Successor to #27931. Makes world metadata authority writes compare-and-swap safe across core in-memory, plugin-inmemorydb, and SQL adapters.

- preserves CAS-managed roles and roleSources during connector-style ensureWorldExists calls
- retries concurrent legacy ensures against a fresh world snapshot and skips no-op writes
- rejects duplicate in-memory world creation instead of resetting revision and authority
- keeps typed stale-write errors, audit atomicity, and connector role CAS behavior
- runs SQL CAS and its role audit insert inside one entity-RLS-scoped transaction

Supersedes #27931.

## Focused verification

- core role-CAS and ensure-world tests: 14 passed
- plugin-inmemorydb world-CAS tests: 15 passed
- plugin-x utility tests: 7 passed
- core/plugin-inmemorydb/plugin-sql/plugin-x typechecks: passed
- touched-file Biome and git diff check: passed
- hosted static smoke, Windows security, and All Tests Passed: green on 1907036281074; fresh checks required for 260b6fecbe48d

Fresh independent review and exact-head checks are required before merge.