### PR TITLE
fix(slack): do not resolve blank get_user lookups to arbitrary workspace members

### DIFF
--- a/plugins/plugin-slack/src/connector-user.test.ts
+++ b/plugins/plugin-slack/src/connector-user.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Connector get_user lookup tests drive the real `SlackService.getConnectorUser`
+ * method with its Slack transport stubbed: a blank identifier must resolve to
+ * null instead of matching an arbitrary workspace member via the substring
+ * scan, while partial-name queries still resolve their intended member.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { SlackService } from "./service";
+
+type StubClient = {
+  users: { list: ReturnType<typeof vi.fn> };
+};
+
+function createService(client: StubClient) {
+  const service = Object.create(SlackService.prototype) as SlackService & {
+    runtime: IAgentRuntime;
+    defaultAccountId?: string;
+    getClientForAccount: (accountId?: string | null) => StubClient | null;
+    resolveSlackTargetUserId: (
+      runtime: IAgentRuntime,
+      lookup: string,
+      accountId: string,
+    ) => Promise<string | null>;
+    getUser: (slackUserId: string, accountId: string) => Promise<unknown>;
+    getEntityId: (userId: string, accountId: string) => string;
+    getTeamIdForAccount: (accountId: string) => string | undefined;
+  };
+  service.runtime = {
+    agentId: "00000000-0000-0000-0000-00000000agent",
+  } as unknown as IAgentRuntime;
+  service.getClientForAccount = vi.fn().mockReturnValue(client);
+  service.resolveSlackTargetUserId = vi.fn().mockResolvedValue(null);
+  service.getUser = vi.fn(async (slackUserId: string) => ({
+    id: slackUserId,
+    name: slackUserId,
+    profile: {},
+  }));
+  service.getEntityId = vi.fn((userId: string) => `entity-${userId}`);
+  service.getTeamIdForAccount = vi.fn().mockReturnValue(undefined);
+  return service;
+}
+
+function createDirectoryClient(members: unknown[]) {
+  return {
+    users: {
+      list: vi.fn().mockResolvedValue({ members }),
+    },
+  };
+}
+
+describe("getConnectorUser blank-query guard", () => {
+  it("resolves null for a whitespace-only query without scanning the directory", async () => {
+    const client = createDirectoryClient([
+      { id: "UAAA111", name: "grace" },
+      { id: "UBBB222", name: "ada-lovelace" },
+    ]);
+    const service = createService(client);
+
+    const result = await (
+      service as unknown as {
+        getConnectorUser: (
+          runtime: IAgentRuntime,
+          params: { query: string },
+        ) => Promise<unknown>;
+      }
+    ).getConnectorUser(service.runtime, { query: "   " });
+
+    expect(result).toBeNull();
+    expect(client.users.list).not.toHaveBeenCalled();
+  });
+
+  it("still resolves partial-name queries against the directory", async () => {
+    const client = createDirectoryClient([
+      { id: "UAAA111", name: "grace" },
+      { id: "UBBB222", name: "ada-lovelace" },
+    ]);
+    const service = createService(client);
+
+    const result = await (
+      service as unknown as {
+        getConnectorUser: (
+          runtime: IAgentRuntime,
+          params: { query: string },
+        ) => Promise<{ id: string }>;
+      }
+    ).getConnectorUser(service.runtime, { query: "Ada" });
+
+    expect(result).not.toBeNull();
+    expect(result.id).toBe("entity-UBBB222");
+  });
+});

--- a/plugins/plugin-slack/src/service.ts
+++ b/plugins/plugin-slack/src/service.ts
@@ -3468,6 +3468,15 @@ export class SlackService extends Service implements ISlackService {
     if (!lookup) {
       return null;
     }
+    // A blank identifier must not reach the directory scan below: the
+    // substring match treats "" as contained in every member, which would
+    // resolve an arbitrary workspace member for a whitespace-only query.
+    if (
+      !SLACK_USER_ID_PATTERN.test(lookup) &&
+      !normalizeSlackConnectorQuery(lookup)
+    ) {
+      return null;
+    }
 
     let slackUserId = SLACK_USER_ID_PATTERN.test(lookup)
       ? lookup


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Fixes #28411

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts (branched from current head).
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Adds one guard clause before the directory scan in `getConnectorUser`. Legitimate lookups (real user IDs, handles, names) are unaffected — both existing behavior and the partial-match path are pinned by tests.

# Background

## What does this PR do?

`SlackService.getConnectorUser` rejected only falsy identifiers. A whitespace-only query passed that check, failed the `SLACK_USER_ID_PATTERN` fast-path, reached the `users.list` directory fallback, and matched via `includes("")` — which is true for every member — so the connector returned the **first workspace member's** profile, entity ID, and email metadata as a confident match instead of `null`.

The guard now also rejects identifiers whose normalized form is empty before scanning the directory.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`plugins/plugin-slack/src/connector-user.test.ts` drives the **real** `getConnectorUser` method with its Slack transport stubbed:

1. whitespace query `"   "` → resolves `null` and never calls `users.list`;
2. query `"Ada"` → still resolves member `UBBB222` (`ada-lovelace`) through the same scan.

## Detailed testing steps

Red-proof: with unfixed `service.ts`, test 1 fails with `expected { id: 'entity-UAAA111', … } to be null` — i.e. the first workspace member was resolved for a blank query. With the fix, both tests pass.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:b593cd05e9f2c14d6bd36cd898323aa5e43e8c7a -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`. — N/A - lookup-correctness defect; red-test output below captures the wrong behavior.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`. — N/A - green test below.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`. — N/A - non-interactive lookup path; assertions capture it fully.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>` — the real method executes against its transport boundary; the stubbed client asserts no directory call fires for blank input.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`. — N/A - no browser/frontend involved.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`. — N/A - no model involvement.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable, or marked `N/A - <reason>` — the resolved user record (null vs arbitrary member) is the artifact; both states captured by the tests.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface. — N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no model involvement.

## Backend + frontend logs

Red-proof against unfixed source (this branch's test file, `develop@094f80ad2d` service):

```text
AssertionError: expected { id: 'entity-UAAA111', …(3) } to be null
```

— the whitespace-only query resolved the FIRST workspace member (`grace`, `UAAA111`), including its entity id and profile metadata.

Green with this PR:

```text
Test Files  1 passed (1)
     Tests  2 passed (2)
```

Full package suite: 173 passed / 0 fail.

## Screenshots (before / after) + video walkthrough

N/A - lookup-correctness defect; no rendered surface.

### Before

Blank query → arbitrary first-member profile returned as confident match.

### After

Blank query → `null`; directory not consulted.

### Walkthrough video

N/A - non-interactive path.

## Audio / voice walkthrough

N/A - no audio surface.

## Known gaps / failures

- Full-repo `bun run verify` not run for this plugin-scoped change; package gates run instead: typecheck ✅, lint ✅, suite 173/173 ✅.
- The Slack transport (`users.list`) is stubbed at the client boundary; the code under test is the unmodified production method.

## Maintainer CI exception record

N/A - no exception requested

AI provider/model: opencode / x-preview-f-free
Client / agent tooling: opencode
Attribution status: self-reported
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"x-preview-f-free","client":"opencode","skill_revision":"self-hosted contribute-to-eliza skill"} -->

AI provider/model: opencode / x-preview-f-free
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-eliza
Attribution status: self-reported
— [contribution-batch]
<!-- slop-contribution-attribution:v1 {"provider":"opencode","model":"x-preview-f-free","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0W0GNDZ5ADHE8R7Y9Z3GJ1K","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-25T08:27:45.472Z","completed_at":"2026-08-25T10:49:22.543Z","skill_sha256":"7d4db0c19ef1171c18744a11ec1aceb613e3f779a9c49953ef1a0018aa80e4fd","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-25T08:27:47.445Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"fb2167ede6d20eed5787424a809871cf0a9d40df9e7e4218e7cbd36879582298","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"4b0ca646-2ecb-4633-9370-c07fc2809e73","object_id":"sha256:fb2167ede6d20eed5787424a809871cf0a9d40df9e7e4218e7cbd36879582298","sha256":"fb2167ede6d20eed5787424a809871cf0a9d40df9e7e4218e7cbd36879582298"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAgtL_SjSjM1n46ptKEJk4PBfQocRxDED3AUsopsbPpj8","device_key_id":"d72975edd2d14b15ee662f87b3c80771c33d1c0659d900ebbc7644d0dfaa241a","device_signature":"nxmZHHqmMXtLWGtaVeqGRoGumLk0qkcSNuMgR-xtiWeEAvUN860h8QV83wq_WLSKm79_xXErCGg_gej96zCPAA"}} -->
