### PR TITLE
chore(plugin-agent-orchestrator): remove unused Octokit deps

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1276,14 +1276,12 @@
       "version": "2.0.3-beta.7",
       "dependencies": {
         "@elizaos/auth": "workspace:*",
-        "@octokit/core": "^7.0.6",
         "@octokit/rest": "^22.0.0",
         "coding-agent-adapters": "0.16.3",
         "drizzle-orm": "0.45.2",
         "effect": "4.0.0-beta.105",
         "smol-toml": "^1.8.0",
         "smthrs": "0.34.0",
-        "universal-user-agent": "^7.0.3",
       },
       "devDependencies": {
         "@biomejs/biome": "2.5.8",

--- a/plugins/plugin-agent-orchestrator/package.json
+++ b/plugins/plugin-agent-orchestrator/package.json
@@ -72,14 +72,12 @@
     "git-workspace-service": "0.4.5"
   },
   "dependencies": {
-    "@octokit/core": "^7.0.6",
     "@octokit/rest": "^22.0.0",
     "smthrs": "0.34.0",
     "coding-agent-adapters": "0.16.3",
     "drizzle-orm": "0.45.2",
     "effect": "4.0.0-beta.105",
     "smol-toml": "^1.8.0",
-    "universal-user-agent": "^7.0.3",
     "@elizaos/auth": "workspace:*"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- remove unused direct `@octokit/core` and `universal-user-agent` dependencies from `@elizaos/plugin-agent-orchestrator`
- update the Bun lockfile importer without changing transitive Octokit resolution

Closes #28390

## Evidence
`git grep -n -E '@octokit/core|universal-user-agent' -- plugins/plugin-agent-orchestrator` on the base tree matched only the two package manifest declarations. The plugin's GitHub integration imports `@octokit/rest`; no source, test, dynamic import, or runtime package-name reference uses either removed direct dependency.

Base: `094f80ad2ded8fdd78da8664ccf3423590f1c25a`
Head: `c9a38bd361b9b402a692b43dd6d4fb74db04fcaa`

## Validation
- `bun install --frozen-lockfile` (pass; no changes)
- `bun run --cwd plugins/plugin-agent-orchestrator build` (pass)
- `bun run --cwd plugins/plugin-agent-orchestrator lint:check` (exit 0; existing warning in `src/services/spend-allowance.test.ts`)
- `bun run --cwd plugins/plugin-agent-orchestrator test` (25 failed, 2957 passed, 10 skipped; 16 suites). Failures are inherited and unrelated to this manifest-only diff: stale cap/truncation expectations, adapter-routing/workdir behavior, DTO key-contract drift, secret-gate behavior, path-prefix differences on macOS, task lifecycle timing, evaluator punctuation, parent-broker runtime setup, one missing imported `tasks-action-aliases.test` fixture, and an unavailable `@elizaos/plugin-sql` dist entry.
- `bun run --cwd plugins/plugin-agent-orchestrator typecheck` (blocked by existing workspace declaration errors for `@elizaos/vault`, `@elizaos/cloud-routing`, and `@elizaos/core/client-public`)
