### PR TITLE
test(personal-assistant): pin parenting guidance source gating and option grounding

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/parenting/sources.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/parenting/sources.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "vitest";
+import {
+  PARENTING_GUIDANCE_SOURCES,
+  parentingOptionsFor,
+  parentingSourcesFor,
+} from "./sources";
+
+describe("parentingSourcesFor framework gate", () => {
+  it("never serves named-framework content unless the framework was explicitly requested", () => {
+    const sources = parentingSourcesFor(
+      "toddler_preschool",
+      "boundary_setting",
+      "none",
+    );
+    expect(sources.length).toBeGreaterThan(0);
+    for (const source of sources) {
+      expect(source.evidenceTier).not.toBe("named_framework_primary");
+    }
+  });
+
+  it("serves named-framework content when good_inside is explicitly requested", () => {
+    const sources = parentingSourcesFor(
+      "toddler_preschool",
+      "boundary_setting",
+      "good_inside",
+    );
+    expect(
+      sources.some((s) => s.evidenceTier === "named_framework_primary"),
+    ).toBe(true);
+  });
+
+  it("filters by age band: teen-only request excludes toddler-only sources", () => {
+    const teen = parentingSourcesFor("teen", "boundary_setting", "none");
+    const toddler = parentingSourcesFor(
+      "toddler_preschool",
+      "boundary_setting",
+      "none",
+    );
+    for (const source of teen) {
+      expect(source.ageBands).toContain("teen");
+    }
+    for (const source of toddler) {
+      expect(source.ageBands).toContain("toddler_preschool");
+    }
+  });
+
+  it("filters by topic: every routines source declares the routines topic", () => {
+    const routines = parentingSourcesFor(
+      "toddler_preschool",
+      "routines",
+      "none",
+    );
+    expect(routines.length).toBeGreaterThan(0);
+    for (const source of routines) {
+      expect(source.topics).toContain("routines");
+    }
+  });
+
+  it("serves every source under its own declared topics", () => {
+    for (const source of PARENTING_GUIDANCE_SOURCES) {
+      for (const topic of source.topics) {
+        const matches = parentingSourcesFor("school_age", topic, "none").some(
+          (s) => s.id === source.id,
+        );
+        // named-framework sources are excluded when the framework isn't
+        // requested; everything else must be reachable under its topics.
+        if (source.evidenceTier === "named_framework_primary") {
+          continue;
+        }
+        // skip age bands this source does not cover
+        if (!source.ageBands.includes("school_age")) {
+          continue;
+        }
+        expect(matches).toBe(true);
+      }
+    }
+  });
+
+  it("recommends nothing for an age band the registry does not cover", () => {
+    // toddler-only source set must not leak into the teen band
+    const sources = parentingSourcesFor("teen", "positive_discipline", "none");
+    for (const source of sources) {
+      expect(source.ageBands).toContain("teen");
+    }
+  });
+});
+
+describe("parentingOptionsFor source grounding", () => {
+  it("returns only options backed by the supplied source ids", () => {
+    const sources = parentingSourcesFor(
+      "toddler_preschool",
+      "boundary_setting",
+      "none",
+    );
+    const sourceIds = new Set(sources.map((s) => s.id));
+    const options = parentingOptionsFor(
+      "toddler_preschool",
+      "boundary_setting",
+      sourceIds,
+    );
+    expect(options.length).toBeGreaterThan(0);
+    for (const option of options) {
+      expect(option.sourceIds.length).toBeGreaterThan(0);
+      for (const sid of option.sourceIds) {
+        expect(sourceIds.has(sid)).toBe(true);
+      }
+    }
+  });
+
+  it("returns an empty list when no backing source is available", () => {
+    const options = parentingOptionsFor(
+      "toddler_preschool",
+      "boundary_setting",
+      new Set(["does-not-exist"]),
+    );
+    expect(options).toEqual([]);
+  });
+
+  it("adds privacy-preserving language for the teen age band only", () => {
+    const sources = parentingSourcesFor("teen", "boundary_setting", "none");
+    const sourceIds = new Set(sources.map((s) => s.id));
+    const teenOptions = parentingOptionsFor(
+      "teen",
+      "boundary_setting",
+      sourceIds,
+    );
+    const toddlerSources = parentingSourcesFor(
+      "toddler_preschool",
+      "boundary_setting",
+      "none",
+    );
+    const toddlerOptions = parentingOptionsFor(
+      "toddler_preschool",
+      "boundary_setting",
+      new Set(toddlerSources.map((s) => s.id)),
+    );
+    for (const option of teenOptions) {
+      expect(option.rationale).toMatch(/privacy|perspective/i);
+    }
+    for (const option of toddlerOptions) {
+      expect(option.rationale).not.toMatch(/privacy.*perspective/i);
+    }
+  });
+
+  it("does not mutate the shared registry options (steps copy)", () => {
+    const sources = parentingSourcesFor(
+      "toddler_preschool",
+      "boundary_setting",
+      "none",
+    );
+    const sourceIds = new Set(sources.map((s) => s.id));
+    const first = parentingOptionsFor(
+      "toddler_preschool",
+      "boundary_setting",
+      sourceIds,
+    );
+    const second = parentingOptionsFor(
+      "toddler_preschool",
+      "boundary_setting",
+      sourceIds,
+    );
+    // same shape across calls — no shared mutation visible
+    expect(first).toEqual(second);
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage pinning a content-safety gate (named-framework
     parenting sources must only be served when explicitly requested). -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Change

Adds `sources.test.ts` pinning two safety-relevant contracts in the
parenting guidance module:

- `parentingSourcesFor` content-safety gate: sources with
  `evidenceTier: "named_framework_primary"` are never served unless the
  caller explicitly requests the `good_inside` framework; age-band and
  topic filters hold.
- `parentingOptionsFor` source grounding: options are only returned when
  backed by the supplied source ids, teen-age-band options carry
  privacy-preserving rationale language, and the shared registry options
  are not mutated across calls.

No production code is modified.

# Risks

Low. Test-only addition; no runtime behavior changes. The named-framework
gate is a real safety boundary, so this pins the current behavior against
accidental loosening.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: 10 passed (10) |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
