### PR TITLE
fix(elizacloud): degrade relay-status probe when service registry throws

### DIFF
--- a/plugins/plugin-elizacloud/src/routes/cloud-relay-routes.test.ts
+++ b/plugins/plugin-elizacloud/src/routes/cloud-relay-routes.test.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { handleCloudRelayRoute } from "./cloud-relay-routes";
+
+interface JsonCall {
+  body: Record<string, unknown>;
+}
+
+function makeHelpers() {
+  const calls: JsonCall[] = [];
+  const helpers = {
+    json: (_res: unknown, body: Record<string, unknown>) => {
+      calls.push({ body });
+    },
+  };
+  return { calls, helpers };
+}
+
+const req = {} as never;
+
+describe("cloud relay status route", () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("returns false for a non-matching path", async () => {
+    const { calls, helpers } = makeHelpers();
+    const handled = await handleCloudRelayRoute(
+      req,
+      {} as never,
+      "/api/other",
+      "GET",
+      { runtime: {} },
+      helpers as never,
+    );
+    expect(handled).toBe(false);
+    expect(calls).toHaveLength(0);
+  });
+
+  it("returns false for a non-GET method", async () => {
+    const { calls, helpers } = makeHelpers();
+    const handled = await handleCloudRelayRoute(
+      req,
+      {} as never,
+      "/api/cloud/relay-status",
+      "POST",
+      { runtime: {} },
+      helpers as never,
+    );
+    expect(handled).toBe(false);
+    expect(calls).toHaveLength(0);
+  });
+
+  it("reports no_runtime when the runtime is not initialized", async () => {
+    const { calls, helpers } = makeHelpers();
+    const handled = await handleCloudRelayRoute(
+      req,
+      {} as never,
+      "/api/cloud/relay-status",
+      "GET",
+      {},
+      helpers as never,
+    );
+    expect(handled).toBe(true);
+    expect(calls[0].body).toMatchObject({
+      available: false,
+      status: "no_runtime",
+    });
+  });
+
+  it("reports not_registered when no known service name resolves", async () => {
+    const { calls, helpers } = makeHelpers();
+    const runtime = {
+      getService: vi.fn(() => undefined),
+    };
+    const handled = await handleCloudRelayRoute(
+      req,
+      {} as never,
+      "/api/cloud/relay-status",
+      "GET",
+      { runtime },
+      helpers as never,
+    );
+    expect(handled).toBe(true);
+    expect(runtime.getService).toHaveBeenCalledTimes(3);
+    expect(calls[0].body).toMatchObject({
+      available: false,
+      status: "not_registered",
+    });
+  });
+
+  it("reports not_registered when the resolved service lacks getSessionInfo", async () => {
+    const { calls, helpers } = makeHelpers();
+    const runtime = {
+      getService: vi.fn(() => ({})),
+    };
+    const handled = await handleCloudRelayRoute(
+      req,
+      {} as never,
+      "/api/cloud/relay-status",
+      "GET",
+      { runtime },
+      helpers as never,
+    );
+    expect(handled).toBe(true);
+    expect(calls[0].body.status).toBe("not_registered");
+  });
+
+  it("degrades to an error state when the service registry throws", async () => {
+    const { calls, helpers } = makeHelpers();
+    const runtime = {
+      getService: vi.fn(() => {
+        throw new Error("service registry unavailable");
+      }),
+    };
+    const handled = await handleCloudRelayRoute(
+      req,
+      {} as never,
+      "/api/cloud/relay-status",
+      "GET",
+      { runtime },
+      helpers as never,
+    );
+    expect(handled).toBe(true);
+    expect(calls[0].body).toMatchObject({
+      available: false,
+      status: "error",
+    });
+  });
+
+  it("renders an error state when getSessionInfo throws", async () => {
+    const { calls, helpers } = makeHelpers();
+    const runtime = {
+      getService: vi.fn(() => ({
+        getSessionInfo: () => {
+          throw new Error("session store down");
+        },
+      })),
+    };
+    const handled = await handleCloudRelayRoute(
+      req,
+      {} as never,
+      "/api/cloud/relay-status",
+      "GET",
+      { runtime },
+      helpers as never,
+    );
+    expect(handled).toBe(true);
+    expect(calls[0].body).toMatchObject({
+      available: false,
+      status: "error",
+      reason: "session store down",
+    });
+  });
+
+  it("serves session info with an access URL when registered", async () => {
+    const { calls, helpers } = makeHelpers();
+    const runtime = {
+      getService: vi.fn(() => undefined),
+      getSetting: vi.fn(() => null),
+    };
+    runtime.getService.mockImplementation((name: string) => {
+      if (name === "CLOUD_MANAGED_GATEWAY_RELAY") {
+        return {
+          getSessionInfo: () => ({
+            sessionId: "sess-1",
+            organizationId: "org-1",
+            userId: "user-1",
+            agentName: "agent-1",
+            platform: "telegram",
+            lastSeenAt: "2026-08-25T00:00:00.000Z",
+            status: "registered",
+          }),
+        };
+      }
+      return undefined;
+    });
+    vi.stubEnv("ELIZAOS_CLOUD_BASE_URL", "https://runner.example.com");
+    const handled = await handleCloudRelayRoute(
+      req,
+      {} as never,
+      "/api/cloud/relay-status",
+      "GET",
+      { runtime },
+      helpers as never,
+    );
+    expect(handled).toBe(true);
+    expect(calls[0].body.available).toBe(true);
+    expect(calls[0].body.status).toBe("registered");
+    expect(calls[0].body.sessionId).toBe("sess-1");
+    expect(String(calls[0].body.accessUrl)).toContain(
+      "homeRemoteRunnerSession=sess-1",
+    );
+  });
+
+  it("prefers runtime settings over env and trims whitespace for the ssh tunnel", async () => {
+    const { calls, helpers } = makeHelpers();
+    const runtime = {
+      getService: vi.fn(() => undefined),
+      getSetting: vi.fn((key: string) => {
+        if (key === "ELIZA_HOME_REMOTE_RUNNER_SSH_TARGET") {
+          return "  runner@example.com  ";
+        }
+        return null;
+      }),
+    };
+    runtime.getService.mockImplementation((name: string) => {
+      if (name === "CLOUD_MANAGED_GATEWAY_RELAY") {
+        return {
+          getSessionInfo: () => ({
+            sessionId: "sess-2",
+            organizationId: null,
+            userId: null,
+            agentName: null,
+            platform: null,
+            lastSeenAt: null,
+            status: "polling",
+          }),
+        };
+      }
+      return undefined;
+    });
+    vi.stubEnv("ELIZA_HOME_REMOTE_RUNNER_URL", "http://runner.example.com:2222");
+    const handled = await handleCloudRelayRoute(
+      req,
+      {} as never,
+      "/api/cloud/relay-status",
+      "GET",
+      { runtime },
+      helpers as never,
+    );
+    expect(handled).toBe(true);
+    expect(calls[0].body.status).toBe("polling");
+    const ssh = calls[0].body.ssh as { command: string; localUrl: string };
+    expect(ssh.command).toContain("runner@example.com");
+    expect(ssh.command).toContain("127.0.0.1:2222");
+    expect(ssh.localUrl).toContain("127.0.0.1:2222");
+  });
+});

--- a/plugins/plugin-elizacloud/src/routes/cloud-relay-routes.ts
+++ b/plugins/plugin-elizacloud/src/routes/cloud-relay-routes.ts
@@ -59,24 +59,26 @@ export async function handleCloudRelayRoute(
     return true;
   }
 
-  // Try known service names used across package boundaries.
-  const service = (state.runtime.getService("CLOUD_MANAGED_GATEWAY_RELAY") ??
-    state.runtime.getService("cloud-managed-gateway-relay") ??
-    state.runtime.getService(
-      "cloudManagedGatewayRelay",
-    )) as RelayServiceLike | null;
-
-  if (!service || typeof service.getSessionInfo !== "function") {
-    helpers.json(res, {
-      available: false,
-      status: "not_registered",
-      reason:
-        "Gateway relay service not active. Connect to Eliza Cloud in Settings to enable instance routing.",
-    });
-    return true;
-  }
-
   try {
+    // Try known service names used across package boundaries. A throwing
+    // registry must degrade like any other probe failure instead of crashing
+    // the route.
+    const service = (state.runtime.getService("CLOUD_MANAGED_GATEWAY_RELAY") ??
+      state.runtime.getService("cloud-managed-gateway-relay") ??
+      state.runtime.getService(
+        "cloudManagedGatewayRelay",
+      )) as RelayServiceLike | null;
+
+    if (!service || typeof service.getSessionInfo !== "function") {
+      helpers.json(res, {
+        available: false,
+        status: "not_registered",
+        reason:
+          "Gateway relay service not active. Connect to Eliza Cloud in Settings to enable instance routing.",
+      });
+      return true;
+    }
+
     const info = service.getSessionInfo();
     helpers.json(res, {
       available: true,


### PR DESCRIPTION
# Relates to

No issue filed; defect found by failing-first focused test.

**Defect:** `handleCloudRelayRoute` resolves the relay service *outside* the
route's try/catch. When `runtime.getService` throws (uninitialized service
registry), the probe rejects instead of rendering the `available: false`
error state the route's own error-policy (J4) promises. The status UI then
sees a broken route rather than a degradable probe.

**Fix:** move the service-name resolution (and the `not_registered` response)
inside the existing try/catch so a throwing registry degrades to the same
`{ available: false, status: "error" }` shape as every other probe failure.

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] Focused vitest verification ran in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Production change is confined to the relay-status probe's error handling:
a throwing service registry now produces the route's documented degrade state
instead of propagating. The `not_registered` response and all success-path
behavior are unchanged and covered by the same test file.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: 1 file, 9 tests passed — see log below |
| before-screenshots | N/A - unit test, no UI |
| after-screenshots | N/A - unit test, no UI |
| walkthrough-video | N/A - unit test, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file + source diff in this PR |

```log
Test Files  1 passed (1)
     Tests  9 passed (9)
```

- Command: `npx vitest run cloud-relay-routes.test.ts`
- Result: all passed (includes the registry-throw regression case, which fails
  on the pre-fix source)

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
