### PR TITLE
fix(github): match PR list authors case-insensitively in the repo branch

### DIFF
--- a/plugins/plugin-github/src/actions/pr-op-list-author.test.ts
+++ b/plugins/plugin-github/src/actions/pr-op-list-author.test.ts
@@ -1,0 +1,81 @@
+/**
+ * GITHUB_PR list author-filter tests drive the real action handler through a
+ * structural GitHubOctokitClient with canonical-cased logins: the repo (REST)
+ * branch must match authors case-insensitively, mirroring GitHub's
+ * case-insensitive `author:` search qualifier used by the no-repo branch.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import type { GitHubOctokitClient } from "../types.js";
+import { prOpAction } from "./pr-op.js";
+
+function createRuntime(octokit: GitHubOctokitClient): IAgentRuntime {
+  return {
+    agentId: "00000000-0000-0000-0000-00000000agent",
+    getService: () => ({ getOctokit: () => octokit }),
+    logger: { warn: vi.fn(), info: vi.fn(), error: vi.fn() },
+  } as unknown as IAgentRuntime;
+}
+
+const OPEN_PRS = [
+  {
+    number: 1,
+    title: "first",
+    state: "open",
+    html_url: "https://github.test/org/repo/pull/1",
+    user: { login: "octocat" },
+  },
+  {
+    number: 2,
+    title: "second",
+    state: "open",
+    html_url: "https://github.test/org/repo/pull/2",
+    user: { login: "hubot" },
+  },
+];
+
+describe("GITHUB_PR list author filter", () => {
+  it("matches authors case-insensitively in the repo branch", async () => {
+    const pullsList = vi.fn().mockResolvedValue({ data: OPEN_PRS });
+    const octokit = {
+      pulls: { list: pullsList },
+    } as unknown as GitHubOctokitClient;
+
+    const result = await prOpAction.handler(
+      createRuntime(octokit),
+      {} as never,
+      undefined,
+      { op: "list", repo: "org/repo", author: "OctoCat" },
+    );
+
+    expect(pullsList).toHaveBeenCalledWith(
+      expect.objectContaining({ owner: "org", repo: "repo" }),
+    );
+    expect(result.success).toBe(true);
+    if (result.success && "prs" in result.data) {
+      expect(result.data.prs).toHaveLength(1);
+      expect(result.data.prs[0]?.author).toBe("octocat");
+    }
+  });
+
+  it("keeps exact-case matches working in the repo branch", async () => {
+    const pullsList = vi.fn().mockResolvedValue({ data: OPEN_PRS });
+    const octokit = {
+      pulls: { list: pullsList },
+    } as unknown as GitHubOctokitClient;
+
+    const result = await prOpAction.handler(
+      createRuntime(octokit),
+      {} as never,
+      undefined,
+      { op: "list", repo: "org/repo", author: "hubot" },
+    );
+
+    if (result.success && "prs" in result.data) {
+      expect(result.data.prs).toHaveLength(1);
+      expect(result.data.prs[0]?.author).toBe("hubot");
+    } else {
+      throw new Error("expected a successful list result");
+    }
+  });
+});

--- a/plugins/plugin-github/src/actions/pr-op.ts
+++ b/plugins/plugin-github/src/actions/pr-op.ts
@@ -127,7 +127,9 @@ async function runList(
       per_page: 100,
     });
     for (const pr of resp.data) {
-      if (author && pr.user?.login !== author) {
+      // GitHub logins are case-insensitive; compare case-insensitively so
+      // this branch matches the `author:` search qualifier's semantics.
+      if (author && pr.user?.login?.toLowerCase() !== author.toLowerCase()) {
         continue;
       }
       prs.push({


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Fixes #28417

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts (branched from current head).
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. One comparison in one action branch plus tests. Exact-case author filters keep working; only previously-dropped case variants now match — which mirrors GitHub's own login semantics and the sibling search branch.

# Background

## What does this PR do?

The `GITHUB_PR` list op filtered authors inconsistently: with a `repo`, the REST branch used an exact-case string compare (`pr.user?.login !== author`), so requesting `OctoCat` while GitHub's canonical login is `octocat` returned "Found 0 pull request(s)"; without a `repo`, the same author rode GitHub's case-insensitive `author:` qualifier and matched. Identical inputs, opposite results.

The fix compares both sides lowercased in the REST branch.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`plugins/plugin-github/src/actions/pr-op-list-author.test.ts` drives the **real** `prOpAction.handler` through a structural `GitHubOctokitClient` whose canonical-cased logins differ from the requested casing:

1. repo branch + `author: "OctoCat"` → the `octocat` PR is listed (was silently empty);
2. repo branch + exact-case `author: "hubot"` → still exactly that PR.

## Detailed testing steps

Red-proof: with unfixed `pr-op.ts`, test 1 fails (`expected 0 to be 1`). With the fix, both pass.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:6e86b98f2bc6a49faa5f75ab9b024381f226872b -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`. — N/A - filter-correctness defect; red-test output below captures the wrong behavior.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`. — N/A - green test below.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`. — N/A - non-interactive action path; assertions capture it fully.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>` — the unmodified production handler runs end to end against its client boundary.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`. — N/A - no browser/frontend involved.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`. — N/A - no model involvement.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable, or marked `N/A - <reason>` — the returned PR list per branch is the artifact; captured by the tests.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface. — N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no model involvement.

## Backend + frontend logs

Red-proof against unfixed source (this branch's tests, `develop@094f80ad2d` handler):

```text
FAIL … > GITHUB_PR list author filter > matches authors case-insensitively in the repo branch
AssertionError: expected 0 to be 1   // "Found 0 pull request(s)" for author "OctoCat" vs login "octocat"
```

Green with this PR:

```text
Test Files  2 passed (2)
     Tests  149 passed (149)  // full package suite
```

## Screenshots (before / after) + video walkthrough

N/A - filter-correctness defect; no rendered surface.

### Before

`GITHUB_PR list {repo, author:"OctoCat"}` → 0 results; same query sans repo → all results.

### After

Both branches agree on case-insensitive matching.

### Walkthrough video

N/A - non-interactive path.

## Audio / voice walkthrough

N/A - no audio surface.

## Known gaps / failures

- Full-repo `bun run verify` not run for this plugin-scoped change; package gates run instead: typecheck ✅, lint ✅, suite 149/149 ✅.
- The Octokit transport is stubbed at the structural client boundary; the code under test is the unmodified production action handler.

## Maintainer CI exception record

N/A - no exception requested

AI provider/model: opencode / x-preview-f-free
Client / agent tooling: opencode
Attribution status: self-reported
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"x-preview-f-free","client":"opencode","skill_revision":"self-hosted contribute-to-eliza skill"} -->

AI provider/model: opencode / x-preview-f-free
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-eliza
Attribution status: self-reported
— [contribution-batch]
<!-- slop-contribution-attribution:v1 {"provider":"opencode","model":"x-preview-f-free","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0W0GNDZ5ADHE8R7Y9Z3GJ1K","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-25T08:27:45.472Z","completed_at":"2026-08-25T10:49:22.543Z","skill_sha256":"7d4db0c19ef1171c18744a11ec1aceb613e3f779a9c49953ef1a0018aa80e4fd","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-25T08:27:47.445Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"fb2167ede6d20eed5787424a809871cf0a9d40df9e7e4218e7cbd36879582298","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"4b0ca646-2ecb-4633-9370-c07fc2809e73","object_id":"sha256:fb2167ede6d20eed5787424a809871cf0a9d40df9e7e4218e7cbd36879582298","sha256":"fb2167ede6d20eed5787424a809871cf0a9d40df9e7e4218e7cbd36879582298"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAgtL_SjSjM1n46ptKEJk4PBfQocRxDED3AUsopsbPpj8","device_key_id":"d72975edd2d14b15ee662f87b3c80771c33d1c0659d900ebbc7644d0dfaa241a","device_signature":"nxmZHHqmMXtLWGtaVeqGRoGumLk0qkcSNuMgR-xtiWeEAvUN860h8QV83wq_WLSKm79_xXErCGg_gej96zCPAA"}} -->
