### PR TITLE
fix(core): normalize omitted and nullish path in getLocalServerUrl

### DIFF
--- a/packages/core/src/utils/node.test.ts
+++ b/packages/core/src/utils/node.test.ts
@@ -46,6 +46,11 @@ describe("node utilities", () => {
 			expect(getLocalServerUrl("")).toBe("http://localhost:3000");
 		});
 
+		it("handles omitted and undefined path cleanly without appending undefined", () => {
+			expect(getLocalServerUrl()).toBe("http://localhost:3000");
+			expect(getLocalServerUrl(undefined)).toBe("http://localhost:3000");
+		});
+
 		it("respects SERVER_PORT environment variable", () => {
 			process.env.SERVER_PORT = "4567";
 			getEnvironment().clearCache();

--- a/packages/core/src/utils/node.ts
+++ b/packages/core/src/utils/node.ts
@@ -5,7 +5,7 @@
 
 import { getEnv } from "./environment";
 
-export function getLocalServerUrl(path: string): string {
+export function getLocalServerUrl(path?: string): string {
 	// The browser/app host advertises its API listener through ELIZA_API_PORT
 	// (or the legacy ELIZA_PORT alias). SERVER_PORT remains the standalone
 	// server fallback. Using only SERVER_PORT silently sent local attachment
@@ -14,7 +14,11 @@ export function getLocalServerUrl(path: string): string {
 		getEnv("ELIZA_API_PORT") ??
 		getEnv("ELIZA_PORT") ??
 		getEnv("SERVER_PORT", "3000");
-	const normalizedPath = path && !path.startsWith("/") ? `/${path}` : path;
+	const normalizedPath = path
+		? path.startsWith("/")
+			? path
+			: `/${path}`
+		: "";
 	return `http://localhost:${port}${normalizedPath}`;
 }
 


### PR DESCRIPTION
## Summary
Closes #28472

Updates `getLocalServerUrl` in `packages/core/src/utils/node.ts` so that when `path` is omitted, `undefined`, `null`, or empty string, it normalizes to `""` and produces `http://localhost:${port}` rather than interpolating `undefined` into `http://localhost:${port}undefined`.

## Changes
- Changed parameter signature to `path?: string`
- Updated path normalization logic to cleanly handle undefined/null/empty path
- Added unit tests for omitted and `undefined` path in `packages/core/src/utils/node.test.ts`

## Evidence

<!-- evidence-table -->

| Evidence | Source / link / artifact | Review notes |
| --- | --- | --- |
| backend-logs | N/A - pure utility function | No runtime backend logging changes |
| scenario-replay | N/A - pure utility function | Scenarios unchanged |
| trajectory | N/A - pure utility function | No LLM interaction required |
| app-interaction | N/A - pure utility function | No visual UI component touched |
| domain-artifacts | N/A - pure utility function | No persistent tables modified |
| external-links | N/A - internal utility improvement | Pure node utility enhancement |
| ci-proof | `bun test packages/core/src/utils/node.test.ts` (7 pass) | Verified passes cleanly |

<!-- /evidence-table -->

<!-- evidence-head:bea97d7bb4de3b45aa1121aa51b97a72d1a91f6d -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - pure utility function

<!-- evidence-row:after-screenshots -->
- [ ] N/A - pure utility function

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - pure utility function

<!-- evidence-row:backend-logs -->
- [ ] N/A - pure utility function

<!-- evidence-row:frontend-logs -->
- [ ] N/A - pure utility function

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - pure utility function

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - pure utility function

<!-- evidence-row:ocr-review -->
- [ ] N/A - pure utility function
