### PR TITLE
feat(documents): first-class pin management + complete pinned-content injection (#23103)

### DIFF
--- a/packages/agent/src/api/documents-service-loader.ts
+++ b/packages/agent/src/api/documents-service-loader.ts
@@ -98,6 +98,11 @@ export interface DocumentsServiceLike {
     documentId: UUID,
     accessContext: AccessContext,
   ): Promise<Memory | null>;
+  setDocumentPinnedWithAccessContext?(
+    documentId: UUID,
+    pinned: boolean,
+    accessContext: AccessContext,
+  ): Promise<Memory>;
   setDocumentDirectGrantsWithAccessContext?(
     documentId: UUID,
     directGrantEntityIds: UUID[],

--- a/packages/core/src/database.ts
+++ b/packages/core/src/database.ts
@@ -32,6 +32,7 @@ import type {
 	DocumentListQueryParams,
 	DocumentListQueryResult,
 	DocumentMutationResult,
+	DocumentPinUpdateParams,
 	DocumentRevisionReplaceParams,
 	Entity,
 	GetConnectorAccountCredentialRefParams,
@@ -166,6 +167,20 @@ export abstract class DatabaseAdapter<DB extends object = object>
 	abstract compareAndSwapDocument(
 		params: DocumentCompareAndSwapParams,
 	): Promise<DocumentMutationResult>;
+
+	/**
+	 * Atomic metadata-only pin toggle under canonical mutation policy.
+	 * Concrete adapters implement this with CAS fencing; the base class
+	 * fail-closes (not_found) so legacy third-party adapters that predate
+	 * pin support remain source-compatible while the service layer surfaces
+	 * an explicit unsupported capability (#23103).
+	 */
+	updateDocumentPinned(
+		params: DocumentPinUpdateParams,
+	): Promise<DocumentMutationResult> {
+		void params;
+		return Promise.resolve({ status: "not_found" });
+	}
 
 	abstract updateDocumentDirectGrants(
 		params: DocumentDirectGrantUpdateParams,

--- a/packages/core/src/database.ts
+++ b/packages/core/src/database.ts
@@ -170,16 +170,21 @@ export abstract class DatabaseAdapter<DB extends object = object>
 
 	/**
 	 * Atomic metadata-only pin toggle under canonical mutation policy.
-	 * Concrete adapters implement this with CAS fencing; the base class
-	 * fail-closes (not_found) so legacy third-party adapters that predate
-	 * pin support remain source-compatible while the service layer surfaces
-	 * an explicit unsupported capability (#23103).
+	 * Concrete adapters implement this with CAS fencing. Following this
+	 * file's optional-domain convention, the base throws a typed
+	 * DOCUMENT_PIN_UNSUPPORTED error so legacy third-party adapters that
+	 * predate pin support remain source-compatible while callers get an
+	 * explicit capability signal — never a fabricated not_found (#23103).
 	 */
 	updateDocumentPinned(
 		params: DocumentPinUpdateParams,
 	): Promise<DocumentMutationResult> {
 		void params;
-		return Promise.resolve({ status: "not_found" });
+		return Promise.reject(
+			new ElizaError("Adapter does not support document pins", {
+				code: "DOCUMENT_PIN_UNSUPPORTED",
+			}),
+		);
 	}
 
 	abstract updateDocumentDirectGrants(

--- a/packages/core/src/database/inMemoryAdapter.ts
+++ b/packages/core/src/database/inMemoryAdapter.ts
@@ -1070,6 +1070,15 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 		if (!documentMutationSnapshotMatches(existing, params.expected)) {
 			return { status: "conflict" };
 		}
+		// Pin-state CAS fence (#23103): the observed pin bit must still match,
+		// so two writers racing from the same observed state cannot both
+		// report updated — the loser gets a typed conflict to retry against.
+		const existingPinned =
+			(existing.metadata as Record<string, unknown> | undefined)?.pinned ===
+			true;
+		if (existingPinned !== params.expectedPinned) {
+			return { status: "conflict" };
+		}
 		if (!canRequesterMutateDocument(existing, params)) {
 			return { status: "forbidden" };
 		}

--- a/packages/core/src/database/inMemoryAdapter.ts
+++ b/packages/core/src/database/inMemoryAdapter.ts
@@ -47,6 +47,7 @@ import type {
 	DocumentListQueryParams,
 	DocumentListQueryResult,
 	DocumentMutationResult,
+	DocumentPinUpdateParams,
 	DocumentRangeReadParams,
 	DocumentRangeReadResult,
 	DocumentRevisionReplaceParams,
@@ -1043,6 +1044,47 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 		}
 		await this.updateMemories([
 			{ ...params.replacement, id: params.documentId },
+		]);
+		const updated = this.memoriesById.get(String(params.documentId));
+		return updated
+			? { status: "updated", document: updated }
+			: { status: "conflict" };
+	}
+
+	async updateDocumentPinned(
+		params: DocumentPinUpdateParams,
+	): Promise<DocumentMutationResult> {
+		const existing = this.memoriesById.get(String(params.documentId));
+		if (
+			!existing ||
+			existing.agentId !== params.agentId ||
+			existing.metadata?.type !== MemoryType.DOCUMENT
+		) {
+			return { status: "not_found" };
+		}
+		// Fail closed before any snapshot or mutation-policy result can
+		// distinguish an existing document from an unknown id (#23103).
+		if (!isDocumentVisibleToRequester(existing, params)) {
+			return { status: "not_found" };
+		}
+		if (!documentMutationSnapshotMatches(existing, params.expected)) {
+			return { status: "conflict" };
+		}
+		if (!canRequesterMutateDocument(existing, params)) {
+			return { status: "forbidden" };
+		}
+		const metadata: Record<string, unknown> = { ...(existing.metadata ?? {}) };
+		if (params.pinned) {
+			metadata.pinned = true;
+		} else {
+			delete metadata.pinned;
+		}
+		await this.updateMemories([
+			{
+				...existing,
+				id: params.documentId,
+				metadata: metadata as Memory["metadata"],
+			},
 		]);
 		const updated = this.memoriesById.get(String(params.documentId));
 		return updated

--- a/packages/core/src/features/documents/__tests__/actions-pin.test.ts
+++ b/packages/core/src/features/documents/__tests__/actions-pin.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Tests the DOCUMENT action's pin/unpin subactions — structured routing to
+ * DocumentService.setDocumentPinned, invalid-id refusal, typed-error
+ * translation (forbidden/not_found → structured refusals, transport faults
+ * still propagate), and the single-delivery user-facing confirmation.
+ * Deterministic: runtime, DocumentService, and callback are vi.fn stubs.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { ElizaError } from "../../../errors";
+import type {
+	HandlerOptions,
+	IAgentRuntime,
+	Memory,
+	UUID,
+} from "../../../types";
+import { documentAction } from "../actions";
+import { DocumentService } from "../service";
+
+const AGENT_ID = "00000000-0000-0000-0000-00000000a9e7" as UUID;
+const USER_ID = "00000000-0000-0000-0000-00000000c0de" as UUID;
+const ROOM_ID = "00000000-0000-0000-0000-00000000d00d" as UUID;
+const DOC_ID = "11111111-2222-3333-4444-555555555555" as UUID;
+
+function makeMessage(): Memory {
+	return {
+		id: "00000000-0000-0000-0000-0000000000aa" as UUID,
+		entityId: USER_ID,
+		agentId: AGENT_ID,
+		roomId: ROOM_ID,
+		content: { text: "pin the launch notes" },
+		createdAt: Date.now(),
+	} as Memory;
+}
+
+function makeService() {
+	return {
+		setDocumentPinned: vi.fn(async () => undefined),
+	} as unknown as DocumentService;
+}
+
+function makeRuntime(service: DocumentService) {
+	const categories = new Map<string, unknown>();
+	const runtime = {
+		agentId: AGENT_ID,
+		getService: vi.fn(<T>(type: string): T | null =>
+			type === DocumentService.serviceType ? (service as unknown as T) : null,
+		),
+		registerSearchCategory: vi.fn((reg: { category: string }) => {
+			categories.set(reg.category, reg);
+		}),
+		getSearchCategory: vi.fn((category: string) => categories.get(category)),
+		getSetting: vi.fn(() => undefined),
+		reportError: vi.fn(),
+	} as unknown as IAgentRuntime;
+	return { runtime };
+}
+
+function options(parameters: Record<string, unknown>): HandlerOptions {
+	return { parameters } as HandlerOptions;
+}
+
+function callback() {
+	return vi.fn(async () => []);
+}
+
+describe("documentAction.handler pin/unpin routing", () => {
+	it("routes pin to setDocumentPinned(true) and confirms once", async () => {
+		const service = makeService();
+		const { runtime } = makeRuntime(service);
+		const cb = callback();
+		const res = await documentAction.handler?.(
+			runtime,
+			makeMessage(),
+			undefined,
+			options({ action: "pin", documentId: DOC_ID }),
+			cb,
+		);
+		expect(service.setDocumentPinned).toHaveBeenCalledWith(
+			DOC_ID,
+			true,
+			expect.anything(),
+		);
+		expect(res?.success).toBe(true);
+		expect(res?.data).toMatchObject({ subaction: "pin" });
+		expect(res?.values).toMatchObject({
+			documentId: DOC_ID,
+			pinned: true,
+		});
+		expect(cb).toHaveBeenCalledTimes(1);
+	});
+
+	it("routes unpin to setDocumentPinned(false)", async () => {
+		const service = makeService();
+		const { runtime } = makeRuntime(service);
+		const cb = callback();
+		const res = await documentAction.handler?.(
+			runtime,
+			makeMessage(),
+			undefined,
+			options({ action: "unpin", documentId: DOC_ID }),
+			cb,
+		);
+		expect(service.setDocumentPinned).toHaveBeenCalledWith(
+			DOC_ID,
+			false,
+			expect.anything(),
+		);
+		expect(res?.success).toBe(true);
+		expect(res?.data).toMatchObject({ subaction: "unpin" });
+		expect(res?.values).toMatchObject({ documentId: DOC_ID, pinned: false });
+		expect(cb).toHaveBeenCalledTimes(1);
+	});
+
+	it("refuses without calling the service when no id is supplied", async () => {
+		const service = makeService();
+		const { runtime } = makeRuntime(service);
+		const cb = callback();
+		const res = await documentAction.handler?.(
+			runtime,
+			makeMessage(),
+			undefined,
+			options({ action: "pin" }),
+			cb,
+		);
+		expect(service.setDocumentPinned).not.toHaveBeenCalled();
+		expect(res?.success).toBe(false);
+		expect(res?.data).toMatchObject({ subaction: "pin" });
+		expect(res?.values).toMatchObject({ error: "invalid_id" });
+	});
+
+	it("translates DOCUMENT_MUTATION_FORBIDDEN into a structured refusal", async () => {
+		const service = makeService();
+		service.setDocumentPinned = vi.fn(async () => {
+			throw new ElizaError("Requester cannot mutate this document", {
+				code: "DOCUMENT_MUTATION_FORBIDDEN",
+			});
+		});
+		const { runtime } = makeRuntime(service);
+		const cb = callback();
+		const res = await documentAction.handler?.(
+			runtime,
+			makeMessage(),
+			undefined,
+			options({ action: "pin", documentId: DOC_ID }),
+			cb,
+		);
+		expect(res?.success).toBe(false);
+		expect(res?.data).toMatchObject({ subaction: "pin" });
+		expect(res?.values).toMatchObject({
+			error: "forbidden",
+			documentId: DOC_ID,
+		});
+		expect(cb).not.toHaveBeenCalled();
+	});
+
+	it("translates DOCUMENT_NOT_FOUND into a structured refusal", async () => {
+		const service = makeService();
+		service.setDocumentPinned = vi.fn(async () => {
+			throw new ElizaError(`Document ${DOC_ID} not found`, {
+				code: "DOCUMENT_NOT_FOUND",
+			});
+		});
+		const { runtime } = makeRuntime(service);
+		const res = await documentAction.handler?.(
+			runtime,
+			makeMessage(),
+			undefined,
+			options({ action: "unpin", documentId: DOC_ID }),
+		);
+		expect(res?.success).toBe(false);
+		expect(res?.data).toMatchObject({ subaction: "unpin" });
+		expect(res?.values).toMatchObject({
+			error: "not_found",
+			documentId: DOC_ID,
+		});
+	});
+
+	it("surfaces unexpected typed error codes through the action boundary", async () => {
+		const service = makeService();
+		service.setDocumentPinned = vi.fn(async () => {
+			throw new ElizaError("Adapter exploded", {
+				code: "DOCUMENT_MUTATION_CONFLICT",
+			});
+		});
+		const { runtime } = makeRuntime(service);
+		const res = await documentAction.handler?.(
+			runtime,
+			makeMessage(),
+			undefined,
+			options({ action: "pin", documentId: DOC_ID }),
+		);
+		// The polymorphic DOCUMENT action's J1 boundary: the handler catch-all
+		// translates the escaping typed error into an explicit failure result
+		// carrying the code — never a fabricated success.
+		expect(res?.success).toBe(false);
+		expect(res?.values).toMatchObject({ error: "DOCUMENT_MUTATION_CONFLICT" });
+	});
+
+	it("refuses cleanly when the adapter lacks pin support", async () => {
+		// Legacy adapters without updateDocumentPinned surface an explicit
+		// DOCUMENT_PIN_UNSUPPORTED instead of a fabricated result.
+		const service = makeService();
+		service.setDocumentPinned = vi.fn(async () => {
+			throw new ElizaError(
+				"The configured database adapter does not support document pins",
+				{ code: "DOCUMENT_PIN_UNSUPPORTED" },
+			);
+		});
+		const { runtime } = makeRuntime(service);
+		const res = await documentAction.handler?.(
+			runtime,
+			makeMessage(),
+			undefined,
+			options({ action: "pin", documentId: DOC_ID }),
+		);
+		expect(res?.success).toBe(false);
+		expect(res?.values).toMatchObject({ error: "DOCUMENT_PIN_UNSUPPORTED" });
+	});
+});

--- a/packages/core/src/features/documents/__tests__/actions-routing.test.ts
+++ b/packages/core/src/features/documents/__tests__/actions-routing.test.ts
@@ -33,6 +33,7 @@ const USER_ID = "00000000-0000-0000-0000-00000000c0de" as UUID;
 const ROOM_ID = "00000000-0000-0000-0000-00000000d00d" as UUID;
 const WORLD_ID = "00000000-0000-4000-8000-00000000face" as UUID;
 const DOC_ID = "11111111-2222-3333-4444-555555555555" as UUID;
+const OTHER_DOC_ID = "12121212-3434-5656-7878-9a9a9a9a9a9a" as UUID;
 
 function listResult(
 	overrides: Partial<DocumentListResult> = {},
@@ -312,6 +313,45 @@ describe("documentAction.handler structured routing", () => {
 		expect(service.listDocumentsDetailed).not.toHaveBeenCalled();
 		expect(res?.success).toBe(false);
 		expect(res?.values).toMatchObject({ error: "DOCUMENT_INVALID_LIMIT" });
+	});
+
+
+	it("marks pinned documents in the action list surface", async () => {
+		// Reviewer finding 3 (#23103): the list formatter emitted only title
+		// and id, so the action surface could not tell which documents the
+		// provider will prioritize. Pinned rows must carry a marker.
+		const service = makeService();
+		const pinned = {
+			id: DOC_ID,
+			content: { text: "Pinned body." },
+			metadata: { title: "Pinned Doc", pinned: true },
+		} as Memory;
+		const unpinned = {
+			id: OTHER_DOC_ID,
+			content: { text: "Unpinned body." },
+			metadata: { title: "Plain Doc" },
+		} as Memory;
+		service.listDocumentsDetailed.mockResolvedValueOnce(
+			listResult({
+				status: "ok",
+				documents: [pinned, unpinned],
+				totalMatched: 2,
+				totalVisible: 2,
+				totalAvailable: 2,
+			}),
+		);
+		const { runtime } = makeRuntime(service);
+
+		const res = await documentAction.handler?.(
+			runtime,
+			makeMessage("list documents"),
+			undefined,
+			options({ action: "list" }),
+		);
+
+		expect(res?.text).toBe(
+			`Available documents:\n1. Pinned Doc [pinned] (${DOC_ID})\n2. Plain Doc (${OTHER_DOC_ID})`,
+		);
 	});
 
 	it("keeps query-miss fallback documents separate from matched documents", async () => {

--- a/packages/core/src/features/documents/__tests__/actions-routing.test.ts
+++ b/packages/core/src/features/documents/__tests__/actions-routing.test.ts
@@ -315,7 +315,6 @@ describe("documentAction.handler structured routing", () => {
 		expect(res?.values).toMatchObject({ error: "DOCUMENT_INVALID_LIMIT" });
 	});
 
-
 	it("marks pinned documents in the action list surface", async () => {
 		// Reviewer finding 3 (#23103): the list formatter emitted only title
 		// and id, so the action surface could not tell which documents the

--- a/packages/core/src/features/documents/actions.ts
+++ b/packages/core/src/features/documents/actions.ts
@@ -177,13 +177,13 @@ const DOCUMENT_SUBACTIONS: SubactionsMap<DocumentSubAction> = {
 	},
 	pin: {
 		description:
-			"Pin a stored document so it is always injected into your context.",
+			"Pin a stored document so the documents provider prioritizes it in documents and knowledge context.",
 		descriptionCompressed: "pin document by id",
 		required: [],
 		optional: ["id", "documentId"],
 	},
 	unpin: {
-		description: "Remove the always-inject pin from a stored document.",
+		description: "Remove the context-priority pin from a stored document.",
 		descriptionCompressed: "unpin document by id",
 		required: [],
 		optional: ["id", "documentId"],
@@ -1206,8 +1206,11 @@ async function handleSetPinned(
 		throw error;
 	}
 	// Humanized single delivery: the pin state change is the complete answer.
+	// Scoped wording (#23103 review): pinned documents are prioritized by the
+	// documents provider, which runs for the `documents` and `knowledge`
+	// contexts — not unconditionally in every context.
 	const text = pinned
-		? "Pinned the document; it will now always be in context."
+		? "Pinned the document; it is prioritized in documents and knowledge context."
 		: "Unpinned the document.";
 	await emit(callback, { text, actions: ["DOCUMENT"] });
 	return result(true, text, subaction, {
@@ -1239,7 +1242,11 @@ function formatDocumentList(documents: Memory[]): string {
 					: typeof metadata?.filename === "string"
 						? metadata.filename
 						: `Document ${index + 1}`;
-			return `${index + 1}. ${title} (${document.id})`;
+			// The pinned marker keeps the action's list surface honest about
+			// pin state (#23103): the planner can see which documents the
+			// provider will prioritize without a separate read.
+			const pinnedMarker = metadata?.pinned === true ? " [pinned]" : "";
+			return `${index + 1}. ${title}${pinnedMarker} (${document.id})`;
 		})
 		.join("\n")}`;
 }

--- a/packages/core/src/features/documents/actions.ts
+++ b/packages/core/src/features/documents/actions.ts
@@ -69,6 +69,8 @@ type DocumentSubAction =
 	| "write"
 	| "edit"
 	| "delete"
+	| "pin"
+	| "unpin"
 	| "import_file"
 	| "import_url";
 
@@ -170,6 +172,19 @@ const DOCUMENT_SUBACTIONS: SubactionsMap<DocumentSubAction> = {
 	delete: {
 		description: "Delete a stored document by id.",
 		descriptionCompressed: "delete document by id",
+		required: [],
+		optional: ["id", "documentId"],
+	},
+	pin: {
+		description:
+			"Pin a stored document so it is always injected into your context.",
+		descriptionCompressed: "pin document by id",
+		required: [],
+		optional: ["id", "documentId"],
+	},
+	unpin: {
+		description: "Remove the always-inject pin from a stored document.",
+		descriptionCompressed: "unpin document by id",
 		required: [],
 		optional: ["id", "documentId"],
 	},
@@ -1150,6 +1165,59 @@ async function handleDelete(
 	});
 }
 
+/** Handles the pin/unpin subactions: metadata-only context-priority toggles. */
+async function handleSetPinned(
+	service: DocumentService,
+	message: Memory,
+	params: DocumentActionParameters,
+	pinned: boolean,
+	callback?: HandlerCallback,
+): Promise<ActionResult> {
+	const subaction = pinned ? "pin" : "unpin";
+	const documentId = getDocumentId(params, message);
+	if (!documentId) {
+		const text = `No valid document id found in the request; ask the user which document to ${subaction}.`;
+		return result(false, text, subaction, {
+			values: { error: "invalid_id" },
+		});
+	}
+
+	// error-policy:J1 boundary translation — the action is the boundary between
+	// the service's typed pin errors and the model-visible ActionResult, mirroring
+	// handleDelete. Refusals become structured results; transport faults still
+	// propagate (they are not refusals).
+	try {
+		await service.setDocumentPinned(documentId, pinned, message);
+	} catch (error) {
+		const code = error instanceof ElizaError ? error.code : undefined;
+		if (code === "DOCUMENT_MUTATION_FORBIDDEN") {
+			const text =
+				"Only the owner can pin or unpin global and owner-private documents; tell the user this one is off limits.";
+			return result(false, text, subaction, {
+				values: { error: "forbidden", documentId },
+			});
+		}
+		if (code === "DOCUMENT_NOT_FOUND") {
+			const text = `Document ${documentId} was not found; tell the user there's nothing to ${subaction}.`;
+			return result(false, text, subaction, {
+				values: { error: "not_found", documentId },
+			});
+		}
+		throw error;
+	}
+	// Humanized single delivery: the pin state change is the complete answer.
+	const text = pinned
+		? "Pinned the document; it will now always be in context."
+		: "Unpinned the document.";
+	await emit(callback, { text, actions: ["DOCUMENT"] });
+	return result(true, text, subaction, {
+		userFacingText: text,
+		verifiedUserFacing: true,
+		turnComplete: true,
+		values: { documentId, pinned },
+	});
+}
+
 function parseTimestampParam(value: unknown): number | undefined {
 	if (typeof value === "number" && Number.isFinite(value)) return value;
 	if (typeof value === "string" && value.trim()) {
@@ -1492,15 +1560,15 @@ export const documentAction: Action = {
 	contextGate: { anyOf: ["documents", "knowledge"] },
 	roleGate: { minRole: "USER" },
 	description:
-		"List, search, read, write, edit, delete, and import stored documents. Select one action and provide the fields needed for that operation.",
+		"List, search, read, write, edit, delete, pin, unpin, and import stored documents. Select one action and provide the fields needed for that operation.",
 	descriptionCompressed:
-		"documents action=list|search|read|write|edit|delete|import_file|import_url",
+		"documents action=list|search|read|write|edit|delete|pin|unpin|import_file|import_url",
 	suppressPostActionContinuation: true,
 	parameters: [
 		{
 			name: "action",
 			description:
-				"Document operation to perform: list, search, read, write, edit, delete, import_file, or import_url.",
+				"Document operation to perform: list, search, read, write, edit, delete, pin, unpin, import_file, or import_url.",
 			required: true,
 			schema: {
 				type: "string",
@@ -1752,6 +1820,22 @@ export const documentAction: Action = {
 					return await handleEdit(service, message, params, callback);
 				case "delete":
 					return await handleDelete(service, message, params, callback);
+				case "pin":
+					return await handleSetPinned(
+						service,
+						message,
+						params,
+						true,
+						callback,
+					);
+				case "unpin":
+					return await handleSetPinned(
+						service,
+						message,
+						params,
+						false,
+						callback,
+					);
 				case "list":
 					return await handleList(service, message, params, callback);
 				case "import_file":

--- a/packages/core/src/features/documents/pin-context-injection.real.test.ts
+++ b/packages/core/src/features/documents/pin-context-injection.real.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Review-response evidence probe (#28474 finding 4, #23103): REAL end-to-end
+ * context-injection evidence that pinning changes provider prompt selection,
+ * on a real AgentRuntime + real PGlite SQL adapter (createTestRuntime harness),
+ * real DocumentService, real documentsProvider, and the REAL pin CAS path
+ * (expectedPinned fence + service retry). getService is bound to the real
+ * service instance exactly as service-authorization.real.test.ts does.
+ */
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import type { AgentRuntime } from "../../runtime.ts";
+import { createTestRuntime } from "../../testing/pglite-runtime.ts";
+import {
+	ChannelType,
+	type Memory,
+	MemoryType,
+	type UUID,
+} from "../../types/index.ts";
+import { documentsProvider } from "./provider.ts";
+import { DocumentService } from "./service.ts";
+
+const OWNER_ID = "f4300000-0000-4000-8000-000000000040" as UUID;
+const WORLD_ID = "f4300000-0000-4000-8000-000000000041" as UUID;
+const ROOM_ID = "f4300000-0000-4000-8000-000000000042" as UUID;
+const DOC_ID = "f4300000-0000-4000-8000-000000000043" as UUID;
+
+let runtime: AgentRuntime;
+let cleanup: () => Promise<void>;
+
+const message = (): Memory => ({
+	id: "f4300000-0000-4000-8000-000000000044" as UUID,
+	agentId: runtime.agentId,
+	entityId: OWNER_ID,
+	roomId: ROOM_ID,
+	worldId: WORLD_ID,
+	content: { text: "What is the weather?" },
+	metadata: {},
+});
+
+describe("pin -> provider context injection (real PGlite)", () => {
+	beforeAll(async () => {
+		({ runtime, cleanup } = await createTestRuntime({
+			characterName: "PinContextInjectionProbe",
+		}));
+		await runtime.ensureConnection({
+			entityId: OWNER_ID,
+			roomId: ROOM_ID,
+			worldId: WORLD_ID,
+			worldName: "Pin context injection probe",
+			userName: "Document owner",
+			name: "Document owner",
+			source: "test",
+			type: ChannelType.DM,
+		});
+		await runtime.ensureWorldExists({
+			id: WORLD_ID,
+			name: "Pin context injection probe",
+			agentId: runtime.agentId,
+			metadata: {
+				roles: { [OWNER_ID]: "OWNER" },
+				roleSources: { [OWNER_ID]: "manual" },
+			},
+		});
+	}, 120_000);
+
+	afterAll(async () => {
+		if (cleanup) await cleanup();
+	});
+
+	it("injects the pinned document body into provider context after a real pin, and removes it after unpin", async () => {
+		const document: Memory = {
+			id: DOC_ID,
+			agentId: runtime.agentId,
+			entityId: OWNER_ID,
+			roomId: ROOM_ID,
+			worldId: WORLD_ID,
+			createdAt: 1_000,
+			content: { text: "ALWAYS TELL THE TRUTH TO THE USER." },
+			metadata: {
+				type: MemoryType.DOCUMENT,
+				documentId: DOC_ID,
+				documentRevision: 0,
+				scope: "global",
+				addedBy: OWNER_ID,
+				addedByRole: "OWNER",
+				addedFrom: "upload",
+				addedAt: 1_000,
+				source: "test",
+				title: "Operating rules",
+				timestamp: 1_000,
+			},
+		} as Memory;
+		await runtime.createMemories([
+			{ memory: document, tableName: "documents" },
+		]);
+
+		// Real service + getService binding (service-authorization.real.test.ts pattern).
+		const service = new DocumentService(runtime);
+		const getService = vi
+			.spyOn(runtime, "getService")
+			.mockImplementation((serviceType) =>
+				serviceType === DocumentService.serviceType ? service : null,
+			);
+
+		// BEFORE: unpinned — body absent from provider context.
+		const before = await documentsProvider.get(
+			runtime as never,
+			message(),
+			undefined,
+		);
+		expect(String(before.text)).not.toContain("ALWAYS TELL THE TRUTH");
+		expect(before.data?.pinnedDocumentIds ?? []).toEqual([]);
+
+		// REAL pin through the canonical CAS path.
+		await service.setDocumentPinned(DOC_ID, true, message());
+
+		// AFTER PIN: full body injected, id reported.
+		const after = await documentsProvider.get(
+			runtime as never,
+			message(),
+			undefined,
+		);
+		expect(String(after.text)).toContain("ALWAYS TELL THE TRUTH TO THE USER.");
+		expect(after.data?.pinnedDocumentIds).toEqual([DOC_ID]);
+
+		// REAL unpin — body removed again.
+		await service.setDocumentPinned(DOC_ID, false, message());
+		const unpinned = await documentsProvider.get(
+			runtime as never,
+			message(),
+			undefined,
+		);
+		expect(String(unpinned.text)).not.toContain("ALWAYS TELL THE TRUTH");
+		expect(unpinned.data?.pinnedDocumentIds ?? []).toEqual([]);
+
+		getService.mockRestore();
+
+		// Evidence log lines (inline transcript for the PR body).
+		console.log(
+			"PIN-PROBE before-pin contains-body:",
+			String(before.text).includes("ALWAYS TELL THE TRUTH"),
+		);
+		console.log(
+			"PIN-PROBE after-pin contains-body:",
+			String(after.text).includes("ALWAYS TELL THE TRUTH"),
+		);
+		console.log(
+			"PIN-PROBE after-pin pinnedDocumentIds:",
+			JSON.stringify(after.data?.pinnedDocumentIds),
+		);
+		console.log(
+			"PIN-PROBE after-unpin contains-body:",
+			String(unpinned.text).includes("ALWAYS TELL THE TRUTH"),
+		);
+		console.log(
+			"PIN-PROBE verdict: PASS (pin toggles provider prompt selection end-to-end on real PGlite)",
+		);
+	});
+});

--- a/packages/core/src/features/documents/service-pinned.test.ts
+++ b/packages/core/src/features/documents/service-pinned.test.ts
@@ -273,6 +273,7 @@ describe("DocumentService pin management", () => {
 			requesterRole: "OWNER",
 			documentId: PINNED_DOC_ID,
 			expected: staleSnapshot as never,
+			expectedPinned: false,
 			pinned: true,
 		});
 		expect(raced.status).toBe("conflict");
@@ -295,6 +296,85 @@ describe("DocumentService pin management", () => {
 			requesterRole: "USER",
 		});
 		expect(visible).toBeNull();
+	});
+
+	it("loses a pin race at the adapter CAS layer: conflicting expectedPinned yields conflict, matching observed state succeeds", async () => {
+		// Reviewer-requested two-writer semantics (#23103) at the core
+		// adapter: a writer whose observed pin bit no longer matches the
+		// stored bit gets a typed conflict even with a CURRENT
+		// authorization snapshot — the pin bit is its own CAS dimension.
+		const { adapter, runtime, service } = await makeHarness();
+		await seedDocuments(runtime, adapter);
+
+		// First writer pins successfully.
+		await service.setDocumentPinnedWithAccessContext(
+			PINNED_DOC_ID,
+			true,
+			ownerContext,
+		);
+
+		// Second writer observed the PRE-pin state (authorization snapshot
+		// still current — revision did not move) but its observed pin bit
+		// (false) is now stale: the fence must reject the write.
+		const stored = await getStoredDocument(adapter, PINNED_DOC_ID);
+		const currentSnapshot = readDocumentMutationSnapshot(stored as Memory);
+		expect(currentSnapshot).not.toBeNull();
+		const raced = await adapter.updateDocumentPinned({
+			agentId: AGENT_ID,
+			requesterEntityId: OWNER_ID,
+			requesterRoomIds: [ROOM_A],
+			requesterRole: "OWNER",
+			documentId: PINNED_DOC_ID,
+			expected: currentSnapshot as never,
+			expectedPinned: false,
+			pinned: true,
+		});
+		expect(raced.status).toBe("conflict");
+	});
+
+	it("service retry converges when a concurrent writer moves the pin bit between read and write", async () => {
+		// The losing writer of a pin race re-reads fresh state inside the
+		// bounded CAS budget and converges instead of surfacing a spurious
+		// typed conflict (#23103).
+		const { adapter, runtime, service } = await makeHarness();
+		await seedDocuments(runtime, adapter);
+
+		let pinCalls = 0;
+		const originalUpdate = adapter.updateDocumentPinned.bind(adapter);
+		adapter.updateDocumentPinned = (async (params: {
+			agentId: UUID;
+			documentId: UUID;
+			requesterEntityId: UUID;
+			requesterRoomIds: UUID[];
+			requesterRole: string;
+			expected: unknown;
+			expectedPinned: boolean;
+			pinned: boolean;
+		}) => {
+			pinCalls++;
+			if (pinCalls === 1) {
+				// A concurrent writer wins the race between our service's
+				// read and write: move the pin bit out from under attempt 1.
+				await originalUpdate({
+					...params,
+					expectedPinned: false,
+					pinned: true,
+				});
+			}
+			// Attempt 1 now conflicts on the moved pin bit; attempt 2 runs
+			// against the fresh state the concurrent writer produced.
+			return originalUpdate(params);
+		}) as typeof adapter.updateDocumentPinned;
+
+		await service.setDocumentPinnedWithAccessContext(
+			PINNED_DOC_ID,
+			true,
+			ownerContext,
+		);
+
+		expect(pinCalls).toBe(2);
+		const stored = await getStoredDocument(adapter, PINNED_DOC_ID);
+		expect(stored?.metadata).toMatchObject({ pinned: true });
 	});
 
 	it("hides document existence from an invisible requester at the adapter CAS layer", async () => {
@@ -324,6 +404,7 @@ describe("DocumentService pin management", () => {
 					requesterRoomIds: [],
 					requesterRole: "USER",
 					expected: expected as never,
+					expectedPinned: false,
 					pinned: true,
 				}),
 			).resolves.toMatchObject({ status: "not_found" });

--- a/packages/core/src/features/documents/service-pinned.test.ts
+++ b/packages/core/src/features/documents/service-pinned.test.ts
@@ -1,0 +1,306 @@
+/**
+ * Exercises document pin/unpin authorization through a real AgentRuntime,
+ * DocumentService, and InMemoryDatabaseAdapter with persisted memory records:
+ * mutation policy (owner vs non-mutator), CAS conflict on concurrent revision
+ * change, and no-access-grant semantics (a pinned document stays invisible to
+ * a requester without visibility).
+ */
+import { describe, expect, it } from "vitest";
+import { readDocumentMutationSnapshot } from "../../database/document-list-query";
+import { InMemoryDatabaseAdapter } from "../../database/inMemoryAdapter";
+import { AgentRuntime } from "../../runtime";
+import {
+	type AccessContext,
+	type Character,
+	type Memory,
+	MemoryType,
+	type UUID,
+} from "../../types";
+import { DocumentService } from "./service";
+
+const AGENT_ID = "10000000-0000-4000-8000-0000000000a1" as UUID;
+const OWNER_ID = "10000000-0000-4000-8000-0000000000b2" as UUID;
+const OTHER_USER_ID = "10000000-0000-4000-8000-0000000000c3" as UUID;
+const ROOM_A = "10000000-0000-4000-8000-0000000000e5" as UUID;
+const WORLD_ID = "10000000-0000-4000-8000-0000000000f6" as UUID;
+const PINNED_DOC_ID = "10000000-0000-4000-8000-000000001111" as UUID;
+const OWNER_DOC_ID = "10000000-0000-4000-8000-000000002222" as UUID;
+const GLOBAL_DOC_ID = "10000000-0000-4000-8000-000000003333" as UUID;
+
+async function makeHarness(): Promise<{
+	adapter: InMemoryDatabaseAdapter;
+	runtime: AgentRuntime;
+	service: DocumentService;
+}> {
+	const adapter = new InMemoryDatabaseAdapter();
+	await adapter.initialize();
+	const runtime = new AgentRuntime({
+		agentId: AGENT_ID,
+		character: {
+			name: "DocumentPinIntegrationAgent",
+			bio: "Exercises document pin storage semantics.",
+			settings: {},
+		} as Character,
+		adapter,
+		logLevel: "fatal",
+	});
+	await adapter.createRoomParticipants(
+		[AGENT_ID, OWNER_ID, OTHER_USER_ID],
+		ROOM_A,
+	);
+	await adapter.createEntities([
+		{ id: AGENT_ID, names: ["agent"], agentId: AGENT_ID } as never,
+		{ id: OWNER_ID, names: ["owner"], agentId: AGENT_ID } as never,
+		{ id: OTHER_USER_ID, names: ["other"], agentId: AGENT_ID } as never,
+	]);
+	return { adapter, runtime, service: new DocumentService(runtime) };
+}
+
+function documentMemory(
+	id: UUID,
+	text: string,
+	options: {
+		entityId?: UUID;
+		scope?: "global" | "owner-private" | "user-private";
+	} = {},
+): Memory {
+	const entityId = options.entityId ?? OWNER_ID;
+	const scope = options.scope ?? "user-private";
+	const filename = `${id}.txt`;
+	return {
+		id,
+		agentId: AGENT_ID,
+		entityId,
+		roomId: ROOM_A,
+		worldId: WORLD_ID,
+		createdAt: 1_000,
+		content: { text },
+		metadata: {
+			type: MemoryType.DOCUMENT,
+			documentId: id,
+			documentRevision: 0,
+			scope,
+			scopedToEntityId: entityId,
+			addedBy: entityId,
+			addedByRole: "OWNER",
+			addedFrom: "upload",
+			addedAt: 1_000,
+			source: "test",
+			title: `Title ${id}`,
+			filename,
+			originalFilename: filename,
+			fileExt: "txt",
+			fileType: "text/plain",
+			contentType: "text/plain",
+			fileSize: Buffer.byteLength(text, "utf8"),
+			textBacked: true,
+			timestamp: 1_000,
+		},
+	} as Memory;
+}
+
+async function seedDocuments(
+	runtime: AgentRuntime,
+	adapter: InMemoryDatabaseAdapter,
+) {
+	await runtime.createMemories([
+		{
+			memory: documentMemory(PINNED_DOC_ID, "PINNED BODY SENTINEL"),
+			tableName: "documents",
+		},
+		{
+			memory: documentMemory(OWNER_DOC_ID, "OWNER DOC BODY"),
+			tableName: "documents",
+		},
+		{
+			// Global + visible in ROOM_A to OTHER_USER, but USER cannot mutate
+			// non-user-private scopes (canRequesterMutateDocument).
+			memory: documentMemory(GLOBAL_DOC_ID, "GLOBAL DOC BODY", {
+				scope: "global",
+			}),
+			tableName: "documents",
+		},
+	]);
+	// Room participants gate requester room ids at the service layer; the
+	// adapter's in-memory participants set matches the service expectations.
+	void adapter;
+}
+
+const ownerContext: AccessContext = {
+	requesterEntityId: OWNER_ID,
+	role: "OWNER",
+	isOwner: true,
+};
+const otherUserContext: AccessContext = {
+	requesterEntityId: OTHER_USER_ID,
+	role: "USER",
+	isOwner: false,
+};
+
+async function getStoredDocument(
+	adapter: InMemoryDatabaseAdapter,
+	documentId: UUID,
+): Promise<Memory | null> {
+	return adapter.getDocument({
+		agentId: AGENT_ID,
+		documentId,
+		requesterEntityId: OWNER_ID,
+		requesterRoomIds: [ROOM_A],
+		requesterRole: "OWNER",
+	});
+}
+
+describe("DocumentService pin management", () => {
+	it("pins and unpins a document through the service + adapter CAS path", async () => {
+		const { adapter, runtime, service } = await makeHarness();
+		await seedDocuments(runtime, adapter);
+
+		await expect(
+			service.setDocumentPinnedWithAccessContext(
+				PINNED_DOC_ID,
+				true,
+				ownerContext,
+			),
+		).resolves.toMatchObject({
+			id: PINNED_DOC_ID,
+			metadata: expect.objectContaining({ pinned: true }),
+		});
+
+		const pinned = await getStoredDocument(adapter, PINNED_DOC_ID);
+		expect(pinned?.metadata).toMatchObject({ pinned: true });
+
+		await expect(
+			service.setDocumentPinnedWithAccessContext(
+				PINNED_DOC_ID,
+				false,
+				ownerContext,
+			),
+		).resolves.toMatchObject({
+			id: PINNED_DOC_ID,
+		});
+		const unpinned = await getStoredDocument(adapter, PINNED_DOC_ID);
+		expect(
+			unpinned?.metadata && "pinned" in unpinned.metadata
+				? unpinned.metadata.pinned
+				: undefined,
+		).not.toBe(true);
+	});
+
+	it("rejects a pin from a requester who can see but not mutate the document", async () => {
+		const { adapter, runtime, service } = await makeHarness();
+		await seedDocuments(runtime, adapter);
+
+		// Sanity: the global doc IS visible to the USER requester (same room).
+		await expect(
+			adapter.getDocument({
+				agentId: AGENT_ID,
+				documentId: GLOBAL_DOC_ID,
+				requesterEntityId: OTHER_USER_ID,
+				requesterRoomIds: [ROOM_A],
+				requesterRole: "USER",
+			}),
+		).resolves.toMatchObject({ id: GLOBAL_DOC_ID });
+
+		await expect(
+			service.setDocumentPinnedWithAccessContext(
+				GLOBAL_DOC_ID,
+				true,
+				otherUserContext,
+			),
+		).rejects.toMatchObject({ code: "DOCUMENT_MUTATION_FORBIDDEN" });
+
+		const stored = await getStoredDocument(adapter, GLOBAL_DOC_ID);
+		expect(stored?.metadata).not.toMatchObject({ pinned: true });
+	});
+
+	it("maps a missing document to DOCUMENT_NOT_FOUND", async () => {
+		const { adapter, runtime, service } = await makeHarness();
+		await seedDocuments(runtime, adapter);
+		const unknown = "10000000-0000-4000-8000-000000009999" as UUID;
+
+		await expect(
+			service.setDocumentPinnedWithAccessContext(unknown, true, ownerContext),
+		).rejects.toMatchObject({ code: "DOCUMENT_NOT_FOUND" });
+	});
+
+	it("rejects with conflict when an authorization field moves between read and write", async () => {
+		const { adapter, runtime, service } = await makeHarness();
+		await seedDocuments(runtime, adapter);
+
+		// Take the mutation snapshot (revision N, no grants), then change a
+		// snapshotted authorization field (direct grants) before the pin CAS
+		// write lands — the stale snapshot must no longer match.
+		const beforePin = await getStoredDocument(adapter, PINNED_DOC_ID);
+		const staleSnapshot = readDocumentMutationSnapshot(beforePin as Memory);
+		expect(staleSnapshot).not.toBeNull();
+
+		await service.setDocumentDirectGrantsWithAccessContext(
+			PINNED_DOC_ID,
+			[OTHER_USER_ID],
+			ownerContext,
+		);
+
+		const raced = await adapter.updateDocumentPinned({
+			agentId: AGENT_ID,
+			requesterEntityId: OWNER_ID,
+			requesterRoomIds: [ROOM_A],
+			requesterRole: "OWNER",
+			documentId: PINNED_DOC_ID,
+			expected: staleSnapshot as never,
+			pinned: true,
+		});
+		expect(raced.status).toBe("conflict");
+	});
+
+	it("never grants access: a pinned document stays invisible to an unauthorized requester", async () => {
+		const { adapter, runtime, service } = await makeHarness();
+		await seedDocuments(runtime, adapter);
+		await service.setDocumentPinnedWithAccessContext(
+			PINNED_DOC_ID,
+			true,
+			ownerContext,
+		);
+
+		const visible = await adapter.getDocument({
+			agentId: AGENT_ID,
+			documentId: PINNED_DOC_ID,
+			requesterEntityId: OTHER_USER_ID,
+			requesterRoomIds: [],
+			requesterRole: "USER",
+		});
+		expect(visible).toBeNull();
+	});
+
+	it("hides document existence from an invisible requester at the adapter CAS layer", async () => {
+		// RP review round-1 must-fix: the core adapter's pin path returned
+		// forbidden/conflict to requesters who cannot see the document,
+		// leaking its existence. Visibility must fail closed before any
+		// snapshot or mutation-policy result.
+		const { adapter, runtime } = await makeHarness();
+		await seedDocuments(runtime, adapter);
+		const stored = await adapter.getDocument({
+			agentId: AGENT_ID,
+			documentId: OWNER_DOC_ID,
+			requesterEntityId: OWNER_ID,
+			requesterRoomIds: [ROOM_A],
+			requesterRole: "OWNER",
+		});
+		const current = readDocumentMutationSnapshot(stored as Memory);
+		expect(current).not.toBeNull();
+		const stale = { ...current, revision: (current?.revision ?? 0) + 99 };
+
+		for (const expected of [current, stale]) {
+			await expect(
+				adapter.updateDocumentPinned({
+					agentId: AGENT_ID,
+					documentId: OWNER_DOC_ID,
+					requesterEntityId: OTHER_USER_ID,
+					requesterRoomIds: [],
+					requesterRole: "USER",
+					expected: expected as never,
+					pinned: true,
+				}),
+			).resolves.toMatchObject({ status: "not_found" });
+		}
+	});
+});

--- a/packages/core/src/features/documents/service-pinned.test.ts
+++ b/packages/core/src/features/documents/service-pinned.test.ts
@@ -6,6 +6,7 @@
  * a requester without visibility).
  */
 import { describe, expect, it } from "vitest";
+import { DatabaseAdapter } from "../../database";
 import { readDocumentMutationSnapshot } from "../../database/document-list-query";
 import { InMemoryDatabaseAdapter } from "../../database/inMemoryAdapter";
 import { AgentRuntime } from "../../runtime";
@@ -184,6 +185,31 @@ describe("DocumentService pin management", () => {
 				? unpinned.metadata.pinned
 				: undefined,
 		).not.toBe(true);
+	});
+
+	it("rejects with DOCUMENT_PIN_UNSUPPORTED when a legacy adapter inherits the base method", async () => {
+		// Real legacy-adapter regression (#23103 r3): an adapter that never
+		// overrode updateDocumentPinned still carries the method (so the
+		// presence check passes) but resolves to the DatabaseAdapter base —
+		// the service must surface the typed unsupported capability, never
+		// a fabricated not_found. Simulate by installing the base method as
+		// an own property, matching a pre-pin subclass's inherited shape.
+		const { adapter, runtime, service } = await makeHarness();
+		Object.defineProperty(adapter, "updateDocumentPinned", {
+			value: DatabaseAdapter.prototype.updateDocumentPinned,
+			writable: true,
+			enumerable: false,
+			configurable: true,
+		});
+		await seedDocuments(runtime, adapter);
+
+		await expect(
+			service.setDocumentPinnedWithAccessContext(
+				PINNED_DOC_ID,
+				true,
+				ownerContext,
+			),
+		).rejects.toMatchObject({ code: "DOCUMENT_PIN_UNSUPPORTED" });
 	});
 
 	it("rejects a pin from a requester who can see but not mutate the document", async () => {

--- a/packages/core/src/features/documents/service.ts
+++ b/packages/core/src/features/documents/service.ts
@@ -16,6 +16,7 @@
  */
 import { existsSync, statSync } from "node:fs";
 import { filterByAccessContext } from "../../access-control/filter";
+import { DatabaseAdapter } from "../../database";
 import {
 	canRequesterManageDocumentDirectGrants,
 	canRequesterMutateDocument,
@@ -611,9 +612,14 @@ export class DocumentService extends Service {
 			accessContext,
 		);
 		const updateDocumentPinned = this.runtime.adapter.updateDocumentPinned;
-		if (!updateDocumentPinned) {
-			// Legacy adapters without pin support surface an explicit
-			// unsupported capability rather than a fabricated result.
+		if (
+			!updateDocumentPinned ||
+			updateDocumentPinned === DatabaseAdapter.prototype.updateDocumentPinned
+		) {
+			// Adapters without pin support (legacy subclasses inherit the
+			// base's typed throw; structural adapters may omit the method)
+			// surface an explicit unsupported capability rather than a
+			// fabricated not_found.
 			throw new ElizaError(
 				"The configured database adapter does not support document pins",
 				{
@@ -2736,9 +2742,14 @@ export class DocumentService extends Service {
 			});
 		}
 		const updateDocumentPinned = this.runtime.adapter.updateDocumentPinned;
-		if (!updateDocumentPinned) {
-			// Legacy adapters without pin support surface an explicit
-			// unsupported capability rather than a fabricated result.
+		if (
+			!updateDocumentPinned ||
+			updateDocumentPinned === DatabaseAdapter.prototype.updateDocumentPinned
+		) {
+			// Adapters without pin support (legacy subclasses inherit the
+			// base's typed throw; structural adapters may omit the method)
+			// surface an explicit unsupported capability rather than a
+			// fabricated not_found.
 			throw new ElizaError(
 				"The configured database adapter does not support document pins",
 				{

--- a/packages/core/src/features/documents/service.ts
+++ b/packages/core/src/features/documents/service.ts
@@ -601,6 +601,95 @@ export class DocumentService extends Service {
 			: null;
 	}
 
+	async setDocumentPinnedWithAccessContext(
+		documentId: UUID,
+		pinned: boolean,
+		accessContext: AccessContext,
+	): Promise<Memory> {
+		const { snapshot, requestContext } = await this.getDocumentPinTarget(
+			documentId,
+			accessContext,
+		);
+		const updateDocumentPinned = this.runtime.adapter.updateDocumentPinned;
+		if (!updateDocumentPinned) {
+			// Legacy adapters without pin support surface an explicit
+			// unsupported capability rather than a fabricated result.
+			throw new ElizaError(
+				"The configured database adapter does not support document pins",
+				{
+					code: "DOCUMENT_PIN_UNSUPPORTED",
+					context: { documentId },
+				},
+			);
+		}
+		const result = await updateDocumentPinned.call(this.runtime.adapter, {
+			...requestContext,
+			documentId,
+			expected: snapshot,
+			pinned,
+		});
+		if (result.status !== "updated") {
+			throw new ElizaError("Document authorization changed before pin update", {
+				code:
+					result.status === "not_found"
+						? "DOCUMENT_NOT_FOUND"
+						: result.status === "forbidden"
+							? "DOCUMENT_MUTATION_FORBIDDEN"
+							: "DOCUMENT_MUTATION_CONFLICT",
+				context: { documentId, status: result.status },
+			});
+		}
+		return result.document;
+	}
+
+	private async getDocumentPinTarget(
+		documentId: UUID,
+		accessContext: AccessContext,
+	) {
+		const requester = await resolveDocumentRequesterFromAccessContext(
+			this.runtime,
+			accessContext,
+		);
+		const requestContext = {
+			agentId: this.runtime.agentId,
+			requesterEntityId: requester.entityId,
+			requesterRoomIds: requester.roomIds,
+			requesterRole: requester.role,
+		};
+		const document = await this.runtime.adapter.getDocument({
+			...requestContext,
+			documentId,
+		});
+		if (!document) {
+			throw new ElizaError(`Document ${documentId} not found`, {
+				code: "DOCUMENT_NOT_FOUND",
+				context: { documentId },
+			});
+		}
+		const snapshot = readDocumentMutationSnapshot(document);
+		if (!snapshot) {
+			throw new ElizaError(
+				"Stored document authorization metadata is invalid",
+				{
+					code: "DOCUMENT_AUTHORIZATION_INVALID",
+					context: { documentId },
+					severity: "fatal",
+				},
+			);
+		}
+		if (!canRequesterMutateDocument(document, requestContext)) {
+			throw new ElizaError("Requester cannot mutate this document", {
+				code: "DOCUMENT_MUTATION_FORBIDDEN",
+				context: {
+					documentId,
+					requesterEntityId: requester.entityId,
+					requesterRole: requester.role,
+				},
+			});
+		}
+		return { snapshot, requestContext };
+	}
+
 	async setDocumentDirectGrantsWithAccessContext(
 		documentId: UUID,
 		directGrantEntityIds: UUID[],
@@ -2600,6 +2689,81 @@ export class DocumentService extends Service {
 		});
 
 		await Promise.all(processingPromises);
+	}
+
+	/** Pins or unpins one document for provider context priority (#23103). */
+	async setDocumentPinned(
+		documentId: UUID,
+		pinned: boolean,
+		message?: Memory,
+	): Promise<void> {
+		const requester = await resolveDocumentRequester(this.runtime, message);
+		const requestContext = {
+			agentId: this.runtime.agentId,
+			requesterEntityId: requester.entityId,
+			requesterRoomIds: requester.roomIds,
+			requesterRole: requester.role,
+		};
+		const existingDocument = await this.runtime.adapter.getDocument({
+			...requestContext,
+			documentId,
+		});
+		if (!existingDocument) {
+			throw new ElizaError(`Document ${documentId} not found`, {
+				code: "DOCUMENT_NOT_FOUND",
+				context: { documentId },
+			});
+		}
+		const snapshot = readDocumentMutationSnapshot(existingDocument);
+		if (!snapshot) {
+			throw new ElizaError(
+				"Stored document authorization metadata is invalid",
+				{
+					code: "DOCUMENT_AUTHORIZATION_INVALID",
+					context: { documentId },
+					severity: "fatal",
+				},
+			);
+		}
+		if (!canRequesterMutateDocument(existingDocument, requestContext)) {
+			throw new ElizaError("Requester cannot mutate this document", {
+				code: "DOCUMENT_MUTATION_FORBIDDEN",
+				context: {
+					documentId,
+					requesterEntityId: requester.entityId,
+					requesterRole: requester.role,
+				},
+			});
+		}
+		const updateDocumentPinned = this.runtime.adapter.updateDocumentPinned;
+		if (!updateDocumentPinned) {
+			// Legacy adapters without pin support surface an explicit
+			// unsupported capability rather than a fabricated result.
+			throw new ElizaError(
+				"The configured database adapter does not support document pins",
+				{
+					code: "DOCUMENT_PIN_UNSUPPORTED",
+					context: { documentId },
+				},
+			);
+		}
+		const result = await updateDocumentPinned.call(this.runtime.adapter, {
+			...requestContext,
+			documentId,
+			expected: snapshot,
+			pinned,
+		});
+		if (result.status !== "updated") {
+			throw new ElizaError("Document authorization changed before pin update", {
+				code:
+					result.status === "not_found"
+						? "DOCUMENT_NOT_FOUND"
+						: result.status === "forbidden"
+							? "DOCUMENT_MUTATION_FORBIDDEN"
+							: "DOCUMENT_MUTATION_CONFLICT",
+				context: { documentId, status: result.status },
+			});
+		}
 	}
 
 	async updateDocument(options: {

--- a/packages/core/src/features/documents/service.ts
+++ b/packages/core/src/features/documents/service.ts
@@ -40,9 +40,12 @@ import {
 	type DocumentListCursor,
 	type DocumentListQueryParams,
 	type DocumentListRequesterRole,
+	type DocumentMutationResult,
 	type DocumentMutationSnapshot,
+	type DocumentPinUpdateParams,
 	type DocumentRangeReadParams,
 	type DocumentRangeReadResult,
+	type DocumentRequesterContext,
 	type IAgentRuntime,
 	type Memory,
 	MemoryType,
@@ -148,6 +151,14 @@ const DOCUMENT_INGESTION_PENDING_TIMEOUT_MS = 5 * 60 * 1_000;
 const CHARACTER_DOCUMENT_EMBEDDING_WAIT_TIMEOUT_MS = 120_000;
 const CHARACTER_DOCUMENT_EMBEDDING_WAIT_INTERVAL_MS = 1_000;
 const DOCUMENT_FRAGMENT_TRAVERSAL_PAGE_SIZE = 1_000;
+/**
+ * Bounded CAS retry budget for pin toggles: each attempt re-reads fresh
+ * state, so only a writer that loses every race across the whole budget
+ * surfaces the typed conflict. Two competing toggles converge well below
+ * this bound; the cap exists so a hotly contested document fails explicitly
+ * instead of looping forever.
+ */
+const DOCUMENT_PIN_CAS_ATTEMPTS = 5;
 const DOCUMENT_SCOPES = new Set<DocumentVisibilityScope>([
 	"global",
 	"owner-private",
@@ -607,19 +618,63 @@ export class DocumentService extends Service {
 		pinned: boolean,
 		accessContext: AccessContext,
 	): Promise<Memory> {
-		const { snapshot, requestContext } = await this.getDocumentPinTarget(
-			documentId,
-			accessContext,
-		);
+		const updateDocumentPinned = this.resolveDocumentPinAdapter(documentId);
+		// The adapter CAS now fences the pin bit itself (expectedPinned), so a
+		// concurrent pin writer between our read and write resolves as a typed
+		// conflict; retry against freshly read state so the losing writer of a
+		// pin race converges instead of surfacing a spurious conflict (#23103).
+		let lastResult: DocumentMutationResult | undefined;
+		for (let attempt = 0; attempt < DOCUMENT_PIN_CAS_ATTEMPTS; attempt++) {
+			const { snapshot, requestContext, document } =
+				await this.getDocumentPinTarget(documentId, accessContext);
+			const result = await updateDocumentPinned.call(this.runtime.adapter, {
+				...requestContext,
+				documentId,
+				expected: snapshot,
+				expectedPinned: this.readObservedPin(document),
+				pinned,
+			});
+			if (result.status === "updated") {
+				return result.document;
+			}
+			if (result.status !== "conflict") {
+				throw new ElizaError(
+					"Document authorization changed before pin update",
+					{
+						code:
+							result.status === "not_found"
+								? "DOCUMENT_NOT_FOUND"
+								: "DOCUMENT_MUTATION_FORBIDDEN",
+						context: { documentId, status: result.status },
+					},
+				);
+			}
+			lastResult = result;
+		}
+		throw new ElizaError("Document pin state changed before update", {
+			code: "DOCUMENT_MUTATION_CONFLICT",
+			context: {
+				documentId,
+				attempts: DOCUMENT_PIN_CAS_ATTEMPTS,
+				lastStatus: lastResult?.status,
+			},
+		});
+	}
+
+	/**
+	 * Resolves the adapter's pin method, surfacing adapters without pin
+	 * support (legacy subclasses inherit the base's typed throw; structural
+	 * adapters may omit the method) as an explicit unsupported capability
+	 * rather than a fabricated not_found.
+	 */
+	private resolveDocumentPinAdapter(
+		documentId: UUID,
+	): (params: DocumentPinUpdateParams) => Promise<DocumentMutationResult> {
 		const updateDocumentPinned = this.runtime.adapter.updateDocumentPinned;
 		if (
 			!updateDocumentPinned ||
 			updateDocumentPinned === DatabaseAdapter.prototype.updateDocumentPinned
 		) {
-			// Adapters without pin support (legacy subclasses inherit the
-			// base's typed throw; structural adapters may omit the method)
-			// surface an explicit unsupported capability rather than a
-			// fabricated not_found.
 			throw new ElizaError(
 				"The configured database adapter does not support document pins",
 				{
@@ -628,30 +683,17 @@ export class DocumentService extends Service {
 				},
 			);
 		}
-		const result = await updateDocumentPinned.call(this.runtime.adapter, {
-			...requestContext,
-			documentId,
-			expected: snapshot,
-			pinned,
-		});
-		if (result.status !== "updated") {
-			throw new ElizaError("Document authorization changed before pin update", {
-				code:
-					result.status === "not_found"
-						? "DOCUMENT_NOT_FOUND"
-						: result.status === "forbidden"
-							? "DOCUMENT_MUTATION_FORBIDDEN"
-							: "DOCUMENT_MUTATION_CONFLICT",
-				context: { documentId, status: result.status },
-			});
-		}
-		return result.document;
+		return updateDocumentPinned;
 	}
 
 	private async getDocumentPinTarget(
 		documentId: UUID,
 		accessContext: AccessContext,
-	) {
+	): Promise<{
+		snapshot: DocumentMutationSnapshot;
+		requestContext: DocumentRequesterContext;
+		document: Memory;
+	}> {
 		const requester = await resolveDocumentRequesterFromAccessContext(
 			this.runtime,
 			accessContext,
@@ -693,7 +735,19 @@ export class DocumentService extends Service {
 				},
 			});
 		}
-		return { snapshot, requestContext };
+		return { snapshot, requestContext, document };
+	}
+
+	/**
+	 * Reads the observed pin bit from a document's metadata. The bit lives in
+	 * free-form metadata rather than a typed field (it predates the typed
+	 * snapshot), so read it defensively: only `true` means pinned.
+	 */
+	private readObservedPin(document: Memory): boolean {
+		return (
+			(document.metadata as Record<string, unknown> | undefined)?.pinned ===
+			true
+		);
 	}
 
 	async setDocumentDirectGrantsWithAccessContext(
@@ -2710,71 +2764,75 @@ export class DocumentService extends Service {
 			requesterRoomIds: requester.roomIds,
 			requesterRole: requester.role,
 		};
-		const existingDocument = await this.runtime.adapter.getDocument({
-			...requestContext,
-			documentId,
-		});
-		if (!existingDocument) {
-			throw new ElizaError(`Document ${documentId} not found`, {
-				code: "DOCUMENT_NOT_FOUND",
-				context: { documentId },
+		const updateDocumentPinned = this.resolveDocumentPinAdapter(documentId);
+		// Same bounded CAS-retry contract as the access-context variant: the
+		// losing writer of a pin race re-reads fresh state and converges
+		// instead of surfacing a spurious typed conflict (#23103).
+		let lastResult: DocumentMutationResult | undefined;
+		for (let attempt = 0; attempt < DOCUMENT_PIN_CAS_ATTEMPTS; attempt++) {
+			const existingDocument = await this.runtime.adapter.getDocument({
+				...requestContext,
+				documentId,
 			});
-		}
-		const snapshot = readDocumentMutationSnapshot(existingDocument);
-		if (!snapshot) {
-			throw new ElizaError(
-				"Stored document authorization metadata is invalid",
-				{
-					code: "DOCUMENT_AUTHORIZATION_INVALID",
+			if (!existingDocument) {
+				throw new ElizaError(`Document ${documentId} not found`, {
+					code: "DOCUMENT_NOT_FOUND",
 					context: { documentId },
-					severity: "fatal",
-				},
-			);
-		}
-		if (!canRequesterMutateDocument(existingDocument, requestContext)) {
-			throw new ElizaError("Requester cannot mutate this document", {
-				code: "DOCUMENT_MUTATION_FORBIDDEN",
-				context: {
-					documentId,
-					requesterEntityId: requester.entityId,
-					requesterRole: requester.role,
-				},
+				});
+			}
+			const snapshot = readDocumentMutationSnapshot(existingDocument);
+			if (!snapshot) {
+				throw new ElizaError(
+					"Stored document authorization metadata is invalid",
+					{
+						code: "DOCUMENT_AUTHORIZATION_INVALID",
+						context: { documentId },
+						severity: "fatal",
+					},
+				);
+			}
+			if (!canRequesterMutateDocument(existingDocument, requestContext)) {
+				throw new ElizaError("Requester cannot mutate this document", {
+					code: "DOCUMENT_MUTATION_FORBIDDEN",
+					context: {
+						documentId,
+						requesterEntityId: requester.entityId,
+						requesterRole: requester.role,
+					},
+				});
+			}
+			const result = await updateDocumentPinned.call(this.runtime.adapter, {
+				...requestContext,
+				documentId,
+				expected: snapshot,
+				expectedPinned: this.readObservedPin(existingDocument),
+				pinned,
 			});
+			if (result.status === "updated") {
+				return;
+			}
+			if (result.status !== "conflict") {
+				throw new ElizaError(
+					"Document authorization changed before pin update",
+					{
+						code:
+							result.status === "not_found"
+								? "DOCUMENT_NOT_FOUND"
+								: "DOCUMENT_MUTATION_FORBIDDEN",
+						context: { documentId, status: result.status },
+					},
+				);
+			}
+			lastResult = result;
 		}
-		const updateDocumentPinned = this.runtime.adapter.updateDocumentPinned;
-		if (
-			!updateDocumentPinned ||
-			updateDocumentPinned === DatabaseAdapter.prototype.updateDocumentPinned
-		) {
-			// Adapters without pin support (legacy subclasses inherit the
-			// base's typed throw; structural adapters may omit the method)
-			// surface an explicit unsupported capability rather than a
-			// fabricated not_found.
-			throw new ElizaError(
-				"The configured database adapter does not support document pins",
-				{
-					code: "DOCUMENT_PIN_UNSUPPORTED",
-					context: { documentId },
-				},
-			);
-		}
-		const result = await updateDocumentPinned.call(this.runtime.adapter, {
-			...requestContext,
-			documentId,
-			expected: snapshot,
-			pinned,
+		throw new ElizaError("Document pin state changed before update", {
+			code: "DOCUMENT_MUTATION_CONFLICT",
+			context: {
+				documentId,
+				attempts: DOCUMENT_PIN_CAS_ATTEMPTS,
+				lastStatus: lastResult?.status,
+			},
 		});
-		if (result.status !== "updated") {
-			throw new ElizaError("Document authorization changed before pin update", {
-				code:
-					result.status === "not_found"
-						? "DOCUMENT_NOT_FOUND"
-						: result.status === "forbidden"
-							? "DOCUMENT_MUTATION_FORBIDDEN"
-							: "DOCUMENT_MUTATION_CONFLICT",
-				context: { documentId, status: result.status },
-			});
-		}
 	}
 
 	async updateDocument(options: {

--- a/packages/core/src/types/database.ts
+++ b/packages/core/src/types/database.ts
@@ -189,6 +189,13 @@ export interface DocumentRevisionReplaceParams
 	fragments: Memory[];
 }
 
+/** Atomic metadata-only pin toggle under canonical mutation policy. */
+export interface DocumentPinUpdateParams extends DocumentRequesterContext {
+	documentId: UUID;
+	expected: DocumentMutationSnapshot;
+	pinned: boolean;
+}
+
 /** Compare-and-swap document deletion under canonical mutation policy. */
 export interface DocumentDeleteParams extends DocumentRequesterContext {
 	documentId: UUID;
@@ -1235,6 +1242,14 @@ export interface IDatabaseAdapter<DB extends object = object> {
 	): Promise<Memory[]>;
 	compareAndSwapDocument(
 		params: DocumentCompareAndSwapParams,
+	): Promise<DocumentMutationResult>;
+	/**
+	 * Optional capability: adapters that predate pin support may omit this
+	 * method (the DatabaseAdapter base fail-closes it); callers must treat
+	 * not_found on a known-visible document as an unsupported pin surface.
+	 */
+	updateDocumentPinned?(
+		params: DocumentPinUpdateParams,
 	): Promise<DocumentMutationResult>;
 	updateDocumentDirectGrants(
 		params: DocumentDirectGrantUpdateParams,

--- a/packages/core/src/types/database.ts
+++ b/packages/core/src/types/database.ts
@@ -1244,9 +1244,10 @@ export interface IDatabaseAdapter<DB extends object = object> {
 		params: DocumentCompareAndSwapParams,
 	): Promise<DocumentMutationResult>;
 	/**
-	 * Optional capability: adapters that predate pin support may omit this
-	 * method (the DatabaseAdapter base fail-closes it); callers must treat
-	 * not_found on a known-visible document as an unsupported pin surface.
+	 * Optional capability: adapters that predate pin support either omit this
+	 * method or inherit the DatabaseAdapter base, which rejects with a typed
+	 * DOCUMENT_PIN_UNSUPPORTED error; callers surface that explicit capability
+	 * signal instead of interpreting a fabricated result (#23103).
 	 */
 	updateDocumentPinned?(
 		params: DocumentPinUpdateParams,

--- a/packages/core/src/types/database.ts
+++ b/packages/core/src/types/database.ts
@@ -189,10 +189,22 @@ export interface DocumentRevisionReplaceParams
 	fragments: Memory[];
 }
 
-/** Atomic metadata-only pin toggle under canonical mutation policy. */
+/**
+ * Atomic metadata-only pin toggle under canonical mutation policy.
+ *
+ * `expectedPinned` fences the pin bit itself: two writers that observed the
+ * same authorization snapshot cannot both report `updated` — the second
+ * writer's CAS fails on the moved pin state and surfaces `conflict` (#23103).
+ * The pin bit is deliberately NOT part of `DocumentMutationSnapshot`: that
+ * snapshot fences authorization fields shared by every document mutation, and
+ * a pin toggle must not invalidate concurrent authorization CAS writers (or
+ * vice versa).
+ */
 export interface DocumentPinUpdateParams extends DocumentRequesterContext {
 	documentId: UUID;
 	expected: DocumentMutationSnapshot;
+	/** Pin state the writer observed when taking `expected`; must still match at write time. */
+	expectedPinned: boolean;
 	pinned: boolean;
 }
 

--- a/packages/core/src/types/runtime.ts
+++ b/packages/core/src/types/runtime.ts
@@ -637,6 +637,7 @@ type RuntimeDatabaseAdapterSurface = Omit<
 	| "getDocument"
 	| "queryDocumentFragments"
 	| "compareAndSwapDocument"
+	| "updateDocumentPinned"
 	| "updateDocumentDirectGrants"
 	| "replaceDocumentRevision"
 	| "deleteDocumentWithSnapshot"

--- a/plugins/plugin-documents/AGENTS.md
+++ b/plugins/plugin-documents/AGENTS.md
@@ -27,6 +27,8 @@ Repo-wide conventions (logger-only, ESM, naming, architecture rules, git workflo
 | PATCH  | `/api/documents/:id` | Update document text content (re-fragments) |
 | PATCH  | `/api/documents/:id/access` | Replace bounded direct entity read grants (OWNER or room ADMIN) |
 | GET    | `/api/documents/:id/access` | Read direct grants through the same management authority |
+| POST   | `/api/documents/:id/pin` | Pin a document for always-inject provider context (metadata-only; canonical mutation policy) |
+| DELETE | `/api/documents/:id/pin` | Remove the always-inject pin (metadata-only; canonical mutation policy) |
 | DELETE | `/api/documents/:id` | Delete document and all its fragments |
 
 **Actions:** none registered here. `OWNER_DOCUMENTS` is registered by

--- a/plugins/plugin-documents/CLAUDE.md
+++ b/plugins/plugin-documents/CLAUDE.md
@@ -27,6 +27,8 @@ Repo-wide conventions (logger-only, ESM, naming, architecture rules, git workflo
 | PATCH  | `/api/documents/:id` | Update document text content (re-fragments) |
 | PATCH  | `/api/documents/:id/access` | Replace bounded direct entity read grants (OWNER or room ADMIN) |
 | GET    | `/api/documents/:id/access` | Read direct grants through the same management authority |
+| POST   | `/api/documents/:id/pin` | Pin a document for always-inject provider context (metadata-only; canonical mutation policy) |
+| DELETE | `/api/documents/:id/pin` | Remove the always-inject pin (metadata-only; canonical mutation policy) |
 | DELETE | `/api/documents/:id` | Delete document and all its fragments |
 
 **Actions:** none registered here. `OWNER_DOCUMENTS` is registered by

--- a/plugins/plugin-documents/src/components/documents/DocumentsSpatialView.tsx
+++ b/plugins/plugin-documents/src/components/documents/DocumentsSpatialView.tsx
@@ -38,6 +38,8 @@ export interface DocumentCard {
   meta: string;
   /** True when the row's pin control should show the pinned state. */
   pinned?: boolean;
+  /** True while this document's pin mutation is inflight — control is disabled. */
+  pinPending?: boolean;
 }
 
 /** A single search result row, already projected by the wrapper. */
@@ -231,9 +233,10 @@ function DocumentRow({
           variant="outline"
           tone={doc.pinned ? "primary" : "default"}
           agent={`pin:${doc.id}`}
+          disabled={doc.pinPending}
           onPress={() => onAction?.(`pin:${doc.id}`)}
         >
-          {doc.pinned ? "★" : "☆"}
+          {doc.pinPending ? "⋯" : doc.pinned ? "★" : "☆"}
         </Button>
         <Button
           variant="outline"

--- a/plugins/plugin-documents/src/components/documents/DocumentsSpatialView.tsx
+++ b/plugins/plugin-documents/src/components/documents/DocumentsSpatialView.tsx
@@ -36,6 +36,8 @@ export interface DocumentCard {
   title: string;
   /** Pre-formatted meta line (e.g. "markdown · 4 KB · Jun 16"), or empty. */
   meta: string;
+  /** True when the row's pin control should show the pinned state. */
+  pinned?: boolean;
 }
 
 /** A single search result row, already projected by the wrapper. */
@@ -67,6 +69,8 @@ export interface DocumentsSnapshot {
   query: string;
   /** Search sub-state (only surfaced when state === "ready"). */
   search: DocumentsSearchState;
+  /** Pin-toggle failure message (visible distinct error state; cleared by retry or a new toggle). */
+  pinError?: { documentId: string; message: string };
   /** Error message when state === "error". */
   error?: string;
 }
@@ -84,10 +88,11 @@ export interface DocumentsSpatialViewProps {
   snapshot: DocumentsSnapshot;
   /**
    * Dispatch by action id:
-   *   `retry`         — reload after an error,
+   *   `retry`         — reload after an error (also clears a pin failure),
    *   `search:<text>` — set the search text and run a document search,
    *   `clear-search`  — drop the active search and show the full list,
-   *   `open:<id>`     — open/inspect the document `<id>`.
+   *   `open:<id>`     — open/inspect the document `<id>`,
+   *   `pin:<id>`      — toggle the always-inject pin on document `<id>`.
    */
   onAction?: (action: string) => void;
 }
@@ -164,6 +169,20 @@ function DocumentsReadyBody({
 
       <DocumentsSearchBody search={snapshot.search} onAction={onAction} />
 
+      {snapshot.pinError ? (
+        <>
+          <Text bold>Pin change failed</Text>
+          <Text tone="danger" style="caption">
+            {snapshot.pinError.message} — showing the stored pin state.
+          </Text>
+          <HStack gap={1}>
+            <Button agent="retry" onPress={() => onAction?.("retry")}>
+              Retry
+            </Button>
+          </HStack>
+        </>
+      ) : null}
+
       <Text style="caption" tone="muted">
         Documents ({snapshot.documents.length})
       </Text>
@@ -208,6 +227,14 @@ function DocumentRow({
         </Text>
       ) : null}
       <HStack gap={1} justify="end">
+        <Button
+          variant="outline"
+          tone={doc.pinned ? "primary" : "default"}
+          agent={`pin:${doc.id}`}
+          onPress={() => onAction?.(`pin:${doc.id}`)}
+        >
+          {doc.pinned ? "★" : "☆"}
+        </Button>
         <Button
           variant="outline"
           tone="default"

--- a/plugins/plugin-documents/src/components/documents/DocumentsSpatialView.tsx
+++ b/plugins/plugin-documents/src/components/documents/DocumentsSpatialView.tsx
@@ -94,7 +94,7 @@ export interface DocumentsSpatialViewProps {
    *   `search:<text>` — set the search text and run a document search,
    *   `clear-search`  — drop the active search and show the full list,
    *   `open:<id>`     — open/inspect the document `<id>`,
-   *   `pin:<id>`      — toggle the always-inject pin on document `<id>`.
+   *   `pin:<id>`      — toggle the context-priority pin on document `<id>`.
    */
   onAction?: (action: string) => void;
 }

--- a/plugins/plugin-documents/src/components/documents/DocumentsView-timeout.test.tsx
+++ b/plugins/plugin-documents/src/components/documents/DocumentsView-timeout.test.tsx
@@ -48,6 +48,7 @@ describe("DocumentsView documents JSON deadline", () => {
           fetchDocuments: stalled,
           fetchStats: stalled,
           fetchSearch: stalled,
+          setPinned: async () => {},
         }}
       />,
     );

--- a/plugins/plugin-documents/src/components/documents/DocumentsView.test.tsx
+++ b/plugins/plugin-documents/src/components/documents/DocumentsView.test.tsx
@@ -100,6 +100,7 @@ function makeFetchers(
     fetchDocuments: async () => documentsList(),
     fetchStats: async () => documentsStats(),
     fetchSearch: async (query: string) => searchResponse(query),
+    setPinned: async () => {},
     ...overrides,
   };
 }
@@ -256,5 +257,285 @@ describe("DocumentsView — open affordance", () => {
     await screen.findByText("Quarterly Plan.md");
     fireEvent.click(agent("open:doc-1"));
     expect(sendChatMessage).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("DocumentsView — pin affordance", () => {
+  it("optimistically flips the pin control, calls setPinned, and reloads", async () => {
+    let listCalls = 0;
+    const fetchDocuments = async () => {
+      listCalls += 1;
+      return documentsList([presentedDocument({ id: "doc-1", pinned: true })]);
+    };
+    const setPinned = vi.fn(async () => {});
+    render(
+      React.createElement(DocumentsView, {
+        fetchers: makeFetchers({ fetchDocuments, setPinned }),
+      }),
+    );
+    await screen.findByText("Quarterly Plan.md");
+    // Pinned row renders the filled star.
+    expect(agent("pin:doc-1").textContent).toContain("★");
+
+    fireEvent.click(agent("pin:doc-1"));
+    await waitFor(() => {
+      // The next authoritative reload re-renders the still-pinned state
+      // (fetchDocuments keeps returning pinned: true — the flip targeted
+      // unpin, and the reload restores storage truth).
+      expect(listCalls).toBeGreaterThan(1);
+    });
+    expect(setPinned).toHaveBeenCalledWith("doc-1", false);
+  });
+
+  it("sends pin=true for an unpinned row", async () => {
+    const setPinned = vi.fn(async () => {});
+    render(
+      React.createElement(DocumentsView, {
+        fetchers: makeFetchers({ setPinned }),
+      }),
+    );
+    await screen.findByText("Quarterly Plan.md");
+    expect(agent("pin:doc-1").textContent).toContain("☆");
+
+    fireEvent.click(agent("pin:doc-1"));
+    await waitFor(() => {
+      expect(setPinned).toHaveBeenCalledWith("doc-1", true);
+    });
+  });
+
+  it("rolls the optimistic flip back when both the mutation and the reload fail", async () => {
+    // RP review round-1 P1: a rejected setPinned followed by a failing silent
+    // reload must not leave the fabricated optimistic state on screen.
+    const fetchDocuments = vi.fn(async () => {
+      return documentsList([presentedDocument({ id: "doc-1", pinned: true })]);
+    });
+    const setPinned = vi.fn(async () => {
+      throw new Error("pin denied");
+    });
+    render(
+      React.createElement(DocumentsView, {
+        fetchers: makeFetchers({ fetchDocuments, setPinned }),
+      }),
+    );
+    await screen.findByText("Quarterly Plan.md");
+    expect(agent("pin:doc-1").textContent).toContain("★");
+
+    // Make every subsequent reload fail too (silent loads preserve state).
+    fetchDocuments.mockRejectedValue(new Error("network down"));
+
+    fireEvent.click(agent("pin:doc-1"));
+    // The rollback restores the captured pre-toggle row (pinned), even though
+    // no authoritative reload can ever arrive.
+    await waitFor(() => {
+      expect(agent("pin:doc-1").textContent).toContain("★");
+    });
+    expect(setPinned).toHaveBeenCalledWith("doc-1", false);
+  });
+
+  it("surfaces a visibly distinct error state when a pin toggle fails", async () => {
+    const setPinned = vi.fn(async () => {
+      throw new Error("403 from storage");
+    });
+    render(
+      React.createElement(DocumentsView, {
+        fetchers: makeFetchers({ setPinned }),
+      }),
+    );
+    await screen.findByText("Quarterly Plan.md");
+    fireEvent.click(agent("pin:doc-1"));
+    await screen.findByText("Pin change failed");
+    expect(screen.getByText(/403 from storage/)).toBeTruthy();
+  });
+
+  it("clears the pin error on retry", async () => {
+    let fail = true;
+    const setPinned = vi.fn(async () => {
+      if (fail) throw new Error("nope");
+    });
+    render(
+      React.createElement(DocumentsView, {
+        fetchers: makeFetchers({ setPinned }),
+      }),
+    );
+    await screen.findByText("Quarterly Plan.md");
+    fireEvent.click(agent("pin:doc-1"));
+    await screen.findByText("Pin change failed");
+    fail = false;
+    fireEvent.click(agent("retry"));
+    await waitFor(() => {
+      expect(screen.queryByText("Pin change failed")).toBeNull();
+    });
+  });
+
+  it("ignores a second click while a toggle is inflight and keeps state consistent", async () => {
+    // Toggles are serialized per document (RP review round-2): a second
+    // click during an inflight toggle is ignored, so no rollback baseline can
+    // ever be another toggle's optimistic state.
+    const deferred: Array<(reason?: Error) => void> = [];
+    const setPinned = vi.fn(
+      async () => new Promise<never>((_, reject) => deferred.push(reject)),
+    );
+    const fetchDocuments = vi.fn(async () =>
+      documentsList([presentedDocument({ id: "doc-1", pinned: true })]),
+    );
+    render(
+      React.createElement(DocumentsView, {
+        fetchers: makeFetchers({ fetchDocuments, setPinned }),
+      }),
+    );
+    await screen.findByText("Quarterly Plan.md");
+
+    // Toggle 1 (unpin) stays pending; toggle 2 must be ignored.
+    fireEvent.click(agent("pin:doc-1")); // unpin -> deferred
+    fireEvent.click(agent("pin:doc-1")); // ignored (inflight)
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(setPinned).toHaveBeenCalledTimes(1);
+
+    // Toggle 1 rejects; rollback restores the pre-toggle pinned truth and
+    // the reload re-affirms it. The rejection surfaces the visible error
+    // state (single-delivery), and no fabricated unpinned state remains.
+    deferred[0]?.(new Error("stale"));
+    await waitFor(() => {
+      expect(agent("pin:doc-1").textContent).toContain("★");
+      expect(screen.getByText("Pin change failed")).toBeTruthy();
+    });
+  });
+
+  it("reloads from storage after a failed toggle instead of keeping the optimistic flip", async () => {
+    let listCalls = 0;
+    const fetchDocuments = async () => {
+      listCalls += 1;
+      return documentsList([presentedDocument({ id: "doc-1" })]);
+    };
+    const setPinned = vi.fn(async () => {
+      throw new Error("pin denied");
+    });
+    render(
+      React.createElement(DocumentsView, {
+        fetchers: makeFetchers({ fetchDocuments, setPinned }),
+      }),
+    );
+    await screen.findByText("Quarterly Plan.md");
+    fireEvent.click(agent("pin:doc-1"));
+    await waitFor(() => {
+      expect(listCalls).toBeGreaterThan(1);
+    });
+    // The authoritative reload keeps the unpinned state — no fabricated pin.
+    expect(agent("pin:doc-1").textContent).toContain("☆");
+  });
+
+  it("does not reverse an older toggle's authoritative reload on a newer rejection", async () => {
+    // RP review round-1 must-fix repro: (1) start pinned, (2) unpin succeeds
+    // and its silent reload lands authoritative pinned:false, (3) a second
+    // toggle (pin) is issued and later rejects, with its own reload also
+    // failing — the late rejection must NOT re-add the pin bit the
+    // authoritative reload removed.
+    let call = 0;
+    let resolveDeferredReload: (() => void) | undefined;
+    const fetchDocuments = vi.fn(async () => {
+      call += 1;
+      if (call === 1) {
+        return documentsList([
+          presentedDocument({ id: "doc-1", pinned: true }),
+        ]);
+      }
+      if (call > 2) {
+        // Any reload after the deferred one fails outright — no further
+        // authoritative state can arrive once the race is set up.
+        throw new Error("network down");
+      }
+      // Toggle 1's silent reload: authoritative unpinned truth, but deferred
+      // so it lands only when the test chooses — WHILE toggle 2 is pending.
+      return new Promise((resolve) => {
+        resolveDeferredReload = () =>
+          resolve(documentsList([presentedDocument({ id: "doc-1" })]));
+      }) as never;
+    });
+    const setPinned = vi.fn(async (_id: string, pinned: boolean) => {
+      if (pinned) {
+        // Toggle 2 (pin) stays pending until the test rejects it.
+        await new Promise<never>((_, reject) => {
+          rejectPinToggle2 = reject as () => void;
+        });
+      }
+    });
+    let rejectPinToggle2: (() => void) | undefined;
+    render(
+      React.createElement(DocumentsView, {
+        fetchers: makeFetchers({ fetchDocuments, setPinned }),
+      }),
+    );
+    await screen.findByText("Quarterly Plan.md");
+    // Toggle 1: unpin succeeds; its silent reload is deferred (pending).
+    fireEvent.click(agent("pin:doc-1"));
+    await waitFor(() => {
+      expect(setPinned).toHaveBeenCalledWith("doc-1", false);
+    });
+    // Toggle 2: pin flips optimistically (★) and stays pending.
+    fireEvent.click(agent("pin:doc-1"));
+    await waitFor(() => {
+      expect(setPinned).toHaveBeenLastCalledWith("doc-1", true);
+    });
+    expect(agent("pin:doc-1").textContent).toContain("★");
+    // Now toggle 1's deferred reload lands the authoritative unpinned truth
+    // while toggle 2 is still pending — replacing the optimistic flip.
+    resolveDeferredReload?.();
+    await waitFor(() => {
+      expect(agent("pin:doc-1").textContent).toContain("☆");
+    });
+    // Toggle 2's late rejection must not reverse that authoritative state.
+    rejectPinToggle2?.(new Error("late failure"));
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    // The row must still reflect the authoritative unpinned truth — the late
+    // rejection may not re-add the pin bit.
+    expect(agent("pin:doc-1").textContent).toContain("☆");
+  });
+
+  it("serializes per-document toggles so overlapping double rejection cannot fabricate state", async () => {
+    // RP review round-2 must-fix repro: with concurrent toggles, the second
+    // toggle captured the first's OPTIMISTIC value as its rollback baseline;
+    // when both rejected and every reload failed, the fabricated optimistic
+    // state stayed on screen. Toggles for one document are now serialized —
+    // a click while a toggle is inflight is ignored.
+    // First (initial) load must succeed for render; only later loads fail.
+    let initial = true;
+    const fetchDocuments = vi.fn(async () => {
+      if (initial) {
+        initial = false;
+        return documentsList([presentedDocument({ id: "doc-1" })]);
+      }
+      throw new Error("network down");
+    });
+    let rejectToggle: ((reason: Error) => void) | undefined;
+    const setPinned = vi.fn(
+      async () =>
+        new Promise<void>((_, reject) => {
+          rejectToggle = reject;
+        }),
+    );
+    render(
+      React.createElement(DocumentsView, {
+        fetchers: makeFetchers({ fetchDocuments, setPinned }),
+      }),
+    );
+    await screen.findByText("Quarterly Plan.md");
+
+    // Toggle 1: pin — stays pending (deferred rejection).
+    fireEvent.click(agent("pin:doc-1"));
+    await waitFor(() => {
+      expect(setPinned).toHaveBeenCalledWith("doc-1", true);
+    });
+    expect(agent("pin:doc-1").textContent).toContain("★");
+    // Toggle 2 while inflight: MUST be ignored (serialized).
+    fireEvent.click(agent("pin:doc-1"));
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(setPinned).toHaveBeenCalledTimes(1);
+
+    // Toggle 1 rejects; reload fails. Rollback restores the captured
+    // pre-toggle truth: unpinned.
+    rejectToggle?.(new Error("denied"));
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(agent("pin:doc-1").textContent).toContain("☆");
   });
 });

--- a/plugins/plugin-documents/src/components/documents/DocumentsView.test.tsx
+++ b/plugins/plugin-documents/src/components/documents/DocumentsView.test.tsx
@@ -471,17 +471,19 @@ describe("DocumentsView — pin affordance", () => {
     await waitFor(() => {
       expect(setPinned).toHaveBeenCalledWith("doc-1", false);
     });
-    // Toggle 2: pin flips optimistically (★) and stays pending.
+    // Toggle 2: pin is issued and stays pending — under the visible-pending
+    // contract the control shows the inflight glyph, not the optimistic star.
     fireEvent.click(agent("pin:doc-1"));
     await waitFor(() => {
       expect(setPinned).toHaveBeenLastCalledWith("doc-1", true);
     });
-    expect(agent("pin:doc-1").textContent).toContain("★");
+    expect(agent("pin:doc-1").textContent).toContain("⋯");
     // Now toggle 1's deferred reload lands the authoritative unpinned truth
-    // while toggle 2 is still pending — replacing the optimistic flip.
+    // while toggle 2 is still pending. The pending glyph still masks the
+    // control; the authoritative truth itself is asserted after the rejection.
     resolveDeferredReload?.();
     await waitFor(() => {
-      expect(agent("pin:doc-1").textContent).toContain("☆");
+      expect(agent("pin:doc-1").textContent).toContain("⋯");
     });
     // Toggle 2's late rejection must not reverse that authoritative state.
     rejectPinToggle2?.(new Error("late failure"));
@@ -521,12 +523,13 @@ describe("DocumentsView — pin affordance", () => {
     );
     await screen.findByText("Quarterly Plan.md");
 
-    // Toggle 1: pin — stays pending (deferred rejection).
+    // Toggle 1: pin — stays pending (deferred rejection); visible pending
+    // contract shows the inflight glyph while the mutation runs.
     fireEvent.click(agent("pin:doc-1"));
     await waitFor(() => {
       expect(setPinned).toHaveBeenCalledWith("doc-1", true);
     });
-    expect(agent("pin:doc-1").textContent).toContain("★");
+    expect(agent("pin:doc-1").textContent).toContain("⋯");
     // Toggle 2 while inflight: MUST be ignored (serialized).
     fireEvent.click(agent("pin:doc-1"));
     await new Promise((resolve) => setTimeout(resolve, 10));

--- a/plugins/plugin-documents/src/components/documents/DocumentsView.tsx
+++ b/plugins/plugin-documents/src/components/documents/DocumentsView.tsx
@@ -85,6 +85,8 @@ export interface DocumentsFetchers {
     query: string,
     signal?: AbortSignal,
   ) => Promise<DocumentsSearchWire>;
+  /** Toggle one document's always-inject pin (#23103). */
+  setPinned: (documentId: string, pinned: boolean) => Promise<void>;
 }
 
 /** Documents JSON GETs are short UI reads — same 15s family as TodosView / GoalsView. */
@@ -134,6 +136,20 @@ const defaultFetchers: DocumentsFetchers = {
       `/api/documents/search?q=${encodeURIComponent(query)}`,
       signal,
     ),
+  setPinned: async (documentId, pinned) => {
+    const response = await fetch(
+      `${client.getBaseUrl()}/api/documents/${documentId}/pin`,
+      {
+        method: pinned ? "POST" : "DELETE",
+        signal: AbortSignal.timeout(DOCUMENTS_VIEW_JSON_TIMEOUT_MS),
+      },
+    );
+    if (!response.ok) {
+      throw new Error(
+        `Pin request failed (${response.status}): /api/documents/${documentId}/pin`,
+      );
+    }
+  },
 };
 
 export interface DocumentsViewProps {
@@ -190,6 +206,7 @@ function toCard(document: PresentedDocument): DocumentCard {
     id: document.id,
     title: document.filename,
     meta: documentMeta(document),
+    ...(document.pinned ? { pinned: true } : {}),
   };
 }
 
@@ -242,9 +259,23 @@ export function DocumentsView(props: DocumentsViewProps = {}): ReactNode {
   const [state, setState] = useState<LoadState>({ kind: "loading" });
   const [query, setQuery] = useState("");
   const [search, setSearch] = useState<SearchState>({ kind: "idle" });
+  const [pinError, setPinError] = useState<
+    { documentId: string; message: string } | undefined
+  >(undefined);
 
   const fetchersRef = useRef(fetchers);
   fetchersRef.current = fetchers;
+  // Mirror of `state` for event handlers that must read the current snapshot
+  // synchronously (React state updaters run lazily).
+  const stateRef = useRef(state);
+  stateRef.current = state;
+  // Per-document pin-mutation tokens: an inflight toggle's late rejection may
+  // only roll back if no newer toggle for that document has started since.
+  const pinMutationTokens = useRef(new Map<string, number>());
+  // Documents with a pin mutation currently inflight; toggles are serialized
+  // per document so a rollback baseline is never another toggle's optimistic
+  // state.
+  const pinInflight = useRef(new Set<string>());
   const activeLoadRef = useRef<AbortController | null>(null);
   const activeSearchRef = useRef<AbortController | null>(null);
 
@@ -392,12 +423,14 @@ export function DocumentsView(props: DocumentsViewProps = {}): ReactNode {
       fragmentCount,
       query,
       search: searchSnapshot,
+      pinError,
     };
-  }, [state, query, searchSnapshot]);
+  }, [state, query, searchSnapshot, pinError]);
 
   const onAction = useCallback(
     (action: string) => {
       if (action === "retry") {
+        setPinError(undefined);
         load();
         return;
       }
@@ -412,6 +445,102 @@ export function DocumentsView(props: DocumentsViewProps = {}): ReactNode {
       }
       if (action.startsWith("open:")) {
         requestOpenDocument(action.slice("open:".length));
+        return;
+      }
+      if (action.startsWith("pin:")) {
+        const documentId = action.slice("pin:".length);
+        // Per-document mutations are SERIALIZED: while a toggle is inflight,
+        // further toggles for the same document are ignored. This guarantees
+        // the rollback baseline is always the last toggle's captured value —
+        // never another toggle's optimistic state (RP review round-2
+        // must-fix). Pin is metadata-only, so a skipped click costs the user
+        // nothing: retrying after the inflight toggle settles.
+        if (pinInflight.current.has(documentId)) return;
+        // Optimistic flip, then the authoritative reload; a failed toggle
+        // rolls ONLY the pin field back (guarded by a per-document token so a
+        // late rejection cannot overwrite a newer reload's authoritative
+        // state, and conditioned on the row still carrying this toggle's
+        // optimistic value) and surfaces a visible error state. The target is
+        // read from the state ref — reading it inside the setState updater
+        // would observe the updater's lazy execution order and always send
+        // `true`.
+        const current = stateRef.current;
+        const target =
+          current.kind === "ready"
+            ? current.data.documents.find(
+                (document) => document.id === documentId,
+              )
+            : undefined;
+        const priorPinned = target?.pinned === true;
+        const nextPinned = !priorPinned;
+        pinInflight.current.add(documentId);
+        const token = (pinMutationTokens.current.get(documentId) ?? 0) + 1;
+        pinMutationTokens.current.set(documentId, token);
+        setPinError(undefined);
+        setState((cur) => {
+          if (cur.kind !== "ready") return cur;
+          return {
+            ...cur,
+            data: {
+              ...cur.data,
+              documents: cur.data.documents.map((document) => {
+                if (document.id !== documentId) return document;
+                if (!nextPinned) {
+                  const { pinned: _pinned, ...rest } = document;
+                  return rest as typeof document;
+                }
+                return { ...document, pinned: true } as typeof document;
+              }),
+            },
+          };
+        });
+        void fetchersRef.current
+          .setPinned(documentId, nextPinned)
+          .catch((error: unknown) => {
+            // error-policy:J4 a failed toggle becomes a visibly distinct
+            // error state; the optimistic pin bit rolls back to the captured
+            // pre-toggle value (pin field only, and only while the row still
+            // carries this toggle's optimistic value so an authoritative
+            // reload that already replaced it is never reversed). A silent
+            // reload failure must never leave a fabricated pin state.
+            if (pinMutationTokens.current.get(documentId) !== token) return;
+            setPinError({
+              documentId,
+              message:
+                error instanceof Error
+                  ? error.message
+                  : "Could not change the pin",
+            });
+            setState((cur) => {
+              if (cur.kind !== "ready") return cur;
+              return {
+                ...cur,
+                data: {
+                  ...cur.data,
+                  documents: cur.data.documents.map((document) => {
+                    if (document.id !== documentId) return document;
+                    // Restore the captured pre-toggle value only when the
+                    // row still shows this toggle's optimistic outcome
+                    // (pinned === true when pinning, pinned absent when
+                    // unpinning).
+                    if ((document.pinned === true) !== nextPinned) {
+                      return document;
+                    }
+                    return priorPinned
+                      ? ({ ...document, pinned: true } as typeof document)
+                      : (() => {
+                          const { pinned: _drop, ...rest } = document;
+                          return rest as typeof document;
+                        })();
+                  }),
+                },
+              };
+            });
+          })
+          .finally(() => {
+            pinInflight.current.delete(documentId);
+            load({ silent: true });
+          });
         return;
       }
     },

--- a/plugins/plugin-documents/src/components/documents/DocumentsView.tsx
+++ b/plugins/plugin-documents/src/components/documents/DocumentsView.tsx
@@ -85,7 +85,7 @@ export interface DocumentsFetchers {
     query: string,
     signal?: AbortSignal,
   ) => Promise<DocumentsSearchWire>;
-  /** Toggle one document's always-inject pin (#23103). */
+  /** Toggle one document's context-priority pin (#23103). */
   setPinned: (documentId: string, pinned: boolean) => Promise<void>;
 }
 

--- a/plugins/plugin-documents/src/components/documents/DocumentsView.tsx
+++ b/plugins/plugin-documents/src/components/documents/DocumentsView.tsx
@@ -274,8 +274,15 @@ export function DocumentsView(props: DocumentsViewProps = {}): ReactNode {
   const pinMutationTokens = useRef(new Map<string, number>());
   // Documents with a pin mutation currently inflight; toggles are serialized
   // per document so a rollback baseline is never another toggle's optimistic
-  // state.
+  // state. Mirrored into state so the snapshot can disable the row's pin
+  // control visibly instead of silently discarding clicks.
+  const [pinInflightSnapshot, setPinInflightSnapshot] = useState<
+    ReadonlySet<string>
+  >(new Set());
   const pinInflight = useRef(new Set<string>());
+  const syncPinInflight = useCallback(() => {
+    setPinInflightSnapshot(new Set(pinInflight.current));
+  }, []);
   const activeLoadRef = useRef<AbortController | null>(null);
   const activeSearchRef = useRef<AbortController | null>(null);
 
@@ -418,14 +425,17 @@ export function DocumentsView(props: DocumentsViewProps = {}): ReactNode {
     }
     return {
       state: "ready",
-      documents: documents.map(toCard),
+      documents: documents.map((document) => ({
+        ...toCard(document),
+        ...(pinInflightSnapshot.has(document.id) ? { pinPending: true } : {}),
+      })),
       documentCount,
       fragmentCount,
       query,
       search: searchSnapshot,
       pinError,
     };
-  }, [state, query, searchSnapshot, pinError]);
+  }, [state, query, searchSnapshot, pinError, pinInflightSnapshot]);
 
   const onAction = useCallback(
     (action: string) => {
@@ -474,6 +484,7 @@ export function DocumentsView(props: DocumentsViewProps = {}): ReactNode {
         const priorPinned = target?.pinned === true;
         const nextPinned = !priorPinned;
         pinInflight.current.add(documentId);
+        syncPinInflight();
         const token = (pinMutationTokens.current.get(documentId) ?? 0) + 1;
         pinMutationTokens.current.set(documentId, token);
         setPinError(undefined);
@@ -539,12 +550,13 @@ export function DocumentsView(props: DocumentsViewProps = {}): ReactNode {
           })
           .finally(() => {
             pinInflight.current.delete(documentId);
+            syncPinInflight();
             load({ silent: true });
           });
         return;
       }
     },
-    [load, updateSearch],
+    [load, updateSearch, syncPinInflight],
   );
 
   return <DocumentsSpatialView snapshot={snapshot} onAction={onAction} />;

--- a/plugins/plugin-documents/src/document-presenter.test.ts
+++ b/plugins/plugin-documents/src/document-presenter.test.ts
@@ -84,3 +84,29 @@ describe("getDocumentTitleFromMetadata — derived-title truncation", () => {
     expect(title.endsWith("...")).toBe(true);
   });
 });
+
+describe("presentDocument — pinned passthrough (#23103)", () => {
+  it("surfaces pinned: true for a pinned document", () => {
+    const dto = presentDocument(
+      docMemory({ type: "document", filename: "rules.txt", pinned: true }),
+      1,
+    );
+    expect(dto.pinned).toBe(true);
+  });
+
+  it("omits pinned for an unpinned document", () => {
+    const dto = presentDocument(
+      docMemory({ type: "document", filename: "rules.txt" }),
+      1,
+    );
+    expect(dto.pinned).toBeUndefined();
+  });
+
+  it("does not treat a non-boolean pinned value as pinned", () => {
+    const dto = presentDocument(
+      docMemory({ type: "document", filename: "rules.txt", pinned: "yes" }),
+      1,
+    );
+    expect(dto.pinned).toBeUndefined();
+  });
+});

--- a/plugins/plugin-documents/src/document-presenter.ts
+++ b/plugins/plugin-documents/src/document-presenter.ts
@@ -42,6 +42,8 @@ export interface PresentedDocument {
   editabilityReason?: string;
   canDelete: boolean;
   deleteabilityReason?: string;
+  /** True when the document is pinned for always-inject provider context. */
+  pinned?: boolean;
   content?: { text?: string };
   /** When this document is the searchable mirror of a voice Transcript, the
    *  original transcript record id (so the Knowledge view can link back to it)
@@ -426,6 +428,7 @@ export function presentDocument(
     editabilityReason: editability.reason,
     canDelete: deleteability.canDelete,
     deleteabilityReason: deleteability.reason,
+    ...(metadata?.pinned === true ? { pinned: true } : {}),
     ...(previewText ? { content: { text: previewText } } : {}),
     ...(asString(metadata?.transcriptId)
       ? { transcriptId: asString(metadata?.transcriptId) }

--- a/plugins/plugin-documents/src/document-presenter.ts
+++ b/plugins/plugin-documents/src/document-presenter.ts
@@ -42,7 +42,7 @@ export interface PresentedDocument {
   editabilityReason?: string;
   canDelete: boolean;
   deleteabilityReason?: string;
-  /** True when the document is pinned for always-inject provider context. */
+  /** True when the document is pinned for prioritized provider context (documents/knowledge). */
   pinned?: boolean;
   content?: { text?: string };
   /** When this document is the searchable mirror of a voice Transcript, the

--- a/plugins/plugin-documents/src/plugin.ts
+++ b/plugins/plugin-documents/src/plugin.ts
@@ -288,6 +288,8 @@ const DOCUMENT_ROUTES: Array<{ type: string; path: string }> = [
   { type: "PATCH", path: "/api/documents/:id" },
   { type: "PATCH", path: "/api/documents/:id/access" },
   { type: "GET", path: "/api/documents/:id/access" },
+  { type: "POST", path: "/api/documents/:id/pin" },
+  { type: "DELETE", path: "/api/documents/:id/pin" },
   { type: "DELETE", path: "/api/documents/:id" },
   { type: "GET", path: "/api/documents/:id/fragments" },
 ];

--- a/plugins/plugin-documents/src/routes.pin.test.ts
+++ b/plugins/plugin-documents/src/routes.pin.test.ts
@@ -185,6 +185,27 @@ describe("document pin REST mutations", () => {
     expect(response.status).toBe(409);
   });
 
+  it("maps DOCUMENT_PIN_UNSUPPORTED to 503, not 500", async () => {
+    // A legacy adapter (inherited base updateDocumentPinned) passes the
+    // method-presence check and surfaces the typed unsupported capability
+    // from the service — the route must translate it to the established
+    // 503 unavailable response, never a 500.
+    service.setDocumentPinnedWithAccessContext.mockRejectedValueOnce(
+      new ElizaError(
+        "The configured database adapter does not support document pins",
+        {
+          code: "DOCUMENT_PIN_UNSUPPORTED",
+        },
+      ),
+    );
+    const { ctx, response } = context(
+      `/api/documents/${DOCUMENT_ID}/pin`,
+      "POST",
+    );
+    await handleDocumentsRoutes(ctx as never);
+    expect(response.status).toBe(503);
+  });
+
   it("rejects a malformed document id with 400", async () => {
     const { ctx, response } = context("/api/documents/not-a-uuid/pin", "POST");
     await handleDocumentsRoutes(ctx as never);

--- a/plugins/plugin-documents/src/routes.pin.test.ts
+++ b/plugins/plugin-documents/src/routes.pin.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Proves document pin/unpin REST mutations cross the canonical
+ * access-context-aware service, map typed pin failures to HTTP statuses, and
+ * 503 cleanly when the canonical pin authority is unavailable.
+ */
+import {
+  type AccessContext,
+  ElizaError,
+  type Memory,
+  type UUID,
+} from "@elizaos/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { DocumentRouteContext } from "./routes.ts";
+import { handleDocumentsRoutes } from "./routes.ts";
+
+const AGENT_ID = "00000000-0000-0000-0000-0000000000aa" as UUID;
+const USER_ID = "00000000-0000-0000-0000-0000000000bb" as UUID;
+const ROOM_ID = "00000000-0000-0000-0000-0000000000cc" as UUID;
+const DOCUMENT_ID = "00000000-0000-0000-0000-0000000000dd" as UUID;
+const accessContext = {
+  requesterEntityId: USER_ID,
+  role: "USER",
+  isOwner: false,
+} satisfies AccessContext;
+
+const document: Memory = {
+  id: DOCUMENT_ID,
+  agentId: AGENT_ID,
+  entityId: USER_ID,
+  roomId: ROOM_ID,
+  createdAt: 1_000,
+  content: { text: "authorized bytes" },
+  metadata: {
+    type: "document",
+    documentId: DOCUMENT_ID,
+    scope: "user-private",
+    scopedToEntityId: USER_ID,
+  } as Memory["metadata"],
+};
+
+const service = vi.hoisted(() => ({
+  listAllDocumentsWithAccessContext: vi.fn(),
+  getDocumentByIdWithAccessContext: vi.fn(),
+  getMutableDocumentWithAccessContext: vi.fn(),
+  setDocumentPinnedWithAccessContext: vi.fn(),
+  setDocumentDirectGrantsWithAccessContext: vi.fn(),
+  getDocumentDirectGrantsWithAccessContext: vi.fn(),
+  listDocumentFragmentsWithAccessContext: vi.fn(),
+  getMemories: vi.fn(),
+  updateDocument: vi.fn(),
+  deleteDocumentWithAccessContext: vi.fn(),
+  deleteMemory: vi.fn(),
+}));
+
+vi.mock("@elizaos/agent/api/documents-service-loader", () => ({
+  getDocumentsService: vi.fn(async () => ({ service })),
+}));
+
+function context(
+  pathname: string,
+  method = "GET",
+): {
+  ctx: DocumentRouteContext;
+  response: { status: number; body: unknown };
+} {
+  const response = { status: 0, body: undefined as unknown };
+  const ctx = {
+    req: { headers: {} },
+    res: { setHeader: vi.fn() },
+    method,
+    pathname,
+    url: new URL(`http://local${pathname}`),
+    accessContext,
+    runtime: {
+      agentId: AGENT_ID,
+      getSetting: vi.fn(),
+      getMemoryById: vi.fn(),
+    },
+    json: (_res: unknown, body: unknown, status = 200) => {
+      response.status = status;
+      response.body = body;
+    },
+    error: (_res: unknown, message: string, status = 400) => {
+      response.status = status;
+      response.body = { error: message };
+    },
+    readJsonBody: vi.fn(async () => null),
+  } as unknown as DocumentRouteContext;
+  return { ctx, response };
+}
+
+describe("document pin REST mutations", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service.setDocumentPinnedWithAccessContext.mockResolvedValue({
+      ...document,
+      metadata: { ...document.metadata, pinned: true, documentRevision: 1 },
+    });
+  });
+
+  it("pins via POST /api/documents/:id/pin through the canonical service", async () => {
+    const { ctx, response } = context(
+      `/api/documents/${DOCUMENT_ID}/pin`,
+      "POST",
+    );
+    const handled = await handleDocumentsRoutes(ctx as never);
+    expect(handled).toBe(true);
+    expect(service.setDocumentPinnedWithAccessContext).toHaveBeenCalledWith(
+      DOCUMENT_ID,
+      true,
+      accessContext,
+    );
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: true,
+      documentId: DOCUMENT_ID,
+      pinned: true,
+      revision: 1,
+    });
+  });
+
+  it("unpins via DELETE /api/documents/:id/pin through the canonical service", async () => {
+    service.setDocumentPinnedWithAccessContext.mockResolvedValueOnce({
+      ...document,
+      metadata: { ...document.metadata, documentRevision: 1 },
+    });
+    const { ctx, response } = context(
+      `/api/documents/${DOCUMENT_ID}/pin`,
+      "DELETE",
+    );
+    const handled = await handleDocumentsRoutes(ctx as never);
+    expect(handled).toBe(true);
+    expect(service.setDocumentPinnedWithAccessContext).toHaveBeenCalledWith(
+      DOCUMENT_ID,
+      false,
+      accessContext,
+    );
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: true,
+      documentId: DOCUMENT_ID,
+      pinned: false,
+    });
+  });
+
+  it("maps DOCUMENT_MUTATION_FORBIDDEN to 403", async () => {
+    service.setDocumentPinnedWithAccessContext.mockRejectedValueOnce(
+      new ElizaError("Requester cannot mutate this document", {
+        code: "DOCUMENT_MUTATION_FORBIDDEN",
+      }),
+    );
+    const { ctx, response } = context(
+      `/api/documents/${DOCUMENT_ID}/pin`,
+      "POST",
+    );
+    await handleDocumentsRoutes(ctx as never);
+    expect(response.status).toBe(403);
+  });
+
+  it("maps DOCUMENT_NOT_FOUND to 404", async () => {
+    service.setDocumentPinnedWithAccessContext.mockRejectedValueOnce(
+      new ElizaError(`Document ${DOCUMENT_ID} not found`, {
+        code: "DOCUMENT_NOT_FOUND",
+      }),
+    );
+    const { ctx, response } = context(
+      `/api/documents/${DOCUMENT_ID}/pin`,
+      "POST",
+    );
+    await handleDocumentsRoutes(ctx as never);
+    expect(response.status).toBe(404);
+  });
+
+  it("maps DOCUMENT_MUTATION_CONFLICT to 409", async () => {
+    service.setDocumentPinnedWithAccessContext.mockRejectedValueOnce(
+      new ElizaError("Document authorization changed before pin update", {
+        code: "DOCUMENT_MUTATION_CONFLICT",
+      }),
+    );
+    const { ctx, response } = context(
+      `/api/documents/${DOCUMENT_ID}/pin`,
+      "POST",
+    );
+    await handleDocumentsRoutes(ctx as never);
+    expect(response.status).toBe(409);
+  });
+
+  it("rejects a malformed document id with 400", async () => {
+    const { ctx, response } = context("/api/documents/not-a-uuid/pin", "POST");
+    await handleDocumentsRoutes(ctx as never);
+    expect(response.status).toBe(400);
+    expect(service.setDocumentPinnedWithAccessContext).not.toHaveBeenCalled();
+  });
+
+  it("returns 503 when the canonical pin authority is unavailable", async () => {
+    const pinCapable = service.setDocumentPinnedWithAccessContext;
+    service.setDocumentPinnedWithAccessContext = undefined as never;
+    try {
+      const { ctx, response } = context(
+        `/api/documents/${DOCUMENT_ID}/pin`,
+        "POST",
+      );
+      await handleDocumentsRoutes(ctx as never);
+      expect(response.status).toBe(503);
+    } finally {
+      service.setDocumentPinnedWithAccessContext = pinCapable;
+    }
+  });
+
+  it("does not handle a GET on the pin route", async () => {
+    const { ctx } = context(`/api/documents/${DOCUMENT_ID}/pin`, "GET");
+    const handled = await handleDocumentsRoutes(ctx as never);
+    expect(handled).toBe(false);
+  });
+});

--- a/plugins/plugin-documents/src/routes.ts
+++ b/plugins/plugin-documents/src/routes.ts
@@ -105,6 +105,7 @@ function documentPinErrorStatus(cause: ElizaError): number {
   if (cause.code === "DOCUMENT_NOT_FOUND") return 404;
   if (cause.code === "DOCUMENT_MUTATION_FORBIDDEN") return 403;
   if (cause.code === "DOCUMENT_MUTATION_CONFLICT") return 409;
+  if (cause.code === "DOCUMENT_PIN_UNSUPPORTED") return 503;
   return 500;
 }
 

--- a/plugins/plugin-documents/src/routes.ts
+++ b/plugins/plugin-documents/src/routes.ts
@@ -101,6 +101,20 @@ function documentGrantErrorStatus(cause: ElizaError): number {
   return 500;
 }
 
+function documentPinErrorStatus(cause: ElizaError): number {
+  if (cause.code === "DOCUMENT_NOT_FOUND") return 404;
+  if (cause.code === "DOCUMENT_MUTATION_FORBIDDEN") return 403;
+  if (cause.code === "DOCUMENT_MUTATION_CONFLICT") return 409;
+  return 500;
+}
+
+/** Committed document revision after a pin mutation (reporting only). */
+function documentPinnedRevision(document: Memory): number | undefined {
+  const metadata = asRecord(document.metadata);
+  const revision = metadata?.documentRevision;
+  return typeof revision === "number" ? revision : undefined;
+}
+
 type DocumentFilter = SharedDocumentFilter & {
   /**
    * Hub display facet (#13594): the coarse client-facing bucket the Knowledge
@@ -998,6 +1012,48 @@ export async function handleDocumentsRoutes(
 
   const docIdMatch = /^\/api\/documents\/([^/]+)$/.exec(pathname);
   const docAccessMatch = /^\/api\/documents\/([^/]+)\/access$/.exec(pathname);
+  const docPinMatch = /^\/api\/documents\/([^/]+)\/pin$/.exec(pathname);
+  if (
+    (method === "POST" || method === "DELETE") &&
+    docPinMatch &&
+    accessContext
+  ) {
+    const decodedDocumentId = decodeMatchedPathComponent(
+      ctx,
+      docPinMatch[1],
+      "document id",
+    );
+    if (!decodedDocumentId) return true;
+    if (!isUuidValue(decodedDocumentId)) {
+      error(res, "document id must be a valid UUID");
+      return true;
+    }
+    if (!documentsService.setDocumentPinnedWithAccessContext) {
+      error(res, "Canonical document pin authority is unavailable", 503);
+      return true;
+    }
+    try {
+      const document =
+        await documentsService.setDocumentPinnedWithAccessContext(
+          decodedDocumentId.trim() as UUID,
+          method === "POST",
+          accessContext,
+        );
+      json(res, {
+        ok: true,
+        documentId: decodedDocumentId.trim(),
+        pinned: method === "POST",
+        revision: documentPinnedRevision(document),
+      });
+    } catch (cause) {
+      // error-policy:J1 The HTTP boundary translates typed pin failures
+      // without exposing storage details.
+      if (!(cause instanceof ElizaError)) throw cause;
+      error(res, cause.message, documentPinErrorStatus(cause));
+    }
+    return true;
+  }
+
   if (method === "GET" && docAccessMatch) {
     const decodedDocumentId = decodeMatchedPathComponent(
       ctx,

--- a/plugins/plugin-inmemorydb/adapter.ts
+++ b/plugins/plugin-inmemorydb/adapter.ts
@@ -35,6 +35,7 @@ import {
   type DocumentListQueryParams,
   type DocumentListQueryResult,
   type DocumentMutationResult,
+  type DocumentPinUpdateParams,
   type DocumentRevisionReplaceParams,
   documentMutationSnapshotMatches,
   ElizaError,
@@ -897,6 +898,39 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
       };
       await this.storage.set(COLLECTIONS.MEMORIES, params.documentId, replacement);
       return { status: "updated", document: toMemory(replacement) };
+    });
+  }
+
+  async updateDocumentPinned(params: DocumentPinUpdateParams): Promise<DocumentMutationResult> {
+    return this.withDocumentMutationLock(async () => {
+      const stored = await this.storage.get<StoredMemory>(COLLECTIONS.MEMORIES, params.documentId);
+      if (
+        !stored ||
+        storedMemoryTableName(stored) !== "documents" ||
+        stored.agentId !== params.agentId
+      ) {
+        return { status: "not_found" };
+      }
+      const existing = toMemory(stored);
+      // Fail closed before any snapshot or mutation-policy result can
+      // distinguish an existing document from an unknown id (#23103).
+      if (!isDocumentVisibleToRequester(existing, params)) return { status: "not_found" };
+      if (!documentMutationSnapshotMatches(existing, params.expected)) {
+        return { status: "conflict" };
+      }
+      if (!canRequesterMutateDocument(existing, params)) return { status: "forbidden" };
+      const metadata = { ...((stored.metadata ?? {}) as Record<string, unknown>) };
+      if (params.pinned) {
+        metadata.pinned = true;
+      } else {
+        delete metadata.pinned;
+      }
+      const updated: StoredMemory = {
+        ...stored,
+        metadata: metadata as MemoryMetadata,
+      };
+      await this.storage.set(COLLECTIONS.MEMORIES, params.documentId, updated);
+      return { status: "updated", document: toMemory(updated) };
     });
   }
 

--- a/plugins/plugin-inmemorydb/adapter.ts
+++ b/plugins/plugin-inmemorydb/adapter.ts
@@ -918,6 +918,15 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
       if (!documentMutationSnapshotMatches(existing, params.expected)) {
         return { status: "conflict" };
       }
+      // Pin-state CAS fence (#23103): the observed pin bit must still match
+      // under the document mutation lock, so a racing writer that moved the
+      // pin bit loses the CAS with a typed conflict instead of silently
+      // overwriting it.
+      const existingPinned =
+        (existing.metadata as Record<string, unknown> | undefined)?.pinned === true;
+      if (existingPinned !== params.expectedPinned) {
+        return { status: "conflict" };
+      }
       if (!canRequesterMutateDocument(existing, params)) return { status: "forbidden" };
       const metadata = { ...((stored.metadata ?? {}) as Record<string, unknown>) };
       if (params.pinned) {

--- a/plugins/plugin-inmemorydb/document-pin.test.ts
+++ b/plugins/plugin-inmemorydb/document-pin.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Exercises the atomic document pin toggle against the first-party ephemeral
+ * adapter: CAS fencing, mutation authority, visibility fail-closed, and the
+ * metadata-only pin write inside the adapter's mutation lock. No mocks.
+ */
+import { type Memory, MemoryType, readDocumentMutationSnapshot, type UUID } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { InMemoryDatabaseAdapter } from "./adapter";
+import { MemoryStorage } from "./storage-memory";
+
+const AGENT_ID = "51000000-0000-0000-0000-000000000001" as UUID;
+const OWNER_ID = "51000000-0000-0000-0000-000000000002" as UUID;
+const OUTSIDER_ID = "51000000-0000-0000-0000-000000000003" as UUID;
+const ROOM_A = "51000000-0000-0000-0000-000000000004" as UUID;
+
+function document(index: number): Memory & { id: UUID } {
+  const id = `51000000-0000-0000-0000-${index.toString(16).padStart(12, "0")}` as UUID;
+  return {
+    id,
+    agentId: AGENT_ID,
+    entityId: OWNER_ID,
+    roomId: ROOM_A,
+    createdAt: 1_000,
+    content: { text: `Document ${index}` },
+    metadata: {
+      type: MemoryType.DOCUMENT,
+      documentId: id,
+      documentRevision: 0,
+      timestamp: 1_000,
+      scope: "user-private",
+      scopedToEntityId: OWNER_ID,
+      addedBy: OWNER_ID,
+    },
+  };
+}
+
+async function makeAdapter() {
+  const adapter = new InMemoryDatabaseAdapter(new MemoryStorage(), AGENT_ID);
+  await adapter.initialize();
+  await adapter.createRoomParticipants([AGENT_ID, OWNER_ID, OUTSIDER_ID], ROOM_A);
+  return adapter;
+}
+
+describe("InMemoryDatabaseAdapter.updateDocumentPinned", () => {
+  it("pins and unpins the document metadata atomically", async () => {
+    const adapter = await makeAdapter();
+    const doc = document(1);
+    await adapter.createMemories([{ memory: doc, tableName: "documents" }]);
+    const expected = readDocumentMutationSnapshot(doc);
+    if (!expected) throw new Error("snapshot must be valid");
+
+    await expect(
+      adapter.updateDocumentPinned({
+        agentId: AGENT_ID,
+        documentId: doc.id,
+        requesterEntityId: OWNER_ID,
+        requesterRoomIds: [ROOM_A],
+        requesterRole: "USER",
+        expected,
+        pinned: true,
+      })
+    ).resolves.toMatchObject({
+      status: "updated",
+      document: { metadata: { pinned: true } },
+    });
+
+    const afterPin = await adapter.getDocument({
+      agentId: AGENT_ID,
+      documentId: doc.id,
+      requesterEntityId: OWNER_ID,
+      requesterRoomIds: [ROOM_A],
+      requesterRole: "USER",
+    });
+    const snapshotAfterPin = readDocumentMutationSnapshot(afterPin as Memory);
+    expect(snapshotAfterPin).not.toBeNull();
+
+    await expect(
+      adapter.updateDocumentPinned({
+        agentId: AGENT_ID,
+        documentId: doc.id,
+        requesterEntityId: OWNER_ID,
+        requesterRoomIds: [ROOM_A],
+        requesterRole: "USER",
+        expected: snapshotAfterPin as never,
+        pinned: false,
+      })
+    ).resolves.toMatchObject({ status: "updated" });
+
+    const afterUnpin = await adapter.getDocument({
+      agentId: AGENT_ID,
+      documentId: doc.id,
+      requesterEntityId: OWNER_ID,
+      requesterRoomIds: [ROOM_A],
+      requesterRole: "USER",
+    });
+    const unpinnedMetadata = afterUnpin?.metadata as Record<string, unknown>;
+    expect(unpinnedMetadata.pinned).toBeUndefined();
+  });
+
+  it("rejects a stale snapshot with conflict after an authorization change", async () => {
+    const adapter = await makeAdapter();
+    const granteeId = "51000000-0000-0000-0000-000000000099" as UUID;
+    await adapter.createEntities([
+      { id: granteeId, agentId: AGENT_ID, names: ["Grantee"] } as never,
+    ]);
+    const doc = document(2);
+    await adapter.createMemories([{ memory: doc, tableName: "documents" }]);
+    const stale = readDocumentMutationSnapshot(doc);
+    if (!stale) throw new Error("snapshot must be valid");
+
+    // Change a snapshotted authorization field (direct grants) after the
+    // snapshot was taken — the pin CAS write must observe the mismatch.
+    const grants = await adapter.updateDocumentDirectGrants({
+      agentId: AGENT_ID,
+      documentId: doc.id,
+      requesterEntityId: OWNER_ID,
+      requesterRoomIds: [ROOM_A],
+      requesterRole: "OWNER",
+      expected: stale,
+      directGrantEntityIds: [granteeId],
+    });
+    expect(grants.status).toBe("updated");
+
+    await expect(
+      adapter.updateDocumentPinned({
+        agentId: AGENT_ID,
+        documentId: doc.id,
+        requesterEntityId: OWNER_ID,
+        requesterRoomIds: [ROOM_A],
+        requesterRole: "USER",
+        expected: stale,
+        pinned: true,
+      })
+    ).resolves.toMatchObject({ status: "conflict" });
+  });
+
+  it("fails closed for a requester who cannot see the document", async () => {
+    const adapter = await makeAdapter();
+    const doc = document(3);
+    await adapter.createMemories([{ memory: doc, tableName: "documents" }]);
+    const expected = readDocumentMutationSnapshot(doc);
+    if (!expected) throw new Error("snapshot must be valid");
+
+    await expect(
+      adapter.updateDocumentPinned({
+        agentId: AGENT_ID,
+        documentId: doc.id,
+        requesterEntityId: OUTSIDER_ID,
+        requesterRoomIds: [],
+        requesterRole: "GUEST",
+        expected,
+        pinned: true,
+      })
+    ).resolves.toMatchObject({ status: "not_found" });
+  });
+
+  it("returns not_found for an unknown document id", async () => {
+    const adapter = await makeAdapter();
+    await expect(
+      adapter.updateDocumentPinned({
+        agentId: AGENT_ID,
+        documentId: "51000000-0000-0000-0000-00000000dead" as UUID,
+        requesterEntityId: OWNER_ID,
+        requesterRoomIds: [ROOM_A],
+        requesterRole: "USER",
+        expected: {
+          scope: "user-private",
+          roomId: ROOM_A,
+          entityId: OWNER_ID,
+          revision: 0,
+        } as never,
+        pinned: true,
+      })
+    ).resolves.toMatchObject({ status: "not_found" });
+  });
+
+  it("hides document existence from an invisible requester even with a stale snapshot", async () => {
+    // RP review round-1 must-fix: CAS-before-visibility ordering let an
+    // invisible requester distinguish an existing document (conflict) from an
+    // unknown id (not_found). Visibility must fail closed FIRST.
+    const adapter = await makeAdapter();
+    const doc = document(4);
+    await adapter.createMemories([{ memory: doc, tableName: "documents" }]);
+    const current = readDocumentMutationSnapshot(doc);
+    if (!current) throw new Error("snapshot must be valid");
+    const stale = { ...current, revision: current.revision + 99 };
+
+    for (const expected of [current, stale]) {
+      await expect(
+        adapter.updateDocumentPinned({
+          agentId: AGENT_ID,
+          documentId: doc.id,
+          requesterEntityId: OUTSIDER_ID,
+          requesterRoomIds: [],
+          requesterRole: "GUEST",
+          expected,
+          pinned: true,
+        })
+      ).resolves.toMatchObject({ status: "not_found" });
+    }
+  });
+
+  it("hides existence from a visible-but-non-mutating requester on CAS mismatch", async () => {
+    // A room member who can see a global document but cannot mutate it must
+    // observe the CAS result (conflict), not forbidden-before-CAS — matching
+    // the sibling CAS mutation methods' observable contract.
+    const adapter = await makeAdapter();
+    const base = document(5);
+    const globalDoc: Memory = {
+      ...base,
+      metadata: {
+        ...base.metadata,
+        scope: "global",
+      },
+    };
+    await adapter.createMemories([{ memory: globalDoc, tableName: "documents" }]);
+    const current = readDocumentMutationSnapshot(globalDoc);
+    if (!current) throw new Error("snapshot must be valid");
+    const stale = { ...current, revision: current.revision + 99 };
+
+    // Sanity: the OUTSIDER (room member) can see the global document.
+    const visible = await adapter.getDocument({
+      agentId: AGENT_ID,
+      documentId: globalDoc.id,
+      requesterEntityId: OUTSIDER_ID,
+      requesterRoomIds: [ROOM_A],
+      requesterRole: "GUEST",
+    });
+    expect(visible?.id).toBe(globalDoc.id);
+
+    // Stale snapshot → conflict (existence already visible to this requester).
+    await expect(
+      adapter.updateDocumentPinned({
+        agentId: AGENT_ID,
+        documentId: globalDoc.id,
+        requesterEntityId: OUTSIDER_ID,
+        requesterRoomIds: [ROOM_A],
+        requesterRole: "GUEST",
+        expected: stale,
+        pinned: true,
+      })
+    ).resolves.toMatchObject({ status: "conflict" });
+
+    // Current snapshot → forbidden (mutation policy), never a write.
+    await expect(
+      adapter.updateDocumentPinned({
+        agentId: AGENT_ID,
+        documentId: globalDoc.id,
+        requesterEntityId: OUTSIDER_ID,
+        requesterRoomIds: [ROOM_A],
+        requesterRole: "GUEST",
+        expected: current,
+        pinned: true,
+      })
+    ).resolves.toMatchObject({ status: "forbidden" });
+  });
+});

--- a/plugins/plugin-inmemorydb/document-pin.test.ts
+++ b/plugins/plugin-inmemorydb/document-pin.test.ts
@@ -57,6 +57,7 @@ describe("InMemoryDatabaseAdapter.updateDocumentPinned", () => {
         requesterRoomIds: [ROOM_A],
         requesterRole: "USER",
         expected,
+        expectedPinned: false,
         pinned: true,
       })
     ).resolves.toMatchObject({
@@ -82,6 +83,7 @@ describe("InMemoryDatabaseAdapter.updateDocumentPinned", () => {
         requesterRoomIds: [ROOM_A],
         requesterRole: "USER",
         expected: snapshotAfterPin as never,
+        expectedPinned: true,
         pinned: false,
       })
     ).resolves.toMatchObject({ status: "updated" });
@@ -129,6 +131,7 @@ describe("InMemoryDatabaseAdapter.updateDocumentPinned", () => {
         requesterRoomIds: [ROOM_A],
         requesterRole: "USER",
         expected: stale,
+        expectedPinned: false,
         pinned: true,
       })
     ).resolves.toMatchObject({ status: "conflict" });
@@ -149,6 +152,7 @@ describe("InMemoryDatabaseAdapter.updateDocumentPinned", () => {
         requesterRoomIds: [],
         requesterRole: "GUEST",
         expected,
+        expectedPinned: false,
         pinned: true,
       })
     ).resolves.toMatchObject({ status: "not_found" });
@@ -169,6 +173,7 @@ describe("InMemoryDatabaseAdapter.updateDocumentPinned", () => {
           entityId: OWNER_ID,
           revision: 0,
         } as never,
+        expectedPinned: false,
         pinned: true,
       })
     ).resolves.toMatchObject({ status: "not_found" });
@@ -194,6 +199,7 @@ describe("InMemoryDatabaseAdapter.updateDocumentPinned", () => {
           requesterRoomIds: [],
           requesterRole: "GUEST",
           expected,
+          expectedPinned: false,
           pinned: true,
         })
       ).resolves.toMatchObject({ status: "not_found" });
@@ -237,6 +243,7 @@ describe("InMemoryDatabaseAdapter.updateDocumentPinned", () => {
         requesterRoomIds: [ROOM_A],
         requesterRole: "GUEST",
         expected: stale,
+        expectedPinned: false,
         pinned: true,
       })
     ).resolves.toMatchObject({ status: "conflict" });
@@ -250,6 +257,7 @@ describe("InMemoryDatabaseAdapter.updateDocumentPinned", () => {
         requesterRoomIds: [ROOM_A],
         requesterRole: "GUEST",
         expected: current,
+        expectedPinned: false,
         pinned: true,
       })
     ).resolves.toMatchObject({ status: "forbidden" });

--- a/plugins/plugin-sql/src/__tests__/integration/document-pin.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/document-pin.real.test.ts
@@ -124,6 +124,7 @@ describe("document pin mutation (real SQL)", () => {
       requesterRoomIds: ownerRoomIds,
       requesterRole: "OWNER",
       expected,
+      expectedPinned: false,
       pinned: true,
     });
     expect(pinned.status).toBe("updated");
@@ -147,6 +148,7 @@ describe("document pin mutation (real SQL)", () => {
       requesterRoomIds: ownerRoomIds,
       requesterRole: "OWNER",
       expected: afterPin as never,
+      expectedPinned: true,
       pinned: false,
     });
     expect(unpinned.status).toBe("updated");
@@ -173,6 +175,7 @@ describe("document pin mutation (real SQL)", () => {
           requesterRoomIds: [],
           requesterRole: "USER",
           expected: expected as never,
+          expectedPinned: false,
           pinned: true,
         })
       ).resolves.toMatchObject({ status: "not_found" });
@@ -204,6 +207,7 @@ describe("document pin mutation (real SQL)", () => {
         requesterRoomIds: ownerRoomIds,
         requesterRole: "USER",
         expected: current,
+        expectedPinned: false,
         pinned: true,
       })
     ).resolves.toMatchObject({ status: "forbidden" });
@@ -224,9 +228,71 @@ describe("document pin mutation (real SQL)", () => {
         requesterRoomIds: ownerRoomIds,
         requesterRole: "OWNER",
         expected: stale as never,
+        expectedPinned: false,
         pinned: true,
       })
     ).resolves.toMatchObject({ status: "conflict" });
+  });
+
+  it("two racing pin writers from the same observed state: exactly one wins, loser conflicts and retry converges", async () => {
+    // Reviewer-requested REAL two-writer proof (#23103): both writers read
+    // the document BEFORE either writes (same authorization snapshot AND
+    // same observed pin bit), then race their CAS writes on one real SQL
+    // engine. The expectedPinned fence must serialize them: exactly one
+    // `updated`, the other `conflict` — never two `updated` (lost update).
+    // The loser then re-reads fresh state and its retry converges.
+    const doc = document(6);
+    await seed([doc]);
+    const observed = await adapter.getDocument({
+      agentId,
+      documentId: doc.id,
+      requesterEntityId: OWNER_ID,
+      requesterRoomIds: ownerRoomIds,
+      requesterRole: "OWNER",
+    });
+    expect(observed).not.toBeNull();
+    const snapshot = readDocumentMutationSnapshot(observed as Memory);
+    if (!snapshot) throw new Error("snapshot must be valid");
+
+    const pinParams = () => ({
+      agentId,
+      documentId: doc.id,
+      requesterEntityId: OWNER_ID,
+      requesterRoomIds: ownerRoomIds,
+      requesterRole: "OWNER",
+      expected: snapshot,
+      expectedPinned: false,
+      pinned: true,
+    });
+    const [first, second] = await Promise.all([
+      adapter.updateDocumentPinned(pinParams()),
+      adapter.updateDocumentPinned(pinParams()),
+    ]);
+    const statuses = [first.status, second.status].sort();
+    expect(statuses).toEqual(["conflict", "updated"]);
+
+    // The losing writer retries against freshly read state and converges.
+    const fresh = await adapter.getDocument({
+      agentId,
+      documentId: doc.id,
+      requesterEntityId: OWNER_ID,
+      requesterRoomIds: ownerRoomIds,
+      requesterRole: "OWNER",
+    });
+    const freshSnapshot = readDocumentMutationSnapshot(fresh as Memory);
+    if (!freshSnapshot) throw new Error("fresh snapshot must be valid");
+    const retried = await adapter.updateDocumentPinned({
+      agentId,
+      documentId: doc.id,
+      requesterEntityId: OWNER_ID,
+      requesterRoomIds: ownerRoomIds,
+      requesterRole: "OWNER",
+      expected: freshSnapshot,
+      expectedPinned: true,
+      pinned: false,
+    });
+    expect(retried.status).toBe("updated");
+    expect(retried.document.metadata).not.toMatchObject({ pinned: true });
   });
 
   it("returns not_found for an unknown document id", async () => {
@@ -243,6 +309,7 @@ describe("document pin mutation (real SQL)", () => {
           entityId: OWNER_ID,
           revision: 0,
         } as never,
+        expectedPinned: false,
         pinned: true,
       })
     ).resolves.toMatchObject({ status: "not_found" });

--- a/plugins/plugin-sql/src/__tests__/integration/document-pin.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/document-pin.real.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Exercises the SQL document pin mutation on real PGlite/Postgres storage:
+ * CAS fencing, mutation authority, fail-closed visibility (an invisible
+ * requester observes not_found for both current and stale snapshots — no
+ * existence leak), and metadata-only persistence of the pin bit.
+ */
+import {
+  ChannelType,
+  type Entity,
+  type Memory,
+  MemoryType,
+  type Room,
+  readDocumentMutationSnapshot,
+  type UUID,
+  type World,
+} from "@elizaos/core";
+import { v4 } from "uuid";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import type { PgDatabaseAdapter } from "../../pg/adapter";
+import type { PgliteDatabaseAdapter } from "../../pglite/adapter";
+import { memoryTable } from "../../schema";
+import type { DrizzleDatabase } from "../../types";
+import { createIsolatedTestDatabase } from "../test-helpers";
+
+const OWNER_ID = "40000000-0000-0000-0000-0000000000a1" as UUID;
+const OUTSIDER_ID = "40000000-0000-0000-0000-0000000000a2" as UUID;
+const MEMBER_ID = "40000000-0000-0000-0000-0000000000a3" as UUID;
+
+describe("document pin mutation (real SQL)", () => {
+  let adapter: PgliteDatabaseAdapter | PgDatabaseAdapter;
+  let cleanup: () => Promise<void>;
+  let agentId: UUID;
+  let roomId: UUID;
+  let worldId: UUID;
+  let ownerRoomIds: UUID[];
+
+  beforeAll(async () => {
+    const setup = await createIsolatedTestDatabase("document_pin_mutation");
+    adapter = setup.adapter;
+    cleanup = setup.cleanup;
+    agentId = setup.testAgentId;
+    worldId = v4() as UUID;
+    roomId = v4() as UUID;
+    ownerRoomIds = [roomId];
+
+    await adapter.createWorld({
+      id: worldId,
+      agentId,
+      name: "Document pin world",
+      serverId: "document-pin",
+    } as World);
+    await adapter.createRooms([
+      {
+        id: roomId,
+        agentId,
+        worldId,
+        name: "documents",
+        source: "test",
+        type: ChannelType.DM,
+      } as unknown as Room,
+    ]);
+    await adapter.createEntities([
+      { id: OWNER_ID, agentId, names: ["Owner"] } as Entity,
+      { id: OUTSIDER_ID, agentId, names: ["Outsider"] } as Entity,
+      { id: MEMBER_ID, agentId, names: ["Member"] } as Entity,
+    ]);
+    await adapter.addParticipant(OWNER_ID, roomId);
+    await adapter.addParticipant(MEMBER_ID, roomId);
+  }, 120_000);
+
+  afterAll(async () => {
+    if (cleanup) await cleanup();
+  });
+
+  beforeEach(async () => {
+    const db = adapter.getDatabase() as DrizzleDatabase;
+    await db.delete(memoryTable);
+  });
+
+  function document(
+    index: number,
+    overrides: {
+      scope?: string;
+      entityId?: UUID;
+    } = {}
+  ): Memory {
+    const id = `40000000-0000-0000-0000-${index.toString(16).padStart(12, "0")}` as UUID;
+    const entityId = overrides.entityId ?? OWNER_ID;
+    return {
+      id,
+      agentId,
+      entityId,
+      roomId,
+      worldId,
+      createdAt: 10_000,
+      content: { text: `Pin target body ${index}` },
+      metadata: {
+        type: MemoryType.DOCUMENT,
+        documentId: id,
+        documentRevision: 0,
+        title: `Pin target ${index}`,
+        scope: overrides.scope ?? "user-private",
+        scopedToEntityId: entityId,
+        addedBy: entityId,
+        timestamp: 10_000,
+      },
+    } as Memory;
+  }
+
+  async function seed(documents: Memory[]): Promise<void> {
+    await adapter.createMemories(documents.map((memory) => ({ memory, tableName: "documents" })));
+  }
+
+  it("pins and unpins through the CAS path, persisting metadata only", async () => {
+    const doc = document(1);
+    await seed([doc]);
+    const expected = readDocumentMutationSnapshot(doc);
+    if (!expected) throw new Error("snapshot must be valid");
+
+    const pinned = await adapter.updateDocumentPinned({
+      agentId,
+      documentId: doc.id,
+      requesterEntityId: OWNER_ID,
+      requesterRoomIds: ownerRoomIds,
+      requesterRole: "OWNER",
+      expected,
+      pinned: true,
+    });
+    expect(pinned.status).toBe("updated");
+    if (pinned.status !== "updated") throw new Error("expected updated");
+    expect(pinned.document.metadata).toMatchObject({ pinned: true });
+
+    const stored = await adapter.getDocument({
+      agentId,
+      documentId: doc.id,
+      requesterEntityId: OWNER_ID,
+      requesterRoomIds: ownerRoomIds,
+      requesterRole: "OWNER",
+    });
+    const afterPin = readDocumentMutationSnapshot(stored as Memory);
+    expect(afterPin).not.toBeNull();
+
+    const unpinned = await adapter.updateDocumentPinned({
+      agentId,
+      documentId: doc.id,
+      requesterEntityId: OWNER_ID,
+      requesterRoomIds: ownerRoomIds,
+      requesterRole: "OWNER",
+      expected: afterPin as never,
+      pinned: false,
+    });
+    expect(unpinned.status).toBe("updated");
+    if (unpinned.status !== "updated") throw new Error("expected updated");
+    expect(unpinned.document.metadata).not.toMatchObject({ pinned: true });
+  });
+
+  it("fails closed for an invisible requester with both current and stale snapshots", async () => {
+    // RP review round-1 must-fix: the pin SELECT must use the
+    // visibility-aware read conditions so an unauthorized requester cannot
+    // distinguish an existing document from an unknown id.
+    const doc = document(2);
+    await seed([doc]);
+    const current = readDocumentMutationSnapshot(doc);
+    if (!current) throw new Error("snapshot must be valid");
+    const stale = { ...current, revision: current.revision + 99 };
+
+    for (const expected of [current, stale]) {
+      await expect(
+        adapter.updateDocumentPinned({
+          agentId,
+          documentId: doc.id,
+          requesterEntityId: OUTSIDER_ID,
+          requesterRoomIds: [],
+          requesterRole: "USER",
+          expected: expected as never,
+          pinned: true,
+        })
+      ).resolves.toMatchObject({ status: "not_found" });
+    }
+  });
+
+  it("rejects a visible non-mutator with forbidden after CAS passes", async () => {
+    // A room member can see a global document but cannot mutate it.
+    const doc = document(3, { scope: "global" });
+    await seed([doc]);
+    const current = readDocumentMutationSnapshot(doc);
+    if (!current) throw new Error("snapshot must be valid");
+
+    // Sanity: MEMBER can read the global document.
+    const visible = await adapter.getDocument({
+      agentId,
+      documentId: doc.id,
+      requesterEntityId: MEMBER_ID,
+      requesterRoomIds: ownerRoomIds,
+      requesterRole: "USER",
+    });
+    expect(visible?.id).toBe(doc.id);
+
+    await expect(
+      adapter.updateDocumentPinned({
+        agentId,
+        documentId: doc.id,
+        requesterEntityId: MEMBER_ID,
+        requesterRoomIds: ownerRoomIds,
+        requesterRole: "USER",
+        expected: current,
+        pinned: true,
+      })
+    ).resolves.toMatchObject({ status: "forbidden" });
+  });
+
+  it("conflicts on a stale snapshot for the owner", async () => {
+    const doc = document(4);
+    await seed([doc]);
+    const current = readDocumentMutationSnapshot(doc);
+    if (!current) throw new Error("snapshot must be valid");
+    const stale = { ...current, revision: current.revision + 99 };
+
+    await expect(
+      adapter.updateDocumentPinned({
+        agentId,
+        documentId: doc.id,
+        requesterEntityId: OWNER_ID,
+        requesterRoomIds: ownerRoomIds,
+        requesterRole: "OWNER",
+        expected: stale as never,
+        pinned: true,
+      })
+    ).resolves.toMatchObject({ status: "conflict" });
+  });
+
+  it("returns not_found for an unknown document id", async () => {
+    await expect(
+      adapter.updateDocumentPinned({
+        agentId,
+        documentId: "40000000-0000-0000-0000-00000000dead" as UUID,
+        requesterEntityId: OWNER_ID,
+        requesterRoomIds: ownerRoomIds,
+        requesterRole: "OWNER",
+        expected: {
+          scope: "user-private",
+          roomId,
+          entityId: OWNER_ID,
+          revision: 0,
+        } as never,
+        pinned: true,
+      })
+    ).resolves.toMatchObject({ status: "not_found" });
+  });
+});

--- a/plugins/plugin-sql/src/base.ts
+++ b/plugins/plugin-sql/src/base.ts
@@ -2617,6 +2617,15 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
       if (!documentMutationSnapshotMatches(existing, params.expected)) {
         return { status: "conflict" };
       }
+      // Pin-state CAS fence (#23103): the observed pin bit must still match
+      // when the row lock is held, so a racing writer that moved the pin bit
+      // between this writer's read and its lock acquisition loses the CAS
+      // with a typed conflict instead of silently overwriting it.
+      const existingPinned =
+        (existing.metadata as Record<string, unknown> | undefined)?.pinned === true;
+      if (existingPinned !== params.expectedPinned) {
+        return { status: "conflict" };
+      }
       if (!canRequesterMutateDocument(existing, params)) {
         return { status: "forbidden" };
       }

--- a/plugins/plugin-sql/src/base.ts
+++ b/plugins/plugin-sql/src/base.ts
@@ -41,6 +41,7 @@ import {
   type DocumentListQueryParams,
   type DocumentListQueryResult,
   type DocumentMutationResult,
+  type DocumentPinUpdateParams,
   type DocumentRangeReadParams,
   type DocumentRangeReadResult,
   type DocumentRevisionReplaceParams,
@@ -2287,7 +2288,11 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
   }
 
   private documentReadConditions(
-    params: DocumentGetQueryParams | DocumentCompareAndSwapParams | DocumentDeleteParams
+    params:
+      | DocumentGetQueryParams
+      | DocumentCompareAndSwapParams
+      | DocumentDeleteParams
+      | DocumentPinUpdateParams
   ): SQL[] {
     const hasGlobalVisibility = documentRoleHasGlobalVisibility(params.requesterRole);
     return [
@@ -2582,6 +2587,48 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
           unique: replacement.unique ?? row.unique,
           metadata: replacement.metadata ?? {},
         })
+        .where(eq(memoryTable.id, params.documentId))
+        .returning();
+      return updated[0]
+        ? { status: "updated", document: memoryFromRow(updated[0]) }
+        : { status: "conflict" };
+    });
+  }
+
+  async updateDocumentPinned(params: DocumentPinUpdateParams): Promise<DocumentMutationResult> {
+    validateDocumentRequesterContext(params);
+    const entityContext = documentRoleHasGlobalVisibility(params.requesterRole)
+      ? params.agentId
+      : params.requesterEntityId;
+    return this.withEntityContext(entityContext, async (tx) => {
+      // Read through the visibility-aware conditions so an unauthorized
+      // requester cannot distinguish an existing document from an unknown id
+      // (#23103); invisible targets resolve as not_found before any snapshot
+      // or mutation-policy result is produced.
+      const rows = await tx
+        .select()
+        .from(memoryTable)
+        .where(and(...this.documentReadConditions(params)))
+        .for("update")
+        .limit(1);
+      const row = rows[0];
+      if (!row) return { status: "not_found" };
+      const existing = memoryFromRow(row);
+      if (!documentMutationSnapshotMatches(existing, params.expected)) {
+        return { status: "conflict" };
+      }
+      if (!canRequesterMutateDocument(existing, params)) {
+        return { status: "forbidden" };
+      }
+      const metadata = { ...((row.metadata ?? {}) as Record<string, unknown>) };
+      if (params.pinned) {
+        metadata.pinned = true;
+      } else {
+        delete metadata.pinned;
+      }
+      const updated = await tx
+        .update(memoryTable)
+        .set({ metadata })
         .where(eq(memoryTable.id, params.documentId))
         .returning();
       return updated[0]


### PR DESCRIPTION
# Relates to

Closes #28603 (bounded child of #23103 — first implementation slice: first-class pin management + post-#24134 prompt-integrity policy on pinned provider injection; the parent security/design issue stays open for entitlements/sharing per its phased scope)

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

The row labels below must **not** reuse the terminal eliza.army footer labels
(`Client / agent tooling`, `Skill revision` / `Contribution skill revision`,
`Attribution status`). Duplicating those strings makes the scoring validator
reject the machine marker (#17855). Keep the `<!-- attribution-row:* -->`
markers; only the human-readable prefixes changed. After filling these rows,
append the standard footer once at the end of the PR body (do not repeat the
visible footer lines here).

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `zai/glm-5.3` (implementation), `zai/glm-5.3` + `openai/gpt-5.6-sol` (review)
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@b447fe2f542af8f12c0c011c3bbf772c7c6b3f50:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Pin management is metadata-only: it changes provider injection priority and
never touches authorization decisions. The adapter contract change is additive
(`updateDocumentPinned` + `documentPinCapability`), with a typed
`DOCUMENT_PIN_UNSUPPORTED` error surfaced as 503 for legacy adapters instead of
a fabricated success.

# Background

## What does this PR do?

Implements the first production slice of #23103:

1. **Pin/unpin/list through service + REST + agent action.** `DocumentService.setDocumentPinned` performs a CAS-protected metadata mutation through the existing authorization + revision fencing plus the dedicated `expectedPinned` pin-bit fence (review r1: two racing pin writers from the same observed state now serialize — exactly one `updated`, the loser gets a typed conflict and the service's bounded retry converges against fresh state; no second write path). REST: `POST /api/documents/:id/pin` / `DELETE /api/documents/:id/pin` behind the existing mutate gate, mapping typed `DOCUMENT_PIN_UNSUPPORTED` to 503. Agent surface: `pin`/`unpin` subactions on the DOCUMENT umbrella action. The presented-document wire shape now carries `pinned`, and the Documents view shows a visible per-row pending state with a fail-closed unsupported-adapter signal.
2. **Post-#24134 prompt-integrity policy on pinned provider injection.** The deterministic 8,000-token pinned-injection cap (first-N selection + `[PINNED KNOWLEDGE TRUNCATED]` marker) is gone: every authorized selected pinned document reaches the model completely. Provider composition exhausts pagination before selecting pinned documents.

**Coordination with upstream #26780/#28112:** during review, upstream landed prompt-integrity work touching the same provider seam (`renderPinnedDocuments` now returns `{text, truncated: boolean, includedIds}` and callers expose `pinnedDocumentsTruncated` as the completeness signal, always `false`). This branch concedes that seam wholesale to upstream (100% upstream bytes for `provider.ts` + its two test files) and keeps the complete-injection policy through upstream's own shape. An independent integration review (round 5) verified no silent cap/clip/marker remains, no semantic conflict with #28112's rewritten limit semantics in the auto-merged files, and that no required deliverable was dropped.

Explicit non-goals (follow-up slices of #23103): durable entitlement grants/sharing flows (#23102 coordination), multi-room pin scoping UI.

## What kind of change is this?

Features (non-breaking change which adds functionality)

# Documentation changes needed?

My changes do not require a change to the project documentation. (The plugin-documents `CLAUDE.md`/`AGENTS.md` pair is updated in-branch for the new pin routes.)

# Testing

## Where should a reviewer start?

`packages/core/src/features/documents/__tests__/actions-pin.test.ts` (agent action wiring), then `plugins/plugin-documents/src/routes.pin.test.ts` (REST + 503 mapping), then `plugins/plugin-inmemorydb/document-pin.test.ts` + `plugins/plugin-sql/src/__tests__/integration/document-pin.real.test.ts` (real adapter persistence, CAS + concurrency).

## Detailed testing steps

- Pin/unpin via the DOCUMENT umbrella action; assert metadata-only mutation through existing authorization (never a second write path).
- `POST /api/documents/:id/pin` on a legacy adapter (inherited base method) — expect 503 typed `DOCUMENT_PIN_UNSUPPORTED`, never a fabricated success.
- Concurrent pin toggles on the same document — REAL two-writer SQL proof on PGlite (`document-pin.real.test.ts`): both writers read before either writes, race `Promise.all` CAS writes; exactly one `updated` + one `conflict`, and the loser's retry against fresh state converges. RED control: removing the `expectedPinned` fence makes both writers report `updated` (lost update) and the test fails.
- Pinned provider injection renders complete content (no budget, no marker).

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:c00f753b9283f67cdd45c9bf332e883729269176 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-first slice; the only UI change (per-row pending glyph + pinned wire field) is covered by serialized-component state tests (DocumentsView.test.tsx 284 lines: pending glyph, disabled control, serialization). Full-page visual capture arrives with the UI-slice follow-up in #23103.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - same reason as before-screenshots: pending-state UI asserted via serialization tests; visual walkthrough deferred to the UI follow-up slice.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive user-flow change in this slice (metadata toggle through API/action surfaces); the visible pending-state flow is tested programmatically and gets a video in the UI follow-up slice.
<!-- evidence-row:backend-logs -->
- [x] Backend logs (latest rebase c00f753b92 onto develop tip 7cd2d742ed: Rebase c00f753b92 onto develop tip 7cd2d742ed (48 commits, zero conflicts; only content delta vs approved head f58a066a7e is the promised reconciliation with landed 246adc8aec getOptionalPlannerLimit + zero-limit test). Gates at new head: core documents suite 379/379 pass (vitest, incl. previously develop-red actions-routing zero-sentinel now green via 246adc8aec); actions-routing + actions-pin 31/31; plugin-documents unit 145/145 pass (4 develop-owned UI-view suites fail import identically at pristine develop tip in this macOS worktree — CI Plugin Tests lane passes the same package 171/171 at 7cd2d742ed, so local-env only); plugin-sql real PGlite document-pin 6/6 (bun test); packages/agent typecheck clean; biome clean on all 26 changed files (one rebase-context blank line fixed, amended before push). GitHub mergeable: CONFLICTING -> MERGEABLE.)

<details>
<summary>vitest run — core actions-pin.test.ts (7/7) + plugin-documents routes.pin.test.ts (9/9)</summary>

```
$ cd packages/core && npx vitest run src/features/documents/__tests__/actions-pin.test.ts
 ✓ routes pin to setDocumentPinned(true) and confirms once
 ✓ routes unpin to setDocumentPinned(false)
 ✓ refuses without calling the service when no id is supplied
 ✓ translates DOCUMENT_MUTATION_FORBIDDEN into a structured refusal
 ✓ translates DOCUMENT_NOT_FOUND into a structured refusal
 ✓ surfaces unexpected typed error codes through the action boundary
 ✓ refuses cleanly when the adapter lacks pin support
 Test Files  1 passed (1)      Tests  7 passed (7)

$ cd plugins/plugin-documents && npx vitest run src/routes.pin.test.ts
 ✓ pins via POST /api/documents/:id/pin through the canonical service
 ✓ unpins via DELETE /api/documents/:id/pin through the canonical service
 ✓ maps DOCUMENT_MUTATION_FORBIDDEN to 403
 ✓ maps DOCUMENT_NOT_FOUND to 404
 ✓ maps DOCUMENT_MUTATION_CONFLICT to 409
 ✓ maps DOCUMENT_PIN_UNSUPPORTED to 503, not 500
 ✓ rejects a malformed document id with 400
 ✓ returns 503 when the canonical pin authority is unavailable
 ✓ does not handle a GET on the pin route
 Test Files  1 passed (1)      Tests  9 passed (9)
```
</details>

<details>
<summary>scoped suites + typecheck + lint at head (commands and exit codes)</summary>

```
$ npx vitest run  (plugin-documents)            Test Files  9 passed (9)
$ npx vitest run  (plugin-inmemorydb)           Test Files  17 passed (17)
$ npx vitest run  (plugin-sql, default cfg)     Test Files  25 passed | 1 skipped (26)
$ npx vitest run src/features/documents (core)  29 passed; 2 files failed = the pre-existing
   #28112 pair (actions-routing sentinel + llm generateText x2) — identical-failure control
   on pristine upstream/develop b7c7c504b9 proves pre-existing, not introduced here.
$ bun run --cwd packages/core test (full lane)  882 passed / 10 files failed — all 10 fail
   IDENTICALLY on the pristine develop control (same tests, same counts).
$ bun run --cwd packages/core typecheck            exit 0
$ bun run --cwd packages/agent typecheck           exit 0
$ bun run --cwd plugins/plugin-documents typecheck exit 0
$ bun run --cwd plugins/plugin-inmemorydb typecheck exit 0
$ bun run --cwd plugins/plugin-sql typecheck       exit 0
$ npx biome check <all 24 changed files>            clean — no fixes applied
```
</details>
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend network/console path changed in this slice; `pinned` is additive in the presented wire shape and asserted by backend serialization tests.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model invocation changed; the model-FACING context change is proven inline: real pin -> provider prompt-selection transcript in "Evidence Details" below (pin-context-injection.real.test.ts at head f58a066a7e, real PGlite: unpinned absent -> pinned injected whole -> unpin removed)
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts (adapter persistence evidence inline below).

<details>
<summary>vitest run — plugin-inmemorydb document-pin.test.ts (6/6) CAS matrix</summary>

```
$ cd plugins/plugin-inmemorydb && npx vitest run document-pin.test.ts
 ✓ pins and unpins the document metadata atomically
 ✓ rejects a stale snapshot with conflict after an authorization change
 ✓ fails closed for a requester who cannot see the document
 ✓ returns not_found for an unknown document id
 ✓ hides document existence from an invisible requester even with a stale snapshot
 ✓ hides existence from a visible-but-non-mutating requester on CAS mismatch
 Test Files  1 passed (1)      Tests  6 passed (6)
```
</details>

<details>
<summary>vitest run — plugin-sql document-pin.real.test.ts (5/5) on real PGlite</summary>

```
$ cd plugins/plugin-sql && npx vitest run -c src/vitest.real.config.ts src/__tests__/integration/document-pin.real.test.ts
 Warn [CORE:SETTINGS] SECRET_SALT is not set — generated an EPHEMERAL random salt for this process.
 ✓ src/__tests__/integration/document-pin.real.test.ts (5 tests) 1496ms
 Test Files  1 passed (1)      Tests  5 passed (5)      Duration  6.33s
```

Real SQL engine (embedded PGlite), real Drizzle schema, real visibility-aware pin read
path: pin metadata UPDATE through the Drizzle stack, CAS conflict semantics against real
rows, visibility-aware read conditions, and typed DOCUMENT_PIN_UNSUPPORTED surfacing for
the inherited-base legacy-adapter shape.
</details>

<details>
<summary>review r1 response — expectedPinned CAS fence + REAL two-writer race at head 5d5c8d6cc2</summary>

```
$ cd plugins/plugin-sql && npx vitest run -c src/vitest.real.config.ts src/__tests__/integration/document-pin.real.test.ts
 ✓ src/__tests__/integration/document-pin.real.test.ts (6 tests) 1435ms
      Tests  6 passed (6)
  # includes "two racing pin writers from the same observed state: exactly one wins,
  # loser conflicts and retry converges" — both writers read BEFORE either writes
  # (same snapshot + same observed pin bit), then race Promise.all CAS writes on
  # real PGlite: statuses == ["conflict","updated"]; loser retry converges.

# RED control (fence removed from plugin-sql base.ts, everything else identical):
  × two racing pin writers from the same observed state ... (retry x1)
      Tests  1 failed | 5 passed (6)
  # without the expectedPinned fence BOTH writers report updated (lost update) —
  # the exact defect the review flagged; the test is a real regression test.

$ cd packages/core && npx vitest run src/features/documents/service-pinned.test.ts src/features/documents/__tests__/actions-pin.test.ts src/features/documents/__tests__/actions-routing.test.ts
      Tests  38 passed | 1 failed (39)
  # the 1 failure is the documented pre-existing #28112 sentinel pair (identical on develop)
  # includes NEW: service retry converges when a concurrent writer moves the pin bit
  # between read and write (pinCalls == 2, converged pinned:true);
  # NEW: conflicting expectedPinned with a CURRENT snapshot yields conflict;
  # NEW: list surface marks pinned rows ("1. Pinned Doc [pinned] (id)").

$ cd plugins/plugin-inmemorydb && npx vitest run document-pin.test.ts   Tests 6 passed (6)
$ cd plugins/plugin-documents && npx vitest run src/routes.pin.test.ts Tests 9 passed (9)
$ cd plugins/plugin-sql && npx vitest run                              Tests 173 passed | 3 skipped
$ cd packages/core && npx vitest run src/features/documents            357 passed | 3 failed (pre-existing #28112 pair, identical on develop control)
$ bun run --cwd packages/core typecheck && --cwd plugins/plugin-sql typecheck && --cwd plugins/plugin-inmemorydb typecheck && --cwd plugins/plugin-documents typecheck   all exit 0
$ npx biome check <13 changed files>   clean, no fixes applied
```
</details>
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface changed in this slice

# Evidence Details

## Real LLM-call trajectory

No model invocation changed (no new/removed LLM calls; routing untouched). The model-FACING context change — pinned selection altering provider prompt content — is proven by the real context-injection transcript above (llm-trajectory row).

## Backend + frontend logs

<details>
<summary>Backend: focused suites at head 59699abf9e (exact commands + summaries)</summary>

```
$ cd packages/core && npx vitest run src/features/documents
Test Files  2 failed | 29 passed (31)   # the 2 failures are the pre-existing #28112 fallout pair
  src/features/documents/__tests__/actions-routing.test.ts > ignores ungrounded strict-decoder zero sentinels on list
  src/features/documents/llm.test.ts > generateText (2 cases)
# CONTROL (pristine upstream/develop b7c7c504b9 worktree, same commands): identical failure set
# → pre-existing on develop, not introduced by this branch.

$ cd plugins/plugin-documents && npx vitest run
Test Files  9 passed (9)   # includes routes.pin.test.ts: REST pin/unpin + DOCUMENT_PIN_UNSUPPORTED→503 mapping

$ cd plugins/plugin-inmemorydb && npx vitest run
Test Files  17 passed (17)  # includes document-pin.test.ts: CAS matrix, concurrent toggles, legacy-adapter typed error

$ cd plugins/plugin-sql && npx vitest run
Test Files  25 passed | 1 skipped (26)  # includes integration/document-pin.real.test.ts: real SQL persistence + visibility-aware pin read

$ bun run --cwd packages/core test   (full lane)
Test Files  10 failed | 882 passed | 2 skipped (894)
# All 10 failing files fail IDENTICALLY on the pristine develop control (same tests, same counts)
# → all pre-existing #28112 test fallout on develop tip; zero failures introduced by this branch.

# Typecheck (all at head): packages/core ✅  packages/agent ✅  plugins/plugin-documents ✅
#   plugins/plugin-inmemorydb ✅  plugins/plugin-sql ✅
# Biome on all 24 changed files: clean ("Checked 22 files … No fixes applied")
```
</details>

## Real pin -> provider context-injection transcript (finding 4)

```
$ cd packages/core && VITEST_LANE=post-merge npx vitest run --config vitest.config.ts \
    src/features/documents/pin-context-injection.real.test.ts --reporter=verbose
PIN-PROBE before-pin contains-body: false
PIN-PROBE after-pin contains-body: true
PIN-PROBE after-pin pinnedDocumentIds: ["f4300000-0000-4000-8000-000000000043"]
PIN-PROBE after-unpin contains-body: false
PIN-PROBE verdict: PASS (pin toggles provider prompt selection end-to-end on real PGlite)
 ✓ src/features/documents/pin-context-injection.real.test.ts > pin -> provider context injection
   (real PGlite) > injects the pinned document body into provider context after a real pin,
   and removes it after unpin 43ms
      Tests  1 passed (1)
```

Real AgentRuntime + PGlite SQL adapter + DocumentService + documentsProvider (createTestRuntime
harness; getService bound to the real service per service-authorization.real.test.ts). The pin
goes through the REAL CAS path (expectedPinned fence + service retry). Checked in as
`packages/core/src/features/documents/pin-context-injection.real.test.ts` so the lane reruns it.

## Screenshots (before / after) + video walkthrough

N/A - see evidence rows.

<!-- evidence-row rows are stamped by scripts/pr-evidence.mjs; evidence-head marker below is set from the live PR head. -->

AI provider/model: zai / glm-5.3
Client / agent tooling: Hermes Agent
Contribution skill revision: elizaOS/eliza@b447fe2f542af8f12c0c011c3bbf772c7c6b3f50:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [hermes-t3rpz]
<!-- eliza-computer-attribution:v1 {"provider":"zai","model":"glm-5.3","client":"Hermes Agent","skill_revision":"elizaOS/eliza@b447fe2f542af8f12c0c011c3bbf772c7c6b3f50:packages/skills/skills/contribute-to-eliza"} -->








