### PR TITLE
fix(plugin-wallet): reject placeholder SOLANA_PRIVATE_KEY in auto-enable gate

### DIFF
--- a/plugins/plugin-wallet/auto-enable.test.ts
+++ b/plugins/plugin-wallet/auto-enable.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import { shouldEnable } from "./wallet-auto-enable";
+
+function ctx(
+  env: Record<string, string | undefined>,
+  config: Record<string, unknown> = {},
+): {
+  env: Record<string, string | undefined>;
+  config: Record<string, unknown>;
+  isNativePlatform: boolean;
+} {
+  return { env, config, isNativePlatform: false };
+}
+
+describe("plugin-wallet auto-enable", () => {
+  it("enables when EVM_PRIVATE_KEY is a concrete value", () => {
+    expect(shouldEnable(ctx({ EVM_PRIVATE_KEY: "0xabc123def" }))).toBe(true);
+  });
+
+  it("does NOT enable when EVM_PRIVATE_KEY is a placeholder token", () => {
+    for (const v of [
+      "REDACTED",
+      "[PLACEHOLDER]",
+      "TODO",
+      "CHANGEME",
+      "EMPTY",
+      "  redacted  ",
+    ]) {
+      expect(shouldEnable(ctx({ EVM_PRIVATE_KEY: v }))).toBe(false);
+    }
+  });
+
+  it("does NOT enable when SOLANA_PRIVATE_KEY is a placeholder token", () => {
+    // The EVM path refuses placeholder tokens (REDACTED/PLACEHOLDER/TODO/...);
+    // the Solana path must apply the same concrete-value guard so a redacted
+    // secret cannot silently boot a wallet whose signing key is not a key.
+    for (const v of ["REDACTED", "PLACEHOLDER", "TODO", "CHANGEME", "EMPTY"]) {
+      expect(shouldEnable(ctx({ SOLANA_PRIVATE_KEY: v }))).toBe(false);
+    }
+  });
+
+  it("enables when SOLANA_PRIVATE_KEY is a concrete value", () => {
+    expect(
+      shouldEnable(
+        ctx({
+          SOLANA_PRIVATE_KEY: "5KQ7m8xYwq3VfVrK9Jp1nTzQ2sLd4RbC6uHnEaXgMh",
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("requires BOTH steward URL and agent token for the EVM steward path", () => {
+    expect(
+      shouldEnable(ctx({ STEWARD_API_URL: "https://steward.example" })),
+    ).toBe(false);
+    expect(shouldEnable(ctx({ STEWARD_AGENT_TOKEN: "tok-123" }))).toBe(false);
+    expect(
+      shouldEnable(
+        ctx({
+          STEWARD_API_URL: "https://steward.example",
+          STEWARD_AGENT_TOKEN: "tok-123",
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("honors the ELIZA_AGENT_WALLET_AUTO_ENABLE=0 opt-out even with a valid key", () => {
+    expect(
+      shouldEnable(
+        ctx({
+          ELIZA_AGENT_WALLET_AUTO_ENABLE: "0",
+          EVM_PRIVATE_KEY: "0xabc123def",
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("respects explicit enabled:false on legacy entry names", () => {
+    const config = {
+      plugins: { entries: { solana: { enabled: false } } },
+    };
+    expect(shouldEnable(ctx({ EVM_PRIVATE_KEY: "0xabc123def" }, config))).toBe(
+      false,
+    );
+  });
+
+  it("the cloud-provisioned flag alone is not enough (requires exact '1' AND steward credentials)", () => {
+    expect(shouldEnable(ctx({ ELIZA_CLOUD_PROVISIONED: "1" }))).toBe(false);
+    expect(shouldEnable(ctx({ ELIZA_CLOUD_PROVISIONED: "true" }))).toBe(false);
+    expect(
+      shouldEnable(
+        ctx({
+          ELIZA_CLOUD_PROVISIONED: "1",
+          STEWARD_API_URL: "https://steward.example",
+          STEWARD_AGENT_TOKEN: "tok-123",
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("does NOT enable with no signing path at all", () => {
+    expect(shouldEnable(ctx({}))).toBe(false);
+    expect(shouldEnable(ctx({ SOLANA_PRIVATE_KEY: "" }))).toBe(false);
+    expect(shouldEnable(ctx({ SOLANA_PRIVATE_KEY: "   " }))).toBe(false);
+  });
+});

--- a/plugins/plugin-wallet/auto-enable.ts
+++ b/plugins/plugin-wallet/auto-enable.ts
@@ -26,12 +26,9 @@ function hasEvmSigningPath(env: NodeJS.ProcessEnv): boolean {
   return Boolean(stewardUrl && stewardToken);
 }
 
-/** True when a Solana private key is set. */
+/** True when a Solana private key is set and is a concrete value (not a placeholder token). */
 function hasSolanaSigningPath(env: NodeJS.ProcessEnv): boolean {
-  return (
-    typeof env.SOLANA_PRIVATE_KEY === "string" &&
-    env.SOLANA_PRIVATE_KEY.trim().length > 0
-  );
+  return isConcreteValue(env.SOLANA_PRIVATE_KEY);
 }
 
 /** True when cloud-provisioned Steward credentials are present. */


### PR DESCRIPTION
# Relates to

<!-- No issue; fixes a credential gate gap found while pinning the wallet auto-enable contract. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# What and why

`plugin-wallet`'s auto-enable gate refuses placeholder tokens for the EVM path
(`isConcreteValue` against `REDACTED` / `PLACEHOLDER` / `TODO` / `CHANGEME` /
`EMPTY`), but `hasSolanaSigningPath` only checked for a non-empty string. A
redacted or placeholder `SOLANA_PRIVATE_KEY` (exactly what secrets-redaction
tooling emits) would silently auto-enable the wallet, which then boots with a
key that is not a key and fails at signing time with a confusing error — the
same footgun the EVM path already guards against.

This PR applies the same concrete-value guard to the Solana path, so a
placeholder Solana key no longer enables the plugin. Concrete keys are
unaffected.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. One-line guard parity with the existing EVM path: only placeholder
token strings (never valid base58 private keys) change behavior. No other
code path touches `hasSolanaSigningPath`.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: see log below |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test + one-line source fix in this PR |

```log
Test Files  1 passed (1)
      Tests  9 passed (9)
```

- The placeholder-Solana-key case fails on the pre-fix source
  (`expected false, received true`) and passes after the one-line fix.

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
