### PR TITLE
fix(plugin-vision): honor explicit media.vision.enabled=false in auto-enable gate

### DIFF
--- a/plugins/plugin-vision/auto-enable.test.ts
+++ b/plugins/plugin-vision/auto-enable.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { shouldEnable } from "./auto-enable";
+
+type Ctx = {
+  config: unknown;
+  env: Record<string, unknown>;
+};
+
+const ctx = (config: unknown, env: Record<string, unknown> = {}): Ctx =>
+  ({ config, env }) as Ctx;
+
+describe("plugin-vision auto-enable gate", () => {
+  it("enables when features.vision is true", () => {
+    expect(shouldEnable(ctx({ features: { vision: true } }))).toBe(true);
+  });
+
+  it("enables when features.vision is an object that is not explicitly disabled", () => {
+    expect(shouldEnable(ctx({ features: { vision: {} } }))).toBe(true);
+    expect(shouldEnable(ctx({ features: { vision: { enabled: true } } }))).toBe(
+      true,
+    );
+  });
+
+  it("disables when features.vision.enabled is false", () => {
+    expect(
+      shouldEnable(ctx({ features: { vision: { enabled: false } } })),
+    ).toBe(false);
+  });
+
+  it("enables when a concrete vision provider is configured", () => {
+    expect(
+      shouldEnable(ctx({ media: { vision: { provider: "openai" } } })),
+    ).toBe(true);
+    expect(
+      shouldEnable(ctx({ media: { vision: { provider: "gemini" } } })),
+    ).toBe(true);
+  });
+
+  it("rejects whitespace-only provider values (fail-open regression)", () => {
+    expect(shouldEnable(ctx({ media: { vision: { provider: " " } } }))).toBe(
+      false,
+    );
+    expect(shouldEnable(ctx({ media: { vision: { provider: "   " } } }))).toBe(
+      false,
+    );
+    expect(shouldEnable(ctx({ media: { vision: { provider: "\t" } } }))).toBe(
+      false,
+    );
+  });
+
+  it("rejects empty provider values", () => {
+    expect(shouldEnable(ctx({ media: { vision: { provider: "" } } }))).toBe(
+      false,
+    );
+  });
+
+  it("keeps whitespace-padded but concrete provider values enabled", () => {
+    expect(
+      shouldEnable(ctx({ media: { vision: { provider: " openai " } } })),
+    ).toBe(true);
+  });
+
+  it("honors explicit media.vision.enabled=false even with a provider", () => {
+    expect(
+      shouldEnable(
+        ctx({ media: { vision: { enabled: false, provider: "openai" } } }),
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects non-string provider values", () => {
+    expect(shouldEnable(ctx({ media: { vision: { provider: 42 } } }))).toBe(
+      false,
+    );
+    expect(shouldEnable(ctx({ media: { vision: { provider: null } } }))).toBe(
+      false,
+    );
+  });
+
+  it("rejects array-valued feature flags (fail-open regression)", () => {
+    expect(shouldEnable(ctx({ features: { vision: [] } }))).toBe(false);
+    expect(shouldEnable(ctx({ features: { vision: ["x"] } }))).toBe(false);
+  });
+
+  it("disables when nothing is configured", () => {
+    expect(shouldEnable(ctx({}))).toBe(false);
+    expect(shouldEnable(ctx({ features: {} }))).toBe(false);
+  });
+});

--- a/plugins/plugin-vision/auto-enable.ts
+++ b/plugins/plugin-vision/auto-enable.ts
@@ -13,7 +13,7 @@ function isFeatureEnabled(
 ): boolean {
   const f = (config?.features as Record<string, unknown> | undefined)?.[key];
   if (f === true) return true;
-  if (f && typeof f === "object" && f !== null) {
+  if (f && typeof f === "object" && f !== null && !Array.isArray(f)) {
     return (f as Record<string, unknown>).enabled !== false;
   }
   return false;
@@ -21,10 +21,16 @@ function isFeatureEnabled(
 
 /**
  * Enable when `config.features.vision` is truthy, or when the user has
- * explicitly chosen a vision provider via `config.media.vision.provider`.
+ * explicitly chosen a vision provider via `config.media.vision.provider`
+ * (honoring an explicit `media.vision.enabled: false` disable switch, matching
+ * the plugin's inline predicate in `index.ts`).
  */
 export function shouldEnable(ctx: PluginAutoEnableContext): boolean {
   if (isFeatureEnabled(ctx.config, "vision")) return true;
-  const visionProvider = ctx.config?.media?.vision?.provider;
-  return typeof visionProvider === "string" && visionProvider.length > 0;
+  const visionMedia = ctx.config?.media?.vision as
+    | { enabled?: unknown; provider?: unknown }
+    | undefined;
+  if (!visionMedia || visionMedia.enabled === false) return false;
+  const visionProvider = visionMedia.provider;
+  return typeof visionProvider === "string" && visionProvider.trim().length > 0;
 }


### PR DESCRIPTION
# Relates to

The `@elizaos/plugin-vision` manifest auto-enable gate (`auto-enable.ts`, referenced by `package.json` `elizaos.plugin.autoEnableModule`) diverges from the plugin's own inline predicate in `index.ts` and from the sibling gates in `plugin-doordash`/`plugin-zerollama`/`plugin-cli-inference`:

1. **`media.vision.enabled: false` is ignored** when a provider string is present. The inline predicate in `index.ts` honors it (`visionMedia.enabled !== false`); the manifest gate returns `true` solely on provider presence, so an explicit user disable is silently overridden at boot.
2. **Whitespace-only provider values enable the plugin** (`provider.length > 0` without trimming). Every sibling gate in the family trims before deciding (`plugin-doordash`: `url.trim().length > 0`, `plugin-zerollama`: `trim() !== ""`, `plugin-cli-inference`: `.trim().toLowerCase()`), so a blank/templated provider field fails open here.
3. **Array-valued `features.vision` values enable the plugin** — `typeof [] === "object"` and `[].enabled !== false`, so `features: { vision: [] }` is treated as enabled. `plugin-doordash`'s copy of the same helper explicitly rejects arrays (`!Array.isArray(feature)`).

All three are config-gate fail-opens: the plugin loads when the user did not actually enable it. Fix aligns the manifest gate with the inline predicate and sibling gates; no behavior change for valid configs.

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] Focused vitest verification ran in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. The changed module is the boot-time auto-enable predicate only; the fix narrows the set of configs that enable the plugin (explicit `enabled: false`, blank providers, array feature values) and cannot disable it for any previously-valid boolean/object config. The inline `index.ts` predicate already applies the same `enabled !== false` rule, so this removes an inconsistency rather than introducing new semantics.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `Test Files 1 passed (1); Tests 11 passed (11) — npx vitest run auto-enable.test.ts` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: gate + test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
