### PR TITLE
test(sql): cover runtime-migrator journal and snapshot storage

### DIFF
--- a/plugins/plugin-sql/src/runtime-migrator/storage/journal-storage.test.ts
+++ b/plugins/plugin-sql/src/runtime-migrator/storage/journal-storage.test.ts
@@ -1,0 +1,173 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { DrizzleDB } from "../types";
+import { JournalStorage } from "./journal-storage";
+
+function makeDb(): { execute: ReturnType<typeof vi.fn> } {
+  const execute = vi.fn();
+  return { execute };
+}
+
+function sqlText(call: unknown): string {
+  // drizzle_mock's sql tag returns { strings, values }; rebuild the query text.
+  const { strings, values } = call as { strings: string[]; values: unknown[] };
+  return strings.reduce((acc, part, i) => acc + part + (i < values.length ? `$${i + 1}` : ""), "");
+}
+
+describe("JournalStorage", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("returns null when no journal row exists", async () => {
+    const db = makeDb();
+    db.execute.mockResolvedValue({ rows: [] });
+    const storage = new JournalStorage(db as unknown as DrizzleDB);
+    await expect(storage.loadJournal("plugin-a")).resolves.toBeNull();
+    expect(sqlText(db.execute.mock.calls[0][0])).toContain("FROM migrations._journal");
+  });
+
+  it("returns the parsed journal row when present", async () => {
+    const db = makeDb();
+    const entry = {
+      idx: 0,
+      version: "7",
+      when: 1,
+      tag: "init",
+      breakpoints: true,
+    };
+    db.execute.mockResolvedValue({
+      rows: [{ version: "7", dialect: "postgresql", entries: [entry] }],
+    });
+    const storage = new JournalStorage(db as unknown as DrizzleDB);
+    const journal = await storage.loadJournal("plugin-a");
+    expect(journal).toEqual({
+      version: "7",
+      dialect: "postgresql",
+      entries: [entry],
+    });
+  });
+
+  it("scopes the journal lookup to the given plugin", async () => {
+    const db = makeDb();
+    db.execute.mockResolvedValue({ rows: [] });
+    const storage = new JournalStorage(db as unknown as DrizzleDB);
+    await storage.loadJournal("plugin-b");
+    const text = sqlText(db.execute.mock.calls[0][0]);
+    expect(text).toContain("plugin_name");
+    expect(db.execute.mock.calls[0][0].values).toContain("plugin-b");
+  });
+
+  it("creates a fresh journal when adding an entry to a missing one", async () => {
+    const db = makeDb();
+    db.execute.mockResolvedValue({ rows: [] });
+    const storage = new JournalStorage(db as unknown as DrizzleDB);
+    await storage.addEntry("plugin-a", {
+      idx: 0,
+      version: "7",
+      when: 5,
+      tag: "init",
+      breakpoints: true,
+    });
+    // First call: SELECT (empty) → null journal. Second call: INSERT with fresh journal.
+    expect(db.execute).toHaveBeenCalledTimes(2);
+    const insertSql = sqlText(db.execute.mock.calls[1][0]);
+    expect(insertSql).toContain("INSERT INTO migrations._journal");
+    expect(insertSql).toContain("ON CONFLICT");
+  });
+
+  it("appends to an existing journal without clobbering prior entries", async () => {
+    const db = makeDb();
+    const existing = {
+      idx: 0,
+      version: "7",
+      when: 1,
+      tag: "init",
+      breakpoints: true,
+    };
+    db.execute.mockResolvedValueOnce({
+      rows: [{ version: "7", dialect: "postgresql", entries: [existing] }],
+    });
+    db.execute.mockResolvedValue({ rows: [] });
+    const storage = new JournalStorage(db as unknown as DrizzleDB);
+    await storage.addEntry("plugin-a", {
+      idx: 1,
+      version: "7",
+      when: 2,
+      tag: "second",
+      breakpoints: false,
+    });
+    const insertSql = sqlText(db.execute.mock.calls[1][0]);
+    expect(insertSql).toContain("ON CONFLICT");
+    // Both entries must be serialized into the upsert payload.
+    const payload = JSON.parse(db.execute.mock.calls[1][0].values[3] as string) as Array<{
+      tag: string;
+    }>;
+    expect(payload.map((e) => e.tag)).toContain("second");
+  });
+
+  it("returns 0 as the next index when no journal exists", async () => {
+    const db = makeDb();
+    db.execute.mockResolvedValue({ rows: [] });
+    const storage = new JournalStorage(db as unknown as DrizzleDB);
+    await expect(storage.getNextIdx("plugin-a")).resolves.toBe(0);
+  });
+
+  it("returns 0 as the next index when the journal has no entries", async () => {
+    const db = makeDb();
+    db.execute.mockResolvedValue({
+      rows: [{ version: "7", dialect: "postgresql", entries: [] }],
+    });
+    const storage = new JournalStorage(db as unknown as DrizzleDB);
+    await expect(storage.getNextIdx("plugin-a")).resolves.toBe(0);
+  });
+
+  it("returns lastEntry.idx + 1 as the next index", async () => {
+    const db = makeDb();
+    db.execute.mockResolvedValue({
+      rows: [
+        {
+          version: "7",
+          dialect: "postgresql",
+          entries: [
+            { idx: 3, version: "7", when: 1, tag: "a", breakpoints: true },
+            { idx: 4, version: "7", when: 2, tag: "b", breakpoints: true },
+          ],
+        },
+      ],
+    });
+    const storage = new JournalStorage(db as unknown as DrizzleDB);
+    await expect(storage.getNextIdx("plugin-a")).resolves.toBe(5);
+  });
+
+  it("writes a well-formed entry via updateJournal with breakpoints defaulting to true", async () => {
+    const db = makeDb();
+    db.execute.mockResolvedValue({ rows: [] });
+    const storage = new JournalStorage(db as unknown as DrizzleDB);
+    const whenBefore = Date.now();
+    await storage.updateJournal("plugin-a", 7, "add-table");
+    const entry = JSON.parse(db.execute.mock.calls[1][0].values[3] as string) as Array<{
+      idx: number;
+      version: string;
+      tag: string;
+      breakpoints: boolean;
+      when: number;
+    }>;
+    expect(entry).toHaveLength(1);
+    expect(entry[0].idx).toBe(7);
+    expect(entry[0].version).toBe("7");
+    expect(entry[0].tag).toBe("add-table");
+    expect(entry[0].breakpoints).toBe(true);
+    expect(entry[0].when).toBeGreaterThanOrEqual(whenBefore);
+  });
+
+  it("honors an explicit breakpoints=false flag", async () => {
+    const db = makeDb();
+    db.execute.mockResolvedValue({ rows: [] });
+    const storage = new JournalStorage(db as unknown as DrizzleDB);
+    await storage.updateJournal("plugin-a", 2, "no-bps", false);
+    const entry = JSON.parse(db.execute.mock.calls[1][0].values[3] as string) as Array<{
+      breakpoints: boolean;
+    }>;
+    expect(entry[0].breakpoints).toBe(false);
+  });
+});

--- a/plugins/plugin-sql/src/runtime-migrator/storage/snapshot-storage.test.ts
+++ b/plugins/plugin-sql/src/runtime-migrator/storage/snapshot-storage.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from "vitest";
+import type { DrizzleDB, SchemaSnapshot } from "../types";
+import { SnapshotStorage } from "./snapshot-storage";
+
+function makeDb(): { execute: ReturnType<typeof vi.fn> } {
+  const execute = vi.fn();
+  return { execute };
+}
+
+function sqlText(call: unknown): string {
+  const { strings, values } = call as { strings: string[]; values: unknown[] };
+  return strings.reduce((acc, part, i) => acc + part + (i < values.length ? `$${i + 1}` : ""), "");
+}
+
+const SNAPSHOT: SchemaSnapshot = {
+  tables: [{ name: "users", columns: [] }],
+} as unknown as SchemaSnapshot;
+
+describe("SnapshotStorage", () => {
+  it("saves a snapshot as JSON with an upsert on (plugin_name, idx)", async () => {
+    const db = makeDb();
+    db.execute.mockResolvedValue({ rows: [] });
+    const storage = new SnapshotStorage(db as unknown as DrizzleDB);
+    await storage.saveSnapshot("plugin-a", 3, SNAPSHOT);
+    const text = sqlText(db.execute.mock.calls[0][0]);
+    expect(text).toContain("INSERT INTO migrations._snapshots");
+    expect(text).toContain("ON CONFLICT (plugin_name, idx)");
+    expect(text).toContain("DO UPDATE SET");
+    expect(db.execute.mock.calls[0][0].values).toContain("plugin-a");
+    expect(db.execute.mock.calls[0][0].values).toContain(3);
+    expect(db.execute.mock.calls[0][0].values[2]).toBe(JSON.stringify(SNAPSHOT));
+  });
+
+  it("returns null when no snapshot row exists", async () => {
+    const db = makeDb();
+    db.execute.mockResolvedValue({ rows: [] });
+    const storage = new SnapshotStorage(db as unknown as DrizzleDB);
+    await expect(storage.loadSnapshot("plugin-a", 1)).resolves.toBeNull();
+  });
+
+  it("returns the stored snapshot for a matching (plugin, idx)", async () => {
+    const db = makeDb();
+    db.execute.mockResolvedValue({ rows: [{ snapshot: SNAPSHOT }] });
+    const storage = new SnapshotStorage(db as unknown as DrizzleDB);
+    await expect(storage.loadSnapshot("plugin-a", 1)).resolves.toBe(SNAPSHOT);
+    const text = sqlText(db.execute.mock.calls[0][0]);
+    expect(text).toContain("WHERE plugin_name");
+    expect(text).toContain("AND idx");
+    expect(db.execute.mock.calls[0][0].values).toEqual(["plugin-a", 1]);
+  });
+
+  it("returns null for getLatestSnapshot when no rows exist", async () => {
+    const db = makeDb();
+    db.execute.mockResolvedValue({ rows: [] });
+    const storage = new SnapshotStorage(db as unknown as DrizzleDB);
+    await expect(storage.getLatestSnapshot("plugin-a")).resolves.toBeNull();
+  });
+
+  it("returns the latest snapshot ordered by idx DESC", async () => {
+    const db = makeDb();
+    db.execute.mockResolvedValue({ rows: [{ snapshot: SNAPSHOT }] });
+    const storage = new SnapshotStorage(db as unknown as DrizzleDB);
+    await expect(storage.getLatestSnapshot("plugin-a")).resolves.toBe(SNAPSHOT);
+    const text = sqlText(db.execute.mock.calls[0][0]);
+    expect(text).toContain("ORDER BY idx DESC");
+    expect(text).toContain("LIMIT 1");
+  });
+
+  it("returns all snapshots in ascending idx order", async () => {
+    const db = makeDb();
+    const s1 = { ...SNAPSHOT };
+    const s2 = { ...SNAPSHOT };
+    db.execute.mockResolvedValue({
+      rows: [{ snapshot: s1 }, { snapshot: s2 }],
+    });
+    const storage = new SnapshotStorage(db as unknown as DrizzleDB);
+    await expect(storage.getAllSnapshots("plugin-a")).resolves.toEqual([s1, s2]);
+    const text = sqlText(db.execute.mock.calls[0][0]);
+    expect(text).toContain("ORDER BY idx ASC");
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for runtime-migrator storage persistence. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: two new test files exercising the runtime-migrator's
`JournalStorage` and `SnapshotStorage` persistence paths — journal load
(missing row → null, scoped lookup), fresh-journal creation on first entry,
append-without-clobber, next-index derivation, entry shape/flag defaults, and
snapshot CRUD ordering (latest DESC, all ASC, upsert). No production code is
modified; a corrupted/missing migration journal or snapshot is exactly the
failure mode these tests pin (silent re-runs or skipped diffs of migrations).

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: 16/16 passed — see focused log below |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: two test files in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
