### PR TITLE
test(sql): cover CacheStore fail-loud boundaries

### DIFF
--- a/plugins/plugin-sql/src/stores/cache.store.test.ts
+++ b/plugins/plugin-sql/src/stores/cache.store.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from "vitest";
+import { CacheStore } from "./cache.store";
+
+type DbChain = ReturnType<typeof makeDb>;
+
+function makeDb(
+  opts: { rows?: Array<{ value: unknown }>; failGet?: Error; failInsert?: Error } = {}
+) {
+  const db = {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn(async () => {
+            if (opts.failGet) throw opts.failGet;
+            return opts.rows ?? [];
+          }),
+        })),
+      })),
+    })),
+    insert: vi.fn(() => ({
+      values: vi.fn(() => ({
+        onConflictDoUpdate: vi.fn(async () => {
+          if (opts.failInsert) throw opts.failInsert;
+        }),
+      })),
+    })),
+    delete: vi.fn(() => ({
+      where: vi.fn(async () => {}),
+    })),
+    transaction: vi.fn(async (fn: (tx: unknown) => Promise<unknown>) =>
+      fn({
+        delete: () => ({ where: vi.fn(async () => {}) }),
+      })
+    ),
+  };
+  return db;
+}
+
+function makeStore(db: DbChain) {
+  return new CacheStore({
+    agentId: "agent-1",
+    getDb: () => db,
+    withRetry: (fn: () => Promise<unknown>) => fn(),
+  } as never);
+}
+
+describe("CacheStore fail-loud boundaries", () => {
+  it("returns the cached value on hit", async () => {
+    const db = makeDb({ rows: [{ value: "v1" }] });
+    await expect(makeStore(db).get<string>("k")).resolves.toBe("v1");
+    expect(db.select).toHaveBeenCalledWith({ value: expect.anything() });
+  });
+
+  it("returns undefined on cache miss (empty result)", async () => {
+    const db = makeDb({ rows: [] });
+    await expect(makeStore(db).get<string>("k")).resolves.toBeUndefined();
+  });
+
+  it("propagates query failures instead of masking them as a miss", async () => {
+    // A broken DB must never read as "not cached": undefined would let the
+    // caller refetch and overwrite a possibly-fresh value silently.
+    const db = makeDb({
+      failGet: new Error("db exploded"),
+    });
+    await expect(makeStore(db).get<string>("k")).rejects.toThrow("db exploded");
+  });
+
+  it("returns true after an upsert on set", async () => {
+    const db = makeDb();
+    const store = makeStore(db);
+    await expect(store.set("k", { n: 1 })).resolves.toBe(true);
+    const chain = db.insert.mock.results[0]?.value as {
+      values: ReturnType<typeof vi.fn>;
+    };
+    const values = chain.values.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(values).toMatchObject({ key: "k", agentId: "agent-1" });
+    const upsert = chain.values.mock.results[0]?.value as {
+      onConflictDoUpdate: ReturnType<typeof vi.fn>;
+    };
+    expect(upsert.onConflictDoUpdate).toHaveBeenCalledWith({
+      target: [expect.anything(), expect.anything()],
+      set: { value: { n: 1 } },
+    });
+  });
+
+  it("propagates write failures instead of returning a benign false", async () => {
+    const db = makeDb({
+      failInsert: new Error("disk full"),
+    });
+    await expect(makeStore(db).set("k", 1)).rejects.toThrow("disk full");
+  });
+
+  it("returns true after delete", async () => {
+    const db = makeDb();
+    await expect(makeStore(db).delete("k")).resolves.toBe(true);
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new test file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: 6 passed (hit, miss, query-failure propagation, upsert, write-failure propagation, delete) |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
