### PR TITLE
fix(core): keep UTF-16 surrogate pairs intact in trimDemonstrationInput truncation

### DIFF
--- a/packages/core/src/services/optimized-prompt-resolver.test.ts
+++ b/packages/core/src/services/optimized-prompt-resolver.test.ts
@@ -23,6 +23,7 @@ import {
 import {
 	resolveOptimizedPrompt,
 	resolveOptimizedPromptForRuntime,
+	trimDemonstrationInput,
 } from "./optimized-prompt-resolver";
 
 const BASELINE = "BASELINE_PROMPT_FOR_TEST";
@@ -269,3 +270,33 @@ describe("resolveOptimizedPromptForRuntime — per-task wiring", () => {
 		expect(out).toBe(BASELINE);
 	});
 });
+
+describe("trimDemonstrationInput surrogate safety", () => {
+	test("preserves surrogate pairs when trimming candidate and raw input", () => {
+		// "🔥" (2 chars * 350 = 700 chars) -> 700 chars > 600 chars
+		// At boundary 600, index 599 is high surrogate of 300th emoji, which bisects without backoff
+		const longEmojiCandidate = "user: " + "🔥".repeat(350);
+		const trimmed = trimDemonstrationInput(longEmojiCandidate);
+		expect(trimmed.endsWith("…")).toBe(true);
+		for (const char of trimmed) {
+			expect(
+				/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(
+					char,
+				),
+			).toBe(false);
+		}
+
+		// Raw input without user prefix
+		const rawEmojiInput = "🔥".repeat(350);
+		const trimmedRaw = trimDemonstrationInput(rawEmojiInput);
+		expect(trimmedRaw.includes("…")).toBe(true);
+		for (const char of trimmedRaw) {
+			expect(
+				/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(
+					char,
+				),
+			).toBe(false);
+		}
+	});
+});
+

--- a/packages/core/src/services/optimized-prompt-resolver.ts
+++ b/packages/core/src/services/optimized-prompt-resolver.ts
@@ -72,7 +72,19 @@ export function resolveOptimizedPrompt(
  * tool catalog (often ~30K chars); for ICL we only need the user's
  * current-turn request.
  */
-function trimDemonstrationInput(rawInput: string): string {
+function truncateText(text: string, maxChars: number): string {
+	if (text.length <= maxChars) return text;
+	let end = maxChars;
+	if (end > 0 && end < text.length) {
+		const code = text.charCodeAt(end - 1);
+		if (code >= 0xd800 && code <= 0xdbff) {
+			end -= 1;
+		}
+	}
+	return text.slice(0, end);
+}
+
+export function trimDemonstrationInput(rawInput: string): string {
 	const userMatch =
 		rawInput.match(
 			/(?:^|\n)user(?:\s+message)?\s*:\s*([^\n]+(?:\n(?!\w+:)[^\n]+)*)/i,
@@ -83,10 +95,17 @@ function trimDemonstrationInput(rawInput: string): string {
 		return candidate;
 	}
 	if (candidate && candidate.length > 0) {
-		return `${candidate.slice(0, 600).trimEnd()} …`;
+		return `${truncateText(candidate, 600).trimEnd()} …`;
 	}
 	if (rawInput.length <= 600) return rawInput;
-	return `${rawInput.slice(0, 400).trimEnd()}\n…\n${rawInput.slice(-200).trimStart()}`;
+	let startTail = rawInput.length - 200;
+	if (startTail > 0 && startTail < rawInput.length) {
+		const code = rawInput.charCodeAt(startTail);
+		if (code >= 0xdc00 && code <= 0xdfff) {
+			startTail += 1;
+		}
+	}
+	return `${truncateText(rawInput, 400).trimEnd()}\n…\n${rawInput.slice(startTail).trimStart()}`;
 }
 
 function injectDemonstrations(


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:cab8f86ac7077fc76714c30805fbd275c4a1fcba -->

## Summary
In `packages/core/src/services/optimized-prompt-resolver.ts`:
`trimDemonstrationInput` trimmed long user demonstration inputs and recorded trajectories using raw slicing:
- `${candidate.slice(0, 600).trimEnd()} …`
- `${rawInput.slice(0, 400).trimEnd()}\n…\n${rawInput.slice(-200).trimStart()}`

When user messages, few-shot examples, or recorded trajectories contain multi-byte UTF-16 surrogate pairs (e.g. emojis or astral unicode symbols), slicing at static index boundaries (such as offset 600, 400, or `-200`) can bisect surrogate pairs and produce orphaned surrogate characters (`\uFFFD`).

## Proposed Changes
1. Added surrogate-pair safe boundary truncation helper `truncateText`.
2. Added surrogate-pair boundary safety for both head and tail slices in `trimDemonstrationInput`.
3. Exported `trimDemonstrationInput` and added unit test in `packages/core/src/services/optimized-prompt-resolver.test.ts`.

## Verification
- Ran vitest: `bun run --cwd packages/core test src/services/optimized-prompt-resolver.test.ts` (93/93 passed).

<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-3-5-sonnet","client":"antigravity","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
