### PR TITLE
fix(core): guard extractFirstSentence and hasFirstSentence against nullish and non-string inputs

### DIFF
--- a/packages/core/src/utils/text-splitting.test.ts
+++ b/packages/core/src/utils/text-splitting.test.ts
@@ -104,6 +104,24 @@ describe("extractFirstSentence", () => {
 		});
 		expect(extractFirstSentence("你好。下一句。").complete).toBe(false);
 	});
+
+	it("safely handles nullish and non-string inputs", () => {
+		expect(extractFirstSentence(null as unknown as string)).toEqual({
+			first: "",
+			rest: "",
+			complete: false,
+		});
+		expect(extractFirstSentence(undefined as unknown as string)).toEqual({
+			first: "",
+			rest: "",
+			complete: false,
+		});
+		expect(extractFirstSentence("")).toEqual({
+			first: "",
+			rest: "",
+			complete: false,
+		});
+	});
 });
 
 describe("hasFirstSentence", () => {
@@ -124,6 +142,8 @@ describe("hasFirstSentence", () => {
 	it("reports false for an incomplete fragment", () => {
 		expect(hasFirstSentence("Sure, I added")).toBe(false);
 		expect(hasFirstSentence("")).toBe(false);
+		expect(hasFirstSentence(null as unknown as string)).toBe(false);
+		expect(hasFirstSentence(undefined as unknown as string)).toBe(false);
 	});
 
 	it("is not fooled by an abbreviation mid-fragment", () => {

--- a/packages/core/src/utils/text-splitting.ts
+++ b/packages/core/src/utils/text-splitting.ts
@@ -76,13 +76,14 @@ export function createFirstSentenceScanner(): FirstSentenceScanner {
 
 	return {
 		push(chunk: string, endOfInput = false): number | undefined {
+			const safeChunk = typeof chunk === "string" ? chunk : "";
 			if (completeAt !== undefined) return completeAt;
-			if (pendingBoundary && (chunk.length > 0 || endOfInput)) {
+			if (pendingBoundary && (safeChunk.length > 0 || endOfInput)) {
 				if (!ABBREVIATIONS.has(pendingBoundary.normalizedWord)) {
 					let closerOffset = 0;
 					while (
-						closerOffset < chunk.length &&
-						TRAILING_CLOSERS.includes(chunk[closerOffset])
+						closerOffset < safeChunk.length &&
+						TRAILING_CLOSERS.includes(safeChunk[closerOffset])
 					) {
 						closerOffset += 1;
 					}
@@ -91,14 +92,14 @@ export function createFirstSentenceScanner(): FirstSentenceScanner {
 						pendingBoundary.sawCloser = true;
 						scanned += closerOffset;
 					}
-					if (closerOffset === chunk.length) {
+					if (closerOffset === safeChunk.length) {
 						if (!endOfInput) return undefined;
 						completeAt = pendingBoundary.boundary;
 						return completeAt;
 					}
 					if (
 						pendingBoundary.sawCloser ||
-						isBoundaryFollower(chunk[closerOffset])
+						isBoundaryFollower(safeChunk[closerOffset])
 					) {
 						completeAt = pendingBoundary.boundary;
 						return completeAt;
@@ -107,11 +108,11 @@ export function createFirstSentenceScanner(): FirstSentenceScanner {
 				pendingBoundary = undefined;
 			}
 
-			for (let offset = 0; offset < chunk.length; offset += 1) {
-				const char = chunk[offset];
+			for (let offset = 0; offset < safeChunk.length; offset += 1) {
+				const char = safeChunk[offset];
 				if (
 					SENTENCE_END.has(char) &&
-					chunk[offset + 1] === undefined &&
+					safeChunk[offset + 1] === undefined &&
 					!endOfInput
 				) {
 					const word = lastWord.endsWith(".")
@@ -124,7 +125,7 @@ export function createFirstSentenceScanner(): FirstSentenceScanner {
 					};
 				} else if (
 					SENTENCE_END.has(char) &&
-					isBoundaryFollower(chunk[offset + 1])
+					isBoundaryFollower(safeChunk[offset + 1])
 				) {
 					const word = lastWord.endsWith(".")
 						? lastWord.slice(0, -1)
@@ -132,12 +133,12 @@ export function createFirstSentenceScanner(): FirstSentenceScanner {
 					if (!ABBREVIATIONS.has(word.toLowerCase())) {
 						let boundary = offset + 1;
 						while (
-							boundary < chunk.length &&
-							TRAILING_CLOSERS.includes(chunk[boundary])
+							boundary < safeChunk.length &&
+							TRAILING_CLOSERS.includes(safeChunk[boundary])
 						) {
 							boundary += 1;
 						}
-						if (boundary === chunk.length && !endOfInput) {
+						if (boundary === safeChunk.length && !endOfInput) {
 							pendingBoundary = {
 								boundary: scanned + boundary,
 								normalizedWord: word.toLowerCase(),
@@ -156,7 +157,7 @@ export function createFirstSentenceScanner(): FirstSentenceScanner {
 				}
 			}
 
-			scanned += chunk.length;
+			scanned += safeChunk.length;
 			return undefined;
 		},
 	};
@@ -212,6 +213,9 @@ export function extractFirstSentence(text: string): {
 	/** Whether a sentence boundary was actually found in `text`. */
 	complete: boolean;
 } {
+	if (typeof text !== "string" || text.length === 0) {
+		return { first: "", rest: "", complete: false };
+	}
 	const boundaryIndex = createFirstSentenceScanner().push(text, true);
 
 	if (boundaryIndex !== undefined) {
@@ -228,6 +232,9 @@ export function extractFirstSentence(text: string): {
  * Useful for streaming to know when to call extractFirstSentence.
  */
 export function hasFirstSentence(text: string): boolean {
+	if (typeof text !== "string" || text.length === 0) {
+		return false;
+	}
 	// A boundary at the end of the text still completes a sentence, so this
 	// cannot key off `rest`: a reply that is exactly one sentence leaves it
 	// empty and would report false.


### PR DESCRIPTION
## Summary
Closes #28586

Defensively guards `extractFirstSentence`, `hasFirstSentence`, and `createFirstSentenceScanner().push()` against nullish and non-string inputs in `packages/core/src/utils/text-splitting.ts`.

## Problem & Motivation
In `packages/core/src/utils/text-splitting.ts`:
1. Calling `extractFirstSentence(null)` or `extractFirstSentence(undefined)` threw `TypeError: text.trim is not a function` or property access errors.
2. `hasFirstSentence` failed to handle non-string or nullish text defensively.
3. `createFirstSentenceScanner().push(chunk)` assumed `chunk` is always a string.

## Changes
- Added nullish and `typeof text !== "string"` checks to `extractFirstSentence` returning `{ first: "", rest: "", complete: false }`.
- Added string type checks to `hasFirstSentence` returning `false` on non-string or empty inputs.
- Guarded `chunk` in `createFirstSentenceScanner().push()` to safely fallback to `""` on non-string inputs.
- Added comprehensive unit test cases in `packages/core/src/utils/text-splitting.test.ts`.

## Validation & Test Coverage
- Executed `bun test packages/core/src/utils/text-splitting.test.ts` (27 passing tests).
- Executed `bun run --cwd packages/core typecheck` (zero TypeScript errors).

## Evidence

<!-- evidence-table -->

| Evidence | Source / link / artifact | Review notes |
| --- | --- | --- |
| before-screenshots | N/A - pure utility function | First sentence boundary parser utility |
| after-screenshots | N/A - pure utility function | First sentence boundary parser utility |
| walkthrough-video | N/A - pure utility function | No dynamic UI interaction involved |
| backend-logs | N/A - pure utility function | No runtime backend logging changes |
| frontend-logs | N/A - pure utility function | Tested via core test suite |
| llm-trajectory | N/A - pure utility function | Text splitting sentence utility |
| domain-artifacts | N/A - pure utility function | No persistent tables modified |
| ocr-review | N/A - pure utility function | Pure string boundary utility |

<!-- /evidence-table -->

<!-- evidence-head:a2d9894f2bd6fdc118662976468c237e757291df -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - pure utility function

<!-- evidence-row:after-screenshots -->
- [ ] N/A - pure utility function

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - pure utility function

<!-- evidence-row:backend-logs -->
- [ ] N/A - pure utility function

<!-- evidence-row:frontend-logs -->
- [ ] N/A - pure utility function

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - pure utility function

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - pure utility function

<!-- evidence-row:ocr-review -->
- [ ] N/A - pure utility function
