### PR TITLE
test(vision): cover PersonDetector lifecycle and detection mapping

### DIFF
--- a/plugins/plugin-vision/src/person-detector.test.ts
+++ b/plugins/plugin-vision/src/person-detector.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PersonDetector } from "./person-detector";
+import { __yoloInstances, YOLODetector } from "./yolo-detector";
+
+const BOX = { x: 10, y: 20, width: 30, height: 40 };
+
+function freshDetector(
+  config?: Parameters<typeof PersonDetector>[0],
+): PersonDetector {
+  __yoloInstances.length = 0;
+  return new PersonDetector(config);
+}
+
+describe("PersonDetector", () => {
+  let initSpy: ReturnType<typeof vi.spyOn>;
+  let detectSpy: ReturnType<typeof vi.spyOn>;
+  let disposeSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    initSpy = vi
+      .spyOn(YOLODetector.prototype, "initialize")
+      .mockResolvedValue();
+    detectSpy = vi
+      .spyOn(YOLODetector.prototype, "detect")
+      .mockResolvedValue([{ confidence: 0.92, boundingBox: BOX }]);
+    disposeSpy = vi
+      .spyOn(YOLODetector.prototype, "dispose")
+      .mockResolvedValue();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    __yoloInstances.length = 0;
+  });
+
+  it("forwards a person-only class filter to the YOLO detector", () => {
+    freshDetector();
+    expect(__yoloInstances[0].config.classFilter).toEqual(["person"]);
+  });
+
+  it("defaults the score threshold to 0.4", () => {
+    freshDetector();
+    expect(__yoloInstances[0].config.scoreThreshold).toBe(0.4);
+  });
+
+  it("honors an explicit score threshold", () => {
+    freshDetector({ scoreThreshold: 0.7 });
+    expect(__yoloInstances[0].config.scoreThreshold).toBe(0.7);
+  });
+
+  it("starts uninitialized and flips after initialize()", async () => {
+    const detector = freshDetector();
+    expect(detector.isInitialized()).toBe(false);
+    await detector.initialize();
+    expect(detector.isInitialized()).toBe(true);
+  });
+
+  it("initializes exactly once when called repeatedly", async () => {
+    const detector = freshDetector();
+    await detector.initialize();
+    await detector.initialize();
+    expect(initSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("lazily initializes on the first detect() call", async () => {
+    const detector = freshDetector();
+    expect(detector.isInitialized()).toBe(false);
+    await detector.detect(Buffer.from("frame"));
+    expect(initSpy).toHaveBeenCalledTimes(1);
+    expect(detector.isInitialized()).toBe(true);
+  });
+
+  it("maps YOLO objects to PersonInfo records with unknown pose/facing", async () => {
+    const detector = freshDetector();
+    const people = await detector.detect(Buffer.from("frame"));
+    expect(people).toHaveLength(1);
+    expect(people[0].confidence).toBe(0.92);
+    expect(people[0].boundingBox).toBe(BOX);
+    expect(people[0].pose).toBe("unknown");
+    expect(people[0].facing).toBe("unknown");
+    expect(people[0].id).toMatch(/^person-\d+-\d+$/);
+  });
+
+  it("assigns unique ids per detection in a single frame", async () => {
+    detectSpy.mockResolvedValue([
+      { confidence: 0.9, boundingBox: BOX },
+      { confidence: 0.8, boundingBox: BOX },
+    ]);
+    const detector = freshDetector();
+    const people = await detector.detect(Buffer.from("frame"));
+    expect(people.map((p) => p.id)).toHaveLength(2);
+    expect(new Set(people.map((p) => p.id)).size).toBe(2);
+  });
+
+  it("dispose tears down the YOLO detector and resets initialization", async () => {
+    const detector = freshDetector();
+    await detector.initialize();
+    await detector.dispose();
+    expect(disposeSpy).toHaveBeenCalledTimes(1);
+    expect(detector.isInitialized()).toBe(false);
+  });
+
+  it("re-initializes after dispose on the next detect()", async () => {
+    const detector = freshDetector();
+    await detector.detect(Buffer.from("frame"));
+    await detector.dispose();
+    await detector.detect(Buffer.from("frame"));
+    expect(initSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("delegates availability to the YOLO detector backend", async () => {
+    const availSpy = vi
+      .spyOn(YOLODetector, "isAvailable")
+      .mockResolvedValue(false);
+    await expect(PersonDetector.isAvailable()).resolves.toBe(false);
+    expect(availSpy).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for the PersonDetector lifecycle. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition exercising the PersonDetector state machine: lazy
initialization on first `detect()`, idempotent `initialize()`, config
forwarding (person-only class filter, 0.4 default score threshold), detection
mapping to PersonInfo (unique ids, unknown pose/facing), and dispose/reset
behavior. A lifecycle regression here would crash the vision service at first
frame or silently drop the person class filter — the exact failures these
tests pin. YOLODetector is stubbed; no native/model code is exercised.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: 11/11 passed — see focused log below |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
