### PR TITLE
fix(core): reject undefined values in writeJsonAtomic serialization

### DIFF
--- a/packages/core/src/utils/atomic-json.test.ts
+++ b/packages/core/src/utils/atomic-json.test.ts
@@ -134,5 +134,13 @@ describe("atomic-json", () => {
 				TypeError,
 			);
 		});
+
+		it("rejects undefined value with TypeError", async () => {
+			const target = path.join(tempDir, "undefined.json");
+			await expect(writeJsonAtomic(target, undefined)).rejects.toThrow(
+				TypeError,
+			);
+			expect(() => writeJsonAtomicSync(target, undefined)).toThrow(TypeError);
+		});
 	});
 });

--- a/packages/core/src/utils/atomic-json.ts
+++ b/packages/core/src/utils/atomic-json.ts
@@ -61,6 +61,9 @@ function tmpPathFor(filePath: string): string {
 
 function serialize(value: unknown, opts: NormalizedWriteOptions): string {
 	const body = JSON.stringify(value, null, opts.indent);
+	if (body === undefined) {
+		throw new TypeError("Cannot serialize undefined to JSON");
+	}
 	return opts.trailingNewline ? `${body}\n` : body;
 }
 


### PR DESCRIPTION
## Summary
Closes #28475

Validates that `JSON.stringify(value)` does not produce `undefined` inside `serialize` in `packages/core/src/utils/atomic-json.ts`.

Previously, attempting to write an `undefined` value with default options (`trailingNewline: true`) serialized to `"undefined\n"` on disk, corrupting the target JSON file and causing subsequent reads to throw `SyntaxError: Unexpected token 'u', "undefined"`. With `trailingNewline: false`, `undefined` was passed to `fsp.writeFile`, throwing `ERR_INVALID_ARG_TYPE`.

## Changes
- Added fail-fast `TypeError("Cannot serialize undefined to JSON")` check in `serialize` in `packages/core/src/utils/atomic-json.ts`
- Added unit test cases for `writeJsonAtomic` and `writeJsonAtomicSync` in `packages/core/src/utils/atomic-json.test.ts`

## Evidence

<!-- evidence-table -->

| Evidence | Source / link / artifact | Review notes |
| --- | --- | --- |
| backend-logs | N/A - pure utility function | No runtime backend logging changes |
| scenario-replay | N/A - pure utility function | Scenarios unchanged |
| trajectory | N/A - pure utility function | No LLM interaction required |
| app-interaction | N/A - pure utility function | No visual UI component touched |
| domain-artifacts | N/A - pure utility function | No persistent tables modified |
| external-links | N/A - internal utility improvement | Pure persistence utility enhancement |
| ci-proof | `bun test packages/core/src/utils/atomic-json.test.ts` (11 pass) | Verified passes cleanly |

<!-- /evidence-table -->

<!-- evidence-head:78817e05e3cfa84644bd55255f87a5e7638ae1f0 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - pure utility function

<!-- evidence-row:after-screenshots -->
- [ ] N/A - pure utility function

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - pure utility function

<!-- evidence-row:backend-logs -->
- [ ] N/A - pure utility function

<!-- evidence-row:frontend-logs -->
- [ ] N/A - pure utility function

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - pure utility function

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - pure utility function

<!-- evidence-row:ocr-review -->
- [ ] N/A - pure utility function
