### PR TITLE
fix(plugin-native-desktop): close AudioContext after each beep to stop leak

### DIFF
--- a/plugins/plugin-native-desktop/src/web.test.ts
+++ b/plugins/plugin-native-desktop/src/web.test.ts
@@ -1,8 +1,10 @@
 /**
  * Tests `DesktopWeb`'s browser-fallback contracts — permission bridging,
- * notifications, window focus/blur listeners, external URL safety, and
- * battery state — against a stubbed `window`/`navigator` and mocked
- * Electrobun RPC, not a real browser or native host.
+ * notifications, window focus/blur listeners, external URL safety, battery
+ * state, and `beep()` AudioContext lifecycle — against a stubbed
+ * `window`/`navigator`/`AudioContext` and mocked Electrobun RPC, not a real
+ * browser or native host. The AudioContext stub is deterministic and records
+ * per-instance close() calls to prove `beep()` does not leak contexts.
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -27,6 +29,106 @@ function setWindow(value: Partial<Window> & Record<string, unknown>): void {
     configurable: true,
     value,
   });
+}
+
+interface FakeOscillator {
+  frequency: { value: number };
+  type: OscillatorType;
+  onended: (() => void) | null;
+  connect: (target: unknown) => unknown;
+  start: (when: number) => void;
+  stop: (when: number) => void;
+  started: number[];
+  stopped: number[];
+  connectedTo: unknown;
+}
+
+interface FakeGain {
+  gain: {
+    setValueAtTime: ReturnType<typeof vi.fn>;
+    exponentialRampToValueAtTime: ReturnType<typeof vi.fn>;
+  };
+  connect: (target: unknown) => unknown;
+}
+
+interface FakeAudioContext {
+  currentTime: number;
+  destination: { id: string };
+  closeCalls: number;
+  osc: FakeOscillator;
+  gain: FakeGain;
+  createOscillator: () => FakeOscillator;
+  createGain: () => FakeGain;
+  close: () => Promise<void>;
+}
+
+/**
+ * Installs a stubbed global `AudioContext` that records every constructed
+ * instance and how many times each is closed. `fireEndedOnStop` mirrors the
+ * real Web Audio contract where a scheduled `osc.stop()` eventually dispatches
+ * `onended`; `closeRejects` models a browser that rejects `close()` (e.g. an
+ * already-closed context) so best-effort teardown can be exercised.
+ */
+function installFakeAudioContext(
+  options: { fireEndedOnStop?: boolean; closeRejects?: boolean } = {},
+): { instances: FakeAudioContext[] } {
+  const { fireEndedOnStop = true, closeRejects = false } = options;
+  const instances: FakeAudioContext[] = [];
+
+  class AudioContextStub implements FakeAudioContext {
+    currentTime = 0;
+    destination = { id: "destination" };
+    closeCalls = 0;
+    osc: FakeOscillator;
+    gain: FakeGain;
+
+    constructor() {
+      const osc: FakeOscillator = {
+        frequency: { value: 0 },
+        type: "square",
+        onended: null,
+        started: [],
+        stopped: [],
+        connectedTo: undefined,
+        connect: (target: unknown) => {
+          osc.connectedTo = target;
+          return target;
+        },
+        start: (when: number) => {
+          osc.started.push(when);
+        },
+        stop: (when: number) => {
+          osc.stopped.push(when);
+          if (fireEndedOnStop) osc.onended?.();
+        },
+      };
+      this.osc = osc;
+      this.gain = {
+        gain: {
+          setValueAtTime: vi.fn(),
+          exponentialRampToValueAtTime: vi.fn(),
+        },
+        connect: (target: unknown) => target,
+      };
+      instances.push(this);
+    }
+
+    createOscillator(): FakeOscillator {
+      return this.osc;
+    }
+    createGain(): FakeGain {
+      return this.gain;
+    }
+    close(): Promise<void> {
+      this.closeCalls += 1;
+      return closeRejects
+        ? Promise.reject(new Error("Cannot close a closed AudioContext"))
+        : Promise.resolve();
+    }
+  }
+
+  vi.stubGlobal("AudioContext", AudioContextStub);
+  return { instances };
 }
 
 describe("DesktopWeb browser fallback contracts", () => {
@@ -267,5 +369,65 @@ describe("DesktopWeb browser fallback contracts", () => {
       isCharging: undefined,
       idleState: "active",
     });
+  });
+
+  it("closes exactly one AudioContext per beep so repeated beeps do not leak", async () => {
+    const { instances } = installFakeAudioContext();
+    const plugin = new DesktopWeb();
+
+    const beeps = 8;
+    for (let i = 0; i < beeps; i += 1) {
+      await plugin.beep();
+    }
+
+    // One context is opened per call...
+    expect(instances).toHaveLength(beeps);
+    // ...and each is closed exactly once (no leaked open contexts). Before the
+    // fix, browsers throw on `new AudioContext()` after ~6 concurrent contexts.
+    const leaked = instances.filter((ctx) => ctx.closeCalls === 0);
+    expect(leaked).toHaveLength(0);
+    for (const ctx of instances) {
+      expect(ctx.closeCalls).toBe(1);
+    }
+  });
+
+  it("drives the oscillator and gain ramp on the stubbed context before closing it", async () => {
+    const { instances } = installFakeAudioContext();
+
+    await new DesktopWeb().beep();
+
+    expect(instances).toHaveLength(1);
+    const ctx = instances[0];
+    expect(ctx.osc.frequency.value).toBe(800);
+    expect(ctx.osc.type).toBe("sine");
+    expect(ctx.osc.connectedTo).toBe(ctx.gain);
+    expect(ctx.osc.started).toEqual([0]);
+    expect(ctx.osc.stopped).toEqual([0.1]);
+    expect(ctx.gain.gain.setValueAtTime).toHaveBeenCalledWith(0.3, 0);
+    expect(ctx.gain.gain.exponentialRampToValueAtTime).toHaveBeenCalledWith(
+      0.01,
+      0.1,
+    );
+    expect(ctx.closeCalls).toBe(1);
+  });
+
+  it("swallows a close() rejection as best-effort teardown without rejecting beep", async () => {
+    const { instances } = installFakeAudioContext({ closeRejects: true });
+
+    await expect(new DesktopWeb().beep()).resolves.toBeUndefined();
+    expect(instances).toHaveLength(1);
+    expect(instances[0].closeCalls).toBe(1);
+  });
+
+  it("closes the AudioContext even when the tone never fires onended", async () => {
+    const { instances } = installFakeAudioContext({ fireEndedOnStop: false });
+
+    await new DesktopWeb().beep();
+
+    expect(instances).toHaveLength(1);
+    // The onended fallback fires manually here to prove teardown is wired to it
+    // rather than to an unconditional synchronous close.
+    instances[0].osc.onended?.();
+    expect(instances[0].closeCalls).toBe(1);
   });
 });

--- a/plugins/plugin-native-desktop/src/web.ts
+++ b/plugins/plugin-native-desktop/src/web.ts
@@ -451,15 +451,35 @@ export class DesktopWeb extends WebPlugin {
 
   async beep(): Promise<void> {
     const ctx = new AudioContext();
-    const osc = ctx.createOscillator();
-    const gain = ctx.createGain();
-    osc.connect(gain).connect(ctx.destination);
-    osc.frequency.value = 800;
-    osc.type = "sine";
-    gain.gain.setValueAtTime(0.3, ctx.currentTime);
-    gain.gain.exponentialRampToValueAtTime(0.01, ctx.currentTime + 0.1);
-    osc.start(ctx.currentTime);
-    osc.stop(ctx.currentTime + 0.1);
+    let closed = false;
+    const closeContext = (): void => {
+      if (closed) return;
+      closed = true;
+      // error-policy:J6 best-effort teardown; a rejected close() (for example
+      // an already-closed context) must not surface as a failed beep().
+      void Promise.resolve(ctx.close()).catch(() => {});
+    };
+    try {
+      const osc = ctx.createOscillator();
+      const gain = ctx.createGain();
+      osc.connect(gain).connect(ctx.destination);
+      osc.frequency.value = 800;
+      osc.type = "sine";
+      gain.gain.setValueAtTime(0.3, ctx.currentTime);
+      gain.gain.exponentialRampToValueAtTime(0.01, ctx.currentTime + 0.1);
+      // Close the context once the scheduled tone ends so each beep() opens and
+      // closes exactly one AudioContext. Browsers cap concurrent AudioContexts
+      // per document (~6 in Chrome); leaking one per call makes
+      // `new AudioContext()` throw after a handful of beeps.
+      osc.onended = closeContext;
+      osc.start(ctx.currentTime);
+      osc.stop(ctx.currentTime + 0.1);
+    } catch (err) {
+      // error-policy:J2 close the just-opened context before rethrowing so a
+      // setup failure does not leak it, then preserve the original error.
+      closeContext();
+      throw err;
+    }
   }
 
   // Events


### PR DESCRIPTION
# Relates to

Closes #28374

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; focused package gates (test, typecheck, lint) pass. See **Known gaps** for the repo-wide `bun run verify` note.
- [x] A reviewer can confirm the change works without reading the code, from the evidence below (failing-before / passing-after test output).

# Sync with develop

- [x] Rebased onto the latest `origin/develop` (`094f80ad2d`); zero conflicts; branch is 0 commits behind.
- [ ] `bun run verify` — not run whole-repo on this constrained host; the owning package's `test`, `typecheck`, and `lint:check` all pass (see evidence). Documented in **Known gaps**.

# Risks

Low. The change is confined to `DesktopWeb.beep()` in `plugins/plugin-native-desktop/src/web.ts` (browser fallback only). No public signature or contract change. `beep()` still schedules the same 800 Hz sine tone with the same gain envelope; the only added behavior is closing the `AudioContext` after the tone ends.

# Background

## What does this PR do?

`DesktopWeb.beep()` constructed `new AudioContext()` on every call and never closed it. Browsers cap the number of concurrent `AudioContext`s per document (Chrome allows ~6). Because `osc.stop()` only schedules the tone to end but leaves the context in the `running` state, each beep leaked one open context. After a handful of beeps in a session `new AudioContext()` throws (`Failed to construct 'AudioContext': ... maximum number of hardware contexts reached`), so `beep()` — a documented `DesktopPlugin` API the agent uses for audible alerts — starts rejecting for the rest of the session.

The fix closes the context once its scheduled tone ends, so each call opens and closes exactly one `AudioContext`:

- `osc.onended = closeContext` before `osc.start()`, so teardown is tied to the real end-of-tone signal.
- `close()` rejections (e.g. an already-closed context) are swallowed as best-effort teardown (`error-policy:J6`) so they never surface as a failed `beep()`.
- A setup failure closes the just-opened context before rethrowing the original error (`error-policy:J2`), so the error path does not leak either.

A `closed` guard makes `closeContext()` idempotent so the context is closed at most once.

## What kind of change is this?

Bug fix (non-breaking change which fixes a resource leak on a normal, repeatable user path).

# Documentation changes needed?

My changes do not require a documentation change. `beep()`'s documented contract (Shell group, `packages/plugin-native-desktop` guide) is unchanged; this is a leak fix behind the same API.

# Testing

## Where should a reviewer start?

`plugins/plugin-native-desktop/src/web.ts` (the `beep()` method) and the four new cases in `plugins/plugin-native-desktop/src/web.test.ts`.

## Detailed testing steps

```bash
bun run --cwd plugins/plugin-native-desktop test        # 10 passed
bun run --cwd plugins/plugin-native-desktop typecheck   # clean
bun run --cwd plugins/plugin-native-desktop lint:check  # clean
```

The tests install a deterministic `AudioContext` stub that records every constructed instance and how many times each is closed. Coverage:

1. **Leak regression** — 8 `beep()` calls open 8 contexts and leak zero (each `closeCalls === 1`). This is the direct reproduction of #28374.
2. **Tone contract** — `beep()` still sets frequency 800 / type `sine`, connects oscillator→gain→destination, ramps gain (`setValueAtTime(0.3, 0)` then `exponentialRampToValueAtTime(0.01, 0.1)`), and starts/stops at the right times, then closes the context.
3. **Best-effort teardown (J6)** — a rejecting `close()` does not reject `beep()`.
4. **onended wiring** — when the stub does not auto-fire `onended`, teardown fires only when `onended` is invoked, proving the close is tied to end-of-tone rather than an unconditional synchronous close.

# Evidence Gate

<!-- evidence-head:deaa25d1c15cc98af9b78e79ad72686672e1a99d -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - no UI surface`. This changes an audio-playback fallback method in a Capacitor plugin; there is no rendered view.
<!-- evidence-row:after-screenshots -->
- [x] `N/A - no UI surface`. Same reason.
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no UI/user flow`. The change is a headless audio-context lifecycle fix; proof is the failing-then-passing unit reproduction below.
<!-- evidence-row:backend-logs -->
- [x] `N/A - no server path`. `DesktopWeb` is a browser/webview fallback with no elizaOS server logger; the exercised path is the vitest reproduction below.
<!-- evidence-row:frontend-logs -->
- [x] `N/A - not app UI`. The reproduction runs under vitest with a stubbed `AudioContext`, not through the app frontend; console/network traces do not apply.
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent/model/prompt change`. This is a resource-leak fix with no action/provider/prompt/model surface.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - artifact is the failing-then-passing vitest reproduction embedded inline under Evidence Details (before: leaked===8; after: 10 passed); release-asset and external attachment upload are not authorized for this fork account, so the artifact is pasted inline rather than linked
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change`.

## Backend + frontend logs

`N/A - browser fallback method with no elizaOS logger and no app-frontend path`. The real code path is exercised by the reproduction below against a stubbed `AudioContext`.

## Screenshots (before / after) + video walkthrough

`N/A - no UI change`.

### Failing before the fix (reverting only `web.ts` to `origin/develop`, tests unchanged)

<details>
<summary>vitest — 4 failed | 6 passed</summary>

```
⎯⎯⎯ Failed Tests 4 ⎯⎯⎯
 FAIL  src/web.test.ts > ... > closes exactly one AudioContext per beep so repeated beeps do not leak
AssertionError: expected [ AudioContextStub{ …(5) }, …(7) ] to have a length of +0 but got 8
    387|     const leaked = instances.filter((ctx) => ctx.closeCalls === 0);
    388|     expect(leaked).toHaveLength(0);
 FAIL  src/web.test.ts > ... > drives the oscillator and gain ramp on the stubbed context before closing it
AssertionError: expected +0 to be 1 // Object.is equality
    411|     expect(ctx.closeCalls).toBe(1);
 FAIL  src/web.test.ts > ... > swallows a close() rejection as best-effort teardown without rejecting beep
AssertionError: expected +0 to be 1 // Object.is equality
    419|     expect(instances[0].closeCalls).toBe(1);
 FAIL  src/web.test.ts > ... > closes the AudioContext even when the tone never fires onended
AssertionError: expected +0 to be 1 // Object.is equality
    431|     expect(instances[0].closeCalls).toBe(1);

 Test Files  1 failed (1)
      Tests  4 failed | 6 passed (10)
```

The `leaked ... to have a length of +0 but got 8` line is the exact reproduction of #28374: 8 beeps leak 8 open contexts.
</details>

### Passing after the fix

<details>
<summary>vitest — 10 passed; typecheck + lint clean</summary>

```
 RUN  v4.1.10 plugins/plugin-native-desktop

 Test Files  1 passed (1)
      Tests  10 passed (10)

$ tsc --noEmit -p tsconfig.json      # (no output = clean)
$ bunx @biomejs/biome check .
Checked 7 files in 50ms. No fixes applied.
```
</details>

### Walkthrough video

`N/A - headless audio-context lifecycle fix; the failing-then-passing reproduction above is the walkthrough`.

## Audio / voice walkthrough

`N/A - this is an AudioContext resource-leak fix, not a voice/transcript/TTS/STT change`. Real audio cannot be captured for `beep()` in a headless CI/host environment (no audio device); the deterministic `AudioContext` stub proves the oscillator/gain/start/stop calls and the lifecycle contract instead.

## Known gaps / failures

- Whole-repo `bun run verify` was not run on this constrained host; the change is isolated to one browser-fallback method and its test, and the owning package's `test`, `typecheck`, and `lint:check` all pass. Not a blocker: no cross-package surface is touched.
- All evidence rows marked `N/A` are for genuinely inapplicable classes (no UI, no server logger, no model/agent surface, no capturable audio device), with the specific reason stated per row.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@094f80ad2ded8fdd78da8664ccf3423590f1c25a:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@094f80ad2ded8fdd78da8664ccf3423590f1c25a:packages/skills/skills/contribute-to-eliza"} -->

