### PR TITLE
test(app-core): cover connector target catalog stop lifecycle and context contracts

### DIFF
--- a/packages/app-core/src/services/connector-target-catalog.test.ts
+++ b/packages/app-core/src/services/connector-target-catalog.test.ts
@@ -122,4 +122,53 @@ describe("createElizaConnectorTargetCatalog", () => {
       ...slackGroups,
     ]);
   });
+
+  it("concatenates multiple sources registered for the same platform in order", async () => {
+    const discordGroups2: TargetGroup[] = [
+      {
+        platform: "discord",
+        groupId: "g2",
+        groupName: "Designers",
+        targets: [{ id: "c2", name: "showcase", kind: "channel" }],
+      },
+    ];
+    const catalog = createElizaConnectorTargetCatalog({
+      listSources: () => [
+        discordSource(),
+        discordSource(async () => discordGroups2),
+      ],
+      getConfig: () => ({}),
+    });
+    expect(await catalog.listGroups({ platform: "discord" })).toEqual([
+      ...DISCORD_GROUPS,
+      ...discordGroups2,
+    ]);
+  });
+
+  it("passes undefined for optional context properties when omitted from options", async () => {
+    const enumerate = vi.fn<TargetSource["enumerate"]>(async () => []);
+    const getConfig = () => ({});
+    const catalog = createElizaConnectorTargetCatalog({
+      listSources: () => [{ platform: "telegram", enumerate }],
+      getConfig,
+    });
+    await catalog.listGroups();
+
+    const ctx = enumerate.mock.calls.at(0)?.[0];
+    expect(ctx).toBeDefined();
+    expect(ctx?.groupId).toBeUndefined();
+    expect(ctx?.fetchImpl).toBeUndefined();
+    expect(ctx?.now).toBeUndefined();
+    expect(ctx?.logger).toBeUndefined();
+    expect(ctx?.getConfig).toBe(getConfig);
+  });
+
+  it("implements a safe no-op stop lifecycle method", async () => {
+    const catalog = createElizaConnectorTargetCatalog({
+      listSources: () => [discordSource()],
+      getConfig: () => ({}),
+    });
+    await expect(catalog.stop()).resolves.toBeUndefined();
+    await expect(catalog.stop()).resolves.toBeUndefined();
+  });
 });


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Unit test additions validating connector target catalog lifecycle, context propagation defaults, and source concatenation order.

# Background

## What does this PR do?

Expands behavioral unit test coverage in `packages/app-core/src/services/connector-target-catalog.test.ts`:
- Tests `catalog.stop()` lifecycle method to ensure it resolves safely without error across multiple calls.
- Tests default enumeration context values when optional parameters (`fetchImpl`, `now`, `logger`, `groupId`) are omitted.
- Tests concatenation order when multiple target sources are registered under the same platform identifier (e.g. multi-bot Discord connectors).

## What kind of change is this?

Improvements (misc. changes to existing features)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Review `packages/app-core/src/services/connector-target-catalog.test.ts`.

## Detailed testing steps

Run:
```bash
bun test packages/app-core/src/services/connector-target-catalog.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows` sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:9b81b6628d8efc72b5a716fbb2412d61278096cc -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only change with no rendered UI surface
<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only change with no rendered UI surface
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - test-only change has no user flow to record
<!-- evidence-row:backend-logs -->
- [ ] N/A - pure unit test does not exercise a server path
<!-- evidence-row:frontend-logs -->
- [ ] N/A - pure unit test does not exercise a browser path
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent model or prompt path is touched
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database rows or generated files produced
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface in this change

# Evidence Details

## Real LLM-call trajectory

N/A - pure unit test change.

## Backend + frontend logs

```
RED (behavior mutated by making catalog.stop() throw an error):
  src/services/connector-target-catalog.test.ts:
  (fail) createElizaConnectorTargetCatalog > implements a safe no-op stop lifecycle method
  error: Expected promise that resolves, Received promise that rejected

GREEN (restored):
  src/services/connector-target-catalog.test.ts:
  9 pass, 0 fail (23 expect calls)
```

## Screenshots (before / after) + video walkthrough

N/A - test-only change with no UI surfaces.

## Audio / voice walkthrough

N/A - test-only change with no voice components.

## Known gaps / failures

None.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: Claude Code
— [lane-byt61-7381]
