### PR TITLE
test(cloud-shared): cover tts custom-voice usage accounting

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/tts-custom-voice-usage.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/tts-custom-voice-usage.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Custom-voice usage accounting — the detached TTS accounting task's only
+ * writer. Pure unit tests with a deterministic repository fixture: voice
+ * ownership binding (org match vs mismatch vs missing voice), usage-count
+ * increment, and the J7 error policy (enrichment failure must never suppress
+ * the canonical billing/usage record — logged, not thrown).
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const findByElevenLabsVoiceId = mock();
+const incrementUsageCount = mock();
+
+mock.module("../../../db/repositories/user-voices", () => ({
+  userVoicesRepository: {
+    findByElevenLabsVoiceId,
+    incrementUsageCount,
+  },
+}));
+
+const loggerWarn = mock();
+
+mock.module("../../utils/logger", () => ({
+  logger: {
+    warn: loggerWarn,
+    debug: mock(),
+    info: mock(),
+    error: mock(),
+  },
+}));
+
+const { recordCustomVoiceUsage } = await import("../tts-custom-voice-usage");
+
+beforeEach(() => {
+  findByElevenLabsVoiceId.mockReset();
+  incrementUsageCount.mockReset();
+  loggerWarn.mockReset();
+});
+
+describe("recordCustomVoiceUsage", () => {
+  test("returns the voice when it belongs to the organization and increments usage", async () => {
+    findByElevenLabsVoiceId.mockResolvedValue({
+      id: "voice-1",
+      organizationId: "org-123",
+      name: "My Voice",
+      elevenLabsVoiceId: "elv-1",
+    });
+    incrementUsageCount.mockResolvedValue(undefined);
+
+    const result = await recordCustomVoiceUsage({
+      elevenLabsVoiceId: "elv-1",
+      organizationId: "org-123",
+    });
+
+    expect(result).toEqual({ userVoiceId: "voice-1", voiceName: "My Voice" });
+    expect(findByElevenLabsVoiceId).toHaveBeenCalledWith("elv-1");
+    expect(incrementUsageCount).toHaveBeenCalledWith("voice-1");
+  });
+
+  test("returns nulls and skips increment when the voice belongs to another organization", async () => {
+    findByElevenLabsVoiceId.mockResolvedValue({
+      id: "voice-2",
+      organizationId: "org-OTHER",
+      name: "Someone Else's Voice",
+      elevenLabsVoiceId: "elv-2",
+    });
+
+    const result = await recordCustomVoiceUsage({
+      elevenLabsVoiceId: "elv-2",
+      organizationId: "org-123",
+    });
+
+    expect(result).toEqual({ userVoiceId: null, voiceName: null });
+    expect(incrementUsageCount).not.toHaveBeenCalled();
+  });
+
+  test("returns nulls and skips increment when no voice exists", async () => {
+    findByElevenLabsVoiceId.mockResolvedValue(null);
+
+    const result = await recordCustomVoiceUsage({
+      elevenLabsVoiceId: "elv-missing",
+      organizationId: "org-123",
+    });
+
+    expect(result).toEqual({ userVoiceId: null, voiceName: null });
+    expect(incrementUsageCount).not.toHaveBeenCalled();
+  });
+
+  test("swallows increment failure with a warning and still reports the voice (J7)", async () => {
+    findByElevenLabsVoiceId.mockResolvedValue({
+      id: "voice-3",
+      organizationId: "org-123",
+      name: "My Voice",
+      elevenLabsVoiceId: "elv-3",
+    });
+    incrementUsageCount.mockRejectedValue(new Error("redis down"));
+
+    const result = await recordCustomVoiceUsage({
+      elevenLabsVoiceId: "elv-3",
+      organizationId: "org-123",
+    });
+
+    expect(result).toEqual({ userVoiceId: "voice-3", voiceName: "My Voice" });
+    expect(loggerWarn).toHaveBeenCalledTimes(1);
+    expect(loggerWarn.mock.calls[0][1]).toMatchObject({
+      voiceId: "voice-3",
+      error: "redis down",
+    });
+  });
+});


### PR DESCRIPTION
## Relates to

Test coverage for `tts-custom-voice-usage.ts` — the detached TTS accounting
task's only custom-voice usage writer.

## Background

`recordCustomVoiceUsage` persists custom-voice usage **only** from the detached
TTS accounting task. It has two contracts worth pinning: (1) **ownership
binding** — usage is only attributed when the found voice actually belongs to
the calling organization; a mismatch or missing voice returns `null`s and
writes nothing; (2) **J7 error policy** — an increment failure is logged and
swallowed so usage enrichment can never suppress the canonical billing/usage
record for audio that was already delivered. Neither behavior was covered.

## Testing

- 4 unit tests, all passing locally (`bun test`): 4 pass / 0 fail / 10 expect
  calls in ~36ms
  - org-owned voice → returns id/name and increments usage count
  - voice owned by another org → `null`s, no increment
  - missing voice → `null`s, no increment
  - increment failure → warning logged with voiceId + error message, still
    returns the voice (J7: enrichment cannot suppress canonical record)
- `bunx biome check --write`: clean

## Evidence

<!-- evidence-row:logs -->
- [x] logs: `bun test` 4/4 pass (output in PR description)

AI provider/model: deepseek / deepseek-v4-flash

<!-- slop-contribution-attribution:v1 -->
