### PR TITLE
test(plugin-computeruse): pin a11y capability gate and degrade-to-null contract

### DIFF
--- a/plugins/plugin-computeruse/src/platform/a11y.test.ts
+++ b/plugins/plugin-computeruse/src/platform/a11y.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  execSync: vi.fn(),
+  currentPlatform: vi.fn(() => "linux"),
+  commandExists: vi.fn(() => false),
+}));
+
+vi.mock("node:child_process", () => ({
+  default: { execSync: mocks.execSync },
+  execSync: mocks.execSync,
+}));
+vi.mock("./helpers.js", () => ({
+  currentPlatform: mocks.currentPlatform,
+  commandExists: mocks.commandExists,
+}));
+
+import { logger } from "@elizaos/core";
+import { extractA11yTree, isA11yAvailable } from "./a11y";
+
+const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+
+afterEach(() => {
+  warnSpy.mockClear();
+  mocks.execSync.mockReset();
+  mocks.currentPlatform.mockReset();
+  mocks.commandExists.mockReset();
+});
+
+describe("isA11yAvailable", () => {
+  it("is always available on macOS and Windows", () => {
+    mocks.currentPlatform.mockReturnValue("darwin");
+    expect(isA11yAvailable()).toBe(true);
+    mocks.currentPlatform.mockReturnValue("win32");
+    expect(isA11yAvailable()).toBe(true);
+  });
+
+  it("requires python3 or gdbus on Linux", () => {
+    mocks.currentPlatform.mockReturnValue("linux");
+    mocks.commandExists.mockReturnValue(false);
+    expect(isA11yAvailable()).toBe(false);
+    mocks.commandExists.mockImplementation((cmd: string) => cmd === "python3");
+    expect(isA11yAvailable()).toBe(true);
+    mocks.commandExists.mockImplementation((cmd: string) => cmd === "gdbus");
+    expect(isA11yAvailable()).toBe(true);
+  });
+
+  it("is unavailable on unsupported platforms", () => {
+    mocks.currentPlatform.mockReturnValue("freebsd");
+    expect(isA11yAvailable()).toBe(false);
+  });
+});
+
+describe("extractA11yTree", () => {
+  it("returns null without invoking tooling on unsupported platforms", () => {
+    mocks.currentPlatform.mockReturnValue("freebsd");
+    expect(extractA11yTree()).toBeNull();
+    expect(mocks.execSync).not.toHaveBeenCalled();
+  });
+
+  it("returns trimmed osascript output on macOS", () => {
+    mocks.currentPlatform.mockReturnValue("darwin");
+    mocks.execSync.mockReturnValue("  Application: Safari\nWindow: Main  ");
+    expect(extractA11yTree()).toBe("Application: Safari\nWindow: Main");
+  });
+
+  it("returns null and warns when macOS extraction fails", () => {
+    mocks.currentPlatform.mockReturnValue("darwin");
+    mocks.execSync.mockImplementation(() => {
+      throw new Error("osascript permission denied");
+    });
+    expect(extractA11yTree()).toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("macOS a11y extraction failed"),
+    );
+  });
+
+  it("returns python3 output on Linux when python3 exists", () => {
+    mocks.currentPlatform.mockReturnValue("linux");
+    mocks.commandExists.mockImplementation((cmd: string) => cmd === "python3");
+    mocks.execSync.mockReturnValue('{"role": "desktop"}');
+    expect(extractA11yTree()).toBe('{"role": "desktop"}');
+  });
+
+  it("returns PowerShell output on Windows", () => {
+    mocks.currentPlatform.mockReturnValue("win32");
+    mocks.execSync.mockReturnValue("Button: OK\n");
+    expect(extractA11yTree()).toBe("Button: OK");
+  });
+
+  it("warns and returns null when the Linux AT-SPI lane fails", () => {
+    mocks.currentPlatform.mockReturnValue("linux");
+    mocks.commandExists.mockReturnValue(true);
+    mocks.execSync.mockImplementation(() => {
+      throw new Error("AT-SPI unavailable");
+    });
+    expect(extractA11yTree()).toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Linux AT-SPI extraction failed"),
+    );
+  });
+
+  it("never throws: unexpected lane errors degrade to null with a warning", () => {
+    mocks.currentPlatform.mockReturnValue("linux");
+    mocks.commandExists.mockImplementation(() => {
+      throw new Error("unexpected lane failure");
+    });
+    expect(() => extractA11yTree()).not.toThrow();
+    expect(extractA11yTree()).toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[a11y] extractA11yTree failed"),
+    );
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing platform capability-gate module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new test file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `Test Files  1 passed (1)
      Tests  10 passed (10)` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
