### PR TITLE
test(memory): add graduated long-horizon lifecycle evals

### DIFF
--- a/packages/agent/src/actions/memories.test.ts
+++ b/packages/agent/src/actions/memories.test.ts
@@ -31,6 +31,7 @@ function assertUuidOrThrowLikeDrizzle(value: unknown, column: string): void {
 function makeRuntime(options?: {
   clusters?: Partial<Record<string, UUID[]>>;
   settings?: Record<string, string | boolean>;
+  embeddingResult?: number[];
 }): { runtime: IAgentRuntime; rows: StoredRow[] } {
   const rows: StoredRow[] = [];
   const runtime = {
@@ -102,6 +103,15 @@ function makeRuntime(options?: {
       assertUuidOrThrowLikeDrizzle(memoryId, "id");
       return rows.find((row) => row.memory.id === memoryId)?.memory ?? null;
     },
+    updateMemory: async (memory: Partial<Memory> & { id: UUID }) => {
+      const row = rows.find((candidate) => candidate.memory.id === memory.id);
+      if (!row) throw new Error(`memory ${memory.id} was not found`);
+      row.memory = { ...row.memory, ...memory } as Memory;
+    },
+    useModel: async () => {
+      if (options?.embeddingResult) return options.embeddingResult;
+      throw new Error("embedding capability should not be requested");
+    },
     deleteMemory: async (memoryId: UUID) => {
       assertUuidOrThrowLikeDrizzle(memoryId, "id");
       const index = rows.findIndex((row) => row.memory.id === memoryId);
@@ -162,6 +172,102 @@ async function runCreate(
 ): Promise<ActionResult> {
   return runAction(runtime, message, { action: "create", ...parameters });
 }
+
+describe("MEMORY op:update", () => {
+  it("updates a text-only memory without requiring an embedding provider", async () => {
+    const { runtime, rows } = makeRuntime();
+    const memoryId = seedFact(rows, {
+      text: "the project codename is Kingfisher",
+      entityId: USER_ID,
+    });
+
+    const result = await runAction(runtime, makeMessage(), {
+      action: "update",
+      memoryId,
+      text: "the project codename is Nightjar",
+      confirm: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(rows[0].memory.content.text).toBe(
+      "the project codename is Nightjar",
+    );
+    expect(rows[0].memory.embedding).toBeUndefined();
+  });
+
+  it("regenerates the vector when updating an embedded memory", async () => {
+    const { runtime, rows } = makeRuntime({ embeddingResult: [0.4, 0.8] });
+    const memoryId = seedFact(rows, {
+      text: "the project codename is Kingfisher",
+      entityId: USER_ID,
+    });
+    rows[0].memory.embedding = [0.1, 0.2];
+
+    const result = await runAction(runtime, makeMessage(), {
+      action: "update",
+      memoryId,
+      text: "the project codename is Nightjar",
+      confirm: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(rows[0].memory.embedding).toEqual([0.4, 0.8]);
+  });
+
+  it("resolves a uniquely matching requester memory from a query", async () => {
+    const { runtime, rows } = makeRuntime();
+    seedFact(rows, {
+      text: "the project codename is Kingfisher",
+      entityId: USER_ID,
+    });
+    seedFact(rows, {
+      text: "the project codename is Kingfisher",
+      entityId: OTHER_USER_ID,
+    });
+
+    const result = await runAction(runtime, makeMessage(), {
+      action: "update",
+      query: "project codename Kingfisher",
+      text: "the project codename is Nightjar",
+      confirm: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(rows[0].memory.content.text).toBe(
+      "the project codename is Nightjar",
+    );
+    expect(rows[1].memory.content.text).toBe(
+      "the project codename is Kingfisher",
+    );
+  });
+
+  it("refuses a query that matches distinct requester memories", async () => {
+    const { runtime, rows } = makeRuntime();
+    seedFact(rows, {
+      text: "the project codename is Kingfisher",
+      entityId: USER_ID,
+    });
+    seedFact(rows, {
+      text: "the archived project codename is Kingfisher Two",
+      entityId: USER_ID,
+    });
+
+    const result = await runAction(runtime, makeMessage(), {
+      action: "update",
+      query: "project codename Kingfisher",
+      text: "the project codename is Nightjar",
+      confirm: true,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.data).toMatchObject({ error: "MEMORY_AMBIGUOUS_QUERY" });
+    expect(
+      rows.every(
+        (row) => !(row.memory.content.text ?? "").includes("Nightjar"),
+      ),
+    ).toBe(true);
+  });
+});
 
 describe("MEMORY op:create", () => {
   it("persists to the facts table scoped to the conversation room and speaker", async () => {
@@ -328,8 +434,8 @@ describe("MEMORY op:search terminal recall", () => {
     expect(result.success).toBe(true);
     expect(result.turnComplete).toBe(true);
     expect(result.verifiedUserFacing).toBe(true);
-    expect(result.userFacingText).toBe(
-      "I found 1 matching memory record(s):\n- [facts] Royce taught Shadow guitar",
+    expect(result.userFacingText).toMatch(
+      /^I found 1 matching memory record\(s\):\n- \[facts\] at \d{4}-\d{2}-\d{2}T.*Z: Royce taught Shadow guitar$/,
     );
     expect(result.userFacingText).not.toContain(memoryId);
   });
@@ -595,6 +701,36 @@ describe("MEMORY op:delete by query", () => {
 });
 
 describe("MEMORY op:search complete traversal", () => {
+  it("ranks an exact all-term match ahead of newer partial decoys", async () => {
+    const { runtime, rows } = makeRuntime();
+    const targetId = seedFact(rows, {
+      text: "the archival project codename is Copper Heron 9184",
+      entityId: USER_ID,
+    });
+    rows[0].memory.createdAt = 1;
+    seedFact(rows, {
+      text: "the archival project codename is Copper Heron 8194",
+      entityId: USER_ID,
+    });
+    seedFact(rows, {
+      text: "the archival project codename is Bronze Heron 9184",
+      entityId: USER_ID,
+    });
+
+    const result = await runAction(runtime, makeMessage(), {
+      action: "search",
+      type: "facts",
+      query: "archival project codename Copper Heron 9184",
+    });
+
+    expect(result.success).toBe(true);
+    const responseText = result.text ?? "";
+    expect(responseText.indexOf(targetId)).toBeLessThan(
+      responseText.indexOf("Copper Heron 8194"),
+    );
+    expect(responseText).toContain("1970-01-01T00:00:00.001Z");
+  });
+
   it("finds a matching fact older than the former 200-row window", async () => {
     const { runtime, rows } = makeRuntime();
     seedFact(rows, { text: "my sister is named vega", entityId: USER_ID });

--- a/packages/agent/src/actions/memories.ts
+++ b/packages/agent/src/actions/memories.ts
@@ -421,9 +421,18 @@ async function collectCandidates(
     });
   }
 
-  filtered.sort(
-    (a, b) => (b.memory.createdAt ?? 0) - (a.memory.createdAt ?? 0),
-  );
+  filtered.sort((a, b) => {
+    if (scope.query) {
+      const leftText =
+        (a.memory.content as { text?: string } | undefined)?.text ?? "";
+      const rightText =
+        (b.memory.content as { text?: string } | undefined)?.text ?? "";
+      const relevance =
+        scoreText(rightText, scope.query) - scoreText(leftText, scope.query);
+      if (relevance !== 0) return relevance;
+    }
+    return (b.memory.createdAt ?? 0) - (a.memory.createdAt ?? 0);
+  });
   return { matches: filtered, tables, scanned: collected.length };
 }
 
@@ -487,13 +496,15 @@ async function doSearch(
   // The text projection carries enough of each hit for model reasoning; the
   // complete records remain machine data for state and trajectory consumers.
   const lines = items.map(
-    (m) => `- [${m.type}] ${m.id}: ${toWellFormedUnicode(m.text)}`,
+    (m) =>
+      `- [${m.type}] ${m.id} at ${new Date(m.createdAt).toISOString()}: ${toWellFormedUnicode(m.text)}`,
   );
   const userFacingText = items.length
     ? [
         `I found ${items.length} matching memory record(s):`,
         ...items.map(
-          (item) => `- [${item.type}] ${toWellFormedUnicode(item.text)}`,
+          (item) =>
+            `- [${item.type}] at ${new Date(item.createdAt).toISOString()}: ${toWellFormedUnicode(item.text)}`,
         ),
       ].join("\n")
     : undefined;
@@ -542,13 +553,17 @@ async function doSearch(
 
 async function doUpdate(
   runtime: IAgentRuntime,
+  message: Memory,
   params: MemoryParams,
 ): Promise<ActionResult> {
   const memoryParam = parseUuidParam(params.memoryId, "memoryId");
   if (!memoryParam.ok) return memoryParam.result;
   const memoryId = memoryParam.id;
+  const query = params.query?.trim();
   const text = typeof params.text === "string" ? params.text.trim() : "";
-  if (!memoryId) return fail("memoryId is required.", "MEMORY_MISSING_ID");
+  if (!memoryId && !query) {
+    return fail("memoryId or query is required.", "MEMORY_MISSING_ID");
+  }
   if (!text) return fail("text is required.", "MEMORY_MISSING_TEXT");
   if (params.confirm !== true) {
     return fail(
@@ -557,38 +572,101 @@ async function doUpdate(
     );
   }
 
-  const existing = await runtime.getMemoryById(memoryId);
-  if (!existing) {
-    return fail(`Memory ${memoryId} was not found.`, "MEMORY_NOT_FOUND");
-  }
-
-  const existingContent =
-    (existing.content as Record<string, unknown> | undefined) ?? {};
-  const nextContent = { ...existingContent, text };
-
-  const embedding = await runtime.useModel(ModelType.TEXT_EMBEDDING, { text });
-  if (!Array.isArray(embedding) || embedding.length === 0) {
-    return fail(
-      "Embedding model returned no vector.",
-      "MEMORY_EMBEDDING_FAILED",
+  let existingMemories: Memory[];
+  if (memoryId) {
+    const existing = await runtime.getMemoryById(memoryId);
+    if (!existing) {
+      return fail(`Memory ${memoryId} was not found.`, "MEMORY_NOT_FOUND");
+    }
+    existingMemories = [existing];
+  } else {
+    const scan = await collectCandidates(runtime, {
+      type:
+        params.type && MEMORY_TYPES.includes(params.type)
+          ? params.type
+          : undefined,
+      entityId: message.entityId,
+      query,
+    });
+    const matched = scan.matches.filter((candidate) => {
+      const candidateText =
+        (candidate.memory.content as { text?: string } | undefined)?.text ?? "";
+      return scoreText(candidateText, query ?? "") >= 1;
+    });
+    if (matched.length === 0) {
+      return fail(
+        `No stored memory matches "${query}". ${describeCompleteScan(scan)}`,
+        "MEMORY_NOT_FOUND",
+      );
+    }
+    const distinctTexts = new Set(
+      matched.map((candidate) =>
+        (
+          (candidate.memory.content as { text?: string } | undefined)?.text ??
+          ""
+        )
+          .trim()
+          .toLowerCase(),
+      ),
     );
+    if (distinctTexts.size > 1) {
+      const lines = matched.map((candidate) => {
+        const item = toListItem(candidate.memory, candidate.type);
+        return `- [${item.type}] ${item.id}: ${toWellFormedUnicode(item.text)}`;
+      });
+      return {
+        success: false,
+        text: [
+          `Query "${query}" matches ${distinctTexts.size} distinct memories. Update by memoryId instead:`,
+          ...lines,
+        ].join("\n"),
+        data: { error: "MEMORY_AMBIGUOUS_QUERY" },
+      };
+    }
+    existingMemories = matched.map((candidate) => candidate.memory);
   }
 
-  await runtime.updateMemory({
-    id: memoryId,
-    content: nextContent,
-    embedding,
-  });
+  const updatedIds: UUID[] = [];
+  for (const existing of existingMemories) {
+    if (!existing.id) continue;
+    const existingContent =
+      (existing.content as Record<string, unknown> | undefined) ?? {};
+    const nextContent = { ...existingContent, text };
+    let embedding: number[] | undefined;
+    if (Array.isArray(existing.embedding) && existing.embedding.length > 0) {
+      const regenerated = await runtime.useModel(ModelType.TEXT_EMBEDDING, {
+        text,
+      });
+      if (!Array.isArray(regenerated) || regenerated.length === 0) {
+        return fail(
+          "Embedding model returned no vector.",
+          "MEMORY_EMBEDDING_FAILED",
+        );
+      }
+      embedding = regenerated;
+    }
 
-  const updated = await runtime.getMemoryById(memoryId);
+    await runtime.updateMemory({
+      id: existing.id,
+      content: nextContent,
+      ...(embedding ? { embedding } : {}),
+    });
+    updatedIds.push(existing.id);
+  }
+
+  const primaryMemoryId = updatedIds[0];
+  const updated = primaryMemoryId
+    ? await runtime.getMemoryById(primaryMemoryId)
+    : null;
   return {
     success: true,
-    text: `Updated memory ${memoryId}.`,
-    values: { memoryId },
+    text: `Updated ${updatedIds.length} memory record(s).`,
+    values: { memoryId: primaryMemoryId, updatedCount: updatedIds.length },
     data: {
       actionName: "MEMORY",
       op: "update" as const,
-      memoryId,
+      memoryId: primaryMemoryId,
+      memoryIds: updatedIds,
       memory: updated ?? null,
     },
   };
@@ -761,9 +839,9 @@ export const memoryAction: Action = {
     "MODIFY_MEMORY",
   ],
   description:
-    "Manage agent memory records. op:create stores a new memory; op:search filters by type/entityId/roomId/query; op:update edits text and re-embeds (requires confirm:true); op:delete removes a memory by memoryId or by query text match (requires confirm:true).",
+    "Manage agent memory records. op:create stores a new memory; op:search filters by type/entityId/roomId/query; op:update edits by memoryId or a unique requester-scoped query match (requires confirm:true); op:delete removes by memoryId or requester-scoped query match (requires confirm:true).",
   descriptionCompressed:
-    "manage agent memory create search update delete; delete by memoryId or query; update/delete require confirm:true",
+    "manage agent memory create search update delete; update/delete by memoryId or query; update/delete require confirm:true",
   routingHint:
     "NOTES ARE NOT MEMORY: 'make a note', 'note to self', 'jot this down', 'what notes do i have' -> the NOTES action, which writes the durable note store the user sees in the Notes view. MEMORY is the agent's own recall of the conversation. store/search/edit the agent's OWN memory records about the user or conversation -> MEMORY. This includes recalling or COUNTING what was said earlier than the messages shown in context ('how many times have I mentioned X', 'have I ever told you about X', 'what did we say about X last week') — the conversation block in context is only the most recent turns, so answer those from op:search over the stored record, never from that block alone. Do NOT use for open-web lookups -> WEB_SEARCH, for searching connected external channels such as email or another platform's inbox -> MESSAGE (action=search), or for the skill catalog -> SKILL",
   validate: async () => true,
@@ -789,7 +867,7 @@ export const memoryAction: Action = {
         case "search":
           return await doSearch(runtime, params);
         case "update":
-          return await doUpdate(runtime, params);
+          return await doUpdate(runtime, message, params);
         case "delete":
           return await doDelete(runtime, message, params);
       }
@@ -865,14 +943,14 @@ export const memoryAction: Action = {
     {
       name: "query",
       description:
-        "search/delete: case-insensitive text match against memory content. delete: resolves the memory to remove when memoryId is unknown; scoped to the requesting user's own memories.",
+        "search/update/delete: case-insensitive text match against memory content. update/delete: resolves the memory to mutate when memoryId is unknown; scoped to the requesting user's own memories.",
       required: false,
       schema: { type: "string" as const },
     },
     {
       name: "memoryId",
       description:
-        "update/delete: id of the memory to mutate. delete: optional when query is provided.",
+        "update/delete: id of the memory to mutate; optional when query is provided.",
       required: false,
       schema: { type: "string" as const, pattern: UUID_SCHEMA_PATTERN },
     },

--- a/packages/agent/src/api/message-corpus.test.ts
+++ b/packages/agent/src/api/message-corpus.test.ts
@@ -77,4 +77,38 @@ describe("message-corpus", () => {
     expect(messageMemories).toHaveLength(4);
     expect(factMemories).toHaveLength(2);
   });
+
+  it("binds planted conversations to an explicit existing owner", async () => {
+    const ownerEntityId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa" as UUID;
+    const createdMemories: Array<{
+      memory: { entityId?: UUID };
+      table: string;
+    }> = [];
+    const mockRuntime: MessageCorpusRuntime = {
+      agentId: "12345678-1234-1234-1234-123456789abc" as UUID,
+      character: { name: "Eliza" },
+      ensureConnection: vi.fn().mockResolvedValue(undefined),
+      createMemory: vi.fn().mockImplementation(async (memory, table) => {
+        createdMemories.push({ memory, table });
+        return memory.id;
+      }),
+    };
+    const corpus = generateMessageCorpus({
+      conversationCount: 1,
+      messagesPerConversation: 2,
+      factsPerConversation: 1,
+      seed: 101,
+    });
+
+    await seedMessageCorpus(mockRuntime, corpus, { ownerEntityId });
+
+    expect(mockRuntime.ensureConnection).toHaveBeenCalledWith(
+      expect.objectContaining({ entityId: ownerEntityId }),
+    );
+    expect(
+      createdMemories
+        .filter(({ memory }) => memory.entityId !== mockRuntime.agentId)
+        .every(({ memory }) => memory.entityId === ownerEntityId),
+    ).toBe(true);
+  });
 });

--- a/packages/agent/src/api/message-corpus.ts
+++ b/packages/agent/src/api/message-corpus.ts
@@ -463,6 +463,11 @@ export interface MessageCorpusSeedSummary {
   sampleQueries: string[];
 }
 
+export interface MessageCorpusSeedOptions {
+  /** Existing owner identity to use instead of the dev seeder's synthetic owner. */
+  ownerEntityId?: UUID;
+}
+
 /**
  * Land a generated corpus through the runtime as real web-chat conversations:
  * one `web-conv-*` room per conversation in the agent's web-chat world (the
@@ -474,13 +479,14 @@ export interface MessageCorpusSeedSummary {
 export async function seedMessageCorpus(
   runtime: MessageCorpusRuntime,
   corpus: GeneratedMessageCorpus,
+  options: MessageCorpusSeedOptions = {},
 ): Promise<MessageCorpusSeedSummary> {
   const agentName = runtime.character.name ?? "Eliza";
   const worldId = stringToUuid(`${agentName}-web-chat-world`);
   const messageServerId = stringToUuid(`${agentName}-web-server`) as UUID;
-  const ownerEntityId = stringToUuid(
-    `message-corpus-owner-${runtime.agentId}`,
-  ) as UUID;
+  const ownerEntityId =
+    options.ownerEntityId ??
+    (stringToUuid(`message-corpus-owner-${runtime.agentId}`) as UUID);
 
   const seeded: SeededConversationRef[] = [];
   let messagesCreated = 0;

--- a/packages/scenario-runner/package.json
+++ b/packages/scenario-runner/package.json
@@ -79,6 +79,7 @@
     "eval:when2speak": "bun --conditions eliza-source --tsconfig-override ../../tsconfig.json src/when2speak-eval-cli.ts",
     "eval:timing:matrix": "bun --conditions eliza-source --tsconfig-override ../../tsconfig.json src/timing-matrix-runner-cli.ts",
     "eval:timing:merge": "bun --conditions eliza-source --tsconfig-override ../../tsconfig.json src/timing-report-merge-cli.ts",
+    "eval:memory-horizon": "bun --conditions eliza-source --tsconfig-override ../../tsconfig.json src/memory-horizon-matrix-cli.ts",
     "format": "bunx @biomejs/biome format --write package.json",
     "format:check": "bunx @biomejs/biome format package.json",
     "typecheck": "tsc --noEmit"

--- a/packages/scenario-runner/src/memory-horizon-matrix-cli.ts
+++ b/packages/scenario-runner/src/memory-horizon-matrix-cli.ts
@@ -1,0 +1,219 @@
+/**
+ * Runs the planted-conversation recall scenario once per supported horizon in
+ * isolated child processes, then writes one auditable aggregate JSON report.
+ */
+
+import { spawn } from "node:child_process";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { MEMORY_HORIZON_SIZES, type MemoryHorizonSize } from "./memory-horizon";
+
+interface MatrixCell {
+  messageCount: MemoryHorizonSize;
+  exitCode: number;
+  status: string;
+  durationMs: number | null;
+  providerName: string | null;
+  executionProfile: string | null;
+  scannedRows: number[];
+  totalMatches: number[];
+  response: string | null;
+  reportPath: string;
+}
+
+interface MatrixReport {
+  schemaVersion: 1;
+  generatedAt: string;
+  status: "passed" | "failed";
+  sizes: readonly MemoryHorizonSize[];
+  cells: MatrixCell[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function stringField(
+  record: Record<string, unknown>,
+  key: string,
+): string | null {
+  return typeof record[key] === "string" ? record[key] : null;
+}
+
+function numberField(
+  record: Record<string, unknown>,
+  key: string,
+): number | null {
+  return typeof record[key] === "number" && Number.isFinite(record[key])
+    ? record[key]
+    : null;
+}
+
+function parseSizes(value: string | undefined): MemoryHorizonSize[] {
+  if (!value) return [...MEMORY_HORIZON_SIZES];
+  const requested = value.split(",").map((entry) => Number(entry.trim()));
+  const sizes = requested.filter((candidate): candidate is MemoryHorizonSize =>
+    MEMORY_HORIZON_SIZES.some((supported) => supported === candidate),
+  );
+  if (
+    sizes.length !== requested.length ||
+    new Set(sizes).size !== sizes.length
+  ) {
+    throw new Error(
+      `--sizes must contain unique values from ${MEMORY_HORIZON_SIZES.join(", ")}`,
+    );
+  }
+  return sizes;
+}
+
+function argumentValue(name: string): string | undefined {
+  const prefix = `--${name}=`;
+  return process.argv
+    .slice(2)
+    .find((arg) => arg.startsWith(prefix))
+    ?.slice(prefix.length);
+}
+
+function actionMetric(
+  action: Record<string, unknown>,
+  key: "scanned" | "totalMatches",
+): number | null {
+  const result = isRecord(action.result) ? action.result : null;
+  const values = result && isRecord(result.values) ? result.values : null;
+  return values ? numberField(values, key) : null;
+}
+
+function parseCell(
+  messageCount: MemoryHorizonSize,
+  exitCode: number,
+  reportPath: string,
+  input: unknown,
+): MatrixCell {
+  if (!isRecord(input) || !Array.isArray(input.scenarios)) {
+    throw new Error(`${reportPath} is not a scenario aggregate report`);
+  }
+  const scenario = input.scenarios[0];
+  if (!isRecord(scenario)) {
+    throw new Error(`${reportPath} has no scenario result`);
+  }
+  const actions = Array.isArray(scenario.actionsCalled)
+    ? scenario.actionsCalled.filter(isRecord)
+    : [];
+  const searches = actions.filter(
+    (action) => stringField(action, "actionName") === "MEMORY_SEARCH",
+  );
+  const turns = Array.isArray(scenario.turns)
+    ? scenario.turns.filter(isRecord)
+    : [];
+  return {
+    messageCount,
+    exitCode,
+    status: stringField(scenario, "status") ?? "invalid",
+    durationMs: numberField(scenario, "durationMs"),
+    providerName: stringField(scenario, "providerName"),
+    executionProfile: stringField(scenario, "executionProfile"),
+    scannedRows: searches
+      .map((action) => actionMetric(action, "scanned"))
+      .filter((value): value is number => value !== null),
+    totalMatches: searches
+      .map((action) => actionMetric(action, "totalMatches"))
+      .filter((value): value is number => value !== null),
+    response:
+      turns.length > 0 ? stringField(turns.at(-1) ?? {}, "responseText") : null,
+    reportPath,
+  };
+}
+
+async function runCell(args: {
+  packageRoot: string;
+  outputRoot: string;
+  provider: string;
+  size: MemoryHorizonSize;
+}): Promise<MatrixCell> {
+  const cellDirectory = path.join(args.outputRoot, String(args.size));
+  await mkdir(cellDirectory, { recursive: true });
+  const child = spawn(
+    process.execPath,
+    [
+      "--conditions",
+      "eliza-source",
+      "--tsconfig-override",
+      "../../tsconfig.json",
+      "src/cli.ts",
+      "run",
+      "test/scenarios",
+      "--scenario",
+      "live-planted-conversation-memory-horizon",
+      "--provider",
+      args.provider,
+      "--run-dir",
+      cellDirectory,
+      "--report-dir",
+      cellDirectory,
+    ],
+    {
+      cwd: args.packageRoot,
+      env: {
+        ...process.env,
+        ELIZA_MEMORY_HORIZON_MESSAGES: String(args.size),
+      },
+      stdio: "inherit",
+    },
+  );
+  const exitCode = await new Promise<number>((resolve, reject) => {
+    child.once("error", reject);
+    child.once("exit", (code, signal) => {
+      if (code !== null) {
+        resolve(code);
+        return;
+      }
+      reject(
+        new Error(`${args.size}-message cell exited from signal ${signal}`),
+      );
+    });
+  });
+  const reportPath = path.join(cellDirectory, "matrix.json");
+  const parsed: unknown = JSON.parse(await readFile(reportPath, "utf8"));
+  return parseCell(args.size, exitCode, reportPath, parsed);
+}
+
+async function writeAtomicJson(
+  filePath: string,
+  value: unknown,
+): Promise<void> {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  const temporaryPath = `${filePath}.tmp-${process.pid}`;
+  await writeFile(temporaryPath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+  await rename(temporaryPath, filePath);
+}
+
+async function main(): Promise<void> {
+  const packageRoot = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "..",
+  );
+  const sizes = parseSizes(argumentValue("sizes"));
+  const provider = argumentValue("provider") ?? "cli";
+  const outputRoot = path.resolve(
+    packageRoot,
+    argumentValue("output-dir") ?? "../../reports/memory-horizon",
+  );
+  const cells: MatrixCell[] = [];
+  for (const size of sizes) {
+    cells.push(await runCell({ packageRoot, outputRoot, provider, size }));
+  }
+  const report: MatrixReport = {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    status: cells.every((cell) => cell.status === "passed")
+      ? "passed"
+      : "failed",
+    sizes,
+    cells,
+  };
+  await writeAtomicJson(path.join(outputRoot, "matrix.json"), report);
+  if (report.status === "failed") process.exitCode = 1;
+}
+
+await main();

--- a/packages/scenario-runner/src/memory-horizon.test.ts
+++ b/packages/scenario-runner/src/memory-horizon.test.ts
@@ -1,0 +1,38 @@
+/** Validates the closed configuration boundary for graduated memory-horizon runs. */
+
+import { describe, expect, it } from "vitest";
+import {
+  MEMORY_HORIZON_SIZES,
+  memoryHorizonCorpusShape,
+  parseMemoryHorizonSize,
+} from "./memory-horizon";
+
+describe("memory horizon configuration", () => {
+  it.each(MEMORY_HORIZON_SIZES)(
+    "accepts the supported %i-message tier",
+    (size) => {
+      expect(parseMemoryHorizonSize(String(size))).toEqual({
+        kind: "valid",
+        size,
+      });
+      expect(memoryHorizonCorpusShape(size)).toEqual({
+        conversationCount: 10,
+        messagesPerConversation: size / 10,
+      });
+    },
+  );
+
+  it.each(["499", "1001", "5.5", "many", "-1000"])(
+    "rejects unsupported input %s",
+    (value) => {
+      expect(parseMemoryHorizonSize(value).kind).toBe("invalid");
+    },
+  );
+
+  it("defaults to the first graduated tier", () => {
+    expect(parseMemoryHorizonSize(undefined)).toEqual({
+      kind: "valid",
+      size: 500,
+    });
+  });
+});

--- a/packages/scenario-runner/src/memory-horizon.ts
+++ b/packages/scenario-runner/src/memory-horizon.ts
@@ -1,0 +1,44 @@
+/**
+ * Defines the supported planted-conversation horizons and validates evaluator
+ * configuration before a runtime or database is started.
+ */
+
+export const MEMORY_HORIZON_SIZES = [500, 1_000, 5_000, 10_000] as const;
+
+export type MemoryHorizonSize = (typeof MEMORY_HORIZON_SIZES)[number];
+
+export type ParsedMemoryHorizonSize =
+  | { kind: "valid"; size: MemoryHorizonSize }
+  | { kind: "invalid"; reason: string };
+
+export function parseMemoryHorizonSize(
+  value: string | undefined,
+): ParsedMemoryHorizonSize {
+  if (value === undefined || value.trim() === "") {
+    return { kind: "valid", size: MEMORY_HORIZON_SIZES[0] };
+  }
+  if (!/^\d+$/.test(value)) {
+    return {
+      kind: "invalid",
+      reason: `message horizon must be an integer, received ${JSON.stringify(value)}`,
+    };
+  }
+  const parsed = Number(value);
+  const matched = MEMORY_HORIZON_SIZES.find((size) => size === parsed);
+  return matched === undefined
+    ? {
+        kind: "invalid",
+        reason: `message horizon must be one of ${MEMORY_HORIZON_SIZES.join(", ")}, received ${parsed}`,
+      }
+    : { kind: "valid", size: matched };
+}
+
+export function memoryHorizonCorpusShape(size: MemoryHorizonSize): {
+  conversationCount: 10;
+  messagesPerConversation: number;
+} {
+  return {
+    conversationCount: 10,
+    messagesPerConversation: size / 10,
+  };
+}

--- a/packages/scenario-runner/src/memory-recall-metrics.test.ts
+++ b/packages/scenario-runner/src/memory-recall-metrics.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Quantitative memory-recall scoring at the scenario-report boundary.
+ * The cases are synthetic evaluator inputs; no model or storage collaborator is mocked.
+ */
+import { describe, expect, it } from "vitest";
+import { scoreMemoryRecall } from "./memory-recall-metrics";
+
+describe("scoreMemoryRecall", () => {
+  it("reports recall, precision, and false-positive rate independently", () => {
+    const result = scoreMemoryRecall([
+      {
+        id: "retained",
+        response: "Your launch codename is Kingfisher.",
+        expected: ["kingfisher"],
+        forbidden: ["kestrel"],
+      },
+      {
+        id: "superseded",
+        response: "The corrected city is Atlanta, not Houston.",
+        expected: ["atlanta"],
+        forbidden: ["houston"],
+      },
+      {
+        id: "forgotten",
+        response: "I do not have that locker code.",
+        expected: [],
+        forbidden: ["7391"],
+      },
+      {
+        id: "missed",
+        response: "I cannot recall the tea preference.",
+        expected: ["oolong"],
+        forbidden: ["earl grey"],
+      },
+    ]);
+
+    expect(result).toEqual({
+      kind: "scored",
+      caseCount: 4,
+      expectedFactCount: 3,
+      truePositiveCount: 2,
+      falseNegativeCount: 1,
+      falsePositiveCount: 1,
+      precision: 2 / 3,
+      recall: 2 / 3,
+      falsePositiveRate: 1 / 4,
+      cases: [
+        { id: "retained", recalled: true, falsePositive: false },
+        { id: "superseded", recalled: true, falsePositive: true },
+        { id: "forgotten", recalled: true, falsePositive: false },
+        { id: "missed", recalled: false, falsePositive: false },
+      ],
+    });
+  });
+
+  it("rejects an empty evaluation instead of fabricating perfect metrics", () => {
+    expect(scoreMemoryRecall([])).toEqual({
+      kind: "invalid",
+      reason: "at least one recall case is required",
+    });
+  });
+});

--- a/packages/scenario-runner/src/memory-recall-metrics.ts
+++ b/packages/scenario-runner/src/memory-recall-metrics.ts
@@ -1,0 +1,87 @@
+/**
+ * Scores observable recall answers without depending on a model or storage implementation.
+ * Scenario and live-test adapters supply complete responses plus independently authored
+ * expected and forbidden facts; this module returns reviewable quality metrics.
+ */
+
+export interface MemoryRecallCase {
+  id: string;
+  response: string;
+  expected: string[];
+  forbidden: string[];
+}
+
+export type MemoryRecallScore =
+  | {
+      kind: "invalid";
+      reason: string;
+    }
+  | {
+      kind: "scored";
+      caseCount: number;
+      expectedFactCount: number;
+      truePositiveCount: number;
+      falseNegativeCount: number;
+      falsePositiveCount: number;
+      precision: number;
+      recall: number;
+      falsePositiveRate: number;
+      cases: Array<{
+        id: string;
+        recalled: boolean;
+        falsePositive: boolean;
+      }>;
+    };
+
+function includesFact(response: string, fact: string): boolean {
+  return response.toLocaleLowerCase().includes(fact.toLocaleLowerCase());
+}
+
+export function scoreMemoryRecall(
+  recallCases: MemoryRecallCase[],
+): MemoryRecallScore {
+  if (recallCases.length === 0) {
+    return {
+      kind: "invalid",
+      reason: "at least one recall case is required",
+    };
+  }
+
+  const cases = recallCases.map((recallCase) => ({
+    id: recallCase.id,
+    recalled:
+      recallCase.expected.length === 0 ||
+      recallCase.expected.every((fact) =>
+        includesFact(recallCase.response, fact),
+      ),
+    falsePositive: recallCase.forbidden.some((fact) =>
+      includesFact(recallCase.response, fact),
+    ),
+  }));
+  const expectedFactCount = recallCases.filter(
+    (recallCase) => recallCase.expected.length > 0,
+  ).length;
+  const truePositiveCount = cases.filter(
+    (result, index) =>
+      recallCases[index]?.expected.length !== 0 && result.recalled,
+  ).length;
+  const falseNegativeCount = expectedFactCount - truePositiveCount;
+  const falsePositiveCount = cases.filter(
+    (result) => result.falsePositive,
+  ).length;
+  const precisionDenominator = truePositiveCount + falsePositiveCount;
+
+  return {
+    kind: "scored",
+    caseCount: cases.length,
+    expectedFactCount,
+    truePositiveCount,
+    falseNegativeCount,
+    falsePositiveCount,
+    precision:
+      precisionDenominator === 0 ? 1 : truePositiveCount / precisionDenominator,
+    recall: expectedFactCount === 0 ? 1 : truePositiveCount / expectedFactCount,
+    falsePositiveRate: falsePositiveCount / cases.length,
+    cases,
+  };
+}

--- a/packages/scenario-runner/test/scenarios/live-memory-lifecycle-long-horizon.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/live-memory-lifecycle-long-horizon.scenario.ts
@@ -1,0 +1,199 @@
+/**
+ * Live-model memory lifecycle evaluation against the real SQL-backed AgentRuntime.
+ * It places durable facts six months behind 30 similar distractors, then drives
+ * search, correction, supersession, deletion, and an honest post-delete miss via chat.
+ */
+import { type Memory, MemoryType, type UUID } from "@elizaos/core";
+import type { ScenarioContext } from "@elizaos/scenario-runner/schema";
+import { scenario } from "@elizaos/scenario-runner/schema";
+import { scoreMemoryRecall } from "../../src/memory-recall-metrics";
+import { prepareOwnerMemoryRuntime } from "./_helpers/history-recall-runtime";
+
+const DISTRACTOR_COUNT = 30;
+const OLD_CODENAME = "Kingfisher";
+const NEW_CODENAME = "Nightjar";
+const LOCKER_CODE = "7391";
+
+type SeedRuntime = {
+  agentId: UUID;
+  createMemories(
+    memories: Array<{
+      memory: Memory;
+      tableName: string;
+      unique?: boolean;
+    }>,
+  ): Promise<UUID[]>;
+};
+
+async function seedLongHorizonMemory(
+  ctx: ScenarioContext,
+): Promise<string | undefined> {
+  const prepared = await prepareOwnerMemoryRuntime(ctx);
+  if (typeof prepared === "string") return prepared;
+  if (!ctx.primaryRoomId || !ctx.primaryUserId) {
+    return "scenario runtime did not expose the owner room and entity";
+  }
+  const runtime = prepared as SeedRuntime;
+  const base = new Date("2026-02-01T12:00:00.000Z").getTime();
+  const facts = [
+    `The owner's project codename is ${OLD_CODENAME}.`,
+    `The owner's temporary locker code is ${LOCKER_CODE}.`,
+    "The owner's preferred afternoon tea is oolong.",
+    ...Array.from(
+      { length: DISTRACTOR_COUNT },
+      (_, index) =>
+        `Archived project note ${String(index).padStart(4, "0")}: reference bird ${index % 2 === 0 ? "kestrel" : "sparrow"}, locker ${8_000 + index}, tea ${index % 3 === 0 ? "earl grey" : "sencha"}.`,
+    ),
+  ];
+  const rows = facts.map((text, index) => ({
+    memory: {
+      id: crypto.randomUUID() as UUID,
+      entityId: ctx.primaryUserId as UUID,
+      agentId: runtime.agentId,
+      roomId: ctx.primaryRoomId as UUID,
+      content: { text, source: "memory-lifecycle-eval" },
+      metadata: {
+        type: MemoryType.CUSTOM,
+        source: "memory-lifecycle-eval",
+        kind: "durable",
+        category: "evaluation_fact",
+        confidence: 1,
+      },
+      createdAt: base + index * 60_000,
+      unique: false,
+    } satisfies Memory,
+    tableName: "facts",
+    unique: false,
+  }));
+  await runtime.createMemories(rows);
+  return undefined;
+}
+
+function scoreLifecycle(ctx: ScenarioContext): string | undefined {
+  const firstRecall = ctx.turns?.[0]?.responseText ?? "";
+  const correctedRecall = ctx.turns?.[2]?.responseText ?? "";
+  const forgottenRecall = ctx.turns?.[4]?.responseText ?? "";
+  const score = scoreMemoryRecall([
+    {
+      id: "six-month-recall",
+      response: firstRecall,
+      expected: [OLD_CODENAME],
+      forbidden: ["kestrel"],
+    },
+    {
+      id: "superseded-recall",
+      response: correctedRecall,
+      expected: [NEW_CODENAME],
+      forbidden: [OLD_CODENAME],
+    },
+    {
+      id: "post-delete-honest-miss",
+      response: forgottenRecall,
+      expected: [],
+      forbidden: [LOCKER_CODE],
+    },
+  ]);
+  if (score.kind === "invalid") return score.reason;
+  if (score.recall < 1 || score.precision < 1) {
+    return `memory recall quality missed the perfect lifecycle threshold: ${JSON.stringify(score)}`;
+  }
+  if (score.falsePositiveRate !== 0) {
+    return `memory recall produced a forbidden stale or deleted fact: ${JSON.stringify(score)}`;
+  }
+  return undefined;
+}
+
+export default scenario({
+  id: "live-memory-lifecycle-long-horizon",
+  lane: "live-only",
+  title:
+    "Memory survives a six-month horizon and supports correction plus forgetting",
+  domain: "scenario-runner",
+  tags: [
+    "live",
+    "real-llm",
+    "memory",
+    "long-horizon",
+    "crud",
+    "quality-metrics",
+  ],
+  isolation: "per-scenario",
+  now: "2026-08-25T12:00:00.000Z",
+  rooms: [
+    {
+      id: "main",
+      source: "chat",
+      channelType: "DM",
+      title: "Long-horizon memory lifecycle",
+    },
+  ],
+  seed: [
+    {
+      type: "custom",
+      name: "seed six-month-old targets behind 30 distractors",
+      apply: seedLongHorizonMemory,
+    },
+  ],
+  turns: [
+    {
+      kind: "message",
+      name: "recall an old fact through stored-memory search",
+      room: "main",
+      text: "What is my project codename? Search my stored memory before answering.",
+      responseIncludesAny: [OLD_CODENAME.toLowerCase()],
+      responseExcludes: [/kestrel/i],
+    },
+    {
+      kind: "message",
+      name: "correct and supersede the old fact",
+      room: "main",
+      text: `Replace the stored project-codename memory. It is ${NEW_CODENAME}, not ${OLD_CODENAME}. This is explicit confirmation to update it.`,
+    },
+    {
+      kind: "message",
+      name: "recall only the corrected fact",
+      room: "main",
+      text: "What is my current project codename? Search stored memory again.",
+      responseIncludesAny: [NEW_CODENAME.toLowerCase()],
+      responseExcludes: [new RegExp(OLD_CODENAME, "i")],
+    },
+    {
+      kind: "message",
+      name: "forget a specific stored fact",
+      room: "main",
+      text: `Forget my stored temporary locker code ${LOCKER_CODE}. I explicitly confirm deletion.`,
+    },
+    {
+      kind: "message",
+      name: "deleted fact stays unavailable",
+      room: "main",
+      text: "What was my temporary locker code? Search stored memory and be honest if it is gone.",
+      responseExcludes: [new RegExp(LOCKER_CODE)],
+    },
+  ],
+  finalChecks: [
+    {
+      type: "actionCalled",
+      actionName: "MEMORY_SEARCH",
+      status: "success",
+      minCount: 2,
+    },
+    {
+      type: "actionCalled",
+      actionName: "MEMORY_UPDATE",
+      status: "success",
+      minCount: 1,
+    },
+    {
+      type: "actionCalled",
+      actionName: "MEMORY_DELETE",
+      status: "success",
+      minCount: 1,
+    },
+    {
+      type: "custom",
+      name: "quantitative recall quality is perfect across lifecycle cases",
+      predicate: scoreLifecycle,
+    },
+  ],
+});

--- a/packages/scenario-runner/test/scenarios/live-planted-conversation-memory-horizon.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/live-planted-conversation-memory-horizon.scenario.ts
@@ -1,0 +1,195 @@
+/**
+ * Exercises recall from an Eliza-generated, runtime-ingested conversation corpus.
+ * The selected tier plants one target in the oldest conversation, adds three
+ * plausible decoys later in history, and recalls from a separate fresh room.
+ */
+
+import { asUUID } from "@elizaos/core";
+import type {
+  CapturedAction,
+  ScenarioContext,
+} from "@elizaos/scenario-runner/schema";
+import { scenario } from "@elizaos/scenario-runner/schema";
+import {
+  generateMessageCorpus,
+  seedMessageCorpus,
+} from "../../../agent/src/api/message-corpus";
+import {
+  memoryHorizonCorpusShape,
+  parseMemoryHorizonSize,
+} from "../../src/memory-horizon";
+import { scoreMemoryRecall } from "../../src/memory-recall-metrics";
+import { prepareOwnerMemoryRuntime } from "./_helpers/history-recall-runtime";
+
+const TARGET_FACT =
+  "The owner's archival project codename is Copper Heron 9184.";
+const TARGET_VALUE = "Copper Heron 9184";
+const DECOY_VALUES = [
+  "Bronze Heron 9184",
+  "Copper Egret 9184",
+  "Copper Heron 8194",
+] as const;
+
+const parsedHorizon = parseMemoryHorizonSize(
+  process.env.ELIZA_MEMORY_HORIZON_MESSAGES,
+);
+if (parsedHorizon.kind === "invalid") {
+  throw new Error(parsedHorizon.reason);
+}
+const MESSAGE_COUNT = parsedHorizon.size;
+
+function plantRecallCases(
+  corpus: ReturnType<typeof generateMessageCorpus>,
+): string | undefined {
+  const target = corpus.conversations[0]?.messages[0];
+  if (target?.role !== "user") {
+    return "generated corpus did not expose an oldest user message";
+  }
+  target.text = TARGET_FACT;
+
+  const decoyConversationIndexes = [3, 6, 9] as const;
+  for (const [index, conversationIndex] of decoyConversationIndexes.entries()) {
+    const decoy = corpus.conversations[conversationIndex]?.messages[0];
+    if (decoy?.role !== "user") {
+      return `generated corpus did not expose decoy user message ${conversationIndex}`;
+    }
+    decoy.text = `The owner's archival project codename is ${DECOY_VALUES[index]}.`;
+  }
+  return undefined;
+}
+
+async function seedPlantedConversationCorpus(
+  ctx: ScenarioContext,
+): Promise<string | undefined> {
+  const prepared = await prepareOwnerMemoryRuntime(ctx);
+  if (typeof prepared === "string") return prepared;
+  if (!ctx.primaryUserId) return "scenario owner identity was not available";
+
+  const corpus = generateMessageCorpus({
+    ...memoryHorizonCorpusShape(MESSAGE_COUNT),
+    spanMonths: 24,
+    factsPerConversation: 0,
+    seed: 9184,
+    now: new Date("2026-08-25T12:00:00.000Z").getTime(),
+  });
+  const plantFailure = plantRecallCases(corpus);
+  if (plantFailure) return plantFailure;
+
+  const summary = await seedMessageCorpus(prepared, corpus, {
+    ownerEntityId: asUUID(ctx.primaryUserId),
+  });
+  if (summary.messagesCreated !== MESSAGE_COUNT) {
+    return `expected ${MESSAGE_COUNT} planted messages, created ${summary.messagesCreated}`;
+  }
+  if (summary.factsCreated !== 0) {
+    return `expected no derived fact shortcuts, created ${summary.factsCreated}`;
+  }
+  return undefined;
+}
+
+function actionValues(call: CapturedAction): Record<string, unknown> | null {
+  const values = call.result?.values;
+  return isRecord(values) ? values : null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function validateHorizonEvidence(ctx: ScenarioContext): string | undefined {
+  const searches = ctx.actionsCalled.filter(
+    (call) => call.actionName === "MEMORY_SEARCH",
+  );
+  if (searches.length < 2) {
+    return `expected direct and live MEMORY_SEARCH calls, saw ${searches.length}`;
+  }
+  const directScanned = actionValues(searches[0])?.scanned;
+  if (typeof directScanned !== "number" || directScanned < MESSAGE_COUNT) {
+    return `direct search scanned ${String(directScanned)} rows, expected at least ${MESSAGE_COUNT} planted rows`;
+  }
+  const liveScanned = actionValues(searches.at(-1) ?? searches[0])?.scanned;
+  if (liveScanned !== directScanned + 1) {
+    return `live search scanned ${String(liveScanned)} rows, expected exactly one more than the direct scan of ${directScanned}`;
+  }
+
+  const response = ctx.turns?.[1]?.responseText ?? "";
+  const score = scoreMemoryRecall([
+    {
+      id: `${MESSAGE_COUNT}-message-live-recall`,
+      response,
+      expected: [TARGET_VALUE],
+      forbidden: [...DECOY_VALUES],
+    },
+  ]);
+  if (score.kind === "invalid") return score.reason;
+  if (
+    score.recall !== 1 ||
+    score.precision !== 1 ||
+    score.falsePositiveRate !== 0
+  ) {
+    return `recall quality failed at ${MESSAGE_COUNT} messages: ${JSON.stringify(score)}`;
+  }
+  return undefined;
+}
+
+export default scenario({
+  id: "live-planted-conversation-memory-horizon",
+  lane: "live-only",
+  title: "Recall from a graduated planted conversation corpus",
+  domain: "scenario-runner",
+  tags: ["live", "memory", "long-horizon", "planted-conversation", "scale"],
+  isolation: "per-scenario",
+  now: "2026-08-25T12:00:00.000Z",
+  rooms: [
+    {
+      id: "main",
+      source: "chat",
+      channelType: "DM",
+      title: "Fresh long-horizon recall room",
+    },
+  ],
+  seed: [
+    {
+      type: "custom",
+      name: "plant canonical runtime conversation corpus",
+      apply: seedPlantedConversationCorpus,
+    },
+  ],
+  turns: [
+    {
+      kind: "action",
+      name: "prove exhaustive direct retrieval before model recall",
+      text: "Search the planted conversation history for the exact archival project codename.",
+      actionName: "MEMORY_SEARCH",
+      options: {
+        parameters: {
+          action: "search",
+          type: "messages",
+          query: "archival project codename Copper Heron 9184",
+        },
+      },
+      responseIncludesAny: [TARGET_VALUE.toLowerCase()],
+    },
+    {
+      kind: "message",
+      name: "recall the oldest planted fact from a fresh room",
+      room: "main",
+      text: "What was the oldest archival project codename I told you? Search all stored conversation memory and use the stored timestamps before answering with only that oldest codename.",
+      responseIncludesAny: [TARGET_VALUE.toLowerCase()],
+      responseExcludes: DECOY_VALUES.map((value) => new RegExp(value, "i")),
+    },
+  ],
+  finalChecks: [
+    {
+      type: "actionCalled",
+      actionName: "MEMORY_SEARCH",
+      status: "success",
+      minCount: 2,
+    },
+    {
+      type: "custom",
+      name: "complete scan and perfect recall quality at selected horizon",
+      predicate: validateHorizonEvidence,
+    },
+  ],
+});

--- a/plugins/plugin-personal-assistant/test/helpers/lifeops-live-harness.ts
+++ b/plugins/plugin-personal-assistant/test/helpers/lifeops-live-harness.ts
@@ -593,6 +593,8 @@ async function waitForLiveRuntimeBootstrap(
 export async function startLifeOpsLiveRuntime(options?: {
   bootTimeoutMs?: number;
   selectedProvider?: SelectedLiveProvider | null;
+  runtimeRoot?: string;
+  removeRuntimeRootOnClose?: boolean;
 }): Promise<StartedLifeOpsLiveRuntime> {
   const selectedProvider =
     options?.selectedProvider ?? (await selectLifeOpsLiveProvider());
@@ -603,7 +605,10 @@ export async function startLifeOpsLiveRuntime(options?: {
     );
   }
 
-  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "eliza-lifeops-live-"));
+  const ownsRuntimeRoot = !options?.runtimeRoot;
+  const tempRoot =
+    options?.runtimeRoot ??
+    (await mkdtemp(path.join(os.tmpdir(), "eliza-lifeops-live-")));
   const stateDir = path.join(tempRoot, "state");
   const pgliteDir = path.join(tempRoot, "pglite");
   const configPath = path.join(tempRoot, "eliza.json");
@@ -653,6 +658,7 @@ export async function startLifeOpsLiveRuntime(options?: {
       ? (baseConfig.cloud as Record<string, unknown>)
       : {};
 
+  await mkdir(tempRoot, { recursive: true });
   await mkdir(stateDir, { recursive: true });
   await mkdir(pgliteDir, { recursive: true });
   await writeFile(
@@ -805,7 +811,9 @@ export async function startLifeOpsLiveRuntime(options?: {
       child.kill("SIGKILL");
       await waitForChildExit(child, 5_000);
     }
-    await rm(tempRoot, { recursive: true, force: true });
+    if (ownsRuntimeRoot || options?.removeRuntimeRootOnClose === true) {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
     throw new Error(
       `Live runtime failed to start: ${error instanceof Error ? error.message : String(error)}\n${logTail}`,
     );
@@ -824,7 +832,9 @@ export async function startLifeOpsLiveRuntime(options?: {
           await waitForChildExit(child, 5_000);
         }
       }
-      await rm(tempRoot, { recursive: true, force: true });
+      if (ownsRuntimeRoot || options?.removeRuntimeRootOnClose === true) {
+        await rm(tempRoot, { recursive: true, force: true });
+      }
     },
   };
 }

--- a/plugins/plugin-personal-assistant/test/memory-restart-chat.live.e2e.test.ts
+++ b/plugins/plugin-personal-assistant/test/memory-restart-chat.live.e2e.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Live chat proof that an explicitly stored owner memory survives a full child-process
+ * restart and remains recallable from a fresh conversation through the HTTP API.
+ */
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, expect, it } from "vitest";
+import { describeIf } from "../../../packages/app-core/test/helpers/conditional-tests.ts";
+import { createConversation } from "../../../packages/app-core/test/helpers/http";
+import {
+  assertNoProviderIssue,
+  LIVE_TESTS_ENABLED,
+  postLiveConversationMessageWithRecovery,
+  type StartedLifeOpsLiveRuntime,
+  selectLifeOpsLiveProvider,
+  startLifeOpsLiveRuntime,
+} from "./helpers/lifeops-live-harness";
+
+const selectedProvider = await selectLifeOpsLiveProvider();
+const suiteEnabled = LIVE_TESTS_ENABLED && selectedProvider !== null;
+let runtimeRoot: string | undefined;
+let runtime: StartedLifeOpsLiveRuntime | undefined;
+
+describeIf(suiteEnabled)("Live: chat memory across process restart", () => {
+  afterAll(async () => {
+    await runtime?.close();
+    if (runtimeRoot) {
+      await rm(runtimeRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("recalls an explicit memory after stopping and rebuilding the runtime", async () => {
+    runtimeRoot = await mkdtemp(
+      path.join(os.tmpdir(), "eliza-memory-chat-restart-"),
+    );
+    runtime = await startLifeOpsLiveRuntime({
+      selectedProvider,
+      runtimeRoot,
+    });
+    const before = await createConversation(runtime.port, {
+      title: "Memory before restart",
+    });
+    const storePrompt =
+      "Remember this exact durable phrase for after a restart: violet comet 4826.";
+    const stored = await postLiveConversationMessageWithRecovery(
+      runtime,
+      before.conversationId,
+      storePrompt,
+      "store durable restart phrase",
+    );
+    assertNoProviderIssue("store durable restart phrase", stored, runtime);
+    await runtime.close();
+    runtime = undefined;
+
+    runtime = await startLifeOpsLiveRuntime({
+      selectedProvider,
+      runtimeRoot,
+    });
+    const after = await createConversation(runtime.port, {
+      title: "Memory after restart",
+    });
+    const recalled = await postLiveConversationMessageWithRecovery(
+      runtime,
+      after.conversationId,
+      "What exact durable phrase did I ask you to remember before the restart? Search stored memory.",
+      "recall durable restart phrase",
+    );
+    assertNoProviderIssue("recall durable restart phrase", recalled, runtime);
+    expect(recalled.toLowerCase()).toContain("violet comet 4826");
+  }, 600_000);
+});

--- a/plugins/plugin-sql/src/__tests__/integration/memory-restart.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/memory-restart.real.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Real PGlite restart coverage for durable memory lifecycle behavior.
+ * The test closes every database object, opens the same on-disk database through
+ * a fresh manager and adapter, then verifies read, update, and delete behavior.
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  ChannelType,
+  type Entity,
+  type Memory,
+  MemoryType,
+  type Room,
+  type UUID,
+  type World,
+} from "@elizaos/core";
+import { v4 } from "uuid";
+import { afterEach, describe, expect, it } from "vitest";
+import { plugin as sqlPlugin } from "../../index";
+import { DatabaseMigrationService } from "../../migration-service";
+import { PgliteDatabaseAdapter } from "../../pglite/adapter";
+import { PGliteClientManager } from "../../pglite/manager";
+import type { DrizzleDatabase } from "../../types";
+
+const tempDirectories: string[] = [];
+
+async function openDatabase(dataDir: string, agentId: UUID) {
+  const manager = new PGliteClientManager({ dataDir });
+  await manager.initialize();
+  const adapter = new PgliteDatabaseAdapter(agentId, manager);
+  await adapter.init();
+  return { adapter, manager };
+}
+
+describe("durable memory restart lifecycle", () => {
+  afterEach(() => {
+    for (const directory of tempDirectories.splice(0)) {
+      fs.rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("recalls, updates, and forgets a fact through fresh database processes", async () => {
+    const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-memory-restart-"));
+    tempDirectories.push(dataDir);
+    const agentId = v4() as UUID;
+    const ownerId = v4() as UUID;
+    const worldId = v4() as UUID;
+    const serverId = v4() as UUID;
+    const roomId = v4() as UUID;
+    const memoryId = v4() as UUID;
+
+    const first = await openDatabase(dataDir, agentId);
+    const migrations = new DatabaseMigrationService();
+    await migrations.initializeWithDatabase(first.adapter.getDatabase() as DrizzleDatabase);
+    migrations.discoverAndRegisterPluginSchemas([sqlPlugin]);
+    await migrations.runAllPluginMigrations();
+    await first.adapter.createAgent({
+      id: agentId,
+      name: "Memory restart evaluator",
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+    await first.adapter.createWorld({
+      id: worldId,
+      agentId,
+      name: "Private owner world",
+      serverId,
+    } satisfies World);
+    await first.adapter.createRooms([
+      {
+        id: roomId,
+        agentId,
+        worldId,
+        name: "Owner DM",
+        source: "test",
+        type: ChannelType.DM,
+      } satisfies Room,
+    ]);
+    await first.adapter.createEntities([
+      {
+        id: ownerId,
+        agentId,
+        names: ["Owner"],
+      } satisfies Entity,
+    ]);
+    await first.adapter.addParticipant(ownerId, roomId);
+    await first.adapter.createMemory(
+      {
+        id: memoryId,
+        agentId,
+        entityId: ownerId,
+        roomId,
+        content: {
+          text: "The durable restart codename is Kingfisher.",
+          source: "memory-restart-eval",
+        },
+        metadata: {
+          type: MemoryType.CUSTOM,
+          source: "memory-restart-eval",
+        },
+        createdAt: Date.now(),
+        unique: false,
+      } satisfies Memory,
+      "facts"
+    );
+    await first.adapter.close();
+
+    const second = await openDatabase(dataDir, agentId);
+    const afterRestart = await second.adapter.getMemoryById(memoryId);
+    expect(afterRestart?.content.text).toBe("The durable restart codename is Kingfisher.");
+    await second.adapter.updateMemories([
+      {
+        id: memoryId,
+        content: {
+          text: "The durable restart codename is Nightjar.",
+          source: "memory-restart-eval",
+        },
+      },
+    ]);
+    await second.adapter.close();
+
+    const third = await openDatabase(dataDir, agentId);
+    expect((await third.adapter.getMemoryById(memoryId))?.content.text).toBe(
+      "The durable restart codename is Nightjar."
+    );
+    await third.adapter.deleteMemory(memoryId);
+    await third.adapter.close();
+
+    const fourth = await openDatabase(dataDir, agentId);
+    expect(await fourth.adapter.getMemoryById(memoryId)).toBeNull();
+    await fourth.adapter.close();
+  });
+});


### PR DESCRIPTION
# Relates to

Operator-requested validation of elizaOS long-horizon memory CRUD, restart persistence, and recall. Follow-up fix: #28521.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync. The unrelated root failure is recorded below.
- [x] A reviewer can confirm the change works without reading the code from the evidence below.

# Sync with develop

- [x] Rebased onto `43b4e75fc64b1baa573c36d820ff8dbb6bf8c7b9`; zero conflicts.
- [x] `bun run verify` ran post-sync. Its unrelated `packages/ui` stale generated inventory failure is documented below.

# Risks

Medium. The MEMORY action now supports requester-scoped query updates and relevance-first search ordering, and search output includes record timestamps. The evaluation additions exercise real SQL persistence and live model routing but do not change retention policy or silently cap context.

# Background

## What does this PR do?

- Fixes text-only MEMORY_UPDATE requests and requester-scoped query updates.
- Traverses complete memory tables for search and destructive lookup instead of the former bounded window.
- Ranks exact all-term matches before newer partial decoys and includes timestamps in search evidence.
- Adds real PGlite restart CRUD coverage and a child-process live-chat restart test.
- Adds live lifecycle and graduated 500, 1,000, 5,000, and 10,000 planted-conversation evaluations through the canonical runtime corpus seeder.
- Adds recall, precision, and false-positive metrics plus a matrix CLI that continues through failed tiers.

## What kind of change is this?

Bug fixes and test/evaluation improvements.

# Documentation changes needed?

No user documentation changes. The new evaluator is exposed as `bun run --cwd packages/scenario-runner eval:memory-horizon`.

# Testing

## Where should a reviewer start?

Start with `packages/scenario-runner/test/scenarios/live-planted-conversation-memory-horizon.scenario.ts`, then inspect `packages/agent/src/actions/memories.ts` and the real PGlite restart test.

## Detailed testing steps

```bash
bun x vitest run packages/agent/src/actions/memories.test.ts packages/agent/src/api/message-corpus.test.ts
bun test packages/scenario-runner/src/memory-horizon.test.ts packages/scenario-runner/src/memory-recall-metrics.test.ts
bun x vitest run --config plugins/plugin-sql/src/vitest.real.config.ts plugins/plugin-sql/src/__tests__/integration/memory-restart.real.test.ts
bun run --cwd packages/agent typecheck
bun run --cwd packages/scenario-runner typecheck
bun run --cwd plugins/plugin-sql typecheck
ELIZA_CHAT_VIA_CLI=codex-sdk ELIZA_CLI_CODEX_BIN=/Users/studio/.local/bin/codex ELIZA_CLI_CODEX_REASONING_EFFORT=low SCENARIO_TURN_TIMEOUT_MS=600000 bun run --cwd packages/scenario-runner eval:memory-horizon -- --sizes=500,1000,5000,10000 --provider=cli
```

# Evidence Gate

<!-- evidence-head:4eee9727e316748bce73243f83daeb3e1c621bc6 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - the changed path is a headless runtime evaluator.
<!-- evidence-row:backend-logs -->
- [x] Real runtime results are included below.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path changed.
<!-- evidence-row:llm-trajectory -->
- [x] Real Codex-backed scenario run IDs and observed outputs are included below.
<!-- evidence-row:domain-artifacts -->
- [x] Complete memory scan counts and restart CRUD results are included below.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual surface changed.

# Evidence Details

## Real LLM-call trajectory

Provider: Codex CLI through `@openai/codex-sdk`. Client: Codex. Reasoning effort: low.

| Planted messages | Run ID | Runtime scan | Final response | Result |
| ---: | --- | ---: | --- | --- |
| 500 | `5f4161d8-f4d7-4dea-91e4-5afeeb3c5b2e` | 508 then 509 | `Copper Heron 9184` | passed |
| 1,000 | `ad371956-228b-4c74-ac61-8d22aca26100` | 1,008 then 1,009 | `Copper Heron 9184` | passed |
| 5,000 | `e7e6672d-34aa-49b8-a904-73f7d932d738` | 5,008 | provider rejected complete context | retrieval passed, chat failed |
| 10,000 | `41599c21-a72f-4042-9b23-0c28fe531fdd` | 10,008 | `actual_chars=1225088`, `max_chars=1048576` | retrieval passed, chat failed |

The 5K and 10K failures are retained as honest evidence. `recent-conversations` rendered the complete authorized cross-room transcript before MEMORY_SEARCH could narrow it. No truncation or fabricated pass occurred.

## Backend + frontend logs

<details><summary>Focused exact-head results</summary>

```text
Agent memories and corpus: 38 passed
Memory horizon and metrics: 12 passed
Real PGlite restart lifecycle: 1 passed
Agent typecheck: passed
Scenario-runner typecheck: passed
plugin-sql typecheck: passed
PGlite restart: create -> close -> reopen/read -> update -> close -> reopen/delete -> close -> reopen/null
```

</details>

Frontend logs: N/A - no frontend code or transport changed.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no audio, voice, transcription, TTS, or STT change.

## Known gaps / failures

- `bun run verify` fails in the untouched `packages/ui` workspace because `duplicate-molecular-components-report.md` is stale. This branch changes no `packages/ui` file.
- Direct `plugins/plugin-personal-assistant` typecheck reports missing `@elizaos/native-activity-tracker` and `@elizaos/capacitor-mobile-signals` declarations before reaching the changed test helper. Root Turbo resolves/builds those workspaces, then fails later at the unrelated UI inventory gate.
- Full chat recall passes at 500 and 1,000 planted messages. Complete storage traversal still passes at 5,000 and 10,000, but Codex-backed chat fails because eager cross-room history exceeds the model context. This PR intentionally exposes that bottleneck rather than claiming it fixed.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
