### PR TITLE
test(local-inference): pin aosp imagegen boundary guards

### DIFF
--- a/plugins/plugin-local-inference/src/services/imagegen/aosp-unavailable.test.ts
+++ b/plugins/plugin-local-inference/src/services/imagegen/aosp-unavailable.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it, vi } from "vitest";
+import { loadAospImageGenBackend } from "./aosp-unavailable.js";
+import {
+	ImageGenBackendUnavailableError,
+	isImageGenUnavailable,
+} from "./errors.js";
+import { resolveSeed } from "./sd-cpp.js";
+
+function makeBinding(handle: unknown, hasImageGen = true) {
+	return {
+		hasImageGen: () => hasImageGen,
+		initImageGen: vi.fn().mockResolvedValue(handle),
+	};
+}
+
+function makeHandle() {
+	return {
+		generate: vi
+			.fn()
+			.mockResolvedValue({
+				png: new Uint8Array([1]),
+				seedUsed: 7,
+				inferenceMs: 12,
+			}),
+		dispose: vi.fn().mockResolvedValue(undefined),
+	};
+}
+
+function makeRequest(overrides: Record<string, unknown> = {}) {
+	return {
+		prompt: "a cat",
+		width: 512,
+		height: 512,
+		seed: 3,
+		...overrides,
+	};
+}
+
+async function makeBackend(opts: {
+	binding?: unknown;
+	handle?: unknown;
+	hasImageGen?: boolean;
+	now?: () => number;
+}) {
+	const handle = opts.handle ?? makeHandle();
+	const binding = opts.binding ?? makeBinding(handle, opts.hasImageGen);
+	return loadAospImageGenBackend({
+		loadArgs: { modelPath: "/m.gguf", accelerator: "auto" },
+		modelKey: "z-image",
+		binding: binding as never,
+		now: opts.now,
+	});
+}
+
+describe("loadAospImageGenBackend", () => {
+	it("throws a structured unavailable error when no binding is provided", async () => {
+		await expect(
+			loadAospImageGenBackend({
+				loadArgs: { modelPath: "/m.gguf" },
+				modelKey: "z-image",
+			}),
+		).rejects.toMatchObject({
+			code: "IMAGE_GEN_BACKEND_UNAVAILABLE",
+			reason: "binding_unavailable",
+			backendId: "aosp",
+		});
+	});
+
+	it("throws when the binding reports no imagegen symbols", async () => {
+		await expect(makeBackend({ hasImageGen: false })).rejects.toMatchObject({
+			code: "IMAGE_GEN_BACKEND_UNAVAILABLE",
+			reason: "binding_unavailable",
+		});
+	});
+
+	it("rejects out-of-range dimensions in supports()", async () => {
+		const backend = await makeBackend({});
+		expect(backend.supports(makeRequest({ width: 0 }))).toBe(false);
+		expect(backend.supports(makeRequest({ height: -1 }))).toBe(false);
+		expect(backend.supports(makeRequest({ width: 2049 }))).toBe(false);
+		expect(backend.supports(makeRequest({ height: 4096 }))).toBe(false);
+		expect(backend.supports(makeRequest())).toBe(true);
+		expect(backend.supports(makeRequest({ width: 2048, height: 2048 }))).toBe(
+			true,
+		);
+	});
+
+	it("refuses generate() after dispose() (state machine guard)", async () => {
+		const handle = makeHandle();
+		const backend = await makeBackend({ handle });
+		await backend.dispose();
+		await expect(backend.generate(makeRequest())).rejects.toMatchObject({
+			code: "IMAGE_GEN_BACKEND_UNAVAILABLE",
+			reason: "binding_unavailable",
+		});
+		expect(handle.generate).not.toHaveBeenCalled();
+	});
+
+	it("refuses empty prompts as unsupported_request", async () => {
+		const handle = makeHandle();
+		const backend = await makeBackend({ handle });
+		await expect(
+			backend.generate(makeRequest({ prompt: "   " })),
+		).rejects.toMatchObject({
+			code: "IMAGE_GEN_BACKEND_UNAVAILABLE",
+			reason: "unsupported_request",
+		});
+		expect(handle.generate).not.toHaveBeenCalled();
+	});
+
+	it("applies defaults and forwards the resolved seed on the happy path", async () => {
+		const handle = makeHandle();
+		const backend = await makeBackend({ handle });
+		const result = await backend.generate(makeRequest({ seed: -2 }));
+		expect(handle.generate).toHaveBeenCalledWith({
+			prompt: "a cat",
+			negativePrompt: undefined,
+			width: 512,
+			height: 512,
+			steps: 4,
+			guidanceScale: 0,
+			seed: resolveSeed(-2),
+			scheduler: undefined,
+			signal: undefined,
+		});
+		expect(result.mime).toBe("image/png");
+		expect(result.image).toBeInstanceOf(Uint8Array);
+		expect(result.seed).toBe(7);
+		expect(result.metadata.model).toBe("z-image");
+	});
+
+	it("falls back to wall-clock elapsed when inferenceMs is not positive", async () => {
+		const handle = makeHandle();
+		let t = 1000;
+		handle.generate.mockImplementation(async () => {
+			// The real native call takes wall-clock time; advance the injected
+			// clock inside the awaited call so the fallback has a delta to read.
+			t += 500;
+			return { png: new Uint8Array([1]), seedUsed: 1, inferenceMs: 0 };
+		});
+		const backend = await makeBackend({ handle, now: () => t });
+		const result = await backend.generate(makeRequest());
+		expect(result.metadata.inferenceTimeMs).toBe(500);
+	});
+
+	it("falls back to the requested seed when seedUsed is not a number", async () => {
+		const handle = makeHandle();
+		handle.generate.mockResolvedValue({
+			png: new Uint8Array([1]),
+			seedUsed: "nope",
+			inferenceMs: 5,
+		});
+		const backend = await makeBackend({ handle });
+		const result = await backend.generate(makeRequest({ seed: 11 }));
+		expect(result.seed).toBe(11);
+	});
+
+	it("reports progress once with the full step count", async () => {
+		const handle = makeHandle();
+		const backend = await makeBackend({ handle });
+		const onProgressChunk = vi.fn();
+		await backend.generate(makeRequest({ onProgressChunk }));
+		expect(onProgressChunk).toHaveBeenCalledWith({ step: 4, total: 4 });
+	});
+
+	it("dispose is idempotent", async () => {
+		const handle = makeHandle();
+		const backend = await makeBackend({ handle });
+		await backend.dispose();
+		await backend.dispose();
+		expect(handle.dispose).toHaveBeenCalledTimes(1);
+	});
+
+	it("emits errors that satisfy isImageGenUnavailable", async () => {
+		const err = new ImageGenBackendUnavailableError(
+			"aosp",
+			"binding_unavailable",
+			"no symbols",
+		);
+		expect(isImageGenUnavailable(err)).toBe(true);
+		expect(isImageGenUnavailable(new Error("x"))).toBe(false);
+	});
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage pinning the AOSP imagegen backend boundary guards. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: new tests pinning `loadAospImageGenBackend` guards —
structured unavailable error when the binding is missing, dimension bounds in
`supports()`, refuse-after-dispose, empty-prompt rejection, seed/inference-ms
fallbacks, and idempotent dispose. No production code is modified, no runtime
behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused test run, isolation | Concrete |
| Reviewer can verify without reading code | Concrete |

Focused test run in isolation, at the PR head:

```log
 ✓ imagegen/aosp-unavailable.test.ts (11 tests) 17ms

 Test Files  1 passed (1)
      Tests  11 passed (11)
```

- Command: `npx vitest run imagegen/aosp-unavailable.test.ts`
- Result: all passed
---
- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
