### PR TITLE
fix(plugin-github): add missing error-policy annotation in hasSearchCategory

### DIFF
--- a/plugins/plugin-github/src/search-category.ts
+++ b/plugins/plugin-github/src/search-category.ts
@@ -78,6 +78,8 @@ function hasSearchCategory(runtime: IAgentRuntime, category: string): boolean {
     runtime.getSearchCategory(category, { includeDisabled: true });
     return true;
   } catch {
+    // error-policy:J4 explicit user-facing degrade — an unregistered search
+    // category throws from getSearchCategory; translate to false for idempotent registration.
     return false;
   }
 }


### PR DESCRIPTION
## Summary
Closes #28482

Adds the repository-standard `// error-policy:J4` comment on the `hasSearchCategory` catch handler in `plugins/plugin-github/src/search-category.ts`.

## Changes
- Documented `// error-policy:J4` on `hasSearchCategory` catch block

## Evidence

<!-- evidence-table -->

| Evidence | Source / link / artifact | Review notes |
| --- | --- | --- |
| backend-logs | N/A - pure utility function | No runtime backend logging changes |
| scenario-replay | N/A - pure utility function | Scenarios unchanged |
| trajectory | N/A - pure utility function | No LLM interaction required |
| app-interaction | N/A - pure utility function | No visual UI component touched |
| domain-artifacts | N/A - pure utility function | No persistent tables modified |
| external-links | N/A - internal utility improvement | Documentation and error policy compliance |
| ci-proof | `bun test plugins/plugin-github/src/search-category.test.ts` (1 pass) | Verified passes cleanly |

<!-- /evidence-table -->

<!-- evidence-head:b7cc683175c8d6d2dc07de4c1ffe24fb401d0bbc -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - pure utility function

<!-- evidence-row:after-screenshots -->
- [ ] N/A - pure utility function

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - pure utility function

<!-- evidence-row:backend-logs -->
- [ ] N/A - pure utility function

<!-- evidence-row:frontend-logs -->
- [ ] N/A - pure utility function

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - pure utility function

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - pure utility function

<!-- evidence-row:ocr-review -->
- [ ] N/A - pure utility function
