### PR TITLE
test(plugin-zerollama): cover output-boundary finish rejection and missing-terminal-event guard

### DIFF
--- a/plugins/plugin-zerollama/utils/__tests__/model-output.test.ts
+++ b/plugins/plugin-zerollama/utils/__tests__/model-output.test.ts
@@ -1,0 +1,75 @@
+import { ElizaError } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { assertCompleteOllamaGeneration, assertZerollamaStreamTerminated } from "../model-output";
+
+describe("assertCompleteOllamaGeneration", () => {
+  it("accepts an absent finish reason", () => {
+    expect(() => assertCompleteOllamaGeneration(undefined, "ollama")).not.toThrow();
+  });
+
+  it("accepts normal completion reasons", () => {
+    for (const reason of ["stop", "tool_calls", "function_call", "eos_token"]) {
+      expect(() => assertCompleteOllamaGeneration(reason, "ollama"), reason).not.toThrow();
+    }
+  });
+
+  it("rejects budget-exhausted finish reasons for ollama", () => {
+    for (const reason of [
+      "length",
+      "max_tokens",
+      "max_output_tokens",
+      "max_completion_tokens",
+      "stop_length",
+    ]) {
+      expect(() => assertCompleteOllamaGeneration(reason, "ollama"), reason).toThrowError(
+        ElizaError
+      );
+    }
+  });
+
+  it("normalizes case, whitespace, and hyphen separators before matching", () => {
+    for (const reason of [" MAX_TOKENS ", "max-tokens", "Max_Output_Tokens", "STOP-LENGTH"]) {
+      expect(() => assertCompleteOllamaGeneration(reason, "zerollama"), reason).toThrowError(
+        ElizaError
+      );
+    }
+  });
+
+  it("carries the provider and original finish reason in error context", () => {
+    try {
+      assertCompleteOllamaGeneration("max_tokens", "ollama");
+      expect.unreachable("expected throw");
+    } catch (error) {
+      const err = error as ElizaError;
+      expect(err.code).toBe("MODEL_INCOMPLETE_OUTPUT");
+      expect(err.context).toEqual({ provider: "ollama", finishReason: "max_tokens" });
+    }
+  });
+});
+
+describe("assertZerollamaStreamTerminated", () => {
+  it("accepts a terminal event that means the output is complete", () => {
+    expect(() => assertZerollamaStreamTerminated("stop")).not.toThrow();
+  });
+
+  it("rejects a terminal event that means the output is a prefix", () => {
+    for (const reason of ["length", "max_tokens", "stop_length"]) {
+      expect(() => assertZerollamaStreamTerminated(reason), reason).toThrowError(
+        /zerollama reached its output boundary/
+      );
+    }
+  });
+
+  it("fails closed when the stream ended without any terminal event", () => {
+    expect(() => assertZerollamaStreamTerminated(undefined)).toThrowError(ElizaError);
+    try {
+      assertZerollamaStreamTerminated(undefined);
+      expect.unreachable("expected throw");
+    } catch (error) {
+      const err = error as ElizaError;
+      expect(err.code).toBe("MODEL_INCOMPLETE_OUTPUT");
+      expect(err.context).toEqual({ provider: "zerollama", finishReason: null });
+      expect(err.message).toMatch(/without a terminal event/);
+    }
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing output-boundary guard module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new test file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `Test Files  1 passed (1)
      Tests  8 passed (8)` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
