### PR TITLE
fix(core): safe memory.content property access in isSyntheticConversationArtifactMemory

### DIFF
--- a/packages/core/src/utils/synthetic-conversation-artifact.test.ts
+++ b/packages/core/src/utils/synthetic-conversation-artifact.test.ts
@@ -175,6 +175,8 @@ describe("isSyntheticConversationArtifactMemory", () => {
 			["null metadata", memory("hello", null)],
 			["non-object metadata", memory("hello", "compaction")],
 			["non-string content text", memory(123, {})],
+			["absent content", { metadata: {} } as never],
+			["null content", { content: null, metadata: {} } as never],
 			["clean memory", memory("hello", { source: "discord", tags: ["chat"] })],
 		])("returns false for %s", (_label, value) => {
 			expect(isSyntheticConversationArtifactMemory(value)).toBe(false);

--- a/packages/core/src/utils/synthetic-conversation-artifact.ts
+++ b/packages/core/src/utils/synthetic-conversation-artifact.ts
@@ -35,7 +35,7 @@ export function isSyntheticConversationArtifactMemory(
 		? metadata.tags.filter((tag): tag is string => typeof tag === "string")
 		: [];
 	const text =
-		typeof memory.content.text === "string" ? memory.content.text : "";
+		typeof memory?.content?.text === "string" ? memory.content.text : "";
 	return (
 		SYNTHETIC_SOURCE_RE.test(source) ||
 		tags.some((tag) => SYNTHETIC_SOURCE_RE.test(tag)) ||


### PR DESCRIPTION
## Summary
Closes #28504

Uses optional chaining (`memory?.content?.text`) in `isSyntheticConversationArtifactMemory` (`packages/core/src/utils/synthetic-conversation-artifact.ts`) to handle memory records with absent or null `content` without throwing.

## Changes
- Changed direct property access to `memory?.content?.text`
- Added unit test cases for absent and null `content` in `packages/core/src/utils/synthetic-conversation-artifact.test.ts`

## Evidence

<!-- evidence-table -->

| Evidence | Source / link / artifact | Review notes |
| --- | --- | --- |
| backend-logs | N/A - pure utility function | No runtime backend logging changes |
| scenario-replay | N/A - pure utility function | Scenarios unchanged |
| trajectory | N/A - pure utility function | No LLM interaction required |
| app-interaction | N/A - pure utility function | No visual UI component touched |
| domain-artifacts | N/A - pure utility function | No persistent tables modified |
| external-links | N/A - internal utility improvement | Pure memory classifier helper enhancement |
| ci-proof | `bun test packages/core/src/utils/synthetic-conversation-artifact.test.ts` (38 pass) | Verified passes cleanly |

<!-- /evidence-table -->

<!-- evidence-head:0f3f5f5f5245f1e19376fa566725ecc6c31b542b -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - pure utility function

<!-- evidence-row:after-screenshots -->
- [ ] N/A - pure utility function

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - pure utility function

<!-- evidence-row:backend-logs -->
- [ ] N/A - pure utility function

<!-- evidence-row:frontend-logs -->
- [ ] N/A - pure utility function

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - pure utility function

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - pure utility function

<!-- evidence-row:ocr-review -->
- [ ] N/A - pure utility function
