### PR TITLE
feat(core): formatRelativeTime and formatTimestamp accept Date and ISO string inputs

### DIFF
--- a/packages/core/src/utils/time-format.test.ts
+++ b/packages/core/src/utils/time-format.test.ts
@@ -86,6 +86,17 @@ describe("formatRelativeTime (compact)", () => {
 		expect(formatRelativeTime(NOW + 6 * DAY + 1)).toBe("in 7d");
 		expect(formatRelativeTime(NOW + 7 * DAY - 1)).toBe("in 7d");
 	});
+
+	it("formats Date instances and ISO string representations", () => {
+		expect(formatRelativeTime(new Date(NOW - 5 * MINUTE))).toBe("5m ago");
+		expect(formatRelativeTime(new Date(NOW - 5 * MINUTE).toISOString())).toBe(
+			"5m ago",
+		);
+		expect(formatTimestamp(new Date(NOW - HOUR))).toBe("1 hour ago");
+		expect(formatTimestamp(new Date(NOW - HOUR).toISOString())).toBe(
+			"1 hour ago",
+		);
+	});
 });
 
 describe("formatTimestamp (verbose)", () => {

--- a/packages/core/src/utils/time-format.ts
+++ b/packages/core/src/utils/time-format.ts
@@ -1,10 +1,21 @@
 /** Formats durations and timestamps for human-readable display. */
 
 function describeRelativeTime(
-	timestamp: number,
+	timestamp: number | string | Date,
 	style: "compact" | "verbose",
 ): string {
-	if (typeof timestamp !== "number" || !Number.isFinite(timestamp)) {
+	let rawMs: number;
+	if (timestamp instanceof Date) {
+		rawMs = timestamp.getTime();
+	} else if (typeof timestamp === "string") {
+		rawMs = new Date(timestamp).getTime();
+	} else if (typeof timestamp === "number") {
+		rawMs = timestamp;
+	} else {
+		return "just now";
+	}
+
+	if (!Number.isFinite(rawMs)) {
 		return "just now";
 	}
 
@@ -13,7 +24,7 @@ function describeRelativeTime(
 	// values outside the ±8.64e15 Date range (which still pass
 	// Number.isFinite but yield "Invalid Date" from toLocaleDateString or
 	// absurd multi-million-day relative strings).
-	const time = new Date(timestamp).getTime();
+	const time = new Date(rawMs).getTime();
 	if (!Number.isFinite(time)) {
 		return "just now";
 	}
@@ -100,13 +111,13 @@ function describeRelativeTime(
  * formatRelativeTime(Date.now() - 604800000) // => "Jan 15" (or similar)
  * ```
  */
-export function formatRelativeTime(timestamp: number): string {
+export function formatRelativeTime(timestamp: number | string | Date): string {
 	return describeRelativeTime(timestamp, "compact");
 }
 
 /**
  * Format a timestamp as a verbose relative string.
  */
-export function formatTimestamp(timestamp: number): string {
+export function formatTimestamp(timestamp: number | string | Date): string {
 	return describeRelativeTime(timestamp, "verbose");
 }


### PR DESCRIPTION
## Summary
Closes #28528

Expands `formatRelativeTime` and `formatTimestamp` in `packages/core/src/utils/time-format.ts` to accept polymorphic timestamp inputs (`number | string | Date`), aligning with `@elizaos/shared` and UI date formatting conventions.

## Problem & Motivation
In `packages/core/src/utils/time-format.ts`, `describeRelativeTime` previously performed a strict `typeof timestamp !== "number"` check. When callers across agent runtime logging, task status messages, or UI adapters passed a JavaScript `Date` object or an ISO 8601 string timestamp, the function rejected the input and defaulted to `"just now"`.

## Changes
- Updated `describeRelativeTime`, `formatRelativeTime`, and `formatTimestamp` signatures to accept `number | string | Date`.
- Normalized `Date` instances via `.getTime()` and parse string timestamps via `new Date(timestamp).getTime()`.
- Maintained strict fail-closed handling for non-finite / invalid dates, returning `"just now"`.
- Added unit test cases in `packages/core/src/utils/time-format.test.ts` testing `Date` instances and ISO 8601 strings.

## Validation & Test Coverage
- Executed `bun run --cwd packages/core test src/utils/time-format.test.ts` (16 passing tests).
- Executed `bun run --cwd packages/core typecheck` (zero TypeScript errors).

## Evidence

<!-- evidence-table -->

| Evidence | Source / link / artifact | Review notes |
| --- | --- | --- |
| before-screenshots | N/A - pure utility function | Relative time formatting helper |
| after-screenshots | N/A - pure utility function | Relative time formatting helper |
| walkthrough-video | N/A - pure utility function | No dynamic UI interaction involved |
| backend-logs | N/A - pure utility function | No runtime backend logging changes |
| frontend-logs | N/A - pure utility function | Formatter verified via unit test suite |
| llm-trajectory | N/A - pure utility function | No LLM interaction required |
| domain-artifacts | N/A - pure utility function | No persistent tables modified |
| ocr-review | N/A - pure utility function | Pure time string format utility |

<!-- /evidence-table -->

<!-- evidence-head:9772b100e94a0037588e5ea61b8a2b403bcab05b -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - pure utility function

<!-- evidence-row:after-screenshots -->
- [ ] N/A - pure utility function

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - pure utility function

<!-- evidence-row:backend-logs -->
- [ ] N/A - pure utility function

<!-- evidence-row:frontend-logs -->
- [ ] N/A - pure utility function

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - pure utility function

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - pure utility function

<!-- evidence-row:ocr-review -->
- [ ] N/A - pure utility function
