### PR TITLE
fix(logger): parse enable and enabled in parseBooleanFromText

### DIFF
--- a/packages/logger/src/logger.test.ts
+++ b/packages/logger/src/logger.test.ts
@@ -1141,4 +1141,35 @@ describe("file sink permissions", () => {
       }
     },
   );
+
+  describe("parseBooleanFromText", () => {
+    const { parseBooleanFromText } = __loggerTestHooks;
+
+    it("parses truthy boolean strings including enable and enabled", () => {
+      for (const val of [
+        "true",
+        "TRUE",
+        "1",
+        "yes",
+        "YES",
+        "on",
+        "ON",
+        "enable",
+        "ENABLE",
+        "enabled",
+        "ENABLED",
+        " enabled ",
+      ]) {
+        expect(parseBooleanFromText(val)).toBe(true);
+      }
+    });
+
+    it("returns false for falsy and unrecognized strings", () => {
+      for (const val of ["false", "0", "no", "off", "disabled", "maybe", ""]) {
+        expect(parseBooleanFromText(val)).toBe(false);
+      }
+      expect(parseBooleanFromText(null)).toBe(false);
+      expect(parseBooleanFromText(undefined)).toBe(false);
+    });
+  });
 });

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -18,10 +18,11 @@
  * `chat.log`, all 0600) with prompt/response/chat instrumentation helpers.
  * Adapts between node and a console-based browser path.
  */
-// Test hook to clear env cache in logger tests (kept internal)
 export const __loggerTestHooks = {
   clearEnvCacheForTests: () => {},
   stripAnsi: (str: string): string => stripAnsi(str),
+  parseBooleanFromText: (value: string | undefined | null): boolean =>
+    parseBooleanFromText(value),
   // Core owns the model/tool redactor while this leaf package owns the log
   // sink. Expose a copy only to the cross-package contract test so duplicated
   // credential shapes cannot silently drift between those two boundaries.
@@ -240,7 +241,9 @@ function parseBooleanFromText(value: string | undefined | null): boolean {
     normalized === "true" ||
     normalized === "1" ||
     normalized === "yes" ||
-    normalized === "on"
+    normalized === "on" ||
+    normalized === "enable" ||
+    normalized === "enabled"
   );
 }
 


### PR DESCRIPTION
## Summary
Closes #28486

Updates the `parseBooleanFromText` helper in `packages/logger/src/logger.ts` to parse `"enable"` and `"enabled"` as truthy boolean values.

Previously, setting logger boolean environment variables like `LOG_JSON_FORMAT=enabled` or `LOG_STRUCTURED_ERRORS=enable` evaluated to `false` because only `["true", "1", "yes", "on"]\n were checked.

## Changes
- Added `"enable"` and `"enabled"` to truthy checks in `parseBooleanFromText`
- Exposed `parseBooleanFromText` on `__loggerTestHooks`
- Added unit tests in `packages/logger/src/logger.test.ts`

## Evidence

<!-- evidence-table -->

| Evidence | Source / link / artifact | Review notes |
| --- | --- | --- |
| backend-logs | N/A - pure utility function | No runtime backend logging changes |
| scenario-replay | N/A - pure utility function | Scenarios unchanged |
| trajectory | N/A - pure utility function | No LLM interaction required |
| app-interaction | N/A - pure utility function | No visual UI component touched |
| domain-artifacts | N/A - pure utility function | No persistent tables modified |
| external-links | N/A - internal utility improvement | Pure boolean token parsing enhancement |
| ci-proof | `bun run --cwd packages/logger test` (62 pass) | Verified passes cleanly |

<!-- /evidence-table -->

<!-- evidence-head:fc332812da4ac9221f4b719f46bf4e13de0da3bb -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - pure utility function

<!-- evidence-row:after-screenshots -->
- [ ] N/A - pure utility function

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - pure utility function

<!-- evidence-row:backend-logs -->
- [ ] N/A - pure utility function

<!-- evidence-row:frontend-logs -->
- [ ] N/A - pure utility function

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - pure utility function

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - pure utility function

<!-- evidence-row:ocr-review -->
- [ ] N/A - pure utility function
