### PR TITLE
test(wallet): cover cache-timed freshness boundary

### DIFF
--- a/plugins/plugin-wallet/src/analytics/birdeye/providers/trending.test.ts
+++ b/plugins/plugin-wallet/src/analytics/birdeye/providers/trending.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from "vitest";
+import { getCacheTimed } from "./trending";
+
+function makeRuntime(getCache: ReturnType<typeof vi.fn>) {
+  return { getCache } as never;
+}
+
+describe("getCacheTimed freshness boundary", () => {
+  it("returns false on cache miss (no wrapper)", async () => {
+    const runtime = makeRuntime(vi.fn().mockResolvedValue(undefined));
+    await expect(getCacheTimed(runtime, "k")).resolves.toBe(false);
+    await expect(
+      getCacheTimed(runtime, "k", { notOlderThan: 5000 }),
+    ).resolves.toBe(false);
+  });
+
+  it("returns data without notOlderThan regardless of age", async () => {
+    const runtime = makeRuntime(
+      vi.fn().mockResolvedValue({ data: { x: 1 }, setAt: 0 }),
+    );
+    await expect(getCacheTimed(runtime, "k")).resolves.toEqual({ x: 1 });
+  });
+
+  it("returns data while within the freshness window", async () => {
+    const runtime = makeRuntime(
+      vi.fn().mockResolvedValue({ data: "fresh", setAt: Date.now() - 1000 }),
+    );
+    await expect(
+      getCacheTimed(runtime, "k", { notOlderThan: 5000 }),
+    ).resolves.toBe("fresh");
+  });
+
+  it("treats diff === notOlderThan as fresh (inclusive bound)", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(1_000_000_000_000);
+      const runtime = makeRuntime(
+        vi.fn().mockResolvedValue({
+          data: "edge",
+          setAt: 1_000_000_000_000 - 5000,
+        }),
+      );
+      await expect(
+        getCacheTimed(runtime, "k", { notOlderThan: 5000 }),
+      ).resolves.toBe("edge");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("returns false when older than the window", async () => {
+    const runtime = makeRuntime(
+      vi.fn().mockResolvedValue({ data: "stale", setAt: Date.now() - 5001 }),
+    );
+    await expect(
+      getCacheTimed(runtime, "k", { notOlderThan: 5000 }),
+    ).resolves.toBe(false);
+  });
+
+  it("serves corrupt wrappers missing setAt as fresh (NaN diff never expires)", async () => {
+    // A wrapper without a numeric setAt yields NaN; NaN > notOlderThan is
+    // false, so corrupt payloads are indistinguishable from fresh ones.
+    // Pins the degenerate case so a future fix is a deliberate change.
+    const runtime = makeRuntime(
+      vi.fn().mockResolvedValue({ data: "corrupt", setAt: undefined }),
+    );
+    await expect(
+      getCacheTimed(runtime, "k", { notOlderThan: 5000 }),
+    ).resolves.toBe("corrupt");
+  });
+
+  it("serves future-dated wrappers (clock skew) as fresh forever", async () => {
+    const future = Date.now() + 60_000;
+    const runtime = makeRuntime(
+      vi.fn().mockResolvedValue({ data: "skewed", setAt: future }),
+    );
+    await expect(
+      getCacheTimed(runtime, "k", { notOlderThan: 5000 }),
+    ).resolves.toBe("skewed");
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new test file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: 7 passed (freshness window, inclusive bound, corrupt setAt, future setAt) |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
