### PR TITLE
fix(elizacloud): fail closed on degenerate ELIZA_CLOUD_ISSUER values

### DIFF
--- a/plugins/plugin-elizacloud/src/services/cloud-bootstrap.test.ts
+++ b/plugins/plugin-elizacloud/src/services/cloud-bootstrap.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+import { CloudBootstrapServiceImpl } from "./cloud-bootstrap";
+
+const ISSUER = "ELIZA_CLOUD_ISSUER";
+const CONTAINER = "ELIZA_CLOUD_CONTAINER_ID";
+
+function runtimeWithSettings(settings: Record<string, unknown> = {}) {
+  return {
+    getSetting: (key: string) => settings[key] ?? null,
+  };
+}
+
+function clearEnv() {
+  delete process.env[ISSUER];
+  delete process.env[CONTAINER];
+}
+
+beforeEach(clearEnv);
+afterEach(clearEnv);
+
+function newService(settings: Record<string, unknown> = {}) {
+  return new CloudBootstrapServiceImpl(runtimeWithSettings(settings) as never);
+}
+
+describe("CloudBootstrapServiceImpl — no-fail-open trust anchor", () => {
+  it("throws when the issuer is not configured anywhere", () => {
+    expect(() => newService().getExpectedIssuer()).toThrow(
+      /ELIZA_CLOUD_ISSUER is not configured/,
+    );
+  });
+
+  it("rejects a slash-only and whitespace-only issuer instead of failing open", () => {
+    for (const degenerate of ["/", "//", "///", "  ", "\t", "\n"]) {
+      expect(() => newService({ [ISSUER]: degenerate }).getExpectedIssuer()).toThrow(
+        /ELIZA_CLOUD_ISSUER is not configured/,
+      );
+    }
+  });
+
+  it("does not throw when a non-empty issuer is configured", () => {
+    expect(
+      newService({ [ISSUER]: "https://cloud.elizaos.com" }).getExpectedIssuer(),
+    ).toBe("https://cloud.elizaos.com");
+  });
+});
+
+describe("CloudBootstrapServiceImpl — issuer resolution", () => {
+  it("prefers the runtime setting over the environment", () => {
+    process.env[ISSUER] = "https://env.example.com";
+    const service = newService({ [ISSUER]: "https://runtime.example.com" });
+    expect(service.getExpectedIssuer()).toBe("https://runtime.example.com");
+  });
+
+  it("falls back to the environment when the runtime setting is missing", () => {
+    process.env[ISSUER] = "https://env.example.com";
+    expect(newService().getExpectedIssuer()).toBe("https://env.example.com");
+  });
+
+  it("ignores an empty-string runtime setting and uses the environment", () => {
+    process.env[ISSUER] = "https://env.example.com";
+    expect(newService({ [ISSUER]: "" }).getExpectedIssuer()).toBe(
+      "https://env.example.com",
+    );
+  });
+
+  it("trims trailing slashes from the issuer", () => {
+    expect(newService({ [ISSUER]: "https://cloud.elizaos.com/" }).getExpectedIssuer()).toBe(
+      "https://cloud.elizaos.com",
+    );
+    expect(
+      newService({ [ISSUER]: "https://cloud.elizaos.com///" }).getExpectedIssuer(),
+    ).toBe("https://cloud.elizaos.com");
+  });
+
+  it("trims surrounding whitespace from the issuer", () => {
+    expect(
+      newService({ [ISSUER]: "  https://cloud.elizaos.com/  " }).getExpectedIssuer(),
+    ).toBe("https://cloud.elizaos.com");
+  });
+});
+
+describe("CloudBootstrapServiceImpl — endpoint derivation", () => {
+  it("builds the JWKS URL from the issuer without a double slash", () => {
+    const service = newService({ [ISSUER]: "https://cloud.elizaos.com/" });
+    expect(service.getJwksUrl()).toBe(
+      "https://cloud.elizaos.com/.well-known/jwks.json",
+    );
+  });
+
+  it("builds the revocation list URL from the issuer", () => {
+    const service = newService({ [ISSUER]: "https://cloud.elizaos.com" });
+    expect(service.getRevocationListUrl()).toBe(
+      "https://cloud.elizaos.com/.well-known/revocations.json",
+    );
+  });
+
+  it("propagates the no-fail-open error through endpoint derivation", () => {
+    expect(() => newService().getJwksUrl()).toThrow(
+      /ELIZA_CLOUD_ISSUER is not configured/,
+    );
+    expect(() => newService().getRevocationListUrl()).toThrow(
+      /ELIZA_CLOUD_ISSUER is not configured/,
+    );
+  });
+});
+
+describe("CloudBootstrapServiceImpl — container id", () => {
+  it("returns null when the container id is unset", () => {
+    expect(newService().getExpectedContainerId()).toBeNull();
+  });
+
+  it("returns the configured container id", () => {
+    expect(newService({ [CONTAINER]: "container-7" }).getExpectedContainerId()).toBe(
+      "container-7",
+    );
+  });
+
+  it("falls back to the environment for the container id", () => {
+    process.env[CONTAINER] = "env-container";
+    expect(newService().getExpectedContainerId()).toBe("env-container");
+  });
+});

--- a/plugins/plugin-elizacloud/src/services/cloud-bootstrap.ts
+++ b/plugins/plugin-elizacloud/src/services/cloud-bootstrap.ts
@@ -89,7 +89,13 @@ export class CloudBootstrapServiceImpl extends Service implements CloudBootstrap
         "ELIZA_CLOUD_ISSUER is not configured — bootstrap-token verification cannot proceed"
       );
     }
-    return trimTrailingSlash(issuer);
+    const normalized = trimTrailingSlash(issuer.trim());
+    if (normalized.length === 0) {
+      throw new Error(
+        "ELIZA_CLOUD_ISSUER is not configured — bootstrap-token verification cannot proceed"
+      );
+    }
+    return normalized;
   }
 
   getJwksUrl(): string {


### PR DESCRIPTION
# Relates to

<!-- No issue; reproduces a degenerate-config fail-open in the bootstrap trust anchor. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. The change tightens an existing no-fail-open guard: degenerate ELIZA_CLOUD_ISSUER values (slash-only or whitespace-only) now throw exactly like an unset issuer instead of producing a bogus relative JWKS URL. Normal issuers are unchanged except leading/trailing whitespace is trimmed.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `Test Files  1 passed (1)
      Tests  14 passed (14)` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: source fix + test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
