### PR TITLE
test(plugin-app-control): pin APP/stop target resolution gate before the stop boundary

### DIFF
--- a/plugins/plugin-app-control/src/actions/app-stop.test.ts
+++ b/plugins/plugin-app-control/src/actions/app-stop.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Behavioral contract for the APP/stop action (plugin-app-control).
+ *
+ * The dangerous surface here is the state-changing HTTP boundary: once a run
+ * id or resolved app name reaches `client.stopAppRun`/`client.stopApp`, an
+ * app process is killed. Name resolution must therefore be airtight *before*
+ * the boundary — ambiguous or unknown planner targets must never reach it.
+ * These tests pin that gate plus the callback/result shapes for every branch.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { runStop } from "./app-stop";
+
+const installedApps = [
+	{
+		name: "Feed",
+		displayName: "Daily Digest",
+		pluginName: "feed-plugin",
+		version: "1.0.0",
+		installedAt: "t",
+	},
+	{
+		name: "Chat",
+		displayName: "Chat",
+		pluginName: "chat-plugin",
+		version: "1.0.0",
+		installedAt: "t",
+	},
+	// Shares the normalized "feed" key with the app above -> ambiguous for "feed"
+	{
+		name: "Other",
+		displayName: "Feed",
+		pluginName: "other-plugin",
+		version: "1.0.0",
+		installedAt: "t",
+	},
+];
+
+function makeClient() {
+	return {
+		stopAppRun: vi.fn(),
+		stopApp: vi.fn(),
+		listInstalledApps: vi.fn().mockResolvedValue(installedApps),
+	};
+}
+
+function makeMessage(text: string) {
+	return { content: { text }, agentId: "agent-1", userId: "user-1" } as any;
+}
+
+function stopResult(success: boolean, extra: Record<string, unknown> = {}) {
+	return {
+		success,
+		message: success ? "Stopped." : "Stop failed.",
+		appName: "Feed",
+		runId: "run-1",
+		stopScope: "app",
+		...extra,
+	};
+}
+describe("runStop — resolution gate before the state-changing HTTP boundary", () => {
+	let client: ReturnType<typeof makeClient>;
+	let callback: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		client = makeClient();
+		callback = vi.fn();
+	});
+
+	it("stops a run directly by runId and reports the stop result", async () => {
+		client.stopAppRun.mockResolvedValue(stopResult(true));
+		const result = await runStop({
+			client,
+			message: makeMessage("stop the feed app"),
+			options: { runId: "run-7" },
+			callback,
+		} as any);
+
+		expect(client.stopAppRun).toHaveBeenCalledWith("run-7");
+		expect(client.stopApp).not.toHaveBeenCalled();
+		expect(callback).toHaveBeenCalledWith({ text: "Stopped." });
+		expect(result.success).toBe(true);
+		expect(result.values).toMatchObject({
+			mode: "stop",
+			runId: "run-1",
+			appName: "Feed",
+		});
+	});
+
+	it("resolves a name to the installed app and stops it by resolved name", async () => {
+		client.stopApp.mockResolvedValue(stopResult(true));
+		const result = await runStop({
+			client,
+			message: makeMessage("stop the chat app"),
+			options: {},
+			callback,
+		} as any);
+
+		expect(client.listInstalledApps).toHaveBeenCalledOnce();
+		expect(client.stopApp).toHaveBeenCalledWith("Chat");
+		expect(client.stopAppRun).not.toHaveBeenCalled();
+		expect(result.success).toBe(true);
+		expect(result.values).toMatchObject({ mode: "stop", appName: "Feed" });
+	});
+
+	it("NEVER stops anything when the target is ambiguous — clarifies with candidates instead", async () => {
+		// "feed" matches both "Feed" (exact) and the app whose displayName is "Feed"
+		const result = await runStop({
+			client,
+			message: makeMessage("stop the feed app"),
+			options: {},
+			callback,
+		} as any);
+
+		expect(client.stopApp).not.toHaveBeenCalled();
+		expect(client.stopAppRun).not.toHaveBeenCalled();
+		expect(result.success).toBe(false);
+		const callText = (callback.mock.calls[0] as any)[0].text as string;
+		expect(callText).toContain("matches multiple apps");
+		expect(callText).toContain("Please specify which one");
+		expect(result.data).toHaveProperty("candidates");
+	});
+
+	it("NEVER stops anything for an unknown target — replies with the no-match message", async () => {
+		const result = await runStop({
+			client,
+			message: makeMessage("stop the nonexistent app"),
+			options: {},
+			callback,
+		} as any);
+
+		expect(client.stopApp).not.toHaveBeenCalled();
+		expect(client.stopAppRun).not.toHaveBeenCalled();
+		expect(result.success).toBe(false);
+		const callText = (callback.mock.calls[0] as any)[0].text as string;
+		expect(callText).toContain("No installed app matches");
+	});
+
+	it("asks for a target when neither runId nor app name is present and makes no client calls", async () => {
+		const result = await runStop({
+			client,
+			message: makeMessage("please stop"),
+			options: {},
+			callback,
+		} as any);
+
+		expect(client.stopApp).not.toHaveBeenCalled();
+		expect(client.stopAppRun).not.toHaveBeenCalled();
+		expect(client.listInstalledApps).not.toHaveBeenCalled();
+		expect(result.success).toBe(false);
+		const callText = (callback.mock.calls[0] as any)[0].text as string;
+		expect(callText).toContain("I need an app name or runId");
+	});
+
+	it("propagates a failed stop as success:false with the API message", async () => {
+		client.stopApp.mockResolvedValue(
+			stopResult(false, { message: "Stop failed: not owner" }),
+		);
+		const result = await runStop({
+			client,
+			message: makeMessage("stop the chat app"),
+			options: {},
+			callback,
+		} as any);
+
+		expect(result.success).toBe(false);
+		expect(result.text).toBe("Stop failed: not owner");
+		expect(callback).toHaveBeenCalledWith({ text: "Stop failed: not owner" });
+	});
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only behavioral contract for the APP/stop action. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: pins the behavioral contract of `runStop` in
`plugin-app-control/src/actions/app-stop.ts`. The property under test is the
resolution gate in front of the state-changing HTTP boundary: an ambiguous or
unknown app target must never reach `client.stopApp`/`client.stopAppRun` (a
killed process is unrecoverable), and the clarify-with-candidates reply is the
designed safe outcome. No production code is modified.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `Test Files  1 passed (1) / Tests  6 passed (6)` |
| before-screenshots | N/A - pure unit tests, no UI |
| after-screenshots | N/A - pure unit tests, no UI |
| walkthrough-video | N/A - pure unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
