### PR TITLE
fix(plugin-agent-orchestrator): keep UTF-16 surrogate pairs intact in acp-service stderr, output tail, and log preview truncation

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-normalize-tool-output.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-normalize-tool-output.test.ts
@@ -82,4 +82,22 @@ describe("normalizeToolOutput — exec records (#11578)", () => {
     const record = { call_id: "c5", command: "true" };
     expect(normalizeToolOutput(record)).toBe("$ true → exit ?");
   });
+
+  it("preserves surrogate pairs when formatting long stdout tails", () => {
+    // "x" (1 char) + "🔥" (2 chars * 120 = 240 chars) -> bisects at 200
+    const record = {
+      call_id: "c6",
+      command: "echo test",
+      exit_code: 0,
+      stdout: "x" + "🔥".repeat(120),
+    };
+    const out = normalizeToolOutput(record);
+    for (const char of out) {
+      expect(
+        /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(
+          char,
+        ),
+      ).toBe(false);
+    }
+  });
 });

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -232,6 +232,18 @@ const LEASE_REVOKE_EVENTS: ReadonlySet<SessionEventName> = new Set([
   "cancelled",
 ]);
 
+function truncateText(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  let end = maxChars;
+  if (end > 0 && end < text.length) {
+    const code = text.charCodeAt(end - 1);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      end -= 1;
+    }
+  }
+  return text.slice(0, end);
+}
+
 function isIncompletePromptStopReason(stopReason: string | undefined): boolean {
   const reason = (stopReason ?? "").toLowerCase();
   return (
@@ -3883,7 +3895,7 @@ export class AcpService extends Service {
       // an explicit invalid (null) result the caller skips.
       this.log("warn", "malformed acpx NDJSON line ignored", {
         sessionId,
-        line: line.slice(0, 200),
+        line: truncateText(line, 200),
       });
       return null;
     }
@@ -4843,7 +4855,7 @@ export class AcpService extends Service {
       return "acpx session was not found. This is likely an internal session bookkeeping error.";
     if (code === 5) return "acpx permission denied.";
     if (code === 3) return "acpx prompt timed out.";
-    if (stderr.trim()) return stderr.trim().slice(0, 500);
+    if (stderr.trim()) return truncateText(stderr.trim(), 500);
     return `acpx subprocess exited with code ${code ?? "unknown"}`;
   }
 
@@ -5451,7 +5463,7 @@ function execRecordOutputTail(record: Record<string, unknown>): string {
     .filter((entry) => entry.length > 0);
   if (candidates.length === 0) return "";
   const joined = candidates.join("\n").trim();
-  return joined.length > 200 ? `${joined.slice(0, 200)}…` : joined;
+  return joined.length > 200 ? `${truncateText(joined, 200)}…` : joined;
 }
 
 function parseJsonRecord(text: string): Record<string, unknown> | undefined {
@@ -5524,7 +5536,7 @@ function capStderr(text: string): string {
 }
 
 function preview(text: string): string {
-  return text.replace(/\s+/g, " ").slice(0, 80);
+  return truncateText(text.replace(/\s+/g, " "), 80);
 }
 
 function errorMessage(err: unknown): string {


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:670916293ff14f1fc71b8736ad3960c8900dd9b6 -->

## Summary
In `plugins/plugin-agent-orchestrator/src/services/acp-service.ts`:
1. Raw line logging in `handleAcpEvent` used raw slicing on `line` (200 chars).
2. Subprocess exit error descriptions used raw slicing on `stderr.trim()` (500 chars).
3. `execRecordOutputTail` used raw slicing on `joined` (200 chars).
4. `preview` used raw slicing on `text` (80 chars).

When process output, error messages, or logs contain multi-byte UTF-16 surrogate pairs (e.g. emojis or unicode logs), slicing at byte boundaries can bisect surrogate pairs and produce orphaned surrogate characters (`\uFFFD`).

## Proposed Changes
1. Added surrogate-pair safe boundary truncation helper `truncateText`.
2. Applied `truncateText` across `acp-service.ts`.
3. Added regression tests in `__tests__/unit/acp-normalize-tool-output.test.ts`.

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-agent-orchestrator test __tests__/unit/acp-normalize-tool-output.test.ts` (9/9 passed).

<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-3-5-sonnet","client":"antigravity","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
