### PR TITLE
test(cloud): cover container-billing-policy split rules

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/container-billing-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/container-billing-policy.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Unit coverage for the pure container-billing split policy: earnings-first
+ * charging, the pay-as-you-go opt-out freeze, and the insufficient-warning
+ * boundary. Pure function under test — no harness, deterministic.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { computeContainerBillingPlan } from "../container-billing-policy";
+
+describe("computeContainerBillingPlan", () => {
+  test("earnings absorb the bill first; credits cover only the remainder", () => {
+    const plan = computeContainerBillingPlan({
+      dailyCost: 2.5,
+      currentBalance: 5,
+      ownerEarningsAvailable: 1,
+      payAsYouGoFromEarnings: true,
+    });
+    expect(plan).toEqual({
+      action: "billed",
+      fromEarnings: 1,
+      fromCredits: 1.5,
+      totalAvailable: 6,
+      earningsEligible: 1,
+    });
+  });
+
+  test("a single fully-funded charge debits credits for exactly the cost", () => {
+    const plan = computeContainerBillingPlan({
+      dailyCost: 0.75,
+      currentBalance: 0.75,
+      ownerEarningsAvailable: 0,
+      payAsYouGoFromEarnings: true,
+    });
+    expect(plan.action).toBe("billed");
+    expect(plan.fromEarnings).toBe(0);
+    expect(plan.fromCredits).toBe(0.75);
+  });
+
+  test("earnings alone can carry the full daily cost (survival economics)", () => {
+    const plan = computeContainerBillingPlan({
+      dailyCost: 1,
+      currentBalance: 0,
+      ownerEarningsAvailable: 3,
+      payAsYouGoFromEarnings: true,
+    });
+    expect(plan.action).toBe("billed");
+    expect(plan.fromEarnings).toBe(1);
+    expect(plan.fromCredits).toBe(0);
+  });
+
+  test("opting out freezes earnings entirely — credits pay the whole bill", () => {
+    const plan = computeContainerBillingPlan({
+      dailyCost: 2,
+      currentBalance: 4,
+      ownerEarningsAvailable: 10,
+      payAsYouGoFromEarnings: false,
+    });
+    expect(plan).toEqual({
+      action: "billed",
+      fromEarnings: 0,
+      fromCredits: 2,
+      totalAvailable: 4,
+      earningsEligible: 0,
+    });
+  });
+
+  test("opting out also excludes earnings from the insufficiency check", () => {
+    // 1 credit + 10 earnings with the toggle off is still insufficient for a
+    // 2 charge: earnings never count when the org opted out.
+    const plan = computeContainerBillingPlan({
+      dailyCost: 2,
+      currentBalance: 1,
+      ownerEarningsAvailable: 10,
+      payAsYouGoFromEarnings: false,
+    });
+    expect(plan).toEqual({
+      action: "insufficient",
+      fromEarnings: 0,
+      fromCredits: 0,
+      totalAvailable: 1,
+      earningsEligible: 0,
+    });
+  });
+
+  test("insufficient when earnings plus credits cannot cover the cost", () => {
+    const plan = computeContainerBillingPlan({
+      dailyCost: 3,
+      currentBalance: 1,
+      ownerEarningsAvailable: 1,
+      payAsYouGoFromEarnings: true,
+    });
+    expect(plan).toEqual({
+      action: "insufficient",
+      fromEarnings: 0,
+      fromCredits: 0,
+      totalAvailable: 2,
+      earningsEligible: 1,
+    });
+  });
+
+  test("the exact-availability boundary still bills (strict insufficiency)", () => {
+    const plan = computeContainerBillingPlan({
+      dailyCost: 3,
+      currentBalance: 2,
+      ownerEarningsAvailable: 1,
+      payAsYouGoFromEarnings: true,
+    });
+    expect(plan.action).toBe("billed");
+    expect(plan.fromEarnings).toBe(1);
+    expect(plan.fromCredits).toBe(2);
+  });
+
+  test("a zero-cost day is a no-op bill, not insufficiency", () => {
+    const plan = computeContainerBillingPlan({
+      dailyCost: 0,
+      currentBalance: 0,
+      ownerEarningsAvailable: 0,
+      payAsYouGoFromEarnings: true,
+    });
+    expect(plan.action).toBe("billed");
+    expect(plan.fromEarnings).toBe(0);
+    expect(plan.fromCredits).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Adds unit coverage for `computeContainerBillingPlan` in `packages/cloud/shared/src/lib/services/container-billing-policy.ts` — the pure split policy behind the container-billing cron. The module header documents its rules as load-bearing survival-economics behavior that should be provable without a database; until now the function had zero direct tests (the cron route test mocks it; the idempotency suite covers only `computeContainerBillingPeriod`).

Covered rules:

- earnings-first charging with credits covering only the remainder (partial split, credits-only, earnings-only)
- the pay-as-you-go opt-out freezing earnings entirely — including excluding them from the insufficiency check
- combined insufficiency returns `action: "insufficient"` with zero debits
- the exact-availability boundary still bills (strict `<` insufficiency)
- a zero-cost day is a no-op bill, not insufficiency

## Verification

- `bun test src/lib/services/__tests__/container-billing-policy.test.ts` — 8/8 pass
- `bun test` on the neighboring `container-billing-idempotency.test.ts` — 25/25 combined pass
- `biome check` on the new file — clean
- `bun run --cwd packages/cloud/shared typecheck` — clean (fresh `bun install --frozen-lockfile` worktree)

Test-only change: no production code modified.

## Evidence

| Row | Value |
| --- | --- |
| backend-logs | N/A - test-only change, no backend behavior modified; full test transcript above and in the verification commands |
| frontend-screenshots | N/A - test-only change, no UI surface touched |
| frontend-mobile-screenshots | N/A - test-only change, no UI surface touched |
| video-walkthrough | N/A - test-only change, nothing user-visible to walk through |
| llm-trajectory | N/A - no model/trajectory code touched |
| db-schema-changes | N/A - no schema or migration files touched |
| api-contract-changes | N/A - no API surface touched |
| core-unit-tests | [test run log](https://github.com/elizaOS/eliza/actions) - `bun test` 25/25 across both container-billing suites |

## Contribution attribution

| Field | Value |
| --- | --- |
| AI provider | zai |
| AI model | glm-5.3 |
| Client / agent tooling | Hermes Agent |
| Attribution status | self-reported |

<!-- evidence-head:db5e9ffe7775699528884c4ca6a534644a1eea2b -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only change, no UI surface touched

<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only change, no UI surface touched

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - test-only change, nothing user-visible to walk through

<!-- evidence-row:backend-logs -->
- [ ] N/A - test-only change; verification transcript: bun test container-billing-policy.test.ts => 8 pass / 0 fail (16 expect calls); combined with container-billing-idempotency.test.ts => 25 pass / 0 fail; biome check clean; cloud/shared tsc typecheck clean at head db5e9ffe77

<!-- evidence-row:frontend-logs -->
- [ ] N/A - test-only change, no frontend touched

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model or trajectory code touched

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - pure-function unit tests, no domain/DB artifact produced

AI provider/model: zai / glm-5.3
Client / agent tooling: Hermes Agent
Contribution skill revision: elizaOS/eliza@b447fe2f542af8f12c0c011c3bbf772c7c6b3f50:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [hermes-t3rpz]
<!-- eliza-computer-attribution:v1 {"provider":"zai","model":"glm-5.3","client":"Hermes Agent","skill_revision":"elizaOS/eliza@b447fe2f542af8f12c0c011c3bbf772c7c6b3f50:packages/skills/skills/contribute-to-eliza"} -->

