### PR TITLE
fix(cloud): read managed activation routing atomically

### DIFF
--- a/packages/cloud/services/_common/package.json
+++ b/packages/cloud/services/_common/package.json
@@ -8,6 +8,7 @@
   "types": "src/index.ts",
   "exports": {
     ".": "./src/index.ts",
+    "./activation-routing": "./src/activation-routing.ts",
     "./logger": "./src/logger.ts",
     "./k8s-service-account": "./src/k8s-service-account.ts",
     "./k8s-deployment-wake": "./src/k8s-deployment-wake.ts",

--- a/packages/cloud/services/_common/src/activation-routing.ts
+++ b/packages/cloud/services/_common/src/activation-routing.ts
@@ -6,6 +6,8 @@
  * while the activation route is a renewable TTL projection of that authority.
  */
 
+import { createHash } from "node:crypto";
+
 const CANONICAL_UUID =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 const SHA256 = /^[0-9a-f]{64}$/;
@@ -27,8 +29,18 @@ const ROUTE_KEYS = [
   "generation",
   "publicationId",
   "endpointSha256",
-  "serverName",
+  "endpoint",
 ] as const;
+const ENDPOINT_KEYS = [
+  "version",
+  "generation",
+  "kind",
+  "serverName",
+  "registryUrl",
+  "bridgeUrl",
+  "healthUrl",
+] as const;
+const MAX_ENDPOINT_URL_BYTES = 4096;
 
 export type ActivationRoutingSnapshotKeys = readonly [
   managedMarker: string,
@@ -88,13 +100,23 @@ export type ActivationRegistrationAuthorityV1 =
   | ActiveRegistrationAuthorityV1
   | InactiveRegistrationAuthorityV1;
 
+export interface ActivationRoutingEndpointEnvelopeV1 {
+  readonly version: 1;
+  readonly generation: string;
+  readonly kind: "dedicated-sandbox";
+  readonly serverName: string;
+  readonly registryUrl: string;
+  readonly bridgeUrl: string;
+  readonly healthUrl: string;
+}
+
 export interface DedicatedSandboxActivationRouteV1 {
   readonly version: 1;
   readonly kind: "dedicated-sandbox";
   readonly generation: string;
   readonly publicationId: string;
   readonly endpointSha256: string;
-  readonly serverName: string;
+  readonly endpoint: ActivationRoutingEndpointEnvelopeV1;
 }
 
 export type ActivationRoutingAuthorityUnavailableReason =
@@ -210,6 +232,84 @@ function isSha256(value: unknown): value is string {
   return typeof value === "string" && SHA256.test(value);
 }
 
+function isBoundedHttpEndpoint(value: unknown): value is string {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value !== value.trim() ||
+    !/^https?:\/\//u.test(value) ||
+    new TextEncoder().encode(value).byteLength > MAX_ENDPOINT_URL_BYTES
+  ) {
+    return false;
+  }
+
+  for (const character of value) {
+    const codePoint = character.codePointAt(0) ?? 0;
+    if (
+      /[\s\\?#]/u.test(character) ||
+      codePoint <= 0x1f ||
+      (codePoint >= 0x7f && codePoint <= 0x9f)
+    ) {
+      return false;
+    }
+  }
+
+  try {
+    const parsed = new URL(value);
+    return (
+      (parsed.protocol === "http:" || parsed.protocol === "https:") &&
+      parsed.hostname.length > 0 &&
+      parsed.username === "" &&
+      parsed.password === "" &&
+      parsed.search === "" &&
+      parsed.hash === ""
+    );
+  } catch {
+    return false;
+  }
+}
+
+function parseEndpoint(
+  value: unknown,
+  expectedGeneration: string,
+): ActivationRoutingEndpointEnvelopeV1 | null {
+  if (
+    !hasExactKeys(value, ENDPOINT_KEYS) ||
+    value.version !== 1 ||
+    value.generation !== expectedGeneration ||
+    value.kind !== "dedicated-sandbox" ||
+    value.serverName !== `sandbox-${expectedGeneration}` ||
+    !isBoundedHttpEndpoint(value.registryUrl) ||
+    !isBoundedHttpEndpoint(value.bridgeUrl) ||
+    !isBoundedHttpEndpoint(value.healthUrl)
+  ) {
+    return null;
+  }
+
+  return Object.freeze({
+    version: 1,
+    generation: expectedGeneration,
+    kind: "dedicated-sandbox",
+    serverName: value.serverName,
+    registryUrl: value.registryUrl,
+    bridgeUrl: value.bridgeUrl,
+    healthUrl: value.healthUrl,
+  });
+}
+
+function hashEndpoint(endpoint: ActivationRoutingEndpointEnvelopeV1): string {
+  const canonical = JSON.stringify({
+    version: 1,
+    generation: endpoint.generation,
+    kind: "dedicated-sandbox",
+    serverName: endpoint.serverName,
+    registryUrl: endpoint.registryUrl,
+    bridgeUrl: endpoint.bridgeUrl,
+    healthUrl: endpoint.healthUrl,
+  });
+  return createHash("sha256").update(canonical, "utf8").digest("hex");
+}
+
 function parseMarker(raw: string): ActivationRoutingMarkerV1 | null {
   const value = parseJsonObject(raw);
   if (
@@ -272,11 +372,12 @@ function parseRoute(raw: string): DedicatedSandboxActivationRouteV1 | null {
     value.kind !== "dedicated-sandbox" ||
     !isCanonicalUuid(value.generation) ||
     !isCanonicalUuid(value.publicationId) ||
-    !isSha256(value.endpointSha256) ||
-    value.serverName !== `sandbox-${value.generation}`
+    !isSha256(value.endpointSha256)
   ) {
     return null;
   }
+  const endpoint = parseEndpoint(value.endpoint, value.generation);
+  if (!endpoint) return null;
 
   return Object.freeze({
     version: 1,
@@ -284,7 +385,7 @@ function parseRoute(raw: string): DedicatedSandboxActivationRouteV1 | null {
     generation: value.generation,
     publicationId: value.publicationId,
     endpointSha256: value.endpointSha256,
-    serverName: value.serverName,
+    endpoint,
   });
 }
 
@@ -418,6 +519,12 @@ export async function readActivationRoutingState(
     });
   }
   if (route.endpointSha256 !== authority.endpointSha256) {
+    return Object.freeze({
+      status: "conflict",
+      reason: "endpoint_hash_mismatch",
+    });
+  }
+  if (hashEndpoint(route.endpoint) !== route.endpointSha256) {
     return Object.freeze({
       status: "conflict",
       reason: "endpoint_hash_mismatch",

--- a/packages/cloud/services/_common/src/activation-routing.ts
+++ b/packages/cloud/services/_common/src/activation-routing.ts
@@ -1,0 +1,428 @@
+/**
+ * Atomically resolves the managed dedicated-sandbox activation route for one agent.
+ *
+ * The durable managed marker is the one-way cutover fence: once present, callers
+ * must not consult a legacy routing source. The registration authority is durable,
+ * while the activation route is a renewable TTL projection of that authority.
+ */
+
+const CANONICAL_UUID =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const SHA256 = /^[0-9a-f]{64}$/;
+const SNAPSHOT_MISSING_SENTINEL = "activation-routing-missing:v1";
+const SNAPSHOT_SENTINEL = "activation-routing-snapshot:v1";
+const SNAPSHOT_VALUE_PREFIX = "activation-routing:v1:";
+
+const MARKER_KEYS = ["version", "managed"] as const;
+const AUTHORITY_KEYS = [
+  "version",
+  "state",
+  "generation",
+  "publicationId",
+  "endpointSha256",
+] as const;
+const ROUTE_KEYS = [
+  "version",
+  "kind",
+  "generation",
+  "publicationId",
+  "endpointSha256",
+  "serverName",
+] as const;
+
+export type ActivationRoutingSnapshotKeys = readonly [
+  managedMarker: string,
+  registrationAuthority: string,
+  activationRoute: string,
+];
+
+/**
+ * Purpose-bound read-only boundary implemented by each Redis transport.
+ *
+ * A direct Redis adapter must execute {@link ACTIVATION_ROUTING_REDIS_EVAL_RO_SCRIPT}
+ * with EVAL_RO. An `@upstash/redis` adapter must call
+ * `evalRo(ACTIVATION_ROUTING_UPSTASH_READ_ONLY_SCRIPT, keys, [])`. Keeping
+ * that transport choice behind this method prevents the authority reader from
+ * being handed a generic, potentially mutating EVAL capability.
+ */
+export interface ActivationRoutingSnapshotReader {
+  readActivationRoutingSnapshot(
+    keys: ActivationRoutingSnapshotKeys,
+  ): Promise<unknown>;
+}
+
+export interface ActivationRoutingMarkerV1 {
+  readonly version: 1;
+  readonly managed: true;
+}
+
+export interface ActiveRegistrationAuthorityV1 {
+  readonly version: 1;
+  readonly state: "active";
+  readonly generation: string;
+  readonly publicationId: string;
+  readonly endpointSha256: string;
+}
+
+export interface TransitionRegistrationAuthorityV1 {
+  readonly version: 1;
+  readonly state: "transition";
+  readonly generation: string;
+  readonly publicationId: null;
+  readonly endpointSha256: null;
+}
+
+export interface RevokedRegistrationAuthorityV1 {
+  readonly version: 1;
+  readonly state: "revoked";
+  readonly generation: string;
+  readonly publicationId: null;
+  readonly endpointSha256: null;
+}
+
+export type InactiveRegistrationAuthorityV1 =
+  | TransitionRegistrationAuthorityV1
+  | RevokedRegistrationAuthorityV1;
+
+export type ActivationRegistrationAuthorityV1 =
+  | ActiveRegistrationAuthorityV1
+  | InactiveRegistrationAuthorityV1;
+
+export interface DedicatedSandboxActivationRouteV1 {
+  readonly version: 1;
+  readonly kind: "dedicated-sandbox";
+  readonly generation: string;
+  readonly publicationId: string;
+  readonly endpointSha256: string;
+  readonly serverName: string;
+}
+
+export type ActivationRoutingAuthorityUnavailableReason =
+  | "invalid_agent_id"
+  | "redis_unavailable"
+  | "invalid_snapshot"
+  | "invalid_marker"
+  | "authority_missing"
+  | "invalid_authority";
+
+export type ActivationRoutingConflictReason =
+  | "partial_managed_state"
+  | "invalid_route"
+  | "generation_mismatch"
+  | "publication_mismatch"
+  | "endpoint_hash_mismatch";
+
+export type ActivationRoutingReadResult =
+  | Readonly<{ status: "unmanaged" }>
+  | Readonly<{
+      status: "authority_unavailable";
+      reason: ActivationRoutingAuthorityUnavailableReason;
+    }>
+  | Readonly<{
+      status: "starting";
+      authority:
+        | ActiveRegistrationAuthorityV1
+        | TransitionRegistrationAuthorityV1;
+    }>
+  | Readonly<{
+      status: "revoked";
+      authority: RevokedRegistrationAuthorityV1;
+    }>
+  | Readonly<{
+      status: "conflict";
+      reason: ActivationRoutingConflictReason;
+    }>
+  | Readonly<{
+      status: "ready";
+      authority: ActiveRegistrationAuthorityV1;
+      route: DedicatedSandboxActivationRouteV1;
+    }>;
+
+const ACTIVATION_ROUTING_READ_SCRIPT_BODY = `if #KEYS ~= 3 or #ARGV ~= 0 then
+  return redis.error_reply("activation-routing read requires exactly 3 keys and 0 args")
+end
+
+local function capture(key)
+  local value = redis.call("GET", key)
+  if value == false then
+    return "${SNAPSHOT_MISSING_SENTINEL}"
+  end
+  return "${SNAPSHOT_VALUE_PREFIX}" .. value
+end
+
+return {
+  "${SNAPSHOT_SENTINEL}",
+  capture(KEYS[1]),
+  capture(KEYS[2]),
+  capture(KEYS[3])
+}
+`;
+
+/**
+ * Direct-Redis variant. Adapters must invoke this script with EVAL_RO, never
+ * EVAL. It deliberately omits the Upstash-only `allow-key-locking` flag, which
+ * Redis OSS does not recognize.
+ */
+export const ACTIVATION_ROUTING_REDIS_EVAL_RO_SCRIPT =
+  ACTIVATION_ROUTING_READ_SCRIPT_BODY;
+
+/**
+ * Upstash variant. Even `evalRo` defaults to a database-wide lock, so the
+ * shebang preserves read-only enforcement while opting into per-key read locks
+ * for the three declared keys.
+ */
+export const ACTIVATION_ROUTING_UPSTASH_READ_ONLY_SCRIPT = `#!lua flags=no-writes,allow-key-locking\n${ACTIVATION_ROUTING_READ_SCRIPT_BODY}`;
+
+type JsonObject = Record<string, unknown>;
+
+function hasExactKeys(
+  value: unknown,
+  expected: readonly string[],
+): value is JsonObject {
+  if (typeof value !== "object" || value === null || Array.isArray(value))
+    return false;
+  const actual = Object.keys(value);
+  return (
+    actual.length === expected.length &&
+    expected.every((key) => actual.includes(key))
+  );
+}
+
+function parseJsonObject(raw: string): JsonObject | null {
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return typeof parsed === "object" &&
+      parsed !== null &&
+      !Array.isArray(parsed)
+      ? (parsed as JsonObject)
+      : null;
+  } catch {
+    // error-policy:J3 untrusted Redis JSON becomes an explicit invalid result.
+    return null;
+  }
+}
+
+function isCanonicalUuid(value: unknown): value is string {
+  return typeof value === "string" && CANONICAL_UUID.test(value);
+}
+
+function isSha256(value: unknown): value is string {
+  return typeof value === "string" && SHA256.test(value);
+}
+
+function parseMarker(raw: string): ActivationRoutingMarkerV1 | null {
+  const value = parseJsonObject(raw);
+  if (
+    !hasExactKeys(value, MARKER_KEYS) ||
+    value.version !== 1 ||
+    value.managed !== true
+  ) {
+    return null;
+  }
+  return Object.freeze({ version: 1, managed: true });
+}
+
+function parseAuthority(raw: string): ActivationRegistrationAuthorityV1 | null {
+  const value = parseJsonObject(raw);
+  if (
+    !hasExactKeys(value, AUTHORITY_KEYS) ||
+    value.version !== 1 ||
+    !isCanonicalUuid(value.generation)
+  ) {
+    return null;
+  }
+
+  if (value.state === "active") {
+    if (
+      !isCanonicalUuid(value.publicationId) ||
+      !isSha256(value.endpointSha256)
+    )
+      return null;
+    return Object.freeze({
+      version: 1,
+      state: "active",
+      generation: value.generation,
+      publicationId: value.publicationId,
+      endpointSha256: value.endpointSha256,
+    });
+  }
+
+  if (
+    (value.state === "transition" || value.state === "revoked") &&
+    value.publicationId === null &&
+    value.endpointSha256 === null
+  ) {
+    return Object.freeze({
+      version: 1,
+      state: value.state,
+      generation: value.generation,
+      publicationId: null,
+      endpointSha256: null,
+    });
+  }
+
+  return null;
+}
+
+function parseRoute(raw: string): DedicatedSandboxActivationRouteV1 | null {
+  const value = parseJsonObject(raw);
+  if (
+    !hasExactKeys(value, ROUTE_KEYS) ||
+    value.version !== 1 ||
+    value.kind !== "dedicated-sandbox" ||
+    !isCanonicalUuid(value.generation) ||
+    !isCanonicalUuid(value.publicationId) ||
+    !isSha256(value.endpointSha256) ||
+    value.serverName !== `sandbox-${value.generation}`
+  ) {
+    return null;
+  }
+
+  return Object.freeze({
+    version: 1,
+    kind: "dedicated-sandbox",
+    generation: value.generation,
+    publicationId: value.publicationId,
+    endpointSha256: value.endpointSha256,
+    serverName: value.serverName,
+  });
+}
+
+function parseSnapshot(
+  value: unknown,
+): readonly [string | null, string | null, string | null] | null {
+  if (
+    !Array.isArray(value) ||
+    value.length !== 4 ||
+    value[0] !== SNAPSHOT_SENTINEL
+  ) {
+    return null;
+  }
+  const decoded: Array<string | null> = [];
+  for (const entry of value.slice(1)) {
+    if (entry === SNAPSHOT_MISSING_SENTINEL) {
+      decoded.push(null);
+      continue;
+    }
+    if (typeof entry !== "string" || !entry.startsWith(SNAPSHOT_VALUE_PREFIX)) {
+      return null;
+    }
+    decoded.push(entry.slice(SNAPSHOT_VALUE_PREFIX.length));
+  }
+  return decoded as [string | null, string | null, string | null];
+}
+
+function redisKeys(agentId: string): ActivationRoutingSnapshotKeys {
+  return [
+    `agent:${agentId}:routing-managed`,
+    `agent:${agentId}:registration-authority`,
+    `agent:${agentId}:activation-route`,
+  ];
+}
+
+/**
+ * Resolve managed activation routing without any legacy read.
+ *
+ * Redis transport and untrusted-value failures are returned as non-ready typed
+ * states, so callers cannot accidentally route through malformed authority.
+ */
+export async function readActivationRoutingState(
+  snapshotReader: ActivationRoutingSnapshotReader,
+  agentId: string,
+): Promise<ActivationRoutingReadResult> {
+  if (!isCanonicalUuid(agentId)) {
+    return Object.freeze({
+      status: "authority_unavailable",
+      reason: "invalid_agent_id",
+    });
+  }
+
+  let evaluated: unknown;
+  try {
+    evaluated = await snapshotReader.readActivationRoutingSnapshot(
+      redisKeys(agentId),
+    );
+  } catch {
+    // error-policy:J4 Redis failure becomes an explicit authority-unavailable state.
+    return Object.freeze({
+      status: "authority_unavailable",
+      reason: "redis_unavailable",
+    });
+  }
+
+  const snapshot = parseSnapshot(evaluated);
+  if (!snapshot) {
+    return Object.freeze({
+      status: "authority_unavailable",
+      reason: "invalid_snapshot",
+    });
+  }
+
+  const [rawMarker, rawAuthority, rawRoute] = snapshot;
+  if (rawMarker === null) {
+    if (rawAuthority === null && rawRoute === null) {
+      return Object.freeze({ status: "unmanaged" });
+    }
+    return Object.freeze({
+      status: "conflict",
+      reason: "partial_managed_state",
+    });
+  }
+
+  const marker = parseMarker(rawMarker);
+  if (!marker) {
+    return Object.freeze({
+      status: "authority_unavailable",
+      reason: "invalid_marker",
+    });
+  }
+
+  if (rawAuthority === null) {
+    return Object.freeze({
+      status: "authority_unavailable",
+      reason: "authority_missing",
+    });
+  }
+
+  const authority = parseAuthority(rawAuthority);
+  if (!authority) {
+    return Object.freeze({
+      status: "authority_unavailable",
+      reason: "invalid_authority",
+    });
+  }
+
+  // Parse every present projection in JS as a second trust boundary. A durable
+  // transition or tombstone still dominates any stale TTL route.
+  const route = rawRoute === null ? null : parseRoute(rawRoute);
+  if (authority.state === "revoked") {
+    return Object.freeze({ status: "revoked", authority });
+  }
+  if (authority.state === "transition") {
+    return Object.freeze({ status: "starting", authority });
+  }
+
+  if (rawRoute === null) {
+    return Object.freeze({ status: "starting", authority });
+  }
+  if (!route) {
+    return Object.freeze({ status: "conflict", reason: "invalid_route" });
+  }
+  if (route.generation !== authority.generation) {
+    return Object.freeze({ status: "conflict", reason: "generation_mismatch" });
+  }
+  if (route.publicationId !== authority.publicationId) {
+    return Object.freeze({
+      status: "conflict",
+      reason: "publication_mismatch",
+    });
+  }
+  if (route.endpointSha256 !== authority.endpointSha256) {
+    return Object.freeze({
+      status: "conflict",
+      reason: "endpoint_hash_mismatch",
+    });
+  }
+
+  return Object.freeze({ status: "ready", authority, route });
+}

--- a/packages/cloud/services/_common/src/activation-routing.ts
+++ b/packages/cloud/services/_common/src/activation-routing.ts
@@ -36,11 +36,24 @@ const ENDPOINT_KEYS = [
   "generation",
   "kind",
   "serverName",
+  "runtimeAgentId",
   "registryUrl",
   "bridgeUrl",
   "healthUrl",
 ] as const;
 const MAX_ENDPOINT_URL_BYTES = 4096;
+// Deliberately narrower than the WHATWG URL grammar so the reader accepts the
+// exact same endpoint language as the durable PostgreSQL authority contract.
+// V1 accepts canonical ASCII DNS names or IPv4 literals and ports 1..65535.
+const IPV4_OCTET = "(?:25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])";
+const IPV4_HOST = String.raw`${IPV4_OCTET}(?:\.${IPV4_OCTET}){3}`;
+const DNS_LABEL = "(?:[A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9-]{0,61}[A-Za-z0-9])";
+const DNS_HOST = String.raw`(?:${DNS_LABEL}\.)*[A-Za-z](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?`;
+const TCP_PORT =
+  "(?::(?:6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[1-9][0-9]{0,3}))?";
+const ENDPOINT_URL_V1 = new RegExp(
+  String.raw`^https?://(?:${IPV4_HOST}|${DNS_HOST})${TCP_PORT}(?:/[^\\?#\s\u0000-\u001f\u007f-\u009f]*)?$`,
+);
 
 export type ActivationRoutingSnapshotKeys = readonly [
   managedMarker: string,
@@ -105,6 +118,7 @@ export interface ActivationRoutingEndpointEnvelopeV1 {
   readonly generation: string;
   readonly kind: "dedicated-sandbox";
   readonly serverName: string;
+  readonly runtimeAgentId: string;
   readonly registryUrl: string;
   readonly bridgeUrl: string;
   readonly healthUrl: string;
@@ -233,25 +247,17 @@ function isSha256(value: unknown): value is string {
 }
 
 function isBoundedHttpEndpoint(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  const encodedLength = new TextEncoder().encode(value).byteLength;
   if (
-    typeof value !== "string" ||
     value.length === 0 ||
     value !== value.trim() ||
-    !/^https?:\/\//u.test(value) ||
-    new TextEncoder().encode(value).byteLength > MAX_ENDPOINT_URL_BYTES
+    !/^https?:\/\//.test(value) ||
+    encodedLength !== value.length ||
+    encodedLength > MAX_ENDPOINT_URL_BYTES ||
+    !ENDPOINT_URL_V1.test(value)
   ) {
     return false;
-  }
-
-  for (const character of value) {
-    const codePoint = character.codePointAt(0) ?? 0;
-    if (
-      /[\s\\?#]/u.test(character) ||
-      codePoint <= 0x1f ||
-      (codePoint >= 0x7f && codePoint <= 0x9f)
-    ) {
-      return false;
-    }
   }
 
   try {
@@ -279,6 +285,7 @@ function parseEndpoint(
     value.generation !== expectedGeneration ||
     value.kind !== "dedicated-sandbox" ||
     value.serverName !== `sandbox-${expectedGeneration}` ||
+    !isCanonicalUuid(value.runtimeAgentId) ||
     !isBoundedHttpEndpoint(value.registryUrl) ||
     !isBoundedHttpEndpoint(value.bridgeUrl) ||
     !isBoundedHttpEndpoint(value.healthUrl)
@@ -291,6 +298,7 @@ function parseEndpoint(
     generation: expectedGeneration,
     kind: "dedicated-sandbox",
     serverName: value.serverName,
+    runtimeAgentId: value.runtimeAgentId,
     registryUrl: value.registryUrl,
     bridgeUrl: value.bridgeUrl,
     healthUrl: value.healthUrl,
@@ -303,6 +311,7 @@ function hashEndpoint(endpoint: ActivationRoutingEndpointEnvelopeV1): string {
     generation: endpoint.generation,
     kind: "dedicated-sandbox",
     serverName: endpoint.serverName,
+    runtimeAgentId: endpoint.runtimeAgentId,
     registryUrl: endpoint.registryUrl,
     bridgeUrl: endpoint.bridgeUrl,
     healthUrl: endpoint.healthUrl,

--- a/packages/cloud/services/_common/src/index.ts
+++ b/packages/cloud/services/_common/src/index.ts
@@ -1,6 +1,23 @@
 // Shares index service primitives across cloud worker sidecars.
 
 export {
+  ACTIVATION_ROUTING_REDIS_EVAL_RO_SCRIPT,
+  ACTIVATION_ROUTING_UPSTASH_READ_ONLY_SCRIPT,
+  type ActivationRegistrationAuthorityV1,
+  type ActivationRoutingAuthorityUnavailableReason,
+  type ActivationRoutingConflictReason,
+  type ActivationRoutingMarkerV1,
+  type ActivationRoutingReadResult,
+  type ActivationRoutingSnapshotKeys,
+  type ActivationRoutingSnapshotReader,
+  type ActiveRegistrationAuthorityV1,
+  type DedicatedSandboxActivationRouteV1,
+  type InactiveRegistrationAuthorityV1,
+  type RevokedRegistrationAuthorityV1,
+  readActivationRoutingState,
+  type TransitionRegistrationAuthorityV1,
+} from "./activation-routing";
+export {
   GATEWAY_TOKEN_MAX_LIFETIME_SECONDS,
   GATEWAY_TOKEN_REQUEST_TIMEOUT_MS,
   type GatewayTokenResponse,

--- a/packages/cloud/services/_common/tests/activation-routing.test.ts
+++ b/packages/cloud/services/_common/tests/activation-routing.test.ts
@@ -1,6 +1,7 @@
 /** Exercises the atomic, fail-closed managed activation-routing reader. */
 
 import { describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
 import {
   ACTIVATION_ROUTING_REDIS_EVAL_RO_SCRIPT,
   ACTIVATION_ROUTING_UPSTASH_READ_ONLY_SCRIPT,
@@ -13,8 +14,10 @@ const GENERATION = "00000000-0000-4000-8000-000000000002";
 const OTHER_GENERATION = "00000000-0000-4000-8000-000000000003";
 const PUBLICATION_ID = "00000000-0000-4000-8000-000000000004";
 const OTHER_PUBLICATION_ID = "00000000-0000-4000-8000-000000000005";
+const RUNTIME_AGENT_ID = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeee6";
+const OTHER_RUNTIME_AGENT_ID = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeee7";
 const ENDPOINT_SHA256 =
-  "73eb701612c13ee660f3598e5309e6ce83743070eb648ea7670a57e060047e11";
+  "7278b3fce767689aae03cb1df507ec11dd20ed8c192c67ace95c57e0bb67bbdd";
 const OTHER_ENDPOINT_SHA256 = "b".repeat(64);
 const SNAPSHOT_MISSING_SENTINEL = "activation-routing-missing:v1";
 const SNAPSHOT_SENTINEL = "activation-routing-snapshot:v1";
@@ -48,6 +51,7 @@ interface EndpointFixture {
   generation: string;
   kind: string;
   serverName: string;
+  runtimeAgentId: string;
   registryUrl: string;
   bridgeUrl: string;
   healthUrl: string;
@@ -58,6 +62,7 @@ const ENDPOINT: EndpointFixture = {
   generation: GENERATION,
   kind: "dedicated-sandbox",
   serverName: `sandbox-${GENERATION}`,
+  runtimeAgentId: RUNTIME_AGENT_ID,
   registryUrl: "https://sandbox.internal:3000/",
   bridgeUrl: "http://100.64.0.2:3000",
   healthUrl: "http://100.64.0.2:3000/health",
@@ -70,7 +75,7 @@ function route(
     generation: string;
     publicationId: string;
     endpointSha256: string;
-    endpoint: EndpointFixture;
+    endpoint: unknown;
   }> = {},
 ): string {
   return JSON.stringify({
@@ -82,6 +87,10 @@ function route(
     endpoint: ENDPOINT,
     ...overrides,
   });
+}
+
+function routeWithEndpoint(overrides: Record<string, unknown>): string {
+  return route({ endpoint: { ...ENDPOINT, ...overrides } });
 }
 
 class SnapshotReaderProbe implements ActivationRoutingSnapshotReader {
@@ -280,6 +289,27 @@ describe("atomic activation-routing reader", () => {
     }),
     route({ kind: "shared-runtime" }),
     route({ endpointSha256: ENDPOINT_SHA256.toUpperCase() }),
+    routeWithEndpoint({ runtimeAgentId: undefined }),
+    routeWithEndpoint({ runtimeAgentId: "not-a-uuid" }),
+    routeWithEndpoint({ runtimeAgentId: RUNTIME_AGENT_ID.toUpperCase() }),
+    routeWithEndpoint({ extra: true }),
+    routeWithEndpoint({ registryUrl: "HTTPS://sandbox.internal" }),
+    routeWithEndpoint({ registryUrl: "https://user:secret@sandbox.internal" }),
+    routeWithEndpoint({ registryUrl: "http://:80/path" }),
+    routeWithEndpoint({ registryUrl: "http://127.0.0.1:0/path" }),
+    routeWithEndpoint({ registryUrl: "http://[::1]:3000/path" }),
+    routeWithEndpoint({ registryUrl: "https://sandbox.internal./path" }),
+    routeWithEndpoint({ registryUrl: "http://999.999/path" }),
+    routeWithEndpoint({ registryUrl: "https://tést.internal/path" }),
+    routeWithEndpoint({ bridgeUrl: "https://sandbox.internal/?token=secret" }),
+    routeWithEndpoint({ healthUrl: "https://sandbox.internal/health#ready" }),
+    routeWithEndpoint({ registryUrl: "https://sandbox.internal\\evil/path" }),
+    routeWithEndpoint({ healthUrl: " https://sandbox.internal/health" }),
+    routeWithEndpoint({ healthUrl: "https://sandbox.internal/a\u00a0b" }),
+    routeWithEndpoint({ healthUrl: "https://sandbox.internal/a\u202fb" }),
+    routeWithEndpoint({ healthUrl: "https://sandbox.internal/a\ufeffb" }),
+    routeWithEndpoint({ healthUrl: "https://sandbox.internal/café" }),
+    routeWithEndpoint({ healthUrl: "https://sandbox.internal:65536/health" }),
   ])("rejects malformed route JSON or shape: %s", async (rawRoute) => {
     await expect(read([MARKER, ACTIVE_AUTHORITY, rawRoute])).resolves.toEqual({
       status: "conflict",
@@ -356,6 +386,45 @@ describe("atomic activation-routing reader", () => {
     ).resolves.toEqual({
       status: "conflict",
       reason: "endpoint_hash_mismatch",
+    });
+    await expect(
+      read([
+        MARKER,
+        ACTIVE_AUTHORITY,
+        route({
+          endpoint: {
+            ...ENDPOINT,
+            runtimeAgentId: OTHER_RUNTIME_AGENT_ID,
+          },
+        }),
+      ]),
+    ).resolves.toEqual({
+      status: "conflict",
+      reason: "endpoint_hash_mismatch",
+    });
+  });
+
+  test.each([1, 65535])("accepts the V1 TCP port boundary %d", async (port) => {
+    const endpoint = {
+      ...ENDPOINT,
+      bridgeUrl: `http://127.0.0.1:${port}/bridge`,
+    };
+    const endpointSha256 = createHash("sha256")
+      .update(JSON.stringify(endpoint), "utf8")
+      .digest("hex");
+    const authority = JSON.stringify({
+      version: 1,
+      state: "active",
+      generation: GENERATION,
+      publicationId: PUBLICATION_ID,
+      endpointSha256,
+    });
+
+    await expect(
+      read([MARKER, authority, route({ endpoint, endpointSha256 })]),
+    ).resolves.toMatchObject({
+      status: "ready",
+      route: { endpoint },
     });
   });
 

--- a/packages/cloud/services/_common/tests/activation-routing.test.ts
+++ b/packages/cloud/services/_common/tests/activation-routing.test.ts
@@ -1,0 +1,447 @@
+/** Exercises the atomic, fail-closed managed activation-routing reader. */
+
+import { describe, expect, test } from "bun:test";
+import {
+  ACTIVATION_ROUTING_REDIS_EVAL_RO_SCRIPT,
+  ACTIVATION_ROUTING_UPSTASH_READ_ONLY_SCRIPT,
+  type ActivationRoutingSnapshotReader,
+  readActivationRoutingState,
+} from "../src/activation-routing";
+
+const AGENT_ID = "00000000-0000-4000-8000-000000000001";
+const GENERATION = "00000000-0000-4000-8000-000000000002";
+const OTHER_GENERATION = "00000000-0000-4000-8000-000000000003";
+const PUBLICATION_ID = "00000000-0000-4000-8000-000000000004";
+const OTHER_PUBLICATION_ID = "00000000-0000-4000-8000-000000000005";
+const ENDPOINT_SHA256 = "a".repeat(64);
+const OTHER_ENDPOINT_SHA256 = "b".repeat(64);
+const SNAPSHOT_MISSING_SENTINEL = "activation-routing-missing:v1";
+const SNAPSHOT_SENTINEL = "activation-routing-snapshot:v1";
+const SNAPSHOT_VALUE_PREFIX = "activation-routing:v1:";
+
+const MARKER = JSON.stringify({ version: 1, managed: true });
+const ACTIVE_AUTHORITY = JSON.stringify({
+  version: 1,
+  state: "active",
+  generation: GENERATION,
+  publicationId: PUBLICATION_ID,
+  endpointSha256: ENDPOINT_SHA256,
+});
+const TRANSITION_AUTHORITY = JSON.stringify({
+  version: 1,
+  state: "transition",
+  generation: GENERATION,
+  publicationId: null,
+  endpointSha256: null,
+});
+const REVOKED_AUTHORITY = JSON.stringify({
+  version: 1,
+  state: "revoked",
+  generation: GENERATION,
+  publicationId: null,
+  endpointSha256: null,
+});
+
+function route(
+  overrides: Partial<{
+    version: number;
+    kind: string;
+    generation: string;
+    publicationId: string;
+    endpointSha256: string;
+    serverName: string;
+  }> = {},
+): string {
+  return JSON.stringify({
+    version: 1,
+    kind: "dedicated-sandbox",
+    generation: GENERATION,
+    publicationId: PUBLICATION_ID,
+    endpointSha256: ENDPOINT_SHA256,
+    serverName: `sandbox-${GENERATION}`,
+    ...overrides,
+  });
+}
+
+class SnapshotReaderProbe implements ActivationRoutingSnapshotReader {
+  readonly snapshotCalls: Array<readonly string[]> = [];
+  evalCalls = 0;
+  getCalls = 0;
+
+  constructor(
+    private readonly snapshot: unknown,
+    private readonly snapshotError?: Error,
+  ) {}
+
+  async readActivationRoutingSnapshot(
+    keys: readonly [string, string, string],
+  ): Promise<unknown> {
+    this.snapshotCalls.push([...keys]);
+    if (this.snapshotError) throw this.snapshotError;
+    return Array.isArray(this.snapshot)
+      ? [
+          SNAPSHOT_SENTINEL,
+          ...this.snapshot.map((value) =>
+            value === null
+              ? SNAPSHOT_MISSING_SENTINEL
+              : typeof value === "string"
+                ? `${SNAPSHOT_VALUE_PREFIX}${value}`
+                : value,
+          ),
+        ]
+      : this.snapshot;
+  }
+
+  async eval(): Promise<never> {
+    this.evalCalls += 1;
+    throw new Error("generic EVAL must not be called");
+  }
+
+  async get(): Promise<never> {
+    this.getCalls += 1;
+    throw new Error("legacy/non-atomic GET must not be called");
+  }
+}
+
+async function read(snapshot: unknown) {
+  return readActivationRoutingState(
+    new SnapshotReaderProbe(snapshot),
+    AGENT_ID,
+  );
+}
+
+describe("atomic activation-routing reader", () => {
+  test("uses exactly one purpose-bound snapshot read over the canonical keys", async () => {
+    const reader = new SnapshotReaderProbe([MARKER, ACTIVE_AUTHORITY, route()]);
+
+    await expect(
+      readActivationRoutingState(reader, AGENT_ID),
+    ).resolves.toMatchObject({
+      status: "ready",
+    });
+    expect(reader.snapshotCalls).toEqual([
+      [
+        `agent:${AGENT_ID}:routing-managed`,
+        `agent:${AGENT_ID}:registration-authority`,
+        `agent:${AGENT_ID}:activation-route`,
+      ],
+    ]);
+    expect(reader.evalCalls).toBe(0);
+    expect(reader.getCalls).toBe(0);
+  });
+
+  test("returns unmanaged only when all three new keys are absent", async () => {
+    await expect(read([null, null, null])).resolves.toEqual({
+      status: "unmanaged",
+    });
+    await expect(read([null, ACTIVE_AUTHORITY, null])).resolves.toEqual({
+      status: "conflict",
+      reason: "partial_managed_state",
+    });
+    await expect(read([null, null, route()])).resolves.toEqual({
+      status: "conflict",
+      reason: "partial_managed_state",
+    });
+  });
+
+  test.each([
+    "not-json",
+    "null",
+    JSON.stringify({ version: 1, managed: false }),
+    JSON.stringify({ version: 2, managed: true }),
+    JSON.stringify({ version: 1, managed: true, extra: true }),
+  ])("fails closed for a malformed managed marker: %s", async (rawMarker) => {
+    await expect(read([rawMarker, ACTIVE_AUTHORITY, route()])).resolves.toEqual(
+      {
+        status: "authority_unavailable",
+        reason: "invalid_marker",
+      },
+    );
+  });
+
+  test("fails closed when durable registration authority is missing", async () => {
+    await expect(read([MARKER, null, route()])).resolves.toEqual({
+      status: "authority_unavailable",
+      reason: "authority_missing",
+    });
+  });
+
+  test.each([
+    "not-json",
+    JSON.stringify({
+      version: 1,
+      state: "active",
+      generation: "00000000-0000-4A00-8000-000000000002",
+      publicationId: PUBLICATION_ID,
+      endpointSha256: ENDPOINT_SHA256,
+    }),
+    JSON.stringify({
+      version: 1,
+      state: "active",
+      generation: GENERATION,
+      publicationId: PUBLICATION_ID,
+      endpointSha256: ENDPOINT_SHA256.toUpperCase(),
+    }),
+    JSON.stringify({
+      version: 1,
+      state: "transition",
+      generation: GENERATION,
+      publicationId: PUBLICATION_ID,
+      endpointSha256: null,
+    }),
+    JSON.stringify({
+      version: 1,
+      state: "active",
+      generation: GENERATION,
+      publicationId: PUBLICATION_ID,
+      endpointSha256: ENDPOINT_SHA256,
+      extra: true,
+    }),
+  ])(
+    "fails closed for malformed authority JSON or shape: %s",
+    async (rawAuthority) => {
+      await expect(read([MARKER, rawAuthority, route()])).resolves.toEqual({
+        status: "authority_unavailable",
+        reason: "invalid_authority",
+      });
+    },
+  );
+
+  test("maps a durable transition to starting without trusting a stale route", async () => {
+    await expect(
+      read([
+        MARKER,
+        TRANSITION_AUTHORITY,
+        route({
+          generation: OTHER_GENERATION,
+          serverName: `sandbox-${OTHER_GENERATION}`,
+        }),
+      ]),
+    ).resolves.toMatchObject({
+      status: "starting",
+      authority: { state: "transition" },
+    });
+  });
+
+  test("maps a durable tombstone to revoked even when a stale TTL route remains", async () => {
+    await expect(
+      read([MARKER, REVOKED_AUTHORITY, route()]),
+    ).resolves.toMatchObject({
+      status: "revoked",
+      authority: { state: "revoked" },
+    });
+  });
+
+  test("maps an active authority without its TTL route to starting", async () => {
+    await expect(read([MARKER, ACTIVE_AUTHORITY, null])).resolves.toMatchObject(
+      {
+        status: "starting",
+        authority: { state: "active" },
+      },
+    );
+  });
+
+  test.each([
+    "not-json",
+    "[]",
+    JSON.stringify({
+      version: 1,
+      kind: "dedicated-sandbox",
+      generation: GENERATION,
+      publicationId: PUBLICATION_ID,
+      endpointSha256: ENDPOINT_SHA256,
+      serverName: `sandbox-${GENERATION}`,
+      extra: true,
+    }),
+    route({ kind: "shared-runtime" }),
+    route({ endpointSha256: ENDPOINT_SHA256.toUpperCase() }),
+  ])("rejects malformed route JSON or shape: %s", async (rawRoute) => {
+    await expect(read([MARKER, ACTIVE_AUTHORITY, rawRoute])).resolves.toEqual({
+      status: "conflict",
+      reason: "invalid_route",
+    });
+  });
+
+  test.each([
+    [
+      route({
+        generation: OTHER_GENERATION,
+        serverName: `sandbox-${OTHER_GENERATION}`,
+      }),
+      "generation_mismatch",
+    ],
+    [route({ publicationId: OTHER_PUBLICATION_ID }), "publication_mismatch"],
+    [
+      route({ endpointSha256: OTHER_ENDPOINT_SHA256 }),
+      "endpoint_hash_mismatch",
+    ],
+    [route({ serverName: `sandbox-${OTHER_GENERATION}` }), "invalid_route"],
+  ])("rejects authority/route divergence (%s)", async (rawRoute, reason) => {
+    await expect(read([MARKER, ACTIVE_AUTHORITY, rawRoute])).resolves.toEqual({
+      status: "conflict",
+      reason,
+    });
+  });
+
+  test("returns the exact validated authority and route when ready", async () => {
+    await expect(read([MARKER, ACTIVE_AUTHORITY, route()])).resolves.toEqual({
+      status: "ready",
+      authority: {
+        version: 1,
+        state: "active",
+        generation: GENERATION,
+        publicationId: PUBLICATION_ID,
+        endpointSha256: ENDPOINT_SHA256,
+      },
+      route: {
+        version: 1,
+        kind: "dedicated-sandbox",
+        generation: GENERATION,
+        publicationId: PUBLICATION_ID,
+        endpointSha256: ENDPOINT_SHA256,
+        serverName: `sandbox-${GENERATION}`,
+      },
+    });
+  });
+
+  test("fails closed for an invalid snapshot envelope or reader error", async () => {
+    await expect(read([MARKER, ACTIVE_AUTHORITY])).resolves.toEqual({
+      status: "authority_unavailable",
+      reason: "invalid_snapshot",
+    });
+
+    const reader = new SnapshotReaderProbe(
+      null,
+      new Error("redis unavailable"),
+    );
+    await expect(readActivationRoutingState(reader, AGENT_ID)).resolves.toEqual(
+      {
+        status: "authority_unavailable",
+        reason: "redis_unavailable",
+      },
+    );
+    expect(reader.snapshotCalls).toHaveLength(1);
+    expect(reader.evalCalls).toBe(0);
+    expect(reader.getCalls).toBe(0);
+  });
+
+  test("keeps Redis EVAL_RO and Upstash read-only script contracts distinct", () => {
+    const upstashShebang = "#!lua flags=no-writes,allow-key-locking\n";
+
+    expect(ACTIVATION_ROUTING_REDIS_EVAL_RO_SCRIPT.startsWith("#!lua")).toBe(
+      false,
+    );
+    expect(ACTIVATION_ROUTING_REDIS_EVAL_RO_SCRIPT).not.toContain(
+      "allow-key-locking",
+    );
+    expect(
+      ACTIVATION_ROUTING_UPSTASH_READ_ONLY_SCRIPT.startsWith(upstashShebang),
+    ).toBe(true);
+    expect(
+      ACTIVATION_ROUTING_UPSTASH_READ_ONLY_SCRIPT.slice(upstashShebang.length),
+    ).toBe(ACTIVATION_ROUTING_REDIS_EVAL_RO_SCRIPT);
+  });
+
+  test("requires the Lua presence envelope that defeats Upstash JSON auto-deserialization", async () => {
+    const reader = new SnapshotReaderProbe([MARKER, ACTIVE_AUTHORITY, route()]);
+    await expect(
+      readActivationRoutingState(reader, AGENT_ID),
+    ).resolves.toMatchObject({
+      status: "ready",
+    });
+    expect(ACTIVATION_ROUTING_REDIS_EVAL_RO_SCRIPT).toContain(
+      `return "${SNAPSHOT_VALUE_PREFIX}" .. value`,
+    );
+    expect(ACTIVATION_ROUTING_REDIS_EVAL_RO_SCRIPT).toContain(
+      `return "${SNAPSHOT_MISSING_SENTINEL}"`,
+    );
+    expect(ACTIVATION_ROUTING_REDIS_EVAL_RO_SCRIPT).toContain(
+      `"${SNAPSHOT_SENTINEL}"`,
+    );
+
+    const unenvelopedReader: ActivationRoutingSnapshotReader = {
+      async readActivationRoutingSnapshot() {
+        return [
+          JSON.parse(MARKER),
+          JSON.parse(ACTIVE_AUTHORITY),
+          JSON.parse(route()),
+        ];
+      },
+    };
+    await expect(
+      readActivationRoutingState(unenvelopedReader, AGENT_ID),
+    ).resolves.toEqual({
+      status: "authority_unavailable",
+      reason: "invalid_snapshot",
+    });
+
+    const wrongSentinelReader: ActivationRoutingSnapshotReader = {
+      async readActivationRoutingSnapshot() {
+        return [
+          "activation-routing-snapshot:v2",
+          `${SNAPSHOT_VALUE_PREFIX}${MARKER}`,
+          `${SNAPSHOT_VALUE_PREFIX}${ACTIVE_AUTHORITY}`,
+          `${SNAPSHOT_VALUE_PREFIX}${route()}`,
+        ];
+      },
+    };
+    await expect(
+      readActivationRoutingState(wrongSentinelReader, AGENT_ID),
+    ).resolves.toEqual({
+      status: "authority_unavailable",
+      reason: "invalid_snapshot",
+    });
+
+    const exactMissingEnvelopeReader: ActivationRoutingSnapshotReader = {
+      async readActivationRoutingSnapshot() {
+        return [
+          SNAPSHOT_SENTINEL,
+          SNAPSHOT_MISSING_SENTINEL,
+          SNAPSHOT_MISSING_SENTINEL,
+          SNAPSHOT_MISSING_SENTINEL,
+        ];
+      },
+    };
+    await expect(
+      readActivationRoutingState(exactMissingEnvelopeReader, AGENT_ID),
+    ).resolves.toEqual({ status: "unmanaged" });
+  });
+
+  test.each([null, false])(
+    "rejects a raw RESP missing value outside the versioned protocol: %p",
+    async (rawMissing) => {
+      const reader: ActivationRoutingSnapshotReader = {
+        async readActivationRoutingSnapshot() {
+          return [
+            SNAPSHOT_SENTINEL,
+            `${SNAPSHOT_VALUE_PREFIX}${MARKER}`,
+            rawMissing,
+            `${SNAPSHOT_VALUE_PREFIX}${route()}`,
+          ];
+        },
+      };
+      await expect(
+        readActivationRoutingState(reader, AGENT_ID),
+      ).resolves.toEqual({
+        status: "authority_unavailable",
+        reason: "invalid_snapshot",
+      });
+    },
+  );
+
+  test("rejects a non-canonical agent id before constructing Redis keys", async () => {
+    const reader = new SnapshotReaderProbe([null, null, null]);
+    await expect(
+      readActivationRoutingState(
+        reader,
+        "00000000-0000-4A00-8000-000000000001",
+      ),
+    ).resolves.toEqual({
+      status: "authority_unavailable",
+      reason: "invalid_agent_id",
+    });
+    expect(reader.snapshotCalls).toHaveLength(0);
+    expect(reader.evalCalls).toBe(0);
+    expect(reader.getCalls).toBe(0);
+  });
+});

--- a/packages/cloud/services/_common/tests/activation-routing.test.ts
+++ b/packages/cloud/services/_common/tests/activation-routing.test.ts
@@ -13,7 +13,8 @@ const GENERATION = "00000000-0000-4000-8000-000000000002";
 const OTHER_GENERATION = "00000000-0000-4000-8000-000000000003";
 const PUBLICATION_ID = "00000000-0000-4000-8000-000000000004";
 const OTHER_PUBLICATION_ID = "00000000-0000-4000-8000-000000000005";
-const ENDPOINT_SHA256 = "a".repeat(64);
+const ENDPOINT_SHA256 =
+  "73eb701612c13ee660f3598e5309e6ce83743070eb648ea7670a57e060047e11";
 const OTHER_ENDPOINT_SHA256 = "b".repeat(64);
 const SNAPSHOT_MISSING_SENTINEL = "activation-routing-missing:v1";
 const SNAPSHOT_SENTINEL = "activation-routing-snapshot:v1";
@@ -42,6 +43,26 @@ const REVOKED_AUTHORITY = JSON.stringify({
   endpointSha256: null,
 });
 
+interface EndpointFixture {
+  version: number;
+  generation: string;
+  kind: string;
+  serverName: string;
+  registryUrl: string;
+  bridgeUrl: string;
+  healthUrl: string;
+}
+
+const ENDPOINT: EndpointFixture = {
+  version: 1,
+  generation: GENERATION,
+  kind: "dedicated-sandbox",
+  serverName: `sandbox-${GENERATION}`,
+  registryUrl: "https://sandbox.internal:3000/",
+  bridgeUrl: "http://100.64.0.2:3000",
+  healthUrl: "http://100.64.0.2:3000/health",
+};
+
 function route(
   overrides: Partial<{
     version: number;
@@ -49,7 +70,7 @@ function route(
     generation: string;
     publicationId: string;
     endpointSha256: string;
-    serverName: string;
+    endpoint: EndpointFixture;
   }> = {},
 ): string {
   return JSON.stringify({
@@ -58,7 +79,7 @@ function route(
     generation: GENERATION,
     publicationId: PUBLICATION_ID,
     endpointSha256: ENDPOINT_SHA256,
-    serverName: `sandbox-${GENERATION}`,
+    endpoint: ENDPOINT,
     ...overrides,
   });
 }
@@ -214,7 +235,11 @@ describe("atomic activation-routing reader", () => {
         TRANSITION_AUTHORITY,
         route({
           generation: OTHER_GENERATION,
-          serverName: `sandbox-${OTHER_GENERATION}`,
+          endpoint: {
+            ...ENDPOINT,
+            generation: OTHER_GENERATION,
+            serverName: `sandbox-${OTHER_GENERATION}`,
+          },
         }),
       ]),
     ).resolves.toMatchObject({
@@ -250,7 +275,7 @@ describe("atomic activation-routing reader", () => {
       generation: GENERATION,
       publicationId: PUBLICATION_ID,
       endpointSha256: ENDPOINT_SHA256,
-      serverName: `sandbox-${GENERATION}`,
+      endpoint: ENDPOINT,
       extra: true,
     }),
     route({ kind: "shared-runtime" }),
@@ -266,7 +291,11 @@ describe("atomic activation-routing reader", () => {
     [
       route({
         generation: OTHER_GENERATION,
-        serverName: `sandbox-${OTHER_GENERATION}`,
+        endpoint: {
+          ...ENDPOINT,
+          generation: OTHER_GENERATION,
+          serverName: `sandbox-${OTHER_GENERATION}`,
+        },
       }),
       "generation_mismatch",
     ],
@@ -275,7 +304,15 @@ describe("atomic activation-routing reader", () => {
       route({ endpointSha256: OTHER_ENDPOINT_SHA256 }),
       "endpoint_hash_mismatch",
     ],
-    [route({ serverName: `sandbox-${OTHER_GENERATION}` }), "invalid_route"],
+    [
+      route({
+        endpoint: {
+          ...ENDPOINT,
+          serverName: `sandbox-${OTHER_GENERATION}`,
+        },
+      }),
+      "invalid_route",
+    ],
   ])("rejects authority/route divergence (%s)", async (rawRoute, reason) => {
     await expect(read([MARKER, ACTIVE_AUTHORITY, rawRoute])).resolves.toEqual({
       status: "conflict",
@@ -299,8 +336,26 @@ describe("atomic activation-routing reader", () => {
         generation: GENERATION,
         publicationId: PUBLICATION_ID,
         endpointSha256: ENDPOINT_SHA256,
-        serverName: `sandbox-${GENERATION}`,
+        endpoint: ENDPOINT,
       },
+    });
+  });
+
+  test("rejects a route whose endpoint body no longer matches its content hash", async () => {
+    await expect(
+      read([
+        MARKER,
+        ACTIVE_AUTHORITY,
+        route({
+          endpoint: {
+            ...ENDPOINT,
+            registryUrl: "https://attacker-selected.invalid/",
+          },
+        }),
+      ]),
+    ).resolves.toEqual({
+      status: "conflict",
+      reason: "endpoint_hash_mismatch",
     });
   });
 


### PR DESCRIPTION
# Relates to

- #20726
- Contract transposition for Draft PR #28644; managed consumer wiring remains stacked in Draft PRs #28656 and #28657.

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] Targets `develop` and retains the reviewed base snapshot `origin/develop@f2ccf2555d18d9ec768c3ace447f595799c44ed0`.
- [ ] Refresh from current `develop` after #28644 lands; no history rewrite is planned.
- [ ] Full `bun run verify` remains pending before Ready.
- [x] Exact head `42916337b10a32e149c2572f6e8d12bcd19b86d3` received a fresh independent adversarial review with no P0-P3 findings.

# Risks

Medium — this defines the fail-closed authority reader used by later gateway consumers. It changes no live route, publishes no managed marker, and remains Draft until the producer contract is available on its base.

# Background

## What does this PR do?

Adds one atomic read-only snapshot for the durable managed marker, registration authority, and TTL activation route.

The route carries the complete nested V1 endpoint envelope, including the canonical `runtimeAgentId`. The reader validates exact shape, generation, immutable server name, canonical runtime UUID, strict ASCII DNS/IPv4 HTTP endpoints with ports 1..65535, canonical SHA-256 content digest, and equality with the durable authority's generation/publication/hash. The runtime identity is content-addressed but is deliberately not compared with the managed sandbox ID; that binding belongs to the consumer in #28656.

The transport contract remains purpose-bound:

- Redis OSS adapters must use `EVAL_RO`.
- Upstash adapters must use `evalRo` with the byte-zero `no-writes,allow-key-locking` shebang.
- The authority reader is not handed a generic mutating `EVAL` capability.

## What kind of change is this?

Bug fix and non-breaking routing foundation.

# Testing

Reviewer entry points:

- `packages/cloud/services/_common/src/activation-routing.ts`
- `packages/cloud/services/_common/tests/activation-routing.test.ts`

Exact-head validation:

```bash
bun test tests/activation-routing.test.ts --config=/dev/null --isolate
bun run typecheck
../../../../node_modules/.bin/biome check src/activation-routing.ts tests/activation-routing.test.ts
git diff --check
```

Observed:

- activation authority: 56/56 passed, 78 assertions;
- shared-package typecheck: passed;
- Biome and diff-check: passed;
- canonical field order, digest, URL grammar, missing/invalid runtime identity, and TCP port boundaries covered;
- independent exact-SHA adversarial review: CLEAN, no P0-P3.

# Evidence Gate

<!-- evidence-head:42916337b10a32e149c2572f6e8d12bcd19b86d3 -->

- [ ] Before/after screenshots: N/A — backend-only.
- [ ] Walkthrough video: N/A — no rendered flow.
- [ ] Backend logs: Pending — producer and consumers are separate Draft slices.
- [ ] Frontend logs: N/A.
- [ ] Real-LLM trajectory: N/A.
- [x] Domain artifacts: exact tests and independent review above.

# Known gaps / failures

The full repository verification, concrete producer landing, consumer wiring, and live Redis evidence remain pending while this PR is Draft. No deployment or environment mutation was performed.

# Deploy Notes

No deploy is included or authorized by this Draft PR.
