### PR TITLE
refactor(ui): clean and enforce shared molecules

### DIFF
--- a/packages/ui/DESIGN_SYSTEM.md
+++ b/packages/ui/DESIGN_SYSTEM.md
@@ -122,13 +122,19 @@ density presentation stay in the table primitives.
 
 Repeated multi-atom structures belong in a shared pattern only when they own
 the same behavior and state lifecycle. Dependency similarity alone is not a
-pattern. The molecular inventory records a final disposition and rationale for
-every detected cluster; unresolved candidates and duplicate implementations
-must not pass the completion gate. The accepted final dispositions are
+pattern. `scripts/molecule-contracts.json` records the exact owner, composition
+signals, consumer floor, and required consumers for established shared
+molecules. The audit fails when any of those contracts drift, including for
+molecules that compose only one canonical atom.
+
+Structural duplicate discovery is a separate review queue. The molecular
+inventory records a final disposition and rationale for every detected cluster;
+unresolved candidates and duplicate implementations must not pass the
+completion gate. The accepted final dispositions are
 `distinct-domain-compositions` and `shared-lifecycle-owner`; adding another
 requires a gate and policy change in the same review. Run
-`audit:molecular-inventory` to update the committed report after source or
-decision changes. Package lint checks that the report is current.
+`audit:molecular-inventory` to update the committed report after source,
+contract, or decision changes. Package lint checks that the report is current.
 
 ## Story and accessibility proof
 

--- a/packages/ui/DESIGN_SYSTEM.md
+++ b/packages/ui/DESIGN_SYSTEM.md
@@ -112,6 +112,12 @@ Use the narrowest shared lifecycle owner that fits:
 - `SelectableTile` owns controlled settings choices with a leading visual,
   centered label, pressed state, and selected indicator. Selected state must
   not add visible `ON` or `OFF` copy.
+- `AuthResultShell` owns the full-page background, centered card, and content
+  geometry for public authentication outcomes. Result pages supply only their
+  state-specific icon, copy, and actions.
+- `ConnectionCapabilityTile` owns the icon, title, and description hierarchy
+  used by connector setup grids. Provider screens supply translated content
+  and provider-specific icon paint.
 - `StatusBadge` owns status paint. Domain adapters map typed domain states to a
   canonical tone and label; they do not reproduce badge classes.
 
@@ -125,7 +131,9 @@ the same behavior and state lifecycle. Dependency similarity alone is not a
 pattern. `scripts/molecule-contracts.json` records the exact owner, composition
 signals, consumer floor, and required consumers for established shared
 molecules. The audit fails when any of those contracts drift, including for
-molecules that compose only one canonical atom.
+molecules that compose only one or no canonical atoms. Rendered stories and
+the app visual audit own geometry proof; source-text class assertions are not
+an acceptable substitute for rendered behavior.
 
 Structural duplicate discovery is a separate review queue. The molecular
 inventory records a final disposition and rationale for every detected cluster;

--- a/packages/ui/scripts/duplicate-molecular-components-report.md
+++ b/packages/ui/scripts/duplicate-molecular-components-report.md
@@ -4,6 +4,19 @@ Scanned 927 maintained React files. 68 exported compositions have a recognized m
 
 Clusters share both a role and an atomic dependency signature. Detection creates a review queue; this committed report contains only final dispositions based on product behavior, state ownership, and responsive layout.
 
+## Canonical molecule contracts
+
+These owners are fail-closed contracts. The audit fails if an owner disappears, drops a required canonical atom, or loses its maintained consumers.
+
+| Contract | Canonical owner | Maintained references | Responsibility |
+| --- | --- | ---: | --- |
+| content-state | `ContentState` in `packages/ui/src/components/composites/page-panel/content-state.tsx` | 2 | Empty and loading presentation inside page-panel placements. |
+| settings-row | `SettingsRow` in `packages/ui/src/components/settings/settings-layout.tsx` | 40 | Label, description, control, and navigation alignment for settings. |
+| selectable-tile | `SelectableTile` in `packages/ui/src/components/composites/settings/selectable-tile.tsx` | 1 | Pressed-state selection tile with a leading visual and check indicator. |
+| action-list-row | `ActionListRow` in `packages/ui/src/components/shared/ActionListRow.tsx` | 2 | Button, link, and static list rows with shared content slots. |
+
+## Duplicate review queue
+
 | Role | Atomic dependencies | Components | Decision |
 | --- | --- | ---: | --- |
 | dialog | button, dialog | 6 | distinct-domain-compositions |

--- a/packages/ui/scripts/duplicate-molecular-components-report.md
+++ b/packages/ui/scripts/duplicate-molecular-components-report.md
@@ -1,6 +1,6 @@
 # Molecular component duplicate inventory
 
-Scanned 927 maintained React files. 68 exported compositions have a recognized molecular role and at least two atomic dependencies.
+Scanned 929 maintained React files. 68 exported compositions have a recognized molecular role and at least two atomic dependencies.
 
 Clusters share both a role and an atomic dependency signature. Detection creates a review queue; this committed report contains only final dispositions based on product behavior, state ownership, and responsive layout.
 
@@ -10,6 +10,8 @@ These owners are fail-closed contracts. The audit fails if an owner disappears, 
 
 | Contract | Canonical owner | Maintained references | Responsibility |
 | --- | --- | ---: | --- |
+| auth-result-shell | `AuthResultShell` in `packages/ui/src/cloud/public-pages/pages/auth/auth-result-shell.tsx` | 2 | Full-page surface, centered card, and content geometry for authentication results. |
+| connection-capability-tile | `ConnectionCapabilityTile` in `packages/ui/src/cloud/connectors/connection-capability-tile.tsx` | 2 | Icon, title, and description hierarchy for connector capability grids. |
 | content-state | `ContentState` in `packages/ui/src/components/composites/page-panel/content-state.tsx` | 2 | Empty and loading presentation inside page-panel placements. |
 | settings-row | `SettingsRow` in `packages/ui/src/components/settings/settings-layout.tsx` | 40 | Label, description, control, and navigation alignment for settings. |
 | selectable-tile | `SelectableTile` in `packages/ui/src/components/composites/settings/selectable-tile.tsx` | 1 | Pressed-state selection tile with a leading visual and check indicator. |

--- a/packages/ui/scripts/find-duplicate-components.mjs
+++ b/packages/ui/scripts/find-duplicate-components.mjs
@@ -98,6 +98,13 @@ function* walk(directory) {
   }
 }
 
+export function listMaintainedSourceFiles() {
+  return [
+    ...walk(path.join(repoRoot, "packages")),
+    ...walk(path.join(repoRoot, "plugins")),
+  ];
+}
+
 function componentName(node) {
   if (ts.isFunctionDeclaration(node) && node.name) return node.name.text;
   if (ts.isClassDeclaration(node) && node.name) return node.name.text;

--- a/packages/ui/scripts/find-duplicate-molecular-components.mjs
+++ b/packages/ui/scripts/find-duplicate-molecular-components.mjs
@@ -8,7 +8,11 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { buildInventory } from "./find-duplicate-components.mjs";
+import ts from "typescript";
+import {
+  buildInventory,
+  listMaintainedSourceFiles,
+} from "./find-duplicate-components.mjs";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const reportJson = path.join(
@@ -25,6 +29,9 @@ const decisionsPath = path.join(
 );
 const contractsPath = path.join(scriptDir, "molecule-contracts.json");
 const repoRoot = path.resolve(scriptDir, "../../..");
+const sourceFileCache = new Map();
+const compositionCache = new Map();
+const moduleExportCache = new Map();
 
 const FINAL_DISPOSITIONS = new Set([
   "distinct-domain-compositions",
@@ -138,10 +145,10 @@ export function validateMoleculeContracts(components, contracts, references) {
 
     for (const consumerFile of contract.requiredConsumerFiles ?? []) {
       const absoluteConsumer = path.join(repoRoot, consumerFile);
-      const source = fs.existsSync(absoluteConsumer)
-        ? fs.readFileSync(absoluteConsumer, "utf8")
-        : "";
-      if (!new RegExp(`\\b${contract.symbol}\\b`).test(source)) {
+      if (
+        !fs.existsSync(absoluteConsumer) ||
+        !fileComposesContract(absoluteConsumer, contract)
+      ) {
         errors.push(
           `${consumerFile} no longer consumes canonical ${contract.symbol}`,
         );
@@ -156,7 +163,7 @@ export function validateMoleculeContracts(components, contracts, references) {
   }
 }
 
-function maintainedReferenceCounts(components, contracts) {
+function maintainedReferenceCounts(contracts) {
   const references = Object.fromEntries(
     contracts.map((contract) => [`${contract.owner}:${contract.symbol}`, 0]),
   );
@@ -164,12 +171,13 @@ function maintainedReferenceCounts(components, contracts) {
     contracts.map((contract) => [contract.symbol, contract]),
   );
 
-  const maintainedFiles = [...new Set(components.map(({ file }) => file))];
-  for (const file of maintainedFiles) {
-    const source = fs.readFileSync(path.join(repoRoot, file), "utf8");
+  for (const absoluteFile of listMaintainedSourceFiles()) {
+    const file = path
+      .relative(repoRoot, absoluteFile)
+      .replaceAll(path.sep, "/");
     for (const [symbol, contract] of symbols) {
       if (file === contract.owner) continue;
-      if (new RegExp(`\\b${symbol}\\b`).test(source)) {
+      if (fileComposesContract(absoluteFile, contract)) {
         references[`${contract.owner}:${symbol}`] += 1;
       }
     }
@@ -177,14 +185,136 @@ function maintainedReferenceCounts(components, contracts) {
   return references;
 }
 
+export function fileComposesContract(absoluteFile, contract) {
+  const cacheKey = `${absoluteFile}:${contract.owner}:${contract.symbol}`;
+  if (compositionCache.has(cacheKey)) return compositionCache.get(cacheKey);
+  const source = fs.readFileSync(absoluteFile, "utf8");
+  const sourceFile = parsedSourceFile(absoluteFile, source);
+  const bindings = new Set();
+  for (const statement of sourceFile.statements) {
+    if (
+      !ts.isImportDeclaration(statement) ||
+      !statement.importClause?.namedBindings ||
+      !ts.isNamedImports(statement.importClause.namedBindings) ||
+      !ts.isStringLiteral(statement.moduleSpecifier)
+    ) {
+      continue;
+    }
+    const modulePath = resolveSourceModule(
+      absoluteFile,
+      statement.moduleSpecifier.text,
+    );
+    if (!modulePath) continue;
+    for (const element of statement.importClause.namedBindings.elements) {
+      const importedName = element.propertyName?.text ?? element.name.text;
+      if (
+        moduleExportsContract(modulePath, importedName, contract, new Set())
+      ) {
+        bindings.add(element.name.text);
+      }
+    }
+  }
+  let composed = false;
+  const visit = (node) => {
+    if (
+      (ts.isJsxOpeningElement(node) || ts.isJsxSelfClosingElement(node)) &&
+      ts.isIdentifier(node.tagName) &&
+      bindings.has(node.tagName.text)
+    ) {
+      composed = true;
+      return;
+    }
+    if (!composed) ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  compositionCache.set(cacheKey, composed);
+  return composed;
+}
+
+function moduleExportsContract(modulePath, exportedName, contract, visited) {
+  const visitKey = `${modulePath}:${exportedName}`;
+  if (visited.has(visitKey)) return false;
+  visited.add(visitKey);
+  const cacheKey = `${visitKey}:${contract.owner}:${contract.symbol}`;
+  if (moduleExportCache.has(cacheKey)) return moduleExportCache.get(cacheKey);
+  const relativeModule = path
+    .relative(repoRoot, modulePath)
+    .replaceAll(path.sep, "/");
+  if (relativeModule === contract.owner && exportedName === contract.symbol) {
+    moduleExportCache.set(cacheKey, true);
+    return true;
+  }
+
+  const source = fs.readFileSync(modulePath, "utf8");
+  const sourceFile = parsedSourceFile(modulePath, source);
+  for (const statement of sourceFile.statements) {
+    if (!ts.isExportDeclaration(statement) || !statement.moduleSpecifier)
+      continue;
+    if (!ts.isStringLiteral(statement.moduleSpecifier)) continue;
+    const nextModule = resolveSourceModule(
+      modulePath,
+      statement.moduleSpecifier.text,
+    );
+    if (!nextModule) continue;
+    if (!statement.exportClause) {
+      if (moduleExportsContract(nextModule, exportedName, contract, visited)) {
+        moduleExportCache.set(cacheKey, true);
+        return true;
+      }
+      continue;
+    }
+    if (!ts.isNamedExports(statement.exportClause)) continue;
+    for (const element of statement.exportClause.elements) {
+      if (element.name.text !== exportedName) continue;
+      const importedName = element.propertyName?.text ?? element.name.text;
+      if (moduleExportsContract(nextModule, importedName, contract, visited)) {
+        moduleExportCache.set(cacheKey, true);
+        return true;
+      }
+    }
+  }
+  moduleExportCache.set(cacheKey, false);
+  return false;
+}
+
+function parsedSourceFile(absoluteFile, source) {
+  if (sourceFileCache.has(absoluteFile))
+    return sourceFileCache.get(absoluteFile);
+  const sourceFile = ts.createSourceFile(
+    absoluteFile,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    absoluteFile.endsWith("x") ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+  );
+  sourceFileCache.set(absoluteFile, sourceFile);
+  return sourceFile;
+}
+
+function resolveSourceModule(importingFile, specifier) {
+  if (!specifier.startsWith(".")) return null;
+  const base = path.resolve(path.dirname(importingFile), specifier);
+  for (const candidate of [
+    base,
+    `${base}.tsx`,
+    `${base}.ts`,
+    path.join(base, "index.tsx"),
+    path.join(base, "index.ts"),
+  ]) {
+    if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
 export function buildMolecularInventory() {
   const atomicReport = buildInventory();
   const decisions = JSON.parse(fs.readFileSync(decisionsPath, "utf8"));
-  const contractRegistry = JSON.parse(fs.readFileSync(contractsPath, "utf8"));
-  const references = maintainedReferenceCounts(
-    atomicReport.components,
-    contractRegistry.contracts,
+  const contractRegistry = parseMoleculeContractRegistry(
+    JSON.parse(fs.readFileSync(contractsPath, "utf8")),
   );
+  const references = maintainedReferenceCounts(contractRegistry.contracts);
   validateMoleculeContracts(
     atomicReport.components,
     contractRegistry.contracts,
@@ -250,6 +380,87 @@ export function buildMolecularInventory() {
       largestCluster: clusters[0]?.entries.length ?? 0,
     },
   };
+}
+
+export function parseMoleculeContractRegistry(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("Molecule contract registry must be an object");
+  }
+  if (value.schemaVersion !== 1 || !Array.isArray(value.contracts)) {
+    throw new Error(
+      "Molecule contract registry requires schemaVersion 1 and contracts",
+    );
+  }
+
+  for (const [index, contract] of value.contracts.entries()) {
+    const context = `Molecule contract at index ${index}`;
+    if (!contract || typeof contract !== "object" || Array.isArray(contract)) {
+      throw new Error(`${context} must be an object`);
+    }
+    const allowedFields = new Set([
+      "id",
+      "minimumMaintainedReferences",
+      "owner",
+      "requiredAtomicDependencies",
+      "requiredConsumerFiles",
+      "requiredRenderedTags",
+      "responsibility",
+      "symbol",
+    ]);
+    const unknownField = Object.keys(contract).find(
+      (field) => !allowedFields.has(field),
+    );
+    if (unknownField)
+      throw new Error(`${context} has unknown field ${unknownField}`);
+    for (const field of ["id", "owner", "symbol", "responsibility"]) {
+      if (
+        typeof contract[field] !== "string" ||
+        contract[field].trim() === ""
+      ) {
+        throw new Error(`${context} requires non-empty ${field}`);
+      }
+    }
+    if (
+      path.isAbsolute(contract.owner) ||
+      contract.owner.split("/").includes("..") ||
+      !contract.owner.startsWith("packages/")
+    ) {
+      throw new Error(`${context} owner must be a safe packages-relative path`);
+    }
+    for (const field of [
+      "requiredAtomicDependencies",
+      "requiredRenderedTags",
+      "requiredConsumerFiles",
+    ]) {
+      if (
+        !Array.isArray(contract[field]) ||
+        contract[field].some(
+          (entry) => typeof entry !== "string" || entry.trim() === "",
+        )
+      ) {
+        throw new Error(`${context} requires a string array for ${field}`);
+      }
+    }
+    if (
+      contract.requiredConsumerFiles.some(
+        (consumer) =>
+          path.isAbsolute(consumer) ||
+          consumer.split("/").includes("..") ||
+          !consumer.startsWith("packages/"),
+      )
+    ) {
+      throw new Error(
+        `${context} consumers must be safe packages-relative paths`,
+      );
+    }
+    if (
+      !Number.isInteger(contract.minimumMaintainedReferences) ||
+      contract.minimumMaintainedReferences < 0
+    ) {
+      throw new Error(`${context} requires a non-negative reference floor`);
+    }
+  }
+  return value;
 }
 
 export function renderMolecularMarkdown(report) {

--- a/packages/ui/scripts/find-duplicate-molecular-components.mjs
+++ b/packages/ui/scripts/find-duplicate-molecular-components.mjs
@@ -23,6 +23,8 @@ const decisionsPath = path.join(
   scriptDir,
   "molecular-inventory-decisions.json",
 );
+const contractsPath = path.join(scriptDir, "molecule-contracts.json");
+const repoRoot = path.resolve(scriptDir, "../../..");
 
 const FINAL_DISPOSITIONS = new Set([
   "distinct-domain-compositions",
@@ -66,8 +68,7 @@ export function validateMolecularDecisions(clusters, decisions) {
     .filter((cluster) => {
       const disposition = decisions[cluster.signature]?.disposition;
       return (
-        typeof disposition === "string" &&
-        !FINAL_DISPOSITIONS.has(disposition)
+        typeof disposition === "string" && !FINAL_DISPOSITIONS.has(disposition)
       );
     })
     .map(
@@ -89,9 +90,106 @@ export function validateMolecularDecisions(clusters, decisions) {
   }
 }
 
+export function validateMoleculeContracts(components, contracts, references) {
+  const errors = [];
+  const ids = new Set();
+  const owners = new Set();
+
+  for (const contract of contracts) {
+    const ownerKey = `${contract.owner}:${contract.symbol}`;
+    if (ids.has(contract.id)) errors.push(`duplicate id ${contract.id}`);
+    if (owners.has(ownerKey)) errors.push(`duplicate owner ${ownerKey}`);
+    ids.add(contract.id);
+    owners.add(ownerKey);
+
+    const owner = components.find(
+      (component) =>
+        component.file === contract.owner && component.name === contract.symbol,
+    );
+    if (!owner) {
+      errors.push(`missing owner ${ownerKey}`);
+      continue;
+    }
+
+    const missingDependencies = contract.requiredAtomicDependencies.filter(
+      (dependency) => !owner.atomicDependencies.includes(dependency),
+    );
+    if (missingDependencies.length > 0) {
+      errors.push(
+        `${ownerKey} is missing atomic dependencies ${missingDependencies.join(", ")}`,
+      );
+    }
+
+    const missingTags = (contract.requiredRenderedTags ?? []).filter(
+      (tag) => !owner.renderedTags.includes(tag),
+    );
+    if (missingTags.length > 0) {
+      errors.push(
+        `${ownerKey} is missing rendered tags ${missingTags.join(", ")}`,
+      );
+    }
+
+    const referenceCount = references[ownerKey] ?? 0;
+    if (referenceCount < contract.minimumMaintainedReferences) {
+      errors.push(
+        `${ownerKey} has ${referenceCount} maintained references; expected at least ${contract.minimumMaintainedReferences}`,
+      );
+    }
+
+    for (const consumerFile of contract.requiredConsumerFiles ?? []) {
+      const absoluteConsumer = path.join(repoRoot, consumerFile);
+      const source = fs.existsSync(absoluteConsumer)
+        ? fs.readFileSync(absoluteConsumer, "utf8")
+        : "";
+      if (!new RegExp(`\\b${contract.symbol}\\b`).test(source)) {
+        errors.push(
+          `${consumerFile} no longer consumes canonical ${contract.symbol}`,
+        );
+      }
+    }
+  }
+
+  if (errors.length > 0) {
+    throw new Error(
+      `Canonical molecule contracts failed: ${errors.join("; ")}`,
+    );
+  }
+}
+
+function maintainedReferenceCounts(components, contracts) {
+  const references = Object.fromEntries(
+    contracts.map((contract) => [`${contract.owner}:${contract.symbol}`, 0]),
+  );
+  const symbols = new Map(
+    contracts.map((contract) => [contract.symbol, contract]),
+  );
+
+  const maintainedFiles = [...new Set(components.map(({ file }) => file))];
+  for (const file of maintainedFiles) {
+    const source = fs.readFileSync(path.join(repoRoot, file), "utf8");
+    for (const [symbol, contract] of symbols) {
+      if (file === contract.owner) continue;
+      if (new RegExp(`\\b${symbol}\\b`).test(source)) {
+        references[`${contract.owner}:${symbol}`] += 1;
+      }
+    }
+  }
+  return references;
+}
+
 export function buildMolecularInventory() {
   const atomicReport = buildInventory();
   const decisions = JSON.parse(fs.readFileSync(decisionsPath, "utf8"));
+  const contractRegistry = JSON.parse(fs.readFileSync(contractsPath, "utf8"));
+  const references = maintainedReferenceCounts(
+    atomicReport.components,
+    contractRegistry.contracts,
+  );
+  validateMoleculeContracts(
+    atomicReport.components,
+    contractRegistry.contracts,
+    references,
+  );
   const components = atomicReport.components
     .map((component) => ({
       ...component,
@@ -134,9 +232,13 @@ export function buildMolecularInventory() {
   }));
 
   return {
-    schemaVersion: 1,
+    schemaVersion: 2,
     sourceAtomicSchemaVersion: atomicReport.schemaVersion,
     scannedFiles: atomicReport.scannedFiles,
+    canonicalContracts: contractRegistry.contracts.map((contract) => ({
+      ...contract,
+      maintainedReferences: references[`${contract.owner}:${contract.symbol}`],
+    })),
     eligibleComponents: components.length,
     clusters,
     summary: {
@@ -157,6 +259,19 @@ export function renderMolecularMarkdown(report) {
     `Scanned ${report.scannedFiles} maintained React files. ${report.eligibleComponents} exported compositions have a recognized molecular role and at least two atomic dependencies.`,
     "",
     "Clusters share both a role and an atomic dependency signature. Detection creates a review queue; this committed report contains only final dispositions based on product behavior, state ownership, and responsive layout.",
+    "",
+    "## Canonical molecule contracts",
+    "",
+    "These owners are fail-closed contracts. The audit fails if an owner disappears, drops a required canonical atom, or loses its maintained consumers.",
+    "",
+    "| Contract | Canonical owner | Maintained references | Responsibility |",
+    "| --- | --- | ---: | --- |",
+    ...report.canonicalContracts.map(
+      (contract) =>
+        `| ${contract.id} | \`${contract.symbol}\` in \`${contract.owner}\` | ${contract.maintainedReferences} | ${contract.responsibility} |`,
+    ),
+    "",
+    "## Duplicate review queue",
     "",
     "| Role | Atomic dependencies | Components | Decision |",
     "| --- | --- | ---: | --- |",

--- a/packages/ui/scripts/find-duplicate-molecular-components.test.mjs
+++ b/packages/ui/scripts/find-duplicate-molecular-components.test.mjs
@@ -6,6 +6,7 @@ import {
   buildMolecularInventory,
   renderMolecularMarkdown,
   validateMolecularDecisions,
+  validateMoleculeContracts,
 } from "./find-duplicate-molecular-components.mjs";
 
 test("molecular inventory is deterministic and requires meaningful signatures", () => {
@@ -20,6 +21,81 @@ test("molecular inventory is deterministic and requires meaningful signatures", 
   );
   assert.ok(first.clusters.every((cluster) => cluster.disposition));
   assert.ok(first.clusters.every((cluster) => cluster.rationale));
+  assert.deepEqual(
+    first.canonicalContracts.map((contract) => contract.id),
+    ["content-state", "settings-row", "selectable-tile", "action-list-row"],
+  );
+  assert.ok(
+    first.canonicalContracts.every(
+      (contract) =>
+        contract.maintainedReferences >= contract.minimumMaintainedReferences,
+    ),
+  );
+});
+
+test("canonical molecule contracts fail closed on owner drift", () => {
+  const components = [
+    {
+      atomicDependencies: ["button"],
+      file: "packages/ui/src/example.tsx",
+      name: "ExampleRow",
+      renderedTags: [],
+    },
+  ];
+  const contracts = [
+    {
+      id: "example-row",
+      minimumMaintainedReferences: 2,
+      owner: "packages/ui/src/example.tsx",
+      requiredAtomicDependencies: ["button", "badge"],
+      requiredRenderedTags: ["Button", "Badge"],
+      symbol: "ExampleRow",
+    },
+    {
+      id: "missing-row",
+      minimumMaintainedReferences: 0,
+      owner: "packages/ui/src/missing.tsx",
+      requiredAtomicDependencies: [],
+      symbol: "MissingRow",
+    },
+  ];
+
+  assert.throws(
+    () =>
+      validateMoleculeContracts(components, contracts, {
+        "packages/ui/src/example.tsx:ExampleRow": 1,
+      }),
+    /missing rendered tags Button, Badge.*has 1 maintained references; expected at least 2.*missing owner packages\/ui\/src\/missing\.tsx:MissingRow/,
+  );
+});
+
+test("canonical molecule contracts require named consumers to keep composing the owner", () => {
+  assert.throws(
+    () =>
+      validateMoleculeContracts(
+        [
+          {
+            atomicDependencies: ["button"],
+            file: "packages/ui/src/example.tsx",
+            name: "ExampleRow",
+            renderedTags: ["Button"],
+          },
+        ],
+        [
+          {
+            id: "example-row",
+            minimumMaintainedReferences: 0,
+            owner: "packages/ui/src/example.tsx",
+            requiredAtomicDependencies: ["button"],
+            requiredConsumerFiles: ["packages/ui/src/missing-consumer.tsx"],
+            requiredRenderedTags: ["Button"],
+            symbol: "ExampleRow",
+          },
+        ],
+        {},
+      ),
+    /missing-consumer\.tsx no longer consumes canonical ExampleRow/,
+  );
 });
 
 test("molecular decisions reject candidate and duplicate states", () => {
@@ -48,6 +124,8 @@ test("molecular report includes roles, dependencies, and source evidence", () =>
   const markdown = renderMolecularMarkdown(buildMolecularInventory());
 
   assert.match(markdown, /# Molecular component duplicate inventory/);
+  assert.match(markdown, /Canonical molecule contracts/);
+  assert.match(markdown, /ContentState/);
   assert.match(markdown, /Reviewed clusters/);
   assert.doesNotMatch(markdown, /-candidate\*\*/);
   assert.doesNotMatch(markdown, /Decision: \*\*duplicate-implementation\*\*/);

--- a/packages/ui/scripts/find-duplicate-molecular-components.test.mjs
+++ b/packages/ui/scripts/find-duplicate-molecular-components.test.mjs
@@ -1,13 +1,21 @@
 /** Tests deterministic molecular grouping against the maintained repository. */
 
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 import {
   buildMolecularInventory,
+  fileComposesContract,
+  parseMoleculeContractRegistry,
   renderMolecularMarkdown,
   validateMolecularDecisions,
   validateMoleculeContracts,
 } from "./find-duplicate-molecular-components.mjs";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "../../..");
 
 test("molecular inventory is deterministic and requires meaningful signatures", () => {
   const first = buildMolecularInventory();
@@ -23,7 +31,14 @@ test("molecular inventory is deterministic and requires meaningful signatures", 
   assert.ok(first.clusters.every((cluster) => cluster.rationale));
   assert.deepEqual(
     first.canonicalContracts.map((contract) => contract.id),
-    ["content-state", "settings-row", "selectable-tile", "action-list-row"],
+    [
+      "auth-result-shell",
+      "connection-capability-tile",
+      "content-state",
+      "settings-row",
+      "selectable-tile",
+      "action-list-row",
+    ],
   );
   assert.ok(
     first.canonicalContracts.every(
@@ -96,6 +111,68 @@ test("canonical molecule contracts require named consumers to keep composing the
       ),
     /missing-consumer\.tsx no longer consumes canonical ExampleRow/,
   );
+});
+
+test("molecule contract registry rejects incomplete boundary data", () => {
+  assert.throws(
+    () =>
+      parseMoleculeContractRegistry({
+        schemaVersion: 1,
+        contracts: [{ id: "incomplete" }],
+      }),
+    /requires non-empty owner/,
+  );
+  assert.throws(
+    () => parseMoleculeContractRegistry({ schemaVersion: 2, contracts: [] }),
+    /requires schemaVersion 1 and contracts/,
+  );
+});
+
+test("consumer composition resolves the owner binding through aliases and barrels", () => {
+  const fixtureRoot = fs.mkdtempSync(
+    path.join(scriptDir, ".molecule-binding-"),
+  );
+  const relativeRoot = path
+    .relative(repoRoot, fixtureRoot)
+    .replaceAll(path.sep, "/");
+  const contract = {
+    owner: `${relativeRoot}/owner.tsx`,
+    symbol: "CanonicalRow",
+  };
+
+  try {
+    fs.writeFileSync(
+      path.join(fixtureRoot, "owner.tsx"),
+      "export function CanonicalRow() { return <div />; }\n",
+    );
+    fs.writeFileSync(
+      path.join(fixtureRoot, "barrel.ts"),
+      'export { CanonicalRow } from "./owner";\n',
+    );
+    fs.writeFileSync(
+      path.join(fixtureRoot, "consumer.tsx"),
+      'import { CanonicalRow as Row } from "./barrel"; export const Consumer = () => <Row />;\n',
+    );
+    fs.writeFileSync(
+      path.join(fixtureRoot, "decoy.tsx"),
+      'import { CanonicalRow } from "./wrong"; export const Decoy = () => <CanonicalRow />;\n',
+    );
+    fs.writeFileSync(
+      path.join(fixtureRoot, "wrong.tsx"),
+      "export function CanonicalRow() { return <span />; }\n",
+    );
+
+    assert.equal(
+      fileComposesContract(path.join(fixtureRoot, "consumer.tsx"), contract),
+      true,
+    );
+    assert.equal(
+      fileComposesContract(path.join(fixtureRoot, "decoy.tsx"), contract),
+      false,
+    );
+  } finally {
+    fs.rmSync(fixtureRoot, { recursive: true });
+  }
 });
 
 test("molecular decisions reject candidate and duplicate states", () => {

--- a/packages/ui/scripts/molecule-contracts.json
+++ b/packages/ui/scripts/molecule-contracts.json
@@ -2,6 +2,32 @@
   "schemaVersion": 1,
   "contracts": [
     {
+      "id": "auth-result-shell",
+      "owner": "packages/ui/src/cloud/public-pages/pages/auth/auth-result-shell.tsx",
+      "symbol": "AuthResultShell",
+      "requiredAtomicDependencies": [],
+      "requiredRenderedTags": ["main"],
+      "requiredConsumerFiles": [
+        "packages/ui/src/cloud/public-pages/pages/auth/auth-error-page.tsx",
+        "packages/ui/src/cloud/public-pages/pages/auth/auth-success-page.tsx"
+      ],
+      "minimumMaintainedReferences": 2,
+      "responsibility": "Full-page surface, centered card, and content geometry for authentication results."
+    },
+    {
+      "id": "connection-capability-tile",
+      "owner": "packages/ui/src/cloud/connectors/connection-capability-tile.tsx",
+      "symbol": "ConnectionCapabilityTile",
+      "requiredAtomicDependencies": [],
+      "requiredRenderedTags": ["p"],
+      "requiredConsumerFiles": [
+        "packages/ui/src/cloud/connectors/google-connection.tsx",
+        "packages/ui/src/cloud/connectors/microsoft-connection.tsx"
+      ],
+      "minimumMaintainedReferences": 2,
+      "responsibility": "Icon, title, and description hierarchy for connector capability grids."
+    },
+    {
       "id": "content-state",
       "owner": "packages/ui/src/components/composites/page-panel/content-state.tsx",
       "symbol": "ContentState",

--- a/packages/ui/scripts/molecule-contracts.json
+++ b/packages/ui/scripts/molecule-contracts.json
@@ -1,0 +1,56 @@
+{
+  "schemaVersion": 1,
+  "contracts": [
+    {
+      "id": "content-state",
+      "owner": "packages/ui/src/components/composites/page-panel/content-state.tsx",
+      "symbol": "ContentState",
+      "requiredAtomicDependencies": [],
+      "requiredRenderedTags": ["LoadingContent", "PlainEmptyContent"],
+      "requiredConsumerFiles": [
+        "packages/ui/src/components/composites/page-panel/page-panel-empty.tsx",
+        "packages/ui/src/components/composites/page-panel/page-panel-loading.tsx"
+      ],
+      "minimumMaintainedReferences": 2,
+      "responsibility": "Empty and loading presentation inside page-panel placements."
+    },
+    {
+      "id": "settings-row",
+      "owner": "packages/ui/src/components/settings/settings-layout.tsx",
+      "symbol": "SettingsRow",
+      "requiredAtomicDependencies": ["button"],
+      "requiredRenderedTags": ["Button"],
+      "requiredConsumerFiles": [
+        "packages/ui/src/components/settings/settings-agent-rows.tsx",
+        "packages/ui/src/components/settings/cloud-panel/cloud-settings-primitives.tsx"
+      ],
+      "minimumMaintainedReferences": 10,
+      "responsibility": "Label, description, control, and navigation alignment for settings."
+    },
+    {
+      "id": "selectable-tile",
+      "owner": "packages/ui/src/components/composites/settings/selectable-tile.tsx",
+      "symbol": "SelectableTile",
+      "requiredAtomicDependencies": ["button"],
+      "requiredRenderedTags": ["Button"],
+      "requiredConsumerFiles": [
+        "packages/ui/src/components/settings/AppearanceSettingsSection.tsx"
+      ],
+      "minimumMaintainedReferences": 1,
+      "responsibility": "Pressed-state selection tile with a leading visual and check indicator."
+    },
+    {
+      "id": "action-list-row",
+      "owner": "packages/ui/src/components/shared/ActionListRow.tsx",
+      "symbol": "ActionListRow",
+      "requiredAtomicDependencies": ["button"],
+      "requiredRenderedTags": ["Button"],
+      "requiredConsumerFiles": [
+        "packages/ui/src/components/settings/LoadedPacksList.tsx",
+        "packages/ui/src/components/composites/skills/skill-sidebar-item.tsx"
+      ],
+      "minimumMaintainedReferences": 2,
+      "responsibility": "Button, link, and static list rows with shared content slots."
+    }
+  ]
+}

--- a/packages/ui/src/cloud/connectors/connection-capability-tile.stories.tsx
+++ b/packages/ui/src/cloud/connectors/connection-capability-tile.stories.tsx
@@ -1,0 +1,92 @@
+/** Story coverage for the shared connector capability tile molecule. */
+
+import type { Meta, StoryObj } from "@storybook/react";
+import { Calendar, Mail } from "lucide-react";
+import { ConnectionCapabilityTile } from "./connection-capability-tile";
+
+const meta = {
+  title: "Cloud/Connectors/ConnectionCapabilityTile",
+  component: ConnectionCapabilityTile,
+  parameters: { layout: "centered" },
+  decorators: [
+    (Story) => (
+      <div className="theme-cloud bg-bg p-4 text-txt">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof ConnectionCapabilityTile>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const MailCapability: Story = {
+  args: {
+    description: "Send and read emails",
+    icon: <Mail className="size-6 text-accent" aria-hidden />,
+    title: "Mail",
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-40">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const CalendarCapability: Story = {
+  args: {
+    description: "Manage events",
+    icon: <Calendar className="size-6 text-muted" aria-hidden />,
+    title: "Calendar",
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-40">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const GoogleCapabilityGrid: Story = {
+  args: MailCapability.args,
+  render: () => (
+    <div className="grid w-[320px] grid-cols-3 gap-3">
+      <ConnectionCapabilityTile
+        icon={<Mail className="size-6 text-accent" aria-hidden />}
+        title="Gmail"
+        description="Send and read emails"
+      />
+      <ConnectionCapabilityTile
+        icon={<Calendar className="size-6 text-txt" aria-hidden />}
+        title="Calendar"
+        description="Manage events across multiple shared calendars"
+      />
+      <ConnectionCapabilityTile
+        icon={<Mail className="size-6 text-accent" aria-hidden />}
+        title="Contacts"
+        description="Access contacts"
+      />
+    </div>
+  ),
+};
+
+export const MicrosoftCapabilityGrid: Story = {
+  args: CalendarCapability.args,
+  render: () => (
+    <div className="grid w-[320px] grid-cols-2 gap-3">
+      <ConnectionCapabilityTile
+        icon={<Mail className="size-6 text-muted" aria-hidden />}
+        title="Outlook"
+        description="Send and read emails"
+      />
+      <ConnectionCapabilityTile
+        icon={<Calendar className="size-6 text-muted" aria-hidden />}
+        title="Calendar"
+        description="Manage events"
+      />
+    </div>
+  ),
+};

--- a/packages/ui/src/cloud/connectors/connection-capability-tile.tsx
+++ b/packages/ui/src/cloud/connectors/connection-capability-tile.tsx
@@ -1,0 +1,29 @@
+/**
+ * Presents one provider capability inside a connector setup grid. Provider
+ * screens supply translated content and an identifying icon while this
+ * molecule owns the shared tile geometry and text hierarchy.
+ */
+
+import type { ReactNode } from "react";
+
+export interface ConnectionCapabilityTileProps {
+  description: string;
+  icon: ReactNode;
+  title: string;
+}
+
+export function ConnectionCapabilityTile({
+  description,
+  icon,
+  title,
+}: ConnectionCapabilityTileProps) {
+  return (
+    <div className="rounded-sm bg-muted p-3 text-center">
+      <div className="mx-auto mb-2 flex size-6 items-center justify-center">
+        {icon}
+      </div>
+      <p className="text-sm font-medium">{title}</p>
+      <p className="text-xs text-muted-foreground">{description}</p>
+    </div>
+  );
+}

--- a/packages/ui/src/cloud/connectors/google-connection.tsx
+++ b/packages/ui/src/cloud/connectors/google-connection.tsx
@@ -18,6 +18,7 @@ import {
 import { Badge } from "../../components/ui/badge";
 import { Button } from "../../components/ui/button";
 import { useCloudT } from "../shell/CloudI18nProvider";
+import { ConnectionCapabilityTile } from "./connection-capability-tile";
 import { useOAuthConnections } from "./oauth-connection";
 
 export function GoogleConnection() {
@@ -174,39 +175,31 @@ export function GoogleConnection() {
       setupContent={
         <div className="space-y-4">
           <div className="grid grid-cols-3 gap-3">
-            <div className="p-3 bg-muted rounded-sm text-center">
-              <Mail className="size-6 mx-auto mb-2 text-accent" />
-              <p className="text-sm font-medium">
-                {t("cloud.google.gmail", { defaultValue: "Gmail" })}
-              </p>
-              <p className="text-xs text-muted-foreground">
-                {t("cloud.google.gmailDesc", {
-                  defaultValue: "Send & read emails",
-                })}
-              </p>
-            </div>
-            <div className="p-3 bg-muted rounded-sm text-center">
-              <Calendar className="size-6 mx-auto mb-2 text-txt" />
-              <p className="text-sm font-medium">
-                {t("cloud.google.calendar", { defaultValue: "Calendar" })}
-              </p>
-              <p className="text-xs text-muted-foreground">
-                {t("cloud.google.calendarDesc", {
-                  defaultValue: "Manage events",
-                })}
-              </p>
-            </div>
-            <div className="p-3 bg-muted rounded-sm text-center">
-              <Users className="size-6 mx-auto mb-2 text-accent" />
-              <p className="text-sm font-medium">
-                {t("cloud.google.contacts", { defaultValue: "Contacts" })}
-              </p>
-              <p className="text-xs text-muted-foreground">
-                {t("cloud.google.contactsDesc", {
-                  defaultValue: "Access contacts",
-                })}
-              </p>
-            </div>
+            <ConnectionCapabilityTile
+              icon={<Mail className="size-6 text-accent" aria-hidden />}
+              title={t("cloud.google.gmail", { defaultValue: "Gmail" })}
+              description={t("cloud.google.gmailDesc", {
+                defaultValue: "Send & read emails",
+              })}
+            />
+            <ConnectionCapabilityTile
+              icon={<Calendar className="size-6 text-txt" aria-hidden />}
+              title={t("cloud.google.calendar", {
+                defaultValue: "Calendar",
+              })}
+              description={t("cloud.google.calendarDesc", {
+                defaultValue: "Manage events",
+              })}
+            />
+            <ConnectionCapabilityTile
+              icon={<Users className="size-6 text-accent" aria-hidden />}
+              title={t("cloud.google.contacts", {
+                defaultValue: "Contacts",
+              })}
+              description={t("cloud.google.contactsDesc", {
+                defaultValue: "Access contacts",
+              })}
+            />
           </div>
 
           <ConnectionCallout

--- a/packages/ui/src/cloud/connectors/microsoft-connection.tsx
+++ b/packages/ui/src/cloud/connectors/microsoft-connection.tsx
@@ -19,6 +19,7 @@ import {
 import { Badge } from "../../components/ui/badge";
 import { Button } from "../../components/ui/button";
 import { useCloudT } from "../shell/CloudI18nProvider";
+import { ConnectionCapabilityTile } from "./connection-capability-tile";
 import { useOAuthConnections } from "./oauth-connection";
 
 export function MicrosoftConnection() {
@@ -184,28 +185,24 @@ export function MicrosoftConnection() {
       setupContent={
         <div className="space-y-4">
           <div className="grid grid-cols-2 gap-3">
-            <div className="p-3 bg-muted rounded-sm text-center">
-              <Mail className="size-6 mx-auto mb-2 text-muted" />
-              <p className="text-sm font-medium">
-                {t("cloud.microsoft.outlook", { defaultValue: "Outlook" })}
-              </p>
-              <p className="text-xs text-muted-foreground">
-                {t("cloud.microsoft.outlookDesc", {
-                  defaultValue: "Send & read emails",
-                })}
-              </p>
-            </div>
-            <div className="p-3 bg-muted rounded-sm text-center">
-              <Calendar className="size-6 mx-auto mb-2 text-muted" />
-              <p className="text-sm font-medium">
-                {t("cloud.microsoft.calendar", { defaultValue: "Calendar" })}
-              </p>
-              <p className="text-xs text-muted-foreground">
-                {t("cloud.microsoft.calendarDesc", {
-                  defaultValue: "Manage events",
-                })}
-              </p>
-            </div>
+            <ConnectionCapabilityTile
+              icon={<Mail className="size-6 text-muted" aria-hidden />}
+              title={t("cloud.microsoft.outlook", {
+                defaultValue: "Outlook",
+              })}
+              description={t("cloud.microsoft.outlookDesc", {
+                defaultValue: "Send & read emails",
+              })}
+            />
+            <ConnectionCapabilityTile
+              icon={<Calendar className="size-6 text-muted" aria-hidden />}
+              title={t("cloud.microsoft.calendar", {
+                defaultValue: "Calendar",
+              })}
+              description={t("cloud.microsoft.calendarDesc", {
+                defaultValue: "Manage events",
+              })}
+            />
           </div>
 
           <ConnectionCallout

--- a/packages/ui/src/cloud/public-pages/pages/auth/auth-error-page.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/auth/auth-error-page.tsx
@@ -8,6 +8,7 @@ import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import { Button } from "../../../../components/primitives";
 import { useCloudT } from "../../../shell/CloudI18nProvider";
 import { usePageTitle } from "../../lib/use-page-title";
+import { AuthResultShell } from "./auth-result-shell";
 
 export default function AuthErrorPage() {
   const t = useCloudT();
@@ -55,44 +56,40 @@ export default function AuthErrorPage() {
   const error = errorMessages[reason] || errorMessages.unknown;
 
   return (
-    <div className="theme-cloud relative flex min-h-[100dvh] items-center justify-center bg-bg p-4">
-      <div className="relative w-full max-w-md bg-card border border-border p-8">
-        <div className="flex flex-col items-center gap-6 text-center">
-          <div className="flex size-14 items-center justify-center bg-destructive-subtle">
-            <AlertCircle className="size-7 text-destructive" />
-          </div>
-          <div className="space-y-2">
-            <h2 className="text-xl font-semibold text-txt">{error.title}</h2>
-            <p className="text-sm text-muted">{error.description}</p>
-          </div>
-
-          <div className="w-full space-y-3">
-            <Button
-              onClick={() => navigate("/login")}
-              className="w-full h-11 bg-accent hover:bg-accent-hover text-accent-foreground"
-            >
-              <RefreshCw className="size-4 mr-2" />
-              {t("cloud.authError.tryAgain", { defaultValue: "Try Again" })}
-            </Button>
-            <Button
-              variant="outline"
-              asChild
-              className="w-full h-11 border-border hover:bg-bg-hover"
-            >
-              <Link to="/">
-                <Home className="size-4 mr-2" />
-                {t("cloud.authError.goHome", { defaultValue: "Go Home" })}
-              </Link>
-            </Button>
-          </div>
-
-          <p className="text-xs text-muted">
-            {t("cloud.authError.contactSupport", {
-              defaultValue: "If this problem persists, please contact support.",
-            })}
-          </p>
-        </div>
+    <AuthResultShell>
+      <div className="flex size-14 items-center justify-center bg-destructive-subtle">
+        <AlertCircle className="size-7 text-destructive" />
       </div>
-    </div>
+      <div className="space-y-2">
+        <h2 className="text-xl font-semibold text-txt">{error.title}</h2>
+        <p className="text-sm text-muted">{error.description}</p>
+      </div>
+
+      <div className="w-full space-y-3">
+        <Button
+          onClick={() => navigate("/login")}
+          className="w-full h-11 bg-accent hover:bg-accent-hover text-accent-foreground"
+        >
+          <RefreshCw className="size-4 mr-2" />
+          {t("cloud.authError.tryAgain", { defaultValue: "Try Again" })}
+        </Button>
+        <Button
+          variant="outline"
+          asChild
+          className="w-full h-11 border-border hover:bg-bg-hover"
+        >
+          <Link to="/">
+            <Home className="size-4 mr-2" />
+            {t("cloud.authError.goHome", { defaultValue: "Go Home" })}
+          </Link>
+        </Button>
+      </div>
+
+      <p className="text-xs text-muted">
+        {t("cloud.authError.contactSupport", {
+          defaultValue: "If this problem persists, please contact support.",
+        })}
+      </p>
+    </AuthResultShell>
   );
 }

--- a/packages/ui/src/cloud/public-pages/pages/auth/auth-result-shell.stories.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/auth/auth-result-shell.stories.tsx
@@ -1,0 +1,75 @@
+/** Storybook states for the shared public authentication result shell. */
+
+import type { Meta, StoryObj } from "@storybook/react";
+import { AlertCircle, CheckCircle, Loader2 } from "lucide-react";
+import { Button } from "../../../../components/primitives";
+import { AuthResultShell } from "./auth-result-shell";
+
+const meta = {
+  title: "Cloud/Public/AuthResultShell",
+  component: AuthResultShell,
+  tags: ["autodocs"],
+  args: {
+    children: (
+      <>
+        <div className="flex size-14 items-center justify-center bg-status-success-bg">
+          <CheckCircle className="size-7 text-status-success" aria-hidden />
+        </div>
+        <div className="space-y-2">
+          <h1 className="text-xl font-semibold text-txt">Account connected</h1>
+          <p className="text-sm text-muted">Return to the app to continue.</p>
+        </div>
+      </>
+    ),
+  },
+} satisfies Meta<typeof AuthResultShell>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Success: Story = {};
+
+export const Pending: Story = {
+  args: {
+    children: (
+      <>
+        <div className="flex size-14 items-center justify-center bg-bg-muted">
+          <Loader2 className="size-7 animate-spin text-muted" aria-hidden />
+        </div>
+        <div className="space-y-2">
+          <h1 className="text-xl font-semibold text-txt">
+            Verifying connection
+          </h1>
+          <p className="text-sm text-muted">Confirming this connection…</p>
+        </div>
+      </>
+    ),
+  },
+};
+
+export const ErrorState: Story = {
+  args: {
+    children: (
+      <>
+        <div className="flex size-14 items-center justify-center bg-destructive-subtle">
+          <AlertCircle className="size-7 text-destructive" aria-hidden />
+        </div>
+        <div className="space-y-2">
+          <h1 className="text-xl font-semibold text-txt">
+            Authentication failed
+          </h1>
+          <p className="text-sm text-muted">Please try signing in again.</p>
+        </div>
+        <div className="w-full space-y-3">
+          <Button className="h-11 w-full">Try again</Button>
+          <Button className="h-11 w-full" variant="outline">
+            Go home
+          </Button>
+        </div>
+        <p className="text-xs text-muted">
+          If this problem persists, please contact support.
+        </p>
+      </>
+    ),
+  },
+};

--- a/packages/ui/src/cloud/public-pages/pages/auth/auth-result-shell.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/auth/auth-result-shell.tsx
@@ -1,0 +1,23 @@
+/**
+ * Owns the shared full-page surface and centered card geometry for public
+ * authentication result states. Callers retain state-specific content and
+ * actions while composing one canonical shell.
+ */
+
+import type { ReactNode } from "react";
+
+export interface AuthResultShellProps {
+  children: ReactNode;
+}
+
+export function AuthResultShell({ children }: AuthResultShellProps) {
+  return (
+    <main className="theme-cloud relative flex min-h-[100dvh] items-center justify-center bg-bg p-4">
+      <div className="relative w-full max-w-md border border-border bg-card p-8">
+        <div className="flex flex-col items-center gap-6 text-center">
+          {children}
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/packages/ui/src/cloud/public-pages/pages/auth/auth-success-page.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/auth/auth-success-page.tsx
@@ -26,6 +26,7 @@ import { getBootConfig } from "../../../../config/boot-config";
 import { ApiError, api, readCloudBearerToken } from "../../../lib/api-client";
 import { useCloudT } from "../../../shell/CloudI18nProvider";
 import { usePageTitle } from "../../lib/use-page-title";
+import { AuthResultShell } from "./auth-result-shell";
 
 /** Hosts that may receive OAuth success redirects but are not Eliza Cloud. */
 const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "[::1]", "::1"]);
@@ -646,75 +647,67 @@ export default function AuthSuccessPage() {
 
   if (view.phase === "pending") {
     return (
-      <div className="theme-cloud relative flex min-h-[100dvh] items-center justify-center bg-bg p-4">
-        <div className="relative w-full max-w-md bg-card border border-border p-8">
-          <div className="flex flex-col items-center gap-6 text-center">
-            <div className="flex size-14 items-center justify-center bg-bg-muted">
-              <Loader2 className="size-7 animate-spin text-muted" aria-hidden />
-            </div>
-            <div className="space-y-2">
-              <h1 className="text-xl font-semibold text-txt">
-                {t("cloud.authSuccess.pendingTitle", {
-                  defaultValue: "Verifying Connection",
-                })}
-              </h1>
-              <p className="text-sm text-muted">
-                {t("cloud.authSuccess.pendingDescription", {
-                  defaultValue: "Confirming this connection with Eliza Cloud…",
-                })}
-              </p>
-            </div>
-          </div>
+      <AuthResultShell>
+        <div className="flex size-14 items-center justify-center bg-bg-muted">
+          <Loader2 className="size-7 animate-spin text-muted" aria-hidden />
         </div>
-      </div>
+        <div className="space-y-2">
+          <h1 className="text-xl font-semibold text-txt">
+            {t("cloud.authSuccess.pendingTitle", {
+              defaultValue: "Verifying Connection",
+            })}
+          </h1>
+          <p className="text-sm text-muted">
+            {t("cloud.authSuccess.pendingDescription", {
+              defaultValue: "Confirming this connection with Eliza Cloud…",
+            })}
+          </p>
+        </div>
+      </AuthResultShell>
     );
   }
 
   if (view.phase === "unavailable") {
     return (
-      <div className="theme-cloud relative flex min-h-[100dvh] items-center justify-center bg-bg p-4">
-        <div className="relative w-full max-w-md bg-card border border-border p-8">
-          <div className="flex flex-col items-center gap-6 text-center">
-            <div className="flex size-14 items-center justify-center bg-bg-muted">
-              <AlertCircle className="size-7 text-muted" aria-hidden />
-            </div>
-            <div className="space-y-2">
-              <h1 className="text-xl font-semibold text-txt">
-                {t("cloud.authSuccess.unavailableTitle", {
-                  defaultValue: "Could Not Reach Eliza Cloud",
-                })}
-              </h1>
-              <p className="text-sm text-muted">
-                {t("cloud.authSuccess.unavailableDescription", {
-                  defaultValue:
-                    "We could not verify this connection because the verification service is temporarily unavailable. Try again in a moment.",
-                })}
-              </p>
-            </div>
-            <div className="w-full space-y-3">
-              <Button
-                onClick={() => window.location.reload()}
-                className="w-full h-11 bg-accent hover:bg-accent-hover text-accent-foreground"
-              >
-                <RefreshCw className="size-4 mr-2" aria-hidden />
-                {t("cloud.authSuccess.tryAgain", {
-                  defaultValue: "Try Again",
-                })}
-              </Button>
-              <Button
-                variant="outline"
-                asChild
-                className="w-full h-11 border-border hover:bg-bg-hover"
-              >
-                <Link to="/">
-                  <Home className="size-4 mr-2" aria-hidden />
-                  {t("cloud.authSuccess.goHome", { defaultValue: "Go Home" })}
-                </Link>
-              </Button>
-            </div>
-          </div>
+      <AuthResultShell>
+        <div className="flex size-14 items-center justify-center bg-bg-muted">
+          <AlertCircle className="size-7 text-muted" aria-hidden />
         </div>
-      </div>
+        <div className="space-y-2">
+          <h1 className="text-xl font-semibold text-txt">
+            {t("cloud.authSuccess.unavailableTitle", {
+              defaultValue: "Could Not Reach Eliza Cloud",
+            })}
+          </h1>
+          <p className="text-sm text-muted">
+            {t("cloud.authSuccess.unavailableDescription", {
+              defaultValue:
+                "We could not verify this connection because the verification service is temporarily unavailable. Try again in a moment.",
+            })}
+          </p>
+        </div>
+        <div className="w-full space-y-3">
+          <Button
+            onClick={() => window.location.reload()}
+            className="w-full h-11 bg-accent hover:bg-accent-hover text-accent-foreground"
+          >
+            <RefreshCw className="size-4 mr-2" aria-hidden />
+            {t("cloud.authSuccess.tryAgain", {
+              defaultValue: "Try Again",
+            })}
+          </Button>
+          <Button
+            variant="outline"
+            asChild
+            className="w-full h-11 border-border hover:bg-bg-hover"
+          >
+            <Link to="/">
+              <Home className="size-4 mr-2" aria-hidden />
+              {t("cloud.authSuccess.goHome", { defaultValue: "Go Home" })}
+            </Link>
+          </Button>
+        </div>
+      </AuthResultShell>
     );
   }
 
@@ -731,94 +724,86 @@ export default function AuthSuccessPage() {
           });
 
     return (
-      <div className="theme-cloud relative flex min-h-[100dvh] items-center justify-center bg-bg p-4">
-        <div className="relative w-full max-w-md bg-card border border-border p-8">
-          <div className="flex flex-col items-center gap-6 text-center">
-            <div className="flex size-14 items-center justify-center bg-destructive-subtle">
-              <AlertCircle className="size-7 text-destructive" aria-hidden />
-            </div>
-            <div className="space-y-2">
-              <h1 className="text-xl font-semibold text-txt">
-                {t("cloud.authSuccess.unverifiedTitle", {
-                  defaultValue: "Connection Could Not Be Verified",
-                })}
-              </h1>
-              <p className="text-sm text-muted">{description}</p>
-            </div>
-
-            <div className="w-full space-y-3">
-              <Button
-                onClick={() => navigate("/login")}
-                className="w-full h-11 bg-accent hover:bg-accent-hover text-accent-foreground"
-              >
-                <RefreshCw className="size-4 mr-2" aria-hidden />
-                {t("cloud.authSuccess.backToSignIn", {
-                  defaultValue: "Back to Sign In",
-                })}
-              </Button>
-              <Button
-                variant="outline"
-                asChild
-                className="w-full h-11 border-border hover:bg-bg-hover"
-              >
-                <Link to="/">
-                  <Home className="size-4 mr-2" aria-hidden />
-                  {t("cloud.authSuccess.goHome", { defaultValue: "Go Home" })}
-                </Link>
-              </Button>
-            </div>
-          </div>
+      <AuthResultShell>
+        <div className="flex size-14 items-center justify-center bg-destructive-subtle">
+          <AlertCircle className="size-7 text-destructive" aria-hidden />
         </div>
-      </div>
+        <div className="space-y-2">
+          <h1 className="text-xl font-semibold text-txt">
+            {t("cloud.authSuccess.unverifiedTitle", {
+              defaultValue: "Connection Could Not Be Verified",
+            })}
+          </h1>
+          <p className="text-sm text-muted">{description}</p>
+        </div>
+
+        <div className="w-full space-y-3">
+          <Button
+            onClick={() => navigate("/login")}
+            className="w-full h-11 bg-accent hover:bg-accent-hover text-accent-foreground"
+          >
+            <RefreshCw className="size-4 mr-2" aria-hidden />
+            {t("cloud.authSuccess.backToSignIn", {
+              defaultValue: "Back to Sign In",
+            })}
+          </Button>
+          <Button
+            variant="outline"
+            asChild
+            className="w-full h-11 border-border hover:bg-bg-hover"
+          >
+            <Link to="/">
+              <Home className="size-4 mr-2" aria-hidden />
+              {t("cloud.authSuccess.goHome", { defaultValue: "Go Home" })}
+            </Link>
+          </Button>
+        </div>
+      </AuthResultShell>
     );
   }
 
   const { platformDisplay } = view;
 
   return (
-    <div className="theme-cloud relative flex min-h-[100dvh] items-center justify-center bg-bg p-4">
-      <div className="relative w-full max-w-md bg-card border border-border p-8">
-        <div className="flex flex-col items-center gap-6 text-center">
-          <div className="flex size-14 items-center justify-center bg-status-success-bg">
-            <CheckCircle className="size-7 text-status-success" aria-hidden />
-          </div>
-          <div className="space-y-2">
-            <h1 className="text-xl font-semibold text-txt">
-              {t("cloud.authSuccess.platformConnected", {
-                platform: platformDisplay,
-                defaultValue: "{{platform}} Connected",
-              })}
-            </h1>
-            <p className="text-sm text-muted">
-              {t("cloud.authSuccess.platformAccountConnected", {
-                platform: platformDisplay,
-                defaultValue:
-                  "Your {{platform}} account has been connected successfully.",
-              })}
-            </p>
-          </div>
-
-          <p className="text-xs text-muted">
-            {t("cloud.authSuccess.returnToApp", {
-              defaultValue: "Return to the app to continue.",
-            })}
-          </p>
-
-          <div className="w-full">
-            <Button
-              variant="outline"
-              asChild
-              className="w-full h-11 border-border hover:bg-bg-hover"
-            >
-              <Link to="/">
-                {t("cloud.authSuccess.returnToAppCta", {
-                  defaultValue: "Return to App",
-                })}
-              </Link>
-            </Button>
-          </div>
-        </div>
+    <AuthResultShell>
+      <div className="flex size-14 items-center justify-center bg-status-success-bg">
+        <CheckCircle className="size-7 text-status-success" aria-hidden />
       </div>
-    </div>
+      <div className="space-y-2">
+        <h1 className="text-xl font-semibold text-txt">
+          {t("cloud.authSuccess.platformConnected", {
+            platform: platformDisplay,
+            defaultValue: "{{platform}} Connected",
+          })}
+        </h1>
+        <p className="text-sm text-muted">
+          {t("cloud.authSuccess.platformAccountConnected", {
+            platform: platformDisplay,
+            defaultValue:
+              "Your {{platform}} account has been connected successfully.",
+          })}
+        </p>
+      </div>
+
+      <p className="text-xs text-muted">
+        {t("cloud.authSuccess.returnToApp", {
+          defaultValue: "Return to the app to continue.",
+        })}
+      </p>
+
+      <div className="w-full">
+        <Button
+          variant="outline"
+          asChild
+          className="w-full h-11 border-border hover:bg-bg-hover"
+        >
+          <Link to="/">
+            {t("cloud.authSuccess.returnToAppCta", {
+              defaultValue: "Return to App",
+            })}
+          </Link>
+        </Button>
+      </div>
+    </AuthResultShell>
   );
 }


### PR DESCRIPTION
Closes #28349

Follow-up to the closed #28366 after independent standards, enforcement, and UI/accessibility review.

## What changed
- extracts `AuthResultShell` across five public auth result states
- extracts `ConnectionCapabilityTile` across Google and Microsoft connector setup grids
- validates the molecule registry fail-closed at the JSON boundary
- resolves canonical consumers through TypeScript imports, aliases, barrels, and JSX usage instead of source-text matching
- adds Cloud-themed, responsive Storybook coverage and refreshes the committed molecular inventory

## Verification
- `bun run --cwd packages/ui lint:check`
- `bun run --cwd packages/ui typecheck`
- auth-success Vitest: 27/27
- molecular inventory tests: 7/7
- `bun run verify`
- `ELIZA_NODE_PATH=/opt/homebrew/opt/node@24/bin/node bun run --cwd packages/app audit:app`: 227/227; broken=0, needs-work=0

The repository forbids CSS-literal tests, so molecular geometry is proven through rendered stories and the app audit; static enforcement is limited to ownership and real composition bindings.