### PR TITLE
fix(calendar): fail loud when runtime adapter is missing in getRuntimeDb

### DIFF
--- a/plugins/plugin-calendar/src/internal/sql.test.ts
+++ b/plugins/plugin-calendar/src/internal/sql.test.ts
@@ -1,0 +1,194 @@
+import { ElizaError } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import {
+  executeRawSql,
+  executeRawSqlTx,
+  extractRows,
+  getRuntimeDb,
+  parseJsonArray,
+  parseJsonRecord,
+  sqlBoolean,
+  sqlInteger,
+  sqlJson,
+  sqlQuote,
+  sqlText,
+  toBoolean,
+  toNumber,
+  toText,
+  withCalendarTransaction,
+} from "./sql";
+
+describe("calendar/internal/sql value coercion", () => {
+  it("toText falls back for nullish and stringifies primitives", () => {
+    expect(toText("keep")).toBe("keep");
+    expect(toText(null)).toBe("");
+    expect(toText(undefined, "fb")).toBe("fb");
+    expect(toText(123)).toBe("123");
+    expect(toText(false)).toBe("false");
+  });
+
+  it("toNumber rejects non-finite numbers and unparsable strings", () => {
+    expect(toNumber(7)).toBe(7);
+    expect(toNumber("42")).toBe(42);
+    expect(toNumber(" 3.5 ")).toBe(3.5);
+    expect(toNumber("abc", -1)).toBe(-1);
+    expect(toNumber(null)).toBe(0);
+    expect(toNumber(Number.NaN, 9)).toBe(9);
+    expect(toNumber(Number.POSITIVE_INFINITY, 9)).toBe(9);
+  });
+
+  it("toBoolean normalizes string truthiness and rejects unknown values", () => {
+    expect(toBoolean(true)).toBe(true);
+    expect(toBoolean(0)).toBe(false);
+    expect(toBoolean(3)).toBe(true);
+    expect(toBoolean(" TRUE ")).toBe(true);
+    expect(toBoolean("yes")).toBe(true);
+    expect(toBoolean("on")).toBe(true);
+    expect(toBoolean("1")).toBe(true);
+    expect(toBoolean("off")).toBe(false);
+    expect(toBoolean("no")).toBe(false);
+    expect(toBoolean("0")).toBe(false);
+    expect(toBoolean("banana", true)).toBe(true);
+    expect(toBoolean(null)).toBe(false);
+  });
+});
+
+describe("calendar/internal/sql JSON parsing boundaries", () => {
+  it("parseJsonRecord requires an object and defaults missing values to {}", () => {
+    expect(parseJsonRecord(null)).toEqual({});
+    expect(parseJsonRecord("")).toEqual({});
+    expect(parseJsonRecord('{"a":1}')).toEqual({ a: 1 });
+    expect(() => parseJsonRecord("[]")).toThrow(
+      "[CalendarSql] Expected JSON object",
+    );
+    expect(() => parseJsonRecord("[1,2]")).toThrow(
+      "[CalendarSql] Expected JSON object",
+    );
+  });
+
+  it("parseJsonArray requires an array and defaults missing values to []", () => {
+    expect(parseJsonArray(null)).toEqual([]);
+    expect(parseJsonArray(undefined)).toEqual([]);
+    expect(parseJsonArray("")).toEqual([]);
+    expect(parseJsonArray("[1,2]")).toEqual([1, 2]);
+    expect(() => parseJsonArray("{}")).toThrow(
+      "[CalendarSql] Expected JSON array",
+    );
+    expect(() => parseJsonArray('{"a":1}')).toThrow(
+      "[CalendarSql] Expected JSON array",
+    );
+  });
+
+  it("parseJsonArray wraps malformed JSON parse failures", () => {
+    expect(() => parseJsonArray("{nope")).toThrow(
+      "[CalendarSql] Invalid JSON value:",
+    );
+  });
+});
+
+describe("calendar/internal/sql row extraction", () => {
+  it("extractRows flattens array results and {rows} results, dropping non-records", () => {
+    expect(extractRows([{ a: 1 }, null, 5, { b: 2 }])).toEqual([
+      { a: 1 },
+      { b: 2 },
+    ]);
+    expect(extractRows({ rows: [{ id: 1 }] })).toEqual([{ id: 1 }]);
+    expect(extractRows({ rows: [] })).toEqual([]);
+    expect(extractRows({ rows: "x" })).toEqual([]);
+    expect(extractRows("junk")).toEqual([]);
+    expect(extractRows(undefined)).toEqual([]);
+  });
+});
+
+describe("calendar/internal/sql runtime DB access", () => {
+  it("getRuntimeDb returns the adapter db and fails loud when absent", () => {
+    const db = { execute: async () => [] };
+    expect(getRuntimeDb({ adapter: { db } })).toBe(db);
+    expect(() => getRuntimeDb({})).toThrow(
+      "runtime database adapter unavailable",
+    );
+    expect(() => getRuntimeDb({ db: { execute: async () => [] } })).toThrow(
+      "runtime database adapter unavailable",
+    );
+  });
+
+  it("executeRawSql runs raw SQL through the adapter and extracts rows", async () => {
+    const db = { execute: async () => [{ id: 1 }] };
+    await expect(
+      executeRawSql({ adapter: { db } }, "SELECT id FROM t"),
+    ).resolves.toEqual([{ id: 1 }]);
+  });
+
+  it("executeRawSqlTx runs raw SQL through a transaction handle", async () => {
+    const tx = { execute: async () => ({ rows: [{ n: 1 }] }) };
+    await expect(executeRawSqlTx(tx, "UPDATE t SET n = 1")).resolves.toEqual([
+      { n: 1 },
+    ]);
+  });
+
+  it("withCalendarTransaction rejects non-transactional adapters with a typed error", async () => {
+    const db = { execute: async () => [] };
+    const err = await withCalendarTransaction(
+      { agentId: "agent-1", adapter: { db } },
+      async () => "never",
+    ).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(ElizaError);
+    const elizaErr = err as ElizaError;
+    expect(elizaErr.code).toBe("CALENDAR_SOURCE_TRANSACTION_REQUIRED");
+    expect(elizaErr.context).toEqual({ agentId: "agent-1" });
+  });
+
+  it("withCalendarTransaction commits through the adapter transaction", async () => {
+    const tx = { execute: async () => [] };
+    const db = {
+      execute: async () => [],
+      transaction: async (op: unknown) => op(tx),
+    };
+    const result = await withCalendarTransaction(
+      { agentId: "agent-2", adapter: { db } },
+      async (handle) => {
+        expect(handle).toBe(tx);
+        return "committed";
+      },
+    );
+    expect(result).toBe("committed");
+  });
+});
+
+describe("calendar/internal/sql SQL literal encoding", () => {
+  it("sqlQuote doubles embedded single quotes to prevent SQL string break-out", () => {
+    expect(sqlQuote("O'Brien")).toBe("'O''Brien'");
+    expect(sqlQuote("plain")).toBe("'plain'");
+    expect(sqlQuote("")).toBe("''");
+  });
+
+  it("sqlText encodes null/undefined as NULL", () => {
+    expect(sqlText(null)).toBe("NULL");
+    expect(sqlText(undefined)).toBe("NULL");
+    expect(sqlText("a'b")).toBe("'a''b'");
+  });
+
+  it("sqlBoolean emits SQL boolean literals", () => {
+    expect(sqlBoolean(true)).toBe("TRUE");
+    expect(sqlBoolean(false)).toBe("FALSE");
+  });
+
+  it("sqlInteger rejects unsafe integers instead of emitting lossy literals", () => {
+    expect(sqlInteger(42)).toBe("42");
+    expect(sqlInteger(Number.MAX_SAFE_INTEGER)).toBe("9007199254740991");
+    expect(() => sqlInteger(1.5)).toThrow("invalid integer SQL literal");
+    expect(() => sqlInteger(Number.NaN)).toThrow("invalid integer SQL literal");
+    expect(() => sqlInteger(Number.POSITIVE_INFINITY)).toThrow(
+      "invalid integer SQL literal",
+    );
+    expect(() => sqlInteger(Number.MAX_SAFE_INTEGER + 1)).toThrow(
+      "invalid integer SQL literal",
+    );
+  });
+
+  it("sqlJson stringifies values through the quote seam, null-safe", () => {
+    expect(sqlJson({ a: 1 })).toBe("'{\"a\":1}'");
+    expect(sqlJson(null)).toBe("'null'");
+    expect(sqlJson(undefined)).toBe("'null'");
+  });
+});

--- a/plugins/plugin-calendar/src/internal/sql.ts
+++ b/plugins/plugin-calendar/src/internal/sql.ts
@@ -114,7 +114,7 @@ async function getSqlRaw(): Promise<(query: string) => RawSqlQuery> {
 }
 
 export function getRuntimeDb(runtime: IAgentRuntime): RuntimeDb {
-  const db = runtime.adapter.db as RuntimeDb | undefined;
+  const db = runtime.adapter?.db as RuntimeDb | undefined;
   if (!db || typeof db.execute !== "function") {
     throw new Error("runtime database adapter unavailable");
   }


### PR DESCRIPTION
# Relates to

<!-- No issue; defect found while adding focused coverage for the calendar raw-SQL helper seam. -->

## Defect

`getRuntimeDb` in `plugins/plugin-calendar/src/internal/sql.ts` reads `runtime.adapter.db` without guarding a missing `adapter`. A runtime that has not loaded an SQL adapter therefore crashes with a raw `TypeError: Cannot read properties of undefined (reading 'db')` instead of the intended, namespaced fail-loud error `runtime database adapter unavailable`. The downstream callers (`executeRawSql`, `withCalendarTransaction`) rely on that error message to surface a clear configuration problem.

The scheduling plugin's sibling helper already optional-chains (`runtime.adapter?.db`); the calendar helper did not. Fix is a one-token change to optional chaining; regression coverage pins both the happy path and the adapter-less crash path.

## Test evidence

- `getRuntimeDb({})` → throws `runtime database adapter unavailable` (previously TypeError).
- `getRuntimeDb({ db })` without `adapter` → still throws the intended error (calendar does not fall back to `runtime.db`).
- `withCalendarTransaction` on a non-transactional adapter → `ElizaError` with `code: CALENDAR_SOURCE_TRANSACTION_REQUIRED` and `context.agentId` (unchanged behavior, now pinned).

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] Focused vitest suite passes in isolation (see evidence).
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. One-token production change (optional chaining) that only affects the error path for adapter-less runtimes; the previously crashing path now throws the documented error. All other paths unchanged and covered by the new test file.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `npx vitest run calendar/sql.test.ts` → 17/17 passed |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff + one-line source fix in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
