### PR TITLE
test(plugin-agent-skills): cover buildManifestEntriesFromMemory helper

### DIFF
--- a/plugins/plugin-agent-skills/src/security/manifest-scanner.entries.test.ts
+++ b/plugins/plugin-agent-skills/src/security/manifest-scanner.entries.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Covers buildManifestEntriesFromMemory pure helper.
+ * Converts in-memory file maps to manifest entries with sizeBytes.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { buildManifestEntriesFromMemory } from "./manifest-scanner.ts";
+
+describe("buildManifestEntriesFromMemory", () => {
+  it("returns empty for empty map", () => {
+    expect(buildManifestEntriesFromMemory(new Map())).toEqual([]);
+  });
+
+  it("converts string content to sizeBytes via UTF-8 byte length", () => {
+    const files = new Map([["a.txt", { content: "hello", isText: true }]]);
+    const entries = buildManifestEntriesFromMemory(files);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].relativePath).toBe("a.txt");
+    expect(entries[0].sizeBytes).toBe(5);
+    expect(entries[0].isSymlink).toBe(false);
+  });
+
+  it("handles Uint8Array content", () => {
+    const buf = new Uint8Array([1, 2, 3, 4]);
+    const files = new Map([["b.bin", { content: buf, isText: false }]]);
+    const entries = buildManifestEntriesFromMemory(files);
+    expect(entries[0].sizeBytes).toBe(4);
+  });
+
+  it("handles multi-byte UTF-8 string correctly", () => {
+    const files = new Map([["c.txt", { content: "é", isText: true }]]); // 2 bytes in UTF-8
+    const entries = buildManifestEntriesFromMemory(files);
+    expect(entries[0].sizeBytes).toBe(2);
+  });
+
+  it("handles multiple files", () => {
+    const files = new Map([
+      ["a.txt", { content: "hi", isText: true }],
+      ["b.bin", { content: new Uint8Array([1, 2]), isText: false }],
+    ]);
+    const entries = buildManifestEntriesFromMemory(files);
+    expect(entries).toHaveLength(2);
+    expect(entries.map((e) => e.relativePath).sort()).toEqual(["a.txt", "b.bin"]);
+  });
+
+  it("preserves isSymlink false for all entries", () => {
+    const files = new Map([
+      ["x", { content: "y", isText: true }],
+      ["z", { content: new Uint8Array(0), isText: true }],
+    ]);
+    const entries = buildManifestEntriesFromMemory(files);
+    for (const e of entries) expect(e.isSymlink).toBe(false);
+  });
+
+  it("handles empty string and empty buffer", () => {
+    const files = new Map([
+      ["empty.txt", { content: "", isText: true }],
+      ["empty.bin", { content: new Uint8Array(0), isText: false }],
+    ]);
+    const entries = buildManifestEntriesFromMemory(files);
+    expect(entries.find((e) => e.relativePath === "empty.txt")?.sizeBytes).toBe(0);
+    expect(entries.find((e) => e.relativePath === "empty.bin")?.sizeBytes).toBe(0);
+  });
+});


### PR DESCRIPTION
# Relates to

N/A - unsourced test coverage for manifest helper with no prior dedicated suite.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low - additive test-only

# Background

## What does this PR do?

Adds 7 behavioral tests for `buildManifestEntriesFromMemory` pure helper:

- empty map, string UTF-8 byte length, Uint8Array, multi-byte UTF-8 (é → 2 bytes), multiple files, isSymlink false, and empty content

## What kind of change is this?

Test coverage

# Documentation changes needed?

No

# Testing

## Where should a reviewer start?

`plugins/plugin-agent-skills/src/security/manifest-scanner.entries.test.ts` - 7 tests

## Detailed testing steps

`bun run --cwd plugins/plugin-agent-skills test --run src/security/manifest-scanner.entries.test.ts` - 7 passed, mutation (string length vs byteLength) fails 1.

# Evidence Gate

<!-- evidence-head:05c898c9db4aa616ce1b1703cda10b7a20b6a118 -->

# Evidence Details

## Real LLM-call trajectory

N/A - no agent model or prompt path is touched

## Backend + frontend logs

N/A - pure unit test does not exercise a server path

## Screenshots (before / after) + video walkthrough

N/A - test-only change with no rendered UI surface

## Testing - Red vs Green

**RED (string length vs byteLength - multi-byte UTF-8):**
```
✗ src/security/manifest-scanner.entries.test.ts (7 tests | 1 failed)
  × handles multi-byte UTF-8 string correctly - expected 1 to be 2
```
7 tests | 1 failed

**GREEN (restored):**
```
✓ src/security/manifest-scanner.entries.test.ts (7 tests)
 7 passed
```
7 tests | 7 passed

**Suite collection:** 7 tests collected (not 0)
**Biome:** clean
**Typecheck:** clean

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: Muse Code
— [lane-byt61-8798]

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only change with no rendered UI surface

<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only change with no rendered UI surface

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - test-only change has no user flow to record

<!-- evidence-row:backend-logs -->
- [ ] N/A - pure unit test does not exercise a server path

<!-- evidence-row:frontend-logs -->
- [ ] N/A - pure unit test does not exercise a browser path

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent model or prompt path is touched; manifest helper

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database rows or generated files produced

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface in this change
