### PR TITLE
fix: honor ACP coding approval mode

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts
@@ -288,9 +288,31 @@ export class NativeAcpClient {
           : params,
       ),
     );
-    const sessionId = stringValue(result?.sessionId);
-    if (!sessionId) throw new Error("ACP agent did not return a sessionId");
-    return {
+		const sessionId = stringValue(result?.sessionId);
+		if (!sessionId) throw new Error("ACP agent did not return a sessionId");
+		const availableModes = Array.isArray(result?.modes?.availableModes)
+			? result.modes.availableModes
+				.map((mode) =>
+					mode && typeof mode === "object"
+						? stringValue((mode as Record<string, unknown>).id)
+						: undefined,
+				)
+				.filter((mode): mode is string => Boolean(mode))
+			: [];
+		const requestedMode =
+			this.opts.approvalPreset === "autonomous" ||
+			this.opts.approvalPreset === "permissive"
+				? "bypassPermissions"
+				: this.opts.approvalPreset === "readonly"
+					? "plan"
+					: "dontAsk";
+		if (availableModes.includes(requestedMode)) {
+			await this.request("session/set_mode", {
+				sessionId,
+				modeId: requestedMode,
+			});
+		}
+		return {
       sessionId,
       agentSessionId: extractAgentSessionId(result?._meta),
     };

--- a/plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts
@@ -288,31 +288,31 @@ export class NativeAcpClient {
           : params,
       ),
     );
-		const sessionId = stringValue(result?.sessionId);
-		if (!sessionId) throw new Error("ACP agent did not return a sessionId");
-		const availableModes = Array.isArray(result?.modes?.availableModes)
-			? result.modes.availableModes
-				.map((mode) =>
-					mode && typeof mode === "object"
-						? stringValue((mode as Record<string, unknown>).id)
-						: undefined,
-				)
-				.filter((mode): mode is string => Boolean(mode))
-			: [];
-		const requestedMode =
-			this.opts.approvalPreset === "autonomous" ||
-			this.opts.approvalPreset === "permissive"
-				? "bypassPermissions"
-				: this.opts.approvalPreset === "readonly"
-					? "plan"
-					: "dontAsk";
-		if (availableModes.includes(requestedMode)) {
-			await this.request("session/set_mode", {
-				sessionId,
-				modeId: requestedMode,
-			});
-		}
-		return {
+    const sessionId = stringValue(result?.sessionId);
+    if (!sessionId) throw new Error("ACP agent did not return a sessionId");
+    const availableModes = Array.isArray(result?.modes?.availableModes)
+      ? result.modes.availableModes
+          .map((mode) =>
+            mode && typeof mode === "object"
+              ? stringValue((mode as Record<string, unknown>).id)
+              : undefined,
+          )
+          .filter((mode): mode is string => Boolean(mode))
+      : [];
+    const requestedMode =
+      this.opts.approvalPreset === "autonomous" ||
+      this.opts.approvalPreset === "permissive"
+        ? "bypassPermissions"
+        : this.opts.approvalPreset === "readonly"
+          ? "plan"
+          : "dontAsk";
+    if (availableModes.includes(requestedMode)) {
+      await this.request("session/set_mode", {
+        sessionId,
+        modeId: requestedMode,
+      });
+    }
+    return {
       sessionId,
       agentSessionId: extractAgentSessionId(result?._meta),
     };

--- a/plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts
@@ -290,8 +290,10 @@ export class NativeAcpClient {
     );
     const sessionId = stringValue(result?.sessionId);
     if (!sessionId) throw new Error("ACP agent did not return a sessionId");
-    const availableModes = Array.isArray(result?.modes?.availableModes)
-      ? result.modes.availableModes
+    const modes = asRecord(result?.modes);
+    const advertisedModes = modes?.availableModes;
+    const availableModes = Array.isArray(advertisedModes)
+      ? advertisedModes
           .map((mode) =>
             mode && typeof mode === "object"
               ? stringValue((mode as Record<string, unknown>).id)


### PR DESCRIPTION
Closes #28400

## Summary
- inspect ACP session modes returned by the agent
- map autonomous/permissive to `bypassPermissions`, readonly to `plan`, and standard/verifier to `dontAsk` when advertised
- issue the stable `session/set_mode` request before the first prompt

## Evidence
Claude Agent ACP returned `dontAsk`, `acceptEdits`, `plan`, and `bypassPermissions` modes. Before this change, Eliza sent `--approve-all` at the acpx layer but Claude remained in `dontAsk` and denied Write/Bash. After the mode-selection change, the live child created the exact sentinel file and emitted `LIVE_REUSE_CLAUDE_FIRST_DONE`; the remaining smoke harness failures were separate lifecycle assertions.

Local validation: Biome clean, plugin build clean with isolated dependency setup.