### PR TITLE
fix(shared): isTimeoutError recognize POSIX and fetch timeout error codes

### DIFF
--- a/packages/shared/src/utils/errors.test.ts
+++ b/packages/shared/src/utils/errors.test.ts
@@ -6,14 +6,22 @@ import { describe, expect, it } from "vitest";
 import { errorMessage, isRedirectResponse, isTimeoutError } from "./errors";
 
 describe("isTimeoutError", () => {
-  it("identifies standard TimeoutError and AbortError instances", () => {
+  it("identifies standard TimeoutError instances and distinguishes from AbortError", () => {
     const timeoutErr = new Error("Gateway timeout");
     timeoutErr.name = "TimeoutError";
     expect(isTimeoutError(timeoutErr)).toBe(true);
 
+    const domTimeout = new DOMException("deadline", "TimeoutError");
+    expect(isTimeoutError(domTimeout)).toBe(true);
+
     const abortErr = new Error("The operation was aborted");
     abortErr.name = "AbortError";
-    expect(isTimeoutError(abortErr)).toBe(true);
+    expect(isTimeoutError(abortErr)).toBe(false);
+
+    const domAbort = new DOMException("caller canceled", "AbortError");
+    expect(isTimeoutError(domAbort)).toBe(false);
+
+    expect(isTimeoutError({ code: "ABORT_ERR" })).toBe(false);
   });
 
   it("identifies timeout keywords in Error message", () => {
@@ -34,24 +42,60 @@ describe("isTimeoutError", () => {
 
   it("identifies duck-typed error objects", () => {
     expect(isTimeoutError({ name: "TimeoutError" })).toBe(true);
-    expect(isTimeoutError({ name: "AbortError" })).toBe(true);
+    expect(isTimeoutError({ name: "AbortError" })).toBe(false);
     expect(isTimeoutError({ message: "Socket timed out" })).toBe(true);
     expect(isTimeoutError({ message: "Invalid payload" })).toBe(false);
   });
 
-  it("identifies error code properties (ETIMEDOUT, ESOCKETTIMEDOUT, etc.)", () => {
+  it("identifies direct and Undici timeout codes (ETIMEDOUT, UND_ERR_BODY_TIMEOUT, etc.)", () => {
     const etimedout = Object.assign(new Error("Connection failed"), {
       code: "ETIMEDOUT",
     });
     expect(isTimeoutError(etimedout)).toBe(true);
 
-    const undConnect = Object.assign(new Error("Headers failed"), {
+    const undConnect = Object.assign(new Error("Connect failed"), {
       code: "UND_ERR_CONNECT_TIMEOUT",
     });
     expect(isTimeoutError(undConnect)).toBe(true);
 
+    const undHeaders = Object.assign(new Error("Headers failed"), {
+      code: "UND_ERR_HEADERS_TIMEOUT",
+    });
+    expect(isTimeoutError(undHeaders)).toBe(true);
+
+    const undBody = Object.assign(new Error("Body failed"), {
+      code: "UND_ERR_BODY_TIMEOUT",
+    });
+    expect(isTimeoutError(undBody)).toBe(true);
+
     expect(isTimeoutError({ code: "ESOCKETTIMEDOUT" })).toBe(true);
     expect(isTimeoutError({ code: "ECONNREFUSED" })).toBe(false);
+  });
+
+  it("follows wrapped cause chains and safely handles cyclic error graphs", () => {
+    const wrappedFetch = new TypeError("fetch failed", {
+      cause: Object.assign(new Error("Connect timed out"), {
+        code: "UND_ERR_CONNECT_TIMEOUT",
+      }),
+    });
+    expect(isTimeoutError(wrappedFetch)).toBe(true);
+
+    const wrappedDom = new Error("Request failed", {
+      cause: new DOMException("deadline elapsed", "TimeoutError"),
+    });
+    expect(isTimeoutError(wrappedDom)).toBe(true);
+
+    // Cyclic cause graph
+    const cyclic: Record<string, unknown> = new Error("Generic failure");
+    cyclic.cause = cyclic;
+    expect(isTimeoutError(cyclic)).toBe(false);
+
+    const cyclicWithTimeout: Record<string, unknown> = new Error("Outer error");
+    cyclicWithTimeout.cause = {
+      code: "ETIMEDOUT",
+      cause: cyclicWithTimeout,
+    };
+    expect(isTimeoutError(cyclicWithTimeout)).toBe(true);
   });
 
   it("returns false for null, undefined, and non-timeout values", () => {

--- a/packages/shared/src/utils/errors.test.ts
+++ b/packages/shared/src/utils/errors.test.ts
@@ -39,6 +39,21 @@ describe("isTimeoutError", () => {
     expect(isTimeoutError({ message: "Invalid payload" })).toBe(false);
   });
 
+  it("identifies error code properties (ETIMEDOUT, ESOCKETTIMEDOUT, etc.)", () => {
+    const etimedout = Object.assign(new Error("Connection failed"), {
+      code: "ETIMEDOUT",
+    });
+    expect(isTimeoutError(etimedout)).toBe(true);
+
+    const undConnect = Object.assign(new Error("Headers failed"), {
+      code: "UND_ERR_CONNECT_TIMEOUT",
+    });
+    expect(isTimeoutError(undConnect)).toBe(true);
+
+    expect(isTimeoutError({ code: "ESOCKETTIMEDOUT" })).toBe(true);
+    expect(isTimeoutError({ code: "ECONNREFUSED" })).toBe(false);
+  });
+
   it("returns false for null, undefined, and non-timeout values", () => {
     expect(isTimeoutError(null)).toBe(false);
     expect(isTimeoutError(undefined)).toBe(false);

--- a/packages/shared/src/utils/errors.ts
+++ b/packages/shared/src/utils/errors.ts
@@ -7,18 +7,40 @@
 
 import { formatError } from "@elizaos/core";
 
+const TIMEOUT_CODES = new Set([
+  "ETIMEDOUT",
+  "ESOCKETTIMEDOUT",
+  "UND_ERR_CONNECT_TIMEOUT",
+  "UND_ERR_HEADERS_TIMEOUT",
+  "ABORT_ERR",
+]);
+
 /** Classify an error as a fetch/AbortSignal timeout. */
 export function isTimeoutError(error: unknown): boolean {
   if (!error) return false;
   if (error instanceof Error) {
     if (error.name === "TimeoutError" || error.name === "AbortError")
       return true;
+    const code = (error as { code?: unknown }).code;
+    if (typeof code === "string" && TIMEOUT_CODES.has(code)) {
+      return true;
+    }
     const msg = error.message.toLowerCase();
     return msg.includes("timed out") || msg.includes("timeout");
   }
   if (typeof error === "object") {
-    const candidate = error as { name?: unknown; message?: unknown };
+    const candidate = error as {
+      name?: unknown;
+      message?: unknown;
+      code?: unknown;
+    };
     if (candidate.name === "TimeoutError" || candidate.name === "AbortError") {
+      return true;
+    }
+    if (
+      typeof candidate.code === "string" &&
+      TIMEOUT_CODES.has(candidate.code)
+    ) {
       return true;
     }
     if (typeof candidate.message === "string") {

--- a/packages/shared/src/utils/errors.ts
+++ b/packages/shared/src/utils/errors.ts
@@ -12,20 +12,15 @@ const TIMEOUT_CODES = new Set([
   "ESOCKETTIMEDOUT",
   "UND_ERR_CONNECT_TIMEOUT",
   "UND_ERR_HEADERS_TIMEOUT",
-  "ABORT_ERR",
+  "UND_ERR_BODY_TIMEOUT",
 ]);
 
-/** Classify an error as a fetch/AbortSignal timeout. */
-export function isTimeoutError(error: unknown): boolean {
+const MAX_CAUSE_DEPTH = 10;
+
+function checkDirectTimeout(error: unknown): boolean {
   if (!error) return false;
-  if (error instanceof Error) {
-    if (error.name === "TimeoutError" || error.name === "AbortError")
-      return true;
-    const code = (error as { code?: unknown }).code;
-    if (typeof code === "string" && TIMEOUT_CODES.has(code)) {
-      return true;
-    }
-    const msg = error.message.toLowerCase();
+  if (typeof error === "string") {
+    const msg = error.toLowerCase();
     return msg.includes("timed out") || msg.includes("timeout");
   }
   if (typeof error === "object") {
@@ -34,7 +29,7 @@ export function isTimeoutError(error: unknown): boolean {
       message?: unknown;
       code?: unknown;
     };
-    if (candidate.name === "TimeoutError" || candidate.name === "AbortError") {
+    if (candidate.name === "TimeoutError") {
       return true;
     }
     if (
@@ -45,13 +40,41 @@ export function isTimeoutError(error: unknown): boolean {
     }
     if (typeof candidate.message === "string") {
       const msg = candidate.message.toLowerCase();
-      return msg.includes("timed out") || msg.includes("timeout");
+      if (msg.includes("timed out") || msg.includes("timeout")) {
+        return true;
+      }
     }
   }
-  if (typeof error === "string") {
-    const msg = error.toLowerCase();
-    return msg.includes("timed out") || msg.includes("timeout");
+  return false;
+}
+
+/** Classify an error as a fetch/AbortSignal/network timeout. */
+export function isTimeoutError(error: unknown): boolean {
+  if (!error) return false;
+  let current: unknown = error;
+  const visited = new Set<unknown>();
+  let depth = 0;
+
+  while (current && typeof current === "object" && depth < MAX_CAUSE_DEPTH) {
+    if (visited.has(current)) break;
+    visited.add(current);
+
+    if (checkDirectTimeout(current)) {
+      return true;
+    }
+
+    if ("cause" in current) {
+      current = (current as { cause?: unknown }).cause;
+      depth++;
+    } else {
+      break;
+    }
   }
+
+  if (typeof current === "string") {
+    return checkDirectTimeout(current);
+  }
+
   return false;
 }
 


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Closes #28523

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low risk. Confined to `isTimeoutError` in `packages/shared/src/utils/errors.ts`.

# Background

## What does this PR do?
`isTimeoutError` recognizes standard POSIX and Undici timeout error codes (`ETIMEDOUT`, `ESOCKETTIMEDOUT`, `UND_ERR_CONNECT_TIMEOUT`, `UND_ERR_HEADERS_TIMEOUT`, `UND_ERR_BODY_TIMEOUT`), distinguishes `TimeoutError` from generic `AbortError`/`ABORT_ERR` cancellations, and traverses wrapped `.cause` chains with cycle safety.

## What kind of change is this?
Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?
My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?
Review `packages/shared/src/utils/errors.ts` and unit tests in `packages/shared/src/utils/errors.test.ts`.

## Detailed testing steps
Run:
```bash
bun test packages/shared/src/utils/errors.test.ts
bun run --cwd packages/shared typecheck
```

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:49a2907edda7fa4ba10eb1006509f6e62a8fc522 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots: N/A - Shared error utility change.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots: N/A - Shared error utility change.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough: N/A - Shared error utility change.
<!-- evidence-row:backend-logs -->
- [x] Backend logs:
<details>
<summary>bun test packages/shared/src/utils/errors.test.ts output</summary>

```
 11 pass
 0 fail
 46 expect() calls
Ran 11 tests across 1 file. [880.00ms]
```
</details>
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs: N/A - Shared utility without frontend execution.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory: N/A - Deterministic error classifier.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts: N/A - In-memory data structures without persistent storage.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review: N/A - No UI rendered.

# Known gaps / failures
None.

# Maintainer CI exception record
N/A - no exception requested

---

AI provider/model: Google / Gemini 3.7 Flash
Client / agent tooling: Antigravity
Contribution skill revision: elizaOS/eliza@7d55350499b702ec4c979c3dcb6bb5e56d482939:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [antigravity-contrib]
<!-- eliza-computer-attribution:v1 {"provider":"google","model":"gemini-3.7-flash","client":"Antigravity","skill_revision":"elizaOS/eliza@7d55350499b702ec4c979c3dcb6bb5e56d482939:packages/skills/skills/contribute-to-eliza"} -->