### PR TITLE
fix(core): guard extractUserText against non-string and nullish inputs

### DIFF
--- a/packages/core/src/utils/message-text.test.ts
+++ b/packages/core/src/utils/message-text.test.ts
@@ -7,10 +7,20 @@
 import { describe, expect, it } from "vitest";
 import type { Memory } from "../types/memory";
 import {
+	extractUserText,
 	getUserMessageText,
 	hasDocumentAugmentationEnvelope,
 	stripAugmentationForPersistence,
 } from "./message-text";
+
+describe("extractUserText", () => {
+	it("safely handles nullish and non-string inputs", () => {
+		expect(extractUserText("")).toBe("");
+		expect(extractUserText(null as unknown as string)).toBe("");
+		expect(extractUserText(undefined as unknown as string)).toBe("");
+		expect(extractUserText(123 as unknown as string)).toBe("");
+	});
+});
 
 describe("getUserMessageText", () => {
 	it("prefers connector-provided current-turn text over rendered envelopes", () => {

--- a/packages/core/src/utils/message-text.ts
+++ b/packages/core/src/utils/message-text.ts
@@ -13,6 +13,9 @@ const USER_REQUEST_WRAPPER = /<user_request>\s*([\s\S]*?)\s*<\/user_request>/i;
 const LANGUAGE_INSTRUCTION_SUFFIX = /\n*\[language instruction:[^\]]*\]\s*$/i;
 
 export function extractUserText(raw: string): string {
+	if (!raw || typeof raw !== "string") {
+		return "";
+	}
 	let text = raw;
 	if (text.trimStart().startsWith(DOCUMENT_AUGMENTATION_PREFIX)) {
 		const match = text.match(USER_REQUEST_WRAPPER);


### PR DESCRIPTION
## Summary
Closes #28542

Guards `extractUserText` in `packages/core/src/utils/message-text.ts` against non-string and falsy/nullish input values.

## Problem & Motivation
`extractUserText` in `packages/core/src/utils/message-text.ts` directly invoked `raw.trimStart()` without validating that `raw` is a string. If callers passed a `null`, `undefined`, or non-string argument directly to `extractUserText`, a `TypeError: raw.trimStart is not a function` exception was thrown.

## Changes
- Added a defensive check `if (!raw || typeof raw !== "string") return ""` to `extractUserText` in `packages/core/src/utils/message-text.ts`.
- Added unit test cases in `packages/core/src/utils/message-text.test.ts` verifying nullish and non-string inputs return `""` cleanly.

## Validation & Test Coverage
- Executed `bun test packages/core/src/utils/message-text.test.ts` (8 passing unit tests).
- Executed `bun run --cwd packages/core typecheck` (zero TypeScript errors).

## Evidence

<!-- evidence-table -->

| Evidence | Source / link / artifact | Review notes |
| --- | --- | --- |
| before-screenshots | N/A - pure utility function | Message text extraction helper |
| after-screenshots | N/A - pure utility function | Message text extraction helper |
| walkthrough-video | N/A - pure utility function | No dynamic UI interaction involved |
| backend-logs | N/A - pure utility function | No runtime backend logging changes |
| frontend-logs | N/A - pure utility function | Extraction guard verified via unit tests |
| llm-trajectory | N/A - pure utility function | No LLM interaction required |
| domain-artifacts | N/A - pure utility function | No persistent tables modified |
| ocr-review | N/A - pure utility function | Pure string helper utility |

<!-- /evidence-table -->

<!-- evidence-head:758bbe9d98f42a5a9f2645f264c18180dcdd8efa -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - pure utility function

<!-- evidence-row:after-screenshots -->
- [ ] N/A - pure utility function

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - pure utility function

<!-- evidence-row:backend-logs -->
- [ ] N/A - pure utility function

<!-- evidence-row:frontend-logs -->
- [ ] N/A - pure utility function

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - pure utility function

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - pure utility function

<!-- evidence-row:ocr-review -->
- [ ] N/A - pure utility function
