### PR TITLE
test(cloud-apps): cover interrupted domain purchase fact lifecycle

### DIFF
--- a/plugins/plugin-cloud-apps/src/domain-facts.test.ts
+++ b/plugins/plugin-cloud-apps/src/domain-facts.test.ts
@@ -1,0 +1,190 @@
+import { MemoryType } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import {
+  hasInterruptedDomainPurchase,
+  INTERRUPTED_DOMAIN_PURCHASE_SOURCE,
+  recordInterruptedDomainPurchase,
+  removeInterruptedDomainPurchase,
+} from "./domain-facts";
+
+const SOURCE = INTERRUPTED_DOMAIN_PURCHASE_SOURCE;
+
+function interruptedRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "fact-1",
+    entityId: "entity-1",
+    agentId: "agent-1",
+    roomId: "room-1",
+    content: { text: "purchase interrupted", type: "fact" },
+    metadata: {
+      type: MemoryType.CUSTOM,
+      source: SOURCE,
+      appId: "app-1",
+      domain: "example.com",
+      ...overrides,
+    },
+  };
+}
+
+function makeRuntime(overrides: Record<string, unknown> = {}) {
+  return {
+    getMemories: vi.fn(async () => []),
+    createMemory: vi.fn(async () => undefined),
+    deleteMemory: vi.fn(async () => undefined),
+    agentId: "agent-1",
+    ...overrides,
+  } as never;
+}
+
+const message = { entityId: "entity-1", roomId: "room-1" } as never;
+const app = { id: "app-1", name: "My App" } as never;
+
+describe("interrupted domain purchase durable fact", () => {
+  it("reports false when no matching fact exists", async () => {
+    const runtime = makeRuntime();
+    await expect(
+      hasInterruptedDomainPurchase(runtime, message, "app-1", "example.com"),
+    ).resolves.toBe(false);
+  });
+
+  it("finds a matching fact by source, appId and domain", async () => {
+    const runtime = makeRuntime({
+      getMemories: vi.fn(async () => [interruptedRow()]),
+    });
+    await expect(
+      hasInterruptedDomainPurchase(runtime, message, "app-1", "example.com"),
+    ).resolves.toBe(true);
+  });
+
+  it("does not match a different app or domain", async () => {
+    const runtime = makeRuntime({
+      getMemories: vi.fn(async () => [interruptedRow()]),
+    });
+    await expect(
+      hasInterruptedDomainPurchase(runtime, message, "app-1", "other.com"),
+    ).resolves.toBe(false);
+    await expect(
+      hasInterruptedDomainPurchase(runtime, message, "app-2", "example.com"),
+    ).resolves.toBe(false);
+  });
+
+  it("scopes the lookup to the sender entity and skips the read without one", async () => {
+    const getMemories = vi.fn(async () => [interruptedRow()]);
+    const runtime = makeRuntime({ getMemories });
+    await expect(
+      hasInterruptedDomainPurchase(
+        runtime,
+        { roomId: "room-1" } as never,
+        "app-1",
+        "example.com",
+      ),
+    ).resolves.toBe(false);
+    expect(getMemories).not.toHaveBeenCalled();
+  });
+
+  it("fails soft when the memory read throws", async () => {
+    const runtime = makeRuntime({
+      getMemories: vi.fn(async () => {
+        throw new Error("db down");
+      }),
+    });
+    await expect(
+      hasInterruptedDomainPurchase(runtime, message, "app-1", "example.com"),
+    ).resolves.toBe(false);
+  });
+
+  it("records a durable fact tagged with the interrupted-purchase source", async () => {
+    const createMemory = vi.fn(async () => undefined);
+    const runtime = makeRuntime({ createMemory });
+    const ok = await recordInterruptedDomainPurchase(
+      runtime,
+      message,
+      app,
+      "example.com",
+    );
+    expect(ok).toBe(true);
+    const memory = createMemory.mock.calls[0][0] as {
+      entityId: string;
+      metadata: Record<string, unknown>;
+    };
+    expect(memory.entityId).toBe("entity-1");
+    expect(memory.metadata.source).toBe(SOURCE);
+    expect(memory.metadata.appId).toBe("app-1");
+    expect(memory.metadata.domain).toBe("example.com");
+    expect(memory.metadata.kind).toBe("durable");
+    expect(createMemory).toHaveBeenCalledWith(expect.anything(), "facts", true);
+  });
+
+  it("is idempotent — never creates a duplicate when the fact already exists", async () => {
+    const createMemory = vi.fn(async () => undefined);
+    const runtime = makeRuntime({
+      getMemories: vi.fn(async () => [interruptedRow()]),
+      createMemory,
+    });
+    const ok = await recordInterruptedDomainPurchase(
+      runtime,
+      message,
+      app,
+      "example.com",
+    );
+    expect(ok).toBe(true);
+    expect(createMemory).not.toHaveBeenCalled();
+  });
+
+  it("refuses to record without an entity id", async () => {
+    const createMemory = vi.fn(async () => undefined);
+    const runtime = makeRuntime({ createMemory });
+    const ok = await recordInterruptedDomainPurchase(
+      runtime,
+      { roomId: "room-1" } as never,
+      app,
+      "example.com",
+    );
+    expect(ok).toBe(false);
+    expect(createMemory).not.toHaveBeenCalled();
+  });
+
+  it("fails soft when recording throws", async () => {
+    const runtime = makeRuntime({
+      createMemory: vi.fn(async () => {
+        throw new Error("boom");
+      }),
+    });
+    const ok = await recordInterruptedDomainPurchase(
+      runtime,
+      message,
+      app,
+      "example.com",
+    );
+    expect(ok).toBe(false);
+  });
+
+  it("removes the fact after a successful buy", async () => {
+    const deleteMemory = vi.fn(async () => undefined);
+    const runtime = makeRuntime({
+      getMemories: vi.fn(async () => [interruptedRow()]),
+      deleteMemory,
+    });
+    const ok = await removeInterruptedDomainPurchase(
+      runtime,
+      message,
+      "app-1",
+      "example.com",
+    );
+    expect(ok).toBe(true);
+    expect(deleteMemory).toHaveBeenCalledWith("fact-1");
+  });
+
+  it("does not delete when no fact is on record", async () => {
+    const deleteMemory = vi.fn(async () => undefined);
+    const runtime = makeRuntime({ deleteMemory });
+    const ok = await removeInterruptedDomainPurchase(
+      runtime,
+      message,
+      "app-1",
+      "example.com",
+    );
+    expect(ok).toBe(false);
+    expect(deleteMemory).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
# Relates to

No issue; behavioral coverage for the interrupted-domain-purchase durable
fact (`plugin-cloud-apps`).

The marker is money-critical: it is the only record that a charged +
registered domain was never attached, so a retried buy can finish it without
a second charge. The tests pin the fail-soft contract (a memory error never
fails the action), entity scoping, idempotent recording, and removal after a
successful buy — regressions here would produce wrong "domain unavailable"
advice for a domain the user already paid for.

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] Focused vitest verification ran in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new test file exercising existing exported
functions against a stubbed runtime. No production code is modified.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: 1 file, 11 tests passed — see log below |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

```log
Test Files  1 passed (1)
     Tests  11 passed (11)
```

- Command: `npx vitest run domain-facts.test.ts`
- Result: all passed

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
