### PR TITLE
fix(plugin-openai): keep UTF-16 surrogate pairs intact in deterministic embedding text truncation

### DIFF
--- a/plugins/plugin-openai/__tests__/embedding-deterministic.test.ts
+++ b/plugins/plugin-openai/__tests__/embedding-deterministic.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { createDeterministicEmbedding } from "../models/embedding";
+
+describe("createDeterministicEmbedding surrogate safety", () => {
+  it("generates normalized embedding vectors for long emoji inputs without surrogate bisection", () => {
+    // "🔥" (2 code units * 300 = 600 units) -> > 512
+    const longEmojiText = "🔥".repeat(300);
+    const vec = createDeterministicEmbedding(longEmojiText, 384);
+
+    expect(vec).toHaveLength(384);
+    const norm = Math.sqrt(vec.reduce((sum, v) => sum + v * v, 0));
+    expect(norm).toBeCloseTo(1.0, 4);
+  });
+});

--- a/plugins/plugin-openai/models/embedding.ts
+++ b/plugins/plugin-openai/models/embedding.ts
@@ -79,7 +79,19 @@ function hashFeature(feature: string): number {
   return hash >>> 0;
 }
 
-function createDeterministicEmbedding(text: string, dimension: VectorDimension): number[] {
+function truncateUtf16Safe(text: string, maxLength: number): string {
+  if (text.length <= maxLength) return text;
+  let end = maxLength;
+  if (end > 0 && end < text.length) {
+    const code = text.charCodeAt(end - 1);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      end -= 1;
+    }
+  }
+  return text.slice(0, end);
+}
+
+export function createDeterministicEmbedding(text: string, dimension: VectorDimension): number[] {
   const vector = new Array(dimension).fill(0);
   const normalized = text.toLowerCase();
   const tokens = normalized.match(/[a-z0-9]+(?:[_-][a-z0-9]+)*/g) ?? [normalized];
@@ -102,7 +114,7 @@ function createDeterministicEmbedding(text: string, dimension: VectorDimension):
       addFeature(`${tokens[index - 1]} ${token}`, 0.35);
     }
   });
-  addFeature(normalized.slice(0, 512), 0.15);
+  addFeature(truncateUtf16Safe(normalized, 512), 0.15);
 
   const norm = Math.sqrt(vector.reduce((sum, value) => sum + value * value, 0));
   if (norm === 0) {


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:71a87c5534684f613248f00fe87877d4f9205aaf -->

## Summary
In `plugins/plugin-openai/models/embedding.ts`:
`createDeterministicEmbedding` extracts whole-text character n-gram features by taking `normalized.slice(0, 512)`.

When input strings contain multi-byte UTF-16 surrogate pairs (e.g. emojis or astral unicode symbols), slicing at offset 512 can bisect a surrogate pair in half, producing orphaned surrogate characters (`\uFFFD`).

## Proposed Changes
1. Added surrogate-pair safe boundary back-off `truncateUtf16Safe` in `plugins/plugin-openai/models/embedding.ts`.
2. Exported `createDeterministicEmbedding` and added unit test in `plugins/plugin-openai/__tests__/embedding-deterministic.test.ts`.

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-openai test __tests__/embedding-deterministic.test.ts __tests__/embedding-timeout.test.ts` (5/5 passed).

<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-3-5-sonnet","client":"antigravity","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
