### PR TITLE
fix(plugin-wallet): fail loud on degenerate concentrated-liquidity ranges

### DIFF
--- a/plugins/plugin-wallet/src/lp/services/ConcentratedLiquidityService.test.ts
+++ b/plugins/plugin-wallet/src/lp/services/ConcentratedLiquidityService.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Behavioral contract for ConcentratedLiquidityService (plugin-wallet).
+ *
+ * The range/utilization math is the only live logic in this service today.
+ * Two defect classes are pinned here (fix + test):
+ *
+ * 1. A non-positive rangeWidthPercent produced an inverted or zero-width
+ *    range (priceLower >= priceUpper) instead of failing loud.
+ * 2. A zero-width range made calculateUtilization divide by zero; the
+ *    resulting Infinity was silently clamped to 100 — a fabricated "fully
+ *    utilized" answer for a range with no width.
+ *
+ * The unimplemented position/rebalance operations must also keep failing
+ * loud ("coming soon") rather than silently returning empty results.
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import type { IRangeParams } from "../types";
+import { ConcentratedLiquidityService } from "./ConcentratedLiquidityService";
+
+describe("ConcentratedLiquidityService — range math bounds and fail-loud contract", () => {
+  it("computes a symmetric range around the current price", () => {
+    const svc = new ConcentratedLiquidityService();
+    const wide = svc.calculateOptimalRange(100, 20);
+    expect(wide.priceLower).toBeCloseTo(90, 10);
+    expect(wide.priceUpper).toBeCloseTo(110, 10);
+    const narrow = svc.calculateOptimalRange(100, 0.5);
+    expect(narrow.priceLower).toBeCloseTo(99.75, 10);
+    expect(narrow.priceUpper).toBeCloseTo(100.25, 10);
+  });
+
+  it("throws RangeError on a non-positive range width instead of producing an inverted range", () => {
+    const svc = new ConcentratedLiquidityService();
+    expect(() => svc.calculateOptimalRange(100, 0)).toThrow(RangeError);
+    expect(() => svc.calculateOptimalRange(100, -20)).toThrow(RangeError);
+  });
+
+  it("throws RangeError on non-finite inputs instead of returning NaN bounds", () => {
+    const svc = new ConcentratedLiquidityService();
+    expect(() => svc.calculateOptimalRange(Number.NaN, 20)).toThrow(RangeError);
+    expect(() => svc.calculateOptimalRange(100, Number.NaN)).toThrow(
+      RangeError,
+    );
+    expect(() =>
+      svc.calculateOptimalRange(100, Number.POSITIVE_INFINITY),
+    ).toThrow(RangeError);
+  });
+
+  it("returns 100% utilization at the center of the range", () => {
+    const svc = new ConcentratedLiquidityService();
+    expect(svc.calculateUtilization(100, 90, 110)).toBe(100);
+  });
+
+  it("returns 0% utilization at the range bounds and outside the range", () => {
+    const svc = new ConcentratedLiquidityService();
+    expect(svc.calculateUtilization(90, 90, 110)).toBe(0);
+    expect(svc.calculateUtilization(110, 90, 110)).toBe(0);
+    expect(svc.calculateUtilization(50, 90, 110)).toBe(0);
+    expect(svc.calculateUtilization(150, 90, 110)).toBe(0);
+  });
+
+  it("returns the intermediate utilization between bound and center", () => {
+    const svc = new ConcentratedLiquidityService();
+    // Distance from lower bound = 5 of a half-range of 10 -> 50%
+    expect(svc.calculateUtilization(95, 90, 110)).toBe(50);
+  });
+
+  it("throws RangeError on a zero-width range instead of dividing by zero into a silent 100%", () => {
+    const svc = new ConcentratedLiquidityService();
+    // Previously: priceRange = 0 -> Infinity -> Math.min(Infinity, 100) = 100.
+    expect(() => svc.calculateUtilization(100, 100, 100)).toThrow(RangeError);
+  });
+
+  it("throws RangeError on an inverted range instead of reporting 0% utilization", () => {
+    const svc = new ConcentratedLiquidityService();
+    expect(() => svc.calculateUtilization(100, 110, 90)).toThrow(RangeError);
+  });
+
+  it("keeps the unimplemented position operations failing loud", async () => {
+    const svc = new ConcentratedLiquidityService();
+    await expect(
+      svc.createConcentratedPosition("u", {} as IRangeParams),
+    ).rejects.toThrow(/coming soon/);
+    await expect(svc.rebalanceConcentratedPosition("u", "p")).rejects.toThrow(
+      /coming soon/,
+    );
+    await expect(svc.getConcentratedPositions("u")).resolves.toEqual([]);
+  });
+
+  it("exposes the service type and starts/stops without side effects", async () => {
+    expect(ConcentratedLiquidityService.serviceType).toBe(
+      "concentrated-liquidity",
+    );
+    const started = await ConcentratedLiquidityService.start(
+      {} as IAgentRuntime,
+    );
+    expect(started).toBeInstanceOf(ConcentratedLiquidityService);
+    await started.stop();
+    await ConcentratedLiquidityService.stop({} as IAgentRuntime);
+  });
+});

--- a/plugins/plugin-wallet/src/lp/services/ConcentratedLiquidityService.ts
+++ b/plugins/plugin-wallet/src/lp/services/ConcentratedLiquidityService.ts
@@ -70,6 +70,18 @@ export class ConcentratedLiquidityService
     rangeWidthPercent: number,
     _targetUtilization: number = 80,
   ): { priceLower: number; priceUpper: number } {
+    // Fail loud on degenerate width: a non-positive width produces an
+    // inverted or zero-width range (priceLower >= priceUpper), which would
+    // silently break every downstream in-range/utilization decision.
+    if (
+      !Number.isFinite(currentPrice) ||
+      !Number.isFinite(rangeWidthPercent) ||
+      rangeWidthPercent <= 0
+    ) {
+      throw new RangeError(
+        "calculateOptimalRange requires a finite currentPrice and a positive rangeWidthPercent",
+      );
+    }
     // Simple symmetric range calculation
     const halfWidth = rangeWidthPercent / 2;
     const priceLower = currentPrice * (1 - halfWidth / 100);
@@ -97,11 +109,20 @@ export class ConcentratedLiquidityService
     priceLower: number,
     priceUpper: number,
   ): number {
+    const priceRange = priceUpper - priceLower;
+    // Fail loud on a degenerate range: a zero-width or inverted range makes
+    // the utilization formula divide by zero (previously surfaced as
+    // Infinity clamped to 100 — a silent 100% for a range with no width).
+    if (!Number.isFinite(priceRange) || priceRange <= 0) {
+      throw new RangeError(
+        "calculateUtilization requires priceUpper > priceLower",
+      );
+    }
+
     if (!this.isPriceInRange(currentPrice, priceLower, priceUpper)) {
       return 0;
     }
 
-    const priceRange = priceUpper - priceLower;
     const distanceFromLower = currentPrice - priceLower;
     const distanceFromUpper = priceUpper - currentPrice;
 


### PR DESCRIPTION
# Relates to

<!-- No issue; hardens degenerate-range math in ConcentratedLiquidityService. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Two degenerate-input defects in the concentrated-liquidity range math,
fixed to fail loud at the boundary:

1. `calculateOptimalRange` with a non-positive `rangeWidthPercent` produced an
   inverted or zero-width range (`priceLower >= priceUpper`) instead of
   rejecting the input.
2. `calculateUtilization` with a zero-width range divided by zero; the
   resulting `Infinity` was silently clamped to 100 — a fabricated "fully
   utilized" answer for a range with no width. The guard now runs before the
   in-range early return so inverted bounds are rejected too.

Both now throw `RangeError`; valid inputs behave exactly as before (verified
by the accompanying tests, including the previously-working 90/110 and
99.75/100.25 cases). No callers exist yet (the position operations are
"coming soon" stubs that keep failing loud), so there is no live-behavior
change outside the degenerate inputs.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `Test Files  1 passed (1) / Tests  10 passed (10)` |
| before-screenshots | N/A - pure unit tests, no UI |
| after-screenshots | N/A - pure unit tests, no UI |
| walkthrough-video | N/A - pure unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: source + test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
