### PR TITLE
fix(plugin-documents): truncateLabel guard bounds before checking surrogate code point

### DIFF
--- a/plugins/plugin-documents/src/document-presenter.test.ts
+++ b/plugins/plugin-documents/src/document-presenter.test.ts
@@ -83,4 +83,10 @@ describe("getDocumentTitleFromMetadata — derived-title truncation", () => {
     expect(title.startsWith("😀")).toBe(true);
     expect(title.endsWith("...")).toBe(true);
   });
+
+  it("handles short input strings safely", () => {
+    const line = "Short title";
+    const title = getDocumentTitleFromMetadata(undefined, line);
+    expect(title).toBe("Short title");
+  });
 });

--- a/plugins/plugin-documents/src/document-presenter.ts
+++ b/plugins/plugin-documents/src/document-presenter.ts
@@ -121,8 +121,10 @@ function truncateLabel(value: string, maxLength = 80): string {
   // surrogate pair — otherwise the label ends in a lone high surrogate that
   // renders as U+FFFD in the documents view.
   let end = maxLength - 1;
-  const lastKept = value.charCodeAt(end - 1);
-  if (lastKept >= 0xd800 && lastKept <= 0xdbff) end -= 1;
+  if (end > 0) {
+    const lastKept = value.charCodeAt(end - 1);
+    if (lastKept >= 0xd800 && lastKept <= 0xdbff) end -= 1;
+  }
   return `${value.slice(0, end).trimEnd()}...`;
 }
 


### PR DESCRIPTION
## Summary
Closes #28510

Guards `end > 0` in `truncateLabel` (`plugins/plugin-documents/src/document-presenter.ts`) before checking `value.charCodeAt(end - 1)` to prevent negative index indexing on small maxLength values.

## Changes
- Added bounds check `if (end > 0)` in `truncateLabel`
- Added unit test case in `plugins/plugin-documents/src/document-presenter.test.ts`

## Evidence

<!-- evidence-table -->

| Evidence | Source / link / artifact | Review notes |
| --- | --- | --- |
| backend-logs | N/A - pure utility function | No runtime backend logging changes |
| scenario-replay | N/A - pure utility function | Scenarios unchanged |
| trajectory | N/A - pure utility function | No LLM interaction required |
| app-interaction | N/A - pure utility function | No visual UI component touched |
| domain-artifacts | N/A - pure utility function | No persistent tables modified |
| external-links | N/A - internal utility improvement | Pure label truncation helper fix |
| ci-proof | `bun test plugins/plugin-documents/src/document-presenter.test.ts` (6 pass) | Verified passes cleanly |

<!-- /evidence-table -->

<!-- evidence-head:953d55b3d4084882ea17c91bc2c566f9eb941e23 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - pure utility function

<!-- evidence-row:after-screenshots -->
- [ ] N/A - pure utility function

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - pure utility function

<!-- evidence-row:backend-logs -->
- [ ] N/A - pure utility function

<!-- evidence-row:frontend-logs -->
- [ ] N/A - pure utility function

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - pure utility function

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - pure utility function

<!-- evidence-row:ocr-review -->
- [ ] N/A - pure utility function
