### PR TITLE
fix(plugin-personal-assistant): expand truthy/falsy normalization in normalizePlannerBoolean

### DIFF
--- a/plugins/plugin-personal-assistant/src/actions/subscriptions.test.ts
+++ b/plugins/plugin-personal-assistant/src/actions/subscriptions.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Deterministic unit tests for subscriptions action helper functions.
+ * Validates planner boolean normalization against booleans, truthy/falsy strings, and invalid inputs.
+ */
+import { describe, expect, it } from "vitest";
+import { normalizePlannerBoolean } from "./subscriptions.ts";
+
+describe("normalizePlannerBoolean", () => {
+  it("passes boolean literals through unchanged", () => {
+    expect(normalizePlannerBoolean(true)).toBe(true);
+    expect(normalizePlannerBoolean(false)).toBe(false);
+  });
+
+  it("normalizes truthy strings into boolean true", () => {
+    for (const val of [
+      "true",
+      "TRUE",
+      "yes",
+      "YES",
+      "1",
+      "on",
+      "ON",
+      "enable",
+      "enabled",
+      " ENABLED ",
+    ]) {
+      expect(normalizePlannerBoolean(val)).toBe(true);
+    }
+  });
+
+  it("normalizes falsy strings into boolean false", () => {
+    for (const val of [
+      "false",
+      "FALSE",
+      "no",
+      "NO",
+      "0",
+      "off",
+      "OFF",
+      "disable",
+      "disabled",
+      " DISABLED ",
+    ]) {
+      expect(normalizePlannerBoolean(val)).toBe(false);
+    }
+  });
+
+  it("returns null for non-boolean, non-recognized inputs", () => {
+    expect(normalizePlannerBoolean("maybe")).toBeNull();
+    expect(normalizePlannerBoolean("")).toBeNull();
+    expect(normalizePlannerBoolean(null)).toBeNull();
+    expect(normalizePlannerBoolean(undefined)).toBeNull();
+    expect(normalizePlannerBoolean({})).toBeNull();
+    expect(normalizePlannerBoolean(42)).toBeNull();
+  });
+});

--- a/plugins/plugin-personal-assistant/src/actions/subscriptions.ts
+++ b/plugins/plugin-personal-assistant/src/actions/subscriptions.ts
@@ -110,14 +110,32 @@ function normalizePlannerNumber(value: unknown): number | undefined {
   return whole > 0 ? whole : undefined;
 }
 
-function normalizePlannerBoolean(value: unknown): boolean | null {
+export function normalizePlannerBoolean(value: unknown): boolean | null {
   if (typeof value === "boolean") {
     return value;
   }
   if (typeof value === "string") {
     const normalized = value.trim().toLowerCase();
-    if (normalized === "true") return true;
-    if (normalized === "false") return false;
+    if (
+      normalized === "true" ||
+      normalized === "yes" ||
+      normalized === "1" ||
+      normalized === "on" ||
+      normalized === "enable" ||
+      normalized === "enabled"
+    ) {
+      return true;
+    }
+    if (
+      normalized === "false" ||
+      normalized === "no" ||
+      normalized === "0" ||
+      normalized === "off" ||
+      normalized === "disable" ||
+      normalized === "disabled"
+    ) {
+      return false;
+    }
   }
   return null;
 }


### PR DESCRIPTION
## Summary
Closes #28479

Expands `normalizePlannerBoolean` in `plugins/plugin-personal-assistant/src/actions/subscriptions.ts` to parse standard truthy and falsy strings commonly emitted by structured model planners (`"yes"`, `"no"`, `"1"`, `"0"`, `"on"`, `"off"`, `"enable"`, `"enabled"`, `"disable"`, `"disabled"`).

Previously, `normalizePlannerBoolean` only checked for literal `"true"` and `"false"`, dropping valid truthy/falsy responses from fast or small models to `null` and discarding the `shouldAct` decision.

## Changes
- Expanded truthy string check in `normalizePlannerBoolean` to include `"yes"`, `"1"`, `"on"`, `"enable"`, `"enabled"`
- Expanded falsy string check in `normalizePlannerBoolean` to include `"no"`, `"0"`, `"off"`, `"disable"`, `"disabled"`
- Exported `normalizePlannerBoolean` and added unit test suite in `plugins/plugin-personal-assistant/src/actions/subscriptions.test.ts`

## Evidence

<!-- evidence-table -->

| Evidence | Source / link / artifact | Review notes |
| --- | --- | --- |
| backend-logs | N/A - pure utility function | No runtime backend logging changes |
| scenario-replay | N/A - pure utility function | Scenarios unchanged |
| trajectory | N/A - pure utility function | No LLM interaction required |
| app-interaction | N/A - pure utility function | No visual UI component touched |
| domain-artifacts | N/A - pure utility function | No persistent tables modified |
| external-links | N/A - internal utility improvement | Pure planner boolean parser enhancement |
| ci-proof | `bun run --cwd plugins/plugin-personal-assistant test src/actions/subscriptions.test.ts` (4 pass) | Verified passes cleanly |

<!-- /evidence-table -->

<!-- evidence-head:71903fc4bcd4016a0ee21d72520fde4fbdafafd6 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - pure utility function

<!-- evidence-row:after-screenshots -->
- [ ] N/A - pure utility function

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - pure utility function

<!-- evidence-row:backend-logs -->
- [ ] N/A - pure utility function

<!-- evidence-row:frontend-logs -->
- [ ] N/A - pure utility function

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - pure utility function

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - pure utility function

<!-- evidence-row:ocr-review -->
- [ ] N/A - pure utility function
