### PR TITLE
fix(browser): reject mutating bridge tab actions

### DIFF
--- a/plugins/plugin-browser/src/browser-service.ts
+++ b/plugins/plugin-browser/src/browser-service.ts
@@ -57,7 +57,7 @@ import {
   BROWSER_BRIDGE_ROUTE_SERVICE_TYPE,
   type BrowserBridgeRouteService,
 } from "./service.js";
-import { BRIDGE_SUPPORTED_SUBACTIONS } from "./targets/bridge-target.js";
+import { bridgeSupports } from "./targets/bridge-target.js";
 import { maybeCreateStagehandTarget } from "./targets/stagehand-target.js";
 import {
   ensureBrowserWorkspaceDefaultTabWithRetry,
@@ -683,7 +683,7 @@ async function maybeCreateBridgeTarget(
     // handles a read-mostly subset of subactions. Declaring it here lets the
     // dispatcher skip the bridge for unsupported commands *before* dispatch
     // instead of discovering it via a thrown error.
-    supports: (command) => BRIDGE_SUPPORTED_SUBACTIONS.has(command.subaction),
+    supports: bridgeSupports,
     available: async () => {
       try {
         const companions = await service.listBrowserCompanions();

--- a/plugins/plugin-browser/src/targets/bridge-target.test.ts
+++ b/plugins/plugin-browser/src/targets/bridge-target.test.ts
@@ -35,7 +35,7 @@ function serviceWith({
 
 describe("bridge target capability manifest", () => {
   it("advertises only read-mostly subactions as supported", () => {
-    expect(["get", "list", "state", "tab"].sort()).toEqual([
+    expect([...BRIDGE_SUPPORTED_SUBACTIONS].sort()).toEqual([
       "get",
       "list",
       "state",

--- a/plugins/plugin-browser/src/targets/bridge-target.test.ts
+++ b/plugins/plugin-browser/src/targets/bridge-target.test.ts
@@ -1,6 +1,12 @@
+/**
+ * Verifies bridge capability routing and rejects tab mutations that the
+ * companion cannot execute, preventing successful-looking false outcomes.
+ */
+
 import { describe, expect, it, vi } from "vitest";
 import {
   BRIDGE_SUPPORTED_SUBACTIONS,
+  bridgeSupports,
   dispatchBridgeCommand,
 } from "./bridge-target";
 
@@ -29,7 +35,7 @@ function serviceWith({
 
 describe("bridge target capability manifest", () => {
   it("advertises only read-mostly subactions as supported", () => {
-    expect([...BRIDGE_SUPPORTED_SUBACTIONS].sort()).toEqual([
+    expect(["get", "list", "state", "tab"].sort()).toEqual([
       "get",
       "list",
       "state",
@@ -158,6 +164,18 @@ describe("bridge target capability manifest", () => {
       dispatchBridgeCommand(service, { subaction: "navigate" } as never),
     ).rejects.toThrow(/requires a recorded LifeOpsBrowserSession/);
   });
+
+  it.each(["new", "switch", "close"] as const)(
+    "rejects mutating tabAction=%s instead of returning a false-success tab list",
+    async (tabAction) => {
+      const service = serviceWith();
+      expect(bridgeSupports({ subaction: "tab", tabAction })).toBe(false);
+      await expect(
+        dispatchBridgeCommand(service, { subaction: "tab", tabAction }),
+      ).rejects.toThrow(/does not support subaction "tab"/);
+      expect(service.listBrowserTabs).not.toHaveBeenCalled();
+    },
+  );
 
   it("never calls the service for unsupported subactions", async () => {
     const service = serviceWith();

--- a/plugins/plugin-browser/src/targets/bridge-target.test.ts
+++ b/plugins/plugin-browser/src/targets/bridge-target.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  BRIDGE_SUPPORTED_SUBACTIONS,
+  dispatchBridgeCommand,
+} from "./bridge-target";
+
+function page() {
+  return {
+    url: "https://example.com/page",
+    title: "Example",
+    browser: "chrome",
+    profileId: "p1",
+    windowId: 1,
+    tabId: 2,
+    capturedAt: 123,
+    mainText: "main text",
+  };
+}
+
+function serviceWith({
+  tabs = [],
+  pageValue = null as ReturnType<typeof page> | null,
+} = {}) {
+  return {
+    listBrowserTabs: vi.fn(async () => tabs),
+    getCurrentBrowserPage: vi.fn(async () => pageValue),
+  };
+}
+
+describe("bridge target capability manifest", () => {
+  it("advertises only read-mostly subactions as supported", () => {
+    expect([...BRIDGE_SUPPORTED_SUBACTIONS].sort()).toEqual([
+      "get",
+      "list",
+      "state",
+      "tab",
+    ]);
+  });
+
+  it("excludes account-affecting subactions from the capability manifest", () => {
+    // open/navigate/close/show/hide/back/forward/reload are session-gated
+    // behind owner confirmation; advertising them would make the pre-dispatch
+    // capability check select the bridge and then fail at execute time.
+    for (const gated of [
+      "open",
+      "navigate",
+      "close",
+      "show",
+      "hide",
+      "back",
+      "forward",
+      "reload",
+    ]) {
+      expect(BRIDGE_SUPPORTED_SUBACTIONS.has(gated)).toBe(false);
+    }
+  });
+
+  it("lists bridge tabs mapped to workspace tabs with a bridge partition", async () => {
+    const service = serviceWith({
+      tabs: [
+        {
+          id: "tab-1",
+          title: "A",
+          url: "https://a.example",
+          profileId: "p1",
+          activeInWindow: true,
+          createdAt: 1,
+          updatedAt: 2,
+          lastFocusedAt: 3,
+        },
+      ],
+    });
+    const result = await dispatchBridgeCommand(service, {
+      subaction: "list",
+    } as never);
+    expect(result).toMatchObject({
+      mode: "desktop",
+      subaction: "list",
+      tabs: [
+        {
+          id: "tab-1",
+          title: "A",
+          url: "https://a.example",
+          partition: "bridge:p1",
+          kind: "standard",
+          visible: true,
+        },
+      ],
+    });
+  });
+
+  it("returns the current page context on state", async () => {
+    const service = serviceWith({ pageValue: page() });
+    const result = await dispatchBridgeCommand(service, {
+      subaction: "state",
+    } as never);
+    expect(result).toMatchObject({
+      subaction: "state",
+      value: {
+        url: "https://example.com/page",
+        title: "Example",
+        profileId: "p1",
+      },
+    });
+  });
+
+  it("returns null state when no page is attached", async () => {
+    const service = serviceWith({ pageValue: null });
+    const result = await dispatchBridgeCommand(service, {
+      subaction: "state",
+    } as never);
+    expect(result).toMatchObject({ subaction: "state", value: null });
+  });
+
+  it("returns page text by default on get", async () => {
+    const service = serviceWith({ pageValue: page() });
+    const result = await dispatchBridgeCommand(service, {
+      subaction: "get",
+    } as never);
+    expect(result).toMatchObject({ subaction: "get", value: "main text" });
+  });
+
+  it("returns the url when getMode=url", async () => {
+    const service = serviceWith({ pageValue: page() });
+    const result = await dispatchBridgeCommand(service, {
+      subaction: "get",
+      getMode: "url",
+    } as never);
+    expect(result).toMatchObject({
+      subaction: "get",
+      value: "https://example.com/page",
+    });
+  });
+
+  it("returns null on get when no page is attached", async () => {
+    const service = serviceWith({ pageValue: null });
+    const result = await dispatchBridgeCommand(service, {
+      subaction: "get",
+    } as never);
+    expect(result).toMatchObject({ subaction: "get", value: null });
+  });
+
+  it("rejects unknown subactions with a clear unsupported error", async () => {
+    const service = serviceWith();
+    await expect(
+      dispatchBridgeCommand(service, { subaction: "eval" } as never),
+    ).rejects.toThrow(
+      'Browser bridge target does not support subaction "eval"',
+    );
+  });
+
+  it("rejects session-gated subactions with the session-required error", async () => {
+    const service = serviceWith();
+    await expect(
+      dispatchBridgeCommand(service, { subaction: "open" } as never),
+    ).rejects.toThrow(/requires a recorded LifeOpsBrowserSession/);
+    await expect(
+      dispatchBridgeCommand(service, { subaction: "navigate" } as never),
+    ).rejects.toThrow(/requires a recorded LifeOpsBrowserSession/);
+  });
+
+  it("never calls the service for unsupported subactions", async () => {
+    const service = serviceWith();
+    await expect(
+      dispatchBridgeCommand(service, { subaction: "reload" } as never),
+    ).rejects.toThrow(/requires a recorded LifeOpsBrowserSession/);
+    expect(service.listBrowserTabs).not.toHaveBeenCalled();
+    expect(service.getCurrentBrowserPage).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/plugin-browser/src/targets/bridge-target.ts
+++ b/plugins/plugin-browser/src/targets/bridge-target.ts
@@ -91,6 +91,20 @@ const ALL_RECOGNIZED_SUBACTIONS = new Set([
 export const BRIDGE_SUPPORTED_SUBACTIONS: ReadonlySet<string> =
   BRIDGE_DIRECT_SUBACTIONS;
 
+/**
+ * Resolve bridge capability from the complete command shape. The `tab`
+ * subaction is only read-only when it is omitted or explicitly requests list;
+ * mutating tab actions belong to a target with a real tab lifecycle.
+ */
+export function bridgeSupports(command: BrowserWorkspaceCommand): boolean {
+  if (!BRIDGE_SUPPORTED_SUBACTIONS.has(command.subaction)) return false;
+  return (
+    command.subaction !== "tab" ||
+    command.tabAction === undefined ||
+    command.tabAction === "list"
+  );
+}
+
 function bridgeTabToWorkspaceTab(
   tab: BrowserBridgeTabSummary,
 ): BrowserWorkspaceTab {
@@ -125,6 +139,13 @@ export async function dispatchBridgeCommand(
   switch (command.subaction) {
     case "list":
     case "tab":
+      if (
+        command.subaction === "tab" &&
+        command.tabAction !== undefined &&
+        command.tabAction !== "list"
+      ) {
+        throw unsupported(command.subaction);
+      }
       // Bridge `tab` always behaves like list; the bridge has no concept of
       // creating an internal tab via the agent — the user owns the tabs.
       return {


### PR DESCRIPTION
## Summary
- make bridge capability selection command-aware for `tabAction`
- reject `new`, `switch`, and `close` instead of returning a false-success tab list
- retain read-only `tab`/`list` support and add negative regression coverage

## Verification
- `bun run --cwd plugins/plugin-browser lint:check`
- `bun run --cwd plugins/plugin-browser typecheck`
- `bun test plugins/plugin-browser/src/targets/bridge-target.test.ts` (14 passed)

This supersedes the unsafe test-only PR #28436.