### PR TITLE
fix(core): keep UTF-16 surrogate pairs intact in structured evaluator parseError truncation

### DIFF
--- a/packages/core/src/runtime/__tests__/evaluator.test.ts
+++ b/packages/core/src/runtime/__tests__/evaluator.test.ts
@@ -1349,4 +1349,19 @@ describe("fabricated marker invocations are rejected, real widgets pass", () => 
 			expect(result.messageToUser).toBe(answer);
 		}
 	});
+
+	it("preserves UTF-16 surrogate pairs in malformed structured output parse error", () => {
+		// "🔥" (2 code units * 120 = 240 units)
+		const badObject = { payload: "🔥".repeat(120) };
+		const result = parseEvaluatorOutput({ object: badObject as any });
+		expect(result.protocolFailure).toBe(true);
+		expect(result.parseError).toBeDefined();
+		for (const char of result.parseError!) {
+			expect(
+				/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(
+					char,
+				),
+			).toBe(false);
+		}
+	});
 });

--- a/packages/core/src/runtime/evaluator.ts
+++ b/packages/core/src/runtime/evaluator.ts
@@ -1796,9 +1796,17 @@ function getStructuredEvaluatorObject(
 		// parse-error path so the loop sees a malformed evaluation and retries,
 		// instead of a silent default verdict.
 		if (!isEvaluatorShapedObject(raw.object)) {
+			const objStr = JSON.stringify(raw.object);
+			let end = 200;
+			if (end > 0 && end < objStr.length) {
+				const code = objStr.charCodeAt(end - 1);
+				if (code >= 0xd800 && code <= 0xdbff) {
+					end -= 1;
+				}
+			}
 			return {
 				object: null,
-				parseError: `structured evaluator output is not evaluator-shaped: ${JSON.stringify(raw.object).slice(0, 200)}`,
+				parseError: `structured evaluator output is not evaluator-shaped: ${objStr.slice(0, end)}`,
 			};
 		}
 		return { object: raw.object as RawEvaluatorOutput };


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:0603180328320fb53f3798c1fa8d0cd1058f4d56 -->

## Summary
In `packages/core/src/runtime/evaluator.ts`:
`getStructuredEvaluatorObject` constructs diagnostic parse errors for malformed structured model outputs using `parseError: \`structured evaluator output is not evaluator-shaped: ${JSON.stringify(raw.object).slice(0, 200)}\``.

When model output payloads contain multi-byte UTF-16 surrogate pairs (e.g. emojis or unicode strings), slicing the serialized JSON directly at character index 200 can split a surrogate pair in half and leave an orphaned surrogate character (`\uFFFD`).

## Proposed Changes
1. Added surrogate-pair safe boundary back-off to structured output JSON slicing in `getStructuredEvaluatorObject`.
2. Added unit tests in `packages/core/src/runtime/__tests__/evaluator.test.ts`.

## Verification
- Ran vitest: `bun run --cwd packages/core test src/runtime/__tests__/evaluator.test.ts` (55/55 passed).

<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-3-5-sonnet","client":"antigravity","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
