### PR TITLE
test(personal-assistant): cover app blocker contribution permission gate

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/registries/app-blocker-contribution.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/registries/app-blocker-contribution.test.ts
@@ -1,0 +1,180 @@
+import * as blockerEngine from "@elizaos/plugin-blocker/services/app-blocker/index";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { appBlockerContribution } from "./app-blocker-contribution";
+
+beforeEach(() => {
+  vi.spyOn(blockerEngine, "getAppBlockerStatus").mockResolvedValue({
+    available: true,
+    permissionStatus: "granted",
+    active: false,
+    blockedCount: 0,
+    endsAt: null,
+    reason: null,
+  });
+  vi.spyOn(blockerEngine, "startAppBlock").mockResolvedValue({ success: true });
+  vi.spyOn(blockerEngine, "stopAppBlock").mockResolvedValue({ success: true });
+});
+
+describe("appBlockerContribution.verifyAvailable", () => {
+  it("reports denied with the engine reason when unavailable", async () => {
+    vi.mocked(blockerEngine.getAppBlockerStatus).mockResolvedValue({
+      available: false,
+      permissionStatus: "denied",
+      active: false,
+      blockedCount: 0,
+      endsAt: null,
+      reason: "Family Controls not configured",
+    });
+    await expect(appBlockerContribution.verifyAvailable()).resolves.toEqual({
+      available: false,
+      reason: "Family Controls not configured",
+      permission: "denied",
+    });
+  });
+
+  it("falls back to a default message when unavailable without a reason", async () => {
+    vi.mocked(blockerEngine.getAppBlockerStatus).mockResolvedValue({
+      available: false,
+      permissionStatus: "denied",
+      active: false,
+      blockedCount: 0,
+      endsAt: null,
+      reason: null,
+    });
+    const result = await appBlockerContribution.verifyAvailable();
+    expect(result.available).toBe(false);
+    expect(result.permission).toBe("denied");
+    expect(result.reason).toMatch(/not available/i);
+  });
+
+  it("maps a granted permission status through", async () => {
+    await expect(appBlockerContribution.verifyAvailable()).resolves.toEqual({
+      available: true,
+      reason: null,
+      permission: "granted",
+    });
+  });
+
+  it("maps a denied permission status through", async () => {
+    vi.mocked(blockerEngine.getAppBlockerStatus).mockResolvedValue({
+      available: true,
+      permissionStatus: "denied",
+      active: false,
+      blockedCount: 0,
+      endsAt: null,
+      reason: null,
+    });
+    await expect(appBlockerContribution.verifyAvailable()).resolves.toEqual({
+      available: true,
+      reason: null,
+      permission: "denied",
+    });
+  });
+
+  it("treats unknown permission statuses as prompt", async () => {
+    vi.mocked(blockerEngine.getAppBlockerStatus).mockResolvedValue({
+      available: true,
+      permissionStatus: "notDetermined",
+      active: false,
+      blockedCount: 0,
+      endsAt: null,
+      reason: null,
+    });
+    await expect(appBlockerContribution.verifyAvailable()).resolves.toEqual({
+      available: true,
+      reason: null,
+      permission: "prompt",
+    });
+  });
+});
+
+describe("appBlockerContribution.start", () => {
+  it("delegates to the engine with the request options", async () => {
+    const request = { appIds: ["com.example.game"], durationMs: 3600000 };
+    await appBlockerContribution.start(request as never);
+    expect(blockerEngine.startAppBlock).toHaveBeenCalledWith(request);
+  });
+});
+
+describe("appBlockerContribution.stop", () => {
+  it("resolves when the engine reports success", async () => {
+    await expect(appBlockerContribution.stop()).resolves.toBeUndefined();
+  });
+
+  it("throws when the engine reports failure", async () => {
+    vi.mocked(blockerEngine.stopAppBlock).mockResolvedValue({
+      success: false,
+      error: "Cannot remove block",
+    });
+    await expect(appBlockerContribution.stop()).rejects.toThrow(
+      "Cannot remove block",
+    );
+  });
+
+  it("throws a fallback message when failure carries no error text", async () => {
+    vi.mocked(blockerEngine.stopAppBlock).mockResolvedValue({
+      success: false,
+      error: undefined,
+    });
+    await expect(appBlockerContribution.stop()).rejects.toThrow(
+      /Failed to remove app block/,
+    );
+  });
+});
+
+describe("appBlockerContribution.status", () => {
+  it("reports inactive with the engine reason when unavailable", async () => {
+    vi.mocked(blockerEngine.getAppBlockerStatus).mockResolvedValue({
+      available: false,
+      permissionStatus: "denied",
+      active: false,
+      blockedCount: 0,
+      endsAt: null,
+      reason: "Usage Access not granted",
+    });
+    await expect(appBlockerContribution.status()).resolves.toEqual({
+      active: false,
+      endsAt: null,
+      text: "Usage Access not granted",
+    });
+  });
+
+  it("reports inactive when no block is active", async () => {
+    await expect(appBlockerContribution.status()).resolves.toEqual({
+      active: false,
+      endsAt: null,
+      text: "No app block is active right now.",
+    });
+  });
+
+  it("reports a single blocked app with singular phrasing", async () => {
+    vi.mocked(blockerEngine.getAppBlockerStatus).mockResolvedValue({
+      available: true,
+      permissionStatus: "granted",
+      active: true,
+      blockedCount: 1,
+      endsAt: "2026-08-25T13:00:00Z",
+      reason: null,
+    });
+    const result = await appBlockerContribution.status();
+    expect(result.active).toBe(true);
+    expect(result.endsAt).toBe("2026-08-25T13:00:00Z");
+    expect(result.text).toContain("1 app");
+    expect(result.text).toContain("until 2026-08-25T13:00:00Z");
+  });
+
+  it("reports multiple blocked apps with plural phrasing", async () => {
+    vi.mocked(blockerEngine.getAppBlockerStatus).mockResolvedValue({
+      available: true,
+      permissionStatus: "granted",
+      active: true,
+      blockedCount: 3,
+      endsAt: null,
+      reason: null,
+    });
+    const result = await appBlockerContribution.status();
+    expect(result.active).toBe(true);
+    expect(result.text).toContain("3 apps");
+    expect(result.text).toContain("until you remove it");
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for the app-blocker contribution availability/permission gate. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new test file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `Test Files  1 passed (1)
      Tests  13 passed (13)` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
