### PR TITLE
test(local-inference): cover requested voice id normalization boundary

### DIFF
--- a/plugins/plugin-local-inference/src/services/voice/requested-voice.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/requested-voice.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	extractRequestedKokoroVoiceId,
+	extractRequestedVoiceId,
+} from "./requested-voice";
+
+describe("extractRequestedVoiceId", () => {
+	it("returns undefined for a plain string", () => {
+		expect(extractRequestedVoiceId("nova")).toBeUndefined();
+	});
+
+	it("returns undefined for null and non-objects", () => {
+		expect(extractRequestedVoiceId(null)).toBeUndefined();
+		expect(extractRequestedVoiceId(undefined)).toBeUndefined();
+		expect(extractRequestedVoiceId(42)).toBeUndefined();
+	});
+
+	it("reads the explicit voice string", () => {
+		expect(extractRequestedVoiceId({ voice: "af_bella" })).toBe("af_bella");
+	});
+
+	it("trims surrounding whitespace", () => {
+		expect(extractRequestedVoiceId({ voice: "  af_bella  " })).toBe("af_bella");
+	});
+
+	it("returns undefined for an all-whitespace voice", () => {
+		expect(extractRequestedVoiceId({ voice: "   " })).toBeUndefined();
+	});
+
+	it("returns undefined for an empty voice string", () => {
+		expect(extractRequestedVoiceId({ voice: "" })).toBeUndefined();
+	});
+
+	it("falls back to the legacy voiceId spelling", () => {
+		expect(extractRequestedVoiceId({ voiceId: "af_bella" })).toBe("af_bella");
+	});
+
+	it("prefers voice over the legacy voiceId spelling", () => {
+		expect(
+			extractRequestedVoiceId({ voice: "af_nicole", voiceId: "af_bella" }),
+		).toBe("af_nicole");
+	});
+
+	it("ignores a non-string legacy voiceId", () => {
+		expect(extractRequestedVoiceId({ voiceId: 7 })).toBeUndefined();
+	});
+
+	it("does not fall back to voiceId when voice is present but empty", () => {
+		expect(extractRequestedVoiceId({ voice: "", voiceId: "af_bella" })).toBe(
+			undefined,
+		);
+	});
+
+	it("trims the legacy voiceId too", () => {
+		expect(extractRequestedVoiceId({ voiceId: "  af_bella  " })).toBe(
+			"af_bella",
+		);
+	});
+});
+
+describe("extractRequestedKokoroVoiceId", () => {
+	it("returns undefined when no voice is requested", () => {
+		expect(extractRequestedKokoroVoiceId({})).toBeUndefined();
+		expect(extractRequestedKokoroVoiceId("nova")).toBeUndefined();
+	});
+
+	it("maps historical Piper names to bundled Kokoro ids", () => {
+		expect(
+			extractRequestedKokoroVoiceId({ voice: "en_us-female-medium" }),
+		).toBe("af_nicole");
+		expect(extractRequestedKokoroVoiceId({ voice: "en_us-female" })).toBe(
+			"af_bella",
+		);
+		expect(extractRequestedKokoroVoiceId({ voice: "en_us-male-medium" })).toBe(
+			"am_michael",
+		);
+	});
+
+	it("maps OpenAI-era voice names case-insensitively", () => {
+		expect(extractRequestedKokoroVoiceId({ voice: "nova" })).toBe("af_nova");
+		expect(extractRequestedKokoroVoiceId({ voice: "NOVA" })).toBe("af_nova");
+		expect(extractRequestedKokoroVoiceId({ voice: "Alloy" })).toBe("af_alloy");
+	});
+
+	it("maps aliases after trimming", () => {
+		expect(extractRequestedKokoroVoiceId({ voice: "  nova  " })).toBe(
+			"af_nova",
+		);
+	});
+
+	it("passes unknown voice ids through unchanged", () => {
+		expect(extractRequestedKokoroVoiceId({ voice: "af_custom" })).toBe(
+			"af_custom",
+		);
+	});
+
+	it("preserves the original casing of unknown voice ids", () => {
+		expect(extractRequestedKokoroVoiceId({ voice: "MyCustomVoice" })).toBe(
+			"MyCustomVoice",
+		);
+	});
+
+	it("resolves legacy voiceId through the alias table", () => {
+		expect(extractRequestedKokoroVoiceId({ voiceId: "nova" })).toBe("af_nova");
+	});
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for the TTS voice identifier normalization boundary. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new test file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `Test Files  1 passed (1)
      Tests  18 passed (18)` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
