### PR TITLE
fix(plugin-mcp): safe property access for message and state in handleMcpError

### DIFF
--- a/plugins/plugin-mcp/__tests__/error.test.ts
+++ b/plugins/plugin-mcp/__tests__/error.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Deterministic unit tests for handleMcpError and McpError helpers.
+ * Exercises graceful handling of partial/malformed memory and state inputs.
+ */
+import type { IAgentRuntime, Memory, State } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { handleMcpError, McpError } from "../src/utils/error.js";
+
+describe("handleMcpError", () => {
+  it("handles standard error execution without callback", async () => {
+    const runtime = {} as IAgentRuntime;
+    const result = await handleMcpError(
+      {} as State,
+      {} as never,
+      new Error("connection dropped"),
+      runtime,
+      { content: { text: "call tool" } } as Memory,
+      "tool",
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.text).toBe("Failed to execute MCP tool");
+    expect(result.data?.error).toBe("connection dropped");
+  });
+
+  it("handles nullish/malformed memory content when callback is supplied", async () => {
+    const runtime = {
+      useModel: vi.fn().mockResolvedValue("Helpful explanation"),
+    } as unknown as IAgentRuntime;
+    const callback = vi.fn();
+
+    const result = await handleMcpError(
+      {} as State,
+      {} as never,
+      "plain string error",
+      runtime,
+      { content: {} } as Memory,
+      "resource",
+      callback,
+    );
+
+    expect(result.success).toBe(false);
+    expect(callback).toHaveBeenCalledWith({
+      text: "Helpful explanation",
+      actions: ["REPLY"],
+    });
+  });
+
+  it("constructs typed McpError variants", () => {
+    const err = McpError.connectionError("test-server", "timeout");
+    expect(err.code).toBe("CONNECTION_ERROR");
+    expect(err.message).toContain("test-server");
+    expect(err.message).toContain("timeout");
+  });
+});

--- a/plugins/plugin-mcp/src/utils/error.ts
+++ b/plugins/plugin-mcp/src/utils/error.ts
@@ -34,11 +34,11 @@ export async function handleMcpError(
 
   if (callback) {
     const enhancedState: State = {
-      ...state,
+      ...(state ?? {}),
       values: {
-        ...state.values,
+        ...(state?.values ?? {}),
         mcpProvider,
-        userMessage: message.content.text ?? "",
+        userMessage: message?.content?.text ?? "",
         error: errorMessage,
       },
     };


### PR DESCRIPTION
## Summary
Closes #28506

Adds safe optional property access (`message?.content?.text`, `state?.values`) in `handleMcpError` (`plugins/plugin-mcp/src/utils/error.ts`) to protect against unhandled TypeErrors when handling errors from partial or malformed message/state objects.

## Changes
- Safely defaulted `state ?? {}`, `state?.values ?? {}`, and `message?.content?.text ?? ""` when constructing `enhancedState`
- Added unit test suite in `plugins/plugin-mcp/__tests__/error.test.ts`

## Evidence

<!-- evidence-table -->

| Evidence | Source / link / artifact | Review notes |
| --- | --- | --- |
| backend-logs | N/A - pure utility function | No runtime backend logging changes |
| scenario-replay | N/A - pure utility function | Scenarios unchanged |
| trajectory | N/A - pure utility function | No LLM interaction required |
| app-interaction | N/A - pure utility function | No visual UI component touched |
| domain-artifacts | N/A - pure utility function | No persistent tables modified |
| external-links | N/A - internal utility improvement | Pure error handler robustness enhancement |
| ci-proof | `bun run --cwd plugins/plugin-mcp test __tests__/error.test.ts` (3 pass) | Verified passes cleanly |

<!-- /evidence-table -->

<!-- evidence-head:9a598728ffa8dca5944f52a758b0f9f1a3e0cac0 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - pure utility function

<!-- evidence-row:after-screenshots -->
- [ ] N/A - pure utility function

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - pure utility function

<!-- evidence-row:backend-logs -->
- [ ] N/A - pure utility function

<!-- evidence-row:frontend-logs -->
- [ ] N/A - pure utility function

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - pure utility function

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - pure utility function

<!-- evidence-row:ocr-review -->
- [ ] N/A - pure utility function
