### PR TITLE
fix(core): preserve Error instances in flattenTextValues

### DIFF
--- a/packages/core/src/utils/text-normalize.test.ts
+++ b/packages/core/src/utils/text-normalize.test.ts
@@ -188,6 +188,32 @@ describe("flattenTextValues", () => {
 		});
 	});
 
+	describe("errors", () => {
+		it("renders Error instances as name: message", () => {
+			expect(
+				flattenTextValues(new Error("Database connection timed out")),
+			).toEqual(["Error: Database connection timed out"]);
+			expect(flattenTextValues(new TypeError("Invalid property"))).toEqual([
+				"TypeError: Invalid property",
+			]);
+		});
+
+		it("renders empty message errors as their name", () => {
+			expect(flattenTextValues(new Error(""))).toEqual(["Error"]);
+		});
+
+		it("preserves Errors in nested object properties and arrays", () => {
+			expect(
+				flattenTextValues({
+					lastError: new Error("Request failed"),
+				}),
+			).toEqual(["lastError: Error: Request failed"]);
+			expect(
+				flattenTextValues(["diagnostic", new Error("Timeout")]),
+			).toEqual(["diagnostic", "Error: Timeout"]);
+		});
+	});
+
 	describe("non-plain objects have no enumerable own entries and are dropped", () => {
 		// Map and Set do not have a canonical prompt representation, so they retain
 		// the existing empty-object behavior rather than relying on their toString().

--- a/packages/core/src/utils/text-normalize.ts
+++ b/packages/core/src/utils/text-normalize.ts
@@ -131,6 +131,18 @@ function flattenTextValuesWithAncestors(
 				? [Date.prototype.toString.call(value)]
 				: [Date.prototype.toISOString.call(value)];
 		}
+
+		if (
+			value instanceof Error ||
+			Object.prototype.toString.call(value) === "[object Error]"
+		) {
+			const error = value as Error;
+			const message =
+				typeof error.message === "string" ? error.message.trim() : "";
+			const name =
+				typeof error.name === "string" && error.name ? error.name : "Error";
+			return message ? [`${name}: ${message}`] : [name];
+		}
 	}
 
 	if (typeof value === "object") {


### PR DESCRIPTION
## Summary
Closes #28477

Adds explicit handling for JavaScript `Error` instances in `flattenTextValuesWithAncestors` (`packages/core/src/utils/text-normalize.ts`).

Previously, standard Error properties (`message`, `name`, `stack`) were non-enumerable, causing objects such as `new Error("Database timeout")` to yield an empty array `[]` during text normalization and silently discarding the error message from model prompts/context.

## Changes
- Recognized `Error` instances in `flattenTextValuesWithAncestors` to format as `name: message` (or `name` when message is empty)
- Added unit tests in `packages/core/src/utils/text-normalize.test.ts` verifying standalone, empty, and nested Error objects

## Evidence

<!-- evidence-table -->

| Evidence | Source / link / artifact | Review notes |
| --- | --- | --- |
| backend-logs | N/A - pure utility function | No runtime backend logging changes |
| scenario-replay | N/A - pure utility function | Scenarios unchanged |
| trajectory | N/A - pure utility function | No LLM interaction required |
| app-interaction | N/A - pure utility function | No visual UI component touched |
| domain-artifacts | N/A - pure utility function | No persistent tables modified |
| external-links | N/A - internal utility improvement | Pure text normalization enhancement |
| ci-proof | `bun test packages/core/src/utils/text-normalize.test.ts` (32 pass) | Verified passes cleanly |

<!-- /evidence-table -->

<!-- evidence-head:f8809a2e5a5ad8b1effb7cc5c57a8b3dbdc4577c -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - pure utility function

<!-- evidence-row:after-screenshots -->
- [ ] N/A - pure utility function

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - pure utility function

<!-- evidence-row:backend-logs -->
- [ ] N/A - pure utility function

<!-- evidence-row:frontend-logs -->
- [ ] N/A - pure utility function

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - pure utility function

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - pure utility function

<!-- evidence-row:ocr-review -->
- [ ] N/A - pure utility function
