### PR TITLE
test(orchestrator): isolate subscription probes

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/task-agent-frameworks.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/task-agent-frameworks.test.ts
@@ -53,6 +53,8 @@ function installedProbe(): TaskAgentFrameworkProbe {
       { adapter: "Claude Code", installed: true },
       { adapter: "OpenAI Codex", installed: true },
     ]),
+    hasClaudeSubscriptionAuth: () => false,
+    hasCodexSubscriptionAuth: () => false,
   };
 }
 
@@ -69,6 +71,8 @@ function delayedInstalledProbe(): TaskAgentFrameworkProbe {
           }, 10);
         }),
     ),
+    hasClaudeSubscriptionAuth: () => false,
+    hasCodexSubscriptionAuth: () => false,
   };
 }
 

--- a/plugins/plugin-agent-orchestrator/src/services/task-agent-frameworks.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/task-agent-frameworks.ts
@@ -85,6 +85,12 @@ export interface TaskAgentFrameworkProbe {
     types?: string[],
   ) => Promise<TaskAgentPreflightResult[]>;
   getAgentMetrics?: () => Record<string, AgentMetricsSummary>;
+  /**
+   * Overrides host credential discovery for deterministic inventory checks.
+   * Production callers omit these hooks and use the real subscription probes.
+   */
+  hasClaudeSubscriptionAuth?: () => boolean;
+  hasCodexSubscriptionAuth?: () => boolean;
 }
 
 export type TaskAgentTaskKind =
@@ -762,11 +768,13 @@ async function computeTaskAgentFrameworkState(
   );
 
   const claudeSubscriptionReady =
-    claudePreflightAuth === "authenticated" || hasClaudeSubscriptionAuth();
+    claudePreflightAuth === "authenticated" ||
+    (probe?.hasClaudeSubscriptionAuth ?? hasClaudeSubscriptionAuth)();
   const claudeAuthReady =
     cloudReady || claudeSubscriptionReady || hasClaudeApiKey(runtime);
   const codexSubscriptionReady =
-    codexPreflightAuth === "authenticated" || hasCodexSubscriptionAuth();
+    codexPreflightAuth === "authenticated" ||
+    (probe?.hasCodexSubscriptionAuth ?? hasCodexSubscriptionAuth)();
   const codexAuthReady =
     cloudReady || codexSubscriptionReady || hasCodexApiKey(runtime);
   const kimiProbe = probeSubscriptionCodingAdapter("kimi", {


### PR DESCRIPTION
## Summary
- make host subscription discovery injectable for framework inventory tests
- keep production behavior unchanged while preventing ambient Claude/Codex credentials from changing unit-test preference results

## Verification
- `bunx @biomejs/biome check plugins/plugin-agent-orchestrator/src/services/task-agent-frameworks.ts plugins/plugin-agent-orchestrator/__tests__/unit/task-agent-frameworks.test.ts`
- `bun test --conditions=eliza-source plugins/plugin-agent-orchestrator/__tests__/unit/task-agent-frameworks.test.ts` (30 passed)

The failure was reproducible on a logged-in Claude.ai Max macOS host before this seam: 2 preference tests failed because keychain auth changed the candidate score.