### PR TITLE
fix(auth): report the real OAuth flow timeout window (15 minutes, not 5)

### DIFF
--- a/packages/auth/src/oauth-flow.test.ts
+++ b/packages/auth/src/oauth-flow.test.ts
@@ -200,6 +200,34 @@ describe("oauth-flow FlowState broadcast", () => {
     await expect(handle.completion).rejects.toThrow("Cancelled");
   });
 
+  it("reports the real timeout window in the terminal state", async () => {
+    useTempElizaHome();
+    stubCodexLogin();
+    vi.useFakeTimers();
+    try {
+      const handle = await startCodexOAuthFlow({
+        label: "Timeout",
+        accountId: "acct-timeout",
+      });
+      const frames: FlowState[] = [];
+      subscribeFlow(handle.sessionId, (state) => {
+        frames.push(state);
+      });
+
+      const rejection = expect(handle.completion).rejects.toThrow(
+        "OAuth flow timed out after 15 minutes",
+      );
+      await vi.advanceTimersByTimeAsync(15 * 60 * 1000);
+      await rejection;
+
+      const terminal = frames.at(-1);
+      expect(terminal?.status).toBe("timeout");
+      expect(terminal?.error).toBe("OAuth flow timed out after 15 minutes");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("emits a success state without the OAuth tokens", async () => {
     useTempElizaHome();
     const vendor = stubCodexLogin();

--- a/packages/auth/src/oauth-flow.ts
+++ b/packages/auth/src/oauth-flow.ts
@@ -419,7 +419,12 @@ async function startGenericFlow(args: {
   };
 
   const timer = setTimeout(() => {
-    const err = new Error("OAuth flow timed out after 5 minutes");
+    // Derive the window from the constant so the message cannot drift from
+    // the actual timer again (it previously said 5 minutes for a 15-minute
+    // timeout and reached the UI verbatim through FlowState.error).
+    const err = new Error(
+      `OAuth flow timed out after ${FLOW_TIMEOUT_MS / 60_000} minutes`,
+    );
     try {
       vendor.cancel("timeout");
     } catch (cancelErr) {


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Fixes #28379

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts (branched from current head).
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. One message string in one module plus a test. The message text reaches the UI through the existing `FlowState.error` field; no shape or timing changes.

# Background

## What does this PR do?

The OAuth subscription-login flow window was deliberately raised from 5 to 15 minutes (`FLOW_TIMEOUT_MS = 15 * 60 * 1000`, comment explains MFA/account-selection/consent), but the terminal timeout message still hardcoded `"OAuth flow timed out after 5 minutes"`. That string propagates verbatim into `FlowState.error`, which every `/api/accounts/:provider/oauth/status` SSE subscriber renders — users were told they hit a 5-minute timeout after waiting 15.

The fix derives the minutes from `FLOW_TIMEOUT_MS` so message and timer cannot drift apart again, and adds a fake-timer regression test that drives the real flow state machine and asserts the emitted terminal state says "15 minutes".

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/auth/src/oauth-flow.test.ts`: "reports the real timeout window in the terminal state" — starts a real flow whose vendor never completes, advances fake timers by 15 minutes, subscribes to FlowState frames, and asserts both the completion rejection and the terminal frame's `status: "timeout"` / exact error text.

## Detailed testing steps

Red-proof: check out this branch's test file with unfixed `oauth-flow.ts` — the new test fails with `expected … 'after 15 minutes' but got 'after 5 minutes'`. With the fix, the suite passes.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:c057ed79d3113ffc0cf34fc7335ba6e5447831f2 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`. — N/A - text-only defect on the OAuth status surface; the red-test output below captures the wrong behavior.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`. — N/A - same surface; green test below.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`. — N/A - no interactive UI flow changed; the emitted state machine output is the observable behavior.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>` — the regression test drives the real flow/persistence/state paths against a temp home.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`. — N/A - SSE rendering of `FlowState.error` is unchanged; only the string content changed.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`. — N/A - no model involvement.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable, or marked `N/A - <reason>` — the emitted `FlowState` frame is the artifact; asserted exactly by the test.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface. — N/A - no code change touches rendered views.

# Evidence Details

## Real LLM-call trajectory

N/A - no model involvement.

## Backend + frontend logs

Red-proof against unfixed source (this branch's test, `develop@4d13f256c7` source):

```text
FAIL src/oauth-flow.test.ts > oauth-flow FlowState broadcast > reports the real timeout window in the terminal state
AssertionError: expected [Function] to throw error including
'OAuth flow timed out after 15 minutes' but got 'OAuth flow timed out after 5 minutes'
```

Green with this PR:

```text
Test Files  1 passed (1)
     Tests  20 passed (20)
```

## Screenshots (before / after) + video walkthrough

N/A - text-only defect on the OAuth status surface.

### Before

`FlowState { status: "timeout", error: "OAuth flow timed out after 5 minutes" }` after a 15-minute wait.

### After

`FlowState { status: "timeout", error: "OAuth flow timed out after 15 minutes" }`.

### Walkthrough video

N/A - no interactive flow changed.

## Audio / voice walkthrough

N/A - no audio surface.

## Known gaps / failures

- Full-repo `bun run verify` not run for this package-scoped change; package gates run instead: typecheck ✅, lint:check ✅, focused oauth-flow suite 20/20 ✅ (full package suite carries no additional failures).

## Maintainer CI exception record

N/A - no exception requested

AI provider/model: opencode / x-preview-f-free
Client / agent tooling: opencode
Attribution status: self-reported
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"x-preview-f-free","client":"opencode","skill_revision":"self-hosted contribute-to-eliza skill"} -->

AI provider/model: opencode / x-preview-f-free
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-eliza
Attribution status: self-reported
— [contribution-batch]
<!-- slop-contribution-attribution:v1 {"provider":"opencode","model":"x-preview-f-free","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0W0GNDZ5ADHE8R7Y9Z3GJ1K","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-25T08:27:45.472Z","completed_at":"2026-08-25T10:49:22.543Z","skill_sha256":"7d4db0c19ef1171c18744a11ec1aceb613e3f779a9c49953ef1a0018aa80e4fd","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-25T08:27:47.445Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"fb2167ede6d20eed5787424a809871cf0a9d40df9e7e4218e7cbd36879582298","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"4b0ca646-2ecb-4633-9370-c07fc2809e73","object_id":"sha256:fb2167ede6d20eed5787424a809871cf0a9d40df9e7e4218e7cbd36879582298","sha256":"fb2167ede6d20eed5787424a809871cf0a9d40df9e7e4218e7cbd36879582298"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAgtL_SjSjM1n46ptKEJk4PBfQocRxDED3AUsopsbPpj8","device_key_id":"d72975edd2d14b15ee662f87b3c80771c33d1c0659d900ebbc7644d0dfaa241a","device_signature":"nxmZHHqmMXtLWGtaVeqGRoGumLk0qkcSNuMgR-xtiWeEAvUN860h8QV83wq_WLSKm79_xXErCGg_gej96zCPAA"}} -->
