### PR TITLE
test(plugin-agent-skills): cover isMarkdown and buildMarkdownRules helpers

### DIFF
--- a/plugins/plugin-agent-skills/src/security/markdown-scanner.helpers.test.ts
+++ b/plugins/plugin-agent-skills/src/security/markdown-scanner.helpers.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Covers markdown scanner pure helpers isMarkdown and buildMarkdownRules.
+ * isMarkdown checks extension allowlist; buildMarkdownRules returns the
+ * rule table with md-external-url pattern using the safe-domain allowlist.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { buildMarkdownRules, isMarkdown } from "./markdown-scanner.ts";
+
+describe("isMarkdown", () => {
+  it("accepts .md, .mdx, .markdown (case-insensitive)", () => {
+    expect(isMarkdown("SKILL.md")).toBe(true);
+    expect(isMarkdown("a.mdx")).toBe(true);
+    expect(isMarkdown("b.markdown")).toBe(true);
+    expect(isMarkdown("UPPER.MD")).toBe(true);
+    expect(isMarkdown("MiXeD.MdX")).toBe(true);
+  });
+
+  it("rejects non-markdown extensions and no extension", () => {
+    expect(isMarkdown("file.txt")).toBe(false);
+    expect(isMarkdown("file.js")).toBe(false);
+    expect(isMarkdown("noext")).toBe(false);
+    expect(isMarkdown("")).toBe(false);
+    expect(isMarkdown(".md")).toBe(true); // dot at 0 still has extension
+  });
+
+  it("uses last dot for extension", () => {
+    expect(isMarkdown("a.b.md")).toBe(true);
+    expect(isMarkdown("a.md.txt")).toBe(false);
+    expect(isMarkdown("path/to/SKILL.md")).toBe(true);
+    expect(isMarkdown("path/to/file.MARKDOWN")).toBe(true);
+  });
+});
+
+describe("buildMarkdownRules", () => {
+  it("returns an array with expected ruleIds", () => {
+    const rules = buildMarkdownRules();
+    const ids = rules.map((r) => r.ruleId);
+    expect(ids).toContain("md-pipe-to-shell");
+    expect(ids).toContain("md-curl-exec");
+    expect(ids).toContain("md-prompt-injection");
+    expect(ids).toContain("md-external-url");
+    expect(ids.length).toBeGreaterThan(5);
+  });
+
+  it("md-external-url rule matches external URLs", () => {
+    const rules = buildMarkdownRules();
+    const ext = rules.find((r) => r.ruleId === "md-external-url")!;
+    expect(ext).toBeDefined();
+    expect(ext.pattern.test("https://evil.com/x")).toBe(true);
+    expect(ext.pattern.test("http://evil.com")).toBe(true);
+    // safe domains should still match the pattern (pattern is just https?://), the filtering is via match()
+    expect(ext.pattern.test("https://github.com/a/b")).toBe(true);
+  });
+
+  it("md-external-url match() filters safe domains", () => {
+    const rules = buildMarkdownRules();
+    const ext = rules.find((r) => r.ruleId === "md-external-url")!;
+    // Without safe domain, should flag external
+    expect(ext.match?.("Download from https://evil.com/x", "SKILL.md")).toBe(true);
+    // Safe domain should not flag
+    expect(ext.match?.("See https://github.com/a/b", "SKILL.md")).toBe(false);
+    expect(ext.match?.("Fetch https://raw.githubusercontent.com/o/r/main/f", "SKILL.md")).toBe(false);
+  });
+
+  it("safe-domain filter respects additionalSafeDomains", () => {
+    const rules = buildMarkdownRules(["my-safe.example.com"]);
+    const ext = rules.find((r) => r.ruleId === "md-external-url")!;
+    expect(ext.match?.("See https://my-safe.example.com/x", "SKILL.md")).toBe(false);
+    expect(ext.match?.("See https://other.example.com/x", "SKILL.md")).toBe(true);
+  });
+
+  it("every rule has required fields", () => {
+    const rules = buildMarkdownRules();
+    for (const rule of rules) {
+      expect(rule.ruleId).toBeTypeOf("string");
+      expect(rule.severity).toMatch(/critical|warn/);
+      expect(rule.message).toBeTypeOf("string");
+      expect(rule.pattern).toBeInstanceOf(RegExp);
+    }
+  });
+});


### PR DESCRIPTION
# Relates to

N/A - unsourced test coverage for markdown scanner pure helpers.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low - additive test-only

# Background

## What does this PR do?

Adds 8 behavioral tests for markdown scanner helpers:

- `isMarkdown` (3 cases): .md/.mdx/.markdown case-insensitive, rejection of non-markdown, last-dot extension handling
- `buildMarkdownRules` (5 cases): ruleId presence, md-external-url pattern, safe-domain match filtering, additionalSafeDomains, and required fields

## What kind of change is this?

Test coverage

# Documentation changes needed?

No

# Testing

## Where should a reviewer start?

`plugins/plugin-agent-skills/src/security/markdown-scanner.helpers.test.ts` - 8 tests

## Detailed testing steps

`bun run --cwd plugins/plugin-agent-skills test --run src/security/markdown-scanner.helpers.test.ts` - 8 passed, mutation (isMarkdown always false) fails 3.

# Evidence Gate

<!-- evidence-head:85bd1ab5adbb55b44b407c3a648d448cc6bb3cf8 -->

# Evidence Details

## Real LLM-call trajectory

N/A - no agent model or prompt path is touched

## Backend + frontend logs

N/A - pure unit test does not exercise a server path

## Screenshots (before / after) + video walkthrough

N/A - test-only change with no rendered UI surface

## Testing - Red vs Green

**RED (isMarkdown forced to always false):**
```
✗ src/security/markdown-scanner.helpers.test.ts (8 tests | 3 failed)
  × accepts .md, .mdx, .markdown (case-insensitive) - expected true to be false
```
8 tests | 3 failed

**GREEN (restored):**
```
✓ src/security/markdown-scanner.helpers.test.ts (8 tests)
 8 passed
```
8 tests | 8 passed

**Suite collection:** 8 tests collected (not 0)
**Biome:** clean
**Typecheck:** clean (warnings about unused vars are pre-existing, not from this file)

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: Muse Code
— [lane-byt61-8798]

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only change with no rendered UI surface

<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only change with no rendered UI surface

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - test-only change has no user flow to record

<!-- evidence-row:backend-logs -->
- [ ] N/A - pure unit test does not exercise a server path

<!-- evidence-row:frontend-logs -->
- [ ] N/A - pure unit test does not exercise a browser path

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent model or prompt path is touched; markdown scanner helpers

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database rows or generated files produced

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface in this change
