### PR TITLE
test(plugin-codex-cli): cover auto-enable provider gate and subscription force path

### DIFF
--- a/plugins/plugin-codex-cli/auto-enable.test.ts
+++ b/plugins/plugin-codex-cli/auto-enable.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { shouldEnable, shouldForce } from "./codex-cli-auto-enable";
+
+function ctx(config: Record<string, unknown>): {
+	env: Record<string, string | undefined>;
+	config: Record<string, unknown>;
+	isNativePlatform: boolean;
+} {
+	return { env: {}, config, isNativePlatform: false };
+}
+
+describe("plugin-codex-cli auto-enable", () => {
+	it("enables when an auth profile selects the codex-cli provider", () => {
+		expect(
+			shouldEnable(ctx({ auth: { profiles: { dev: { provider: "codex-cli" } } } })),
+		).toBe(true);
+	});
+
+	it("does NOT enable when no auth profiles are configured", () => {
+		expect(shouldEnable(ctx({}))).toBe(false);
+		expect(shouldEnable(ctx({ auth: {} }))).toBe(false);
+		expect(shouldEnable(ctx({ auth: { profiles: {} } }))).toBe(false);
+	});
+
+	it("does NOT enable when profiles select a different provider", () => {
+		expect(
+			shouldEnable(ctx({ auth: { profiles: { dev: { provider: "anthropic" } } } })),
+		).toBe(false);
+	});
+
+	it("skips non-object profile entries", () => {
+		expect(shouldEnable(ctx({ auth: { profiles: { dev: "codex-cli" } } }))).toBe(false);
+	});
+
+	it("force-enables when the openai-codex subscription is selected", () => {
+		expect(
+			shouldForce(ctx({ agents: { defaults: { subscriptionProvider: "openai-codex" } } })),
+		).toBe(true);
+	});
+
+	it("does NOT force-enable for other subscription providers", () => {
+		expect(
+			shouldForce(ctx({ agents: { defaults: { subscriptionProvider: "pro" } } })),
+		).toBe(false);
+		expect(shouldForce(ctx({}))).toBe(false);
+	});
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for the codex-cli auto-enable gate. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# What and why

Pins the `plugin-codex-cli` auto-enable decision contract: the plugin enables
only when an auth profile selects the `codex-cli` provider (non-object profile
entries and other providers must not enable), and `shouldForce` force-enables
only for the deliberate `openai-codex` subscription choice — the force path
must never fire for arbitrary subscription providers.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new test file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: see log below |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

```log
Test Files  1 passed (1)
      Tests  6 passed (6)
```

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
