### PR TITLE
fix(plugin-sql): normalize Postgres type aliases in migration data-loss check

### DIFF
--- a/plugins/plugin-sql/src/runtime-migrator/drizzle-adapters/sql-generator.test.ts
+++ b/plugins/plugin-sql/src/runtime-migrator/drizzle-adapters/sql-generator.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "vitest";
+import type { SchemaDiff } from "./diff-calculator";
+import { checkForDataLoss } from "./sql-generator";
+
+function emptyDiff(): SchemaDiff {
+  return {
+    tables: { created: [], deleted: [], modified: [] },
+    columns: { added: [], deleted: [], modified: [] },
+    indexes: { created: [], deleted: [], altered: [] },
+    foreignKeys: { created: [], deleted: [], altered: [] },
+    uniqueConstraints: { created: [], deleted: [] },
+    checkConstraints: { created: [], deleted: [] },
+  };
+}
+
+function typeChange(from: string, to: string): SchemaDiff {
+  const diff = emptyDiff();
+  diff.columns.modified.push({
+    table: "users",
+    column: "count",
+    changes: {
+      typeChanged: true,
+      prevType: from,
+      newType: to,
+      from: { name: "count", type: from },
+      to: { name: "count", type: to },
+    },
+  });
+  return diff;
+}
+
+describe("checkForDataLoss type-change classification", () => {
+  it("treats equivalent integer spellings as non-destructive (int vs integer)", () => {
+    const result = checkForDataLoss(typeChange("int", "integer"));
+    expect(result.hasDataLoss).toBe(false);
+    expect(result.typeChanges).toEqual([]);
+  });
+
+  it("treats int4/int8/int2 spellings as non-destructive", () => {
+    expect(checkForDataLoss(typeChange("int4", "integer")).hasDataLoss).toBe(false);
+    expect(checkForDataLoss(typeChange("int8", "bigint")).hasDataLoss).toBe(false);
+    expect(checkForDataLoss(typeChange("int2", "smallint")).hasDataLoss).toBe(false);
+  });
+
+  it("treats bool as non-destructive vs boolean", () => {
+    const result = checkForDataLoss(typeChange("bool", "boolean"));
+    expect(result.hasDataLoss).toBe(false);
+    expect(result.typeChanges).toEqual([]);
+  });
+
+  it("treats float8/float4 as non-destructive", () => {
+    expect(checkForDataLoss(typeChange("float8", "double precision")).hasDataLoss).toBe(false);
+    expect(checkForDataLoss(typeChange("float4", "real")).hasDataLoss).toBe(false);
+  });
+
+  it("treats precision-less numeric(p) as non-destructive vs numeric(p,0)", () => {
+    const result = checkForDataLoss(typeChange("numeric(10)", "numeric(10,0)"));
+    expect(result.hasDataLoss).toBe(false);
+  });
+
+  it("still flags genuinely destructive type changes (text -> integer)", () => {
+    const result = checkForDataLoss(typeChange("text", "integer"));
+    expect(result.hasDataLoss).toBe(true);
+    expect(result.requiresConfirmation).toBe(true);
+    expect(result.typeChanges).toHaveLength(1);
+    expect(result.typeChanges[0]).toMatchObject({
+      table: "users",
+      column: "count",
+      from: "text",
+      to: "integer",
+    });
+    expect(result.tablesToTruncate).toContain("users");
+  });
+
+  it("still flags narrowing integer -> smallint as destructive", () => {
+    const result = checkForDataLoss(typeChange("integer", "smallint"));
+    expect(result.hasDataLoss).toBe(true);
+    expect(result.typeChanges).toHaveLength(1);
+  });
+
+  it("treats safe widening integer -> bigint as non-destructive", () => {
+    const result = checkForDataLoss(typeChange("integer", "bigint"));
+    expect(result.hasDataLoss).toBe(false);
+  });
+
+  it("treats varchar -> text as non-destructive", () => {
+    const result = checkForDataLoss(typeChange("varchar", "text"));
+    expect(result.hasDataLoss).toBe(false);
+  });
+});
+
+describe("checkForDataLoss structural findings", () => {
+  it("flags dropped tables as data loss", () => {
+    const diff = emptyDiff();
+    diff.tables.deleted.push("users");
+    const result = checkForDataLoss(diff);
+    expect(result.hasDataLoss).toBe(true);
+    expect(result.requiresConfirmation).toBe(true);
+    expect(result.tablesToRemove).toContain("users");
+    expect(result.warnings.some((w) => w.includes('Table "users"'))).toBe(true);
+  });
+
+  it("flags dropped columns as data loss", () => {
+    const diff = emptyDiff();
+    diff.columns.deleted.push({ table: "users", column: "email" });
+    const result = checkForDataLoss(diff);
+    expect(result.hasDataLoss).toBe(true);
+    expect(result.requiresConfirmation).toBe(true);
+    expect(result.columnsToRemove).toContain("users.email");
+  });
+
+  it("flags NOT NULL added without default as a failure risk", () => {
+    const diff = emptyDiff();
+    diff.columns.modified.push({
+      table: "users",
+      column: "name",
+      changes: {
+        nullabilityChanged: true,
+        wasNullable: true,
+        isNullable: false,
+        from: { name: "name", type: "text", notNull: false },
+        to: { name: "name", type: "text", notNull: true },
+      },
+    });
+    const result = checkForDataLoss(diff);
+    expect(result.hasDataLoss).toBe(true);
+    expect(result.requiresConfirmation).toBe(true);
+  });
+
+  it("warns (but does not hard-fail) on added NOT NULL column without default", () => {
+    const diff = emptyDiff();
+    diff.columns.added.push({
+      table: "users",
+      column: "handle",
+      definition: { name: "handle", type: "text", notNull: true },
+    });
+    const result = checkForDataLoss(diff);
+    expect(result.hasDataLoss).toBe(false);
+    expect(result.requiresConfirmation).toBe(false);
+    expect(result.warnings.some((w) => w.includes('"handle"'))).toBe(true);
+  });
+
+  it("returns a clean bill for an empty diff", () => {
+    const result = checkForDataLoss(emptyDiff());
+    expect(result.hasDataLoss).toBe(false);
+    expect(result.requiresConfirmation).toBe(false);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("does not flag a type change with equal normalized types (timestamp variants)", () => {
+    const result = checkForDataLoss(
+      typeChange("timestamp with time zone", "timestamp without time zone")
+    );
+    expect(result.hasDataLoss).toBe(false);
+  });
+});

--- a/plugins/plugin-sql/src/runtime-migrator/drizzle-adapters/sql-generator.ts
+++ b/plugins/plugin-sql/src/runtime-migrator/drizzle-adapters/sql-generator.ts
@@ -141,8 +141,7 @@ function normalizeType(type: string | undefined): string {
     return "timestamp";
   }
 
-  // Handle serial vs integer with identity
-  // serial is essentially integer with auto-increment
+  // serial/identity aliases
   if (normalized === "serial") {
     return "integer";
   }
@@ -153,12 +152,38 @@ function normalizeType(type: string | undefined): string {
     return "smallint";
   }
 
+  // integer family aliases
+  if (normalized === "int" || normalized === "int4") {
+    return "integer";
+  }
+  if (normalized === "int2") {
+    return "smallint";
+  }
+  if (normalized === "int8") {
+    return "bigint";
+  }
+
+  // boolean alias
+  if (normalized === "bool") {
+    return "boolean";
+  }
+
+  // floating-point aliases
+  if (normalized === "float4") {
+    return "real";
+  }
+  if (normalized === "float8") {
+    return "double precision";
+  }
+
   // Handle numeric/decimal equivalence
   if (normalized.startsWith("numeric") || normalized.startsWith("decimal")) {
     // Extract precision and scale if present
     const match = normalized.match(/\((\d+)(?:,\s*(\d+))?\)/);
     if (match) {
-      return `numeric(${match[1]}${match[2] ? `,${match[2]}` : ""})`;
+      // A missing scale defaults to 0 in Postgres, so `numeric(10)` is the
+      // same type as `numeric(10,0)`.
+      return `numeric(${match[1]},${match[2] ?? "0"})`;
     }
     return "numeric";
   }


### PR DESCRIPTION
# Relates to

<!-- No issue; defect found via focused boundary tests: the migration
     data-loss check misclassified Postgres type aliases as destructive. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Change

`checkForDataLoss` classifies column type changes as destructive via a
`normalizeType` that only canonicalized a handful of spellings. Safe
alias-equivalent spellings and widening conversions were therefore reported
as data loss (`hasDataLoss: true`, `requiresConfirmation: true`), blocking
or alarming migrations that are no-ops:

- `int`/`int4` → `integer`, `int2` → `smallint`, `int8` → `bigint`
- `bool` → `boolean`
- `float4` → `real`, `float8` → `double precision`
- `numeric(p)` → `numeric(p,0)` — a missing scale defaults to `0` in Postgres

Tests pin the alias-equivalence cases plus the still-destructive cases
(`text`→`integer`, `integer`→`smallint`) and the structural findings
(dropped tables/columns, NOT NULL without default).

# Risks

Low. The change only widens type normalization to spellings Postgres treats
as identical; genuinely destructive conversions and structural data-loss
findings are unchanged.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: 15 passed (15) |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: source fix + test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
