### PR TITLE
fix(cli): reject unsupported --language for single-language create templates

### DIFF
--- a/packages/elizaos/src/commands/create.test.ts
+++ b/packages/elizaos/src/commands/create.test.ts
@@ -66,6 +66,7 @@ vi.mock("../scaffold.js", () => ({
 
 describe("create command", () => {
   afterEach(() => {
+    vi.clearAllMocks();
     vi.restoreAllMocks();
   });
 
@@ -109,5 +110,26 @@ describe("create command", () => {
     expect(buildPluginTemplateValues).toHaveBeenCalledWith(
       expect.objectContaining({ elizaVersion: "test-version" }),
     );
+  });
+
+  it("rejects unsupported explicit language options for single-language templates", async () => {
+    const exit = vi.spyOn(process, "exit").mockImplementation((code) => {
+      throw new Error(`exit:${code}`);
+    });
+
+    await expect(
+      create("proof", {
+        language: "python",
+        skipUpstream: true,
+        template: "project",
+        yes: true,
+      }),
+    ).rejects.toThrow("exit:1");
+
+    expect(clack.cancel).toHaveBeenCalledWith(
+      "Template 'Project' does not support language 'python'.",
+    );
+    expect(renderTemplateTree).not.toHaveBeenCalled();
+    expect(exit).toHaveBeenCalledWith(1);
   });
 });

--- a/packages/elizaos/src/commands/create.ts
+++ b/packages/elizaos/src/commands/create.ts
@@ -99,10 +99,10 @@ async function promptLanguage(
 ): Promise<string | undefined> {
   const template = getTemplateById(templateId);
   if (!template) return undefined;
+  if (initial) return initial;
   if (template.languages.length <= 1) {
     return template.languages[0];
   }
-  if (initial) return initial;
 
   const choice = await clack.select({
     message: "Select a language:",


### PR DESCRIPTION
# Relates to

Closes #28395

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. This change only ensures explicit `--language` options are validated before defaulting to a single template language in `packages/elizaos/src/commands/create.ts`.

# Background

## What does this PR do?

Validates explicit `--language` option in `promptLanguage` before falling back to the template's single supported language. When an unsupported language (e.g. `--language python`) is passed for a single-language template, `promptLanguage` returns the requested language so the subsequent compatibility check catches it, cancels the operation, and exits with code 1 without rendering a project destination.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

- `packages/elizaos/src/commands/create.ts`
- `packages/elizaos/src/commands/create.test.ts`

## Detailed testing steps

Automated unit tests in Vitest:
`vitest run packages/elizaos/src/commands/create.test.ts`

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:09baed6506186324af8c4ee73efa91183103b13f -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only change with no rendered UI surface
<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only change with no rendered UI surface
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - test-only change has no user flow to record
<!-- evidence-row:backend-logs -->
- [ ] N/A - pure unit test does not exercise a server path
<!-- evidence-row:frontend-logs -->
- [ ] N/A - pure unit test does not exercise a browser path
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent model or prompt path is touched
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database rows or generated files produced
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface in this change

# Evidence Details

## Real LLM-call trajectory

N/A - no agent model or prompt path is touched

## Backend + frontend logs

```
RED (unpatched promptLanguage silently defaulted to typescript when python requested):
  AssertionError: promise resolved "undefined" instead of rejecting
  3 tests | 1 failed (create.test.ts)

GREEN (patched promptLanguage validates initial language option first):
  3 passed (3) (create.test.ts)
```

## Screenshots (before / after) + video walkthrough

N/A - CLI command with no visual surface

## Audio / voice walkthrough

N/A - no audio/voice path touched

## Known gaps / failures

None

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: Claude Code
— [lane-byt61-6832]

