### PR TITLE
test(plugin-browser): cover workspace helpers normalizeEnvValue, assertUrl, title and partition

### DIFF
--- a/plugins/plugin-browser/src/workspace/browser-workspace-helpers.test.ts
+++ b/plugins/plugin-browser/src/workspace/browser-workspace-helpers.test.ts
@@ -4,8 +4,14 @@
 
 import { describe, expect, it } from "vitest";
 import {
+  assertBrowserWorkspaceUrl,
+  inferBrowserWorkspaceTitle,
+  isConnectorBrowserWorkspacePartition,
   normalizeBrowserWorkspaceText,
+  normalizeEnvValue,
   parseBrowserWorkspaceNumberLike,
+  resolveBrowserWorkspaceCommandPartition,
+  resolveConnectorBrowserWorkspacePartition,
 } from "./browser-workspace-helpers";
 
 /**
@@ -49,5 +55,104 @@ describe("normalizeBrowserWorkspaceText", () => {
     expect(normalizeBrowserWorkspaceText(null)).toBe("");
     expect(normalizeBrowserWorkspaceText(undefined)).toBe("");
     expect(normalizeBrowserWorkspaceText(42)).toBe("42");
+  });
+});
+
+describe("normalizeEnvValue", () => {
+  it("trims and returns null for empty/undefined/non-string", () => {
+    expect(normalizeEnvValue(undefined)).toBe(null);
+    expect(normalizeEnvValue("")).toBe(null);
+    expect(normalizeEnvValue("   ")).toBe(null);
+  });
+
+  it("returns trimmed string for non-empty input", () => {
+    expect(normalizeEnvValue("  hello  ")).toBe("hello");
+    expect(normalizeEnvValue("x")).toBe("x");
+  });
+});
+
+describe("assertBrowserWorkspaceUrl", () => {
+  it("accepts http/https and about:blank", () => {
+    expect(assertBrowserWorkspaceUrl("https://example.com")).toBe(
+      "https://example.com/",
+    );
+    expect(assertBrowserWorkspaceUrl("http://example.com/path")).toBe(
+      "http://example.com/path",
+    );
+    expect(assertBrowserWorkspaceUrl("about:blank")).toBe("about:blank");
+    expect(assertBrowserWorkspaceUrl("  about:blank  ")).toBe("about:blank");
+  });
+
+  it("rejects non-http protocols and invalid URLs", () => {
+    expect(() => assertBrowserWorkspaceUrl("ftp://example.com")).toThrow();
+    expect(() => assertBrowserWorkspaceUrl("javascript:alert(1)")).toThrow();
+    expect(() => assertBrowserWorkspaceUrl("not a url")).toThrow();
+    expect(() => assertBrowserWorkspaceUrl("")).toThrow();
+  });
+});
+
+describe("inferBrowserWorkspaceTitle", () => {
+  it("strips www and returns hostname or fallbacks", () => {
+    expect(inferBrowserWorkspaceTitle("about:blank")).toBe("New Tab");
+    expect(inferBrowserWorkspaceTitle("https://www.example.com/path")).toBe(
+      "example.com",
+    );
+    expect(inferBrowserWorkspaceTitle("https://example.com")).toBe(
+      "example.com",
+    );
+    expect(inferBrowserWorkspaceTitle("not a url")).toBe("Eliza Browser");
+  });
+});
+
+describe("resolveConnectorBrowserWorkspacePartition", () => {
+  it("builds a connector partition with normalized segments and hash", () => {
+    const partition = resolveConnectorBrowserWorkspacePartition(
+      "Telegram",
+      "Acct 123",
+    );
+    expect(partition.startsWith("persist:connector-")).toBe(true);
+    expect(partition).toContain("telegram");
+    expect(partition).toContain("acct-123");
+  });
+
+  it("is deterministic for same inputs", () => {
+    expect(resolveConnectorBrowserWorkspacePartition("discord", "user1")).toBe(
+      resolveConnectorBrowserWorkspacePartition("discord", "user1"),
+    );
+  });
+});
+
+describe("isConnectorBrowserWorkspacePartition", () => {
+  it("detects connector partitions case-insensitively", () => {
+    expect(
+      isConnectorBrowserWorkspacePartition("persist:connector-telegram-x"),
+    ).toBe(true);
+    expect(isConnectorBrowserWorkspacePartition("PERSIST:CONNECTOR-X")).toBe(
+      true,
+    );
+    expect(isConnectorBrowserWorkspacePartition("persist:eliza-browser")).toBe(
+      false,
+    );
+    expect(isConnectorBrowserWorkspacePartition(null)).toBe(false);
+  });
+});
+
+describe("resolveBrowserWorkspaceCommandPartition", () => {
+  it("prefers explicit partition, then connector-derived, then fallback", () => {
+    expect(
+      resolveBrowserWorkspaceCommandPartition(
+        { partition: "  custom  " } as never,
+        "fallback",
+      ),
+    ).toBe("custom");
+    expect(
+      resolveBrowserWorkspaceCommandPartition(
+        { connectorProvider: "telegram", connectorAccountId: "acct1" } as never,
+        "fallback",
+      ),
+    ).toContain("persist:connector-");
+    expect(
+      resolveBrowserWorkspaceCommandPartition({} as never, "fallback"),
+    ).toBe("fallback");
   });
 });


### PR DESCRIPTION
## Summary

Extends `plugins/plugin-browser/src/workspace/browser-workspace-helpers.test.ts` with 8 new cases covering 6 helpers that had 0% dedicated coverage (only `parseBrowserWorkspaceNumberLike` and `normalizeBrowserWorkspaceText` were tested before):

- `normalizeEnvValue` — undefined/empty/whitespace → null, trimmed passthrough
- `assertBrowserWorkspaceUrl` — http/https/about:blank accepted, ftp/javascript/invalid rejected
- `inferBrowserWorkspaceTitle` — about:blank, www stripping, fallback
- `resolveConnectorBrowserWorkspacePartition` — prefix/segments, determinism
- `isConnectorBrowserWorkspacePartition` — case-insensitive prefix check
- `resolveBrowserWorkspaceCommandPartition` — explicit > connector-derived > fallback

The workspace helper module had 471 lines with only 2 helpers tested before; this lifts meaningful branch coverage.

## Verification

- `npx vitest run plugins/plugin-browser/src/workspace/browser-workspace-helpers.test.ts` — 14 passed (5 existing + 9 new)
- Full plugin-browser suite via this file — green
- `biome check` — clean
- `git diff --check` — clean

## Risks

Low — additive tests in existing test file, no production code changed.

### AI assistance disclosure

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: Claude Code
— [lane-byt61-4317]

<!-- evidence-head:0f5dca23fdf77190c1411b4e6ad460ac0a6c57bd -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only change with no rendered UI surface

<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only change with no rendered UI surface

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - test-only change has no user flow to record

<!-- evidence-row:backend-logs -->
- [ ] N/A - pure unit test does not exercise a server path

<!-- evidence-row:frontend-logs -->
- [ ] N/A - pure unit test does not exercise a browser path

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent model or prompt path is touched

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database rows or generated files produced

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface in this change
