### PR TITLE
fix(core): replace deprecated substr with slice in buffer fromHex

### DIFF
--- a/packages/core/src/utils/buffer.test.ts
+++ b/packages/core/src/utils/buffer.test.ts
@@ -26,6 +26,7 @@ describe("hex / string round-trips", () => {
 		expect(bufferToString(fromHex("48656c6c6f"))).toBe("Hello");
 		// fromHex tolerates separators.
 		expect(bufferToString(fromHex("48 65 6c 6c 6f"))).toBe("Hello");
+		expect(toHex(fromHex("010203"))).toBe("010203");
 	});
 
 	it("base64 ⇄ utf8", () => {

--- a/packages/core/src/utils/buffer.ts
+++ b/packages/core/src/utils/buffer.ts
@@ -33,9 +33,10 @@ export function fromHex(hex: string): BufferLike {
 	}
 
 	// Browser implementation using Uint8Array
-	const bytes = new Uint8Array(cleanHex.length / 2);
+	const byteLength = Math.floor(cleanHex.length / 2);
+	const bytes = new Uint8Array(byteLength);
 	for (let i = 0; i < bytes.length; i++) {
-		bytes[i] = parseInt(cleanHex.substr(i * 2, 2), 16);
+		bytes[i] = parseInt(cleanHex.slice(i * 2, i * 2 + 2), 16);
 	}
 	return bytes;
 }


### PR DESCRIPTION
## Summary
Closes #28499

Replaces the deprecated `String.prototype.substr` call with `String.prototype.slice` and uses `Math.floor` on the byte length computation in `fromHex` (`packages/core/src/utils/buffer.ts`).

## Changes
- Updated `fromHex` to use `Math.floor(cleanHex.length / 2)` and `cleanHex.slice(i * 2, i * 2 + 2)`
- Added unit test assertion in `packages/core/src/utils/buffer.test.ts`

## Evidence

<!-- evidence-table -->

| Evidence | Source / link / artifact | Review notes |
| --- | --- | --- |
| backend-logs | N/A - pure utility function | No runtime backend logging changes |
| scenario-replay | N/A - pure utility function | Scenarios unchanged |
| trajectory | N/A - pure utility function | No LLM interaction required |
| app-interaction | N/A - pure utility function | No visual UI component touched |
| domain-artifacts | N/A - pure utility function | No persistent tables modified |
| external-links | N/A - internal utility improvement | Pure buffer utility modernization |
| ci-proof | `bun test packages/core/src/utils/buffer.test.ts` (8 pass) | Verified passes cleanly |

<!-- /evidence-table -->

<!-- evidence-head:a2b37efa89dde3af3594497cbeb35a72ba7584d6 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - pure utility function

<!-- evidence-row:after-screenshots -->
- [ ] N/A - pure utility function

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - pure utility function

<!-- evidence-row:backend-logs -->
- [ ] N/A - pure utility function

<!-- evidence-row:frontend-logs -->
- [ ] N/A - pure utility function

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - pure utility function

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - pure utility function

<!-- evidence-row:ocr-review -->
- [ ] N/A - pure utility function
