### PR TITLE
fix(plugin-web-search): guard HTML entity and metadata extraction against nullish content

### DIFF
--- a/plugins/plugin-web-search/src/services/webSearchService.test.ts
+++ b/plugins/plugin-web-search/src/services/webSearchService.test.ts
@@ -525,4 +525,17 @@ describe("WebSearchService", () => {
         // Policy must reject before the injected transport is invoked.
         expect(fetchImpl).not.toHaveBeenCalled();
     });
+
+    it("handles empty or sparse HTML safely without crashing extraction", async () => {
+        const fetchImpl = vi.fn(async () => new Response(""));
+        setPageInfoHttpTransportForTests({ fetchImpl });
+        const service = await WebSearchService.start(runtime({ TAVILY_API_KEY: "tvly-test" }));
+
+        const pageInfo = await service.getPageInfo("https://example.test/empty");
+        expect(pageInfo.title).toBe("https://example.test/empty");
+        expect(pageInfo.description).toBe("");
+        expect(pageInfo.metadata).toEqual({});
+        expect(pageInfo.images).toEqual([]);
+        expect(pageInfo.links).toEqual([]);
+    });
 });

--- a/plugins/plugin-web-search/src/services/webSearchService.ts
+++ b/plugins/plugin-web-search/src/services/webSearchService.ts
@@ -223,6 +223,7 @@ function freshnessToDays(freshness: NewsSearchOptions["freshness"]): number {
 }
 
 function decodeHtmlEntities(text: string): string {
+    if (!text || typeof text !== "string") return "";
     const decodeNumericEntity = (entity: string, digits: string, radix: number): string => {
         const codePoint = Number.parseInt(digits, radix);
         if (
@@ -334,6 +335,7 @@ async function readBoundedPageHtml(response: Response): Promise<string> {
 }
 
 function extractTitle(content: string, fallbackUrl: string): string {
+    if (!content || typeof content !== "string") return fallbackUrl ?? "";
     const match = content.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
     if (!match?.[1]) return fallbackUrl;
     const cleanText = match[1].replace(/<[^>]+>/g, "").trim();
@@ -346,6 +348,9 @@ function extractMetaTags(content: string): {
 } {
     const metadata: Record<string, string> = {};
     let description = "";
+    if (!content || typeof content !== "string") {
+        return { description, metadata };
+    }
 
     const metaRegex = /<meta\s+([^>]+)>/gi;
     let match = metaRegex.exec(content);
@@ -387,6 +392,7 @@ function resolveHttpUrl(raw: string, baseUrl: URL): string | null {
 
 function extractImages(content: string, baseUrl: URL): string[] {
     const images: string[] = [];
+    if (!content || typeof content !== "string") return images;
     const seen = new Set<string>();
     const imgRegex = /<img\s+[^>]*src=["']([^"']+)["']/gi;
     let match = imgRegex.exec(content);
@@ -409,6 +415,7 @@ function extractImages(content: string, baseUrl: URL): string[] {
 
 function extractLinks(content: string, baseUrl: URL): string[] {
     const links: string[] = [];
+    if (!content || typeof content !== "string") return links;
     const seen = new Set<string>();
     const anchorRegex = /<a\s+[^>]*href=["']([^"']+)["']/gi;
     let match = anchorRegex.exec(content);


### PR DESCRIPTION
## Summary
Closes #28579

Adds defensive guards against nullish and non-string content across `decodeHtmlEntities`, `extractTitle`, `extractMetaTags`, `extractImages`, and `extractLinks` in `plugins/plugin-web-search/src/services/webSearchService.ts`.

## Problem & Motivation
In `plugins/plugin-web-search/src/services/webSearchService.ts`, HTML scraping helper functions assumed their `content` string argument was always defined. When processing unexpected, empty, or non-string response streams, regex matches and string prototype invocations threw `TypeError` rather than safely returning fallback metadata.

## Changes
- Added string typeguard in `decodeHtmlEntities` returning `""` for nullish or non-string input.
- Added input validation in `extractTitle`, `extractMetaTags`, `extractImages`, and `extractLinks` returning empty arrays, empty metadata objects, and fallback URLs respectively on non-string inputs.
- Added unit test in `plugins/plugin-web-search/src/services/webSearchService.test.ts` verifying safe extraction from empty HTML bodies.

## Validation & Test Coverage
- Executed `bun run --cwd plugins/plugin-web-search test` (4 test files passing, 37 passing tests).
- Executed `bun run --cwd plugins/plugin-web-search typecheck` (zero TypeScript errors).

## Evidence

<!-- evidence-table -->

| Evidence | Source / link / artifact | Review notes |
| --- | --- | --- |
| before-screenshots | N/A - pure utility function | Web search HTML scraper extraction |
| after-screenshots | N/A - pure utility function | Web search HTML scraper extraction |
| walkthrough-video | N/A - pure utility function | No dynamic UI interaction involved |
| backend-logs | N/A - pure utility function | No runtime backend logging changes |
| frontend-logs | N/A - pure utility function | Tested via plugin-web-search vitest suite |
| llm-trajectory | N/A - pure utility function | Web search service page info helper |
| domain-artifacts | N/A - pure utility function | No persistent tables modified |
| ocr-review | N/A - pure utility function | Pure scraping parser utility |

<!-- /evidence-table -->

<!-- evidence-head:8fe614013ff477af18887c219a93fd0db558a54c -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - pure utility function

<!-- evidence-row:after-screenshots -->
- [ ] N/A - pure utility function

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - pure utility function

<!-- evidence-row:backend-logs -->
- [ ] N/A - pure utility function

<!-- evidence-row:frontend-logs -->
- [ ] N/A - pure utility function

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - pure utility function

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - pure utility function

<!-- evidence-row:ocr-review -->
- [ ] N/A - pure utility function
