### PR TITLE
fix(coding-tools): default runCommandWithTimeout to 10s instead of killing immediately

### DIFF
--- a/plugins/plugin-coding-tools/src/shell/utils/processQueue.test.ts
+++ b/plugins/plugin-coding-tools/src/shell/utils/processQueue.test.ts
@@ -1,0 +1,129 @@
+import { EventEmitter } from "node:events";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const spawnMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", () => ({
+  execFile: vi.fn(),
+  spawn: spawnMock,
+}));
+
+import {
+  CommandLane,
+  clearCommandLane,
+  enqueueCommand,
+  getQueueSize,
+  runCommandWithTimeout,
+} from "./processQueue";
+
+function fakeChild() {
+  const child = new EventEmitter();
+  child.kill = vi.fn(() => {
+    child.killed = true;
+    return true;
+  });
+  child.killed = false;
+  child.stdout = { on: vi.fn() };
+  child.stderr = { on: vi.fn() };
+  child.stdin = { write: vi.fn(), end: vi.fn() };
+  return child;
+}
+
+beforeEach(() => {
+  spawnMock.mockReset();
+  clearCommandLane(CommandLane.Main);
+  vi.useRealTimers();
+});
+
+describe("runCommandWithTimeout timeout contract", () => {
+  it("defaults the command timeout to 10s instead of killing immediately when timeoutMs is omitted", async () => {
+    vi.useFakeTimers();
+    const child = fakeChild();
+    spawnMock.mockReturnValue(child);
+
+    const promise = runCommandWithTimeout(["node", "-e", "1"], {
+      input: "x",
+    });
+
+    // Well before any sensible default, the child must not be SIGKILLed.
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(child.kill).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(9_000);
+    expect(child.kill).toHaveBeenCalledWith("SIGKILL");
+
+    child.emit("close", null, "SIGKILL");
+    const result = await promise;
+    expect(result.killed).toBe(true);
+  });
+
+  it("honors an explicit numeric timeout", async () => {
+    vi.useFakeTimers();
+    const child = fakeChild();
+    spawnMock.mockReturnValue(child);
+
+    const promise = runCommandWithTimeout(["node", "-e", "1"], 5_000);
+
+    await vi.advanceTimersByTimeAsync(4_900);
+    expect(child.kill).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(200);
+    expect(child.kill).toHaveBeenCalledWith("SIGKILL");
+
+    child.emit("close", null, "SIGKILL");
+    await promise;
+  });
+
+  it("resolves with stdout/stderr/code on clean close", async () => {
+    const child = fakeChild();
+    spawnMock.mockReturnValue(child);
+
+    const promise = runCommandWithTimeout(["echo", "hi"], { timeoutMs: 1000 });
+    child.stdout.on.mock.calls[0][1](Buffer.from("hello\n"));
+    child.stderr.on.mock.calls[0][1](Buffer.from(""));
+    child.emit("close", 0, null);
+
+    const result = await promise;
+    expect(result.stdout).toBe("hello\n");
+    expect(result.code).toBe(0);
+    expect(result.killed).toBe(false);
+  });
+});
+
+describe("command lane queue", () => {
+  it("serializes tasks within the main lane and reports queued + active", async () => {
+    const order: string[] = [];
+    let releaseFirst: () => void = () => {};
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+
+    const p1 = enqueueCommand(async () => {
+      order.push("a-start");
+      await firstGate;
+      order.push("a-end");
+      return 1;
+    });
+    const p2 = enqueueCommand(async () => {
+      order.push("b");
+      return 2;
+    });
+
+    await vi.waitFor(() => expect(order).toContain("a-start"));
+    expect(order).not.toContain("b");
+    expect(getQueueSize(CommandLane.Main)).toBe(2);
+
+    releaseFirst();
+    await Promise.all([p1, p2]);
+    expect(order).toEqual(["a-start", "a-end", "b"]);
+    expect(getQueueSize(CommandLane.Main)).toBe(0);
+  });
+
+  it("propagates task failures to the awaiting caller", async () => {
+    const p = enqueueCommand(async () => {
+      throw new Error("task boom");
+    });
+    await expect(p).rejects.toThrow("task boom");
+    expect(getQueueSize(CommandLane.Main)).toBe(0);
+  });
+});

--- a/plugins/plugin-coding-tools/src/shell/utils/processQueue.ts
+++ b/plugins/plugin-coding-tools/src/shell/utils/processQueue.ts
@@ -162,8 +162,12 @@ export async function runCommandWithTimeout(
     typeof optionsOrTimeout === "number"
       ? { timeoutMs: optionsOrTimeout }
       : optionsOrTimeout;
-  const { timeoutMs, cwd, input, env } = options;
+  const { cwd, input, env } = options;
   const { windowsVerbatimArguments } = options;
+  // Default the timeout the same way the number shorthand does; without this,
+  // an options object that omits timeoutMs schedules setTimeout(…, undefined)
+  // which fires on the next tick and SIGKILLs a healthy command immediately.
+  const timeoutMs = options.timeoutMs ?? 10_000;
   const hasInput = input !== undefined;
 
   const shouldSuppressNpmFund = (() => {


### PR DESCRIPTION
## What

`runCommandWithTimeout(argv, { ... })` destructured `timeoutMs` straight from the options object. When a caller passed an options object **without** `timeoutMs` (e.g. `{ input, cwd }`), `setTimeout(fn, undefined)` fired on the next tick and SIGKILLed a perfectly healthy command immediately — while the numeric shorthand (`runCommandWithTimeout(argv, 10_000)`) and `runExec` default to 10s. An omitted timeout silently turned into "kill now".

Now the object form defaults `timeoutMs` to 10_000, matching the number shorthand and `runExec`'s default. Explicit `timeoutMs` values are honored unchanged.

## Evidence

Focused test run in isolation, at the PR head:

```log
Test Files  1 passed (1)
      Tests  5 passed (5)
```

- Command: `npx vitest run processQueue.test.ts`
- Result: all passed (omitted timeout no longer kills early; explicit numeric timeout honored; clean-close resolution; main-lane serialization; failure propagation)

## Risks

Low. Restores the documented default for the object form; the only behavior change is for callers that previously (accidentally) relied on an immediate SIGKILL when omitting `timeoutMs`.

## Checklist

- [x] Rebased onto `fork/develop` (no conflicts)
- [x] `biome check --write` clean
- [x] Focused vitest run green

<!-- contribution-attribution:v1 -->
- <!-- attribution-row:ai-assistance --> AI assistance: `yes`
- <!-- attribution-row:models --> Model(s) used: `deepseek/deepseek-v4-flash`
- <!-- attribution-row:client --> Agent tooling: `Hermes Agent`
- <!-- attribution-row:skill-revision --> Skill path: `N/A - no contribution skill used`
- <!-- attribution-row:status --> Provenance status: `self-reported`
