### PR TITLE
fix(local-inference): fail cleanly on prompt-less coreml image-gen requests

### DIFF
--- a/plugins/plugin-local-inference/src/services/imagegen/coreml-unavailable.test.ts
+++ b/plugins/plugin-local-inference/src/services/imagegen/coreml-unavailable.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Production-boundary coverage for the Core ML image-gen backend
+ * (`loadCoreMlImageGenBackend`): unavailability gating, input validation
+ * (empty / missing prompt), PNG payload trust boundary (signature + length),
+ * dimension gates, seed fallback, and the dispose state machine.
+ */
+import { describe, expect, it } from "vitest";
+
+import { loadCoreMlImageGenBackend } from "./coreml-unavailable";
+import { ImageGenBackendUnavailableError } from "./errors";
+import { PNG_SIGNATURE } from "./sd-cpp";
+
+const VALID_PNG_B64 = Buffer.from(PNG_SIGNATURE).toString("base64");
+
+function fakeBridge(overrides: Record<string, unknown> = {}) {
+	return {
+		isAvailable: () => true,
+		generateImage: async (args: unknown) => ({
+			png: VALID_PNG_B64,
+			seed: 3,
+			inferenceTimeMs: 12,
+			...(args as Record<string, unknown>),
+		}),
+		...overrides,
+	};
+}
+
+function loadWith(bridge: unknown) {
+	return loadCoreMlImageGenBackend({
+		loadArgs: {} as never,
+		modelKey: "imagegen-coreml-sd-1_5",
+		bridge: bridge as never,
+	});
+}
+
+describe("loadCoreMlImageGenBackend", () => {
+	it("throws binding_unavailable when the Capacitor bridge is missing", async () => {
+		await expect(loadWith(undefined)).rejects.toThrow(
+			ImageGenBackendUnavailableError,
+		);
+		await expect(loadWith(undefined)).rejects.toMatchObject({
+			code: "IMAGE_GEN_BACKEND_UNAVAILABLE",
+			reason: "binding_unavailable",
+		});
+	});
+
+	it("throws binding_unavailable when the bridge reports unavailable", async () => {
+		await expect(loadWith({ isAvailable: () => false })).rejects.toMatchObject({
+			reason: "binding_unavailable",
+		});
+	});
+
+	it("rejects requests outside the compiled .mlpackage shapes", async () => {
+		const backend = await loadWith(fakeBridge());
+		expect(backend.supports({ width: 512, height: 512 } as never)).toBe(true);
+		expect(backend.supports({ width: 1024, height: 1024 } as never)).toBe(true);
+		expect(backend.supports({} as never)).toBe(true); // defaults to 512
+		expect(backend.supports({ width: 256, height: 512 } as never)).toBe(false);
+		expect(backend.supports({ width: 512, height: 2048 } as never)).toBe(false);
+		expect(backend.supports({ width: 0, height: 0 } as never)).toBe(false);
+	});
+
+	it("rejects an empty prompt with a structured error instead of a TypeError", async () => {
+		const backend = await loadWith(fakeBridge());
+		await expect(
+			backend.generate({ prompt: "   " } as never),
+		).rejects.toMatchObject({ reason: "unsupported_request" });
+	});
+
+	it("rejects a missing prompt with a structured error instead of a raw TypeError", async () => {
+		// Regression: `req.prompt.trim()` threw `TypeError: Cannot read
+		// properties of undefined` for a prompt-less request, breaking the
+		// backend's contract that every failure is a structured
+		// ImageGenBackendUnavailableError the selector can classify.
+		const backend = await loadWith(fakeBridge());
+		await expect(backend.generate({} as never)).rejects.toMatchObject({
+			code: "IMAGE_GEN_BACKEND_UNAVAILABLE",
+			reason: "unsupported_request",
+		});
+	});
+
+	it("throws binding_unavailable when generate is called after dispose", async () => {
+		const backend = await loadWith(fakeBridge());
+		await backend.dispose();
+		await expect(
+			backend.generate({ prompt: "hello" } as never),
+		).rejects.toMatchObject({ reason: "binding_unavailable" });
+		expect(backend.supports({ width: 512, height: 512 } as never)).toBe(false);
+		// dispose is idempotent
+		await expect(backend.dispose()).resolves.toBeUndefined();
+	});
+
+	it("returns decoded PNG bytes and metadata for a valid bridge result", async () => {
+		const backend = await loadWith(fakeBridge());
+		const result = await backend.generate({
+			prompt: "a red cube",
+			seed: 5,
+			steps: 10,
+			guidanceScale: 3.5,
+		} as never);
+		expect(result.mime).toBe("image/png");
+		expect([...result.image]).toEqual([...PNG_SIGNATURE]);
+		expect(result.seed).toBe(5); // explicit request seed flows through
+		expect(result.metadata).toMatchObject({
+			model: "imagegen-coreml-sd-1_5",
+			steps: 10,
+			guidanceScale: 3.5,
+			inferenceTimeMs: 12,
+		});
+	});
+
+	it("falls back to the resolved seed when the bridge omits it", async () => {
+		const bridge = fakeBridge({
+			generateImage: async () => ({
+				png: VALID_PNG_B64,
+				seed: undefined,
+				inferenceTimeMs: 5,
+			}),
+		});
+		const backend = await loadWith(bridge);
+		const result = await backend.generate({ prompt: "x", seed: -1 } as never);
+		expect(result.seed).toBe(7); // resolveSeed(-1) → deterministic stub pick
+	});
+
+	it("rejects an empty base64 payload", async () => {
+		const backend = await loadWith(
+			fakeBridge({
+				generateImage: async () => ({ png: "", seed: 1, inferenceTimeMs: 1 }),
+			}),
+		);
+		await expect(
+			backend.generate({ prompt: "x" } as never),
+		).rejects.toMatchObject({ reason: "unsupported_request" });
+	});
+
+	it("rejects a payload shorter than the PNG signature", async () => {
+		const backend = await loadWith(
+			fakeBridge({
+				generateImage: async () => ({
+					png: Buffer.from([0x89, 0x50]).toString("base64"),
+					seed: 1,
+					inferenceTimeMs: 1,
+				}),
+			}),
+		);
+		await expect(
+			backend.generate({ prompt: "x" } as never),
+		).rejects.toMatchObject({ reason: "unsupported_request" });
+	});
+
+	it("rejects a payload whose bytes are not the PNG signature", async () => {
+		const backend = await loadWith(
+			fakeBridge({
+				generateImage: async () => ({
+					png: Buffer.from("not-a-png-bytes").toString("base64"),
+					seed: 1,
+					inferenceTimeMs: 1,
+				}),
+			}),
+		);
+		await expect(
+			backend.generate({ prompt: "x" } as never),
+		).rejects.toMatchObject({ reason: "unsupported_request" });
+	});
+
+	it("falls back to wall-clock elapsed time when inferenceTimeMs is not positive", async () => {
+		let calls = 0;
+		const backend = await loadCoreMlImageGenBackend({
+			loadArgs: {} as never,
+			modelKey: "imagegen-coreml-sd-1_5",
+			bridge: fakeBridge({
+				generateImage: async () => ({
+					png: VALID_PNG_B64,
+					seed: 1,
+					inferenceTimeMs: 0,
+				}),
+			}) as never,
+			// First now() read is startMs; the second is the elapsed fallback.
+			now: () => {
+				calls += 1;
+				return calls === 1 ? 1_000 : 1_250;
+			},
+		});
+		const result = await backend.generate({ prompt: "x" } as never);
+		expect(result.metadata.inferenceTimeMs).toBe(250);
+	});
+});

--- a/plugins/plugin-local-inference/src/services/imagegen/coreml-unavailable.ts
+++ b/plugins/plugin-local-inference/src/services/imagegen/coreml-unavailable.ts
@@ -151,7 +151,7 @@ export async function loadCoreMlImageGenBackend(
 					"[imagegen/coreml] generate called after dispose()",
 				);
 			}
-			if (!req.prompt.trim()) {
+			if (typeof req.prompt !== "string" || !req.prompt.trim()) {
 				throw new ImageGenBackendUnavailableError(
 					"coreml",
 					"unsupported_request",


### PR DESCRIPTION
# Relates to

<!-- No issue; guards an input-validation defect found while writing
production-boundary tests for the Core ML image-gen backend. -->

## Summary

`loadCoreMlImageGenBackend` threw a raw `TypeError: Cannot read properties of undefined (reading 'trim')` for a request without a `prompt`, breaking the backend contract that every failure surfaces as a structured `ImageGenBackendUnavailableError` the WS3 selector can classify and fall through. This guards the input (`typeof req.prompt !== "string" || !req.prompt.trim()`) so a prompt-less request fails cleanly with `unsupported_request`, and adds production-boundary tests for the trust surfaces: PNG signature/length validation, compiled-shape dimension gates, the dispose state machine, seed fallback, and the elapsed-time fallback.

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] Focused vitest run passed in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. One-line guard on an internal input boundary plus a new test file; the
change makes an unclassified TypeError into the module's documented structured
error type. No runtime behavior change for valid requests.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: ````log
Test Files  1 passed (1)
      Tests  12 passed (12)
```
- Command: `npx vitest run coreml/coreml-unavailable.test.ts` (isolated)
- Result: all passed, including the missing-prompt regression test (fails with a raw TypeError before the guard, passes after)` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: fix + test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
