### PR TITLE
test(agent): cover planner empty-string replacement and provider-absent placeholder

### DIFF
--- a/packages/agent/src/actions/extract-params.test.ts
+++ b/packages/agent/src/actions/extract-params.test.ts
@@ -437,6 +437,50 @@ describe("extractActionParamsViaLlm", () => {
       );
     });
 
+    it("replaces a planner empty-string required field with the extracted value", async () => {
+      const { runtime: rt } = runtime(
+        vi.fn(async () => '{"subaction":"search"}'),
+      );
+      const { promise } = extract({
+        runtime: rt,
+        existingParams: { subaction: "" },
+        requiredFields: ["subaction"],
+      });
+      expect(await promise).toEqual({ subaction: "search" });
+    });
+
+    it("preserves planner values that are empty arrays and zero while still filling the missing required field", async () => {
+      const { runtime: rt } = runtime(
+        vi.fn(async () => '{"subaction":"digest","query":"from-llm"}'),
+      );
+      const existingParams = {
+        subaction: "",
+        query: [],
+        limit: 0,
+      } as unknown as Partial<Params>;
+      const { promise } = extract({
+        runtime: rt,
+        existingParams,
+        requiredFields: ["subaction"],
+      });
+      expect(await promise).toEqual({
+        subaction: "digest",
+        query: [],
+        limit: 0,
+      });
+    });
+
+    it("uses the placeholder when state has no RECENT_MESSAGES provider", async () => {
+      const { useModel, promise } = extract({
+        existingParams: { subaction: null },
+        state: { data: { providers: {} } } as unknown as State,
+      });
+      await promise;
+      const prompt = (useModel as ReturnType<typeof vi.fn>).mock.calls[0][1]
+        .prompt as string;
+      expect(prompt).toContain("(no recent conversation context)");
+    });
+
     it("copies extra non-empty planner keys onto the merged result", async () => {
       const { runtime: rt } = runtime(
         vi.fn(async () => '{"subaction":"respond"}'),


### PR DESCRIPTION
# Relates to
N/A - unsourced additive coverage for LLM param extraction helper; no issue (high-signal planner-wins and placeholder boundaries with production callers verified).

Definition of Done: full standard in [CONTRIBUTING.md](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks
Low. Test-only, no production code changed. Touches only `packages/agent/src/actions/extract-params.test.ts`.

# Background

## What does this PR do?
Adds 3 behavioral cases to the canonical `extract-params.test.ts` suite for `extractActionParamsViaLlm`: (1) planner empty-string considered missing and replaced by extracted value, (2) planner empty array and zero preserved while missing required field is filled, and (3) placeholder used when state has no RECENT_MESSAGES provider. Exercises real prompt construction and planner-wins merge with typed runtime stubs.

## What kind of change is this?
Test coverage - fills missing contract for LLM param extraction planner-wins and placeholder boundaries with real production callers (`contact`, `connector`, `password-manager`).

# Documentation changes needed?
My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?
`packages/agent/src/actions/extract-params.test.ts` - new cases at end of `describe("parse, merge, and fallbacks")` block.

## Detailed testing steps
- `npx vitest run packages/agent/src/actions/extract-params.test.ts` (147 passed, previously 144)
- Mutation check: change missing check to ignore `""` as missing → 6 failed / 141 passed (2 new + 4 existing, proves empty-string contract)
- `npx biome check packages/agent/src/actions/extract-params.test.ts` clean
- `bun --cwd packages/agent typecheck` shows pre-existing unrelated errors in `ui/radio-group` and `minimatch` (not caused by this change; same on `origin/develop`)

# Evidence Gate

<!-- evidence-head:c2f8394a5beecc38ca2b1e6463328c7fdc4e7dfa -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only change with no rendered UI surface
<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only change with no rendered UI surface
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - test-only change has no user flow to record
<!-- evidence-row:backend-logs -->
- [ ] N/A - pure unit test does not exercise a server path
<!-- evidence-row:frontend-logs -->
- [ ] N/A - pure unit test does not exercise a browser path
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent model or prompt path is touched
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database rows or generated files produced
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface in this change

# Evidence Details

## Real LLM-call trajectory
N/A - no agent model or prompt path is touched

## Backend + frontend logs
N/A - pure unit test does not exercise a server path

## Screenshots (before / after) + video walkthrough
N/A - test-only change with no rendered UI surface

## Audio / voice walkthrough
N/A - no voice path touched

## Known gaps / failures
- `bun --cwd packages/agent typecheck` reports `TS2307: Cannot find module '@radix-ui/react-radio-group'` and `TS7016: minimatch` — pre-existing on `origin/develop`, unrelated to this change. Same errors reproduce without this diff.

## Maintainer CI exception record
- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: Claude Code
— [lane-byt61-9514]

