### PR TITLE
fix(core): unwrapWholeCodeFence trim outer whitespace from input

### DIFF
--- a/packages/core/src/utils/code-fence.test.ts
+++ b/packages/core/src/utils/code-fence.test.ts
@@ -22,6 +22,12 @@ describe("unwrapWholeCodeFence", () => {
 		).toBeNull();
 	});
 
+	it("unwraps code fences with leading or trailing whitespace", () => {
+		expect(
+			unwrapWholeCodeFence('  \n```json\n{"ok":true}\n```\n\n  ', ["json"]),
+		).toBe('{"ok":true}');
+	});
+
 	it("scans a 100k-character body without backtracking", () => {
 		const body = "\t".repeat(100_000);
 		expect(unwrapWholeCodeFence(`\`\`\`json\n${body}x\n\`\`\``, ["json"])).toBe(

--- a/packages/core/src/utils/code-fence.ts
+++ b/packages/core/src/utils/code-fence.ts
@@ -4,26 +4,31 @@ export function unwrapWholeCodeFence(
 	value: string,
 	languages: readonly string[],
 ): string | null {
-	if (!value.startsWith("```") || !value.endsWith("```") || value.length < 6) {
+	const trimmed = value.trim();
+	if (
+		!trimmed.startsWith("```") ||
+		!trimmed.endsWith("```") ||
+		trimmed.length < 6
+	) {
 		return null;
 	}
-	const lowerValue = value.toLowerCase();
+	const lowerValue = trimmed.toLowerCase();
 	const acceptedLanguage = [...languages]
 		.sort((left, right) => right.length - left.length)
 		.find((language) => lowerValue.startsWith(language.toLowerCase(), 3));
 	let cursor = acceptedLanguage ? 3 + acceptedLanguage.length : 3;
 	if (!acceptedLanguage) {
-		while (cursor < value.length && /[A-Za-z0-9]/.test(value[cursor]))
+		while (cursor < trimmed.length && /[A-Za-z0-9]/.test(trimmed[cursor]))
 			cursor += 1;
-		const language = value.slice(3, cursor);
+		const language = trimmed.slice(3, cursor);
 		// A whitespace-delimited token is an explicit (unsupported) language
 		// label. Otherwise it is compact unlabeled content such as ```true``` or
 		// ```name: value```, which the previous whole-fence parsers accepted.
-		if (language && /\s/u.test(value[cursor] ?? "")) return null;
+		if (language && /\s/u.test(trimmed[cursor] ?? "")) return null;
 		cursor = 3;
 	}
-	while (cursor < value.length - 3 && /\s/u.test(value[cursor])) cursor += 1;
-	let end = value.length - 3;
-	while (end > cursor && /\s/u.test(value[end - 1])) end -= 1;
-	return value.slice(cursor, end);
+	while (cursor < trimmed.length - 3 && /\s/u.test(trimmed[cursor])) cursor += 1;
+	let end = trimmed.length - 3;
+	while (end > cursor && /\s/u.test(trimmed[end - 1])) end -= 1;
+	return trimmed.slice(cursor, end);
 }


### PR DESCRIPTION
## Summary
Closes #28515

Trims leading and trailing whitespace from the input string in `unwrapWholeCodeFence` (`packages/core/src/utils/code-fence.ts`) before parsing delimiters.

Previously, code fences generated by LLMs that contained surrounding newlines or leading spaces were erroneously rejected with `null` because `value.startsWith("```")` evaluated to `false`.

## Changes
- Applied `value.trim()` before checking code fence bounds in `unwrapWholeCodeFence`
- Added unit test case in `packages/core/src/utils/code-fence.test.ts`

## Evidence

<!-- evidence-table -->

| Evidence | Source / link / artifact | Review notes |
| --- | --- | --- |
| backend-logs | N/A - pure utility function | No runtime backend logging changes |
| scenario-replay | N/A - pure utility function | Scenarios unchanged |
| trajectory | N/A - pure utility function | No LLM interaction required |
| app-interaction | N/A - pure utility function | No visual UI component touched |
| domain-artifacts | N/A - pure utility function | No persistent tables modified |
| external-links | N/A - internal utility improvement | Pure markdown parser helper fix |
| ci-proof | `bun test packages/core/src/utils/code-fence.test.ts` (4 pass) | Verified passes cleanly |

<!-- /evidence-table -->

<!-- evidence-head:56e725cffdd32394bdee8828b250a4e0aea66bdb -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - pure utility function

<!-- evidence-row:after-screenshots -->
- [ ] N/A - pure utility function

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - pure utility function

<!-- evidence-row:backend-logs -->
- [ ] N/A - pure utility function

<!-- evidence-row:frontend-logs -->
- [ ] N/A - pure utility function

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - pure utility function

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - pure utility function

<!-- evidence-row:ocr-review -->
- [ ] N/A - pure utility function
