### PR TITLE
test(personal-assistant): cover blocker registry duplicate registration integrity

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/registries/blocker-registry.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/registries/blocker-registry.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  __resetBlockerRegistryForTests,
+  type BlockerContribution,
+  createBlockerRegistry,
+  getBlockerRegistry,
+  registerBlockerRegistry,
+} from "./blocker-registry";
+
+type Runtime = { agentId: string };
+const runtimeA = { agentId: "a" } as Runtime;
+const runtimeB = { agentId: "b" } as Runtime;
+
+function websiteContribution(
+  label: string,
+): BlockerContribution<unknown, unknown> {
+  return {
+    kind: "website",
+    describe: { label },
+    verifyAvailable: async () => ({
+      available: true,
+      reason: null,
+      permission: "granted",
+    }),
+    start: async () => ({}),
+    stop: async () => {},
+    status: async () => ({ active: false, endsAt: null, text: "idle" }),
+  };
+}
+
+describe("createBlockerRegistry", () => {
+  it("starts empty with null lookups for every kind", () => {
+    const registry = createBlockerRegistry();
+    expect(registry.list()).toEqual([]);
+    expect(registry.get("website")).toBeNull();
+    expect(registry.get("app")).toBeNull();
+  });
+
+  it("returns a registered contribution by kind and lists it", () => {
+    const registry = createBlockerRegistry();
+    const website = websiteContribution("hosts-file");
+    registry.register(website);
+    expect(registry.get("website")).toBe(website);
+    expect(registry.list()).toEqual([website]);
+  });
+
+  it("holds contributions of distinct kinds side by side", () => {
+    const registry = createBlockerRegistry();
+    const website = websiteContribution("hosts-file");
+    const app = websiteContribution("family-controls");
+    (app as { kind: string }).kind = "app";
+    registry.register(website);
+    registry.register(app);
+    expect(registry.list()).toHaveLength(2);
+    expect(registry.get("app")).toBe(app);
+  });
+
+  it("rejects duplicate kind registration instead of silently replacing", () => {
+    const registry = createBlockerRegistry();
+    registry.register(websiteContribution("first"));
+    expect(() => registry.register(websiteContribution("second"))).toThrow(
+      /kind "website" already registered/,
+    );
+    // The original enforcer must remain the dispatcher target.
+    expect(registry.get("website")?.describe.label).toBe("first");
+    expect(registry.list()).toHaveLength(1);
+  });
+});
+
+describe("registerBlockerRegistry / getBlockerRegistry", () => {
+  beforeEach(() => {
+    __resetBlockerRegistryForTests(runtimeA);
+    __resetBlockerRegistryForTests(runtimeB);
+  });
+
+  it("returns null for a runtime that never registered", () => {
+    expect(getBlockerRegistry(runtimeA)).toBeNull();
+  });
+
+  it("returns the registry registered for the same runtime", () => {
+    const registry = createBlockerRegistry();
+    registerBlockerRegistry(runtimeA, registry);
+    expect(getBlockerRegistry(runtimeA)).toBe(registry);
+  });
+
+  it("isolates registries per runtime (WeakMap keying, no cross-runtime leakage)", () => {
+    const registryA = createBlockerRegistry();
+    registerBlockerRegistry(runtimeA, registryA);
+    expect(getBlockerRegistry(runtimeB)).toBeNull();
+  });
+
+  it("forgets a runtime after test reset", () => {
+    const registry = createBlockerRegistry();
+    registerBlockerRegistry(runtimeA, registry);
+    __resetBlockerRegistryForTests(runtimeA);
+    expect(getBlockerRegistry(runtimeA)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Pin the `BlockerRegistry` dispatch-contract behaviors:

- Duplicate `kind` registration throws instead of silently replacing the
  first enforcer (the canonical BLOCK dispatch target must stay unambiguous).
- Unknown-kind `get` returns null; fresh registries list empty.
- Per-runtime registry isolation via `WeakMap` keying: registrations never
  leak across runtimes, and `__resetBlockerRegistryForTests` forgets a
  runtime for test isolation.

<!-- contribution-attribution:v1 -->
- <!-- attribution-row:ai-assistance --> AI assistance: `yes`
- <!-- attribution-row:models --> Model(s) used: `deepseek/deepseek-v4-flash`
- <!-- attribution-row:client --> Agent tooling: `Hermes Agent`
- <!-- attribution-row:skill-revision --> Skill path: `N/A - no contribution skill used`
- <!-- attribution-row:status --> Provenance status: `self-reported`

## Evidence

| Requirement | Evidence |
| --- | --- |
| Behavioral tests | Focused test run, all green (8 tests) |
| Risk covered | Registry integrity, cross-runtime leakage, null-safe lookup |

## Risks

Low. Test-only change; no production code touched.

## Definition of Done

- [x] Code rebased onto develop
- [x] Tests verify behavior
- [x] Attribution row present