### PR TITLE
feat(ui): enforce canonical molecule contracts

### DIFF
--- a/packages/ui/DESIGN_SYSTEM.md
+++ b/packages/ui/DESIGN_SYSTEM.md
@@ -122,13 +122,19 @@ density presentation stay in the table primitives.
 
 Repeated multi-atom structures belong in a shared pattern only when they own
 the same behavior and state lifecycle. Dependency similarity alone is not a
-pattern. The molecular inventory records a final disposition and rationale for
-every detected cluster; unresolved candidates and duplicate implementations
-must not pass the completion gate. The accepted final dispositions are
+pattern. `scripts/molecule-contracts.json` records the exact owner, composition
+signals, consumer floor, and required consumers for established shared
+molecules. The audit fails when any of those contracts drift, including for
+molecules that compose only one canonical atom.
+
+Structural duplicate discovery is a separate review queue. The molecular
+inventory records a final disposition and rationale for every detected cluster;
+unresolved candidates and duplicate implementations must not pass the
+completion gate. The accepted final dispositions are
 `distinct-domain-compositions` and `shared-lifecycle-owner`; adding another
 requires a gate and policy change in the same review. Run
-`audit:molecular-inventory` to update the committed report after source or
-decision changes. Package lint checks that the report is current.
+`audit:molecular-inventory` to update the committed report after source,
+contract, or decision changes. Package lint checks that the report is current.
 
 ## Story and accessibility proof
 

--- a/packages/ui/scripts/duplicate-molecular-components-report.md
+++ b/packages/ui/scripts/duplicate-molecular-components-report.md
@@ -4,6 +4,19 @@ Scanned 927 maintained React files. 68 exported compositions have a recognized m
 
 Clusters share both a role and an atomic dependency signature. Detection creates a review queue; this committed report contains only final dispositions based on product behavior, state ownership, and responsive layout.
 
+## Canonical molecule contracts
+
+These owners are fail-closed contracts. The audit fails if an owner disappears, drops a required canonical atom, or loses its maintained consumers.
+
+| Contract | Canonical owner | Maintained references | Responsibility |
+| --- | --- | ---: | --- |
+| content-state | `ContentState` in `packages/ui/src/components/composites/page-panel/content-state.tsx` | 2 | Empty and loading presentation inside page-panel placements. |
+| settings-row | `SettingsRow` in `packages/ui/src/components/settings/settings-layout.tsx` | 40 | Label, description, control, and navigation alignment for settings. |
+| selectable-tile | `SelectableTile` in `packages/ui/src/components/composites/settings/selectable-tile.tsx` | 1 | Pressed-state selection tile with a leading visual and check indicator. |
+| action-list-row | `ActionListRow` in `packages/ui/src/components/shared/ActionListRow.tsx` | 2 | Button, link, and static list rows with shared content slots. |
+
+## Duplicate review queue
+
 | Role | Atomic dependencies | Components | Decision |
 | --- | --- | ---: | --- |
 | dialog | button, dialog | 6 | distinct-domain-compositions |

--- a/packages/ui/scripts/find-duplicate-molecular-components.mjs
+++ b/packages/ui/scripts/find-duplicate-molecular-components.mjs
@@ -23,6 +23,8 @@ const decisionsPath = path.join(
   scriptDir,
   "molecular-inventory-decisions.json",
 );
+const contractsPath = path.join(scriptDir, "molecule-contracts.json");
+const repoRoot = path.resolve(scriptDir, "../../..");
 
 const FINAL_DISPOSITIONS = new Set([
   "distinct-domain-compositions",
@@ -66,8 +68,7 @@ export function validateMolecularDecisions(clusters, decisions) {
     .filter((cluster) => {
       const disposition = decisions[cluster.signature]?.disposition;
       return (
-        typeof disposition === "string" &&
-        !FINAL_DISPOSITIONS.has(disposition)
+        typeof disposition === "string" && !FINAL_DISPOSITIONS.has(disposition)
       );
     })
     .map(
@@ -89,9 +90,106 @@ export function validateMolecularDecisions(clusters, decisions) {
   }
 }
 
+export function validateMoleculeContracts(components, contracts, references) {
+  const errors = [];
+  const ids = new Set();
+  const owners = new Set();
+
+  for (const contract of contracts) {
+    const ownerKey = `${contract.owner}:${contract.symbol}`;
+    if (ids.has(contract.id)) errors.push(`duplicate id ${contract.id}`);
+    if (owners.has(ownerKey)) errors.push(`duplicate owner ${ownerKey}`);
+    ids.add(contract.id);
+    owners.add(ownerKey);
+
+    const owner = components.find(
+      (component) =>
+        component.file === contract.owner && component.name === contract.symbol,
+    );
+    if (!owner) {
+      errors.push(`missing owner ${ownerKey}`);
+      continue;
+    }
+
+    const missingDependencies = contract.requiredAtomicDependencies.filter(
+      (dependency) => !owner.atomicDependencies.includes(dependency),
+    );
+    if (missingDependencies.length > 0) {
+      errors.push(
+        `${ownerKey} is missing atomic dependencies ${missingDependencies.join(", ")}`,
+      );
+    }
+
+    const missingTags = (contract.requiredRenderedTags ?? []).filter(
+      (tag) => !owner.renderedTags.includes(tag),
+    );
+    if (missingTags.length > 0) {
+      errors.push(
+        `${ownerKey} is missing rendered tags ${missingTags.join(", ")}`,
+      );
+    }
+
+    const referenceCount = references[ownerKey] ?? 0;
+    if (referenceCount < contract.minimumMaintainedReferences) {
+      errors.push(
+        `${ownerKey} has ${referenceCount} maintained references; expected at least ${contract.minimumMaintainedReferences}`,
+      );
+    }
+
+    for (const consumerFile of contract.requiredConsumerFiles ?? []) {
+      const absoluteConsumer = path.join(repoRoot, consumerFile);
+      const source = fs.existsSync(absoluteConsumer)
+        ? fs.readFileSync(absoluteConsumer, "utf8")
+        : "";
+      if (!new RegExp(`\\b${contract.symbol}\\b`).test(source)) {
+        errors.push(
+          `${consumerFile} no longer consumes canonical ${contract.symbol}`,
+        );
+      }
+    }
+  }
+
+  if (errors.length > 0) {
+    throw new Error(
+      `Canonical molecule contracts failed: ${errors.join("; ")}`,
+    );
+  }
+}
+
+function maintainedReferenceCounts(components, contracts) {
+  const references = Object.fromEntries(
+    contracts.map((contract) => [`${contract.owner}:${contract.symbol}`, 0]),
+  );
+  const symbols = new Map(
+    contracts.map((contract) => [contract.symbol, contract]),
+  );
+
+  const maintainedFiles = [...new Set(components.map(({ file }) => file))];
+  for (const file of maintainedFiles) {
+    const source = fs.readFileSync(path.join(repoRoot, file), "utf8");
+    for (const [symbol, contract] of symbols) {
+      if (file === contract.owner) continue;
+      if (new RegExp(`\\b${symbol}\\b`).test(source)) {
+        references[`${contract.owner}:${symbol}`] += 1;
+      }
+    }
+  }
+  return references;
+}
+
 export function buildMolecularInventory() {
   const atomicReport = buildInventory();
   const decisions = JSON.parse(fs.readFileSync(decisionsPath, "utf8"));
+  const contractRegistry = JSON.parse(fs.readFileSync(contractsPath, "utf8"));
+  const references = maintainedReferenceCounts(
+    atomicReport.components,
+    contractRegistry.contracts,
+  );
+  validateMoleculeContracts(
+    atomicReport.components,
+    contractRegistry.contracts,
+    references,
+  );
   const components = atomicReport.components
     .map((component) => ({
       ...component,
@@ -134,9 +232,13 @@ export function buildMolecularInventory() {
   }));
 
   return {
-    schemaVersion: 1,
+    schemaVersion: 2,
     sourceAtomicSchemaVersion: atomicReport.schemaVersion,
     scannedFiles: atomicReport.scannedFiles,
+    canonicalContracts: contractRegistry.contracts.map((contract) => ({
+      ...contract,
+      maintainedReferences: references[`${contract.owner}:${contract.symbol}`],
+    })),
     eligibleComponents: components.length,
     clusters,
     summary: {
@@ -157,6 +259,19 @@ export function renderMolecularMarkdown(report) {
     `Scanned ${report.scannedFiles} maintained React files. ${report.eligibleComponents} exported compositions have a recognized molecular role and at least two atomic dependencies.`,
     "",
     "Clusters share both a role and an atomic dependency signature. Detection creates a review queue; this committed report contains only final dispositions based on product behavior, state ownership, and responsive layout.",
+    "",
+    "## Canonical molecule contracts",
+    "",
+    "These owners are fail-closed contracts. The audit fails if an owner disappears, drops a required canonical atom, or loses its maintained consumers.",
+    "",
+    "| Contract | Canonical owner | Maintained references | Responsibility |",
+    "| --- | --- | ---: | --- |",
+    ...report.canonicalContracts.map(
+      (contract) =>
+        `| ${contract.id} | \`${contract.symbol}\` in \`${contract.owner}\` | ${contract.maintainedReferences} | ${contract.responsibility} |`,
+    ),
+    "",
+    "## Duplicate review queue",
     "",
     "| Role | Atomic dependencies | Components | Decision |",
     "| --- | --- | ---: | --- |",

--- a/packages/ui/scripts/find-duplicate-molecular-components.test.mjs
+++ b/packages/ui/scripts/find-duplicate-molecular-components.test.mjs
@@ -6,6 +6,7 @@ import {
   buildMolecularInventory,
   renderMolecularMarkdown,
   validateMolecularDecisions,
+  validateMoleculeContracts,
 } from "./find-duplicate-molecular-components.mjs";
 
 test("molecular inventory is deterministic and requires meaningful signatures", () => {
@@ -20,6 +21,81 @@ test("molecular inventory is deterministic and requires meaningful signatures", 
   );
   assert.ok(first.clusters.every((cluster) => cluster.disposition));
   assert.ok(first.clusters.every((cluster) => cluster.rationale));
+  assert.deepEqual(
+    first.canonicalContracts.map((contract) => contract.id),
+    ["content-state", "settings-row", "selectable-tile", "action-list-row"],
+  );
+  assert.ok(
+    first.canonicalContracts.every(
+      (contract) =>
+        contract.maintainedReferences >= contract.minimumMaintainedReferences,
+    ),
+  );
+});
+
+test("canonical molecule contracts fail closed on owner drift", () => {
+  const components = [
+    {
+      atomicDependencies: ["button"],
+      file: "packages/ui/src/example.tsx",
+      name: "ExampleRow",
+      renderedTags: [],
+    },
+  ];
+  const contracts = [
+    {
+      id: "example-row",
+      minimumMaintainedReferences: 2,
+      owner: "packages/ui/src/example.tsx",
+      requiredAtomicDependencies: ["button", "badge"],
+      requiredRenderedTags: ["Button", "Badge"],
+      symbol: "ExampleRow",
+    },
+    {
+      id: "missing-row",
+      minimumMaintainedReferences: 0,
+      owner: "packages/ui/src/missing.tsx",
+      requiredAtomicDependencies: [],
+      symbol: "MissingRow",
+    },
+  ];
+
+  assert.throws(
+    () =>
+      validateMoleculeContracts(components, contracts, {
+        "packages/ui/src/example.tsx:ExampleRow": 1,
+      }),
+    /missing rendered tags Button, Badge.*has 1 maintained references; expected at least 2.*missing owner packages\/ui\/src\/missing\.tsx:MissingRow/,
+  );
+});
+
+test("canonical molecule contracts require named consumers to keep composing the owner", () => {
+  assert.throws(
+    () =>
+      validateMoleculeContracts(
+        [
+          {
+            atomicDependencies: ["button"],
+            file: "packages/ui/src/example.tsx",
+            name: "ExampleRow",
+            renderedTags: ["Button"],
+          },
+        ],
+        [
+          {
+            id: "example-row",
+            minimumMaintainedReferences: 0,
+            owner: "packages/ui/src/example.tsx",
+            requiredAtomicDependencies: ["button"],
+            requiredConsumerFiles: ["packages/ui/src/missing-consumer.tsx"],
+            requiredRenderedTags: ["Button"],
+            symbol: "ExampleRow",
+          },
+        ],
+        {},
+      ),
+    /missing-consumer\.tsx no longer consumes canonical ExampleRow/,
+  );
 });
 
 test("molecular decisions reject candidate and duplicate states", () => {
@@ -48,6 +124,8 @@ test("molecular report includes roles, dependencies, and source evidence", () =>
   const markdown = renderMolecularMarkdown(buildMolecularInventory());
 
   assert.match(markdown, /# Molecular component duplicate inventory/);
+  assert.match(markdown, /Canonical molecule contracts/);
+  assert.match(markdown, /ContentState/);
   assert.match(markdown, /Reviewed clusters/);
   assert.doesNotMatch(markdown, /-candidate\*\*/);
   assert.doesNotMatch(markdown, /Decision: \*\*duplicate-implementation\*\*/);

--- a/packages/ui/scripts/molecule-contracts.json
+++ b/packages/ui/scripts/molecule-contracts.json
@@ -1,0 +1,56 @@
+{
+  "schemaVersion": 1,
+  "contracts": [
+    {
+      "id": "content-state",
+      "owner": "packages/ui/src/components/composites/page-panel/content-state.tsx",
+      "symbol": "ContentState",
+      "requiredAtomicDependencies": [],
+      "requiredRenderedTags": ["LoadingContent", "PlainEmptyContent"],
+      "requiredConsumerFiles": [
+        "packages/ui/src/components/composites/page-panel/page-panel-empty.tsx",
+        "packages/ui/src/components/composites/page-panel/page-panel-loading.tsx"
+      ],
+      "minimumMaintainedReferences": 2,
+      "responsibility": "Empty and loading presentation inside page-panel placements."
+    },
+    {
+      "id": "settings-row",
+      "owner": "packages/ui/src/components/settings/settings-layout.tsx",
+      "symbol": "SettingsRow",
+      "requiredAtomicDependencies": ["button"],
+      "requiredRenderedTags": ["Button"],
+      "requiredConsumerFiles": [
+        "packages/ui/src/components/settings/settings-agent-rows.tsx",
+        "packages/ui/src/components/settings/cloud-panel/cloud-settings-primitives.tsx"
+      ],
+      "minimumMaintainedReferences": 10,
+      "responsibility": "Label, description, control, and navigation alignment for settings."
+    },
+    {
+      "id": "selectable-tile",
+      "owner": "packages/ui/src/components/composites/settings/selectable-tile.tsx",
+      "symbol": "SelectableTile",
+      "requiredAtomicDependencies": ["button"],
+      "requiredRenderedTags": ["Button"],
+      "requiredConsumerFiles": [
+        "packages/ui/src/components/settings/AppearanceSettingsSection.tsx"
+      ],
+      "minimumMaintainedReferences": 1,
+      "responsibility": "Pressed-state selection tile with a leading visual and check indicator."
+    },
+    {
+      "id": "action-list-row",
+      "owner": "packages/ui/src/components/shared/ActionListRow.tsx",
+      "symbol": "ActionListRow",
+      "requiredAtomicDependencies": ["button"],
+      "requiredRenderedTags": ["Button"],
+      "requiredConsumerFiles": [
+        "packages/ui/src/components/settings/LoadedPacksList.tsx",
+        "packages/ui/src/components/composites/skills/skill-sidebar-item.tsx"
+      ],
+      "minimumMaintainedReferences": 2,
+      "responsibility": "Button, link, and static list rows with shared content slots."
+    }
+  ]
+}


### PR DESCRIPTION
Closes #28349

## What changed

- adds fail-closed contracts for `ContentState`, `SettingsRow`, `SelectableTile`, and `ActionListRow`
- validates exact owner/export, required canonical composition signals, maintained-reference floors, and named consumer adapters
- keeps canonical ownership separate from the heuristic multi-atom duplicate review queue
- regenerates the molecular report with contract ownership and real maintained-reference counts
- documents the molecule enforcement boundary

The stricter review found no remaining confirmed duplicate to migrate: candidate wrappers and typed rows already compose their canonical owner, while chat/sidebar/notification/domain states own different behavior. Their canonical consumer links are now enforced so they cannot silently regress.

## Verification

- `bun test packages/ui/scripts/find-duplicate-molecular-components.test.mjs` (5/5)
- `bun run --cwd packages/ui lint:check` (23/23 script tests; molecular report current; existing advisory warnings only)
- `bun run --cwd packages/ui typecheck`
- `git diff --check origin/develop...HEAD`
- `bun run verify` after final rebase (375/375 Turbo tasks plus all repository audits)

## Visual evidence

N/A: policy, inventory, tests, and documentation only; no rendered component code changed.