### PR TITLE
test(agent): remove literal-copy startup assertions

### DIFF
--- a/packages/agent/src/runtime/source-start-contract.test.ts
+++ b/packages/agent/src/runtime/source-start-contract.test.ts
@@ -6,7 +6,6 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
@@ -15,32 +14,9 @@ const AGENT_ROOT = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   "../..",
 );
-const REPO_ROOT = path.resolve(AGENT_ROOT, "../..");
-const PLUGIN_SQL_SOURCE_ROOT = path.join(REPO_ROOT, "plugins/plugin-sql/src");
 
 describe("standalone source-checkout start contract", () => {
   it("runs the agent and its required SQL plugin against workspace source", () => {
-    const agentPackage = JSON.parse(
-      readFileSync(path.join(AGENT_ROOT, "package.json"), "utf8"),
-    ) as { scripts?: Record<string, string> };
-    const pluginSqlTsconfig = JSON.parse(
-      readFileSync(path.join(PLUGIN_SQL_SOURCE_ROOT, "tsconfig.json"), "utf8"),
-    ) as { compilerOptions?: { paths?: Record<string, string[]> } };
-    const pluginSqlTypecheckConfig = JSON.parse(
-      readFileSync(
-        path.join(PLUGIN_SQL_SOURCE_ROOT, "tsconfig.typecheck.json"),
-        "utf8",
-      ),
-    ) as { compilerOptions?: { paths?: Record<string, string[]> } };
-
-    expect(agentPackage.scripts?.start).toBe(
-      "bun --no-install --conditions=eliza-source src/bin.ts",
-    );
-    expect(pluginSqlTsconfig.compilerOptions?.paths).toBeUndefined();
-    expect(
-      pluginSqlTypecheckConfig.compilerOptions?.paths?.["@elizaos/core"],
-    ).toEqual(["../../../packages/core/dist/index.d.ts"]);
-
     const imported = spawnSync(
       "bun",
       [


### PR DESCRIPTION
Resolves #28089

Removes manifest and tsconfig literal-copy assertions from the source-start contract test while preserving the real Bun child-process import smoke for @elizaos/plugin-sql.

Validation (exact head 07dea175d70c52866b5a88bcbccbe1bd5d4a8f95):
- `bunx vitest run packages/agent/src/runtime/source-start-contract.test.ts --coverage.enabled=false` (pass)
- `bun run --cwd packages/agent lint:check` (pass)
- `bun run --cwd packages/agent typecheck` (blocked by pre-existing missing built optional workspace exports: plugin-capacitor-bridge, plugin-wallet, plugin-wifi, plugin-contacts, plugin-video, plugin-vision, plugin-notes, cloud-sdk/browser-contracts, plugin-todos/edge)