### PR TITLE
fix(plugin-agent-orchestrator): keep UTF-16 surrogate pairs intact in interruption prompt and verdict truncation

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/interruption-decider.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/interruption-decider.test.ts
@@ -317,4 +317,24 @@ describe("decideInterruptionWithModel", () => {
     // Invalid action → regex fallback (mid-turn relevant → queue).
     expect(decision.action).toBe("queue");
   });
+
+  it("preserves surrogate pairs when parsing model verdict reasons", async () => {
+    // "x" (1 char) + "⚡" (2 chars * 100 = 200 chars) -> bisects at index 160
+    const emojis = "x" + "⚡".repeat(100);
+    const useModel = vi.fn(async () =>
+      JSON.stringify({ action: "interrupt", reason: emojis }),
+    );
+    const decision = await decideInterruptionWithModel(
+      runtimeWithModel(useModel),
+      { ...base, text: "stop now", sessionBusy: true },
+    );
+    expect(decision.action).toBe("interrupt");
+    for (const char of decision.reason) {
+      expect(
+        /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(
+          char,
+        ),
+      ).toBe(false);
+    }
+  });
 });

--- a/plugins/plugin-agent-orchestrator/src/services/interruption-decider.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/interruption-decider.ts
@@ -166,10 +166,22 @@ export function decideInterruption(
 // redirect"). The regex decision remains the fallback whenever the model is
 // unavailable or returns an unparseable verdict, so behavior only ever improves.
 
+function truncateText(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  let end = maxChars;
+  if (end > 0 && end < text.length) {
+    const code = text.charCodeAt(end - 1);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      end -= 1;
+    }
+  }
+  return text.slice(0, end);
+}
+
 function buildInterruptionClassifierPrompt(input: InterruptionInput): string {
   const label = input.agentLabel?.trim() || input.agentType;
   const work = input.taskContext?.trim()
-    ? input.taskContext.trim().slice(0, 500)
+    ? truncateText(input.taskContext.trim(), 500)
     : "a coding task";
   const state = input.sessionBusy
     ? "MID-TURN (actively generating or running a tool right now)"
@@ -193,7 +205,7 @@ function buildInterruptionClassifierPrompt(input: InterruptionInput): string {
     `State: ${state}`,
     `Room: ${room}`,
     "",
-    `Incoming message: """${input.text.trim().slice(0, 800)}"""`,
+    `Incoming message: """${truncateText(input.text.trim(), 800)}"""`,
     "",
     "Choose EXACTLY one action:",
     '- "interrupt": stop or change direction RIGHT NOW — an explicit halt ("stop", "cancel", "wait"), or a redirect that invalidates the work in progress ("no, use Postgres not MySQL", "scrap that, start over"). Reserve for genuine halts/redirects worth cancelling live work for.',
@@ -225,7 +237,7 @@ function parseInterruptionVerdict(raw: string): InterruptionDecision | null {
   }
   const detail =
     typeof obj.reason === "string" && obj.reason.trim()
-      ? obj.reason.trim().slice(0, 160)
+      ? truncateText(obj.reason.trim(), 160)
       : "verdict";
   return { action, reason: `model: ${detail}` };
 }


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:a29682d9a9763fe73ebe18a14c7527a9255b1f16 -->

## Summary
In `plugins/plugin-agent-orchestrator/src/services/interruption-decider.ts`:
1. `buildInterruptionClassifierPrompt` used raw string slicing on `taskContext` (500 chars) and `input.text` (800 chars).
2. `parseInterruptionVerdict` used raw slicing on `obj.reason` (160 chars).

When user messages, task contexts, or model verdict reasons contain multi-byte UTF-16 surrogate pairs (e.g. emojis), slicing at byte boundaries can bisect surrogate pairs and produce orphaned surrogate characters (`\uFFFD`).

## Proposed Changes
1. Added surrogate-pair safe boundary truncation helper `truncateText`.
2. Applied `truncateText` to task context, prompt message, and verdict reason parsing in `interruption-decider.ts`.
3. Added regression test in `__tests__/unit/interruption-decider.test.ts`.

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-agent-orchestrator test __tests__/unit/interruption-decider.test.ts` (19/19 passed).

<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-3-5-sonnet","client":"antigravity","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
