### PR TITLE
feat(shared): export getBrowserTabsRendererImpl and add registry unit tests

### DIFF
--- a/packages/shared/src/utils/browser-tabs-renderer-registry.test.ts
+++ b/packages/shared/src/utils/browser-tabs-renderer-registry.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Unit tests for browser tabs renderer registry and preload script in
+ * packages/shared/src/utils/browser-tabs-renderer-registry.ts.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  BROWSER_TAB_PRELOAD_SCRIPT,
+  type BrowserTabsRendererImpl,
+  getBrowserTabsRendererImpl,
+  setBrowserTabsRendererImpl,
+} from "./browser-tabs-renderer-registry.js";
+
+describe("browser-tabs-renderer-registry", () => {
+  const REGISTRY_KEY = "__ELIZA_BROWSER_TABS_REGISTRY__";
+
+  beforeEach(() => {
+    delete (globalThis as unknown as Record<string, unknown>)[REGISTRY_KEY];
+  });
+
+  afterEach(() => {
+    delete (globalThis as unknown as Record<string, unknown>)[REGISTRY_KEY];
+  });
+
+  describe("setBrowserTabsRendererImpl and getBrowserTabsRendererImpl", () => {
+    it("returns null when no renderer implementation is registered", () => {
+      expect(getBrowserTabsRendererImpl()).toBeNull();
+    });
+
+    it("registers and retrieves a renderer implementation", async () => {
+      const mockImpl: BrowserTabsRendererImpl = {
+        evaluate: vi.fn().mockResolvedValue({ ok: true, result: 42 }),
+        getTabRect: vi
+          .fn()
+          .mockResolvedValue({ x: 0, y: 0, width: 800, height: 600 }),
+      };
+
+      setBrowserTabsRendererImpl(mockImpl);
+      expect(getBrowserTabsRendererImpl()).toBe(mockImpl);
+
+      const evalRes = await getBrowserTabsRendererImpl()?.evaluate(
+        "tab-1",
+        "1 + 1",
+        1000,
+      );
+      expect(evalRes).toEqual({ ok: true, result: 42 });
+      expect(mockImpl.evaluate).toHaveBeenCalledWith("tab-1", "1 + 1", 1000);
+
+      const rectRes = await getBrowserTabsRendererImpl()?.getTabRect("tab-1");
+      expect(rectRes).toEqual({ x: 0, y: 0, width: 800, height: 600 });
+      expect(mockImpl.getTabRect).toHaveBeenCalledWith("tab-1");
+    });
+
+    it("clears the registry when null is passed", () => {
+      const mockImpl: BrowserTabsRendererImpl = {
+        evaluate: vi.fn().mockResolvedValue({ ok: true }),
+        getTabRect: vi.fn().mockResolvedValue(null),
+      };
+
+      setBrowserTabsRendererImpl(mockImpl);
+      expect(getBrowserTabsRendererImpl()).toBe(mockImpl);
+
+      setBrowserTabsRendererImpl(null);
+      expect(getBrowserTabsRendererImpl()).toBeNull();
+      expect(
+        (globalThis as unknown as Record<string, unknown>)[REGISTRY_KEY],
+      ).toBeUndefined();
+    });
+  });
+
+  describe("BROWSER_TAB_PRELOAD_SCRIPT", () => {
+    it("exports a valid JavaScript IIFE string containing required hooks", () => {
+      expect(typeof BROWSER_TAB_PRELOAD_SCRIPT).toBe("string");
+      expect(BROWSER_TAB_PRELOAD_SCRIPT.length).toBeGreaterThan(1000);
+
+      // Verify core contracts and global bridge installations
+      expect(BROWSER_TAB_PRELOAD_SCRIPT).toContain("window.__elizaTabExec");
+      expect(BROWSER_TAB_PRELOAD_SCRIPT).toContain("window.__elizaTabKit");
+      expect(BROWSER_TAB_PRELOAD_SCRIPT).toContain("__electrobunSendToHost");
+      expect(BROWSER_TAB_PRELOAD_SCRIPT).toContain("scanLoginForms");
+    });
+  });
+});

--- a/packages/shared/src/utils/browser-tabs-renderer-registry.ts
+++ b/packages/shared/src/utils/browser-tabs-renderer-registry.ts
@@ -1292,13 +1292,26 @@ declare global {
   }
 }
 
+function getGlobalRegistryTarget(): Window | undefined {
+  if (typeof window !== "undefined") return window;
+  if (typeof globalThis !== "undefined") return globalThis as unknown as Window;
+  return undefined;
+}
+
 export function setBrowserTabsRendererImpl(
   impl: BrowserTabsRendererImpl | null,
 ): void {
-  if (typeof window === "undefined") return;
+  const target = getGlobalRegistryTarget();
+  if (!target) return;
   if (impl) {
-    window[REGISTRY_KEY] = impl;
+    target[REGISTRY_KEY] = impl;
   } else {
-    delete window[REGISTRY_KEY];
+    delete target[REGISTRY_KEY];
   }
+}
+
+export function getBrowserTabsRendererImpl(): BrowserTabsRendererImpl | null {
+  const target = getGlobalRegistryTarget();
+  if (!target) return null;
+  return target[REGISTRY_KEY] ?? null;
 }


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Additive getter `getBrowserTabsRendererImpl()` and unit test coverage in `packages/shared/src/utils/browser-tabs-renderer-registry.ts`.

# Background

## What does this PR do?

1. Implements `getBrowserTabsRendererImpl(): BrowserTabsRendererImpl | null` complementing `setBrowserTabsRendererImpl` with `window` / `globalThis` environment fallbacks.
2. Adds unit test suite in `packages/shared/src/utils/browser-tabs-renderer-registry.test.ts` covering `setBrowserTabsRendererImpl`, `getBrowserTabsRendererImpl`, registry teardown via `null`, mock evaluate and getTabRect invocations, and `BROWSER_TAB_PRELOAD_SCRIPT` IIFE structural integrity.

## What kind of change is this?

New feature (non-breaking change which adds functionality)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/shared/src/utils/browser-tabs-renderer-registry.test.ts`

## Detailed testing steps

```bash
npx vitest run packages/shared/src/utils/browser-tabs-renderer-registry.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:c8fb9dc53bcc04ab81ee05c0478942e8415d81c6 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - shared utility change with no rendered UI surface
<!-- evidence-row:after-screenshots -->
- [ ] N/A - shared utility change with no rendered UI surface
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - shared utility has no user flow to record
<!-- evidence-row:backend-logs -->
- [ ] N/A - pure utility function executed via test runner
<!-- evidence-row:frontend-logs -->
- [ ] N/A - pure shared utility does not exercise a live browser path
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - browser tabs renderer registry with no LLM model or prompt path involved
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database rows or persistent domain records produced
<!-- evidence-row:ocr-review -->
- [ ] N/A - shared utility change with no rendered visual surface

# Evidence Details

## Real LLM-call trajectory

N/A - browser tabs renderer registry with no LLM model or prompt path involved.

## Backend + frontend logs

```
RED (mutated packages/shared/src/utils/browser-tabs-renderer-registry.ts: getBrowserTabsRendererImpl returns null):
  4 tests | 2 failed
  FAIL packages/shared/src/utils/browser-tabs-renderer-registry.test.ts > browser-tabs-renderer-registry > setBrowserTabsRendererImpl and getBrowserTabsRendererImpl > registers and retrieves a renderer implementation
  AssertionError: expected null to be { evaluate: [Function Mock], getTabRect: [Function Mock] }

GREEN (restored production source):
  4 tests | 4 passed [122ms]
```

## Screenshots (before / after) + video walkthrough

N/A - shared utility change with no rendered UI surfaces or visual modifications.

### Before

N/A - shared utility change with no rendered UI surface.

### After

N/A - shared utility change with no rendered UI surface.

### Walkthrough video

N/A - shared utility has no user flow to record.

## Audio / voice walkthrough

N/A - no voice or audio paths touched in this change.

## Known gaps / failures

None. All 4 tests pass in `packages/shared/src/utils/browser-tabs-renderer-registry.test.ts`.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: Claude Code
— [lane-byt61-8427]

