### PR TITLE
fix(cloud): guard replacement cutover with ledger authority

### DIFF
--- a/packages/cloud/shared/src/db/agent-backup-restore-api-boundary.test.ts
+++ b/packages/cloud/shared/src/db/agent-backup-restore-api-boundary.test.ts
@@ -70,7 +70,6 @@ describe("dormant restore API boundary", () => {
       "startAgentSandboxReplacementAttemptInTransaction",
       "recordAgentSandboxReplacementIntentInTransaction",
       "commitAgentSandboxReplacementLifecycleAdoptionInTransaction",
-      "recordAgentSandboxReplacementCleanupProvenInTransaction",
     ]) {
       const occurrences = sources.flatMap(({ path, source }) =>
         source.includes(symbol) ? [path] : [],
@@ -86,11 +85,34 @@ describe("dormant restore API boundary", () => {
       const invocationLikeOccurrences = production.match(
         new RegExp(`\\b${symbol}(?:<[^>]+>)?\\s*\\(`, "g"),
       );
-      const expectedInvocationLikeOccurrences = symbol === "loadAgentBackupRestoreSourceV3" ? 2 : 1;
+      const expectedInvocationLikeOccurrences =
+        symbol === "loadAgentBackupRestoreSourceV3" ||
+        symbol === "startAgentSandboxReplacementAttemptInTransaction"
+          ? 2
+          : 1;
       expect(
         invocationLikeOccurrences ?? [],
         `${symbol} gained a production call site`,
       ).toHaveLength(expectedInvocationLikeOccurrences);
+    }
+    // The cleanup reconciler is the first deliberately activated consumer of
+    // the replacement ledger. Keep both terminal settlement APIs confined to
+    // that service until admission/provider/adoption are wired end-to-end.
+    for (const symbol of [
+      "recordAgentSandboxReplacementCleanupProvenInTransaction",
+      "recordAgentSandboxReplacementPreviousCleanupProvenInTransaction",
+    ]) {
+      const occurrences = sources
+        .filter(({ source }) => source.includes(symbol))
+        .map(({ path }) => path)
+        .sort();
+      expect(occurrences, `${symbol} gained an unexpected production consumer`).toEqual(
+        [
+          join(import.meta.dir, "repositories/agent-sandbox-replacement-attempts.ts"),
+          join(import.meta.dir, "../lib/services/eliza-sandbox.ts"),
+        ].sort(),
+      );
+      expect(production.match(new RegExp(`\\b${symbol}\\s*\\(`, "g")) ?? []).toHaveLength(2);
     }
     // Capture already consumes current vault authority in one deliberately
     // narrow production adapter; restore must not add another caller here.

--- a/packages/cloud/shared/src/db/agent-restore-capacity-ownership-migration.test.ts
+++ b/packages/cloud/shared/src/db/agent-restore-capacity-ownership-migration.test.ts
@@ -79,6 +79,7 @@ const ABA_NODE_HISTORY_ID = "50000000-0000-4000-8000-000000000005";
 const ABA_NODE_RECORD_ID = "60000000-0000-4000-8000-000000000005";
 const ABA_NODE_INCARNATION = "70000000-0000-4000-8000-000000000005";
 const AGENT_ID = "80000000-0000-4000-8000-000000000001";
+const PREVIOUS_ACTIVATION_GENERATION = "90000000-0000-4000-8000-000000000000";
 const ACTIVATION_GENERATION = "90000000-0000-4000-8000-000000000001";
 const NEXT_ACTIVATION_GENERATION = "90000000-0000-4000-8000-000000000002";
 const LIFECYCLE_JOB_ID = "a0000000-0000-4000-8000-000000000001";
@@ -178,6 +179,7 @@ async function prerequisiteDatabase(
       deletion_attempt_id uuid,
       deletion_allocation_counted boolean,
       activation_generation uuid,
+      activation_previous_generation uuid,
       lifecycle_revision bigint NOT NULL,
       lifecycle_job_id uuid,
       lifecycle_execution_generation uuid,
@@ -250,11 +252,12 @@ async function prerequisiteDatabase(
         '${PREVIOUS_NODE_HISTORY_ID}', 1);
     INSERT INTO agent_sandboxes (
       id, organization_id, sandbox_id, node_id, container_name, status,
-      activation_generation, lifecycle_revision, lifecycle_job_id,
+      activation_generation, activation_previous_generation, lifecycle_revision, lifecycle_job_id,
       lifecycle_execution_generation
     ) VALUES (
       '${AGENT_ID}', '${ORGANIZATION_ID}', 'old-sandbox', 'old-node', 'old-container', 'running',
-      '${ACTIVATION_GENERATION}', ${ATTEMPT_LIFECYCLE_REVISION}, '${LIFECYCLE_JOB_ID}',
+      '${ACTIVATION_GENERATION}', '${PREVIOUS_ACTIVATION_GENERATION}',
+      ${ATTEMPT_LIFECYCLE_REVISION}, '${LIFECYCLE_JOB_ID}',
       '${LIFECYCLE_EXECUTION_GENERATION}'
     );
     INSERT INTO agent_activation_publications (
@@ -262,7 +265,8 @@ async function prerequisiteDatabase(
       node_history_id, docker_node_record_id, node_id, node_incarnation
     ) VALUES (
       'e0000000-0000-4000-8000-000000000001', '${ORGANIZATION_ID}', '${AGENT_ID}',
-      '${ACTIVATION_GENERATION}', '${PREVIOUS_CONTAINER_ID}', '${PREVIOUS_NODE_HISTORY_ID}',
+      '${PREVIOUS_ACTIVATION_GENERATION}', '${PREVIOUS_CONTAINER_ID}',
+      '${PREVIOUS_NODE_HISTORY_ID}',
       '${PREVIOUS_NODE_RECORD_ID}', '${PREVIOUS_NODE_ID}', '${PREVIOUS_NODE_INCARNATION}'
     );
   `);
@@ -637,11 +641,17 @@ async function commitExactHandoff(db: PGlite): Promise<void> {
   await db.exec("COMMIT");
 }
 
-async function prepareProviderSucceededReceiver(db: PGlite): Promise<void> {
-  await insertReceiver(db, { restoreAttemptId: null });
+async function prepareProviderSucceededReceiver(
+  db: PGlite,
+  input: { candidateFence?: boolean; previousContainerId?: string } = {},
+): Promise<void> {
+  await insertReceiver(db, {
+    previousContainerId: input.previousContainerId,
+    restoreAttemptId: null,
+  });
   await reserveReceiver(db);
   await db.exec("UPDATE agent_sandbox_replacement_attempts SET state = 'provider_succeeded'");
-  await recordCandidateCleanup(db);
+  if (input.candidateFence !== false) await recordCandidateCleanup(db);
 }
 
 afterEach(async () => {
@@ -1316,6 +1326,86 @@ describe("0314 restore capacity ownership", () => {
     ]);
   });
 
+  test("adopts directly from the exact ledger without a mirrored candidate fence", async () => {
+    const exactDb = await database();
+    await prepareProviderSucceededReceiver(exactDb, { candidateFence: false });
+    const emptyFence = await exactDb.query<{
+      replacement_cleanup_attempt_id: string | null;
+      replacement_cleanup_sandbox_id: string | null;
+    }>(`SELECT replacement_cleanup_attempt_id, replacement_cleanup_sandbox_id
+      FROM agent_sandboxes`);
+    expect(emptyFence.rows).toEqual([
+      {
+        replacement_cleanup_attempt_id: null,
+        replacement_cleanup_sandbox_id: null,
+      },
+    ]);
+
+    await exactDb.exec("BEGIN");
+    await commitCanonicalSandbox(exactDb);
+    await handoffReceiverLifecycle(exactDb);
+    await exactDb.exec("COMMIT");
+    const committed = await exactDb.query<{
+      capacity_state: string;
+      replacement_cleanup_attempt_id: string;
+      replacement_cleanup_container_id: string;
+      replacement_cleanup_sandbox_id: string;
+      sandbox_id: string;
+      state: string;
+    }>(`SELECT attempt.state, attempt.capacity_state, sandbox.sandbox_id,
+        sandbox.replacement_cleanup_sandbox_id,
+        sandbox.replacement_cleanup_attempt_id,
+        sandbox.replacement_cleanup_container_id
+      FROM agent_sandbox_replacement_attempts AS attempt
+      JOIN agent_sandboxes AS sandbox ON sandbox.id = attempt.agent_id`);
+    expect(committed.rows).toEqual([
+      {
+        capacity_state: "handed_off",
+        replacement_cleanup_attempt_id: RECEIVER_ID,
+        replacement_cleanup_container_id: PREVIOUS_CONTAINER_ID,
+        replacement_cleanup_sandbox_id: "old-sandbox",
+        sandbox_id: LOCATOR_SANDBOX_ID,
+        state: "lifecycle_committed",
+      },
+    ]);
+
+    const ledgerOnlyMismatches: Array<{
+      canonical: Parameters<typeof commitCanonicalSandbox>[1];
+      previousContainerId?: string;
+    }> = [
+      { canonical: { cleanupAttemptId: null } },
+      { canonical: { cleanupContainerId: "a".repeat(64) } },
+      { canonical: { cleanupSandboxId: "forged-old-sandbox" } },
+      { canonical: { lifecycleRevision: ATTEMPT_LIFECYCLE_REVISION + 2 } },
+      { canonical: { sandboxId: "forged-candidate" } },
+      { canonical: {}, previousContainerId: "a".repeat(64) },
+    ];
+    for (const mismatch of ledgerOnlyMismatches) {
+      const db = await database();
+      await prepareProviderSucceededReceiver(db, {
+        candidateFence: false,
+        previousContainerId: mismatch.previousContainerId,
+      });
+      await expect(
+        (async () => {
+          await db.exec("BEGIN");
+          await commitCanonicalSandbox(db, mismatch.canonical);
+          await handoffReceiverLifecycle(db);
+          await db.exec("COMMIT");
+        })(),
+      ).rejects.toThrow(
+        /protocol does not match|exact canonical.*placement|fresh .*previous|durable attempt authority|replacement_cleanup_(?:occurrence|locator)_check/,
+      );
+    }
+
+    const unresolvedDb = await database();
+    await insertReceiver(unresolvedDb, { restoreAttemptId: null });
+    await reserveReceiver(unresolvedDb);
+    await unresolvedDb.exec("BEGIN");
+    await expect(commitCanonicalSandbox(unresolvedDb)).rejects.toThrow(/protocol does not match/);
+    await unresolvedDb.exec("ROLLBACK");
+  });
+
   test("rejects tenant-identity toggles used to hide placement drift", async () => {
     for (const [identityColumn, temporaryIdentity, originalIdentity] of [
       ["id", SECOND_RECEIVER_ID, AGENT_ID],
@@ -1532,13 +1622,14 @@ describe("0314 restore capacity ownership", () => {
         '${OTHER_NODE_HISTORY_ID}', 1
       )
     `);
-    await replacementDb.exec(`UPDATE agent_sandboxes
-      SET activation_generation = '${NEXT_ACTIVATION_GENERATION}'::uuid`);
+    await replacementDb.exec(`UPDATE agent_sandboxes SET
+      activation_previous_generation = '${ACTIVATION_GENERATION}'::uuid,
+      activation_generation = '${NEXT_ACTIVATION_GENERATION}'::uuid`);
     await replacementDb.exec(`INSERT INTO agent_activation_publications (
       id, organization_id, agent_id, activation_generation, container_id,
       node_history_id, docker_node_record_id, node_id, node_incarnation
     ) VALUES ('e0000000-0000-4000-8000-000000000002', '${ORGANIZATION_ID}',
-      '${AGENT_ID}', '${NEXT_ACTIVATION_GENERATION}', '${LOCATOR_CONTAINER_ID}',
+      '${AGENT_ID}', '${ACTIVATION_GENERATION}', '${LOCATOR_CONTAINER_ID}',
       '${NODE_HISTORY_ID}', '${NODE_RECORD_ID}', '${NODE_ID}', '${NODE_INCARNATION}')`);
     await insertReceiver(replacementDb, {
       activationGeneration: NEXT_ACTIVATION_GENERATION,

--- a/packages/cloud/shared/src/db/migrations/0325_agent_replacement_cleanup_occurrence_guard.sql
+++ b/packages/cloud/shared/src/db/migrations/0325_agent_replacement_cleanup_occurrence_guard.sql
@@ -61,6 +61,84 @@ BEGIN
               AND attempt."agent_id" = NEW."id"
               AND attempt."state" = 'provider_succeeded'
               AND attempt."capacity_state" = 'reserved'))
+        OR (NEW."replacement_cleanup_attempt_id" IS NOT NULL
+          AND num_nonnulls(
+            OLD."replacement_cleanup_sandbox_id",
+            OLD."replacement_cleanup_node_id",
+            OLD."replacement_cleanup_node_record_id",
+            OLD."replacement_cleanup_node_incarnation",
+            OLD."replacement_cleanup_node_history_id",
+            OLD."replacement_cleanup_node_hostname",
+            OLD."replacement_cleanup_node_ssh_port",
+            OLD."replacement_cleanup_node_ssh_user",
+            OLD."replacement_cleanup_node_host_key_fingerprint",
+            OLD."replacement_cleanup_secret_cleanup_version",
+            OLD."replacement_cleanup_container_name",
+            OLD."replacement_cleanup_attempt_id",
+            OLD."replacement_cleanup_container_id",
+            OLD."replacement_cleanup_vpn_node_id",
+            OLD."replacement_cleanup_vpn_node_name",
+            OLD."replacement_cleanup_preserved_vpn_node_id",
+            OLD."replacement_cleanup_vpn_registration_started_at",
+            OLD."replacement_cleanup_allocation_counted",
+            OLD."replacement_cleanup_created_at") = 0
+          AND OLD."activation_previous_generation" IS NOT NULL
+          AND NEW."activation_previous_generation"
+            IS NOT DISTINCT FROM OLD."activation_previous_generation"
+          AND EXISTS (
+            SELECT 1
+            FROM "agent_sandbox_replacement_attempts" AS attempt
+            JOIN "agent_activation_publications" AS publication
+              ON publication."organization_id" = attempt."organization_id"
+              AND publication."agent_id" = attempt."agent_id"
+              AND publication."activation_generation"
+                = OLD."activation_previous_generation"
+              AND ROW(publication."container_id", publication."node_id",
+                publication."docker_node_record_id", publication."node_incarnation",
+                publication."node_history_id") IS NOT DISTINCT FROM ROW(
+                attempt."previous_container_id", attempt."previous_node_id",
+                attempt."previous_node_record_id", attempt."previous_node_incarnation",
+                attempt."previous_node_history_id")
+            WHERE attempt."id" = NEW."replacement_cleanup_attempt_id"
+              AND attempt."organization_id" = NEW."organization_id"
+              AND attempt."agent_id" = NEW."id"
+              AND attempt."state" = 'provider_succeeded'
+              AND attempt."capacity_state" = 'reserved'
+              AND attempt."previous_placement_absent" IS FALSE
+              AND attempt."lifecycle_revision" = OLD."lifecycle_revision"
+              AND NEW."lifecycle_revision" = attempt."lifecycle_revision" + 1
+              AND attempt."activation_generation" = OLD."activation_generation"
+              AND NEW."activation_generation" = attempt."activation_generation"
+              AND attempt."lifecycle_job_id"
+                IS NOT DISTINCT FROM OLD."lifecycle_job_id"
+              AND attempt."lifecycle_job_id"
+                IS NOT DISTINCT FROM NEW."lifecycle_job_id"
+              AND attempt."lifecycle_execution_generation"
+                IS NOT DISTINCT FROM OLD."lifecycle_execution_generation"
+              AND attempt."lifecycle_execution_generation"
+                IS NOT DISTINCT FROM NEW."lifecycle_execution_generation"
+              AND ROW(attempt."locator_sandbox_id", attempt."locator_node_id",
+                attempt."locator_container_name") IS NOT DISTINCT FROM ROW(
+                NEW."sandbox_id", NEW."node_id", NEW."container_name")
+              AND ROW(attempt."previous_sandbox_id", attempt."previous_node_id",
+                attempt."previous_container_name", attempt."previous_container_id",
+                attempt."previous_allocation_counted", attempt."previous_node_record_id",
+                attempt."previous_node_incarnation", attempt."previous_node_history_id",
+                attempt."previous_node_hostname", attempt."previous_node_ssh_port",
+                attempt."previous_node_ssh_user",
+                attempt."previous_node_host_key_fingerprint",
+                attempt."locator_previous_vpn_node_id") IS NOT DISTINCT FROM ROW(
+                OLD."sandbox_id", OLD."node_id", OLD."container_name",
+                NEW."replacement_cleanup_container_id",
+                NEW."replacement_cleanup_allocation_counted",
+                NEW."replacement_cleanup_node_record_id",
+                NEW."replacement_cleanup_node_incarnation",
+                NEW."replacement_cleanup_node_history_id",
+                NEW."replacement_cleanup_node_hostname",
+                NEW."replacement_cleanup_node_ssh_port",
+                NEW."replacement_cleanup_node_ssh_user",
+                NEW."replacement_cleanup_node_host_key_fingerprint",
+                NEW."replacement_cleanup_vpn_node_id")))
       );
     IF (NEW."replacement_cleanup_secret_cleanup_version" IS NULL) <> primary_cutover THEN
       RAISE EXCEPTION 'replacement cleanup protocol does not match cutover state'

--- a/packages/cloud/shared/src/db/migrations/0332_agent_replacement_previous_placement_guard.sql
+++ b/packages/cloud/shared/src/db/migrations/0332_agent_replacement_previous_placement_guard.sql
@@ -40,7 +40,7 @@ BEGIN
   JOIN "agent_activation_publications" AS publication
     ON publication."organization_id" = attempt."organization_id"
     AND publication."agent_id" = attempt."agent_id"
-    AND publication."activation_generation" = attempt."activation_generation"
+    AND publication."activation_generation" = OLD."activation_previous_generation"
     AND ROW(publication."container_id", publication."node_id",
       publication."docker_node_record_id", publication."node_incarnation",
       publication."node_history_id") IS NOT DISTINCT FROM ROW(attempt."previous_container_id",
@@ -59,6 +59,9 @@ BEGIN
     AND attempt."lifecycle_revision" = OLD."lifecycle_revision"
     AND attempt."activation_generation" = OLD."activation_generation"
     AND attempt."activation_generation" = current_sandbox."activation_generation"
+    AND OLD."activation_previous_generation" IS NOT NULL
+    AND current_sandbox."activation_previous_generation"
+      IS NOT DISTINCT FROM OLD."activation_previous_generation"
     AND attempt."lifecycle_job_id" IS NOT DISTINCT FROM OLD."lifecycle_job_id"
     AND attempt."lifecycle_execution_generation"
       IS NOT DISTINCT FROM OLD."lifecycle_execution_generation"

--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-sandbox-replacement-attempts.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-sandbox-replacement-attempts.pglite.test.ts
@@ -633,6 +633,7 @@ async function completeCurrentActivationForAdmission(): Promise<string> {
   const [active] = await dbWrite
     .update(agentSandboxes)
     .set({
+      docker_image: "ghcr.io/elizaos/eliza:old",
       image_digest: IMAGE_DIGEST,
       activation_lifecycle_revision: sql`${agentSandboxes.lifecycle_revision} + 1`,
       activation_phase: "active",
@@ -1723,6 +1724,52 @@ describe("agent sandbox replacement attempts", () => {
     ).rejects.toMatchObject({ code: "AGENT_SANDBOX_REPLACEMENT_ATTEMPT_CONFLICT" });
   });
 
+  test("adopts provider success after admission against the immutable previous publication", async () => {
+    const expectedLifecycleRevision = await completeCurrentActivationForAdmission();
+    const admitted = await dbWrite.transaction((tx) =>
+      admitAndStartAgentSandboxReplacementInTransaction(
+        tx,
+        admissionInput({ expectedLifecycleRevision }),
+      ),
+    );
+    await persistSuccessfulProviderAttemptAfterExistingStart(ATTEMPT_ID);
+
+    const committed = await dbWrite.transaction((tx) =>
+      commitAgentSandboxReplacementLifecycleAdoptionInTransaction(tx, {
+        ...admitted.startInput,
+        locator: locator("final"),
+        previousPlacement: admitted.previousPlacement,
+        canonicalPatch: {
+          ...adoptionInput().canonicalPatch,
+          previousDockerImage: "ghcr.io/elizaos/eliza:old",
+          previousImageDigest: IMAGE_DIGEST,
+        },
+        providerReceiptDigest: PROVIDER_DIGEST,
+        lifecycleReceiptDigest: LIFECYCLE_DIGEST,
+      }),
+    );
+
+    expect(committed).toMatchObject({
+      replayed: false,
+      attempt: {
+        state: "lifecycle_committed",
+        activation_generation: NEXT_ACTIVATION_GENERATION,
+        previous_container_id: PREVIOUS_CONTAINER_ID,
+        previous_cleanup_state: "pending",
+      },
+    });
+    expect(
+      (await dbWrite.select().from(agentSandboxes).where(eq(agentSandboxes.id, AGENT_ID)))[0],
+    ).toMatchObject({
+      sandbox_id: CONTAINER_NAME,
+      node_id: "robot-node-a",
+      replacement_cleanup_attempt_id: ATTEMPT_ID,
+      replacement_cleanup_container_id: PREVIOUS_CONTAINER_ID,
+      activation_previous_generation: ACTIVATION_GENERATION,
+      activation_generation: NEXT_ACTIVATION_GENERATION,
+    });
+  });
+
   test("derives restore activation authority while revalidating its operation and lease", async () => {
     const { restoreAuthority } = await seedRestoreCapacityAuthority();
     const [sleeping] = await dbWrite
@@ -1784,6 +1831,7 @@ describe("agent sandbox replacement attempts", () => {
     expect(
       (await dbWrite.select().from(agentSandboxes).where(eq(agentSandboxes.id, AGENT_ID)))[0],
     ).toMatchObject({
+      status: "provisioning",
       activation_previous_generation: null,
       activation_generation: RESTORE_ATTEMPT_ID,
       activation_lifecycle_revision: 9n,
@@ -1838,6 +1886,60 @@ describe("agent sandbox replacement attempts", () => {
         previous_cleanup_proven_at: null,
         previous_cleanup_receipt_digest: null,
       },
+    });
+    expect(
+      (await dbWrite.select().from(agentSandboxes).where(eq(agentSandboxes.id, AGENT_ID)))[0],
+    ).toMatchObject({ status: "provisioning" });
+  });
+
+  test("atomically moves an unplaced sleeping wake into provisioning before provider work", async () => {
+    const [sleeping] = await dbWrite
+      .update(agentSandboxes)
+      .set({
+        status: "sleeping",
+        sandbox_id: null,
+        node_id: null,
+        container_name: null,
+        activation_generation: null,
+        activation_previous_generation: null,
+        activation_lifecycle_revision: null,
+        activation_purpose: null,
+        activation_phase: null,
+        activation_token_hash: null,
+        activation_token_ciphertext: null,
+        updated_at: new Date(),
+      })
+      .where(eq(agentSandboxes.id, AGENT_ID))
+      .returning({ lifecycleRevision: agentSandboxes.lifecycle_revision });
+    if (!sleeping) throw new Error("Expected sleeping wake admission fixture");
+    await dbWrite
+      .update(dockerNodes)
+      .set({ allocated_count: 0 })
+      .where(eq(dockerNodes.id, PREVIOUS_NODE_RECORD_ID));
+
+    const admitted = await dbWrite.transaction((tx) =>
+      admitAndStartAgentSandboxReplacementInTransaction(
+        tx,
+        admissionInput({
+          operationKind: "provision",
+          activationPurpose: "wake",
+          expectedLifecycleRevision: sleeping.lifecycleRevision.toString(),
+        }),
+      ),
+    );
+
+    expect(admitted).toMatchObject({
+      previousPlacement: null,
+      startInput: { operationKind: "provision" },
+      attempt: { previous_placement_absent: true },
+    });
+    expect(
+      (await dbWrite.select().from(agentSandboxes).where(eq(agentSandboxes.id, AGENT_ID)))[0],
+    ).toMatchObject({
+      status: "provisioning",
+      activation_purpose: "wake",
+      activation_phase: "container_pending",
+      activation_generation: NEXT_ACTIVATION_GENERATION,
     });
   });
 

--- a/packages/cloud/shared/src/db/repositories/agent-sandbox-replacement-attempts.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-sandbox-replacement-attempts.ts
@@ -24,7 +24,11 @@ import {
   type AgentSandboxReplacementOperationKind,
   agentSandboxReplacementAttempts,
 } from "../schemas/agent-sandbox-replacement-attempts";
-import { agentSandboxBackups, agentSandboxes } from "../schemas/agent-sandboxes";
+import {
+  type AgentSandboxStatus,
+  agentSandboxBackups,
+  agentSandboxes,
+} from "../schemas/agent-sandboxes";
 import { dockerNodes, PLACEABLE_NODE_STATE } from "../schemas/docker-nodes";
 import { organizations } from "../schemas/organizations";
 import { readPostLockDatabaseNow } from "./primary-database-clock";
@@ -999,7 +1003,7 @@ interface LockedAgentSandboxAuthority {
   activationConsentHeadBackupHash: string | null;
   lifecycleJobId: string | null;
   lifecycleExecutionGeneration: string | null;
-  status: string;
+  status: AgentSandboxStatus;
   deletedAt: Date | null;
   deletionAttemptId: string | null;
   deletionAllocationCounted: boolean | null;
@@ -1284,12 +1288,13 @@ function classifyPreviousPlacementAbsent(
       sandbox.activationPurpose === "provision" &&
       expected.restoreAuthority === null &&
       ["pending", "provisioning"].includes(sandbox.status);
-    const wake = sandbox.activationPurpose === "wake" && sandbox.status === "sleeping";
+    const wake =
+      sandbox.activationPurpose === "wake" && ["sleeping", "provisioning"].includes(sandbox.status);
     const restore =
       sandbox.activationPurpose === "restore" &&
       expected.restoreAuthority !== null &&
       sandbox.activationGeneration === expected.restoreAuthority.restoreAttemptId &&
-      sandbox.status === "sleeping";
+      ["sleeping", "provisioning"].includes(sandbox.status);
     if (
       (hasAnyReplacementCleanupAuthority(sandbox) && !allowAdvancedLifecycleRevision) ||
       expected.operationKind !== "provision" ||
@@ -1297,7 +1302,7 @@ function classifyPreviousPlacementAbsent(
       sandbox.deletionAllocationCounted === true
     ) {
       throw conflict(
-        "Only a fresh provision or sleeping wake may own an absent placement",
+        "Only a fresh provision or admitted wake/restore may own an absent placement",
         expected,
       );
     }
@@ -2055,9 +2060,16 @@ export async function admitAndStartAgentSandboxReplacementInTransaction(
   const sandbox = await lockAgentSandboxAuthority(tx, admission);
   assertReplacementAdmissionPreState(sandbox, admission);
   const databaseNow = await readPostLockDatabaseNow(tx);
+  // A no-placement lifecycle must become visibly non-routable before any
+  // provider effect. This folds the legacy sleeping/pending -> provisioning
+  // CAS into the same transaction as activation rotation and attempt start.
+  // Existing-placement upgrades keep serving on their current status until
+  // the later exact adoption/publication sequence takes ownership.
+  const admittedStatus = sandbox.sandboxId === null ? "provisioning" : sandbox.status;
   const [rotated] = await tx
     .update(agentSandboxes)
     .set({
+      status: admittedStatus,
       activation_previous_generation: sandbox.activationGeneration,
       activation_generation: admission.targetActivationGeneration,
       activation_lifecycle_revision: sql`${agentSandboxes.lifecycle_revision} + 1`,
@@ -2100,6 +2112,7 @@ export async function admitAndStartAgentSandboxReplacementInTransaction(
       ),
     )
     .returning({
+      status: agentSandboxes.status,
       lifecycleRevision: agentSandboxes.lifecycle_revision,
       activationGeneration: agentSandboxes.activation_generation,
       activationPreviousGeneration: agentSandboxes.activation_previous_generation,
@@ -2111,6 +2124,7 @@ export async function admitAndStartAgentSandboxReplacementInTransaction(
     });
   if (
     !rotated ||
+    rotated.status !== admittedStatus ||
     BigInt(rotated.lifecycleRevision) !== admission.expectedLifecycleRevision + 1n ||
     rotated.activationGeneration !== admission.targetActivationGeneration ||
     rotated.activationPreviousGeneration !== sandbox.activationGeneration ||

--- a/packages/cloud/shared/src/lib/services/__tests__/app-container-store-recovery.integration.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-container-store-recovery.integration.test.ts
@@ -95,6 +95,9 @@ beforeAll(async () => {
       replacement_cleanup_attempt_id uuid,
       replacement_cleanup_sandbox_id text,
       replacement_cleanup_node_id text,
+      replacement_cleanup_node_record_id uuid,
+      replacement_cleanup_node_incarnation uuid,
+      replacement_cleanup_node_history_id uuid,
       replacement_cleanup_container_name text,
       replacement_cleanup_allocation_counted boolean,
       deletion_allocation_counted boolean
@@ -111,6 +114,8 @@ beforeAll(async () => {
       locator_sandbox_id text,
       locator_node_record_id uuid,
       locator_node_id text,
+      locator_node_incarnation uuid,
+      locator_node_history_id uuid,
       locator_container_name text,
       capacity_state text
     );

--- a/packages/cloud/shared/src/lib/services/__tests__/orphan-reaper-warm-claim-keys.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/orphan-reaper-warm-claim-keys.test.ts
@@ -187,6 +187,8 @@ describe("orphan reaper key resolution for warm-claimed containers", () => {
       const reusedIncarnation = crypto.randomUUID();
       const rowId = crypto.randomUUID();
       const cleanupNameId = crypto.randomUUID();
+      const cleanupAttemptId = crypto.randomUUID();
+      const cleanupContainerId = "a".repeat(64);
 
       await dbWrite.insert(agentNodeIncarnationHistories).values([
         {
@@ -260,6 +262,8 @@ describe("orphan reaper key resolution for warm-claimed containers", () => {
         replacement_cleanup_node_ssh_user: "root",
         replacement_cleanup_node_host_key_fingerprint: "SHA256:owner-old",
         replacement_cleanup_container_name: `agent-${cleanupNameId}`,
+        replacement_cleanup_attempt_id: cleanupAttemptId,
+        replacement_cleanup_container_id: cleanupContainerId,
         replacement_cleanup_allocation_counted: true,
         replacement_cleanup_created_at: new Date(),
       });


### PR DESCRIPTION
# Relates to

- #20726
- Depends on the preceding cleanup-settlement Draft PR.

Definition of Done: full standard in `CONTRIBUTING.md`.

- [ ] This PR will target `develop` after its stack predecessors merge and will then be rebased onto the latest `origin/develop`.
- [ ] `bun install` and `bun run verify` will be rerun on the final rebased head before Ready.
- [ ] Final reviewer-facing behavior evidence will be attached before Ready.

# Sync with develop

- [x] Created from the exact planned stack parent with zero local conflicts.
- [ ] Final rebase onto the latest `origin/develop` and full verification pending predecessor merges.

# Risks

Medium - replacement cutover authorization and effect admission.

# Background

## What does this PR do?

Admet les effets de remplacement atomiquement et autorise le cutover uniquement depuis l'autorite du ledger, avec les harnesses exacts alignes.

## What kind of change is this?

Bug fix (non-breaking correctness hardening).

# Documentation changes needed?

No user-facing documentation change is required for this backend-only slice. Operational evidence and stack dependencies are recorded here.

# Testing

## Where should a reviewer start?

Review the commit(s) unique to `fix/20726-06-cutover-guards`, then the colocated tests changed by this slice.

## Detailed testing steps

- Inspect only the stack delta: `git diff fix/20726-05-cleanup-settlement...fix/20726-06-cutover-guards`.
- Run the targeted tests and typechecks for the changed Cloud packages.
- Run `git diff --check fix/20726-05-cleanup-settlement...fix/20726-06-cutover-guards`.
- Full `bun run verify` and exact-head integration evidence remain pending while this PR is Draft.

# Evidence Gate

<!-- evidence-head:ccf8da60eeadc64d9cdcdbfa67cd1be38e55738e -->

- [ ] Before full-page screenshots: N/A - backend-only change with no rendered UI.
- [ ] After full-page screenshots: N/A - backend-only change with no rendered UI.
- [ ] Walkthrough video: N/A - backend-only change with no rendered UI flow.
- [ ] Backend logs: Pending - final stack integration run has not been authorized or executed yet.
- [ ] Frontend logs: N/A - no frontend surface changes.
- [ ] Real-LLM trajectory: N/A - no prompt, provider, model, or agent behavior change.
- [ ] Domain artifacts: Pending - exact DB/Redis/control-plane artifacts will be attached with final integration evidence.
- [ ] OCR review: N/A - no visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM call path is changed.

## Backend + frontend logs

Backend integration evidence pending final stack assembly. Frontend logs are N/A because this slice has no frontend surface.

## Screenshots (before / after) + video walkthrough

N/A - backend-only change.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, TTS, or STT change.

## Known gaps / failures

This is intentionally Draft. Final rebase, repository-wide verification, hosted CI, and real integration evidence remain pending. No deployment or environment mutation was performed.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: N/A - no exception requested
- Validated `origin/develop` SHA: N/A - no exception requested
- Live ruleset readback and named bypass eligibility: N/A - no exception requested
- Queued or failing checks and run URLs: N/A - no exception requested
- Infrastructure-only or unrelated-failure proof: N/A - no exception requested
- Exact-head commands, exit status, and artifacts: N/A - no exception requested
- Exact-head security, secret-scan, and provenance results: N/A - no exception requested
- Conflict-free and affected-path failure attestation: N/A - no exception requested
- Independent approving reviewer: N/A - no exception requested
- Bypass authorizer: N/A - no exception requested
- Merge method: N/A - no exception requested
- Rollback owner: N/A - no exception requested
- Post-merge `develop` validation: N/A - no exception requested

# Deploy Notes

No deploy is included or authorized by this Draft PR.