### PR TITLE
fix(wallet): align token-balance intent gate with plural and chain keywords

### DIFF
--- a/plugins/plugin-wallet/src/chains/evm/providers/get-balance.test.ts
+++ b/plugins/plugin-wallet/src/chains/evm/providers/get-balance.test.ts
@@ -1,0 +1,56 @@
+import { __setParseJSONObjectFromTextResult } from "@elizaos/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { runIntentModel } from "../../../utils/intent-trajectory";
+import { tokenBalanceProvider } from "./get-balance";
+import { initWalletProvider } from "./wallet";
+
+function message(text: string) {
+  return { content: { text } } as never;
+}
+
+describe("token balance provider intent gate", () => {
+  beforeEach(() => {
+    runIntentModel.mockReset();
+    runIntentModel.mockResolvedValue("{}");
+    initWalletProvider.mockReset();
+    __setParseJSONObjectFromTextResult(null);
+  });
+
+  it("returns an empty result without calling the model for unrelated text", async () => {
+    const result = await tokenBalanceProvider.get({} as never, message("tell me a joke"));
+    expect(result).toEqual({ text: "", data: {}, values: {} });
+    expect(runIntentModel).not.toHaveBeenCalled();
+  });
+
+  it("passes the gate for the singular keyword forms", async () => {
+    await tokenBalanceProvider.get({} as never, message("what is my wallet balance"));
+    expect(runIntentModel).toHaveBeenCalledTimes(1);
+    await tokenBalanceProvider.get({} as never, message("show token holdings"));
+    expect(runIntentModel).toHaveBeenCalledTimes(2);
+    await tokenBalanceProvider.get({} as never, message("erc20 positions"));
+    expect(runIntentModel).toHaveBeenCalledTimes(3);
+  });
+
+  it("passes the gate for plural forms like wallets and tokens", async () => {
+    await tokenBalanceProvider.get({} as never, message("check my wallets"));
+    expect(runIntentModel).toHaveBeenCalledTimes(1);
+    await tokenBalanceProvider.get({} as never, message("list my tokens"));
+    expect(runIntentModel).toHaveBeenCalledTimes(2);
+    await tokenBalanceProvider.get({} as never, message("what chains do I hold"));
+    expect(runIntentModel).toHaveBeenCalledTimes(3);
+  });
+
+  it("returns an empty result when the model output carries no token/chain", async () => {
+    __setParseJSONObjectFromTextResult(null);
+    const result = await tokenBalanceProvider.get({} as never, message("wallet balance"));
+    expect(result).toEqual({ text: "", data: {}, values: {} });
+  });
+
+  it("never throws and reports an error result for an unconfigured chain", async () => {
+    __setParseJSONObjectFromTextResult({ token: "USDC", chain: "solana" });
+    initWalletProvider.mockResolvedValue({ chains: {} } as never);
+    const result = await tokenBalanceProvider.get({} as never, message("wallet balance"));
+    expect(result.values.tokenBalanceAvailable).toBe(false);
+    expect(String(result.text)).toContain("Token balance unavailable");
+  });
+});

--- a/plugins/plugin-wallet/src/chains/evm/providers/get-balance.ts
+++ b/plugins/plugin-wallet/src/chains/evm/providers/get-balance.ts
@@ -46,8 +46,10 @@ export const tokenBalanceProvider: Provider = {
       normalizedText.includes("balance") ||
       normalizedText.includes("token") ||
       normalizedText.includes("erc20") ||
-      normalizedText.includes("wallet");
-    const regexMatch = /\b(?:balance|token|erc20|wallet|chain)\b/i.test(inputText);
+      normalizedText.includes("wallet") ||
+      normalizedText.includes("chain");
+    const regexMatch =
+      /\b(?:balance|token|erc20|wallet|chain)s?\b/i.test(inputText);
     if (!keywordMatch || !regexMatch) {
       return { text: "", data: {}, values: {} };
     }


### PR DESCRIPTION
# Relates to

No issue filed; defect found by failing-first focused test.

**Defect:** the `tokenBalanceProvider` intent gate is internally
inconsistent. The keyword check accepts substrings (`includes`) but the
regex check uses word boundaries that reject the natural plural forms —
"check my wallets", "list my tokens", "what chains do I hold" all fail the
gate, so the provider silently no-ops on legitimate balance requests and the
planner never receives wallet context. Additionally `chain` appears in the
regex tier but is missing from the keyword tier, so "chains" requests can
never pass.

**Fix:** align both tiers — plural-tolerant word-boundary regex
(`wallet|token|...s?`) and add the missing `chain` keyword — so the gate
matches the message-intent surface it documents.

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] Focused vitest verification ran in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. The gate change only widens which messages reach the (already
best-effort) intent extraction; unrelated text still short-circuits before
any model call, and every failure path still returns the never-throws error
result. All covered by the test file.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: 1 file, 5 tests passed — see log below |
| before-screenshots | N/A - unit test, no UI |
| after-screenshots | N/A - unit test, no UI |
| walkthrough-video | N/A - unit test, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - model call is mocked (runIntentModel spy) |
| domain-artifacts | Concrete: test file + source diff in this PR |

```log
Test Files  1 passed (1)
     Tests  5 passed (5)
```

- Command: `npx vitest run get-balance.test.ts`
- Result: all passed (the plural/chain cases fail on the pre-fix source)

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
