### PR TITLE
test(agent): cover chat idempotency store normalization, firstSeenAt, and reset

### DIFF
--- a/packages/agent/src/services/chat-idempotency-service.test.ts
+++ b/packages/agent/src/services/chat-idempotency-service.test.ts
@@ -235,4 +235,58 @@ describe("chat idempotency store", () => {
       error: { code: "CHAT_IDEMPOTENCY_CONFLICT" },
     });
   });
+
+  it("normalizes keys with default and custom length limits, rejecting invalid values", () => {
+    const store = createChatIdempotencyStore();
+    expect(store.normalize("  client-key-1  ")).toBe("client-key-1");
+    expect(store.normalize("")).toBeNull();
+    expect(store.normalize("   ")).toBeNull();
+    expect(store.normalize(123)).toBeNull();
+    expect(store.normalize(null)).toBeNull();
+    expect(store.normalize(undefined)).toBeNull();
+    expect(store.normalize({})).toBeNull();
+    expect(store.normalize("a".repeat(128))).toBe("a".repeat(128));
+    expect(store.normalize("a".repeat(129))).toBeNull();
+
+    const boundedStore = createChatIdempotencyStore({ maxKeyLength: 10 });
+    expect(boundedStore.normalize("a".repeat(10))).toBe("a".repeat(10));
+    expect(boundedStore.normalize("a".repeat(11))).toBeNull();
+  });
+
+  it("tracks and returns firstSeenAt for active and settled keys and null for missing or unkeyed", () => {
+    const store = createChatIdempotencyStore();
+    expect(store.firstSeenAt("room", null)).toBeNull();
+    expect(store.firstSeenAt("room", "unknown")).toBeNull();
+
+    store.admit("room", "admitted", { now: 12345 });
+    expect(store.firstSeenAt("room", "admitted")).toBe(12345);
+
+    store.reserve("room", "reserved", 54321);
+    expect(store.firstSeenAt("room", "reserved")).toBe(54321);
+  });
+
+  it("resets the store and notifies active duplicate waiters as released", async () => {
+    const store = createChatIdempotencyStore<{ value: string }>();
+    const owner = store.admit("room", "id", { now: 1 });
+    const duplicate = store.admit("room", "id", { now: 2 });
+    if (owner.kind !== "owner" || duplicate.kind !== "duplicate") {
+      throw new Error("fixture admission failed");
+    }
+
+    const waiter = duplicate.wait();
+    store.reset();
+
+    await expect(waiter).resolves.toEqual({ kind: "released" });
+    expect(store.firstSeenAt("room", "id")).toBeNull();
+    expect(store.outcome("room", "id")).toBeNull();
+  });
+
+  it("safely handles unkeyed requests across all store methods", () => {
+    const store = createChatIdempotencyStore<{ value: string }>();
+    expect(store.admit("room", null)).toEqual({ kind: "unkeyed" });
+    expect(store.reserve("room", null)).toBe(false);
+    expect(store.outcome("room", null)).toBeNull();
+    expect(() => store.release("room", null)).not.toThrow();
+    expect(() => store.settle("room", null, { value: "done" })).not.toThrow();
+  });
 });


### PR DESCRIPTION
# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low risk. Pure unit test additions in `packages/agent/src/services/chat-idempotency-service.test.ts` covering key normalization, lookup timestamps, reset notification propagation, and unkeyed request handling in `createChatIdempotencyStore`.

# Background

## What does this PR do?

Extends behavioral unit test coverage for `packages/agent/src/services/chat-idempotency-service.ts`:
- Exercises key normalization rules with default (128 chars) and custom `maxKeyLength` boundaries, whitespace trimming, and rejection of invalid types/empty strings.
- Verifies `firstSeenAt(scope, clientMessageId)` behavior for active, settled, missing, and unkeyed requests.
- Validates `reset()` clearing entries and waking pending duplicate waiters with `{ kind: "released" }`.
- Validates safe execution of unkeyed (`clientMessageId == null`) calls across store methods (`admit`, `reserve`, `outcome`, `release`, `settle`).

## What kind of change is this?

Improvements (misc. changes to existing features)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Inspect new test cases in `packages/agent/src/services/chat-idempotency-service.test.ts`.

## Detailed testing steps

Run:
```bash
bun test packages/agent/src/services/chat-idempotency-service.test.ts
bun run --cwd packages/agent typecheck
bunx @biomejs/biome check packages/agent/src/services/chat-idempotency-service.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:e33b715fd9d648500bd0e8a08b58095e5c8ffc8d -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only change with no rendered UI surface
<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only change with no rendered UI surface
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - test-only change has no user flow to record
<!-- evidence-row:backend-logs -->
- [ ] N/A - pure unit test does not exercise a server path
<!-- evidence-row:frontend-logs -->
- [ ] N/A - pure unit test does not exercise a browser path
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent model or prompt path is touched
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database rows or generated files produced
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface in this change

# Evidence Details

## Real LLM-call trajectory

N/A - no agent model or prompt path is touched

## Backend + frontend logs

```
RED (normalize mutated in chat-idempotency-service.ts):
  (fail) chat idempotency store > normalizes keys with default and custom length limits, rejecting invalid values [0.15ms]
  Expected: "client-key-1"
  Received: null

GREEN (restored):
  15 passed (15 tests) [0.04s]
```

## Screenshots (before / after) + video walkthrough

N/A - test-only change with no rendered UI surface

### Before

N/A - test-only change with no rendered UI surface

### After

N/A - test-only change with no rendered UI surface

### Walkthrough video

N/A - test-only change has no user flow to record

## Audio / voice walkthrough

N/A - no voice or audio path touched

## Known gaps / failures

None

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: Claude Code
— [lane-byt61-7182]
