### PR TITLE
fix(plugin-capacitor-bridge): keep UTF-16 surrogate pairs intact in bridge error diagnostics and model grind sample truncation

### DIFF
--- a/plugins/plugin-capacitor-bridge/src/android/bridge.ts
+++ b/plugins/plugin-capacitor-bridge/src/android/bridge.ts
@@ -130,6 +130,18 @@ async function loadAgentModule(): Promise<AndroidAgentModule> {
 //   3. Set sandbox root = canonical HOME → covers .eliza/, agent/ assets, etc.
 let _logPath = "";
 
+function truncateText(text: string, maxChars: number): string {
+	if (text.length <= maxChars) return text;
+	let end = maxChars;
+	if (end > 0 && end < text.length) {
+		const code = text.charCodeAt(end - 1);
+		if (code >= 0xd800 && code <= 0xdbff) {
+			end -= 1;
+		}
+	}
+	return text.slice(0, end);
+}
+
 function setupAndroidBridgeEnvironment(): string {
 	const rawHome =
 		process.env.HOME ||
@@ -393,7 +405,7 @@ export async function runAndroidBridgeCli(): Promise<void> {
 		_logToFile(`[android-bridge] unhandledRejection: ${msg}`);
 		_appendDiagnostics("agent-fatal", {
 			kind: "unhandledRejection",
-			message: msg.slice(0, 2000),
+			message: truncateText(msg, 2000),
 		});
 		console.error("[android-bridge] unhandled rejection:", msg);
 	});
@@ -403,7 +415,7 @@ export async function runAndroidBridgeCli(): Promise<void> {
 		);
 		_appendDiagnostics("agent-fatal", {
 			kind: "uncaughtException",
-			message: (error.stack || error.message).slice(0, 2000),
+			message: truncateText(error.stack || error.message, 2000),
 		});
 		console.error(
 			"[android-bridge] uncaught exception:",
@@ -455,7 +467,7 @@ export async function runAndroidBridgeCli(): Promise<void> {
 		_logToFile(`[android-bridge] startEliza THREW: ${msg}`);
 		_appendDiagnostics("agent-fatal", {
 			kind: "startEliza-threw",
-			message: msg.slice(0, 2000),
+			message: truncateText(msg, 2000),
 		});
 		throw err;
 	} finally {

--- a/plugins/plugin-capacitor-bridge/src/ios/model-grind.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/ios/model-grind.test.ts
@@ -171,4 +171,24 @@ describe("runModelGrind", () => {
 		);
 		expect(report.models.find((m) => m.model === "asr")?.ok).toBe(false);
 	});
+
+	it("preserves surrogate pairs in detail sample truncation", async () => {
+		// "x" + "🎉" * 70 -> 141 chars > 120 chars (bisects at 120)
+		const longEmojiText = "x" + "🎉".repeat(70);
+		const report = await runModelGrind(
+			baseDeps({
+				callIosHost: async () => ({ text: longEmojiText, outputTokens: 10 }),
+			}),
+		);
+		const text = report.models.find((m) => m.model === "text");
+		const sample = (text?.detail as { sample: string })?.sample;
+		expect(sample.length).toBe(119);
+		for (const char of sample) {
+			expect(
+				/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(
+					char,
+				),
+			).toBe(false);
+		}
+	});
 });

--- a/plugins/plugin-capacitor-bridge/src/ios/model-grind.ts
+++ b/plugins/plugin-capacitor-bridge/src/ios/model-grind.ts
@@ -61,6 +61,18 @@ export interface ModelGrindReport {
 
 const GRIND_PHRASE = "Eliza local voice end to end check, one two three.";
 
+function truncateText(text: string, maxChars: number): string {
+	if (text.length <= maxChars) return text;
+	let end = maxChars;
+	if (end > 0 && end < text.length) {
+		const code = text.charCodeAt(end - 1);
+		if (code >= 0xd800 && code <= 0xdbff) {
+			end -= 1;
+		}
+	}
+	return text.slice(0, end);
+}
+
 function now(): number {
 	// performance.now() is monotonic; epoch via Date is only used for stamps.
 	return typeof performance !== "undefined"
@@ -258,7 +270,7 @@ export async function runModelGrind(
 			};
 			r.detail = {
 				outputTokens: outTokens,
-				sample: text.slice(0, 120),
+				sample: truncateText(text, 120),
 				mtp: res.specAccepted ?? res.mtpAccepted ?? null,
 			};
 			r.ok = outTokens > 0 && text.trim().length > 0;


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:6529db9c50ae740445b464e4d78a79770b22404e -->

## Summary
In `plugins/plugin-capacitor-bridge`:
1. `src/android/bridge.ts` used raw `.slice(0, 2000)` on error messages and stacks in `unhandledRejection`, `uncaughtException`, and `startEliza` catch blocks.
2. `src/ios/model-grind.ts` used raw `.slice(0, 120)` on sample model output strings in `runModelGrind`.

When exception messages, logs, or model outputs contain multi-byte UTF-16 surrogate pairs (e.g. emojis or astral unicode symbols), raw index slicing can bisect surrogate pairs and produce orphaned surrogate characters (`\uFFFD`).

## Proposed Changes
1. Added surrogate-pair safe boundary truncation helper `truncateText`.
2. Applied `truncateText` across `src/android/bridge.ts` and `src/ios/model-grind.ts`.
3. Added unit tests in `src/ios/model-grind.test.ts`.

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-capacitor-bridge test src/ios/model-grind.test.ts` (14/14 passed).

<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-3-5-sonnet","client":"antigravity","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
