### PR TITLE
test(zai): cover api-key and model-name validation gates

### DIFF
--- a/plugins/plugin-zai/types/index.test.ts
+++ b/plugins/plugin-zai/types/index.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Trust-boundary coverage for the z.ai configuration guards:
+ * `assertValidApiKey` is the credential gate that stops an unset/blank
+ * ZAI_API_KEY from reaching the provider, and `createModelName` rejects
+ * empty model names before they can be routed to the API.
+ */
+import { describe, expect, it } from "vitest";
+
+import { assertValidApiKey, createModelName } from "./index";
+
+describe("assertValidApiKey", () => {
+  it("accepts a configured non-blank key", () => {
+    expect(() => assertValidApiKey("sk-zai-123")).not.toThrow();
+  });
+
+  it("rejects a missing key", () => {
+    expect(() => assertValidApiKey(undefined)).toThrow(
+      "ZAI_API_KEY is required but not configured"
+    );
+  });
+
+  it("rejects a null key", () => {
+    expect(() => assertValidApiKey(null)).toThrow("ZAI_API_KEY is required but not configured");
+  });
+
+  it("rejects an empty key", () => {
+    expect(() => assertValidApiKey("")).toThrow("ZAI_API_KEY is required but not configured");
+  });
+
+  it("rejects a whitespace-only key", () => {
+    expect(() => assertValidApiKey("   ")).toThrow("ZAI_API_KEY is required but not configured");
+  });
+
+  it("narrows the argument type when it passes", () => {
+    const key = "sk-zai-456" as string;
+    assertValidApiKey(key);
+    // Type-level assertion: after the guard the value is ValidatedApiKey.
+    expect(key.length).toBeGreaterThan(0);
+  });
+});
+
+describe("createModelName", () => {
+  it("returns a non-empty model name unchanged", () => {
+    expect(createModelName("llama-3.1-8b")).toBe("llama-3.1-8b");
+  });
+
+  it("rejects an empty model name", () => {
+    expect(() => createModelName("")).toThrow("Model name cannot be empty");
+  });
+
+  it("rejects a whitespace-only model name", () => {
+    expect(() => createModelName("  \t ")).toThrow("Model name cannot be empty");
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; trust-boundary coverage for the z.ai configuration guards. -->

## Summary

Covers the two validation gates in `plugin-zai/types`: `assertValidApiKey` (the credential gate that stops a missing/blank `ZAI_API_KEY` from reaching the provider) and `createModelName` (rejects empty model names before they are routed to the API). Both functions currently have no direct test coverage — the existing `__tests__/config.test.ts` exercises the optional-key path but never the throw path.

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] Focused vitest run passed in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition; no production code is modified.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: ````log
Test Files  1 passed (1)
      Tests  9 passed (9)
```
- Command: `npx vitest run zai-types/index.test.ts` (isolated)
- Result: all passed` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
