### PR TITLE
test(plugin-omarchy): pin desktop provider host gate and degrade contract

### DIFF
--- a/plugins/plugin-omarchy/src/providers/desktop.test.ts
+++ b/plugins/plugin-omarchy/src/providers/desktop.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Behavioral contract for the Omarchy desktop provider (plugin-omarchy).
+ *
+ * The provider only runs on Omarchy Linux hosts. Two safety properties:
+ *
+ * 1. The host gate: on a non-Omarchy host the provider returns an empty
+ *    payload and MUST NOT touch the native bridge (no probe, no crash, no
+ *    side effects on every other deployment).
+ * 2. The degrade contract: when the bridge reports unavailable, the provider
+ *    says so explicitly instead of fabricating a snapshot.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { createOmarchyDesktopProvider } from "./desktop";
+
+function bridge(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    snapshot: async () => ({
+      available: true,
+      version: "1.2.3",
+      theme: "dark",
+      plugins: [],
+      ...overrides,
+    }),
+  } as any;
+}
+
+function hostOn(): () => boolean {
+  return () => true;
+}
+
+function hostOff(): () => boolean {
+  return () => false;
+}
+
+describe("createOmarchyDesktopProvider — host gate and degrade contract", () => {
+  it("pins the provider surface: dynamic, turn-scoped, system/automation/settings contexts", () => {
+    const provider = createOmarchyDesktopProvider(bridge(), hostOn());
+    expect(provider.name).toBe("omarchyDesktop");
+    expect(provider.dynamic).toBe(true);
+    expect(provider.contexts).toEqual(["system", "automation", "settings"]);
+    expect(provider.contextGate).toEqual({
+      anyOf: ["system", "automation", "settings"],
+    });
+    expect(provider.cacheScope).toBe("turn");
+  });
+
+  it("returns empty text on a non-Omarchy host and never touches the bridge", async () => {
+    const snap = bridge();
+    const spy = vi.spyOn(snap, "snapshot");
+    const provider = createOmarchyDesktopProvider(snap, hostOff());
+
+    const out = await provider.get!();
+
+    expect(out).toEqual({ text: "" });
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("reports unavailable explicitly when the bridge snapshot is unavailable", async () => {
+    const provider = createOmarchyDesktopProvider(
+      { snapshot: async () => ({ available: false }) } as any,
+      hostOn(),
+    );
+
+    const out = await provider.get!();
+
+    expect(out.text).toBe("Omarchy desktop integration is unavailable.");
+    expect(out.values).toEqual({ omarchyAvailable: false });
+    expect(out.data).toEqual({ available: false });
+  });
+
+  it("renders version, theme, and enabled Eliza shell plugin state", async () => {
+    const provider = createOmarchyDesktopProvider(
+      bridge({
+        plugins: [{ id: "elizaos.eliza", enabled: true }],
+      }),
+      hostOn(),
+    );
+
+    const out = await provider.get!();
+
+    expect(out.text).toBe(
+      "Omarchy 1.2.3; theme dark; Eliza shell plugin enabled.",
+    );
+    expect(out.values).toMatchObject({
+      omarchyAvailable: true,
+      omarchyVersion: "1.2.3",
+      omarchyTheme: "dark",
+      omarchyElizaPluginInstalled: true,
+      omarchyElizaPluginEnabled: true,
+    });
+  });
+
+  it("reports the Eliza shell plugin as disabled when present but disabled", async () => {
+    const provider = createOmarchyDesktopProvider(
+      bridge({ plugins: [{ id: "elizaos.eliza", enabled: false }] }),
+      hostOn(),
+    );
+
+    const out = await provider.get!();
+
+    expect(out.text).toContain("Eliza shell plugin disabled");
+    expect(out.values).toMatchObject({ omarchyElizaPluginEnabled: false });
+  });
+
+  it("reports the Eliza shell plugin as not installed when absent", async () => {
+    const provider = createOmarchyDesktopProvider(
+      bridge({ plugins: [] }),
+      hostOn(),
+    );
+
+    const out = await provider.get!();
+
+    expect(out.text).toContain("Eliza shell plugin not installed");
+    expect(out.values).toMatchObject({ omarchyElizaPluginInstalled: false });
+  });
+
+  it("omits the theme segment when the snapshot has no theme", async () => {
+    const provider = createOmarchyDesktopProvider(
+      bridge({ theme: undefined }),
+      hostOn(),
+    );
+
+    const out = await provider.get!();
+
+    expect(out.text).toContain("Omarchy 1.2.3");
+    expect(out.text).not.toContain("theme");
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only behavioral contract for the Omarchy desktop provider. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: pins the host gate and degrade contract of
`createOmarchyDesktopProvider` in `plugin-omarchy/src/providers/desktop.ts`.
On a non-Omarchy host the provider must return an empty payload and never
touch the native bridge (the gate prevents a bridge probe on every other
deployment), and an unavailable bridge snapshot must be reported explicitly
rather than fabricating state. No production code is modified.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `Test Files  1 passed (1) / Tests  7 passed (7)` |
| before-screenshots | N/A - pure unit tests, no UI |
| after-screenshots | N/A - pure unit tests, no UI |
| walkthrough-video | N/A - pure unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
