### PR TITLE
test(build): cover externalsFromPackageJson parsing boundaries

### DIFF
--- a/plugins/plugin-build-externals.test.ts
+++ b/plugins/plugin-build-externals.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({ readFile: vi.fn() }));
+
+vi.mock("node:fs/promises", () => ({
+  default: { readFile: mocks.readFile },
+  readFile: mocks.readFile,
+}));
+
+import { externalsFromPackageJson } from "./build-externals";
+
+function pkg(partial: Record<string, unknown> = {}) {
+  return JSON.stringify({
+    name: "p",
+    dependencies: { a: "^1.0.0", b: "^2.0.0" },
+    peerDependencies: { peer1: "^1.0.0" },
+    optionalDependencies: { opt1: "^1.0.0" },
+    ...partial,
+  });
+}
+
+describe("externalsFromPackageJson boundary", () => {
+  it("externalizes runtime, peer, and optional deps, sorted for stable diffs", async () => {
+    mocks.readFile.mockResolvedValue(pkg());
+    await expect(externalsFromPackageJson("/x/package.json")).resolves.toEqual([
+      "a",
+      "b",
+      "opt1",
+      "peer1",
+    ]);
+  });
+
+  it("excludes peer deps when includePeer=false", async () => {
+    mocks.readFile.mockResolvedValue(pkg());
+    await expect(
+      externalsFromPackageJson("/x/package.json", { includePeer: false }),
+    ).resolves.toEqual(["a", "b", "opt1"]);
+  });
+
+  it("excludes optional deps when includeOptional=false", async () => {
+    mocks.readFile.mockResolvedValue(pkg());
+    await expect(
+      externalsFromPackageJson("/x/package.json", { includeOptional: false }),
+    ).resolves.toEqual(["a", "b", "peer1"]);
+  });
+
+  it("merges caller-supplied extras and dedupes against package deps", async () => {
+    mocks.readFile.mockResolvedValue(pkg());
+    await expect(
+      externalsFromPackageJson("/x/package.json", { extra: ["node:fs", "a"] }),
+    ).resolves.toEqual(["a", "b", "node:fs", "opt1", "peer1"]);
+  });
+
+  it("tolerates missing dependency sections", async () => {
+    mocks.readFile.mockResolvedValue(
+      pkg({
+        dependencies: undefined,
+        peerDependencies: undefined,
+        optionalDependencies: undefined,
+      }),
+    );
+    await expect(externalsFromPackageJson("/x/package.json")).resolves.toEqual(
+      [],
+    );
+  });
+
+  it("propagates malformed JSON as a hard error (fail loud, no partial externals)", async () => {
+    mocks.readFile.mockResolvedValue("{ not json");
+    await expect(externalsFromPackageJson("/x/package.json")).rejects.toThrow(
+      SyntaxError,
+    );
+  });
+
+  it("propagates read failures instead of returning an empty list", async () => {
+    mocks.readFile.mockRejectedValue(new Error("ENOENT: no such file"));
+    await expect(externalsFromPackageJson("/x/package.json")).rejects.toThrow(
+      "ENOENT",
+    );
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new test file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: 7 passed (sorting, includePeer/includeOptional toggles, dedupe, malformed JSON fail-loud, read-failure propagation) |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
