### PR TITLE
fix(core): safe message and content access in context-routing helpers

### DIFF
--- a/packages/core/src/utils/context-routing.test.ts
+++ b/packages/core/src/utils/context-routing.test.ts
@@ -14,9 +14,12 @@ import {
 	deriveAvailableContexts,
 	getActiveRoutingContexts,
 	getActiveRoutingContextsForTurn,
+	getContextRoutingFromMessage,
+	inferContextRoutingFromMessage,
 	inferContextRoutingFromText,
 	mergeContextRouting,
 	routingContextsOverlap,
+	setContextRoutingMetadata,
 	shouldIncludeByContext,
 } from "./context-routing.ts";
 
@@ -326,5 +329,34 @@ describe("mergeContextRouting", () => {
 			(context) => `${context}`.toLowerCase() === "knowledge",
 		).length;
 		expect(countKnowledge).toBe(1);
+	});
+});
+
+describe("safe message context routing helpers", () => {
+	it("getContextRoutingFromMessage returns empty object for nullish or invalid message", () => {
+		expect(getContextRoutingFromMessage(null)).toEqual({});
+		expect(getContextRoutingFromMessage(undefined)).toEqual({});
+		expect(
+			getContextRoutingFromMessage({
+				content: {} as unknown,
+			} as unknown as Memory),
+		).toEqual({});
+	});
+
+	it("inferContextRoutingFromMessage handles nullish message and empty content", () => {
+		expect(inferContextRoutingFromMessage(null)).toEqual({
+			primaryContext: "general",
+			secondaryContexts: [],
+		});
+		expect(inferContextRoutingFromMessage(undefined)).toEqual({
+			primaryContext: "general",
+			secondaryContexts: [],
+		});
+	});
+
+	it("setContextRoutingMetadata is a safe no-op on invalid message content", () => {
+		const invalidMsg = { content: null } as unknown as Memory;
+		setContextRoutingMetadata(invalidMsg, { primaryContext: "code" });
+		expect(invalidMsg.content).toBeNull();
 	});
 });

--- a/packages/core/src/utils/context-routing.ts
+++ b/packages/core/src/utils/context-routing.ts
@@ -160,9 +160,9 @@ export function getContextRoutingFromState(
 }
 
 export function getContextRoutingFromMessage(
-	message: Memory,
+	message: Memory | null | undefined,
 ): ContextRoutingDecision {
-	const metadata = message.content.metadata;
+	const metadata = message?.content?.metadata;
 	if (!metadata || typeof metadata !== "object") {
 		return {};
 	}
@@ -253,14 +253,15 @@ export function setContextRoutingMetadata(
 	message: Memory,
 	routing: ContextRoutingDecision,
 ): void {
-	const existingMetadata =
-		message.content && typeof message.content.metadata === "object"
-			? (message.content.metadata as Record<string, ContentValue>)
-			: {};
-
-	if (!message.content || typeof message.content !== "object") {
+	if (!message || !message.content || typeof message.content !== "object") {
 		return;
 	}
+
+	const existingMetadata =
+		typeof message.content.metadata === "object" &&
+		message.content.metadata !== null
+			? (message.content.metadata as Record<string, ContentValue>)
+			: {};
 
 	const routingMetadata: Record<string, ContentValue> = {};
 	if (routing.primaryContext) {
@@ -464,13 +465,16 @@ export function inferContextRoutingFromText(
 }
 
 export function inferContextRoutingFromMessage(
-	message: Pick<Memory, "content">,
+	message: Pick<Memory, "content"> | null | undefined,
 ): ContextRoutingDecision {
+	if (!message || !message.content) {
+		return { primaryContext: "general", secondaryContexts: [] };
+	}
 	return inferContextRoutingFromText(
 		typeof message.content === "string"
 			? message.content
-			: typeof message.content.text === "string"
-				? message.content.text
+			: typeof (message.content as { text?: unknown })?.text === "string"
+				? ((message.content as { text: string }).text)
 				: "",
 	);
 }


### PR DESCRIPTION
## Summary
Closes #28558

Adds safe optional chaining and input verification to `getContextRoutingFromMessage`, `setContextRoutingMetadata`, and `inferContextRoutingFromMessage` in `packages/core/src/utils/context-routing.ts`.

## Problem & Motivation
In `packages/core/src/utils/context-routing.ts`:
1. `getContextRoutingFromMessage` previously performed a direct dereference `message.content.metadata`. When `message` or `message.content` was nullish or not an object, this threw an unhandled `TypeError`.
2. `setContextRoutingMetadata` checked `message.content` only after attempting to read `message.content.metadata`.
3. `inferContextRoutingFromMessage` accessed `message.content` without guarding against nullish message inputs.

## Changes
- Used optional chaining `message?.content?.metadata` in `getContextRoutingFromMessage`.
- Guarded `setContextRoutingMetadata` by validating `message && message.content` before accessing existing metadata.
- Guarded `inferContextRoutingFromMessage` against nullish messages, returning `{ primaryContext: "general", secondaryContexts: [] }` on missing content.
- Added unit tests in `packages/core/src/utils/context-routing.test.ts` covering nullish and empty message inputs.

## Validation & Test Coverage
- Executed `bun test packages/core/src/utils/context-routing.test.ts` (21 passing tests).
- Executed `bun run --cwd packages/core typecheck` (zero TypeScript errors).

## Evidence

<!-- evidence-table -->

| Evidence | Source / link / artifact | Review notes |
| --- | --- | --- |
| before-screenshots | N/A - pure utility function | Context routing safe property access |
| after-screenshots | N/A - pure utility function | Context routing safe property access |
| walkthrough-video | N/A - pure utility function | No dynamic UI interaction involved |
| backend-logs | N/A - pure utility function | No runtime backend logging changes |
| frontend-logs | N/A - pure utility function | Verified via context routing unit tests |
| llm-trajectory | N/A - pure utility function | Turn-level context routing helper |
| domain-artifacts | N/A - pure utility function | No persistent tables modified |
| ocr-review | N/A - pure utility function | Pure routing utility |

<!-- /evidence-table -->

<!-- evidence-head:00da1ea3dc1b1f2f0188c45005690a11b1e376bc -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - pure utility function

<!-- evidence-row:after-screenshots -->
- [ ] N/A - pure utility function

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - pure utility function

<!-- evidence-row:backend-logs -->
- [ ] N/A - pure utility function

<!-- evidence-row:frontend-logs -->
- [ ] N/A - pure utility function

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - pure utility function

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - pure utility function

<!-- evidence-row:ocr-review -->
- [ ] N/A - pure utility function
