### PR TITLE
test(auth): cover http_error severity mapping and field validation in codex usage

### DIFF
--- a/packages/auth/src/codex-usage.test.ts
+++ b/packages/auth/src/codex-usage.test.ts
@@ -136,12 +136,33 @@ describe("fetchCodexUsage — success parsing", () => {
     expect(seen[0]?.["User-Agent"]).toBe("codex-cli");
     expect(seen[1]).not.toHaveProperty("ChatGPT-Account-Id");
   });
+
+  it("filters out empty plan_type and invalid email strings without @", async () => {
+    const usage = await fetchCodexUsage(
+      "tok",
+      "a",
+      fetchReturning(
+        jsonResponse({
+          plan_type: "",
+          email: "notanemail",
+        }),
+      ),
+    );
+    expect(usage.planType).toBeUndefined();
+    expect(usage.email).toBeUndefined();
+  });
 });
 
 describe("fetchCodexUsage — typed failures (never fabricated data)", () => {
-  it.each([[401], [429], [503]])(
-    "throws a typed http_error carrying status %s in context and message",
-    async (status) => {
+  it.each([
+    [401, "fatal"],
+    [403, "fatal"],
+    [429, "fatal"],
+    [500, "ephemeral"],
+    [503, "ephemeral"],
+  ])(
+    "throws a typed http_error carrying status %s and severity %s",
+    async (status, expectedSeverity) => {
       const err = await fetchCodexUsage(
         "tok",
         "a",
@@ -151,6 +172,7 @@ describe("fetchCodexUsage — typed failures (never fabricated data)", () => {
       const typed = err as ElizaError;
       expect(typed.code).toBe("codex_usage.http_error");
       expect(typed.context?.status).toBe(status);
+      expect(typed.severity).toBe(expectedSeverity);
       // Callers (rate-limit regexes, dashboards) read the status from the message.
       expect(typed.message).toContain(String(status));
     },


### PR DESCRIPTION
# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Test-only behavioral coverage in `@elizaos/auth` for HTTP status error severity mapping (fatal 4xx vs ephemeral 5xx) and optional field sanitization in `fetchCodexUsage`.

# Background

## What does this PR do?

Adds behavioral unit test coverage in `@elizaos/auth` (`packages/auth/src/codex-usage.test.ts`) verifying that `fetchCodexUsage` sets `ElizaError` severity according to the error policy (`fatal` on 4xx statuses, `ephemeral` on 5xx statuses) and safely sanitizes empty plan types and non-email strings.

## What kind of change is this?

Improvements (misc. changes to existing features)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

- `packages/auth/src/codex-usage.test.ts`

## Detailed testing steps

Run unit tests:
```bash
./node_modules/.bin/vitest run packages/auth/src/codex-usage.test.ts
```

```
RED (when 5xx errors are mutated to fatal):
  24 tests | 2 failed (throws a typed http_error carrying status 500/503 and severity ephemeral)
  AssertionError: expected 'fatal' to be 'ephemeral'

GREEN (restored):
  24 tests | 24 passed
```

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:10d6ba4646996aead879f4da5e51dbe5ea880bd7 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only change with no rendered UI surface
<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only change with no rendered UI surface
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - test-only change has no user flow to record
<!-- evidence-row:backend-logs -->
- [ ] N/A - pure unit test does not exercise a server path
<!-- evidence-row:frontend-logs -->
- [ ] N/A - pure unit test does not exercise a browser path
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent model or prompt path is touched
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database rows or generated files produced
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface in this change

# Evidence Details

## Real LLM-call trajectory
N/A - no agent model or prompt path is touched

## Backend + frontend logs
N/A - pure unit test does not exercise a server path

## Screenshots (before / after) + video walkthrough
N/A - test-only change with no rendered UI surface

## Audio / voice walkthrough
N/A - test-only change has no voice surface

## Known gaps / failures
N/A - all unit tests pass cleanly

## Maintainer CI exception record
- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: Claude Code
— [lane-byt61-7842]

