### PR TITLE
fix(core): reject NaN and non-finite timestamps in withinCreatedAtWindow

### DIFF
--- a/packages/core/src/search.test.ts
+++ b/packages/core/src/search.test.ts
@@ -214,14 +214,19 @@ describe("withinCreatedAtWindow", () => {
 	it("rejects undefined, NaN, and non-finite timestamps when any bound is active", () => {
 		expect(withinCreatedAtWindow(undefined, 1000)).toBe(false);
 		expect(withinCreatedAtWindow(Number.NaN, 1000, 2000)).toBe(false);
-		expect(withinCreatedAtWindow(Number.POSITIVE_INFINITY, 1000, 2000)).toBe(false);
-		expect(withinCreatedAtWindow(Number.NEGATIVE_INFINITY, 1000, 2000)).toBe(false);
+		expect(withinCreatedAtWindow(Number.POSITIVE_INFINITY, 1000, 2000)).toBe(
+			false,
+		);
+		expect(withinCreatedAtWindow(Number.NEGATIVE_INFINITY, 1000, 2000)).toBe(
+			false,
+		);
 	});
 
 	it("rejects non-finite bounds", () => {
 		expect(withinCreatedAtWindow(1500, Number.NaN, 2000)).toBe(false);
 		expect(withinCreatedAtWindow(1500, 1000, Number.NaN)).toBe(false);
-		expect(withinCreatedAtWindow(1500, Number.POSITIVE_INFINITY, 2000)).toBe(false);
+		expect(withinCreatedAtWindow(1500, Number.POSITIVE_INFINITY, 2000)).toBe(
+			false,
+		);
 	});
 });
-

--- a/packages/core/src/search.test.ts
+++ b/packages/core/src/search.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { BM25, rankMessageSearch } from "./search.ts";
+import { BM25, rankMessageSearch, withinCreatedAtWindow } from "./search.ts";
 
 describe("rankMessageSearch", () => {
 	it("matches a typo by trigram similarity, not only exact substrings", () => {
@@ -192,3 +192,36 @@ describe("BM25 empty text at the remaining tokenize call sites", () => {
 		expect(hits.map((hit) => hit.item.id)).toEqual(["filled"]);
 	});
 });
+
+describe("withinCreatedAtWindow", () => {
+	it("accepts valid timestamps within inclusive bounds", () => {
+		expect(withinCreatedAtWindow(1500, 1000, 2000)).toBe(true);
+		expect(withinCreatedAtWindow(1000, 1000, 2000)).toBe(true);
+		expect(withinCreatedAtWindow(2000, 1000, 2000)).toBe(true);
+	});
+
+	it("rejects timestamps outside bounds", () => {
+		expect(withinCreatedAtWindow(999, 1000, 2000)).toBe(false);
+		expect(withinCreatedAtWindow(2001, 1000, 2000)).toBe(false);
+	});
+
+	it("allows any finite timestamp when bounds are unconstrained", () => {
+		expect(withinCreatedAtWindow(1500)).toBe(true);
+		expect(withinCreatedAtWindow(undefined)).toBe(true);
+		expect(withinCreatedAtWindow(Number.NaN)).toBe(true);
+	});
+
+	it("rejects undefined, NaN, and non-finite timestamps when any bound is active", () => {
+		expect(withinCreatedAtWindow(undefined, 1000)).toBe(false);
+		expect(withinCreatedAtWindow(Number.NaN, 1000, 2000)).toBe(false);
+		expect(withinCreatedAtWindow(Number.POSITIVE_INFINITY, 1000, 2000)).toBe(false);
+		expect(withinCreatedAtWindow(Number.NEGATIVE_INFINITY, 1000, 2000)).toBe(false);
+	});
+
+	it("rejects non-finite bounds", () => {
+		expect(withinCreatedAtWindow(1500, Number.NaN, 2000)).toBe(false);
+		expect(withinCreatedAtWindow(1500, 1000, Number.NaN)).toBe(false);
+		expect(withinCreatedAtWindow(1500, Number.POSITIVE_INFINITY, 2000)).toBe(false);
+	});
+});
+

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -1952,9 +1952,9 @@ export function withinCreatedAtWindow(
 	until?: number,
 ): boolean {
 	if (since === undefined && until === undefined) return true;
-	if (typeof createdAt !== "number") return false;
-	if (since !== undefined && createdAt < since) return false;
-	if (until !== undefined && createdAt > until) return false;
+	if (typeof createdAt !== "number" || !Number.isFinite(createdAt)) return false;
+	if (since !== undefined && (!Number.isFinite(since) || createdAt < since)) return false;
+	if (until !== undefined && (!Number.isFinite(until) || createdAt > until)) return false;
 	return true;
 }
 

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -1952,9 +1952,12 @@ export function withinCreatedAtWindow(
 	until?: number,
 ): boolean {
 	if (since === undefined && until === undefined) return true;
-	if (typeof createdAt !== "number" || !Number.isFinite(createdAt)) return false;
-	if (since !== undefined && (!Number.isFinite(since) || createdAt < since)) return false;
-	if (until !== undefined && (!Number.isFinite(until) || createdAt > until)) return false;
+	if (typeof createdAt !== "number" || !Number.isFinite(createdAt))
+		return false;
+	if (since !== undefined && (!Number.isFinite(since) || createdAt < since))
+		return false;
+	if (until !== undefined && (!Number.isFinite(until) || createdAt > until))
+		return false;
 	return true;
 }
 


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Closes #28698

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low risk. Confined to `withinCreatedAtWindow` in `packages/core/src/search.ts`.

# Background

## What does this PR do?
`withinCreatedAtWindow` checks whether a message timestamp falls within an optional inclusive time window (`since` to `until`).

Previously, `if (typeof createdAt !== "number") return false;` did not verify `Number.isFinite(createdAt)`. When `createdAt` was `NaN`, both comparisons `NaN < since` and `NaN > until` evaluated to `false`, causing `withinCreatedAtWindow` to return `true` and bypass active time window filters.

This PR ensures `createdAt`, `since`, and `until` are finite numbers when bounds are evaluated, correctly rejecting `NaN` and non-finite timestamps when any bound is active.

## What kind of change is this?
Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?
My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?
Review `packages/core/src/search.ts` around `withinCreatedAtWindow` and unit tests in `packages/core/src/search.test.ts`.

## Detailed testing steps
Run:
```bash
bun test packages/core/src/search.test.ts
bun run --cwd packages/core typecheck
```

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:9d1bc7a25dd4a72d42e03aa3727bf192ef976378 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots: N/A - Non-UI core search utility change.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots: N/A - Non-UI core search utility change.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough: N/A - Non-UI core search utility change.
<!-- evidence-row:backend-logs -->
- [x] Backend logs:
<details>
<summary>bun test packages/core/src/search.test.ts output</summary>

```
packages/core/src/search.test.ts:
✓ rankMessageSearch > matches a typo by trigram similarity, not only exact substrings [0.74ms]
✓ rankMessageSearch > requires every multi-term query token to match before using typo recall [0.43ms]
✓ rankMessageSearch > does not admit unrelated text through the trigram branch [0.06ms]
✓ BM25.search result ordering > returns descending scores even when fewer matches exist than topK [9.28ms]
✓ BM25.search result ordering > keeps the bounded top-K path intact when the buffer fills [0.17ms]
✓ BM25.search result ordering > breaks score ties in ascending document order on the partial path [0.12ms]
✓ BM25 empty string fields > indexes documents containing empty string fields without throwing [0.24ms]
✓ BM25 empty string fields > treats whitespace-only fields as zero-length documents [0.12ms]
✓ BM25 empty string fields > accepts incremental addDocument with empty string fields [0.47ms]
✓ BM25 empty text at the remaining tokenize call sites > returns no hits for an empty or whitespace-only query [0.05ms]
✓ BM25 empty text at the remaining tokenize call sites > returns no hits for an empty phrase [0.13ms]
✓ BM25 empty text at the remaining tokenize call sites > scans a matching document with an empty field without throwing [0.53ms]
✓ BM25 empty text at the remaining tokenize call sites > scores an empty field identically to an absent field [0.24ms]
✓ BM25 empty text at the remaining tokenize call sites > ranks a memory whose text is empty instead of throwing [0.17ms]
✓ withinCreatedAtWindow > accepts valid timestamps within inclusive bounds [0.06ms]
✓ withinCreatedAtWindow > rejects timestamps outside bounds [0.01ms]
✓ withinCreatedAtWindow > allows any finite timestamp when bounds are unconstrained [0.02ms]
✓ withinCreatedAtWindow > rejects undefined, NaN, and non-finite timestamps when any bound is active [0.02ms]
✓ withinCreatedAtWindow > rejects non-finite bounds [0.02ms]

 19 pass
 0 fail
 36 expect() calls
Ran 19 tests across 1 file. [138.00ms]
```
</details>
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs: N/A - Core search utility without frontend execution.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory: N/A - Deterministic search ranking and filtering algorithm.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts: N/A - In-memory data structures without persistent storage.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review: N/A - No UI rendered.

# Known gaps / failures
None.

# Maintainer CI exception record
N/A - no exception requested

---

AI provider/model: Google / Gemini 3.7 Flash
Client / agent tooling: Antigravity
Contribution skill revision: elizaOS/eliza@7d55350499b702ec4c979c3dcb6bb5e56d482939:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [antigravity-contrib]
<!-- eliza-computer-attribution:v1 {"provider":"google","model":"gemini-3.7-flash","client":"Antigravity","skill_revision":"elizaOS/eliza@7d55350499b702ec4c979c3dcb6bb5e56d482939:packages/skills/skills/contribute-to-eliza"} -->