### PR TITLE
test(plugin-browser): pin browser-workspace provider role gate and degrade contract

### DIFF
--- a/plugins/plugin-browser/src/providers/workspace.test.ts
+++ b/plugins/plugin-browser/src/providers/workspace.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Behavioral contract for the browser-workspace provider (plugin-browser).
+ *
+ * The provider surfaces live browser-workspace state (dispatch mode + open
+ * tab list) into agent context. Two properties are worth pinning:
+ *
+ * 1. The role/context gates travel WITH the provider (owner-operator context,
+ *    issue #12094): a rename or refactor cannot silently drop them.
+ * 2. The degrade contract: any failure reading workspace state must turn into
+ *    a structured `available: false` payload — never a thrown error that
+ *    breaks the whole provider composition.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as workspaceBridge from "../workspace/browser-workspace";
+
+interface ParsedWorkspacePayload {
+  browser_workspace?: {
+    mode?: string;
+    tabCount?: number;
+    tabs?: Array<Record<string, unknown>>;
+    available?: boolean;
+    error?: string;
+  };
+}
+
+import { browserWorkspaceProvider } from "./workspace";
+
+describe("browserWorkspaceProvider — gates and degrade contract", () => {
+  beforeEach(() => {
+    vi.spyOn(workspaceBridge, "getBrowserWorkspaceMode").mockReturnValue(
+      "desktop",
+    );
+    vi.spyOn(workspaceBridge, "listBrowserWorkspaceTabs").mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("pins the owner-only role gate and browser/web context gates on the provider", () => {
+    // The comment on the provider states the gate must travel with it so a
+    // rename can't silently drop owner-operator context protection.
+    expect(browserWorkspaceProvider.roleGate).toEqual({ minRole: "OWNER" });
+    expect(browserWorkspaceProvider.contextGate).toEqual({
+      anyOf: ["browser", "web"],
+    });
+    expect(browserWorkspaceProvider.contexts).toEqual(["browser", "web"]);
+    expect(browserWorkspaceProvider.cacheStable).toBe(false);
+    expect(browserWorkspaceProvider.cacheScope).toBe("turn");
+  });
+
+  it("renders mode, tab count, and tab details into context on the happy path", async () => {
+    vi.mocked(workspaceBridge.listBrowserWorkspaceTabs).mockResolvedValue([
+      { id: "t1", visible: true, url: "https://example.com", title: "Example" },
+      { id: "t2", visible: false, url: "https://elizaos.ai", title: "Eliza" },
+    ]);
+
+    const out = await browserWorkspaceProvider.get?.();
+
+    expect(out.data).toEqual({
+      available: true,
+      mode: "desktop",
+      tabs: [
+        {
+          id: "t1",
+          visible: true,
+          url: "https://example.com",
+          title: "Example",
+        },
+        { id: "t2", visible: false, url: "https://elizaos.ai", title: "Eliza" },
+      ],
+    });
+    const parsed = JSON.parse(out.text) as ParsedWorkspacePayload;
+    expect(parsed.browser_workspace.mode).toBe("desktop");
+    expect(parsed.browser_workspace.tabCount).toBe(2);
+    expect(parsed.browser_workspace.tabs[1].url).toBe("https://elizaos.ai");
+  });
+
+  it("degrades to available:false with the error message when tab listing throws", async () => {
+    vi.mocked(workspaceBridge.listBrowserWorkspaceTabs).mockRejectedValue(
+      new Error("workspace unreachable"),
+    );
+
+    const out = await browserWorkspaceProvider.get?.();
+
+    expect(out.data).toEqual({
+      available: false,
+      error: "workspace unreachable",
+    });
+    const parsed = JSON.parse(out.text) as ParsedWorkspacePayload;
+    expect(parsed.browser_workspace.available).toBe(false);
+    expect(parsed.browser_workspace.error).toBe("workspace unreachable");
+  });
+
+  it("degrades to available:false when the mode probe throws", async () => {
+    vi.mocked(workspaceBridge.getBrowserWorkspaceMode).mockImplementation(
+      () => {
+        throw new Error("bridge dead");
+      },
+    );
+
+    const out = await browserWorkspaceProvider.get?.();
+
+    expect(out.data).toEqual({ available: false, error: "bridge dead" });
+    const parsed = JSON.parse(out.text) as ParsedWorkspacePayload;
+    expect(parsed.browser_workspace.available).toBe(false);
+  });
+
+  it("stringifies non-Error failures without crashing", async () => {
+    vi.mocked(workspaceBridge.listBrowserWorkspaceTabs).mockRejectedValue(
+      "raw string failure",
+    );
+
+    const out = await browserWorkspaceProvider.get?.();
+
+    expect(out.data).toEqual({ available: false, error: "raw string failure" });
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only behavioral contract for the browser-workspace provider. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: pins two contracts of `browserWorkspaceProvider` in
`plugins/plugin-browser/src/providers/workspace.ts`. First, the owner-only
role gate and browser/web context gates travel with the provider (per issue
#12094, a rename must not silently drop owner-operator context protection).
Second, the degrade contract: any failure reading workspace state yields a
structured `available: false` payload instead of a thrown error breaking
provider composition. No production code is modified.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `Test Files  1 passed (1) / Tests  5 passed (5)` |
| before-screenshots | N/A - pure unit tests, no UI |
| after-screenshots | N/A - pure unit tests, no UI |
| walkthrough-video | N/A - pure unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
