### PR TITLE
fix(personal-assistant): make raw audio feature guard case- and separator-agnostic

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/voice-affect.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/voice-affect.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import { type VoiceAffectService, voiceAffectService } from "./voice-affect";
+
+function baseInput(
+  features: Record<string, unknown> = {},
+): Parameters<VoiceAffectService["analyze"]>[0] {
+  return {
+    utteranceId: "utterance-1",
+    messageId: "message-1",
+    capturedAt: "2026-08-25T00:00:00.000Z",
+    consent: "ephemeral_only",
+    retention: { kind: "ttl", expiresAt: "2026-09-01T00:00:00.000Z" },
+    features,
+  };
+}
+
+describe("voice affect raw audio guard", () => {
+  it.each([
+    ["Audio", "different casing"],
+    ["RAW_AUDIO", "upper snake case"],
+    ["raw_audio", "snake case"],
+    ["audio_data", "snake case variant"],
+    ["audioData", "camelCase variant"],
+    ["base64Audio", "base64 camelCase"],
+    ["audioBlob", "blob camelCase"],
+    ["pcm", "pcm"],
+  ])("rejects raw audio smuggled under key %s (%s)", (key) => {
+    expect(() =>
+      voiceAffectService.analyze(
+        baseInput({ [key]: "UE9TVC1TSEFSRUQgTUVUQURBVEE=" }),
+      ),
+    ).toThrow(/raw audio/i);
+  });
+
+  it("accepts legitimate non-audio affect features", () => {
+    const result = voiceAffectService.analyze(
+      baseInput({
+        pauseDurationsMs: [120, 340],
+        speechRateWpm: 140,
+        transcriptTokenCount: 200,
+        transcriptUncertaintyTokenCount: 10,
+        pitchVarianceHz: 3.5,
+      }),
+    );
+    expect(result.eventType).toBe("voice_affect_event");
+    expect(result.scores.hesitance).toBeGreaterThanOrEqual(0);
+    expect(result.scores.hesitance).toBeLessThanOrEqual(1);
+    expect(result.withheldReasons).toEqual([]);
+  });
+
+  it("still rejects the canonical raw audio keys", () => {
+    for (const key of ["audio", "buffer", "samples", "waveform"]) {
+      expect(() =>
+        voiceAffectService.analyze(baseInput({ [key]: "x" })),
+      ).toThrow(/raw audio/i);
+    }
+  });
+});
+
+describe("voice affect durable record gate", () => {
+  it("withholds durable storage unless persist_features consent is granted", () => {
+    const result = voiceAffectService.buildDurableRecord(baseInput());
+    expect(result.status).toBe("withheld");
+    expect(result.reasons).toContain(
+      "durable_storage_requires_persist_features_consent",
+    );
+  });
+
+  it("withholds durable storage when retention is not ttl", () => {
+    const result = voiceAffectService.buildDurableRecord({
+      ...baseInput(),
+      consent: "persist_features",
+      retention: { kind: "ephemeral" },
+    });
+    expect(result.status).toBe("withheld");
+    expect(result.reasons).toContain("durable_storage_requires_ttl_retention");
+  });
+
+  it("withholds when the ttl retention has already expired", () => {
+    const expired = voiceAffectService.buildDurableRecord({
+      ...baseInput(),
+      consent: "persist_features",
+      retention: {
+        kind: "ttl",
+        expiresAt: "2026-08-01T00:00:00.000Z",
+      },
+    });
+    expect(expired.status).toBe("withheld");
+    expect(expired.reasons).toContain("retention_expired");
+  });
+
+  it("persists when consent and a future ttl are present", () => {
+    const result = voiceAffectService.buildDurableRecord({
+      ...baseInput({ pauseDurationsMs: [100] }),
+      consent: "persist_features",
+    });
+    expect(result.status).toBe("persistable");
+    if (result.status === "persistable") {
+      expect(result.event.retention.kind).toBe("ttl");
+      expect(result.event.retention.expiresAt).toBe("2026-09-01T00:00:00.000Z");
+    }
+  });
+});

--- a/plugins/plugin-personal-assistant/src/lifeops/voice-affect.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/voice-affect.ts
@@ -79,15 +79,24 @@ export type VoiceAffectPlannerSlice = {
 };
 
 const RAW_AUDIO_KEYS = new Set([
+  // Canonical spellings (lowercased for case-insensitive matching) plus the
+  // snake_case variants callers may plausibly use to smuggle raw audio past
+  // the guard. The guard exists so raw audio never reaches durable storage;
+  // a case- or separator-variant key must not bypass it.
   "audio",
-  "audioBlob",
-  "audioData",
-  "base64Audio",
+  "audioblob",
+  "audiodata",
+  "base64audio",
   "buffer",
   "pcm",
-  "rawAudio",
+  "rawaudio",
   "samples",
   "waveform",
+  "raw_audio",
+  "audio_data",
+  "audio_blob",
+  "base64_audio",
+  "pcm_data",
 ]);
 
 function clamp01(value: number): number {
@@ -117,7 +126,7 @@ function assertNonEmpty(value: string, field: string): void {
 
 function assertNoRawAudio(features: Record<string, unknown>): void {
   for (const key of Object.keys(features)) {
-    if (RAW_AUDIO_KEYS.has(key)) {
+    if (RAW_AUDIO_KEYS.has(key.toLowerCase())) {
       throw new Error(
         `voice affect features must not include raw audio key: ${key}`,
       );


### PR DESCRIPTION
## What

The voice-affect raw-audio guard (`assertNoRawAudio`) blocks raw audio keys from reaching durable storage, but the key check was case-sensitive and separator-exact. A caller (or a buggy upstream feature extractor) can smuggle raw audio past the guard with trivially different spellings — `Audio`, `RAW_AUDIO`, `raw_audio`, `audio_data`, `base64Audio` — defeating the privacy boundary and letting raw audio be persisted.

Fixes the guard to match keys case-insensitively against a normalized set that also covers snake_case variants, keeping the original key spelling in the error message.

## Evidence

Focused test run in isolation, at the PR head:

```log
Test Files  1 passed (1)
      Tests  14 passed (14)
```

- Command: `npx vitest run voice-affect.test.ts`
- Result: all passed (guard-bypass variants now rejected; canonical keys still rejected; legitimate affect features still accepted; durable-record consent/TTL gate unchanged)

## Risks

Low. The change only widens the set of feature keys rejected before persistence; no accepted-input behavior changes.

## Checklist

- [x] Rebased onto `fork/develop` (no conflicts)
- [x] `biome check --write` clean
- [x] Focused vitest run green

<!-- contribution-attribution:v1 -->
- <!-- attribution-row:ai-assistance --> AI assistance: `yes`
- <!-- attribution-row:models --> Model(s) used: `deepseek/deepseek-v4-flash`
- <!-- attribution-row:client --> Agent tooling: `Hermes Agent`
- <!-- attribution-row:skill-revision --> Skill path: `N/A - no contribution skill used`
- <!-- attribution-row:status --> Provenance status: `self-reported`
