### PR TITLE
fix(personal-assistant): strip resolvedAt from non-resolved browser task interventions

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/browser-session-lifecycle.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/browser-session-lifecycle.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { summarizeBrowserTaskLifecycle } from "./browser-session-lifecycle";
+
+function sessionWithInterventions(
+  interventions: Array<Record<string, unknown>>,
+) {
+  return {
+    actions: [],
+    status: "running",
+    metadata: {},
+    result: {
+      browserTask: {
+        lastUpdatedAt: "2026-08-25T12:00:00.000Z",
+        interventions,
+      },
+    },
+  };
+}
+
+describe("browser task intervention normalization", () => {
+  it("drops resolvedAt on an intervention that is not resolved", () => {
+    const summary = summarizeBrowserTaskLifecycle(
+      sessionWithInterventions([
+        {
+          kind: "confirm",
+          status: "requested",
+          requestedAt: "2026-08-25T00:00:00.000Z",
+          resolvedAt: "2026-08-25T00:05:00.000Z",
+        },
+      ]),
+    );
+    expect(summary.interventions).toHaveLength(1);
+    const intervention = summary.interventions[0];
+    expect(intervention.status).toBe("requested");
+    expect(intervention.resolvedAt).toBeNull();
+  });
+
+  it("keeps resolvedAt for resolved interventions", () => {
+    const summary = summarizeBrowserTaskLifecycle(
+      sessionWithInterventions([
+        {
+          kind: "confirm",
+          status: "resolved",
+          requestedAt: "2026-08-25T00:00:00.000Z",
+          resolvedAt: "2026-08-25T00:05:00.000Z",
+        },
+      ]),
+    );
+    expect(summary.interventions[0].resolvedAt).toBe(
+      "2026-08-25T00:05:00.000Z",
+    );
+  });
+
+  it("defaults resolvedAt to the patch timestamp for resolved interventions missing it", () => {
+    const summary = summarizeBrowserTaskLifecycle(
+      sessionWithInterventions([
+        {
+          kind: "confirm",
+          status: "resolved",
+          requestedAt: "2026-08-25T00:00:00.000Z",
+        },
+      ]),
+    );
+    expect(summary.interventions[0].resolvedAt).toBe(
+      "2026-08-25T12:00:00.000Z",
+    );
+  });
+
+  it("surfaces a pending intervention as needsHuman with its reason as blockedReason", () => {
+    const summary = summarizeBrowserTaskLifecycle(
+      sessionWithInterventions([
+        {
+          kind: "approval",
+          status: "requested",
+          reason: "owner confirmation required",
+          requestedAt: "2026-08-25T00:00:00.000Z",
+        },
+      ]),
+    );
+    expect(summary.needsHuman).toBe(true);
+    expect(summary.blockedReason).toBe("owner confirmation required");
+  });
+});

--- a/plugins/plugin-personal-assistant/src/lifeops/browser-session-lifecycle.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/browser-session-lifecycle.ts
@@ -156,9 +156,7 @@ function normalizeIntervention(
     channel: stringOrNull(value.channel),
     requestedAt,
     resolvedAt:
-      status === "resolved"
-        ? (stringOrNull(value.resolvedAt) ?? now)
-        : stringOrNull(value.resolvedAt),
+      status === "resolved" ? (stringOrNull(value.resolvedAt) ?? now) : null,
     detail: stringOrNull(value.detail),
   };
 }


### PR DESCRIPTION
## What

`normalizeIntervention` kept a `resolvedAt` timestamp on an intervention whose `status` is not `"resolved"` (e.g. a stale/corrupt `resolvedAt` on a `"requested"` intervention). Consumers of `BrowserTaskSummary` (UI, approval flows, reporting) treat a non-null `resolvedAt` as "this intervention was resolved" — so contradictory session data leaks a false resolution state into the summary.

Now a non-resolved intervention always gets `resolvedAt: null`; only `"resolved"` interventions carry a timestamp (falling back to the patch timestamp when missing, unchanged).

## Evidence

Focused test run in isolation, at the PR head:

```log
Test Files  1 passed (1)
      Tests  4 passed (4)
```

- Command: `npx vitest run browser-session-lifecycle.test.ts`
- Result: all passed (contradictory resolvedAt dropped; resolvedAt kept for resolved; default fallback intact; needsHuman/blockedReason surfacing intact)

## Risks

Low. Sanitizes a contradictory input shape; all valid shapes behave as before.

## Checklist

- [x] Rebased onto `fork/develop` (no conflicts)
- [x] `biome check --write` clean
- [x] Focused vitest run green

<!-- contribution-attribution:v1 -->
- <!-- attribution-row:ai-assistance --> AI assistance: `yes`
- <!-- attribution-row:models --> Model(s) used: `deepseek/deepseek-v4-flash`
- <!-- attribution-row:client --> Agent tooling: `Hermes Agent`
- <!-- attribution-row:skill-revision --> Skill path: `N/A - no contribution skill used`
- <!-- attribution-row:status --> Provenance status: `self-reported`
