### PR TITLE
fix(core): keep UTF-16 surrogate pairs intact in failure signature and repeatKey truncation

### DIFF
--- a/packages/core/src/runtime/limits.test.ts
+++ b/packages/core/src/runtime/limits.test.ts
@@ -99,6 +99,23 @@ describe("getFailureSignature", () => {
 		// "X:" + 240 chars
 		expect(sig).toHaveLength(2 + 240);
 	});
+
+	it("preserves surrogate pairs when normalizing long errors or repeatKeys", () => {
+		// "🔥" (2 chars * 130 = 260 chars) -> 260 chars > 240 chars
+		// At boundary 240, index 239 is high surrogate of 120th emoji, which bisects without backoff
+		const longEmojiError = "🔥".repeat(130);
+		const sig = getFailureSignature({ toolName: "X", error: longEmojiError });
+		expect(sig).not.toBeNull();
+		const errorPart = (sig as string).slice(2);
+		expect(errorPart.length).toBe(240);
+		for (const char of errorPart) {
+			expect(
+				/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(
+					char,
+				),
+			).toBe(false);
+		}
+	});
 });
 
 describe("countRepeatedFailures / assertRepeatedFailureLimit", () => {

--- a/packages/core/src/runtime/limits.ts
+++ b/packages/core/src/runtime/limits.ts
@@ -187,6 +187,18 @@ export interface FailureLike {
 	failureProvenance?: ActionFailureProvenance;
 }
 
+function truncateText(text: string, maxChars: number): string {
+	if (text.length <= maxChars) return text;
+	let end = maxChars;
+	if (end > 0 && end < text.length) {
+		const code = text.charCodeAt(end - 1);
+		if (code >= 0xd800 && code <= 0xdbff) {
+			end -= 1;
+		}
+	}
+	return text.slice(0, end);
+}
+
 export function getFailureSignature(failure: FailureLike): string | null {
 	if (failure.success !== false && failure.error == null) {
 		return null;
@@ -201,7 +213,7 @@ export function getFailureSignature(failure: FailureLike): string | null {
 				: failure.error == null
 					? "failed"
 					: JSON.stringify(failure.error);
-	const normalizedError = rawError.trim().replace(/\s+/g, " ").slice(0, 240);
+	const normalizedError = truncateText(rawError.trim().replace(/\s+/g, " "), 240);
 	return `${toolName}:${normalizedError}`;
 }
 
@@ -227,7 +239,7 @@ function getFailureComparisonKey(failure: FailureLike): string | null {
 	const signature = getFailureSignature(failure);
 	if (!signature) return null;
 	const repeatKey = failure.repeatKey?.trim();
-	return repeatKey ? `${signature}:${repeatKey.slice(0, 240)}` : signature;
+	return repeatKey ? `${signature}:${truncateText(repeatKey, 240)}` : signature;
 }
 
 export function assertRepeatedFailureLimit(params: {


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:150db5db6b94a112e30911821b30e2ceb4be13a7 -->

## Summary
In `packages/core/src/runtime/limits.ts`:
`getFailureSignature` and `getFailureComparisonKey` truncated normalized error messages and `repeatKey` values using raw `.slice(0, 240)`. When error strings or repeat keys contain multi-byte UTF-16 surrogate pairs (e.g. emojis or unicode text in tool failure messages), slicing at offset 240 can bisect a surrogate pair and leave an orphaned surrogate character (`\uFFFD`).

## Proposed Changes
1. Added surrogate-pair safe boundary truncation helper `truncateText`.
2. Applied `truncateText` to both error message normalization and repeat key truncation in `getFailureSignature` and `getFailureComparisonKey`.
3. Added unit test in `packages/core/src/runtime/limits.test.ts`.

## Verification
- Ran vitest: `bun run --cwd packages/core test src/runtime/limits.test.ts` (15/15 passed).

<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-3-5-sonnet","client":"antigravity","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
