### PR TITLE
fix: keep durable coding sessions alive for follow-ups

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
@@ -906,11 +906,17 @@ async function runCreateLegacy(
     ? completeUserReferenceView(baseLabelParam)
     : undefined;
   const extraMetadata = additionalSessionMetadata(params, content);
-  const keepAliveAfterComplete = hasVerifiedRetryLifecycle(
-    params,
-    content,
-    extraMetadata,
+  const useSmithers = shouldUseSmithersTaskRunner();
+  const durableTaskServiceAvailable = Boolean(
+    runtime.getService?.(OrchestratorTaskService.serviceType),
   );
+  // Durable Smithers sessions are the orchestrator's ongoing coding surface:
+  // the task service owns their bounded idle reclamation and follow-up state.
+  // Direct ACP compatibility runs remain one-shot unless they carry the
+  // validated app-verification retry contract.
+  const keepAliveAfterComplete =
+    (useSmithers && durableTaskServiceAvailable) ||
+    hasVerifiedRetryLifecycle(params, content, extraMetadata);
   const originConnectorMessageId = connectorMessageIdFromMemory(
     message,
     content,
@@ -997,7 +1003,6 @@ async function runCreateLegacy(
       };
     }
   }
-  const useSmithers = shouldUseSmithersTaskRunner();
   let threadId: string | null = null;
   try {
     if (!taskService || typeof taskService.createTask !== "function") {


### PR DESCRIPTION
Closes #28407

## Summary
- retain ordinary TASKS:create sessions when Smithers and the durable task service are active
- preserve one-shot behavior for direct ACP compatibility runs and validator-less test doubles
- align the public TASKS action with OrchestratorTaskService, which already owns bounded idle reclamation and follow-up state

## Evidence
With this change applied locally, the real Claude and Codex sequential orchestrator smoke both created exact first and second sentinel files in the same durable task workdir. Claude: `claude-sequential-keepalive-pass3.log`; Codex: `codex-sequential-keepalive-pass.log`.

The runtime still emits expected diagnostics because this minimal PGLite fixture has no embedding or evaluator model provider; those did not prevent the child coding sessions from completing.