### PR TITLE
test(skills): cover prompt whitespace compaction, command fallback, and alias contracts

### DIFF
--- a/packages/skills/test/formatter.test.ts
+++ b/packages/skills/test/formatter.test.ts
@@ -280,4 +280,114 @@ describe("buildSkillCommandSpecs", () => {
     const specs = buildSkillCommandSpecs(entries);
     assert.strictEqual(specs[0].dispatch, undefined);
   });
+
+  it("compacts multi-line whitespace and trims fields in formatted prompt", () => {
+    const skills: Skill[] = [
+      {
+        name: "  multi   line  \n skill  ",
+        description: "  A \n\t description  with   extra \r\n spaces  ",
+        filePath: "  /path/to/\n  SKILL.md  ",
+      },
+    ];
+    const result = formatSkillsForPrompt(skills);
+    assert.ok(result.includes("- name: multi line skill"));
+    assert.ok(result.includes("description: A description with extra spaces"));
+    assert.ok(result.includes("location: /path/to/ SKILL.md"));
+  });
+
+  it("falls back to default command name when sanitized name is empty", () => {
+    const entries: SkillEntry[] = [
+      {
+        skill: { name: "!!! @@@ ###", description: "Symbol-only name" },
+        frontmatter: {},
+        metadata: {},
+        invocation: {},
+      },
+    ];
+    const specs = buildSkillCommandSpecs(entries);
+    assert.strictEqual(specs[0].name, "skill");
+    assert.strictEqual(specs[0].skillName, "!!! @@@ ###");
+  });
+
+  it("strips duplicate and leading/trailing underscores from sanitized command names", () => {
+    const entries: SkillEntry[] = [
+      {
+        skill: {
+          name: "___MY---Awesome___Skill___",
+          description: "Decorated name",
+        },
+        frontmatter: {},
+        metadata: {},
+        invocation: {},
+      },
+    ];
+    const specs = buildSkillCommandSpecs(entries);
+    assert.strictEqual(specs[0].name, "my_awesome_skill");
+  });
+
+  it("handles collisions on long names by truncating base to fit numeric suffix", () => {
+    const longName = "a".repeat(35);
+    const entries: SkillEntry[] = [
+      {
+        skill: { name: longName, description: "First long skill" },
+        frontmatter: {},
+        metadata: {},
+        invocation: {},
+      },
+      {
+        skill: { name: longName, description: "Second long skill" },
+        frontmatter: {},
+        metadata: {},
+        invocation: {},
+      },
+    ];
+    const specs = buildSkillCommandSpecs(entries);
+    assert.strictEqual(specs.length, 2);
+    assert.strictEqual(specs[0].name, "a".repeat(32));
+    assert.strictEqual(specs[1].name, `${"a".repeat(30)}_1`);
+    assert.strictEqual(specs[0].name.length, 32);
+    assert.strictEqual(specs[1].name.length, 32);
+  });
+
+  it("treats reserved command names case-insensitively", () => {
+    const entries: SkillEntry[] = [
+      {
+        skill: { name: "admin", description: "Admin skill" },
+        frontmatter: {},
+        metadata: {},
+        invocation: {},
+      },
+    ];
+    const specs = buildSkillCommandSpecs(entries, new Set(["ADMIN", "HeLp"]));
+    assert.strictEqual(specs[0].name, "admin_1");
+  });
+
+  it("supports snake_case dispatch frontmatter aliases and case-insensitive dispatch values", () => {
+    const entries: SkillEntry[] = [
+      {
+        skill: { name: "aliased", description: "Uses snake_case dispatch" },
+        frontmatter: {
+          command_dispatch: "TOOL",
+          command_tool: "executeAction",
+        },
+        metadata: {},
+        invocation: {},
+      },
+      {
+        skill: { name: "empty-tool", description: "Tool is blank" },
+        frontmatter: {
+          command_dispatch: "tool",
+          command_tool: "   ",
+        },
+        metadata: {},
+        invocation: {},
+      },
+    ];
+    const specs = buildSkillCommandSpecs(entries);
+    assert.ok(specs[0].dispatch);
+    assert.strictEqual(specs[0].dispatch?.kind, "tool");
+    assert.strictEqual(specs[0].dispatch?.toolName, "executeAction");
+    assert.strictEqual(specs[0].dispatch?.argMode, "raw");
+    assert.strictEqual(specs[1].dispatch, undefined);
+  });
 });


### PR DESCRIPTION
# Relates to

Additive behavioral contract coverage for `@elizaos/skills` prompt formatting, command name sanitization, collision suffix resolution, case-insensitive reserved command checking, and dispatch alias resolution.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low — purely additive test cases in `packages/skills/test/formatter.test.ts`.

# Background

## What does this PR do?

Extends `packages/skills/test/formatter.test.ts` to cover:
1. `formatSkillsForPrompt`: multi-line whitespace and tab compaction across name, description, and location fields.
2. `buildSkillCommandSpecs`: fallback to default command name (`skill`) when sanitized command name contains only symbols.
3. `buildSkillCommandSpecs`: stripping of duplicate and leading/trailing underscores from sanitized command names.
4. `buildSkillCommandSpecs`: collision resolution for long skill names (>32 characters) ensuring truncation leaves room for numeric suffixes while honoring the 32-character maximum.
5. `buildSkillCommandSpecs`: case-insensitive collision prevention for reserved command names.
6. `buildSkillCommandSpecs`: support for `command_dispatch` / `command_tool` snake_case aliases and case-insensitive dispatch value normalization, with fail-closed behavior for empty tool names.

## What kind of change is this?

Improvements (misc. changes to existing features / behavioral test coverage).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/skills/test/formatter.test.ts`

## Detailed testing steps

```bash
bun test --cwd packages/skills test/formatter.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:e492a9fe5d8c02cd3408a05b138ce4c417a34e9d -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only change with no rendered UI surface
<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only change with no rendered UI surface
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - test-only change has no user flow to record
<!-- evidence-row:backend-logs -->
- [ ] N/A - pure unit test does not exercise a server path
<!-- evidence-row:frontend-logs -->
- [ ] N/A - pure unit test does not exercise a browser path
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent model or prompt path is touched
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database rows or generated files produced
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface in this change

# Evidence Details

## Real LLM-call trajectory

N/A - pure unit test does not touch an LLM prompt or model path.

## Backend + frontend logs

```
RED (mutation in compactPromptField):
  27 tests | 1 failed — false == true (multi line skill not found)
GREEN (restored):
  27 tests | 27 passed
```

## Screenshots (before / after) + video walkthrough

N/A - test-only change with no rendered visual surface.

## Audio / voice walkthrough

N/A - test-only change with no audio or voice component.

## Known gaps / failures

N/A - all package tests and typecheck pass cleanly.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: Claude Code
— [lane-byt61-8291]

