### PR TITLE
fix(cloud): enforce read-only gateway routing snapshots

### DIFF
--- a/packages/cloud/services/gateway-webhook/src/__tests__/activation-routing-redis-adapters.test.ts
+++ b/packages/cloud/services/gateway-webhook/src/__tests__/activation-routing-redis-adapters.test.ts
@@ -1,0 +1,166 @@
+/** Proves each gateway Redis transport uses its purpose-bound read-only path. */
+import { describe, expect, spyOn, test } from "bun:test";
+import {
+  ACTIVATION_ROUTING_REDIS_EVAL_RO_SCRIPT,
+  ACTIVATION_ROUTING_UPSTASH_READ_ONLY_SCRIPT,
+  type ActivationRoutingSnapshotKeys,
+} from "@elizaos/cloud-services-common";
+import { Redis as UpstashRedis } from "@upstash/redis";
+import IORedis from "ioredis";
+import { createRedis, NativeRedisAdapter, UpstashRedisAdapter } from "../redis";
+
+const SNAPSHOT_KEYS: ActivationRoutingSnapshotKeys = [
+  "agent:00000000-0000-4000-8000-000000000001:routing-managed",
+  "agent:00000000-0000-4000-8000-000000000001:registration-authority",
+  "agent:00000000-0000-4000-8000-000000000001:activation-route",
+];
+const SNAPSHOT = [
+  "activation-routing-snapshot:v1",
+  "activation-routing-missing:v1",
+  "activation-routing-missing:v1",
+  "activation-routing-missing:v1",
+];
+
+type FetchImplementation = (
+  input: Parameters<typeof fetch>[0],
+  init?: Parameters<typeof fetch>[1],
+) => ReturnType<typeof fetch>;
+
+function hermeticFetch(implementation: FetchImplementation): typeof fetch {
+  return Object.assign(implementation, { preconnect: () => undefined });
+}
+
+function restoreEnvironmentValue(
+  name: "MOCK_REDIS" | "REDIS_URL" | "KV_REST_API_URL" | "KV_REST_API_TOKEN",
+  value: string | undefined,
+): void {
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+}
+
+describe("activation-routing Redis transports", () => {
+  test("native Redis uses EVAL_RO exactly and never falls back to EVAL", async () => {
+    const client = new IORedis({ lazyConnect: true });
+    const evalRo = spyOn(client, "eval_ro").mockResolvedValue(SNAPSHOT);
+    const evalWrite = spyOn(client, "eval").mockResolvedValue(SNAPSHOT);
+    const redis = new NativeRedisAdapter(client);
+
+    try {
+      expect(await redis.readActivationRoutingSnapshot(SNAPSHOT_KEYS)).toEqual(
+        SNAPSHOT,
+      );
+      expect(evalRo).toHaveBeenCalledTimes(1);
+      expect(evalRo).toHaveBeenCalledWith(
+        ACTIVATION_ROUTING_REDIS_EVAL_RO_SCRIPT,
+        3,
+        ...SNAPSHOT_KEYS,
+      );
+      expect(evalWrite).not.toHaveBeenCalled();
+    } finally {
+      evalRo.mockRestore();
+      evalWrite.mockRestore();
+      client.disconnect();
+    }
+  });
+
+  test("Upstash uses evalRo exactly and never calls mutating eval", async () => {
+    const requestBodies: unknown[] = [];
+    const fetchMock = spyOn(globalThis, "fetch").mockImplementation(
+      hermeticFetch(async (_input, init) => {
+        requestBodies.push(JSON.parse(String(init?.body)) as unknown);
+        return new Response(
+          JSON.stringify([
+            {
+              result: SNAPSHOT.map((value) =>
+                Buffer.from(value).toString("base64"),
+              ),
+            },
+          ]),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }),
+    );
+
+    try {
+      const client = new UpstashRedis({
+        url: "https://example.invalid",
+        token: "test-token",
+        automaticDeserialization: false,
+      });
+      const redis = new UpstashRedisAdapter(client);
+
+      expect(await redis.readActivationRoutingSnapshot(SNAPSHOT_KEYS)).toEqual(
+        SNAPSHOT,
+      );
+      expect(requestBodies).toEqual([
+        [
+          [
+            "eval_ro",
+            ACTIVATION_ROUTING_UPSTASH_READ_ONLY_SCRIPT,
+            3,
+            ...SNAPSHOT_KEYS,
+          ],
+        ],
+      ]);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
+
+  test("Upstash preserves raw missing and literal-null routing values", async () => {
+    const previousEnvironment = {
+      MOCK_REDIS: process.env.MOCK_REDIS,
+      REDIS_URL: process.env.REDIS_URL,
+      KV_REST_API_URL: process.env.KV_REST_API_URL,
+      KV_REST_API_TOKEN: process.env.KV_REST_API_TOKEN,
+    };
+    const encodedResults: Array<string | null> = [null, "bnVsbA==", "bnVsbA=="];
+    const fetchMock = spyOn(globalThis, "fetch").mockImplementation(
+      hermeticFetch(async () => {
+        const result = encodedResults.shift();
+        if (result === undefined) {
+          throw new Error("unexpected extra Upstash request");
+        }
+        return new Response(JSON.stringify([{ result }]), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }),
+    );
+
+    delete process.env.MOCK_REDIS;
+    delete process.env.REDIS_URL;
+    process.env.KV_REST_API_URL = "https://example.invalid";
+    process.env.KV_REST_API_TOKEN = "test-token";
+
+    try {
+      const redis = createRedis();
+      expect(await redis.readAgentServerRoutingValue("missing")).toBeNull();
+      expect(await redis.readAgentServerRoutingValue("literal-null")).toBe(
+        "null",
+      );
+      expect(await redis.get("literal-null")).toBeNull();
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+      expect(encodedResults).toHaveLength(0);
+    } finally {
+      fetchMock.mockRestore();
+      restoreEnvironmentValue("MOCK_REDIS", previousEnvironment.MOCK_REDIS);
+      restoreEnvironmentValue("REDIS_URL", previousEnvironment.REDIS_URL);
+      restoreEnvironmentValue(
+        "KV_REST_API_URL",
+        previousEnvironment.KV_REST_API_URL,
+      );
+      restoreEnvironmentValue(
+        "KV_REST_API_TOKEN",
+        previousEnvironment.KV_REST_API_TOKEN,
+      );
+    }
+  });
+});

--- a/packages/cloud/services/gateway-webhook/src/__tests__/redis-mock.test.ts
+++ b/packages/cloud/services/gateway-webhook/src/__tests__/redis-mock.test.ts
@@ -1,5 +1,16 @@
 /** Exercises the gateway Redis mock adapter with deterministic service fixtures. */
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import {
+  readActivationRoutingState,
+  resolveAgentServerRouting,
+} from "@elizaos/cloud-services-common";
+
+const AGENT_ID = "00000000-0000-4000-8000-000000000001";
+const UNMANAGED_AGENT_ID = "00000000-0000-4000-8000-000000000005";
+const RUNTIME_AGENT_ID = "00000000-0000-4000-8000-000000000004";
+const GENERATION = "00000000-0000-4000-8000-000000000002";
+const PUBLICATION_ID = "00000000-0000-4000-8000-000000000003";
+const ENDPOINT_SHA256 = "a".repeat(64);
 
 const PREV_MOCK = process.env.MOCK_REDIS;
 
@@ -50,6 +61,107 @@ describe("MemoryRedisAdapter (MOCK_REDIS=1)", () => {
 
     // get returns null for missing key
     expect(await redis.get("nope")).toBeNull();
+
+    // The legacy getter preserves its JSON parsing behavior, while the routing
+    // authority reader must distinguish a missing key from the literal value.
+    await redis.set("literal-null", "null");
+    expect(await redis.readAgentServerRoutingValue("nope")).toBeNull();
+    expect(await redis.readAgentServerRoutingValue("literal-null")).toBe(
+      "null",
+    );
+    expect(await redis.get("literal-null")).toBeNull();
+
+    if (redis.quit) await redis.quit();
+  });
+
+  test("executes a real atomic activation-routing snapshot in ioredis-mock", async () => {
+    const { createRedis } = await import("../redis");
+    const redis = createRedis();
+
+    const authority = {
+      version: 1 as const,
+      state: "active" as const,
+      generation: GENERATION,
+      publicationId: PUBLICATION_ID,
+      endpointSha256: ENDPOINT_SHA256,
+    };
+    const route = {
+      version: 1 as const,
+      kind: "dedicated-sandbox" as const,
+      generation: GENERATION,
+      publicationId: PUBLICATION_ID,
+      endpointSha256: ENDPOINT_SHA256,
+      serverName: `sandbox-${GENERATION}`,
+    };
+
+    await redis.set(
+      `agent:${AGENT_ID}:routing-managed`,
+      JSON.stringify({ version: 1, managed: true }),
+    );
+    await redis.set(
+      `agent:${AGENT_ID}:registration-authority`,
+      JSON.stringify(authority),
+    );
+    await redis.set(
+      `agent:${AGENT_ID}:activation-route`,
+      JSON.stringify(route),
+    );
+
+    expect(await readActivationRoutingState(redis, AGENT_ID)).toEqual({
+      status: "ready",
+      authority,
+      route,
+    });
+    await redis.set(
+      `server:${route.serverName}:url`,
+      "https://sandbox.internal:3000",
+    );
+    // A legacy pointer is deliberately present: the durable managed marker
+    // must prevent it from influencing the selected route.
+    await redis.set(`agent:${RUNTIME_AGENT_ID}:server`, "shared-eliza");
+    await redis.set(
+      "server:shared-eliza:url",
+      "http://shared-eliza.internal:3000",
+    );
+    expect(
+      await resolveAgentServerRouting(redis, {
+        managedAgentId: AGENT_ID,
+        runtimeAgentId: RUNTIME_AGENT_ID,
+      }),
+    ).toEqual({
+      kind: "ready",
+      mode: "managed",
+      managedAgentId: AGENT_ID,
+      runtimeAgentId: RUNTIME_AGENT_ID,
+      serverName: route.serverName,
+      serverUrl: "https://sandbox.internal:3000",
+    });
+
+    if (redis.quit) await redis.quit();
+  });
+
+  test("resolves the legacy runtime id only when managed state is absent", async () => {
+    const { createRedis } = await import("../redis");
+    const redis = createRedis();
+
+    await redis.set(`agent:${RUNTIME_AGENT_ID}:server`, "shared-eliza");
+    await redis.set(
+      "server:shared-eliza:url",
+      "http://shared-eliza.internal:3000",
+    );
+    expect(
+      await resolveAgentServerRouting(redis, {
+        managedAgentId: UNMANAGED_AGENT_ID,
+        runtimeAgentId: RUNTIME_AGENT_ID,
+      }),
+    ).toEqual({
+      kind: "ready",
+      mode: "legacy",
+      managedAgentId: UNMANAGED_AGENT_ID,
+      runtimeAgentId: RUNTIME_AGENT_ID,
+      serverName: "shared-eliza",
+      serverUrl: "http://shared-eliza.internal:3000",
+    });
 
     if (redis.quit) await redis.quit();
   });

--- a/packages/cloud/services/gateway-webhook/src/__tests__/redis-mock.test.ts
+++ b/packages/cloud/services/gateway-webhook/src/__tests__/redis-mock.test.ts
@@ -10,7 +10,8 @@ const UNMANAGED_AGENT_ID = "00000000-0000-4000-8000-000000000005";
 const RUNTIME_AGENT_ID = "00000000-0000-4000-8000-000000000004";
 const GENERATION = "00000000-0000-4000-8000-000000000002";
 const PUBLICATION_ID = "00000000-0000-4000-8000-000000000003";
-const ENDPOINT_SHA256 = "a".repeat(64);
+const ENDPOINT_SHA256 =
+  "73eb701612c13ee660f3598e5309e6ce83743070eb648ea7670a57e060047e11";
 
 const PREV_MOCK = process.env.MOCK_REDIS;
 
@@ -91,7 +92,15 @@ describe("MemoryRedisAdapter (MOCK_REDIS=1)", () => {
       generation: GENERATION,
       publicationId: PUBLICATION_ID,
       endpointSha256: ENDPOINT_SHA256,
-      serverName: `sandbox-${GENERATION}`,
+      endpoint: {
+        version: 1 as const,
+        generation: GENERATION,
+        kind: "dedicated-sandbox" as const,
+        serverName: `sandbox-${GENERATION}`,
+        registryUrl: "https://sandbox.internal:3000/",
+        bridgeUrl: "http://100.64.0.2:3000",
+        healthUrl: "http://100.64.0.2:3000/health",
+      },
     };
 
     await redis.set(
@@ -113,8 +122,8 @@ describe("MemoryRedisAdapter (MOCK_REDIS=1)", () => {
       route,
     });
     await redis.set(
-      `server:${route.serverName}:url`,
-      "https://sandbox.internal:3000",
+      `server:${route.endpoint.serverName}:url`,
+      route.endpoint.registryUrl,
     );
     // A legacy pointer is deliberately present: the durable managed marker
     // must prevent it from influencing the selected route.
@@ -133,8 +142,8 @@ describe("MemoryRedisAdapter (MOCK_REDIS=1)", () => {
       mode: "managed",
       managedAgentId: AGENT_ID,
       runtimeAgentId: RUNTIME_AGENT_ID,
-      serverName: route.serverName,
-      serverUrl: "https://sandbox.internal:3000",
+      serverName: route.endpoint.serverName,
+      serverUrl: route.endpoint.registryUrl,
     });
 
     if (redis.quit) await redis.quit();

--- a/packages/cloud/services/gateway-webhook/src/__tests__/redis-mock.test.ts
+++ b/packages/cloud/services/gateway-webhook/src/__tests__/redis-mock.test.ts
@@ -11,7 +11,7 @@ const RUNTIME_AGENT_ID = "00000000-0000-4000-8000-000000000004";
 const GENERATION = "00000000-0000-4000-8000-000000000002";
 const PUBLICATION_ID = "00000000-0000-4000-8000-000000000003";
 const ENDPOINT_SHA256 =
-  "73eb701612c13ee660f3598e5309e6ce83743070eb648ea7670a57e060047e11";
+  "4bd23c045b9b9ee9fece3064056f68f5d7505c0e63b93439ecfa8f8d13b64a40";
 
 const PREV_MOCK = process.env.MOCK_REDIS;
 
@@ -97,6 +97,7 @@ describe("MemoryRedisAdapter (MOCK_REDIS=1)", () => {
         generation: GENERATION,
         kind: "dedicated-sandbox" as const,
         serverName: `sandbox-${GENERATION}`,
+        runtimeAgentId: RUNTIME_AGENT_ID,
         registryUrl: "https://sandbox.internal:3000/",
         bridgeUrl: "http://100.64.0.2:3000",
         healthUrl: "http://100.64.0.2:3000/health",

--- a/packages/cloud/services/gateway-webhook/src/redis.ts
+++ b/packages/cloud/services/gateway-webhook/src/redis.ts
@@ -1,5 +1,11 @@
 /** Provides native and in-memory Redis adapters for webhook routing state. */
 import { createRequire } from "node:module";
+import {
+  ACTIVATION_ROUTING_REDIS_EVAL_RO_SCRIPT,
+  ACTIVATION_ROUTING_UPSTASH_READ_ONLY_SCRIPT,
+  type ActivationRoutingSnapshotKeys,
+  type ActivationRoutingSnapshotReader,
+} from "@elizaos/cloud-services-common";
 import { Redis as UpstashRedis } from "@upstash/redis";
 import IORedis from "ioredis";
 import { logger } from "./logger";
@@ -24,6 +30,16 @@ interface SetOptions {
   nx?: boolean;
 }
 
+function parseRedisValue<T>(value: string | null): T | null {
+  if (value === null) return null;
+
+  try {
+    return JSON.parse(value) as T;
+  } catch {
+    return value as T;
+  }
+}
+
 export interface GatewayRedis {
   get<T = unknown>(key: string): Promise<T | null>;
   set(key: string, value: string, options?: SetOptions): Promise<unknown>;
@@ -34,18 +50,30 @@ export interface GatewayRedis {
   quit?(): Promise<unknown>;
 }
 
-class NativeRedisAdapter implements GatewayRedis {
-  constructor(private readonly client: IORedis) {}
+/** Redis boundary required by managed activation routing consumers. */
+export interface GatewayRoutingRedis
+  extends GatewayRedis,
+    ActivationRoutingSnapshotReader {
+  readAgentServerRoutingValue(key: string): Promise<unknown>;
+}
+
+type NativeRedisClient = Pick<
+  IORedis,
+  "get" | "set" | "del" | "lpush" | "ltrim" | "expire" | "eval_ro" | "quit"
+>;
+
+type UpstashRedisClient = Pick<
+  UpstashRedis,
+  "get" | "set" | "del" | "lpush" | "ltrim" | "expire" | "evalRo"
+> & {
+  quit?(): Promise<unknown>;
+};
+
+export class NativeRedisAdapter implements GatewayRoutingRedis {
+  constructor(private readonly client: NativeRedisClient) {}
 
   async get<T = unknown>(key: string): Promise<T | null> {
-    const value = await this.client.get(key);
-    if (value === null) return null;
-
-    try {
-      return JSON.parse(value) as T;
-    } catch {
-      return value as T;
-    }
+    return parseRedisValue<T>(await this.client.get(key));
   }
 
   async set(
@@ -81,12 +109,85 @@ class NativeRedisAdapter implements GatewayRedis {
     return this.client.expire(key, seconds);
   }
 
+  async readActivationRoutingSnapshot(
+    keys: ActivationRoutingSnapshotKeys,
+  ): Promise<unknown> {
+    return this.client.eval_ro(
+      ACTIVATION_ROUTING_REDIS_EVAL_RO_SCRIPT,
+      3,
+      ...keys,
+    );
+  }
+
+  async readAgentServerRoutingValue(key: string): Promise<string | null> {
+    return this.client.get(key);
+  }
+
   async quit(): Promise<unknown> {
     return this.client.quit();
   }
 }
 
-class MemoryRedisAdapter implements GatewayRedis {
+export class UpstashRedisAdapter implements GatewayRoutingRedis {
+  constructor(private readonly client: UpstashRedisClient) {}
+
+  async get<T = unknown>(key: string): Promise<T | null> {
+    return parseRedisValue<T>(await this.client.get<string>(key));
+  }
+
+  async set(
+    key: string,
+    value: string,
+    options: SetOptions = {},
+  ): Promise<unknown> {
+    if (options.ex && options.nx) {
+      return this.client.set(key, value, { ex: options.ex, nx: true });
+    }
+    if (options.ex) {
+      return this.client.set(key, value, { ex: options.ex });
+    }
+    if (options.nx) {
+      return this.client.set(key, value, { nx: true });
+    }
+    return this.client.set(key, value);
+  }
+
+  async del(key: string): Promise<unknown> {
+    return this.client.del(key);
+  }
+
+  async lpush(key: string, value: string): Promise<unknown> {
+    return this.client.lpush(key, value);
+  }
+
+  async ltrim(key: string, start: number, stop: number): Promise<unknown> {
+    return this.client.ltrim(key, start, stop);
+  }
+
+  async expire(key: string, seconds: number): Promise<unknown> {
+    return this.client.expire(key, seconds);
+  }
+
+  async readActivationRoutingSnapshot(
+    keys: ActivationRoutingSnapshotKeys,
+  ): Promise<unknown> {
+    return this.client.evalRo(
+      ACTIVATION_ROUTING_UPSTASH_READ_ONLY_SCRIPT,
+      [...keys],
+      [],
+    );
+  }
+
+  async readAgentServerRoutingValue(key: string): Promise<string | null> {
+    return this.client.get<string>(key);
+  }
+
+  async quit(): Promise<unknown> {
+    return this.client.quit?.();
+  }
+}
+
+class MemoryRedisAdapter implements GatewayRoutingRedis {
   private readonly client: IORedis;
 
   constructor() {
@@ -98,13 +199,7 @@ class MemoryRedisAdapter implements GatewayRedis {
   }
 
   async get<T = unknown>(key: string): Promise<T | null> {
-    const value = await this.client.get(key);
-    if (value === null) return null;
-    try {
-      return JSON.parse(value) as T;
-    } catch {
-      return value as T;
-    }
+    return parseRedisValue<T>(await this.client.get(key));
   }
 
   async set(
@@ -140,12 +235,28 @@ class MemoryRedisAdapter implements GatewayRedis {
     return this.client.expire(key, seconds);
   }
 
+  async readActivationRoutingSnapshot(
+    keys: ActivationRoutingSnapshotKeys,
+  ): Promise<unknown> {
+    // ioredis-mock does not implement EVAL_RO. This adapter is selected only by
+    // MOCK_REDIS=1, so execute the same portable read-only script with EVAL.
+    return this.client.eval(
+      ACTIVATION_ROUTING_REDIS_EVAL_RO_SCRIPT,
+      3,
+      ...keys,
+    );
+  }
+
+  async readAgentServerRoutingValue(key: string): Promise<string | null> {
+    return this.client.get(key);
+  }
+
   async quit(): Promise<unknown> {
     return this.client.quit();
   }
 }
 
-export function createRedis(): GatewayRedis {
+export function createRedis(): GatewayRoutingRedis {
   if (process.env.MOCK_REDIS === "1") {
     logger.info("[GatewayRedis] using in-memory mock adapter");
     return new MemoryRedisAdapter();
@@ -156,10 +267,13 @@ export function createRedis(): GatewayRedis {
 
   if (kvRestApiUrl && kvRestApiToken) {
     logger.info("Using Upstash Redis REST client");
-    return new UpstashRedis({
-      url: kvRestApiUrl,
-      token: kvRestApiToken,
-    }) as GatewayRedis;
+    return new UpstashRedisAdapter(
+      new UpstashRedis({
+        url: kvRestApiUrl,
+        token: kvRestApiToken,
+        automaticDeserialization: false,
+      }),
+    );
   }
 
   if (process.env.REDIS_URL) {


### PR DESCRIPTION
# Relates to

- #20726
- Stacked on Draft #28656.

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] Merged the updated resolver head `79e96ee8770ae3ce0548b345a7d3e3adea452dc6` normally, without rebase or force-push.
- [ ] Full repository `bun run verify` remains pending before Ready.
- [x] Exact head `efe88e3c054d8717ac70099bc776c9da6ca26c92` received a fresh independent adversarial review with no P0-P3 findings.

# Sync with base

- [x] Clean stacked ancestry on `fix/20726-11-managed-agent-routing`.
- [ ] Recheck after any base update and immediately before Ready.

# Risks

Medium — adds production-capable Redis transport methods, but this slice does not yet switch the gateway routing caller.

# Background

## What does this PR do?

Implements the purpose-bound routing reader on every gateway Redis transport without changing legacy operations.

- Native Redis calls `eval_ro(script, 3, ...keys)` exactly and has no mutating `EVAL` fallback.
- Upstash calls `evalRo(readOnlyScript, keys, [])` with automatic deserialization disabled.
- Raw GET preserves the difference between a missing key and the literal stored value `"null"`.
- The in-memory `EVAL` implementation exists only behind `MOCK_REDIS=1`.
- Hermetic transport tests inspect the actual Upstash command payload.
- Real `ioredis-mock` integration covers the nested content-addressed endpoint, including its canonical `runtimeAgentId`, managed selection despite a legacy pointer, double-snapshot confirmation, and unmanaged legacy resolution.

## What kind of change is this?

Bug fix and gateway routing adapter foundation.

# Testing

Reviewer entry points:

- `packages/cloud/services/gateway-webhook/src/redis.ts`
- `packages/cloud/services/gateway-webhook/src/__tests__/activation-routing-redis-adapters.test.ts`
- `packages/cloud/services/gateway-webhook/src/__tests__/redis-mock.test.ts`

Observed on the exact head:

- gateway targeted tests: 6/6 passed, 25 assertions;
- common activation/resolver tests: 103/103 passed, 222 assertions;
- gateway and common typechecks: passed;
- gateway build, Biome, and diff-check: passed;
- full gateway suite: 451 passed, 1 unrelated pre-existing Telegram failure;
- full common suite: 167 passed, 1 unrelated pre-existing Telegram delivery failure;
- independent exact-head review: CLEAN, no P0-P3.

# Evidence Gate

<!-- evidence-head:efe88e3c054d8717ac70099bc776c9da6ca26c92 -->

- [ ] Before/after screenshots: N/A — backend-only.
- [ ] Walkthrough video: N/A.
- [ ] Backend logs: Pending — concrete consumer wiring is a later Draft slice.
- [ ] Frontend logs: N/A.
- [ ] Real-LLM trajectory: N/A.
- [x] Domain artifacts: hermetic transport payload tests, ioredis-mock integration, exact tests, and independent review above.

# Known gaps / failures

The two full-package failures are in unchanged Telegram tests and reproduce outside this routing delta. No live Redis/Upstash endpoint or credential was used; consumer wiring remains pending. No deployment or environment mutation was performed.

# Deploy Notes

No deploy is included or authorized by this Draft PR.
