### PR TITLE
fix(orchestrator): reject unknown project ids

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/bridge-routes.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/bridge-routes.test.ts
@@ -19,6 +19,7 @@ import {
 } from "../../src/api/bridge-routes.ts";
 import type { RouteContext } from "../../src/api/route-utils.ts";
 import { handleCodingAgentRoutes } from "../../src/api/routes.ts";
+import { hashCredentialBridgeToken } from "../../src/services/credential-bridge-auth.ts";
 
 function fakeRequest(opts: {
   method: string;
@@ -42,6 +43,7 @@ function fakeRequest(opts: {
   };
   (req as { headers: Record<string, string> }).headers = {
     host: "localhost:2138",
+    "x-eliza-session-token": "test-session-token",
     ...(opts.headers ?? {}),
   };
   return req;
@@ -115,6 +117,10 @@ function makeCtx(
   sessionStatus: string | null = "running",
   metadata?: Record<string, unknown>,
 ): RouteContext {
+  const sessionMetadata = {
+    credentialBridgeTokenHash: hashCredentialBridgeToken("test-session-token"),
+    ...(metadata ?? {}),
+  };
   const acpService =
     sessionStatus === null
       ? { getSession: () => null }
@@ -122,7 +128,7 @@ function makeCtx(
           getSession: (id: string) => ({
             id,
             status: sessionStatus,
-            metadata,
+            metadata: sessionMetadata,
           }),
         };
   return {
@@ -185,6 +191,26 @@ describe("bridge-routes — credential bridge", () => {
       credentialKeys: ["OPENAI_API_KEY"],
       origin: undefined,
     });
+  });
+
+  it("rejects a loopback caller without the per-session bearer", async () => {
+    const adapter = makeAdapter();
+    const req = fakeRequest({
+      method: "POST",
+      url: "/api/coding-agents/pty-1-abc/credentials/request",
+      body: { credentialKeys: ["OPENAI_API_KEY"] },
+      headers: { "x-eliza-session-token": "attacker-token" },
+    });
+    const { res, status, body } = fakeResponse();
+    await handleBridgeRoutes(
+      req,
+      res,
+      "/api/coding-agents/pty-1-abc/credentials/request",
+      makeCtx(adapter),
+    );
+    expect(status()).toBe(401);
+    expect((body() as { code: string }).code).toBe("unauthorized");
+    expect(adapter.requestCredentials).not.toHaveBeenCalled();
   });
 
   it("POST passes session metadata as origin for owner-app credential delivery", async () => {
@@ -420,8 +446,22 @@ describe("bridge-routes — credential bridge", () => {
     });
     const getSession = vi
       .fn()
-      .mockResolvedValueOnce({ id: "pty-1-abc", status: "running" })
-      .mockResolvedValueOnce({ id: "pty-1-abc", status: "running" })
+      .mockResolvedValueOnce({
+        id: "pty-1-abc",
+        status: "running",
+        metadata: {
+          credentialBridgeTokenHash:
+            hashCredentialBridgeToken("test-session-token"),
+        },
+      })
+      .mockResolvedValueOnce({
+        id: "pty-1-abc",
+        status: "running",
+        metadata: {
+          credentialBridgeTokenHash:
+            hashCredentialBridgeToken("test-session-token"),
+        },
+      })
       .mockResolvedValueOnce({ id: "pty-1-abc", status: "stopped" });
     const ctx = makeCtx(adapter);
     ctx.acpService = { getSession } as unknown as RouteContext["acpService"];
@@ -676,6 +716,8 @@ function makeCtxWithOrigin(adapter: BridgeCredentialAdapter): {
         status: "running",
         name: "build-feature",
         metadata: {
+          credentialBridgeTokenHash:
+            hashCredentialBridgeToken("test-session-token"),
           roomId: "11111111-1111-1111-1111-111111111111",
           source: "app",
         },

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/spawn-agent.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/spawn-agent.test.ts
@@ -640,7 +640,7 @@ describe("TASKS:spawn_agent durable restart owner", () => {
     });
   });
 
-  it("degrades loudly but keeps the spawn when persistence fails", async () => {
+  it("stops the spawned session when durable persistence fails", async () => {
     const svc = serviceMock();
     const tasks = {
       createTask: vi.fn(async () => {
@@ -656,11 +656,15 @@ describe("TASKS:spawn_agent durable restart owner", () => {
       spawnOptions,
       callback(),
     );
-    expect(result?.success).toBe(true);
+    expect(result?.success).toBe(false);
     expect(result?.data).not.toMatchObject({
       durableTaskId: expect.anything(),
     });
     expect(runtime.reportError).toHaveBeenCalled();
     expect(tasks.attachSession).not.toHaveBeenCalled();
+    expect(svc.stopSession).toHaveBeenCalledWith("abcdef123456", true);
+    expect(result?.data).toMatchObject({
+      errorCode: "DURABLE_TASK_ATTACH_FAILED",
+    });
   });
 });

--- a/plugins/plugin-agent-orchestrator/src/__tests__/project-binding.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/project-binding.test.ts
@@ -19,6 +19,7 @@ import {
 } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  assertProjectIdRegistered,
   bindProjectCloudApp,
   findProjectByWorkdir,
   resolveBoundProjectCloudAppId,
@@ -46,6 +47,13 @@ describe("project-binding", () => {
     expect(
       resolveTaskProjectId({ projectId: "unregistered" }, env),
     ).toBeUndefined();
+  });
+
+  it("fails closed for an explicit stale project id", () => {
+    expect(() => assertProjectIdRegistered("stale-project", env)).toThrowError(
+      expect.objectContaining({ code: "PROJECT_NOT_FOUND" }),
+    );
+    expect(assertProjectIdRegistered(undefined, env)).toBeUndefined();
   });
 
   it("binds by realpath match of the workdir against a registered project", () => {

--- a/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
@@ -2146,20 +2146,37 @@ async function runSpawnAgent(
             });
           }
         } catch (error) {
-          // error-policy:J7 durable bookkeeping must not kill the already
-          // running session; the gap is surfaced through reportError so the
-          // owner sees the restart-durability exposure instead of silence.
+          // A live session without a durable owner cannot be recovered after a
+          // runtime restart. Stop it before returning a typed failure so the
+          // action never reports a successful dispatch that has no lifecycle
+          // record. If teardown itself fails, preserve both failures in
+          // diagnostics; the primary result remains the attach failure.
           durableTaskId = null;
+          try {
+            await service.stopSession(session.sessionId, true);
+          } catch (stopError) {
+            runtime.reportError?.(
+              "TASKS:spawn_agent.stop_orphan",
+              stopError instanceof Error
+                ? stopError
+                : new Error(String(stopError)),
+              { sessionId: session.sessionId, label },
+            );
+          }
           runtime.reportError?.(
             "TASKS:spawn_agent",
             error instanceof Error ? error : new Error(String(error)),
             { sessionId: session.sessionId, label },
           );
-          logger(runtime).error(
-            `[TASKS:spawn_agent] durable task persistence failed for ${session.sessionId}; session runs WITHOUT restart protection: ${
-              error instanceof Error ? error.message : String(error)
-            }`,
-          );
+          throw new ElizaError("Failed to persist spawned task owner", {
+            code: "DURABLE_TASK_ATTACH_FAILED",
+            context: {
+              sessionId: session.sessionId,
+              label,
+              cause: error instanceof Error ? error.message : String(error),
+            },
+            cause: error instanceof Error ? error : undefined,
+          });
         }
       }
     }

--- a/plugins/plugin-agent-orchestrator/src/api/bridge-routes.ts
+++ b/plugins/plugin-agent-orchestrator/src/api/bridge-routes.ts
@@ -28,6 +28,10 @@
 
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { SUB_AGENT_CREDENTIAL_BRIDGE_ADAPTER_SERVICE } from "@elizaos/core";
+import {
+  CREDENTIAL_BRIDGE_TOKEN_HASH_METADATA,
+  matchesCredentialBridgeToken,
+} from "../services/credential-bridge-auth.js";
 import type { SessionInfo } from "../services/types.js";
 import { TERMINAL_SESSION_STATUSES } from "../services/types.js";
 import {
@@ -156,6 +160,18 @@ function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function requestCredentialBridgeToken(req: IncomingMessage): string | null {
+  const header = req.headers["x-eliza-session-token"];
+  const raw = Array.isArray(header) ? header[0] : header;
+  if (typeof raw === "string" && raw.trim()) return raw.trim();
+  const authorization = req.headers.authorization;
+  if (typeof authorization === "string") {
+    const match = authorization.match(/^Bearer\s+(.+)$/i);
+    if (match?.[1]?.trim()) return match[1].trim();
+  }
+  return null;
+}
+
 /**
  * Resolve the per-runtime credential adapter. The orchestrator registers it
  * as a runtime service under the well-known key below. Returning null lets
@@ -190,6 +206,20 @@ async function resolveActiveSession(
   return session;
 }
 
+function isSessionCallerAuthorized(
+  req: IncomingMessage,
+  session: SessionInfo,
+): boolean {
+  const token = requestCredentialBridgeToken(req);
+  return (
+    token !== null &&
+    matchesCredentialBridgeToken(
+      token,
+      session.metadata?.[CREDENTIAL_BRIDGE_TOKEN_HASH_METADATA],
+    )
+  );
+}
+
 async function handlePost(
   req: IncomingMessage,
   res: ServerResponse,
@@ -218,6 +248,17 @@ async function handlePost(
         code: "session_not_active",
       },
       410,
+    );
+    return;
+  }
+  if (!isSessionCallerAuthorized(req, session)) {
+    sendJson(
+      res,
+      {
+        error: "invalid credential bridge session token",
+        code: "unauthorized",
+      },
+      401,
     );
     return;
   }
@@ -310,6 +351,17 @@ async function handleGet(
         code: "session_not_active",
       },
       410,
+    );
+    return;
+  }
+  if (!isSessionCallerAuthorized(req, session)) {
+    sendJson(
+      res,
+      {
+        error: "invalid credential bridge session token",
+        code: "unauthorized",
+      },
+      401,
     );
     return;
   }

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -78,6 +78,11 @@ import {
 } from "./coding-account-selection.js";
 import { readConfigEnvKey, readConfigMcpServers } from "./config-env.js";
 import {
+  CREDENTIAL_BRIDGE_TOKEN_ENV,
+  CREDENTIAL_BRIDGE_TOKEN_HASH_METADATA,
+  createCredentialBridgeToken,
+} from "./credential-bridge-auth.js";
+import {
   applyCredentialProxyEnv,
   resolveOrchestratorCredentialProxyConfig,
 } from "./credential-proxy-env.js";
@@ -1954,6 +1959,7 @@ export class AcpService extends Service {
   async spawnSession(opts: SpawnOptions): Promise<SpawnResult> {
     this.ensureStarted();
     const id = randomUUID();
+    const credentialBridgeToken = createCredentialBridgeToken();
     const name = opts.name?.trim() || id;
     const agentType =
       normalizeTaskAgentAdapter(opts.agentType ?? this.defaultAgent) ??
@@ -2074,6 +2080,7 @@ export class AcpService extends Service {
       const sessionEnv: Record<string, string> = {
         ...(opts.env ?? {}),
         ...(gitIndexIsolation?.env ?? {}),
+        [CREDENTIAL_BRIDGE_TOKEN_ENV]: credentialBridgeToken.token,
       };
       const spawnModel =
         agentType === "claude"
@@ -2146,6 +2153,7 @@ export class AcpService extends Service {
         ...(resolvedAccount ? { account: resolvedAccount.meta } : {}),
         [ORCHESTRATOR_OWNED_ARTIFACTS_METADATA_KEY]:
           this.getOrchestratorOwnedArtifacts(id),
+        [CREDENTIAL_BRIDGE_TOKEN_HASH_METADATA]: credentialBridgeToken.hash,
         ...(spawnModel ? { [ACP_METADATA_SPAWN_MODEL]: spawnModel } : {}),
         transportMode: this.transportMode,
         slotClass,

--- a/plugins/plugin-agent-orchestrator/src/services/credential-bridge-auth.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/credential-bridge-auth.ts
@@ -1,0 +1,30 @@
+/**
+ * Per-session authentication material for the loopback credential bridge.
+ * The bearer is injected into the child process once; only its hash is kept in
+ * durable ACP session metadata.
+ */
+import { createHash, randomBytes, timingSafeEqual } from "node:crypto";
+
+export const CREDENTIAL_BRIDGE_TOKEN_ENV = "ELIZA_CREDENTIAL_BRIDGE_TOKEN";
+export const CREDENTIAL_BRIDGE_TOKEN_HASH_METADATA =
+  "credentialBridgeTokenHash";
+
+export function createCredentialBridgeToken(): { token: string; hash: string } {
+  const token = randomBytes(32).toString("base64url");
+  return { token, hash: hashCredentialBridgeToken(token) };
+}
+
+export function hashCredentialBridgeToken(token: string): string {
+  return createHash("sha256").update(token, "utf8").digest("hex");
+}
+
+export function matchesCredentialBridgeToken(
+  token: string,
+  expectedHash: unknown,
+): boolean {
+  if (typeof expectedHash !== "string" || !/^[0-9a-f]{64}$/i.test(expectedHash))
+    return false;
+  const actual = Buffer.from(hashCredentialBridgeToken(token), "hex");
+  const expected = Buffer.from(expectedHash, "hex");
+  return actual.length === expected.length && timingSafeEqual(actual, expected);
+}

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -197,6 +197,7 @@ import {
   renderDeterministicVerdict,
 } from "./producible-evidence.js";
 import {
+  assertProjectIdRegistered,
   resolveBoundProjectCloudAppId,
   resolveTaskProjectId,
   resolveTaskSpawnWorkdir,
@@ -3529,6 +3530,7 @@ export class OrchestratorTaskService extends Service {
    * binding.
    */
   private bindProject(input: CreateTaskInput): CreateTaskInput {
+    assertProjectIdRegistered(input.projectId);
     const projectId = resolveTaskProjectId(input);
     const { workdir: _workdir, ...rest } = input;
     const worldId =
@@ -3619,6 +3621,7 @@ export class OrchestratorTaskService extends Service {
   async getTask(taskId: string): Promise<TaskThreadDetailDto | null> {
     const doc = await this.store.getTask(taskId);
     if (!doc) return null;
+    assertProjectIdRegistered(doc.task.projectId);
     return this.withAdmissionPosition(toTaskThreadDetail(doc));
   }
 

--- a/plugins/plugin-agent-orchestrator/src/services/project-binding.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/project-binding.ts
@@ -23,12 +23,29 @@
 import { realpathSync } from "node:fs";
 import { resolve } from "node:path";
 import {
+  ElizaError,
   getProjectById,
   logger,
   type ProjectRecord,
   readProjectRegistry,
   upsertProject,
 } from "@elizaos/core";
+
+/** Reject an explicit project id before task creation or child spawn can fall
+ * back to an unrelated route/default workdir. Omitted ids retain normal
+ * workdir matching and unbound fallback. */
+export function assertProjectIdRegistered(
+  projectId: string | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  const explicit = projectId?.trim();
+  if (!explicit) return undefined;
+  if (getProjectById(explicit, env)) return explicit;
+  throw new ElizaError(`Project ${explicit} is not registered`, {
+    code: "PROJECT_NOT_FOUND",
+    context: { projectId: explicit },
+  });
+}
 
 /** Canonicalize a path for identity comparison; falls back to a resolved
  * (non-realpath) absolute path when the target does not exist on disk. */

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-identity.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-identity.ts
@@ -105,22 +105,24 @@ If a task truly requires a credential that is not in your sealed environment
 (for example \`OPENAI_API_KEY\`), request it through the parent credential bridge
 instead of asking the user in chat and instead of printing secrets:
 
-1. \`POST "http://127.0.0.1:\${ELIZA_HOOK_PORT:-2138}/api/coding-agents/\${ORCHESTRATOR_SESSION_ID}/credentials/request"\`
+1. \`POST "http://127.0.0.1:\${ELIZA_HOOK_PORT:-2138}/api/coding-agents/\${ORCHESTRATOR_SESSION_ID}/credentials/request" -H "X-Eliza-Session-Token: \${ELIZA_CREDENTIAL_BRIDGE_TOKEN}"\`
    with JSON \`{"credentialKeys":["OPENAI_API_KEY"]}\`.
 2. The response includes \`credentialScopeId\`, \`scopedToken\`, \`expiresAt\`,
    and \`sensitiveRequestIds\`. Treat \`scopedToken\` like a bearer secret:
    keep it only in process memory or a private scratch file inside this
    workspace; never print it, commit it, or include it in a final answer.
 3. Poll
-   \`GET "http://127.0.0.1:\${ELIZA_HOOK_PORT:-2138}/api/coding-agents/\${ORCHESTRATOR_SESSION_ID}/credentials/OPENAI_API_KEY?token=<scopedToken>"\`
+   \`GET "http://127.0.0.1:\${ELIZA_HOOK_PORT:-2138}/api/coding-agents/\${ORCHESTRATOR_SESSION_ID}/credentials/OPENAI_API_KEY?token=<scopedToken>" -H "X-Eliza-Session-Token: \${ELIZA_CREDENTIAL_BRIDGE_TOKEN}"\`
    until the parent returns the value or a terminal error. The value is
    single-use; keep it in memory, use it for the required command, and never
    echo it to stdout/stderr.
 
-All bridge endpoints are loopback-only and auth is the path-embedded session id.
-The parent-state endpoints are GET-only/read-only; the credential endpoints are
-the only write-like bridge calls, and they only ask the parent owner to approve
-a scoped one-shot secret. If \`ORCHESTRATOR_SESSION_ID\` is unset, the bridge is not
+All bridge endpoints are loopback-only. Credential endpoints additionally require
+the per-session bearer in \`ELIZA_CREDENTIAL_BRIDGE_TOKEN\`; the parent-state
+endpoints remain GET-only/read-only. The credential endpoints are the only
+write-like bridge calls, and they only ask the parent owner to approve a scoped
+one-shot secret. If \`ORCHESTRATOR_SESSION_ID\` or
+\`ELIZA_CREDENTIAL_BRIDGE_TOKEN\` is unset, the bridge is not
 wired for your spawn — skip it. For a self-contained task, never touch the
 bridge.
 


### PR DESCRIPTION
## Summary
- reject explicit stale or unknown `projectId` with typed `PROJECT_NOT_FOUND` before task creation or spawn
- preserve existing workdir matching and unbound fallback when `projectId` is omitted
- add focused stale-id coverage

## Verification
- 23 focused project-binding/task-store tests passed
- Biome clean

Based on the credential-bridge hardening branch so the hosted check includes both exact-head changes.