### PR TITLE
fix(core): support "enabled" and "disabled" tokens in boolean parsing utils

### DIFF
--- a/packages/core/src/utils.parsing.test.ts
+++ b/packages/core/src/utils.parsing.test.ts
@@ -82,10 +82,29 @@ describe("parseToonKeyValue", () => {
 
 describe("parseBooleanFromText", () => {
 	it("maps affirmative/negative tokens, defaults false", () => {
-		for (const v of ["yes", "Y", "true", "1", "on", "ENABLE"]) {
+		for (const v of [
+			"yes",
+			"Y",
+			"true",
+			"1",
+			"on",
+			"ENABLE",
+			"enabled",
+			"ENABLED",
+		]) {
 			expect(parseBooleanFromText(v)).toBe(true);
 		}
-		for (const v of ["no", "false", "0", "off", "maybe", ""]) {
+		for (const v of [
+			"no",
+			"false",
+			"0",
+			"off",
+			"disable",
+			"disabled",
+			"DISABLED",
+			"maybe",
+			"",
+		]) {
 			expect(parseBooleanFromText(v)).toBe(false);
 		}
 		expect(parseBooleanFromText(true)).toBe(true);

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1081,8 +1081,26 @@ export function parseBooleanFromText(
 	if (value === undefined || value === null) return false;
 	if (typeof value === "boolean") return value;
 
-	const affirmative = ["YES", "Y", "TRUE", "T", "1", "ON", "ENABLE"];
-	const negative = ["NO", "N", "FALSE", "F", "0", "OFF", "DISABLE"];
+	const affirmative = [
+		"YES",
+		"Y",
+		"TRUE",
+		"T",
+		"1",
+		"ON",
+		"ENABLE",
+		"ENABLED",
+	];
+	const negative = [
+		"NO",
+		"N",
+		"FALSE",
+		"F",
+		"0",
+		"OFF",
+		"DISABLE",
+		"DISABLED",
+	];
 
 	const normalizedText = value.trim().toUpperCase();
 	if (affirmative.includes(normalizedText)) return true;

--- a/packages/core/src/utils/boolean.test.ts
+++ b/packages/core/src/utils/boolean.test.ts
@@ -64,14 +64,18 @@ describe("parseBooleanValue", () => {
 });
 
 describe("parseBooleanText", () => {
-	it("parses extended text booleans (y/n, enable/disable) with false fallback", () => {
+	it("parses extended text booleans (y/n, enable/disable, enabled/disabled) with false fallback", () => {
 		expect(parseBooleanText("yes")).toBe(true);
 		expect(parseBooleanText("y")).toBe(true);
 		expect(parseBooleanText("enable")).toBe(true);
 		expect(parseBooleanText("ENABLE")).toBe(true);
+		expect(parseBooleanText("enabled")).toBe(true);
+		expect(parseBooleanText("ENABLED")).toBe(true);
 		expect(parseBooleanText("no")).toBe(false);
 		expect(parseBooleanText("n")).toBe(false);
 		expect(parseBooleanText("disable")).toBe(false);
+		expect(parseBooleanText("disabled")).toBe(false);
+		expect(parseBooleanText("DISABLED")).toBe(false);
 		expect(parseBooleanText("random_unknown_text")).toBe(false);
 		expect(parseBooleanText(null)).toBe(false);
 		expect(parseBooleanText(undefined)).toBe(false);

--- a/packages/core/src/utils/boolean.ts
+++ b/packages/core/src/utils/boolean.ts
@@ -14,8 +14,26 @@ const DEFAULT_TRUTHY = ["true", "1", "yes", "on"] as const;
 const DEFAULT_FALSY = ["false", "0", "no", "off"] as const;
 const DEFAULT_TRUTHY_SET = new Set<string>(DEFAULT_TRUTHY);
 const DEFAULT_FALSY_SET = new Set<string>(DEFAULT_FALSY);
-const TEXT_TRUTHY = ["yes", "y", "true", "t", "1", "on", "enable"] as const;
-const TEXT_FALSY = ["no", "n", "false", "f", "0", "off", "disable"] as const;
+const TEXT_TRUTHY = [
+	"yes",
+	"y",
+	"true",
+	"t",
+	"1",
+	"on",
+	"enable",
+	"enabled",
+] as const;
+const TEXT_FALSY = [
+	"no",
+	"n",
+	"false",
+	"f",
+	"0",
+	"off",
+	"disable",
+	"disabled",
+] as const;
 
 /**
  * Parse a value as a boolean.


### PR DESCRIPTION
## Summary
Closes #28467

Expands `TEXT_TRUTHY` and `TEXT_FALSY` in `packages/core/src/utils/boolean.ts` as well as the `affirmative` and `negative` token lists in `parseBooleanFromText` (`packages/core/src/utils.ts`) to include `"enabled"` and `"disabled"`.

Previously, inputs like `"enabled"` (commonly supplied in environment variables or configuration objects, e.g., `FEATURE_FLAG=enabled`) evaluated to `false` because they were not recognized in truthy sets and fell through to the default `false` return.

## Changes
- Added `"enabled"` to `TEXT_TRUTHY` in `packages/core/src/utils/boolean.ts`
- Added `"disabled"` to `TEXT_FALSY` in `packages/core/src/utils/boolean.ts`
- Added `"ENABLED"` to `affirmative` in `packages/core/src/utils.ts`
- Added `"DISABLED"` to `negative` in `packages/core/src/utils.ts`
- Added unit test coverage for `"enabled"` and `"disabled"` in `packages/core/src/utils/boolean.test.ts` and `packages/core/src/utils.parsing.test.ts`

## Evidence

<!-- evidence-table -->

| Evidence | Source / link / artifact | Review notes |
| --- | --- | --- |
| backend-logs | N/A - pure utility function | No runtime backend logging changes |
| scenario-replay | N/A - pure utility function | Scenarios unchanged |
| trajectory | N/A - pure utility function | No LLM interaction required |
| app-interaction | N/A - pure utility function | No visual UI component touched |
| domain-artifacts | N/A - pure utility function | No database/domain storage records modified |
| external-links | N/A - internal utility improvement | Pure core parser enhancement |
| ci-proof | `bun test packages/core/src/utils/boolean.test.ts packages/core/src/utils.parsing.test.ts` (21 pass) | Verified passes cleanly |

<!-- /evidence-table -->

<!-- evidence-head:ebf06cd8ce0c4a80345e68c71cc8e9d363d62b4a -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - pure utility function

<!-- evidence-row:after-screenshots -->
- [ ] N/A - pure utility function

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - pure utility function

<!-- evidence-row:backend-logs -->
- [ ] N/A - pure utility function

<!-- evidence-row:frontend-logs -->
- [ ] N/A - pure utility function

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - pure utility function

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - pure utility function

<!-- evidence-row:ocr-review -->
- [ ] N/A - pure utility function
