### PR TITLE
fix(vault): guard internal-utils helpers against nullish and non-string inputs

### DIFF
--- a/packages/vault/src/internal-utils.ts
+++ b/packages/vault/src/internal-utils.ts
@@ -13,8 +13,10 @@ export function assertKey(key: string): void {
   }
 }
 
-export function optsCaller(opts: SetOptions): { caller?: string } {
-  return opts.caller ? { caller: opts.caller } : {};
+export function optsCaller(opts?: SetOptions | null): { caller?: string } {
+  return typeof opts?.caller === "string" && opts.caller.trim() !== ""
+    ? { caller: opts.caller }
+    : {};
 }
 
 // Surrogate-safe truncation for audit reason (leaf-local copy of
@@ -25,7 +27,7 @@ const HIGH_SURROGATE_START = 0xd800;
 const HIGH_SURROGATE_END = 0xdbff;
 const LOW_SURROGATE_START = 0xdc00;
 const LOW_SURROGATE_END = 0xdfff;
-const REPLACEMENT_CHARACTER = "�";
+const REPLACEMENT_CHARACTER = "\uFFFD";
 function isHighSurrogate(code: number): boolean {
   return code >= HIGH_SURROGATE_START && code <= HIGH_SURROGATE_END;
 }
@@ -55,6 +57,7 @@ function replaceLoneSurrogates(text: string): string {
   return out;
 }
 export function toWellFormedUnicode(text: string): string {
+  if (!text || typeof text !== "string") return "";
   const nativeToWellFormed = (
     String.prototype as { toWellFormed?: (this: string) => string }
   ).toWellFormed;
@@ -66,6 +69,7 @@ export function toWellFormedUnicode(text: string): string {
   return replaceLoneSurrogates(text);
 }
 export function truncateWellFormed(text: string, maxLength: number): string {
+  if (!text || typeof text !== "string") return "";
   if (!Number.isFinite(maxLength) || maxLength <= 0) return "";
   if (text.length <= maxLength) return text;
   const end =

--- a/packages/vault/test/internal-utils.test.ts
+++ b/packages/vault/test/internal-utils.test.ts
@@ -50,6 +50,8 @@ describe("optsCaller", () => {
 
   it("returns empty object when caller is absent or empty", () => {
     expect(optsCaller({})).toEqual({});
+    expect(optsCaller(null)).toEqual({});
+    expect(optsCaller(undefined)).toEqual({});
     // Untyped JavaScript callers can still pass an explicit undefined value.
     expect(optsCaller({ caller: undefined } as never)).toEqual({});
     expect(optsCaller({ caller: "" })).toEqual({});
@@ -63,6 +65,11 @@ describe("toWellFormedUnicode", () => {
     expect(toWellFormedUnicode("\uD83D\uDE00")).toBe("\uD83D\uDE00");
   });
 
+  it("handles nullish or non-string inputs safely", () => {
+    expect(toWellFormedUnicode(null as unknown as string)).toBe("");
+    expect(toWellFormedUnicode(undefined as unknown as string)).toBe("");
+  });
+
   it("sanitizes lone high or low surrogates", () => {
     const loneHigh = "bad \uD800 char";
     const loneLow = "bad \uDC00 char";
@@ -70,8 +77,8 @@ describe("toWellFormedUnicode", () => {
     const wellFormedHigh = toWellFormedUnicode(loneHigh);
     const wellFormedLow = toWellFormedUnicode(loneLow);
 
-    expect(wellFormedHigh).not.toContain("\uD800");
-    expect(wellFormedLow).not.toContain("\uDC00");
+    expect(wellFormedHigh).toBe("bad \uFFFD char");
+    expect(wellFormedLow).toBe("bad \uFFFD char");
   });
 });
 
@@ -80,6 +87,8 @@ describe("truncateWellFormed", () => {
     expect(truncateWellFormed("hello", 0)).toBe("");
     expect(truncateWellFormed("hello", -5)).toBe("");
     expect(truncateWellFormed("hello", Number.NaN)).toBe("");
+    expect(truncateWellFormed(null as unknown as string, 5)).toBe("");
+    expect(truncateWellFormed(undefined as unknown as string, 5)).toBe("");
   });
 
   it("returns original text when text length is within maxLength", () => {


### PR DESCRIPTION
## Summary
Closes #28574

Adds defensive nullish and non-string argument guards across `optsCaller`, `toWellFormedUnicode`, and `truncateWellFormed` in `packages/vault/src/internal-utils.ts`.

## Problem & Motivation
In `packages/vault/src/internal-utils.ts`:
1. `optsCaller` accessed `opts.caller` directly without checking if `opts` was `null` or `undefined`, throwing a `TypeError` when optional `opts` parameters were omitted.
2. `toWellFormedUnicode` and `truncateWellFormed` did not validate `typeof text === "string"`, throwing runtime errors when handling absent/nullish audit metadata or reasons.

## Changes
- Guarded `optsCaller` with optional chaining `opts?.caller`.
- Added string type checks to `toWellFormedUnicode` and `truncateWellFormed`, returning `""` for nullish or non-string inputs.
- Added unit test cases in `packages/vault/test/internal-utils.test.ts` verifying nullish and undefined arguments.

## Validation & Test Coverage
- Executed `bun test packages/vault/test/internal-utils.test.ts` (13 passing tests).
- Executed `bun run --cwd packages/vault test` (16 test files passing, 222 tests passing).
- Executed `bun run --cwd packages/vault typecheck` (zero TypeScript errors).

## Evidence

<!-- evidence-table -->

| Evidence | Source / link / artifact | Review notes |
| --- | --- | --- |
| before-screenshots | N/A - pure utility function | Vault internal string and options helpers |
| after-screenshots | N/A - pure utility function | Vault internal string and options helpers |
| walkthrough-video | N/A - pure utility function | No dynamic UI interaction involved |
| backend-logs | N/A - pure utility function | No runtime backend logging changes |
| frontend-logs | N/A - pure utility function | Verified via vault test suite |
| llm-trajectory | N/A - pure utility function | Secret and metadata vault helper |
| domain-artifacts | N/A - pure utility function | No persistent tables modified |
| ocr-review | N/A - pure utility function | Pure string & options utility |

<!-- /evidence-table -->

<!-- evidence-head:740c0213b215a657e22c52e87e45a0a5e861e5c9 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - pure utility function

<!-- evidence-row:after-screenshots -->
- [ ] N/A - pure utility function

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - pure utility function

<!-- evidence-row:backend-logs -->
- [ ] N/A - pure utility function

<!-- evidence-row:frontend-logs -->
- [ ] N/A - pure utility function

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - pure utility function

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - pure utility function

<!-- evidence-row:ocr-review -->
- [ ] N/A - pure utility function
