### PR TITLE
fix(slack): surface the real files.uploadV2 receipt instead of always-empty ids

### DIFF
--- a/plugins/plugin-slack/src/service.ts
+++ b/plugins/plugin-slack/src/service.ts
@@ -51,10 +51,7 @@ import {
   type World,
 } from "@elizaos/core";
 import { App, LogLevel } from "@slack/bolt";
-import {
-  WebClient as SlackWebClient,
-  type WebAPICallResult,
-} from "@slack/web-api";
+import { WebClient as SlackWebClient } from "@slack/web-api";
 
 type WebClient = App["client"];
 type AccountScopedTargetInfo = TargetInfo & { accountId?: string };
@@ -218,6 +215,45 @@ const SLACK_CONNECTOR_CAPABILITIES = [
   "get_user",
 ];
 const SLACK_USER_ID_PATTERN = /^[UW][A-Z0-9]{2,}$/i;
+
+/**
+ * Extract the provider receipt from a `files.uploadV2` result. The SDK
+ * resolves `{ ok, files: [...] }` where each entry is one
+ * `files.completeUploadExternal` response whose own `files` array carries
+ * the file object (`result.files[i].files[j]`) — there is no singular
+ * `file` key. A result with no file data anywhere is an explicit failure
+ * rather than fabricated empty identifiers.
+ */
+export function extractUploadReceipt(result: unknown): {
+  fileId: string;
+  permalink: string;
+} {
+  const responses = (result as { files?: unknown } | null)?.files;
+  if (Array.isArray(responses)) {
+    for (const response of responses) {
+      const inner = (response as { files?: unknown })?.files;
+      if (Array.isArray(inner)) {
+        const file = inner.find(
+          (candidate) => Boolean(candidate) && typeof candidate === "object",
+        ) as Record<string, unknown> | undefined;
+        if (file) {
+          return toReceipt(file);
+        }
+      }
+    }
+  }
+  throw new Error("Slack files.uploadV2 response contained no file data");
+}
+
+function toReceipt(file: Record<string, unknown>): {
+  fileId: string;
+  permalink: string;
+} {
+  return {
+    fileId: typeof file.id === "string" ? file.id : "",
+    permalink: typeof file.permalink === "string" ? file.permalink : "",
+  };
+}
 
 function normalizeSlackConnectorQuery(value: string): string {
   return value
@@ -4169,14 +4205,7 @@ export class SlackService extends Service implements ISlackService {
 
     const result = await client.files.uploadV2(uploadArgs);
 
-    const resultWithFile = result as WebAPICallResult & {
-      file?: { id: string; permalink: string };
-    };
-    const file = resultWithFile.file;
-    return {
-      fileId: file?.id || "",
-      permalink: file?.permalink || "",
-    };
+    return extractUploadReceipt(result);
   }
 
   private splitMessage(text: string): string[] {

--- a/plugins/plugin-slack/src/upload-receipt.test.ts
+++ b/plugins/plugin-slack/src/upload-receipt.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Upload receipt extraction tests drive a real @slack/web-api WebClient
+ * against a local mock of the three-step files.uploadV2 wire flow
+ * (getUploadURLExternal → external POST → completeUploadExternal) and assert
+ * the provider receipt SlackService.uploadFile surfaces, including the
+ * explicit failure when the completion response carries no file data.
+ */
+import http from "node:http";
+import { WebClient } from "@slack/web-api";
+import { afterEach, describe, expect, it } from "vitest";
+import { extractUploadReceipt } from "./service";
+
+const servers: http.Server[] = [];
+
+afterEach(() => {
+  for (const server of servers.splice(0)) {
+    server.close();
+  }
+});
+
+function startMockSlackApi(
+  completeResponse: string,
+): Promise<{ apiUrl: string; requests: string[] }> {
+  const requests: string[] = [];
+  return new Promise((resolve) => {
+    const server = http.createServer((req, res) => {
+      let _body = "";
+      req.on("data", (chunk) => {
+        _body += chunk;
+      });
+      req.on("end", () => {
+        requests.push(`${req.url}`);
+        if (req.url?.includes("/files.getUploadURLExternal")) {
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(
+            JSON.stringify({
+              ok: true,
+              upload_url: `http://${req.headers.host}/external-upload`,
+              file_id: "F06A5F9PQ0Z",
+            }),
+          );
+        } else if (req.url === "/external-upload") {
+          res.writeHead(200);
+          res.end("OK");
+        } else if (req.url?.includes("/files.completeUploadExternal")) {
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(completeResponse);
+        } else {
+          res.writeHead(404);
+          res.end("{}");
+        }
+      });
+    });
+    servers.push(server);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      const port = typeof address === "object" ? address?.port : 0;
+      resolve({ apiUrl: `http://127.0.0.1:${port}/api/`, requests });
+    });
+  });
+}
+
+async function runUploadV2(apiUrl: string): Promise<unknown> {
+  const client = new WebClient("xoxb-test-token", { slackApiUrl: apiUrl });
+  return client.files.uploadV2({
+    channel_id: "C0614G0B5LY",
+    filename: "cat.png",
+    content: "fake-png-bytes",
+  });
+}
+
+describe("extractUploadReceipt / files.uploadV2 wire shape", () => {
+  it("surfaces the real file id and permalink from result.files[0]", async () => {
+    const { apiUrl } = await startMockSlackApi(
+      JSON.stringify({
+        ok: true,
+        files: [
+          {
+            id: "F06A5F9PQ0Z",
+            created: 1756000000,
+            timestamp: 1756000000,
+            name: "cat.png",
+            permalink: "https://example.slack.com/files/F06A5F9PQ0Z/cat.png",
+          },
+        ],
+      }),
+    );
+
+    const result = await runUploadV2(apiUrl);
+
+    expect(extractUploadReceipt(result)).toEqual({
+      fileId: "F06A5F9PQ0Z",
+      permalink: "https://example.slack.com/files/F06A5F9PQ0Z/cat.png",
+    });
+  });
+
+  it("fails explicitly when the completion response carries no file data", async () => {
+    const { apiUrl } = await startMockSlackApi(JSON.stringify({ ok: true }));
+
+    const result = await runUploadV2(apiUrl);
+
+    expect(() => extractUploadReceipt(result)).toThrow(
+      "Slack files.uploadV2 response contained no file data",
+    );
+  });
+});


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Fixes #28405

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts (branched from current head).
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low-to-medium, contained to `SlackService.uploadFile`. Today every call returns fabricated empty receipts, so no caller can be depending on a non-empty value that now changes — the change can only turn broken output into real receipts (or an explicit error where previously an empty success was returned). The in-tree caller (`sendOutboundAttachments`) already wraps each upload in try/catch per part.

# Background

## What does this PR do?

`SlackService.uploadFile` parsed a singular `result.file` key that `files.uploadV2` never returns. Verified against the pinned `@slack/web-api@7.15.2`: the method resolves

```json
{ "ok": true, "files": [ { "ok": true, "files": [ { "id": "F…", "permalink": "…" } ] } ] }
```

— each entry of the outer `files` array is one `files.completeUploadExternal` response whose own `files` array carries the file object. The old parse always yielded `undefined`, so **every** upload resolved `{ fileId: "", permalink: "" }` despite succeeding — fabricated empty success on a data path.

The fix extracts the receipt from the actual shape via a new exported `extractUploadReceipt` helper and throws explicitly when the response carries no file data anywhere.

Note for reviewers: open PR #28074 treats an empty `fileId` from this method as a failed part at its boundary ("never fabricated evidence"). With the root cause fixed here, its guard becomes a genuine anomaly path instead of the always-taken branch — the two changes are complementary.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`plugins/plugin-slack/src/upload-receipt.test.ts` drives a **real** `WebClient` against a local mock implementing the three-step `uploadV2` wire flow (`files.getUploadURLExternal` → external POST → `files.completeUploadExternal`) and asserts both the extracted receipt and the explicit no-data failure.

## Detailed testing steps

Run `bun run --cwd plugins/plugin-slack test -- upload-receipt`. The mock's `completeUploadExternal` response mirrors the real Slack payload shape; capture shows the SDK resolves it nested as `result.files[0].files[0]`.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:9e8b7557ea1c885e2f233002465f9e82156a0c46 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`. — N/A - API-parsing defect; before behavior shown by the SDK source trace + test below.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`. — N/A - same surface; after receipt asserted by test.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`. — N/A - network/parsing path; wire transcript below.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>` — the proof exercises the real `WebClient` over HTTP against the three-step mock.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`. — N/A - no browser/frontend involved.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`. — N/A - no model involvement.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable, or marked `N/A - <reason>` — the `{ fileId, permalink }` receipt is the artifact; captured in Evidence Details.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface. — N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no model involvement.

## Backend + frontend logs

Real wire shape captured by driving `WebClient("xoxb-test", { slackApiUrl: http://127.0.0.1:<mock> })` through the full three-step upload against a local mock:

```json
RESULT: {"ok":true,"files":[{"ok":true,"files":[{"id":"F06A5F9PQ0Z","name":"cat.png","permalink":"https://example.slack.com/files/F06A5F9PQ0Z/cat.png"}],"response_metadata":{}}]}
```

Before this PR, `uploadFile` on exactly that result returned `{ fileId: "", permalink: "" }` (it read the nonexistent `result.file`). After, it returns `{ fileId: "F06A5F9PQ0Z", permalink: "https://example.slack.com/files/F06A5F9PQ0Z/cat.png" }`, and a completion response with no file data raises `Error: Slack files.uploadV2 response contained no file data`.

Package suite: 173 passed / 0 fail (2 new tests included).

## Screenshots (before / after) + video walkthrough

N/A - network/parsing path only.

### Before

Always-empty receipts despite successful uploads.

### After

Real provider receipt surfaced; missing data fails explicitly.

### Walkthrough video

N/A - non-interactive path.

## Audio / voice walkthrough

N/A - no audio surface.

## Known gaps / failures

- Full-repo `bun run verify` not run for this plugin-scoped change; package gates run instead: typecheck ✅, lint ✅, suite 173/173 ✅.
- Live-workspace upload against real Slack credentials was not available in this environment; the mocked three-step wire flow uses the real SDK client and mirrors the documented request/response contract.

## Maintainer CI exception record

N/A - no exception requested

AI provider/model: opencode / x-preview-f-free
Client / agent tooling: opencode
Attribution status: self-reported
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"x-preview-f-free","client":"opencode","skill_revision":"self-hosted contribute-to-eliza skill"} -->

AI provider/model: opencode / x-preview-f-free
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-eliza
Attribution status: self-reported
— [contribution-batch]
<!-- slop-contribution-attribution:v1 {"provider":"opencode","model":"x-preview-f-free","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0W0GNDZ5ADHE8R7Y9Z3GJ1K","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-25T08:27:45.472Z","completed_at":"2026-08-25T10:49:22.543Z","skill_sha256":"7d4db0c19ef1171c18744a11ec1aceb613e3f779a9c49953ef1a0018aa80e4fd","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-25T08:27:47.445Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"fb2167ede6d20eed5787424a809871cf0a9d40df9e7e4218e7cbd36879582298","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"4b0ca646-2ecb-4633-9370-c07fc2809e73","object_id":"sha256:fb2167ede6d20eed5787424a809871cf0a9d40df9e7e4218e7cbd36879582298","sha256":"fb2167ede6d20eed5787424a809871cf0a9d40df9e7e4218e7cbd36879582298"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAgtL_SjSjM1n46ptKEJk4PBfQocRxDED3AUsopsbPpj8","device_key_id":"d72975edd2d14b15ee662f87b3c80771c33d1c0659d900ebbc7644d0dfaa241a","device_signature":"nxmZHHqmMXtLWGtaVeqGRoGumLk0qkcSNuMgR-xtiWeEAvUN860h8QV83wq_WLSKm79_xXErCGg_gej96zCPAA"}} -->
