### PR TITLE
fix: make coding verification recovery truthful

### DIFF
--- a/packages/core/src/runtime/__tests__/planner-loop.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop.test.ts
@@ -13,6 +13,7 @@ import { ModelType } from "../../types/model";
 import { TrajectoryLimitExceeded } from "../limits";
 import {
 	__codingMutationRequiresVerificationForTests,
+	__isSuccessfulCodingVerificationStepForTests,
 	__renderRoutingHintsBlockForTests,
 	actionResultToPlannerToolResult,
 	FAILED_TOOL_FALLBACK_MESSAGE,
@@ -1476,6 +1477,38 @@ describe("v5 planner loop skeleton", () => {
 		);
 	});
 
+	it("does not accept a successful test command that ran no tests as verification", () => {
+		const noTestsStep = {
+			toolCall: {
+				name: "SHELL",
+				params: { command: "go test ./internal/config -run TestEnvSubstitution" },
+			},
+			result: {
+				success: true,
+				text: "ok  go.flipt.io/flipt/internal/config 0.2s [no tests to run]",
+				data: {
+					output:
+						"ok  go.flipt.io/flipt/internal/config 0.2s [no tests to run]",
+				},
+			},
+		} as Parameters<typeof __isSuccessfulCodingVerificationStepForTests>[0];
+		expect(__isSuccessfulCodingVerificationStepForTests(noTestsStep)).toBe(false);
+
+		const mixedStep = {
+			...noTestsStep,
+			result: {
+				...noTestsStep.result,
+				text:
+					"ok  go.flipt.io/flipt/internal/config 0.2s [no tests to run]\nok  go.flipt.io/flipt/internal/config 0.4s",
+				data: {
+					output:
+						"ok  go.flipt.io/flipt/internal/config 0.2s [no tests to run]\nok  go.flipt.io/flipt/internal/config 0.4s",
+				},
+			},
+		} as Parameters<typeof __isSuccessfulCodingVerificationStepForTests>[0];
+		expect(__isSuccessfulCodingVerificationStepForTests(mixedStep)).toBe(true);
+	});
+
 	it("does not treat a successful inspection command as coding verification", async () => {
 		await withCodingRequiredToolDefaults(async () => {
 			const runtime = {
@@ -2535,9 +2568,22 @@ describe("v5 planner loop skeleton", () => {
 
 	it("lets final verification supersede failed intermediate coding commands", async () => {
 		await withCodingRequiredToolDefaults(async () => {
-			const toolResult = (success: boolean, text: string) => ({
+			const toolResult = (
+				success: boolean,
+				text: string,
+				command?: string,
+			) => ({
 				success,
 				text,
+				...(command
+					? {
+						data: {
+							command,
+							exit_code: success ? 0 : 1,
+							output: text,
+						},
+					}
+					: {}),
 			});
 			const runtime = {
 				useModel: vi
@@ -2582,7 +2628,9 @@ describe("v5 planner loop skeleton", () => {
 							{
 								id: "shell-passed",
 								name: "SHELL",
-								arguments: { command: "npm test -- dice.html" },
+								arguments: {
+									command: "npm test -- dice.html --runInBand",
+								},
 							},
 						],
 					})
@@ -2593,9 +2641,17 @@ describe("v5 planner loop skeleton", () => {
 			const executeToolCall = vi
 				.fn()
 				.mockResolvedValueOnce(toolResult(true, "wrote draft"))
-				.mockResolvedValueOnce(toolResult(false, "test failed"))
+				.mockResolvedValueOnce(
+					toolResult(false, "test failed", "npm test -- dice.html"),
+				)
 				.mockResolvedValueOnce(toolResult(true, "fixed file"))
-				.mockResolvedValueOnce(toolResult(true, "test passed"));
+				.mockResolvedValueOnce(
+					toolResult(
+						true,
+						"test passed",
+						"npm test -- dice.html --runInBand",
+					),
+				);
 
 			const result = await runPlannerLoop({
 				runtime,

--- a/packages/core/src/runtime/__tests__/planner-loop.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop.test.ts
@@ -1481,7 +1481,9 @@ describe("v5 planner loop skeleton", () => {
 		const noTestsStep = {
 			toolCall: {
 				name: "SHELL",
-				params: { command: "go test ./internal/config -run TestEnvSubstitution" },
+				params: {
+					command: "go test ./internal/config -run TestEnvSubstitution",
+				},
 			},
 			result: {
 				success: true,
@@ -1492,14 +1494,15 @@ describe("v5 planner loop skeleton", () => {
 				},
 			},
 		} as Parameters<typeof __isSuccessfulCodingVerificationStepForTests>[0];
-		expect(__isSuccessfulCodingVerificationStepForTests(noTestsStep)).toBe(false);
+		expect(__isSuccessfulCodingVerificationStepForTests(noTestsStep)).toBe(
+			false,
+		);
 
 		const mixedStep = {
 			...noTestsStep,
 			result: {
 				...noTestsStep.result,
-				text:
-					"ok  go.flipt.io/flipt/internal/config 0.2s [no tests to run]\nok  go.flipt.io/flipt/internal/config 0.4s",
+				text: "ok  go.flipt.io/flipt/internal/config 0.2s [no tests to run]\nok  go.flipt.io/flipt/internal/config 0.4s",
 				data: {
 					output:
 						"ok  go.flipt.io/flipt/internal/config 0.2s [no tests to run]\nok  go.flipt.io/flipt/internal/config 0.4s",
@@ -2577,12 +2580,12 @@ describe("v5 planner loop skeleton", () => {
 				text,
 				...(command
 					? {
-						data: {
-							command,
-							exit_code: success ? 0 : 1,
-							output: text,
-						},
-					}
+							data: {
+								command,
+								exit_code: success ? 0 : 1,
+								output: text,
+							},
+						}
 					: {}),
 			});
 			const runtime = {
@@ -2646,11 +2649,7 @@ describe("v5 planner loop skeleton", () => {
 				)
 				.mockResolvedValueOnce(toolResult(true, "fixed file"))
 				.mockResolvedValueOnce(
-					toolResult(
-						true,
-						"test passed",
-						"npm test -- dice.html --runInBand",
-					),
+					toolResult(true, "test passed", "npm test -- dice.html --runInBand"),
 				);
 
 			const result = await runPlannerLoop({

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -3930,10 +3930,13 @@ function deferCodingCompletionUntilMutationVerified(args: {
 				success: false,
 				decision: "CONTINUE",
 				thought:
-					"A successful WRITE or EDIT has not been followed by a successful SHELL verification.",
-				messageToUser:
-					"Run the narrowest relevant test, typecheck, lint, build, or diff check with SHELL before finishing.",
-			};
+					latestSuccessfulNoTestVerification(args.trajectory)
+						? "The last test command selected no tests."
+						: "A successful WRITE or EDIT has not been followed by a successful SHELL verification.",
+				messageToUser: latestSuccessfulNoTestVerification(args.trajectory)
+					? "The last test command selected no tests. Run the task's actual acceptance tests with SHELL before finishing."
+					: "Run the narrowest relevant test, typecheck, lint, build, or diff check with SHELL before finishing.",
+		};
 	args.trajectory.evaluatorOutputs.push(
 		projectToolDiagnosticValue(
 			evaluator,
@@ -3948,6 +3951,21 @@ function deferCodingCompletionUntilMutationVerified(args: {
 	);
 	args.trajectory.plannedQueue.length = 0;
 	return true;
+}
+
+function latestSuccessfulNoTestVerification(
+	trajectory: PlannerTrajectory,
+): boolean {
+	const steps = [...trajectory.archivedSteps, ...trajectory.steps];
+	for (let index = steps.length - 1; index >= 0; index--) {
+		const step = steps[index];
+		if (!step?.toolCall || step.toolCall.name.toUpperCase() !== "SHELL") continue;
+		if (step.result?.success !== true) continue;
+		const command = shellCommandParam(step.toolCall);
+		if (codingVerificationKind(command) !== "test") return false;
+		return verificationRanNoTests(step);
+	}
+	return false;
 }
 
 function codingMutationRequiresVerification(
@@ -4241,7 +4259,42 @@ function isSuccessfulCodingVerificationStep(step: PlannerStep): boolean {
 	}
 	const command = shellCommandParam(step.toolCall);
 	if (!command) return false;
-	return codingVerificationKind(command) !== undefined;
+	const kind = codingVerificationKind(command);
+	if (kind === undefined) return false;
+	return !(kind === "test" && verificationRanNoTests(step));
+}
+
+/** Test seam for rejecting zero-test verification as completion proof. */
+export function __isSuccessfulCodingVerificationStepForTests(
+	step: PlannerStep,
+): boolean {
+	return isSuccessfulCodingVerificationStep(step);
+}
+
+/**
+ * A command that exits zero while selecting no tests is not completion proof.
+ * Go and several test runners report this as an `ok` line annotated with
+ * `[no tests to run]`; reject only when every package result is so annotated,
+ * preserving mixed runs where at least one real test suite executed.
+ */
+function verificationRanNoTests(step: PlannerStep): boolean {
+	const result = step.result;
+	const data = result?.data;
+	const output = [
+		result?.text,
+		result?.summary,
+		typeof data?.output === "string" ? data.output : undefined,
+	]
+		.filter((value): value is string => typeof value === "string")
+		.join("\n");
+	if (!/\[no tests to run\]/i.test(output)) return false;
+	const packageResults = output
+		.split(/\r?\n/u)
+		.filter((line) => /^ok\s+\S+\s+\S+/u.test(line));
+	return (
+		packageResults.length > 0 &&
+		packageResults.every((line) => /\[no tests to run\]/i.test(line))
+	);
 }
 
 function isNoopShellVerificationCommand(command: string): boolean {
@@ -4421,8 +4474,32 @@ function resolveShellFailuresSubsumedBy(
 		if (!failedCommand || shellCwdParam(failedCall) !== cwd) continue;
 		if (containsCommandVerbatim(command, failedCommand)) {
 			unresolvedByOperation.delete(key);
+			continue;
+		}
+		// A narrower successful verifier is a valid recovery for a broader failed
+		// verifier when both commands belong to the same tool family (for example,
+		// `go test ./...` followed by `go test ./internal/config -run TestLoad`).
+		// This is restricted to coding verification commands and an identical
+		// executable prefix so an unrelated deploy/build failure cannot be laundered
+		// by a later test.
+		if (
+			codingVerificationKind(failedCommand) !== undefined &&
+			codingVerificationKind(command) === codingVerificationKind(failedCommand) &&
+			verificationCommandFamily(command) === verificationCommandFamily(failedCommand)
+		) {
+			unresolvedByOperation.delete(key);
 		}
 	}
+}
+
+function verificationCommandFamily(command: string): string {
+	const segment = splitSafeShellVerificationChain(command)?.[0] ?? command;
+	return stripShellVerificationPrefix(segment)
+		.trim()
+		.split(/\s+/u)
+		.slice(0, 2)
+		.join(" ")
+		.toLowerCase();
 }
 
 function shellCommandParam(call: PlannerToolCall): string {

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -3929,14 +3929,13 @@ function deferCodingCompletionUntilMutationVerified(args: {
 		: {
 				success: false,
 				decision: "CONTINUE",
-				thought:
-					latestSuccessfulNoTestVerification(args.trajectory)
-						? "The last test command selected no tests."
-						: "A successful WRITE or EDIT has not been followed by a successful SHELL verification.",
+				thought: latestSuccessfulNoTestVerification(args.trajectory)
+					? "The last test command selected no tests."
+					: "A successful WRITE or EDIT has not been followed by a successful SHELL verification.",
 				messageToUser: latestSuccessfulNoTestVerification(args.trajectory)
 					? "The last test command selected no tests. Run the task's actual acceptance tests with SHELL before finishing."
 					: "Run the narrowest relevant test, typecheck, lint, build, or diff check with SHELL before finishing.",
-		};
+			};
 	args.trajectory.evaluatorOutputs.push(
 		projectToolDiagnosticValue(
 			evaluator,
@@ -3959,7 +3958,7 @@ function latestSuccessfulNoTestVerification(
 	const steps = [...trajectory.archivedSteps, ...trajectory.steps];
 	for (let index = steps.length - 1; index >= 0; index--) {
 		const step = steps[index];
-		if (!step?.toolCall || step.toolCall.name.toUpperCase() !== "SHELL") continue;
+		if (step.toolCall?.name.toUpperCase() !== "SHELL") continue;
 		if (step.result?.success !== true) continue;
 		const command = shellCommandParam(step.toolCall);
 		if (codingVerificationKind(command) !== "test") return false;
@@ -4484,8 +4483,10 @@ function resolveShellFailuresSubsumedBy(
 		// by a later test.
 		if (
 			codingVerificationKind(failedCommand) !== undefined &&
-			codingVerificationKind(command) === codingVerificationKind(failedCommand) &&
-			verificationCommandFamily(command) === verificationCommandFamily(failedCommand)
+			codingVerificationKind(command) ===
+				codingVerificationKind(failedCommand) &&
+			verificationCommandFamily(command) ===
+				verificationCommandFamily(failedCommand)
 		) {
 			unresolvedByOperation.delete(key);
 		}


### PR DESCRIPTION
Closes #28364

## Summary
- let a successful narrower verification supersede an earlier failed verification only when cwd, verification kind, and executable family match
- preserve unrelated failure authority
- reject zero-test runs as coding completion proof while allowing mixed real/no-test output
- add planner-loop regression coverage

## Evidence
- Full planner-loop suite: 217 passed, 0 failed
- Isolated matched benchmark rerun: the whitespace task hidden grader passed and Eliza now reports verification failure truthfully; typed env substitution remains a separate task/model correctness failure
- Shared checkout untouched
