### PR TITLE
fix(discord): reject unknown permission tiers in invite URL construction

### DIFF
--- a/plugins/plugin-discord/__tests__/permissions.test.ts
+++ b/plugins/plugin-discord/__tests__/permissions.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+import {
+	DiscordPermissionTiers,
+	generateAllInviteUrls,
+	generateInviteUrl,
+	getPermissionValues,
+	PERMISSIONS_ADMIN,
+	PERMISSIONS_ADMIN_VOICE,
+	PERMISSIONS_BASIC,
+	PERMISSIONS_BASIC_VOICE,
+	PERMISSIONS_MODERATOR,
+	PERMISSIONS_MODERATOR_VOICE,
+	REQUIRED_PERMISSIONS,
+} from "../permissions";
+
+// Discord permission bit constants used to assert tier composition.
+// Bitwise math happens on the exported BigInt constants: JS `&` truncates
+// to 32 bits, and tiers include bits up to 1n << 46n.
+const KICK_MEMBERS = 1n << 1n;
+const BAN_MEMBERS = 1n << 2n;
+const CONNECT = 1n << 20n;
+const SPEAK = 1n << 21n;
+const MANAGE_CHANNELS = 1n << 4n;
+
+const hasBits = (value: bigint, bits: bigint): boolean =>
+	(value & bits) === bits;
+
+describe("DiscordPermissionTiers", () => {
+	it("exposes six distinct non-zero tier values", () => {
+		const values = Object.values(DiscordPermissionTiers);
+		expect(values).toHaveLength(6);
+		expect(new Set(values).size).toBe(6);
+		for (const value of values) {
+			expect(value).toBeGreaterThan(0);
+		}
+	});
+
+	it("keeps BASIC a strict subset of MODERATOR and ADMIN", () => {
+		expect(hasBits(PERMISSIONS_MODERATOR, PERMISSIONS_BASIC)).toBe(true);
+		expect(hasBits(PERMISSIONS_ADMIN, PERMISSIONS_MODERATOR)).toBe(true);
+		expect(PERMISSIONS_MODERATOR).not.toBe(PERMISSIONS_BASIC);
+		expect(PERMISSIONS_ADMIN).not.toBe(PERMISSIONS_MODERATOR);
+	});
+
+	it("grants ADMIN moderation powers (kick, ban, channel management)", () => {
+		expect(hasBits(PERMISSIONS_ADMIN, KICK_MEMBERS | BAN_MEMBERS)).toBe(true);
+		expect(hasBits(PERMISSIONS_ADMIN, MANAGE_CHANNELS)).toBe(true);
+		expect(hasBits(PERMISSIONS_MODERATOR, KICK_MEMBERS)).toBe(false);
+	});
+
+	it("adds voice bits to the voice tier variants", () => {
+		expect(hasBits(PERMISSIONS_BASIC_VOICE, CONNECT | SPEAK)).toBe(true);
+		expect(hasBits(PERMISSIONS_BASIC, CONNECT)).toBe(false);
+		expect(hasBits(PERMISSIONS_MODERATOR_VOICE, PERMISSIONS_BASIC_VOICE)).toBe(
+			true,
+		);
+		expect(hasBits(PERMISSIONS_ADMIN_VOICE, PERMISSIONS_MODERATOR_VOICE)).toBe(
+			true,
+		);
+	});
+
+	it("exports the moderator-voice set as the required permission floor", () => {
+		expect(Number(REQUIRED_PERMISSIONS)).toBe(
+			DiscordPermissionTiers.MODERATOR_VOICE,
+		);
+	});
+});
+
+describe("getPermissionValues", () => {
+	it("mirrors the tier constants for all six tiers", () => {
+		const values = getPermissionValues();
+		expect(values.basic).toBe(DiscordPermissionTiers.BASIC);
+		expect(values.basicVoice).toBe(DiscordPermissionTiers.BASIC_VOICE);
+		expect(values.moderator).toBe(DiscordPermissionTiers.MODERATOR);
+		expect(values.moderatorVoice).toBe(DiscordPermissionTiers.MODERATOR_VOICE);
+		expect(values.admin).toBe(DiscordPermissionTiers.ADMIN);
+		expect(values.adminVoice).toBe(DiscordPermissionTiers.ADMIN_VOICE);
+	});
+});
+
+describe("generateInviteUrl", () => {
+	it("builds the OAuth authorize URL with bot + application.commands scopes", () => {
+		const url = generateInviteUrl("1234567890");
+		expect(url.startsWith("https://discord.com/api/oauth2/authorize?")).toBe(
+			true,
+		);
+		expect(url).toContain("client_id=1234567890");
+		expect(url).toContain("scope=bot%20applications.commands");
+	});
+
+	it("defaults to the MODERATOR_VOICE permission set", () => {
+		expect(generateInviteUrl("1")).toContain(
+			`permissions=${DiscordPermissionTiers.MODERATOR_VOICE}`,
+		);
+	});
+
+	it("encodes the requested tier's permission bitfield", () => {
+		expect(generateInviteUrl("1", "BASIC")).toContain(
+			`permissions=${DiscordPermissionTiers.BASIC}`,
+		);
+		expect(generateInviteUrl("1", "ADMIN")).toContain(
+			`permissions=${DiscordPermissionTiers.ADMIN}`,
+		);
+	});
+
+	it("throws a RangeError for an unknown tier instead of emitting permissions=undefined", () => {
+		// A typo'd or stale tier string must fail loudly: emitting
+		// `permissions=undefined` would produce an invite URL that grants the
+		// bot no (or an unintended) permission set while looking plausible.
+		expect(() => generateInviteUrl("1", "SUPERUSER" as never)).toThrow(
+			RangeError,
+		);
+		expect(() => generateInviteUrl("1", "" as never)).toThrow(RangeError);
+	});
+});
+
+describe("generateAllInviteUrls", () => {
+	it("emits one URL per tier with the same bitfields as getPermissionValues", () => {
+		const urls = generateAllInviteUrls("app-1");
+		const values = getPermissionValues();
+		expect(Object.keys(urls).sort()).toEqual(Object.keys(values).sort());
+		for (const tier of Object.keys(values) as Array<keyof typeof values>) {
+			expect(urls[tier]).toContain(`permissions=${values[tier]}`);
+		}
+	});
+
+	it("always references the same application id", () => {
+		const urls = generateAllInviteUrls("app-42");
+		for (const url of Object.values(urls)) {
+			expect(url).toContain("client_id=app-42");
+		}
+	});
+});

--- a/plugins/plugin-discord/permissions.ts
+++ b/plugins/plugin-discord/permissions.ts
@@ -111,6 +111,13 @@ export function generateInviteUrl(
 	tier: DiscordPermissionTier = "MODERATOR_VOICE",
 ): string {
 	const permissions = DiscordPermissionTiers[tier];
+	if (permissions === undefined) {
+		throw new RangeError(
+			`Unknown Discord permission tier: ${tier}. Expected one of: ${Object.keys(
+				DiscordPermissionTiers,
+			).join(", ")}`,
+		);
+	}
 	return `https://discord.com/api/oauth2/authorize?client_id=${applicationId}&permissions=${permissions}&scope=bot%20applications.commands`;
 }
 


### PR DESCRIPTION
# Relates to

<!-- No issue; hardens invite-URL construction against unknown permission tiers. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. `generateInviteUrl` now throws a `RangeError` when handed a tier string
that is not one of the six declared tiers, instead of silently emitting
`permissions=undefined` in the Discord OAuth authorize URL (which Discord
rejects, or which grants an unintended/empty permission set). All existing
call sites pass only declared tier keys (`generateAllInviteUrls`, the startup
banner), so no runtime path changes behavior; the failure mode becomes visible
instead of silent.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: 12/12 passed — see focused log below |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file + 7-line guard in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
