### PR TITLE
feat(core): export trimStartCharacters and trimBoundaryCharacters in string-boundaries

### DIFF
--- a/packages/core/src/utils/string-boundaries.test.ts
+++ b/packages/core/src/utils/string-boundaries.test.ts
@@ -1,7 +1,12 @@
 /** Validates core's deterministic boundary scanners against long adversarial suffixes. */
 
 import { describe, expect, it } from "vitest";
-import { trimEndCharacters, trimEndWhitespace } from "./string-boundaries";
+import {
+	trimBoundaryCharacters,
+	trimEndCharacters,
+	trimEndWhitespace,
+	trimStartCharacters,
+} from "./string-boundaries";
 
 describe("core string boundary scanners", () => {
 	it("trims only the requested suffix", () => {
@@ -11,8 +16,18 @@ describe("core string boundary scanners", () => {
 		expect(trimEndWhitespace("answer \t\n")).toBe("answer");
 	});
 
+	it("trims requested prefixes and boundaries", () => {
+		expect(trimStartCharacters("///https://example.test", "/")).toBe(
+			"https://example.test",
+		);
+		expect(trimBoundaryCharacters("///https://example.test///", "/")).toBe(
+			"https://example.test",
+		);
+	});
+
 	it("handles 100k-character suffixes in linear time", () => {
 		expect(trimEndCharacters(`root${"/".repeat(100_000)}`, "/")).toBe("root");
+		expect(trimStartCharacters(`${"/".repeat(100_000)}root`, "/")).toBe("root");
 		expect(trimEndWhitespace(`root${"\t".repeat(100_000)}`)).toBe("root");
 	});
 
@@ -21,6 +36,9 @@ describe("core string boundary scanners", () => {
 		const sameLowSurrogate = String.fromCodePoint(0x1f200);
 		expect(trimEndCharacters(`root${sameLowSurrogate}`, allowed)).toBe(
 			`root${sameLowSurrogate}`,
+		);
+		expect(trimStartCharacters(`${sameLowSurrogate}root`, allowed)).toBe(
+			`${sameLowSurrogate}root`,
 		);
 	});
 });

--- a/packages/core/src/utils/string-boundaries.ts
+++ b/packages/core/src/utils/string-boundaries.ts
@@ -1,19 +1,61 @@
 /** Provides linear boundary trimming for explicit character sets and whitespace. */
 
+/** Remove characters from the start while they belong to `characters`. */
+export function trimStartCharacters(value: string, characters: string): string {
+	const accepted = new Set(characters);
+	let start = 0;
+	while (start < value.length) {
+		const codePoint = value.codePointAt(start);
+		if (codePoint === undefined) break;
+		const character = String.fromCodePoint(codePoint);
+		if (!accepted.has(character)) break;
+		start += character.length;
+	}
+	return start === 0 ? value : value.slice(start);
+}
+
+function previousCharacterStart(value: string, end: number): number {
+	const last = value.charCodeAt(end - 1);
+	if (last >= 0xdc00 && last <= 0xdfff && end > 1) {
+		const previous = value.charCodeAt(end - 2);
+		if (previous >= 0xd800 && previous <= 0xdbff) return end - 2;
+	}
+	return end - 1;
+}
+
+/** Remove characters from the end while they belong to `characters`. */
 export function trimEndCharacters(value: string, characters: string): string {
 	const accepted = new Set(characters);
 	let end = value.length;
 	while (end > 0) {
-		let start = end - 1;
-		const last = value.charCodeAt(start);
-		if (last >= 0xdc00 && last <= 0xdfff && start > 0) {
-			const previous = value.charCodeAt(start - 1);
-			if (previous >= 0xd800 && previous <= 0xdbff) start -= 1;
-		}
+		const start = previousCharacterStart(value, end);
 		if (!accepted.has(value.slice(start, end))) break;
 		end = start;
 	}
 	return end === value.length ? value : value.slice(0, end);
+}
+
+/** Remove characters from both boundaries with one scan per boundary. */
+export function trimBoundaryCharacters(
+	value: string,
+	characters: string,
+): string {
+	const accepted = new Set(characters);
+	let start = 0;
+	let end = value.length;
+	while (start < end) {
+		const codePoint = value.codePointAt(start);
+		if (codePoint === undefined) break;
+		const character = String.fromCodePoint(codePoint);
+		if (!accepted.has(character)) break;
+		start += character.length;
+	}
+	while (end > start) {
+		const candidate = previousCharacterStart(value, end);
+		if (!accepted.has(value.slice(candidate, end))) break;
+		end = candidate;
+	}
+	return start === 0 && end === value.length ? value : value.slice(start, end);
 }
 
 export function trimEndWhitespace(value: string): string {


### PR DESCRIPTION
## Summary
Closes #28508

Exports `trimStartCharacters` and `trimBoundaryCharacters` from `packages/core/src/utils/string-boundaries.ts`, aligning with `@elizaos/shared` linear-time surrogate-safe string boundary trimming helpers.

## Changes
- Implemented `trimStartCharacters` and `trimBoundaryCharacters`
- Added unit tests in `packages/core/src/utils/string-boundaries.test.ts`

## Evidence

<!-- evidence-table -->

| Evidence | Source / link / artifact | Review notes |
| --- | --- | --- |
| backend-logs | N/A - pure utility function | No runtime backend logging changes |
| scenario-replay | N/A - pure utility function | Scenarios unchanged |
| trajectory | N/A - pure utility function | No LLM interaction required |
| app-interaction | N/A - pure utility function | No visual UI component touched |
| domain-artifacts | N/A - pure utility function | No persistent tables modified |
| external-links | N/A - internal utility improvement | Pure string boundary trimming helper |
| ci-proof | `bun test packages/core/src/utils/string-boundaries.test.ts` (4 pass) | Verified passes cleanly |

<!-- /evidence-table -->

<!-- evidence-head:499863e68497965cae9fb02e94cc254fcfd119a5 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - pure utility function

<!-- evidence-row:after-screenshots -->
- [ ] N/A - pure utility function

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - pure utility function

<!-- evidence-row:backend-logs -->
- [ ] N/A - pure utility function

<!-- evidence-row:frontend-logs -->
- [ ] N/A - pure utility function

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - pure utility function

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - pure utility function

<!-- evidence-row:ocr-review -->
- [ ] N/A - pure utility function
