### PR TITLE
fix(plugin-form): reject array-valued feature configs in auto-enable gate

### DIFF
--- a/plugins/plugin-form/auto-enable.test.ts
+++ b/plugins/plugin-form/auto-enable.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { shouldEnable } from "./auto-enable";
+
+type Ctx = {
+  config: unknown;
+  env: Record<string, unknown>;
+};
+
+const ctx = (config: unknown, env: Record<string, unknown> = {}): Ctx =>
+  ({ config, env }) as Ctx;
+
+describe("plugin-form auto-enable gate", () => {
+  it("enables when features.form is true", () => {
+    expect(shouldEnable(ctx({ features: { form: true } }))).toBe(true);
+  });
+
+  it("enables when features.form is an object that is not explicitly disabled", () => {
+    expect(shouldEnable(ctx({ features: { form: {} } }))).toBe(true);
+    expect(shouldEnable(ctx({ features: { form: { enabled: true } } }))).toBe(
+      true,
+    );
+  });
+
+  it("disables when features.form.enabled is false", () => {
+    expect(shouldEnable(ctx({ features: { form: { enabled: false } } }))).toBe(
+      false,
+    );
+  });
+
+  it("rejects array-valued feature configs (fail-open regression)", () => {
+    expect(shouldEnable(ctx({ features: { form: [] } }))).toBe(false);
+    expect(shouldEnable(ctx({ features: { form: ["x"] } }))).toBe(false);
+  });
+
+  it("disables when the feature flag is absent", () => {
+    expect(shouldEnable(ctx({}))).toBe(false);
+    expect(shouldEnable(ctx({ features: {} }))).toBe(false);
+  });
+
+  it("disables on null or scalar feature values", () => {
+    expect(shouldEnable(ctx({ features: { form: null } }))).toBe(false);
+    expect(shouldEnable(ctx({ features: { form: "yes" } }))).toBe(false);
+    expect(shouldEnable(ctx({ features: { form: 0 } }))).toBe(false);
+  });
+});

--- a/plugins/plugin-form/auto-enable.ts
+++ b/plugins/plugin-form/auto-enable.ts
@@ -10,7 +10,7 @@ function isFeatureEnabled(
 ): boolean {
   const f = (config?.features as Record<string, unknown> | undefined)?.[key];
   if (f === true) return true;
-  if (f && typeof f === "object" && f !== null) {
+  if (f && typeof f === "object" && f !== null && !Array.isArray(f)) {
     return (f as Record<string, unknown>).enabled !== false;
   }
   return false;


### PR DESCRIPTION
# Relates to

`@elizaos/plugin-form`'s auto-enable gate (`auto-enable.ts`, referenced by `package.json` `elizaos.plugin.autoEnableModule`) treats **array-valued feature configs as enabled**: `features: { form: [] }` passes the object check (`typeof [] === "object"`, non-null) and `[].enabled !== false` is `true`, so the form plugin auto-enables for a config value that can never be a valid feature flag. The sibling copy in `plugin-doordash` explicitly rejects arrays (`!Array.isArray(feature)`), so the same helper has divergent semantics across the codebase — a config-gate fail-open for malformed input.

Fix adds `!Array.isArray(f)` to the object-form check, matching `plugin-doordash`. No behavior change for boolean or object config values.

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] Focused vitest verification ran in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. One-line guard addition to the boot-time predicate; only invalid (array) feature configs change behavior, and only in the fail-closed direction.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `Test Files 1 passed (1); Tests 6 passed (6) — npx vitest run auto-enable.test.ts` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: gate + test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
