### PR TITLE
fix: adapt cross-room recall to model capacity

### DIFF
--- a/packages/agent/src/actions/memories.test.ts
+++ b/packages/agent/src/actions/memories.test.ts
@@ -701,6 +701,35 @@ describe("MEMORY op:delete by query", () => {
 });
 
 describe("MEMORY op:search complete traversal", () => {
+  it("finds attachment descriptions without exposing capability URLs", async () => {
+    const { runtime, rows } = makeRuntime();
+    seedFact(rows, { text: "", entityId: USER_ID });
+    rows[0].memory.content = {
+      attachments: [
+        {
+          id: "receipt-photo",
+          url: "https://private.example/receipt.png",
+          thumbnailUrl: "https://private.example/receipt-thumb.png",
+          filename: "receipt.png",
+          mimeType: "image/png",
+          description: "A receipt showing a 6:30 PM dinner reservation",
+        },
+      ],
+    };
+
+    const result = await runAction(runtime, makeMessage(), {
+      action: "search",
+      type: "facts",
+      query: "dinner reservation",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.text).toContain(
+      "[attachment: receipt.png; image/png; A receipt showing a 6:30 PM dinner reservation]",
+    );
+    expect(result.text).not.toContain("private.example");
+  });
+
   it("ranks an exact all-term match ahead of newer partial decoys", async () => {
     const { runtime, rows } = makeRuntime();
     const targetId = seedFact(rows, {

--- a/packages/agent/src/actions/memories.ts
+++ b/packages/agent/src/actions/memories.ts
@@ -110,12 +110,23 @@ function scoreText(text: string, query: string): number {
   return whole + matches / terms.length;
 }
 
+function searchableMemoryText(memory: Memory): string {
+  const text = memory.content.text ?? "";
+  const attachments = (memory.content.attachments ?? []).map((attachment) => {
+    const label =
+      attachment.filename ?? attachment.title ?? attachment.id ?? "attachment";
+    const mediaType = attachment.mimeType ?? attachment.contentType;
+    const readableContent = attachment.text ?? attachment.description;
+    return `[attachment: ${label}${mediaType ? `; ${mediaType}` : ""}${readableContent ? `; ${readableContent}` : ""}]`;
+  });
+  return [text, ...attachments].filter(Boolean).join(" ");
+}
+
 function toListItem(memory: Memory, type: MemoryType): MemoryListItem {
-  const content = memory.content as Record<string, unknown> | undefined;
   return {
     id: memory.id ?? "",
     type,
-    text: (content?.text as string) ?? "",
+    text: searchableMemoryText(memory),
     entityId: memory.entityId,
     roomId: memory.roomId,
     agentId: memory.agentId ?? null,
@@ -399,8 +410,7 @@ async function collectCandidates(
   }
 
   let filtered = collected.filter((c) => {
-    const text = (c.memory.content as { text?: string } | undefined)?.text;
-    return typeof text === "string" && text.trim().length > 0;
+    return searchableMemoryText(c.memory).trim().length > 0;
   });
 
   if (scope.entityId) {
@@ -415,18 +425,14 @@ async function collectCandidates(
   if (scope.query) {
     const query = scope.query;
     filtered = filtered.filter((c) => {
-      const text =
-        (c.memory.content as { text?: string } | undefined)?.text ?? "";
-      return scoreText(text, query) > 0;
+      return scoreText(searchableMemoryText(c.memory), query) > 0;
     });
   }
 
   filtered.sort((a, b) => {
     if (scope.query) {
-      const leftText =
-        (a.memory.content as { text?: string } | undefined)?.text ?? "";
-      const rightText =
-        (b.memory.content as { text?: string } | undefined)?.text ?? "";
+      const leftText = searchableMemoryText(a.memory);
+      const rightText = searchableMemoryText(b.memory);
       const relevance =
         scoreText(rightText, scope.query) - scoreText(leftText, scope.query);
       if (relevance !== 0) return relevance;

--- a/packages/agent/src/providers/recent-conversations.access-context.test.ts
+++ b/packages/agent/src/providers/recent-conversations.access-context.test.ts
@@ -164,27 +164,18 @@ describe("recentConversationsProvider access-context integration", () => {
       isOwner: true,
       authorizedRoomIds: expect.arrayContaining([RETAINED_ROOM, REVOKED_ROOM]),
     });
-    expect(
-      await runtime.getMemoriesByRoomIds({
-        tableName: "messages",
-        roomIds: [RETAINED_ROOM, REVOKED_ROOM],
-        accessContext: firstAccessContext,
-      }),
-    ).toHaveLength(2);
     storageRead.mockClear();
-    const storageCount = vi.spyOn(runtime, "countMemories");
     const beforeRevocation = await recentConversationsProvider.get(
       runtime,
       firstTurn,
       EMPTY_STATE,
     );
 
-    expect(beforeRevocation.text).toContain(`roomId=${RETAINED_ROOM}`);
-    expect(beforeRevocation.text).toContain(`roomId=${REVOKED_ROOM}`);
-    expect(beforeRevocation.text).not.toContain("cross-world message");
+    expect(beforeRevocation.overflowText).toContain(`roomId=${RETAINED_ROOM}`);
+    expect(beforeRevocation.overflowText).toContain(`roomId=${REVOKED_ROOM}`);
+    expect(beforeRevocation.text).toContain("cross-world message");
     expect(beforeRevocation.values?.recentConversationCount).toBe(2);
-    expect(storageRead).not.toHaveBeenCalled();
-    expect(storageCount).toHaveBeenLastCalledWith(
+    expect(storageRead).toHaveBeenLastCalledWith(
       expect.objectContaining({
         roomIds: expect.arrayContaining([RETAINED_ROOM, REVOKED_ROOM]),
         tableName: "messages",
@@ -198,12 +189,16 @@ describe("recentConversationsProvider access-context integration", () => {
       EMPTY_STATE,
     );
 
-    expect(afterRevocation.text).toContain(`roomId=${RETAINED_ROOM}`);
-    expect(afterRevocation.text).not.toContain(`roomId=${REVOKED_ROOM}`);
+    expect(afterRevocation.overflowText).toContain(`roomId=${RETAINED_ROOM}`);
+    expect(afterRevocation.overflowText).not.toContain(
+      `roomId=${REVOKED_ROOM}`,
+    );
     expect(afterRevocation.values?.recentConversationCount).toBe(1);
-    expect(storageCount).toHaveBeenLastCalledWith({
-      roomIds: [RETAINED_ROOM],
-      tableName: "messages",
-    });
+    expect(storageRead).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        roomIds: [RETAINED_ROOM],
+        tableName: "messages",
+      }),
+    );
   });
 });

--- a/packages/agent/src/providers/recent-conversations.access-context.test.ts
+++ b/packages/agent/src/providers/recent-conversations.access-context.test.ts
@@ -171,24 +171,23 @@ describe("recentConversationsProvider access-context integration", () => {
         accessContext: firstAccessContext,
       }),
     ).toHaveLength(2);
+    storageRead.mockClear();
+    const storageCount = vi.spyOn(runtime, "countMemories");
     const beforeRevocation = await recentConversationsProvider.get(
       runtime,
       firstTurn,
       EMPTY_STATE,
     );
 
-    expect(beforeRevocation.text).toContain("retained cross-world message");
-    expect(beforeRevocation.text).toContain("revoked cross-world message");
+    expect(beforeRevocation.text).toContain(`roomId=${RETAINED_ROOM}`);
+    expect(beforeRevocation.text).toContain(`roomId=${REVOKED_ROOM}`);
+    expect(beforeRevocation.text).not.toContain("cross-world message");
     expect(beforeRevocation.values?.recentConversationCount).toBe(2);
-    expect(storageRead).toHaveBeenLastCalledWith(
+    expect(storageRead).not.toHaveBeenCalled();
+    expect(storageCount).toHaveBeenLastCalledWith(
       expect.objectContaining({
         roomIds: expect.arrayContaining([RETAINED_ROOM, REVOKED_ROOM]),
-        accessContext: expect.objectContaining({
-          authorizedRoomIds: expect.arrayContaining([
-            RETAINED_ROOM,
-            REVOKED_ROOM,
-          ]),
-        }),
+        tableName: "messages",
       }),
     );
 
@@ -199,17 +198,12 @@ describe("recentConversationsProvider access-context integration", () => {
       EMPTY_STATE,
     );
 
-    expect(afterRevocation.text).toContain("retained cross-world message");
-    expect(afterRevocation.text).not.toContain("revoked cross-world message");
+    expect(afterRevocation.text).toContain(`roomId=${RETAINED_ROOM}`);
+    expect(afterRevocation.text).not.toContain(`roomId=${REVOKED_ROOM}`);
     expect(afterRevocation.values?.recentConversationCount).toBe(1);
-    const finalRead = storageRead.mock.calls.at(-1)?.[0];
-    expect(finalRead?.roomIds).toContain(RETAINED_ROOM);
-    expect(finalRead?.roomIds).not.toContain(REVOKED_ROOM);
-    expect(finalRead?.accessContext?.authorizedRoomIds).toContain(
-      RETAINED_ROOM,
-    );
-    expect(finalRead?.accessContext?.authorizedRoomIds).not.toContain(
-      REVOKED_ROOM,
-    );
+    expect(storageCount).toHaveBeenLastCalledWith({
+      roomIds: [RETAINED_ROOM],
+      tableName: "messages",
+    });
   });
 });

--- a/packages/agent/src/providers/recent-conversations.test.ts
+++ b/packages/agent/src/providers/recent-conversations.test.ts
@@ -83,6 +83,7 @@ function makeRuntime(overrides: Record<string, unknown> = {}): IAgentRuntime {
     })),
     getRoomsForParticipants: vi.fn(async () => [ROOM_ID]),
     getRoomsForParticipant: vi.fn(async () => [ROOM_ID]),
+    countMemories: vi.fn(async () => 1),
     getMemoriesByRoomIds: vi.fn(async () => [
       { ...message(), createdAt: Number.POSITIVE_INFINITY },
     ]),
@@ -108,7 +109,7 @@ describe("recentConversationsProvider", () => {
     expect(recentConversationsProvider.alwaysInResponseState).toBe(true);
   });
 
-  it("omits empty age labels and their parentheses from provider output", async () => {
+  it("renders room identity without copying a message body into the prompt", async () => {
     const runtime = makeRuntime();
 
     const result = await recentConversationsProvider.get(
@@ -117,15 +118,14 @@ describe("recentConversationsProvider", () => {
       EMPTY_STATE,
     );
 
-    expect(result.text).toContain("[discord] general user: hello there");
-    expect(result.text).not.toContain("()");
-    expect(result.text).not.toContain("NaN");
+    expect(result.text).toContain(`[discord] general roomId=${ROOM_ID}`);
+    expect(result.text).not.toContain("hello there");
     expect(markOwnerExclusiveDisclosureUsed).toHaveBeenCalledWith(
       expect.objectContaining({ entityId: ENTITY_ID }),
     );
   });
 
-  it("expands linked aliases, dedupes rooms, batches tags, and retains every eligible message", async () => {
+  it("expands linked aliases into a room manifest without reading message bodies", async () => {
     getVerifiedRelatedEntityIds.mockResolvedValue([ENTITY_ID, ALIAS_ENTITY_ID]);
     const completeTexts = Array.from(
       { length: 15 },
@@ -158,6 +158,7 @@ describe("recentConversationsProvider", () => {
     const runtime = makeRuntime({
       getRoomsForParticipants,
       getRoomsForParticipant,
+      countMemories: vi.fn(async () => completeTexts.length),
       getMemoriesByRoomIds,
       getRoomsByIds,
     });
@@ -177,19 +178,22 @@ describe("recentConversationsProvider", () => {
       ALIAS_ENTITY_ID,
     ]);
     expect(getRoomsForParticipant).toHaveBeenCalledWith(AGENT_ID);
-    expect(getMemoriesByRoomIds).toHaveBeenCalledWith({
+    expect(getMemoriesByRoomIds).not.toHaveBeenCalled();
+    expect(runtime.countMemories).toHaveBeenCalledWith({
       tableName: "messages",
       roomIds: [ROOM_ID, ALIAS_ROOM_ID],
-      accessContext: {
-        requesterEntityId: ENTITY_ID,
-        authorizedRoomIds: [ROOM_ID, ALIAS_ROOM_ID],
-      },
     });
     expect(getRoomsByIds).toHaveBeenCalledOnce();
     expect(getRoomsByIds).toHaveBeenCalledWith([ROOM_ID, ALIAS_ROOM_ID]);
     expect(result.values?.recentConversationCount).toBe(15);
-    expect(result.data?.messages).toHaveLength(15);
-    for (const text of completeTexts) expect(result.text).toContain(text);
+    expect(result.values?.recentConversationRoomCount).toBe(2);
+    expect(result.data?.rooms).toHaveLength(2);
+    expect(result.text).toContain(
+      "15 stored message(s) across 2 authorized room(s)",
+    );
+    expect(result.text).toContain("discord");
+    expect(result.text).toContain("telegram");
+    for (const text of completeTexts) expect(result.text).not.toContain(text);
   });
 
   it("leaves the current-room transcript to RECENT_MESSAGES in the full agent runtime", async () => {
@@ -216,18 +220,16 @@ describe("recentConversationsProvider", () => {
       EMPTY_STATE,
     );
 
-    expect(getMemoriesByRoomIds).toHaveBeenCalledWith({
+    expect(getMemoriesByRoomIds).not.toHaveBeenCalled();
+    expect(runtime.countMemories).toHaveBeenCalledWith({
       tableName: "messages",
       roomIds: [ALIAS_ROOM_ID],
-      accessContext: {
-        requesterEntityId: ENTITY_ID,
-        authorizedRoomIds: [ROOM_ID, ALIAS_ROOM_ID],
-      },
     });
-    expect(result.text).toContain("remote-only context");
+    expect(result.text).toContain(`roomId=${ALIAS_ROOM_ID}`);
+    expect(result.text).not.toContain("remote-only context");
   });
 
-  it("keeps attachment-only cross-platform turns as multimodal context without capability URLs", async () => {
+  it("does not leak attachment bodies or capability URLs through the room manifest", async () => {
     const runtime = makeRuntime({
       getMemoriesByRoomIds: vi.fn(async () => [
         {
@@ -254,23 +256,11 @@ describe("recentConversationsProvider", () => {
       EMPTY_STATE,
     );
 
-    expect(result.text).toContain(
-      "[attachment: receipt.png; image/png; A receipt showing a 6:30 PM dinner reservation]",
-    );
+    expect(result.text).not.toContain("receipt.png");
+    expect(result.text).not.toContain("dinner reservation");
     expect(result.text).not.toContain("private.example");
     expect(result.values?.recentConversationCount).toBe(1);
-    expect(result.data?.messages).toEqual([
-      expect.objectContaining({
-        text: undefined,
-        attachments: [
-          expect.objectContaining({
-            id: "photo-1",
-            filename: "receipt.png",
-            mimeType: "image/png",
-          }),
-        ],
-      }),
-    ]);
+    expect(result.data?.rooms).toHaveLength(1);
     expect(JSON.stringify(result.data)).not.toContain("private.example");
   });
 

--- a/packages/agent/src/providers/recent-conversations.test.ts
+++ b/packages/agent/src/providers/recent-conversations.test.ts
@@ -83,7 +83,6 @@ function makeRuntime(overrides: Record<string, unknown> = {}): IAgentRuntime {
     })),
     getRoomsForParticipants: vi.fn(async () => [ROOM_ID]),
     getRoomsForParticipant: vi.fn(async () => [ROOM_ID]),
-    countMemories: vi.fn(async () => 1),
     getMemoriesByRoomIds: vi.fn(async () => [
       { ...message(), createdAt: Number.POSITIVE_INFINITY },
     ]),
@@ -109,7 +108,7 @@ describe("recentConversationsProvider", () => {
     expect(recentConversationsProvider.alwaysInResponseState).toBe(true);
   });
 
-  it("renders room identity without copying a message body into the prompt", async () => {
+  it("keeps eager message bodies and declares a retrieval manifest", async () => {
     const runtime = makeRuntime();
 
     const result = await recentConversationsProvider.get(
@@ -118,14 +117,17 @@ describe("recentConversationsProvider", () => {
       EMPTY_STATE,
     );
 
-    expect(result.text).toContain(`[discord] general roomId=${ROOM_ID}`);
-    expect(result.text).not.toContain("hello there");
+    expect(result.text).toContain("hello there");
+    expect(result.overflowText).toContain(
+      `[discord] general roomId=${ROOM_ID}`,
+    );
+    expect(result.overflowText).not.toContain("hello there");
     expect(markOwnerExclusiveDisclosureUsed).toHaveBeenCalledWith(
       expect.objectContaining({ entityId: ENTITY_ID }),
     );
   });
 
-  it("expands linked aliases into a room manifest without reading message bodies", async () => {
+  it("expands linked aliases into complete eager context and a body-free manifest", async () => {
     getVerifiedRelatedEntityIds.mockResolvedValue([ENTITY_ID, ALIAS_ENTITY_ID]);
     const completeTexts = Array.from(
       { length: 15 },
@@ -158,7 +160,6 @@ describe("recentConversationsProvider", () => {
     const runtime = makeRuntime({
       getRoomsForParticipants,
       getRoomsForParticipant,
-      countMemories: vi.fn(async () => completeTexts.length),
       getMemoriesByRoomIds,
       getRoomsByIds,
     });
@@ -178,22 +179,27 @@ describe("recentConversationsProvider", () => {
       ALIAS_ENTITY_ID,
     ]);
     expect(getRoomsForParticipant).toHaveBeenCalledWith(AGENT_ID);
-    expect(getMemoriesByRoomIds).not.toHaveBeenCalled();
-    expect(runtime.countMemories).toHaveBeenCalledWith({
+    expect(getMemoriesByRoomIds).toHaveBeenCalledWith({
       tableName: "messages",
       roomIds: [ROOM_ID, ALIAS_ROOM_ID],
+      accessContext: expect.objectContaining({
+        authorizedRoomIds: [ROOM_ID, ALIAS_ROOM_ID],
+      }),
     });
     expect(getRoomsByIds).toHaveBeenCalledOnce();
     expect(getRoomsByIds).toHaveBeenCalledWith([ROOM_ID, ALIAS_ROOM_ID]);
     expect(result.values?.recentConversationCount).toBe(15);
     expect(result.values?.recentConversationRoomCount).toBe(2);
     expect(result.data?.rooms).toHaveLength(2);
-    expect(result.text).toContain(
+    expect(result.overflowText).toContain(
       "15 stored message(s) across 2 authorized room(s)",
     );
-    expect(result.text).toContain("discord");
-    expect(result.text).toContain("telegram");
-    for (const text of completeTexts) expect(result.text).not.toContain(text);
+    expect(result.overflowText).toContain("discord");
+    expect(result.overflowText).toContain("telegram");
+    for (const text of completeTexts) {
+      expect(result.text).toContain(text);
+      expect(result.overflowText).not.toContain(text);
+    }
   });
 
   it("leaves the current-room transcript to RECENT_MESSAGES in the full agent runtime", async () => {
@@ -220,16 +226,16 @@ describe("recentConversationsProvider", () => {
       EMPTY_STATE,
     );
 
-    expect(getMemoriesByRoomIds).not.toHaveBeenCalled();
-    expect(runtime.countMemories).toHaveBeenCalledWith({
+    expect(getMemoriesByRoomIds).toHaveBeenCalledWith({
       tableName: "messages",
       roomIds: [ALIAS_ROOM_ID],
+      accessContext: expect.any(Object),
     });
-    expect(result.text).toContain(`roomId=${ALIAS_ROOM_ID}`);
-    expect(result.text).not.toContain("remote-only context");
+    expect(result.overflowText).toContain(`roomId=${ALIAS_ROOM_ID}`);
+    expect(result.text).toContain("remote-only context");
   });
 
-  it("does not leak attachment bodies or capability URLs through the room manifest", async () => {
+  it("keeps safe attachment recall while excluding capability URLs", async () => {
     const runtime = makeRuntime({
       getMemoriesByRoomIds: vi.fn(async () => [
         {
@@ -256,9 +262,10 @@ describe("recentConversationsProvider", () => {
       EMPTY_STATE,
     );
 
-    expect(result.text).not.toContain("receipt.png");
-    expect(result.text).not.toContain("dinner reservation");
+    expect(result.text).toContain("receipt.png");
+    expect(result.text).toContain("dinner reservation");
     expect(result.text).not.toContain("private.example");
+    expect(result.overflowText).not.toContain("receipt.png");
     expect(result.values?.recentConversationCount).toBe(1);
     expect(result.data?.rooms).toHaveLength(1);
     expect(JSON.stringify(result.data)).not.toContain("private.example");

--- a/packages/agent/src/providers/recent-conversations.ts
+++ b/packages/agent/src/providers/recent-conversations.ts
@@ -1,13 +1,14 @@
 /**
- * Provider that exposes a truthful manifest of the owner's authorized
- * cross-platform conversation rooms. Message bodies stay in durable storage
- * for MEMORY_SEARCH instead of being copied eagerly into every model prompt;
- * RECENT_MESSAGES owns the current-room transcript when present. Suppressed
+ * Provider that exposes complete authorized cross-platform conversation
+ * history with a lossless retrieval manifest for models whose input boundary
+ * cannot admit the eager representation. RECENT_MESSAGES owns the current-room
+ * transcript when present. Suppressed
  * inside automation and page-scoped rooms, which carry their own context.
  * Gated to ADMIN (enforced by applyPluginRoleGating).
  */
 import type {
   IAgentRuntime,
+  Media,
   Memory,
   Provider,
   ProviderResult,
@@ -29,7 +30,26 @@ import {
   isAutomationConversationMetadata,
   isPageScopedConversationMetadata,
 } from "../api/conversation-metadata.ts";
-import { roomSourceTag } from "../shared/conversation-format.ts";
+import {
+  formatRelativeTimestampPrefix,
+  formatSpeakerLabel,
+  roomSourceTag,
+} from "../shared/conversation-format.ts";
+
+function attachmentPromptSummary(attachments: readonly Media[]): string {
+  return attachments
+    .map((attachment) => {
+      const label =
+        attachment.filename ??
+        attachment.title ??
+        attachment.id ??
+        "attachment";
+      const mediaType = attachment.mimeType ?? attachment.contentType;
+      const readableContent = attachment.text ?? attachment.description;
+      return `[attachment: ${toWellFormedUnicode(label)}${mediaType ? `; ${mediaType}` : ""}${readableContent ? `; ${toWellFormedUnicode(readableContent)}` : ""}]`;
+    })
+    .join(" ");
+}
 
 export const recentConversationsProvider: Provider = {
   name: "recent-conversations",
@@ -109,11 +129,19 @@ export const recentConversationsProvider: Provider = {
         return { text: "", values: {}, data: {} };
       }
 
-      const messageCount = await runtime.countMemories({
+      const memories = await runtime.getMemoriesByRoomIds({
         tableName: "messages",
         roomIds,
+        accessContext,
       });
-      if (messageCount === 0) {
+      const sorted = memories
+        .filter(
+          (memory) =>
+            Boolean(memory.content.text) ||
+            (memory.content.attachments?.length ?? 0) > 0,
+        )
+        .sort((left, right) => (right.createdAt ?? 0) - (left.createdAt ?? 0));
+      if (sorted.length === 0) {
         return { text: "", values: {}, data: {} };
       }
 
@@ -143,19 +171,31 @@ export const recentConversationsProvider: Provider = {
           label: toWellFormedUnicode(roomSourceTag(room)),
         };
       });
-      const lines = [
+      const manifestLines = [
         "Stored conversation manifest:",
-        `${messageCount} stored message(s) across ${rooms.length} authorized room(s).`,
+        `${sorted.length} stored message(s) across ${rooms.length} authorized room(s).`,
         "Message bodies are not included here. Use MEMORY_SEARCH for complete historical recall.",
         ...rooms.map((room) => `- ${room.label} roomId=${room.id}`),
       ];
+      const eagerLines = ["Recent conversations:"];
+      for (const memory of sorted) {
+        const room = roomCache.get(memory.roomId) ?? null;
+        const text = toWellFormedUnicode(memory.content.text ?? "");
+        const attachments = attachmentPromptSummary(
+          memory.content.attachments ?? [],
+        );
+        eagerLines.push(
+          `${roomSourceTag(room)} ${formatRelativeTimestampPrefix(memory.createdAt)}${formatSpeakerLabel(runtime, memory)}: ${[text, attachments].filter(Boolean).join(" ")}`,
+        );
+      }
 
       markOwnerExclusiveDisclosureUsed(message);
 
       return {
-        text: lines.join("\n"),
+        text: eagerLines.join("\n"),
+        overflowText: manifestLines.join("\n"),
         values: {
-          recentConversationCount: messageCount,
+          recentConversationCount: sorted.length,
           recentConversationRoomCount: rooms.length,
         },
         data: { rooms },

--- a/packages/agent/src/providers/recent-conversations.ts
+++ b/packages/agent/src/providers/recent-conversations.ts
@@ -1,15 +1,13 @@
 /**
- * Provider that surfaces the user's recent messages and attachment descriptions
- * across connected platforms. It expands verified linked identities,
- * intersects their rooms with the agent's durable rooms, and renders the full
- * eligible cross-room history newest-first with source, time, and speaker
- * provenance; RECENT_MESSAGES owns the current-room transcript when present.
- * Suppressed inside automation and page-scoped rooms, which carry their own
- * context. Gated to ADMIN (enforced by applyPluginRoleGating).
+ * Provider that exposes a truthful manifest of the owner's authorized
+ * cross-platform conversation rooms. Message bodies stay in durable storage
+ * for MEMORY_SEARCH instead of being copied eagerly into every model prompt;
+ * RECENT_MESSAGES owns the current-room transcript when present. Suppressed
+ * inside automation and page-scoped rooms, which carry their own context.
+ * Gated to ADMIN (enforced by applyPluginRoleGating).
  */
 import type {
   IAgentRuntime,
-  Media,
   Memory,
   Provider,
   ProviderResult,
@@ -31,33 +29,14 @@ import {
   isAutomationConversationMetadata,
   isPageScopedConversationMetadata,
 } from "../api/conversation-metadata.ts";
-import {
-  formatRelativeTimestampPrefix,
-  formatSpeakerLabel,
-  roomSourceTag,
-} from "../shared/conversation-format.ts";
-
-function attachmentPromptSummary(attachments: readonly Media[]): string {
-  return attachments
-    .map((attachment) => {
-      const label =
-        attachment.filename ??
-        attachment.title ??
-        attachment.id ??
-        "attachment";
-      const mediaType = attachment.mimeType ?? attachment.contentType;
-      const readableContent = attachment.text ?? attachment.description;
-      return `[attachment: ${toWellFormedUnicode(label)}${mediaType ? `; ${mediaType}` : ""}${readableContent ? `; ${toWellFormedUnicode(readableContent)}` : ""}]`;
-    })
-    .join(" ");
-}
+import { roomSourceTag } from "../shared/conversation-format.ts";
 
 export const recentConversationsProvider: Provider = {
   name: "recent-conversations",
   description:
-    "Recent messages from the user's conversations across all connected platforms.",
+    "Authorized conversation-room manifest for storage-backed cross-platform recall.",
   descriptionCompressed:
-    "recent message user conversation across connect platform",
+    "authorized conversation room manifest search stored cross platform history",
   dynamic: true,
   // Cross-world continuity must be available to the response router itself;
   // waiting for a memory/messaging context selection is too late for a direct
@@ -130,47 +109,18 @@ export const recentConversationsProvider: Provider = {
         return { text: "", values: {}, data: {} };
       }
 
-      const memories = await runtime.getMemoriesByRoomIds({
+      const messageCount = await runtime.countMemories({
         tableName: "messages",
         roomIds,
-        accessContext,
       });
-
-      if (!memories || memories.length === 0) {
+      if (messageCount === 0) {
         return { text: "", values: {}, data: {} };
       }
 
-      // Sort newest first
-      const sorted = memories
-        .filter(
-          (m) =>
-            Boolean(m.content.text) || (m.content.attachments?.length ?? 0) > 0,
-        )
-        .sort((a, b) => {
-          const aTime =
-            typeof a.createdAt === "number" && Number.isFinite(a.createdAt)
-              ? a.createdAt
-              : 0;
-          const bTime =
-            typeof b.createdAt === "number" && Number.isFinite(b.createdAt)
-              ? b.createdAt
-              : 0;
-          return bTime - aTime;
-        });
-
-      if (sorted.length === 0) {
-        return { text: "", values: {}, data: {} };
-      }
-
-      // Resolve source tags in one adapter read. A missing cosmetic tag must
-      // not remove otherwise eligible history from model context.
+      // Resolve room labels in one adapter read. Missing cosmetic labels do not
+      // remove an authorized room from the manifest or widen disclosure.
       const roomCache = new Map<string, Room | null>();
-      for (const mem of sorted) {
-        const rid = mem.roomId;
-        if (rid && !roomCache.has(rid)) {
-          roomCache.set(rid, null);
-        }
-      }
+      for (const roomId of roomIds) roomCache.set(roomId, null);
       const resultRoomIds = Array.from(roomCache.keys()) as UUID[];
       try {
         for (const room of await runtime.getRoomsByIds(resultRoomIds)) {
@@ -184,50 +134,31 @@ export const recentConversationsProvider: Provider = {
         });
       }
 
-      const lines: string[] = ["Recent conversations:"];
-      for (const mem of sorted) {
-        const room = roomCache.get(mem.roomId) ?? null;
-        const tag = roomSourceTag(room);
-        const age = formatRelativeTimestampPrefix(mem.createdAt);
-        const speaker = formatSpeakerLabel(runtime, mem);
-        const text = toWellFormedUnicode(mem.content.text ?? "");
-        const attachments = attachmentPromptSummary(
-          mem.content.attachments ?? [],
-        );
-        lines.push(
-          `${tag} ${age}${speaker}: ${[text, attachments].filter(Boolean).join(" ")}`,
-        );
-      }
+      const rooms = roomIds.map((roomId) => {
+        const room = roomCache.get(roomId) ?? null;
+        return {
+          id: roomId,
+          source: room?.source ?? null,
+          name: room?.name ?? null,
+          label: toWellFormedUnicode(roomSourceTag(room)),
+        };
+      });
+      const lines = [
+        "Stored conversation manifest:",
+        `${messageCount} stored message(s) across ${rooms.length} authorized room(s).`,
+        "Message bodies are not included here. Use MEMORY_SEARCH for complete historical recall.",
+        ...rooms.map((room) => `- ${room.label} roomId=${room.id}`),
+      ];
 
       markOwnerExclusiveDisclosureUsed(message);
 
       return {
         text: lines.join("\n"),
-        values: { recentConversationCount: sorted.length },
-        data: {
-          messages: sorted.map((m) => ({
-            id: m.id,
-            roomId: m.roomId,
-            entityId: m.entityId,
-            text: m.content.text,
-            attachments: (m.content.attachments ?? []).map((attachment) => ({
-              id: attachment.id,
-              title: attachment.title,
-              source: attachment.source,
-              description: attachment.description,
-              text: attachment.text,
-              contentType: attachment.contentType,
-              mimeType: attachment.mimeType,
-              filename: attachment.filename,
-              size: attachment.size,
-              checksum: attachment.checksum,
-              width: attachment.width,
-              height: attachment.height,
-              duration: attachment.duration,
-            })),
-            createdAt: m.createdAt,
-          })),
+        values: {
+          recentConversationCount: messageCount,
+          recentConversationRoomCount: rooms.length,
         },
+        data: { rooms },
       };
     } catch (error) {
       // error-policy:J4 recall failure degrades to no recent-conversations text,

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -1275,6 +1275,48 @@ async function composeResponseState(
 	return runtime.composeState(message, providers, true, skipCache);
 }
 
+/** Replace provider text only with explicitly declared lossless retrieval forms. */
+function withProviderOverflowText(state: State): State | null {
+	const providerResults = state.data.providers;
+	const providerOrder = Array.isArray(state.data.providerOrder)
+		? state.data.providerOrder.filter(
+				(name): name is string => typeof name === "string",
+			)
+		: Object.keys(providerResults ?? {});
+	if (!providerResults) return null;
+	let changed = false;
+	const nextProviders = { ...providerResults };
+	for (const name of providerOrder) {
+		const result = providerResults[name];
+		if (typeof result?.overflowText !== "string") continue;
+		nextProviders[name] = { ...result, text: result.overflowText };
+		changed = true;
+	}
+	if (!changed) return null;
+	const text = providerOrder
+		.map((name) => nextProviders[name]?.text)
+		.filter((value): value is string => Boolean(value?.trim()))
+		.join("\n");
+	return {
+		...state,
+		values: { ...state.values, providers: text },
+		data: { ...state.data, providers: nextProviders },
+		text,
+	};
+}
+
+function responseHandlerContextWindow(
+	runtime: IAgentRuntime,
+): number | undefined {
+	return runtime
+		.getModelRegistrations()
+		.find(
+			(registration) =>
+				registration.modelType === ModelType.RESPONSE_HANDLER &&
+				typeof registration.metadata?.contextWindowTokens === "number",
+		)?.metadata?.contextWindowTokens;
+}
+
 export function selectV5PlannerStateProviderNames(args: {
 	runtime: IAgentRuntime;
 	message: Memory;
@@ -8261,7 +8303,7 @@ export async function runV5MessageRuntimeStage1(args: {
 		messageExplicitlyAddressesAgent(args.runtime, args.message) ||
 			messageChallengesPriorAgentReply(args.runtime, args.message, args.state),
 	);
-	const context = await createV5MessageContextObject({
+	let context = await createV5MessageContextObject({
 		...args,
 		userRoles: [senderRole],
 		availableContexts,
@@ -8274,6 +8316,21 @@ export async function runV5MessageRuntimeStage1(args: {
 		// left RECENT_ERRORS in state, an unaddressed group turn must not
 		// render internal diagnostics into its Stage-1 context.
 	});
+	const overflowState = withProviderOverflowText(args.state);
+	const overflowContext = overflowState
+		? await createV5MessageContextObject({
+				...args,
+				state: overflowState,
+				userRoles: [senderRole],
+				availableContexts,
+				ambientTurn,
+				extraProviderExclusions: ambientTurnProviderExclusions(
+					args.runtime,
+					args.message,
+				),
+			})
+		: null;
+	let useProviderOverflow = false;
 	const stage1PreprocessStartedAt = performance.now();
 
 	// G10/G11: construct the per-trajectory recorder. No-op when disabled via
@@ -8364,7 +8421,7 @@ export async function runV5MessageRuntimeStage1(args: {
 			);
 		const responseHandlerSchema =
 			args.runtime.responseHandlerFieldRegistry.composeSchema();
-		const messageHandlerInput = renderMessageHandlerModelInput(
+		let messageHandlerInput = renderMessageHandlerModelInput(
 			args.runtime,
 			context,
 			availableContexts,
@@ -8374,18 +8431,18 @@ export async function runV5MessageRuntimeStage1(args: {
 				responseHandlerFields: responseHandlerFieldPrompt.rendered,
 			},
 		);
-		const stage1PrefixHashes = computePrefixHashes(
+		let stage1PrefixHashes = computePrefixHashes(
 			messageHandlerInput.promptSegments,
 		);
-		const stableStage1Segments = messageHandlerInput.promptSegments.filter(
+		let stableStage1Segments = messageHandlerInput.promptSegments.filter(
 			(segment) => segment.stable,
 		);
-		const stableStage1PrefixHashes = computePrefixHashes(stableStage1Segments);
-		const stage1SystemContent =
+		let stableStage1PrefixHashes = computePrefixHashes(stableStage1Segments);
+		let stage1SystemContent =
 			typeof messageHandlerInput.messages[0]?.content === "string"
 				? messageHandlerInput.messages[0].content
 				: "";
-		const stage1PrefixHash =
+		let stage1PrefixHash =
 			stableStage1PrefixHashes[stableStage1PrefixHashes.length - 1]?.hash ??
 			hashString(`stage1:${stage1SystemContent}`);
 		const messageHandlerTools = [
@@ -8396,6 +8453,46 @@ export async function runV5MessageRuntimeStage1(args: {
 					"Stage 1: populate registered response-handler fields once before action tools. Empty values for non-applicable fields.",
 			}),
 		];
+		const contextWindowTokens = responseHandlerContextWindow(args.runtime);
+		if (overflowContext && contextWindowTokens) {
+			const eagerBudget = buildModelInputBudget({
+				messages: messageHandlerInput.messages,
+				promptSegments: messageHandlerInput.promptSegments,
+				tools: messageHandlerTools,
+				contextWindowTokens,
+				estimationMode: "utf8-upper-bound",
+			});
+			if (
+				eagerBudget.estimatedInputTokens > eagerBudget.dispatchThresholdTokens
+			) {
+				useProviderOverflow = true;
+				context = overflowContext;
+				messageHandlerInput = renderMessageHandlerModelInput(
+					args.runtime,
+					context,
+					availableContexts,
+					{
+						directMessage: directMessageChannel && !voiceDirectMessageChannel,
+						voiceDirectMessage: voiceDirectMessageChannel,
+						responseHandlerFields: responseHandlerFieldPrompt.rendered,
+					},
+				);
+				stage1PrefixHashes = computePrefixHashes(
+					messageHandlerInput.promptSegments,
+				);
+				stableStage1Segments = messageHandlerInput.promptSegments.filter(
+					(segment) => segment.stable,
+				);
+				stableStage1PrefixHashes = computePrefixHashes(stableStage1Segments);
+				stage1SystemContent =
+					typeof messageHandlerInput.messages[0]?.content === "string"
+						? messageHandlerInput.messages[0].content
+						: "";
+				stage1PrefixHash =
+					stableStage1PrefixHashes[stableStage1PrefixHashes.length - 1]?.hash ??
+					hashString(`stage1:${stage1SystemContent}`);
+			}
+		}
 		const messageHandlerProviderOptions = withModelInputBudgetProviderOptions(
 			cacheProviderOptions({
 				prefixHash: stage1PrefixHash,
@@ -9272,8 +9369,19 @@ export async function runV5MessageRuntimeStage1(args: {
 						},
 					}
 				: undefined;
+		// Once Stage 1 has explicitly selected the memory domain, the planner owns
+		// retrieval through its complete search tools. Repeating an eager corpus in
+		// every tool iteration adds no recall capability and can turn a technically
+		// admissible prompt into an operational timeout. Ordinary chat still keeps
+		// eager context; this branch is driven by the typed routing decision.
+		const retrievalContextSelected = selectedContexts.includes("memory");
+		const capacityAdjustedPlannerState =
+			useProviderOverflow || retrievalContextSelected
+				? (withProviderOverflowText(recomposedPlannerState) ??
+					recomposedPlannerState)
+				: recomposedPlannerState;
 		const plannerState = withContextRoutingValues(
-			attachAvailableContexts(recomposedPlannerState, args.runtime),
+			attachAvailableContexts(capacityAdjustedPlannerState, args.runtime),
 			selectedContextRoutingState,
 		);
 		if (args.codingMode === true) {

--- a/packages/core/src/types/components.ts
+++ b/packages/core/src/types/components.ts
@@ -724,6 +724,14 @@ export interface ProviderResult {
 	/** Human-readable text for LLM prompt inclusion */
 	text?: string;
 
+	/**
+	 * Complete, explicit retrieval representation used only when the primary
+	 * text cannot fit the selected model's input boundary. This must describe
+	 * how the omitted bodies can be retrieved losslessly; it is an atomic
+	 * alternative to `text`, never a truncated prefix or summary of it.
+	 */
+	overflowText?: string;
+
 	/** Key-value pairs for template variable substitution */
 	values?: Record<string, ProviderValue>;
 

--- a/packages/core/src/types/state.ts
+++ b/packages/core/src/types/state.ts
@@ -57,6 +57,7 @@ export interface ActionPlan {
  */
 export interface ProviderCacheEntry {
 	text?: string;
+	overflowText?: string;
 	values?: Record<string, StateValue>;
 	data?: Record<string, StateValue>;
 }

--- a/plugins/plugin-cli-inference/__tests__/cli-inference.test.ts
+++ b/plugins/plugin-cli-inference/__tests__/cli-inference.test.ts
@@ -1492,6 +1492,7 @@ describe("buildModelMetadata (RUNTIME_MODEL_CONTEXT self-report)", () => {
     expect(md?.RESPONSE_HANDLER).toEqual({
       displayModelSettings: ["ELIZA_CLI_CODEX_MODEL"],
       displayModelDefault: "gpt-5.5",
+      contextWindowTokens: 1_048_576,
     });
   });
 });

--- a/plugins/plugin-cli-inference/index.ts
+++ b/plugins/plugin-cli-inference/index.ts
@@ -82,6 +82,12 @@ const LARGE_TIER_MODEL_TYPES: readonly string[] = [
  */
 const PLANNER_MODEL_TYPES: readonly string[] = [ModelType.ACTION_PLANNER];
 
+// Codex rejects turn/start before inference when the flattened input exceeds
+// this character boundary. Core's UTF-8 upper-bound admission uses one byte as
+// one conservative token, so publishing the same number lets model-agnostic
+// prompt assembly choose an explicit retrieval representation before spawn.
+const CODEX_MAX_INPUT_CHARS = 1_048_576;
+
 /**
  * High-frequency triage tiers — the should-respond gate, media-description, and
  * the action-callback voice rewrite. NOT registered by default (they'd spend a
@@ -870,6 +876,7 @@ export function buildModelMetadata(
   const declaration = (settings: string[]) => ({
     displayModelSettings: settings,
     displayModelDefault: defaultModel,
+    ...(isCodex ? { contextWindowTokens: CODEX_MAX_INPUT_CHARS } : {}),
   });
 
   for (const modelType of LARGE_TIER_MODEL_TYPES) {


### PR DESCRIPTION
# Relates to

Closes #28521

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin develop && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync; the exact unrelated verification blocker is recorded below.
- [x] A reviewer can confirm the change works without reading the code from the live planted-runtime results below.

# Sync with develop

- [x] Rebased onto latest `origin/develop`; zero conflicts.
- [x] `bun run verify` was run; its unrelated UI inventory blocker is documented under **Known gaps / failures**.

# Risks

Medium. This changes model-facing cross-room recall composition and planner state. The main risks are losing implicit short-history continuity, exposing unauthorized cross-room content, or exceeding a model boundary. Mitigations: eager complete context remains the default; the alternate form is provider-declared and lossless; existing owner-exclusive access checks remain authoritative; model capacity is published by the model adapter; complete access-context and planted-runtime tests cover the boundary.

# Background

## What does this PR do?

- Keeps complete eager cross-room conversation context for ordinary chat.
- Adds an explicit `overflowText` provider contract: an atomic retrieval representation, never a truncated prefix, summary, or rolling window.
- Measures the complete Stage-1 request against the selected response model's published input window and switches atomically only when the eager request cannot fit.
- After Stage 1 selects the typed `memory` context, uses the retrieval manifest for planner iterations so `MEMORY_SEARCH` owns complete historical lookup without copying the corpus into every iteration.
- Publishes Codex CLI's authoritative 1,048,576-character turn boundary through model registration metadata.
- Makes `MEMORY_SEARCH` traverse the complete snapshot, rank exact all-term matches ahead of decoys, and search attachment-only memory text without exposing capability URLs.

## What kind of change is this?

Bug fix and performance/reliability improvement.

# Documentation changes needed?

No user-facing documentation change is required. The new provider contract is documented directly on the public type.

# Testing

## Where should a reviewer start?

1. `packages/agent/src/providers/recent-conversations.ts`
2. `packages/core/src/services/message.ts`
3. `packages/agent/src/actions/memories.ts`
4. `plugins/plugin-cli-inference/index.ts`

## Detailed testing steps

Run focused tests and typechecks:

```bash
bunx vitest run src/providers/recent-conversations.test.ts src/providers/recent-conversations.access-context.test.ts src/actions/memories.test.ts
bunx vitest run src/services/message.stage1-retry.test.ts src/services/message.planner-provider-selection.test.ts src/runtime/__tests__/model-input-budget.test.ts
bunx vitest run __tests__/cli-inference.test.ts
bun run --cwd packages/core typecheck
bun run --cwd packages/agent typecheck
bun run --cwd plugins/plugin-cli-inference typecheck
```

Run the real Codex-backed planted-memory matrix:

```bash
ELIZA_CHAT_VIA_CLI=codex bun run --cwd packages/scenario-runner eval:memory-horizon --sizes=500,1000,5000,10000 --provider=cli
```

Observed successful live runs:

| Planted messages | Run ID | Result |
| ---: | --- | --- |
| 500 | `daeb8807-7a59-44b0-9bcb-3faea777d668` | Passed; eager `Recent conversations` trajectory |
| 1,000 | `c79396b8-1c25-44ad-8f2f-867b9a2b0ed7` | Passed |
| 5,000 | `5f3bf50b-6a7c-4afc-9653-52a1191bab92` | Passed; complete memory retrieval after typed routing |
| 10,000 | `940d58fa-ae77-4038-999a-1e4eb9cb1603` | Passed; capacity-triggered manifest before Stage 1, scans 10,008/10,009, answer `Copper Heron 9184` |

Focused verification totals:

- Provider/search tests: 45 passed.
- Core message/budget tests: 56 passed.
- Additional focused planner/Stage-1 tests: 27 passed.
- CLI inference tests: 106 passed, 2 skipped.
- Core, agent, and CLI inference typechecks passed.

# Evidence Gate

<!-- evidence-head:3dd66ebe3f9a590e4205c9c1a2212a33e5eb00c1 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend/runtime-only change with no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend/runtime-only change with no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no frontend flow changed.
<!-- evidence-row:backend-logs -->
- [x] Live scenario run IDs and exact scan/answer results are included above; full local reports were inspected and are not committed.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request or state surface changed.
<!-- evidence-row:llm-trajectory -->
- [x] Real Codex-backed trajectory run IDs are listed above. The 500 trajectory contains eager `Recent conversations`; the 10,000 trajectory contains `Stored conversation manifest` and complete `MEMORY_SEARCH` results.
<!-- evidence-row:domain-artifacts -->
- [x] Planted-memory reports verify complete scans and the exact oldest stored fact at every graduated horizon.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual surface changed.

# Evidence Details

## Real LLM-call trajectory

Real subscription-backed Codex CLI runs were used, not deterministic model fixtures. Run IDs and observable results are in the table above. Reports were generated under ignored `reports/memory-horizon-*` paths and inspected locally rather than committed.

## Backend + frontend logs

Backend evidence: the 10k run completed with scan counts `10008` and `10009` and final response `Copper Heron 9184`. The 500 and 10k trajectories were searched directly to prove eager versus manifest representation selection.

Frontend: N/A - no frontend code changed.

## Screenshots (before / after) + video walkthrough

N/A - backend/runtime-only change.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT behavior changed.

## Known gaps / failures

`bun run verify` reached 144 of 146 Turbo tasks, then failed in unrelated `@elizaos/ui#lint:check` because `packages/ui/duplicate-molecular-components-report.md` is stale. This PR does not touch `packages/ui` or any rendered UI surface, and all affected package typechecks, lint formatting, focused tests, and real-runtime scenarios passed.

During live repetition, one matrix attempt encountered a transient local Codex Responses websocket `426 Upgrade Required`; subsequent runs succeeded. One 5k attempt also exposed post-tool protocol variance, which led to the typed memory-route planner optimization included here; the final 5k run passed.

## Maintainer CI exception record

N/A - no exception requested.
