### PR TITLE
fix(plugin-agent-orchestrator): keep UTF-16 surrogate pairs intact in lane title truncation

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/lane-planner-surrogates.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/lane-planner-surrogates.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { createDeterministicLanePlan } from "../../src/services/lane-planner.ts";
+
+describe("lane planner surrogate safety", () => {
+  it("preserves surrogate pairs when constructing lane titles", () => {
+    // "x" (1 char) + "🚀" (2 chars * 50 = 100 chars) -> bisects at 80
+    const longTask = "x" + "🚀".repeat(50);
+    const plan = createDeterministicLanePlan({
+      task: longTask,
+      lanes: [{ task: longTask }],
+    });
+
+    expect(plan.lanes.length).toBe(1);
+    const title = plan.lanes[0].title;
+    expect(title.length).toBe(79);
+    for (const char of title) {
+      expect(
+        /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(
+          char,
+        ),
+      ).toBe(false);
+    }
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/services/lane-planner.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/lane-planner.ts
@@ -83,6 +83,18 @@ export interface LaneReadiness {
   blockers: string[];
 }
 
+function truncateText(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  let end = maxChars;
+  if (end > 0 && end < text.length) {
+    const code = text.charCodeAt(end - 1);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      end -= 1;
+    }
+  }
+  return text.slice(0, end);
+}
+
 function isEnabledValue(value: unknown): boolean {
   if (typeof value !== "string") return value === true;
   return ["1", "true", "yes", "on"].includes(value.trim().toLowerCase());
@@ -410,7 +422,7 @@ function buildLane(
       : staticAcceptanceCriteria(laneTask);
   return {
     id: `lane-${index + 1}`,
-    title: (input.title ?? laneTask).slice(0, 80),
+    title: truncateText(input.title ?? laneTask, 80),
     branchName,
     dependencies: [...dependencies],
     scopePaths: scopes,
@@ -519,7 +531,7 @@ function applyRefinement(plan: LanePlan, raw: string): LanePlan {
         ...lane,
         title:
           typeof refined.title === "string" && refined.title.trim()
-            ? refined.title.trim().slice(0, 80)
+            ? truncateText(refined.title.trim(), 80)
             : lane.title,
         initialPrompt:
           typeof refined.initialPrompt === "string" &&


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:18330b224a56283c616fbdd40f2576af0f0f7777 -->

## Summary
In `plugins/plugin-agent-orchestrator/src/services/lane-planner.ts`:
1. `buildLane` used raw string slicing on `input.title ?? laneTask` (80 chars).
2. `applyRefinement` used raw string slicing on `refined.title.trim()` (80 chars).

When task descriptions or titles contain multi-byte UTF-16 surrogate pairs (e.g. emojis or astral unicode characters), slicing at byte offset 80 can bisect surrogate pairs and produce orphaned surrogate characters (`\uFFFD`).

## Proposed Changes
1. Added surrogate-pair safe boundary truncation helper `truncateText`.
2. Applied `truncateText` to lane title creation and refinement in `lane-planner.ts`.
3. Added regression tests in `__tests__/unit/lane-planner-surrogates.test.ts`.

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-agent-orchestrator test __tests__/unit/lane-planner-surrogates.test.ts` (passed).

<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-3-5-sonnet","client":"antigravity","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
