### PR TITLE
fix(plugin-agent-orchestrator): keep UTF-16 surrogate pairs intact in verifier summary and error message truncation

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/goal-llm-verifier.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/goal-llm-verifier.test.ts
@@ -472,4 +472,38 @@ describe("verifyGoalCompletion (orchestration paths)", () => {
     expect(result.summary).toBe("tests not run");
     expect(result.missing).toEqual(["test suite green"]);
   });
+
+  it("preserves surrogate pairs when parsing verifier summary and error messages", async () => {
+    // "x" + "🎯" * 150 -> 301 code units > 280 (bisects at index 280)
+    const longEmoji = "x" + "🎯".repeat(150);
+    const parsed = parseJudgeResponse(
+      JSON.stringify({ passed: true, summary: longEmoji, missing: [] }),
+      ["c1"],
+    );
+    expect(parsed.passed).toBe(true);
+    for (const char of parsed.summary) {
+      expect(
+        /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(
+          char,
+        ),
+      ).toBe(false);
+    }
+
+    // Error detail bisecting at index 200
+    const longError = "x" + "🔥".repeat(110);
+    const runtime = makeMockRuntime({ shouldThrow: new Error(longError) });
+    const result = await verifyGoalCompletion(runtime, {
+      goal: "x",
+      acceptanceCriteria: ["c1"],
+      completionEvidence: "evidence",
+    });
+    expect(result.passed).toBe(false);
+    for (const char of result.summary) {
+      expect(
+        /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(
+          char,
+        ),
+      ).toBe(false);
+    }
+  });
 });

--- a/plugins/plugin-agent-orchestrator/src/services/goal-llm-verifier.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/goal-llm-verifier.ts
@@ -377,6 +377,18 @@ function findFirstJsonObject(raw: string): string | null {
   return null;
 }
 
+function truncateText(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  let end = maxChars;
+  if (end > 0 && end < text.length) {
+    const code = text.charCodeAt(end - 1);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      end -= 1;
+    }
+  }
+  return text.slice(0, end);
+}
+
 export function parseJudgeResponse(
   raw: string,
   acceptanceCriteria: readonly string[],
@@ -422,7 +434,7 @@ export function parseJudgeResponse(
   const passed = passedRaw === true && missing.length === 0;
   const summary =
     typeof summaryRaw === "string" && summaryRaw.trim().length > 0
-      ? summaryRaw.trim().slice(0, 280)
+      ? truncateText(summaryRaw.trim(), 280)
       : passed
         ? "All acceptance criteria confirmed by verifier."
         : "Verifier did not confirm every acceptance criterion.";
@@ -473,7 +485,7 @@ export async function verifyGoalCompletion(
     const detail = err instanceof Error ? err.message : String(err);
     return {
       passed: false,
-      summary: `Verifier model call failed: ${detail.slice(0, 200)}`,
+      summary: `Verifier model call failed: ${truncateText(detail, 200)}`,
       missing: [...input.acceptanceCriteria],
       rawResponse: "",
     };


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:b20f016c0fb36fc6eb238f9c36a51436695160f5 -->

## Summary
In `plugins/plugin-agent-orchestrator/src/services/goal-llm-verifier.ts`:
1. `parseJudgeResponse` used raw string slicing on `summaryRaw.trim()` (280 chars).
2. `verifyGoalCompletion` used raw string slicing on `detail` error message (200 chars).

When model judge responses or error messages contain multi-byte UTF-16 surrogate pairs (e.g. emojis), slicing at byte boundaries can bisect surrogate pairs and produce orphaned surrogate characters (`\uFFFD`).

## Proposed Changes
1. Added surrogate-pair safe boundary truncation helper `truncateText`.
2. Applied `truncateText` to `summaryRaw` and `detail` in `goal-llm-verifier.ts`.
3. Added regression tests in `__tests__/unit/goal-llm-verifier.test.ts`.

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-agent-orchestrator test __tests__/unit/goal-llm-verifier.test.ts` (43/43 passed).

<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-3-5-sonnet","client":"antigravity","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
