### PR TITLE
test(plugin-x): cover connector auto-enable gate and legacy twitter alias

### DIFF
--- a/plugins/plugin-x/auto-enable.test.ts
+++ b/plugins/plugin-x/auto-enable.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { shouldEnable } from "./x-auto-enable";
+
+function ctx(config: Record<string, unknown>): {
+  env: Record<string, string | undefined>;
+  config: Record<string, unknown>;
+  isNativePlatform: boolean;
+} {
+  return { env: {}, config, isNativePlatform: false };
+}
+
+describe("plugin-x auto-enable", () => {
+  it("enables when connectors.x is present and not disabled", () => {
+    expect(
+      shouldEnable(ctx({ connectors: { x: { apiKey: "k", apiSecret: "s" } } })),
+    ).toBe(true);
+  });
+
+  it("enables via the legacy connectors.twitter alias", () => {
+    expect(
+      shouldEnable(ctx({ connectors: { twitter: { apiKey: "k" } } })),
+    ).toBe(true);
+  });
+
+  it("does NOT enable when the connector block is explicitly disabled", () => {
+    expect(
+      shouldEnable(ctx({ connectors: { x: { enabled: false, apiKey: "k" } } })),
+    ).toBe(false);
+    expect(
+      shouldEnable(ctx({ connectors: { twitter: { enabled: false } } })),
+    ).toBe(false);
+  });
+
+  it("does NOT enable without a connectors block", () => {
+    expect(shouldEnable(ctx({}))).toBe(false);
+  });
+
+  it("skips non-object connector entries", () => {
+    expect(shouldEnable(ctx({ connectors: { x: "not-an-object" } }))).toBe(
+      false,
+    );
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for the X connector auto-enable gate. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# What and why

Pins the `plugin-x` auto-enable decision contract: the connector block
(`connectors.x` or the legacy `connectors.twitter` alias) enables the plugin
when present and not explicitly `enabled: false`; non-object entries, explicit
disables, and the absence of a connectors block must never enable it. A
regression here would either boot the X connector without credentials or skip
it when the owner configured it.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new test file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: see log below |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

```log
Test Files  1 passed (1)
      Tests  5 passed (5)
```

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
