### PR TITLE
fix(plugin-cli-inference): fail closed on non-string ELIZA_CHAT_VIA_CLI in auto-enable gate

### DIFF
--- a/plugins/plugin-cli-inference/auto-enable.test.ts
+++ b/plugins/plugin-cli-inference/auto-enable.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { shouldEnable } from "./auto-enable";
+
+type Ctx = {
+  config: unknown;
+  env: Record<string, unknown>;
+};
+
+const ctx = (env: Record<string, unknown>): Ctx =>
+  ({ config: {}, env }) as Ctx;
+
+describe("plugin-cli-inference auto-enable env gate", () => {
+  it.each(["claude", "CLAUDE", " claude ", "Claude", "claude-sdk", "codex", "codex-sdk", " Codex "])(
+    "enables for whitelisted backend %j",
+    (value) => {
+      expect(shouldEnable(ctx({ ELIZA_CHAT_VIA_CLI: value }))).toBe(true);
+    },
+  );
+
+  it.each(["", "   ", "claude-cli", "codex-cli", "opencode", "gpt", "claude3", "codex-claude", "anthropic", "claude code"])(
+    "stays fail-closed for non-whitelisted value %j",
+    (value) => {
+      expect(shouldEnable(ctx({ ELIZA_CHAT_VIA_CLI: value }))).toBe(false);
+    },
+  );
+
+  it("stays fail-closed when the env var is unset", () => {
+    expect(shouldEnable(ctx({}))).toBe(false);
+  });
+
+  it("stays fail-closed for non-string env values", () => {
+    expect(shouldEnable(ctx({ ELIZA_CHAT_VIA_CLI: 42 }))).toBe(false);
+    expect(shouldEnable(ctx({ ELIZA_CHAT_VIA_CLI: null }))).toBe(false);
+  });
+
+  it("never enables when a different env var is set", () => {
+    expect(
+      shouldEnable(
+        ctx({ ELIZA_CHAT_VIA_CLI: undefined, OTHER_SETTING: "claude" }),
+      ),
+    ).toBe(false);
+  });
+});

--- a/plugins/plugin-cli-inference/auto-enable.ts
+++ b/plugins/plugin-cli-inference/auto-enable.ts
@@ -15,11 +15,13 @@ import type { PluginAutoEnableContext } from "@elizaos/core";
  * provider keeps serving every tier.
  */
 export function shouldEnable(ctx: PluginAutoEnableContext): boolean {
-  const raw = ctx.env.ELIZA_CHAT_VIA_CLI?.trim().toLowerCase();
+  const raw = ctx.env.ELIZA_CHAT_VIA_CLI;
+  if (typeof raw !== "string") return false;
+  const normalized = raw.trim().toLowerCase();
   return (
-    raw === "claude" ||
-    raw === "claude-sdk" ||
-    raw === "codex" ||
-    raw === "codex-sdk"
+    normalized === "claude" ||
+    normalized === "claude-sdk" ||
+    normalized === "codex" ||
+    normalized === "codex-sdk"
   );
 }


### PR DESCRIPTION
# Relates to

`@elizaos/plugin-cli-inference`'s auto-enable gate (`auto-enable.ts`) is the single env gate for the SAFE/CLOUD CLI-inference route. Its predicate is typed to return a boolean verdict and must never throw (the engine's `evaluatePluginManifest` treats a throwing predicate as disabled-with-error), but `ctx.env.ELIZA_CHAT_VIA_CLI?.trim().toLowerCase()` throws `TypeError: ...trim is not a function` when the env value is a non-string (numbers, booleans, objects from settings/config merges or embedding hosts that construct the context programmatically). Optional chaining only guards `null`/`undefined`, not non-string primitives.

Fix guards the value with `typeof raw !== "string" → false` (fail-closed: the plugin stays unloaded for non-string values, matching the gate's whitelist contract). Behavior for all string values — the only values `NodeJS.ProcessEnv` can hold — is unchanged.

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] Focused vitest verification ran in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. The guard is fail-closed and only triggers for non-string inputs that previously crashed the predicate; whitelisted string values take the identical path.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `Test Files 1 passed (1); Tests 21 passed (21) — npx vitest run auto-enable.test.ts` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: gate + test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
