### PR TITLE
fix(plugin-elizacloud): tolerate non-string env values in auto-enable gate

### DIFF
--- a/plugins/plugin-elizacloud/auto-enable.test.ts
+++ b/plugins/plugin-elizacloud/auto-enable.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { shouldEnable } from "./auto-enable";
+
+function ctx(env: Record<string, unknown>): {
+  env: Record<string, unknown>;
+  config: Record<string, never>;
+} {
+  return { env, config: {} };
+}
+
+describe("plugin-elizacloud auto-enable gate", () => {
+  it("enables when an Eliza Cloud API key is present", () => {
+    expect(
+      shouldEnable(ctx({ ELIZAOS_CLOUD_API_KEY: "sk-live-123" }) as never),
+    ).toBe(true);
+  });
+
+  it("disables when the API key is only whitespace", () => {
+    expect(
+      shouldEnable(ctx({ ELIZAOS_CLOUD_API_KEY: "   " }) as never),
+    ).toBe(false);
+  });
+
+  it("enables when ELIZAOS_CLOUD_ENABLED is a truthy string", () => {
+    for (const v of ["1", "true", "yes", "TRUE", " Yes "]) {
+      expect(shouldEnable(ctx({ ELIZAOS_CLOUD_ENABLED: v }) as never)).toBe(
+        true,
+      );
+    }
+  });
+
+  it("disables when ELIZAOS_CLOUD_ENABLED is a falsy string", () => {
+    for (const v of ["0", "false", "no", ""]) {
+      expect(shouldEnable(ctx({ ELIZAOS_CLOUD_ENABLED: v }) as never)).toBe(
+        false,
+      );
+    }
+  });
+
+  it("disables when no cloud signal is present", () => {
+    expect(shouldEnable(ctx({}) as never)).toBe(false);
+  });
+
+  it("tolerates non-string ELIZAOS_CLOUD_ENABLED values instead of throwing", () => {
+    // `42` / `{}` are not strings; calling `.trim()` on them throws a
+    // TypeError. The auto-enable engine treats a throwing predicate as
+    // disabled-with-error, so a malformed value must fail closed cleanly.
+    expect(shouldEnable(ctx({ ELIZAOS_CLOUD_ENABLED: 42 }) as never)).toBe(
+      false,
+    );
+    expect(shouldEnable(ctx({ ELIZAOS_CLOUD_ENABLED: {} }) as never)).toBe(
+      false,
+    );
+    expect(
+      shouldEnable(ctx({ ELIZAOS_CLOUD_ENABLED: true }) as never),
+    ).toBe(false);
+  });
+
+  it("tolerates non-string ELIZAOS_CLOUD_API_KEY values instead of throwing", () => {
+    expect(shouldEnable(ctx({ ELIZAOS_CLOUD_API_KEY: 42 }) as never)).toBe(
+      false,
+    );
+  });
+});

--- a/plugins/plugin-elizacloud/auto-enable.ts
+++ b/plugins/plugin-elizacloud/auto-enable.ts
@@ -7,7 +7,7 @@
 import type { PluginAutoEnableContext } from "@elizaos/core";
 
 function isTruthyCloudFlag(value: string | undefined): boolean {
-  if (!value) return false;
+  if (typeof value !== "string" || !value) return false;
   const normalized = value.trim().toLowerCase();
   return normalized === "1" || normalized === "true" || normalized === "yes";
 }


### PR DESCRIPTION
# Relates to

<!-- No issue; hardening the auto-enable gate against non-string env values. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. One-line behavioral change in the auto-enable predicate plus a new test
file. `isTruthyCloudFlag` previously called `.trim()` on any truthy value, so a
non-string `ELIZAOS_CLOUD_ENABLED` env value (e.g. a numeric or object value in
embedded/unit contexts) threw a TypeError. The auto-enable engine treats a
throwing predicate as disabled-with-error, violating the predicate contract of
never throwing; the gate now fails closed cleanly.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `Test Files 1 passed (1) / Tests 7 passed (7)` — run at PR head |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: one-line source fix + test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
