### PR TITLE
test(app-core): cover sweep expiration in sensitive rate limiter

### DIFF
--- a/packages/app-core/src/api/auth/sensitive-rate-limit.test.ts
+++ b/packages/app-core/src/api/auth/sensitive-rate-limit.test.ts
@@ -90,4 +90,47 @@ describe("sensitive auth rate limiters", () => {
     expect(routeLimiter.consume("192.0.2.44", now + 21)).toBe(true);
     expect(bootstrapExchangeLimiter.consume("192.0.2.55", now + 21)).toBe(true);
   });
+
+  it("sweep removes expired bucket entries while preserving active ones", () => {
+    const limiter = getSensitiveLimiter("auth.test.sweep");
+    const t0 = 10_000;
+
+    limiter.consume("10.0.0.1", t0);
+    limiter.consume("10.0.0.2", t0 + 20_000);
+
+    // Sweep before any expiration: both entries remain active
+    limiter.sweep(t0 + 50_000);
+    for (let i = 0; i < SENSITIVE_RATE_LIMIT_MAX - 1; i += 1) {
+      expect(limiter.consume("10.0.0.1", t0 + 50_000)).toBe(true);
+    }
+    // 10.0.0.1 is exhausted within its initial window
+    expect(limiter.consume("10.0.0.1", t0 + 50_000)).toBe(false);
+
+    // Sweep at t0 + 75_000: 10.0.0.1 resetAt (70_000) expired and cleaned up; 10.0.0.2 resetAt (90_000) remains
+    limiter.sweep(t0 + 75_000);
+
+    const bucketMap = (limiter as unknown as { buckets: Map<string, unknown> })
+      .buckets;
+    expect(bucketMap.has("10.0.0.1")).toBe(false);
+    expect(bucketMap.has("10.0.0.2")).toBe(true);
+
+    // 10.0.0.1 starts a fresh window
+    expect(limiter.consume("10.0.0.1", t0 + 75_000)).toBe(true);
+    expect(bucketMap.has("10.0.0.1")).toBe(true);
+
+    // 10.0.0.2 remained active in its window and reaches max
+    for (let i = 0; i < SENSITIVE_RATE_LIMIT_MAX - 1; i += 1) {
+      expect(limiter.consume("10.0.0.2", t0 + 75_000)).toBe(true);
+    }
+    expect(limiter.consume("10.0.0.2", t0 + 75_000)).toBe(false);
+
+    // Sweep after all windows expired: cleans up everything
+    limiter.sweep(t0 + 100_000);
+    expect(bucketMap.size).toBe(1); // 10.0.0.1 was consumed at 75_000 (resetAt 135_000); 10.0.0.2 (resetAt 90_000) deleted
+    expect(bucketMap.has("10.0.0.2")).toBe(false);
+    expect(bucketMap.has("10.0.0.1")).toBe(true);
+
+    limiter.sweep(t0 + 140_000);
+    expect(bucketMap.size).toBe(0);
+  });
 });


### PR DESCRIPTION
# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Test-only behavioral coverage in `@elizaos/app-core` testing bucket eviction and cleanup in `SensitiveRateLimiter.sweep`.

# Background

## What does this PR do?

Adds unit test coverage for the `sweep()` eviction method of `SensitiveRateLimiter` in `@elizaos/app-core` (`packages/app-core/src/api/auth/sensitive-rate-limit.ts`), ensuring expired client rate limit buckets are purged to reclaim memory while active windows are preserved.

## What kind of change is this?

Improvements (misc. changes to existing features)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

- `packages/app-core/src/api/auth/sensitive-rate-limit.test.ts`

## Detailed testing steps

Run unit tests:
```bash
./node_modules/.bin/vitest run packages/app-core/src/api/auth/sensitive-rate-limit.test.ts
```

```
RED (when sweep is a no-op):
  6 tests | 1 failed (sweep removes expired bucket entries while preserving active ones)
  AssertionError: expected true to be false

GREEN (restored):
  6 tests | 6 passed
```

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:8318a2252f01a74b22c7c7bec284385a21e1f2c4 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only change with no rendered UI surface
<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only change with no rendered UI surface
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - test-only change has no user flow to record
<!-- evidence-row:backend-logs -->
- [ ] N/A - pure unit test does not exercise a server path
<!-- evidence-row:frontend-logs -->
- [ ] N/A - pure unit test does not exercise a browser path
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent model or prompt path is touched
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database rows or generated files produced
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface in this change

# Evidence Details

## Real LLM-call trajectory
N/A - no agent model or prompt path is touched

## Backend + frontend logs
N/A - pure unit test does not exercise a server path

## Screenshots (before / after) + video walkthrough
N/A - test-only change with no rendered UI surface

## Audio / voice walkthrough
N/A - test-only change has no voice surface

## Known gaps / failures
N/A - all unit tests pass cleanly

## Maintainer CI exception record
- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: Claude Code
— [lane-byt61-7842]

