### PR TITLE
test(agent-skills): cover skill code scanner standard ports, obfuscation, and context rules

### DIFF
--- a/plugins/plugin-agent-skills/src/security/skill-scanner.test.ts
+++ b/plugins/plugin-agent-skills/src/security/skill-scanner.test.ts
@@ -128,4 +128,96 @@ describe("skill code scanner", () => {
 		).toEqual([]);
 		expect(report.status).toBe("clean");
 	});
+
+	it("identifies all scannable code extensions and rejects non-code or extensionless files", () => {
+		expect(isScannableCode("Makefile")).toBe(false);
+		expect(isScannableCode("Dockerfile")).toBe(false);
+		expect(isScannableCode("package.json")).toBe(false);
+		expect(isScannableCode("styles.css")).toBe(false);
+		expect(isScannableCode("image.png")).toBe(false);
+
+		expect(isScannableCode("index.js")).toBe(true);
+		expect(isScannableCode("index.mjs")).toBe(true);
+		expect(isScannableCode("index.cjs")).toBe(true);
+		expect(isScannableCode("index.ts")).toBe(true);
+		expect(isScannableCode("index.mts")).toBe(true);
+		expect(isScannableCode("index.cts")).toBe(true);
+		expect(isScannableCode("Component.jsx")).toBe(true);
+		expect(isScannableCode("Component.tsx")).toBe(true);
+		expect(isScannableCode("UPPERCASE.JSX")).toBe(true);
+		expect(isScannableCode("UPPERCASE.TSX")).toBe(true);
+	});
+
+	it("ignores standard WebSocket ports and flags non-standard ports as suspicious", () => {
+		for (const port of [80, 443, 8080, 8443, 3000]) {
+			const safeFindings = scanCodeSource(
+				`const ws = new WebSocket("ws://127.0.0.1:${port}");`,
+				"client.ts",
+			);
+			expect(
+				safeFindings.find((f) => f.ruleId === "suspicious-network"),
+			).toBeUndefined();
+		}
+
+		const suspiciousFindings = scanCodeSource(
+			'const ws = new WebSocket("ws://127.0.0.1:9999");',
+			"client.ts",
+		);
+		const finding = suspiciousFindings.find(
+			(f) => f.ruleId === "suspicious-network",
+		);
+		expect(finding).toBeDefined();
+		expect(finding?.severity).toBe("warn");
+		expect(finding?.line).toBe(1);
+	});
+
+	it("detects obfuscated hex sequences and large base64 decode payloads", () => {
+		const hexFindings = scanCodeSource(
+			'const code = "\\x65\\x76\\x61\\x6c\\x28\\x61\\x29";',
+			"obfuscated.js",
+		);
+		expect(hexFindings.map((f) => f.ruleId)).toContain("obfuscated-code");
+
+		const base64Findings = scanCodeSource(
+			`const payload = Buffer.from("${"A".repeat(250)}");`,
+			"obfuscated.js",
+		);
+		expect(base64Findings.map((f) => f.ruleId)).toContain("obfuscated-code");
+	});
+
+	it("detects crypto mining signatures with critical severity", () => {
+		const stratumFindings = scanCodeSource(
+			'const pool = "stratum+tcp://mine.monero.org:3333";',
+			"miner.ts",
+		);
+		expect(
+			stratumFindings.find((f) => f.ruleId === "crypto-mining")?.severity,
+		).toBe("critical");
+
+		const xmrigFindings = scanCodeSource(
+			'const bin = "xmrig --donate-level 1";',
+			"miner.ts",
+		);
+		expect(
+			xmrigFindings.find((f) => f.ruleId === "crypto-mining")?.severity,
+		).toBe("critical");
+	});
+
+	it("enforces context requirements before flagging dangerous-exec and env-harvesting", () => {
+		const execWithoutChildProcess = scanCodeSource(
+			'const result = exec("calc");',
+			"safe-custom-exec.ts",
+		);
+		expect(
+			execWithoutChildProcess.find((f) => f.ruleId === "dangerous-exec"),
+		).toBeUndefined();
+
+		const envWithoutNetwork = scanCodeSource(
+			'const port = process.env.PORT || "3000";\nconsole.log(port);',
+			"server.ts",
+		);
+		expect(
+			envWithoutNetwork.find((f) => f.ruleId === "env-harvesting"),
+		).toBeUndefined();
+	});
 });


### PR DESCRIPTION
# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low risk. Pure unit test additions in `plugins/plugin-agent-skills/src/security/skill-scanner.test.ts` covering file extension filtering, standard port allowlisting, obfuscated payload detection, crypto mining patterns, and execution/network context constraints.

# Background

## What does this PR do?

Extends behavioral unit test coverage for `plugins/plugin-agent-skills/src/security/skill-scanner.ts`:
- Validates `isScannableCode` against all supported file extensions (`.js`, `.mjs`, `.cjs`, `.ts`, `.mts`, `.cts`, `.jsx`, `.tsx`, case-insensitively) while rejecting non-code or extensionless files.
- Verifies standard WebSocket port allowlisting (ports 80, 443, 8080, 8443, 3000) versus non-standard ports flagging `suspicious-network`.
- Verifies `obfuscated-code` detection on long hex sequences and large base64 buffers.
- Verifies `crypto-mining` detection (`stratum+tcp`, `xmrig`) with `critical` severity.
- Confirms context requirement gating (`child_process` required for `dangerous-exec`, network required for `env-harvesting`).

## What kind of change is this?

Improvements (misc. changes to existing features)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Inspect new test assertions in `plugins/plugin-agent-skills/src/security/skill-scanner.test.ts`.

## Detailed testing steps

Run:
```bash
npx vitest run plugins/plugin-agent-skills/src/security/skill-scanner.test.ts
bun run --cwd plugins/plugin-agent-skills typecheck
```

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:e11d8390317cdbaf570b3b93932d22d93ff6973e -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only change with no rendered UI surface
<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only change with no rendered UI surface
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - test-only change has no user flow to record
<!-- evidence-row:backend-logs -->
- [ ] N/A - pure unit test does not exercise a server path
<!-- evidence-row:frontend-logs -->
- [ ] N/A - pure unit test does not exercise a browser path
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent model or prompt path is touched
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database rows or generated files produced
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface in this change

# Evidence Details

## Real LLM-call trajectory

N/A - no agent model or prompt path is touched

## Backend + frontend logs

```
RED (STANDARD_PORTS mutated in skill-scanner.ts):
  FAIL  plugins/plugin-agent-skills/src/security/skill-scanner.test.ts > skill code scanner > ignores standard WebSocket ports and flags non-standard ports as suspicious
  AssertionError: expected { ruleId: 'suspicious-network', ... } to be undefined

GREEN (restored):
  10 tests | 10 passed (2.88s)
```

## Screenshots (before / after) + video walkthrough

N/A - test-only change with no rendered UI surface

### Before

N/A - test-only change with no rendered UI surface

### After

N/A - test-only change with no rendered UI surface

### Walkthrough video

N/A - test-only change has no user flow to record

## Audio / voice walkthrough

N/A - no voice or audio path touched

## Known gaps / failures

None

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: Claude Code
— [lane-byt61-7182]
