### PR TITLE
fix(core): keep UTF-16 surrogate pairs intact in cleanPriorDialogueSpeakerName truncation

### DIFF
--- a/packages/core/src/services/message-speaker-name-surrogates.test.ts
+++ b/packages/core/src/services/message-speaker-name-surrogates.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Unit tests for surrogate-pair safe speaker name truncation in message services.
+ *
+ * Verifies that cleanPriorDialogueSpeakerName keeps UTF-16 surrogate pairs intact
+ * when truncating long speaker/entity names to 80 characters with trailing ellipsis.
+ */
+
+import { describe, expect, it } from "vitest";
+import { cleanPriorDialogueSpeakerName } from "./message.ts";
+
+describe("cleanPriorDialogueSpeakerName surrogate safety", () => {
+	it("returns undefined for non-strings or empty strings", () => {
+		expect(cleanPriorDialogueSpeakerName(null)).toBeUndefined();
+		expect(cleanPriorDialogueSpeakerName(undefined)).toBeUndefined();
+		expect(cleanPriorDialogueSpeakerName(123)).toBeUndefined();
+		expect(cleanPriorDialogueSpeakerName("   ")).toBeUndefined();
+	});
+
+	it("returns short names unchanged", () => {
+		expect(cleanPriorDialogueSpeakerName("Alice")).toBe("Alice");
+		expect(cleanPriorDialogueSpeakerName("  Bob  Smith  ")).toBe("Bob Smith");
+	});
+
+	it("preserves surrogate pairs when truncating at 80 characters", () => {
+		// "🔥" (2 chars * 45 = 90 chars) -> 90 chars > 80 chars
+		// At boundary 77, index 76 is high surrogate of 39th emoji, which bisects without backoff
+		const longEmojiName = "🔥".repeat(45);
+		const cleaned = cleanPriorDialogueSpeakerName(longEmojiName);
+		expect(cleaned).toBeDefined();
+		expect(cleaned?.endsWith("...")).toBe(true);
+		expect(cleaned?.length).toBe(79); // 76 chars (38 full emojis) + 3 dots
+
+		for (const char of cleaned!) {
+			expect(
+				/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(
+					char,
+				),
+			).toBe(false);
+		}
+	});
+});

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -2221,11 +2221,19 @@ function asPlainRecord(value: unknown): Record<string, unknown> | undefined {
 	return value as Record<string, unknown>;
 }
 
-function cleanPriorDialogueSpeakerName(value: unknown): string | undefined {
+export function cleanPriorDialogueSpeakerName(value: unknown): string | undefined {
 	if (typeof value !== "string") return undefined;
 	const normalized = value.trim().split(/\s+/).join(" ");
 	if (!normalized) return undefined;
-	return normalized.length > 80 ? `${normalized.slice(0, 77)}...` : normalized;
+	if (normalized.length <= 80) return normalized;
+	let end = 77;
+	if (end > 0 && end < normalized.length) {
+		const code = normalized.charCodeAt(end - 1);
+		if (code >= 0xd800 && code <= 0xdbff) {
+			end -= 1;
+		}
+	}
+	return `${normalized.slice(0, end)}...`;
 }
 
 function senderIdentityName(value: unknown): string | undefined {


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:7274ee8e204d60d1e6a6816f3f361e0319d22ce9 -->

## Summary
In `packages/core/src/services/message.ts`:
`cleanPriorDialogueSpeakerName` normalizes speaker/author names from dialogue history and truncates strings exceeding 80 characters using `${normalized.slice(0, 77)}...`.

When user/speaker names or entity labels contain multi-byte UTF-16 surrogate pairs (e.g. emojis or astral plane unicode), slicing at character offset 77 can split a surrogate pair in half, generating invalid orphaned surrogate characters (`\uFFFD`).

## Proposed Changes
1. Added surrogate-pair safe boundary back-off to `cleanPriorDialogueSpeakerName`.
2. Exported `cleanPriorDialogueSpeakerName` for unit testing.
3. Added unit tests in `packages/core/src/services/message-speaker-name-surrogates.test.ts`.

## Verification
- Ran vitest: `bun run --cwd packages/core test src/services/message-speaker-name-surrogates.test.ts` (3/3 passed).

<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-3-5-sonnet","client":"antigravity","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
