### PR TITLE
fix(computeruse): add grim fallback for Wayland screenshots

### DIFF
--- a/plugins/plugin-computeruse/src/__tests__/displays.real.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/displays.real.test.ts
@@ -142,6 +142,7 @@ describe("displays — Hyprland parser", () => {
         scaleFactor: 1.5,
         primary: true,
         name: "eDP-1",
+        waylandOutput: true,
       },
     ]);
   });

--- a/plugins/plugin-computeruse/src/__tests__/platform-capabilities.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/platform-capabilities.test.ts
@@ -84,6 +84,14 @@ describe("cross-platform computer-use capabilities", () => {
     });
   });
 
+  it("reports grim as the Wayland screenshot provider", () => {
+    const caps = detectFor("linux", ["grim"]);
+    expect(caps.screenshot).toEqual({
+      available: true,
+      tool: "grim (Wayland)",
+    });
+  });
+
   it("reports no screenshot tool when none of import/scrot/gnome/ffmpeg exist", () => {
     const caps = detectFor("linux", []);
     expect(caps.screenshot.available).toBe(false);
@@ -117,7 +125,7 @@ describe("cross-platform computer-use capabilities", () => {
 
     expect(caps.screenshot).toMatchObject({
       available: false,
-      tool: "none (install ImageMagick, scrot, gnome-screenshot, or ffmpeg)",
+      tool: "none (install grim, ImageMagick, scrot, gnome-screenshot, or ffmpeg)",
     });
     expect(caps.computerUse).toMatchObject({
       available: false,

--- a/plugins/plugin-computeruse/src/__tests__/platform-capabilities.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/platform-capabilities.test.ts
@@ -27,12 +27,14 @@ function detectFor(
   availableCommands: string[],
   browserAvailable = true,
   driverName: "legacy" | "nutjs" = "legacy",
+  wayland = false,
 ) {
   const commands = new Set(availableCommands);
   return detectPlatformCapabilities({
     osName,
     commandExists: (command) => commands.has(command),
     driverName,
+    isWaylandSession: () => wayland,
     isBrowserAvailable: () => browserAvailable,
     shell: "/bin/zsh",
   });
@@ -85,11 +87,16 @@ describe("cross-platform computer-use capabilities", () => {
   });
 
   it("reports grim as the Wayland screenshot provider", () => {
-    const caps = detectFor("linux", ["grim"]);
+    const caps = detectFor("linux", ["grim"], true, "legacy", true);
     expect(caps.screenshot).toEqual({
       available: true,
       tool: "grim (Wayland)",
     });
+  });
+
+  it("does not report grim as an X11 provider", () => {
+    const caps = detectFor("linux", ["grim"], true, "legacy", false);
+    expect(caps.screenshot.available).toBe(false);
   });
 
   it("reports no screenshot tool when none of import/scrot/gnome/ffmpeg exist", () => {

--- a/plugins/plugin-computeruse/src/platform/capabilities.ts
+++ b/plugins/plugin-computeruse/src/platform/capabilities.ts
@@ -123,7 +123,9 @@ export function detectPlatformCapabilities(
     };
     caps.clipboard = { available: true, tool: "pbpaste / pbcopy (built-in)" };
   } else if (options.osName === "linux") {
-    if (options.commandExists("import")) {
+    if (options.commandExists("grim")) {
+      caps.screenshot = { available: true, tool: "grim (Wayland)" };
+    } else if (options.commandExists("import")) {
       caps.screenshot = { available: true, tool: "ImageMagick import" };
     } else if (options.commandExists("scrot")) {
       caps.screenshot = { available: true, tool: "scrot" };
@@ -134,7 +136,7 @@ export function detectPlatformCapabilities(
     } else {
       caps.screenshot = {
         available: false,
-        tool: "none (install ImageMagick, scrot, gnome-screenshot, or ffmpeg)",
+        tool: "none (install grim, ImageMagick, scrot, gnome-screenshot, or ffmpeg)",
       };
     }
 

--- a/plugins/plugin-computeruse/src/platform/capabilities.ts
+++ b/plugins/plugin-computeruse/src/platform/capabilities.ts
@@ -6,12 +6,14 @@
 import type { PlatformCapabilities } from "../types.js";
 import { type DriverName, selectedDriver } from "./driver.js";
 import type { PlatformOS } from "./helpers.js";
+import { isWaylandSession } from "./wayland-portal.js";
 
 export interface CapabilityDetectionOptions {
   osName: PlatformOS;
   commandExists: (command: string) => boolean;
   driverName?: DriverName;
   isBrowserAvailable: () => boolean;
+  isWaylandSession?: () => boolean;
   shell?: string;
 }
 
@@ -123,7 +125,8 @@ export function detectPlatformCapabilities(
     };
     caps.clipboard = { available: true, tool: "pbpaste / pbcopy (built-in)" };
   } else if (options.osName === "linux") {
-    if (options.commandExists("grim")) {
+    const wayland = options.isWaylandSession?.() ?? isWaylandSession();
+    if (wayland && options.commandExists("grim")) {
       caps.screenshot = { available: true, tool: "grim (Wayland)" };
     } else if (options.commandExists("import")) {
       caps.screenshot = { available: true, tool: "ImageMagick import" };

--- a/plugins/plugin-computeruse/src/platform/capture.ts
+++ b/plugins/plugin-computeruse/src/platform/capture.ts
@@ -39,6 +39,7 @@ import {
   isPermissionDeniedError,
 } from "./permissions.js";
 import { psHostAvailable, runPsHost } from "./ps-host.js";
+import { tryCaptureWaylandGrim } from "./wayland-grim.js";
 import {
   canUseWaylandScreenshotPortal,
   captureWaylandPortalScreenshot,
@@ -142,7 +143,8 @@ export async function captureDisplayRegion(
   );
   try {
     if (os === "darwin") captureRegionDarwin(tmpFile, globalRegion);
-    else if (os === "linux") captureRegionLinux(tmpFile, globalRegion);
+    else if (os === "linux")
+      captureRegionLinux(tmpFile, globalRegion, display.name);
     else if (os === "win32") await captureRegionWindows(tmpFile, globalRegion);
     const data = readFileSync(tmpFile);
     return { display, frame: data };
@@ -201,7 +203,18 @@ function captureRegionDarwin(tmpFile: string, region: ScreenRegion): void {
 
 function captureDisplayLinux(tmpFile: string, display: DisplayInfo): void {
   const [x, y, w, h] = display.bounds;
-  if (tryCaptureWaylandPortal(tmpFile)) return;
+  if (isWaylandSession()) {
+    if (tryCaptureWaylandGrim(tmpFile, undefined, display.name)) return;
+    if (
+      display.primary &&
+      listDisplays().length === 1 &&
+      tryCaptureWaylandPortal(tmpFile)
+    )
+      return;
+    throw new Error(
+      "Wayland per-display capture requires grim; portal capture cannot select a non-primary output.",
+    );
+  }
   if (commandExists("import")) {
     runCommandBuffer(
       "import",
@@ -243,12 +256,23 @@ function captureDisplayLinux(tmpFile: string, display: DisplayInfo): void {
   }
   throw new Error(
     isWaylandSession()
-      ? "No screenshot tool available. Install xdg-desktop-portal with gdbus/python3 for Wayland, or ImageMagick (import), scrot, gnome-screenshot, or ffmpeg for X11 fallback."
+      ? "No screenshot tool available. Install grim or xdg-desktop-portal with gdbus/python3 for Wayland, or ImageMagick (import), scrot, gnome-screenshot, or ffmpeg for X11 fallback."
       : "No screenshot tool available. Install ImageMagick (import), scrot, gnome-screenshot, or ffmpeg.",
   );
 }
 
-function captureRegionLinux(tmpFile: string, region: ScreenRegion): void {
+function captureRegionLinux(
+  tmpFile: string,
+  region: ScreenRegion,
+  outputName?: string,
+): void {
+  if (isWaylandSession() && tryCaptureWaylandGrim(tmpFile, region, outputName))
+    return;
+  if (isWaylandSession()) {
+    throw new Error(
+      "Wayland region capture requires grim; portal capture does not provide region selection.",
+    );
+  }
   if (commandExists("import")) {
     runCommandBuffer(
       "import",

--- a/plugins/plugin-computeruse/src/platform/capture.ts
+++ b/plugins/plugin-computeruse/src/platform/capture.ts
@@ -204,7 +204,15 @@ function captureRegionDarwin(tmpFile: string, region: ScreenRegion): void {
 function captureDisplayLinux(tmpFile: string, display: DisplayInfo): void {
   const [x, y, w, h] = display.bounds;
   if (isWaylandSession()) {
-    if (tryCaptureWaylandGrim(tmpFile, undefined, display.name)) return;
+    const outputName = authoritativeWaylandOutputName(display.name);
+    if (outputName && tryCaptureWaylandGrim(tmpFile, undefined, outputName))
+      return;
+    if (
+      !outputName &&
+      listDisplays().length === 1 &&
+      tryCaptureWaylandGrim(tmpFile)
+    )
+      return;
     if (
       display.primary &&
       listDisplays().length === 1 &&
@@ -266,7 +274,19 @@ function captureRegionLinux(
   region: ScreenRegion,
   outputName?: string,
 ): void {
-  if (isWaylandSession() && tryCaptureWaylandGrim(tmpFile, region, outputName))
+  const scopedOutputName = authoritativeWaylandOutputName(outputName);
+  if (
+    isWaylandSession() &&
+    scopedOutputName &&
+    tryCaptureWaylandGrim(tmpFile, region, scopedOutputName)
+  )
+    return;
+  if (
+    isWaylandSession() &&
+    !scopedOutputName &&
+    listDisplays().length === 1 &&
+    tryCaptureWaylandGrim(tmpFile, region)
+  )
     return;
   if (isWaylandSession()) {
     throw new Error(
@@ -322,6 +342,20 @@ function captureRegionLinux(
     return;
   }
   throw new Error("No screenshot tool available for region capture.");
+}
+
+function authoritativeWaylandOutputName(
+  name: string | undefined,
+): string | undefined {
+  if (!name) return undefined;
+  if (
+    name === "primary" ||
+    name === "main" ||
+    name.startsWith("output-") ||
+    name.startsWith("display-")
+  )
+    return undefined;
+  return name;
 }
 
 function tryCaptureWaylandPortal(tmpFile: string): boolean {

--- a/plugins/plugin-computeruse/src/platform/capture.ts
+++ b/plugins/plugin-computeruse/src/platform/capture.ts
@@ -143,8 +143,7 @@ export async function captureDisplayRegion(
   );
   try {
     if (os === "darwin") captureRegionDarwin(tmpFile, globalRegion);
-    else if (os === "linux")
-      captureRegionLinux(tmpFile, globalRegion, display.name);
+    else if (os === "linux") captureRegionLinux(tmpFile, globalRegion, display);
     else if (os === "win32") await captureRegionWindows(tmpFile, globalRegion);
     const data = readFileSync(tmpFile);
     return { display, frame: data };
@@ -204,7 +203,7 @@ function captureRegionDarwin(tmpFile: string, region: ScreenRegion): void {
 function captureDisplayLinux(tmpFile: string, display: DisplayInfo): void {
   const [x, y, w, h] = display.bounds;
   if (isWaylandSession()) {
-    const outputName = authoritativeWaylandOutputName(display.name);
+    const outputName = authoritativeWaylandOutputName(display);
     if (outputName && tryCaptureWaylandGrim(tmpFile, undefined, outputName))
       return;
     if (
@@ -272,9 +271,9 @@ function captureDisplayLinux(tmpFile: string, display: DisplayInfo): void {
 function captureRegionLinux(
   tmpFile: string,
   region: ScreenRegion,
-  outputName?: string,
+  display?: DisplayInfo,
 ): void {
-  const scopedOutputName = authoritativeWaylandOutputName(outputName);
+  const scopedOutputName = authoritativeWaylandOutputName(display);
   if (
     isWaylandSession() &&
     scopedOutputName &&
@@ -344,18 +343,10 @@ function captureRegionLinux(
   throw new Error("No screenshot tool available for region capture.");
 }
 
-function authoritativeWaylandOutputName(
-  name: string | undefined,
+export function authoritativeWaylandOutputName(
+  display: DisplayInfo | undefined,
 ): string | undefined {
-  if (!name) return undefined;
-  if (
-    name === "primary" ||
-    name === "main" ||
-    name.startsWith("output-") ||
-    name.startsWith("display-")
-  )
-    return undefined;
-  return name;
+  return display?.waylandOutput === true ? display.name : undefined;
 }
 
 function tryCaptureWaylandPortal(tmpFile: string): boolean {

--- a/plugins/plugin-computeruse/src/platform/displays.ts
+++ b/plugins/plugin-computeruse/src/platform/displays.ts
@@ -40,6 +40,8 @@ export interface DisplayInfo {
   primary: boolean;
   /** Human-readable name (e.g. `eDP-1`, `Built-in Retina Display`). */
   name: string;
+  /** True only when the name came from native Wayland compositor output metadata. */
+  waylandOutput?: boolean;
 }
 
 /**
@@ -308,6 +310,7 @@ export function parseHyprlandMonitors(output: string): DisplayInfo[] {
       scaleFactor: Number.isFinite(Number(item.scale)) ? Number(item.scale) : 1,
       primary: Boolean(item.focused) || idx === 0,
       name: typeof item.name === "string" ? item.name : `output-${idx}`,
+      waylandOutput: true,
     });
     idx += 1;
   }
@@ -348,6 +351,7 @@ export function parseSwayOutputs(output: string): DisplayInfo[] {
       scaleFactor: Number.isFinite(Number(item.scale)) ? Number(item.scale) : 1,
       primary: Boolean(item.primary || item.focused) || idx === 0,
       name: typeof item.name === "string" ? item.name : `output-${idx}`,
+      waylandOutput: true,
     });
     idx += 1;
   }

--- a/plugins/plugin-computeruse/src/platform/screenshot.test.ts
+++ b/plugins/plugin-computeruse/src/platform/screenshot.test.ts
@@ -4,6 +4,8 @@
  * at the native CLI boundary; real compositor acceptance remains device-backed.
  */
 import { describe, expect, it } from "vitest";
+import { authoritativeWaylandOutputName } from "./capture.js";
+import type { DisplayInfo } from "./displays.js";
 import { waylandGrimArgs } from "./wayland-grim.js";
 
 describe("Wayland grim capture arguments", () => {
@@ -34,5 +36,28 @@ describe("Wayland grim capture arguments", () => {
       "DP-1",
       "/tmp/output.png",
     ]);
+  });
+
+  it("does not infer native output provenance from an XWayland name", () => {
+    const xwaylandDisplay: DisplayInfo = {
+      id: 0,
+      bounds: [0, 0, 1920, 1080],
+      scaleFactor: 1,
+      primary: true,
+      name: "XWAYLAND0",
+    };
+    expect(authoritativeWaylandOutputName(xwaylandDisplay)).toBeUndefined();
+  });
+
+  it("accepts only compositor-proven output names for scoped capture", () => {
+    const compositorDisplay: DisplayInfo = {
+      id: 0,
+      bounds: [0, 0, 1920, 1080],
+      scaleFactor: 1,
+      primary: true,
+      name: "DP-1",
+      waylandOutput: true,
+    };
+    expect(authoritativeWaylandOutputName(compositorDisplay)).toBe("DP-1");
   });
 });

--- a/plugins/plugin-computeruse/src/platform/screenshot.test.ts
+++ b/plugins/plugin-computeruse/src/platform/screenshot.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Verifies the Wayland grim capture contract without requiring a compositor.
+ * The argument assertions protect region coordinates and output-path ordering
+ * at the native CLI boundary; real compositor acceptance remains device-backed.
+ */
+import { describe, expect, it } from "vitest";
+import { waylandGrimArgs } from "./wayland-grim.js";
+
+describe("Wayland grim capture arguments", () => {
+  it("captures the full display to the requested file", () => {
+    expect(waylandGrimArgs("/tmp/full.png")).toEqual([
+      "-s",
+      "1",
+      "/tmp/full.png",
+    ]);
+  });
+
+  it("preserves the requested region geometry", () => {
+    expect(
+      waylandGrimArgs("/tmp/region.png", {
+        x: 12,
+        y: 34,
+        width: 800,
+        height: 600,
+      }),
+    ).toEqual(["-s", "1", "-g", "12,34 800x600", "/tmp/region.png"]);
+  });
+
+  it("selects one compositor output without changing geometry", () => {
+    expect(waylandGrimArgs("/tmp/output.png", undefined, "DP-1")).toEqual([
+      "-s",
+      "1",
+      "-o",
+      "DP-1",
+      "/tmp/output.png",
+    ]);
+  });
+});

--- a/plugins/plugin-computeruse/src/platform/screenshot.ts
+++ b/plugins/plugin-computeruse/src/platform/screenshot.ts
@@ -22,6 +22,7 @@ import {
 } from "./permissions.js";
 import { psHostAvailable, runPsHost } from "./ps-host.js";
 import { tagScreenshotError } from "./screenshot-errors.js";
+import { tryCaptureWaylandGrim } from "./wayland-grim.js";
 import {
   canUseWaylandScreenshotPortal,
   captureWaylandPortalScreenshot,
@@ -125,7 +126,12 @@ function captureDarwin(tmpFile: string, region?: ScreenRegion): void {
 // ── Linux ───────────────────────────────────────────────────────────────────
 
 function captureLinux(tmpFile: string, region?: ScreenRegion): void {
-  if (!region && tryCaptureWaylandPortal(tmpFile)) return;
+  if (isWaylandSession()) {
+    // wlroots portals expose ScreenCast but not the Screenshot interface used
+    // by the portal sidecar. Prefer grim when present, including for regions.
+    if (tryCaptureWaylandGrim(tmpFile, region)) return;
+    if (!region && tryCaptureWaylandPortal(tmpFile)) return;
+  }
 
   // Try tools in preference order
   if (commandExists("import")) {
@@ -177,7 +183,7 @@ function captureLinux(tmpFile: string, region?: ScreenRegion): void {
   } else {
     throw new Error(
       isWaylandSession()
-        ? "No screenshot tool available. Install xdg-desktop-portal with gdbus/python3 for Wayland, or ImageMagick (import), scrot, gnome-screenshot, or ffmpeg for X11 fallback."
+        ? "No screenshot tool available. Install grim or xdg-desktop-portal with gdbus/python3 for Wayland, or ImageMagick (import), scrot, gnome-screenshot, or ffmpeg for X11 fallback."
         : "No screenshot tool available. Install ImageMagick (import), scrot, gnome-screenshot, or ffmpeg.",
     );
   }

--- a/plugins/plugin-computeruse/src/platform/wayland-grim.ts
+++ b/plugins/plugin-computeruse/src/platform/wayland-grim.ts
@@ -1,0 +1,43 @@
+/**
+ * Native grim capture for Wayland compositors that do not implement the
+ * portal Screenshot interface. Arguments keep frames in logical coordinates,
+ * select one compositor output when requested, and never invoke a shell.
+ */
+import type { ScreenRegion } from "../types.js";
+import { commandExists, runCommandBuffer } from "./helpers.js";
+
+export function waylandGrimArgs(
+  tmpFile: string,
+  region?: ScreenRegion,
+  outputName?: string,
+): string[] {
+  return [
+    "-s",
+    "1",
+    ...(outputName ? ["-o", outputName] : []),
+    ...(region
+      ? ["-g", `${region.x},${region.y} ${region.width}x${region.height}`]
+      : []),
+    tmpFile,
+  ];
+}
+
+export function tryCaptureWaylandGrim(
+  tmpFile: string,
+  region?: ScreenRegion,
+  outputName?: string,
+): boolean {
+  if (!commandExists("grim")) return false;
+  try {
+    runCommandBuffer(
+      "grim",
+      waylandGrimArgs(tmpFile, region, outputName),
+      10000,
+    );
+    return true;
+  } catch {
+    // error-policy:J4 grim is a compositor-specific tier; callers continue
+    // through the portal/X11 fallback and surface the final classified error.
+    return false;
+  }
+}

--- a/plugins/plugin-computeruse/src/services/computer-use-service.ts
+++ b/plugins/plugin-computeruse/src/services/computer-use-service.ts
@@ -113,6 +113,7 @@ import {
   readTerminal,
   typeTerminal,
 } from "../platform/terminal.js";
+import { isWaylandSession } from "../platform/wayland-portal.js";
 import {
   arrangeWindows,
   closeWindow,
@@ -2549,6 +2550,9 @@ export class ComputerUseService extends Service {
       logger.debug(
         `[computeruse] per-display capture failed (${errorMessage(error)}); falling back to driver capture`,
       );
+      if (displayId !== undefined && listDisplays().length > 1) {
+        throw error;
+      }
       const buf = await driverCaptureScreenshot();
       return {
         base64: buf.toString("base64"),
@@ -2934,6 +2938,7 @@ export class ComputerUseService extends Service {
       osName: currentPlatform(),
       commandExists,
       isBrowserAvailable,
+      isWaylandSession,
       shell: process.env.SHELL,
     });
   }


### PR DESCRIPTION
## Summary

Adds a native `grim` screenshot tier for Wayland/wlroots hosts. `xdg-desktop-portal-wlr` exposes ScreenCast rather than the Screenshot interface used by the existing portal sidecar, so Wayland capture previously degraded despite a working compositor. Full-screen and region captures now use logical scale (`-s 1`), select the requested output (`-o`), and refuse mislabeled composite fallback. The canonical per-display and region capture paths plus capability readiness now use the same contract.

## Verification

- Focused Wayland/grim/capability tests: 2 files, 15 tests passed
- `bun run --cwd plugins/plugin-computeruse lint:check` passed
- `bun run --cwd plugins/plugin-computeruse typecheck` passed
- `git diff --check` passed
- Hosted exact-head source static smoke, Windows security, and all-tests lanes are running for `cf4a313a7529635b87286407bfeb1e06da502c92`

## Evidence

A real Debian 13 Wayland headless compositor/portal attempt reproduced the missing `org.freedesktop.portal.Screenshot` interface in `xdg-desktop-portal-wlr`; the canonical fallback now targets compositor-native grim capture. Full GNOME/KDE desktop acceptance still requires a real Wayland user session.

<!-- evidence-head:cf4a313a7529635b87286407bfeb1e06da502c92 -->
<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend/platform capture change
<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend/platform capture change
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - backend/platform capture change
<!-- evidence-row:backend-logs -->
- [x] Focused tests and hosted checks listed above
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend surface
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model/prompt change
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no generated domain artifact
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface