### PR TITLE
fix(plugin-agent-skills): reject array-valued feature configs in auto-enable gate

### DIFF
--- a/plugins/plugin-agent-skills/auto-enable.test.ts
+++ b/plugins/plugin-agent-skills/auto-enable.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { shouldEnable } from "./auto-enable";
+
+type Ctx = {
+  config: {
+    features?: Record<string, unknown>;
+  };
+  env?: Record<string, string | undefined>;
+};
+
+function ctx(features: Record<string, unknown> | undefined): Ctx {
+  return { config: { features } };
+}
+
+describe("plugin-agent-skills auto-enable gate", () => {
+  it("enables when the agentSkills feature flag is boolean true", () => {
+    expect(shouldEnable(ctx({ agentSkills: true }) as never)).toBe(true);
+  });
+
+  it("enables when the agentSkills feature is an object with enabled: true", () => {
+    expect(shouldEnable(ctx({ agentSkills: { enabled: true } }) as never)).toBe(
+      true,
+    );
+  });
+
+  it("enables when the agentSkills feature is an object without explicit disable", () => {
+    expect(shouldEnable(ctx({ agentSkills: {} }) as never)).toBe(true);
+  });
+
+  it("disables when the agentSkills feature is explicitly disabled", () => {
+    expect(shouldEnable(ctx({ agentSkills: { enabled: false } }) as never)).toBe(
+      false,
+    );
+  });
+
+  it("disables when the agentSkills feature is missing", () => {
+    expect(shouldEnable(ctx({}) as never)).toBe(false);
+    expect(shouldEnable(ctx(undefined) as never)).toBe(false);
+  });
+
+  it("disables when the agentSkills feature is a non-object truthy value", () => {
+    expect(shouldEnable(ctx({ agentSkills: "yes" }) as never)).toBe(false);
+  });
+
+  it("rejects array-valued feature configs instead of treating them as enabled objects", () => {
+    // `[]` passes `typeof [] === "object"` and `[].enabled !== false`, which
+    // would silently enable the plugin for a malformed/empty list value.
+    expect(shouldEnable(ctx({ agentSkills: [] }) as never)).toBe(false);
+    expect(shouldEnable(ctx({ agentSkills: ["a", "b"] }) as never)).toBe(false);
+  });
+});

--- a/plugins/plugin-agent-skills/auto-enable.ts
+++ b/plugins/plugin-agent-skills/auto-enable.ts
@@ -11,7 +11,7 @@ function isFeatureEnabled(
 ): boolean {
   const f = (config.features as Record<string, unknown> | undefined)?.[key];
   if (f === true) return true;
-  if (f && typeof f === "object" && f !== null) {
+  if (f && typeof f === "object" && f !== null && !Array.isArray(f)) {
     return (f as Record<string, unknown>).enabled !== false;
   }
   return false;


### PR DESCRIPTION
# Relates to

<!-- No issue; hardening the auto-enable gate against malformed feature config. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. One-line behavioral change in the plugin auto-enable predicate plus a new
test file. An array-valued `features.agentSkills` config (e.g. `[]` or a list)
previously passed the `typeof === "object"` check and was treated as enabled
(`[].enabled !== false`), silently enabling the plugin for malformed config;
it now falls through to disabled, matching the sibling `plugin-doordash` gate
which already guards with `!Array.isArray`.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `Test Files 1 passed (1) / Tests 7 passed (7)` — run at PR head |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: one-line source fix + test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
