### PR TITLE
test(auth): cover keyed mutex task isolation, failure recovery, and map cleanup

### DIFF
--- a/packages/auth/src/refresh-mutex.test.ts
+++ b/packages/auth/src/refresh-mutex.test.ts
@@ -71,4 +71,85 @@ describe("refresh-mutex", () => {
     expect(result).toBe("success");
     expect(order).toEqual(["failed", "recovered"]);
   });
+
+  it("handles a three-stage queue on the same key preserving distinct return values", async () => {
+    const mutex = new KeyedMutex();
+    const sequence: number[] = [];
+
+    const t1 = mutex.acquire("same-key", async () => {
+      await new Promise((r) => setTimeout(r, 10));
+      sequence.push(1);
+      return "val-1";
+    });
+
+    const t2 = mutex.acquire("same-key", async () => {
+      await new Promise((r) => setTimeout(r, 5));
+      sequence.push(2);
+      return "val-2";
+    });
+
+    const t3 = mutex.acquire("same-key", async () => {
+      sequence.push(3);
+      return "val-3";
+    });
+
+    const results = await Promise.all([t1, t2, t3]);
+    expect(results).toEqual(["val-1", "val-2", "val-3"]);
+    expect(sequence).toEqual([1, 2, 3]);
+  });
+
+  it("preserves ordering when an intermediate queued task throws in a multi-task chain", async () => {
+    const mutex = new KeyedMutex();
+    const execution: string[] = [];
+
+    const first = mutex.acquire("chain-key", async () => {
+      execution.push("first");
+      return 100;
+    });
+
+    const second = mutex.acquire("chain-key", async () => {
+      execution.push("second-fails");
+      throw new Error("intermediate failure");
+    });
+
+    const third = mutex.acquire("chain-key", async () => {
+      execution.push("third-succeeds");
+      return 300;
+    });
+
+    expect(await first).toBe(100);
+    await expect(second).rejects.toThrow("intermediate failure");
+    expect(await third).toBe(300);
+    expect(execution).toEqual(["first", "second-fails", "third-succeeds"]);
+  });
+
+  it("cleans up key from inflight map when last task in queue completes", async () => {
+    const mutex = new KeyedMutex();
+    const internals = mutex as unknown as {
+      inflight: Map<string, Promise<unknown>>;
+    };
+
+    expect(internals.inflight.has("cleanup-key")).toBe(false);
+
+    const task = mutex.acquire("cleanup-key", async () => {
+      expect(internals.inflight.has("cleanup-key")).toBe(true);
+      return "done";
+    });
+
+    await task;
+    expect(internals.inflight.has("cleanup-key")).toBe(false);
+  });
+
+  it("exports a singleton accountRefreshMutex instance of KeyedMutex", async () => {
+    const { accountRefreshMutex } = await import("./refresh-mutex.js");
+    expect(accountRefreshMutex).toBeInstanceOf(KeyedMutex);
+
+    const res = await accountRefreshMutex.acquire(
+      "test-provider:account-1",
+      async () => {
+        return "refreshed-token";
+      },
+    );
+    expect(res).toBe("refreshed-token");
+  });
 });


### PR DESCRIPTION
# Relates to

Additive behavioral contract coverage for `@elizaos/auth` `KeyedMutex` multi-task serialization, distinct task result isolation, failure recovery across multi-task chains, inflight map cleanup, and `accountRefreshMutex` singleton wiring.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low — purely additive test cases in `packages/auth/src/refresh-mutex.test.ts`.

# Background

## What does this PR do?

Extends `packages/auth/src/refresh-mutex.test.ts` to test:
1. `KeyedMutex`: multi-task chaining on the same key where 3 tasks queue sequentially and each caller resolves with its distinct return value.
2. `KeyedMutex`: intermediate failure resilience in a multi-task chain where task 1 succeeds, task 2 throws, and task 3 still executes sequentially and resolves with its value.
3. `KeyedMutex`: cleanup of key from internal `inflight` map upon completion of the terminal queued task.
4. `accountRefreshMutex`: exported singleton instance verification and execution semantics.

## What kind of change is this?

Improvements (misc. changes to existing features / behavioral test coverage).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/auth/src/refresh-mutex.test.ts`

## Detailed testing steps

```bash
bun test --cwd packages/auth src/refresh-mutex.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:d6fdb17c4abe5923bd4696e92d0acf0e657f993b -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only change with no rendered UI surface
<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only change with no rendered UI surface
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - test-only change has no user flow to record
<!-- evidence-row:backend-logs -->
- [ ] N/A - pure unit test does not exercise a server path
<!-- evidence-row:frontend-logs -->
- [ ] N/A - pure unit test does not exercise a browser path
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent model or prompt path is touched
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database rows or generated files produced
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface in this change

# Evidence Details

## Real LLM-call trajectory

N/A - pure unit test does not touch an LLM prompt or model path.

## Backend + frontend logs

```
RED (mutation: bypass previous promise chaining in acquire):
  7 tests | 3 failed — serializes concurrent executions, handles a three-stage queue, cleans up key from inflight map
GREEN (restored):
  7 tests | 7 passed
```

## Screenshots (before / after) + video walkthrough

N/A - test-only change with no rendered visual surface.

## Audio / voice walkthrough

N/A - test-only change with no audio or voice component.

## Known gaps / failures

N/A - all package tests and typecheck pass cleanly.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: Claude Code
— [lane-byt61-8291]

