### PR TITLE
test(plugin-telegram): cover personal helpers normalize, enabled, externalId and listing

### DIFF
--- a/plugins/plugin-telegram/src/personal-helpers.test.ts
+++ b/plugins/plugin-telegram/src/personal-helpers.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Coverage for Telegram personal (MTProto user-account) helpers — pure
+ * config predicates used by the owner-binding gate. No live Telegram API.
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_ACCOUNT_ID,
+  isTelegramPersonalEnabled,
+  listPersonalTelegramAccounts,
+  normalizeTelegramAccountId,
+  telegramPersonalExternalId,
+} from "./accounts.ts";
+
+function runtime(accounts?: Record<string, unknown>): IAgentRuntime {
+  return {
+    agentId: "agent-1",
+    character: { settings: { telegram: { accounts } } },
+    getSetting: () => undefined,
+  } as unknown as IAgentRuntime;
+}
+
+describe("normalizeTelegramAccountId", () => {
+  it("defaults empty/null/blank to default", () => {
+    expect(normalizeTelegramAccountId(undefined)).toBe(DEFAULT_ACCOUNT_ID);
+    expect(normalizeTelegramAccountId(null)).toBe(DEFAULT_ACCOUNT_ID);
+    expect(normalizeTelegramAccountId("")).toBe(DEFAULT_ACCOUNT_ID);
+    expect(normalizeTelegramAccountId("   ")).toBe(DEFAULT_ACCOUNT_ID);
+  });
+
+  it("trims and preserves a non-empty id", () => {
+    expect(normalizeTelegramAccountId("  acct-a  ")).toBe("acct-a");
+    expect(normalizeTelegramAccountId("default")).toBe("default");
+  });
+});
+
+describe("isTelegramPersonalEnabled", () => {
+  it("returns false when no personal block exists", () => {
+    expect(isTelegramPersonalEnabled(makeAccount({}))).toBe(false);
+    expect(
+      isTelegramPersonalEnabled(
+        makeAccount({ personal: { enabled: false, phone: "+1555" } }),
+      ),
+    ).toBe(false);
+  });
+
+  it("returns true when phone or session is present and not disabled", () => {
+    expect(
+      isTelegramPersonalEnabled(
+        makeAccount({ personal: { phone: "+15551234567" } }),
+      ),
+    ).toBe(true);
+    expect(
+      isTelegramPersonalEnabled(
+        makeAccount({ personal: { session: "sess_abc" } }),
+      ),
+    ).toBe(true);
+    expect(
+      isTelegramPersonalEnabled(
+        makeAccount({ personal: { phone: "  ", session: "x" } }),
+      ),
+    ).toBe(true);
+  });
+
+  it("returns false when personal has no phone or session", () => {
+    expect(isTelegramPersonalEnabled(makeAccount({ personal: {} }))).toBe(
+      false,
+    );
+    expect(
+      isTelegramPersonalEnabled(makeAccount({ personal: { appId: "123" } })),
+    ).toBe(false);
+  });
+});
+
+function makeAccount(config: Record<string, unknown>) {
+  return { config } as unknown as Parameters<
+    typeof isTelegramPersonalEnabled
+  >[0];
+}
+
+describe("telegramPersonalExternalId", () => {
+  it("derives tg-user:<phone> when phone is present", () => {
+    expect(
+      telegramPersonalExternalId(
+        makeAccount({ personal: { phone: "+15551234567" } }),
+      ),
+    ).toBe("tg-user:+15551234567");
+  });
+
+  it("returns undefined when no phone is configured", () => {
+    expect(
+      telegramPersonalExternalId(
+        makeAccount({ personal: { session: "sess" } }),
+      ),
+    ).toBeUndefined();
+    expect(
+      telegramPersonalExternalId(makeAccount({ personal: {} })),
+    ).toBeUndefined();
+    expect(telegramPersonalExternalId(makeAccount({}))).toBeUndefined();
+  });
+
+  it("trims whitespace from phone", () => {
+    expect(
+      telegramPersonalExternalId(
+        makeAccount({ personal: { phone: "  +1555  " } }),
+      ),
+    ).toBe("tg-user:+1555");
+  });
+});
+
+describe("listPersonalTelegramAccounts", () => {
+  it("returns only accounts with a usable personal identity", () => {
+    const rt = runtime({
+      alice: { personal: { phone: "+111" } },
+      bob: { personal: { enabled: false, phone: "+222" } },
+      carol: { personal: { session: "sess" } },
+      dave: {},
+    });
+    const list = listPersonalTelegramAccounts(rt);
+    const ids = list.map((a) => a.accountId);
+    expect(ids).toContain("alice");
+    expect(ids).toContain("carol");
+    expect(ids).not.toContain("bob");
+    expect(ids).not.toContain("dave");
+  });
+
+  it("returns empty when no accounts declare personal", () => {
+    const rt = runtime({ x: {}, y: { personal: {} } });
+    expect(listPersonalTelegramAccounts(rt)).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Adds 10 deterministic tests for `plugins/plugin-telegram/src/accounts.ts` personal (MTProto user-account) helpers that had no dedicated coverage (existing `accounts.test.ts` covers only `resolveTelegramAccount` owner-bind fail-closed):

- `normalizeTelegramAccountId` — undefined/null/empty/blank → default, trimming
- `isTelegramPersonalEnabled` — no personal block, disabled flag, phone/session present, no phone/session, appId-only not enabled
- `telegramPersonalExternalId` — phone → tg-user: prefix, no phone → undefined, whitespace trimming
- `listPersonalTelegramAccounts` — filtered to usable personal identities only, empty case

Pure unit tests with fake runtimes — no live Telegram API.

## Verification

- `npx vitest run plugins/plugin-telegram/src/personal-helpers.test.ts` — 10 passed, 0 failed
- `npx vitest run plugins/plugin-telegram/src/` — 94 passed (13 files), 0 failed
- `biome check` — clean
- `git diff --check` — clean

## Risks

Low — additive test file only, no production code changed.

### AI assistance disclosure

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: Claude Code
— [lane-byt61-4317]

<!-- evidence-head:d8fc3d2d1abf20ac0366d7d0a4b085e3a1697147 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only change with no rendered UI surface

<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only change with no rendered UI surface

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - test-only change has no user flow to record

<!-- evidence-row:backend-logs -->
- [ ] N/A - pure unit test does not exercise a server path

<!-- evidence-row:frontend-logs -->
- [ ] N/A - pure unit test does not exercise a browser path

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent model or prompt path is touched

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database rows or generated files produced

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface in this change
