### PR TITLE
fix(skills): scan to the first valid frontmatter closer instead of truncating

### DIFF
--- a/packages/skills/src/frontmatter.ts
+++ b/packages/skills/src/frontmatter.ts
@@ -68,14 +68,29 @@ function extractFrontmatter(content: string): {
     return { yamlString: null, body: normalized };
   }
 
+  // Scan forward to the first line that actually closes the block. A `\n---`
+  // sequence can also occur inside a quoted multi-line YAML scalar (e.g. a
+  // description quoting a markdown rule); cutting there truncates the value
+  // and turns legal frontmatter into invalid YAML.
   const startOffset = openMatch[0].length;
-  const endIndex = normalized.indexOf("\n---", startOffset - 1);
+  // Start one character back so an immediately adjacent closer (an empty
+  // frontmatter block, `---\n---`) is still recognized as a candidate.
+  let cursor = startOffset - 1;
+  let endIndex = -1;
+  while (cursor < normalized.length) {
+    const candidate = normalized.indexOf("\n---", cursor);
+    if (candidate === -1) break;
+    if (/^---\s*(?:\n|$)/.test(normalized.slice(candidate + 1))) {
+      endIndex = candidate;
+      break;
+    }
+    cursor = candidate + 1;
+  }
   if (endIndex === -1) {
     return { yamlString: null, body: normalized };
   }
 
-  const afterClosing = normalized.slice(endIndex + 1);
-  const closeMatch = afterClosing.match(/^---\s*(?:\n|$)/);
+  const closeMatch = normalized.slice(endIndex + 1).match(/^---\s*(?:\n|$)/);
   const closingLength = closeMatch ? closeMatch[0].length : 4;
 
   return {

--- a/packages/skills/test/frontmatter.test.ts
+++ b/packages/skills/test/frontmatter.test.ts
@@ -72,6 +72,35 @@ Body`;
     assert.deepStrictEqual(result.frontmatter, {});
   });
 
+  it("rejects a typo'd ---- separator instead of swallowing frontmatter into the body", () => {
+    const content =
+      '---\ndescription: "A skill"\nname: my-skill\n----\nversion: 2\n---\nBody';
+    assert.throws(() => parseFrontmatter(content), (error: unknown) => {
+      assert.ok(error instanceof ElizaError);
+      assert.equal(error.code, INVALID_SKILL_FRONTMATTER_YAML);
+      return true;
+    });
+  });
+
+  it("preserves a dashes rule inside the body after a valid closer", () => {
+    const result = parseFrontmatter(
+      "---\nname: ok\n---\nRules\n----\nMore rules",
+    );
+    assert.deepStrictEqual(result.frontmatter, { name: "ok" });
+    assert.equal(result.body, "Rules\n----\nMore rules");
+  });
+
+  it("parses quoted scalars whose indented continuation contains ---", () => {
+    const result = parseFrontmatter(
+      '---\ndescription: "alpha\n  --- beta\n  gamma"\nname: quoted-skill\n---\nBody',
+    );
+    assert.deepStrictEqual(result.frontmatter, {
+      description: "alpha --- beta gamma",
+      name: "quoted-skill",
+    });
+    assert.equal(result.body, "Body");
+  });
+
   it("parses complex frontmatter with arrays", () => {
     const content = `---
 name: complex-skill


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Fixes #28388 (see the correction comment on the issue for the refined reproduction)

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts (branched from current head).
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. One pure function plus tests. Documents that parsed correctly before (valid closers, no closers at all, empty blocks) produce byte-identical results — covered by the existing suite. Only documents whose first `\n---` candidate is an invalid closer change behavior: they previously loaded with silently corrupted frontmatter/body and now fail loudly through the existing typed loader diagnostic.

# Background

## What does this PR do?

`extractFrontmatter` cut the YAML block at the **first** `\n---` sequence even when its own closer validation (`closeMatch`) failed, discarding the validation result. With a typo'd separator line:

    ---
    description: "A skill"
    name: my-skill
    ----
    version: 2
    ---
    Body

the `----` line became the closing delimiter, `version: 2` was silently swallowed into the body, and the corrupted skill loaded with **zero diagnostics** — a fabricated success on a parse path.

The fix scans forward past invalid candidates to the first *valid* closer (`---` alone on its line); a document with no valid closer is treated as plain markdown (existing semantics). The typo'd file now fails explicitly via the existing `INVALID_SKILL_FRONTMATTER_YAML` loader diagnostic.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/skills/test/frontmatter.test.ts`: three new cases — "rejects a typo'd ---- separator…", "preserves a dashes rule inside the body after a valid closer", "parses quoted scalars whose indented continuation contains ---". Then reproduce end-to-end through the real loader (below).

## Detailed testing steps

```bash
mkdir -p /tmp/skills-e2e/typo-skill
printf -- '---\ndescription: "A skill"\nname: typo-skill\n----\nversion: 2\n---\nBody' > /tmp/skills-e2e/typo-skill/SKILL.md
bun -e 'import("…/loader.ts").then(m => console.log(JSON.stringify(m.loadSkillsFromDir({ dir: "/tmp/skills-e2e" }))))'
```

Before: skill loads, `diagnostics: []`, corrupted body. After: `skills: []` + explicit invalid-YAML warning diagnostic.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:329be59f1377c6fb2bd4e2ccf8cd4d5e53fb3d53 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`. — N/A - loader-output defect; before transcript below.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`. — N/A - loader-output defect; after transcript below.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`. — N/A - deterministic file-load path; transcripts capture it fully.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>` — proof runs through the real `loadSkillsFromDir` boundary including its diagnostics.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`. — N/A - no browser/frontend involved.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`. — N/A - no model involvement.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable, or marked `N/A - <reason>` — the loaded-skills list + diagnostics arrays below are the artifacts.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface. — N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no model involvement.

## Backend + frontend logs

Real `loadSkillsFromDir` against a temp directory containing one skill whose SKILL.md has the typo'd `----` separator:

Before (unfixed `develop@094f80ad2d`):

```json
{ "skills": ["typo-skill"], "diagnostics": [] }
```

— the corrupted skill loads silently; frontmatter after `----` is swallowed into the body.

After (this PR):

```json
{
  "skills": [],
  "diagnostics": [
    { "type": "warning", "message": "Skill frontmatter contains invalid YAML", "path": "/tmp/skills-e2e-…/typo-skill/SKILL.md" }
  ]
}
```

Package suite: 110 pass / 0 fail (3 new tests included).

## Screenshots (before / after) + video walkthrough

N/A - loader-output only; transcripts above are the complete observable behavior.

### Before

Silent load of a corrupted skill, empty diagnostics.

### After

Explicit typed warning, skill not half-loaded.

### Walkthrough video

N/A - deterministic file-load path.

## Audio / voice walkthrough

N/A - no audio surface.

## Known gaps / failures

- Full-repo `bun run verify` not run for this package-scoped change; package gates run instead: typecheck ✅, lint ✅, test 110/110 ✅.

## Maintainer CI exception record

N/A - no exception requested

AI provider/model: opencode / x-preview-f-free
Client / agent tooling: opencode
Attribution status: self-reported
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"x-preview-f-free","client":"opencode","skill_revision":"self-hosted contribute-to-eliza skill"} -->

AI provider/model: opencode / x-preview-f-free
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-eliza
Attribution status: self-reported
— [contribution-batch]
<!-- slop-contribution-attribution:v1 {"provider":"opencode","model":"x-preview-f-free","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0W0GNDZ5ADHE8R7Y9Z3GJ1K","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-25T08:27:45.472Z","completed_at":"2026-08-25T10:49:22.543Z","skill_sha256":"7d4db0c19ef1171c18744a11ec1aceb613e3f779a9c49953ef1a0018aa80e4fd","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-25T08:27:47.445Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"fb2167ede6d20eed5787424a809871cf0a9d40df9e7e4218e7cbd36879582298","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"4b0ca646-2ecb-4633-9370-c07fc2809e73","object_id":"sha256:fb2167ede6d20eed5787424a809871cf0a9d40df9e7e4218e7cbd36879582298","sha256":"fb2167ede6d20eed5787424a809871cf0a9d40df9e7e4218e7cbd36879582298"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAgtL_SjSjM1n46ptKEJk4PBfQocRxDED3AUsopsbPpj8","device_key_id":"d72975edd2d14b15ee662f87b3c80771c33d1c0659d900ebbc7644d0dfaa241a","device_signature":"nxmZHHqmMXtLWGtaVeqGRoGumLk0qkcSNuMgR-xtiWeEAvUN860h8QV83wq_WLSKm79_xXErCGg_gej96zCPAA"}} -->
