### PR TITLE
fix(shared): validate min <= max bounds in parseClampedFloat and parseClampedInteger

### DIFF
--- a/packages/shared/src/utils/number-parsing.test.ts
+++ b/packages/shared/src/utils/number-parsing.test.ts
@@ -96,4 +96,13 @@ describe("number parsing utilities", () => {
       }),
     ).toBe(15);
   });
+
+  it("throws RangeError when min is greater than max", () => {
+    expect(() =>
+      parseClampedFloat("5", { min: 10, max: 2 }),
+    ).toThrow(RangeError);
+    expect(() =>
+      parseClampedInteger("5", { min: 10, max: 2 }),
+    ).toThrow(RangeError);
+  });
 });

--- a/packages/shared/src/utils/number-parsing.ts
+++ b/packages/shared/src/utils/number-parsing.ts
@@ -155,6 +155,9 @@ export function parseClampedFloat(
 
   const min = options.min ?? -Infinity;
   const max = options.max ?? Infinity;
+  if (min > max) {
+    throw new RangeError("min cannot be greater than max");
+  }
   return Math.max(min, Math.min(max, parsed));
 }
 
@@ -182,5 +185,8 @@ export function parseClampedInteger(
 
   const min = options.min ?? -Infinity;
   const max = options.max ?? Infinity;
+  if (min > max) {
+    throw new RangeError("min cannot be greater than max");
+  }
   return Math.max(min, Math.min(max, parsed));
 }


### PR DESCRIPTION
## Summary
Closes #28493

Adds a `min <= max` validation check throwing a `RangeError` in `parseClampedFloat` and `parseClampedInteger` (`packages/shared/src/utils/number-parsing.ts`).

Previously, inverted bounds options like `{ min: 10, max: 5 }` would silently clamp any input number to `10` instead of throwing a validation error.

## Changes
- Added `if (min > max) throw new RangeError("min cannot be greater than max");` in `parseClampedFloat` and `parseClampedInteger`
- Added unit tests in `packages/shared/src/utils/number-parsing.test.ts`

## Evidence

<!-- evidence-table -->

| Evidence | Source / link / artifact | Review notes |
| --- | --- | --- |
| backend-logs | N/A - pure utility function | No runtime backend logging changes |
| scenario-replay | N/A - pure utility function | Scenarios unchanged |
| trajectory | N/A - pure utility function | No LLM interaction required |
| app-interaction | N/A - pure utility function | No visual UI component touched |
| domain-artifacts | N/A - pure utility function | No persistent tables modified |
| external-links | N/A - internal utility improvement | Pure numeric bounds validation enhancement |
| ci-proof | `bun test packages/shared/src/utils/number-parsing.test.ts` (10 pass) | Verified passes cleanly |

<!-- /evidence-table -->

<!-- evidence-head:0100d9bba39f16b9a11f89cce40db645e5f19a23 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - pure utility function

<!-- evidence-row:after-screenshots -->
- [ ] N/A - pure utility function

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - pure utility function

<!-- evidence-row:backend-logs -->
- [ ] N/A - pure utility function

<!-- evidence-row:frontend-logs -->
- [ ] N/A - pure utility function

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - pure utility function

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - pure utility function

<!-- evidence-row:ocr-review -->
- [ ] N/A - pure utility function
