### PR TITLE
fix(core): keep UTF-16 surrogate pairs intact in userReferenceLogView clamping

### DIFF
--- a/packages/core/src/utils/reference-echo.test.ts
+++ b/packages/core/src/utils/reference-echo.test.ts
@@ -133,4 +133,21 @@ describe("userReferenceLogView", () => {
 		expect(clamped.endsWith("…")).toBe(true);
 		expect(clamped.slice(0, 119)).toBe("b".repeat(119));
 	});
+
+	it("preserves surrogate pairs when clamping at 120 chars", () => {
+		// "🔥" (2 chars * 70 = 140 chars) -> 140 chars > 120 chars
+		// At boundary 119, index 118 is the high surrogate of the 60th emoji, which bisects without backoff
+		const longEmojiRef = "🔥".repeat(70);
+		const clamped = userReferenceLogView(longEmojiRef);
+
+		expect(clamped.endsWith("…")).toBe(true);
+		expect(clamped.length).toBe(119); // 118 chars (59 full emojis) + 1 ellipsis char
+		for (const char of clamped) {
+			expect(
+				/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(
+					char,
+				),
+			).toBe(false);
+		}
+	});
 });

--- a/packages/core/src/utils/reference-echo.ts
+++ b/packages/core/src/utils/reference-echo.ts
@@ -33,5 +33,15 @@ export function describeUserReference(
 export function userReferenceLogView(reference: string): string {
 	const safeRef = typeof reference === "string" ? reference : "";
 	const collapsed = safeRef.replace(/\s+/g, " ").trim();
-	return collapsed.length > 120 ? `${collapsed.slice(0, 119)}…` : collapsed;
+	if (collapsed.length <= 120) {
+		return collapsed;
+	}
+	let end = 119;
+	if (end > 0 && end < collapsed.length) {
+		const code = collapsed.charCodeAt(end - 1);
+		if (code >= 0xd800 && code <= 0xdbff) {
+			end -= 1;
+		}
+	}
+	return `${collapsed.slice(0, end)}…`;
 }


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:17c0ddcdb042e1e72e5103f91248684ac4e427e7 -->

## Summary
In `packages/core/src/utils/reference-echo.ts`:
`userReferenceLogView` clamps log references longer than 120 chars using `${collapsed.slice(0, 119)}…`. When user reference text contains multi-byte UTF-16 surrogate pairs (e.g. emojis or astral unicode symbols), slicing at offset 119 can split a surrogate pair across the boundary, producing an orphaned surrogate character (`\uFFFD`).

## Proposed Changes
1. Added surrogate-pair safe boundary back-off to `userReferenceLogView`.
2. Added unit test in `packages/core/src/utils/reference-echo.test.ts`.

## Verification
- Ran vitest: `bun run --cwd packages/core test src/utils/reference-echo.test.ts` (15/15 passed).

<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-3-5-sonnet","client":"antigravity","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
