### PR TITLE
fix(cli): bound capability-router response body read failures

### DIFF
--- a/packages/elizaos/src/commands/capability-router.test.ts
+++ b/packages/elizaos/src/commands/capability-router.test.ts
@@ -135,6 +135,25 @@ describe("runCapabilityRouterConnect", () => {
     );
   });
 
+  it("treats a body-read failure as a clean command failure instead of an unhandled rejection", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: vi.fn().mockRejectedValue(new Error("terminated")),
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const code = await runCapabilityRouterConnect({
+      endpointUrl: "https://capability.example.test",
+    });
+
+    expect(code).toBe(1);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to call agent API: terminated"),
+    );
+  });
+
   it("can request an ephemeral direct connection", async () => {
     const fetchMock = mockFetch({
       success: true,

--- a/packages/elizaos/src/commands/capability-router.ts
+++ b/packages/elizaos/src/commands/capability-router.ts
@@ -69,7 +69,6 @@ export async function runCapabilityRouterConnect(
   if (payload instanceof Error) {
     return fail(options, payload.message);
   }
-
   const apiToken = options.apiToken ?? process.env.ELIZA_API_TOKEN;
   const headers: Record<string, string> = {
     accept: "application/json",
@@ -80,20 +79,23 @@ export async function runCapabilityRouterConnect(
   }
 
   let response: Response;
+  let text: string;
   try {
     response = await fetch(`${apiBase}/api/capability-router/connect`, {
       method: "POST",
       headers,
       body: JSON.stringify(payload),
     });
+    // error-policy:J1 the body read is part of the same transport boundary:
+    // a reset mid-response must render as the command's clean failure line
+    // instead of an unhandled rejection.
+    text = await response.text();
   } catch (err) {
     return fail(
       options,
       `Failed to call agent API: ${err instanceof Error ? err.message : String(err)}`,
     );
   }
-
-  const text = await response.text();
   const data = parseJson(text);
   if (data instanceof Error && response.ok) {
     return fail(options, data.message);
@@ -131,7 +133,15 @@ export async function runCapabilityRouterConnect(
 export function capabilityRouterConnect(
   options: CapabilityRouterConnectOptions,
 ): void {
-  runCapabilityRouterConnect(options).then((code) => process.exit(code));
+  // error-policy:J1 the process boundary translates any residual rejection
+  // into the same red-message + exit-1 contract as an in-band failure.
+  runCapabilityRouterConnect(options).then(
+    (code) => process.exit(code),
+    (err) => {
+      console.error(pc.red(err instanceof Error ? err.message : String(err)));
+      process.exit(1);
+    },
+  );
 }
 
 function buildConnectPayload(


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Fixes #28370

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts (branched from current head).
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. One command file plus one test. Success and error-status handling are unchanged; only a previously-uncaught rejection now flows through the existing `fail()` boundary.

# Background

## What does this PR do?

`runCapabilityRouterConnect` guarded `fetch()` but read the body outside the try/catch, and its sync wrapper attached only `.then()`. A connection reset while reading the response body (proxy drop mid-response, keep-alive race, server crash after headers) therefore escaped as an unhandled promise rejection: Node printed a raw undici stack trace (`TypeError: terminated`) and died abnormally instead of the clean red message + exit 1 every other failure mode produces.

The fix reads `response.text()` inside the same transport-boundary try/catch and gives the wrapper promise a rejection handler that prints through the same `fail()` contract.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/elizaos/src/commands/capability-router.test.ts`: "treats a body-read failure as a clean command failure instead of an unhandled rejection" (fetch resolves, `text()` rejects). Then reproduce live against a truncated-response TCP server:

```js
// /tmp/trunc-server.js
const net = require("net");
net.createServer((s) => {
  s.write("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 100\r\n\r\n{\"partial\"");
  setTimeout(() => s.destroy(), 50);
}).listen(8642, "127.0.0.1");
```

```bash
node /tmp/trunc-server.js &
ELIZA_API_BASE_URL=http://127.0.0.1:8642 \
  node packages/elizaos/dist/cli.js capability-router connect --endpoint-url https://example.test
```

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:7a412075cebe187b2bc5d85810df580bc82d2b93 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`. — N/A - terminal-only; before transcript below.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`. — N/A - terminal-only; after transcript below.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`. — N/A - single non-interactive command; transcripts capture it fully.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>` — before/after stderr transcripts captured from the real truncated-response server.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`. — N/A - no browser/frontend involved.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`. — N/A - no model involvement.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable, or marked `N/A - <reason>` — the process exit mode (stack trace vs clean line) is the observable artifact; both transcripts below.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface. — N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no model involvement.

## Backend + frontend logs

Before (built dist from unfixed `develop@4d13f256c7`, local server that destroys the socket mid-body):

```text
$ ELIZA_API_BASE_URL=http://127.0.0.1:8642 node dist/cli.js capability-router connect --endpoint-url https://example.test
node:internal/deps/undici/undici:14538
            fetchParams.controller.controller.error(new TypeError("terminated", {
                                                    ^
TypeError: terminated
    at Fetch.onAborted (node:internal/deps/undici/undici:14538:53)
    ...
exit=1   (raw unhandled-rejection dump)
```

After (this PR, same server):

```text
$ ELIZA_API_BASE_URL=http://127.0.0.1:8642 node dist/cli.js capability-router connect --endpoint-url https://example.test
Failed to call agent API: terminated
exit=1
```

## Screenshots (before / after) + video walkthrough

N/A - terminal-only; transcripts above are the complete observable behavior.

### Before

Raw undici `TypeError: terminated` unhandled-rejection dump.

### After

Single clean red line `Failed to call agent API: terminated`, exit 1.

### Walkthrough video

N/A - single non-interactive command.

## Audio / voice walkthrough

N/A - no audio surface.

## Known gaps / failures

- Full-repo `bun run verify` not run for this CLI-scoped change; package gates run instead: build ✅, typecheck ✅, lint ✅, focused capability-router suite ✅ (full package suite carries the pre-existing unrelated `cli-version.test.ts` failure also present on clean `develop`).

## Maintainer CI exception record

N/A - no exception requested

AI provider/model: opencode / x-preview-f-free
Client / agent tooling: opencode
Attribution status: self-reported
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"x-preview-f-free","client":"opencode","skill_revision":"self-hosted contribute-to-eliza skill"} -->

AI provider/model: opencode / x-preview-f-free
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-eliza
Attribution status: self-reported
— [contribution-batch]
<!-- slop-contribution-attribution:v1 {"provider":"opencode","model":"x-preview-f-free","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0W0GNDZ5ADHE8R7Y9Z3GJ1K","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-25T08:27:45.472Z","completed_at":"2026-08-25T10:49:22.543Z","skill_sha256":"7d4db0c19ef1171c18744a11ec1aceb613e3f779a9c49953ef1a0018aa80e4fd","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-25T08:27:47.445Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"fb2167ede6d20eed5787424a809871cf0a9d40df9e7e4218e7cbd36879582298","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"4b0ca646-2ecb-4633-9370-c07fc2809e73","object_id":"sha256:fb2167ede6d20eed5787424a809871cf0a9d40df9e7e4218e7cbd36879582298","sha256":"fb2167ede6d20eed5787424a809871cf0a9d40df9e7e4218e7cbd36879582298"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAgtL_SjSjM1n46ptKEJk4PBfQocRxDED3AUsopsbPpj8","device_key_id":"d72975edd2d14b15ee662f87b3c80771c33d1c0659d900ebbc7644d0dfaa241a","device_signature":"nxmZHHqmMXtLWGtaVeqGRoGumLk0qkcSNuMgR-xtiWeEAvUN860h8QV83wq_WLSKm79_xXErCGg_gej96zCPAA"}} -->
