### PR TITLE
fix(plugin-google-workspace): keep UTF-16 surrogate pairs intact in Google Meet transcript summary truncation

### DIFF
--- a/plugins/plugin-google-workspace/src/meet-summary-surrogates.test.ts
+++ b/plugins/plugin-google-workspace/src/meet-summary-surrogates.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Unit tests for surrogate-pair safe meeting transcript summary truncation.
+ *
+ * Verifies that summarizeTranscript cleanly handles long continuous text without
+ * splitting UTF-16 surrogate pairs into orphaned high/low surrogate code units.
+ */
+
+import { describe, expect, it } from "vitest";
+import { summarizeTranscript, type GoogleMeetTranscript } from "./meet.ts";
+
+describe("summarizeTranscript surrogate safety", () => {
+  it("preserves surrogate pairs when falling back to raw text slice", () => {
+    // "x" (1 char) + "🔥" (2 chars * 300 = 600 chars) -> bisects at 500
+    const longEmojiText = "x" + "🔥".repeat(300);
+    const fakeTranscript: GoogleMeetTranscript = {
+      name: "conferenceRecords/conf_1/transcripts/trans_1",
+      documentTitle: "Transcript",
+      text: longEmojiText,
+      startTime: "2026-01-01T00:00:00Z",
+      endTime: "2026-01-01T01:00:00Z",
+    };
+
+    const result = summarizeTranscript([fakeTranscript]);
+    expect(result.summary.length).toBe(499);
+    for (const char of result.summary) {
+      expect(
+        /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(
+          char,
+        ),
+      ).toBe(false);
+    }
+  });
+});

--- a/plugins/plugin-google-workspace/src/meet.ts
+++ b/plugins/plugin-google-workspace/src/meet.ts
@@ -56,6 +56,18 @@ interface MeetPaginationState {
   seenPageTokens: Set<string>;
 }
 
+function truncateText(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  let end = maxChars;
+  if (end > 0 && end < text.length) {
+    const code = text.charCodeAt(end - 1);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      end -= 1;
+    }
+  }
+  return text.slice(0, end);
+}
+
 function createMeetPaginationState(): MeetPaginationState {
   return { pageCount: 0, seenPageTokens: new Set<string>() };
 }
@@ -562,7 +574,7 @@ function durationMinutes(conference: GoogleMeetConferenceRecord): number {
   return Math.max(0, Math.round((end - start) / 60000));
 }
 
-function summarizeTranscript(entries: readonly GoogleMeetTranscript[]): {
+export function summarizeTranscript(entries: readonly GoogleMeetTranscript[]): {
   summary: string;
   keyPoints: string[];
   actionItems: GoogleMeetReport["actionItems"];
@@ -581,7 +593,7 @@ function summarizeTranscript(entries: readonly GoogleMeetTranscript[]): {
     .split(/(?<=[.!?])\s+/)
     .map((sentence) => sentence.trim())
     .filter(Boolean);
-  const summary = sentences.slice(0, 3).join(" ") || plainText.slice(0, 500);
+  const summary = truncateText(sentences.slice(0, 3).join(" ") || plainText, 500);
   const keyPoints = lines.filter((line) => line.length >= 20).slice(0, 6);
   const actionItems = lines
     .filter((line) => /\b(action item|to[- ]?do|follow up|need to|will|should)\b/i.test(line))


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:313861ef124bd2112638554029837c92bce9d24b -->

## Summary
In `plugins/plugin-google-workspace/src/meet.ts`:
`summarizeTranscript` constructed the meeting summary using:
```typescript
const summary = sentences.slice(0, 3).join(" ") || plainText.slice(0, 500);
```
1. When sentences contained continuous text or multi-byte UTF-16 surrogate pairs (such as emojis or astral plane unicode), falling back to `plainText.slice(0, 500)` would bisect high/low surrogate pairs and generate invalid orphaned surrogate characters (`\uFFFD`).
2. When the first 3 sentences exceeded 500 characters, the summary was left unbounded because the logical OR evaluated truthy on the first operand.

## Proposed Changes
1. Added surrogate-pair safe boundary truncation helper `truncateText`.
2. Wrapped the entire summary generation in `truncateText(..., 500)`.
3. Exported `summarizeTranscript` for unit testing.
4. Added unit test in `src/meet-summary-surrogates.test.ts`.

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-google-workspace test` (19/19 test files passed, 171/171 tests passed).

<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-3-5-sonnet","client":"antigravity","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
