### PR TITLE
fix(plugin-local-inference): fail loud on out-of-range pyannote class winners in frame segmentation

### DIFF
--- a/plugins/plugin-local-inference/src/services/voice/speaker/diarizer.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/speaker/diarizer.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from "vitest";
+import {
+	classifyFramesToSegments,
+	DiarizerUnavailableError,
+	PYANNOTE_CLASS_COUNT,
+	PYANNOTE_CLASS_TO_SPEAKERS,
+	PYANNOTE_FRAME_STRIDE_MS,
+} from "./diarizer";
+
+/** One-hot row: class c = 1.0, everything else ~0. */
+function oneHot(rowCount: number, c: number): Float32Array {
+	const row = new Float32Array(rowCount);
+	row[c] = 1;
+	return row;
+}
+
+/** Stack rows into a frames×classCount tensor. */
+function tensor(rows: Float32Array[]): Float32Array {
+	const out = new Float32Array(rows.length * rows[0].length);
+	for (let f = 0; f < rows.length; f += 1) {
+		out.set(rows[f], f * rows[0].length);
+	}
+	return out;
+}
+
+describe("classifyFramesToSegments shape guard", () => {
+	it("throws model-load-failed on tensor length mismatch", () => {
+		expect(() =>
+			classifyFramesToSegments(
+				new Float32Array(10),
+				3,
+				PYANNOTE_CLASS_COUNT,
+				0,
+				PYANNOTE_FRAME_STRIDE_MS,
+			),
+		).toThrow(DiarizerUnavailableError);
+		try {
+			classifyFramesToSegments(
+				new Float32Array(10),
+				3,
+				PYANNOTE_CLASS_COUNT,
+				0,
+				PYANNOTE_FRAME_STRIDE_MS,
+			);
+		} catch (e) {
+			expect((e as DiarizerUnavailableError).code).toBe("model-load-failed");
+		}
+	});
+
+	it("throws model-shape-mismatch when the model emits a class outside the known powerset", () => {
+		// A wrong ONNX export with an extra class makes the winner index land
+		// beyond PYANNOTE_CLASS_TO_SPEAKERS; those frames used to be silently
+		// classified as silence, dropping an entire speaker's audio.
+		const classCount = PYANNOTE_CLASS_COUNT + 1;
+		const frames = tensor([oneHot(classCount, 7), oneHot(classCount, 0)]);
+		expect(() =>
+			classifyFramesToSegments(
+				frames,
+				2,
+				classCount,
+				0,
+				PYANNOTE_FRAME_STRIDE_MS,
+			),
+		).toThrow(DiarizerUnavailableError);
+		try {
+			classifyFramesToSegments(
+				frames,
+				2,
+				classCount,
+				0,
+				PYANNOTE_FRAME_STRIDE_MS,
+			);
+		} catch (e) {
+			expect((e as DiarizerUnavailableError).code).toBe("model-shape-mismatch");
+		}
+	});
+});
+
+describe("classifyFramesToSegments segmentation", () => {
+	it("produces no segments and zero speechMs when silence wins every frame", () => {
+		const frames = tensor([
+			oneHot(PYANNOTE_CLASS_COUNT, 0),
+			oneHot(PYANNOTE_CLASS_COUNT, 0),
+		]);
+		const out = classifyFramesToSegments(
+			frames,
+			2,
+			PYANNOTE_CLASS_COUNT,
+			1000,
+			PYANNOTE_FRAME_STRIDE_MS,
+		);
+		expect(out.segments).toHaveLength(0);
+		expect(out.localSpeakerCount).toBe(0);
+		expect(out.speechMs).toBe(0);
+	});
+
+	it("builds one segment for a single-speaker run with confidence and times", () => {
+		const frames = tensor([
+			oneHot(PYANNOTE_CLASS_COUNT, 1),
+			oneHot(PYANNOTE_CLASS_COUNT, 1),
+		]);
+		const out = classifyFramesToSegments(
+			frames,
+			2,
+			PYANNOTE_CLASS_COUNT,
+			0,
+			PYANNOTE_FRAME_STRIDE_MS,
+		);
+		expect(out.segments).toHaveLength(1);
+		const seg = out.segments[0];
+		expect(seg.localSpeakerId).toBe(0);
+		expect(seg.startMs).toBe(0);
+		expect(seg.endMs).toBe(Math.round(2 * PYANNOTE_FRAME_STRIDE_MS));
+		// softmax over 7 classes with a 1.0 winner (float32 arithmetic)
+		expect(seg.confidence).toBeCloseTo(
+			Math.E / (Math.E + PYANNOTE_CLASS_COUNT - 1),
+			6,
+		);
+		expect(seg.hasOverlap).toBe(false);
+		expect(out.localSpeakerCount).toBe(1);
+		expect(out.speechMs).toBe(Math.round(2 * PYANNOTE_FRAME_STRIDE_MS));
+	});
+
+	it("splits into separate segments when the speaker switches", () => {
+		const frames = tensor([
+			oneHot(PYANNOTE_CLASS_COUNT, 1),
+			oneHot(PYANNOTE_CLASS_COUNT, 1),
+			oneHot(PYANNOTE_CLASS_COUNT, 2),
+			oneHot(PYANNOTE_CLASS_COUNT, 2),
+		]);
+		const out = classifyFramesToSegments(
+			frames,
+			4,
+			PYANNOTE_CLASS_COUNT,
+			0,
+			PYANNOTE_FRAME_STRIDE_MS,
+		);
+		expect(out.segments).toHaveLength(2);
+		expect(out.segments[0].localSpeakerId).toBe(0);
+		expect(out.segments[1].localSpeakerId).toBe(1);
+		expect(out.localSpeakerCount).toBe(2);
+	});
+
+	it("marks overlap frames on the owning segment", () => {
+		const frames = tensor([oneHot(PYANNOTE_CLASS_COUNT, 4)]); // speakers 0+1
+		const out = classifyFramesToSegments(
+			frames,
+			1,
+			PYANNOTE_CLASS_COUNT,
+			0,
+			PYANNOTE_FRAME_STRIDE_MS,
+		);
+		expect(out.segments).toHaveLength(2);
+		for (const seg of out.segments) {
+			expect(seg.hasOverlap).toBe(true);
+		}
+	});
+
+	it("merges a speaker's interrupted runs into separate segments", () => {
+		const frames = tensor([
+			oneHot(PYANNOTE_CLASS_COUNT, 1),
+			oneHot(PYANNOTE_CLASS_COUNT, 0),
+			oneHot(PYANNOTE_CLASS_COUNT, 1),
+		]);
+		const out = classifyFramesToSegments(
+			frames,
+			3,
+			PYANNOTE_CLASS_COUNT,
+			0,
+			PYANNOTE_FRAME_STRIDE_MS,
+		);
+		expect(out.segments).toHaveLength(2);
+		expect(out.segments[0].startMs).toBe(0);
+		expect(out.segments[1].startMs).toBe(
+			Math.round(2 * PYANNOTE_FRAME_STRIDE_MS),
+		);
+	});
+
+	it("averages confidence across the run", () => {
+		const rowA = new Float32Array(PYANNOTE_CLASS_COUNT);
+		rowA[1] = 0.8;
+		rowA[0] = 0.2;
+		const rowB = new Float32Array(PYANNOTE_CLASS_COUNT);
+		rowB[1] = 0.6;
+		rowB[0] = 0.4;
+		const frames = tensor([rowA, rowB]);
+		const out = classifyFramesToSegments(
+			frames,
+			2,
+			PYANNOTE_CLASS_COUNT,
+			0,
+			PYANNOTE_FRAME_STRIDE_MS,
+		);
+		// softmax(rowA)[1] = e^0.8 / (e^0.8 + e^0.2 + 5); softmax(rowB)[1] = e^0.6 / (e^0.6 + e^0.4 + 5)
+		const softmaxA = Math.exp(0.8) / (Math.exp(0.8) + Math.exp(0.2) + 5);
+		const softmaxB = Math.exp(0.6) / (Math.exp(0.6) + Math.exp(0.4) + 5);
+		expect(out.segments[0].confidence).toBeCloseTo(
+			(softmaxA + softmaxB) / 2,
+			6,
+		);
+	});
+});

--- a/plugins/plugin-local-inference/src/services/voice/speaker/diarizer.ts
+++ b/plugins/plugin-local-inference/src/services/voice/speaker/diarizer.ts
@@ -162,6 +162,15 @@ export function classifyFramesToSegments(
 				winnerProb = probs[c];
 			}
 		}
+		// A model that emits a class outside the known powerset (wrong ONNX
+		// export / extra class) would otherwise be silently treated as
+		// silence, dropping that speaker's frames from the transcript.
+		if (winner >= PYANNOTE_CLASS_TO_SPEAKERS.length) {
+			throw new DiarizerUnavailableError(
+				"model-shape-mismatch",
+				`[pyannote] class ${winner} outside known powerset (max ${PYANNOTE_CLASS_TO_SPEAKERS.length - 1})`,
+			);
+		}
 		const activeSpeakers = PYANNOTE_CLASS_TO_SPEAKERS[winner] ?? [];
 		const isOverlap = activeSpeakers.length > 1;
 		if (activeSpeakers.length > 0) speechFrames += 1;


### PR DESCRIPTION
# Relates to

<!-- No issue; fix for a silent speaker-drop in the pyannote frame classifier. -->

## What changed

`classifyFramesToSegments` looks the winning frame class up in
`PYANNOTE_CLASS_TO_SPEAKERS` with `?? []`. When the model emits a class index **outside** the
known 7-class powerset (wrong ONNX export with an extra class, or a caller passing a larger
`classCount`), the lookup falls back to the empty array — those frames are **silently
classified as silence**, dropping that speaker's audio from the transcript with no error.

The shape guard already fails loud on tensor length mismatch (`model-load-failed`); this adds
the matching fail-loud branch for out-of-range winners (`model-shape-mismatch`), reusing the
existing error code.

## Why it matters

Speaker diarization feeds the transcript and speaker attribution. A silently dropped class
means a speaker vanishes from the output with no log — hard to detect and exactly the class
of model-shape mismatch this module already guards against.

## Tests

- Tensor length mismatch still throws `model-load-failed`.
- A model emitting class 7 (with `classCount = 8`) throws `model-shape-mismatch` instead of
  silently producing silence.
- Silence-only windows yield zero segments / zero speechMs.
- Single-speaker runs produce one segment with correct bounds, softmax confidence, and
  speechMs; speaker switches split segments; overlap frames mark `hasOverlap`; interrupted
  runs stay separate; confidence averages across the run.

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. The new throw only fires for class indices the known powerset cannot represent; all
in-range inputs behave identically.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `<TEST_OUTPUT>` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
