### PR TITLE
fix(cli): treat blank capability-router env vars as unset

### DIFF
--- a/packages/elizaos/src/commands/capability-router.test.ts
+++ b/packages/elizaos/src/commands/capability-router.test.ts
@@ -135,6 +135,49 @@ describe("runCapabilityRouterConnect", () => {
     );
   });
 
+  it("treats blank env values as unset and uses the documented default api base", async () => {
+    process.env.ELIZA_API_BASE_URL = "";
+    process.env.ELIZA_API_PORT = "";
+    const fetchMock = mockFetch({
+      success: true,
+      endpoint: { id: "tools", baseUrl: "https://capability.example.test" },
+      sync: { registered: [], unloaded: [], skipped: [] },
+    });
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const code = await runCapabilityRouterConnect({
+      endpointUrl: "https://capability.example.test",
+    });
+
+    expect(code).toBe(0);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://127.0.0.1:2138/api/capability-router/connect",
+      expect.anything(),
+    );
+  });
+
+  it("skips a blank ELIZA_API_PORT in favor of the next env candidate", async () => {
+    process.env.ELIZA_API_BASE_URL = "";
+    process.env.ELIZA_API_PORT = "";
+    process.env.ELIZA_PORT = "4599";
+    const fetchMock = mockFetch({
+      success: true,
+      endpoint: { id: "tools", baseUrl: "https://capability.example.test" },
+      sync: { registered: [], unloaded: [], skipped: [] },
+    });
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const code = await runCapabilityRouterConnect({
+      endpointUrl: "https://capability.example.test",
+    });
+
+    expect(code).toBe(0);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://127.0.0.1:4599/api/capability-router/connect",
+      expect.anything(),
+    );
+  });
+
   it("can request an ephemeral direct connection", async () => {
     const fetchMock = mockFetch({
       success: true,

--- a/packages/elizaos/src/commands/capability-router.test.ts
+++ b/packages/elizaos/src/commands/capability-router.test.ts
@@ -135,9 +135,11 @@ describe("runCapabilityRouterConnect", () => {
     );
   });
 
-  it("treats blank env values as unset and uses the documented default api base", async () => {
-    process.env.ELIZA_API_BASE_URL = "";
-    process.env.ELIZA_API_PORT = "";
+  it("treats blank and whitespace env values as unset and uses the documented default api base", async () => {
+    process.env.ELIZA_API_BASE_URL = "   ";
+    process.env.ELIZA_API_BASE = "";
+    process.env.ELIZA_API_PORT = "  ";
+    process.env.ELIZA_PORT = "";
     const fetchMock = mockFetch({
       success: true,
       endpoint: { id: "tools", baseUrl: "https://capability.example.test" },
@@ -156,9 +158,10 @@ describe("runCapabilityRouterConnect", () => {
     );
   });
 
-  it("skips a blank ELIZA_API_PORT in favor of the next env candidate", async () => {
-    process.env.ELIZA_API_BASE_URL = "";
-    process.env.ELIZA_API_PORT = "";
+  it("skips blank and whitespace candidates in favor of the next valid env candidate", async () => {
+    process.env.ELIZA_API_BASE_URL = " \t ";
+    process.env.ELIZA_API_BASE = "";
+    process.env.ELIZA_API_PORT = " ";
     process.env.ELIZA_PORT = "4599";
     const fetchMock = mockFetch({
       success: true,

--- a/packages/elizaos/src/commands/capability-router.ts
+++ b/packages/elizaos/src/commands/capability-router.ts
@@ -56,9 +56,8 @@ export async function runCapabilityRouterConnect(
 ): Promise<number> {
   const apiBase = normalizeBaseUrl(
     options.apiBase ??
-      process.env.ELIZA_API_BASE_URL ??
-      process.env.ELIZA_API_BASE ??
-      `http://127.0.0.1:${process.env.ELIZA_API_PORT ?? process.env.ELIZA_PORT ?? "2138"}`,
+      envString("ELIZA_API_BASE_URL", "ELIZA_API_BASE") ??
+      `http://127.0.0.1:${envString("ELIZA_API_PORT", "ELIZA_PORT") ?? "2138"}`,
     "api base",
   );
   if (apiBase instanceof Error) {
@@ -234,6 +233,21 @@ function hasCloudProvisioningOptions(
       options.provisionTimeoutMs ||
       options.pollIntervalMs,
   );
+}
+
+/**
+ * First non-blank environment value among `names`. Blank or whitespace-only
+ * values are treated as unset so one-shot exports like `ELIZA_API_PORT= cmd`
+ * keep the documented defaults instead of silently targeting port 80.
+ */
+function envString(...names: string[]): string | undefined {
+  for (const name of names) {
+    const value = process.env[name];
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value;
+    }
+  }
+  return undefined;
 }
 
 function normalizeBaseUrl(


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Closes #28358

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low risk. Confined to environment variable reading in capability-router CLI command.

# Background

## What does this PR do?
Treats empty and whitespace-only environment variables (`ELIZA_API_BASE_URL`, `ELIZA_API_BASE`, `ELIZA_API_PORT`, `ELIZA_PORT`) as unset when determining the API base URL in `capability-router`, falling back to documented defaults.

## What kind of change is this?
Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?
My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?
Review `packages/elizaos/src/commands/capability-router.ts` and test suite in `packages/elizaos/src/commands/capability-router.test.ts`.

## Detailed testing steps
Run:
```bash
bun run --cwd packages/elizaos test -- src/commands/capability-router.test.ts
bun run --cwd packages/elizaos typecheck
```

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:e14729a4216858e72db579e2e652a65f97973796 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots: N/A - CLI command execution.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots: N/A - CLI command execution.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough: N/A - CLI command execution.
<!-- evidence-row:backend-logs -->
- [x] Backend logs:
<details>
<summary>bun run --cwd packages/elizaos test -- src/commands/capability-router.test.ts output</summary>

```
 Test Files  1 passed (1)
      Tests  24 passed (24)
   Start at  18:55:44
   Duration  221ms
```
</details>
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs: N/A - CLI command without frontend execution.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory: N/A - Deterministic CLI argument parsing.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts: N/A - CLI command generates no files.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review: N/A - No UI rendered.

# Known gaps / failures
None.

# Maintainer CI exception record
N/A - no exception requested

---

AI provider/model: Google / Gemini 3.7 Flash
Client / agent tooling: Antigravity
Contribution skill revision: elizaOS/eliza@7d55350499b702ec4c979c3dcb6bb5e56d482939:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [antigravity-contrib]
<!-- eliza-computer-attribution:v1 {"provider":"google","model":"gemini-3.7-flash","client":"Antigravity","skill_revision":"elizaOS/eliza@7d55350499b702ec4c979c3dcb6bb5e56d482939:packages/skills/skills/contribute-to-eliza"} -->