### PR TITLE
fix(plugin-browser): reject array-valued feature configs in auto-enable gate

### DIFF
--- a/plugins/plugin-browser/auto-enable.test.ts
+++ b/plugins/plugin-browser/auto-enable.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { shouldEnable } from "./auto-enable";
+
+type Ctx = {
+  config: unknown;
+  env: Record<string, unknown>;
+};
+
+const ctx = (config: unknown, env: Record<string, unknown> = {}): Ctx =>
+  ({ config, env }) as Ctx;
+
+describe("plugin-browser auto-enable gate", () => {
+  it("enables when features.browser is true", () => {
+    expect(shouldEnable(ctx({ features: { browser: true } }))).toBe(true);
+  });
+
+  it("enables when features.browser is an object that is not explicitly disabled", () => {
+    expect(shouldEnable(ctx({ features: { browser: {} } }))).toBe(true);
+    expect(
+      shouldEnable(ctx({ features: { browser: { enabled: true } } })),
+    ).toBe(true);
+  });
+
+  it("disables when features.browser.enabled is false", () => {
+    expect(
+      shouldEnable(ctx({ features: { browser: { enabled: false } } })),
+    ).toBe(false);
+  });
+
+  it("rejects array-valued feature configs (fail-open regression)", () => {
+    expect(shouldEnable(ctx({ features: { browser: [] } }))).toBe(false);
+    expect(shouldEnable(ctx({ features: { browser: ["x"] } }))).toBe(false);
+    expect(shouldEnable(ctx({ features: { browser: [1, 2] } }))).toBe(false);
+  });
+
+  it("disables when the feature flag is absent", () => {
+    expect(shouldEnable(ctx({}))).toBe(false);
+    expect(shouldEnable(ctx({ features: {} }))).toBe(false);
+    expect(shouldEnable(ctx({ features: { other: true } }))).toBe(false);
+  });
+
+  it("disables on null or scalar feature values", () => {
+    expect(shouldEnable(ctx({ features: { browser: null } }))).toBe(false);
+    expect(shouldEnable(ctx({ features: { browser: "yes" } }))).toBe(false);
+    expect(shouldEnable(ctx({ features: { browser: 0 } }))).toBe(false);
+  });
+});

--- a/plugins/plugin-browser/auto-enable.ts
+++ b/plugins/plugin-browser/auto-enable.ts
@@ -12,7 +12,7 @@ function isFeatureEnabled(
 ): boolean {
   const f = (config?.features as Record<string, unknown> | undefined)?.[key];
   if (f === true) return true;
-  if (f && typeof f === "object" && f !== null) {
+  if (f && typeof f === "object" && f !== null && !Array.isArray(f)) {
     return (f as Record<string, unknown>).enabled !== false;
   }
   return false;


### PR DESCRIPTION
# Relates to

`@elizaos/plugin-browser`'s auto-enable gate (`auto-enable.ts`, referenced by `package.json` `elizaos.plugin.autoEnableModule`) treats **array-valued feature configs as enabled**: `features: { browser: [] }` passes the object check (`typeof [] === "object"`, non-null) and `[].enabled !== false` is `true`, so the browser plugin auto-enables for a config value that can never be a valid feature flag. The sibling copy in `plugin-doordash` explicitly rejects arrays (`!Array.isArray(feature)`), so the same helper has divergent semantics across the codebase — a config-gate fail-open for malformed input.

Fix adds `!Array.isArray(f)` to the object-form check, matching `plugin-doordash`. No behavior change for boolean or object config values.

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] Focused vitest verification ran in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. One-line guard addition to the boot-time predicate; only invalid (array) feature configs change behavior, and only in the fail-closed direction.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `Test Files 1 passed (1); Tests 6 passed (6) — npx vitest run auto-enable.test.ts` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: gate + test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
