### PR TITLE
fix(plugin-browser): make wait_for_url regex predicate stateless

### DIFF
--- a/plugins/plugin-browser/src/actions/wait-for-url-predicate.test.ts
+++ b/plugins/plugin-browser/src/actions/wait-for-url-predicate.test.ts
@@ -54,4 +54,29 @@ describe("buildWaitForUrlPredicate", () => {
     expect(predicate.kind).toBe("substring");
     expect(predicate.test("https://anything.example")).toBe(false);
   });
+
+  it("is deterministic across repeated calls when pattern has global flag", () => {
+    const predicate = buildWaitForUrlPredicate("/auth\\/callback/g");
+    expect(predicate.kind).toBe("regex");
+    const url = "https://example.com/auth/callback";
+    expect(predicate.test(url)).toBe(true);
+    expect(predicate.test(url)).toBe(true);
+    expect(predicate.test(url)).toBe(true);
+  });
+
+  it("is deterministic across repeated calls when pattern has sticky flag", () => {
+    const predicate = buildWaitForUrlPredicate("/callback/y");
+    expect(predicate.kind).toBe("regex");
+    const url = "https://example.com/callback";
+    expect(predicate.test(url)).toBe(true);
+    expect(predicate.test(url)).toBe(true);
+  });
+
+  it("preserves other flags while stripping global and sticky", () => {
+    const predicate = buildWaitForUrlPredicate("/callback/gi");
+    expect(predicate.kind).toBe("regex");
+    expect(predicate.test("https://example.com/CALLBACK")).toBe(true);
+    expect(predicate.test("https://example.com/CALLBACK")).toBe(true);
+    expect(predicate.test("https://example.com/other")).toBe(false);
+  });
 });

--- a/plugins/plugin-browser/src/actions/wait-for-url-predicate.ts
+++ b/plugins/plugin-browser/src/actions/wait-for-url-predicate.ts
@@ -27,7 +27,8 @@ const REGEX_LITERAL = /^\/(.+)\/([a-z]*)$/i;
 
 function compileRegex(source: string, flags: string): RegExp | null {
   try {
-    return new RegExp(source, flags);
+    const sanitizedFlags = flags.replace(/[gy]/g, "");
+    return new RegExp(source, sanitizedFlags);
   } catch {
     return null;
   }
@@ -54,7 +55,10 @@ export function buildWaitForUrlPredicate(pattern: string): WaitForUrlPredicate {
       return {
         pattern,
         kind: "regex",
-        test: (url: string) => compiled.test(url),
+        test: (url: string) => {
+          compiled.lastIndex = 0;
+          return compiled.test(url);
+        },
       };
     }
     // Invalid regex literal: fall through to substring on the raw pattern.


### PR DESCRIPTION
Fixes #28598

## What does this PR do?
Makes `buildWaitForUrlPredicate` stateless by stripping stateful `g`/`y` flags in `compileRegex` and resetting `compiled.lastIndex = 0` before each `.test(url)`. Previously a global regex retained `lastIndex` across polling iterations, causing alternating true/false on the same URL.

## Tests
- Extended `wait-for-url-predicate.test.ts` from 7 to 10 tests:
  - `g` flag determinism: same URL returns true 3 consecutive times
  - `y` flag determinism
  - `gi` preserves `i` while stripping `g`

```
vitest run plugins/plugin-browser/src/actions/wait-for-url-predicate.test.ts --run
10 passed
```

## Risks
Low. Only affects regex literal compilation; substring path unchanged. Preserves i/m/s/u flags.

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: Claude Code
— [lane-byt61-2576]