### PR TITLE
test(elizacloud): pin cloud runtime proxy chat and status contract

### DIFF
--- a/plugins/plugin-elizacloud/src/cloud/cloud-proxy.test.ts
+++ b/plugins/plugin-elizacloud/src/cloud/cloud-proxy.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi } from "vitest";
+
+import { CloudRuntimeProxy } from "./cloud-proxy";
+
+function makeClient() {
+  return {
+    sendMessage: vi.fn(async () => "reply text"),
+    sendMessageStream: vi.fn(async function* () {
+      yield { type: "chunk", data: { text: "a" } };
+      yield { type: "chunk", data: { text: 42 } };
+      yield { type: "done", data: {} };
+      yield { type: "chunk", data: { text: "b" } };
+    }),
+    getAgent: vi.fn(async () => ({ status: "online", agentName: "solo" })),
+    heartbeat: vi.fn(async () => true),
+  };
+}
+
+describe("CloudRuntimeProxy", () => {
+  it("exposes the agent name captured at construction", () => {
+    const proxy = new CloudRuntimeProxy(makeClient() as never, "agent-1", "solo");
+    expect(proxy.agentName).toBe("solo");
+  });
+
+  it("forwards chat messages with the configured defaults", async () => {
+    const client = makeClient();
+    const proxy = new CloudRuntimeProxy(client as never, "agent-1", "solo");
+    const reply = await proxy.handleChatMessage("hello");
+    expect(client.sendMessage).toHaveBeenCalledWith(
+      "agent-1",
+      "hello",
+      "web-chat",
+      "DM",
+    );
+    expect(reply).toBe("reply text");
+  });
+
+  it("forwards explicit room and channel overrides", async () => {
+    const client = makeClient();
+    const proxy = new CloudRuntimeProxy(client as never, "agent-1", "solo");
+    await proxy.handleChatMessage("hello", "room-9", "GROUP");
+    expect(client.sendMessage).toHaveBeenCalledWith(
+      "agent-1",
+      "hello",
+      "room-9",
+      "GROUP",
+    );
+  });
+
+  it("yields only chunk events whose text is a string", async () => {
+    const client = makeClient();
+    const proxy = new CloudRuntimeProxy(client as never, "agent-1", "solo");
+    const chunks: string[] = [];
+    for await (const chunk of proxy.handleChatMessageStream("hello")) {
+      chunks.push(chunk);
+    }
+    expect(client.sendMessageStream).toHaveBeenCalledWith(
+      "agent-1",
+      "hello",
+      "web-chat",
+      "DM",
+    );
+    expect(chunks).toEqual(["a", "b"]);
+  });
+
+  it("propagates stream errors from the client", async () => {
+    const client = makeClient();
+    client.sendMessageStream = vi.fn(async function* () {
+      throw new Error("stream broke");
+    });
+    const proxy = new CloudRuntimeProxy(client as never, "agent-1", "solo");
+    const collect = async () => {
+      const out: string[] = [];
+      for await (const chunk of proxy.handleChatMessageStream("hello")) {
+        out.push(chunk);
+      }
+      return out;
+    };
+    await expect(collect()).rejects.toThrow("stream broke");
+  });
+
+  it("reports the agent status from the cloud client", async () => {
+    const client = makeClient();
+    const proxy = new CloudRuntimeProxy(client as never, "agent-1", "solo");
+    const status = await proxy.getStatus();
+    expect(client.getAgent).toHaveBeenCalledWith("agent-1");
+    expect(status).toEqual({ state: "online", agentName: "solo" });
+  });
+
+  it("surfaces getAgent failures instead of swallowing them", async () => {
+    const client = makeClient();
+    client.getAgent = vi.fn(async () => {
+      throw new Error("sandbox unreachable");
+    });
+    const proxy = new CloudRuntimeProxy(client as never, "agent-1", "solo");
+    await expect(proxy.getStatus()).rejects.toThrow("sandbox unreachable");
+  });
+
+  it("reports alive when the heartbeat succeeds", async () => {
+    const client = makeClient();
+    const proxy = new CloudRuntimeProxy(client as never, "agent-1", "solo");
+    await expect(proxy.isAlive()).resolves.toBe(true);
+  });
+
+  it("degrades to false when the heartbeat fails", async () => {
+    const client = makeClient();
+    client.heartbeat = vi.fn(async () => {
+      throw new Error("timeout");
+    });
+    const proxy = new CloudRuntimeProxy(client as never, "agent-1", "solo");
+    await expect(proxy.isAlive()).resolves.toBe(false);
+  });
+
+  it("does not throw when heartbeat rejects with a non-Error value", async () => {
+    const client = makeClient();
+    client.heartbeat = vi.fn(async () => {
+      throw "raw rejection";
+    });
+    const proxy = new CloudRuntimeProxy(client as never, "agent-1", "solo");
+    await expect(proxy.isAlive()).resolves.toBe(false);
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for the CloudRuntimeProxy chat/status contract. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new test file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `Test Files  1 passed (1)
      Tests  10 passed (10)` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
