### PR TITLE
test(plugin-telegram): cover blockquote and plain-text edge cases

### DIFF
--- a/plugins/plugin-telegram/src/utils.test.ts
+++ b/plugins/plugin-telegram/src/utils.test.ts
@@ -190,3 +190,31 @@ describe("cleanText", () => {
     expect(cleanText(undefined)).toBe("");
   });
 });
+
+describe("convertMarkdownToTelegram blockquote and plain-text edge cases", () => {
+  it("preserves blockquote markers while escaping the quoted text", () => {
+    expect(convertMarkdownToTelegram("> hello. world")).toBe("> hello\\. world");
+    expect(convertMarkdownToTelegram(">> nested! quote")).toBe(">> nested\\! quote");
+    expect(convertMarkdownToTelegram("> _italic inside quote_")).toBe("> _italic inside quote_");
+  });
+
+  it("escapes plain-text dots and exclamation outside any formatting", () => {
+    expect(convertMarkdownToTelegram("End. Next! Done.")).toBe("End\\. Next\\! Done\\.");
+  });
+
+  it("keeps code spans unescaped inside, escapes outside", () => {
+    expect(convertMarkdownToTelegram("Use `a.b` now.")).toBe("Use `a.b` now\\.");
+    expect(convertMarkdownToTelegram("Code `x_y` and text.")).toBe("Code `x_y` and text\\.");
+  });
+
+  it("handles headers with bold-like content without double-escaping", () => {
+    expect(convertMarkdownToTelegram("# **Bold header**")).toBe("**Bold header**");
+    expect(convertMarkdownToTelegram("## Header with *italic* inside")).toBe("*Header with _italic_ inside*");
+  });
+
+  it("returns empty string for empty input and preserves plain text as escaped", () => {
+    expect(convertMarkdownToTelegram("")).toBe("");
+    expect(convertMarkdownToTelegram("plain")).toBe("plain");
+  });
+});
+


### PR DESCRIPTION
# Relates to
N/A - unsourced additive coverage for Telegram MarkdownV2 conversion; no issue (high-signal blockquote and escaping boundaries with production callers verified).

Definition of Done: full standard in [CONTRIBUTING.md](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks
Low. Test-only, no production code changed. Touches only `plugins/plugin-telegram/src/utils.test.ts`.

# Background

## What does this PR do?
Adds 5 behavioral cases to the canonical `utils.test.ts` suite for `convertMarkdownToTelegram`: blockquote marker preservation while quoted text is escaped, plain-text punctuation escaping outside formatting, code spans keeping inner content raw while outer punctuation is escaped, headers with bold/italic not double-escaped, and empty input handling. Exercises the real sentinel and MarkdownV2 escaping logic with production caller `messageManager.ts`.

## What kind of change is this?
Test coverage - fills missing contract for Telegram outbound formatting blockquote and escaping boundaries.

# Documentation changes needed?
My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?
`plugins/plugin-telegram/src/utils.test.ts` - new `describe("convertMarkdownToTelegram blockquote and plain-text edge cases")` block.

## Detailed testing steps
- `npx vitest run plugins/plugin-telegram/src/utils.test.ts` (131 passed, previously 126)
- Mutation check: break blockquote regex in `escapePlainTextPreservingBlockquote` to escape `>` marker → 3 failed / 2 passed in new block (proves blockquote cases catch sentinel leak)
- `npx biome check plugins/plugin-telegram/src/utils.test.ts` clean
- `bun --cwd plugins/plugin-telegram typecheck` clean

# Evidence Gate

<!-- evidence-head:77ca598c3c596b771f79bc759d18f655f99a2b46 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only change with no rendered UI surface
<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only change with no rendered UI surface
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - test-only change has no user flow to record
<!-- evidence-row:backend-logs -->
- [ ] N/A - pure unit test does not exercise a server path
<!-- evidence-row:frontend-logs -->
- [ ] N/A - pure unit test does not exercise a browser path
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent model or prompt path is touched
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database rows or generated files produced
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface in this change

# Evidence Details

## Real LLM-call trajectory
N/A - no agent model or prompt path is touched

## Backend + frontend logs
N/A - pure unit test does not exercise a server path

## Screenshots (before / after) + video walkthrough
N/A - test-only change with no rendered UI surface

## Audio / voice walkthrough
N/A - no voice path touched

## Known gaps / failures
None. Typecheck and biome clean after fix.

## Maintainer CI exception record
- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: Claude Code
— [lane-byt61-9514]

