### PR TITLE
test(blocker): pin selfcontrol role check fail-closed contract

### DIFF
--- a/plugins/plugin-blocker/src/services/website-blocker/roles.test.ts
+++ b/plugins/plugin-blocker/src/services/website-blocker/roles.test.ts
@@ -1,0 +1,63 @@
+import { checkSenderRole as coreCheckSenderRole } from "@elizaos/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { checkSenderRole } from "./roles.js";
+
+vi.mock("@elizaos/core", () => ({
+  checkSenderRole: vi.fn(),
+}));
+
+function makeMessage(overrides: Record<string, unknown> = {}) {
+  return {
+    roomId: "room-7",
+    entityId: "entity-9",
+    content: { text: "hi" },
+    ...overrides,
+  };
+}
+
+describe("checkSenderRole (selfcontrol)", () => {
+  beforeEach(() => {
+    vi.mocked(coreCheckSenderRole).mockReset();
+  });
+
+  it("throws a descriptive error when the core check returns null (fail closed)", async () => {
+    vi.mocked(coreCheckSenderRole).mockResolvedValue(null);
+    const message = makeMessage();
+    await expect(
+      checkSenderRole({ agentId: "agent-1" } as never, message as never),
+    ).rejects.toThrow(/checkSenderRole returned null/);
+    await expect(
+      checkSenderRole({ agentId: "agent-1" } as never, message as never),
+    ).rejects.toThrow(/roomId=room-7/);
+    await expect(
+      checkSenderRole({ agentId: "agent-1" } as never, message as never),
+    ).rejects.toThrow(/entityId=entity-9/);
+    await expect(
+      checkSenderRole({ agentId: "agent-1" } as never, message as never),
+    ).rejects.toThrow(/agentId=agent-1/);
+  });
+
+  it("throws when the core check returns undefined", async () => {
+    vi.mocked(coreCheckSenderRole).mockResolvedValue(undefined);
+    await expect(
+      checkSenderRole({ agentId: "agent-2" } as never, makeMessage() as never),
+    ).rejects.toThrow(/checkSenderRole returned null/);
+  });
+
+  it("passes the runtime and message through to the core check", async () => {
+    vi.mocked(coreCheckSenderRole).mockResolvedValue({ role: "admin" });
+    const runtime = { agentId: "agent-3" };
+    const message = makeMessage({ roomId: "room-11" });
+    const result = await checkSenderRole(runtime as never, message as never);
+    expect(result).toEqual({ role: "admin" });
+    expect(coreCheckSenderRole).toHaveBeenCalledWith(runtime, message);
+  });
+
+  it("forwards core failures unchanged", async () => {
+    const err = new Error("core exploded");
+    vi.mocked(coreCheckSenderRole).mockRejectedValue(err);
+    await expect(
+      checkSenderRole({ agentId: "agent-4" } as never, makeMessage() as never),
+    ).rejects.toThrow("core exploded");
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage pinning the selfcontrol role check fail-closed contract. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new test file pinning the `checkSenderRole` wrapper's
fail-closed contract — a null/undefined result from the core role check throws a
descriptive error (with room/entity/agent ids) instead of silently hiding the
action from the LLM. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused test run, isolation | Concrete |
| Reviewer can verify without reading code | Concrete |

Focused test run in isolation, at the PR head:

```log
 ✓ roles.test.ts (4 tests) 10ms

 Test Files  1 passed (1)
      Tests  4 passed (4)
```

- Command: `npx vitest run roles.test.ts`
- Result: all passed
---
- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
