### PR TITLE
fix(cloud): fence replacement capacity by occurrence

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/app-container-store-recovery.integration.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-container-store-recovery.integration.test.ts
@@ -79,6 +79,7 @@ beforeAll(async () => {
       updated_at timestamp NOT NULL DEFAULT now()
     );
     CREATE TABLE docker_nodes (
+      id uuid UNIQUE NOT NULL,
       node_id text PRIMARY KEY,
       allocated_count integer NOT NULL DEFAULT 0,
       capacity integer NOT NULL,
@@ -88,14 +89,35 @@ beforeAll(async () => {
     );
     CREATE TABLE agent_sandboxes (
       id uuid PRIMARY KEY,
+      organization_id uuid,
       node_id text,
       status text NOT NULL,
+      replacement_cleanup_attempt_id uuid,
+      replacement_cleanup_sandbox_id text,
       replacement_cleanup_node_id text,
+      replacement_cleanup_container_name text,
       replacement_cleanup_allocation_counted boolean,
       deletion_allocation_counted boolean
     );
-    INSERT INTO docker_nodes (node_id, allocated_count, capacity, enabled)
-    VALUES ('node-1', 0, 2, true), ('node-full', 1, 1, true);
+    CREATE TABLE agent_backup_restore_operations (
+      expected_node_record_id uuid,
+      expected_node_id text,
+      capacity_state text
+    );
+    CREATE TABLE agent_sandbox_replacement_attempts (
+      id uuid,
+      organization_id uuid,
+      agent_id uuid,
+      locator_sandbox_id text,
+      locator_node_record_id uuid,
+      locator_node_id text,
+      locator_container_name text,
+      capacity_state text
+    );
+    INSERT INTO docker_nodes (id, node_id, allocated_count, capacity, enabled)
+    VALUES
+      ('00000000-0000-0000-0000-0000000000d1', 'node-1', 0, 2, true),
+      ('00000000-0000-0000-0000-0000000000d2', 'node-full', 1, 1, true);
     INSERT INTO containers
       (id, name, project_name, image_tag, port, organization_id, user_id, status)
     VALUES

--- a/packages/cloud/shared/src/lib/services/__tests__/deletion-allocation-ownership.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/deletion-allocation-ownership.test.ts
@@ -27,7 +27,7 @@ process.env.NODE_ENV ||= "test";
 process.env.MOCK_REDIS = "1";
 
 import { pushSchema } from "drizzle-kit/api";
-import { and, eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import { agentNodeIncarnationHistories } from "../../../db/schemas/agent-node-incarnation-histories";
 import { agentSandboxes } from "../../../db/schemas/agent-sandboxes";
 import { apiKeys } from "../../../db/schemas/api-keys";
@@ -95,6 +95,34 @@ beforeAll(async () => {
     };
     const { apply } = await pushSchema(schema as never, dbWrite as never);
     await apply();
+    // The workload query counts dormant restore/replacement capacity owners as
+    // well as sandbox rows. This suite does not exercise those repositories,
+    // so minimal empty authority tables keep its real SQL surface complete.
+    await dbWrite.execute(
+      sql.raw(`
+      CREATE TABLE IF NOT EXISTS agent_backup_restore_operations (
+        expected_node_record_id uuid,
+        expected_node_id text,
+        capacity_state text
+      )
+    `),
+    );
+    await dbWrite.execute(
+      sql.raw(`
+      CREATE TABLE IF NOT EXISTS agent_sandbox_replacement_attempts (
+        id uuid,
+        organization_id uuid,
+        agent_id uuid,
+        locator_sandbox_id text,
+        locator_node_record_id uuid,
+        locator_node_id text,
+        locator_node_incarnation uuid,
+        locator_node_history_id uuid,
+        locator_container_name text,
+        capacity_state text
+      )
+    `),
+    );
   } catch (error) {
     pgliteReady = false;
     console.error(

--- a/packages/cloud/shared/src/lib/services/__tests__/docker-sandbox-replacement-cleanup.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/docker-sandbox-replacement-cleanup.test.ts
@@ -25,6 +25,8 @@ import {
 } from "../sandbox-provider-types";
 import * as stewardTenantConfig from "../steward-tenant-config";
 
+const NODE_INCARNATION = "22222222-2222-4222-8222-222222222222";
+const NODE_HISTORY_ID = "44444444-4444-4444-8444-444444444444";
 const NODE: DockerNode = {
   id: "11111111-1111-4111-8111-111111111111",
   node_id: "node-replacement-b",
@@ -37,6 +39,8 @@ const NODE: DockerNode = {
   last_health_check: null,
   ssh_user: "root",
   host_key_fingerprint: "SHA256:replacement-node",
+  node_incarnation: NODE_INCARNATION,
+  current_node_history_id: NODE_HISTORY_ID,
   metadata: {},
   created_at: new Date("2026-07-23T00:00:00.000Z"),
   updated_at: new Date("2026-07-23T00:00:00.000Z"),
@@ -46,6 +50,7 @@ const CONTAINER_NAME = "agent-11111111-1111-4111-8111-111111111111";
 const VOLUME_PATH = "/data/agents/11111111-1111-4111-8111-111111111111";
 const ATTEMPT_ID = "33333333-3333-4333-8333-333333333333";
 const CONTAINER_ID = "a".repeat(64);
+const REPLACEMENT_BOOT_ID_READ_COMMAND = "cat '/proc/sys/kernel/random/boot_id'";
 const PREVIOUS_VPN_NODE_ID = "1403";
 const EXACT_VPN_NODE_ID = "1404";
 const REGISTRATION_STARTED_AT = "2026-07-23T00:05:00.000Z";
@@ -84,16 +89,22 @@ function stubNodeLookup(node: DockerNode = NODE) {
 function stubSsh(execute: (command: string) => Promise<string> = async () => ""): {
   getClient: ReturnType<typeof spyOn>;
   commands: string[];
+  bootCheckCommands: string[];
   candidateObservationCommands: string[];
   secretCleanupCommands: string[];
 } {
   const commands: string[] = [];
+  const bootCheckCommands: string[] = [];
   const candidateObservationCommands: string[] = [];
   const secretCleanupCommands: string[] = [];
   const getClient = spyOn(DockerSSHClient, "getClient").mockImplementation(((hostname: string) => {
     expect(hostname).toBe(NODE.hostname);
     return {
       exec: mock(async (command: string) => {
+        if (command === REPLACEMENT_BOOT_ID_READ_COMMAND) {
+          bootCheckCommands.push(command);
+          return `${NODE_INCARNATION}\n`;
+        }
         if (command.includes("ELIZA_REPLACEMENT_SECRET_PURGED_V1")) {
           secretCleanupCommands.push(command);
           return `${getReplacementSecretArtifactsCleanupReceipt(ATTEMPT_ID)}\n`;
@@ -107,7 +118,13 @@ function stubSsh(execute: (command: string) => Promise<string> = async () => "")
       }),
     } as unknown as DockerSSHClient;
   }) as unknown as typeof DockerSSHClient.getClient);
-  return { getClient, commands, candidateObservationCommands, secretCleanupCommands };
+  return {
+    getClient,
+    commands,
+    bootCheckCommands,
+    candidateObservationCommands,
+    secretCleanupCommands,
+  };
 }
 
 function replacementIdentity(overrides?: {
@@ -122,6 +139,8 @@ function replacementIdentity(overrides?: {
     overrides?.vpnNodeName === undefined ? "agent-replacement" : overrides.vpnNodeName;
   return {
     nodeRecordId: NODE.id,
+    nodeIncarnation: NODE_INCARNATION,
+    nodeHistoryId: NODE_HISTORY_ID,
     nodeHostname: NODE.hostname,
     nodeSshPort: NODE.ssh_port,
     nodeSshUser: NODE.ssh_user,
@@ -146,11 +165,32 @@ function replacementIdentity(overrides?: {
   };
 }
 
+function postCutoverPrimaryIdentity(containerId: string | null = CONTAINER_ID) {
+  return {
+    nodeRecordId: NODE.id,
+    nodeIncarnation: NODE_INCARNATION,
+    nodeHistoryId: NODE_HISTORY_ID,
+    nodeHostname: NODE.hostname,
+    nodeSshPort: NODE.ssh_port,
+    nodeSshUser: NODE.ssh_user,
+    nodeHostKeyFingerprint: NODE.host_key_fingerprint,
+    replacementSecretCleanupVersion: null,
+    replacementAttemptId: null,
+    containerId,
+    vpnNodeName: null,
+    previousVpnNodeId: null,
+    vpnRegistrationStartedAt: null,
+    allocationCounted: true,
+  };
+}
+
 function legacyReplacementIdentity(
   overrides?: Parameters<typeof replacementIdentity>[0],
 ): Omit<
   ReturnType<typeof replacementIdentity>,
   | "nodeRecordId"
+  | "nodeIncarnation"
+  | "nodeHistoryId"
   | "nodeHostname"
   | "nodeSshPort"
   | "nodeSshUser"
@@ -159,6 +199,8 @@ function legacyReplacementIdentity(
 > {
   const {
     nodeRecordId: _nodeRecordId,
+    nodeIncarnation: _nodeIncarnation,
+    nodeHistoryId: _nodeHistoryId,
     nodeHostname: _nodeHostname,
     nodeSshPort: _nodeSshPort,
     nodeSshUser: _nodeSshUser,
@@ -179,6 +221,8 @@ function replacementHandle(replacementAttemptId = ATTEMPT_ID): SandboxHandle {
       nodeId: NODE.node_id,
       hostname: NODE.hostname,
       nodeRecordId: NODE.id,
+      nodeIncarnation: NODE_INCARNATION,
+      nodeHistoryId: NODE_HISTORY_ID,
       nodeSshPort: NODE.ssh_port,
       nodeSshUser: NODE.ssh_user,
       nodeHostKeyFingerprint: NODE.host_key_fingerprint ?? undefined,
@@ -206,6 +250,8 @@ function replacementIntentHandle(replacementAttemptId = ATTEMPT_ID): SandboxHand
 function legacyReplacementHandle(handle: SandboxHandle): SandboxHandle {
   const {
     nodeRecordId: _nodeRecordId,
+    nodeIncarnation: _nodeIncarnation,
+    nodeHistoryId: _nodeHistoryId,
     nodeSshPort: _nodeSshPort,
     nodeSshUser: _nodeSshUser,
     nodeHostKeyFingerprint: _nodeHostKeyFingerprint,
@@ -2126,7 +2172,7 @@ describe("DockerSandboxProvider replacement cleanup", () => {
 
   test("verifies attempt label and id before exact-node cleanup without releasing capacity", async () => {
     const { primary: findNode } = stubNodeLookup();
-    const { commands } = stubSsh(async (command) => {
+    const { bootCheckCommands, commands, secretCleanupCommands } = stubSsh(async (command) => {
       if (command.startsWith("docker inspect")) {
         return inspectLine(CONTAINER_ID, ATTEMPT_ID);
       }
@@ -2144,14 +2190,200 @@ describe("DockerSandboxProvider replacement cleanup", () => {
     );
 
     expect(findNode).toHaveBeenCalledWith(NODE.id);
+    expect(bootCheckCommands).toHaveLength(2);
     expect(commands[0]).toContain("docker inspect --format");
     expect(commands[0]).toContain(CONTAINER_ID);
-    expect(commands.slice(1)).toEqual([
-      `docker stop -t 10 '${CONTAINER_ID}'`,
-      `docker rm -f '${CONTAINER_ID}'`,
-    ]);
+    expect(commands[1]).toContain(`docker stop -t 10 '${CONTAINER_ID}'`);
+    expect(commands[2]).toContain(`docker rm -f '${CONTAINER_ID}'`);
+    expect(commands[1]).toContain("ELIZA_REPLACEMENT_BOOT_ID_MISMATCH");
+    expect(commands[2]).toContain("ELIZA_REPLACEMENT_BOOT_ID_MISMATCH");
+    expect(secretCleanupCommands[0]).toContain("ELIZA_REPLACEMENT_BOOT_ID_MISMATCH");
     expect(deleteVpn).toHaveBeenCalledWith("1442");
     expect(decrement).not.toHaveBeenCalled();
+  });
+
+  test("retires an exact post-cutover primary without candidate secret cleanup", async () => {
+    const { primary: findNode } = stubNodeLookup();
+    const { commands, candidateObservationCommands, secretCleanupCommands } = stubSsh(
+      async (command) => {
+        if (command.startsWith("docker inspect")) {
+          return inspectLine(CONTAINER_ID, "");
+        }
+        return "";
+      },
+    );
+    const decrement = spyOn(dockerNodesRepository, "decrementAllocated").mockResolvedValue();
+
+    await replacementProvider().stopOnSpecificNodeForReplacement(
+      NODE.node_id,
+      CONTAINER_NAME,
+      null,
+      postCutoverPrimaryIdentity(),
+    );
+
+    expect(findNode).toHaveBeenCalledWith(NODE.id);
+    expect(secretCleanupCommands).toEqual([]);
+    expect(candidateObservationCommands).toEqual([]);
+    expect(commands).toHaveLength(3);
+    expect(commands[0]).toContain(`docker inspect --format`);
+    expect(commands[0]).toContain(`'${CONTAINER_ID}'`);
+    expect(commands[1]).toContain(`docker stop -t 10 '${CONTAINER_ID}'`);
+    expect(commands[2]).toContain(`docker rm -f '${CONTAINER_ID}'`);
+    expect(commands.every((command) => !command.includes(`'${CONTAINER_NAME}'`))).toBe(true);
+    expect(decrement).not.toHaveBeenCalled();
+  });
+
+  test("never targets a same-name successor when the published primary disappears after stop", async () => {
+    stubNodeLookup();
+    const successorContainerId = "b".repeat(64);
+    let oldContainerPresent = true;
+    let successorOwnsName = false;
+    const destructiveDockerCommands: string[] = [];
+    const ssh = {
+      exec: mock(async (command: string) => {
+        if (command === REPLACEMENT_BOOT_ID_READ_COMMAND) return `${NODE_INCARNATION}\n`;
+        if (command.startsWith("docker inspect")) {
+          expect(command).toContain(`'${CONTAINER_ID}'`);
+          return inspectLine(CONTAINER_ID, "");
+        }
+        if (command.includes("docker stop")) {
+          destructiveDockerCommands.push(command);
+          expect(command).toContain(`docker stop -t 10 '${CONTAINER_ID}'`);
+          oldContainerPresent = false;
+          successorOwnsName = true;
+          return "";
+        }
+        if (command.includes("docker rm")) {
+          destructiveDockerCommands.push(command);
+          expect(successorOwnsName).toBe(true);
+          expect(command).toContain(`docker rm -f '${CONTAINER_ID}'`);
+          expect(command).not.toContain(successorContainerId);
+          if (!oldContainerPresent) {
+            throw new Error(`Error response from daemon: No such container: ${CONTAINER_ID}`);
+          }
+        }
+        return "";
+      }),
+    };
+    spyOn(DockerSSHClient, "getClient").mockReturnValue(ssh as unknown as DockerSSHClient);
+
+    await expect(
+      replacementProvider().stopOnSpecificNodeForReplacement(
+        NODE.node_id,
+        CONTAINER_NAME,
+        null,
+        postCutoverPrimaryIdentity(),
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(destructiveDockerCommands).toHaveLength(2);
+    expect(
+      destructiveDockerCommands.every(
+        (command) =>
+          command.includes(`'${CONTAINER_ID}'`) &&
+          !command.includes(`'${CONTAINER_NAME}'`) &&
+          !command.includes(successorContainerId),
+      ),
+    ).toBe(true);
+  });
+
+  test("rejects post-cutover cleanup without a published full Docker id before SSH", async () => {
+    stubNodeLookup();
+
+    for (const containerId of [null, CONTAINER_ID.slice(0, 12)]) {
+      const ssh = spyOn(DockerSSHClient, "getClient");
+      const error = await replacementProvider()
+        .stopOnSpecificNodeForReplacement(
+          NODE.node_id,
+          CONTAINER_NAME,
+          null,
+          postCutoverPrimaryIdentity(containerId),
+        )
+        .catch((caught: unknown) => caught);
+
+      expect(error).toBeInstanceOf(SandboxReplacementCleanupUnresolvedError);
+      expect((error as Error).cause).toMatchObject({
+        code: "SANDBOX_REPLACEMENT_NODE_AUTHORITY_INVALID",
+      });
+      expect(ssh).not.toHaveBeenCalled();
+      mock.restore();
+      stubNodeLookup();
+    }
+  });
+
+  test("fails unresolved before Docker or Headscale mutation when SSH boot differs from DB", async () => {
+    stubNodeLookup();
+    const remoteCommands: string[] = [];
+    const differentBootId = "99999999-9999-4999-8999-999999999999";
+    spyOn(DockerSSHClient, "getClient").mockReturnValue({
+      exec: mock(async (command: string) => {
+        remoteCommands.push(command);
+        if (command === REPLACEMENT_BOOT_ID_READ_COMMAND) return `${differentBootId}\n`;
+        throw new Error("unexpected remote mutation");
+      }),
+    } as unknown as DockerSSHClient);
+    const deleteVpn = spyOn(headscaleClient, "deleteNode").mockResolvedValue();
+
+    const error = await replacementProvider()
+      .stopOnSpecificNodeForReplacement(
+        NODE.node_id,
+        CONTAINER_NAME,
+        EXACT_VPN_NODE_ID,
+        replacementIdentity(),
+      )
+      .catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(SandboxReplacementCleanupUnresolvedError);
+    expect((error as Error).cause).toMatchObject({
+      code: "SANDBOX_REPLACEMENT_REMOTE_NODE_INCARNATION_MISMATCH",
+    });
+    expect(remoteCommands).toEqual([REPLACEMENT_BOOT_ID_READ_COMMAND]);
+    expect(remoteCommands.some((command) => /docker (stop|rm)/.test(command))).toBe(false);
+    expect(deleteVpn).not.toHaveBeenCalled();
+  });
+
+  test("fences rm independently when the node reboots after a successful stop", async () => {
+    stubNodeLookup();
+    let remoteBootId = NODE_INCARNATION;
+    const executedDockerMutations: string[] = [];
+    const ssh = {
+      exec: mock(async (command: string) => {
+        if (command === REPLACEMENT_BOOT_ID_READ_COMMAND) return `${remoteBootId}\n`;
+        if (command.includes("ELIZA_REPLACEMENT_SECRET_PURGED_V1")) {
+          return `${getReplacementSecretArtifactsCleanupReceipt(ATTEMPT_ID)}\n`;
+        }
+        if (command.startsWith("docker inspect")) return inspectLine(CONTAINER_ID, ATTEMPT_ID);
+        if (command.includes("docker stop")) {
+          expect(command).toContain("ELIZA_REPLACEMENT_BOOT_ID_MISMATCH");
+          expect(remoteBootId).toBe(NODE_INCARNATION);
+          executedDockerMutations.push("stop");
+          remoteBootId = "99999999-9999-4999-8999-999999999999";
+          return "";
+        }
+        if (command.includes("docker rm")) {
+          expect(command).toContain("ELIZA_REPLACEMENT_BOOT_ID_MISMATCH");
+          if (remoteBootId !== NODE_INCARNATION) {
+            throw new Error("ELIZA_REPLACEMENT_BOOT_ID_MISMATCH");
+          }
+          executedDockerMutations.push("rm");
+        }
+        return "";
+      }),
+    };
+    spyOn(DockerSSHClient, "getClient").mockReturnValue(ssh as unknown as DockerSSHClient);
+    const deleteVpn = spyOn(headscaleClient, "deleteNode").mockResolvedValue();
+
+    await expect(
+      replacementProvider().stopOnSpecificNodeForReplacement(
+        NODE.node_id,
+        CONTAINER_NAME,
+        EXACT_VPN_NODE_ID,
+        replacementIdentity(),
+      ),
+    ).rejects.toThrow("ELIZA_REPLACEMENT_BOOT_ID_MISMATCH");
+
+    expect(executedDockerMutations).toEqual(["stop"]);
+    expect(deleteVpn).not.toHaveBeenCalled();
   });
 
   test("rejects a malformed secret-cleanup receipt before inspecting Docker or mutating Headscale", async () => {
@@ -2159,6 +2391,7 @@ describe("DockerSandboxProvider replacement cleanup", () => {
     const commands: string[] = [];
     spyOn(DockerSSHClient, "getClient").mockReturnValue({
       exec: mock(async (command: string) => {
+        if (command === REPLACEMENT_BOOT_ID_READ_COMMAND) return `${NODE_INCARNATION}\n`;
         commands.push(command);
         return "unexpected-output\n";
       }),
@@ -2217,7 +2450,13 @@ describe("DockerSandboxProvider replacement cleanup", () => {
   test("rejects exact node-record ABA or SSH tuple drift before opening SSH", async () => {
     for (const authoritativeNode of [
       null,
+      { ...NODE, id: "55555555-5555-4555-8555-555555555555" },
+      { ...NODE, node_id: "node-reused-by-sibling" },
+      { ...NODE, node_incarnation: "66666666-6666-4666-8666-666666666666" },
+      { ...NODE, current_node_history_id: "77777777-7777-4777-8777-777777777777" },
       { ...NODE, hostname: "192.0.2.99" },
+      { ...NODE, ssh_port: 2222 },
+      { ...NODE, ssh_user: "operator" },
       { ...NODE, host_key_fingerprint: "SHA256:rotated-key" },
     ]) {
       const provider = replacementProvider();
@@ -2290,27 +2529,24 @@ describe("DockerSandboxProvider replacement cleanup", () => {
     }
   });
 
-  test("keeps legacy nodeId-only cleanup compatible without claiming exact authority", async () => {
+  test("refuses legacy nodeId-only cleanup before lookup, SSH, or remote mutation", async () => {
     const legacyLookup = spyOn(dockerNodesRepository, "findByNodeId").mockResolvedValue(NODE);
-    const { commands, secretCleanupCommands } = stubSsh(async (command) => {
-      if (command.startsWith("docker inspect")) return inspectLine(CONTAINER_ID, ATTEMPT_ID);
-      return "";
-    });
+    const ssh = spyOn(DockerSSHClient, "getClient");
 
-    await replacementProvider().stopOnSpecificNodeForReplacement(
-      NODE.node_id,
-      CONTAINER_NAME,
-      null,
-      {
+    const error = await replacementProvider()
+      .stopOnSpecificNodeForReplacement(NODE.node_id, CONTAINER_NAME, null, {
         replacementAttemptId: ATTEMPT_ID,
         containerId: CONTAINER_ID,
         allocationCounted: true,
-      },
-    );
+      })
+      .catch((caught: unknown) => caught);
 
-    expect(legacyLookup).toHaveBeenCalledWith(NODE.node_id);
-    expect(commands[0]).toContain("docker inspect");
-    expect(secretCleanupCommands).toEqual([]);
+    expect(error).toBeInstanceOf(SandboxReplacementCleanupUnresolvedError);
+    expect((error as Error).cause).toMatchObject({
+      code: "SANDBOX_REPLACEMENT_NODE_AUTHORITY_INVALID",
+    });
+    expect(legacyLookup).not.toHaveBeenCalled();
+    expect(ssh).not.toHaveBeenCalled();
   });
 
   test("refuses a same-name label mismatch inside the converge grace window", async () => {
@@ -2335,35 +2571,6 @@ describe("DockerSandboxProvider replacement cleanup", () => {
     expect(deleteVpn).not.toHaveBeenCalled();
   });
 
-  test("converges a same-name label mismatch past the grace window via id+name identity", async () => {
-    stubNodeLookup();
-    const { commands } = stubSsh(async (command) => {
-      if (command.startsWith("docker inspect")) {
-        return inspectLine(CONTAINER_ID, "another-attempt");
-      }
-      return "";
-    });
-    const deleteVpn = spyOn(headscaleClient, "deleteNode").mockResolvedValue();
-    const decrement = spyOn(dockerNodesRepository, "decrementAllocated").mockResolvedValue();
-    const provider = replacementProvider({
-      now: () => CONTAINER_CREATED_AT_MS + 2 * 60 * 60 * 1000,
-    });
-
-    await provider.stopOnSpecificNodeForReplacement(
-      NODE.node_id,
-      CONTAINER_NAME,
-      "1444",
-      legacyReplacementIdentity(),
-    );
-
-    expect(commands.slice(1)).toEqual([
-      `docker stop -t 10 '${CONTAINER_ID}'`,
-      `docker rm -f '${CONTAINER_ID}'`,
-    ]);
-    expect(deleteVpn).toHaveBeenCalledWith("1444");
-    expect(decrement).not.toHaveBeenCalled();
-  });
-
   test("keeps failing closed past the grace window when the observed name differs", async () => {
     stubNodeLookup();
     const { commands } = stubSsh(async () =>
@@ -2381,29 +2588,6 @@ describe("DockerSandboxProvider replacement cleanup", () => {
     expect(error).toBeInstanceOf(SandboxReplacementCleanupUnresolvedError);
     expect(commands).toHaveLength(1);
     expect(deleteVpn).not.toHaveBeenCalled();
-  });
-
-  test("bounds an id-less stale fence when the name belongs to a newer attempt", async () => {
-    stubNodeLookup();
-    const newerContainerId = "b".repeat(64);
-    const { commands } = stubSsh(async () => inspectLine(newerContainerId, "newer-attempt"));
-    const deleteVpn = spyOn(headscaleClient, "deleteNode").mockResolvedValue();
-    const provider = replacementProvider();
-
-    await expect(
-      provider.stopOnSpecificNodeForReplacement(
-        NODE.node_id,
-        CONTAINER_NAME,
-        "1446",
-        legacyReplacementIdentity({ containerId: null }),
-      ),
-    ).resolves.toBeUndefined();
-
-    expect(commands).toHaveLength(1);
-    expect(commands[0]).toContain(CONTAINER_NAME);
-    expect(commands[0]).not.toContain(`docker stop`);
-    expect(commands[0]).not.toContain(`docker rm`);
-    expect(deleteVpn).toHaveBeenCalledWith("1446");
   });
 
   test("refuses cleanup when Docker's inspected id differs from the persisted id", async () => {
@@ -2473,6 +2657,7 @@ describe("DockerSandboxProvider replacement cleanup", () => {
     const commands: string[] = [];
     const ssh = {
       exec: mock(async (command: string) => {
+        if (command === REPLACEMENT_BOOT_ID_READ_COMMAND) return `${NODE_INCARNATION}\n`;
         if (command.includes("ELIZA_REPLACEMENT_SECRET_PURGED_V1")) {
           return `${getReplacementSecretArtifactsCleanupReceipt(ATTEMPT_ID)}\n${getReplacementDockerCreateQuiescentReceipt(ATTEMPT_ID)}\n`;
         }
@@ -2516,8 +2701,9 @@ describe("DockerSandboxProvider replacement cleanup", () => {
 
     expect(commands).toHaveLength(3);
     expect(candidateObservationCommands).toHaveLength(1);
-    expect(commands[1]).toBe(`docker stop -t 10 '${CONTAINER_ID}'`);
-    expect(commands[2]).toBe(`docker rm -f '${CONTAINER_ID}'`);
+    expect(candidateObservationCommands[0]).toContain("ELIZA_REPLACEMENT_BOOT_ID_MISMATCH");
+    expect(commands[1]).toContain(`docker stop -t 10 '${CONTAINER_ID}'`);
+    expect(commands[2]).toContain(`docker rm -f '${CONTAINER_ID}'`);
   });
 
   test("replays an exact id-less cleanup after its first successful removal", async () => {
@@ -2528,6 +2714,7 @@ describe("DockerSandboxProvider replacement cleanup", () => {
     const stopCommands: string[] = [];
     const ssh = {
       exec: mock(async (command: string) => {
+        if (command === REPLACEMENT_BOOT_ID_READ_COMMAND) return `${NODE_INCARNATION}\n`;
         if (command.includes("ELIZA_REPLACEMENT_SECRET_PURGED_V1")) {
           return [
             getReplacementSecretArtifactsCleanupReceipt(ATTEMPT_ID),
@@ -2547,11 +2734,11 @@ describe("DockerSandboxProvider replacement cleanup", () => {
           }
           return inspectLine(CONTAINER_ID, ATTEMPT_ID);
         }
-        if (command.startsWith("docker stop")) {
+        if (command.includes("docker stop")) {
           stopCommands.push(command);
           return "";
         }
-        if (command.startsWith("docker rm")) {
+        if (command.includes("docker rm")) {
           stopCommands.push(command);
           candidatePresent = false;
           return "";
@@ -2573,10 +2760,8 @@ describe("DockerSandboxProvider replacement cleanup", () => {
     expect(inspectCommands).toHaveLength(2);
     expect(inspectCommands[0]).toContain(CONTAINER_NAME);
     expect(inspectCommands[1]).toContain(CONTAINER_ID);
-    expect(stopCommands).toEqual([
-      `docker stop -t 10 '${CONTAINER_ID}'`,
-      `docker rm -f '${CONTAINER_ID}'`,
-    ]);
+    expect(stopCommands[0]).toContain(`docker stop -t 10 '${CONTAINER_ID}'`);
+    expect(stopCommands[1]).toContain(`docker rm -f '${CONTAINER_ID}'`);
   });
 
   test("converges when an active id-less create materializes after the first cleanup", async () => {
@@ -2588,6 +2773,7 @@ describe("DockerSandboxProvider replacement cleanup", () => {
     const retirementEvents: string[] = [];
     const ssh = {
       exec: mock(async (command: string) => {
+        if (command === REPLACEMENT_BOOT_ID_READ_COMMAND) return `${NODE_INCARNATION}\n`;
         if (command.includes("ELIZA_REPLACEMENT_SECRET_PURGED_V1")) {
           return [
             getReplacementSecretArtifactsCleanupReceipt(ATTEMPT_ID),
@@ -2607,12 +2793,12 @@ describe("DockerSandboxProvider replacement cleanup", () => {
           if (!candidatePresent) throw new Error(`Error: No such object: ${target}`);
           return inspectLine(CONTAINER_ID, ATTEMPT_ID);
         }
-        if (command.startsWith("docker stop")) {
+        if (command.includes("docker stop")) {
           retirementEvents.push("stop");
           lifecycleCommands.push(command);
           return "";
         }
-        if (command.startsWith("docker rm")) {
+        if (command.includes("docker rm")) {
           retirementEvents.push("rm");
           lifecycleCommands.push(command);
           candidatePresent = false;
@@ -2640,10 +2826,8 @@ describe("DockerSandboxProvider replacement cleanup", () => {
     expect(candidateObserved).toBe(true);
     expect(inspectTargets).toEqual([CONTAINER_NAME, CONTAINER_NAME, CONTAINER_ID]);
     expect(retirementEvents).toEqual(["observe", "stop", "rm"]);
-    expect(lifecycleCommands).toEqual([
-      `docker stop -t 10 '${CONTAINER_ID}'`,
-      `docker rm -f '${CONTAINER_ID}'`,
-    ]);
+    expect(lifecycleCommands[0]).toContain(`docker stop -t 10 '${CONTAINER_ID}'`);
+    expect(lifecycleCommands[1]).toContain(`docker rm -f '${CONTAINER_ID}'`);
   });
 
   test("recovers an observation-marker response loss before or after commit", async () => {
@@ -2656,6 +2840,7 @@ describe("DockerSandboxProvider replacement cleanup", () => {
     const inspectTargets: string[] = [];
     const ssh = {
       exec: mock(async (command: string) => {
+        if (command === REPLACEMENT_BOOT_ID_READ_COMMAND) return `${NODE_INCARNATION}\n`;
         if (command.includes("ELIZA_REPLACEMENT_SECRET_PURGED_V1")) {
           return [
             getReplacementSecretArtifactsCleanupReceipt(ATTEMPT_ID),
@@ -2679,7 +2864,7 @@ describe("DockerSandboxProvider replacement cleanup", () => {
           if (!candidatePresent) throw new Error(`Error: No such object: ${CONTAINER_ID}`);
           return inspectLine(CONTAINER_ID, ATTEMPT_ID);
         }
-        if (command.startsWith("docker rm")) {
+        if (command.includes("docker rm")) {
           candidatePresent = false;
         }
         return "";
@@ -2719,7 +2904,7 @@ describe("DockerSandboxProvider replacement cleanup", () => {
       if (command.startsWith("docker inspect")) {
         return inspectLine(CONTAINER_ID, ATTEMPT_ID);
       }
-      if (command.startsWith("docker rm")) {
+      if (command.includes("docker rm")) {
         throw new Error(
           `[docker-ssh] Command exited with code 1 on ${NODE.hostname}: [stderr] Error response from daemon: No such container: ${CONTAINER_ID}`,
         );
@@ -2780,188 +2965,9 @@ describe("DockerSandboxProvider replacement cleanup", () => {
     expect(deleteVpn).not.toHaveBeenCalled();
   });
 
-  test("legacy cleanup recovers a post-start VPN registration by name, suffix, time, and excluded live id", async () => {
-    stubNodeLookup();
-    stubSsh(async () => {
-      throw new Error(`Error response from daemon: No such container: ${CONTAINER_NAME}`);
-    });
-    const matchingNodes = [
-      headscaleNode(PREVIOUS_VPN_NODE_ID, "agent-replacement", "2026-07-22T23:00:00.000Z"),
-      headscaleNode("1404", "agent-replacement-ab12cd34", "2026-07-23T00:05:02.000Z"),
-      headscaleNode("1405", "agent-other", "2026-07-23T00:05:03.000Z"),
-    ];
-    const listNodes = spyOn(headscaleClient, "listNodesStrict")
-      .mockResolvedValueOnce(matchingNodes)
-      .mockResolvedValue([]);
-    const deleteVpn = spyOn(headscaleClient, "deleteNode").mockResolvedValue();
-    const provider = replacementProvider();
-
-    await provider.stopOnSpecificNodeForReplacement(
-      NODE.node_id,
-      CONTAINER_NAME,
-      null,
-      legacyReplacementIdentity(),
-    );
-
-    expect(listNodes).toHaveBeenCalledTimes(4);
-    expect(deleteVpn).toHaveBeenCalledWith("1404");
-  });
-
-  test("legacy cleanup waits through an empty list and deletes a registration that commits late", async () => {
-    stubNodeLookup();
-    stubSsh(async () => {
-      throw new Error(`Error: No such object: ${CONTAINER_NAME}`);
-    });
-    const lateNode = headscaleNode(
-      "1406",
-      "agent-replacement-ab12cd34",
-      "2026-07-23T00:05:02.000Z",
-    );
-    const listNodes = spyOn(headscaleClient, "listNodesStrict")
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([lateNode])
-      .mockResolvedValue([]);
-    const deleteVpn = spyOn(headscaleClient, "deleteNode").mockResolvedValue();
-    const provider = replacementProvider();
-
-    await provider.stopOnSpecificNodeForReplacement(
-      NODE.node_id,
-      CONTAINER_NAME,
-      null,
-      legacyReplacementIdentity(),
-    );
-
-    expect(listNodes).toHaveBeenCalledTimes(4);
-    expect(deleteVpn).toHaveBeenCalledTimes(1);
-    expect(deleteVpn).toHaveBeenCalledWith("1406");
-  });
-
-  test("legacy cleanup retains the fence through the registration window and removes a late VPN node afterward", async () => {
-    stubNodeLookup();
-    stubSsh(async () => {
-      throw new Error(`Error: No such object: ${CONTAINER_NAME}`);
-    });
-    const startedAt = Date.parse(REGISTRATION_STARTED_AT);
-    let now = startedAt + 1_000;
-    const lateNode = headscaleNode(
-      "1407",
-      "agent-replacement-ab12cd34",
-      "2026-07-23T00:07:00.000Z",
-    );
-    const listNodes = spyOn(headscaleClient, "listNodesStrict")
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([lateNode])
-      .mockResolvedValue([]);
-    const deleteVpn = spyOn(headscaleClient, "deleteNode").mockResolvedValue();
-    const provider = replacementProvider({ now: () => now });
-
-    await expect(
-      provider.stopOnSpecificNodeForReplacement(
-        NODE.node_id,
-        CONTAINER_NAME,
-        null,
-        legacyReplacementIdentity(),
-      ),
-    ).rejects.toThrow("VPN registration window remains open");
-    expect(listNodes).not.toHaveBeenCalled();
-    expect(deleteVpn).not.toHaveBeenCalled();
-
-    now = startedAt + 60 * 60 * 1_000;
-    await expect(
-      provider.stopOnSpecificNodeForReplacement(
-        NODE.node_id,
-        CONTAINER_NAME,
-        null,
-        legacyReplacementIdentity(),
-      ),
-    ).resolves.toBeUndefined();
-
-    expect(listNodes).toHaveBeenCalledTimes(4);
-    expect(deleteVpn).toHaveBeenCalledTimes(1);
-    expect(deleteVpn).toHaveBeenCalledWith("1407");
-  });
-
-  test("legacy cleanup allows bounded Headscale clock skew while retaining the name fence", async () => {
-    stubNodeLookup();
-    stubSsh(async () => {
-      throw new Error(`Error: No such object: ${CONTAINER_NAME}`);
-    });
-    const skewedNode = headscaleNode(
-      "1408",
-      "agent-replacement-ab12cd34",
-      "2026-07-23T00:04:55.000Z",
-    );
-    spyOn(headscaleClient, "listNodesStrict")
-      .mockResolvedValueOnce([skewedNode])
-      .mockResolvedValue([]);
-    const deleteVpn = spyOn(headscaleClient, "deleteNode").mockResolvedValue();
-    const provider = replacementProvider();
-
-    await provider.stopOnSpecificNodeForReplacement(
-      NODE.node_id,
-      CONTAINER_NAME,
-      null,
-      legacyReplacementIdentity(),
-    );
-
-    expect(deleteVpn).toHaveBeenCalledWith("1408");
-  });
-
-  test("fails closed when multiple new VPN registrations match the same intent", async () => {
-    stubNodeLookup();
-    stubSsh(async () => {
-      throw new Error(`Error: No such object: ${CONTAINER_NAME}`);
-    });
-    spyOn(headscaleClient, "listNodesStrict").mockResolvedValue([
-      headscaleNode("1409", "agent-replacement", "2026-07-23T00:05:01.000Z"),
-      headscaleNode("1410", "agent-replacement-ab12cd34", "2026-07-23T00:05:02.000Z"),
-    ]);
-    const deleteVpn = spyOn(headscaleClient, "deleteNode").mockResolvedValue();
-    const provider = replacementProvider();
-
-    await expect(
-      provider.stopOnSpecificNodeForReplacement(
-        NODE.node_id,
-        CONTAINER_NAME,
-        null,
-        legacyReplacementIdentity(),
-      ),
-    ).rejects.toThrow("2 matching registrations");
-    expect(deleteVpn).not.toHaveBeenCalled();
-  });
-
-  test("fails closed when ambiguity appears after an initially empty Headscale list", async () => {
-    stubNodeLookup();
-    stubSsh(async () => {
-      throw new Error(`Error: No such object: ${CONTAINER_NAME}`);
-    });
-    const listNodes = spyOn(headscaleClient, "listNodesStrict")
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([
-        headscaleNode("1411", "agent-replacement", "2026-07-23T00:05:01.000Z"),
-        headscaleNode("1412", "agent-replacement-ab12cd34", "2026-07-23T00:05:02.000Z"),
-      ]);
-    const deleteVpn = spyOn(headscaleClient, "deleteNode").mockResolvedValue();
-    const provider = replacementProvider();
-
-    await expect(
-      provider.stopOnSpecificNodeForReplacement(
-        NODE.node_id,
-        CONTAINER_NAME,
-        null,
-        legacyReplacementIdentity(),
-      ),
-    ).rejects.toThrow("2 matching registrations");
-    expect(listNodes).toHaveBeenCalledTimes(2);
-    expect(deleteVpn).not.toHaveBeenCalled();
-  });
-
-  test("retains the complete locator across VPN API failure and never decrements capacity", async () => {
-    stubNodeLookup();
-    stubSsh(async () => {
-      throw new Error(`Error: No such object: ${CONTAINER_NAME}`);
-    });
-    spyOn(headscaleClient, "listNodesStrict").mockRejectedValue(new Error("Headscale unavailable"));
+  test("retains the complete legacy locator when exact node authority is absent", async () => {
+    const ssh = spyOn(DockerSSHClient, "getClient");
+    const listNodes = spyOn(headscaleClient, "listNodesStrict");
     const decrement = spyOn(dockerNodesRepository, "decrementAllocated").mockResolvedValue();
     const provider = replacementProvider();
 
@@ -2984,6 +2990,11 @@ describe("DockerSandboxProvider replacement cleanup", () => {
       vpnRegistrationStartedAt: REGISTRATION_STARTED_AT,
       allocationCounted: true,
     });
+    expect((error as Error).cause).toMatchObject({
+      code: "SANDBOX_REPLACEMENT_NODE_AUTHORITY_INVALID",
+    });
+    expect(ssh).not.toHaveBeenCalled();
+    expect(listNodes).not.toHaveBeenCalled();
     expect(decrement).not.toHaveBeenCalled();
   });
 

--- a/packages/cloud/shared/src/lib/services/__tests__/orphan-reaper-warm-claim-keys.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/orphan-reaper-warm-claim-keys.test.ts
@@ -11,7 +11,9 @@ process.env.NODE_ENV ||= "test";
 process.env.MOCK_REDIS = "1";
 
 import { pushSchema } from "drizzle-kit/api";
+import { agentNodeIncarnationHistories } from "../../../db/schemas/agent-node-incarnation-histories";
 import { agentSandboxes } from "../../../db/schemas/agent-sandboxes";
+import { dockerNodes } from "../../../db/schemas/docker-nodes";
 import { organizations } from "../../../db/schemas/organizations";
 import { userCharacters } from "../../../db/schemas/user-characters";
 import { users } from "../../../db/schemas/users";
@@ -46,7 +48,14 @@ beforeAll(async () => {
   }
   ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import("../../../db/client"));
   ({ loadSandboxStatusesByIds } = await import("../docker-node-workloads"));
-  const schema = { organizations, users, userCharacters, agentSandboxes };
+  const schema = {
+    organizations,
+    users,
+    userCharacters,
+    agentNodeIncarnationHistories,
+    dockerNodes,
+    agentSandboxes,
+  };
   const { apply } = await pushSchema(schema as never, dbWrite as never);
   await apply();
 }, PGLITE_TIMEOUT);
@@ -158,6 +167,109 @@ describe("orphan reaper key resolution for warm-claimed containers", () => {
           key: cleanupNameId,
           status: "replacement_cleanup_owned",
           nodeId: "node-8",
+        },
+      ]);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "a stale exact cleanup follows its immutable record after reboot, rename, and logical-id reuse",
+    async () => {
+      const { orgId, userId } = await seedOwner();
+      const ownerRecordId = crypto.randomUUID();
+      const ownerOldHistoryId = crypto.randomUUID();
+      const ownerOldIncarnation = crypto.randomUUID();
+      const ownerCurrentHistoryId = crypto.randomUUID();
+      const ownerCurrentIncarnation = crypto.randomUUID();
+      const reusedRecordId = crypto.randomUUID();
+      const reusedHistoryId = crypto.randomUUID();
+      const reusedIncarnation = crypto.randomUUID();
+      const rowId = crypto.randomUUID();
+      const cleanupNameId = crypto.randomUUID();
+
+      await dbWrite.insert(agentNodeIncarnationHistories).values([
+        {
+          id: ownerOldHistoryId,
+          docker_node_record_id: ownerRecordId,
+          node_id: "old-logical-node",
+          node_incarnation: ownerOldIncarnation,
+          fleet_kind: "robot",
+          infrastructure_provider: "hetzner",
+          host_key_fingerprint: "SHA256:owner-old",
+        },
+        {
+          id: ownerCurrentHistoryId,
+          docker_node_record_id: ownerRecordId,
+          node_id: "retired-owner-node",
+          node_incarnation: ownerCurrentIncarnation,
+          fleet_kind: "robot",
+          infrastructure_provider: "hetzner",
+          host_key_fingerprint: "SHA256:owner-current",
+        },
+        {
+          id: reusedHistoryId,
+          docker_node_record_id: reusedRecordId,
+          node_id: "old-logical-node",
+          node_incarnation: reusedIncarnation,
+          fleet_kind: "robot",
+          infrastructure_provider: "hetzner",
+          host_key_fingerprint: "SHA256:reused",
+        },
+      ]);
+      await dbWrite.insert(dockerNodes).values([
+        {
+          id: ownerRecordId,
+          node_id: "retired-owner-node",
+          hostname: "owner.internal",
+          host_key_fingerprint: "SHA256:owner-current",
+          fleet_kind: "robot",
+          infrastructure_provider: "hetzner",
+          status: "healthy",
+          node_incarnation: ownerCurrentIncarnation,
+          current_node_history_id: ownerCurrentHistoryId,
+        },
+        {
+          id: reusedRecordId,
+          node_id: "old-logical-node",
+          hostname: "reused.internal",
+          host_key_fingerprint: "SHA256:reused",
+          fleet_kind: "robot",
+          infrastructure_provider: "hetzner",
+          status: "healthy",
+          node_incarnation: reusedIncarnation,
+          current_node_history_id: reusedHistoryId,
+        },
+      ]);
+      await dbWrite.insert(agentSandboxes).values({
+        id: rowId,
+        organization_id: orgId,
+        user_id: userId,
+        agent_name: uniq("stale-cleanup"),
+        status: "running",
+        execution_tier: "dedicated-always",
+        node_id: "canonical-node",
+        container_name: `agent-${rowId}`,
+        replacement_cleanup_sandbox_id: crypto.randomUUID(),
+        replacement_cleanup_node_id: "old-logical-node",
+        replacement_cleanup_node_record_id: ownerRecordId,
+        replacement_cleanup_node_incarnation: ownerOldIncarnation,
+        replacement_cleanup_node_history_id: ownerOldHistoryId,
+        replacement_cleanup_node_hostname: "owner.internal",
+        replacement_cleanup_node_ssh_port: 22,
+        replacement_cleanup_node_ssh_user: "root",
+        replacement_cleanup_node_host_key_fingerprint: "SHA256:owner-old",
+        replacement_cleanup_container_name: `agent-${cleanupNameId}`,
+        replacement_cleanup_allocation_counted: true,
+        replacement_cleanup_created_at: new Date(),
+      });
+
+      const placements = await loadSandboxStatusesByIds([cleanupNameId]);
+      expect(placements.filter(({ key }) => key === cleanupNameId)).toEqual([
+        {
+          key: cleanupNameId,
+          status: "replacement_cleanup_owned",
+          nodeId: "retired-owner-node",
         },
       ]);
     },

--- a/packages/cloud/shared/src/lib/services/admin-agent-image-rollout.pglite.test.ts
+++ b/packages/cloud/shared/src/lib/services/admin-agent-image-rollout.pglite.test.ts
@@ -351,6 +351,7 @@ beforeEach(async () => {
   await dbWrite.delete(jobs);
   await dbWrite.delete(agentSandboxes);
   await dbWrite.delete(dockerNodes);
+  await dbWrite.delete(agentNodeIncarnationHistories);
   await dbWrite.delete(users);
   await dbWrite.delete(organizations);
 });
@@ -678,6 +679,292 @@ describe("admin agent image rollout on primary PGlite", () => {
     ).toMatchObject({
       replacement_cleanup_sandbox_id: null,
       replacement_cleanup_attempt_id: null,
+    });
+  });
+
+  test("legacy rollout fences stay readable and defer without remote cleanup or decrement", async () => {
+    const seeded = await seedAgents(1);
+    const agentId = seeded.targets[0]!.agentId;
+    await dbWrite
+      .update(agentSandboxes)
+      .set({
+        replacement_cleanup_sandbox_id: "legacy-candidate",
+        replacement_cleanup_node_id: "legacy-node",
+        replacement_cleanup_container_name: "legacy-candidate",
+        replacement_cleanup_attempt_id: REPLACEMENT_ATTEMPT_ID,
+        replacement_cleanup_allocation_counted: true,
+        replacement_cleanup_created_at: new Date("2026-07-23T12:01:00.000Z"),
+      })
+      .where(eq(agentSandboxes.id, agentId));
+
+    const provider = new DockerSandboxProvider();
+    const remoteCleanup = spyOn(provider, "stopOnSpecificNodeForReplacement").mockResolvedValue(
+      undefined,
+    );
+    const service = new ElizaSandboxService(provider as unknown as SandboxProvider);
+
+    await expect(
+      service.convergeReplacementCleanupFence(agentId, seeded.organizationId),
+    ).rejects.toThrow(/lacks exact node occurrence authority/);
+    expect(remoteCleanup).not.toHaveBeenCalled();
+    expect(
+      await agentSandboxesRepository.findByIdAndOrg(agentId, seeded.organizationId),
+    ).toMatchObject({
+      replacement_cleanup_sandbox_id: "legacy-candidate",
+      replacement_cleanup_node_id: "legacy-node",
+      replacement_cleanup_node_record_id: null,
+      replacement_cleanup_allocation_counted: true,
+    });
+  });
+
+  test("post-cutover DB attempt correlation never selects candidate secret cleanup", async () => {
+    const seeded = await seedAgents(1);
+    const agentId = seeded.targets[0]!.agentId;
+    const nodeRecordId = "10000000-0000-4000-8000-000000000001";
+    const nodeIncarnation = "10000000-0000-4000-8000-000000000002";
+    const nodeHistoryId = "10000000-0000-4000-8000-000000000003";
+    await dbWrite.insert(agentNodeIncarnationHistories).values({
+      id: nodeHistoryId,
+      docker_node_record_id: nodeRecordId,
+      node_id: "old-exact-node",
+      node_incarnation: nodeIncarnation,
+      fleet_kind: "robot",
+      infrastructure_provider: "hetzner",
+      provider_server_id: null,
+      host_key_fingerprint: "SHA256:old-exact-node",
+    });
+    await dbWrite.insert(dockerNodes).values({
+      id: nodeRecordId,
+      node_id: "old-exact-node",
+      node_incarnation: nodeIncarnation,
+      current_node_history_id: nodeHistoryId,
+      hostname: "old-exact-node.internal",
+      ssh_port: 2222,
+      ssh_user: "operator",
+      host_key_fingerprint: "SHA256:old-exact-node",
+      fleet_kind: "robot",
+      infrastructure_provider: "hetzner",
+      provider_server_id: null,
+      status: "healthy",
+      enabled: true,
+      capacity: 8,
+      allocated_count: 2,
+    });
+    await dbWrite
+      .update(agentSandboxes)
+      .set({
+        replacement_cleanup_sandbox_id: "old-exact-sandbox",
+        replacement_cleanup_node_id: "old-exact-node",
+        replacement_cleanup_node_record_id: nodeRecordId,
+        replacement_cleanup_node_incarnation: nodeIncarnation,
+        replacement_cleanup_node_history_id: nodeHistoryId,
+        replacement_cleanup_node_hostname: "old-exact-node.internal",
+        replacement_cleanup_node_ssh_port: 2222,
+        replacement_cleanup_node_ssh_user: "operator",
+        replacement_cleanup_node_host_key_fingerprint: "SHA256:old-exact-node",
+        replacement_cleanup_secret_cleanup_version: null,
+        replacement_cleanup_container_name: "old-exact-container",
+        replacement_cleanup_attempt_id: REPLACEMENT_ATTEMPT_ID,
+        replacement_cleanup_allocation_counted: true,
+        replacement_cleanup_created_at: new Date("2026-07-23T12:01:00.000Z"),
+      })
+      .where(eq(agentSandboxes.id, agentId));
+
+    const provider = new DockerSandboxProvider();
+    const remoteCleanup = spyOn(provider, "stopOnSpecificNodeForReplacement").mockResolvedValue(
+      undefined,
+    );
+    const service = new ElizaSandboxService(provider as unknown as SandboxProvider);
+    await service.convergeReplacementCleanupFence(agentId, seeded.organizationId);
+
+    expect(remoteCleanup).toHaveBeenCalledTimes(1);
+    expect(remoteCleanup.mock.calls[0]?.[3]).toMatchObject({
+      nodeRecordId,
+      nodeIncarnation,
+      nodeHistoryId,
+      replacementSecretCleanupVersion: null,
+      replacementAttemptId: null,
+    });
+    expect(
+      (await dbWrite.select().from(dockerNodes).where(eq(dockerNodes.id, nodeRecordId)))[0]
+        ?.allocated_count,
+    ).toBe(1);
+    await service.convergeReplacementCleanupFence(agentId, seeded.organizationId);
+    expect(remoteCleanup).toHaveBeenCalledTimes(1);
+  });
+
+  test("reboot and logical-id reuse retain exact fences without touching new siblings", async () => {
+    const seeded = await seedAgents(2);
+    const rebootAgentId = seeded.targets[0]!.agentId;
+    const reuseAgentId = seeded.targets[1]!.agentId;
+    const rebootRecordId = "20000000-0000-4000-8000-000000000001";
+    const rebootIncarnation = "20000000-0000-4000-8000-000000000002";
+    const rebootHistoryId = "20000000-0000-4000-8000-000000000003";
+    const rebootNextIncarnation = "20000000-0000-4000-8000-000000000004";
+    const rebootNextHistoryId = "20000000-0000-4000-8000-000000000005";
+    const reuseRecordId = "30000000-0000-4000-8000-000000000001";
+    const reuseIncarnation = "30000000-0000-4000-8000-000000000002";
+    const reuseHistoryId = "30000000-0000-4000-8000-000000000003";
+    const siblingRecordId = "30000000-0000-4000-8000-000000000004";
+    const siblingIncarnation = "30000000-0000-4000-8000-000000000005";
+    const siblingHistoryId = "30000000-0000-4000-8000-000000000006";
+    await dbWrite.insert(agentNodeIncarnationHistories).values([
+      {
+        id: rebootHistoryId,
+        docker_node_record_id: rebootRecordId,
+        node_id: "reboot-node",
+        node_incarnation: rebootIncarnation,
+        fleet_kind: "robot",
+        infrastructure_provider: "hetzner",
+        host_key_fingerprint: "SHA256:reboot-node",
+      },
+      {
+        id: rebootNextHistoryId,
+        docker_node_record_id: rebootRecordId,
+        node_id: "reboot-node",
+        node_incarnation: rebootNextIncarnation,
+        fleet_kind: "robot",
+        infrastructure_provider: "hetzner",
+        host_key_fingerprint: "SHA256:reboot-node",
+      },
+      {
+        id: reuseHistoryId,
+        docker_node_record_id: reuseRecordId,
+        node_id: "reuse-node",
+        node_incarnation: reuseIncarnation,
+        fleet_kind: "robot",
+        infrastructure_provider: "hetzner",
+        host_key_fingerprint: "SHA256:reuse-node",
+      },
+      {
+        id: siblingHistoryId,
+        docker_node_record_id: siblingRecordId,
+        node_id: "reuse-node",
+        node_incarnation: siblingIncarnation,
+        fleet_kind: "robot",
+        infrastructure_provider: "hetzner",
+        host_key_fingerprint: "SHA256:reuse-sibling",
+      },
+    ]);
+    await dbWrite.insert(dockerNodes).values([
+      {
+        id: rebootRecordId,
+        node_id: "reboot-node",
+        node_incarnation: rebootIncarnation,
+        current_node_history_id: rebootHistoryId,
+        hostname: "reboot-node.internal",
+        ssh_user: "root",
+        host_key_fingerprint: "SHA256:reboot-node",
+        fleet_kind: "robot",
+        infrastructure_provider: "hetzner",
+        provider_server_id: null,
+        allocated_count: 2,
+      },
+      {
+        id: reuseRecordId,
+        node_id: "reuse-node",
+        node_incarnation: reuseIncarnation,
+        current_node_history_id: reuseHistoryId,
+        hostname: "reuse-node.internal",
+        ssh_user: "root",
+        host_key_fingerprint: "SHA256:reuse-node",
+        fleet_kind: "robot",
+        infrastructure_provider: "hetzner",
+        provider_server_id: null,
+        allocated_count: 3,
+      },
+    ]);
+    const exactCleanup = (
+      nodeId: string,
+      recordId: string,
+      incarnation: string,
+      historyId: string,
+    ) => ({
+      replacement_cleanup_sandbox_id: `${nodeId}-sandbox`,
+      replacement_cleanup_node_id: nodeId,
+      replacement_cleanup_node_record_id: recordId,
+      replacement_cleanup_node_incarnation: incarnation,
+      replacement_cleanup_node_history_id: historyId,
+      replacement_cleanup_node_hostname: `${nodeId}.internal`,
+      replacement_cleanup_node_ssh_port: 22,
+      replacement_cleanup_node_ssh_user: "root",
+      replacement_cleanup_node_host_key_fingerprint: `SHA256:${nodeId}`,
+      replacement_cleanup_secret_cleanup_version: null,
+      replacement_cleanup_container_name: `${nodeId}-container`,
+      replacement_cleanup_attempt_id: null,
+      replacement_cleanup_allocation_counted: true,
+      replacement_cleanup_created_at: new Date("2026-07-23T12:01:00.000Z"),
+    });
+    await dbWrite
+      .update(agentSandboxes)
+      .set(exactCleanup("reboot-node", rebootRecordId, rebootIncarnation, rebootHistoryId))
+      .where(eq(agentSandboxes.id, rebootAgentId));
+    await dbWrite
+      .update(agentSandboxes)
+      .set(exactCleanup("reuse-node", reuseRecordId, reuseIncarnation, reuseHistoryId))
+      .where(eq(agentSandboxes.id, reuseAgentId));
+
+    await dbWrite
+      .update(dockerNodes)
+      .set({
+        node_incarnation: rebootNextIncarnation,
+        current_node_history_id: rebootNextHistoryId,
+      })
+      .where(eq(dockerNodes.id, rebootRecordId));
+    await dbWrite
+      .update(dockerNodes)
+      .set({ node_id: "retired-reuse-node" })
+      .where(eq(dockerNodes.id, reuseRecordId));
+    await dbWrite.insert(dockerNodes).values({
+      id: siblingRecordId,
+      node_id: "reuse-node",
+      node_incarnation: siblingIncarnation,
+      current_node_history_id: siblingHistoryId,
+      hostname: "reuse-sibling.internal",
+      ssh_user: "root",
+      host_key_fingerprint: "SHA256:reuse-sibling",
+      fleet_kind: "robot",
+      infrastructure_provider: "hetzner",
+      provider_server_id: null,
+      allocated_count: 7,
+      capacity: 8,
+    });
+
+    const provider = new DockerSandboxProvider();
+    const remoteCleanup = spyOn(provider, "stopOnSpecificNodeForReplacement").mockResolvedValue(
+      undefined,
+    );
+    const service = new ElizaSandboxService(provider as unknown as SandboxProvider);
+    for (const agentId of [rebootAgentId, reuseAgentId, rebootAgentId, reuseAgentId]) {
+      await expect(
+        service.convergeReplacementCleanupFence(agentId, seeded.organizationId),
+      ).rejects.toThrow(/occurrence is no longer current/);
+    }
+
+    expect(remoteCleanup).not.toHaveBeenCalled();
+    expect(
+      (await dbWrite.select().from(dockerNodes).where(eq(dockerNodes.id, rebootRecordId)))[0]
+        ?.allocated_count,
+    ).toBe(2);
+    expect(
+      (await dbWrite.select().from(dockerNodes).where(eq(dockerNodes.id, reuseRecordId)))[0]
+        ?.allocated_count,
+    ).toBe(3);
+    expect(
+      (await dbWrite.select().from(dockerNodes).where(eq(dockerNodes.id, siblingRecordId)))[0]
+        ?.allocated_count,
+    ).toBe(7);
+    expect(
+      await agentSandboxesRepository.findByIdAndOrg(rebootAgentId, seeded.organizationId),
+    ).toMatchObject({
+      replacement_cleanup_node_incarnation: rebootIncarnation,
+      replacement_cleanup_sandbox_id: "reboot-node-sandbox",
+    });
+    expect(
+      await agentSandboxesRepository.findByIdAndOrg(reuseAgentId, seeded.organizationId),
+    ).toMatchObject({
+      replacement_cleanup_node_record_id: reuseRecordId,
+      replacement_cleanup_sandbox_id: "reuse-node-sandbox",
     });
   });
 

--- a/packages/cloud/shared/src/lib/services/docker-node-capacity-ownership.pglite.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-capacity-ownership.pglite.test.ts
@@ -1,0 +1,465 @@
+/** Real-SQL coverage for restore -> replacement -> sandbox slot reconciliation. */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { PGlite } from "@electric-sql/pglite";
+import { drizzle } from "drizzle-orm/pglite";
+import {
+  countAllocatedWorkloadsOnNodeWithDatabase,
+  countRetainedWorkloadsOnNodeWithDatabase,
+} from "./docker-node-workload-queries";
+
+const NODE_RECORD_ID = "00000000-0000-0000-0000-0000000000d1";
+const OTHER_NODE_RECORD_ID = "00000000-0000-0000-0000-0000000000d2";
+const NODE_INCARNATION = "00000000-0000-0000-0000-0000000000d3";
+const NODE_HISTORY_ID = "00000000-0000-0000-0000-0000000000d4";
+const OTHER_NODE_INCARNATION = "00000000-0000-0000-0000-0000000000d5";
+const OTHER_NODE_HISTORY_ID = "00000000-0000-0000-0000-0000000000d6";
+const ORGANIZATION_ID = "00000000-0000-0000-0000-0000000000e1";
+const AGENT_ID = "00000000-0000-0000-0000-0000000000e2";
+const REPLACEMENT_ATTEMPT_ID = "00000000-0000-0000-0000-0000000000e3";
+const OTHER_ORGANIZATION_ID = "00000000-0000-0000-0000-0000000000e4";
+const OTHER_AGENT_ID = "00000000-0000-0000-0000-0000000000e5";
+const OTHER_REPLACEMENT_ATTEMPT_ID = "00000000-0000-0000-0000-0000000000e6";
+
+let client: PGlite;
+let database: ReturnType<typeof drizzle>;
+
+beforeAll(async () => {
+  client = new PGlite();
+  database = drizzle(client);
+  await client.exec(`
+    CREATE TABLE containers (
+      node_id text,
+      status text NOT NULL,
+      volume_path text,
+      hcloud_volume_id integer,
+      metadata jsonb NOT NULL DEFAULT '{}'::jsonb
+    );
+    CREATE TABLE agent_sandboxes (
+      id uuid,
+      organization_id uuid,
+      node_id text,
+      status text NOT NULL,
+      pool_status text,
+      deletion_allocation_counted boolean,
+      replacement_cleanup_sandbox_id text,
+      replacement_cleanup_node_id text,
+      replacement_cleanup_node_record_id uuid,
+      replacement_cleanup_node_incarnation uuid,
+      replacement_cleanup_node_history_id uuid,
+      replacement_cleanup_container_name text,
+      replacement_cleanup_attempt_id uuid,
+      replacement_cleanup_container_id text,
+      replacement_cleanup_allocation_counted boolean
+    );
+    CREATE TABLE docker_nodes (
+      id uuid PRIMARY KEY,
+      node_id text UNIQUE NOT NULL,
+      node_incarnation uuid,
+      current_node_history_id uuid
+    );
+    CREATE TABLE agent_backup_restore_operations (
+      id uuid PRIMARY KEY,
+      expected_node_record_id uuid,
+      expected_node_id text,
+      expected_node_incarnation uuid,
+      expected_node_history_id uuid,
+      capacity_state text
+    );
+    CREATE TABLE agent_sandbox_replacement_attempts (
+      id uuid PRIMARY KEY,
+      organization_id uuid,
+      agent_id uuid,
+      locator_sandbox_id text,
+      locator_node_record_id uuid,
+      locator_node_id text,
+      locator_node_incarnation uuid,
+      locator_node_history_id uuid,
+      locator_container_name text,
+      locator_container_id text,
+      capacity_state text
+    );
+    INSERT INTO docker_nodes (
+      id, node_id, node_incarnation, current_node_history_id
+    ) VALUES
+      ('${NODE_RECORD_ID}', 'node-a', '${NODE_INCARNATION}', '${NODE_HISTORY_ID}'),
+      ('${OTHER_NODE_RECORD_ID}', 'node-b',
+        '${OTHER_NODE_INCARNATION}', '${OTHER_NODE_HISTORY_ID}');
+  `);
+});
+
+afterAll(async () => {
+  await client.close();
+});
+
+async function resetCapacityFixtures(): Promise<void> {
+  await client.exec(`
+    DELETE FROM containers;
+    DELETE FROM agent_sandboxes;
+    DELETE FROM agent_backup_restore_operations;
+    DELETE FROM agent_sandbox_replacement_attempts;
+    UPDATE docker_nodes
+    SET node_id = CASE
+      WHEN id = '${NODE_RECORD_ID}' THEN 'reset-node-a'
+      ELSE 'reset-node-b'
+    END;
+    UPDATE docker_nodes SET node_id = 'node-a' WHERE id = '${NODE_RECORD_ID}';
+    UPDATE docker_nodes SET node_id = 'node-b' WHERE id = '${OTHER_NODE_RECORD_ID}';
+    UPDATE docker_nodes SET
+      node_incarnation = CASE
+        WHEN id = '${NODE_RECORD_ID}' THEN '${NODE_INCARNATION}'::uuid
+        ELSE '${OTHER_NODE_INCARNATION}'::uuid
+      END,
+      current_node_history_id = CASE
+        WHEN id = '${NODE_RECORD_ID}' THEN '${NODE_HISTORY_ID}'::uuid
+        ELSE '${OTHER_NODE_HISTORY_ID}'::uuid
+      END;
+  `);
+}
+
+beforeEach(async () => {
+  await resetCapacityFixtures();
+});
+
+describe("durable capacity-owner workload reconciliation", () => {
+  test("uses app slot markers as authority with a legacy status fallback", async () => {
+    await client.exec(`
+      INSERT INTO containers (node_id, status, metadata) VALUES
+        ('node-a', 'running', '{}'::jsonb),
+        ('node-a', 'failed', '{"slotClaimedAt":"2026-08-24T00:00:00Z"}'::jsonb),
+        ('node-a', 'running', '{"slotReleasedAt":"2026-08-24T00:01:00Z"}'::jsonb),
+        ('node-a', 'stopped', '{}'::jsonb);
+    `);
+
+    expect(await countAllocatedWorkloadsOnNodeWithDatabase(database, "node-a")).toBe(2);
+  });
+
+  test("retains a failed app while its durable slot claim remains unreleased", async () => {
+    await client.exec(`
+      INSERT INTO containers (node_id, status, volume_path, metadata)
+      VALUES (
+        'node-a', 'failed', NULL,
+        '{"slotClaimedAt":"2026-08-24T00:00:00Z"}'::jsonb
+      );
+    `);
+
+    expect(await countRetainedWorkloadsOnNodeWithDatabase(database, "node-a")).toBe(1);
+
+    await client.exec(`
+      UPDATE containers
+      SET metadata = jsonb_set(
+        metadata, '{slotReleasedAt}', '"2026-08-24T00:01:00Z"'::jsonb
+      );
+    `);
+    expect(await countRetainedWorkloadsOnNodeWithDatabase(database, "node-a")).toBe(0);
+  });
+
+  test("retains terminal agents while durable deletion ownership remains true", async () => {
+    await client.exec(`
+      INSERT INTO agent_sandboxes (
+        node_id, status, pool_status, deletion_allocation_counted
+      ) VALUES
+        ('node-a', 'stopped', NULL, TRUE),
+        ('node-a', 'error', NULL, TRUE),
+        ('node-a', 'stopped', NULL, NULL),
+        ('node-a', 'error', NULL, FALSE);
+    `);
+
+    expect(await countRetainedWorkloadsOnNodeWithDatabase(database, "node-a")).toBe(2);
+  });
+
+  test("retains every app volume_path even after a terminal status", async () => {
+    await client.exec(`
+      INSERT INTO containers (node_id, status, volume_path, hcloud_volume_id) VALUES
+        ('node-a', 'failed', '/data/projects/org/failed', NULL),
+        ('node-a', 'deleted', '/data/projects/org/deleted', NULL),
+        ('node-a', 'failed', '/mnt/hcloud/project', 42),
+        ('node-a', 'failed', NULL, NULL);
+    `);
+
+    expect(await countRetainedWorkloadsOnNodeWithDatabase(database, "node-a")).toBe(3);
+  });
+
+  test("counts exactly one owner through restore, replacement, and sandbox handoffs", async () => {
+    await client.exec(`
+      INSERT INTO agent_backup_restore_operations (
+        id, expected_node_record_id, expected_node_id, capacity_state
+      ) VALUES (
+        '00000000-0000-0000-0000-000000000101', '${NODE_RECORD_ID}', 'node-a', 'reserved'
+      );
+    `);
+    expect(await countAllocatedWorkloadsOnNodeWithDatabase(database, "node-a")).toBe(1);
+    expect(await countRetainedWorkloadsOnNodeWithDatabase(database, "node-a")).toBe(1);
+
+    await client.transaction(async (tx) => {
+      await tx.exec(`
+        UPDATE agent_backup_restore_operations SET capacity_state = 'handed_off';
+        INSERT INTO agent_sandbox_replacement_attempts (
+          id, locator_node_record_id, locator_node_id, capacity_state
+        ) VALUES (
+          '00000000-0000-0000-0000-000000000102', '${NODE_RECORD_ID}', 'node-a', 'reserved'
+        );
+      `);
+    });
+    expect(await countAllocatedWorkloadsOnNodeWithDatabase(database, "node-a")).toBe(1);
+    expect(await countRetainedWorkloadsOnNodeWithDatabase(database, "node-a")).toBe(1);
+
+    await client.transaction(async (tx) => {
+      await tx.exec(`
+        UPDATE agent_sandbox_replacement_attempts SET capacity_state = 'handed_off';
+        INSERT INTO agent_sandboxes (
+          node_id, status, deletion_allocation_counted,
+          replacement_cleanup_node_id, replacement_cleanup_allocation_counted
+        ) VALUES ('node-a', 'running', NULL, NULL, NULL);
+      `);
+    });
+    expect(await countAllocatedWorkloadsOnNodeWithDatabase(database, "node-a")).toBe(1);
+    expect(await countRetainedWorkloadsOnNodeWithDatabase(database, "node-a")).toBe(1);
+  });
+
+  test("released and handed-off ledger rows do not duplicate a sandbox", async () => {
+    await client.exec(`
+      INSERT INTO agent_backup_restore_operations (
+        id, expected_node_record_id, expected_node_id, capacity_state
+      ) VALUES (
+        '00000000-0000-0000-0000-000000000103', '${NODE_RECORD_ID}', 'node-a', 'handed_off'
+      );
+      INSERT INTO agent_sandbox_replacement_attempts (
+        id, locator_node_record_id, locator_node_id, capacity_state
+      ) VALUES (
+        '00000000-0000-0000-0000-000000000104', '${NODE_RECORD_ID}', 'node-a', 'released'
+      );
+      INSERT INTO agent_sandboxes (
+        node_id, status, deletion_allocation_counted,
+        replacement_cleanup_node_id, replacement_cleanup_allocation_counted
+      ) VALUES ('node-a', 'running', NULL, NULL, NULL);
+    `);
+    expect(await countAllocatedWorkloadsOnNodeWithDatabase(database, "node-a")).toBe(1);
+    expect(await countRetainedWorkloadsOnNodeWithDatabase(database, "node-a")).toBe(1);
+    await client.exec(`DELETE FROM agent_sandboxes;`);
+    expect(await countAllocatedWorkloadsOnNodeWithDatabase(database, "node-a")).toBe(0);
+    expect(await countRetainedWorkloadsOnNodeWithDatabase(database, "node-a")).toBe(0);
+  });
+
+  test("keeps a reserved owner across reboot but not logical-id reuse", async () => {
+    await client.exec(`
+      INSERT INTO agent_backup_restore_operations (
+        id, expected_node_record_id, expected_node_id, capacity_state
+      ) VALUES (
+        '00000000-0000-0000-0000-000000000105', '${NODE_RECORD_ID}', 'node-a', 'reserved'
+      );
+      UPDATE docker_nodes
+      SET node_incarnation = '00000000-0000-0000-0000-000000000201',
+          current_node_history_id = '00000000-0000-0000-0000-000000000202'
+      WHERE id = '${NODE_RECORD_ID}';
+    `);
+    expect(await countAllocatedWorkloadsOnNodeWithDatabase(database, "node-a")).toBe(1);
+    expect(await countRetainedWorkloadsOnNodeWithDatabase(database, "node-a")).toBe(1);
+
+    await client.exec(`
+      UPDATE docker_nodes SET node_id = 'retired-node-a' WHERE id = '${NODE_RECORD_ID}';
+      UPDATE docker_nodes SET node_id = 'node-a' WHERE id = '${OTHER_NODE_RECORD_ID}';
+    `);
+    expect(await countAllocatedWorkloadsOnNodeWithDatabase(database, "node-a")).toBe(0);
+    expect(await countRetainedWorkloadsOnNodeWithDatabase(database, "node-a")).toBe(0);
+    expect(await countAllocatedWorkloadsOnNodeWithDatabase(database, "retired-node-a")).toBe(1);
+    expect(await countRetainedWorkloadsOnNodeWithDatabase(database, "retired-node-a")).toBe(1);
+  });
+
+  test("retains stale cleanup on the same record without charging a reused logical id", async () => {
+    await client.exec(`
+      INSERT INTO agent_sandboxes (
+        id, organization_id, status,
+        replacement_cleanup_sandbox_id, replacement_cleanup_node_id,
+        replacement_cleanup_node_record_id, replacement_cleanup_node_incarnation,
+        replacement_cleanup_node_history_id, replacement_cleanup_container_name,
+        replacement_cleanup_allocation_counted
+      ) VALUES (
+        '${AGENT_ID}', '${ORGANIZATION_ID}', 'stopped',
+        'agent-old', 'node-a', '${NODE_RECORD_ID}', '${NODE_INCARNATION}',
+        '${NODE_HISTORY_ID}', 'agent-old', TRUE
+      );
+    `);
+    expect(await countAllocatedWorkloadsOnNodeWithDatabase(database, "node-a")).toBe(1);
+    expect(await countRetainedWorkloadsOnNodeWithDatabase(database, "node-a")).toBe(1);
+
+    await client.exec(`
+      UPDATE docker_nodes
+      SET node_incarnation = '00000000-0000-0000-0000-000000000301',
+          current_node_history_id = '00000000-0000-0000-0000-000000000302'
+      WHERE id = '${NODE_RECORD_ID}';
+    `);
+    expect(await countAllocatedWorkloadsOnNodeWithDatabase(database, "node-a")).toBe(1);
+    expect(await countRetainedWorkloadsOnNodeWithDatabase(database, "node-a")).toBe(1);
+
+    await client.exec(`
+      UPDATE docker_nodes SET node_id = 'retired-node-a' WHERE id = '${NODE_RECORD_ID}';
+      UPDATE docker_nodes SET node_id = 'node-a' WHERE id = '${OTHER_NODE_RECORD_ID}';
+    `);
+    expect(await countAllocatedWorkloadsOnNodeWithDatabase(database, "node-a")).toBe(0);
+    expect(await countRetainedWorkloadsOnNodeWithDatabase(database, "node-a")).toBe(0);
+    expect(await countAllocatedWorkloadsOnNodeWithDatabase(database, "retired-node-a")).toBe(1);
+    expect(await countRetainedWorkloadsOnNodeWithDatabase(database, "retired-node-a")).toBe(1);
+  });
+
+  test("keeps a legacy logical-only cleanup conservatively counted during rollout", async () => {
+    await client.exec(`
+      INSERT INTO agent_sandboxes (
+        id, organization_id, status,
+        replacement_cleanup_sandbox_id, replacement_cleanup_node_id,
+        replacement_cleanup_container_name, replacement_cleanup_allocation_counted
+      ) VALUES (
+        '${AGENT_ID}', '${ORGANIZATION_ID}', 'stopped',
+        'legacy-old', 'node-a', 'legacy-old', TRUE
+      );
+    `);
+    expect(await countAllocatedWorkloadsOnNodeWithDatabase(database, "node-a")).toBe(1);
+    expect(await countRetainedWorkloadsOnNodeWithDatabase(database, "node-a")).toBe(1);
+
+    await client.exec(`
+      UPDATE docker_nodes SET node_id = 'retired-node-a' WHERE id = '${NODE_RECORD_ID}';
+      UPDATE docker_nodes SET node_id = 'node-a' WHERE id = '${OTHER_NODE_RECORD_ID}';
+    `);
+    expect(await countAllocatedWorkloadsOnNodeWithDatabase(database, "node-a")).toBe(1);
+    expect(await countRetainedWorkloadsOnNodeWithDatabase(database, "node-a")).toBe(1);
+  });
+
+  test("deduplicates an exact cleanup locator covered by its reserved attempt", async () => {
+    await client.exec(`
+      INSERT INTO agent_sandboxes (
+        id, organization_id, status,
+        replacement_cleanup_sandbox_id, replacement_cleanup_node_id,
+        replacement_cleanup_node_record_id, replacement_cleanup_node_incarnation,
+        replacement_cleanup_node_history_id,
+        replacement_cleanup_container_name, replacement_cleanup_attempt_id,
+        replacement_cleanup_container_id, replacement_cleanup_allocation_counted
+      ) VALUES (
+        '${AGENT_ID}', '${ORGANIZATION_ID}', 'stopped',
+        'agent-candidate', 'node-a', '${NODE_RECORD_ID}', '${NODE_INCARNATION}',
+        '${NODE_HISTORY_ID}', 'agent-candidate', '${REPLACEMENT_ATTEMPT_ID}',
+        NULL, TRUE
+      );
+      INSERT INTO agent_sandbox_replacement_attempts (
+        id, organization_id, agent_id, locator_sandbox_id,
+        locator_node_record_id, locator_node_id, locator_node_incarnation,
+        locator_node_history_id, locator_container_name,
+        locator_container_id, capacity_state
+      ) VALUES (
+        '${REPLACEMENT_ATTEMPT_ID}', '${ORGANIZATION_ID}', '${AGENT_ID}',
+        'agent-candidate', '${NODE_RECORD_ID}', 'node-a', '${NODE_INCARNATION}',
+        '${NODE_HISTORY_ID}', 'agent-candidate',
+        'abcdef123456', 'reserved'
+      );
+    `);
+
+    expect(await countAllocatedWorkloadsOnNodeWithDatabase(database, "node-a")).toBe(1);
+    expect(await countRetainedWorkloadsOnNodeWithDatabase(database, "node-a")).toBe(1);
+
+    await client.exec(`
+      UPDATE docker_nodes
+      SET node_incarnation = '${OTHER_NODE_INCARNATION}',
+          current_node_history_id = '${OTHER_NODE_HISTORY_ID}'
+      WHERE id = '${NODE_RECORD_ID}';
+    `);
+    expect(await countAllocatedWorkloadsOnNodeWithDatabase(database, "node-a")).toBe(1);
+    expect(await countRetainedWorkloadsOnNodeWithDatabase(database, "node-a")).toBe(1);
+  });
+
+  test("does not deduplicate a different attempt, tenant, or agent owner", async () => {
+    await client.exec(`
+      INSERT INTO agent_sandboxes (
+        id, organization_id, status,
+        replacement_cleanup_sandbox_id, replacement_cleanup_node_id,
+        replacement_cleanup_node_record_id, replacement_cleanup_node_incarnation,
+        replacement_cleanup_node_history_id,
+        replacement_cleanup_container_name, replacement_cleanup_attempt_id,
+        replacement_cleanup_container_id, replacement_cleanup_allocation_counted
+      ) VALUES (
+        '${AGENT_ID}', '${ORGANIZATION_ID}', 'stopped',
+        'agent-candidate', 'node-a', '${NODE_RECORD_ID}', '${NODE_INCARNATION}',
+        '${NODE_HISTORY_ID}', 'agent-candidate', '${REPLACEMENT_ATTEMPT_ID}',
+        NULL, TRUE
+      );
+      INSERT INTO agent_sandbox_replacement_attempts (
+        id, organization_id, agent_id, locator_sandbox_id,
+        locator_node_record_id, locator_node_id, locator_node_incarnation,
+        locator_node_history_id, locator_container_name,
+        locator_container_id, capacity_state
+      ) VALUES (
+        '${REPLACEMENT_ATTEMPT_ID}', '${ORGANIZATION_ID}', '${AGENT_ID}',
+        'agent-candidate', '${NODE_RECORD_ID}', 'node-a', '${NODE_INCARNATION}',
+        '${NODE_HISTORY_ID}', 'agent-candidate',
+        'abcdef123456', 'reserved'
+      );
+    `);
+
+    await client.exec(`
+      UPDATE agent_sandboxes
+      SET replacement_cleanup_attempt_id = '${OTHER_REPLACEMENT_ATTEMPT_ID}';
+    `);
+    expect(await countAllocatedWorkloadsOnNodeWithDatabase(database, "node-a")).toBe(2);
+    expect(await countRetainedWorkloadsOnNodeWithDatabase(database, "node-a")).toBe(2);
+
+    await client.exec(`
+      UPDATE agent_sandboxes
+      SET replacement_cleanup_attempt_id = '${REPLACEMENT_ATTEMPT_ID}',
+          organization_id = '${OTHER_ORGANIZATION_ID}';
+    `);
+    expect(await countAllocatedWorkloadsOnNodeWithDatabase(database, "node-a")).toBe(2);
+    expect(await countRetainedWorkloadsOnNodeWithDatabase(database, "node-a")).toBe(2);
+
+    await client.exec(`
+      UPDATE agent_sandboxes
+      SET organization_id = '${ORGANIZATION_ID}', id = '${OTHER_AGENT_ID}';
+    `);
+    expect(await countAllocatedWorkloadsOnNodeWithDatabase(database, "node-a")).toBe(2);
+    expect(await countRetainedWorkloadsOnNodeWithDatabase(database, "node-a")).toBe(2);
+  });
+
+  test("counts distinct cleanup and reserved-attempt placements separately", async () => {
+    await client.exec(`
+      INSERT INTO agent_sandboxes (
+        id, organization_id, status,
+        replacement_cleanup_sandbox_id, replacement_cleanup_node_id,
+        replacement_cleanup_node_record_id, replacement_cleanup_node_incarnation,
+        replacement_cleanup_node_history_id,
+        replacement_cleanup_container_name, replacement_cleanup_attempt_id,
+        replacement_cleanup_container_id, replacement_cleanup_allocation_counted
+      ) VALUES (
+        '${AGENT_ID}', '${ORGANIZATION_ID}', 'stopped',
+        'agent-old', 'node-a', '${NODE_RECORD_ID}', '${NODE_INCARNATION}',
+        '${NODE_HISTORY_ID}', 'agent-old', '${REPLACEMENT_ATTEMPT_ID}',
+        '111111111111', TRUE
+      );
+      INSERT INTO agent_sandbox_replacement_attempts (
+        id, organization_id, agent_id, locator_sandbox_id,
+        locator_node_record_id, locator_node_id, locator_node_incarnation,
+        locator_node_history_id, locator_container_name,
+        locator_container_id, capacity_state
+      ) VALUES (
+        '${REPLACEMENT_ATTEMPT_ID}', '${ORGANIZATION_ID}', '${AGENT_ID}',
+        'agent-candidate', '${NODE_RECORD_ID}', 'node-a', '${NODE_INCARNATION}',
+        '${NODE_HISTORY_ID}', 'agent-candidate',
+        '222222222222', 'reserved'
+      );
+    `);
+
+    expect(await countAllocatedWorkloadsOnNodeWithDatabase(database, "node-a")).toBe(2);
+    expect(await countRetainedWorkloadsOnNodeWithDatabase(database, "node-a")).toBe(2);
+
+    await client.exec(`
+      UPDATE agent_sandboxes
+      SET replacement_cleanup_sandbox_id = 'agent-candidate',
+          replacement_cleanup_container_name = 'agent-candidate',
+          replacement_cleanup_container_id = '222222222222';
+      UPDATE agent_sandbox_replacement_attempts
+      SET locator_node_record_id = '${OTHER_NODE_RECORD_ID}', locator_node_id = 'node-b',
+          locator_node_incarnation = '${OTHER_NODE_INCARNATION}',
+          locator_node_history_id = '${OTHER_NODE_HISTORY_ID}';
+    `);
+    expect(await countAllocatedWorkloadsOnNodeWithDatabase(database, "node-a")).toBe(1);
+    expect(await countRetainedWorkloadsOnNodeWithDatabase(database, "node-a")).toBe(1);
+    expect(await countAllocatedWorkloadsOnNodeWithDatabase(database, "node-b")).toBe(1);
+    expect(await countRetainedWorkloadsOnNodeWithDatabase(database, "node-b")).toBe(1);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/docker-node-manager.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-manager.ts
@@ -27,7 +27,10 @@ import {
   attestHetznerCloudNode,
   isTypedHetznerCloudNode,
 } from "./containers/hetzner-node-attestation";
-import { countAllocatedWorkloadsOnNode } from "./docker-node-workloads";
+import {
+  countAllocatedWorkloadsOnNode,
+  reconcileAllocatedWorkloadsOnNode,
+} from "./docker-node-workloads";
 import {
   dockerPlatformFlag,
   inferNodeArchitectureFromMetadata,
@@ -1353,17 +1356,12 @@ export class DockerNodeManager {
     const changes = new Map<string, { before: number; after: number }>();
 
     for (const node of nodes) {
-      const actualCount = await countAllocatedWorkloadsOnNode(node.node_id);
-
-      if (actualCount !== node.allocated_count) {
+      const reconciled = await reconcileAllocatedWorkloadsOnNode(node.node_id);
+      if (reconciled && reconciled.before !== reconciled.after) {
         logger.info(
-          `[docker-node-manager] Sync ${node.node_id}: allocated_count ${node.allocated_count} → ${actualCount}`,
+          `[docker-node-manager] Sync ${node.node_id}: allocated_count ${reconciled.before} → ${reconciled.after}`,
         );
-        await dockerNodesRepository.setAllocatedCount(node.node_id, actualCount);
-        changes.set(node.node_id, {
-          before: node.allocated_count,
-          after: actualCount,
-        });
+        changes.set(node.node_id, reconciled);
       }
     }
 

--- a/packages/cloud/shared/src/lib/services/docker-node-workload-queries.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-workload-queries.ts
@@ -3,10 +3,13 @@
  * reconciliation and isolated Postgres integration tests execute the same query.
  */
 
-import { and, eq, sql } from "drizzle-orm";
+import { sql } from "drizzle-orm";
 import type { dbRead } from "../../db/helpers";
+import { agentBackupRestoreOperations } from "../../db/schemas/agent-backup-catalog";
+import { agentSandboxReplacementAttempts } from "../../db/schemas/agent-sandbox-replacement-attempts";
 import { agentSandboxes } from "../../db/schemas/agent-sandboxes";
 import { containers } from "../../db/schemas/containers";
+import { dockerNodes } from "../../db/schemas/docker-nodes";
 
 /** Sandbox states that no longer consume a live Docker slot. */
 export const TERMINAL_SANDBOX_STATUSES = [
@@ -67,62 +70,191 @@ export function holdsCountedNodeSlot(row: { status: string; node_id: string | nu
   return !TERMINAL_SANDBOX_STATUS_SET.has(row.status);
 }
 
-type WorkloadCountDatabase = Pick<typeof dbRead, "select">;
+type WorkloadCountDatabase = Pick<typeof dbRead, "execute">;
 
-/** Counts live app and agent rows assigned to one Docker node. */
+/**
+ * Counts every live or reserved slot in one database snapshot.
+ *
+ * A restore->replacement->sandbox handoff changes two authorities in one
+ * transaction. Separate SELECTs under READ COMMITTED could observe opposite
+ * sides of that commit and derive either zero or two owners. Scalar subqueries
+ * inside this single statement all share one snapshot, so each atomic handoff
+ * contributes exactly one slot. Reserved owners join the immutable node-record
+ * id as well as logical node id, but deliberately remain counted across an
+ * incarnation change: reboot invalidates the remote target, not the retained
+ * slot, and cleanup must settle that authority before capacity is reusable.
+ * App-container slot markers outrank lifecycle status: a durable claim remains
+ * counted until its durable release, while rows created before those markers
+ * retain the historical status fallback.
+ */
 export async function countAllocatedWorkloadsOnNodeWithDatabase(
   database: WorkloadCountDatabase,
   nodeId: string,
 ): Promise<number> {
-  const [[containerRow], [agentRow], [replacementRow]] = await Promise.all([
-    database
-      .select({ count: sql<number>`count(*)::int` })
-      .from(containers)
-      .where(
-        and(
-          eq(containers.node_id, nodeId),
-          sql`${containers.status} not in ('failed','stopped','deleted')`,
-        ),
-      ),
-    database
-      .select({ count: sql<number>`count(*)::int` })
-      .from(agentSandboxes)
-      .where(
-        and(
-          eq(agentSandboxes.node_id, nodeId),
-          // Recorded allocation ownership outranks status. Once a deletion
-          // generation has handed its slot back the row stops consuming
-          // capacity immediately, even though it can linger in a deletion
-          // status until final row cleanup; conversely a `deletion_failed` row
-          // that still owns its slot genuinely occupies one, which a
-          // status-only rule counted as free (#17185).
-          //
-          // NULL keeps the pre-ownership behaviour byte for byte: rows with no
-          // deletion intent never had ownership recorded, and neither did
-          // deletion intents that predate the column — both fall through to the
-          // terminal-status rule rather than being guessed either way.
-          sql`(
+  const result = await database.execute<{ count: number | string }>(sql`
+    SELECT (
+      (SELECT count(*) FROM ${containers}
+        WHERE ${containers.node_id} = ${nodeId}
+          AND NOT jsonb_exists(
+            COALESCE(${containers.metadata}, '{}'::jsonb), 'slotReleasedAt'
+          )
+          AND (
+            jsonb_exists(COALESCE(${containers.metadata}, '{}'::jsonb), 'slotClaimedAt')
+            OR ${containers.status} NOT IN ('failed', 'stopped', 'deleted')
+          ))
+      + (SELECT count(*) FROM ${agentSandboxes}
+        WHERE ${agentSandboxes.node_id} = ${nodeId}
+          AND (
             ${agentSandboxes.deletion_allocation_counted} IS TRUE
             OR (
               ${agentSandboxes.deletion_allocation_counted} IS NULL
-              AND ${agentSandboxes.status} not in (${sql.join(
+              AND ${agentSandboxes.status} NOT IN (${sql.join(
                 TERMINAL_SANDBOX_STATUSES.map((status) => sql`${status}`),
                 sql`, `,
               )})
             )
-          )`,
-        ),
-      ),
-    database
-      .select({ count: sql<number>`count(*)::int` })
-      .from(agentSandboxes)
-      .where(
-        and(
-          eq(agentSandboxes.replacement_cleanup_node_id, nodeId),
-          eq(agentSandboxes.replacement_cleanup_allocation_counted, true),
-        ),
-      ),
-  ]);
+          ))
+      + (SELECT count(*) FROM ${agentSandboxes} AS cleanup
+        WHERE cleanup."replacement_cleanup_allocation_counted" IS TRUE
+          AND (
+            (cleanup."replacement_cleanup_node_record_id" IS NULL
+              AND cleanup."replacement_cleanup_node_id" = ${nodeId})
+            OR (cleanup."replacement_cleanup_node_record_id" IS NOT NULL AND EXISTS (
+              SELECT 1 FROM ${dockerNodes} AS cleanup_node
+              WHERE cleanup_node."id" = cleanup."replacement_cleanup_node_record_id"
+                AND cleanup_node."node_id" = ${nodeId}
+            ))
+          )
+          AND NOT EXISTS (
+            SELECT 1
+            FROM ${agentSandboxReplacementAttempts} AS reserved_attempt
+            WHERE reserved_attempt."capacity_state" = 'reserved'
+              AND reserved_attempt."id"
+                = cleanup."replacement_cleanup_attempt_id"
+              AND reserved_attempt."organization_id" = cleanup."organization_id"
+              AND reserved_attempt."agent_id" = cleanup."id"
+              AND reserved_attempt."locator_sandbox_id"
+                = cleanup."replacement_cleanup_sandbox_id"
+              AND reserved_attempt."locator_node_id"
+                = cleanup."replacement_cleanup_node_id"
+              AND reserved_attempt."locator_node_record_id"
+                = cleanup."replacement_cleanup_node_record_id"
+              AND reserved_attempt."locator_node_incarnation"
+                = cleanup."replacement_cleanup_node_incarnation"
+              AND reserved_attempt."locator_node_history_id"
+                = cleanup."replacement_cleanup_node_history_id"
+              AND reserved_attempt."locator_container_name"
+                = cleanup."replacement_cleanup_container_name"
+          ))
+      + (SELECT count(*)
+        FROM ${agentBackupRestoreOperations}
+        INNER JOIN ${dockerNodes}
+          ON ${dockerNodes.id} = ${agentBackupRestoreOperations.expected_node_record_id}
+        WHERE ${dockerNodes.node_id} = ${nodeId}
+          AND ${agentBackupRestoreOperations.capacity_state} = 'reserved')
+      + (SELECT count(*)
+        FROM ${agentSandboxReplacementAttempts}
+        INNER JOIN ${dockerNodes}
+          ON ${dockerNodes.id} = ${agentSandboxReplacementAttempts.locator_node_record_id}
+        WHERE ${dockerNodes.node_id} = ${nodeId}
+          AND ${agentSandboxReplacementAttempts.capacity_state} = 'reserved')
+    )::int AS count
+  `);
+  const row = result.rows[0];
+  const count = Number(row?.count);
+  if (!Number.isSafeInteger(count) || count < 0) {
+    throw new Error("Docker-node workload count query returned an invalid aggregate");
+  }
+  return count;
+}
 
-  return containerRow.count + agentRow.count + replacementRow.count;
+/**
+ * Counts live, retained, and reserved owners that make a node unsafe to drain.
+ * Durable app and agent slot ownership outranks a terminal lifecycle status:
+ * drain must not destroy a node until the corresponding release is recorded.
+ * Any app container with volume_path set pins its host regardless of lifecycle
+ * status. This is the autoscaler contract even when external-volume metadata is
+ * also present.
+ */
+export async function countRetainedWorkloadsOnNodeWithDatabase(
+  database: WorkloadCountDatabase,
+  nodeId: string,
+): Promise<number> {
+  const result = await database.execute<{ count: number | string }>(sql`
+    SELECT (
+      (SELECT count(*) FROM ${containers}
+        WHERE ${containers.node_id} = ${nodeId}
+          AND (
+            ${containers.status} NOT IN ('failed', 'deleted')
+            OR ${containers.volume_path} IS NOT NULL
+            OR (
+              NOT jsonb_exists(
+                COALESCE(${containers.metadata}, '{}'::jsonb), 'slotReleasedAt'
+              )
+              AND jsonb_exists(
+                COALESCE(${containers.metadata}, '{}'::jsonb), 'slotClaimedAt'
+              )
+            )
+          ))
+      + (SELECT count(*) FROM ${agentSandboxes}
+        WHERE ${agentSandboxes.node_id} = ${nodeId}
+          AND (
+            ${agentSandboxes.deletion_allocation_counted} IS TRUE
+            OR (
+              ${agentSandboxes.status} NOT IN ('stopped', 'error')
+              AND (${agentSandboxes.pool_status} IS NULL
+                OR ${agentSandboxes.pool_status} <> 'unclaimed')
+            )
+          ))
+      + (SELECT count(*) FROM ${agentSandboxes} AS cleanup
+        WHERE (
+            (cleanup."replacement_cleanup_node_record_id" IS NULL
+              AND cleanup."replacement_cleanup_node_id" = ${nodeId})
+            OR (cleanup."replacement_cleanup_node_record_id" IS NOT NULL AND EXISTS (
+              SELECT 1 FROM ${dockerNodes} AS cleanup_node
+              WHERE cleanup_node."id" = cleanup."replacement_cleanup_node_record_id"
+                AND cleanup_node."node_id" = ${nodeId}
+            ))
+          )
+          AND NOT EXISTS (
+            SELECT 1
+            FROM ${agentSandboxReplacementAttempts} AS reserved_attempt
+            WHERE reserved_attempt."capacity_state" = 'reserved'
+              AND reserved_attempt."id"
+                = cleanup."replacement_cleanup_attempt_id"
+              AND reserved_attempt."organization_id" = cleanup."organization_id"
+              AND reserved_attempt."agent_id" = cleanup."id"
+              AND reserved_attempt."locator_sandbox_id"
+                = cleanup."replacement_cleanup_sandbox_id"
+              AND reserved_attempt."locator_node_id"
+                = cleanup."replacement_cleanup_node_id"
+              AND reserved_attempt."locator_node_record_id"
+                = cleanup."replacement_cleanup_node_record_id"
+              AND reserved_attempt."locator_node_incarnation"
+                = cleanup."replacement_cleanup_node_incarnation"
+              AND reserved_attempt."locator_node_history_id"
+                = cleanup."replacement_cleanup_node_history_id"
+              AND reserved_attempt."locator_container_name"
+                = cleanup."replacement_cleanup_container_name"
+          ))
+      + (SELECT count(*)
+        FROM ${agentBackupRestoreOperations}
+        INNER JOIN ${dockerNodes}
+          ON ${dockerNodes.id} = ${agentBackupRestoreOperations.expected_node_record_id}
+        WHERE ${dockerNodes.node_id} = ${nodeId}
+          AND ${agentBackupRestoreOperations.capacity_state} = 'reserved')
+      + (SELECT count(*)
+        FROM ${agentSandboxReplacementAttempts}
+        INNER JOIN ${dockerNodes}
+          ON ${dockerNodes.id} = ${agentSandboxReplacementAttempts.locator_node_record_id}
+        WHERE ${dockerNodes.node_id} = ${nodeId}
+          AND ${agentSandboxReplacementAttempts.capacity_state} = 'reserved')
+    )::int AS count
+  `);
+  const row = result.rows[0];
+  const count = Number(row?.count);
+  if (!Number.isSafeInteger(count) || count < 0) {
+    throw new Error("Docker-node retained workload query returned an invalid aggregate");
+  }
+  return count;
 }

--- a/packages/cloud/shared/src/lib/services/docker-node-workloads.count.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-workloads.count.test.ts
@@ -3,32 +3,35 @@
  * agent sandbox rows must not inflate allocated_count, or the autoscaler reads
  * bare-metal robots as full and bills new Hetzner-cloud nodes instead (#15378).
  */
-// These suites mock `db/helpers` with a partial `dbWrite` (no `execute`), so the
-// self-healing DDL guard cannot run here. Skipping it is the house pattern for
-// mocked-database suites; the guard itself is covered by the PGlite tests.
-const PRIOR_SKIP_ENSURE = process.env.SKIP_AGENT_SANDBOX_ENSURE;
-process.env.SKIP_AGENT_SANDBOX_ENSURE = "1";
-
-import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import type { SQL } from "drizzle-orm";
 import { PgDialect } from "drizzle-orm/pg-core";
 
-const capturedWheres: SQL[] = [];
+const capturedQueries: SQL[] = [];
+const capturedPrimaryQueries: SQL[] = [];
 
-// dbRead.select().from().where(clause) captures each clause and resolves to a
-// single count row, so the query builder runs end-to-end without a live DB.
-const where = mock((clause: SQL) => {
-  capturedWheres.push(clause);
-  return [{ count: 1 }];
+// Production uses one statement so every handoff is observed in one snapshot.
+const execute = mock((query: SQL) => {
+  capturedQueries.push(query);
+  return { rows: [{ count: 5 }] };
 });
-const from = mock(() => ({ where }));
-const select = mock(() => ({ from }));
+const primaryExecute = mock((query: SQL) => {
+  capturedPrimaryQueries.push(query);
+  return { rows: [{ count: 6 }] };
+});
+const primaryTransaction = mock(async (_callback: unknown) => null);
 
 // Replace the whole helpers module: dbRead captures the query, the rest are
 // stubs so every static import in the transitive chain still resolves.
 mock.module("../../db/helpers", () => ({
-  dbRead: { select },
-  dbWrite: { update: mock(() => ({ set: mock(() => ({ where: mock(() => []) })) })) },
+  dbRead: { execute },
+  dbWrite: {
+    execute: primaryExecute,
+    transaction: primaryTransaction,
+    update: mock(() => ({ set: mock(() => ({ where: mock(() => []) })) })),
+  },
   useReadDb: mock(),
   useWriteDb: mock(),
   readQuery: mock(),
@@ -40,29 +43,32 @@ mock.module("../../db/helpers", () => ({
   getDbRoutingInfo: mock(() => ({})),
 }));
 
-const { countAllocatedWorkloadsOnNode } = await import("./docker-node-workloads");
+const {
+  countAllocatedWorkloadsOnNode,
+  countRetainedWorkloadsOnNode,
+  reconcileAllocatedWorkloadsOnNode,
+} = await import("./docker-node-workloads");
 
-function renderParams(clause: SQL): string[] {
-  const { params } = new PgDialect().sqlToQuery(clause);
-  return params.map((p) => String(p));
+function renderQuery(query: SQL): { sql: string; params: string[] } {
+  const rendered = new PgDialect().sqlToQuery(query);
+  return { sql: rendered.sql, params: rendered.params.map((param) => String(param)) };
 }
 
 describe("countAllocatedWorkloadsOnNode — live-slot accounting (#15378)", () => {
   beforeEach(() => {
-    capturedWheres.length = 0;
-    where.mockClear();
+    capturedQueries.length = 0;
+    capturedPrimaryQueries.length = 0;
+    execute.mockClear();
+    primaryExecute.mockClear();
+    primaryTransaction.mockReset();
+    primaryTransaction.mockImplementation(async () => null);
   });
 
   test("the agent_sandboxes filter recognizes every terminal status before ownership override", async () => {
     await countAllocatedWorkloadsOnNode("node-under-test");
 
-    // Two queries run (containers + agent_sandboxes); the agent one is the
-    // clause whose params carry the sandbox terminal-status vocab.
-    const agentParams = capturedWheres
-      .map(renderParams)
-      .find((params) => params.includes("sleeping"));
+    const agentParams = renderQuery(capturedQueries[0]!).params;
 
-    expect(agentParams).toBeDefined();
     // Regression: the status vocabulary previously omitted sleeping and
     // deletion_failed. The query's ownership branch may still count a terminal
     // deletion row when its container has not been proven stopped.
@@ -75,25 +81,130 @@ describe("countAllocatedWorkloadsOnNode — live-slot accounting (#15378)", () =
     expect(agentParams).not.toContain("running");
   });
 
-  test("sums container + agent counts (one row each here) into total live slots", async () => {
+  test("derives every owner class in one database statement", async () => {
     const total = await countAllocatedWorkloadsOnNode("node-under-test");
-    expect(where).toHaveBeenCalledTimes(3);
-    expect(total).toBe(3);
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(total).toBe(5);
   });
 
-  test("counts a durable replacement reservation as its own live slot", async () => {
+  test("uses durable app slot markers before the legacy status fallback", async () => {
+    await countAllocatedWorkloadsOnNode("node-under-test");
+
+    const rendered = renderQuery(capturedQueries[0]!).sql;
+    expect(rendered).toContain("slotClaimedAt");
+    expect(rendered).toContain("slotReleasedAt");
+    expect(rendered).toContain("jsonb_exists");
+  });
+
+  test("counts only reserved restore and replacement ledger owners", async () => {
     await countAllocatedWorkloadsOnNode("replacement-node");
 
-    const rendered = capturedWheres.map(renderParams);
-    expect(rendered.filter((params) => params.includes("replacement-node"))).toHaveLength(3);
-    expect(rendered.some((params) => params.includes("true"))).toBe(true);
+    const rendered = renderQuery(capturedQueries[0]!);
+    expect(rendered.params.filter((param) => param === "replacement-node")).toHaveLength(6);
+    expect(rendered.sql).toContain('"agent_backup_restore_operations"');
+    expect(rendered.sql).toContain('"agent_sandbox_replacement_attempts"');
+    // Two owner subqueries count reserved ledgers; the cleanup subquery also
+    // checks for an exact reserved replacement attempt so it cannot double-count
+    // the same physical placement during the handoff window.
+    expect(rendered.sql.match(/capacity_state/g)).toHaveLength(3);
+    expect(rendered.sql.match(/= 'reserved'/g)).toHaveLength(3);
+    expect(rendered.sql).not.toContain("handed_off");
+    expect(rendered.sql).not.toContain("released");
   });
-});
 
-// bun shares one process across files without --isolate, so an unrestored env
-// override here would silently disable the ensure guard for whatever suite runs
-// next. Restore exactly what was there before.
-afterAll(() => {
-  if (PRIOR_SKIP_ENSURE === undefined) delete process.env.SKIP_AGENT_SANDBOX_ENSURE;
-  else process.env.SKIP_AGENT_SANDBOX_ENSURE = PRIOR_SKIP_ENSURE;
+  test("fails closed once when migration 0315 ownership columns are missing", async () => {
+    const driverError = Object.assign(new Error('column "capacity_state" does not exist'), {
+      code: "42703",
+    });
+    const missingColumn = new Error("Failed query", { cause: driverError });
+    execute.mockImplementationOnce(() => {
+      throw missingColumn;
+    });
+
+    await expect(countAllocatedWorkloadsOnNode("pre-0315-node")).rejects.toMatchObject({
+      code: "DOCKER_NODE_CAPACITY_OWNERSHIP_MIGRATION_REQUIRED",
+      context: {
+        nodeId: "pre-0315-node",
+        migration: "0315_agent_restore_capacity_ownership",
+      },
+      cause: missingColumn,
+    });
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(primaryExecute).not.toHaveBeenCalled();
+  });
+
+  test("reads retained and reserved owners from the primary", async () => {
+    const total = await countRetainedWorkloadsOnNode("draining-node");
+
+    expect(total).toBe(6);
+    expect(primaryExecute).toHaveBeenCalledTimes(1);
+    expect(execute).not.toHaveBeenCalled();
+    const rendered = renderQuery(capturedPrimaryQueries[0]!).sql;
+    expect(rendered).toContain('"containers"."volume_path" IS NOT NULL');
+    expect(rendered).not.toContain('"containers"."hcloud_volume_id"');
+    expect(rendered).toContain("slotClaimedAt");
+    expect(rendered).toContain("slotReleasedAt");
+    expect(rendered).toContain('"agent_sandboxes"."deletion_allocation_counted" IS TRUE');
+  });
+
+  test("fails a pre-0315 retained count closed on the primary without retrying", async () => {
+    const missingColumn = Object.assign(new Error('column "capacity_state" does not exist'), {
+      code: "42703",
+    });
+    primaryExecute.mockImplementationOnce(() => {
+      throw missingColumn;
+    });
+
+    await expect(countRetainedWorkloadsOnNode("pre-0315-drain-node")).rejects.toMatchObject({
+      code: "DOCKER_NODE_CAPACITY_OWNERSHIP_MIGRATION_REQUIRED",
+      context: {
+        nodeId: "pre-0315-drain-node",
+        migration: "0315_agent_restore_capacity_ownership",
+      },
+      cause: missingColumn,
+    });
+    expect(primaryExecute).toHaveBeenCalledTimes(1);
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  test("fails reconciliation closed with the typed migration error", async () => {
+    const missingColumn = Object.assign(new Error('column "capacity_state" does not exist'), {
+      code: "42703",
+    });
+    primaryTransaction.mockImplementationOnce(async () => {
+      throw missingColumn;
+    });
+
+    await expect(reconcileAllocatedWorkloadsOnNode("pre-0315-sync-node")).rejects.toMatchObject({
+      code: "DOCKER_NODE_CAPACITY_OWNERSHIP_MIGRATION_REQUIRED",
+      context: {
+        nodeId: "pre-0315-sync-node",
+        migration: "0315_agent_restore_capacity_ownership",
+      },
+      cause: missingColumn,
+    });
+    expect(primaryTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  test("sync performs the recount and write under the node-locking helper", () => {
+    const managerSource = readFileSync(join(import.meta.dir, "docker-node-manager.ts"), "utf8");
+    const workloadsSource = readFileSync(join(import.meta.dir, "docker-node-workloads.ts"), "utf8");
+    const syncSource = managerSource.slice(
+      managerSource.indexOf("async syncAllocatedCounts"),
+      managerSource.indexOf("async prePullAgentImageOnAvailableNodes"),
+    );
+    const reconcileSource = workloadsSource.slice(
+      workloadsSource.indexOf("export async function reconcileAllocatedWorkloadsOnNode"),
+      workloadsSource.indexOf(
+        "// ---------------------------------------------------------------------------",
+      ),
+    );
+    expect(syncSource).toContain("await reconcileAllocatedWorkloadsOnNode(node.node_id)");
+    expect(syncSource).not.toContain("countAllocatedWorkloadsOnNode(node.node_id)");
+    expect(syncSource).not.toContain("setAllocatedCount");
+    expect(reconcileSource.indexOf('.for("update")')).toBeGreaterThanOrEqual(0);
+    expect(reconcileSource.indexOf('.for("update")')).toBeLessThan(
+      reconcileSource.indexOf("countAllocatedWorkloadsOnNodeWithDatabase(tx, nodeId)"),
+    );
+  });
 });

--- a/packages/cloud/shared/src/lib/services/docker-node-workloads.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-workloads.ts
@@ -6,14 +6,13 @@
  */
 import { ElizaError } from "@elizaos/core";
 import { and, eq, inArray, or, sql } from "drizzle-orm";
-import { ensureAgentSandboxSchema } from "../../db/ensure-agent-sandbox-schema";
 import { dbRead, dbWrite } from "../../db/helpers";
 import { agentSandboxesRepository } from "../../db/repositories/agent-sandboxes";
 import { agentSandboxes } from "../../db/schemas/agent-sandboxes";
-import { containers } from "../../db/schemas/containers";
-import { logger } from "../utils/logger";
+import { dockerNodes } from "../../db/schemas/docker-nodes";
 import {
   countAllocatedWorkloadsOnNodeWithDatabase,
+  countRetainedWorkloadsOnNodeWithDatabase,
   TERMINAL_SANDBOX_STATUS_SET,
   TERMINAL_SANDBOX_STATUSES,
 } from "./docker-node-workload-queries";
@@ -29,24 +28,35 @@ import {
 
 export type { OrphanReconcileResult } from "./orphan-container-reconciler";
 
-async function countRows(query: Promise<Array<{ count: number }>>): Promise<number> {
-  const [row] = await query;
-  if (!row) {
-    throw new ElizaError("Workload count query returned no aggregate row", {
-      code: "DOCKER_NODE_WORKLOAD_COUNT_MISSING",
-    });
-  }
-  return row.count;
-}
-
 /** Postgres `undefined_column` — the shape a pre-migration read takes. */
 const UNDEFINED_COLUMN = "42703";
+const CAPACITY_OWNERSHIP_MIGRATION = "0315_agent_restore_capacity_ownership";
 
 function isUndefinedColumn(error: unknown): boolean {
-  return (
-    typeof error === "object" &&
-    error !== null &&
-    (error as { code?: unknown }).code === UNDEFINED_COLUMN
+  const seen = new Set<object>();
+  let current = error;
+  for (let depth = 0; depth < 8; depth += 1) {
+    if (typeof current !== "object" || current === null || seen.has(current)) return false;
+    seen.add(current);
+    try {
+      const candidate = current as { cause?: unknown; code?: unknown };
+      if (candidate.code === UNDEFINED_COLUMN) return true;
+      current = candidate.cause;
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}
+
+function capacityOwnershipMigrationRequired(nodeId: string, cause: unknown): ElizaError {
+  return new ElizaError(
+    "Docker-node capacity ownership migration is required before workload accounting can run",
+    {
+      code: "DOCKER_NODE_CAPACITY_OWNERSHIP_MIGRATION_REQUIRED",
+      context: { nodeId, migration: CAPACITY_OWNERSHIP_MIGRATION },
+      cause,
+    },
   );
 }
 
@@ -71,51 +81,71 @@ function isUndefinedColumn(error: unknown): boolean {
  * container is up but unreachable) and still occupies the slot.
  */
 export async function countAllocatedWorkloadsOnNode(nodeId: string): Promise<number> {
-  // Repair-on-failure rather than prophylactic DDL. This is the placement hot
-  // path (`getAvailableNode`, the autoscaler, `syncAllocatedCounts`, each once
-  // per node per sweep) and it reads ownership columns added after the base
-  // table, which the provisioning worker can reach before its migration has run
-  // — its deploy has no `migrate-db` gate.
-  //
-  // Calling ensure up front would guard that, but at a cost the guard does not
-  // justify: it puts a ~15-statement ALTER/CREATE block on every placement, and
-  // `ensureAgentSandboxSchema` rethrows AND drops its memo on failure, so one
-  // transient DDL failure would fail placement for every agent — a strictly
-  // wider blast radius than the missing column it protects against.
-  //
-  // Instead the query runs unguarded, and only an actual `undefined_column`
-  // triggers the self-heal and one retry. The happy path pays nothing, the
-  // pre-migration path still recovers, and a DDL failure surfaces on a request
-  // that was already failing rather than taking down placement wholesale.
+  // Migration 0315 introduces the two durable capacity-owner ledgers read by
+  // this placement hot path. `ensureAgentSandboxSchema` deliberately converges
+  // only the older agent-sandbox compatibility surface; it cannot add those
+  // ledger columns. Omitting either ledger would undercount reserved slots, so
+  // a pre-0315 database must fail closed and wait for db:migrate rather than
+  // retrying the same impossible query or falling back to legacy owners.
   try {
     return await countAllocatedWorkloadsOnNodeWithDatabase(dbRead, nodeId);
   } catch (error) {
-    // error-policy:J2 context-adding rethrow — only the known pre-migration
-    // shape is repairable; every other database failure keeps its cause and the
-    // node whose placement count could not be established.
-    if (!isUndefinedColumn(error)) {
-      throw new ElizaError("Failed to count allocated workloads on Docker node", {
-        code: "DOCKER_NODE_WORKLOAD_COUNT_FAILED",
-        context: { nodeId },
-        cause: error,
-      });
-    }
-    logger.warn(
-      "[docker-node-workloads] Workload count hit a missing column; applying agent-sandbox schema ensure and retrying once",
-      { nodeId },
-    );
-    try {
-      await ensureAgentSandboxSchema();
-      return await countAllocatedWorkloadsOnNodeWithDatabase(dbRead, nodeId);
-    } catch (retryError) {
-      // error-policy:J2 context-adding rethrow — a failed repair must distinguish
-      // the recovery path from an ordinary placement query failure.
-      throw new ElizaError("Failed to repair the Docker workload-count schema", {
-        code: "DOCKER_NODE_WORKLOAD_SCHEMA_REPAIR_FAILED",
-        context: { nodeId },
-        cause: retryError,
-      });
-    }
+    // error-policy:J2 context-adding rethrow — distinguish migration drift from
+    // ordinary query failures while preserving the original SQLSTATE cause.
+    if (isUndefinedColumn(error)) throw capacityOwnershipMigrationRequired(nodeId, error);
+    throw new ElizaError("Failed to count allocated workloads on Docker node", {
+      code: "DOCKER_NODE_WORKLOAD_COUNT_FAILED",
+      context: { nodeId },
+      cause: error,
+    });
+  }
+}
+
+/**
+ * Recompute and persist one node's slot count under the same primary row lock
+ * used by every reservation/release transition. This closes the count->write
+ * race where an older replica snapshot could overwrite a just-committed slot.
+ */
+export async function reconcileAllocatedWorkloadsOnNode(
+  nodeId: string,
+): Promise<{ before: number; after: number } | null> {
+  try {
+    return await dbWrite.transaction(async (tx) => {
+      const [node] = await tx
+        .select()
+        .from(dockerNodes)
+        .where(eq(dockerNodes.node_id, nodeId))
+        .for("update")
+        .limit(1);
+      if (!node) return null;
+
+      const actualCount = await countAllocatedWorkloadsOnNodeWithDatabase(tx, nodeId);
+      if (actualCount !== node.allocated_count) {
+        const [updated] = await tx
+          .update(dockerNodes)
+          .set({ allocated_count: actualCount, updated_at: new Date() })
+          .where(
+            and(
+              eq(dockerNodes.id, node.id),
+              sql`${dockerNodes.node_incarnation} IS NOT DISTINCT FROM ${node.node_incarnation}`,
+              sql`${dockerNodes.current_node_history_id} IS NOT DISTINCT FROM ${
+                node.current_node_history_id
+              }`,
+            ),
+          )
+          .returning({ id: dockerNodes.id });
+        if (!updated) {
+          throw new ElizaError("Docker-node allocation reconciliation lost its node CAS", {
+            code: "DOCKER_NODE_ALLOCATION_RECONCILE_CONFLICT",
+            context: { nodeId },
+          });
+        }
+      }
+      return { before: node.allocated_count, after: actualCount };
+    });
+  } catch (error) {
+    if (isUndefinedColumn(error)) throw capacityOwnershipMigrationRequired(nodeId, error);
+    throw error;
   }
 }
 
@@ -178,7 +208,14 @@ export async function loadSandboxStatusesByIds(
       containerName: agentSandboxes.container_name,
       status: agentSandboxes.status,
       nodeId: agentSandboxes.node_id,
-      replacementNodeId: agentSandboxes.replacement_cleanup_node_id,
+      replacementNodeId: sql<string | null>`CASE
+        WHEN ${agentSandboxes.replacement_cleanup_node_record_id} IS NULL
+          THEN ${agentSandboxes.replacement_cleanup_node_id}
+        ELSE (
+          SELECT cleanup_node."node_id" FROM ${dockerNodes} AS cleanup_node
+          WHERE cleanup_node."id" = ${agentSandboxes.replacement_cleanup_node_record_id}
+        )
+      END`,
       replacementContainerName: agentSandboxes.replacement_cleanup_container_name,
     })
     .from(agentSandboxes)
@@ -269,37 +306,12 @@ export function reconcileOrphanContainersOnNodes(): Promise<OrphanReconcileResul
  * recreate them elsewhere — so they do NOT count as retained.
  */
 export async function countRetainedWorkloadsOnNode(nodeId: string): Promise<number> {
-  const [containerCount, agentCount, replacementCount] = await Promise.all([
-    countRows(
-      dbRead
-        .select({ count: sql<number>`count(*)::int` })
-        .from(containers)
-        .where(
-          and(
-            eq(containers.node_id, nodeId),
-            sql`${containers.status} not in ('failed','deleted')`,
-          ),
-        ),
-    ),
-    countRows(
-      dbRead
-        .select({ count: sql<number>`count(*)::int` })
-        .from(agentSandboxes)
-        .where(
-          and(
-            eq(agentSandboxes.node_id, nodeId),
-            sql`${agentSandboxes.status} not in ('stopped','error')`,
-            sql`(${agentSandboxes.pool_status} is null or ${agentSandboxes.pool_status} <> 'unclaimed')`,
-          ),
-        ),
-    ),
-    countRows(
-      dbRead
-        .select({ count: sql<number>`count(*)::int` })
-        .from(agentSandboxes)
-        .where(eq(agentSandboxes.replacement_cleanup_node_id, nodeId)),
-    ),
-  ]);
-
-  return containerCount + agentCount + replacementCount;
+  // Drain/deprovision is destructive, so replica lag must not hide a retained
+  // or freshly reserved owner. Read every owner from the primary.
+  try {
+    return await countRetainedWorkloadsOnNodeWithDatabase(dbWrite, nodeId);
+  } catch (error) {
+    if (isUndefinedColumn(error)) throw capacityOwnershipMigrationRequired(nodeId, error);
+    throw error;
+  }
 }

--- a/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
+++ b/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
@@ -124,6 +124,8 @@ export interface DockerSandboxMetadata {
   hostname: string;
   /** Exact DB record + SSH authority used by replacement cleanup. */
   nodeRecordId?: string;
+  nodeIncarnation?: string;
+  nodeHistoryId?: string;
   nodeSshPort?: number;
   nodeSshUser?: string;
   nodeHostKeyFingerprint?: string;
@@ -207,11 +209,8 @@ const REPLACEMENT_ATTEMPT_LABEL = "ai.elizaos.replacement-attempt";
 const REPLACEMENT_VPN_SETTLE_OBSERVATIONS = 4;
 const REPLACEMENT_VPN_SETTLE_INTERVAL_MS = 750;
 const REPLACEMENT_VPN_CLOCK_SKEW_ALLOWANCE_MS = 30_000;
-// Converge window for an id-verified container whose attempt label drifted
-// from the fence record (#18032): the immutable Docker id plus a matching
-// deterministic name identify the fenced target beyond doubt, but a young
-// container is still retained in case a concurrent lifecycle op is mid-write.
-const REPLACEMENT_LABEL_MISMATCH_RETIRE_GRACE_MS = 60 * 60 * 1000;
+const REMOTE_NODE_BOOT_ID_PATH = "/proc/sys/kernel/random/boot_id";
+const REPLACEMENT_REMOTE_BOOT_FENCE_EXIT_CODE = 78;
 
 class ReplacementPlacementPersistenceError extends Error {
   constructor(cause: unknown) {
@@ -278,6 +277,8 @@ function replacementCleanupLocatorFromHandle(
     nodeId: metadata.nodeId,
     containerName: metadata.containerName,
     nodeRecordId: optionalLocatorString(metadata.nodeRecordId),
+    nodeIncarnation: optionalLocatorString(metadata.nodeIncarnation),
+    nodeHistoryId: optionalLocatorString(metadata.nodeHistoryId),
     nodeHostname: optionalLocatorString(metadata.hostname),
     nodeSshPort: optionalLocatorNumber(metadata.nodeSshPort),
     nodeSshUser: optionalLocatorString(metadata.nodeSshUser),
@@ -303,6 +304,28 @@ function dockerContainerIdsMatch(expected: string, actual: string): boolean {
 
 function isCanonicalDockerContainerId(value: unknown): value is string {
   return typeof value === "string" && /^[a-f0-9]{12,64}$/.test(value);
+}
+
+/** Full Docker object identity persisted when a serving generation is published. */
+function isCanonicalPublishedDockerContainerId(value: unknown): value is string {
+  return typeof value === "string" && /^[a-f0-9]{64}$/.test(value);
+}
+
+/**
+ * Keeps the remote boot-id comparison and the destructive mutation inside one
+ * shell invocation. A successful earlier probe is not sufficient: the host can
+ * reboot between stop and rm, so every mutation carries its own occurrence
+ * fence.
+ */
+function buildReplacementCleanupBootFencedCommand(
+  expectedNodeIncarnation: string,
+  destructiveCommand: string,
+): string {
+  return [
+    `observed_boot_id=$(cat ${shellQuote(REMOTE_NODE_BOOT_ID_PATH)} 2>/dev/null) || { printf '%s\\n' 'ELIZA_REPLACEMENT_BOOT_ID_UNREADABLE' >&2; exit ${REPLACEMENT_REMOTE_BOOT_FENCE_EXIT_CODE}; }`,
+    `if [ "$observed_boot_id" != ${shellQuote(expectedNodeIncarnation)} ]; then printf '%s\\n' 'ELIZA_REPLACEMENT_BOOT_ID_MISMATCH' >&2; exit ${REPLACEMENT_REMOTE_BOOT_FENCE_EXIT_CODE}; fi`,
+    destructiveCommand,
+  ].join("; ");
 }
 
 function isCanonicalReplacementLocatorCore(
@@ -335,6 +358,22 @@ function isCanonicalReplacementLocatorCore(
   );
 }
 
+function isCanonicalExactNodeAuthority(locator: SandboxReplacementCleanupLocator): boolean {
+  return (
+    isCanonicalNodeAuthorityUuid(locator.nodeRecordId) &&
+    isCanonicalNodeAuthorityUuid(locator.nodeIncarnation) &&
+    isCanonicalNodeAuthorityUuid(locator.nodeHistoryId) &&
+    Boolean(locator.nodeHostname?.trim()) &&
+    typeof locator.nodeSshPort === "number" &&
+    Number.isSafeInteger(locator.nodeSshPort) &&
+    locator.nodeSshPort >= 1 &&
+    locator.nodeSshPort <= 65_535 &&
+    Boolean(locator.nodeSshUser?.trim()) &&
+    Boolean(locator.nodeHostKeyFingerprint?.trim()) &&
+    locator.allocationCounted === true
+  );
+}
+
 function isCanonicalExactReplacementLocator(
   locator: SandboxReplacementCleanupLocator,
   expected?: { readonly containerName?: string; readonly replacementAttemptId?: string },
@@ -353,19 +392,27 @@ function isCanonicalExactReplacementLocator(
     /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/.test(
       locator.replacementAttemptId ?? "",
     ) &&
-    isCanonicalNodeAuthorityUuid(locator.nodeRecordId) &&
-    Boolean(locator.nodeHostname?.trim()) &&
-    typeof locator.nodeSshPort === "number" &&
-    Number.isSafeInteger(locator.nodeSshPort) &&
-    locator.nodeSshPort >= 1 &&
-    locator.nodeSshPort <= 65_535 &&
-    Boolean(locator.nodeSshUser?.trim()) &&
-    Boolean(locator.nodeHostKeyFingerprint?.trim()) &&
+    isCanonicalExactNodeAuthority(locator) &&
     locator.replacementSecretCleanupVersion === 1 &&
-    locator.allocationCounted === true &&
     (previousVpnNodeId === null || hasVpnRegistrationPair) &&
     (vpnNodeId === null ||
       (containerId !== null && hasVpnRegistrationPair && vpnNodeId !== previousVpnNodeId))
+  );
+}
+
+function isCanonicalExactPrimaryCleanupLocator(locator: SandboxReplacementCleanupLocator): boolean {
+  return (
+    isCanonicalExactNodeAuthority(locator) &&
+    locator.sandboxId === locator.containerName &&
+    isCanonicalReplacementContainerName(locator.containerName) &&
+    locator.nodeId.trim().length > 0 &&
+    locator.replacementSecretCleanupVersion == null &&
+    locator.replacementAttemptId == null &&
+    isCanonicalPublishedDockerContainerId(locator.containerId) &&
+    locator.vpnNodeName == null &&
+    locator.previousVpnNodeId == null &&
+    locator.vpnRegistrationStartedAt == null &&
+    (locator.vpnNodeId == null || isCanonicalHeadscaleNodeId(locator.vpnNodeId))
   );
 }
 
@@ -1620,6 +1667,8 @@ export class DockerSandboxProvider implements SandboxProvider {
       "replacementAttemptId",
       "allocationCounted",
       "nodeRecordId",
+      "nodeIncarnation",
+      "nodeHistoryId",
       "nodeHostname",
       "nodeSshPort",
       "nodeSshUser",
@@ -2062,6 +2111,8 @@ export class DockerSandboxProvider implements SandboxProvider {
     const nodePlacementMetadata = dbNode
       ? {
           nodeRecordId: dbNode.id,
+          nodeIncarnation: dbNode.node_incarnation ?? undefined,
+          nodeHistoryId: dbNode.current_node_history_id ?? undefined,
           nodeSshPort: sshPort,
           nodeSshUser: sshUser,
           nodeHostKeyFingerprint: hostKeyFingerprint,
@@ -3115,6 +3166,8 @@ export class DockerSandboxProvider implements SandboxProvider {
   ): Promise<DockerNodeConnection> {
     const exactAuthorityValues = [
       locator.nodeRecordId,
+      locator.nodeIncarnation,
+      locator.nodeHistoryId,
       locator.nodeHostname,
       locator.nodeSshPort,
       locator.nodeSshUser,
@@ -3125,22 +3178,24 @@ export class DockerSandboxProvider implements SandboxProvider {
       (value) => value !== undefined && value !== null,
     );
     if (!hasAnyExactAuthority) {
-      const legacyNode = await dockerNodesRepository.findByNodeId(locator.nodeId);
-      if (!legacyNode) {
-        throw new ElizaError(`[docker-sandbox] Node ${locator.nodeId} is not registered`, {
-          code: "SANDBOX_REPLACEMENT_NODE_NOT_REGISTERED",
-          context: { nodeId: locator.nodeId, containerName: locator.containerName },
-          severity: "fatal",
-        });
-      }
-      return legacyNode;
+      throw new ElizaError("Replacement cleanup requires exact node occurrence authority", {
+        code: "SANDBOX_REPLACEMENT_NODE_AUTHORITY_INVALID",
+        context: { nodeId: locator.nodeId, nodeRecordId: null },
+        severity: "fatal",
+      });
     }
 
-    assertSandboxReplacementAttemptId(locator.replacementAttemptId);
-
     const nodeRecordId = locator.nodeRecordId;
+    // Secret cleanup is an explicit protocol version, not an inference from a
+    // DB-only handoff correlation id retained by the control plane.
+    const candidateCleanup = locator.replacementSecretCleanupVersion === 1;
+    if (candidateCleanup) {
+      assertSandboxReplacementAttemptId(locator.replacementAttemptId);
+    }
     if (
-      !isCanonicalExactReplacementLocator(locator) ||
+      !(candidateCleanup
+        ? isCanonicalExactReplacementLocator(locator)
+        : isCanonicalExactPrimaryCleanupLocator(locator)) ||
       !isCanonicalNodeAuthorityUuid(nodeRecordId)
     ) {
       throw new ElizaError("Exact replacement cleanup node authority is incomplete", {
@@ -3159,7 +3214,10 @@ export class DockerSandboxProvider implements SandboxProvider {
       });
     }
     const drifted = [
+      ["nodeRecordId", node.id, locator.nodeRecordId],
       ["nodeId", node.node_id, locator.nodeId],
+      ["nodeIncarnation", node.node_incarnation, locator.nodeIncarnation],
+      ["nodeHistoryId", node.current_node_history_id, locator.nodeHistoryId],
       ["nodeHostname", node.hostname, locator.nodeHostname],
       ["nodeSshPort", node.ssh_port, locator.nodeSshPort],
       ["nodeSshUser", node.ssh_user, locator.nodeSshUser],
@@ -3179,24 +3237,61 @@ export class DockerSandboxProvider implements SandboxProvider {
     return node;
   }
 
+  private async assertReplacementCleanupRemoteNodeIncarnation(
+    ssh: DockerSSHClient,
+    expectedNodeIncarnation: string,
+  ): Promise<void> {
+    let observedNodeIncarnation: string;
+    try {
+      observedNodeIncarnation = (
+        await ssh.exec(`cat ${shellQuote(REMOTE_NODE_BOOT_ID_PATH)}`, DOCKER_CMD_TIMEOUT_MS)
+      ).trim();
+    } catch (cause) {
+      throw new ElizaError("Replacement cleanup could not read the remote node boot ID", {
+        code: "SANDBOX_REPLACEMENT_REMOTE_NODE_INCARNATION_UNRESOLVED",
+        context: { expectedNodeIncarnation },
+        cause,
+        severity: "fatal",
+      });
+    }
+    if (observedNodeIncarnation !== expectedNodeIncarnation) {
+      throw new ElizaError("Replacement cleanup remote node occurrence changed", {
+        code: "SANDBOX_REPLACEMENT_REMOTE_NODE_INCARNATION_MISMATCH",
+        context: {
+          expectedNodeIncarnation,
+          observedNodeIncarnation: observedNodeIncarnation || null,
+        },
+        severity: "fatal",
+      });
+    }
+  }
+
   private async stopOnSpecificNodeWithPolicy(
     node: DockerNodeConnection,
     containerName: string,
     gracefulSeconds: number,
     allowUnreachableAbandon: boolean,
     releaseCapacity: boolean,
+    expectedNodeIncarnation?: string,
+    exactCleanupSsh?: DockerSSHClient,
   ): Promise<void> {
-    const ssh = DockerSSHClient.getClient(
-      node.hostname,
-      node.ssh_port ?? DEFAULT_SSH_PORT,
-      node.host_key_fingerprint ?? undefined,
-      node.ssh_user ?? DEFAULT_SSH_USERNAME,
-    );
+    const ssh =
+      exactCleanupSsh ??
+      DockerSSHClient.getClient(
+        node.hostname,
+        node.ssh_port ?? DEFAULT_SSH_PORT,
+        node.host_key_fingerprint ?? undefined,
+        node.ssh_user ?? DEFAULT_SSH_USERNAME,
+      );
+    const fenceMutation = (command: string): string =>
+      expectedNodeIncarnation
+        ? buildReplacementCleanupBootFencedCommand(expectedNodeIncarnation, command)
+        : command;
     let stopErr: unknown;
     let rmErr: unknown;
     try {
       await ssh.exec(
-        `docker stop -t ${gracefulSeconds} ${shellQuote(containerName)}`,
+        fenceMutation(`docker stop -t ${gracefulSeconds} ${shellQuote(containerName)}`),
         DOCKER_CMD_TIMEOUT_MS,
       );
     } catch (err) {
@@ -3209,7 +3304,10 @@ export class DockerSandboxProvider implements SandboxProvider {
       }
     }
     try {
-      await ssh.exec(`docker rm -f ${shellQuote(containerName)}`, DOCKER_CMD_TIMEOUT_MS);
+      await ssh.exec(
+        fenceMutation(`docker rm -f ${shellQuote(containerName)}`),
+        DOCKER_CMD_TIMEOUT_MS,
+      );
     } catch (err) {
       rmErr = err;
       const msg = err instanceof Error ? err.message : String(err);
@@ -3264,25 +3362,30 @@ export class DockerSandboxProvider implements SandboxProvider {
     try {
       let observedCandidateId: string | null = null;
       let dockerCreateQuiescent = false;
-      let exactCleanupSsh: DockerSSHClient | null = null;
+      const exactCleanupSsh = DockerSSHClient.getClient(
+        node.hostname,
+        node.ssh_port ?? DEFAULT_SSH_PORT,
+        node.host_key_fingerprint ?? undefined,
+        node.ssh_user ?? DEFAULT_SSH_USERNAME,
+      );
+      await this.assertReplacementCleanupRemoteNodeIncarnation(
+        exactCleanupSsh,
+        locator.nodeIncarnation!,
+      );
       if (locator.replacementSecretCleanupVersion === 1 && locator.replacementAttemptId) {
-        const ssh = DockerSSHClient.getClient(
-          node.hostname,
-          node.ssh_port ?? DEFAULT_SSH_PORT,
-          node.host_key_fingerprint ?? undefined,
-          node.ssh_user ?? DEFAULT_SSH_USERNAME,
-        );
-        exactCleanupSsh = ssh;
         // Tombstone first, under the same remote flock used by both plaintext
         // producers. The receipt proves the attempt cannot start again and its
         // plaintext files are absent. It intentionally does NOT claim that an
         // already-submitted Docker daemon request cannot materialize later;
         // id-less absence settles only with a quiescent producer marker or a
         // durable exact candidate observation from an earlier cleanup pass.
-        const cleanupReceipt = await ssh.exec(
-          buildReplacementSecretArtifactsCleanupCommand(
-            locator.containerName,
-            locator.replacementAttemptId,
+        const cleanupReceipt = await exactCleanupSsh.exec(
+          buildReplacementCleanupBootFencedCommand(
+            locator.nodeIncarnation!,
+            buildReplacementSecretArtifactsCleanupCommand(
+              locator.containerName,
+              locator.replacementAttemptId,
+            ),
           ),
           DOCKER_CMD_TIMEOUT_MS,
         );
@@ -3357,12 +3460,14 @@ export class DockerSandboxProvider implements SandboxProvider {
           );
         }
       }
-      const cleanupTarget = locator.replacementAttemptId
-        ? await this.resolveReplacementContainerForCleanup(locator, node, {
-            observedCandidateId,
-            dockerCreateQuiescent,
-          })
-        : locator.containerName;
+      const cleanupTarget = await this.resolveReplacementContainerForCleanup(
+        locator,
+        exactCleanupSsh,
+        {
+          observedCandidateId,
+          dockerCreateQuiescent,
+        },
+      );
       if (cleanupTarget) {
         if (
           locator.replacementSecretCleanupVersion === 1 &&
@@ -3370,22 +3475,11 @@ export class DockerSandboxProvider implements SandboxProvider {
           !locator.containerId &&
           !observedCandidateId
         ) {
-          if (!exactCleanupSsh) {
-            throw new ElizaError(
-              `[docker-sandbox] Exact replacement cleanup SSH authority is unavailable for ${locator.containerName}`,
-              {
-                code: "SANDBOX_REPLACEMENT_CLEANUP_SSH_AUTHORITY_UNAVAILABLE",
-                context: {
-                  nodeId: locator.nodeId,
-                  containerName: locator.containerName,
-                  replacementAttemptId: locator.replacementAttemptId,
-                },
-                severity: "fatal",
-              },
-            );
-          }
           const observationReceipt = await exactCleanupSsh.exec(
-            buildReplacementCandidateObservedCommand(locator.replacementAttemptId, cleanupTarget),
+            buildReplacementCleanupBootFencedCommand(
+              locator.nodeIncarnation!,
+              buildReplacementCandidateObservedCommand(locator.replacementAttemptId, cleanupTarget),
+            ),
             DOCKER_CMD_TIMEOUT_MS,
           );
           const expectedObservationReceipt = getReplacementCandidateObservedReceipt(
@@ -3407,7 +3501,15 @@ export class DockerSandboxProvider implements SandboxProvider {
             );
           }
         }
-        await this.stopOnSpecificNodeWithPolicy(node, cleanupTarget, 10, false, false);
+        await this.stopOnSpecificNodeWithPolicy(
+          node,
+          cleanupTarget,
+          10,
+          false,
+          false,
+          locator.nodeIncarnation!,
+          exactCleanupSsh,
+        );
       }
       if (locator.vpnNodeId) {
         if (!isCanonicalHeadscaleNodeId(locator.vpnNodeId)) {
@@ -3423,6 +3525,10 @@ export class DockerSandboxProvider implements SandboxProvider {
             },
           );
         }
+        await this.assertReplacementCleanupRemoteNodeIncarnation(
+          exactCleanupSsh,
+          locator.nodeIncarnation!,
+        );
         await withTimeout(
           headscaleClient.deleteNode(locator.vpnNodeId),
           HEADSCALE_CLEANUP_TIMEOUT_MS,
@@ -3480,18 +3586,12 @@ export class DockerSandboxProvider implements SandboxProvider {
 
   private async resolveReplacementContainerForCleanup(
     locator: SandboxReplacementCleanupLocator,
-    node: DockerNodeConnection,
+    ssh: DockerSSHClient,
     remoteProof: {
       observedCandidateId: string | null;
       dockerCreateQuiescent: boolean;
     },
   ): Promise<string | null> {
-    const ssh = DockerSSHClient.getClient(
-      node.hostname,
-      node.ssh_port ?? DEFAULT_SSH_PORT,
-      node.host_key_fingerprint ?? undefined,
-      node.ssh_user ?? DEFAULT_SSH_USERNAME,
-    );
     const format = `{{.Id}}|{{index .Config.Labels "${REPLACEMENT_ATTEMPT_LABEL}"}}|{{.Name}}|{{.Created}}`;
     // When Docker returned the create id before a later phase failed, inspect
     // that immutable object directly. A same-name replacement can never make
@@ -3550,8 +3650,6 @@ export class DockerSandboxProvider implements SandboxProvider {
     }
     const containerId = fields[0]!.trim();
     const attemptId = fields[1]!.trim();
-    const observedName = fields[2]!.trim().replace(/^\//, "");
-    const observedCreatedAt = Date.parse(fields[3]!.trim());
     if (!/^[a-f0-9]{12,64}$/i.test(containerId)) {
       throw new Error(
         `[docker-sandbox] Cannot verify replacement identity for ${locator.containerName}: invalid Docker id`,
@@ -3574,74 +3672,29 @@ export class DockerSandboxProvider implements SandboxProvider {
         },
       );
     }
-    if (attemptId !== locator.replacementAttemptId) {
-      if (locator.replacementSecretCleanupVersion === 1) {
-        throw new ElizaError(
-          `[docker-sandbox] Exact replacement attempt label mismatch for ${locator.containerName}`,
-          {
-            code: "SANDBOX_REPLACEMENT_EXACT_ATTEMPT_LABEL_MISMATCH",
-            context: {
-              containerName: locator.containerName,
-              expectedAttemptId: locator.replacementAttemptId ?? null,
-              observedAttemptId: attemptId || null,
-            },
-            severity: "fatal",
-          },
-        );
-      }
-      // A timeout before Docker returned an id leaves only the deterministic
-      // name + attempt label as identity. If that name is now occupied by a
-      // DIFFERENT attempt, Docker's name uniqueness proves the unknown target
-      // is no longer at that name. Retain the occupant and converge the stale
-      // cleanup fence; the node-wide orphan reconciler remains responsible for
-      // any independently renamed debris. With an immutable id, a label
-      // mismatch is corruption and stays fail-closed.
-      if (!locator.containerId) {
-        logger.warn(
-          "[docker-sandbox] Replacement cleanup name is occupied by a different attempt; retaining occupant and treating the id-less target as absent",
-          {
-            nodeId: locator.nodeId,
-            containerName: locator.containerName,
-            expectedAttemptId: locator.replacementAttemptId,
-            observedAttemptId: attemptId || null,
-          },
-        );
-        return null;
-      }
-      // With an immutable id the inspect was addressed at the exact persisted
-      // object, so a label mismatch cannot be a name reuse — it is attempt-id
-      // drift between the fence row and the container's create-time label
-      // (#18032). Refusing forever wedges the agent out of every exclusive
-      // lifecycle job, so converge once identity is proven by the stronger
-      // signals: the id matches the fence record, the deterministic name
-      // matches, and the container is old enough that no concurrent
-      // replacement attempt can still be mid-write.
-      if (
-        dockerContainerIdsMatch(locator.containerId, containerId) &&
-        observedName === locator.containerName &&
-        Number.isFinite(observedCreatedAt) &&
-        this.now() - observedCreatedAt >= REPLACEMENT_LABEL_MISMATCH_RETIRE_GRACE_MS
-      ) {
-        logger.warn(
-          "[docker-sandbox] Replacement attempt label drifted from the fence record; converging via id+name identity past the grace window",
-          {
-            nodeId: locator.nodeId,
-            containerName: locator.containerName,
-            containerId,
-            expectedAttemptId: locator.replacementAttemptId,
-            observedAttemptId: attemptId || null,
-            containerAgeMs: this.now() - observedCreatedAt,
-          },
-        );
-        return containerId;
-      }
-      throw new Error(
-        `[docker-sandbox] Replacement attempt label mismatch for ${locator.containerName}`,
-      );
-    }
     if (locator.containerId && !dockerContainerIdsMatch(locator.containerId, containerId)) {
       throw new Error(
         `[docker-sandbox] Replacement container id mismatch for ${locator.containerName}`,
+      );
+    }
+    // Post-cutover primary cleanup has no candidate-attempt label contract.
+    // Its published full Docker id is stronger: inspect was addressed at that
+    // immutable object, and the inspected id is also the only stop/rm target.
+    if (locator.replacementSecretCleanupVersion !== 1) {
+      return containerId;
+    }
+    if (attemptId !== locator.replacementAttemptId) {
+      throw new ElizaError(
+        `[docker-sandbox] Exact replacement attempt label mismatch for ${locator.containerName}`,
+        {
+          code: "SANDBOX_REPLACEMENT_EXACT_ATTEMPT_LABEL_MISMATCH",
+          context: {
+            containerName: locator.containerName,
+            expectedAttemptId: locator.replacementAttemptId ?? null,
+            observedAttemptId: attemptId || null,
+          },
+          severity: "fatal",
+        },
       );
     }
     return containerId;

--- a/packages/cloud/shared/src/lib/services/sandbox-provider-types.ts
+++ b/packages/cloud/shared/src/lib/services/sandbox-provider-types.ts
@@ -68,6 +68,10 @@ export interface SandboxReplacementCleanupLocator {
   containerName: string;
   /** Immutable docker_nodes primary key for exact-placement recovery. */
   nodeRecordId?: string | null;
+  /** Exact boot occurrence bound to nodeRecordId. */
+  nodeIncarnation?: string | null;
+  /** Append-only history receipt for the exact boot occurrence. */
+  nodeHistoryId?: string | null;
   /** SSH authority frozen with nodeRecordId before candidate effects. */
   nodeHostname?: string | null;
   nodeSshPort?: number | null;
@@ -76,6 +80,12 @@ export interface SandboxReplacementCleanupLocator {
   /** Attempt-scoped remote secret cleanup protocol understood by this locator. */
   replacementSecretCleanupVersion?: 1 | null;
   replacementAttemptId?: string | null;
+  /**
+   * Immutable Docker object identity. Candidate intents may temporarily omit
+   * it before create returns and candidate publications may use Docker's
+   * canonical short/full form. A post-cutover primary cleanup must publish the
+   * full lowercase 64-hex id and is never retired by reusable container name.
+   */
   containerId?: string | null;
   vpnNodeId?: string | null;
   vpnNodeName?: string | null;
@@ -130,6 +140,8 @@ export class SandboxReplacementCleanupUnresolvedError extends ElizaError {
   readonly nodeId: string;
   readonly containerName: string;
   readonly nodeRecordId: string | null;
+  readonly nodeIncarnation: string | null;
+  readonly nodeHistoryId: string | null;
   readonly nodeHostname: string | null;
   readonly nodeSshPort: number | null;
   readonly nodeSshUser: string | null;
@@ -158,6 +170,8 @@ export class SandboxReplacementCleanupUnresolvedError extends ElizaError {
           nodeId: locator.nodeId,
           containerName: locator.containerName,
           nodeRecordId: locator.nodeRecordId ?? null,
+          nodeIncarnation: locator.nodeIncarnation ?? null,
+          nodeHistoryId: locator.nodeHistoryId ?? null,
           replacementAttemptId: locator.replacementAttemptId ?? null,
           containerId: locator.containerId ?? null,
           vpnNodeId: locator.vpnNodeId ?? null,
@@ -170,6 +184,8 @@ export class SandboxReplacementCleanupUnresolvedError extends ElizaError {
     this.nodeId = locator.nodeId;
     this.containerName = locator.containerName;
     this.nodeRecordId = locator.nodeRecordId ?? null;
+    this.nodeIncarnation = locator.nodeIncarnation ?? null;
+    this.nodeHistoryId = locator.nodeHistoryId ?? null;
     this.nodeHostname = locator.nodeHostname ?? null;
     this.nodeSshPort = locator.nodeSshPort ?? null;
     this.nodeSshUser = locator.nodeSshUser ?? null;
@@ -247,7 +263,9 @@ export interface SandboxProvider {
    * because a submitted daemon create can materialize after its SSH client has
    * disconnected. Exact cleanup may settle only when the remote producer is
    * durably quiescent or after observing and recording the exact labeled
-   * candidate ID before removing it.
+   * candidate ID before removing it. Post-cutover primary cleanup instead
+   * requires a published full Docker ID. Every destructive SSH mutation is
+   * fenced against the persisted node boot ID inside the same remote command.
    */
   stopOnSpecificNodeForReplacement?(
     nodeId: string,


### PR DESCRIPTION
# Relates to

- #20726
- Depends on the preceding replacement-adoption Draft PR.

Definition of Done: full standard in `CONTRIBUTING.md`.

- [ ] This PR will target `develop` after its stack predecessors merge and will then be rebased onto the latest `origin/develop`.
- [ ] `bun install` and `bun run verify` will be rerun on the final rebased head before Ready.
- [ ] Final reviewer-facing behavior evidence will be attached before Ready.

# Sync with develop

- [x] Created from the exact planned stack parent with zero local conflicts.
- [ ] Final rebase onto the latest `origin/develop` and full verification pending predecessor merges.

# Risks

Medium - node occurrence fencing and capacity settlement.

# Background

## What does this PR do?

Fence la capacite d'un remplacement sur l'occurrence exacte du noeud pour empecher une occurrence recyclee de solder le mauvais travail.

## What kind of change is this?

Bug fix (non-breaking correctness hardening).

# Documentation changes needed?

No user-facing documentation change is required for this backend-only slice. Operational evidence and stack dependencies are recorded here.

# Testing

## Where should a reviewer start?

Review the commit(s) unique to `fix/20726-04-occurrence-capacity`, then the colocated tests changed by this slice.

## Detailed testing steps

- Inspect only the stack delta: `git diff fix/20726-03-replacement-adoption...fix/20726-04-occurrence-capacity`.
- Run the targeted tests and typechecks for the changed Cloud packages.
- Run `git diff --check fix/20726-03-replacement-adoption...fix/20726-04-occurrence-capacity`.
- Full `bun run verify` and exact-head integration evidence remain pending while this PR is Draft.

# Evidence Gate

<!-- evidence-head:b845dda31ae28be006e3a41a4c635ba90391b718 -->

- [ ] Before full-page screenshots: N/A - backend-only change with no rendered UI.
- [ ] After full-page screenshots: N/A - backend-only change with no rendered UI.
- [ ] Walkthrough video: N/A - backend-only change with no rendered UI flow.
- [ ] Backend logs: Pending - final stack integration run has not been authorized or executed yet.
- [ ] Frontend logs: N/A - no frontend surface changes.
- [ ] Real-LLM trajectory: N/A - no prompt, provider, model, or agent behavior change.
- [ ] Domain artifacts: Pending - exact DB/Redis/control-plane artifacts will be attached with final integration evidence.
- [ ] OCR review: N/A - no visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM call path is changed.

## Backend + frontend logs

Backend integration evidence pending final stack assembly. Frontend logs are N/A because this slice has no frontend surface.

## Screenshots (before / after) + video walkthrough

N/A - backend-only change.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, TTS, or STT change.

## Known gaps / failures

This is intentionally Draft. Final rebase, repository-wide verification, hosted CI, and real integration evidence remain pending. No deployment or environment mutation was performed.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: N/A - no exception requested
- Validated `origin/develop` SHA: N/A - no exception requested
- Live ruleset readback and named bypass eligibility: N/A - no exception requested
- Queued or failing checks and run URLs: N/A - no exception requested
- Infrastructure-only or unrelated-failure proof: N/A - no exception requested
- Exact-head commands, exit status, and artifacts: N/A - no exception requested
- Exact-head security, secret-scan, and provenance results: N/A - no exception requested
- Conflict-free and affected-path failure attestation: N/A - no exception requested
- Independent approving reviewer: N/A - no exception requested
- Bypass authorizer: N/A - no exception requested
- Merge method: N/A - no exception requested
- Rollback owner: N/A - no exception requested
- Post-merge `develop` validation: N/A - no exception requested

# Deploy Notes

No deploy is included or authorized by this Draft PR.