### PR TITLE
fix(ci): invoke Windows security scripts as paths

### DIFF
--- a/.github/workflows/browser-bridge-windows-security.yml
+++ b/.github/workflows/browser-bridge-windows-security.yml
@@ -24,10 +24,10 @@ jobs:
         run: bun install --frozen-lockfile --ignore-scripts
       - name: Execute Windows PowerShell 5.1 security helpers
         shell: powershell
-        run: packages/app-core/platforms/electrobun/scripts/test-browser-bridge-windows-security.ps1
+        run: .\packages/app-core/platforms/electrobun/scripts/test-browser-bridge-windows-security.ps1
       - name: Compile and probe staged Windows native host
         shell: powershell
-        run: packages/app-core/platforms/electrobun/scripts/test-browser-bridge-windows-native-host.ps1
+        run: .\packages/app-core/platforms/electrobun/scripts/test-browser-bridge-windows-native-host.ps1
       - name: Run browser broker security contracts
         shell: powershell
         working-directory: packages/app-core/platforms/electrobun

--- a/packages/app-core/platforms/electrobun/src/native/browser-bridge-windows-native-host-proof.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/browser-bridge-windows-native-host-proof.test.ts
@@ -28,7 +28,7 @@ describe("browser bridge hosted Windows native-host proof", () => {
   it("runs a staged compiled-host probe and registration lifecycle contracts", () => {
     expect(workflowSource).toContain("timeout-minutes: 30");
     expect(workflowSource).toContain(
-      "- name: Compile and probe staged Windows native host\n        shell: powershell\n        run: packages/app-core/platforms/electrobun/scripts/test-browser-bridge-windows-native-host.ps1",
+      "- name: Compile and probe staged Windows native host\n        shell: powershell\n        run: .\\packages/app-core/platforms/electrobun/scripts/test-browser-bridge-windows-native-host.ps1",
     );
     expect(workflowSource).toContain("browser-bridge-registration.test.ts");
     expect(workflowSource).toContain("browser-bridge-unregister.test.ts");


### PR DESCRIPTION
# Relates to

Fixes the Windows security reusable workflow's PowerShell script invocation.

## Problem

PowerShell 5.1 does not resolve a repository-relative script as a command when the path is written without `.` or `./`. The workflow currently invokes both security helper scripts as bare paths, producing `CommandNotFoundException` on Windows runners.

## Fix

Prefix both scripts with `.` so PowerShell executes the checked-out files:

- `test-browser-bridge-windows-security.ps1`
- `test-browser-bridge-windows-native-host.ps1`

## Evidence

- `git diff --check` passed.
- The failure is directly reproduced in the hosted Windows lane on the current browser bridge PRs; the source files exist in current develop.
