### PR TITLE
test(agent): cover escalate, complete, and keyboard action parsing and display stripping

### DIFF
--- a/packages/agent/src/api/parse-action-block.test.ts
+++ b/packages/agent/src/api/parse-action-block.test.ts
@@ -84,6 +84,36 @@ describe("parseActionBlock", () => {
       '```json\n{"action":"respond","reasoning":"x","response":"hi","permission":"reminders"}\n```';
     expect(parseActionBlock(text)).toBeNull();
   });
+
+  it("parses escalate and complete actions", () => {
+    const escalateResult = parseActionBlock(
+      'Need help.\n```json\n{"action":"escalate","reasoning":"requires human operator"}\n```',
+    );
+    expect(escalateResult?.action).toBe("escalate");
+    expect(escalateResult?.reasoning).toBe("requires human operator");
+
+    const completeResult = parseActionBlock(
+      'All done.\n{"action":"complete","reasoning":"task finished"}',
+    );
+    expect(completeResult?.action).toBe("complete");
+    expect(completeResult?.reasoning).toBe("task finished");
+  });
+
+  it("parses respond with useKeys array", () => {
+    const result = parseActionBlock(
+      'Pressing shortcut.\n```json\n{"action":"respond","reasoning":"send keystroke","useKeys":true,"keys":["Enter","Escape"]}\n```',
+    );
+    expect(result?.action).toBe("respond");
+    expect(result?.useKeys).toBe(true);
+    expect(result?.keys).toEqual(["Enter", "Escape"]);
+  });
+
+  it("rejects respond with empty keys array and no response text", () => {
+    const result = parseActionBlock(
+      '```json\n{"action":"respond","reasoning":"no keys","useKeys":true,"keys":[]}\n```',
+    );
+    expect(result).toBeNull();
+  });
 });
 
 describe("stripActionBlockFromDisplay", () => {
@@ -93,6 +123,14 @@ describe("stripActionBlockFromDisplay", () => {
       '{"action":"permission_request","reasoning":"x","permission":"camera","reason":"y","feature":"a.b.c"}' +
       "\n```";
     expect(stripActionBlockFromDisplay(text)).toBe("Here is the result.");
+  });
+
+  it("strips a fenced respond block", () => {
+    const text =
+      "Here is the message.\n```json\n" +
+      '{"action":"respond","reasoning":"test","response":"hi"}' +
+      "\n```";
+    expect(stripActionBlockFromDisplay(text)).toBe("Here is the message.");
   });
 
   it("strips a bare permission_request block", () => {
@@ -105,5 +143,11 @@ describe("stripActionBlockFromDisplay", () => {
     expect(stripActionBlockFromDisplay("just plain text")).toBe(
       "just plain text",
     );
+  });
+
+  it("leaves text with unknown action block unchanged", () => {
+    const text =
+      'Look at this: ```json\n{"action":"custom_external","data":123}\n```';
+    expect(stripActionBlockFromDisplay(text)).toBe(text);
   });
 });


### PR DESCRIPTION
# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Test-only behavioral coverage in `@elizaos/agent` for action parsing (`escalate`, `complete`, `useKeys`) and display text stripping in `parse-action-block`.

# Background

## What does this PR do?

Adds behavioral unit test coverage in `@elizaos/agent` (`packages/agent/src/api/parse-action-block.test.ts`) verifying that `parseActionBlock` correctly parses `escalate`, `complete`, and `useKeys` keyboard action blocks, rejects empty key arrays, and verifies `stripActionBlockFromDisplay` preserves text with unrecognized action payloads.

## What kind of change is this?

Improvements (misc. changes to existing features)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

- `packages/agent/src/api/parse-action-block.test.ts`

## Detailed testing steps

Run unit tests:
```bash
./node_modules/.bin/vitest run packages/agent/src/api/parse-action-block.test.ts
```

```
RED (when escalate is dropped from VALID_ACTIONS):
  18 tests | 1 failed (parses escalate and complete actions)
  AssertionError: expected undefined to be 'escalate'

GREEN (restored):
  18 tests | 18 passed
```

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:52153ec11216167a1767fc5430972413565fdf32 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only change with no rendered UI surface
<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only change with no rendered UI surface
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - test-only change has no user flow to record
<!-- evidence-row:backend-logs -->
- [ ] N/A - pure unit test does not exercise a server path
<!-- evidence-row:frontend-logs -->
- [ ] N/A - pure unit test does not exercise a browser path
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent model or prompt path is touched
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database rows or generated files produced
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface in this change

# Evidence Details

## Real LLM-call trajectory
N/A - no agent model or prompt path is touched

## Backend + frontend logs
N/A - pure unit test does not exercise a server path

## Screenshots (before / after) + video walkthrough
N/A - test-only change with no rendered UI surface

## Audio / voice walkthrough
N/A - test-only change has no voice surface

## Known gaps / failures
N/A - all unit tests pass cleanly

## Maintainer CI exception record
- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: Claude Code
— [lane-byt61-7842]

