### PR TITLE
test(plugin-agent-skills): cover extractBody and generateSkillsJson helpers

### DIFF
--- a/plugins/plugin-agent-skills/src/parser.extract.test.ts
+++ b/plugins/plugin-agent-skills/src/parser.extract.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Covers parser helpers extractBody and generateSkillsJson.
+ * extractBody delegates to parseFrontmatter; generateSkillsJson builds the
+ * availableSkills prompt JSON with optional location.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { extractBody, generateSkillsJson } from "./parser.ts";
+
+describe("extractBody", () => {
+  it("returns body when frontmatter present", () => {
+    const content = ["---", "name: s", "description: d", "---", "", "# Body here"].join("\n");
+    expect(extractBody(content)).toBe("# Body here");
+  });
+
+  it("returns full content when no frontmatter", () => {
+    expect(extractBody("# just body")).toBe("# just body");
+    expect(extractBody("")).toBe("");
+  });
+
+  it("trims body and handles CRLF frontmatter", () => {
+    const crlf = ["---", "name: s", "description: d", "---", "", "Body"].join("\r\n");
+    expect(extractBody(crlf)).toBe("Body");
+  });
+
+  it("returns empty when body is empty after frontmatter", () => {
+    const content = ["---", "name: s", "description: d", "---", ""].join("\n");
+    expect(extractBody(content)).toBe("");
+  });
+
+  it("handles mixed line endings and preserves body newlines", () => {
+    const content = "---\r\nname: s\r\ndescription: d\r\n---\n\nLine1\nLine2";
+    expect(extractBody(content)).toBe("Line1\nLine2");
+  });
+});
+
+describe("generateSkillsJson", () => {
+  it("returns empty string for empty skills", () => {
+    expect(generateSkillsJson([])).toBe("");
+    expect(generateSkillsJson([], { includeLocation: true })).toBe("");
+  });
+
+  it("serializes single skill without location by default", () => {
+    const json = generateSkillsJson([{ name: "a", description: "desc" }]);
+    expect(JSON.parse(json)).toEqual({ availableSkills: [{ name: "a", description: "desc" }] });
+  });
+
+  it("includes location only when requested and present", () => {
+    const skills = [{ name: "a", description: "d", location: "/x/SKILL.md" }];
+    expect(JSON.parse(generateSkillsJson(skills))).toEqual({ availableSkills: [{ name: "a", description: "d" }] });
+    expect(JSON.parse(generateSkillsJson(skills, { includeLocation: true }))).toEqual({
+      availableSkills: [{ name: "a", description: "d", location: "/x/SKILL.md" }],
+    });
+  });
+
+  it("omits location when skill has no location even if requested", () => {
+    const json = generateSkillsJson([{ name: "a", description: "d" }], { includeLocation: true });
+    expect(JSON.parse(json)).toEqual({ availableSkills: [{ name: "a", description: "d" }] });
+  });
+
+  it("handles multiple skills", () => {
+    const skills = [
+      { name: "a", description: "da", location: "/a" },
+      { name: "b", description: "db", location: "/b" },
+    ];
+    const parsed = JSON.parse(generateSkillsJson(skills, { includeLocation: true }));
+    expect(parsed.availableSkills).toHaveLength(2);
+    expect(parsed.availableSkills[0]).toEqual({ name: "a", description: "da", location: "/a" });
+    expect(parsed.availableSkills[1]).toEqual({ name: "b", description: "db", location: "/b" });
+  });
+
+  it("produces valid JSON for any input", () => {
+    const json = generateSkillsJson([{ name: "x", description: "y" }]);
+    expect(() => JSON.parse(json)).not.toThrow();
+  });
+});


### PR DESCRIPTION
# Relates to

N/A - unsourced test coverage for parser extract helpers with no prior dedicated suite.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low - additive test-only, no production code.

# Background

## What does this PR do?

Adds 11 behavioral tests for two pure parser helpers with no prior dedicated coverage:

- `extractBody` (5 cases): frontmatter delegation, no-frontmatter passthrough, CRLF handling, empty body, and mixed line-ending newline preservation
- `generateSkillsJson` (6 cases): empty, single, location opt-in, omitted location, multiple, and valid JSON

## What kind of change is this?

Test coverage (non-breaking)

# Documentation changes needed?

No

# Testing

## Where should a reviewer start?

`plugins/plugin-agent-skills/src/parser.extract.test.ts` - 11 tests, pure, no mocking.

## Detailed testing steps

`bun run --cwd plugins/plugin-agent-skills test --run src/parser.extract.test.ts` - 11 passed, mutation (always-empty) fails 5.

# Evidence Gate

<!-- evidence-head:94fe53af3b98ba7452beb59e12d047f332315f21 -->

# Evidence Details

## Real LLM-call trajectory

N/A - no agent model or prompt path is touched; pure parser helpers.

## Backend + frontend logs

N/A - pure unit test does not exercise a server path.

## Screenshots (before / after) + video walkthrough

N/A - test-only change with no rendered UI surface.

## Testing - Red vs Green

**RED (generateSkillsJson forced to always return empty):**
```
RUN  v4.1.10  plugins/plugin-agent-skills
 ✗ src/parser.extract.test.ts (11 tests | 5 failed)
  × serializes single skill without location - expected '' to equal json
  × includes location only when requested - expected '' to have property
```
11 tests | 5 failed

**GREEN (restored):**
```
RUN  v4.1.10  plugins/plugin-agent-skills
 ✓ src/parser.extract.test.ts (11 tests)
 11 passed
```
11 tests | 11 passed (full package: 403 passed, 35 files)

**Suite collection:** 11 tests collected (not 0), all passed in green.

**Biome:** clean
**Typecheck:** clean

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: Muse Code
— [lane-byt61-8798]

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only change with no rendered UI surface

<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only change with no rendered UI surface

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - test-only change has no user flow to record

<!-- evidence-row:backend-logs -->
- [ ] N/A - pure unit test does not exercise a server path

<!-- evidence-row:frontend-logs -->
- [ ] N/A - pure unit test does not exercise a browser path

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent model or prompt path is touched; pure parser helpers

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database rows or generated files produced

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface in this change
