### PR TITLE
feat(cloud): require independent consent for multi-principal groups

### DIFF
--- a/packages/cloud/api/__tests__/personal-telegram-edge.test.ts
+++ b/packages/cloud/api/__tests__/personal-telegram-edge.test.ts
@@ -193,8 +193,12 @@ describe("Personal Shared Telegram edge", () => {
   test("delivers reminders with the edge bot and returns a durable duplicate receipt", async () => {
     const ledger = namespace();
     let sends = 0;
-    globalThis.fetch = mock(async (input) => {
-      if (String(input).endsWith("/sendMessage")) sends += 1;
+    const bodies: Array<Record<string, unknown>> = [];
+    globalThis.fetch = mock(async (input, init) => {
+      if (String(input).endsWith("/sendMessage")) {
+        sends += 1;
+        bodies.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+      }
       return Response.json({ ok: true, result: { message_id: 9010 } });
     }) as unknown as typeof fetch;
     const env = {
@@ -214,6 +218,78 @@ describe("Personal Shared Telegram edge", () => {
     expect(delivered).toMatchObject({ ok: true, providerMessageIds: ["9010"] });
     expect(duplicate).toEqual(delivered);
     expect(sends).toBe(1);
+    expect(bodies).toEqual([
+      {
+        chat_id: "123456",
+        text: "time to stretch",
+        parse_mode: "Markdown",
+      },
+    ]);
+  });
+
+  test("delivers a Telegram group reminder inside its forum topic once", async () => {
+    const ledger = namespace();
+    const bodies: Array<Record<string, unknown>> = [];
+    globalThis.fetch = mock(async (input, init) => {
+      if (String(input).endsWith("/sendMessage")) {
+        bodies.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+      }
+      return Response.json({ ok: true, result: { message_id: 9011 } });
+    }) as unknown as typeof fetch;
+    const env = {
+      ELIZA_APP_TELEGRAM_BOT_TOKEN: "123:test-token",
+      PERSONAL_TELEGRAM_DELIVERIES: ledger.binding,
+    } as AppEnv["Bindings"];
+    const input = {
+      project: "eliza-app",
+      chatId: "-100123456789",
+      providerThreadId: "909",
+      text: "time to stretch",
+      idempotencyKey: "reminder-topic-1:2026-08-20T19:30:00.000Z",
+    };
+
+    const delivered = await dispatchPersonalTelegramReminder(env, input);
+    const duplicate = await dispatchPersonalTelegramReminder(env, input);
+
+    expect(delivered).toMatchObject({ ok: true, providerMessageIds: ["9011"] });
+    expect(duplicate).toEqual(delivered);
+    expect(bodies).toEqual([
+      {
+        chat_id: "-100123456789",
+        message_thread_id: 909,
+        text: "time to stretch",
+        parse_mode: "Markdown",
+      },
+    ]);
+  });
+
+  test("rejects invalid reminder topic ids before state or egress", async () => {
+    const ledger = namespace();
+    globalThis.fetch = mock(async () => {
+      throw new Error("egress must not run");
+    }) as unknown as typeof fetch;
+    const env = {
+      ELIZA_APP_TELEGRAM_BOT_TOKEN: "123:test-token",
+      PERSONAL_TELEGRAM_DELIVERIES: ledger.binding,
+    } as AppEnv["Bindings"];
+
+    for (const providerThreadId of ["0", "0909", "topic", "9999999999999999"]) {
+      await expect(
+        dispatchPersonalTelegramReminder(env, {
+          project: "eliza-app",
+          chatId: "-100123456789",
+          providerThreadId,
+          text: "time to stretch",
+          idempotencyKey: `invalid-topic:${providerThreadId}`,
+        }),
+      ).resolves.toEqual({
+        ok: false,
+        acceptance: "not_accepted",
+        message: "Telegram reminder topic is invalid",
+      });
+    }
+    expect(ledger.names).toHaveLength(0);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
   });
 
   test("runs the canonical turn and Telegram egress once without a Railway hop", async () => {

--- a/packages/cloud/api/__tests__/shared-reminder-dedicated-delivery.group.test.ts
+++ b/packages/cloud/api/__tests__/shared-reminder-dedicated-delivery.group.test.ts
@@ -37,6 +37,7 @@ const committedGroupTask = {
       project: "eliza-app",
       connectorAccountId: "telegram:test-bot",
       chatId: "-100123456789",
+      providerThreadId: "909",
       ownerLabel: "Nubs",
       authority: AUTHORITY,
     },
@@ -187,6 +188,7 @@ describe("Dedicated cutover group reminder relay", () => {
       platform: "telegram",
       project: "eliza-app",
       chatId: "-100123456789",
+      providerThreadId: "909",
       text: "Reminder for this group from Nubs: pay the rent",
       idempotencyKey: "shared-reminder-1:2026-08-15T17:00:00.000Z",
     });

--- a/packages/cloud/api/eliza-app/webhook/_telegram-edge.ts
+++ b/packages/cloud/api/eliza-app/webhook/_telegram-edge.ts
@@ -44,6 +44,7 @@ const RETRY_DELAY_CAP_MS = 5_000;
 const TYPING_REFRESH_MS = 4_000;
 const DELIVERY_PROJECT_RE = /^[a-z0-9][a-z0-9-]{0,63}$/;
 const DELIVERY_SENDER_RE = /^\d{1,32}$/;
+const DELIVERY_THREAD_RE = /^[1-9]\d{0,15}$/;
 
 export interface TelegramEdgeDeps {
   runTurn(
@@ -71,6 +72,7 @@ interface LedgerResponse {
 export interface PersonalTelegramReminderDispatchInput {
   project: string;
   chatId: string;
+  providerThreadId?: string;
   text: string;
   idempotencyKey: string;
 }
@@ -384,6 +386,17 @@ export async function dispatchPersonalTelegramReminder(
   env: AppEnv["Bindings"],
   input: PersonalTelegramReminderDispatchInput,
 ): Promise<PersonalTelegramReminderDispatchResult> {
+  if (
+    input.providerThreadId !== undefined &&
+    (!DELIVERY_THREAD_RE.test(input.providerThreadId) ||
+      !Number.isSafeInteger(Number(input.providerThreadId)))
+  ) {
+    return {
+      ok: false,
+      acceptance: "not_accepted",
+      message: "Telegram reminder topic is invalid",
+    };
+  }
   const botToken = readEnvString(env, "ELIZA_APP_TELEGRAM_BOT_TOKEN");
   if (!botToken) {
     return {
@@ -397,10 +410,13 @@ export async function dispatchPersonalTelegramReminder(
     messageId: input.idempotencyKey,
     platformRecordId: input.idempotencyKey,
     chatId: input.chatId,
-    chatType: "private",
+    chatType: input.chatId.startsWith("-") ? "supergroup" : "private",
     senderId: input.chatId,
     text: "",
     isCommand: false,
+    ...(input.providerThreadId
+      ? { providerThreadId: input.providerThreadId }
+      : {}),
     rawPayload: { source: "shared-reminder" },
   };
   try {

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.all-adults-claim.test.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.all-adults-claim.test.ts
@@ -1,0 +1,193 @@
+/** Red/green route proof for the explicit all-adults owner claim command. */
+
+import { beforeEach, expect, mock, test } from "bun:test";
+
+const issueGroupClaim = mock(async () => undefined);
+const resolvePersonalDelivery = mock(async () => ({
+  userId: "00000000-0000-4000-8000-000000000002",
+  organizationId: "00000000-0000-4000-8000-000000000001",
+  dedicatedTarget: null,
+  isNew: false,
+  resolution: "synthetic-parent-a" as const,
+}));
+const findActivePersonalDedicatedTarget = mock(async () => null);
+const prewarmPersonalSharedAgentTurnCaches = mock(async () => undefined);
+const sharedRestMessageSend = mock(async () => ({ text: "unexpected" }));
+const namespace = {
+  getByName: mock(() => ({ fetch: mock(async () => new Response()) })),
+};
+const { sharedTurnServerTiming } = await import(
+  "@/lib/services/shared-runtime/shared-rest-adapter"
+);
+class StubPersonalSharedGroupDeliveryPendingError extends Error {}
+
+mock.module("@/lib/services/eliza-app", () => ({
+  elizaAppUserService: { resolvePersonalDelivery },
+}));
+mock.module("@/db/repositories/personal-shared-groups", () => ({
+  PersonalSharedGroupDeliveryPendingError:
+    StubPersonalSharedGroupDeliveryPendingError,
+  personalSharedGroupsRepository: { issueClaim: issueGroupClaim },
+}));
+mock.module("@/db/repositories/personal-shared-group-consent", () => ({
+  personalSharedGroupConsentRepository: {},
+}));
+mock.module("@/db/repositories/personal-shared-group-participants", () => ({
+  personalSharedGroupParticipantsRepository: {},
+}));
+mock.module("@/lib/services/agent-tier-upgrade-target", () => ({
+  findActivePersonalDedicatedTarget,
+  isAuthoritativePersonalDedicatedTarget: () => false,
+}));
+mock.module("@/lib/services/shared-runtime/prewarm-shared-agent", () => ({
+  prewarmPersonalSharedAgentTurnCaches,
+}));
+mock.module("@/lib/services/shared-runtime/shared-rest-adapter", () => ({
+  sharedRestMessageSend,
+  sharedTurnServerTiming,
+}));
+mock.module("@/lib/services/shared-runtime/resolve-shared-agent", () => ({
+  resolveSharedRuntimeWorkerRequestContext: () => ({
+    namespace,
+    executionCtx: { waitUntil() {} },
+  }),
+}));
+
+const { default: app } = await import("./route");
+
+function request(
+  message: string,
+  messageId: string,
+  allAdultsEnabled = "true",
+) {
+  return app.request(
+    "/",
+    {
+      method: "POST",
+      headers: {
+        authorization: "Bearer test-secret",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        platform: "telegram",
+        project: "eliza-app",
+        connectorAccountId: "telegram:parent-a-bot",
+        chatId: "100000000001",
+        telegramUserId: "100000000001",
+        displayName: "Parent A",
+        messageId,
+        message,
+      }),
+    },
+    {
+      INTERNAL_SECRET: "test-secret",
+      SHARED_RUNTIME_CONVERSATIONS: namespace,
+      ELIZA_APP_PERSONAL_SHARED_ALL_ADULTS_ENABLED: allAdultsEnabled,
+      ELIZA_APP_PERSONAL_SHARED_JOIN_CODE_SECRET:
+        "synthetic-personal-shared-join-code-secret-v1",
+    } as never,
+    { waitUntil() {}, passThroughOnException() {}, props: {} } as never,
+  );
+}
+
+beforeEach(() => {
+  issueGroupClaim.mockClear();
+  resolvePersonalDelivery.mockClear();
+  findActivePersonalDedicatedTarget.mockClear();
+  prewarmPersonalSharedAgentTurnCaches.mockClear();
+  sharedRestMessageSend.mockClear();
+});
+
+test("binds an omitted all-adults count as two without entering a runtime", async () => {
+  const response = await request(
+    "/group all-adults",
+    "telegram:parent-a:all-adults-default",
+  );
+
+  expect(response.status).toBe(200);
+  await expect(response.json()).resolves.toMatchObject({
+    success: true,
+    data: {
+      code: "group_claim_issued",
+      reply: expect.stringMatching(
+        /all-adults consent for 2 independently authenticated participants[\s\S]*plaintext messages and attachments transit the configured relay provider/i,
+      ),
+    },
+  });
+  expect(issueGroupClaim).toHaveBeenCalledWith(
+    expect.objectContaining({
+      ownerUserId: "00000000-0000-4000-8000-000000000002",
+      issuedToPlatformUserId: "100000000001",
+      consentMode: "all_adults",
+      requiredPrincipalCount: 2,
+      codeHash: expect.stringMatching(/^[0-9a-f]{64}$/),
+    }),
+  );
+  expect(findActivePersonalDedicatedTarget).not.toHaveBeenCalled();
+  expect(prewarmPersonalSharedAgentTurnCaches).not.toHaveBeenCalled();
+  expect(sharedRestMessageSend).not.toHaveBeenCalled();
+});
+
+test("passes an explicit natural-language all-adults count through the claim", async () => {
+  const response = await request(
+    "Eliza group all adults 3",
+    "telegram:parent-a:all-adults-three",
+  );
+
+  expect(response.status).toBe(200);
+  expect(issueGroupClaim).toHaveBeenCalledWith(
+    expect.objectContaining({
+      consentMode: "all_adults",
+      requiredPrincipalCount: 3,
+    }),
+  );
+  expect(sharedRestMessageSend).not.toHaveBeenCalled();
+});
+
+test("fails closed while all-adults issuance is not explicitly enabled", async () => {
+  const response = await request(
+    "/group all-adults 2",
+    "telegram:parent-a:all-adults-disabled",
+    "false",
+  );
+
+  await expect(response.json()).resolves.toMatchObject({
+    success: true,
+    data: {
+      code: "group_all_adults_unavailable",
+      reply: expect.stringMatching(
+        /not enabled[\s\S]*no group link was created/i,
+      ),
+    },
+  });
+  expect(issueGroupClaim).not.toHaveBeenCalled();
+  expect(findActivePersonalDedicatedTarget).not.toHaveBeenCalled();
+  expect(prewarmPersonalSharedAgentTurnCaches).not.toHaveBeenCalled();
+  expect(sharedRestMessageSend).not.toHaveBeenCalled();
+});
+
+test("asks a provisional owner to authenticate without issuing a claim", async () => {
+  issueGroupClaim.mockImplementationOnce(async () => {
+    throw Object.assign(new Error("synthetic independent-auth boundary"), {
+      code: "PERSONAL_SHARED_GROUP_OWNER_INDEPENDENT_AUTHENTICATION_REQUIRED",
+    });
+  });
+
+  const response = await request(
+    "/group all-adults",
+    "telegram:parent-a:all-adults-auth-required",
+  );
+
+  await expect(response.json()).resolves.toMatchObject({
+    success: true,
+    data: {
+      code: "group_claim_authentication_required",
+      reply: expect.stringMatching(
+        /finish signing in to your own Eliza account/i,
+      ),
+    },
+  });
+  expect(findActivePersonalDedicatedTarget).not.toHaveBeenCalled();
+  expect(prewarmPersonalSharedAgentTurnCaches).not.toHaveBeenCalled();
+  expect(sharedRestMessageSend).not.toHaveBeenCalled();
+});

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.all-adults-consent.test.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.all-adults-consent.test.ts
@@ -1,0 +1,718 @@
+/** Focused route coverage for the synthetic Parent A/B/Child C consent handshake. */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import type { PersonalSharedGroupConsentStatus } from "@/db/repositories/personal-shared-group-consent";
+
+const PARENT_A_USER_ID = "00000000-0000-4000-8000-00000000000a";
+const PARENT_B_USER_ID = "00000000-0000-4000-8000-00000000000b";
+const ORGANIZATION_ID = "00000000-0000-4000-8000-000000000001";
+const BINDING_ID = "00000000-0000-4000-8000-000000000030";
+const PROVIDER_THREAD_ID = "909";
+
+const restrictedConsent = {
+  mode: "all_adults" as const,
+  gate: "restricted" as const,
+  requiredPrincipalCount: 2,
+  registeredParticipantCount: 2,
+  linkedParticipantCount: 1,
+  consentedParticipantCount: 1,
+  participants: [
+    {
+      ordinal: 1,
+      isOwner: true,
+      linked: true,
+      consented: true,
+      revoked: false,
+    },
+    {
+      ordinal: 2,
+      isOwner: false,
+      linked: false,
+      consented: false,
+      revoked: false,
+    },
+  ],
+};
+
+const enabledConsent = {
+  ...restrictedConsent,
+  gate: "enabled" as const,
+  linkedParticipantCount: 2,
+  consentedParticipantCount: 2,
+  participants: restrictedConsent.participants.map((participant) => ({
+    ...participant,
+    linked: true,
+    consented: true,
+  })),
+};
+
+const enabledConsentWithChildC = {
+  ...enabledConsent,
+  registeredParticipantCount: 3,
+  participants: [
+    ...enabledConsent.participants,
+    {
+      ordinal: 3,
+      isOwner: false,
+      linked: false,
+      consented: false,
+      revoked: false,
+    },
+  ],
+};
+
+const consentAfterParentBLeaves = {
+  ...restrictedConsent,
+  participants: [
+    restrictedConsent.participants[0],
+    {
+      ordinal: 2,
+      isOwner: false,
+      linked: false,
+      consented: false,
+      revoked: true,
+    },
+  ],
+};
+
+const binding = {
+  id: BINDING_ID,
+  organization_id: ORGANIZATION_ID,
+  owner_user_id: PARENT_A_USER_ID,
+  personal_agent_id: "personal:0885455d-7126-52e2-a9b7-ef2a19c66fea",
+  platform: "telegram",
+  project: "eliza-app",
+  connector_account_id: "telegram:parent-a-bot",
+  provider_chat_id: "-100000000001",
+  conversation_id: "group:00000000-0000-5000-8000-000000000030",
+  state: "active",
+  response_policy: "mention_only",
+  consent_mode: "all_adults",
+  required_principal_count: 2,
+  consent_version: 4,
+  created_by_platform_user_id: "100000000001",
+  authority_version: 7,
+};
+
+const resolveGroupBinding = mock(async () => binding);
+const revokeGroupBinding = mock(async () => true);
+const consumeGroupClaim = mock(async () => ({ status: "invalid" as const }));
+const issueJoinAuthenticateChallenge = mock(async () => ({
+  status: "issued" as const,
+  consentVersion: 4,
+}));
+const consumeJoinAuthenticateChallenge = mock(async () => ({
+  status: "confirm_issued" as const,
+  bindingId: BINDING_ID,
+  consentVersion: 4,
+}));
+const consumeJoinConfirmChallenge = mock(async () => ({
+  status: "consented" as const,
+  consent: enabledConsent,
+}));
+const deriveConsentStatus = mock(
+  async (): Promise<PersonalSharedGroupConsentStatus> => restrictedConsent,
+);
+const selfRevoke = mock(async () => ({
+  status: "revoked" as const,
+  consent: consentAfterParentBLeaves,
+}));
+const hasDeliveryReceipt = mock(async () => false);
+const recordGroupParticipantTurn = mock(
+  async ({ platformUserId }: { platformUserId: string }) => {
+    const ordinal =
+      platformUserId === "100000000001"
+        ? 1
+        : platformUserId === "200000000002"
+          ? 2
+          : 3;
+    const actor = {
+      platformUserId,
+      ordinal,
+      displayName:
+        ordinal === 3
+          ? "Child C"
+          : `Parent ${String.fromCharCode(64 + ordinal)}`,
+    };
+    return { actor, roster: [actor] };
+  },
+);
+const resolvePersonalDelivery = mock(async () => ({
+  userId: PARENT_B_USER_ID,
+  organizationId: ORGANIZATION_ID,
+  dedicatedTarget: null,
+  isNew: false,
+  resolution: "authenticated-parent-b" as const,
+}));
+const findActivePersonalDedicatedTarget = mock(async () => null);
+const prewarmPersonalSharedAgentTurnCaches = mock(async () => undefined);
+const sharedRestMessageSend = mock(async () => ({ text: "unexpected" }));
+const enrichInboundImageMedia = mock(async () => ({
+  kind: "skipped" as const,
+}));
+const namespace = {
+  getByName: mock(() => ({ fetch: mock(async () => new Response()) })),
+};
+const { sharedTurnServerTiming } = await import(
+  "@/lib/services/shared-runtime/shared-rest-adapter"
+);
+class StubPersonalSharedGroupDeliveryPendingError extends Error {}
+
+mock.module("@/db/repositories/personal-shared-groups", () => ({
+  PersonalSharedGroupDeliveryPendingError:
+    StubPersonalSharedGroupDeliveryPendingError,
+  personalSharedGroupsRepository: {
+    resolveBinding: resolveGroupBinding,
+    revokeBinding: revokeGroupBinding,
+    consumeClaimAndBind: consumeGroupClaim,
+    setResponsePolicy: mock(async () => binding),
+    hasDeliveryReceipt,
+  },
+}));
+mock.module("@/db/repositories/personal-shared-group-consent", () => ({
+  personalSharedGroupConsentRepository: {
+    issueJoinAuthenticateChallenge,
+    consumeJoinAuthenticateChallenge,
+    consumeJoinConfirmChallenge,
+    deriveConsentStatus,
+    selfRevoke,
+  },
+}));
+mock.module("@/db/repositories/personal-shared-group-participants", () => ({
+  personalSharedGroupParticipantsRepository: {
+    recordTurn: recordGroupParticipantTurn,
+  },
+}));
+mock.module("@/lib/services/eliza-app", () => ({
+  elizaAppUserService: { resolvePersonalDelivery },
+}));
+mock.module("@/lib/services/agent-tier-upgrade-target", () => ({
+  findActivePersonalDedicatedTarget,
+  isAuthoritativePersonalDedicatedTarget: () => false,
+}));
+mock.module("@/lib/services/shared-runtime/prewarm-shared-agent", () => ({
+  prewarmPersonalSharedAgentTurnCaches,
+}));
+mock.module("@/lib/services/shared-runtime/shared-rest-adapter", () => ({
+  sharedRestMessageSend,
+  sharedTurnServerTiming,
+}));
+mock.module("@/lib/services/eliza-app/inbound-media-enrichment", () => ({
+  enrichInboundImageMedia,
+}));
+mock.module("@/lib/services/shared-runtime/resolve-shared-agent", () => ({
+  resolveSharedRuntimeWorkerRequestContext: () => ({
+    namespace,
+    executionCtx: { waitUntil() {} },
+  }),
+}));
+
+const { default: app } = await import("./route");
+const executionCtx = {
+  waitUntil() {},
+  passThroughOnException() {},
+  props: {},
+};
+
+function groupRequest(input: {
+  actor: "Parent A" | "Parent B" | "Child C";
+  message: string;
+  invocation?: "mention" | "command" | "reply" | "ambient";
+}) {
+  const ordinal =
+    input.actor === "Parent A" ? 1 : input.actor === "Parent B" ? 2 : 3;
+  return request({
+    platform: "telegram",
+    chatType: "supergroup",
+    project: "eliza-app",
+    connectorAccountId: "telegram:parent-a-bot",
+    chatId: "-100000000001",
+    providerThreadId: PROVIDER_THREAD_ID,
+    actor: {
+      platformUserId: `${ordinal}0000000000${ordinal}`,
+      displayName: input.actor,
+      role: input.actor === "Parent A" ? "administrator" : "member",
+    },
+    messageId: `telegram:group:${input.actor.toLowerCase().replace(" ", "-")}`,
+    message: input.message,
+    invocation: input.invocation ?? "command",
+  });
+}
+
+function parentBDirectRequest(message: string) {
+  return request({
+    platform: "telegram",
+    project: "eliza-app",
+    connectorAccountId: "telegram:parent-a-bot",
+    chatId: "200000000002",
+    telegramUserId: "200000000002",
+    displayName: "Parent B",
+    messageId: "telegram:dm:parent-b",
+    message,
+  });
+}
+
+function request(body: unknown) {
+  return app.request(
+    "/",
+    {
+      method: "POST",
+      headers: {
+        authorization: "Bearer test-secret",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(body),
+    },
+    {
+      INTERNAL_SECRET: "test-secret",
+      ELIZA_APP_PERSONAL_SHARED_JOIN_CODE_SECRET:
+        "synthetic-personal-shared-join-code-secret-v1",
+      SHARED_RUNTIME_CONVERSATIONS: namespace,
+    } as never,
+    executionCtx as never,
+  );
+}
+
+describe("all-adults Personal Shared route consent", () => {
+  beforeEach(() => {
+    resolveGroupBinding.mockClear();
+    resolveGroupBinding.mockImplementation(async () => binding);
+    revokeGroupBinding.mockClear();
+    consumeGroupClaim.mockClear();
+    issueJoinAuthenticateChallenge.mockClear();
+    consumeJoinAuthenticateChallenge.mockClear();
+    consumeJoinConfirmChallenge.mockClear();
+    deriveConsentStatus.mockClear();
+    deriveConsentStatus.mockImplementation(async () => restrictedConsent);
+    selfRevoke.mockClear();
+    hasDeliveryReceipt.mockClear();
+    recordGroupParticipantTurn.mockClear();
+    resolvePersonalDelivery.mockClear();
+    findActivePersonalDedicatedTarget.mockClear();
+    prewarmPersonalSharedAgentTurnCaches.mockClear();
+    sharedRestMessageSend.mockClear();
+    enrichInboundImageMedia.mockClear();
+  });
+
+  test("issues Parent B an actor-bound authenticate challenge in the group", async () => {
+    const response = await groupRequest({
+      actor: "Parent B",
+      message: "Eliza join",
+    });
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      data: {
+        groupDelivery: { authority: Record<string, unknown> };
+      };
+    };
+    expect(body).toMatchObject({
+      data: {
+        code: "group_join_authenticate_issued",
+        reply: expect.stringMatching(
+          /exact participant[\s\S]*direct chat[\s\S]*Eliza join [2-9A-HJ-NP-Z]{12}[\s\S]*plaintext messages and attachments transit/i,
+        ),
+        consentStatus: restrictedConsent,
+        groupDelivery: { kind: "binding" },
+      },
+    });
+    expect(body.data.groupDelivery.authority).toMatchObject({
+      requiresAllAdultsConsent: false,
+    });
+    expect(recordGroupParticipantTurn).toHaveBeenCalledWith({
+      bindingId: BINDING_ID,
+      platformUserId: "200000000002",
+      displayName: "Parent B",
+    });
+    expect(issueJoinAuthenticateChallenge).toHaveBeenCalledWith({
+      codeHash: expect.stringMatching(/^[0-9a-f]{64}$/),
+      sourceMessageId: "telegram:group:parent-b",
+      bindingId: BINDING_ID,
+      platform: "telegram",
+      project: "eliza-app",
+      connectorAccountId: "telegram:parent-a-bot",
+      providerChatId: "-100000000001",
+      providerThreadId: PROVIDER_THREAD_ID,
+      actorPlatformUserId: "200000000002",
+      expiresAt: expect.any(Date),
+    });
+    expect(sharedRestMessageSend).not.toHaveBeenCalled();
+  });
+
+  test("keeps an unauthenticated all-adults owner claim unbound", async () => {
+    consumeGroupClaim.mockImplementationOnce(async () => {
+      throw Object.assign(new Error("synthetic independent-auth boundary"), {
+        code: "PERSONAL_SHARED_GROUP_OWNER_INDEPENDENT_AUTHENTICATION_REQUIRED",
+      });
+    });
+
+    const response = await groupRequest({
+      actor: "Parent A",
+      message: "Eliza link ABCD2345",
+      invocation: "command",
+    });
+
+    await expect(response.json()).resolves.toMatchObject({
+      data: {
+        code: "group_claim_authentication_required",
+        reply: expect.stringMatching(/owner to finish signing in/i),
+        groupDelivery: { kind: "control" },
+      },
+    });
+    expect(resolveGroupBinding).not.toHaveBeenCalled();
+    expect(sharedRestMessageSend).not.toHaveBeenCalled();
+  });
+
+  test("authenticates Parent B in DM and returns only a distinct group confirm code", async () => {
+    const response = await parentBDirectRequest("Eliza join ABCD2345EFGH");
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      data: { code: string; reply: string; consentStatus: unknown };
+    };
+    expect(body.data).toMatchObject({
+      code: "group_join_confirm_issued",
+      consentStatus: restrictedConsent,
+    });
+    expect(body.data.reply).toMatch(
+      /original group[\s\S]*Eliza join [2-9A-HJ-NP-Z]{12}[\s\S]*plaintext messages and attachments transit/i,
+    );
+    expect(body.data.reply).not.toContain("Eliza join ABCD2345EFGH");
+    expect(consumeJoinAuthenticateChallenge).toHaveBeenCalledWith({
+      codeHash: expect.stringMatching(/^[0-9a-f]{64}$/),
+      confirmCodeHash: expect.stringMatching(/^[0-9a-f]{64}$/),
+      sourceMessageId: "telegram:dm:parent-b",
+      platform: "telegram",
+      project: "eliza-app",
+      connectorAccountId: "telegram:parent-a-bot",
+      actorPlatformUserId: "200000000002",
+      linkedUserId: PARENT_B_USER_ID,
+      linkedOrganizationId: ORGANIZATION_ID,
+      expiresAt: expect.any(Date),
+    });
+    expect(findActivePersonalDedicatedTarget).not.toHaveBeenCalled();
+    expect(prewarmPersonalSharedAgentTurnCaches).not.toHaveBeenCalled();
+    expect(sharedRestMessageSend).not.toHaveBeenCalled();
+  });
+
+  test("consumes Parent B's confirm before owner-link handling and returns redacted status", async () => {
+    resolveGroupBinding.mockImplementationOnce(async () => binding);
+    resolveGroupBinding.mockImplementationOnce(async () => ({
+      ...binding,
+      authority_version: 8,
+    }));
+    const response = await groupRequest({
+      actor: "Parent B",
+      message: "Eliza join WXYZ2345ABCD",
+    });
+
+    await expect(response.json()).resolves.toMatchObject({
+      data: {
+        code: "group_join_consented",
+        consentStatus: enabledConsent,
+        groupDelivery: {
+          kind: "binding",
+          authority: { version: 8, requiresAllAdultsConsent: false },
+        },
+      },
+    });
+    expect(consumeJoinConfirmChallenge).toHaveBeenCalledWith({
+      codeHash: expect.stringMatching(/^[0-9a-f]{64}$/),
+      sourceMessageId: "telegram:group:parent-b",
+      bindingId: BINDING_ID,
+      platform: "telegram",
+      project: "eliza-app",
+      connectorAccountId: "telegram:parent-a-bot",
+      providerChatId: "-100000000001",
+      providerThreadId: PROVIDER_THREAD_ID,
+      actorPlatformUserId: "200000000002",
+    });
+    expect(sharedRestMessageSend).not.toHaveBeenCalled();
+  });
+
+  test("attests Child C and blocks a restricted ordinary turn before capabilities", async () => {
+    const order: string[] = [];
+    recordGroupParticipantTurn.mockImplementationOnce(async () => {
+      order.push("record");
+      const actor = {
+        platformUserId: "300000000003",
+        ordinal: 3,
+        displayName: "Child C",
+      };
+      return { actor, roster: [actor] };
+    });
+    deriveConsentStatus.mockImplementationOnce(async () => {
+      order.push("derive");
+      return {
+        ...restrictedConsent,
+        registeredParticipantCount: 3,
+        participants: [
+          ...restrictedConsent.participants,
+          {
+            ordinal: 3,
+            isOwner: false,
+            linked: false,
+            consented: false,
+            revoked: false,
+          },
+        ],
+      };
+    });
+
+    const response = await groupRequest({
+      actor: "Child C",
+      message: "Eliza plan dinner",
+      invocation: "mention",
+    });
+
+    await expect(response.json()).resolves.toMatchObject({
+      data: {
+        code: "group_consent_restricted",
+        consentStatus: {
+          registeredParticipantCount: 3,
+          participants: expect.arrayContaining([
+            expect.objectContaining({ ordinal: 3, linked: false }),
+          ]),
+        },
+        groupDelivery: {
+          kind: "binding",
+          authority: { requiresAllAdultsConsent: false },
+        },
+      },
+    });
+    expect(order).toEqual(["record", "derive"]);
+    expect(findActivePersonalDedicatedTarget).not.toHaveBeenCalled();
+    expect(prewarmPersonalSharedAgentTurnCaches).not.toHaveBeenCalled();
+    expect(enrichInboundImageMedia).not.toHaveBeenCalled();
+    expect(sharedRestMessageSend).not.toHaveBeenCalled();
+  });
+
+  test("silences an all-adults Blooio forged reply before restricted-gate disclosure", async () => {
+    resolveGroupBinding.mockImplementationOnce(async () => ({
+      ...binding,
+      platform: "blooio",
+      connector_account_id: "blooio:test-number",
+      provider_chat_id: "synthetic-family-group",
+      created_by_platform_user_id: "+15550100001",
+    }));
+
+    const response = await request({
+      platform: "blooio",
+      chatType: "group",
+      project: "eliza-app",
+      connectorAccountId: "blooio:test-number",
+      chatId: "synthetic-family-group",
+      actor: {
+        platformUserId: "+15550100003",
+        displayName: "Child C",
+        role: "member",
+      },
+      messageId: "blooio:group:forged-reply",
+      message: "following up",
+      invocation: "reply",
+      replyToMessageId: "unreceipted-provider-message",
+    });
+
+    await expect(response.json()).resolves.toMatchObject({
+      data: { code: "group_silent", reply: "" },
+    });
+    expect(hasDeliveryReceipt).toHaveBeenCalledWith({
+      bindingId: BINDING_ID,
+      providerMessageId: "unreceipted-provider-message",
+    });
+    expect(sharedRestMessageSend).not.toHaveBeenCalled();
+    expect(prewarmPersonalSharedAgentTurnCaches).not.toHaveBeenCalled();
+  });
+
+  test("returns only redacted consent status to Parent B", async () => {
+    const response = await groupRequest({
+      actor: "Parent B",
+      message: "Eliza consent status",
+    });
+
+    const body = (await response.json()) as {
+      data: {
+        code: string;
+        consentStatus: unknown;
+        groupDelivery: { authority: Record<string, unknown> };
+      };
+    };
+    expect(body.data).toMatchObject({
+      code: "group_consent_status",
+      consentStatus: restrictedConsent,
+      groupDelivery: {
+        authority: { requiresAllAdultsConsent: false },
+      },
+    });
+    const serializedStatus = JSON.stringify(body.data.consentStatus);
+    expect(serializedStatus).not.toContain(PARENT_A_USER_ID);
+    expect(serializedStatus).not.toContain(PARENT_B_USER_ID);
+    expect(serializedStatus).not.toContain("100000000001");
+    expect(serializedStatus).not.toContain("200000000002");
+    expect(serializedStatus).not.toContain("Parent A");
+    expect(serializedStatus).not.toContain("Parent B");
+    expect(recordGroupParticipantTurn).toHaveBeenCalledTimes(1);
+    expect(sharedRestMessageSend).not.toHaveBeenCalled();
+  });
+
+  test("records Child C without re-restricting an enabled two-adult group", async () => {
+    const order: string[] = [];
+    recordGroupParticipantTurn.mockImplementationOnce(async () => {
+      order.push("record");
+      const actor = {
+        platformUserId: "300000000003",
+        ordinal: 3,
+        displayName: "Child C",
+      };
+      return { actor, roster: [actor] };
+    });
+    deriveConsentStatus.mockImplementationOnce(async () => {
+      order.push("derive");
+      return enabledConsentWithChildC;
+    });
+    findActivePersonalDedicatedTarget.mockImplementationOnce(async () => {
+      order.push("dedicated_lookup");
+      return null;
+    });
+    prewarmPersonalSharedAgentTurnCaches.mockImplementationOnce(async () => {
+      order.push("prewarm");
+    });
+    sharedRestMessageSend.mockImplementationOnce(async () => {
+      order.push("capability");
+      return { text: "Dinner planning is ready." };
+    });
+
+    const response = await groupRequest({
+      actor: "Child C",
+      message: "Eliza plan dinner",
+      invocation: "mention",
+    });
+
+    await expect(response.json()).resolves.toMatchObject({
+      data: {
+        reply: "Dinner planning is ready.",
+        groupDelivery: {
+          kind: "binding",
+          authority: { requiresAllAdultsConsent: true },
+        },
+      },
+    });
+    expect(deriveConsentStatus).toHaveBeenCalledWith({ bindingId: BINDING_ID });
+    expect(order).toEqual([
+      "record",
+      "derive",
+      "dedicated_lookup",
+      "prewarm",
+      "capability",
+    ]);
+    expect(sharedRestMessageSend).toHaveBeenCalledTimes(1);
+  });
+
+  test("leaves consent-status text on the existing single-owner runtime path", async () => {
+    resolveGroupBinding.mockImplementationOnce(async () => ({
+      ...binding,
+      consent_mode: "single_owner",
+      required_principal_count: 1,
+    }));
+    sharedRestMessageSend.mockImplementationOnce(async () => ({
+      text: "Existing single-owner reply.",
+    }));
+
+    const response = await groupRequest({
+      actor: "Parent A",
+      message: "Eliza consent status",
+      invocation: "mention",
+    });
+
+    const body = (await response.json()) as {
+      data: {
+        groupDelivery: { authority: Record<string, unknown> };
+      };
+    };
+    expect(body).toMatchObject({
+      data: {
+        reply: "Existing single-owner reply.",
+        groupDelivery: { kind: "binding" },
+      },
+    });
+    expect(body.data.groupDelivery.authority).not.toHaveProperty(
+      "requiresAllAdultsConsent",
+    );
+    expect(deriveConsentStatus).not.toHaveBeenCalled();
+    expect(sharedRestMessageSend).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not reserve join-code-shaped text in a single-owner group", async () => {
+    resolveGroupBinding.mockImplementation(async () => ({
+      ...binding,
+      consent_mode: "single_owner",
+      required_principal_count: 1,
+    }));
+    sharedRestMessageSend.mockImplementationOnce(async () => ({
+      text: "Existing single-owner join reply.",
+    }));
+
+    const response = await groupRequest({
+      actor: "Parent B",
+      message: "Eliza join WXYZ2345ABCD",
+      invocation: "mention",
+    });
+
+    await expect(response.json()).resolves.toMatchObject({
+      data: {
+        reply: "Existing single-owner join reply.",
+        groupDelivery: { kind: "binding" },
+      },
+    });
+    expect(consumeJoinConfirmChallenge).not.toHaveBeenCalled();
+    expect(sharedRestMessageSend).toHaveBeenCalledTimes(1);
+  });
+
+  test("self-revokes only Parent B while retaining Parent A's binding", async () => {
+    resolveGroupBinding.mockImplementationOnce(async () => binding);
+    resolveGroupBinding.mockImplementationOnce(async () => ({
+      ...binding,
+      authority_version: 8,
+    }));
+    const response = await groupRequest({
+      actor: "Parent B",
+      message: "Eliza leave",
+    });
+
+    await expect(response.json()).resolves.toMatchObject({
+      data: {
+        code: "group_participant_revoked",
+        consentStatus: consentAfterParentBLeaves,
+        groupDelivery: {
+          kind: "binding",
+          authority: { version: 8 },
+        },
+      },
+    });
+    expect(selfRevoke).toHaveBeenCalledWith({
+      bindingId: BINDING_ID,
+      actorPlatformUserId: "200000000002",
+    });
+    expect(revokeGroupBinding).not.toHaveBeenCalled();
+    expect(sharedRestMessageSend).not.toHaveBeenCalled();
+  });
+
+  test("keeps Parent A's whole-binding leave authority unchanged", async () => {
+    const response = await groupRequest({
+      actor: "Parent A",
+      message: "Eliza leave",
+    });
+
+    await expect(response.json()).resolves.toMatchObject({
+      data: {
+        code: "group_binding_revoked",
+        groupDelivery: { kind: "control" },
+      },
+    });
+    expect(revokeGroupBinding).toHaveBeenCalledWith({
+      bindingId: BINDING_ID,
+      ownerUserId: PARENT_A_USER_ID,
+    });
+    expect(selfRevoke).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.group-reminders.test.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.group-reminders.test.ts
@@ -1,8 +1,9 @@
 /**
  * Verifies owner-gated group reminder destinations on the trusted messaging
  * route: the owner's group turn receives a destination pinned to the binding's
- * live delivery authority, and every other participant or binding state gets
- * none. Mocked account, runtime, and repository boundaries.
+ * live delivery authority, Telegram forum-topic identity is retained, and
+ * every other participant or binding state gets none. Mocked account,
+ * runtime, and repository boundaries.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -240,6 +241,38 @@ const ownerBlooioGroupTurn = {
   invocation: "mention",
 };
 
+const telegramGroupBinding = {
+  ...blooioGroupBinding,
+  id: "00000000-0000-4000-8000-000000000032",
+  platform: "telegram",
+  connector_account_id: "telegram:test-bot",
+  provider_chat_id: "-100123456789",
+  conversation_id: "group:00000000-0000-5000-8000-000000000032",
+  created_by_platform_user_id: "123456789",
+};
+const telegramGroupAuthority = {
+  bindingId: telegramGroupBinding.id,
+  ownerUserId: telegramGroupBinding.owner_user_id,
+  personalAgentId: telegramGroupBinding.personal_agent_id,
+  version: telegramGroupBinding.authority_version,
+};
+const ownerTelegramTopicTurn = {
+  platform: "telegram",
+  chatType: "supergroup",
+  project: "eliza-app",
+  connectorAccountId: "telegram:test-bot",
+  chatId: "-100123456789",
+  providerThreadId: "909",
+  actor: {
+    platformUserId: "123456789",
+    displayName: "Nubs",
+    role: "possessor",
+  },
+  messageId: "telegram:eliza:group-topic-42",
+  message: "Eliza remind this topic to pay rent in an hour",
+  invocation: "mention",
+};
+
 describe("personal Shared group reminder destinations", () => {
   beforeEach(() => {
     groupParticipantOrdinals.clear();
@@ -300,6 +333,46 @@ describe("personal Shared group reminder destinations", () => {
       kind: "group",
       authority: { ...blooioGroupAuthority, version: 4 },
     });
+  });
+
+  test("pins an owner reminder created in a Telegram forum topic to that topic", async () => {
+    resolveGroupBinding.mockImplementationOnce(
+      async () => telegramGroupBinding,
+    );
+
+    const response = await request(ownerTelegramTopicTurn);
+
+    expect(response.status).toBe(200);
+    expect(sharedRestMessageSend).toHaveBeenCalledTimes(1);
+    expect(sharedRestMessageSend.mock.calls[0]?.[8]).toEqual({
+      platform: "telegram",
+      kind: "group",
+      project: "eliza-app",
+      connectorAccountId: "telegram:test-bot",
+      chatId: "-100123456789",
+      providerThreadId: "909",
+      ownerLabel: "Nubs",
+      authority: telegramGroupAuthority,
+    });
+    await expect(response.json()).resolves.toMatchObject({
+      data: {
+        groupDelivery: {
+          kind: "binding",
+          authority: telegramGroupAuthority,
+        },
+      },
+    });
+  });
+
+  test("rejects a non-canonical Telegram topic before reminder construction", async () => {
+    const response = await request({
+      ...ownerTelegramTopicTurn,
+      providerThreadId: "9999999999999999",
+    });
+
+    expect(response.status).toBe(400);
+    expect(resolveGroupBinding).not.toHaveBeenCalled();
+    expect(sharedRestMessageSend).not.toHaveBeenCalled();
   });
 
   test("labels an owner without a display name as the group owner", async () => {

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
@@ -249,7 +249,8 @@ const sharedMessageSchema = z.union([
     providerThreadId: z
       .string()
       .trim()
-      .regex(/^[1-9]\d{0,19}$/)
+      .regex(/^[1-9]\d{0,15}$/)
+      .refine((value) => Number.isSafeInteger(Number(value)))
       .optional(),
   }),
   z.object({
@@ -307,14 +308,21 @@ interface GroupDeliveryAuthority {
 }
 
 const GROUP_CONTROL_DELIVERY = { kind: "control" as const };
+type GroupBindingDeliveryPurpose = "control" | "capability";
 
-function groupBindingDelivery(binding: {
-  id: string;
-  owner_user_id: string;
-  personal_agent_id: string;
-  authority_version: number;
-  consent_mode?: "single_owner" | "all_adults";
-}): { kind: "binding"; authority: GroupDeliveryAuthority } {
+function groupBindingDelivery(
+  binding: {
+    id: string;
+    owner_user_id: string;
+    personal_agent_id: string;
+    authority_version: number;
+    consent_mode?: "single_owner" | "all_adults";
+  },
+  purpose: GroupBindingDeliveryPurpose,
+): {
+  kind: "binding";
+  authority: GroupDeliveryAuthority;
+} {
   return {
     kind: "binding",
     authority: {
@@ -323,7 +331,7 @@ function groupBindingDelivery(binding: {
       personalAgentId: binding.personal_agent_id,
       version: binding.authority_version,
       ...(binding.consent_mode === "all_adults"
-        ? { requiresAllAdultsConsent: false }
+        ? { requiresAllAdultsConsent: purpose === "capability" }
         : {}),
     },
   };
@@ -793,7 +801,7 @@ app.post("/", async (c) => {
                 code: `group_join_${joined.status}`,
                 reply: `${groupJoinFailureReply(joined.status)} ${GROUP_RELAY_DISCLOSURE}`,
                 ...(consentStatus ? { consentStatus } : {}),
-                groupDelivery: groupBindingDelivery(binding),
+                groupDelivery: groupBindingDelivery(binding, "control"),
               },
             });
           }
@@ -812,7 +820,7 @@ app.post("/", async (c) => {
               consentStatus: joined.consent,
               groupDelivery:
                 currentBinding?.state === "active"
-                  ? groupBindingDelivery(currentBinding)
+                  ? groupBindingDelivery(currentBinding, "control")
                   : GROUP_CONTROL_DELIVERY,
             },
           });
@@ -897,7 +905,7 @@ app.post("/", async (c) => {
               },
               reply: `Eliza is linked to this group in all-adults consent mode. The configured ${claimed.binding.required_principal_count} adult principals must each say \`Eliza join\` here, authenticate from their own direct chat, then confirm here before Eliza capabilities are enabled. ${consentStatus ? groupConsentSummary(consentStatus) : "Consent remains restricted until the required participants join."} ${GROUP_RELAY_DISCLOSURE}`,
               ...(consentStatus ? { consentStatus } : {}),
-              groupDelivery: groupBindingDelivery(claimed.binding),
+              groupDelivery: groupBindingDelivery(claimed.binding, "control"),
             },
           });
         }
@@ -915,7 +923,7 @@ app.post("/", async (c) => {
             },
             reply:
               "Eliza is linked to this group. I respond to explicit mentions, commands, and replies by default. The owner can say `Eliza ambient on`, `Eliza ambient off`, or `Eliza leave`.",
-            groupDelivery: groupBindingDelivery(claimed.binding),
+            groupDelivery: groupBindingDelivery(claimed.binding, "control"),
           },
         });
       }
@@ -972,7 +980,7 @@ app.post("/", async (c) => {
               code: "group_join_unavailable",
               reply:
                 "Multi-principal group joining is temporarily unavailable. No join challenge was created.",
-              groupDelivery: groupBindingDelivery(binding),
+              groupDelivery: groupBindingDelivery(binding, "control"),
             },
           });
         }
@@ -1019,7 +1027,7 @@ app.post("/", async (c) => {
               code: `group_join_${issued.status}`,
               reply: `${groupJoinFailureReply(issued.status)} ${GROUP_RELAY_DISCLOSURE}`,
               ...(consentStatus ? { consentStatus } : {}),
-              groupDelivery: groupBindingDelivery(binding),
+              groupDelivery: groupBindingDelivery(binding, "control"),
             },
           });
         }
@@ -1029,7 +1037,7 @@ app.post("/", async (c) => {
             code: "group_join_authenticate_issued",
             reply: `For the exact participant who requested this join: open that participant's direct chat with Eliza and send \`Eliza join ${authenticateCode}\` within 10 minutes. Do not share the code. ${GROUP_RELAY_DISCLOSURE}`,
             ...(consentStatus ? { consentStatus } : {}),
-            groupDelivery: groupBindingDelivery(binding),
+            groupDelivery: groupBindingDelivery(binding, "control"),
           },
         });
       }
@@ -1052,7 +1060,7 @@ app.post("/", async (c) => {
               ? groupConsentSummary(consentStatus)
               : "Consent status is temporarily unavailable, so this group remains restricted.",
             ...(consentStatus ? { consentStatus } : {}),
-            groupDelivery: groupBindingDelivery(binding),
+            groupDelivery: groupBindingDelivery(binding, "control"),
           },
         });
       }
@@ -1072,7 +1080,7 @@ app.post("/", async (c) => {
             code: "group_owner_required",
             reply:
               "Only the owner who linked Eliza can change this group's response policy.",
-            groupDelivery: groupBindingDelivery(binding),
+            groupDelivery: groupBindingDelivery(binding, "control"),
           },
         });
       }
@@ -1102,7 +1110,7 @@ app.post("/", async (c) => {
               requestedPolicy === "ambient"
                 ? "Ambient replies are on. I may respond without a mention when I have something useful to add. Say `Eliza ambient off` to return to mention-only."
                 : "Mention-only is on. I will answer explicit mentions, commands, and replies to me.",
-            groupDelivery: groupBindingDelivery(updated),
+            groupDelivery: groupBindingDelivery(updated, "control"),
           },
         });
       }
@@ -1150,7 +1158,7 @@ app.post("/", async (c) => {
                   : selfRevoked.status === "owner_forbidden"
                     ? "The owner cannot self-revoke only their row. The owner may say `Eliza leave` to disconnect the whole group."
                     : "Eliza could not verify this participant's exact linked group identity, so no consent was revoked.",
-              groupDelivery: groupBindingDelivery(binding),
+              groupDelivery: groupBindingDelivery(binding, "control"),
             },
           });
         }
@@ -1169,7 +1177,7 @@ app.post("/", async (c) => {
             consentStatus: selfRevoked.consent,
             groupDelivery:
               currentBinding?.state === "active"
-                ? groupBindingDelivery(currentBinding)
+                ? groupBindingDelivery(currentBinding, "control")
                 : GROUP_CONTROL_DELIVERY,
           },
         });
@@ -1215,7 +1223,7 @@ app.post("/", async (c) => {
                 ? `${groupConsentSummary(consentStatus)} Each participant who still needs to link should say \`Eliza join\` here. ${GROUP_RELAY_DISCLOSURE}`
                 : `Consent status is unavailable, so Eliza capabilities remain restricted. Try \`Eliza consent status\` before continuing. ${GROUP_RELAY_DISCLOSURE}`,
               ...(consentStatus ? { consentStatus } : {}),
-              groupDelivery: groupBindingDelivery(binding),
+              groupDelivery: groupBindingDelivery(binding, "control"),
             },
           });
         }
@@ -1238,10 +1246,10 @@ app.post("/", async (c) => {
       accountResolution = "group-binding";
       groupConversationId = binding.conversation_id;
       groupPersonalAgentId = binding.personal_agent_id;
-      groupDeliveryAuthority = {
-        ...groupBindingDelivery(binding).authority,
-        ...(isAllAdultsBinding ? { requiresAllAdultsConsent: true } : {}),
-      };
+      groupDeliveryAuthority = groupBindingDelivery(
+        binding,
+        "capability",
+      ).authority;
       // Only the owner who linked Eliza may schedule proactive sends into the
       // group; other participants have no account or billing authority here.
       // The stored destination pins the binding generation of this turn so a
@@ -1255,6 +1263,10 @@ app.post("/", async (c) => {
           project: parsed.data.project,
           connectorAccountId: parsed.data.connectorAccountId,
           chatId: parsed.data.chatId,
+          ...(parsed.data.platform === "telegram" &&
+          parsed.data.providerThreadId
+            ? { providerThreadId: parsed.data.providerThreadId }
+            : {}),
           ownerLabel:
             parsed.data.actor.displayName ?? GROUP_OWNER_FALLBACK_LABEL,
           authority: groupDeliveryAuthority,

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
@@ -9,6 +9,10 @@ import {
   resolvePersonalDeliveryProjection,
 } from "@/api-app/personal-delivery-projection";
 import {
+  type PersonalSharedGroupConsentStatus,
+  personalSharedGroupConsentRepository,
+} from "@/db/repositories/personal-shared-group-consent";
+import {
   type GroupParticipantIdentity,
   personalSharedGroupParticipantsRepository,
 } from "@/db/repositories/personal-shared-group-participants";
@@ -54,15 +58,21 @@ const DEFAULT_WHISPER_MODEL = "Systran/faster-whisper-small";
 const FAILURE_STAGE_HEADER = "X-Eliza-Failure-Stage";
 const FAILURE_NAME_HEADER = "X-Eliza-Failure-Name";
 const GROUP_CLAIM_TTL_MS = 10 * 60_000;
+const GROUP_JOIN_CHALLENGE_TTL_MS = 10 * 60_000;
 const GROUP_CODE_ALPHABET = "23456789ABCDEFGHJKLMNPQRSTUVWXYZ";
+const GROUP_CLAIM_CODE_LENGTH = 8;
+const GROUP_JOIN_CODE_LENGTH = 12;
 const GROUP_SOURCE_MESSAGE_ID_MAX_LENGTH = 240;
 const GENERATED_MEDIA_ONLY_MESSAGE = /^\[media: https?:\/\/[^\r\n]+\]$/u;
+const GROUP_RELAY_DISCLOSURE =
+  "Privacy note: plaintext messages and attachments transit the configured relay provider; Eliza does not make that relay end-to-end encrypted.";
 
 type DeliveryStage =
   | "authentication"
   | "validation"
   | "worker_context"
   | "account_resolution"
+  | "consent"
   | "voice_transcription"
   | "media_description"
   | "account_claim"
@@ -97,6 +107,14 @@ function isGroupDeliveryPendingError(error: unknown): boolean {
   );
 }
 
+function isIndependentGroupOwnerAuthenticationError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error as { code?: unknown }).code ===
+      "PERSONAL_SHARED_GROUP_OWNER_INDEPENDENT_AUTHENTICATION_REQUIRED"
+  );
+}
+
 const telegramVoiceNoteSchema = z.object({
   bytesBase64: z.string().min(1).max(MAX_TELEGRAM_VOICE_BASE64_LENGTH),
   mimeType: z.literal("audio/ogg"),
@@ -127,6 +145,7 @@ const groupDeliveryAuthoritySchema = z.object({
   ownerUserId: z.string().uuid(),
   personalAgentId: z.string().trim().min(1).max(160),
   version: z.number().int().positive(),
+  requiresAllAdultsConsent: z.boolean().optional(),
 });
 const groupFields = {
   project: projectSchema,
@@ -227,6 +246,11 @@ const sharedMessageSchema = z.union([
     platform: z.literal("telegram"),
     chatType: z.enum(["group", "supergroup"]),
     ...groupFields,
+    providerThreadId: z
+      .string()
+      .trim()
+      .regex(/^[1-9]\d{0,19}$/)
+      .optional(),
   }),
   z.object({
     platform: z.literal("discord"),
@@ -279,6 +303,7 @@ interface GroupDeliveryAuthority {
   ownerUserId: string;
   personalAgentId: string;
   version: number;
+  requiresAllAdultsConsent?: boolean;
 }
 
 const GROUP_CONTROL_DELIVERY = { kind: "control" as const };
@@ -288,6 +313,7 @@ function groupBindingDelivery(binding: {
   owner_user_id: string;
   personal_agent_id: string;
   authority_version: number;
+  consent_mode?: "single_owner" | "all_adults";
 }): { kind: "binding"; authority: GroupDeliveryAuthority } {
   return {
     kind: "binding",
@@ -296,6 +322,9 @@ function groupBindingDelivery(binding: {
       ownerUserId: binding.owner_user_id,
       personalAgentId: binding.personal_agent_id,
       version: binding.authority_version,
+      ...(binding.consent_mode === "all_adults"
+        ? { requiresAllAdultsConsent: false }
+        : {}),
     },
   };
 }
@@ -318,11 +347,34 @@ function isGroupMessage(message: SharedMessage): message is GroupMessage {
   return "chatType" in message;
 }
 
+function providerThreadIdForGroup(message: GroupMessage): string | null {
+  return message.platform === "telegram"
+    ? (message.providerThreadId ?? null)
+    : null;
+}
+
 function groupClaimCommand(message: string): string | null {
   const match = message.match(
     /^(?:\/eliza_link(?:@[a-z0-9_]{5,32})?|eliza\s+link)\s+([2-9A-HJ-NP-Z]{8})$/i,
   );
   return match?.[1]?.toUpperCase() ?? null;
+}
+
+function groupJoinCodeCommand(message: string): string | null {
+  const match = message.match(
+    /^(?:\/eliza_join(?:@[a-z0-9_]{5,32})?|eliza\s+join)\s+((?:[2-9A-HJ-NP-Z]{8}|[2-9A-HJ-NP-Z]{12}))$/i,
+  );
+  return match?.[1]?.toUpperCase() ?? null;
+}
+
+function isGroupJoinRequest(message: string): boolean {
+  return /^(?:\/eliza_join(?:@[a-z0-9_]{5,32})?|eliza\s+join)$/i.test(message);
+}
+
+function isGroupConsentStatusCommand(message: string): boolean {
+  return /^(?:\/eliza_consent_status(?:@[a-z0-9_]{5,32})?|eliza\s+consent\s+status)$/i.test(
+    message,
+  );
 }
 
 function groupPolicyCommand(
@@ -341,16 +393,126 @@ function isGroupLeaveCommand(message: string): boolean {
   );
 }
 
-function isGroupClaimRequest(message: string): boolean {
-  return /^(?:\/group(?:@[a-z0-9_]{5,32})?|eliza\s+group)$/i.test(message);
+interface GroupClaimRequest {
+  consentMode: "single_owner" | "all_adults";
+  requiredPrincipalCount: number;
 }
 
-function createGroupClaimCode(): string {
-  const bytes = crypto.getRandomValues(new Uint8Array(8));
+function groupClaimRequest(message: string): GroupClaimRequest | null {
+  if (/^(?:\/group(?:@[a-z0-9_]{5,32})?|eliza\s+group)$/i.test(message)) {
+    return { consentMode: "single_owner", requiredPrincipalCount: 1 };
+  }
+  const match = message.match(
+    /^(?:\/group(?:@[a-z0-9_]{5,32})?\s+all-adults|eliza\s+group\s+all\s+adults)(?:\s+([0-9]{1,2}))?$/i,
+  );
+  if (!match) return null;
+  const requiredPrincipalCount = match[1] ? Number(match[1]) : 2;
+  if (
+    !Number.isInteger(requiredPrincipalCount) ||
+    requiredPrincipalCount < 2 ||
+    requiredPrincipalCount > 32
+  ) {
+    return null;
+  }
+  return { consentMode: "all_adults", requiredPrincipalCount };
+}
+
+function isInvalidAllAdultsGroupClaimRequest(message: string): boolean {
+  return /^(?:\/group(?:@[a-z0-9_]{5,32})?\s+all-adults|eliza\s+group\s+all\s+adults)\s+\d+$/i.test(
+    message,
+  );
+}
+
+function createGroupCode(length: number): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(length));
   return Array.from(
     bytes,
     (byte) => GROUP_CODE_ALPHABET[byte % GROUP_CODE_ALPHABET.length],
   ).join("");
+}
+
+function createGroupClaimCode(): string {
+  return createGroupCode(GROUP_CLAIM_CODE_LENGTH);
+}
+
+function personalSharedJoinCodeSecret(env: AppEnv["Bindings"]): string | null {
+  const secret = env.ELIZA_APP_PERSONAL_SHARED_JOIN_CODE_SECRET;
+  return typeof secret === "string" &&
+    new TextEncoder().encode(secret).byteLength >= 32
+    ? secret
+    : null;
+}
+
+async function deriveGroupJoinCode(
+  secret: string,
+  stage: "authenticate" | "confirm",
+  source: readonly string[],
+  avoid?: string,
+): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const canonical = JSON.stringify([
+    "personal-shared-group-join/v1",
+    stage,
+    ...source,
+    avoid === undefined ? 0 : 1,
+  ]);
+  const digest = new Uint8Array(
+    await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(canonical)),
+  );
+  const code = Array.from(
+    digest.subarray(0, GROUP_JOIN_CODE_LENGTH),
+    (byte) => GROUP_CODE_ALPHABET[byte & 31],
+  ).join("");
+  return code === avoid
+    ? deriveGroupJoinCode(secret, stage, [...source, "collision"], avoid)
+    : code;
+}
+
+function groupConsentSummary(status: PersonalSharedGroupConsentStatus): string {
+  if (status.gate === "enabled") {
+    return `Consent is enabled: ${status.consentedParticipantCount} of ${status.requiredPrincipalCount} required participants have independently linked and consented.`;
+  }
+  return `Consent is restricted: ${status.consentedParticipantCount} of ${status.requiredPrincipalCount} required participants have independently linked and consented.`;
+}
+
+function groupJoinFailureReply(
+  status:
+    | "invalid"
+    | "expired"
+    | "already_used"
+    | "wrong_sender"
+    | "wrong_scope"
+    | "stale"
+    | "actor_not_registered"
+    | "account_not_authenticated"
+    | "already_linked",
+): string {
+  switch (status) {
+    case "expired":
+      return "That join code expired. In the original group, have the same participant say `Eliza join` for a fresh code.";
+    case "already_used":
+      return "That join code was already used. In the original group, say `Eliza join` to restart the consent flow.";
+    case "wrong_sender":
+      return "That join code belongs to a different participant. The exact participant who requested it must use the code from their own direct chat with Eliza.";
+    case "wrong_scope":
+      return "That join code was used in the wrong chat. Authenticate codes belong in the requesting participant's direct chat with Eliza; confirm codes belong in the original group.";
+    case "stale":
+      return "This group's consent state changed before that join completed. In the original group, say `Eliza join` to restart.";
+    case "actor_not_registered":
+      return "Eliza has not registered this participant in the group yet. In the original group, have that participant say `Eliza join`.";
+    case "account_not_authenticated":
+      return "This direct chat is not connected to a mature, independently authenticated Eliza account. Sign in to that account first, then restart with `Eliza join` in the original group.";
+    case "already_linked":
+      return "This participant is already linked to the group. Say `Eliza consent status` in the group for the redacted status.";
+    default:
+      return "That join code is invalid. In the original group, have the same participant say `Eliza join` for a fresh code.";
+  }
 }
 
 function decodeTelegramVoiceNote(
@@ -577,6 +739,86 @@ app.post("/", async (c) => {
       | undefined;
     let isNewPersonalAccount = false;
     if (isGroupMessage(parsed.data)) {
+      // In all-adults mode a join confirmation must be consumed before the
+      // owner-link parser. Single-owner groups retain their existing handling
+      // for the same ordinary text shape.
+      const joinConfirmCode = groupJoinCodeCommand(parsed.data.message);
+      if (joinConfirmCode) {
+        const binding = await personalSharedGroupsRepository.resolveBinding({
+          platform: parsed.data.platform,
+          project: parsed.data.project,
+          connectorAccountId: parsed.data.connectorAccountId,
+          providerChatId: parsed.data.chatId,
+        });
+        if (binding?.consent_mode === "all_adults") {
+          if (binding.state !== "active") {
+            return c.json({
+              success: true,
+              data: {
+                code: "group_binding_suspended",
+                reply:
+                  "This group link is inactive. The owner can DM Eliza `/group` to reconnect it.",
+                groupDelivery: GROUP_CONTROL_DELIVERY,
+              },
+            });
+          }
+          await personalSharedGroupParticipantsRepository.recordTurn({
+            bindingId: binding.id,
+            platformUserId: parsed.data.actor.platformUserId,
+            displayName: parsed.data.actor.displayName,
+          });
+          stage = "consent";
+          const joined =
+            await personalSharedGroupConsentRepository.consumeJoinConfirmChallenge(
+              {
+                codeHash: await sha256Hex(joinConfirmCode),
+                sourceMessageId: parsed.data.messageId,
+                bindingId: binding.id,
+                platform: parsed.data.platform,
+                project: parsed.data.project,
+                connectorAccountId: parsed.data.connectorAccountId,
+                providerChatId: parsed.data.chatId,
+                providerThreadId: providerThreadIdForGroup(parsed.data),
+                actorPlatformUserId: parsed.data.actor.platformUserId,
+              },
+            );
+          if (joined.status !== "consented") {
+            const consentStatus =
+              await personalSharedGroupConsentRepository.deriveConsentStatus({
+                bindingId: binding.id,
+              });
+            return c.json({
+              success: true,
+              data: {
+                code: `group_join_${joined.status}`,
+                reply: `${groupJoinFailureReply(joined.status)} ${GROUP_RELAY_DISCLOSURE}`,
+                ...(consentStatus ? { consentStatus } : {}),
+                groupDelivery: groupBindingDelivery(binding),
+              },
+            });
+          }
+          const currentBinding =
+            await personalSharedGroupsRepository.resolveBinding({
+              platform: parsed.data.platform,
+              project: parsed.data.project,
+              connectorAccountId: parsed.data.connectorAccountId,
+              providerChatId: parsed.data.chatId,
+            });
+          return c.json({
+            success: true,
+            data: {
+              code: "group_join_consented",
+              reply: `${groupConsentSummary(joined.consent)} ${GROUP_RELAY_DISCLOSURE}`,
+              consentStatus: joined.consent,
+              groupDelivery:
+                currentBinding?.state === "active"
+                  ? groupBindingDelivery(currentBinding)
+                  : GROUP_CONTROL_DELIVERY,
+            },
+          });
+        }
+      }
+
       const claimCode = groupClaimCommand(parsed.data.message);
       if (claimCode) {
         if (
@@ -594,8 +836,11 @@ app.post("/", async (c) => {
             },
           });
         }
-        const claimed =
-          await personalSharedGroupsRepository.consumeClaimAndBind({
+        let claimed: Awaited<
+          ReturnType<typeof personalSharedGroupsRepository.consumeClaimAndBind>
+        >;
+        try {
+          claimed = await personalSharedGroupsRepository.consumeClaimAndBind({
             codeHash: await sha256Hex(claimCode),
             platform: parsed.data.platform,
             project: parsed.data.project,
@@ -603,6 +848,18 @@ app.post("/", async (c) => {
             providerChatId: parsed.data.chatId,
             actorPlatformUserId: parsed.data.actor.platformUserId,
           });
+        } catch (error) {
+          if (!isIndependentGroupOwnerAuthenticationError(error)) throw error;
+          return c.json({
+            success: true,
+            data: {
+              code: "group_claim_authentication_required",
+              reply:
+                "All-adults groups require the owner to finish signing in to their own Eliza account, then retry this exact unexpired link command.",
+              groupDelivery: GROUP_CONTROL_DELIVERY,
+            },
+          });
+        }
         if (claimed.status !== "bound") {
           return c.json({
             success: true,
@@ -617,6 +874,30 @@ app.post("/", async (c) => {
                       ? "This group is already linked to another Eliza owner. That owner must disconnect it before a different owner can link it."
                       : "That group link is not valid for this account or sender. DM Eliza `/group` yourself and paste the exact command here.",
               groupDelivery: GROUP_CONTROL_DELIVERY,
+            },
+          });
+        }
+        if (claimed.binding.consent_mode === "all_adults") {
+          stage = "consent";
+          const consentStatus =
+            await personalSharedGroupConsentRepository.deriveConsentStatus({
+              bindingId: claimed.binding.id,
+            });
+          return c.json({
+            success: true,
+            data: {
+              code: "group_bound",
+              identity: {
+                id: claimed.binding.personal_agent_id,
+                runtime: "shared" as const,
+              },
+              account: {
+                userId: claimed.binding.owner_user_id,
+                organizationId: claimed.binding.organization_id,
+              },
+              reply: `Eliza is linked to this group in all-adults consent mode. The configured ${claimed.binding.required_principal_count} adult principals must each say \`Eliza join\` here, authenticate from their own direct chat, then confirm here before Eliza capabilities are enabled. ${consentStatus ? groupConsentSummary(consentStatus) : "Consent remains restricted until the required participants join."} ${GROUP_RELAY_DISCLOSURE}`,
+              ...(consentStatus ? { consentStatus } : {}),
+              groupDelivery: groupBindingDelivery(claimed.binding),
             },
           });
         }
@@ -661,13 +942,130 @@ app.post("/", async (c) => {
         });
       }
 
-      const requestedPolicy = groupPolicyCommand(parsed.data.message);
-      const ownerControl =
-        requestedPolicy !== null || isGroupLeaveCommand(parsed.data.message);
+      const isAllAdultsBinding = binding.consent_mode === "all_adults";
+      const groupActor = parsed.data.actor;
+      let recordedParticipants:
+        | Awaited<
+            ReturnType<
+              typeof personalSharedGroupParticipantsRepository.recordTurn
+            >
+          >
+        | undefined;
+      const recordActor = async () => {
+        recordedParticipants ??=
+          await personalSharedGroupParticipantsRepository.recordTurn({
+            bindingId: binding.id,
+            platformUserId: groupActor.platformUserId,
+            displayName: groupActor.displayName,
+          });
+        return recordedParticipants;
+      };
+
+      if (isAllAdultsBinding && isGroupJoinRequest(parsed.data.message)) {
+        await recordActor();
+        stage = "consent";
+        const joinCodeSecret = personalSharedJoinCodeSecret(c.env);
+        if (!joinCodeSecret) {
+          return c.json({
+            success: true,
+            data: {
+              code: "group_join_unavailable",
+              reply:
+                "Multi-principal group joining is temporarily unavailable. No join challenge was created.",
+              groupDelivery: groupBindingDelivery(binding),
+            },
+          });
+        }
+        // A source webhook can be reopened after provider egress when only the
+        // receipt response is lost. Deriving from a secret and the immutable
+        // source scope makes that replay return the same high-entropy code,
+        // while the database still stores only its hash.
+        const authenticateCode = await deriveGroupJoinCode(
+          joinCodeSecret,
+          "authenticate",
+          [
+            parsed.data.platform,
+            parsed.data.project,
+            parsed.data.connectorAccountId,
+            parsed.data.chatId,
+            providerThreadIdForGroup(parsed.data) ?? "",
+            parsed.data.actor.platformUserId,
+            parsed.data.messageId,
+          ],
+        );
+        const issued =
+          await personalSharedGroupConsentRepository.issueJoinAuthenticateChallenge(
+            {
+              codeHash: await sha256Hex(authenticateCode),
+              sourceMessageId: parsed.data.messageId,
+              bindingId: binding.id,
+              platform: parsed.data.platform,
+              project: parsed.data.project,
+              connectorAccountId: parsed.data.connectorAccountId,
+              providerChatId: parsed.data.chatId,
+              providerThreadId: providerThreadIdForGroup(parsed.data),
+              actorPlatformUserId: parsed.data.actor.platformUserId,
+              expiresAt: new Date(Date.now() + GROUP_JOIN_CHALLENGE_TTL_MS),
+            },
+          );
+        const consentStatus =
+          await personalSharedGroupConsentRepository.deriveConsentStatus({
+            bindingId: binding.id,
+          });
+        if (issued.status !== "issued") {
+          return c.json({
+            success: true,
+            data: {
+              code: `group_join_${issued.status}`,
+              reply: `${groupJoinFailureReply(issued.status)} ${GROUP_RELAY_DISCLOSURE}`,
+              ...(consentStatus ? { consentStatus } : {}),
+              groupDelivery: groupBindingDelivery(binding),
+            },
+          });
+        }
+        return c.json({
+          success: true,
+          data: {
+            code: "group_join_authenticate_issued",
+            reply: `For the exact participant who requested this join: open that participant's direct chat with Eliza and send \`Eliza join ${authenticateCode}\` within 10 minutes. Do not share the code. ${GROUP_RELAY_DISCLOSURE}`,
+            ...(consentStatus ? { consentStatus } : {}),
+            groupDelivery: groupBindingDelivery(binding),
+          },
+        });
+      }
+
       if (
-        ownerControl &&
-        parsed.data.actor.platformUserId !== binding.created_by_platform_user_id
+        isAllAdultsBinding &&
+        isGroupConsentStatusCommand(parsed.data.message)
       ) {
+        await recordActor();
+        stage = "consent";
+        const consentStatus =
+          await personalSharedGroupConsentRepository.deriveConsentStatus({
+            bindingId: binding.id,
+          });
+        return c.json({
+          success: true,
+          data: {
+            code: "group_consent_status",
+            reply: consentStatus
+              ? groupConsentSummary(consentStatus)
+              : "Consent status is temporarily unavailable, so this group remains restricted.",
+            ...(consentStatus ? { consentStatus } : {}),
+            groupDelivery: groupBindingDelivery(binding),
+          },
+        });
+      }
+
+      const requestedPolicy = groupPolicyCommand(parsed.data.message);
+      const requestedLeave = isGroupLeaveCommand(parsed.data.message);
+      const actorIsOwner =
+        parsed.data.actor.platformUserId ===
+        binding.created_by_platform_user_id;
+      const ownerControl =
+        requestedPolicy !== null ||
+        (requestedLeave && (!isAllAdultsBinding || actorIsOwner));
+      if (ownerControl && !actorIsOwner) {
         return c.json({
           success: true,
           data: {
@@ -708,7 +1106,7 @@ app.post("/", async (c) => {
           },
         });
       }
-      if (isGroupLeaveCommand(parsed.data.message)) {
+      if (requestedLeave && actorIsOwner) {
         const revoked = await personalSharedGroupsRepository.revokeBinding({
           bindingId: binding.id,
           ownerUserId: binding.owner_user_id,
@@ -733,6 +1131,50 @@ app.post("/", async (c) => {
           },
         });
       }
+      if (requestedLeave && isAllAdultsBinding) {
+        await recordActor();
+        stage = "consent";
+        const selfRevoked =
+          await personalSharedGroupConsentRepository.selfRevoke({
+            bindingId: binding.id,
+            actorPlatformUserId: parsed.data.actor.platformUserId,
+          });
+        if (selfRevoked.status !== "revoked") {
+          return c.json({
+            success: true,
+            data: {
+              code: `group_participant_leave_${selfRevoked.status}`,
+              reply:
+                selfRevoked.status === "not_linked"
+                  ? "This participant is not actively linked and consented, so there is nothing to revoke."
+                  : selfRevoked.status === "owner_forbidden"
+                    ? "The owner cannot self-revoke only their row. The owner may say `Eliza leave` to disconnect the whole group."
+                    : "Eliza could not verify this participant's exact linked group identity, so no consent was revoked.",
+              groupDelivery: groupBindingDelivery(binding),
+            },
+          });
+        }
+        const currentBinding =
+          await personalSharedGroupsRepository.resolveBinding({
+            platform: parsed.data.platform,
+            project: parsed.data.project,
+            connectorAccountId: parsed.data.connectorAccountId,
+            providerChatId: parsed.data.chatId,
+          });
+        return c.json({
+          success: true,
+          data: {
+            code: "group_participant_revoked",
+            reply: `This participant's link and consent are revoked; the group binding remains owned and active. ${groupConsentSummary(selfRevoked.consent)}`,
+            consentStatus: selfRevoked.consent,
+            groupDelivery:
+              currentBinding?.state === "active"
+                ? groupBindingDelivery(currentBinding)
+                : GROUP_CONTROL_DELIVERY,
+          },
+        });
+      }
+
       const verifiedInvocation =
         parsed.data.platform === "blooio" &&
         parsed.data.invocation === "reply" &&
@@ -743,6 +1185,42 @@ app.post("/", async (c) => {
           })))
           ? "ambient"
           : parsed.data.invocation;
+
+      if (isAllAdultsBinding) {
+        await recordActor();
+        stage = "consent";
+        const consentStatus =
+          await personalSharedGroupConsentRepository.deriveConsentStatus({
+            bindingId: binding.id,
+          });
+        if (
+          consentStatus?.mode !== "all_adults" ||
+          consentStatus.gate === "restricted"
+        ) {
+          if (verifiedInvocation === "ambient") {
+            return c.json({
+              success: true,
+              data: {
+                code: "group_silent",
+                reply: "",
+                ...(consentStatus ? { consentStatus } : {}),
+              },
+            });
+          }
+          return c.json({
+            success: true,
+            data: {
+              code: "group_consent_restricted",
+              reply: consentStatus
+                ? `${groupConsentSummary(consentStatus)} Each participant who still needs to link should say \`Eliza join\` here. ${GROUP_RELAY_DISCLOSURE}`
+                : `Consent status is unavailable, so Eliza capabilities remain restricted. Try \`Eliza consent status\` before continuing. ${GROUP_RELAY_DISCLOSURE}`,
+              ...(consentStatus ? { consentStatus } : {}),
+              groupDelivery: groupBindingDelivery(binding),
+            },
+          });
+        }
+      }
+
       if (
         binding.response_policy === "mention_only" &&
         verifiedInvocation === "ambient"
@@ -760,7 +1238,10 @@ app.post("/", async (c) => {
       accountResolution = "group-binding";
       groupConversationId = binding.conversation_id;
       groupPersonalAgentId = binding.personal_agent_id;
-      groupDeliveryAuthority = groupBindingDelivery(binding).authority;
+      groupDeliveryAuthority = {
+        ...groupBindingDelivery(binding).authority,
+        ...(isAllAdultsBinding ? { requiresAllAdultsConsent: true } : {}),
+      };
       // Only the owner who linked Eliza may schedule proactive sends into the
       // group; other participants have no account or billing authority here.
       // The stored destination pins the binding generation of this turn so a
@@ -786,12 +1267,7 @@ app.post("/", async (c) => {
       // that sends none (Blooio sends none at all) gets its stable ordinal.
       // Either way the label is enumerable, which is what lets
       // `guardGroupReply` redact a handle back to it.
-      const participants =
-        await personalSharedGroupParticipantsRepository.recordTurn({
-          bindingId: binding.id,
-          platformUserId: parsed.data.actor.platformUserId,
-          displayName: parsed.data.actor.displayName,
-        });
+      const participants = await recordActor();
       groupParticipantRoster = participants.roster;
       groupActorLabel = groupParticipantLabel(participants.actor);
     } else if (parsed.data.platform === "telegram") {
@@ -861,27 +1337,144 @@ app.post("/", async (c) => {
       );
     }
 
-    if (
+    const directJoinCode =
       !isGroupMessage(parsed.data) &&
-      (parsed.data.platform === "telegram" ||
-        parsed.data.platform === "blooio") &&
-      isGroupClaimRequest(parsed.data.message ?? "")
+      (parsed.data.platform === "telegram" || parsed.data.platform === "blooio")
+        ? groupJoinCodeCommand(parsed.data.message ?? "")
+        : null;
+    if (
+      directJoinCode &&
+      !isGroupMessage(parsed.data) &&
+      (parsed.data.platform === "telegram" || parsed.data.platform === "blooio")
     ) {
-      const code = createGroupClaimCode();
-      await personalSharedGroupsRepository.issueClaim({
-        codeHash: await sha256Hex(code),
-        organizationId: account.organizationId,
-        ownerUserId: account.userId,
-        personalAgentId: agent.id,
-        platform: parsed.data.platform,
-        project: parsed.data.project,
-        connectorAccountId: parsed.data.connectorAccountId,
-        issuedToPlatformUserId:
-          parsed.data.platform === "telegram"
-            ? parsed.data.telegramUserId
-            : parsed.data.phoneNumber,
-        expiresAt: new Date(Date.now() + GROUP_CLAIM_TTL_MS),
+      const joinCodeSecret = personalSharedJoinCodeSecret(c.env);
+      if (!joinCodeSecret) {
+        return c.json({
+          success: true,
+          data: {
+            code: "group_join_unavailable",
+            reply:
+              "Multi-principal group joining is temporarily unavailable. The existing group remains restricted.",
+          },
+        });
+      }
+      const directActorPlatformUserId =
+        parsed.data.platform === "telegram"
+          ? parsed.data.telegramUserId
+          : parsed.data.phoneNumber;
+      const confirmCode = await deriveGroupJoinCode(
+        joinCodeSecret,
+        "confirm",
+        [
+          parsed.data.platform,
+          parsed.data.project,
+          parsed.data.connectorAccountId,
+          directActorPlatformUserId,
+          parsed.data.messageId,
+          directJoinCode,
+        ],
+        directJoinCode,
+      );
+      stage = "consent";
+      const authenticated =
+        await personalSharedGroupConsentRepository.consumeJoinAuthenticateChallenge(
+          {
+            codeHash: await sha256Hex(directJoinCode),
+            confirmCodeHash: await sha256Hex(confirmCode),
+            sourceMessageId: parsed.data.messageId,
+            platform: parsed.data.platform,
+            project: parsed.data.project,
+            connectorAccountId: parsed.data.connectorAccountId,
+            actorPlatformUserId: directActorPlatformUserId,
+            linkedUserId: account.userId,
+            linkedOrganizationId: account.organizationId,
+            expiresAt: new Date(Date.now() + GROUP_JOIN_CHALLENGE_TTL_MS),
+          },
+        );
+      if (authenticated.status !== "confirm_issued") {
+        return c.json({
+          success: true,
+          data: {
+            code: `group_join_authenticate_${authenticated.status}`,
+            reply: `${groupJoinFailureReply(authenticated.status)} ${GROUP_RELAY_DISCLOSURE}`,
+          },
+        });
+      }
+      const consentStatus =
+        await personalSharedGroupConsentRepository.deriveConsentStatus({
+          bindingId: authenticated.bindingId,
+        });
+      return c.json({
+        success: true,
+        data: {
+          code: "group_join_confirm_issued",
+          reply: `Authentication succeeded. Return to the original group as this exact participant and send \`Eliza join ${confirmCode}\` within 10 minutes. Do not share the code. ${GROUP_RELAY_DISCLOSURE}`,
+          ...(consentStatus ? { consentStatus } : {}),
+        },
       });
+    }
+
+    const requestedGroupClaim =
+      !isGroupMessage(parsed.data) &&
+      (parsed.data.platform === "telegram" || parsed.data.platform === "blooio")
+        ? groupClaimRequest(parsed.data.message ?? "")
+        : null;
+    if (
+      requestedGroupClaim &&
+      !isGroupMessage(parsed.data) &&
+      (parsed.data.platform === "telegram" || parsed.data.platform === "blooio")
+    ) {
+      // Two-phase rollout fence: schema and every provider egress enforcer must
+      // be deployed before any all-adults binding can be issued. Unset and all
+      // non-exact values fail closed while single-owner behavior stays intact.
+      if (
+        requestedGroupClaim.consentMode === "all_adults" &&
+        (c.env.ELIZA_APP_PERSONAL_SHARED_ALL_ADULTS_ENABLED !== "true" ||
+          !personalSharedJoinCodeSecret(c.env))
+      ) {
+        return c.json({
+          success: true,
+          data: {
+            code: "group_all_adults_unavailable",
+            reply:
+              "Multi-principal group consent is not enabled on this deployment yet. No group link was created.",
+          },
+        });
+      }
+      const code = createGroupClaimCode();
+      try {
+        await personalSharedGroupsRepository.issueClaim({
+          codeHash: await sha256Hex(code),
+          organizationId: account.organizationId,
+          ownerUserId: account.userId,
+          personalAgentId: agent.id,
+          platform: parsed.data.platform,
+          project: parsed.data.project,
+          connectorAccountId: parsed.data.connectorAccountId,
+          issuedToPlatformUserId:
+            parsed.data.platform === "telegram"
+              ? parsed.data.telegramUserId
+              : parsed.data.phoneNumber,
+          ...(requestedGroupClaim.consentMode === "all_adults"
+            ? {
+                consentMode: requestedGroupClaim.consentMode,
+                requiredPrincipalCount:
+                  requestedGroupClaim.requiredPrincipalCount,
+              }
+            : {}),
+          expiresAt: new Date(Date.now() + GROUP_CLAIM_TTL_MS),
+        });
+      } catch (error) {
+        if (!isIndependentGroupOwnerAuthenticationError(error)) throw error;
+        return c.json({
+          success: true,
+          data: {
+            code: "group_claim_authentication_required",
+            reply:
+              "All-adults groups require you to finish signing in to your own Eliza account, then retry this command.",
+          },
+        });
+      }
       const linkCommand =
         parsed.data.platform === "telegram"
           ? `/eliza_link ${code}`
@@ -895,7 +1488,26 @@ app.post("/", async (c) => {
             userId: account.userId,
             organizationId: account.organizationId,
           },
-          reply: `Add Eliza to the group, then send this there within 10 minutes:\n\n${linkCommand}\n\nUse the same ${parsed.data.platform === "telegram" ? "Telegram account" : "iMessage identity"} that requested this code.`,
+          reply:
+            requestedGroupClaim.consentMode === "all_adults"
+              ? `Add Eliza to the group, then send this there within 10 minutes:\n\n${linkCommand}\n\nUse the same ${parsed.data.platform === "telegram" ? "Telegram account" : "iMessage identity"} that requested this code. This starts all-adults consent for ${requestedGroupClaim.requiredPrincipalCount} independently authenticated participants; Eliza capabilities stay restricted until they join and consent. ${GROUP_RELAY_DISCLOSURE}`
+              : `Add Eliza to the group, then send this there within 10 minutes:\n\n${linkCommand}\n\nUse the same ${parsed.data.platform === "telegram" ? "Telegram account" : "iMessage identity"} that requested this code.`,
+        },
+      });
+    }
+    if (
+      !requestedGroupClaim &&
+      !isGroupMessage(parsed.data) &&
+      (parsed.data.platform === "telegram" ||
+        parsed.data.platform === "blooio") &&
+      isInvalidAllAdultsGroupClaimRequest(parsed.data.message ?? "")
+    ) {
+      return c.json({
+        success: true,
+        data: {
+          code: "group_claim_invalid_principal_count",
+          reply:
+            "Choose an all-adults participant count from 2 through 32, for example `/group all-adults 2` or `Eliza group all adults 2`.",
         },
       });
     }

--- a/packages/cloud/scripts/group-room-sim/coparent-consent-scenario.test.ts
+++ b/packages/cloud/scripts/group-room-sim/coparent-consent-scenario.test.ts
@@ -1,0 +1,1167 @@
+/**
+ * Drives the deterministic co-parent choreography through real Personal
+ * Shared repositories, the real group route gate, the real webhook gateway,
+ * a fake Blooio receipt boundary, and the real room-scoped memory store on
+ * isolated PGlite. Model/runtime inference and the narrow direct-account lookup
+ * adapter are deterministic substitutes; the consent repository still
+ * revalidates mature, verified PGlite user rows.
+ */
+
+import { afterAll, beforeAll, describe, expect, mock, test } from "bun:test";
+import { createHash, createHmac } from "node:crypto";
+import type { PlatformAdapter } from "../../services/gateway-webhook/src/adapters/types";
+import type { GatewayRedis } from "../../services/gateway-webhook/src/redis";
+import { pushSchema } from "../../shared/node_modules/drizzle-kit/api.mjs";
+import { sql } from "../../shared/node_modules/drizzle-orm/index.js";
+import {
+  type BindingObservation,
+  type ConsentSnapshot,
+  type CoparentConsentScenarioPort,
+  type JoinAttackObservation,
+  type JoinAttackVector,
+  runCoparentConsentScenario,
+  type TurnObservation,
+} from "./coparent-consent-scenario";
+import {
+  captureFromOutbox,
+  isMessageSend,
+  type OutboxEntry,
+} from "./mock-blooio-provider";
+
+const ENV_KEYS = [
+  "DATABASE_URL",
+  "TEST_DATABASE_URL",
+  "NODE_ENV",
+  "ELIZA_APP_BLOOIO_API_KEY",
+  "ELIZA_APP_BLOOIO_PHONE_NUMBER",
+  "ELIZA_APP_BLOOIO_WEBHOOK_SECRET",
+] as const;
+const originalEnv = new Map(ENV_KEYS.map((key) => [key, process.env[key]]));
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
+process.env.NODE_ENV = "test";
+
+const ORGANIZATION_A = "91000000-0000-4000-8000-000000000001";
+const ORGANIZATION_B = "91000000-0000-4000-8000-000000000002";
+const USER_A = "91000000-0000-4000-8000-000000000011";
+const USER_B = "91000000-0000-4000-8000-000000000012";
+const PARENT_A_HANDLE = "+12025550101";
+const PARENT_B_HANDLE = "+12025550102";
+const CHILD_C_HANDLE = "+12025550103";
+const ELIZA_HANDLE = "+12025550199";
+const MAIN_GROUP_CHAT = "chat_coparent_consent";
+const SINGLE_OWNER_CHAT = "chat_coparent_single_owner";
+const PROJECT = "eliza-app";
+const WEBHOOK_SECRET = "synthetic-coparent-webhook-secret";
+const INTERNAL_SECRET = "synthetic-coparent-internal-secret";
+const JOIN_CODE_SECRET = "synthetic-coparent-join-code-secret-v1";
+const PRE_CONSENT_MEDIA_URL =
+  "https://media.blooio.com/synthetic/parent-a-pre-consent.jpg";
+
+let capabilityExecutions = 0;
+let mainGroupConversationId = "";
+const sharedRestMessageSend = mock(async (...args: unknown[]) => {
+  capabilityExecutions += 1;
+  const conversationId = String(args[1]);
+  const rawParticipants =
+    conversationId === mainGroupConversationId
+      ? `${PARENT_A_HANDLE} and ${PARENT_B_HANDLE}`
+      : PARENT_A_HANDLE;
+  return {
+    text: `Coordination capability completed for ${rawParticipants}.`,
+  };
+});
+const prewarmPersonalSharedAgentTurnCaches = mock(async () => undefined);
+const findActivePersonalDedicatedTarget = mock(async () => null);
+const enrichInboundImageMedia = mock(async () => ({
+  kind: "described" as const,
+  description: "synthetic attachment description",
+  reused: false,
+}));
+const resolvePersonalDelivery = mock(
+  async (input: { platform: string; phoneNumber?: string }) => {
+    if (input.platform !== "phone") {
+      throw new Error("scenario requested an unknown synthetic direct account");
+    }
+    if (input.phoneNumber === PARENT_A_HANDLE) {
+      return {
+        userId: USER_A,
+        organizationId: ORGANIZATION_A,
+        dedicatedTarget: null,
+        isNew: false,
+        resolution: "single-query-repeat" as const,
+      };
+    }
+    if (input.phoneNumber !== PARENT_B_HANDLE) {
+      throw new Error("scenario requested an unknown synthetic direct account");
+    }
+    return {
+      userId: USER_B,
+      organizationId: ORGANIZATION_B,
+      dedicatedTarget: null,
+      isNew: false,
+      resolution: "single-query-repeat" as const,
+    };
+  },
+);
+const namespace = {
+  getByName: mock(() => ({ fetch: mock(async () => new Response()) })),
+};
+const executionWaitUntil = mock((_promise: Promise<unknown>) => undefined);
+
+mock.module("@/lib/services/shared-runtime/shared-rest-adapter", () => ({
+  sharedRestMessageSend,
+  sharedTurnServerTiming: () => "",
+}));
+mock.module("@/lib/services/shared-runtime/prewarm-shared-agent", () => ({
+  prewarmPersonalSharedAgentTurnCaches,
+}));
+mock.module("@/lib/services/agent-tier-upgrade-target", () => ({
+  findActivePersonalDedicatedTarget,
+}));
+mock.module("@/lib/services/eliza-app/inbound-media-enrichment", () => ({
+  enrichInboundImageMedia,
+}));
+mock.module("@/lib/services/eliza-app", () => ({
+  elizaAppUserService: { resolvePersonalDelivery },
+}));
+mock.module("@/lib/services/shared-runtime/resolve-shared-agent", () => ({
+  resolveSharedRuntimeWorkerRequestContext: () => ({
+    namespace,
+    executionCtx: { waitUntil: executionWaitUntil },
+  }),
+}));
+
+let closeDatabaseConnectionsForTests:
+  | typeof import("../../shared/src/db/client").closeDatabaseConnectionsForTests
+  | undefined;
+let database: ReturnType<
+  typeof import("../../shared/src/db/client").getPgliteClientForTests
+>;
+let groupsRepository: typeof import("../../shared/src/db/repositories/personal-shared-groups").personalSharedGroupsRepository;
+let participantsRepository: typeof import("../../shared/src/db/repositories/personal-shared-group-participants").personalSharedGroupParticipantsRepository;
+let consentRepository: typeof import("../../shared/src/db/repositories/personal-shared-group-consent").personalSharedGroupConsentRepository;
+let routeApp: typeof import("../../api/internal/eliza-app/personal-shared/messages/route")["default"];
+let handleWebhook: typeof import("../../services/gateway-webhook/src/webhook-handler").handleWebhook;
+let blooioAdapter: PlatformAdapter;
+let SharedMemoryStore: typeof import("../../shared/src/lib/services/shared-runtime/shared-memory-store").SharedMemoryStore;
+let personalSharedAgent: typeof import("../../shared/src/lib/services/shared-runtime/personal-shared-agent").personalSharedAgent;
+
+interface RouteResult {
+  success: boolean;
+  data?: {
+    code?: string;
+    reply?: string;
+  };
+  error?: string;
+}
+
+type RedisSetOptions = { ex?: number; nx?: boolean };
+
+class MemoryRedis implements GatewayRedis {
+  readonly store = new Map<string, string>();
+
+  async get<T = unknown>(key: string): Promise<T | null> {
+    const value = this.store.get(key);
+    if (value === undefined) return null;
+    try {
+      return JSON.parse(value) as T;
+    } catch {
+      return value as T;
+    }
+  }
+
+  async set(
+    key: string,
+    value: string,
+    options: RedisSetOptions = {},
+  ): Promise<unknown> {
+    if (options.nx && this.store.has(key)) return null;
+    this.store.set(key, value);
+    return "OK";
+  }
+
+  async del(key: string): Promise<unknown> {
+    return this.store.delete(key) ? 1 : 0;
+  }
+
+  async lpush(): Promise<unknown> {
+    return 1;
+  }
+
+  async ltrim(): Promise<unknown> {
+    return "OK";
+  }
+
+  async expire(): Promise<unknown> {
+    return 1;
+  }
+}
+
+function hash(label: string): string {
+  return createHash("sha256").update(label).digest("hex");
+}
+
+function futureExpiry(): Date {
+  return new Date(Date.now() + 60_000);
+}
+
+function requireValue<T>(value: T | null | undefined, label: string): T {
+  if (value == null) throw new Error(`scenario fixture missing ${label}`);
+  return value;
+}
+
+async function waitFor(
+  check: () => boolean | Promise<boolean>,
+  label: string,
+): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    if (await check()) return;
+    await Bun.sleep(10);
+  }
+  throw new Error(`timed out waiting for ${label}`);
+}
+
+async function consentSnapshot(bindingId: string): Promise<ConsentSnapshot> {
+  const status = requireValue(
+    await consentRepository.deriveConsentStatus({ bindingId }),
+    "consent status",
+  );
+  const { rows } = await database.query<{
+    linked_user_id: string | null;
+    consented_at: Date | null;
+    consent_provenance: string | null;
+  }>(
+    `SELECT linked_user_id, consented_at, consent_provenance
+       FROM personal_shared_group_participants
+      WHERE binding_id = $1 AND revoked_at IS NULL AND linked_user_id IS NOT NULL
+      ORDER BY ordinal`,
+    [bindingId],
+  );
+  return {
+    ...status,
+    linkedPrincipalIds: rows.flatMap((row) =>
+      row.linked_user_id ? [row.linked_user_id] : [],
+    ),
+    consentProvenances: rows.flatMap((row) =>
+      row.consented_at && row.consent_provenance
+        ? [row.consent_provenance]
+        : [],
+    ),
+  };
+}
+
+async function routeRequest(
+  requestBody: Record<string, unknown>,
+): Promise<RouteResult> {
+  const response = await routeApp.request(
+    "/",
+    {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${INTERNAL_SECRET}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(requestBody),
+    },
+    {
+      ELIZA_APP_PERSONAL_SHARED_ALL_ADULTS_ENABLED: "true",
+      ELIZA_APP_PERSONAL_SHARED_JOIN_CODE_SECRET: JOIN_CODE_SECRET,
+      INTERNAL_SECRET,
+      SHARED_RUNTIME_CONVERSATIONS: namespace,
+      WHISPER_STT_URL: "https://whisper.invalid",
+    } as never,
+    {
+      waitUntil() {},
+      passThroughOnException() {},
+      props: {},
+    } as never,
+  );
+  const body = (await response.json()) as RouteResult;
+  if (!response.ok) {
+    throw new Error(
+      `group route returned ${response.status}: ${body.error ?? "unknown error"}`,
+    );
+  }
+  return body;
+}
+
+async function routeGroup(input: {
+  chatId: string;
+  actorHandle: string;
+  message: string;
+  messageId: string;
+  invocation?: "mention" | "command" | "reply" | "ambient";
+  mediaUrls?: string[];
+}): Promise<RouteResult> {
+  return routeRequest({
+    platform: "blooio",
+    chatType: "group",
+    project: PROJECT,
+    connectorAccountId: ELIZA_HANDLE,
+    chatId: input.chatId,
+    actor: {
+      platformUserId: input.actorHandle,
+      role: "possessor",
+    },
+    messageId: input.messageId,
+    message: input.message,
+    invocation: input.invocation ?? "mention",
+    ...(input.mediaUrls ? { mediaUrls: input.mediaUrls } : {}),
+  });
+}
+
+async function routeDirectBlooio(input: {
+  actorHandle: string;
+  message: string;
+  messageId: string;
+}): Promise<RouteResult> {
+  return routeRequest({
+    platform: "blooio",
+    project: PROJECT,
+    connectorAccountId: ELIZA_HANDLE,
+    phoneNumber: input.actorHandle,
+    messageId: input.messageId,
+    message: input.message,
+  });
+}
+
+function joinCodeFromRoute(result: RouteResult, expectedCode: string): string {
+  expect(result.data?.code).toBe(expectedCode);
+  const match = result.data?.reply?.match(
+    /Eliza join ([2-9A-HJ-NP-Z]{8}(?:[2-9A-HJ-NP-Z]{4})?)(?=`|\s|$)/,
+  );
+  return requireValue(match?.[1], `${expectedCode} join code`);
+}
+
+function groupLinkCodeFromRoute(result: RouteResult): string {
+  expect(result.data?.code).toBe("group_claim_issued");
+  const match = result.data?.reply?.match(
+    /Eliza link ([2-9A-HJ-NP-Z]{8})(?=`|\s|$)/,
+  );
+  return requireValue(match?.[1], "group claim link code");
+}
+
+async function bindingObservation(input: {
+  chatId: string;
+  codeLabel: string;
+  mode?: "single_owner" | "all_adults";
+}): Promise<BindingObservation> {
+  if (input.mode === "all_adults") {
+    const issued = await routeDirectBlooio({
+      actorHandle: PARENT_A_HANDLE,
+      message: "/group all-adults 2",
+      messageId: `route-${input.codeLabel}-issue`,
+    });
+    const linkCode = groupLinkCodeFromRoute(issued);
+    const bound = await routeGroup({
+      chatId: input.chatId,
+      actorHandle: PARENT_A_HANDLE,
+      message: `Eliza link ${linkCode}`,
+      messageId: `route-${input.codeLabel}-consume`,
+      invocation: "command",
+    });
+    expect(bound.data?.code).toBe("group_bound");
+    const stored = requireValue(
+      await groupsRepository.resolveBinding({
+        platform: "blooio",
+        project: PROJECT,
+        connectorAccountId: ELIZA_HANDLE,
+        providerChatId: input.chatId,
+      }),
+      "route-created all-adults binding",
+    );
+    return {
+      status: "bound",
+      bindingId: stored.id,
+      conversationId: stored.conversation_id,
+      consent: await consentSnapshot(stored.id),
+      routeStages: ["parent_a_dm_claim_issue", "group_claim_consume"],
+    };
+  }
+
+  const agent = personalSharedAgent({
+    userId: USER_A,
+    organizationId: ORGANIZATION_A,
+  });
+  await groupsRepository.issueClaim({
+    codeHash: hash(input.codeLabel),
+    organizationId: ORGANIZATION_A,
+    ownerUserId: USER_A,
+    personalAgentId: agent.id,
+    platform: "blooio",
+    project: PROJECT,
+    connectorAccountId: ELIZA_HANDLE,
+    issuedToPlatformUserId: PARENT_A_HANDLE,
+    expiresAt: futureExpiry(),
+  });
+  const consumed = await groupsRepository.consumeClaimAndBind({
+    codeHash: hash(input.codeLabel),
+    platform: "blooio",
+    project: PROJECT,
+    connectorAccountId: ELIZA_HANDLE,
+    providerChatId: input.chatId,
+    actorPlatformUserId: PARENT_A_HANDLE,
+  });
+  if (consumed.status !== "bound") {
+    throw new Error(`owner claim did not bind: ${consumed.status}`);
+  }
+  return {
+    status: "bound",
+    bindingId: consumed.binding.id,
+    conversationId: consumed.binding.conversation_id,
+    consent: await consentSnapshot(consumed.binding.id),
+  };
+}
+
+async function routeCapability(
+  binding: BindingObservation,
+  actorHandle: string,
+  stage: string,
+): Promise<TurnObservation> {
+  const stored = requireValue(
+    await groupsRepository.findBindingById(binding.bindingId),
+    "group binding",
+  );
+  const before = capabilityExecutions;
+  const enrichmentBefore = enrichInboundImageMedia.mock.calls.length;
+  const prewarmBefore = prewarmPersonalSharedAgentTurnCaches.mock.calls.length;
+  const mediaUrls = stage === "pre_consent" ? [PRE_CONSENT_MEDIA_URL] : [];
+  const result = await routeGroup({
+    chatId: stored.provider_chat_id,
+    actorHandle,
+    message: "Eliza, confirm the synthetic pickup plan",
+    messageId: `route-${stage}`,
+    ...(mediaUrls.length > 0 ? { mediaUrls } : {}),
+  });
+  return {
+    code: result.data?.code ?? "group_capability_reply",
+    reply: result.data?.reply ?? "",
+    roomId: stored.conversation_id,
+    mediaUrlCount: mediaUrls.length,
+    mediaEnrichmentExecuted:
+      enrichInboundImageMedia.mock.calls.length > enrichmentBefore,
+    runtimePrewarmExecuted:
+      prewarmPersonalSharedAgentTurnCaches.mock.calls.length > prewarmBefore,
+    capabilityExecuted: capabilityExecutions === before + 1,
+  };
+}
+
+async function setupSchema(): Promise<void> {
+  const client = await import("../../shared/src/db/client");
+  closeDatabaseConnectionsForTests = client.closeDatabaseConnectionsForTests;
+  database = client.getPgliteClientForTests();
+  await client.dbWrite.execute(sql`CREATE EXTENSION IF NOT EXISTS vector`);
+
+  const { organizations } = await import(
+    "../../shared/src/db/schemas/organizations"
+  );
+  const { users } = await import("../../shared/src/db/schemas/users");
+  const groupSchema = await import(
+    "../../shared/src/db/schemas/personal-shared-groups"
+  );
+  const { sharedAgentMemories } = await import(
+    "../../shared/src/db/schemas/shared-agent-memories"
+  );
+  const { apply } = await pushSchema(
+    {
+      organizations,
+      users,
+      personalSharedGroupClaims: groupSchema.personalSharedGroupClaims,
+      personalSharedGroupBindings: groupSchema.personalSharedGroupBindings,
+      personalSharedGroupJoinChallenges:
+        groupSchema.personalSharedGroupJoinChallenges,
+      personalSharedGroupDeliveryReceipts:
+        groupSchema.personalSharedGroupDeliveryReceipts,
+      personalSharedGroupParticipants:
+        groupSchema.personalSharedGroupParticipants,
+      personalSharedGroupDeliveryAttempts:
+        groupSchema.personalSharedGroupDeliveryAttempts,
+      sharedAgentMemories,
+    } as never,
+    client.dbWrite as never,
+  );
+  await apply();
+  await client.dbWrite.insert(organizations).values([
+    {
+      id: ORGANIZATION_A,
+      name: "Synthetic Parent A",
+      slug: "synthetic-parent-a",
+    },
+    {
+      id: ORGANIZATION_B,
+      name: "Synthetic Parent B",
+      slug: "synthetic-parent-b",
+    },
+  ]);
+  await client.dbWrite.insert(users).values([
+    {
+      id: USER_A,
+      organization_id: ORGANIZATION_A,
+      steward_user_id: "synthetic-mature-parent-a",
+      name: "Parent A",
+      phone_number: PARENT_A_HANDLE,
+      phone_verified: true,
+      is_anonymous: false,
+      is_active: true,
+    },
+    {
+      id: USER_B,
+      organization_id: ORGANIZATION_B,
+      steward_user_id: "synthetic-mature-parent-b",
+      name: "Parent B",
+      phone_number: PARENT_B_HANDLE,
+      phone_verified: true,
+      is_anonymous: false,
+      is_active: true,
+    },
+  ]);
+}
+
+beforeAll(async () => {
+  await setupSchema();
+  ({ personalSharedGroupsRepository: groupsRepository } = await import(
+    "../../shared/src/db/repositories/personal-shared-groups"
+  ));
+  ({ personalSharedGroupParticipantsRepository: participantsRepository } =
+    await import(
+      "../../shared/src/db/repositories/personal-shared-group-participants"
+    ));
+  ({ personalSharedGroupConsentRepository: consentRepository } = await import(
+    "../../shared/src/db/repositories/personal-shared-group-consent"
+  ));
+  ({ SharedMemoryStore } = await import(
+    "../../shared/src/lib/services/shared-runtime/shared-memory-store"
+  ));
+  ({ personalSharedAgent } = await import(
+    "../../shared/src/lib/services/shared-runtime/personal-shared-agent"
+  ));
+  ({ default: routeApp } = await import(
+    "../../api/internal/eliza-app/personal-shared/messages/route"
+  ));
+  ({ handleWebhook } = await import(
+    "../../services/gateway-webhook/src/webhook-handler"
+  ));
+  ({ blooioAdapter } = await import(
+    "../../services/gateway-webhook/src/adapters/blooio"
+  ));
+}, 60_000);
+
+afterAll(async () => {
+  await closeDatabaseConnectionsForTests?.();
+  for (const key of ENV_KEYS) {
+    const value = originalEnv.get(key);
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  mock.restore();
+});
+
+describe("synthetic iMessage co-parent consent scenario", () => {
+  test("returns a machine-readable ledger across consent, isolation, and delivery seams", async () => {
+    let mainBinding: BindingObservation | undefined;
+    let singleOwnerBinding: BindingObservation | undefined;
+    let attackSequence = 0;
+
+    const ensureSingleOwner = async (): Promise<BindingObservation> => {
+      singleOwnerBinding ??= await bindingObservation({
+        chatId: SINGLE_OWNER_CHAT,
+        codeLabel: "single-owner-claim",
+      });
+      return singleOwnerBinding;
+    };
+
+    const issueAuthenticate = async (
+      bindingId: string,
+      label: string,
+      providerThreadId: string | null = null,
+    ) => {
+      const stored = requireValue(
+        await groupsRepository.findBindingById(bindingId),
+        "challenge binding",
+      );
+      return consentRepository.issueJoinAuthenticateChallenge({
+        codeHash: hash(`authenticate-${label}`),
+        bindingId,
+        platform: "blooio",
+        project: PROJECT,
+        connectorAccountId: ELIZA_HANDLE,
+        providerChatId: stored.provider_chat_id,
+        providerThreadId,
+        actorPlatformUserId: PARENT_B_HANDLE,
+        expiresAt: futureExpiry(),
+      });
+    };
+
+    const authenticate = (
+      label: string,
+      actorPlatformUserId = PARENT_B_HANDLE,
+    ) =>
+      consentRepository.consumeJoinAuthenticateChallenge({
+        codeHash: hash(`authenticate-${label}`),
+        confirmCodeHash: hash(`confirm-${label}`),
+        platform: "blooio",
+        project: PROJECT,
+        connectorAccountId: ELIZA_HANDLE,
+        actorPlatformUserId,
+        linkedUserId: USER_B,
+        linkedOrganizationId: ORGANIZATION_B,
+        expiresAt: futureExpiry(),
+      });
+
+    const routeJoinHandoff = async (bindingId: string, label: string) => {
+      const stored = requireValue(
+        await groupsRepository.findBindingById(bindingId),
+        "route join binding",
+      );
+      const capabilityBefore = capabilityExecutions;
+      const prewarmBefore =
+        prewarmPersonalSharedAgentTurnCaches.mock.calls.length;
+      const issued = await routeGroup({
+        chatId: stored.provider_chat_id,
+        actorHandle: PARENT_B_HANDLE,
+        message: "Eliza join",
+        messageId: `route-${label}-join-issue`,
+        invocation: "command",
+      });
+      const authenticateCode = joinCodeFromRoute(
+        issued,
+        "group_join_authenticate_issued",
+      );
+      const authenticated = await routeDirectBlooio({
+        actorHandle: PARENT_B_HANDLE,
+        message: `Eliza join ${authenticateCode}`,
+        messageId: `route-${label}-join-authenticate`,
+      });
+      const confirmCode = joinCodeFromRoute(
+        authenticated,
+        "group_join_confirm_issued",
+      );
+      expect(confirmCode).not.toBe(authenticateCode);
+      // Simulate provider egress succeeding while its receipt response is
+      // lost: reopening the exact source after DM authentication must display
+      // the same code and must not erase the live confirmation handoff.
+      const reopenedIssue = await routeGroup({
+        chatId: stored.provider_chat_id,
+        actorHandle: PARENT_B_HANDLE,
+        message: "Eliza join",
+        messageId: `route-${label}-join-issue`,
+        invocation: "command",
+      });
+      expect(
+        joinCodeFromRoute(reopenedIssue, "group_join_authenticate_issued"),
+      ).toBe(authenticateCode);
+      expect(capabilityExecutions).toBe(capabilityBefore);
+      expect(prewarmPersonalSharedAgentTurnCaches.mock.calls.length).toBe(
+        prewarmBefore,
+      );
+      return { stored, confirmCode };
+    };
+
+    const attackJoin = async (
+      bindingId: string,
+      vector: JoinAttackVector,
+    ): Promise<JoinAttackObservation> => {
+      attackSequence += 1;
+      const label = `${attackSequence}-${vector}`;
+      let status: string;
+      let routeStages: string[] | undefined;
+      let scopeRejectionSeam: "repository" | undefined;
+      switch (vector) {
+        case "forged": {
+          status = (
+            await consentRepository.consumeJoinAuthenticateChallenge({
+              codeHash: hash(`never-issued-${label}`),
+              confirmCodeHash: hash(`confirm-${label}`),
+              platform: "blooio",
+              project: PROJECT,
+              connectorAccountId: ELIZA_HANDLE,
+              actorPlatformUserId: PARENT_B_HANDLE,
+              linkedUserId: USER_B,
+              linkedOrganizationId: ORGANIZATION_B,
+              expiresAt: futureExpiry(),
+            })
+          ).status;
+          expect(status).toBe("invalid");
+          break;
+        }
+        case "expired": {
+          expect((await issueAuthenticate(bindingId, label)).status).toBe(
+            "issued",
+          );
+          await database.query(
+            `UPDATE personal_shared_group_join_challenges
+                SET expires_at = now() - interval '1 second'
+              WHERE code_hash = $1`,
+            [hash(`authenticate-${label}`)],
+          );
+          status = (await authenticate(label)).status;
+          expect(status).toBe("expired");
+          break;
+        }
+        case "replayed": {
+          expect((await issueAuthenticate(bindingId, label)).status).toBe(
+            "issued",
+          );
+          expect((await authenticate(label)).status).toBe("confirm_issued");
+          status = (await authenticate(label)).status;
+          expect(status).toBe("already_used");
+          break;
+        }
+        case "wrong_sender": {
+          expect((await issueAuthenticate(bindingId, label)).status).toBe(
+            "issued",
+          );
+          status = (await authenticate(label, CHILD_C_HANDLE)).status;
+          expect(status).toBe("wrong_sender");
+          break;
+        }
+        case "wrong_binding": {
+          const other = await ensureSingleOwner();
+          expect((await issueAuthenticate(bindingId, label)).status).toBe(
+            "issued",
+          );
+          expect((await authenticate(label)).status).toBe("confirm_issued");
+          const otherStored = requireValue(
+            await groupsRepository.findBindingById(other.bindingId),
+            "wrong-scope binding",
+          );
+          status = (
+            await consentRepository.consumeJoinConfirmChallenge({
+              codeHash: hash(`confirm-${label}`),
+              bindingId: other.bindingId,
+              platform: "blooio",
+              project: PROJECT,
+              connectorAccountId: ELIZA_HANDLE,
+              providerChatId: otherStored.provider_chat_id,
+              actorPlatformUserId: PARENT_B_HANDLE,
+            })
+          ).status;
+          expect(status).toBe("wrong_scope");
+          break;
+        }
+        case "cross_thread": {
+          const { stored, confirmCode } = await routeJoinHandoff(
+            bindingId,
+            label,
+          );
+          status = (
+            await consentRepository.consumeJoinConfirmChallenge({
+              codeHash: hash(confirmCode),
+              bindingId,
+              platform: "blooio",
+              project: PROJECT,
+              connectorAccountId: ELIZA_HANDLE,
+              providerChatId: stored.provider_chat_id,
+              providerThreadId: "thread-other",
+              actorPlatformUserId: PARENT_B_HANDLE,
+            })
+          ).status;
+          expect(status).toBe("wrong_scope");
+          routeStages = ["group_join_issue", "parent_b_dm_authenticate"];
+          scopeRejectionSeam = "repository";
+          break;
+        }
+      }
+      return {
+        vector,
+        status,
+        accepted: false,
+        ...(routeStages ? { routeStages } : {}),
+        ...(scopeRejectionSeam ? { scopeRejectionSeam } : {}),
+      };
+    };
+
+    const port: CoparentConsentScenarioPort = {
+      async bindAllAdults() {
+        mainBinding = await bindingObservation({
+          chatId: MAIN_GROUP_CHAT,
+          codeLabel: "all-adults-owner-claim",
+          mode: "all_adults",
+        });
+        mainGroupConversationId = mainBinding.conversationId;
+        await participantsRepository.recordTurn({
+          bindingId: mainBinding.bindingId,
+          platformUserId: PARENT_B_HANDLE,
+        });
+        mainBinding.consent = await consentSnapshot(mainBinding.bindingId);
+        return mainBinding;
+      },
+
+      readConsent(bindingId) {
+        return consentSnapshot(bindingId);
+      },
+
+      async capabilityTurn(stage, bindingId) {
+        const binding = requireValue(mainBinding, "main binding");
+        expect(binding.bindingId).toBe(bindingId);
+        return routeCapability(
+          binding,
+          stage === "post_consent" ? PARENT_B_HANDLE : PARENT_A_HANDLE,
+          stage,
+        );
+      },
+
+      attackJoin,
+
+      async consentParentB(bindingId) {
+        const label = "successful-parent-b";
+        const { stored, confirmCode } = await routeJoinHandoff(
+          bindingId,
+          label,
+        );
+        const result = await routeGroup({
+          chatId: stored.provider_chat_id,
+          actorHandle: PARENT_B_HANDLE,
+          message: `Eliza join ${confirmCode}`,
+          messageId: `route-${label}-join-confirm`,
+          invocation: "command",
+        });
+        expect(result.data?.code).toBe("group_join_consented");
+        await participantsRepository.recordTurn({
+          bindingId,
+          platformUserId: CHILD_C_HANDLE,
+        });
+        return {
+          status: "consented",
+          consent: await consentSnapshot(bindingId),
+          routeStages: [
+            "group_join_issue",
+            "parent_b_dm_authenticate",
+            "group_join_confirm",
+          ],
+        };
+      },
+
+      async probeMemoryIsolation(binding) {
+        const parentAAgent = personalSharedAgent({
+          userId: USER_A,
+          organizationId: ORGANIZATION_A,
+        });
+        const parentBAgent = personalSharedAgent({
+          userId: USER_B,
+          organizationId: ORGANIZATION_B,
+        });
+        const embed = {
+          model: "synthetic-room-isolation",
+          embedTexts: async (texts: string[]) => texts.map(() => [1, 0, 0]),
+        };
+        const groupStore = new SharedMemoryStore(
+          {
+            organizationId: ORGANIZATION_A,
+            userId: USER_A,
+            agentKey: parentAAgent.id,
+            roomKey: binding.conversationId,
+          },
+          undefined,
+          undefined,
+          embed,
+        );
+        const parentAStore = new SharedMemoryStore(
+          {
+            organizationId: ORGANIZATION_A,
+            userId: USER_A,
+            agentKey: parentAAgent.id,
+            roomKey: parentAAgent.id,
+          },
+          undefined,
+          undefined,
+          embed,
+        );
+        const parentBStore = new SharedMemoryStore(
+          {
+            organizationId: ORGANIZATION_B,
+            userId: USER_B,
+            agentKey: parentBAgent.id,
+            roomKey: parentBAgent.id,
+          },
+          undefined,
+          undefined,
+          embed,
+        );
+        const groupMarker = "SHARED-HANDOFF-MARKER";
+        const parentAMarker = "PARENT-A-PRIVATE-MARKER";
+        const parentBMarker = "PARENT-B-PRIVATE-MARKER";
+        await groupStore.recordTurnPair({
+          userMessage: groupMarker,
+          assistantReply: "shared response",
+          messageIds: {
+            user: "91000000-0000-4000-8000-000000000101",
+            assistant: "91000000-0000-4000-8000-000000000102",
+          },
+        });
+        await parentAStore.recordTurnPair({
+          userMessage: parentAMarker,
+          assistantReply: "private A response",
+          messageIds: {
+            user: "91000000-0000-4000-8000-000000000103",
+            assistant: "91000000-0000-4000-8000-000000000104",
+          },
+        });
+        await parentBStore.recordTurnPair({
+          userMessage: parentBMarker,
+          assistantReply: "private B response",
+          messageIds: {
+            user: "91000000-0000-4000-8000-000000000105",
+            assistant: "91000000-0000-4000-8000-000000000106",
+          },
+        });
+        const texts = (hits: Array<{ content: Record<string, unknown> }>) =>
+          hits.flatMap((hit) =>
+            typeof hit.content.text === "string" ? [hit.content.text] : [],
+          );
+        return {
+          groupRoomId: binding.conversationId,
+          parentADmRoomId: parentAAgent.id,
+          parentBDmRoomId: parentBAgent.id,
+          groupRecall: texts(await groupStore.searchByEmbedding([1, 0, 0], 10)),
+          parentADmRecall: texts(
+            await parentAStore.searchByEmbedding([1, 0, 0], 10),
+          ),
+          parentBDmRecall: texts(
+            await parentBStore.searchByEmbedding([1, 0, 0], 10),
+          ),
+          expectedGroupMarker: groupMarker,
+          expectedParentAMarker: parentAMarker,
+          expectedParentBMarker: parentBMarker,
+        };
+      },
+
+      async deliverExactlyOnce(binding) {
+        process.env.ELIZA_APP_BLOOIO_API_KEY = "synthetic-api-key";
+        process.env.ELIZA_APP_BLOOIO_PHONE_NUMBER = ELIZA_HANDLE;
+        process.env.ELIZA_APP_BLOOIO_WEBHOOK_SECRET = WEBHOOK_SECRET;
+        const originalFetch = globalThis.fetch;
+        const outbox: OutboxEntry[] = [];
+        const receiptIds: string[] = [];
+        let providerSendCount = 0;
+        let routeExecutions = 0;
+        const capabilityBefore = capabilityExecutions;
+
+        globalThis.fetch = mock(async (input, init) => {
+          const request = new Request(input, init);
+          if (
+            request.url.endsWith(
+              "/api/internal/eliza-app/personal-shared/messages",
+            )
+          ) {
+            const rawBody = await request.text();
+            const parsed = JSON.parse(rawBody) as { eventType?: string };
+            if (!parsed.eventType) routeExecutions += 1;
+            return routeApp.request(
+              "/",
+              {
+                method: "POST",
+                headers: {
+                  authorization: `Bearer ${INTERNAL_SECRET}`,
+                  "content-type": "application/json",
+                },
+                body: rawBody,
+              },
+              {
+                INTERNAL_SECRET,
+                ELIZA_APP_PERSONAL_SHARED_JOIN_CODE_SECRET: JOIN_CODE_SECRET,
+                SHARED_RUNTIME_CONVERSATIONS: namespace,
+                WHISPER_STT_URL: "https://whisper.invalid",
+              } as never,
+              {
+                waitUntil() {},
+                passThroughOnException() {},
+                props: {},
+              } as never,
+            );
+          }
+          if (request.url.endsWith("/api/internal/identity/resolve")) {
+            return Response.json({ success: false }, { status: 404 });
+          }
+          const url = new URL(request.url);
+          if (url.hostname === "api.blooio.com") {
+            const body = await request.text();
+            outbox.push({
+              n: outbox.length + 1,
+              at: "synthetic-sequence",
+              method: request.method,
+              path: url.pathname,
+              headers: {
+                authorization: request.headers.has("authorization")
+                  ? "[REDACTED]"
+                  : null,
+                "idempotency-key": request.headers.has("idempotency-key")
+                  ? "[REDACTED]"
+                  : null,
+                "x-from-number": request.headers.get("x-from-number"),
+              },
+              body: body || null,
+            });
+            if (isMessageSend(request.method, url.pathname)) {
+              providerSendCount += 1;
+              const id = `synthetic-provider-receipt-${providerSendCount}`;
+              receiptIds.push(id);
+              return Response.json({ id });
+            }
+            return Response.json({ ok: true });
+          }
+          throw new Error(`unexpected scenario fetch: ${request.url}`);
+        }) as unknown as typeof fetch;
+
+        try {
+          const rawBody = JSON.stringify({
+            id: "evt-coparent-exactly-once",
+            type: "message.received",
+            created_at: Date.now(),
+            data: {
+              id: "msg-coparent-exactly-once",
+              message_id: "msg-coparent-exactly-once",
+              chat_id: MAIN_GROUP_CHAT,
+              channel_id: "synthetic-blooio-channel",
+              channel_type: "blooio",
+              direction: "inbound",
+              sender: PARENT_B_HANDLE,
+              recipient: ELIZA_HANDLE,
+              channel_address: ELIZA_HANDLE,
+              text: "Eliza, confirm the synthetic pickup plan",
+              protocol: "imessage",
+              is_group: true,
+              group: { name: "Synthetic co-parenting" },
+              attachments: [],
+            },
+          });
+          const timestamp = Math.floor(Date.now() / 1_000);
+          const signature = createHmac("sha256", WEBHOOK_SECRET)
+            .update(`${timestamp}.${rawBody}`)
+            .digest("hex");
+          const request = () =>
+            new Request("https://gateway.invalid/webhook/eliza-app/blooio", {
+              method: "POST",
+              headers: {
+                "content-type": "application/json",
+                "x-blooio-signature": `t=${timestamp},v1=${signature}`,
+              },
+              body: rawBody,
+            });
+          const redis = new MemoryRedis();
+          const dependencies = {
+            redis,
+            cloudBaseUrl: "https://cloud.invalid",
+            getAuthHeader: () => ({
+              Authorization: `Bearer ${INTERNAL_SECRET}`,
+            }),
+          };
+          expect(
+            (
+              await handleWebhook(
+                request(),
+                blooioAdapter,
+                dependencies,
+                PROJECT,
+              )
+            ).status,
+          ).toBe(200);
+          await waitFor(
+            async () =>
+              receiptIds.length === 1 &&
+              (await groupsRepository.hasDeliveryReceipt({
+                bindingId: binding.bindingId,
+                providerMessageId: receiptIds[0] ?? "",
+              })),
+            "provider receipt persistence",
+          );
+          expect(
+            (
+              await handleWebhook(
+                request(),
+                blooioAdapter,
+                dependencies,
+                PROJECT,
+              )
+            ).status,
+          ).toBe(200);
+          await Bun.sleep(50);
+          const captured = captureFromOutbox(
+            outbox.map((entry) => JSON.stringify(entry)).join("\n"),
+          );
+          return {
+            inboundAttempts: 2,
+            routeExecutions,
+            providerSends: providerSendCount,
+            providerReceiptIds: [...receiptIds],
+            authoritativeReceiptRecorded:
+              await groupsRepository.hasDeliveryReceipt({
+                bindingId: binding.bindingId,
+                providerMessageId: receiptIds[0] ?? "",
+              }),
+            replies: captured.map((entry) => entry.text),
+          };
+        } finally {
+          globalThis.fetch = originalFetch;
+          expect(capabilityExecutions - capabilityBefore).toBe(1);
+        }
+      },
+
+      async selfLeaveParentB(bindingId) {
+        const stored = requireValue(
+          await groupsRepository.findBindingById(bindingId),
+          "self-leave binding",
+        );
+        const response = await routeGroup({
+          chatId: stored.provider_chat_id,
+          actorHandle: PARENT_B_HANDLE,
+          message: "Eliza leave",
+          messageId: "route-parent-b-self-leave",
+          invocation: "command",
+        });
+        const consent = await consentSnapshot(bindingId);
+        return {
+          status: response.data?.code ?? "unknown",
+          ownerStillConsented: consent.participants.some(
+            (participant) =>
+              participant.isOwner &&
+              participant.consented &&
+              !participant.revoked,
+          ),
+          parentBRevoked: consent.participants.some(
+            (participant) => !participant.isOwner && participant.revoked,
+          ),
+          consent,
+          reply: response.data?.reply ?? "",
+        };
+      },
+
+      async bindSingleOwner() {
+        const binding = await ensureSingleOwner();
+        return {
+          binding,
+          turn: await routeCapability(
+            binding,
+            PARENT_A_HANDLE,
+            "single-owner-regression",
+          ),
+        };
+      },
+    };
+
+    const ledger = await runCoparentConsentScenario(port, [
+      PARENT_A_HANDLE,
+      PARENT_B_HANDLE,
+      CHILD_C_HANDLE,
+      ELIZA_HANDLE,
+    ]);
+    expect(ledger.verdict).toBe("PASS");
+    expect(Object.values(ledger.assertions).every(({ pass }) => pass)).toBe(
+      true,
+    );
+    const serialized = JSON.stringify(ledger);
+    for (const handle of [
+      PARENT_A_HANDLE,
+      PARENT_B_HANDLE,
+      CHILD_C_HANDLE,
+      ELIZA_HANDLE,
+    ]) {
+      expect(serialized).not.toContain(handle);
+    }
+    process.stdout.write(
+      `${JSON.stringify({ kind: "coparent-consent-ledger", ledger })}\n`,
+    );
+  }, 60_000);
+});

--- a/packages/cloud/scripts/group-room-sim/coparent-consent-scenario.ts
+++ b/packages/cloud/scripts/group-room-sim/coparent-consent-scenario.ts
@@ -1,0 +1,637 @@
+/**
+ * Defines the deterministic co-parent consent choreography and its
+ * machine-readable evidence ledger. The CI adapter supplies production-backed
+ * repository, route, gateway, provider, and memory observations; this module
+ * owns ordering and cross-seam invariants without contacting a live service.
+ */
+
+export type ScenarioActor =
+  | "Parent A"
+  | "Parent B"
+  | "Child C"
+  | "Eliza"
+  | "system";
+export type ScenarioChannel =
+  | "group"
+  | "parent_a_dm"
+  | "parent_b_dm"
+  | "repository";
+
+export type JoinAttackVector =
+  | "forged"
+  | "expired"
+  | "replayed"
+  | "wrong_sender"
+  | "wrong_binding"
+  | "cross_thread";
+
+export interface ConsentSnapshot {
+  mode: "single_owner" | "all_adults";
+  gate: "enabled" | "restricted";
+  requiredPrincipalCount: number;
+  registeredParticipantCount: number;
+  linkedParticipantCount: number;
+  consentedParticipantCount: number;
+  linkedPrincipalIds: string[];
+  consentProvenances: string[];
+  participants: Array<{
+    ordinal: number;
+    isOwner: boolean;
+    linked: boolean;
+    consented: boolean;
+    revoked: boolean;
+  }>;
+}
+
+export interface BindingObservation {
+  bindingId: string;
+  conversationId: string;
+  status: "bound";
+  consent: ConsentSnapshot;
+  routeStages?: string[];
+}
+
+export interface JoinAttackObservation {
+  vector: JoinAttackVector;
+  accepted: boolean;
+  status: string;
+  routeStages?: string[];
+  scopeRejectionSeam?: "repository";
+}
+
+export interface TurnObservation {
+  code: string;
+  reply: string;
+  roomId: string;
+  mediaUrlCount: number;
+  mediaEnrichmentExecuted: boolean;
+  runtimePrewarmExecuted: boolean;
+  capabilityExecuted: boolean;
+}
+
+export interface MemoryIsolationObservation {
+  groupRoomId: string;
+  parentADmRoomId: string;
+  parentBDmRoomId: string;
+  groupRecall: string[];
+  parentADmRecall: string[];
+  parentBDmRecall: string[];
+  expectedGroupMarker: string;
+  expectedParentAMarker: string;
+  expectedParentBMarker: string;
+}
+
+export interface ExactlyOnceObservation {
+  inboundAttempts: number;
+  routeExecutions: number;
+  providerSends: number;
+  providerReceiptIds: string[];
+  authoritativeReceiptRecorded: boolean;
+  replies: string[];
+}
+
+export interface SelfLeaveObservation {
+  status: string;
+  ownerStillConsented: boolean;
+  parentBRevoked: boolean;
+  consent: ConsentSnapshot;
+  reply: string;
+}
+
+export interface CoparentConsentScenarioPort {
+  bindAllAdults(): Promise<BindingObservation>;
+  readConsent(bindingId: string): Promise<ConsentSnapshot>;
+  capabilityTurn(
+    stage: "pre_consent" | "post_consent" | "post_leave",
+    bindingId: string,
+  ): Promise<TurnObservation>;
+  attackJoin(
+    bindingId: string,
+    vector: JoinAttackVector,
+  ): Promise<JoinAttackObservation>;
+  consentParentB(bindingId: string): Promise<{
+    status: string;
+    consent: ConsentSnapshot;
+    routeStages: string[];
+  }>;
+  probeMemoryIsolation(
+    binding: BindingObservation,
+  ): Promise<MemoryIsolationObservation>;
+  deliverExactlyOnce(
+    binding: BindingObservation,
+  ): Promise<ExactlyOnceObservation>;
+  selfLeaveParentB(bindingId: string): Promise<SelfLeaveObservation>;
+  bindSingleOwner(): Promise<{
+    binding: BindingObservation;
+    turn: TurnObservation;
+  }>;
+}
+
+export interface ScenarioLedgerEvent {
+  sequence: number;
+  phase: string;
+  actor: ScenarioActor;
+  channel: ScenarioChannel;
+  action: string;
+  outcome: string;
+  details: Record<string, unknown>;
+}
+
+export interface ScenarioLedgerAssertion {
+  pass: true;
+  evidence: Record<string, unknown>;
+}
+
+export interface CoparentConsentScenarioLedger {
+  schemaVersion: "coparent-consent-scenario/v1";
+  fixture: {
+    provider: "fake_blooio";
+    actors: ["Parent A", "Parent B", "Child C"];
+    containsRealUserData: false;
+  };
+  events: ScenarioLedgerEvent[];
+  assertions: Record<string, ScenarioLedgerAssertion>;
+  verdict: "PASS";
+}
+
+export class CoparentConsentScenarioError extends Error {
+  constructor(invariant: string) {
+    super(`co-parent consent scenario invariant failed: ${invariant}`);
+    this.name = "CoparentConsentScenarioError";
+  }
+}
+
+function requireInvariant(
+  condition: boolean,
+  invariant: string,
+): asserts condition {
+  if (!condition) throw new CoparentConsentScenarioError(invariant);
+}
+
+function textsContainToken(texts: readonly string[], token: string): boolean {
+  return texts.some((text) => text.includes(token));
+}
+
+function safeStatusDetails(status: ConsentSnapshot): Record<string, unknown> {
+  return {
+    mode: status.mode,
+    gate: status.gate,
+    requiredPrincipalCount: status.requiredPrincipalCount,
+    registeredParticipantCount: status.registeredParticipantCount,
+    linkedParticipantCount: status.linkedParticipantCount,
+    consentedParticipantCount: status.consentedParticipantCount,
+    participants: status.participants,
+  };
+}
+
+/**
+ * Runs one fixed synthetic scenario and returns a stable JSON-serializable
+ * ledger. The supplied tokens are checked but never copied into the ledger,
+ * so evidence output cannot itself disclose connector handles.
+ */
+export async function runCoparentConsentScenario(
+  port: CoparentConsentScenarioPort,
+  forbiddenOutputTokens: readonly string[],
+): Promise<CoparentConsentScenarioLedger> {
+  const events: ScenarioLedgerEvent[] = [];
+  const assertions: Record<string, ScenarioLedgerAssertion> = {};
+  const outputTexts: string[] = [];
+
+  const event = (
+    phase: string,
+    actor: ScenarioActor,
+    channel: ScenarioChannel,
+    action: string,
+    outcome: string,
+    details: Record<string, unknown> = {},
+  ) => {
+    events.push({
+      sequence: events.length + 1,
+      phase,
+      actor,
+      channel,
+      action,
+      outcome,
+      details,
+    });
+  };
+  const pass = (name: string, evidence: Record<string, unknown>) => {
+    assertions[name] = { pass: true, evidence };
+  };
+
+  const binding = await port.bindAllAdults();
+  requireInvariant(
+    binding.status === "bound",
+    "all_adults owner claim must bind",
+  );
+  requireInvariant(
+    binding.conversationId.startsWith("group:"),
+    "binding must own one group room",
+  );
+  requireInvariant(
+    binding.consent.mode === "all_adults",
+    "binding mode must be all_adults",
+  );
+  requireInvariant(
+    binding.consent.requiredPrincipalCount === 2,
+    "all_adults binding must require exactly two principals",
+  );
+  requireInvariant(
+    binding.routeStages?.join(",") ===
+      "parent_a_dm_claim_issue,group_claim_consume",
+    "all_adults owner binding must traverse direct and group routes",
+  );
+  event("bind", "Parent A", "group", "bind_all_adults", binding.status, {
+    bindingId: binding.bindingId,
+    conversationId: binding.conversationId,
+    routeStages: binding.routeStages,
+    ...safeStatusDetails(binding.consent),
+  });
+  pass("one_all_adults_binding", {
+    bindingId: binding.bindingId,
+    conversationId: binding.conversationId,
+    routeStages: binding.routeStages,
+  });
+
+  const preConsent = await port.readConsent(binding.bindingId);
+  requireInvariant(
+    preConsent.gate === "restricted",
+    "owner-only all_adults binding must restrict",
+  );
+  requireInvariant(
+    preConsent.linkedParticipantCount === 1,
+    "owner must be the sole linked principal",
+  );
+  requireInvariant(
+    preConsent.consentedParticipantCount === 1,
+    "owner binding must record one explicit owner consent",
+  );
+  const preTurn = await port.capabilityTurn("pre_consent", binding.bindingId);
+  outputTexts.push(preTurn.reply);
+  requireInvariant(
+    !preTurn.capabilityExecuted,
+    "pre-consent turn must not execute a capability",
+  );
+  requireInvariant(
+    preTurn.mediaUrlCount === 1,
+    "pre-consent turn must carry one synthetic media URL",
+  );
+  requireInvariant(
+    !preTurn.mediaEnrichmentExecuted,
+    "pre-consent media must not enter enrichment",
+  );
+  requireInvariant(
+    !preTurn.runtimePrewarmExecuted,
+    "pre-consent media must not prewarm the runtime",
+  );
+  requireInvariant(
+    preTurn.roomId === binding.conversationId,
+    "restricted turn must remain in group room",
+  );
+  event("pre_consent", "Parent A", "group", "capability_turn", preTurn.code, {
+    capabilityExecuted: preTurn.capabilityExecuted,
+    mediaUrlCount: preTurn.mediaUrlCount,
+    mediaEnrichmentExecuted: preTurn.mediaEnrichmentExecuted,
+    runtimePrewarmExecuted: preTurn.runtimePrewarmExecuted,
+    roomId: preTurn.roomId,
+    consent: safeStatusDetails(preConsent),
+    reply: preTurn.reply,
+  });
+  pass("pre_consent_restricted", {
+    code: preTurn.code,
+    mediaUrlCount: 1,
+    mediaEnrichmentExecuted: false,
+    runtimePrewarmExecuted: false,
+    capabilityExecuted: false,
+  });
+
+  const attackVectors: JoinAttackVector[] = [
+    "forged",
+    "expired",
+    "replayed",
+    "wrong_sender",
+    "wrong_binding",
+    "cross_thread",
+  ];
+  for (const vector of attackVectors) {
+    const observed = await port.attackJoin(binding.bindingId, vector);
+    requireInvariant(
+      observed.vector === vector,
+      `${vector} observation must retain its vector`,
+    );
+    requireInvariant(!observed.accepted, `${vector} join must fail closed`);
+    if (vector === "cross_thread") {
+      requireInvariant(
+        observed.routeStages?.join(",") ===
+          "group_join_issue,parent_b_dm_authenticate",
+        "cross-thread probe must issue and authenticate through the route",
+      );
+      requireInvariant(
+        observed.scopeRejectionSeam === "repository",
+        "Blooio cross-thread mismatch must be injected at the repository seam",
+      );
+    }
+    event(
+      "join_adversarial",
+      "Child C",
+      "repository",
+      vector,
+      observed.status,
+      {
+        accepted: false,
+        ...(observed.routeStages ? { routeStages: observed.routeStages } : {}),
+        ...(observed.scopeRejectionSeam
+          ? { scopeRejectionSeam: observed.scopeRejectionSeam }
+          : {}),
+      },
+    );
+  }
+  pass("adversarial_joins_fail_closed", { vectors: attackVectors });
+
+  const joined = await port.consentParentB(binding.bindingId);
+  requireInvariant(
+    joined.status === "consented",
+    "Parent B join must end in explicit consent",
+  );
+  requireInvariant(
+    joined.routeStages.join(",") ===
+      "group_join_issue,parent_b_dm_authenticate,group_join_confirm",
+    "Parent B join handshake must traverse the real route at every stage",
+  );
+  requireInvariant(
+    joined.consent.gate === "enabled",
+    "two consents must activate all_adults",
+  );
+  requireInvariant(
+    joined.consent.linkedParticipantCount === 2,
+    "two principals must be linked",
+  );
+  requireInvariant(
+    joined.consent.consentedParticipantCount === 2,
+    "two principals must consent",
+  );
+  requireInvariant(
+    joined.consent.registeredParticipantCount === 3,
+    "the unlinked Child C speaker must remain diagnostic, not a principal",
+  );
+  requireInvariant(
+    new Set(joined.consent.linkedPrincipalIds).size === 2,
+    "linked principals must be distinct accounts",
+  );
+  requireInvariant(
+    new Set(joined.consent.consentProvenances).size === 2 &&
+      joined.consent.consentProvenances.includes("owner_binding") &&
+      joined.consent.consentProvenances.includes("authenticated_dm"),
+    "both principals must have explicit, distinct consent provenance",
+  );
+  event(
+    "consent",
+    "Parent B",
+    "group",
+    "authenticated_join_confirm",
+    joined.status,
+    {
+      ...safeStatusDetails(joined.consent),
+      distinctLinkedPrincipals: 2,
+      consentProvenances: ["owner_binding", "authenticated_dm"],
+      childSpeakerLinkedAsPrincipal: false,
+      routeStages: joined.routeStages,
+    },
+  );
+  pass("two_distinct_linked_principals", {
+    linkedParticipantCount: 2,
+    consentedParticipantCount: 2,
+    consentProvenances: ["owner_binding", "authenticated_dm"],
+    routeStages: joined.routeStages,
+  });
+  pass("child_speaker_not_consent_principal", {
+    registeredParticipantCount: 3,
+    linkedParticipantCount: 2,
+    gate: "enabled",
+  });
+
+  const postTurn = await port.capabilityTurn("post_consent", binding.bindingId);
+  outputTexts.push(postTurn.reply);
+  requireInvariant(
+    postTurn.capabilityExecuted,
+    "post-consent turn must execute a capability",
+  );
+  requireInvariant(
+    postTurn.roomId === binding.conversationId,
+    "active turn must use the shared room",
+  );
+  event("post_consent", "Parent B", "group", "capability_turn", postTurn.code, {
+    capabilityExecuted: true,
+    roomId: postTurn.roomId,
+    reply: postTurn.reply,
+  });
+  pass("post_consent_activation", {
+    code: postTurn.code,
+    capabilityExecuted: true,
+  });
+
+  const memory = await port.probeMemoryIsolation(binding);
+  const rooms = [
+    memory.groupRoomId,
+    memory.parentADmRoomId,
+    memory.parentBDmRoomId,
+  ];
+  requireInvariant(
+    new Set(rooms).size === 3,
+    "group and private DM rooms must be distinct",
+  );
+  requireInvariant(
+    memory.groupRoomId === binding.conversationId,
+    "memory group room must match binding",
+  );
+  requireInvariant(
+    textsContainToken(memory.groupRecall, memory.expectedGroupMarker),
+    "group recall must contain the shared marker",
+  );
+  requireInvariant(
+    !textsContainToken(memory.groupRecall, memory.expectedParentAMarker) &&
+      !textsContainToken(memory.groupRecall, memory.expectedParentBMarker),
+    "private markers must not enter group recall",
+  );
+  requireInvariant(
+    textsContainToken(memory.parentADmRecall, memory.expectedParentAMarker) &&
+      !textsContainToken(memory.parentADmRecall, memory.expectedGroupMarker) &&
+      !textsContainToken(memory.parentADmRecall, memory.expectedParentBMarker),
+    "Parent A DM recall must remain private",
+  );
+  requireInvariant(
+    textsContainToken(memory.parentBDmRecall, memory.expectedParentBMarker) &&
+      !textsContainToken(memory.parentBDmRecall, memory.expectedGroupMarker) &&
+      !textsContainToken(memory.parentBDmRecall, memory.expectedParentAMarker),
+    "Parent B DM recall must remain private",
+  );
+  event(
+    "memory",
+    "system",
+    "repository",
+    "bidirectional_recall_probe",
+    "isolated",
+    {
+      groupRoomId: memory.groupRoomId,
+      parentADmRoomId: memory.parentADmRoomId,
+      parentBDmRoomId: memory.parentBDmRoomId,
+      groupRecallCount: memory.groupRecall.length,
+      parentADmRecallCount: memory.parentADmRecall.length,
+      parentBDmRecallCount: memory.parentBDmRecall.length,
+    },
+  );
+  pass("three_compartments_isolated_bidirectionally", {
+    distinctRooms: 3,
+    groupRecallCount: memory.groupRecall.length,
+    parentADmRecallCount: memory.parentADmRecall.length,
+    parentBDmRecallCount: memory.parentBDmRecall.length,
+  });
+
+  const exactlyOnce = await port.deliverExactlyOnce(binding);
+  outputTexts.push(...exactlyOnce.replies);
+  requireInvariant(
+    exactlyOnce.inboundAttempts === 2,
+    "scenario must replay the inbound webhook once",
+  );
+  requireInvariant(
+    exactlyOnce.routeExecutions === 1,
+    "gateway must route a replay exactly once",
+  );
+  requireInvariant(
+    exactlyOnce.providerSends === 1,
+    "provider reply must send exactly once",
+  );
+  requireInvariant(
+    exactlyOnce.providerReceiptIds.length === 1,
+    "provider must return one authoritative receipt",
+  );
+  requireInvariant(
+    exactlyOnce.authoritativeReceiptRecorded,
+    "authoritative provider receipt must be persisted",
+  );
+  event(
+    "delivery",
+    "Eliza",
+    "group",
+    "inbound_replay_and_reply",
+    "exactly_once",
+    {
+      inboundAttempts: exactlyOnce.inboundAttempts,
+      routeExecutions: exactlyOnce.routeExecutions,
+      providerSends: exactlyOnce.providerSends,
+      providerReceiptCount: exactlyOnce.providerReceiptIds.length,
+      authoritativeReceiptRecorded: true,
+      replies: exactlyOnce.replies,
+    },
+  );
+  pass("exactly_once_with_authoritative_receipt", {
+    inboundAttempts: 2,
+    routeExecutions: 1,
+    providerSends: 1,
+    receiptCount: 1,
+  });
+
+  const left = await port.selfLeaveParentB(binding.bindingId);
+  outputTexts.push(left.reply);
+  requireInvariant(
+    left.parentBRevoked,
+    "Parent B self-leave must revoke Parent B",
+  );
+  requireInvariant(
+    left.ownerStillConsented,
+    "Parent B self-leave must preserve owner consent",
+  );
+  requireInvariant(
+    left.consent.gate === "restricted",
+    "self-leave must restrict the next turn",
+  );
+  requireInvariant(
+    left.consent.consentedParticipantCount === 1,
+    "one consent must remain after leave",
+  );
+  event("revocation", "Parent B", "group", "self_leave", left.status, {
+    ownerStillConsented: true,
+    parentBRevoked: true,
+    consent: safeStatusDetails(left.consent),
+    reply: left.reply,
+  });
+  const postLeaveTurn = await port.capabilityTurn(
+    "post_leave",
+    binding.bindingId,
+  );
+  outputTexts.push(postLeaveTurn.reply);
+  requireInvariant(
+    !postLeaveTurn.capabilityExecuted,
+    "first turn after Parent B leave must not execute a capability",
+  );
+  event(
+    "revocation",
+    "Parent A",
+    "group",
+    "next_capability_turn",
+    postLeaveTurn.code,
+    {
+      capabilityExecuted: false,
+      reply: postLeaveTurn.reply,
+    },
+  );
+  pass("parent_b_self_leave_is_scoped_and_immediate", {
+    ownerStillConsented: true,
+    parentBRevoked: true,
+    nextTurnCapabilityExecuted: false,
+  });
+
+  const singleOwner = await port.bindSingleOwner();
+  requireInvariant(
+    singleOwner.binding.consent.mode === "single_owner",
+    "omitted consent mode must preserve single_owner",
+  );
+  requireInvariant(
+    singleOwner.binding.consent.requiredPrincipalCount === 1 &&
+      singleOwner.binding.consent.gate === "enabled",
+    "single_owner must remain enabled with one principal",
+  );
+  requireInvariant(
+    singleOwner.turn.capabilityExecuted,
+    "unchanged single_owner path must execute a capability",
+  );
+  outputTexts.push(singleOwner.turn.reply);
+  event(
+    "regression",
+    "Parent A",
+    "group",
+    "single_owner_capability_turn",
+    singleOwner.turn.code,
+    {
+      mode: singleOwner.binding.consent.mode,
+      gate: singleOwner.binding.consent.gate,
+      capabilityExecuted: true,
+      reply: singleOwner.turn.reply,
+    },
+  );
+  pass("single_owner_unchanged", {
+    mode: "single_owner",
+    gate: "enabled",
+    capabilityExecuted: true,
+  });
+
+  for (const token of forbiddenOutputTokens) {
+    requireInvariant(
+      !outputTexts.some((text) => text.includes(token)),
+      "raw connector handles must not appear in any output",
+    );
+  }
+  pass("no_raw_handles_in_outputs", { checkedOutputs: outputTexts.length });
+
+  return {
+    schemaVersion: "coparent-consent-scenario/v1",
+    fixture: {
+      provider: "fake_blooio",
+      actors: ["Parent A", "Parent B", "Child C"],
+      containsRealUserData: false,
+    },
+    events,
+    assertions,
+    verdict: "PASS",
+  };
+}

--- a/packages/cloud/services/_common/src/telegram-connector.ts
+++ b/packages/cloud/services/_common/src/telegram-connector.ts
@@ -37,6 +37,7 @@ export interface TelegramConnectorEvent {
   groupActorRole?: "creator" | "administrator" | "member" | "unknown";
   membershipChange?: "joined" | "removed";
   replyToMessageId?: string;
+  providerThreadId?: string;
   providerSentAtMs?: number;
   voiceNote?: {
     fileId: string;
@@ -76,6 +77,7 @@ export interface TelegramResolvedVoiceNote {
 
 export interface TelegramMessage {
   message_id: number;
+  message_thread_id?: number;
   date?: number;
   from?: {
     id: number;
@@ -316,6 +318,17 @@ export function parseTelegramWebhook(
   const isGroup =
     message.chat.type === "group" || message.chat.type === "supergroup";
   if (!isPrivate && !isGroup) return null;
+  const providerThreadId =
+    message.message_thread_id === undefined
+      ? undefined
+      : Number.isSafeInteger(message.message_thread_id) &&
+          message.message_thread_id > 0
+        ? String(message.message_thread_id)
+        : null;
+  if (providerThreadId === null) {
+    logger?.warn("Rejected invalid Telegram message thread identifier");
+    return null;
+  }
   const text = message.text || message.caption || "";
   const voice = message.voice;
   if (!text && !voice) return null;
@@ -359,6 +372,7 @@ export function parseTelegramWebhook(
     ...(Number.isInteger(message.reply_to_message?.message_id)
       ? { replyToMessageId: String(message.reply_to_message?.message_id) }
       : {}),
+    ...(providerThreadId ? { providerThreadId } : {}),
     ...(typeof message.date === "number" &&
     Number.isInteger(message.date) &&
     message.date > 0
@@ -544,6 +558,21 @@ export function splitTelegramMessage(
   return chunks;
 }
 
+function telegramThreadParams(event: TelegramConnectorEvent): {
+  message_thread_id?: number;
+} {
+  const providerThreadId = event.providerThreadId;
+  if (providerThreadId === undefined) return {};
+  if (!/^[1-9]\d{0,15}$/.test(providerThreadId)) {
+    throw new TypeError("Invalid Telegram provider thread identifier");
+  }
+  const messageThreadId = Number(providerThreadId);
+  if (!Number.isSafeInteger(messageThreadId)) {
+    throw new TypeError("Invalid Telegram provider thread identifier");
+  }
+  return { message_thread_id: messageThreadId };
+}
+
 export async function sendTelegramReply(
   config: TelegramConnectorConfig,
   event: TelegramConnectorEvent,
@@ -554,6 +583,7 @@ export async function sendTelegramReply(
   if (!config.botToken) throw new Error("Missing botToken for Telegram reply");
   const providerMessageIds: string[] = [];
   const chunks = splitTelegramMessage(text);
+  const threadParams = telegramThreadParams(event);
   await deliveryHooks?.prepare(chunks);
   for (const [chunkIndex, chunk] of chunks.entries()) {
     let rejectionRetries = 0;
@@ -575,7 +605,12 @@ export async function sendTelegramReply(
           message = await telegramApi<TelegramMessage>(
             config.botToken,
             "sendMessage",
-            { chat_id: event.chatId, text: chunk, parse_mode: "Markdown" },
+            {
+              chat_id: event.chatId,
+              ...threadParams,
+              text: chunk,
+              parse_mode: "Markdown",
+            },
           );
         } catch (error) {
           // error-policy:J4 retry without formatting only for Telegram's exact parse rejection.
@@ -592,7 +627,7 @@ export async function sendTelegramReply(
           message = await telegramApi<TelegramMessage>(
             config.botToken,
             "sendMessage",
-            { chat_id: event.chatId, text: chunk },
+            { chat_id: event.chatId, ...threadParams, text: chunk },
           );
         }
         const providerMessageId = String(message.message_id);
@@ -635,6 +670,7 @@ export async function sendTelegramTyping(
   if (!config.botToken) throw new Error("Missing botToken for Telegram typing");
   await telegramApi(config.botToken, "sendChatAction", {
     chat_id: event.chatId,
+    ...telegramThreadParams(event),
     action: "typing",
   });
 }

--- a/packages/cloud/services/_common/tests/telegram-connector-groups.test.ts
+++ b/packages/cloud/services/_common/tests/telegram-connector-groups.test.ts
@@ -47,6 +47,24 @@ describe("parseTelegramWebhook group policy", () => {
     });
   });
 
+  test("normalizes a forum topic into the provider thread scope", () => {
+    expect(
+      parseTelegramWebhook(
+        update({ text: "ambient", message_thread_id: 909 }),
+        undefined,
+        { ...policy, allowAmbient: true },
+      ),
+    ).toMatchObject({ providerThreadId: "909" });
+
+    expect(
+      parseTelegramWebhook(
+        update({ text: "ambient", message_thread_id: -1 }),
+        undefined,
+        { ...policy, allowAmbient: true },
+      ),
+    ).toBeNull();
+  });
+
   test("rejects an explicit mention of a different bot", () => {
     expect(
       parseTelegramWebhook(

--- a/packages/cloud/services/gateway-webhook/__tests__/internal-delivery.group.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/internal-delivery.group.test.ts
@@ -154,6 +154,65 @@ describe("internal proactive group delivery", () => {
     ]);
   });
 
+  test("keeps a Telegram group reminder inside its forum topic", async () => {
+    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = "telegram-test-token";
+    const redis = new MemoryRedis();
+    const bodies: Array<Record<string, unknown>> = [];
+    globalThis.fetch = mock(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const outgoing = new Request(input, init);
+        expect(outgoing.url).toBe(
+          "https://api.telegram.org/bottelegram-test-token/sendMessage",
+        );
+        bodies.push((await outgoing.json()) as Record<string, unknown>);
+        return Response.json({ ok: true, result: { message_id: 72 } });
+      },
+    ) as typeof fetch;
+
+    const response = await deliverInternalMessage(
+      request({
+        platform: "telegram",
+        chatId: "-100123456789",
+        providerThreadId: "909",
+      }),
+      { redis },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      success: true,
+      providerMessageIds: ["72"],
+    });
+    expect(bodies).toEqual([
+      {
+        chat_id: "-100123456789",
+        message_thread_id: 909,
+        text: "Reminder for this group from Nubs: pay the rent",
+        parse_mode: "Markdown",
+      },
+    ]);
+  });
+
+  test("rejects invalid Telegram topic ids before egress", async () => {
+    const redis = new MemoryRedis();
+    globalThis.fetch = mock(async () => {
+      throw new Error("egress must not run");
+    }) as typeof fetch;
+
+    for (const providerThreadId of ["0", "0909", "topic", "9999999999999999"]) {
+      const response = await deliverInternalMessage(
+        request({
+          platform: "telegram",
+          chatId: "-100123456789",
+          providerThreadId,
+        }),
+        { redis },
+      );
+      expect(response.status).toBe(400);
+    }
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
   test("rejects malformed group recipients before egress", async () => {
     const redis = new MemoryRedis();
     globalThis.fetch = mock(async () => {
@@ -165,6 +224,7 @@ describe("internal proactive group delivery", () => {
       { chatId: "chat_" },
       { chatId: "chat_../escape" },
       { chatId: "+15551234567" },
+      { providerThreadId: "909" },
     ]) {
       const response = await deliverInternalMessage(request(overrides), {
         redis,

--- a/packages/cloud/services/gateway-webhook/__tests__/webhook-handler.groups-adversarial.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/webhook-handler.groups-adversarial.test.ts
@@ -166,12 +166,15 @@ class SharedLedgerMock {
   }
 }
 
-function turnResponse(reply: string): Response {
+function turnResponse(
+  reply: string,
+  authority: Record<string, unknown> = AUTHORITY,
+): Response {
   return Response.json({
     success: true,
     data: {
       reply,
-      groupDelivery: { kind: "binding", authority: AUTHORITY },
+      groupDelivery: { kind: "binding", authority },
     },
   });
 }
@@ -398,6 +401,7 @@ describe("gateway webhook group egress adversarial paths", () => {
       platformRecordId: "tg-group-message-1",
       chatId: "-100123456789",
       chatType: "supergroup",
+      providerThreadId: "909",
       senderId: "123456789",
       senderName: "Nubs",
       text: "@ElizaIsNotABot hello",
@@ -420,8 +424,14 @@ describe("gateway webhook group egress adversarial paths", () => {
     };
     const ledger = new SharedLedgerMock();
     let turnBody: Record<string, unknown> | null = null;
+    let authorizationBody: Record<string, unknown> | null = null;
+    let commitBody: Record<string, unknown> | null = null;
     let receiptBody: Record<string, unknown> | null = null;
     let turnCalls = 0;
+    const allAdultsAuthority = {
+      ...AUTHORITY,
+      requiresAllAdultsConsent: true,
+    };
 
     globalThis.fetch = mock(async (input, init) => {
       const request = new Request(input, init);
@@ -433,9 +443,11 @@ describe("gateway webhook group egress adversarial paths", () => {
       if (request.url.endsWith(SHARED_MESSAGES_PATH)) {
         const body = (await request.json()) as Record<string, unknown>;
         if (body.eventType === "delivery_authorization") {
+          authorizationBody = body;
           return ledger.authorize(body);
         }
         if (body.eventType === "delivery_commit") {
+          commitBody = body;
           return ledger.commit(body);
         }
         if (body.eventType === "delivery_receipt") {
@@ -451,7 +463,7 @@ describe("gateway webhook group egress adversarial paths", () => {
         }
         turnCalls += 1;
         turnBody = body;
-        return turnResponse("group turn reply");
+        return turnResponse("group turn reply", allAdultsAuthority);
       }
       throw new Error(`Unexpected fetch: ${request.url}`);
     }) as typeof fetch;
@@ -480,6 +492,7 @@ describe("gateway webhook group egress adversarial paths", () => {
       connectorAccountId:
         "bot:a7df583dbeed5b233d355143673e458bf882856d938ab4bd0fc7adfa4be6bf3c",
       chatId: "-100123456789",
+      providerThreadId: "909",
       actor: {
         platformUserId: "123456789",
         displayName: "Nubs",
@@ -502,9 +515,13 @@ describe("gateway webhook group egress adversarial paths", () => {
       chatId: "-100123456789",
       sourceMessageId: "telegram:eliza-app:tg-group-update-1",
       providerMessageIds: ["tg-provider-7"],
-      authority: AUTHORITY,
+      authority: allAdultsAuthority,
       leaseToken: ledger.leaseTokens[0],
     });
+    expect(authorizationBody).toMatchObject({
+      authority: allAdultsAuthority,
+    });
+    expect(commitBody).toMatchObject({ authority: allAdultsAuthority });
     expect(
       redis.store.get("webhook:telegram:scope:message:tg-group-update-1"),
     ).toBe("delivered");
@@ -516,5 +533,104 @@ describe("gateway webhook group egress adversarial paths", () => {
     expect(turnCalls).toBe(1);
     expect(ledger.authorizationCalls).toBe(1);
     expect(sendReplyWithReceipt).toHaveBeenCalledTimes(1);
+  });
+
+  test("rejects a non-boolean all-adults egress marker before provider delivery", async () => {
+    process.env.ELIZA_APP_BLOOIO_PHONE_NUMBER = "+15550000001";
+    const redis = new MemoryRedis();
+    const adapter = blooioGroupAdapter(
+      blooioGroupEvent("blooio-invalid-consent-marker"),
+    );
+    const errorLog = spyOn(logger, "error").mockImplementation(() => undefined);
+    let cloudRequests = 0;
+    globalThis.fetch = mock(async () => {
+      cloudRequests += 1;
+      return turnResponse("must not leave the gateway", {
+        ...AUTHORITY,
+        requiresAllAdultsConsent: "true",
+      });
+    }) as typeof fetch;
+
+    const response = await handleWebhook(
+      blooioRequest(),
+      adapter,
+      {
+        redis,
+        cloudBaseUrl: "https://api.elizacloud.ai",
+        getAuthHeader: () => ({ Authorization: "Bearer internal-secret" }),
+      },
+      "eliza-app",
+    );
+
+    expect(response.status).toBe(200);
+    await waitFor(
+      () =>
+        errorLog.mock.calls.some(
+          ([message]) => message === "Background message processing failed",
+        ),
+      "invalid consent marker rejection",
+    );
+    expect(cloudRequests).toBe(1);
+    expect(adapter.sendReplyWithReceipt).not.toHaveBeenCalled();
+  });
+
+  test("preserves a false all-adults marker through the complete delivery ledger", async () => {
+    process.env.ELIZA_APP_BLOOIO_PHONE_NUMBER = "+15550000001";
+    const redis = new MemoryRedis();
+    const adapter = blooioGroupAdapter(
+      blooioGroupEvent("blooio-false-consent-marker"),
+    );
+    const ledger = new SharedLedgerMock();
+    const authority = {
+      ...AUTHORITY,
+      requiresAllAdultsConsent: false,
+    };
+    let authorizationBody: Record<string, unknown> | null = null;
+    let commitBody: Record<string, unknown> | null = null;
+    let receiptBody: Record<string, unknown> | null = null;
+    globalThis.fetch = mock(async (input, init) => {
+      const request = new Request(input, init);
+      const body = (await request.json()) as Record<string, unknown>;
+      if (body.eventType === "delivery_authorization") {
+        authorizationBody = body;
+        return ledger.authorize(body);
+      }
+      if (body.eventType === "delivery_commit") {
+        commitBody = body;
+        return ledger.commit(body);
+      }
+      if (body.eventType === "delivery_receipt") {
+        receiptBody = body;
+        return Response.json({
+          success: true,
+          data: {
+            code: "group_delivery_receipt_recorded",
+            recorded: true,
+            inserted: 1,
+          },
+        });
+      }
+      return turnResponse("consent control reply", authority);
+    }) as typeof fetch;
+
+    const response = await handleWebhook(
+      blooioRequest(),
+      adapter,
+      {
+        redis,
+        cloudBaseUrl: "https://api.elizacloud.ai",
+        getAuthHeader: () => ({ Authorization: "Bearer internal-secret" }),
+      },
+      "eliza-app",
+    );
+
+    expect(response.status).toBe(200);
+    await waitFor(() => receiptBody !== null, "false-marker group receipt");
+    expect(
+      [authorizationBody, commitBody, receiptBody].map(
+        (body) => body?.authority,
+      ),
+    ).toEqual([authority, authority, authority]);
+    expect(adapter.sendReplyWithReceipt).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/cloud/services/gateway-webhook/src/adapters/telegram.test.ts
+++ b/packages/cloud/services/gateway-webhook/src/adapters/telegram.test.ts
@@ -53,6 +53,7 @@ function privateUpdate(overrides: Record<string, unknown> = {}): string {
 function groupUpdate(
   text: string,
   chatType: "group" | "supergroup" = "supergroup",
+  overrides: Record<string, unknown> = {},
 ): string {
   return JSON.stringify({
     update_id: 7001,
@@ -62,6 +63,7 @@ function groupUpdate(
       from: { id: 42, first_name: "Ada", is_bot: false },
       chat: { id: -100123456789, type: chatType },
       text,
+      ...overrides,
     },
   });
 }
@@ -298,6 +300,19 @@ describe("telegramAdapter.extractEvent", () => {
       groupInvocation: "ambient",
     });
     expect(event?.groupActorRole).toBeUndefined();
+  });
+
+  test("preserves a Telegram forum topic on the normalized event", async () => {
+    const event = await telegramAdapter.extractEvent(
+      groupUpdate("hello topic", "supergroup", { message_thread_id: 909 }),
+      { botUsername: "ElizaBot" },
+    );
+
+    expect(event).toMatchObject({
+      chatId: "-100123456789",
+      providerThreadId: "909",
+      groupInvocation: "ambient",
+    });
   });
 
   test("resolves bot identity through getMe for a group ambient message", async () => {
@@ -647,5 +662,32 @@ describe("telegramAdapter outbound delivery", () => {
 
     await telegramAdapter.sendTypingIndicator({ botToken }, telegramEvent);
     expect(body).toEqual({ chat_id: "42", action: "typing" });
+  });
+
+  test("keeps replies and typing inside the inbound forum topic", async () => {
+    const botToken = "9013:thread";
+    const bodies: unknown[] = [];
+    globalThis.fetch = mock(async (_input, init) => {
+      const request = new Request("https://unused", init);
+      const body = await request.json();
+      bodies.push(body);
+      return "text" in (body as Record<string, unknown>)
+        ? jsonOk({ message_id: 79 })
+        : jsonOk(true);
+    }) as unknown as typeof fetch;
+    const topicEvent = { ...telegramEvent, providerThreadId: "909" };
+
+    await telegramAdapter.sendReply({ botToken }, topicEvent, "hello topic");
+    await telegramAdapter.sendTypingIndicator({ botToken }, topicEvent);
+
+    expect(bodies).toEqual([
+      {
+        chat_id: "42",
+        message_thread_id: 909,
+        text: "hello topic",
+        parse_mode: "Markdown",
+      },
+      { chat_id: "42", message_thread_id: 909, action: "typing" },
+    ]);
   });
 });

--- a/packages/cloud/services/gateway-webhook/src/adapters/telegram.ts
+++ b/packages/cloud/services/gateway-webhook/src/adapters/telegram.ts
@@ -59,6 +59,7 @@ function asTelegramEvent(event: ChatEvent): TelegramConnectorEvent {
     groupActorRole: event.groupActorRole,
     membershipChange: event.membershipChange,
     replyToMessageId: event.replyToMessageId,
+    providerThreadId: event.providerThreadId,
     providerSentAtMs: event.providerSentAtMs,
     voiceNote: event.voiceNote,
     rawPayload: event.rawPayload,

--- a/packages/cloud/services/gateway-webhook/src/adapters/types.ts
+++ b/packages/cloud/services/gateway-webhook/src/adapters/types.ts
@@ -24,6 +24,8 @@ export interface ChatEvent {
   membershipChange?: "joined" | "removed";
   /** Provider message referenced by an inline reply, when exposed. */
   replyToMessageId?: string;
+  /** Provider-owned sub-thread or topic containing the inbound message. */
+  providerThreadId?: string;
   /** Provider-accepted message time, used only for coarse ingress latency. */
   providerSentAtMs?: number;
   mediaUrls?: string[];

--- a/packages/cloud/services/gateway-webhook/src/internal-delivery.ts
+++ b/packages/cloud/services/gateway-webhook/src/internal-delivery.ts
@@ -16,6 +16,7 @@ type InternalWebhookDelivery =
       platform: "telegram";
       project: string;
       chatId: string;
+      providerThreadId?: string;
       text: string;
       idempotencyKey: string;
     }
@@ -94,18 +95,26 @@ function parseDelivery(value: unknown): InternalWebhookDelivery | undefined {
   if (
     input.platform === "telegram" &&
     typeof input.chatId === "string" &&
-    /^-?\d{1,20}$/.test(input.chatId)
+    /^-?\d{1,20}$/.test(input.chatId) &&
+    (input.providerThreadId === undefined ||
+      (typeof input.providerThreadId === "string" &&
+        /^[1-9]\d{0,15}$/.test(input.providerThreadId) &&
+        Number.isSafeInteger(Number(input.providerThreadId))))
   ) {
     return {
       platform: "telegram",
       project: input.project,
       chatId: input.chatId,
+      ...(typeof input.providerThreadId === "string"
+        ? { providerThreadId: input.providerThreadId }
+        : {}),
       text: input.text.trim(),
       idempotencyKey: input.idempotencyKey,
     };
   }
   if (
     input.platform === "blooio" &&
+    input.providerThreadId === undefined &&
     typeof input.phoneNumber === "string" &&
     /^\+[1-9]\d{6,14}$/.test(input.phoneNumber)
   ) {
@@ -121,6 +130,7 @@ function parseDelivery(value: unknown): InternalWebhookDelivery | undefined {
   // sends it through `/v4/chats/{id}/messages` with no `to`/`from` pair.
   if (
     input.platform === "blooio" &&
+    input.providerThreadId === undefined &&
     typeof input.chatId === "string" &&
     /^chat_[A-Za-z0-9_-]{1,120}$/i.test(input.chatId)
   ) {
@@ -242,11 +252,17 @@ export async function deliverInternalMessage(
       messageId: delivery.idempotencyKey,
       chatId: recipientId,
       chatType:
-        delivery.platform === "blooio" && "chatId" in delivery
-          ? "group"
+        "chatId" in delivery &&
+        (delivery.platform === "blooio" || delivery.chatId.startsWith("-"))
+          ? delivery.platform === "telegram"
+            ? "supergroup"
+            : "group"
           : "private",
       senderId: recipientId,
       text: delivery.text,
+      ...(delivery.platform === "telegram" && delivery.providerThreadId
+        ? { providerThreadId: delivery.providerThreadId }
+        : {}),
       rawPayload: { source: "shared-reminder" },
     };
     const adapter =

--- a/packages/cloud/services/gateway-webhook/src/webhook-handler.ts
+++ b/packages/cloud/services/gateway-webhook/src/webhook-handler.ts
@@ -99,6 +99,7 @@ interface GroupDeliveryAuthority {
   ownerUserId: string;
   personalAgentId: string;
   version: number;
+  requiresAllAdultsConsent?: boolean;
 }
 
 type GroupDeliveryDirective =
@@ -126,13 +127,25 @@ function parseGroupDeliveryDirective(
     typeof candidate.personalAgentId !== "string" ||
     typeof candidate.version !== "number" ||
     !Number.isSafeInteger(candidate.version) ||
-    candidate.version <= 0
+    candidate.version <= 0 ||
+    (candidate.requiresAllAdultsConsent !== undefined &&
+      typeof candidate.requiresAllAdultsConsent !== "boolean")
   ) {
     return null;
   }
   return {
     kind: "binding",
-    authority: candidate as unknown as GroupDeliveryAuthority,
+    authority: {
+      bindingId: candidate.bindingId,
+      ownerUserId: candidate.ownerUserId,
+      personalAgentId: candidate.personalAgentId,
+      version: candidate.version,
+      ...(candidate.requiresAllAdultsConsent === undefined
+        ? {}
+        : {
+            requiresAllAdultsConsent: candidate.requiresAllAdultsConsent,
+          }),
+    },
   };
 }
 
@@ -1174,6 +1187,9 @@ async function sendPersonalSharedReply(
                 messageId: `${adapter.platform}:${project}:${event.messageId}`,
                 message: event.text,
                 invocation: groupInvocationForEvent(event),
+                ...(adapter.platform === "telegram" && event.providerThreadId
+                  ? { providerThreadId: event.providerThreadId }
+                  : {}),
                 ...(event.replyToMessageId
                   ? { replyToMessageId: event.replyToMessageId }
                   : {}),

--- a/packages/cloud/shared/src/db/index.ts
+++ b/packages/cloud/shared/src/db/index.ts
@@ -1,6 +1,10 @@
 // Coordinates cloud DB index behavior shared by repositories and services.
 export { userCharactersRepository } from "./repositories/characters";
 export { dockerNodesRepository } from "./repositories/docker-nodes";
+export {
+  PersonalSharedGroupConsentRepository,
+  personalSharedGroupConsentRepository,
+} from "./repositories/personal-shared-group-consent";
 export { personalSharedGroupsRepository } from "./repositories/personal-shared-groups";
 export { voiceImprintsRepository } from "./repositories/voice-imprints";
 export type { DockerNode } from "./schemas/docker-nodes";

--- a/packages/cloud/shared/src/db/migrations/0320_personal_shared_multi_principal_consent.sql
+++ b/packages/cloud/shared/src/db/migrations/0320_personal_shared_multi_principal_consent.sql
@@ -1,0 +1,77 @@
+-- Additive authority for independently authenticated principals in Personal Shared groups.
+-- Existing bindings remain byte-compatible through the single_owner / one-principal defaults.
+
+ALTER TABLE personal_shared_group_claims
+  ADD COLUMN consent_mode text NOT NULL DEFAULT 'single_owner',
+  ADD COLUMN required_principal_count integer NOT NULL DEFAULT 1,
+  ADD CONSTRAINT personal_shared_group_claims_consent_config_check CHECK (
+    (consent_mode = 'single_owner' AND required_principal_count = 1)
+    OR (consent_mode = 'all_adults' AND required_principal_count BETWEEN 2 AND 32)
+  );
+
+ALTER TABLE personal_shared_group_bindings
+  ADD COLUMN consent_mode text NOT NULL DEFAULT 'single_owner',
+  ADD COLUMN required_principal_count integer NOT NULL DEFAULT 1,
+  ADD COLUMN consent_version bigint NOT NULL DEFAULT 1,
+  ADD CONSTRAINT personal_shared_group_bindings_consent_config_check CHECK (
+    (consent_mode = 'single_owner' AND required_principal_count = 1)
+    OR (consent_mode = 'all_adults' AND required_principal_count BETWEEN 2 AND 32)
+  );
+
+ALTER TABLE personal_shared_group_participants
+  ADD COLUMN linked_user_id uuid REFERENCES users(id),
+  ADD COLUMN consented_at timestamptz,
+  ADD COLUMN consent_provenance text,
+  ADD COLUMN revoked_at timestamptz,
+  ADD CONSTRAINT personal_shared_group_participants_consent_provenance_check CHECK (
+    consent_provenance IS NULL
+    OR consent_provenance IN ('owner_binding', 'authenticated_dm')
+  ),
+  ADD CONSTRAINT personal_shared_group_participants_consent_shape_check CHECK (
+    (linked_user_id IS NULL AND consented_at IS NULL AND consent_provenance IS NULL)
+    OR (linked_user_id IS NOT NULL AND consented_at IS NOT NULL AND consent_provenance IS NOT NULL)
+  );
+
+CREATE UNIQUE INDEX personal_shared_group_participants_linked_user_uidx
+  ON personal_shared_group_participants (binding_id, linked_user_id);
+CREATE INDEX personal_shared_group_participants_linked_user_idx
+  ON personal_shared_group_participants (linked_user_id);
+
+CREATE TABLE personal_shared_group_join_challenges (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  code_hash text NOT NULL UNIQUE,
+  stage text NOT NULL CHECK (stage IN ('authenticate', 'confirm')),
+  binding_id uuid NOT NULL REFERENCES personal_shared_group_bindings(id) ON DELETE CASCADE,
+  consent_version bigint NOT NULL,
+  platform text NOT NULL CHECK (platform IN ('telegram', 'blooio')),
+  project text NOT NULL,
+  connector_account_id text NOT NULL,
+  provider_chat_id text NOT NULL,
+  provider_thread_id text NOT NULL DEFAULT '',
+  issued_to_platform_user_id text NOT NULL,
+  source_message_id text NOT NULL,
+  linked_user_id uuid REFERENCES users(id) ON DELETE CASCADE,
+  expires_at timestamptz NOT NULL,
+  consumed_at timestamptz,
+  consumed_by_source_message_id text,
+  superseded_at timestamptz,
+  superseded_by_source_message_id text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT personal_shared_group_join_challenges_linked_user_stage_check CHECK (
+    (stage = 'authenticate' AND linked_user_id IS NULL)
+    OR (stage = 'confirm' AND linked_user_id IS NOT NULL)
+  ),
+  CONSTRAINT personal_shared_group_join_challenges_superseded_source_check CHECK (
+    (superseded_at IS NULL) = (superseded_by_source_message_id IS NULL)
+  )
+);
+
+CREATE INDEX personal_shared_group_join_challenges_binding_stage_idx
+  ON personal_shared_group_join_challenges (binding_id, stage);
+CREATE INDEX personal_shared_group_join_challenges_expires_idx
+  ON personal_shared_group_join_challenges (expires_at);
+CREATE INDEX personal_shared_group_join_challenges_linked_user_idx
+  ON personal_shared_group_join_challenges (linked_user_id);
+CREATE UNIQUE INDEX personal_shared_group_join_challenges_source_uidx
+  ON personal_shared_group_join_challenges
+  (binding_id, stage, issued_to_platform_user_id, source_message_id);

--- a/packages/cloud/shared/src/db/migrations/0320_personal_shared_multi_principal_consent.sql
+++ b/packages/cloud/shared/src/db/migrations/0320_personal_shared_multi_principal_consent.sql
@@ -29,7 +29,12 @@ ALTER TABLE personal_shared_group_participants
   ),
   ADD CONSTRAINT personal_shared_group_participants_consent_shape_check CHECK (
     (linked_user_id IS NULL AND consented_at IS NULL AND consent_provenance IS NULL)
-    OR (linked_user_id IS NOT NULL AND consented_at IS NOT NULL AND consent_provenance IS NOT NULL)
+    OR (
+      linked_user_id IS NOT NULL
+      AND consented_at IS NOT NULL
+      AND consent_provenance IS NOT NULL
+      AND revoked_at IS NULL
+    )
   );
 
 CREATE UNIQUE INDEX personal_shared_group_participants_linked_user_uidx

--- a/packages/cloud/shared/src/db/migrations/meta/_journal.json
+++ b/packages/cloud/shared/src/db/migrations/meta/_journal.json
@@ -2122,6 +2122,13 @@
       "when": 1794254400010,
       "tag": "0319_personal_dedicated_upgrade_authorities",
       "breakpoints": true
+    },
+    {
+      "idx": 303,
+      "version": "7",
+      "when": 1794254400011,
+      "tag": "0320_personal_shared_multi_principal_consent",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/cloud/shared/src/db/migrations/personal-shared-multi-principal-consent.test.ts
+++ b/packages/cloud/shared/src/db/migrations/personal-shared-multi-principal-consent.test.ts
@@ -125,6 +125,14 @@ describe("0320 Personal Shared multi-principal consent", () => {
     );
     await expect(
       db.query(
+        `UPDATE personal_shared_group_participants
+            SET revoked_at = now()
+          WHERE binding_id = $1`,
+        [BINDING],
+      ),
+    ).rejects.toThrow();
+    await expect(
+      db.query(
         `INSERT INTO personal_shared_group_participants
            (binding_id, platform_user_id, ordinal, linked_user_id, consented_at,
             consent_provenance)
@@ -138,6 +146,33 @@ describe("0320 Personal Shared multi-principal consent", () => {
       [BINDING],
     );
     expect(retained.rows).toEqual([{ linked_user_id: OWNER }]);
+
+    await db.query(
+      `UPDATE personal_shared_group_participants
+          SET linked_user_id = NULL,
+              consented_at = NULL,
+              consent_provenance = NULL,
+              revoked_at = now()
+        WHERE binding_id = $1`,
+      [BINDING],
+    );
+    const tombstone = await db.query<{
+      linked_user_id: string | null;
+      consented_at: Date | null;
+      consent_provenance: string | null;
+      revoked_at: Date | null;
+    }>(
+      "SELECT linked_user_id, consented_at, consent_provenance, revoked_at FROM personal_shared_group_participants WHERE binding_id = $1",
+      [BINDING],
+    );
+    expect(tombstone.rows).toEqual([
+      {
+        linked_user_id: null,
+        consented_at: null,
+        consent_provenance: null,
+        revoked_at: expect.any(Date),
+      },
+    ]);
   });
 
   test("binds challenge stage to its linked-account shape and cascades authority rows", async () => {

--- a/packages/cloud/shared/src/db/migrations/personal-shared-multi-principal-consent.test.ts
+++ b/packages/cloud/shared/src/db/migrations/personal-shared-multi-principal-consent.test.ts
@@ -1,0 +1,199 @@
+/** Proves the additive Personal Shared consent migration on real PGlite. */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { PGlite } from "@electric-sql/pglite";
+
+const bindingsMigration = await Bun.file(
+  new URL("./0297_personal_shared_group_bindings.sql", import.meta.url),
+).text();
+const participantsMigration = await Bun.file(
+  new URL("./0311_personal_shared_group_participants.sql", import.meta.url),
+).text();
+const consentMigration = await Bun.file(
+  new URL("./0320_personal_shared_multi_principal_consent.sql", import.meta.url),
+).text();
+
+const databases: PGlite[] = [];
+const ORG = "a1000000-0000-4000-8000-000000000001";
+const OWNER = "a1000000-0000-4000-8000-000000000011";
+const JOINER = "a1000000-0000-4000-8000-000000000012";
+const BINDING = "a1000000-0000-4000-8000-000000000021";
+
+async function legacyDatabase(): Promise<PGlite> {
+  const db = new PGlite();
+  databases.push(db);
+  await db.exec(`
+    CREATE TABLE organizations (id uuid PRIMARY KEY);
+    CREATE TABLE users (id uuid PRIMARY KEY);
+    INSERT INTO organizations (id) VALUES ('${ORG}');
+    INSERT INTO users (id) VALUES ('${OWNER}'), ('${JOINER}');
+  `);
+  await db.exec(bindingsMigration);
+  await db.exec(participantsMigration);
+  await db.query(
+    `INSERT INTO personal_shared_group_claims
+       (code_hash, organization_id, owner_user_id, personal_agent_id, platform,
+        project, connector_account_id, issued_to_platform_user_id, expires_at)
+     VALUES ('legacy-claim', $1, $2, 'personal:parent-a', 'blooio', 'eliza-app',
+       'synthetic-connector', 'synthetic-parent-a', now() + interval '1 hour')`,
+    [ORG, OWNER],
+  );
+  await db.query(
+    `INSERT INTO personal_shared_group_bindings
+       (id, organization_id, owner_user_id, personal_agent_id, platform, project,
+        connector_account_id, provider_chat_id, conversation_id,
+        created_by_platform_user_id)
+     VALUES ($1, $2, $3, 'personal:parent-a', 'blooio', 'eliza-app',
+       'synthetic-connector', 'synthetic-family-group', 'group:synthetic-family',
+       'synthetic-parent-a')`,
+    [BINDING, ORG, OWNER],
+  );
+  await db.query(
+    `INSERT INTO personal_shared_group_participants
+       (binding_id, platform_user_id, ordinal)
+     VALUES ($1, 'synthetic-parent-a', 1)`,
+    [BINDING],
+  );
+  await db.exec(consentMigration);
+  return db;
+}
+
+afterEach(async () => {
+  await Promise.all(databases.splice(0).map((db) => db.close()));
+});
+
+describe("0320 Personal Shared multi-principal consent", () => {
+  test("preserves legacy rows as single-owner with nullable participant consent", async () => {
+    const db = await legacyDatabase();
+    const claims = await db.query<{
+      consent_mode: string;
+      required_principal_count: number;
+    }>("SELECT consent_mode, required_principal_count FROM personal_shared_group_claims");
+    expect(claims.rows).toEqual([{ consent_mode: "single_owner", required_principal_count: 1 }]);
+    const bindings = await db.query<{
+      consent_mode: string;
+      required_principal_count: number;
+      consent_version: string;
+    }>(
+      "SELECT consent_mode, required_principal_count, consent_version::text AS consent_version FROM personal_shared_group_bindings",
+    );
+    expect(bindings.rows).toEqual([
+      {
+        consent_mode: "single_owner",
+        required_principal_count: 1,
+        consent_version: "1",
+      },
+    ]);
+    const participants = await db.query<{
+      linked_user_id: string | null;
+      consented_at: Date | null;
+      consent_provenance: string | null;
+      revoked_at: Date | null;
+    }>(
+      "SELECT linked_user_id, consented_at, consent_provenance, revoked_at FROM personal_shared_group_participants",
+    );
+    expect(participants.rows).toEqual([
+      {
+        linked_user_id: null,
+        consented_at: null,
+        consent_provenance: null,
+        revoked_at: null,
+      },
+    ]);
+  });
+
+  test("enforces consent configuration, complete participant links, and one account per binding", async () => {
+    const db = await legacyDatabase();
+    await expect(
+      db.query(
+        "UPDATE personal_shared_group_bindings SET consent_mode = 'all_adults' WHERE id = $1",
+        [BINDING],
+      ),
+    ).rejects.toThrow();
+    await expect(
+      db.query(
+        "UPDATE personal_shared_group_participants SET linked_user_id = $1 WHERE binding_id = $2",
+        [OWNER, BINDING],
+      ),
+    ).rejects.toThrow();
+
+    await db.query(
+      `UPDATE personal_shared_group_participants
+          SET linked_user_id = $1, consented_at = now(), consent_provenance = 'owner_binding'
+        WHERE binding_id = $2`,
+      [OWNER, BINDING],
+    );
+    await expect(
+      db.query(
+        `INSERT INTO personal_shared_group_participants
+           (binding_id, platform_user_id, ordinal, linked_user_id, consented_at,
+            consent_provenance)
+         VALUES ($1, 'synthetic-duplicate-owner', 2, $2, now(), 'authenticated_dm')`,
+        [BINDING, OWNER],
+      ),
+    ).rejects.toThrow();
+    await expect(db.query("DELETE FROM users WHERE id = $1", [OWNER])).rejects.toThrow();
+    const retained = await db.query<{ linked_user_id: string }>(
+      "SELECT linked_user_id FROM personal_shared_group_participants WHERE binding_id = $1",
+      [BINDING],
+    );
+    expect(retained.rows).toEqual([{ linked_user_id: OWNER }]);
+  });
+
+  test("binds challenge stage to its linked-account shape and cascades authority rows", async () => {
+    const db = await legacyDatabase();
+    await expect(
+      db.query(
+        `INSERT INTO personal_shared_group_join_challenges
+           (code_hash, stage, binding_id, consent_version, platform, project,
+            connector_account_id, provider_chat_id, issued_to_platform_user_id,
+            source_message_id, expires_at, superseded_at)
+         VALUES ('bad-supersession-shape', 'authenticate', $1, 1, 'blooio', 'eliza-app',
+           'synthetic-connector', 'synthetic-family-group', 'synthetic-parent-b',
+           'bad-supersession-source', now() + interval '1 minute', now())`,
+        [BINDING],
+      ),
+    ).rejects.toThrow();
+    await expect(
+      db.query(
+        `INSERT INTO personal_shared_group_join_challenges
+           (code_hash, stage, binding_id, consent_version, platform, project,
+            connector_account_id, provider_chat_id, issued_to_platform_user_id,
+            source_message_id, linked_user_id, expires_at)
+         VALUES ('bad-auth-shape', 'authenticate', $1, 1, 'blooio', 'eliza-app',
+           'synthetic-connector', 'synthetic-family-group', 'synthetic-parent-b',
+           'bad-auth-source', $2, now() + interval '1 minute')`,
+        [BINDING, JOINER],
+      ),
+    ).rejects.toThrow();
+    await db.query(
+      `INSERT INTO personal_shared_group_join_challenges
+          (code_hash, stage, binding_id, consent_version, platform, project,
+           connector_account_id, provider_chat_id, issued_to_platform_user_id,
+          source_message_id, linked_user_id, expires_at)
+       VALUES ('confirm-shape', 'confirm', $1, 1, 'blooio', 'eliza-app',
+         'synthetic-connector', 'synthetic-family-group', 'synthetic-parent-b',
+         'confirm-source', $2, now() + interval '1 minute')`,
+      [BINDING, JOINER],
+    );
+    await db.query("DELETE FROM users WHERE id = $1", [JOINER]);
+    const remaining = await db.query<{ count: string }>(
+      "SELECT count(*)::text AS count FROM personal_shared_group_join_challenges",
+    );
+    expect(remaining.rows[0]?.count).toBe("0");
+    const linkedUserIndexes = await db.query<{ indexname: string }>(
+      `SELECT indexname FROM pg_indexes
+       WHERE indexname IN (
+         'personal_shared_group_join_challenges_linked_user_idx',
+         'personal_shared_group_join_challenges_source_uidx',
+         'personal_shared_group_participants_linked_user_idx'
+       )
+       ORDER BY indexname`,
+    );
+    expect(linkedUserIndexes.rows).toEqual([
+      { indexname: "personal_shared_group_join_challenges_linked_user_idx" },
+      { indexname: "personal_shared_group_join_challenges_source_uidx" },
+      { indexname: "personal_shared_group_participants_linked_user_idx" },
+    ]);
+  });
+});

--- a/packages/cloud/shared/src/db/repositories/__tests__/users-link-telegram-phone.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/users-link-telegram-phone.test.ts
@@ -28,6 +28,11 @@ import { eq } from "drizzle-orm";
 import { isUniqueConstraintError } from "../../../lib/utils/db-errors";
 import { closeDatabaseConnectionsForTests, dbWrite } from "../../client";
 import { organizations } from "../../schemas/organizations";
+import {
+  personalSharedGroupBindings,
+  personalSharedGroupJoinChallenges,
+  personalSharedGroupParticipants,
+} from "../../schemas/personal-shared-groups";
 import { userIdentities } from "../../schemas/user-identities";
 import { users } from "../../schemas/users";
 import { usersRepository } from "../users";
@@ -77,7 +82,14 @@ describe("UsersRepository.linkTelegramAndPhoneIdentity (real PGlite)", () => {
       return;
     }
     try {
-      const schema = { organizations, users, userIdentities };
+      const schema = {
+        organizations,
+        users,
+        userIdentities,
+        personalSharedGroupBindings,
+        personalSharedGroupParticipants,
+        personalSharedGroupJoinChallenges,
+      };
       const { apply } = await pushSchema(schema as never, dbWrite as never);
       await apply();
     } catch (error) {

--- a/packages/cloud/shared/src/db/repositories/__tests__/users-promote-phone-personal-account.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/users-promote-phone-personal-account.test.ts
@@ -18,6 +18,11 @@ import { pushSchema } from "drizzle-kit/api";
 import { eq } from "drizzle-orm";
 import { closeDatabaseConnectionsForTests, dbWrite } from "../../client";
 import { organizationBalanceRevisionSequence, organizations } from "../../schemas/organizations";
+import {
+  personalSharedGroupBindings,
+  personalSharedGroupJoinChallenges,
+  personalSharedGroupParticipants,
+} from "../../schemas/personal-shared-groups";
 import { userIdentities } from "../../schemas/user-identities";
 import { users } from "../../schemas/users";
 import { usersRepository } from "../users";
@@ -107,6 +112,9 @@ describe("UsersRepository phone identity transactions (real PGlite)", () => {
           organizations,
           users,
           userIdentities,
+          personalSharedGroupBindings,
+          personalSharedGroupParticipants,
+          personalSharedGroupJoinChallenges,
         } as never,
         dbWrite as never,
       );

--- a/packages/cloud/shared/src/db/repositories/personal-shared-group-consent-lifecycle.ts
+++ b/packages/cloud/shared/src/db/repositories/personal-shared-group-consent-lifecycle.ts
@@ -1,0 +1,127 @@
+/** Account-lifecycle fencing for Personal Shared participant consent. */
+import { ElizaError } from "@elizaos/core";
+import { and, eq, inArray, isNull, sql } from "drizzle-orm";
+import type { DbTransaction } from "../client";
+import {
+  personalSharedGroupBindings,
+  personalSharedGroupJoinChallenges,
+  personalSharedGroupParticipants,
+} from "../schemas/personal-shared-groups";
+import { users } from "../schemas/users";
+
+/**
+ * Revokes every consent authority tied to one user inside the caller's user
+ * mutation transaction. User-associated consent paths all take the durable
+ * account lock before binding -> challenge -> participant authority, so an
+ * account mutation cannot miss a concurrent confirmation and later resurrect
+ * it. A live uncommitted provider lease fails closed and leaves the entire
+ * account mutation retryable.
+ */
+export async function revokePersonalSharedGroupConsentForUser(
+  tx: DbTransaction,
+  linkedUserId: string,
+  now: Date,
+): Promise<{ revokedBindings: number; consumedChallenges: number }> {
+  const [linkedUser] = await tx
+    .select({ id: users.id })
+    .from(users)
+    .where(eq(users.id, linkedUserId))
+    .limit(1)
+    .for("update");
+  if (!linkedUser) return { revokedBindings: 0, consumedChallenges: 0 };
+
+  const participantBindings = await tx
+    .select({ id: personalSharedGroupParticipants.binding_id })
+    .from(personalSharedGroupParticipants)
+    .where(eq(personalSharedGroupParticipants.linked_user_id, linkedUserId));
+  const challengeBindings = await tx
+    .select({ id: personalSharedGroupJoinChallenges.binding_id })
+    .from(personalSharedGroupJoinChallenges)
+    .where(
+      and(
+        eq(personalSharedGroupJoinChallenges.linked_user_id, linkedUserId),
+        isNull(personalSharedGroupJoinChallenges.consumed_at),
+      ),
+    );
+  const candidateBindingIds = [
+    ...new Set([...participantBindings, ...challengeBindings].map(({ id }) => id)),
+  ].sort();
+
+  const bindings =
+    candidateBindingIds.length === 0
+      ? []
+      : await tx
+          .select({
+            id: personalSharedGroupBindings.id,
+            leaseCommittedAt: personalSharedGroupBindings.delivery_lease_committed_at,
+            leaseExpiresAt: personalSharedGroupBindings.delivery_lease_expires_at,
+          })
+          .from(personalSharedGroupBindings)
+          .where(inArray(personalSharedGroupBindings.id, candidateBindingIds))
+          .orderBy(personalSharedGroupBindings.id)
+          .for("update");
+
+  const challenges = await tx
+    .select({ id: personalSharedGroupJoinChallenges.id })
+    .from(personalSharedGroupJoinChallenges)
+    .where(
+      and(
+        eq(personalSharedGroupJoinChallenges.linked_user_id, linkedUserId),
+        isNull(personalSharedGroupJoinChallenges.consumed_at),
+      ),
+    )
+    .orderBy(personalSharedGroupJoinChallenges.id)
+    .for("update");
+
+  if (
+    bindings.some(
+      (binding) =>
+        binding.leaseCommittedAt === null &&
+        binding.leaseExpiresAt !== null &&
+        binding.leaseExpiresAt > now,
+    )
+  ) {
+    throw new ElizaError("A live group delivery reservation is still pending", {
+      code: "PERSONAL_SHARED_GROUP_DELIVERY_PENDING",
+      severity: "fatal",
+    });
+  }
+
+  const bindingIds = bindings.map((binding) => binding.id);
+  if (bindingIds.length > 0) {
+    await tx
+      .update(personalSharedGroupBindings)
+      .set({
+        authority_version: sql`${personalSharedGroupBindings.authority_version} + 1`,
+        consent_version: sql`${personalSharedGroupBindings.consent_version} + 1`,
+        updated_at: now,
+      })
+      .where(inArray(personalSharedGroupBindings.id, bindingIds));
+    await tx
+      .update(personalSharedGroupParticipants)
+      .set({
+        linked_user_id: null,
+        consented_at: null,
+        consent_provenance: null,
+        revoked_at: now,
+      })
+      .where(eq(personalSharedGroupParticipants.linked_user_id, linkedUserId));
+  }
+
+  if (challenges.length > 0) {
+    await tx
+      .update(personalSharedGroupJoinChallenges)
+      .set({ consumed_at: now })
+      .where(
+        inArray(
+          personalSharedGroupJoinChallenges.id,
+          challenges.map(({ id }) => id),
+        ),
+      );
+  }
+
+  return {
+    revokedBindings: bindingIds.length,
+    consumedChallenges: challenges.length,
+  };
+}

--- a/packages/cloud/shared/src/db/repositories/personal-shared-group-consent.integration.test.ts
+++ b/packages/cloud/shared/src/db/repositories/personal-shared-group-consent.integration.test.ts
@@ -1,0 +1,1876 @@
+/** Focused multi-principal consent authority tests on isolated PGlite. */
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
+process.env.NODE_ENV ||= "test";
+
+import { pushSchema } from "drizzle-kit/api";
+import { asc, eq } from "drizzle-orm";
+import { closeDatabaseConnectionsForTests, dbWrite } from "../client";
+import { organizationBalanceRevisionSequence, organizations } from "../schemas/organizations";
+import {
+  personalSharedGroupBindings,
+  personalSharedGroupClaims,
+  personalSharedGroupDeliveryAttempts,
+  personalSharedGroupDeliveryReceipts,
+  personalSharedGroupJoinChallenges,
+  personalSharedGroupParticipants,
+} from "../schemas/personal-shared-groups";
+import { users } from "../schemas/users";
+import { personalSharedGroupConsentRepository } from "./personal-shared-group-consent";
+import { personalSharedGroupParticipantsRepository } from "./personal-shared-group-participants";
+import { personalSharedGroupsRepository } from "./personal-shared-groups";
+import { usersRepository } from "./users";
+
+const OWNER_ORG = "76000000-0000-4000-8000-000000000001";
+const JOINER_ORG = "76000000-0000-4000-8000-000000000002";
+const OWNER_USER = "76000000-0000-4000-8000-000000000011";
+const JOINER_USER = "76000000-0000-4000-8000-000000000012";
+const ADDITIONAL_NON_OWNER_USER = "76000000-0000-4000-8000-000000000013";
+const OWNER_HANDLE = "+15550100001";
+const JOINER_HANDLE = "+15550100002";
+const CHILD_HANDLE = "+15550100003";
+const ADDITIONAL_NON_OWNER_HANDLE = "+15550100004";
+const CONNECTOR = "blooio:+15550100999";
+const CHAT = "synthetic-family-group";
+const AUTH_HASH = "a".repeat(64);
+const CONFIRM_HASH = "b".repeat(64);
+const PGLITE_TIMEOUT_MS = 60_000;
+let ownerClaimSequence = 0;
+let deliverySequence = 0;
+
+async function settleWithin<T>(promise: Promise<T>, label: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(`${label} did not settle`)), 5_000);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+async function seedAccounts(): Promise<void> {
+  await dbWrite.insert(organizations).values([
+    { id: OWNER_ORG, name: "Parent A", slug: "consent-parent-a" },
+    { id: JOINER_ORG, name: "Parent B", slug: "consent-parent-b" },
+  ]);
+  await dbWrite.insert(users).values([
+    {
+      id: OWNER_USER,
+      organization_id: OWNER_ORG,
+      steward_user_id: "steward-parent-a",
+      phone_number: OWNER_HANDLE,
+      phone_verified: true,
+      role: "owner",
+    },
+    {
+      id: JOINER_USER,
+      organization_id: JOINER_ORG,
+      // A provider-attested first contact is not independently authenticated.
+      steward_user_id: `phone:${JOINER_HANDLE}`,
+      phone_number: JOINER_HANDLE,
+      phone_verified: true,
+      role: "owner",
+    },
+  ]);
+}
+
+async function bind(input?: {
+  consentMode?: "single_owner" | "all_adults";
+  requiredPrincipalCount?: number;
+  chatId?: string;
+}) {
+  const chatId = input?.chatId ?? CHAT;
+  const codeHash = `owner-claim-${chatId}-${++ownerClaimSequence}`;
+  await personalSharedGroupsRepository.issueClaim({
+    codeHash,
+    organizationId: OWNER_ORG,
+    ownerUserId: OWNER_USER,
+    personalAgentId: "personal:parent-a",
+    platform: "blooio",
+    project: "eliza-app",
+    connectorAccountId: CONNECTOR,
+    issuedToPlatformUserId: OWNER_HANDLE,
+    consentMode: input?.consentMode,
+    requiredPrincipalCount: input?.requiredPrincipalCount,
+    expiresAt: new Date(Date.now() + 60_000),
+  });
+  const result = await personalSharedGroupsRepository.consumeClaimAndBind({
+    codeHash,
+    platform: "blooio",
+    project: "eliza-app",
+    connectorAccountId: CONNECTOR,
+    providerChatId: chatId,
+    actorPlatformUserId: OWNER_HANDLE,
+  });
+  if (result.status !== "bound") throw new Error(`binding failed: ${result.status}`);
+  return result.binding;
+}
+
+async function register(bindingId: string, platformUserId: string): Promise<void> {
+  await personalSharedGroupParticipantsRepository.recordTurn({ bindingId, platformUserId });
+}
+
+async function issueAuthenticate(
+  bindingId: string,
+  codeHash = AUTH_HASH,
+  options?: {
+    actorPlatformUserId?: string;
+    sourceMessageId?: string;
+    expiresAt?: Date;
+  },
+) {
+  return personalSharedGroupConsentRepository.issueJoinAuthenticateChallenge({
+    codeHash,
+    ...(options?.sourceMessageId ? { sourceMessageId: options.sourceMessageId } : {}),
+    bindingId,
+    platform: "blooio",
+    project: "eliza-app",
+    connectorAccountId: CONNECTOR,
+    providerChatId: CHAT,
+    providerThreadId: null,
+    actorPlatformUserId: options?.actorPlatformUserId ?? JOINER_HANDLE,
+    expiresAt: options?.expiresAt ?? new Date(Date.now() + 60_000),
+  });
+}
+
+function deliveryFor(
+  binding: Awaited<ReturnType<typeof bind>>,
+  requiresAllAdultsConsent?: boolean,
+) {
+  const sequence = ++deliverySequence;
+  return {
+    authority: {
+      bindingId: binding.id,
+      ownerUserId: binding.owner_user_id,
+      personalAgentId: binding.personal_agent_id,
+      version: binding.authority_version,
+      ...(requiresAllAdultsConsent === undefined ? {} : { requiresAllAdultsConsent }),
+    },
+    platform: "blooio" as const,
+    project: "eliza-app",
+    connectorAccountId: CONNECTOR,
+    providerChatId: CHAT,
+    invocation: "mention" as const,
+    sourceMessageId: `consent-egress-${sequence}`,
+    leaseToken: `76000000-0000-4000-8000-${String(sequence).padStart(12, "0")}`,
+  };
+}
+
+async function bindWithEligibleJoiner() {
+  const binding = await bind({
+    consentMode: "all_adults",
+    requiredPrincipalCount: 2,
+  });
+  await register(binding.id, JOINER_HANDLE);
+  await issueAuthenticate(binding.id);
+  await dbWrite
+    .update(users)
+    .set({ steward_user_id: "steward-parent-b" })
+    .where(eq(users.id, JOINER_USER));
+  const authenticated = await personalSharedGroupConsentRepository.consumeJoinAuthenticateChallenge(
+    {
+      codeHash: AUTH_HASH,
+      confirmCodeHash: CONFIRM_HASH,
+      platform: "blooio",
+      project: "eliza-app",
+      connectorAccountId: CONNECTOR,
+      actorPlatformUserId: JOINER_HANDLE,
+      linkedUserId: JOINER_USER,
+      linkedOrganizationId: JOINER_ORG,
+      expiresAt: new Date(Date.now() + 60_000),
+    },
+  );
+  if (authenticated.status !== "confirm_issued") {
+    throw new Error(`join authentication failed: ${authenticated.status}`);
+  }
+  const confirmed = await personalSharedGroupConsentRepository.consumeJoinConfirmChallenge({
+    codeHash: CONFIRM_HASH,
+    bindingId: binding.id,
+    platform: "blooio",
+    project: "eliza-app",
+    connectorAccountId: CONNECTOR,
+    providerChatId: CHAT,
+    providerThreadId: null,
+    actorPlatformUserId: JOINER_HANDLE,
+  });
+  if (confirmed.status !== "consented") {
+    throw new Error(`join confirmation failed: ${confirmed.status}`);
+  }
+  const current = await personalSharedGroupsRepository.findBindingById(binding.id);
+  if (!current) throw new Error("eligible binding vanished");
+  return current;
+}
+
+beforeAll(async () => {
+  const { apply } = await pushSchema(
+    {
+      organizationBalanceRevisionSequence,
+      organizations,
+      users,
+      personalSharedGroupClaims,
+      personalSharedGroupBindings,
+      personalSharedGroupParticipants,
+      personalSharedGroupJoinChallenges,
+      personalSharedGroupDeliveryReceipts,
+      personalSharedGroupDeliveryAttempts,
+    } as never,
+    dbWrite as never,
+  );
+  await apply();
+}, PGLITE_TIMEOUT_MS);
+
+beforeEach(async () => {
+  // Fail-closed participant links deliberately prevent user deletion. Remove
+  // the binding authority first so its cascading roster cleanup releases the
+  // account rows between isolated cases.
+  await dbWrite.delete(personalSharedGroupBindings);
+  await dbWrite.delete(organizations);
+  await seedAccounts();
+}, PGLITE_TIMEOUT_MS);
+
+afterAll(async () => {
+  await closeDatabaseConnectionsForTests();
+}, PGLITE_TIMEOUT_MS);
+
+describe("PersonalSharedGroupConsentRepository", () => {
+  test("requires a mature owner at all-adults issue and consume without burning the claim", async () => {
+    await dbWrite
+      .update(users)
+      .set({ steward_user_id: `phone:${OWNER_HANDLE}` })
+      .where(eq(users.id, OWNER_USER));
+    await expect(
+      personalSharedGroupsRepository.issueClaim({
+        codeHash: "provisional-owner-cannot-issue",
+        organizationId: OWNER_ORG,
+        ownerUserId: OWNER_USER,
+        personalAgentId: "personal:parent-a",
+        platform: "blooio",
+        project: "eliza-app",
+        connectorAccountId: CONNECTOR,
+        issuedToPlatformUserId: OWNER_HANDLE,
+        consentMode: "all_adults",
+        requiredPrincipalCount: 2,
+        expiresAt: new Date(Date.now() + 60_000),
+      }),
+    ).rejects.toMatchObject({
+      code: "PERSONAL_SHARED_GROUP_OWNER_INDEPENDENT_AUTHENTICATION_REQUIRED",
+    });
+    expect(
+      await dbWrite.select({ id: personalSharedGroupClaims.id }).from(personalSharedGroupClaims),
+    ).toHaveLength(0);
+
+    await dbWrite
+      .update(users)
+      .set({ steward_user_id: "steward-parent-a" })
+      .where(eq(users.id, OWNER_USER));
+    const codeHash = "mature-owner-downgraded-before-bind";
+    await personalSharedGroupsRepository.issueClaim({
+      codeHash,
+      organizationId: OWNER_ORG,
+      ownerUserId: OWNER_USER,
+      personalAgentId: "personal:parent-a",
+      platform: "blooio",
+      project: "eliza-app",
+      connectorAccountId: CONNECTOR,
+      issuedToPlatformUserId: OWNER_HANDLE,
+      consentMode: "all_adults",
+      requiredPrincipalCount: 2,
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    await dbWrite
+      .update(users)
+      .set({ steward_user_id: `phone:${OWNER_HANDLE}` })
+      .where(eq(users.id, OWNER_USER));
+    const consume = () =>
+      personalSharedGroupsRepository.consumeClaimAndBind({
+        codeHash,
+        platform: "blooio",
+        project: "eliza-app",
+        connectorAccountId: CONNECTOR,
+        providerChatId: CHAT,
+        actorPlatformUserId: OWNER_HANDLE,
+      });
+    await expect(consume()).rejects.toMatchObject({
+      code: "PERSONAL_SHARED_GROUP_OWNER_INDEPENDENT_AUTHENTICATION_REQUIRED",
+    });
+    expect(
+      await dbWrite
+        .select({ consumedAt: personalSharedGroupClaims.consumed_at })
+        .from(personalSharedGroupClaims)
+        .where(eq(personalSharedGroupClaims.code_hash, codeHash)),
+    ).toEqual([{ consumedAt: null }]);
+
+    await dbWrite
+      .update(users)
+      .set({ steward_user_id: "steward-parent-a" })
+      .where(eq(users.id, OWNER_USER));
+    expect((await consume()).status).toBe("bound");
+  });
+
+  test("requires an active owner organization at all-adults issue and consume", async () => {
+    const issue = (codeHash: string) =>
+      personalSharedGroupsRepository.issueClaim({
+        codeHash,
+        organizationId: OWNER_ORG,
+        ownerUserId: OWNER_USER,
+        personalAgentId: "personal:parent-a",
+        platform: "blooio",
+        project: "eliza-app",
+        connectorAccountId: CONNECTOR,
+        issuedToPlatformUserId: OWNER_HANDLE,
+        consentMode: "all_adults",
+        requiredPrincipalCount: 2,
+        expiresAt: new Date(Date.now() + 60_000),
+      });
+    await dbWrite
+      .update(organizations)
+      .set({ is_active: false })
+      .where(eq(organizations.id, OWNER_ORG));
+    await expect(issue("inactive-owner-org-issue")).rejects.toMatchObject({
+      code: "PERSONAL_SHARED_GROUP_OWNER_INDEPENDENT_AUTHENTICATION_REQUIRED",
+    });
+    expect(
+      await dbWrite.select({ id: personalSharedGroupClaims.id }).from(personalSharedGroupClaims),
+    ).toHaveLength(0);
+
+    await dbWrite
+      .update(organizations)
+      .set({ is_active: true })
+      .where(eq(organizations.id, OWNER_ORG));
+    const codeHash = "inactive-owner-org-consume";
+    await issue(codeHash);
+    await dbWrite
+      .update(organizations)
+      .set({ is_active: false })
+      .where(eq(organizations.id, OWNER_ORG));
+    const consume = () =>
+      personalSharedGroupsRepository.consumeClaimAndBind({
+        codeHash,
+        platform: "blooio",
+        project: "eliza-app",
+        connectorAccountId: CONNECTOR,
+        providerChatId: CHAT,
+        actorPlatformUserId: OWNER_HANDLE,
+      });
+    await expect(consume()).rejects.toMatchObject({
+      code: "PERSONAL_SHARED_GROUP_OWNER_INDEPENDENT_AUTHENTICATION_REQUIRED",
+    });
+    expect(
+      await dbWrite
+        .select({ consumedAt: personalSharedGroupClaims.consumed_at })
+        .from(personalSharedGroupClaims)
+        .where(eq(personalSharedGroupClaims.code_hash, codeHash)),
+    ).toEqual([{ consumedAt: null }]);
+
+    await dbWrite
+      .update(organizations)
+      .set({ is_active: true })
+      .where(eq(organizations.id, OWNER_ORG));
+    expect((await consume()).status).toBe("bound");
+  });
+
+  test("preserves the empty and existing roster on the default single-owner path", async () => {
+    // Legacy provider-created personal accounts remain allowed in the default
+    // mode; the stronger maturity boundary is all-adults-only.
+    await dbWrite
+      .update(users)
+      .set({ steward_user_id: `phone:${OWNER_HANDLE}` })
+      .where(eq(users.id, OWNER_USER));
+    const binding = await bind();
+    expect(binding).toMatchObject({
+      consent_mode: "single_owner",
+      required_principal_count: 1,
+    });
+    expect(
+      await dbWrite
+        .select({ id: personalSharedGroupParticipants.id })
+        .from(personalSharedGroupParticipants)
+        .where(eq(personalSharedGroupParticipants.binding_id, binding.id)),
+    ).toHaveLength(0);
+
+    await register(binding.id, OWNER_HANDLE);
+    await register(binding.id, CHILD_HANDLE);
+    const rosterBefore = await dbWrite
+      .select({
+        platformUserId: personalSharedGroupParticipants.platform_user_id,
+        ordinal: personalSharedGroupParticipants.ordinal,
+        linkedUserId: personalSharedGroupParticipants.linked_user_id,
+        consentedAt: personalSharedGroupParticipants.consented_at,
+        revokedAt: personalSharedGroupParticipants.revoked_at,
+      })
+      .from(personalSharedGroupParticipants)
+      .where(eq(personalSharedGroupParticipants.binding_id, binding.id))
+      .orderBy(asc(personalSharedGroupParticipants.ordinal));
+    const rebound = await bind();
+    expect(rebound.id).toBe(binding.id);
+    expect(
+      await dbWrite
+        .select({
+          platformUserId: personalSharedGroupParticipants.platform_user_id,
+          ordinal: personalSharedGroupParticipants.ordinal,
+          linkedUserId: personalSharedGroupParticipants.linked_user_id,
+          consentedAt: personalSharedGroupParticipants.consented_at,
+          revokedAt: personalSharedGroupParticipants.revoked_at,
+        })
+        .from(personalSharedGroupParticipants)
+        .where(eq(personalSharedGroupParticipants.binding_id, binding.id))
+        .orderBy(asc(personalSharedGroupParticipants.ordinal)),
+    ).toEqual(rosterBefore);
+    expect(
+      await personalSharedGroupsRepository.revokeBinding({
+        bindingId: binding.id,
+        ownerUserId: OWNER_USER,
+      }),
+    ).toBe(true);
+    expect(
+      await dbWrite
+        .select({ revokedAt: personalSharedGroupParticipants.revoked_at })
+        .from(personalSharedGroupParticipants)
+        .where(eq(personalSharedGroupParticipants.binding_id, binding.id)),
+    ).toEqual([{ revokedAt: null }, { revokedAt: null }]);
+  });
+
+  test("creates owner consent, admits the authenticated joiner, and ignores Child C for gating", async () => {
+    const binding = await bind({
+      consentMode: "all_adults",
+      requiredPrincipalCount: 2,
+    });
+    expect(binding).toMatchObject({
+      consent_mode: "all_adults",
+      required_principal_count: 2,
+      consent_version: 1,
+    });
+    expect(
+      await personalSharedGroupConsentRepository.deriveConsentStatus({
+        bindingId: binding.id,
+      }),
+    ).toMatchObject({
+      gate: "restricted",
+      registeredParticipantCount: 1,
+      linkedParticipantCount: 1,
+      consentedParticipantCount: 1,
+      participants: [{ ordinal: 1, isOwner: true, linked: true, consented: true, revoked: false }],
+    });
+
+    await register(binding.id, JOINER_HANDLE);
+    await register(binding.id, CHILD_HANDLE);
+    expect(await issueAuthenticate(binding.id)).toEqual({
+      status: "issued",
+      consentVersion: 1,
+    });
+    expect(
+      await personalSharedGroupConsentRepository.consumeJoinAuthenticateChallenge({
+        codeHash: AUTH_HASH,
+        confirmCodeHash: CONFIRM_HASH,
+        platform: "blooio",
+        project: "eliza-app",
+        connectorAccountId: CONNECTOR,
+        actorPlatformUserId: JOINER_HANDLE,
+        linkedUserId: JOINER_USER,
+        linkedOrganizationId: JOINER_ORG,
+        expiresAt: new Date(Date.now() + 60_000),
+      }),
+    ).toEqual({ status: "account_not_authenticated" });
+
+    // A real sign-in promotes the same durable user away from phone:<E.164>.
+    await dbWrite
+      .update(users)
+      .set({ steward_user_id: "steward-parent-b" })
+      .where(eq(users.id, JOINER_USER));
+    expect(
+      await personalSharedGroupConsentRepository.consumeJoinAuthenticateChallenge({
+        codeHash: AUTH_HASH,
+        confirmCodeHash: CONFIRM_HASH,
+        platform: "blooio",
+        project: "eliza-app",
+        connectorAccountId: CONNECTOR,
+        actorPlatformUserId: "+15550109999",
+        linkedUserId: JOINER_USER,
+        linkedOrganizationId: JOINER_ORG,
+        expiresAt: new Date(Date.now() + 60_000),
+      }),
+    ).toEqual({ status: "wrong_sender" });
+    expect(
+      await personalSharedGroupConsentRepository.consumeJoinAuthenticateChallenge({
+        codeHash: AUTH_HASH,
+        confirmCodeHash: CONFIRM_HASH,
+        platform: "blooio",
+        project: "eliza-app",
+        connectorAccountId: CONNECTOR,
+        actorPlatformUserId: JOINER_HANDLE,
+        linkedUserId: JOINER_USER,
+        linkedOrganizationId: JOINER_ORG,
+        expiresAt: new Date(Date.now() + 60_000),
+      }),
+    ).toEqual({ status: "confirm_issued", bindingId: binding.id, consentVersion: 1 });
+
+    expect(
+      await personalSharedGroupConsentRepository.consumeJoinConfirmChallenge({
+        codeHash: CONFIRM_HASH,
+        bindingId: binding.id,
+        platform: "blooio",
+        project: "eliza-app",
+        connectorAccountId: CONNECTOR,
+        providerChatId: CHAT,
+        providerThreadId: "forged-sub-thread",
+        actorPlatformUserId: JOINER_HANDLE,
+      }),
+    ).toEqual({ status: "wrong_scope" });
+    const joined = await personalSharedGroupConsentRepository.consumeJoinConfirmChallenge({
+      codeHash: CONFIRM_HASH,
+      bindingId: binding.id,
+      platform: "blooio",
+      project: "eliza-app",
+      connectorAccountId: CONNECTOR,
+      providerChatId: CHAT,
+      providerThreadId: null,
+      actorPlatformUserId: JOINER_HANDLE,
+    });
+    expect(joined.status).toBe("consented");
+    if (joined.status !== "consented") throw new Error("expected completed consent");
+    expect(joined.consent).toMatchObject({
+      gate: "enabled",
+      requiredPrincipalCount: 2,
+      registeredParticipantCount: 3,
+      linkedParticipantCount: 2,
+      consentedParticipantCount: 2,
+    });
+    expect(joined.consent.participants[2]).toEqual({
+      ordinal: 3,
+      isOwner: false,
+      linked: false,
+      consented: false,
+      revoked: false,
+    });
+    const serialized = JSON.stringify(joined.consent);
+    expect(serialized).not.toContain(OWNER_HANDLE);
+    expect(serialized).not.toContain(JOINER_HANDLE);
+    expect(serialized).not.toContain(CHILD_HANDLE);
+    expect(serialized).not.toContain(OWNER_USER);
+    expect(serialized).not.toContain(JOINER_USER);
+  });
+
+  test("requires an active participant organization at both join stages", async () => {
+    const binding = await bind({
+      consentMode: "all_adults",
+      requiredPrincipalCount: 2,
+    });
+    await register(binding.id, JOINER_HANDLE);
+    await issueAuthenticate(binding.id);
+    await dbWrite
+      .update(users)
+      .set({ steward_user_id: "steward-parent-b" })
+      .where(eq(users.id, JOINER_USER));
+    await dbWrite
+      .update(organizations)
+      .set({ is_active: false })
+      .where(eq(organizations.id, JOINER_ORG));
+
+    const authenticate = () =>
+      personalSharedGroupConsentRepository.consumeJoinAuthenticateChallenge({
+        codeHash: AUTH_HASH,
+        confirmCodeHash: CONFIRM_HASH,
+        platform: "blooio",
+        project: "eliza-app",
+        connectorAccountId: CONNECTOR,
+        actorPlatformUserId: JOINER_HANDLE,
+        linkedUserId: JOINER_USER,
+        linkedOrganizationId: JOINER_ORG,
+        expiresAt: new Date(Date.now() + 60_000),
+      });
+    expect(await authenticate()).toEqual({ status: "account_not_authenticated" });
+
+    await dbWrite
+      .update(organizations)
+      .set({ is_active: true })
+      .where(eq(organizations.id, JOINER_ORG));
+    expect(await authenticate()).toMatchObject({
+      status: "confirm_issued",
+      bindingId: binding.id,
+    });
+    await dbWrite
+      .update(organizations)
+      .set({ is_active: false })
+      .where(eq(organizations.id, JOINER_ORG));
+    const confirm = () =>
+      personalSharedGroupConsentRepository.consumeJoinConfirmChallenge({
+        codeHash: CONFIRM_HASH,
+        bindingId: binding.id,
+        platform: "blooio",
+        project: "eliza-app",
+        connectorAccountId: CONNECTOR,
+        providerChatId: CHAT,
+        providerThreadId: null,
+        actorPlatformUserId: JOINER_HANDLE,
+      });
+    expect(await confirm()).toEqual({ status: "account_not_authenticated" });
+
+    await dbWrite
+      .update(organizations)
+      .set({ is_active: true })
+      .where(eq(organizations.id, JOINER_ORG));
+    expect(await confirm()).toMatchObject({ status: "consented" });
+  });
+
+  test("retains tombstones past gateway dedupe and rejects the old source after reissue", async () => {
+    const binding = await bind({
+      consentMode: "all_adults",
+      requiredPrincipalCount: 2,
+    });
+    await register(binding.id, JOINER_HANDLE);
+    const supersededHash = "e".repeat(64);
+    const currentHash = "f".repeat(64);
+    expect(
+      await issueAuthenticate(binding.id, supersededHash, {
+        sourceMessageId: "parent-b-source-1",
+      }),
+    ).toMatchObject({
+      status: "issued",
+    });
+    // Simulate delivery after the gateway's finite webhook-dedupe horizon.
+    // The security boundary is the durable source tombstone, not Redis TTL.
+    await dbWrite
+      .update(personalSharedGroupJoinChallenges)
+      .set({ created_at: new Date(Date.now() - 32 * 24 * 60 * 60_000) })
+      .where(eq(personalSharedGroupJoinChallenges.code_hash, supersededHash));
+    expect(
+      await issueAuthenticate(binding.id, currentHash, {
+        sourceMessageId: "parent-b-source-2",
+      }),
+    ).toMatchObject({
+      status: "issued",
+    });
+    expect(
+      await issueAuthenticate(binding.id, supersededHash, {
+        sourceMessageId: "parent-b-source-1",
+      }),
+    ).toEqual({ status: "already_used" });
+
+    expect(
+      await dbWrite
+        .select({
+          codeHash: personalSharedGroupJoinChallenges.code_hash,
+          stage: personalSharedGroupJoinChallenges.stage,
+          consumedAt: personalSharedGroupJoinChallenges.consumed_at,
+          supersededAt: personalSharedGroupJoinChallenges.superseded_at,
+          supersededBy: personalSharedGroupJoinChallenges.superseded_by_source_message_id,
+        })
+        .from(personalSharedGroupJoinChallenges)
+        .where(eq(personalSharedGroupJoinChallenges.binding_id, binding.id))
+        .orderBy(asc(personalSharedGroupJoinChallenges.code_hash)),
+    ).toEqual([
+      {
+        codeHash: supersededHash,
+        stage: "authenticate",
+        consumedAt: expect.any(Date),
+        supersededAt: expect.any(Date),
+        supersededBy: "parent-b-source-2",
+      },
+      {
+        codeHash: currentHash,
+        stage: "authenticate",
+        consumedAt: null,
+        supersededAt: null,
+        supersededBy: null,
+      },
+    ]);
+    await dbWrite
+      .update(users)
+      .set({ steward_user_id: "steward-parent-b" })
+      .where(eq(users.id, JOINER_USER));
+    expect(
+      await personalSharedGroupConsentRepository.consumeJoinAuthenticateChallenge({
+        codeHash: supersededHash,
+        confirmCodeHash: CONFIRM_HASH,
+        platform: "blooio",
+        project: "eliza-app",
+        connectorAccountId: CONNECTOR,
+        actorPlatformUserId: JOINER_HANDLE,
+        linkedUserId: JOINER_USER,
+        linkedOrganizationId: JOINER_ORG,
+        expiresAt: new Date(Date.now() + 60_000),
+      }),
+    ).toEqual({ status: "already_used" });
+    expect(
+      await personalSharedGroupConsentRepository.consumeJoinAuthenticateChallenge({
+        codeHash: currentHash,
+        confirmCodeHash: CONFIRM_HASH,
+        platform: "blooio",
+        project: "eliza-app",
+        connectorAccountId: CONNECTOR,
+        actorPlatformUserId: JOINER_HANDLE,
+        linkedUserId: JOINER_USER,
+        linkedOrganizationId: JOINER_ORG,
+        expiresAt: new Date(Date.now() + 60_000),
+      }),
+    ).toMatchObject({ status: "confirm_issued", bindingId: binding.id });
+  });
+
+  test("keeps source replays stable across another actor's issuance and completed consent", async () => {
+    const binding = await bind({
+      consentMode: "all_adults",
+      requiredPrincipalCount: 2,
+    });
+    await register(binding.id, JOINER_HANDLE);
+    await register(binding.id, CHILD_HANDLE);
+    expect(
+      await issueAuthenticate(binding.id, AUTH_HASH, {
+        sourceMessageId: "group-source-parent-b",
+      }),
+    ).toMatchObject({ status: "issued" });
+    await dbWrite
+      .update(users)
+      .set({ steward_user_id: "steward-parent-b" })
+      .where(eq(users.id, JOINER_USER));
+
+    const authenticate = () =>
+      personalSharedGroupConsentRepository.consumeJoinAuthenticateChallenge({
+        codeHash: AUTH_HASH,
+        confirmCodeHash: CONFIRM_HASH,
+        sourceMessageId: "dm-source-parent-b",
+        platform: "blooio",
+        project: "eliza-app",
+        connectorAccountId: CONNECTOR,
+        actorPlatformUserId: JOINER_HANDLE,
+        linkedUserId: JOINER_USER,
+        linkedOrganizationId: JOINER_ORG,
+        expiresAt: new Date(Date.now() + 60_000),
+      });
+    expect(await authenticate()).toMatchObject({
+      status: "confirm_issued",
+      bindingId: binding.id,
+    });
+    const [confirmBeforeReplay] = await dbWrite
+      .select({
+        id: personalSharedGroupJoinChallenges.id,
+        expiresAt: personalSharedGroupJoinChallenges.expires_at,
+      })
+      .from(personalSharedGroupJoinChallenges)
+      .where(eq(personalSharedGroupJoinChallenges.code_hash, CONFIRM_HASH));
+
+    // A different participant asking to join must not sweep Parent B's
+    // consumed authenticate row, because that row is the durable replay key
+    // for a provider delivery whose response may have been lost.
+    expect(
+      await issueAuthenticate(binding.id, "c".repeat(64), {
+        actorPlatformUserId: CHILD_HANDLE,
+        sourceMessageId: "group-source-child-c",
+      }),
+    ).toMatchObject({ status: "issued" });
+    expect(await authenticate()).toMatchObject({
+      status: "confirm_issued",
+      bindingId: binding.id,
+    });
+
+    // A late replay of the original group delivery keeps the displayed code
+    // and the already-issued confirmation intact.
+    expect(
+      await issueAuthenticate(binding.id, AUTH_HASH, {
+        sourceMessageId: "group-source-parent-b",
+      }),
+    ).toMatchObject({ status: "issued" });
+    const [confirmAfterReplay] = await dbWrite
+      .select({
+        id: personalSharedGroupJoinChallenges.id,
+        expiresAt: personalSharedGroupJoinChallenges.expires_at,
+      })
+      .from(personalSharedGroupJoinChallenges)
+      .where(eq(personalSharedGroupJoinChallenges.code_hash, CONFIRM_HASH));
+    expect(confirmAfterReplay).toEqual(confirmBeforeReplay);
+
+    const confirm = () =>
+      personalSharedGroupConsentRepository.consumeJoinConfirmChallenge({
+        codeHash: CONFIRM_HASH,
+        sourceMessageId: "group-confirm-source-parent-b",
+        bindingId: binding.id,
+        platform: "blooio",
+        project: "eliza-app",
+        connectorAccountId: CONNECTOR,
+        providerChatId: CHAT,
+        providerThreadId: null,
+        actorPlatformUserId: JOINER_HANDLE,
+      });
+    expect(await confirm()).toMatchObject({ status: "consented" });
+    expect(await confirm()).toMatchObject({ status: "consented" });
+  });
+
+  test("rejoins cleanly after a non-owner self-revokes", async () => {
+    const binding = await bindWithEligibleJoiner();
+    expect(
+      await personalSharedGroupConsentRepository.selfRevoke({
+        bindingId: binding.id,
+        actorPlatformUserId: JOINER_HANDLE,
+      }),
+    ).toMatchObject({ status: "revoked", consent: { gate: "restricted" } });
+
+    const nextAuthenticateHash = "d".repeat(64);
+    const nextConfirmHash = "e".repeat(64);
+    expect(
+      await issueAuthenticate(binding.id, nextAuthenticateHash, {
+        sourceMessageId: "group-source-parent-b-rejoin",
+      }),
+    ).toMatchObject({ status: "issued" });
+    expect(
+      await personalSharedGroupConsentRepository.consumeJoinAuthenticateChallenge({
+        codeHash: nextAuthenticateHash,
+        confirmCodeHash: nextConfirmHash,
+        sourceMessageId: "dm-source-parent-b-rejoin",
+        platform: "blooio",
+        project: "eliza-app",
+        connectorAccountId: CONNECTOR,
+        actorPlatformUserId: JOINER_HANDLE,
+        linkedUserId: JOINER_USER,
+        linkedOrganizationId: JOINER_ORG,
+        expiresAt: new Date(Date.now() + 60_000),
+      }),
+    ).toMatchObject({ status: "confirm_issued" });
+    expect(
+      await personalSharedGroupConsentRepository.consumeJoinConfirmChallenge({
+        codeHash: nextConfirmHash,
+        sourceMessageId: "group-confirm-source-parent-b-rejoin",
+        bindingId: binding.id,
+        platform: "blooio",
+        project: "eliza-app",
+        connectorAccountId: CONNECTOR,
+        providerChatId: CHAT,
+        providerThreadId: null,
+        actorPlatformUserId: JOINER_HANDLE,
+      }),
+    ).toMatchObject({ status: "consented", consent: { gate: "enabled" } });
+  });
+
+  test("preserves eligible consent on rejected identity links and revokes it on a real change", async () => {
+    const binding = await bindWithEligibleJoiner();
+    expect(
+      await dbWrite.transaction((tx) =>
+        usersRepository.linkMessagingIdentityInTransaction(
+          tx,
+          JOINER_USER,
+          "phone",
+          "+15550109999",
+        ),
+      ),
+    ).toEqual({ status: "handle_conflict" });
+    expect(
+      await usersRepository.linkTelegramAndPhoneIdentity(JOINER_USER, {
+        telegram_id: "200000000002",
+        phone_number: "+15550109999",
+      }),
+    ).toEqual({ status: "phone_mismatch", existingPhone: JOINER_HANDLE });
+    expect(
+      await personalSharedGroupConsentRepository.deriveConsentStatus({ bindingId: binding.id }),
+    ).toMatchObject({ gate: "enabled", consentedParticipantCount: 2 });
+
+    expect(
+      await usersRepository.linkStewardId(JOINER_USER, "steward-parent-b-rotated"),
+    ).toBeDefined();
+    expect(
+      await personalSharedGroupConsentRepository.deriveConsentStatus({ bindingId: binding.id }),
+    ).toMatchObject({ gate: "restricted", consentedParticipantCount: 1 });
+    expect(await usersRepository.linkStewardId(JOINER_USER, "steward-parent-b")).toBeDefined();
+    expect(
+      await personalSharedGroupConsentRepository.deriveConsentStatus({ bindingId: binding.id }),
+    ).toMatchObject({ gate: "restricted", consentedParticipantCount: 1 });
+  });
+
+  test("self-revokes only a linked non-owner and invalidates the consent epoch", async () => {
+    const binding = await bind({
+      consentMode: "all_adults",
+      requiredPrincipalCount: 2,
+    });
+    await register(binding.id, JOINER_HANDLE);
+    await issueAuthenticate(binding.id);
+    await dbWrite
+      .update(users)
+      .set({ steward_user_id: "steward-parent-b" })
+      .where(eq(users.id, JOINER_USER));
+    await personalSharedGroupConsentRepository.consumeJoinAuthenticateChallenge({
+      codeHash: AUTH_HASH,
+      confirmCodeHash: CONFIRM_HASH,
+      platform: "blooio",
+      project: "eliza-app",
+      connectorAccountId: CONNECTOR,
+      actorPlatformUserId: JOINER_HANDLE,
+      linkedUserId: JOINER_USER,
+      linkedOrganizationId: JOINER_ORG,
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    expect(
+      (
+        await personalSharedGroupConsentRepository.consumeJoinConfirmChallenge({
+          codeHash: CONFIRM_HASH,
+          bindingId: binding.id,
+          platform: "blooio",
+          project: "eliza-app",
+          connectorAccountId: CONNECTOR,
+          providerChatId: CHAT,
+          providerThreadId: null,
+          actorPlatformUserId: JOINER_HANDLE,
+        })
+      ).status,
+    ).toBe("consented");
+    expect(
+      await personalSharedGroupConsentRepository.selfRevoke({
+        bindingId: binding.id,
+        actorPlatformUserId: OWNER_HANDLE,
+      }),
+    ).toEqual({ status: "owner_forbidden" });
+    const revoked = await personalSharedGroupConsentRepository.selfRevoke({
+      bindingId: binding.id,
+      actorPlatformUserId: JOINER_HANDLE,
+    });
+    expect(revoked.status).toBe("revoked");
+    if (revoked.status !== "revoked") throw new Error("expected self-revocation");
+    expect(revoked.consent).toMatchObject({
+      gate: "restricted",
+      registeredParticipantCount: 1,
+      consentedParticipantCount: 1,
+    });
+    expect(await personalSharedGroupsRepository.findBindingById(binding.id)).toMatchObject({
+      state: "active",
+      authority_version: binding.authority_version + 2,
+      consent_version: binding.consent_version + 1,
+    });
+    expect(
+      await dbWrite
+        .select({
+          ordinal: personalSharedGroupParticipants.ordinal,
+          linkedUserId: personalSharedGroupParticipants.linked_user_id,
+          consentedAt: personalSharedGroupParticipants.consented_at,
+          consentProvenance: personalSharedGroupParticipants.consent_provenance,
+          revokedAt: personalSharedGroupParticipants.revoked_at,
+        })
+        .from(personalSharedGroupParticipants)
+        .where(eq(personalSharedGroupParticipants.platform_user_id, JOINER_HANDLE)),
+    ).toEqual([
+      {
+        ordinal: 2,
+        linkedUserId: null,
+        consentedAt: null,
+        consentProvenance: null,
+        revokedAt: expect.any(Date),
+      },
+    ]);
+  });
+
+  test("restricts soft-deleted consent and blocks hard deletion while its authority link is live", async () => {
+    const binding = await bind({
+      consentMode: "all_adults",
+      requiredPrincipalCount: 2,
+    });
+    await register(binding.id, JOINER_HANDLE);
+    await issueAuthenticate(binding.id);
+    await dbWrite
+      .update(users)
+      .set({ steward_user_id: "steward-parent-b" })
+      .where(eq(users.id, JOINER_USER));
+    await personalSharedGroupConsentRepository.consumeJoinAuthenticateChallenge({
+      codeHash: AUTH_HASH,
+      confirmCodeHash: CONFIRM_HASH,
+      platform: "blooio",
+      project: "eliza-app",
+      connectorAccountId: CONNECTOR,
+      actorPlatformUserId: JOINER_HANDLE,
+      linkedUserId: JOINER_USER,
+      linkedOrganizationId: JOINER_ORG,
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    expect(
+      (
+        await personalSharedGroupConsentRepository.consumeJoinConfirmChallenge({
+          codeHash: CONFIRM_HASH,
+          bindingId: binding.id,
+          platform: "blooio",
+          project: "eliza-app",
+          connectorAccountId: CONNECTOR,
+          providerChatId: CHAT,
+          providerThreadId: null,
+          actorPlatformUserId: JOINER_HANDLE,
+        })
+      ).status,
+    ).toBe("consented");
+    expect(
+      await personalSharedGroupConsentRepository.deriveConsentStatus({
+        bindingId: binding.id,
+      }),
+    ).toMatchObject({ gate: "enabled", linkedParticipantCount: 2 });
+
+    await dbWrite.update(users).set({ is_active: false }).where(eq(users.id, JOINER_USER));
+    expect(
+      await personalSharedGroupConsentRepository.deriveConsentStatus({
+        bindingId: binding.id,
+      }),
+    ).toMatchObject({
+      gate: "restricted",
+      registeredParticipantCount: 2,
+      linkedParticipantCount: 1,
+      consentedParticipantCount: 1,
+      participants: [
+        { ordinal: 1, linked: true, consented: true },
+        { ordinal: 2, linked: false, consented: false },
+      ],
+    });
+    await dbWrite
+      .update(users)
+      .set({ is_active: true, deleted_at: new Date() })
+      .where(eq(users.id, JOINER_USER));
+    expect(
+      await personalSharedGroupConsentRepository.deriveConsentStatus({
+        bindingId: binding.id,
+      }),
+    ).toMatchObject({ gate: "restricted", linkedParticipantCount: 1 });
+
+    const [beforeDelete] = await dbWrite
+      .select({
+        id: personalSharedGroupParticipants.id,
+        ordinal: personalSharedGroupParticipants.ordinal,
+        linkedUserId: personalSharedGroupParticipants.linked_user_id,
+        consentedAt: personalSharedGroupParticipants.consented_at,
+        consentProvenance: personalSharedGroupParticipants.consent_provenance,
+      })
+      .from(personalSharedGroupParticipants)
+      .where(eq(personalSharedGroupParticipants.platform_user_id, JOINER_HANDLE));
+    expect(beforeDelete).toMatchObject({
+      ordinal: 2,
+      linkedUserId: JOINER_USER,
+      consentProvenance: "authenticated_dm",
+    });
+    expect(beforeDelete?.consentedAt).toBeInstanceOf(Date);
+    const deleteLinkedUser = async () => {
+      await dbWrite.delete(users).where(eq(users.id, JOINER_USER));
+    };
+    await expect(deleteLinkedUser()).rejects.toThrow();
+    const [preserved] = await dbWrite
+      .select({
+        id: personalSharedGroupParticipants.id,
+        ordinal: personalSharedGroupParticipants.ordinal,
+        linkedUserId: personalSharedGroupParticipants.linked_user_id,
+        consentedAt: personalSharedGroupParticipants.consented_at,
+        consentProvenance: personalSharedGroupParticipants.consent_provenance,
+      })
+      .from(personalSharedGroupParticipants)
+      .where(eq(personalSharedGroupParticipants.platform_user_id, JOINER_HANDLE));
+    expect(preserved).toEqual(beforeDelete);
+    expect(
+      await personalSharedGroupConsentRepository.deriveConsentStatus({
+        bindingId: binding.id,
+      }),
+    ).toMatchObject({
+      gate: "restricted",
+      registeredParticipantCount: 2,
+      linkedParticipantCount: 1,
+      consentedParticipantCount: 1,
+    });
+  });
+
+  test("account deactivation revokes consent durably and reactivation cannot resurrect it", async () => {
+    const binding = await bindWithEligibleJoiner();
+
+    expect(await usersRepository.update(JOINER_USER, { is_active: false })).toMatchObject({
+      id: JOINER_USER,
+      is_active: false,
+    });
+    expect(
+      await dbWrite
+        .select({
+          ordinal: personalSharedGroupParticipants.ordinal,
+          linkedUserId: personalSharedGroupParticipants.linked_user_id,
+          consentedAt: personalSharedGroupParticipants.consented_at,
+          consentProvenance: personalSharedGroupParticipants.consent_provenance,
+          revokedAt: personalSharedGroupParticipants.revoked_at,
+        })
+        .from(personalSharedGroupParticipants)
+        .where(eq(personalSharedGroupParticipants.platform_user_id, JOINER_HANDLE)),
+    ).toEqual([
+      {
+        ordinal: 2,
+        linkedUserId: null,
+        consentedAt: null,
+        consentProvenance: null,
+        revokedAt: expect.any(Date),
+      },
+    ]);
+    expect(await personalSharedGroupsRepository.findBindingById(binding.id)).toMatchObject({
+      authority_version: binding.authority_version + 1,
+      consent_version: binding.consent_version + 1,
+    });
+    expect(
+      await personalSharedGroupConsentRepository.deriveConsentStatus({ bindingId: binding.id }),
+    ).toMatchObject({ gate: "restricted", consentedParticipantCount: 1 });
+
+    expect(await usersRepository.update(JOINER_USER, { is_active: true })).toMatchObject({
+      id: JOINER_USER,
+      is_active: true,
+    });
+    expect(
+      await dbWrite
+        .select({
+          linkedUserId: personalSharedGroupParticipants.linked_user_id,
+          consentedAt: personalSharedGroupParticipants.consented_at,
+          consentProvenance: personalSharedGroupParticipants.consent_provenance,
+          revokedAt: personalSharedGroupParticipants.revoked_at,
+        })
+        .from(personalSharedGroupParticipants)
+        .where(eq(personalSharedGroupParticipants.platform_user_id, JOINER_HANDLE)),
+    ).toEqual([
+      {
+        linkedUserId: null,
+        consentedAt: null,
+        consentProvenance: null,
+        revokedAt: expect.any(Date),
+      },
+    ]);
+    expect(
+      await personalSharedGroupConsentRepository.deriveConsentStatus({ bindingId: binding.id }),
+    ).toMatchObject({ gate: "restricted", consentedParticipantCount: 1 });
+  });
+
+  test("hard user deletion atomically unlinks consent and preserves the roster audit row", async () => {
+    const binding = await bindWithEligibleJoiner();
+
+    await usersRepository.delete(JOINER_USER);
+
+    expect(
+      await dbWrite.select({ id: users.id }).from(users).where(eq(users.id, JOINER_USER)),
+    ).toEqual([]);
+    expect(
+      await dbWrite
+        .select({
+          ordinal: personalSharedGroupParticipants.ordinal,
+          linkedUserId: personalSharedGroupParticipants.linked_user_id,
+          consentedAt: personalSharedGroupParticipants.consented_at,
+          consentProvenance: personalSharedGroupParticipants.consent_provenance,
+          revokedAt: personalSharedGroupParticipants.revoked_at,
+        })
+        .from(personalSharedGroupParticipants)
+        .where(eq(personalSharedGroupParticipants.platform_user_id, JOINER_HANDLE)),
+    ).toEqual([
+      {
+        ordinal: 2,
+        linkedUserId: null,
+        consentedAt: null,
+        consentProvenance: null,
+        revokedAt: expect.any(Date),
+      },
+    ]);
+    expect(await personalSharedGroupsRepository.findBindingById(binding.id)).toMatchObject({
+      authority_version: binding.authority_version + 1,
+      consent_version: binding.consent_version + 1,
+    });
+    expect(
+      await personalSharedGroupConsentRepository.deriveConsentStatus({ bindingId: binding.id }),
+    ).toMatchObject({ gate: "restricted", consentedParticipantCount: 1 });
+  });
+
+  test("a live uncommitted delivery lease rejects account mutation without partial revocation", async () => {
+    const binding = await bindWithEligibleJoiner();
+    const delivery = deliveryFor(binding, true);
+    expect(await personalSharedGroupsRepository.authorizeDelivery(delivery)).toMatchObject({
+      authorized: true,
+      leaseToken: delivery.leaseToken,
+    });
+
+    await expect(usersRepository.update(JOINER_USER, { is_active: false })).rejects.toMatchObject({
+      code: "PERSONAL_SHARED_GROUP_DELIVERY_PENDING",
+    });
+
+    expect(
+      await dbWrite
+        .select({ isActive: users.is_active, deletedAt: users.deleted_at })
+        .from(users)
+        .where(eq(users.id, JOINER_USER)),
+    ).toEqual([{ isActive: true, deletedAt: null }]);
+    expect(
+      await dbWrite
+        .select({
+          linkedUserId: personalSharedGroupParticipants.linked_user_id,
+          consentedAt: personalSharedGroupParticipants.consented_at,
+          consentProvenance: personalSharedGroupParticipants.consent_provenance,
+          revokedAt: personalSharedGroupParticipants.revoked_at,
+        })
+        .from(personalSharedGroupParticipants)
+        .where(eq(personalSharedGroupParticipants.platform_user_id, JOINER_HANDLE)),
+    ).toEqual([
+      {
+        linkedUserId: JOINER_USER,
+        consentedAt: expect.any(Date),
+        consentProvenance: "authenticated_dm",
+        revokedAt: null,
+      },
+    ]);
+    expect(await personalSharedGroupsRepository.findBindingById(binding.id)).toMatchObject({
+      authority_version: binding.authority_version,
+      consent_version: binding.consent_version,
+      delivery_lease_source_id: delivery.sourceMessageId,
+      delivery_lease_token: delivery.leaseToken,
+      delivery_lease_committed_at: null,
+    });
+  });
+
+  test("revalidates the linked account immediately before consuming confirmation", async () => {
+    const binding = await bind({
+      consentMode: "all_adults",
+      requiredPrincipalCount: 2,
+    });
+    await register(binding.id, JOINER_HANDLE);
+    await issueAuthenticate(binding.id);
+    await dbWrite
+      .update(users)
+      .set({ steward_user_id: "steward-parent-b" })
+      .where(eq(users.id, JOINER_USER));
+    expect(
+      await personalSharedGroupConsentRepository.consumeJoinAuthenticateChallenge({
+        codeHash: AUTH_HASH,
+        confirmCodeHash: CONFIRM_HASH,
+        platform: "blooio",
+        project: "eliza-app",
+        connectorAccountId: CONNECTOR,
+        actorPlatformUserId: JOINER_HANDLE,
+        linkedUserId: JOINER_USER,
+        linkedOrganizationId: JOINER_ORG,
+        expiresAt: new Date(Date.now() + 60_000),
+      }),
+    ).toMatchObject({ status: "confirm_issued" });
+    const confirm = () =>
+      personalSharedGroupConsentRepository.consumeJoinConfirmChallenge({
+        codeHash: CONFIRM_HASH,
+        bindingId: binding.id,
+        platform: "blooio",
+        project: "eliza-app",
+        connectorAccountId: CONNECTOR,
+        providerChatId: CHAT,
+        providerThreadId: null,
+        actorPlatformUserId: JOINER_HANDLE,
+      });
+
+    await dbWrite.update(users).set({ is_active: false }).where(eq(users.id, JOINER_USER));
+    expect(await confirm()).toEqual({ status: "account_not_authenticated" });
+    await dbWrite
+      .update(users)
+      .set({ is_active: true, phone_number: "+15550109998" })
+      .where(eq(users.id, JOINER_USER));
+    expect(await confirm()).toEqual({ status: "account_not_authenticated" });
+    expect(
+      await dbWrite
+        .select({ consumedAt: personalSharedGroupJoinChallenges.consumed_at })
+        .from(personalSharedGroupJoinChallenges)
+        .where(eq(personalSharedGroupJoinChallenges.code_hash, CONFIRM_HASH)),
+    ).toEqual([{ consumedAt: null }]);
+    expect(
+      await dbWrite
+        .select({
+          linkedUserId: personalSharedGroupParticipants.linked_user_id,
+          consentedAt: personalSharedGroupParticipants.consented_at,
+        })
+        .from(personalSharedGroupParticipants)
+        .where(eq(personalSharedGroupParticipants.platform_user_id, JOINER_HANDLE)),
+    ).toEqual([{ linkedUserId: null, consentedAt: null }]);
+
+    await dbWrite
+      .update(users)
+      .set({ phone_number: JOINER_HANDLE })
+      .where(eq(users.id, JOINER_USER));
+    expect((await confirm()).status).toBe("consented");
+  });
+
+  test("serializes confirmation against account deactivation without consent resurrection", async () => {
+    const binding = await bind({ consentMode: "all_adults", requiredPrincipalCount: 2 });
+    await register(binding.id, JOINER_HANDLE);
+    await issueAuthenticate(binding.id);
+    await dbWrite
+      .update(users)
+      .set({ steward_user_id: "steward-parent-b" })
+      .where(eq(users.id, JOINER_USER));
+    expect(
+      await personalSharedGroupConsentRepository.consumeJoinAuthenticateChallenge({
+        codeHash: AUTH_HASH,
+        confirmCodeHash: CONFIRM_HASH,
+        platform: "blooio",
+        project: "eliza-app",
+        connectorAccountId: CONNECTOR,
+        actorPlatformUserId: JOINER_HANDLE,
+        linkedUserId: JOINER_USER,
+        linkedOrganizationId: JOINER_ORG,
+        expiresAt: new Date(Date.now() + 60_000),
+      }),
+    ).toMatchObject({ status: "confirm_issued" });
+
+    const raced = await settleWithin(
+      Promise.allSettled([
+        personalSharedGroupConsentRepository.consumeJoinConfirmChallenge({
+          codeHash: CONFIRM_HASH,
+          bindingId: binding.id,
+          platform: "blooio",
+          project: "eliza-app",
+          connectorAccountId: CONNECTOR,
+          providerChatId: CHAT,
+          providerThreadId: null,
+          actorPlatformUserId: JOINER_HANDLE,
+        }),
+        usersRepository.update(JOINER_USER, { is_active: false }),
+      ]),
+      "confirmation/deactivation race",
+    );
+    expect(raced.every((result) => result.status === "fulfilled")).toBe(true);
+    expect(
+      await dbWrite
+        .select({ isActive: users.is_active })
+        .from(users)
+        .where(eq(users.id, JOINER_USER)),
+    ).toEqual([{ isActive: false }]);
+    expect(
+      await personalSharedGroupConsentRepository.deriveConsentStatus({ bindingId: binding.id }),
+    ).toMatchObject({ gate: "restricted", consentedParticipantCount: 1 });
+    expect(
+      await dbWrite
+        .select({ linkedUserId: personalSharedGroupParticipants.linked_user_id })
+        .from(personalSharedGroupParticipants)
+        .where(eq(personalSharedGroupParticipants.platform_user_id, JOINER_HANDLE)),
+    ).toEqual([{ linkedUserId: null }]);
+  });
+
+  test("serializes all-adults owner claim consumption against deactivation", async () => {
+    const codeHash = "owner-claim-deactivation-race";
+    await personalSharedGroupsRepository.issueClaim({
+      codeHash,
+      organizationId: OWNER_ORG,
+      ownerUserId: OWNER_USER,
+      personalAgentId: "personal:parent-a",
+      platform: "blooio",
+      project: "eliza-app",
+      connectorAccountId: CONNECTOR,
+      issuedToPlatformUserId: OWNER_HANDLE,
+      consentMode: "all_adults",
+      requiredPrincipalCount: 2,
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+
+    await settleWithin(
+      Promise.allSettled([
+        personalSharedGroupsRepository.consumeClaimAndBind({
+          codeHash,
+          platform: "blooio",
+          project: "eliza-app",
+          connectorAccountId: CONNECTOR,
+          providerChatId: CHAT,
+          actorPlatformUserId: OWNER_HANDLE,
+        }),
+        usersRepository.update(OWNER_USER, { is_active: false }),
+      ]),
+      "claim/deactivation race",
+    );
+    expect(
+      await dbWrite
+        .select({ isActive: users.is_active })
+        .from(users)
+        .where(eq(users.id, OWNER_USER)),
+    ).toEqual([{ isActive: false }]);
+    const current = await personalSharedGroupsRepository.resolveBinding({
+      platform: "blooio",
+      project: "eliza-app",
+      connectorAccountId: CONNECTOR,
+      providerChatId: CHAT,
+    });
+    if (current) {
+      expect(
+        await personalSharedGroupConsentRepository.deriveConsentStatus({
+          bindingId: current.id,
+        }),
+      ).toMatchObject({ gate: "restricted", consentedParticipantCount: 0 });
+    }
+  });
+
+  test("whole rebind and revoke unlink consent while preserving participant ordinals", async () => {
+    const binding = await bind({
+      consentMode: "all_adults",
+      requiredPrincipalCount: 2,
+    });
+    await register(binding.id, JOINER_HANDLE);
+    await issueAuthenticate(binding.id);
+    await dbWrite
+      .update(users)
+      .set({ steward_user_id: "steward-parent-b" })
+      .where(eq(users.id, JOINER_USER));
+    await personalSharedGroupConsentRepository.consumeJoinAuthenticateChallenge({
+      codeHash: AUTH_HASH,
+      confirmCodeHash: CONFIRM_HASH,
+      platform: "blooio",
+      project: "eliza-app",
+      connectorAccountId: CONNECTOR,
+      actorPlatformUserId: JOINER_HANDLE,
+      linkedUserId: JOINER_USER,
+      linkedOrganizationId: JOINER_ORG,
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    expect(
+      (
+        await personalSharedGroupConsentRepository.consumeJoinConfirmChallenge({
+          codeHash: CONFIRM_HASH,
+          bindingId: binding.id,
+          platform: "blooio",
+          project: "eliza-app",
+          connectorAccountId: CONNECTOR,
+          providerChatId: CHAT,
+          providerThreadId: null,
+          actorPlatformUserId: JOINER_HANDLE,
+        })
+      ).status,
+    ).toBe("consented");
+
+    const rebound = await bind({
+      consentMode: "all_adults",
+      requiredPrincipalCount: 2,
+    });
+    expect(rebound.id).toBe(binding.id);
+    expect(
+      await dbWrite
+        .select({
+          ordinal: personalSharedGroupParticipants.ordinal,
+          linkedUserId: personalSharedGroupParticipants.linked_user_id,
+          consentedAt: personalSharedGroupParticipants.consented_at,
+          consentProvenance: personalSharedGroupParticipants.consent_provenance,
+          revokedAt: personalSharedGroupParticipants.revoked_at,
+        })
+        .from(personalSharedGroupParticipants)
+        .where(eq(personalSharedGroupParticipants.binding_id, binding.id))
+        .orderBy(asc(personalSharedGroupParticipants.ordinal)),
+    ).toEqual([
+      {
+        ordinal: 1,
+        linkedUserId: OWNER_USER,
+        consentedAt: expect.any(Date),
+        consentProvenance: "owner_binding",
+        revokedAt: null,
+      },
+      {
+        ordinal: 2,
+        linkedUserId: null,
+        consentedAt: null,
+        consentProvenance: null,
+        revokedAt: expect.any(Date),
+      },
+    ]);
+
+    expect(
+      await personalSharedGroupsRepository.revokeBinding({
+        bindingId: binding.id,
+        ownerUserId: OWNER_USER,
+      }),
+    ).toBe(true);
+    expect(
+      await dbWrite
+        .select({
+          ordinal: personalSharedGroupParticipants.ordinal,
+          linkedUserId: personalSharedGroupParticipants.linked_user_id,
+          consentedAt: personalSharedGroupParticipants.consented_at,
+          consentProvenance: personalSharedGroupParticipants.consent_provenance,
+          revoked: personalSharedGroupParticipants.revoked_at,
+        })
+        .from(personalSharedGroupParticipants)
+        .where(eq(personalSharedGroupParticipants.binding_id, binding.id))
+        .orderBy(asc(personalSharedGroupParticipants.ordinal)),
+    ).toEqual([
+      {
+        ordinal: 1,
+        linkedUserId: null,
+        consentedAt: null,
+        consentProvenance: null,
+        revoked: expect.any(Date),
+      },
+      {
+        ordinal: 2,
+        linkedUserId: null,
+        consentedAt: null,
+        consentProvenance: null,
+        revoked: expect.any(Date),
+      },
+    ]);
+    await dbWrite.delete(users).where(eq(users.id, JOINER_USER));
+    expect(
+      await dbWrite.select({ id: users.id }).from(users).where(eq(users.id, JOINER_USER)),
+    ).toEqual([]);
+  });
+
+  test("serializes all-adults rebind against a concurrent participant turn", async () => {
+    const binding = await bind({ consentMode: "all_adults", requiredPrincipalCount: 2 });
+    const raced = await settleWithin(
+      Promise.allSettled([
+        bind({ consentMode: "all_adults", requiredPrincipalCount: 2 }),
+        personalSharedGroupParticipantsRepository.recordTurn({
+          bindingId: binding.id,
+          platformUserId: CHILD_HANDLE,
+          displayName: "Child C",
+        }),
+      ]),
+      "all-adults rebind/participant race",
+    );
+    expect(raced.every((result) => result.status === "fulfilled")).toBe(true);
+    const roster = await dbWrite
+      .select({
+        platformUserId: personalSharedGroupParticipants.platform_user_id,
+        ordinal: personalSharedGroupParticipants.ordinal,
+      })
+      .from(personalSharedGroupParticipants)
+      .where(eq(personalSharedGroupParticipants.binding_id, binding.id))
+      .orderBy(asc(personalSharedGroupParticipants.ordinal));
+    expect(new Set(roster.map(({ ordinal }) => ordinal)).size).toBe(roster.length);
+    expect(roster).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ platformUserId: OWNER_HANDLE, ordinal: 1 }),
+        expect.objectContaining({ platformUserId: CHILD_HANDLE }),
+      ]),
+    );
+  });
+
+  test("leaving all-adults mode clears prior consent without changing single-owner defaults", async () => {
+    const allAdults = await bindWithEligibleJoiner();
+    const singleOwner = await bind();
+
+    expect(singleOwner).toMatchObject({
+      id: allAdults.id,
+      consent_mode: "single_owner",
+      required_principal_count: 1,
+    });
+    expect(
+      await dbWrite
+        .select({
+          ordinal: personalSharedGroupParticipants.ordinal,
+          linkedUserId: personalSharedGroupParticipants.linked_user_id,
+          consentedAt: personalSharedGroupParticipants.consented_at,
+          consentProvenance: personalSharedGroupParticipants.consent_provenance,
+          revokedAt: personalSharedGroupParticipants.revoked_at,
+        })
+        .from(personalSharedGroupParticipants)
+        .where(eq(personalSharedGroupParticipants.binding_id, singleOwner.id))
+        .orderBy(asc(personalSharedGroupParticipants.ordinal)),
+    ).toEqual([
+      {
+        ordinal: 1,
+        linkedUserId: null,
+        consentedAt: null,
+        consentProvenance: null,
+        revokedAt: expect.any(Date),
+      },
+      {
+        ordinal: 2,
+        linkedUserId: null,
+        consentedAt: null,
+        consentProvenance: null,
+        revokedAt: expect.any(Date),
+      },
+    ]);
+  });
+
+  test("fails closed below all-adults quorum but permits explicit consent-control delivery", async () => {
+    const binding = await bind({
+      consentMode: "all_adults",
+      requiredPrincipalCount: 2,
+    });
+    expect(binding).toMatchObject({
+      consent_mode: "all_adults",
+      required_principal_count: 2,
+    });
+    expect(
+      await personalSharedGroupsRepository.authorizeDelivery(deliveryFor(binding)),
+    ).toMatchObject({ authorized: false, reason: "not_authorized" });
+    expect(
+      await personalSharedGroupsRepository.authorizeDelivery(deliveryFor(binding, true)),
+    ).toMatchObject({ authorized: false, reason: "not_authorized" });
+
+    const consentControl = deliveryFor(binding, false);
+    expect(
+      await personalSharedGroupConsentRepository.deriveConsentStatus({ bindingId: binding.id }),
+    ).toMatchObject({ gate: "restricted", consentedParticipantCount: 1 });
+    expect(await personalSharedGroupsRepository.authorizeDelivery(consentControl)).toMatchObject({
+      authorized: true,
+      leaseToken: consentControl.leaseToken,
+    });
+    expect(await personalSharedGroupsRepository.commitDelivery(consentControl)).toBe(true);
+  });
+
+  test("authorizes an all-adults capability after eligible quorum is established", async () => {
+    const binding = await bindWithEligibleJoiner();
+    const delivery = deliveryFor(binding, true);
+    expect(
+      await personalSharedGroupConsentRepository.deriveConsentStatus({ bindingId: binding.id }),
+    ).toMatchObject({ gate: "enabled", consentedParticipantCount: 2 });
+    expect(await personalSharedGroupsRepository.authorizeDelivery(delivery)).toMatchObject({
+      authorized: true,
+      leaseToken: delivery.leaseToken,
+    });
+    expect(await personalSharedGroupsRepository.commitDelivery(delivery)).toBe(true);
+  });
+
+  test("denies all-adults capability after user, organization, or deletion ineligibility", async () => {
+    const binding = await bindWithEligibleJoiner();
+
+    await dbWrite
+      .update(organizations)
+      .set({ is_active: false })
+      .where(eq(organizations.id, JOINER_ORG));
+    expect(
+      await personalSharedGroupConsentRepository.deriveConsentStatus({ bindingId: binding.id }),
+    ).toMatchObject({ gate: "restricted", consentedParticipantCount: 1 });
+    expect(
+      await personalSharedGroupsRepository.authorizeDelivery(deliveryFor(binding, true)),
+    ).toMatchObject({ authorized: false, reason: "not_authorized" });
+    await dbWrite
+      .update(organizations)
+      .set({ is_active: true })
+      .where(eq(organizations.id, JOINER_ORG));
+
+    await dbWrite.update(users).set({ is_active: false }).where(eq(users.id, JOINER_USER));
+    expect(
+      await personalSharedGroupsRepository.authorizeDelivery(deliveryFor(binding, true)),
+    ).toMatchObject({ authorized: false, reason: "not_authorized" });
+
+    await dbWrite
+      .update(users)
+      .set({ is_active: true, deleted_at: new Date() })
+      .where(eq(users.id, JOINER_USER));
+    expect(
+      await personalSharedGroupsRepository.authorizeDelivery(deliveryFor(binding, true)),
+    ).toMatchObject({ authorized: false, reason: "not_authorized" });
+  });
+
+  test("does not let two eligible non-owner links substitute for an ineligible owner", async () => {
+    const binding = await bindWithEligibleJoiner();
+    await dbWrite.insert(users).values({
+      id: ADDITIONAL_NON_OWNER_USER,
+      organization_id: JOINER_ORG,
+      steward_user_id: "steward-additional-non-owner",
+      phone_number: ADDITIONAL_NON_OWNER_HANDLE,
+      phone_verified: true,
+    });
+    await register(binding.id, ADDITIONAL_NON_OWNER_HANDLE);
+    expect(
+      await personalSharedGroupConsentRepository.issueJoinAuthenticateChallenge({
+        codeHash: "c".repeat(64),
+        bindingId: binding.id,
+        platform: "blooio",
+        project: "eliza-app",
+        connectorAccountId: CONNECTOR,
+        providerChatId: CHAT,
+        providerThreadId: null,
+        actorPlatformUserId: ADDITIONAL_NON_OWNER_HANDLE,
+        expiresAt: new Date(Date.now() + 60_000),
+      }),
+    ).toMatchObject({ status: "issued" });
+    expect(
+      await personalSharedGroupConsentRepository.consumeJoinAuthenticateChallenge({
+        codeHash: "c".repeat(64),
+        confirmCodeHash: "d".repeat(64),
+        platform: "blooio",
+        project: "eliza-app",
+        connectorAccountId: CONNECTOR,
+        actorPlatformUserId: ADDITIONAL_NON_OWNER_HANDLE,
+        linkedUserId: ADDITIONAL_NON_OWNER_USER,
+        linkedOrganizationId: JOINER_ORG,
+        expiresAt: new Date(Date.now() + 60_000),
+      }),
+    ).toMatchObject({ status: "confirm_issued" });
+    expect(
+      await personalSharedGroupConsentRepository.consumeJoinConfirmChallenge({
+        codeHash: "d".repeat(64),
+        bindingId: binding.id,
+        platform: "blooio",
+        project: "eliza-app",
+        connectorAccountId: CONNECTOR,
+        providerChatId: CHAT,
+        providerThreadId: null,
+        actorPlatformUserId: ADDITIONAL_NON_OWNER_HANDLE,
+      }),
+    ).toMatchObject({ status: "consented" });
+
+    const current = await personalSharedGroupsRepository.findBindingById(binding.id);
+    if (!current) throw new Error("binding vanished after additional consent");
+    await dbWrite.update(users).set({ is_active: false }).where(eq(users.id, OWNER_USER));
+
+    expect(
+      await personalSharedGroupConsentRepository.deriveConsentStatus({ bindingId: binding.id }),
+    ).toMatchObject({
+      gate: "restricted",
+      linkedParticipantCount: 2,
+      consentedParticipantCount: 2,
+    });
+    expect(
+      await personalSharedGroupsRepository.authorizeDelivery(deliveryFor(current, true)),
+    ).toMatchObject({ authorized: false, reason: "not_authorized" });
+
+    await dbWrite.update(users).set({ is_active: true }).where(eq(users.id, OWNER_USER));
+    const inFlight = deliveryFor(current, true);
+    expect(await personalSharedGroupsRepository.authorizeDelivery(inFlight)).toMatchObject({
+      authorized: true,
+      leaseToken: inFlight.leaseToken,
+    });
+    await dbWrite.update(users).set({ is_active: false }).where(eq(users.id, OWNER_USER));
+    expect(await personalSharedGroupsRepository.commitDelivery(inFlight)).toBe(false);
+  });
+
+  test("refuses commit when all-adults eligibility is lost after authorization", async () => {
+    const binding = await bindWithEligibleJoiner();
+    const delivery = deliveryFor(binding, true);
+    expect(await personalSharedGroupsRepository.authorizeDelivery(delivery)).toMatchObject({
+      authorized: true,
+      leaseToken: delivery.leaseToken,
+    });
+
+    await dbWrite.update(users).set({ is_active: false }).where(eq(users.id, JOINER_USER));
+    expect(await personalSharedGroupsRepository.commitDelivery(delivery)).toBe(false);
+    expect(
+      await dbWrite
+        .select({ id: personalSharedGroupDeliveryAttempts.id })
+        .from(personalSharedGroupDeliveryAttempts)
+        .where(eq(personalSharedGroupDeliveryAttempts.binding_id, binding.id)),
+    ).toEqual([]);
+  });
+
+  test("preserves single-owner delivery when the consent marker is absent", async () => {
+    const binding = await bind();
+    const delivery = deliveryFor(binding);
+    expect(delivery.authority).not.toHaveProperty("requiresAllAdultsConsent");
+    expect(await personalSharedGroupsRepository.authorizeDelivery(delivery)).toMatchObject({
+      authorized: true,
+      leaseToken: delivery.leaseToken,
+    });
+    expect(await personalSharedGroupsRepository.commitDelivery(delivery)).toBe(true);
+  });
+
+  test("concurrent replay of one confirmation converges to one consent and one typed loser", async () => {
+    const binding = await bind({
+      consentMode: "all_adults",
+      requiredPrincipalCount: 2,
+    });
+    await register(binding.id, JOINER_HANDLE);
+    await issueAuthenticate(binding.id);
+    await dbWrite
+      .update(users)
+      .set({ steward_user_id: "steward-parent-b" })
+      .where(eq(users.id, JOINER_USER));
+    expect(
+      (
+        await personalSharedGroupConsentRepository.consumeJoinAuthenticateChallenge({
+          codeHash: AUTH_HASH,
+          confirmCodeHash: CONFIRM_HASH,
+          platform: "blooio",
+          project: "eliza-app",
+          connectorAccountId: CONNECTOR,
+          actorPlatformUserId: JOINER_HANDLE,
+          linkedUserId: JOINER_USER,
+          linkedOrganizationId: JOINER_ORG,
+          expiresAt: new Date(Date.now() + 60_000),
+        })
+      ).status,
+    ).toBe("confirm_issued");
+
+    const confirm = () =>
+      personalSharedGroupConsentRepository.consumeJoinConfirmChallenge({
+        codeHash: CONFIRM_HASH,
+        bindingId: binding.id,
+        platform: "blooio",
+        project: "eliza-app",
+        connectorAccountId: CONNECTOR,
+        providerChatId: CHAT,
+        providerThreadId: null,
+        actorPlatformUserId: JOINER_HANDLE,
+      });
+    const raced = await Promise.allSettled([confirm(), confirm()]);
+    expect(raced.every((result) => result.status === "fulfilled")).toBe(true);
+    expect(
+      raced
+        .filter((result) => result.status === "fulfilled")
+        .map((result) => result.value.status)
+        .sort(),
+    ).toEqual(["already_used", "consented"]);
+    expect(
+      await dbWrite
+        .select({ id: personalSharedGroupParticipants.id })
+        .from(personalSharedGroupParticipants)
+        .where(eq(personalSharedGroupParticipants.linked_user_id, JOINER_USER)),
+    ).toHaveLength(1);
+    expect(
+      await personalSharedGroupConsentRepository.deriveConsentStatus({
+        bindingId: binding.id,
+      }),
+    ).toMatchObject({ gate: "enabled", consentedParticipantCount: 2 });
+  });
+
+  test("keeps a Blooio authenticate challenge live after a wrong-platform attempt", async () => {
+    const binding = await bind({
+      consentMode: "all_adults",
+      requiredPrincipalCount: 2,
+    });
+    await register(binding.id, JOINER_HANDLE);
+    await issueAuthenticate(binding.id);
+    await dbWrite
+      .update(users)
+      .set({ steward_user_id: "steward-parent-b" })
+      .where(eq(users.id, JOINER_USER));
+    const authenticate = (platform: "blooio" | "telegram", connectorAccountId: string) =>
+      personalSharedGroupConsentRepository.consumeJoinAuthenticateChallenge({
+        codeHash: AUTH_HASH,
+        confirmCodeHash: CONFIRM_HASH,
+        platform,
+        project: "eliza-app",
+        connectorAccountId,
+        actorPlatformUserId: JOINER_HANDLE,
+        linkedUserId: JOINER_USER,
+        linkedOrganizationId: JOINER_ORG,
+        expiresAt: new Date(Date.now() + 60_000),
+      });
+    expect(await authenticate("telegram", "telegram:synthetic-bot")).toEqual({
+      status: "wrong_scope",
+    });
+    expect(await authenticate("blooio", CONNECTOR)).toEqual({
+      status: "confirm_issued",
+      bindingId: binding.id,
+      consentVersion: binding.consent_version,
+    });
+  });
+
+  test("rejects join authority for single-owner bindings at issuance and direct consumption", async () => {
+    const binding = await bind({ chatId: CHAT });
+    await register(binding.id, JOINER_HANDLE);
+    expect(await issueAuthenticate(binding.id)).toEqual({ status: "wrong_scope" });
+
+    // Defense in depth: even a forged/stale challenge row cannot make the DM
+    // consumption stage rely on the route's consent-mode branch.
+    await dbWrite.insert(personalSharedGroupJoinChallenges).values({
+      code_hash: AUTH_HASH,
+      stage: "authenticate",
+      binding_id: binding.id,
+      consent_version: binding.consent_version,
+      platform: "blooio",
+      project: "eliza-app",
+      connector_account_id: CONNECTOR,
+      provider_chat_id: CHAT,
+      provider_thread_id: "",
+      issued_to_platform_user_id: JOINER_HANDLE,
+      source_message_id: "forged-single-owner-source",
+      expires_at: new Date(Date.now() + 60_000),
+    });
+    await dbWrite
+      .update(users)
+      .set({ steward_user_id: "steward-parent-b" })
+      .where(eq(users.id, JOINER_USER));
+    expect(
+      await personalSharedGroupConsentRepository.consumeJoinAuthenticateChallenge({
+        codeHash: AUTH_HASH,
+        confirmCodeHash: CONFIRM_HASH,
+        platform: "blooio",
+        project: "eliza-app",
+        connectorAccountId: CONNECTOR,
+        actorPlatformUserId: JOINER_HANDLE,
+        linkedUserId: JOINER_USER,
+        linkedOrganizationId: JOINER_ORG,
+        expiresAt: new Date(Date.now() + 60_000),
+      }),
+    ).toEqual({ status: "stale" });
+  });
+});

--- a/packages/cloud/shared/src/db/repositories/personal-shared-group-consent.ts
+++ b/packages/cloud/shared/src/db/repositories/personal-shared-group-consent.ts
@@ -1,0 +1,1104 @@
+/** Multi-principal consent authority for one Personal Shared provider group. */
+import { ElizaError } from "@elizaos/core";
+import { and, asc, eq, gt, inArray, isNotNull, isNull, lte, or, sql } from "drizzle-orm";
+import type { Database, DbTransaction } from "../client";
+import { dbWrite } from "../client";
+import { organizations } from "../schemas/organizations";
+import {
+  type PersonalSharedGroupConsentMode,
+  type PersonalSharedGroupJoinChallenge,
+  type PersonalSharedGroupPlatform,
+  personalSharedGroupBindings,
+  personalSharedGroupJoinChallenges,
+  personalSharedGroupParticipants,
+} from "../schemas/personal-shared-groups";
+import { users } from "../schemas/users";
+
+const AUTHORITY_MUTATION_WAIT_MS = 5_000;
+const AUTHORITY_MUTATION_POLL_MS = 25;
+const MAX_JOIN_CHALLENGE_TTL_MS = 15 * 60_000;
+
+export interface PersonalSharedGroupConsentStatus {
+  mode: PersonalSharedGroupConsentMode;
+  gate: "enabled" | "restricted";
+  requiredPrincipalCount: number;
+  registeredParticipantCount: number;
+  linkedParticipantCount: number;
+  consentedParticipantCount: number;
+  participants: Array<{
+    ordinal: number;
+    isOwner: boolean;
+    linked: boolean;
+    consented: boolean;
+    revoked: boolean;
+  }>;
+}
+
+export type PersonalSharedGroupJoinChallengeFailure =
+  | "invalid"
+  | "expired"
+  | "already_used"
+  | "wrong_sender"
+  | "wrong_scope"
+  | "stale"
+  | "actor_not_registered"
+  | "account_not_authenticated"
+  | "already_linked";
+
+export type IssuePersonalSharedGroupJoinChallengeResult =
+  | { status: "issued"; consentVersion: number }
+  | {
+      status:
+        | "invalid"
+        | "expired"
+        | "already_used"
+        | "wrong_scope"
+        | "stale"
+        | "actor_not_registered"
+        | "already_linked";
+    };
+
+export type ConsumePersonalSharedGroupJoinAuthenticateResult =
+  | { status: "confirm_issued"; bindingId: string; consentVersion: number }
+  | { status: PersonalSharedGroupJoinChallengeFailure };
+
+export type ConsumePersonalSharedGroupJoinConfirmResult =
+  | { status: "consented"; consent: PersonalSharedGroupConsentStatus }
+  | { status: PersonalSharedGroupJoinChallengeFailure };
+
+export type PersonalSharedGroupSelfRevokeResult =
+  | { status: "revoked"; consent: PersonalSharedGroupConsentStatus }
+  | { status: "invalid" | "wrong_sender" | "not_linked" | "owner_forbidden" };
+
+type AuthorityMutationAttempt<T> = { blocked: true } | { blocked: false; result: T };
+
+function normalizedThreadId(providerThreadId: string | null | undefined): string {
+  return providerThreadId ?? "";
+}
+
+function deliveryLeaseAllowsAuthorityMutation(now: Date) {
+  return or(
+    isNull(personalSharedGroupBindings.delivery_lease_source_id),
+    isNotNull(personalSharedGroupBindings.delivery_lease_committed_at),
+    lte(personalSharedGroupBindings.delivery_lease_expires_at, now),
+  );
+}
+
+function deliveryLeaseBlocksAuthorityMutation(now: Date) {
+  return and(
+    isNull(personalSharedGroupBindings.delivery_lease_committed_at),
+    gt(personalSharedGroupBindings.delivery_lease_expires_at, now),
+  )!;
+}
+
+function consentInputError(message: string, context: Record<string, unknown>): ElizaError {
+  return new ElizaError(message, {
+    code: "PERSONAL_SHARED_GROUP_CONSENT_INPUT_INVALID",
+    severity: "fatal",
+    context,
+  });
+}
+
+function consentDeliveryPendingError(): ElizaError {
+  return new ElizaError("A live group delivery reservation is still pending", {
+    code: "PERSONAL_SHARED_GROUP_DELIVERY_PENDING",
+    severity: "fatal",
+  });
+}
+
+function assertChallengeInput(input: {
+  codeHash: string;
+  expiresAt?: Date;
+  bindingId?: string;
+  platform: PersonalSharedGroupPlatform;
+  project: string;
+  connectorAccountId: string;
+  actorPlatformUserId: string;
+}): void {
+  if (
+    !/^[a-f\d]{64}$/i.test(input.codeHash) ||
+    (input.bindingId !== undefined && !input.bindingId) ||
+    !input.project ||
+    !input.connectorAccountId ||
+    !input.actorPlatformUserId
+  ) {
+    throw consentInputError("Personal Shared group join challenge input is incomplete", {
+      bindingId: input.bindingId,
+    });
+  }
+  if (input.expiresAt) {
+    const ttlMs = input.expiresAt.getTime() - Date.now();
+    if (!Number.isFinite(ttlMs) || ttlMs <= 0 || ttlMs > MAX_JOIN_CHALLENGE_TTL_MS) {
+      throw consentInputError("Personal Shared group join challenge expiry is invalid", {
+        bindingId: input.bindingId,
+      });
+    }
+  }
+}
+
+async function withConsentStorageBoundary<T>(
+  operation: () => Promise<T>,
+  context: Record<string, unknown>,
+): Promise<T> {
+  try {
+    return await operation();
+  } catch (error) {
+    if (error instanceof ElizaError) throw error;
+    // error-policy:J2 consent persistence is fail-closed. The route converts
+    // this typed boundary into one structured internal delivery failure.
+    throw new ElizaError("Personal Shared group consent storage failed", {
+      code: "PERSONAL_SHARED_GROUP_CONSENT_STORAGE_FAILURE",
+      severity: "fatal",
+      context,
+      cause: error,
+    });
+  }
+}
+
+async function waitForAuthorityMutation<T>(
+  mutation: () => Promise<AuthorityMutationAttempt<T>>,
+): Promise<T> {
+  const deadline = Date.now() + AUTHORITY_MUTATION_WAIT_MS;
+  while (true) {
+    const attempt = await mutation();
+    if (!attempt.blocked) return attempt.result;
+    if (Date.now() >= deadline) throw consentDeliveryPendingError();
+    await new Promise((resolve) => setTimeout(resolve, AUTHORITY_MUTATION_POLL_MS));
+  }
+}
+
+async function hasActiveOrganization(
+  tx: DbTransaction,
+  organizationId: string | null | undefined,
+): Promise<boolean> {
+  if (!organizationId) return false;
+  const [organization] = await tx
+    .select({ id: organizations.id })
+    .from(organizations)
+    .where(and(eq(organizations.id, organizationId), eq(organizations.is_active, true)))
+    .limit(1);
+  return Boolean(organization);
+}
+
+async function deriveConsentStatusInTransaction(
+  tx: DbTransaction,
+  bindingId: string,
+): Promise<PersonalSharedGroupConsentStatus | null> {
+  const [binding] = await tx
+    .select({
+      state: personalSharedGroupBindings.state,
+      ownerUserId: personalSharedGroupBindings.owner_user_id,
+      platform: personalSharedGroupBindings.platform,
+      mode: personalSharedGroupBindings.consent_mode,
+      requiredPrincipalCount: personalSharedGroupBindings.required_principal_count,
+    })
+    .from(personalSharedGroupBindings)
+    .where(eq(personalSharedGroupBindings.id, bindingId))
+    .limit(1);
+  if (!binding) return null;
+
+  const rows = await tx
+    .select({
+      ordinal: personalSharedGroupParticipants.ordinal,
+      platformUserId: personalSharedGroupParticipants.platform_user_id,
+      linkedUserId: personalSharedGroupParticipants.linked_user_id,
+      consentedAt: personalSharedGroupParticipants.consented_at,
+      revokedAt: personalSharedGroupParticipants.revoked_at,
+      userId: users.id,
+      stewardUserId: users.steward_user_id,
+      telegramId: users.telegram_id,
+      phoneNumber: users.phone_number,
+      phoneVerified: users.phone_verified,
+      isAnonymous: users.is_anonymous,
+      isActive: users.is_active,
+      deletedAt: users.deleted_at,
+      organizationActive: organizations.is_active,
+    })
+    .from(personalSharedGroupParticipants)
+    .leftJoin(users, eq(users.id, personalSharedGroupParticipants.linked_user_id))
+    .leftJoin(organizations, eq(organizations.id, users.organization_id))
+    .where(eq(personalSharedGroupParticipants.binding_id, bindingId))
+    .orderBy(asc(personalSharedGroupParticipants.ordinal));
+  const active = rows.filter((row) => row.revokedAt === null);
+  const isEligibleLinkedParticipant = (row: (typeof rows)[number]): boolean =>
+    row.revokedAt === null &&
+    row.linkedUserId !== null &&
+    row.userId === row.linkedUserId &&
+    row.organizationActive === true &&
+    row.isActive === true &&
+    row.deletedAt === null &&
+    row.isAnonymous === false &&
+    typeof row.stewardUserId === "string" &&
+    !row.stewardUserId.startsWith("phone:") &&
+    !row.stewardUserId.startsWith("telegram:") &&
+    (binding.platform === "blooio"
+      ? row.phoneNumber === row.platformUserId && row.phoneVerified === true
+      : row.telegramId === row.platformUserId);
+  const linked = active.filter(isEligibleLinkedParticipant);
+  const consented = linked.filter((row) => row.consentedAt !== null);
+  const ownerConsented = consented.some((row) => row.linkedUserId === binding.ownerUserId);
+  const enabled =
+    binding.state === "active" &&
+    (binding.mode === "single_owner" ||
+      (ownerConsented && consented.length >= binding.requiredPrincipalCount));
+
+  return {
+    mode: binding.mode,
+    gate: enabled ? "enabled" : "restricted",
+    requiredPrincipalCount: binding.requiredPrincipalCount,
+    registeredParticipantCount: active.length,
+    linkedParticipantCount: linked.length,
+    consentedParticipantCount: consented.length,
+    participants: rows.map((row) => {
+      const revoked = row.revokedAt !== null;
+      const linkedParticipant = isEligibleLinkedParticipant(row);
+      return {
+        ordinal: row.ordinal,
+        isOwner: linkedParticipant && row.linkedUserId === binding.ownerUserId,
+        linked: linkedParticipant,
+        consented: linkedParticipant && row.consentedAt !== null,
+        revoked,
+      };
+    }),
+  };
+}
+
+function classifyChallenge(
+  challenge: PersonalSharedGroupJoinChallenge | undefined,
+  input: {
+    stage: "authenticate" | "confirm";
+    now: Date;
+    bindingId?: string;
+    platform: PersonalSharedGroupPlatform;
+    project: string;
+    connectorAccountId: string;
+    providerChatId?: string;
+    providerThreadId?: string | null;
+    actorPlatformUserId: string;
+  },
+): PersonalSharedGroupJoinChallengeFailure | null {
+  if (!challenge || challenge.stage !== input.stage) return "invalid";
+  if (challenge.consumed_at) return "already_used";
+  if (challenge.expires_at <= input.now) return "expired";
+  if (challenge.issued_to_platform_user_id !== input.actorPlatformUserId) {
+    return "wrong_sender";
+  }
+  if (
+    challenge.platform !== input.platform ||
+    challenge.project !== input.project ||
+    challenge.connector_account_id !== input.connectorAccountId ||
+    (input.bindingId !== undefined && challenge.binding_id !== input.bindingId) ||
+    (input.providerChatId !== undefined && challenge.provider_chat_id !== input.providerChatId) ||
+    (input.providerThreadId !== undefined &&
+      challenge.provider_thread_id !== normalizedThreadId(input.providerThreadId))
+  ) {
+    return "wrong_scope";
+  }
+  return null;
+}
+
+export class PersonalSharedGroupConsentRepository {
+  constructor(private readonly database: Database) {}
+
+  async issueJoinAuthenticateChallenge(input: {
+    codeHash: string;
+    sourceMessageId?: string;
+    bindingId: string;
+    platform: PersonalSharedGroupPlatform;
+    project: string;
+    connectorAccountId: string;
+    providerChatId: string;
+    providerThreadId?: string | null;
+    actorPlatformUserId: string;
+    expiresAt: Date;
+  }): Promise<IssuePersonalSharedGroupJoinChallengeResult> {
+    assertChallengeInput(input);
+    if (!input.providerChatId) {
+      throw consentInputError("Personal Shared group join destination is incomplete", {
+        bindingId: input.bindingId,
+      });
+    }
+    return withConsentStorageBoundary(
+      () =>
+        this.database.transaction(async (tx) => {
+          const now = new Date();
+          const [binding] = await tx
+            .select({
+              id: personalSharedGroupBindings.id,
+              consentVersion: personalSharedGroupBindings.consent_version,
+            })
+            .from(personalSharedGroupBindings)
+            .where(
+              and(
+                eq(personalSharedGroupBindings.id, input.bindingId),
+                eq(personalSharedGroupBindings.platform, input.platform),
+                eq(personalSharedGroupBindings.project, input.project),
+                eq(personalSharedGroupBindings.connector_account_id, input.connectorAccountId),
+                eq(personalSharedGroupBindings.provider_chat_id, input.providerChatId),
+                eq(personalSharedGroupBindings.state, "active"),
+                eq(personalSharedGroupBindings.consent_mode, "all_adults"),
+              ),
+            )
+            .limit(1)
+            .for("update");
+          if (!binding) {
+            const [byId] = await tx
+              .select({ id: personalSharedGroupBindings.id })
+              .from(personalSharedGroupBindings)
+              .where(eq(personalSharedGroupBindings.id, input.bindingId))
+              .limit(1);
+            return { status: byId ? "wrong_scope" : "invalid" } as const;
+          }
+          const sourceMessageId = input.sourceMessageId ?? input.codeHash;
+          const [sourceReplay] = await tx
+            .select()
+            .from(personalSharedGroupJoinChallenges)
+            .where(
+              and(
+                eq(personalSharedGroupJoinChallenges.binding_id, input.bindingId),
+                eq(personalSharedGroupJoinChallenges.stage, "authenticate"),
+                eq(
+                  personalSharedGroupJoinChallenges.issued_to_platform_user_id,
+                  input.actorPlatformUserId,
+                ),
+                eq(personalSharedGroupJoinChallenges.source_message_id, sourceMessageId),
+              ),
+            )
+            .limit(1)
+            .for("update");
+          if (sourceReplay) {
+            const sameImmutableIssue =
+              sourceReplay.code_hash === input.codeHash &&
+              sourceReplay.platform === input.platform &&
+              sourceReplay.project === input.project &&
+              sourceReplay.connector_account_id === input.connectorAccountId &&
+              sourceReplay.provider_chat_id === input.providerChatId &&
+              sourceReplay.provider_thread_id === normalizedThreadId(input.providerThreadId);
+            if (!sameImmutableIssue) return { status: "wrong_scope" } as const;
+            if (sourceReplay.consent_version !== binding.consentVersion) {
+              return { status: "stale" } as const;
+            }
+            if (sourceReplay.superseded_at !== null) {
+              return { status: "already_used" } as const;
+            }
+            if (sourceReplay.expires_at <= now) return { status: "expired" } as const;
+            // Normal consumption is replay-safe: a provider response-loss
+            // replay returns the same deterministic displayed code without
+            // mutating a later flow. Explicit supersession is handled above.
+            return { status: "issued", consentVersion: sourceReplay.consent_version } as const;
+          }
+          // Every challenge mutation for a binding takes the binding lock
+          // first. This serializes the no-existing-row issuance case and keeps
+          // reissue, consume, account lifecycle, and FK cascades on one lock
+          // order instead of participant<->challenge inversion.
+          const priorActorChallenges = await tx
+            .select({ id: personalSharedGroupJoinChallenges.id })
+            .from(personalSharedGroupJoinChallenges)
+            .where(
+              and(
+                eq(personalSharedGroupJoinChallenges.binding_id, input.bindingId),
+                eq(
+                  personalSharedGroupJoinChallenges.issued_to_platform_user_id,
+                  input.actorPlatformUserId,
+                ),
+              ),
+            )
+            .orderBy(personalSharedGroupJoinChallenges.id)
+            .for("update");
+          if (priorActorChallenges.length > 0) {
+            // Retain durable source tombstones for the binding's lifetime.
+            // Gateway dedupe has a finite horizon, so deleting an older source
+            // would let a delayed provider retry recreate its deterministic
+            // code with a fresh TTL and displace a newer flow. Binding deletion
+            // remains the explicit retention boundary through the FK cascade.
+            await tx
+              .update(personalSharedGroupJoinChallenges)
+              .set({
+                consumed_at: sql`COALESCE(${personalSharedGroupJoinChallenges.consumed_at}, ${now})`,
+                superseded_at: now,
+                superseded_by_source_message_id: sourceMessageId,
+              })
+              .where(
+                inArray(
+                  personalSharedGroupJoinChallenges.id,
+                  priorActorChallenges.map(({ id }) => id),
+                ),
+              );
+          }
+
+          const [participant] = await tx
+            .select({
+              linkedUserId: personalSharedGroupParticipants.linked_user_id,
+              consentedAt: personalSharedGroupParticipants.consented_at,
+              revokedAt: personalSharedGroupParticipants.revoked_at,
+            })
+            .from(personalSharedGroupParticipants)
+            .where(
+              and(
+                eq(personalSharedGroupParticipants.binding_id, input.bindingId),
+                eq(personalSharedGroupParticipants.platform_user_id, input.actorPlatformUserId),
+              ),
+            )
+            .limit(1)
+            .for("update");
+          if (!participant) return { status: "actor_not_registered" } as const;
+          if (
+            participant.revokedAt === null &&
+            participant.linkedUserId !== null &&
+            participant.consentedAt !== null
+          ) {
+            return { status: "already_linked" } as const;
+          }
+          await tx.insert(personalSharedGroupJoinChallenges).values({
+            code_hash: input.codeHash,
+            stage: "authenticate",
+            binding_id: input.bindingId,
+            consent_version: binding.consentVersion,
+            platform: input.platform,
+            project: input.project,
+            connector_account_id: input.connectorAccountId,
+            provider_chat_id: input.providerChatId,
+            provider_thread_id: normalizedThreadId(input.providerThreadId),
+            issued_to_platform_user_id: input.actorPlatformUserId,
+            source_message_id: sourceMessageId,
+            expires_at: input.expiresAt,
+          });
+          return { status: "issued", consentVersion: binding.consentVersion } as const;
+        }),
+      { bindingId: input.bindingId },
+    );
+  }
+
+  async consumeJoinAuthenticateChallenge(input: {
+    codeHash: string;
+    confirmCodeHash: string;
+    sourceMessageId?: string;
+    platform: PersonalSharedGroupPlatform;
+    project: string;
+    connectorAccountId: string;
+    actorPlatformUserId: string;
+    linkedUserId: string;
+    linkedOrganizationId: string;
+    expiresAt: Date;
+  }): Promise<ConsumePersonalSharedGroupJoinAuthenticateResult> {
+    assertChallengeInput(input);
+    assertChallengeInput({ ...input, codeHash: input.confirmCodeHash });
+    if (!input.linkedUserId || !input.linkedOrganizationId) {
+      throw consentInputError("Authenticated Personal Shared group account is incomplete", {});
+    }
+    return withConsentStorageBoundary(
+      () =>
+        this.database.transaction(async (tx) => {
+          const now = new Date();
+          const sourceMessageId = input.sourceMessageId ?? input.confirmCodeHash;
+          const [observedChallenge] = await tx
+            .select()
+            .from(personalSharedGroupJoinChallenges)
+            .where(eq(personalSharedGroupJoinChallenges.code_hash, input.codeHash))
+            .limit(1);
+          if (!observedChallenge) return { status: "invalid" } as const;
+          const observedFailure = classifyChallenge(observedChallenge, {
+            stage: "authenticate",
+            now,
+            platform: input.platform,
+            project: input.project,
+            connectorAccountId: input.connectorAccountId,
+            actorPlatformUserId: input.actorPlatformUserId,
+          });
+          if (observedFailure && observedFailure !== "already_used") {
+            return { status: observedFailure };
+          }
+
+          // User-associated authority paths lock the durable account first.
+          // Account deactivation/deletion uses the same U -> B -> C -> P order,
+          // so no confirmation can appear after lifecycle discovery and later
+          // resurrect when the account is reactivated.
+          const [linkedUser] = await tx
+            .select({
+              organizationId: users.organization_id,
+              stewardUserId: users.steward_user_id,
+              telegramId: users.telegram_id,
+              phoneNumber: users.phone_number,
+              phoneVerified: users.phone_verified,
+              isAnonymous: users.is_anonymous,
+              isActive: users.is_active,
+              deletedAt: users.deleted_at,
+            })
+            .from(users)
+            .where(eq(users.id, input.linkedUserId))
+            .limit(1)
+            .for("update");
+          const matureSubject =
+            linkedUser &&
+            !linkedUser.stewardUserId.startsWith("phone:") &&
+            !linkedUser.stewardUserId.startsWith("telegram:");
+          const providerIdentityMatches =
+            linkedUser &&
+            (input.platform === "blooio"
+              ? linkedUser.phoneNumber === input.actorPlatformUserId &&
+                linkedUser.phoneVerified === true
+              : linkedUser.telegramId === input.actorPlatformUserId);
+          const activeOrganization = await hasActiveOrganization(tx, linkedUser?.organizationId);
+          if (
+            !linkedUser ||
+            linkedUser.organizationId !== input.linkedOrganizationId ||
+            !activeOrganization ||
+            !linkedUser.isActive ||
+            linkedUser.deletedAt !== null ||
+            linkedUser.isAnonymous ||
+            !matureSubject ||
+            !providerIdentityMatches
+          ) {
+            return { status: "account_not_authenticated" } as const;
+          }
+
+          const [binding] = await tx
+            .select({
+              id: personalSharedGroupBindings.id,
+              consentVersion: personalSharedGroupBindings.consent_version,
+            })
+            .from(personalSharedGroupBindings)
+            .where(
+              and(
+                eq(personalSharedGroupBindings.id, observedChallenge.binding_id),
+                eq(personalSharedGroupBindings.state, "active"),
+                eq(personalSharedGroupBindings.consent_mode, "all_adults"),
+              ),
+            )
+            .limit(1)
+            .for("update");
+          if (!binding) return { status: "stale" } as const;
+
+          const [challenge] = await tx
+            .select()
+            .from(personalSharedGroupJoinChallenges)
+            .where(eq(personalSharedGroupJoinChallenges.id, observedChallenge.id))
+            .limit(1)
+            .for("update");
+          const priorConfirms = await tx
+            .select()
+            .from(personalSharedGroupJoinChallenges)
+            .where(
+              and(
+                eq(personalSharedGroupJoinChallenges.binding_id, observedChallenge.binding_id),
+                eq(personalSharedGroupJoinChallenges.stage, "confirm"),
+                eq(
+                  personalSharedGroupJoinChallenges.issued_to_platform_user_id,
+                  input.actorPlatformUserId,
+                ),
+              ),
+            )
+            .orderBy(personalSharedGroupJoinChallenges.id)
+            .for("update");
+          const failure = classifyChallenge(challenge, {
+            stage: "authenticate",
+            now,
+            platform: input.platform,
+            project: input.project,
+            connectorAccountId: input.connectorAccountId,
+            actorPlatformUserId: input.actorPlatformUserId,
+          });
+          if (failure === "already_used" && input.sourceMessageId !== undefined) {
+            const replay = priorConfirms.find(
+              (confirm) =>
+                challenge?.consumed_by_source_message_id === sourceMessageId &&
+                confirm.source_message_id === sourceMessageId &&
+                confirm.code_hash === input.confirmCodeHash &&
+                confirm.linked_user_id === input.linkedUserId &&
+                confirm.consumed_at === null &&
+                confirm.expires_at > now,
+            );
+            return replay
+              ? {
+                  status: "confirm_issued" as const,
+                  bindingId: replay.binding_id,
+                  consentVersion: replay.consent_version,
+                }
+              : { status: "already_used" as const };
+          }
+          if (failure) return { status: failure };
+          if (!challenge) return { status: "invalid" } as const;
+          if (
+            binding.consentVersion !== challenge.consent_version ||
+            challenge.binding_id !== binding.id ||
+            challenge.platform !== input.platform ||
+            challenge.project !== input.project ||
+            challenge.connector_account_id !== input.connectorAccountId
+          ) {
+            return { status: "stale" } as const;
+          }
+
+          const [participant] = await tx
+            .select({
+              id: personalSharedGroupParticipants.id,
+              linkedUserId: personalSharedGroupParticipants.linked_user_id,
+              consentedAt: personalSharedGroupParticipants.consented_at,
+              revokedAt: personalSharedGroupParticipants.revoked_at,
+            })
+            .from(personalSharedGroupParticipants)
+            .where(
+              and(
+                eq(personalSharedGroupParticipants.binding_id, challenge.binding_id),
+                eq(personalSharedGroupParticipants.platform_user_id, input.actorPlatformUserId),
+              ),
+            )
+            .limit(1)
+            .for("update");
+          if (!participant) return { status: "actor_not_registered" } as const;
+          if (
+            participant.revokedAt === null &&
+            participant.linkedUserId !== null &&
+            participant.consentedAt !== null
+          ) {
+            return { status: "already_linked" } as const;
+          }
+          const [accountLink] = await tx
+            .select({ id: personalSharedGroupParticipants.id })
+            .from(personalSharedGroupParticipants)
+            .where(
+              and(
+                eq(personalSharedGroupParticipants.binding_id, challenge.binding_id),
+                eq(personalSharedGroupParticipants.linked_user_id, input.linkedUserId),
+              ),
+            )
+            .limit(1);
+          if (accountLink && accountLink.id !== participant.id) {
+            return { status: "already_linked" } as const;
+          }
+
+          await tx
+            .update(personalSharedGroupJoinChallenges)
+            .set({
+              consumed_at: now,
+              consumed_by_source_message_id: input.sourceMessageId ?? null,
+            })
+            .where(eq(personalSharedGroupJoinChallenges.id, challenge.id));
+          if (priorConfirms.length > 0) {
+            await tx.delete(personalSharedGroupJoinChallenges).where(
+              inArray(
+                personalSharedGroupJoinChallenges.id,
+                priorConfirms.map(({ id }) => id),
+              ),
+            );
+          }
+          await tx.insert(personalSharedGroupJoinChallenges).values({
+            code_hash: input.confirmCodeHash,
+            stage: "confirm",
+            binding_id: challenge.binding_id,
+            consent_version: challenge.consent_version,
+            platform: challenge.platform,
+            project: challenge.project,
+            connector_account_id: challenge.connector_account_id,
+            provider_chat_id: challenge.provider_chat_id,
+            provider_thread_id: challenge.provider_thread_id,
+            issued_to_platform_user_id: challenge.issued_to_platform_user_id,
+            source_message_id: sourceMessageId,
+            linked_user_id: input.linkedUserId,
+            expires_at: input.expiresAt,
+          });
+          return {
+            status: "confirm_issued",
+            bindingId: challenge.binding_id,
+            consentVersion: challenge.consent_version,
+          } as const;
+        }),
+      {},
+    );
+  }
+
+  async consumeJoinConfirmChallenge(input: {
+    codeHash: string;
+    sourceMessageId?: string;
+    bindingId: string;
+    platform: PersonalSharedGroupPlatform;
+    project: string;
+    connectorAccountId: string;
+    providerChatId: string;
+    providerThreadId?: string | null;
+    actorPlatformUserId: string;
+  }): Promise<ConsumePersonalSharedGroupJoinConfirmResult> {
+    assertChallengeInput(input);
+    if (!input.providerChatId) {
+      throw consentInputError("Personal Shared group confirmation destination is incomplete", {
+        bindingId: input.bindingId,
+      });
+    }
+    return withConsentStorageBoundary(
+      () =>
+        waitForAuthorityMutation<ConsumePersonalSharedGroupJoinConfirmResult>(() =>
+          this.database.transaction(async (tx) => {
+            const now = new Date();
+            const sourceMessageId = input.sourceMessageId ?? input.codeHash;
+            const [observedChallenge] = await tx
+              .select()
+              .from(personalSharedGroupJoinChallenges)
+              .where(eq(personalSharedGroupJoinChallenges.code_hash, input.codeHash))
+              .limit(1);
+            if (!observedChallenge || !observedChallenge.linked_user_id) {
+              return { blocked: false, result: { status: "invalid" as const } };
+            }
+
+            // Lock the account before any binding/challenge/participant row.
+            // Lifecycle mutations take the same order and therefore cannot
+            // miss a consent link that appears just before deactivation.
+            const [linkedUser] = await tx
+              .select({
+                stewardUserId: users.steward_user_id,
+                telegramId: users.telegram_id,
+                phoneNumber: users.phone_number,
+                phoneVerified: users.phone_verified,
+                isAnonymous: users.is_anonymous,
+                isActive: users.is_active,
+                deletedAt: users.deleted_at,
+                organizationId: users.organization_id,
+              })
+              .from(users)
+              .where(eq(users.id, observedChallenge.linked_user_id))
+              .limit(1)
+              .for("update");
+            const activeOrganization = await hasActiveOrganization(tx, linkedUser?.organizationId);
+
+            const [binding] = await tx
+              .select({
+                id: personalSharedGroupBindings.id,
+                consentVersion: personalSharedGroupBindings.consent_version,
+                deliveryLeaseBlocked: deliveryLeaseBlocksAuthorityMutation(now),
+              })
+              .from(personalSharedGroupBindings)
+              .where(
+                and(
+                  eq(personalSharedGroupBindings.id, observedChallenge.binding_id),
+                  eq(personalSharedGroupBindings.state, "active"),
+                  eq(personalSharedGroupBindings.consent_mode, "all_adults"),
+                ),
+              )
+              .limit(1)
+              .for("update");
+
+            const [challenge] = await tx
+              .select()
+              .from(personalSharedGroupJoinChallenges)
+              .where(eq(personalSharedGroupJoinChallenges.id, observedChallenge.id))
+              .limit(1)
+              .for("update");
+            const failure = classifyChallenge(challenge, {
+              stage: "confirm",
+              now,
+              bindingId: input.bindingId,
+              platform: input.platform,
+              project: input.project,
+              connectorAccountId: input.connectorAccountId,
+              providerChatId: input.providerChatId,
+              providerThreadId: normalizedThreadId(input.providerThreadId),
+              actorPlatformUserId: input.actorPlatformUserId,
+            });
+            if (
+              failure === "already_used" &&
+              input.sourceMessageId !== undefined &&
+              challenge?.consumed_by_source_message_id === sourceMessageId &&
+              challenge.stage === "confirm" &&
+              challenge.expires_at > now &&
+              challenge.binding_id === input.bindingId &&
+              challenge.platform === input.platform &&
+              challenge.project === input.project &&
+              challenge.connector_account_id === input.connectorAccountId &&
+              challenge.provider_chat_id === input.providerChatId &&
+              challenge.provider_thread_id === normalizedThreadId(input.providerThreadId) &&
+              challenge.issued_to_platform_user_id === input.actorPlatformUserId &&
+              binding?.consentVersion === challenge.consent_version
+            ) {
+              const [replayParticipant] = await tx
+                .select({
+                  linkedUserId: personalSharedGroupParticipants.linked_user_id,
+                  consentedAt: personalSharedGroupParticipants.consented_at,
+                  revokedAt: personalSharedGroupParticipants.revoked_at,
+                })
+                .from(personalSharedGroupParticipants)
+                .where(
+                  and(
+                    eq(personalSharedGroupParticipants.binding_id, input.bindingId),
+                    eq(personalSharedGroupParticipants.platform_user_id, input.actorPlatformUserId),
+                  ),
+                )
+                .limit(1)
+                .for("update");
+              const matureReplaySubject =
+                linkedUser &&
+                !linkedUser.stewardUserId.startsWith("phone:") &&
+                !linkedUser.stewardUserId.startsWith("telegram:");
+              const replayIdentityMatches =
+                linkedUser &&
+                (challenge.platform === "blooio"
+                  ? linkedUser.phoneNumber === challenge.issued_to_platform_user_id &&
+                    linkedUser.phoneVerified === true
+                  : linkedUser.telegramId === challenge.issued_to_platform_user_id);
+              if (
+                replayParticipant?.linkedUserId === challenge.linked_user_id &&
+                replayParticipant.consentedAt !== null &&
+                replayParticipant.revokedAt === null &&
+                linkedUser?.isActive === true &&
+                activeOrganization &&
+                linkedUser.deletedAt === null &&
+                linkedUser.isAnonymous === false &&
+                matureReplaySubject &&
+                replayIdentityMatches
+              ) {
+                const consent = await deriveConsentStatusInTransaction(tx, input.bindingId);
+                if (consent) {
+                  return {
+                    blocked: false,
+                    result: { status: "consented" as const, consent },
+                  };
+                }
+              }
+            }
+            if (failure) return { blocked: false, result: { status: failure } };
+            if (!challenge) {
+              return { blocked: false, result: { status: "invalid" as const } };
+            }
+            if (!binding || binding.consentVersion !== challenge.consent_version) {
+              return { blocked: false, result: { status: "stale" as const } };
+            }
+            if (binding.deliveryLeaseBlocked) return { blocked: true } as const;
+
+            const [participant] = await tx
+              .select({
+                id: personalSharedGroupParticipants.id,
+                linkedUserId: personalSharedGroupParticipants.linked_user_id,
+                consentedAt: personalSharedGroupParticipants.consented_at,
+                revokedAt: personalSharedGroupParticipants.revoked_at,
+              })
+              .from(personalSharedGroupParticipants)
+              .where(
+                and(
+                  eq(personalSharedGroupParticipants.binding_id, input.bindingId),
+                  eq(personalSharedGroupParticipants.platform_user_id, input.actorPlatformUserId),
+                ),
+              )
+              .limit(1)
+              .for("update");
+            if (!participant) {
+              return {
+                blocked: false,
+                result: { status: "actor_not_registered" as const },
+              };
+            }
+            if (
+              participant.revokedAt === null &&
+              participant.linkedUserId !== null &&
+              participant.consentedAt !== null
+            ) {
+              return { blocked: false, result: { status: "already_linked" as const } };
+            }
+            const [accountLink] = await tx
+              .select({ id: personalSharedGroupParticipants.id })
+              .from(personalSharedGroupParticipants)
+              .where(
+                and(
+                  eq(personalSharedGroupParticipants.binding_id, input.bindingId),
+                  eq(personalSharedGroupParticipants.linked_user_id, challenge.linked_user_id!),
+                ),
+              )
+              .limit(1);
+            if (accountLink && accountLink.id !== participant.id) {
+              return { blocked: false, result: { status: "already_linked" as const } };
+            }
+
+            // Authentication and confirmation are intentionally separate
+            // handoff stages. Revalidate the account under the U-first row lock
+            // so an identity downgrade cannot cross the consent boundary.
+            const matureSubject =
+              linkedUser &&
+              !linkedUser.stewardUserId.startsWith("phone:") &&
+              !linkedUser.stewardUserId.startsWith("telegram:");
+            const providerIdentityMatches =
+              linkedUser &&
+              (challenge.platform === "blooio"
+                ? linkedUser.phoneNumber === challenge.issued_to_platform_user_id &&
+                  linkedUser.phoneVerified === true
+                : linkedUser.telegramId === challenge.issued_to_platform_user_id);
+            if (
+              !linkedUser ||
+              !activeOrganization ||
+              !linkedUser.isActive ||
+              linkedUser.deletedAt !== null ||
+              linkedUser.isAnonymous ||
+              !matureSubject ||
+              !providerIdentityMatches
+            ) {
+              return {
+                blocked: false,
+                result: { status: "account_not_authenticated" as const },
+              };
+            }
+
+            const [authority] = await tx
+              .update(personalSharedGroupBindings)
+              .set({
+                authority_version: sql`${personalSharedGroupBindings.authority_version} + 1`,
+                updated_at: now,
+              })
+              .where(
+                and(
+                  eq(personalSharedGroupBindings.id, input.bindingId),
+                  eq(personalSharedGroupBindings.consent_version, challenge.consent_version),
+                  deliveryLeaseAllowsAuthorityMutation(now),
+                ),
+              )
+              .returning({ id: personalSharedGroupBindings.id });
+            if (!authority) return { blocked: true } as const;
+            await tx
+              .update(personalSharedGroupParticipants)
+              .set({
+                linked_user_id: challenge.linked_user_id,
+                consented_at: now,
+                consent_provenance: "authenticated_dm",
+                revoked_at: null,
+                last_seen_at: now,
+              })
+              .where(eq(personalSharedGroupParticipants.id, participant.id));
+            await tx
+              .update(personalSharedGroupJoinChallenges)
+              .set({
+                consumed_at: now,
+                consumed_by_source_message_id: input.sourceMessageId ?? null,
+              })
+              .where(
+                and(
+                  eq(personalSharedGroupJoinChallenges.id, challenge.id),
+                  isNull(personalSharedGroupJoinChallenges.consumed_at),
+                ),
+              );
+            const consent = await deriveConsentStatusInTransaction(tx, input.bindingId);
+            if (!consent) {
+              throw new ElizaError("Consent status vanished during join confirmation", {
+                code: "PERSONAL_SHARED_GROUP_CONSENT_STATUS_MISSING",
+                severity: "fatal",
+                context: { bindingId: input.bindingId },
+              });
+            }
+            return { blocked: false, result: { status: "consented" as const, consent } };
+          }),
+        ),
+      { bindingId: input.bindingId },
+    );
+  }
+
+  async deriveConsentStatus(input: {
+    bindingId: string;
+  }): Promise<PersonalSharedGroupConsentStatus | null> {
+    if (!input.bindingId) {
+      throw consentInputError("Personal Shared group consent status binding is missing", {});
+    }
+    return withConsentStorageBoundary(
+      () =>
+        this.database.transaction((tx) => deriveConsentStatusInTransaction(tx, input.bindingId)),
+      { bindingId: input.bindingId },
+    );
+  }
+
+  async selfRevoke(input: {
+    bindingId: string;
+    actorPlatformUserId: string;
+  }): Promise<PersonalSharedGroupSelfRevokeResult> {
+    if (!input.bindingId || !input.actorPlatformUserId) {
+      throw consentInputError("Personal Shared group self-revocation identity is incomplete", {
+        bindingId: input.bindingId,
+      });
+    }
+    return withConsentStorageBoundary(
+      () =>
+        waitForAuthorityMutation<PersonalSharedGroupSelfRevokeResult>(() =>
+          this.database.transaction(async (tx) => {
+            const now = new Date();
+            const [binding] = await tx
+              .select({
+                id: personalSharedGroupBindings.id,
+                ownerUserId: personalSharedGroupBindings.owner_user_id,
+                deliveryLeaseBlocked: deliveryLeaseBlocksAuthorityMutation(now),
+              })
+              .from(personalSharedGroupBindings)
+              .where(
+                and(
+                  eq(personalSharedGroupBindings.id, input.bindingId),
+                  eq(personalSharedGroupBindings.state, "active"),
+                  eq(personalSharedGroupBindings.consent_mode, "all_adults"),
+                ),
+              )
+              .limit(1)
+              .for("update");
+            if (!binding) {
+              return { blocked: false, result: { status: "invalid" as const } };
+            }
+            const [participant] = await tx
+              .select({
+                id: personalSharedGroupParticipants.id,
+                linkedUserId: personalSharedGroupParticipants.linked_user_id,
+                consentedAt: personalSharedGroupParticipants.consented_at,
+                revokedAt: personalSharedGroupParticipants.revoked_at,
+              })
+              .from(personalSharedGroupParticipants)
+              .where(
+                and(
+                  eq(personalSharedGroupParticipants.binding_id, input.bindingId),
+                  eq(personalSharedGroupParticipants.platform_user_id, input.actorPlatformUserId),
+                ),
+              )
+              .limit(1)
+              .for("update");
+            if (
+              !participant ||
+              participant.linkedUserId === null ||
+              participant.consentedAt === null ||
+              participant.revokedAt !== null
+            ) {
+              return { blocked: false, result: { status: "not_linked" as const } };
+            }
+            if (participant.linkedUserId === binding.ownerUserId) {
+              return { blocked: false, result: { status: "owner_forbidden" as const } };
+            }
+            if (binding.deliveryLeaseBlocked) return { blocked: true } as const;
+
+            const [authority] = await tx
+              .update(personalSharedGroupBindings)
+              .set({
+                authority_version: sql`${personalSharedGroupBindings.authority_version} + 1`,
+                consent_version: sql`${personalSharedGroupBindings.consent_version} + 1`,
+                updated_at: now,
+              })
+              .where(
+                and(
+                  eq(personalSharedGroupBindings.id, input.bindingId),
+                  deliveryLeaseAllowsAuthorityMutation(now),
+                ),
+              )
+              .returning({ id: personalSharedGroupBindings.id });
+            if (!authority) return { blocked: true } as const;
+            await tx
+              .update(personalSharedGroupParticipants)
+              .set({
+                linked_user_id: null,
+                consented_at: null,
+                consent_provenance: null,
+                revoked_at: now,
+              })
+              .where(eq(personalSharedGroupParticipants.id, participant.id));
+            const consent = await deriveConsentStatusInTransaction(tx, input.bindingId);
+            if (!consent) {
+              throw new ElizaError("Consent status vanished during self-revocation", {
+                code: "PERSONAL_SHARED_GROUP_CONSENT_STATUS_MISSING",
+                severity: "fatal",
+                context: { bindingId: input.bindingId },
+              });
+            }
+            return { blocked: false, result: { status: "revoked" as const, consent } };
+          }),
+        ),
+      { bindingId: input.bindingId },
+    );
+  }
+}
+
+export const personalSharedGroupConsentRepository = new PersonalSharedGroupConsentRepository(
+  dbWrite,
+);

--- a/packages/cloud/shared/src/db/repositories/personal-shared-group-participants.ts
+++ b/packages/cloud/shared/src/db/repositories/personal-shared-group-participants.ts
@@ -14,7 +14,10 @@ import { resolveGroupParticipantDisplayName } from "../../lib/services/shared-ru
 import type { Database } from "../client";
 import { sqlRows } from "../execute-helpers";
 import { dbWrite } from "../helpers";
-import { personalSharedGroupParticipants } from "../schemas/personal-shared-groups";
+import {
+  personalSharedGroupBindings,
+  personalSharedGroupParticipants,
+} from "../schemas/personal-shared-groups";
 
 /**
  * Second advisory-lock key. The first key is the binding id, so the lock space
@@ -80,10 +83,9 @@ export class PersonalSharedGroupParticipantsRepository {
    * assignments for the same binding can read the same maximum. Two guards
    * make that impossible:
    *
-   *  - a per-binding transaction advisory lock serializes the read-then-insert
-   *    window, so concurrent first-time speakers in one group queue instead of
-   *    racing (the lock is per binding, so unrelated groups never wait, and
-   *    this transaction takes no other lock, so it cannot deadlock);
+   *  - a binding key-share lock followed by a per-binding transaction advisory
+   *    lock serializes the read-then-insert window. Rebind uses the same
+   *    B -> advisory -> participant order, while unrelated groups never wait;
    *  - `personal_shared_group_participants_ordinal_uidx` is the schema-level
    *    backstop: even if the lock were somehow bypassed, a duplicate ordinal
    *    cannot be persisted, and the turn fails loudly instead of quietly
@@ -109,6 +111,18 @@ export class PersonalSharedGroupParticipantsRepository {
     }
     try {
       return await this.database.transaction(async (tx) => {
+        const [binding] = await tx
+          .select({ id: personalSharedGroupBindings.id })
+          .from(personalSharedGroupBindings)
+          .where(eq(personalSharedGroupBindings.id, input.bindingId))
+          .limit(1)
+          .for("key share");
+        if (!binding) {
+          throw storageFailure("Group participant registration failed", {
+            bindingId: input.bindingId,
+            reason: "binding_missing",
+          });
+        }
         await tx.execute(
           sql`SELECT pg_advisory_xact_lock(
             hashtext(${input.bindingId}),

--- a/packages/cloud/shared/src/db/repositories/personal-shared-groups.groups-adversarial.test.ts
+++ b/packages/cloud/shared/src/db/repositories/personal-shared-groups.groups-adversarial.test.ts
@@ -67,8 +67,21 @@ beforeAll(async () => {
   ({ personalSharedGroupsRepository: repository } = await import("./personal-shared-groups"));
   const database = getPgliteClientForTests();
   await database.exec(`
-    CREATE TABLE organizations (id uuid PRIMARY KEY);
-    CREATE TABLE users (id uuid PRIMARY KEY);
+    CREATE TABLE organizations (
+      id uuid PRIMARY KEY,
+      is_active boolean NOT NULL DEFAULT true
+    );
+    CREATE TABLE users (
+      id uuid PRIMARY KEY,
+      organization_id uuid REFERENCES organizations(id),
+      steward_user_id text,
+      telegram_id text,
+      phone_number text,
+      phone_verified boolean,
+      is_anonymous boolean,
+      is_active boolean,
+      deleted_at timestamptz
+    );
   `);
   // The repository reads authority_version and delivery_lease_* columns, so
   // the schema must include the authority (0303) and lease (0304) migrations
@@ -77,6 +90,8 @@ beforeAll(async () => {
     "0297_personal_shared_group_bindings.sql",
     "0303_personal_shared_group_authority_version.sql",
     "0304_personal_shared_group_delivery_lease.sql",
+    "0311_personal_shared_group_participants.sql",
+    "0320_personal_shared_multi_principal_consent.sql",
   ]) {
     const migration = await Bun.file(new URL(`../migrations/${file}`, import.meta.url)).text();
     await database.exec(migration);
@@ -91,7 +106,7 @@ beforeEach(async () => {
       users,
       organizations CASCADE;
     INSERT INTO organizations (id) VALUES ('${ORG_A}');
-    INSERT INTO users (id) VALUES ('${USER_A}');
+    INSERT INTO users (id, organization_id) VALUES ('${USER_A}', '${ORG_A}');
   `);
 });
 

--- a/packages/cloud/shared/src/db/repositories/personal-shared-groups.integration.test.ts
+++ b/packages/cloud/shared/src/db/repositories/personal-shared-groups.integration.test.ts
@@ -59,8 +59,21 @@ beforeAll(async () => {
   ({ personalSharedGroupsRepository: repository } = await import("./personal-shared-groups"));
   const database = getPgliteClientForTests();
   await database.exec(`
-    CREATE TABLE organizations (id uuid PRIMARY KEY);
-    CREATE TABLE users (id uuid PRIMARY KEY);
+    CREATE TABLE organizations (
+      id uuid PRIMARY KEY,
+      is_active boolean NOT NULL DEFAULT true
+    );
+    CREATE TABLE users (
+      id uuid PRIMARY KEY,
+      organization_id uuid REFERENCES organizations(id),
+      steward_user_id text,
+      telegram_id text,
+      phone_number text,
+      phone_verified boolean,
+      is_anonymous boolean,
+      is_active boolean,
+      deleted_at timestamptz
+    );
   `);
   const migration = await Bun.file(
     new URL("../migrations/0297_personal_shared_group_bindings.sql", import.meta.url),
@@ -80,6 +93,14 @@ beforeAll(async () => {
     new URL("../migrations/0312_personal_shared_group_delivery_attempts.sql", import.meta.url),
   ).text();
   await database.exec(attemptsMigration);
+  const participantsMigration = await Bun.file(
+    new URL("../migrations/0311_personal_shared_group_participants.sql", import.meta.url),
+  ).text();
+  await database.exec(participantsMigration);
+  const consentMigration = await Bun.file(
+    new URL("../migrations/0320_personal_shared_multi_principal_consent.sql", import.meta.url),
+  ).text();
+  await database.exec(consentMigration);
 });
 
 beforeEach(async () => {
@@ -91,7 +112,8 @@ beforeEach(async () => {
       users,
       organizations CASCADE;
     INSERT INTO organizations (id) VALUES ('${ORG_A}'), ('${ORG_B}');
-    INSERT INTO users (id) VALUES ('${USER_A}'), ('${USER_B}');
+    INSERT INTO users (id, organization_id)
+    VALUES ('${USER_A}', '${ORG_A}'), ('${USER_B}', '${ORG_B}');
   `);
 });
 

--- a/packages/cloud/shared/src/db/repositories/personal-shared-groups.ts
+++ b/packages/cloud/shared/src/db/repositories/personal-shared-groups.ts
@@ -15,16 +15,20 @@ import {
   sql,
 } from "drizzle-orm";
 import { v5 as uuidv5 } from "uuid";
-import { dbWrite } from "../client";
+import { type DbTransaction, dbWrite } from "../client";
+import { organizations } from "../schemas/organizations";
 import {
   type PersonalSharedGroupBinding,
+  type PersonalSharedGroupConsentMode,
   type PersonalSharedGroupPlatform,
   type PersonalSharedGroupResponsePolicy,
   personalSharedGroupBindings,
   personalSharedGroupClaims,
   personalSharedGroupDeliveryAttempts,
   personalSharedGroupDeliveryReceipts,
+  personalSharedGroupParticipants,
 } from "../schemas/personal-shared-groups";
+import { users } from "../schemas/users";
 
 const PERSONAL_SHARED_GROUP_NAMESPACE = "987af3c6-5e48-4ad7-a5b6-883b51d0c904";
 
@@ -56,6 +60,12 @@ export interface PersonalSharedGroupDeliveryAuthority {
   ownerUserId: string;
   personalAgentId: string;
   version: number;
+  /**
+   * Explicitly false only for consent-control replies. Missing is fail-closed
+   * for an all-adults binding so a rolling gateway cannot strip capability
+   * admission and accidentally bypass the persisted consent policy.
+   */
+  requiresAllAdultsConsent?: boolean;
 }
 
 export interface PersonalSharedGroupDeliveryLease {
@@ -81,6 +91,94 @@ export class PersonalSharedGroupDeliveryPendingError extends ElizaError {
   }
 }
 
+export class PersonalSharedGroupIndependentAuthenticationRequiredError extends ElizaError {
+  constructor(platform: PersonalSharedGroupPlatform, phase: "issue" | "consume") {
+    super("An all-adults group owner must independently authenticate their Eliza account", {
+      code: "PERSONAL_SHARED_GROUP_OWNER_INDEPENDENT_AUTHENTICATION_REQUIRED",
+      severity: "fatal",
+      context: { platform, phase },
+    });
+  }
+}
+
+async function assertIndependentlyAuthenticatedOwner(
+  tx: DbTransaction,
+  input: {
+    ownerUserId: string;
+    organizationId: string;
+    platform: PersonalSharedGroupPlatform;
+    platformSenderId: string;
+    phase: "issue" | "consume";
+  },
+): Promise<void> {
+  const [owner] = await tx
+    .select({
+      organizationId: users.organization_id,
+      stewardUserId: users.steward_user_id,
+      telegramId: users.telegram_id,
+      phoneNumber: users.phone_number,
+      phoneVerified: users.phone_verified,
+      isAnonymous: users.is_anonymous,
+      isActive: users.is_active,
+      deletedAt: users.deleted_at,
+    })
+    .from(users)
+    .where(eq(users.id, input.ownerUserId))
+    .limit(1)
+    .for("update");
+  const matureSubject =
+    owner &&
+    !owner.stewardUserId.startsWith("phone:") &&
+    !owner.stewardUserId.startsWith("telegram:");
+  const providerIdentityMatches =
+    owner &&
+    (input.platform === "blooio"
+      ? owner.phoneNumber === input.platformSenderId && owner.phoneVerified === true
+      : owner.telegramId === input.platformSenderId);
+  const [activeOrganization] = await tx
+    .select({ id: organizations.id })
+    .from(organizations)
+    .where(and(eq(organizations.id, input.organizationId), eq(organizations.is_active, true)))
+    .limit(1);
+  if (
+    !owner ||
+    owner.organizationId !== input.organizationId ||
+    !activeOrganization ||
+    !owner.isActive ||
+    owner.deletedAt !== null ||
+    owner.isAnonymous ||
+    !matureSubject ||
+    !providerIdentityMatches
+  ) {
+    throw new PersonalSharedGroupIndependentAuthenticationRequiredError(
+      input.platform,
+      input.phase,
+    );
+  }
+}
+
+function resolveConsentConfiguration(input: {
+  consentMode?: PersonalSharedGroupConsentMode;
+  requiredPrincipalCount?: number;
+}): { consentMode: PersonalSharedGroupConsentMode; requiredPrincipalCount: number } {
+  const consentMode = input.consentMode ?? "single_owner";
+  const requiredPrincipalCount = input.requiredPrincipalCount ?? 1;
+  const valid =
+    (consentMode === "single_owner" && requiredPrincipalCount === 1) ||
+    (consentMode === "all_adults" &&
+      Number.isInteger(requiredPrincipalCount) &&
+      requiredPrincipalCount >= 2 &&
+      requiredPrincipalCount <= 32);
+  if (!valid) {
+    throw new ElizaError("Personal Shared group consent configuration is invalid", {
+      code: "PERSONAL_SHARED_GROUP_CONSENT_CONFIGURATION_INVALID",
+      severity: "fatal",
+      context: { consentMode, requiredPrincipalCount },
+    });
+  }
+  return { consentMode, requiredPrincipalCount };
+}
+
 function deliveryLeaseAvailable(now: Date) {
   return or(
     isNull(personalSharedGroupBindings.delivery_lease_source_id),
@@ -88,6 +186,43 @@ function deliveryLeaseAvailable(now: Date) {
       isNull(personalSharedGroupBindings.delivery_lease_committed_at),
       lte(personalSharedGroupBindings.delivery_lease_expires_at, now),
     ),
+  );
+}
+
+function deliveryConsentAllowsEgress(authority: PersonalSharedGroupDeliveryAuthority) {
+  if (authority.requiresAllAdultsConsent === false) return sql`true`;
+  return or(
+    eq(personalSharedGroupBindings.consent_mode, "single_owner"),
+    sql`(
+      SELECT
+        count(*) >= ${personalSharedGroupBindings.required_principal_count}
+        AND count(*) FILTER (
+          WHERE participant.linked_user_id = ${personalSharedGroupBindings.owner_user_id}
+        ) = 1
+      FROM ${personalSharedGroupParticipants} participant
+      INNER JOIN ${users} eligible_user
+        ON eligible_user.id = participant.linked_user_id
+      INNER JOIN ${organizations} eligible_organization
+        ON eligible_organization.id = eligible_user.organization_id
+        AND eligible_organization.is_active = true
+      WHERE participant.binding_id = ${personalSharedGroupBindings.id}
+        AND participant.revoked_at IS NULL
+        AND participant.consented_at IS NOT NULL
+        AND participant.consent_provenance IS NOT NULL
+        AND eligible_user.is_active = true
+        AND eligible_user.deleted_at IS NULL
+        AND eligible_user.is_anonymous = false
+        AND eligible_user.steward_user_id NOT LIKE 'phone:%'
+        AND eligible_user.steward_user_id NOT LIKE 'telegram:%'
+        AND (
+          (${personalSharedGroupBindings.platform} = 'blooio'
+            AND eligible_user.phone_number = participant.platform_user_id
+            AND eligible_user.phone_verified = true)
+          OR
+          (${personalSharedGroupBindings.platform} = 'telegram'
+            AND eligible_user.telegram_id = participant.platform_user_id)
+        )
+    )`,
   );
 }
 
@@ -133,10 +268,35 @@ export const personalSharedGroupsRepository = {
     project: string;
     connectorAccountId: string;
     issuedToPlatformUserId: string;
+    consentMode?: PersonalSharedGroupConsentMode;
+    requiredPrincipalCount?: number;
     expiresAt: Date;
   }): Promise<void> {
+    const consent = resolveConsentConfiguration(input);
     await dbWrite.transaction(async (tx) => {
       const now = new Date();
+      if (consent.consentMode === "all_adults") {
+        await assertIndependentlyAuthenticatedOwner(tx, {
+          ownerUserId: input.ownerUserId,
+          organizationId: input.organizationId,
+          platform: input.platform,
+          platformSenderId: input.issuedToPlatformUserId,
+          phase: "issue",
+        });
+      } else {
+        const [owner] = await tx
+          .select({ id: users.id })
+          .from(users)
+          .where(eq(users.id, input.ownerUserId))
+          .limit(1)
+          .for("update");
+        if (!owner) {
+          throw new ElizaError("Personal Shared group claim owner is missing", {
+            code: "PERSONAL_SHARED_GROUP_CLAIM_OWNER_MISSING",
+            severity: "fatal",
+          });
+        }
+      }
       await tx
         .update(personalSharedGroupClaims)
         .set({ consumed_at: now })
@@ -158,6 +318,8 @@ export const personalSharedGroupsRepository = {
         project: input.project,
         connector_account_id: input.connectorAccountId,
         issued_to_platform_user_id: input.issuedToPlatformUserId,
+        consent_mode: consent.consentMode,
+        required_principal_count: consent.requiredPrincipalCount,
         expires_at: input.expiresAt,
       });
     });
@@ -175,6 +337,43 @@ export const personalSharedGroupsRepository = {
     return dbWrite.transaction(async (tx) => {
       const leaseNow = new Date();
       const now = input.verifiedAt ?? leaseNow;
+      const [observedClaim] = await tx
+        .select()
+        .from(personalSharedGroupClaims)
+        .where(eq(personalSharedGroupClaims.code_hash, input.codeHash))
+        .limit(1);
+      if (!observedClaim) return { status: "invalid" } as const;
+      if (observedClaim.consumed_at) return { status: "already_used" } as const;
+      if (observedClaim.expires_at <= now) return { status: "expired" } as const;
+      if (
+        observedClaim.platform !== input.platform ||
+        observedClaim.project !== input.project ||
+        observedClaim.connector_account_id !== input.connectorAccountId ||
+        observedClaim.issued_to_platform_user_id !== input.actorPlatformUserId
+      ) {
+        return { status: "invalid" } as const;
+      }
+
+      // Owner authority takes the user row before the claim row. Account
+      // lifecycle uses the same order, closing both FK-cascade deadlocks and
+      // the no-binding-yet resurrection race during first all-adults bind.
+      if (observedClaim.consent_mode === "all_adults") {
+        await assertIndependentlyAuthenticatedOwner(tx, {
+          ownerUserId: observedClaim.owner_user_id,
+          organizationId: observedClaim.organization_id,
+          platform: input.platform,
+          platformSenderId: input.actorPlatformUserId,
+          phase: "consume",
+        });
+      } else {
+        const [owner] = await tx
+          .select({ id: users.id })
+          .from(users)
+          .where(eq(users.id, observedClaim.owner_user_id))
+          .limit(1)
+          .for("update");
+        if (!owner) return { status: "invalid" } as const;
+      }
       const [claim] = await tx
         .update(personalSharedGroupClaims)
         .set({ consumed_at: now })
@@ -229,6 +428,8 @@ export const personalSharedGroupsRepository = {
       ) {
         return { status: "already_bound" } as const;
       }
+      const resetsAllAdultsConsent =
+        claim.consent_mode === "all_adults" || existing?.consent_mode === "all_adults";
       const [binding] = await tx
         .insert(personalSharedGroupBindings)
         .values({
@@ -242,6 +443,8 @@ export const personalSharedGroupsRepository = {
           conversation_id: conversationId,
           state: "active",
           response_policy: "mention_only",
+          consent_mode: claim.consent_mode,
+          required_principal_count: claim.required_principal_count,
           created_by_platform_user_id: input.actorPlatformUserId,
           last_verified_at: now,
           updated_at: now,
@@ -260,6 +463,9 @@ export const personalSharedGroupsRepository = {
             conversation_id: conversationId,
             state: "active",
             response_policy: "mention_only",
+            consent_mode: claim.consent_mode,
+            required_principal_count: claim.required_principal_count,
+            consent_version: sql`${personalSharedGroupBindings.consent_version} + 1`,
             authority_version: sql`${personalSharedGroupBindings.authority_version} + 1`,
             delivery_lease_source_id: sql`CASE WHEN ${personalSharedGroupBindings.delivery_lease_committed_at} IS NULL THEN NULL ELSE ${personalSharedGroupBindings.delivery_lease_source_id} END`,
             delivery_lease_token: sql`CASE WHEN ${personalSharedGroupBindings.delivery_lease_committed_at} IS NULL THEN NULL ELSE ${personalSharedGroupBindings.delivery_lease_token} END`,
@@ -306,6 +512,48 @@ export const personalSharedGroupsRepository = {
           throw new PersonalSharedGroupDeliveryPendingError();
         }
         return { status: "already_bound" } as const;
+      }
+      if (resetsAllAdultsConsent) {
+        // The upsert holds binding authority before this ordinal lock.
+        // recordTurn takes a binding key-share lock first as well, keeping all
+        // participant mutations on B -> advisory -> P even when ON CONFLICT
+        // discovers a binding that was absent from the earlier observation.
+        await tx.execute(
+          sql`SELECT pg_advisory_xact_lock(
+            hashtext(${binding.id}),
+            hashtext('personal-shared-group-participant-ordinal')
+          )`,
+        );
+        if (existing) {
+          // Rebinding an all-adults group starts a new consent epoch. Keep
+          // ordinal audit rows for redaction/history, but no prior account link
+          // or consent crosses that whole-binding boundary.
+          await tx
+            .update(personalSharedGroupParticipants)
+            .set({
+              linked_user_id: null,
+              consented_at: null,
+              consent_provenance: null,
+              revoked_at: now,
+            })
+            .where(eq(personalSharedGroupParticipants.binding_id, binding.id));
+        }
+      }
+      if (claim.consent_mode === "all_adults") {
+        await tx.execute(sql`INSERT INTO ${personalSharedGroupParticipants}
+          (binding_id, platform_user_id, ordinal, linked_user_id, consented_at,
+            consent_provenance, revoked_at, last_seen_at)
+        SELECT ${binding.id}::uuid, ${input.actorPlatformUserId},
+          COALESCE(MAX(${personalSharedGroupParticipants.ordinal}), 0) + 1,
+          ${claim.owner_user_id}::uuid, ${now}, 'owner_binding', NULL, ${now}
+        FROM ${personalSharedGroupParticipants}
+        WHERE ${personalSharedGroupParticipants.binding_id} = ${binding.id}::uuid
+        ON CONFLICT (binding_id, platform_user_id) DO UPDATE SET
+          linked_user_id = EXCLUDED.linked_user_id,
+          consented_at = EXCLUDED.consented_at,
+          consent_provenance = EXCLUDED.consent_provenance,
+          revoked_at = NULL,
+          last_seen_at = EXCLUDED.last_seen_at`);
       }
       return { status: "bound", binding } as const;
     });
@@ -393,22 +641,40 @@ export const personalSharedGroupsRepository = {
     return Boolean(
       await waitForAuthorityMutation(
         async (now) => {
-          const [binding] = await dbWrite
-            .update(personalSharedGroupBindings)
-            .set({
-              state: "revoked",
-              authority_version: sql`${personalSharedGroupBindings.authority_version} + 1`,
-              updated_at: now,
-            })
-            .where(
-              and(
-                eq(personalSharedGroupBindings.id, input.bindingId),
-                eq(personalSharedGroupBindings.owner_user_id, input.ownerUserId),
-                deliveryLeaseAllowsAuthorityMutation(now),
-              ),
-            )
-            .returning({ id: personalSharedGroupBindings.id });
-          return binding ?? null;
+          return dbWrite.transaction(async (tx) => {
+            const [binding] = await tx
+              .update(personalSharedGroupBindings)
+              .set({
+                state: "revoked",
+                authority_version: sql`${personalSharedGroupBindings.authority_version} + 1`,
+                consent_version: sql`${personalSharedGroupBindings.consent_version} + 1`,
+                updated_at: now,
+              })
+              .where(
+                and(
+                  eq(personalSharedGroupBindings.id, input.bindingId),
+                  eq(personalSharedGroupBindings.owner_user_id, input.ownerUserId),
+                  deliveryLeaseAllowsAuthorityMutation(now),
+                ),
+              )
+              .returning({
+                id: personalSharedGroupBindings.id,
+                consentMode: personalSharedGroupBindings.consent_mode,
+              });
+            if (!binding) return null;
+            if (binding.consentMode === "all_adults") {
+              await tx
+                .update(personalSharedGroupParticipants)
+                .set({
+                  linked_user_id: null,
+                  consented_at: null,
+                  consent_provenance: null,
+                  revoked_at: now,
+                })
+                .where(eq(personalSharedGroupParticipants.binding_id, binding.id));
+            }
+            return binding;
+          });
         },
         async (now) => {
           const [binding] = await dbWrite
@@ -610,6 +876,7 @@ export const personalSharedGroupsRepository = {
             eq(personalSharedGroupBindings.connector_account_id, input.connectorAccountId),
             eq(personalSharedGroupBindings.provider_chat_id, input.providerChatId),
             eq(personalSharedGroupBindings.state, "active"),
+            deliveryConsentAllowsEgress(input.authority),
             notExists(
               tx
                 .select({ id: personalSharedGroupDeliveryAttempts.id })
@@ -735,6 +1002,7 @@ export const personalSharedGroupsRepository = {
             eq(personalSharedGroupBindings.connector_account_id, input.connectorAccountId),
             eq(personalSharedGroupBindings.provider_chat_id, input.providerChatId),
             eq(personalSharedGroupBindings.state, "active"),
+            deliveryConsentAllowsEgress(input.authority),
             eq(personalSharedGroupBindings.delivery_lease_source_id, input.sourceMessageId),
             eq(personalSharedGroupBindings.delivery_lease_token, input.leaseToken),
             or(

--- a/packages/cloud/shared/src/db/repositories/users-account-deletion.integration.test.ts
+++ b/packages/cloud/shared/src/db/repositories/users-account-deletion.integration.test.ts
@@ -6,10 +6,15 @@ process.env.DATABASE_URL ||= "pglite://memory";
 process.env.NODE_ENV ||= "test";
 
 import { pushSchema } from "drizzle-kit/api";
-import { eq, sql } from "drizzle-orm";
+import { asc, eq, inArray, sql } from "drizzle-orm";
 import { resolveAccountDeletionTestDatabase } from "../account-deletion-test-database";
 import { closeDatabaseConnectionsForTests, dbWrite } from "../client";
 import { organizationBalanceRevisionSequence, organizations } from "../schemas/organizations";
+import {
+  personalSharedGroupBindings,
+  personalSharedGroupJoinChallenges,
+  personalSharedGroupParticipants,
+} from "../schemas/personal-shared-groups";
 import { userIdentities } from "../schemas/user-identities";
 import { users } from "../schemas/users";
 import { usersRepository } from "./users";
@@ -17,24 +22,74 @@ import { usersRepository } from "./users";
 const PGLITE_TIMEOUT = 60_000;
 const ORGANIZATION_ID = "11111111-1111-4111-8111-111111111111";
 const USER_ID = "22222222-2222-4222-8222-222222222222";
+const GROUP_OWNER_ORGANIZATION_ID = "11111111-1111-4111-8111-111111111112";
+const GROUP_OWNER_USER_ID = "22222222-2222-4222-8222-222222222223";
+const GROUP_BINDING_ID = "44444444-4444-4444-8444-444444444444";
 const TEST_DATABASE = resolveAccountDeletionTestDatabase();
 let databaseReady = true;
 
 async function seedPersonalAccount(): Promise<void> {
-  await dbWrite.insert(organizations).values({
-    id: ORGANIZATION_ID,
-    name: "Personal account",
-    slug: "personal-account",
-  });
-  await dbWrite.insert(users).values({
-    id: USER_ID,
-    organization_id: ORGANIZATION_ID,
-    steward_user_id: "steward-user",
-  });
+  await dbWrite.insert(organizations).values([
+    {
+      id: ORGANIZATION_ID,
+      name: "Personal account",
+      slug: "personal-account",
+    },
+    {
+      id: GROUP_OWNER_ORGANIZATION_ID,
+      name: "Personal Shared owner",
+      slug: "personal-shared-owner",
+    },
+  ]);
+  await dbWrite.insert(users).values([
+    {
+      id: USER_ID,
+      organization_id: ORGANIZATION_ID,
+      steward_user_id: "steward-user",
+    },
+    {
+      id: GROUP_OWNER_USER_ID,
+      organization_id: GROUP_OWNER_ORGANIZATION_ID,
+      steward_user_id: "steward-group-owner",
+    },
+  ]);
   await dbWrite.insert(userIdentities).values({
     user_id: USER_ID,
     steward_user_id: "steward-user",
   });
+  await dbWrite.insert(personalSharedGroupBindings).values({
+    id: GROUP_BINDING_ID,
+    organization_id: GROUP_OWNER_ORGANIZATION_ID,
+    owner_user_id: GROUP_OWNER_USER_ID,
+    personal_agent_id: "personal:account-deletion-owner",
+    platform: "blooio",
+    project: "eliza-app",
+    connector_account_id: "blooio:+15550100999",
+    provider_chat_id: "account-deletion-family-group",
+    conversation_id: "account-deletion-family-conversation",
+    consent_mode: "all_adults",
+    required_principal_count: 2,
+    created_by_platform_user_id: "+15550100001",
+  });
+  const consentedAt = new Date();
+  await dbWrite.insert(personalSharedGroupParticipants).values([
+    {
+      binding_id: GROUP_BINDING_ID,
+      platform_user_id: "+15550100001",
+      ordinal: 1,
+      linked_user_id: GROUP_OWNER_USER_ID,
+      consented_at: consentedAt,
+      consent_provenance: "owner_binding",
+    },
+    {
+      binding_id: GROUP_BINDING_ID,
+      platform_user_id: "+15550100002",
+      ordinal: 2,
+      linked_user_id: USER_ID,
+      consented_at: consentedAt,
+      consent_provenance: "authenticated_dm",
+    },
+  ]);
 }
 
 beforeAll(async () => {
@@ -54,6 +109,9 @@ beforeAll(async () => {
           organizations,
           users,
           userIdentities,
+          personalSharedGroupBindings,
+          personalSharedGroupParticipants,
+          personalSharedGroupJoinChallenges,
         } as never,
         dbWrite as never,
       );
@@ -83,9 +141,16 @@ beforeEach(async () => {
   await dbWrite.execute(sql`
     DELETE FROM account_deletion_restrict_probe WHERE organization_id = ${ORGANIZATION_ID}
   `);
-  await dbWrite.delete(userIdentities).where(eq(userIdentities.user_id, USER_ID));
-  await dbWrite.delete(users).where(eq(users.id, USER_ID));
-  await dbWrite.delete(organizations).where(eq(organizations.id, ORGANIZATION_ID));
+  await dbWrite
+    .delete(personalSharedGroupBindings)
+    .where(eq(personalSharedGroupBindings.id, GROUP_BINDING_ID));
+  await dbWrite
+    .delete(userIdentities)
+    .where(inArray(userIdentities.user_id, [USER_ID, GROUP_OWNER_USER_ID]));
+  await dbWrite.delete(users).where(inArray(users.id, [USER_ID, GROUP_OWNER_USER_ID]));
+  await dbWrite
+    .delete(organizations)
+    .where(inArray(organizations.id, [ORGANIZATION_ID, GROUP_OWNER_ORGANIZATION_ID]));
   await seedPersonalAccount();
 });
 
@@ -94,15 +159,22 @@ afterAll(async () => {
     await dbWrite.execute(sql`
       DELETE FROM account_deletion_restrict_probe WHERE organization_id = ${ORGANIZATION_ID}
     `);
-    await dbWrite.delete(userIdentities).where(eq(userIdentities.user_id, USER_ID));
-    await dbWrite.delete(users).where(eq(users.id, USER_ID));
-    await dbWrite.delete(organizations).where(eq(organizations.id, ORGANIZATION_ID));
+    await dbWrite
+      .delete(personalSharedGroupBindings)
+      .where(eq(personalSharedGroupBindings.id, GROUP_BINDING_ID));
+    await dbWrite
+      .delete(userIdentities)
+      .where(inArray(userIdentities.user_id, [USER_ID, GROUP_OWNER_USER_ID]));
+    await dbWrite.delete(users).where(inArray(users.id, [USER_ID, GROUP_OWNER_USER_ID]));
+    await dbWrite
+      .delete(organizations)
+      .where(inArray(organizations.id, [ORGANIZATION_ID, GROUP_OWNER_ORGANIZATION_ID]));
   }
   await closeDatabaseConnectionsForTests();
 });
 
 describe("UsersRepository.deletePersonalOrganizationAtomically", () => {
-  test("deletes the organization and cascades its user identity graph", async () => {
+  test("unlinks Personal Shared consent before deleting the personal organization", async () => {
     await usersRepository.deletePersonalOrganizationAtomically(USER_ID, ORGANIZATION_ID);
 
     expect(
@@ -112,6 +184,43 @@ describe("UsersRepository.deletePersonalOrganizationAtomically", () => {
     expect(
       await dbWrite.select().from(userIdentities).where(eq(userIdentities.user_id, USER_ID)),
     ).toHaveLength(0);
+    expect(
+      await dbWrite
+        .select({
+          ordinal: personalSharedGroupParticipants.ordinal,
+          linkedUserId: personalSharedGroupParticipants.linked_user_id,
+          consentedAt: personalSharedGroupParticipants.consented_at,
+          consentProvenance: personalSharedGroupParticipants.consent_provenance,
+          revokedAt: personalSharedGroupParticipants.revoked_at,
+        })
+        .from(personalSharedGroupParticipants)
+        .where(eq(personalSharedGroupParticipants.binding_id, GROUP_BINDING_ID))
+        .orderBy(asc(personalSharedGroupParticipants.ordinal)),
+    ).toEqual([
+      {
+        ordinal: 1,
+        linkedUserId: GROUP_OWNER_USER_ID,
+        consentedAt: expect.any(Date),
+        consentProvenance: "owner_binding",
+        revokedAt: null,
+      },
+      {
+        ordinal: 2,
+        linkedUserId: null,
+        consentedAt: null,
+        consentProvenance: null,
+        revokedAt: expect.any(Date),
+      },
+    ]);
+    expect(
+      await dbWrite
+        .select({
+          authorityVersion: personalSharedGroupBindings.authority_version,
+          consentVersion: personalSharedGroupBindings.consent_version,
+        })
+        .from(personalSharedGroupBindings)
+        .where(eq(personalSharedGroupBindings.id, GROUP_BINDING_ID)),
+    ).toEqual([{ authorityVersion: 2, consentVersion: 2 }]);
   });
 
   test("rolls back the entire account when a retention foreign key blocks deletion", async () => {
@@ -131,5 +240,32 @@ describe("UsersRepository.deletePersonalOrganizationAtomically", () => {
     expect(
       await dbWrite.select().from(userIdentities).where(eq(userIdentities.user_id, USER_ID)),
     ).toHaveLength(1);
+    expect(
+      await dbWrite
+        .select({
+          linkedUserId: personalSharedGroupParticipants.linked_user_id,
+          consentedAt: personalSharedGroupParticipants.consented_at,
+          consentProvenance: personalSharedGroupParticipants.consent_provenance,
+          revokedAt: personalSharedGroupParticipants.revoked_at,
+        })
+        .from(personalSharedGroupParticipants)
+        .where(eq(personalSharedGroupParticipants.linked_user_id, USER_ID)),
+    ).toEqual([
+      {
+        linkedUserId: USER_ID,
+        consentedAt: expect.any(Date),
+        consentProvenance: "authenticated_dm",
+        revokedAt: null,
+      },
+    ]);
+    expect(
+      await dbWrite
+        .select({
+          authorityVersion: personalSharedGroupBindings.authority_version,
+          consentVersion: personalSharedGroupBindings.consent_version,
+        })
+        .from(personalSharedGroupBindings)
+        .where(eq(personalSharedGroupBindings.id, GROUP_BINDING_ID)),
+    ).toEqual([{ authorityVersion: 1, consentVersion: 1 }]);
   });
 });

--- a/packages/cloud/shared/src/db/repositories/users-identity-link.integration.test.ts
+++ b/packages/cloud/shared/src/db/repositories/users-identity-link.integration.test.ts
@@ -16,6 +16,11 @@ import { pushSchema } from "drizzle-kit/api";
 import { eq } from "drizzle-orm";
 import { closeDatabaseConnectionsForTests, dbWrite } from "../client";
 import { organizationBalanceRevisionSequence, organizations } from "../schemas/organizations";
+import {
+  personalSharedGroupBindings,
+  personalSharedGroupJoinChallenges,
+  personalSharedGroupParticipants,
+} from "../schemas/personal-shared-groups";
 import { userIdentities } from "../schemas/user-identities";
 import { users } from "../schemas/users";
 import { usersRepository } from "./users";
@@ -57,6 +62,9 @@ beforeAll(async () => {
         organizations,
         users,
         userIdentities,
+        personalSharedGroupBindings,
+        personalSharedGroupParticipants,
+        personalSharedGroupJoinChallenges,
       } as never,
       dbWrite as never,
     );

--- a/packages/cloud/shared/src/db/repositories/users.ts
+++ b/packages/cloud/shared/src/db/repositories/users.ts
@@ -19,9 +19,23 @@ import {
 } from "../schemas/personal-account-convergences";
 import { type UserIdentity, userIdentities } from "../schemas/user-identities";
 import { type NewUser, type User, users } from "../schemas/users";
+import { revokePersonalSharedGroupConsentForUser } from "./personal-shared-group-consent-lifecycle";
 
 const stewardAuthorityIdentity = alias(userIdentities, "steward_authority_identity");
 const canonicalStewardIdentity = alias(userIdentities, "canonical_steward_identity");
+
+function userMutationRevokesPersonalSharedConsent(data: Partial<NewUser>): boolean {
+  return (
+    data.is_active === false ||
+    data.deleted_at != null ||
+    data.is_anonymous === true ||
+    data.phone_verified === false ||
+    Object.hasOwn(data, "organization_id") ||
+    Object.hasOwn(data, "steward_user_id") ||
+    Object.hasOwn(data, "telegram_id") ||
+    Object.hasOwn(data, "phone_number")
+  );
+}
 
 export type { NewUser, User, UserIdentity };
 
@@ -2318,15 +2332,21 @@ export class UsersRepository {
    * Updates an existing user.
    */
   async update(id: string, data: Partial<NewUser>): Promise<User | undefined> {
-    const [updated] = await dbWrite
-      .update(users)
-      .set({
-        ...data,
-        updated_at: new Date(),
-      })
-      .where(eq(users.id, id))
-      .returning();
-    return updated;
+    return dbWrite.transaction(async (tx) => {
+      const now = new Date();
+      if (userMutationRevokesPersonalSharedConsent(data)) {
+        await revokePersonalSharedGroupConsentForUser(tx, id, now);
+      }
+      const [updated] = await tx
+        .update(users)
+        .set({
+          ...data,
+          updated_at: now,
+        })
+        .where(eq(users.id, id))
+        .returning();
+      return updated;
+    });
   }
 
   /**
@@ -2342,6 +2362,7 @@ export class UsersRepository {
   ): Promise<User | undefined> {
     return dbWrite.transaction(async (tx) => {
       const updatedAt = new Date();
+      await revokePersonalSharedGroupConsentForUser(tx, userId, updatedAt);
       const [updated] = await tx
         .update(users)
         .set({ ...identity, updated_at: updatedAt })
@@ -2380,6 +2401,28 @@ export class UsersRepository {
     platformId: string,
     platformName?: string,
   ): Promise<LinkMessagingIdentityResult> {
+    // Lock and validate the target before revoking any authority. Returning a
+    // conflict must not commit a consent revocation when no identity changed.
+    const [targetUser] = await tx
+      .select({
+        id: users.id,
+        phoneNumber: users.phone_number,
+        phoneVerified: users.phone_verified,
+      })
+      .from(users)
+      .where(eq(users.id, userId))
+      .limit(1)
+      .for("update");
+    if (!targetUser) return { status: "user_not_found" };
+    if (
+      provider === "phone" &&
+      targetUser.phoneVerified === true &&
+      targetUser.phoneNumber !== null &&
+      targetUser.phoneNumber !== platformId
+    ) {
+      return { status: "handle_conflict" };
+    }
+
     const ownerPredicates =
       provider === "telegram"
         ? [eq(users.telegram_id, platformId), eq(userIdentities.telegram_id, platformId)]
@@ -2406,6 +2449,9 @@ export class UsersRepository {
     }
 
     const now = new Date();
+    if (provider === "telegram" || provider === "phone") {
+      await revokePersonalSharedGroupConsentForUser(tx, userId, now);
+    }
     const identity =
       provider === "telegram"
         ? { telegram_id: platformId, telegram_username: platformName ?? null }
@@ -2431,8 +2477,9 @@ export class UsersRepository {
       .where(targetPredicate)
       .returning();
     if (!updated) {
-      const [existing] = await tx.select({ id: users.id }).from(users).where(eq(users.id, userId));
-      return existing ? { status: "handle_conflict" } : { status: "user_not_found" };
+      // The target row is locked above. A miss is only possible if a guarded
+      // phone precondition changes in this transaction; fail closed.
+      return { status: "handle_conflict" };
     }
 
     await tx
@@ -2528,6 +2575,7 @@ export class UsersRepository {
   async linkVerifiedPhone(id: string, phoneNumber: string): Promise<User | undefined> {
     return dbWrite.transaction(async (tx) => {
       const now = new Date();
+      await revokePersonalSharedGroupConsentForUser(tx, id, now);
       const [updated] = await tx
         .update(users)
         .set({
@@ -2604,6 +2652,24 @@ export class UsersRepository {
   ): Promise<LinkTelegramAndPhoneResult> {
     return dbWrite.transaction(async (tx) => {
       const updatedAt = new Date();
+      const [existing] = await tx
+        .select({
+          phoneNumber: users.phone_number,
+          phoneVerified: users.phone_verified,
+        })
+        .from(users)
+        .where(eq(users.id, userId))
+        .limit(1)
+        .for("update");
+      if (!existing) return { status: "user_not_found" };
+      if (
+        existing.phoneVerified === true &&
+        existing.phoneNumber !== null &&
+        existing.phoneNumber !== identity.phone_number
+      ) {
+        return { status: "phone_mismatch", existingPhone: existing.phoneNumber };
+      }
+      await revokePersonalSharedGroupConsentForUser(tx, userId, updatedAt);
       const [updated] = await tx
         .update(users)
         .set({
@@ -2624,17 +2690,9 @@ export class UsersRepository {
         .returning();
 
       if (!updated) {
-        const [existing] = await tx
-          .select({ phone_number: users.phone_number })
-          .from(users)
-          .where(eq(users.id, userId))
-          .limit(1);
-        if (!existing || !existing.phone_number) {
-          // A present row with a NULL phone would have matched the UPDATE
-          // predicate, so a phoneless miss means the user row is gone.
-          return { status: "user_not_found" };
-        }
-        return { status: "phone_mismatch", existingPhone: existing.phone_number };
+        // The user row and guarded phone state are locked above, so a miss is
+        // unreachable unless a future mutation adds another predicate.
+        return { status: "phone_mismatch", existingPhone: existing.phoneNumber ?? "" };
       }
 
       await tx
@@ -2678,15 +2736,19 @@ export class UsersRepository {
    * Links a Steward user ID to an existing user.
    */
   async linkStewardId(userId: string, stewardUserId: string): Promise<User | undefined> {
-    const [updated] = await dbWrite
-      .update(users)
-      .set({
-        steward_user_id: stewardUserId,
-        updated_at: new Date(),
-      })
-      .where(eq(users.id, userId))
-      .returning();
-    return updated;
+    return dbWrite.transaction(async (tx) => {
+      const now = new Date();
+      await revokePersonalSharedGroupConsentForUser(tx, userId, now);
+      const [updated] = await tx
+        .update(users)
+        .set({
+          steward_user_id: stewardUserId,
+          updated_at: now,
+        })
+        .where(eq(users.id, userId))
+        .returning();
+      return updated;
+    });
   }
 
   /**
@@ -3035,7 +3097,10 @@ export class UsersRepository {
    * Deletes a user by ID.
    */
   async delete(id: string): Promise<void> {
-    await dbWrite.delete(users).where(eq(users.id, id));
+    await dbWrite.transaction(async (tx) => {
+      await revokePersonalSharedGroupConsentForUser(tx, id, new Date());
+      await tx.delete(users).where(eq(users.id, id));
+    });
   }
 
   /**
@@ -3049,16 +3114,25 @@ export class UsersRepository {
     organizationId: string,
   ): Promise<void> {
     await dbWrite.transaction(async (tx) => {
-      const members = await tx
+      const observedMembers = await tx
+        .select({ id: users.id })
+        .from(users)
+        .where(eq(users.organization_id, organizationId));
+      if (!observedMembers.some((member) => member.id === userId)) {
+        throw new Error("Account deletion user is not a member of its personal organization");
+      }
+      if (observedMembers.length !== 1) {
+        throw new Error("Account deletion requires a sole-user personal organization");
+      }
+
+      await revokePersonalSharedGroupConsentForUser(tx, userId, new Date());
+      const lockedMembers = await tx
         .select({ id: users.id })
         .from(users)
         .where(eq(users.organization_id, organizationId))
         .for("update");
-      if (!members.some((member) => member.id === userId)) {
-        throw new Error("Account deletion user is not a member of its personal organization");
-      }
-      if (members.length !== 1) {
-        throw new Error("Account deletion requires a sole-user personal organization");
+      if (lockedMembers.length !== 1 || lockedMembers[0]?.id !== userId) {
+        throw new Error("Account deletion personal organization membership changed");
       }
 
       const deleted = await tx

--- a/packages/cloud/shared/src/db/schemas/personal-shared-groups.ts
+++ b/packages/cloud/shared/src/db/schemas/personal-shared-groups.ts
@@ -20,6 +20,15 @@ import { users } from "./users";
 export type PersonalSharedGroupPlatform = "telegram" | "blooio";
 export type PersonalSharedGroupBindingState = "active" | "suspended" | "revoked";
 export type PersonalSharedGroupResponsePolicy = "mention_only" | "ambient";
+/**
+ * `all_adults` v1 is an owner-configured quorum of independently authenticated
+ * adult principals. It does not claim that the provider exposes a complete or
+ * designated adult-membership roster; that audience-attestation work remains
+ * a separate policy layer.
+ */
+export type PersonalSharedGroupConsentMode = "single_owner" | "all_adults";
+export type PersonalSharedGroupConsentProvenance = "owner_binding" | "authenticated_dm";
+export type PersonalSharedGroupJoinChallengeStage = "authenticate" | "confirm";
 export type PersonalSharedGroupDeliveryAttemptState = "committed" | "uncertain" | "reconciled";
 
 export const personalSharedGroupClaims = pgTable(
@@ -38,6 +47,11 @@ export const personalSharedGroupClaims = pgTable(
     project: text("project").notNull(),
     connector_account_id: text("connector_account_id").notNull(),
     issued_to_platform_user_id: text("issued_to_platform_user_id").notNull(),
+    consent_mode: text("consent_mode")
+      .$type<PersonalSharedGroupConsentMode>()
+      .notNull()
+      .default("single_owner"),
+    required_principal_count: integer("required_principal_count").notNull().default(1),
     expires_at: timestamp("expires_at", { withTimezone: true }).notNull(),
     consumed_at: timestamp("consumed_at", { withTimezone: true }),
     created_at: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
@@ -46,6 +60,11 @@ export const personalSharedGroupClaims = pgTable(
     platform_check: check(
       "personal_shared_group_claims_platform_check",
       sql`${table.platform} IN ('telegram', 'blooio')`,
+    ),
+    consent_config_check: check(
+      "personal_shared_group_claims_consent_config_check",
+      sql`(${table.consent_mode} = 'single_owner' AND ${table.required_principal_count} = 1)
+        OR (${table.consent_mode} = 'all_adults' AND ${table.required_principal_count} BETWEEN 2 AND 32)`,
     ),
     expires_idx: index("personal_shared_group_claims_expires_idx").on(table.expires_at),
     owner_idx: index("personal_shared_group_claims_owner_idx").on(
@@ -76,6 +95,12 @@ export const personalSharedGroupBindings = pgTable(
       .$type<PersonalSharedGroupResponsePolicy>()
       .notNull()
       .default("mention_only"),
+    consent_mode: text("consent_mode")
+      .$type<PersonalSharedGroupConsentMode>()
+      .notNull()
+      .default("single_owner"),
+    required_principal_count: integer("required_principal_count").notNull().default(1),
+    consent_version: bigint("consent_version", { mode: "number" }).notNull().default(1),
     authority_version: bigint("authority_version", { mode: "number" }).notNull().default(1),
     delivery_lease_source_id: text("delivery_lease_source_id"),
     delivery_lease_token: uuid("delivery_lease_token"),
@@ -103,6 +128,11 @@ export const personalSharedGroupBindings = pgTable(
       "personal_shared_group_bindings_policy_check",
       sql`${table.response_policy} IN ('mention_only', 'ambient')`,
     ),
+    consent_config_check: check(
+      "personal_shared_group_bindings_consent_config_check",
+      sql`(${table.consent_mode} = 'single_owner' AND ${table.required_principal_count} = 1)
+        OR (${table.consent_mode} = 'all_adults' AND ${table.required_principal_count} BETWEEN 2 AND 32)`,
+    ),
     provider_chat_unique: uniqueIndex("personal_shared_group_bindings_provider_chat_uidx").on(
       table.platform,
       table.project,
@@ -112,6 +142,75 @@ export const personalSharedGroupBindings = pgTable(
     owner_idx: index("personal_shared_group_bindings_owner_idx").on(
       table.owner_user_id,
       table.state,
+    ),
+  }),
+);
+
+/**
+ * Hashed, single-use, actor-bound join handshakes.
+ *
+ * `provider_thread_id` is the normalized provider sub-thread identity. An
+ * empty string means the provider event had no sub-thread, which remains an
+ * exact value rather than a wildcard during confirmation.
+ */
+export const personalSharedGroupJoinChallenges = pgTable(
+  "personal_shared_group_join_challenges",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    code_hash: text("code_hash").notNull().unique(),
+    stage: text("stage").$type<PersonalSharedGroupJoinChallengeStage>().notNull(),
+    binding_id: uuid("binding_id")
+      .notNull()
+      .references(() => personalSharedGroupBindings.id, { onDelete: "cascade" }),
+    consent_version: bigint("consent_version", { mode: "number" }).notNull(),
+    platform: text("platform").$type<PersonalSharedGroupPlatform>().notNull(),
+    project: text("project").notNull(),
+    connector_account_id: text("connector_account_id").notNull(),
+    provider_chat_id: text("provider_chat_id").notNull(),
+    provider_thread_id: text("provider_thread_id").notNull().default(""),
+    issued_to_platform_user_id: text("issued_to_platform_user_id").notNull(),
+    source_message_id: text("source_message_id").notNull(),
+    linked_user_id: uuid("linked_user_id").references(() => users.id, {
+      onDelete: "cascade",
+    }),
+    expires_at: timestamp("expires_at", { withTimezone: true }).notNull(),
+    consumed_at: timestamp("consumed_at", { withTimezone: true }),
+    consumed_by_source_message_id: text("consumed_by_source_message_id"),
+    superseded_at: timestamp("superseded_at", { withTimezone: true }),
+    superseded_by_source_message_id: text("superseded_by_source_message_id"),
+    created_at: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    stage_check: check(
+      "personal_shared_group_join_challenges_stage_check",
+      sql`${table.stage} IN ('authenticate', 'confirm')`,
+    ),
+    platform_check: check(
+      "personal_shared_group_join_challenges_platform_check",
+      sql`${table.platform} IN ('telegram', 'blooio')`,
+    ),
+    linked_user_stage_check: check(
+      "personal_shared_group_join_challenges_linked_user_stage_check",
+      sql`(${table.stage} = 'authenticate' AND ${table.linked_user_id} IS NULL)
+        OR (${table.stage} = 'confirm' AND ${table.linked_user_id} IS NOT NULL)`,
+    ),
+    superseded_source_check: check(
+      "personal_shared_group_join_challenges_superseded_source_check",
+      sql`(${table.superseded_at} IS NULL) = (${table.superseded_by_source_message_id} IS NULL)`,
+    ),
+    binding_stage_idx: index("personal_shared_group_join_challenges_binding_stage_idx").on(
+      table.binding_id,
+      table.stage,
+    ),
+    expires_idx: index("personal_shared_group_join_challenges_expires_idx").on(table.expires_at),
+    linked_user_idx: index("personal_shared_group_join_challenges_linked_user_idx").on(
+      table.linked_user_id,
+    ),
+    source_unique: uniqueIndex("personal_shared_group_join_challenges_source_uidx").on(
+      table.binding_id,
+      table.stage,
+      table.issued_to_platform_user_id,
+      table.source_message_id,
     ),
   }),
 );
@@ -173,6 +272,11 @@ export const personalSharedGroupParticipants = pgTable(
     ordinal: integer("ordinal").notNull(),
     /** Connector-supplied name that passed the resolution rules, else null. */
     display_name: text("display_name"),
+    /** Authenticated Eliza account; never model-facing or returned by status APIs. */
+    linked_user_id: uuid("linked_user_id").references(() => users.id),
+    consented_at: timestamp("consented_at", { withTimezone: true }),
+    consent_provenance: text("consent_provenance").$type<PersonalSharedGroupConsentProvenance>(),
+    revoked_at: timestamp("revoked_at", { withTimezone: true }),
     first_seen_at: timestamp("first_seen_at", { withTimezone: true }).notNull().defaultNow(),
     last_seen_at: timestamp("last_seen_at", { withTimezone: true }).notNull().defaultNow(),
   },
@@ -185,6 +289,15 @@ export const personalSharedGroupParticipants = pgTable(
       "personal_shared_group_participants_display_name_check",
       sql`${table.display_name} IS NULL OR (length(${table.display_name}) > 0 AND length(${table.display_name}) <= 128)`,
     ),
+    consent_provenance_check: check(
+      "personal_shared_group_participants_consent_provenance_check",
+      sql`${table.consent_provenance} IS NULL OR ${table.consent_provenance} IN ('owner_binding', 'authenticated_dm')`,
+    ),
+    consent_shape_check: check(
+      "personal_shared_group_participants_consent_shape_check",
+      sql`(${table.linked_user_id} IS NULL AND ${table.consented_at} IS NULL AND ${table.consent_provenance} IS NULL)
+        OR (${table.linked_user_id} IS NOT NULL AND ${table.consented_at} IS NOT NULL AND ${table.consent_provenance} IS NOT NULL)`,
+    ),
     actor_unique: uniqueIndex("personal_shared_group_participants_actor_uidx").on(
       table.binding_id,
       table.platform_user_id,
@@ -193,6 +306,13 @@ export const personalSharedGroupParticipants = pgTable(
     ordinal_unique: uniqueIndex("personal_shared_group_participants_ordinal_uidx").on(
       table.binding_id,
       table.ordinal,
+    ),
+    linked_user_unique: uniqueIndex("personal_shared_group_participants_linked_user_uidx").on(
+      table.binding_id,
+      table.linked_user_id,
+    ),
+    linked_user_idx: index("personal_shared_group_participants_linked_user_idx").on(
+      table.linked_user_id,
     ),
   }),
 );
@@ -248,6 +368,12 @@ export type PersonalSharedGroupClaim = InferSelectModel<typeof personalSharedGro
 export type NewPersonalSharedGroupClaim = InferInsertModel<typeof personalSharedGroupClaims>;
 export type PersonalSharedGroupBinding = InferSelectModel<typeof personalSharedGroupBindings>;
 export type NewPersonalSharedGroupBinding = InferInsertModel<typeof personalSharedGroupBindings>;
+export type PersonalSharedGroupJoinChallenge = InferSelectModel<
+  typeof personalSharedGroupJoinChallenges
+>;
+export type NewPersonalSharedGroupJoinChallenge = InferInsertModel<
+  typeof personalSharedGroupJoinChallenges
+>;
 export type PersonalSharedGroupDeliveryReceipt = InferSelectModel<
   typeof personalSharedGroupDeliveryReceipts
 >;

--- a/packages/cloud/shared/src/db/schemas/personal-shared-groups.ts
+++ b/packages/cloud/shared/src/db/schemas/personal-shared-groups.ts
@@ -276,6 +276,7 @@ export const personalSharedGroupParticipants = pgTable(
     linked_user_id: uuid("linked_user_id").references(() => users.id),
     consented_at: timestamp("consented_at", { withTimezone: true }),
     consent_provenance: text("consent_provenance").$type<PersonalSharedGroupConsentProvenance>(),
+    /** Roster/authority tombstone; it does not imply this participant previously consented. */
     revoked_at: timestamp("revoked_at", { withTimezone: true }),
     first_seen_at: timestamp("first_seen_at", { withTimezone: true }).notNull().defaultNow(),
     last_seen_at: timestamp("last_seen_at", { withTimezone: true }).notNull().defaultNow(),
@@ -296,7 +297,7 @@ export const personalSharedGroupParticipants = pgTable(
     consent_shape_check: check(
       "personal_shared_group_participants_consent_shape_check",
       sql`(${table.linked_user_id} IS NULL AND ${table.consented_at} IS NULL AND ${table.consent_provenance} IS NULL)
-        OR (${table.linked_user_id} IS NOT NULL AND ${table.consented_at} IS NOT NULL AND ${table.consent_provenance} IS NOT NULL)`,
+        OR (${table.linked_user_id} IS NOT NULL AND ${table.consented_at} IS NOT NULL AND ${table.consent_provenance} IS NOT NULL AND ${table.revoked_at} IS NULL)`,
     ),
     actor_unique: uniqueIndex("personal_shared_group_participants_actor_uidx").on(
       table.binding_id,

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-reminder-cron.group.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-reminder-cron.group.test.ts
@@ -11,6 +11,7 @@
  */
 
 import { afterEach, describe, expect, mock, test } from "bun:test";
+import type { ScheduledTaskInput, ScheduledTaskRunner } from "@elizaos/plugin-scheduling/edge";
 
 const listDueScheduledTaskRefs = mock(async () => []);
 const listRecoverableScheduledTaskRefs = mock(async () => []);
@@ -78,7 +79,9 @@ const recordDeliveryReceipts = mock(async () => ({ recorded: true, inserted: 1 }
 
 // The real prefix builder keeps the asserted fire-time text and the plugin's
 // creation-time budget on the same source of truth.
-const { sharedGroupReminderMessageText } = await import("@elizaos/plugin-scheduling/edge");
+const { createSharedRemindersEdgePlugin, sharedGroupReminderMessageText } = await import(
+  "@elizaos/plugin-scheduling/edge"
+);
 
 mock.module("@elizaos/plugin-scheduling/edge", () => ({
   listDueScheduledTaskRefs,
@@ -259,6 +262,99 @@ describe("Shared group reminder dispatch", () => {
     expect(tokens[2]).not.toBe(tokens[0]);
   });
 
+  test("carries a persisted Telegram forum topic through the gateway wire", async () => {
+    const requests: Request[] = [];
+    globalThis.fetch = acceptingFetch(requests);
+    const dispatcher = sharedReminderDispatcher(env, PERSONAL_AGENT_ID);
+
+    const result = await dispatcher.dispatch(
+      groupRecord({ delivery: { providerThreadId: "909" } }),
+    );
+
+    await expect(requests[0]?.json()).resolves.toEqual({
+      platform: "telegram",
+      project: "eliza-app",
+      chatId: "-100123456789",
+      providerThreadId: "909",
+      text: "Reminder for this group from Nubs: pay the rent",
+      idempotencyKey: IDEMPOTENCY_KEY,
+    });
+    expect(result).toMatchObject({ ok: true, target: "-100123456789" });
+  });
+
+  test("preserves a Telegram forum topic from reminder creation through JSON persistence and fire", async () => {
+    const scheduleWithResult = mock(async (input: ScheduledTaskInput) => ({
+      task: {
+        taskId: "created-topic-reminder",
+        ...input,
+        state: { status: "scheduled" as const, followupCount: 0 },
+      },
+      commit: {
+        logId: "created-topic-reminder-log",
+        occurredAtIso: "2026-08-20T19:25:00.000Z",
+      },
+      replayed: false,
+    }));
+    const runner = {
+      scheduleWithResult,
+      list: mock(async () => []),
+      applyWithResult: mock(),
+      pipeline: mock(async () => []),
+    } as unknown as ScheduledTaskRunner;
+    const delivery = groupRecord({
+      delivery: { providerThreadId: "909" },
+    }).metadata.delivery;
+    const [action] =
+      createSharedRemindersEdgePlugin({
+        runner,
+        agentId: PERSONAL_AGENT_ID,
+        delivery,
+        now: () => new Date("2026-08-20T19:25:00.000Z"),
+      }).actions ?? [];
+
+    const creation = await action?.handler(
+      {} as never,
+      { id: "topic-reminder-create" } as never,
+      undefined,
+      {
+        parameters: {
+          operation: "create",
+          reminderText: "pay the rent",
+          inMinutes: 5,
+        },
+      },
+    );
+
+    expect(creation?.success).toBe(true);
+    expect(scheduleWithResult).toHaveBeenCalledTimes(1);
+    const scheduledInput = scheduleWithResult.mock.calls[0]?.[0];
+    expect(scheduledInput?.metadata).toEqual({ delivery });
+    const persistedInput = JSON.parse(JSON.stringify(scheduledInput)) as ScheduledTaskInput;
+    const requests: Request[] = [];
+    globalThis.fetch = acceptingFetch(requests);
+    const dispatcher = sharedReminderDispatcher(env, PERSONAL_AGENT_ID);
+
+    const result = await dispatcher.dispatch({
+      ...persistedInput,
+      taskId: "created-topic-reminder",
+      firedAtIso: "2026-08-20T19:30:00.000Z",
+      metadata: {
+        ...persistedInput.metadata,
+        dispatchIdempotencyKey: IDEMPOTENCY_KEY,
+      },
+    });
+
+    expect(result).toMatchObject({ ok: true, target: "-100123456789" });
+    await expect(requests[0]?.json()).resolves.toEqual({
+      platform: "telegram",
+      project: "eliza-app",
+      chatId: "-100123456789",
+      providerThreadId: "909",
+      text: "Reminder for this group from Nubs: pay the rent",
+      idempotencyKey: IDEMPOTENCY_KEY,
+    });
+  });
+
   test("delivers a Telegram group reminder through the edge dispatch with the prefixed text and records receipts", async () => {
     globalThis.fetch = mock(async () => {
       throw new Error("gateway egress must not run when edge dispatch is configured");
@@ -270,7 +366,9 @@ describe("Shared group reminder dispatch", () => {
     }));
     const dispatcher = sharedReminderDispatcher(env, PERSONAL_AGENT_ID, { telegramDispatch });
 
-    const result = await dispatcher.dispatch(groupRecord());
+    const result = await dispatcher.dispatch(
+      groupRecord({ delivery: { providerThreadId: "909" } }),
+    );
 
     expect(authorizeDelivery).toHaveBeenCalledTimes(1);
     expect(commitDelivery).toHaveBeenCalledTimes(1);
@@ -280,6 +378,7 @@ describe("Shared group reminder dispatch", () => {
     expect(telegramDispatch).toHaveBeenCalledWith({
       project: "eliza-app",
       chatId: "-100123456789",
+      providerThreadId: "909",
       text: "Reminder for this group from Nubs: pay the rent",
       idempotencyKey: IDEMPOTENCY_KEY,
     });

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-reminder-cron.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-reminder-cron.ts
@@ -64,6 +64,7 @@ type GatewayDeliveryResponse = {
 export interface SharedTelegramReminderDispatchInput {
   project: string;
   chatId: string;
+  providerThreadId?: string;
   text: string;
   idempotencyKey: string;
 }
@@ -156,6 +157,9 @@ function gatewayWireDelivery(delivery: SharedReminderDelivery) {
         platform: delivery.platform,
         project: delivery.project,
         chatId: delivery.chatId,
+        ...(delivery.platform === "telegram" && delivery.providerThreadId
+          ? { providerThreadId: delivery.providerThreadId }
+          : {}),
       }
     : delivery;
 }
@@ -234,6 +238,9 @@ export function sharedReminderDispatcher(
         const result = await options.telegramDispatch({
           project: delivery.project,
           chatId: delivery.chatId,
+          ...(groupDelivery?.platform === "telegram" && groupDelivery.providerThreadId
+            ? { providerThreadId: groupDelivery.providerThreadId }
+            : {}),
           text,
           idempotencyKey,
         });

--- a/packages/cloud/shared/src/types/cloud-worker-env.ts
+++ b/packages/cloud/shared/src/types/cloud-worker-env.ts
@@ -505,6 +505,17 @@ export interface Bindings {
    */
   ELIZA_APP_INBOUND_MEDIA_VISION_SENDER_DAILY_IMAGES?: string;
   ELIZA_APP_INBOUND_MEDIA_VISION_CONNECTOR_DAILY_IMAGES?: string;
+  /**
+   * Exactly `"true"` permits issuance of opt-in Personal Shared all-adults
+   * bindings after schema and egress enforcement are deployed fleet-wide.
+   * Unset is the safe rollout default; single-owner groups are unaffected.
+   */
+  ELIZA_APP_PERSONAL_SHARED_ALL_ADULTS_ENABLED?: string;
+  /**
+   * Stable 32-byte-or-longer HMAC key for source-idempotent, 60-bit join codes.
+   * Required before the all-adults issuance flag can create a new binding.
+   */
+  ELIZA_APP_PERSONAL_SHARED_JOIN_CODE_SECRET?: string;
   /** Moves only the official Personal Shared Telegram transport to the Worker edge. */
   PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED?: string;
   /** Collision-free secret used by the protected staging edge cutover. */

--- a/plugins/plugin-scheduling/src/shared-reminders.group.test.ts
+++ b/plugins/plugin-scheduling/src/shared-reminders.group.test.ts
@@ -40,6 +40,7 @@ const telegramGroupDelivery = {
   project: "eliza-app",
   connectorAccountId: "telegram:test-bot",
   chatId: "-100123456789",
+  providerThreadId: "909",
   ownerLabel: "Nubs",
   authority: AUTHORITY,
 } as const;
@@ -97,6 +98,11 @@ describe("Shared group reminder delivery parsing", () => {
       blooioGroupDelivery,
     );
     expect(isSharedGroupReminderDelivery(telegramGroupDelivery)).toBe(true);
+    const { providerThreadId: _providerThreadId, ...telegramWithoutTopic } =
+      telegramGroupDelivery;
+    expect(parseSharedReminderDelivery(telegramWithoutTopic)).toEqual(
+      telegramWithoutTopic,
+    );
     expect(
       isSharedGroupReminderDelivery({
         platform: "telegram",
@@ -153,6 +159,27 @@ describe("Shared group reminder delivery parsing", () => {
       parseSharedReminderDelivery({
         ...telegramGroupDelivery,
         project: "bad project!",
+      }),
+    ).toBeUndefined();
+    for (const providerThreadId of [
+      "0",
+      "-1",
+      "0909",
+      "topic",
+      "9999999999999999",
+      "9".repeat(17),
+    ]) {
+      expect(
+        parseSharedReminderDelivery({
+          ...telegramGroupDelivery,
+          providerThreadId,
+        }),
+      ).toBeUndefined();
+    }
+    expect(
+      parseSharedReminderDelivery({
+        ...blooioGroupDelivery,
+        providerThreadId: "909",
       }),
     ).toBeUndefined();
   });

--- a/plugins/plugin-scheduling/src/shared-reminders.ts
+++ b/plugins/plugin-scheduling/src/shared-reminders.ts
@@ -38,6 +38,25 @@ export const SHARED_REMINDERS_EDGE_COMPATIBILITY = {
   requiredSecrets: [],
 } as const;
 
+interface SharedGroupReminderDeliveryBase {
+  kind: "group";
+  project: string;
+  connectorAccountId: string;
+  chatId: string;
+  ownerLabel: string;
+  authority: SharedGroupReminderDeliveryAuthority;
+}
+
+export type SharedGroupReminderDelivery =
+  | (SharedGroupReminderDeliveryBase & {
+      platform: "telegram";
+      /** Provider-owned forum topic containing the reminder-creating turn. */
+      providerThreadId?: string;
+    })
+  | (SharedGroupReminderDeliveryBase & {
+      platform: "blooio";
+    });
+
 export type SharedReminderDelivery =
   | {
       platform: "telegram";
@@ -53,15 +72,7 @@ export type SharedReminderDelivery =
       platform: "discord";
       discordUserId: string;
     }
-  | {
-      platform: "telegram" | "blooio";
-      kind: "group";
-      project: string;
-      connectorAccountId: string;
-      chatId: string;
-      ownerLabel: string;
-      authority: SharedGroupReminderDeliveryAuthority;
-    };
+  | SharedGroupReminderDelivery;
 
 /**
  * The binding generation a group reminder was scheduled under. Fire-time
@@ -74,11 +85,6 @@ export interface SharedGroupReminderDeliveryAuthority {
   personalAgentId: string;
   version: number;
 }
-
-export type SharedGroupReminderDelivery = Extract<
-  SharedReminderDelivery,
-  { kind: "group" }
->;
 
 export function isSharedGroupReminderDelivery(
   delivery: SharedReminderDelivery,
@@ -130,6 +136,7 @@ export function sharedReminderMaxBodyLength(
 
 const PROJECT_PATTERN = /^[a-z0-9][a-z0-9_-]{0,63}$/i;
 const TELEGRAM_CHAT_ID_PATTERN = /^-?\d{1,20}$/;
+const TELEGRAM_THREAD_ID_PATTERN = /^[1-9]\d{0,15}$/;
 const BLOOIO_GROUP_CHAT_ID_PATTERN = /^chat_[A-Za-z0-9_-]{1,120}$/i;
 const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -171,6 +178,12 @@ export function parseSharedReminderDelivery(
   const delivery = value as Record<string, unknown>;
   if (delivery.kind === "group") {
     const authority = parseGroupDeliveryAuthority(delivery.authority);
+    const providerThreadId = delivery.providerThreadId;
+    const validTelegramThread =
+      providerThreadId === undefined ||
+      (typeof providerThreadId === "string" &&
+        TELEGRAM_THREAD_ID_PATTERN.test(providerThreadId) &&
+        Number.isSafeInteger(Number(providerThreadId)));
     if (
       authority &&
       (delivery.platform === "telegram" || delivery.platform === "blooio") &&
@@ -186,17 +199,28 @@ export function parseSharedReminderDelivery(
       ).test(delivery.chatId) &&
       typeof delivery.ownerLabel === "string" &&
       delivery.ownerLabel.trim().length > 0 &&
-      delivery.ownerLabel.length <= 128
+      delivery.ownerLabel.length <= 128 &&
+      (delivery.platform === "telegram"
+        ? validTelegramThread
+        : providerThreadId === undefined)
     ) {
-      return {
-        platform: delivery.platform,
+      const groupDelivery = {
         kind: "group",
         project: delivery.project,
         connectorAccountId: delivery.connectorAccountId,
         chatId: delivery.chatId,
         ownerLabel: sanitizedOwnerLabel(delivery.ownerLabel),
         authority,
-      };
+      } as const;
+      return delivery.platform === "telegram"
+        ? {
+            platform: "telegram",
+            ...groupDelivery,
+            ...(typeof providerThreadId === "string"
+              ? { providerThreadId }
+              : {}),
+          }
+        : { platform: "blooio", ...groupDelivery };
     }
     return undefined;
   }


### PR DESCRIPTION
## Summary

- add an opt-in `all_adults` Personal Shared consent mode while preserving `single_owner` defaults
- link each required participant through an actor-, binding-, connector-, and thread-scoped authenticated DM handshake
- fail closed before capability work and again at provider egress/commit; add self-scoped revocation and redacted consent status
- propagate Telegram topic identity and add a deterministic fake-provider consent, isolation, replay, receipt, and leave ledger

## Security and rollout

- HMAC-derived 12-character join codes are hashed at rest, expire, are single-use, and retain binding-lifetime source tombstones against delayed webhook replay
- eligible consent requires a mature active user, matching provider identity, and active organization; account/identity lifecycle changes revoke consent transactionally
- deploy migration and egress enforcement across the fleet before setting `ELIZA_APP_PERSONAL_SHARED_ALL_ADULTS_ENABLED=true`
- configure the same 32+ byte `ELIZA_APP_PERSONAL_SHARED_JOIN_CODE_SECRET` on every worker; drain the 15-minute challenge horizon before rotating it
- V1 is an owner-configured quorum, not provider-attested proof of a complete adult roster

## Verification

- `bun run verify:cloud` — 84/84 tasks
- consent repository — 29/29
- migration — 3/3
- legacy group repositories — 17/17
- new all-adults routes — 16/16
- deterministic fake-provider scenario — PASS, 41 assertions
- focused route/gateway/topic/account-lifecycle regression suites — PASS
- clean `origin/develop` claim proof — 0/2; fixed head — 4/4

Closes #28282
