### PR TITLE
test(agent-skills): cover sync catalog task lifecycle

### DIFF
--- a/plugins/plugin-agent-skills/src/tasks/sync-catalog.test.ts
+++ b/plugins/plugin-agent-skills/src/tasks/sync-catalog.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { startSyncTask, syncCatalogTask } from "./sync-catalog";
+
+const SYNC_INTERVAL_MS = 1000 * 60 * 60;
+
+function makeRuntime(overrides: Record<string, unknown> = {}) {
+  return {
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    reportError: vi.fn(),
+    ...overrides,
+  } as never;
+}
+
+describe("skill catalog sync task", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("warns and returns when the skills service is unavailable", async () => {
+    const runtime = makeRuntime({ getService: vi.fn(() => undefined) });
+    await syncCatalogTask.execute(runtime);
+    expect(runtime.logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("service not available"),
+    );
+    expect(runtime.reportError).not.toHaveBeenCalled();
+  });
+
+  it("logs the sync result on success", async () => {
+    const runtime = makeRuntime({
+      getService: vi.fn(() => ({
+        syncCatalog: vi.fn(async () => ({ updated: 3, added: 1 })),
+      })),
+    });
+    await syncCatalogTask.execute(runtime);
+    expect(runtime.logger.info).toHaveBeenCalledWith(
+      expect.stringContaining("3 skills, 1 new"),
+    );
+    expect(runtime.reportError).not.toHaveBeenCalled();
+  });
+
+  it("surfaces sync failures via reportError without rethrowing", async () => {
+    const boom = new Error("registry timeout");
+    const runtime = makeRuntime({
+      getService: vi.fn(() => ({
+        syncCatalog: vi.fn(async () => {
+          throw boom;
+        }),
+      })),
+    });
+    await expect(syncCatalogTask.execute(runtime)).resolves.toBeUndefined();
+    expect(runtime.reportError).toHaveBeenCalledWith(
+      "AgentSkills.catalogSync",
+      boom,
+    );
+  });
+
+  it("does not run eagerly — the interval owns the periodic refresh", async () => {
+    const execute = vi.spyOn(syncCatalogTask, "execute");
+    const runtime = makeRuntime();
+    const cleanup = startSyncTask(runtime);
+    expect(execute).not.toHaveBeenCalled();
+    cleanup();
+  });
+
+  it("runs the sync on each interval tick and stops after cleanup", async () => {
+    const execute = vi.spyOn(syncCatalogTask, "execute").mockResolvedValue();
+    const runtime = makeRuntime();
+    const cleanup = startSyncTask(runtime);
+    await vi.advanceTimersByTimeAsync(SYNC_INTERVAL_MS);
+    expect(execute).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(SYNC_INTERVAL_MS);
+    expect(execute).toHaveBeenCalledTimes(2);
+    cleanup();
+    await vi.advanceTimersByTimeAsync(SYNC_INTERVAL_MS * 3);
+    expect(execute).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
# Relates to

No issue; behavioral coverage for the skill-catalog background sync task
(`plugin-agent-skills`).

The task runs on a one-hour interval; its value is the error policy, not the
sync itself. The tests pin: no eager execution (initial sync belongs to
service init), warn-and-return when the skills service is missing, success
logging, `reportError` surfacing without rethrow on sync failure, and that
cleanup actually stops the interval so a stale loop cannot keep firing.

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] Focused vitest verification ran in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new test file exercising existing exported
functions with fake timers and a stubbed runtime. No production code is
modified.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: 1 file, 5 tests passed — see log below |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

```log
Test Files  1 passed (1)
     Tests  5 passed (5)
```

- Command: `npx vitest run sync-catalog.test.ts`
- Result: all passed

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
