### PR TITLE
fix(plugin-openai): keep UTF-16 surrogate pairs intact in prompt event and provider error body truncation

### DIFF
--- a/plugins/plugin-openai/__tests__/events.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/events.shape.test.ts
@@ -10,7 +10,7 @@
 import { EventType, ModelType } from "@elizaos/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ModelRetryTelemetry } from "../utils/events";
-import { emitModelUsageEvent } from "../utils/events";
+import { emitModelUsageEvent, truncatePrompt } from "../utils/events";
 
 function createRuntime() {
   return {
@@ -221,3 +221,24 @@ describe("emitModelUsageEvent — reasoningTokens on MODEL_USED", () => {
     });
   });
 });
+
+describe("truncatePrompt surrogate safety", () => {
+  it("preserves surrogate pairs when prompt length exceeds MAX_PROMPT_LENGTH", () => {
+    // "🔥" (2 chars * 110 = 220 chars) -> 220 chars > 200 chars
+    // At boundary 199 (MAX_PROMPT_LENGTH - 1), index 198 is the high surrogate of the 100th emoji,
+    // which bisects without boundary backoff.
+    const longEmojiPrompt = "🔥".repeat(110);
+    const truncated = truncatePrompt(longEmojiPrompt);
+
+    expect(truncated.endsWith("…")).toBe(true);
+    expect(truncated.length).toBe(199); // 198 chars (99 full emojis) + 1 ellipsis char
+    for (const char of truncated) {
+      expect(
+        /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(
+          char,
+        ),
+      ).toBe(false);
+    }
+  });
+});
+

--- a/plugins/plugin-openai/models/text.ts
+++ b/plugins/plugin-openai/models/text.ts
@@ -173,6 +173,18 @@ const TEXT_MEGA_MODEL_TYPE = ModelType.TEXT_MEGA as ModelTypeName;
 const RESPONSE_HANDLER_MODEL_TYPE = ModelType.RESPONSE_HANDLER as ModelTypeName;
 const ACTION_PLANNER_MODEL_TYPE = ModelType.ACTION_PLANNER as ModelTypeName;
 
+function truncateText(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  let end = maxChars;
+  if (end > 0 && end < text.length) {
+    const code = text.charCodeAt(end - 1);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      end -= 1;
+    }
+  }
+  return text.slice(0, end);
+}
+
 function resolveRequestedModelName(
   params: GenerateTextParamsWithOpenAIOptions,
   runtime: IAgentRuntime,
@@ -1766,7 +1778,7 @@ function providerErrorBodyMessage(error: unknown): string | undefined {
         // error-policy:J3 untrusted-input sanitizing — a non-JSON error body is
         // still diagnostic; return a bounded excerpt instead of dropping it.
       }
-      return body.replace(/\s+/g, " ").trim().slice(0, 300);
+      return truncateText(body.replace(/\s+/g, " ").trim(), 300);
     }
     node = record.cause;
   }

--- a/plugins/plugin-openai/utils/events.ts
+++ b/plugins/plugin-openai/utils/events.ts
@@ -58,11 +58,18 @@ interface OpenAIAPIUsage {
 
 type ModelUsage = TokenUsage | AISDKUsage | OpenAIAPIUsage;
 
-function truncatePrompt(prompt: string): string {
+export function truncatePrompt(prompt: string): string {
   if (prompt.length <= MAX_PROMPT_LENGTH) {
     return prompt;
   }
-  return `${prompt.slice(0, MAX_PROMPT_LENGTH - 1)}…`;
+  let end = MAX_PROMPT_LENGTH - 1;
+  if (end > 0 && end < prompt.length) {
+    const code = prompt.charCodeAt(end - 1);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      end -= 1;
+    }
+  }
+  return `${prompt.slice(0, end)}…`;
 }
 
 function normalizeUsage(usage: ModelUsage): TokenUsage {


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:c2816488af0c425cde5fb5f490164bb17a9c5267 -->

## Summary
In `plugins/plugin-openai`:
1. `utils/events.ts` truncated prompts longer than `MAX_PROMPT_LENGTH` using raw slicing `${prompt.slice(0, MAX_PROMPT_LENGTH - 1)}…`.
2. `models/text.ts` truncated raw provider error bodies using `body.replace(/\s+/g, " ").trim().slice(0, 300)`.

When prompt strings or provider error bodies contain multi-byte UTF-16 surrogate pairs (e.g. emojis or unicode text), cutting at character boundary offsets can split surrogate pairs, leading to orphaned surrogate characters (`\uFFFD`).

## Proposed Changes
1. Added surrogate-pair safe boundary back-off to `truncatePrompt` in `utils/events.ts`.
2. Added `truncateText` helper to `models/text.ts` for provider error body excerpts.
3. Exported `truncatePrompt` and added unit test in `__tests__/events.shape.test.ts`.

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-openai test __tests__/events.shape.test.ts` (10/10 passed).

<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-3-5-sonnet","client":"antigravity","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
