### PR TITLE
test(ui): cover useResyncReconcile resync event contract

### DIFF
--- a/packages/ui/src/state/useResyncReconcile.test.tsx
+++ b/packages/ui/src/state/useResyncReconcile.test.tsx
@@ -1,0 +1,107 @@
+/** Covers useResyncReconcile — the RESYNC_EVENT window listener that reloads the active conversation. */
+// @vitest-environment jsdom
+
+/**
+ * Real-event harness: no module mocks. The hook is mounted with renderHook,
+ * resync signals are dispatched through the REAL dispatchConversationResync
+ * boundary from AppContext.hooks (so the event name/detail contract is what
+ * production code exercises), and the loader is an observable spy.
+ */
+import { renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { dispatchConversationResync } from "./AppContext.hooks";
+import { useResyncReconcile } from "./useResyncReconcile";
+
+function mountHook(activeIdAtMount: string | null) {
+  const activeConversationIdRef = { current: activeIdAtMount };
+  const loadConversationMessages = vi.fn(
+    async (): Promise<{ ok: true }> => ({ ok: true }),
+  );
+  const utils = renderHook(() =>
+    useResyncReconcile({ activeConversationIdRef, loadConversationMessages }),
+  );
+  return { activeConversationIdRef, loadConversationMessages, ...utils };
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useResyncReconcile", () => {
+  it("reloads the active conversation when the resync names it", async () => {
+    const { loadConversationMessages } = mountHook("conv-active");
+
+    dispatchConversationResync({
+      conversationId: "conv-active",
+      reason: "connection-recovered",
+    });
+
+    await Promise.resolve();
+    expect(loadConversationMessages).toHaveBeenCalledTimes(1);
+    expect(loadConversationMessages).toHaveBeenCalledWith("conv-active");
+  });
+
+  it("falls back to the active ref when the event carries a null conversation id", async () => {
+    const { loadConversationMessages } = mountHook("conv-active");
+
+    dispatchConversationResync({ conversationId: null });
+
+    await Promise.resolve();
+    expect(loadConversationMessages).toHaveBeenCalledTimes(1);
+    expect(loadConversationMessages).toHaveBeenCalledWith("conv-active");
+  });
+
+  it("ignores a resync that names a background conversation", async () => {
+    const { loadConversationMessages } = mountHook("conv-active");
+
+    dispatchConversationResync({
+      conversationId: "conv-background",
+      reason: "voice-turn-complete",
+    });
+
+    await Promise.resolve();
+    expect(loadConversationMessages).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when no conversation is active and the event carries no id", async () => {
+    const { loadConversationMessages } = mountHook(null);
+
+    dispatchConversationResync({ conversationId: null });
+
+    await Promise.resolve();
+    expect(loadConversationMessages).not.toHaveBeenCalled();
+  });
+
+  it("stops reloading after the user navigates away from the named conversation", async () => {
+    const { activeConversationIdRef, loadConversationMessages } =
+      mountHook("conv-first");
+
+    activeConversationIdRef.current = "conv-second";
+    dispatchConversationResync({ conversationId: "conv-first" });
+
+    await Promise.resolve();
+    expect(loadConversationMessages).not.toHaveBeenCalled();
+  });
+
+  it("reloads the newly active conversation after the active id changes", async () => {
+    const { activeConversationIdRef, loadConversationMessages } =
+      mountHook("conv-first");
+
+    activeConversationIdRef.current = "conv-second";
+    dispatchConversationResync({ conversationId: "conv-second" });
+
+    await Promise.resolve();
+    expect(loadConversationMessages).toHaveBeenCalledTimes(1);
+    expect(loadConversationMessages).toHaveBeenCalledWith("conv-second");
+  });
+
+  it("unsubscribes on unmount", async () => {
+    const { loadConversationMessages, unmount } = mountHook("conv-active");
+
+    unmount();
+    dispatchConversationResync({ conversationId: "conv-active" });
+
+    await Promise.resolve();
+    expect(loadConversationMessages).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Test-only change: adds a colocated vitest suite for `packages/ui/src/state/useResyncReconcile.ts`, the hook that reloads the active conversation when a canonical conversation-resync signal (`RESYNC_EVENT` = `elizaos:needs-resync`, dispatched by `dispatchConversationResync` from `packages/ui/src/state/AppContext.hooks.ts`) fires after another transport (WebSocket recovery, realtime voice) persisted messages outside the mounted chat sender. The hook previously had zero direct test coverage.

**7 tests, +107 lines, one new file. No production code changes.**

The suite drives the real production dispatch boundary (`dispatchConversationResync` — no module mocks) through `renderHook` under jsdom and asserts:

- reload of the active conversation when the event names it (loader called once, with the exact id)
- fallback to the active ref when the event carries `conversationId: null`
- ignore of a resync naming a background conversation
- no-op when neither the event nor the ref supplies an id
- drop of a resync targeting a conversation the user just navigated away from (stale-event guard)
- reload of the newly active conversation after the active id changes (ref read at event time)
- listener removal on unmount

## Verification

- `npx vitest run src/state/useResyncReconcile.test.tsx` — **7/7 pass** (1.03s)
- Mutation probe (RED control equivalent for coverage PRs): deleting the guard line `if (activeConversationIdRef.current !== convId) return;` from the module makes exactly the background-conversation and navigate-away tests fail (2/7 red), proving the suite bites; source restored afterward
- `npx biome check src/state/useResyncReconcile.test.tsx` — clean
- `bun run typecheck` (packages/ui, tsc --noEmit) — exit 0
- Full `src/state/` directory suite: 1361 passed / 7 failed — the 7 failures are in `startup-phase-restore.steward-refresh.test.ts` and `startup-phase-restore.concurrency.test.ts` and reproduce identically at this develop commit with the new file removed (control run), i.e. pre-existing and unrelated to this PR

RP-assisted review (RepoPrompt CE, gpt-5.6-sol engineer role): APPROVE, no must-fix items — "Assertions are not tautological… Uses the real dispatch boundary and real event listener; the system under test is not mocked."

<!-- evidence-rows-start -->
| evidence row | value |
| --- | --- |
| unit-tests | `npx vitest run src/state/useResyncReconcile.test.tsx` → Test Files 1 passed (1), Tests 7 passed (7), Duration 1.03s |
| lint | `npx biome check src/state/useResyncReconcile.test.tsx` → "Checked 1 file … No fixes applied", no findings |
| typecheck | `bun run typecheck` (packages/ui) → tsc --noEmit exit 0 |
| backend-logs | N/A - test-only change, no server or model path exercised |
| screenshots | N/A - test-only change, no UI surface rendered |
| llm-trajectory | N/A - test-only change, no model behavior involved |
<!-- evidence-rows-end -->

<!-- evidence-head:3b40cb92ab8d69ed9b9d2408b94605ead69027c2 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only change, no UI surface rendered

<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only change, no UI surface rendered

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - test-only change, no UI surface rendered

<!-- evidence-row:backend-logs -->
- [ ] N/A - test-only change; inline transcript: vitest 7/7 pass (1.03s) + biome clean + tsc --noEmit exit 0; mutation control: removing active-id guard fails 2/7

<!-- evidence-row:frontend-logs -->
- [ ] N/A - test-only change, no browser session involved

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - test-only change, no model behavior involved

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - test-only change, no domain artifact produced

AI provider/model: zai / glm-5.3
Client / agent tooling: Hermes Agent
Contribution skill revision: elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [hermes-t3rpz]
<!-- eliza-computer-attribution:v1 {"provider":"zai","model":"glm-5.3","client":"Hermes Agent","skill_revision":"elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza"} -->

