### PR TITLE
test(ui): cover agent-startup-timing deadline math

### DIFF
--- a/packages/ui/src/state/agent-startup-timing.test.ts
+++ b/packages/ui/src/state/agent-startup-timing.test.ts
@@ -9,7 +9,7 @@
  * in jsdom (no module mocks).
  */
 // @vitest-environment jsdom
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   AGENT_STARTING_SLIDE_MS,
   AGENT_STARTUP_ABSOLUTE_MAX_MS,
@@ -84,12 +84,29 @@ describe("computeAgentDeadlineExtensions", () => {
     expect(extend({ now: START + 980_000 })).toBe(START + 900_000);
   });
 
-  it("clamps epoch-scale deadlines to wait start + 900s", () => {
+  it("slides to the real clock when `now` is omitted (production shape)", () => {
+    // Every production call site in startup-phase-runtime.ts omits `now`;
+    // this pins the Date.now() fallback with fake timers.
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(START + 60_000);
+      const out = computeAgentDeadlineExtensions({
+        agentWaitStartedAt: START,
+        agentDeadlineAt: START + 120_000,
+        state: "starting",
+      });
+      expect(out).toBe(START + 60_000 + 180_000);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("applies epoch-scale slide arithmetic with the cap not binding", () => {
     const epochStart = 1_756_000_000_000;
     // 600s into the wait: now+slide = epochStart+780_000, below the
-    // incoming deadline's ceiling — the slide applies, then the absolute
-    // cap does NOT bind. The expectation pins the slide arithmetic on
-    // epoch-scale numbers where a ms-vs-s unit slip would show.
+    // 900s absolute cap — the slide applies and the cap does not bind.
+    // The expectation pins the slide arithmetic on epoch-scale numbers
+    // where a ms-vs-s unit slip would show.
     const out = computeAgentDeadlineExtensions({
       agentWaitStartedAt: epochStart,
       agentDeadlineAt: epochStart + 120_000,

--- a/packages/ui/src/state/agent-startup-timing.test.ts
+++ b/packages/ui/src/state/agent-startup-timing.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Direct coverage for the agent-ready wait-loop deadline math in
+ * `agent-startup-timing.ts`: the electrobun-aware initial timeout floor and
+ * the sliding extension applied while the agent stays in `starting`.
+ *
+ * The suite is deterministic: `computeAgentDeadlineExtensions` takes an
+ * explicit `now`, and the electrobun path is exercised through the real
+ * `isElectrobunRuntime` detector by seeding `window.__electrobunWindowId`
+ * in jsdom (no module mocks).
+ */
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  AGENT_STARTING_SLIDE_MS,
+  AGENT_STARTUP_ABSOLUTE_MAX_MS,
+  computeAgentDeadlineExtensions,
+  getAgentReadyTimeoutMs,
+} from "./agent-startup-timing";
+
+const START = 1_000_000;
+const DAY_MS = 86_400_000;
+
+function extend(
+  options: Partial<Parameters<typeof computeAgentDeadlineExtensions>[0]> & {
+    state?: string | undefined;
+  },
+): number {
+  return computeAgentDeadlineExtensions({
+    agentWaitStartedAt: START,
+    agentDeadlineAt: START + 120_000,
+    state: "starting",
+    now: START + 60_000,
+    ...options,
+  });
+}
+
+afterEach(() => {
+  delete (globalThis.window as { __electrobunWindowId?: number })
+    .__electrobunWindowId;
+});
+
+describe("getAgentReadyTimeoutMs", () => {
+  it("returns the 180s floor for non-electrobun runtimes", () => {
+    expect(getAgentReadyTimeoutMs()).toBe(180_000);
+  });
+
+  it("returns the 300s electrobun floor when the renderer bridge is present", () => {
+    (
+      globalThis.window as { __electrobunWindowId?: number }
+    ).__electrobunWindowId = 7;
+    expect(getAgentReadyTimeoutMs()).toBe(300_000);
+  });
+});
+
+describe("computeAgentDeadlineExtensions", () => {
+  it("keeps the existing deadline when state is not starting", () => {
+    const deadline = START + 120_000;
+    expect(extend({ state: "running", agentDeadlineAt: deadline })).toBe(
+      deadline,
+    );
+    expect(extend({ state: undefined, agentDeadlineAt: deadline })).toBe(
+      deadline,
+    );
+  });
+
+  it("keeps the existing deadline during the first 15s of the wait", () => {
+    const deadline = START + 120_000;
+    expect(extend({ now: START + 14_999, agentDeadlineAt: deadline })).toBe(
+      deadline,
+    );
+  });
+
+  it("extends to now+180s once the wait is at least 15s old", () => {
+    expect(extend({ now: START + 15_000 })).toBe(START + 15_000 + 180_000);
+  });
+
+  it("does not shrink a deadline that is already further out", () => {
+    const far = START + 500_000;
+    expect(extend({ now: START + 60_000, agentDeadlineAt: far })).toBe(far);
+  });
+
+  it("caps the extension at 900s from wait start", () => {
+    // now+slide would be START+1_160_000, above the 900s absolute cap.
+    expect(extend({ now: START + 980_000 })).toBe(START + 900_000);
+  });
+
+  it("clamps epoch-scale deadlines to wait start + 900s", () => {
+    const epochStart = 1_756_000_000_000;
+    // 600s into the wait: now+slide = epochStart+780_000, below the
+    // incoming deadline's ceiling — the slide applies, then the absolute
+    // cap does NOT bind. The expectation pins the slide arithmetic on
+    // epoch-scale numbers where a ms-vs-s unit slip would show.
+    const out = computeAgentDeadlineExtensions({
+      agentWaitStartedAt: epochStart,
+      agentDeadlineAt: epochStart + 120_000,
+      state: "starting",
+      now: epochStart + 600_000,
+    });
+    expect(out).toBe(epochStart + 780_000);
+    expect(out - epochStart).toBe(600_000 + AGENT_STARTING_SLIDE_MS);
+  });
+
+  it("caps at wait start + 900s even when the incoming deadline is later", () => {
+    const out = computeAgentDeadlineExtensions({
+      agentWaitStartedAt: START,
+      agentDeadlineAt: START + 2_000_000,
+      state: "starting",
+      now: START + 60_000,
+    });
+    expect(out).toBe(START + AGENT_STARTUP_ABSOLUTE_MAX_MS);
+  });
+
+  it("handles wait timestamps spanning day boundaries", () => {
+    const out = computeAgentDeadlineExtensions({
+      agentWaitStartedAt: DAY_MS - 30_000,
+      agentDeadlineAt: DAY_MS + 90_000,
+      state: "starting",
+      now: DAY_MS - 10_000,
+    });
+    // 20s into the wait (> 15s warmup), so the deadline slides to
+    // now+180s — past midnight — rather than staying at +90s.
+    expect(out).toBe(DAY_MS - 10_000 + 180_000);
+  });
+});


### PR DESCRIPTION
# Relates to

No linked issue — self-sourced test-coverage contribution (byt61-class coverage lane). The module had zero direct coverage: no test file referenced any export of `packages/ui/src/state/agent-startup-timing.ts`, and its consumer suite (`startup-phase-runtime.test.ts`, 407 lines) never exercises the deadline math.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts. Base is `origin/develop` tip `85b9e7215a` at authoring time; branch adds a single test file on top.
- [x] Focused verification passes post-sync (details below); no `bun run verify` blockers introduced.

# Risks

Low. Test-only change: one new vitest file, no production code touched, no public surface changed, no config changed. Worst case is a flaky test, mitigated by fully deterministic inputs (explicit `now`, fake clock for the fallback test).

# Background

## What does this PR do?

Adds direct unit coverage for the agent-ready wait-loop deadline math in `packages/ui/src/state/agent-startup-timing.ts`:

- `getAgentReadyTimeoutMs()` — the 180s web floor and the 300s Electrobun floor. The Electrobun branch is exercised through the **real** `isElectrobunRuntime()` detector chain (`agent-startup-timing.ts` → `../bridge` → `electrobun-runtime.ts`) by seeding `window.__electrobunWindowId` in a jsdom environment — no module mocks.
- `computeAgentDeadlineExtensions()` — the 15s warmup gate (including the exact `14_999ms`/`15_000ms` boundary), the sliding 180s extension, the never-shrink `max()` rule, the 900s absolute cap (including the case where an incoming deadline beyond the cap is pulled back to it, since `Math.min` applies after `Math.max`), epoch-scale timestamps, day-boundary arithmetic, non-`starting` passthrough, and the production invocation shape where `now` is omitted (every call site in `startup-phase-runtime.ts` omits it) via `vi.useFakeTimers`/`vi.setSystemTime`.

11 tests, single file, +146 net lines.

## What kind of change is this?

Improvements (test-only coverage addition; no behavior change).

## Why are we doing this? Any context or related work?

The module is the sole owner of the agent-ready timeout budget: an incorrect slide/cap regression would either kill a slow booting agent's wait loop early or let it hang forever. None of its branches had any direct or indirect test coverage before this PR.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/ui/src/state/agent-startup-timing.test.ts` — read the module source (43 lines) next to it; every expectation is an exact-value assertion derived from the source semantics.

## Detailed testing steps

Automated tests are acceptable. Reproduce with:

```bash
cd packages/ui && npx vitest run src/state/agent-startup-timing.test.ts   # 11/11 pass
```

Verification performed at head `6e9978c2db`:

- **Mutation battery (6/6 caught):** slide `180_000→90_000`, absolute cap `900_000→600_000`, warmup gate `15_000→5_000`, Electrobun floor `300_000→200_000`, web floor `180_000→60_000`, and `options.now ?? Date.now()` → `options.now ?? 0`. Each mutation makes at least one test fail; the fallback mutation fails **only** the new fake-clock test, proving it uniquely guards the production invocation shape.
- **Typecheck:** `npx tsc --noEmit -p tsconfig.json` in `packages/ui` — 0 errors.
- **Lint:** `npx biome check` on the new file — clean (imports organized, formatting applied).
- **No-mocks audit:** the file contains no forbidden pattern from `lint-no-vi-mocks.mjs` (`vi.mock`/`vi.fn`/`vi.spyOn`/`vi.mocked`/jest equivalents); `vi.useFakeTimers`/`vi.setSystemTime` are not banned and are the established pattern in sibling suites (`client-base-timeout.test.ts`, `client-base-resume.test.ts`).
- **Neighbor suites:** `agent-session-recovery.test.ts`, `startup-phase-runtime.test.ts`, `startup-phase-runtime.cloud-warm.test.ts` — 51/51 pass.
- **Full `src/state/` lane:** 1365/1372 pass; the 7 failures are confined to `startup-phase-restore.concurrency.test.ts`/`startup-phase-restore.steward-refresh.test.ts` (JWT/Steward refresh) and reproduce **identically on pristine `origin/develop`** (7 failed | 14 passed in both) — pre-existing, unrelated to this PR.
- **Independent review:** RepoPrompt CE review agent (gpt-5.6-sol, engineer role) round 1 returned REQUEST_CHANGES with one must-fix (production `Date.now()` fallback untested) and one naming nit — both addressed in `6e9978c2db`; round 2 independently executed the suite (11/11) and biome, returning **APPROVE with zero findings**, including verification that all four production call sites omit `now` and that the fake-timer hygiene is correct.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:6e9978c2db76116589101e6d1f50e6407837d707 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only addition; no rendered UI surface changes.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only addition; no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - test-only addition; no user flow to walk through.
<!-- evidence-row:backend-logs -->
- [ ] N/A - no server path touched; the real code path here is the vitest run itself (11/11 pass + 6/6 mutation battery quoted inline in Testing, reproducible via the command there).
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no browser/console/network surface touched.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model-related code touched.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no domain state (DB/memories/tasks/wallet) touched.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - test-only change with no agent/action/provider/prompt/model code touched.

## Evidence row reasons (all N/A)

- **before-screenshots:** N/A - test-only addition; no rendered UI surface changes.
- **after-screenshots:** N/A - test-only addition; no rendered UI surface changes.
- **walkthrough-video:** N/A - test-only addition; no user flow to walk through.
- **backend-logs:** N/A - no server path touched; the "real code path" here is the vitest run itself (11/11 pass and the 6/6 mutation battery are quoted inline above and reproducible with the command in Testing).
- **frontend-logs:** N/A - no browser/console/network surface touched.
- **llm-trajectory:** N/A - no model-related code touched.
- **domain-artifacts:** N/A - no domain state (DB/memories/tasks/wallet) touched.
- **ocr-review:** N/A - no rendered visual surface.

---

**Verification summary:** 11/11 tests pass · 6/6 mutations caught (incl. RED control for the `Date.now()` fallback) · tsc 0 errors · biome clean · neighbor suites 51/51 · pre-existing failures proven identical on pristine develop.

AI provider/model: zai / glm-5.3 (manual) + GPT-5.6-sol (RepoPrompt CE review agent)
Client / agent tooling: Hermes Agent
Skill revision: elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [hermes-t3rpz]
<!-- eliza-computer-attribution:v1 {"provider":"zai","model":"glm-5.3","client":"Hermes Agent","skill_revision":"elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza"} -->

