### PR TITLE
test(personal-assistant): cover harsh-no-bypass rule SQL gate

### DIFF
--- a/plugins/plugin-personal-assistant/src/website-blocker/chat-integration/harsh-mode-check.test.ts
+++ b/plugins/plugin-personal-assistant/src/website-blocker/chat-integration/harsh-mode-check.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as sqlMod from "../../lifeops/sql.js";
+import { hasActiveHarshNoBypassRule } from "./harsh-mode-check.js";
+
+function makeRuntime(db: unknown, agentId = "agent-1") {
+  return {
+    agentId,
+    adapter: { db },
+  };
+}
+
+describe("hasActiveHarshNoBypassRule", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("fails closed to false when the runtime exposes no db adapter", async () => {
+    const spy = vi.spyOn(sqlMod, "executeRawSql");
+    const result = await hasActiveHarshNoBypassRule(makeRuntime(undefined));
+    expect(result).toBe(false);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("fails closed to false when the db lacks an execute function", async () => {
+    const spy = vi.spyOn(sqlMod, "executeRawSql");
+    const result = await hasActiveHarshNoBypassRule(makeRuntime({}));
+    expect(result).toBe(false);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("queries the block-rules table with the agent id quoted and the harsh gate type", async () => {
+    const spy = vi.spyOn(sqlMod, "executeRawSql").mockResolvedValue([]);
+    const db = { execute: vi.fn() };
+    const result = await hasActiveHarshNoBypassRule(
+      makeRuntime(db, "agent-42"),
+    );
+    expect(result).toBe(false);
+    expect(spy).toHaveBeenCalledTimes(1);
+    const [, sql] = spy.mock.calls[0];
+    expect(sql).toContain("app_lifeops.life_block_rules");
+    expect(sql).toContain("agent_id = 'agent-42'");
+    expect(sql).toContain("active = TRUE");
+    expect(sql).toContain("gate_type = 'harsh_no_bypass'");
+    expect(sql).toContain("LIMIT 1");
+  });
+
+  it("quotes single quotes inside the agent id to defeat SQL injection", async () => {
+    const spy = vi.spyOn(sqlMod, "executeRawSql").mockResolvedValue([]);
+    const db = { execute: vi.fn() };
+    await hasActiveHarshNoBypassRule(makeRuntime(db, "agent-1' OR '1'='1"));
+    const [, sql] = spy.mock.calls[0];
+    expect(sql).toContain("agent_id = 'agent-1'' OR ''1''=''1'");
+    expect(sql).not.toContain("OR '1'='1'");
+  });
+
+  it("returns true when the query returns rows", async () => {
+    vi.spyOn(sqlMod, "executeRawSql").mockResolvedValue([{ ok: 1 }]);
+    const result = await hasActiveHarshNoBypassRule(
+      makeRuntime({ execute: vi.fn() }),
+    );
+    expect(result).toBe(true);
+  });
+
+  it("returns false when the query returns no rows", async () => {
+    vi.spyOn(sqlMod, "executeRawSql").mockResolvedValue([]);
+    const result = await hasActiveHarshNoBypassRule(
+      makeRuntime({ execute: vi.fn() }),
+    );
+    expect(result).toBe(false);
+  });
+
+  it("propagates db failures instead of silently opening the unblock path", async () => {
+    vi.spyOn(sqlMod, "executeRawSql").mockRejectedValue(
+      new Error("connection refused"),
+    );
+    await expect(
+      hasActiveHarshNoBypassRule(makeRuntime({ execute: vi.fn() })),
+    ).rejects.toThrow("connection refused");
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage pinning the harsh-no-bypass SQL gate contract. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new test file exercising `hasActiveHarshNoBypassRule`
against a stub `executeRawSql`, including the fail-closed no-db path, the SQL
construction path (table name, agent-id quoting, harsh gate type, LIMIT 1), the
SQL-injection quoting of single quotes in the agent id, and failure propagation.
No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused test run, isolation | Concrete |
| Reviewer can verify without reading code | Concrete |

Focused test run in isolation, at the PR head:

```log
 ✓ website-blocker/chat-integration/harsh-mode-check.test.ts (7 tests) 10ms

 Test Files  1 passed (1)
      Tests  7 passed (7)
```

- Command: `npx vitest run website-blocker/chat-integration/harsh-mode-check.test.ts`
- Result: all passed
---
- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
