### PR TITLE
fix(agent): reject requests when rate limit maxRequests is 0 or negative

### DIFF
--- a/packages/agent/src/api/rate-limiter.test.ts
+++ b/packages/agent/src/api/rate-limiter.test.ts
@@ -59,4 +59,21 @@ describe("checkRateLimit", () => {
     // Still only 6 minutes into hourly-op's 1-hour window: must stay blocked.
     expect(checkRateLimit("hourly-op", hourly).allowed).toBe(false);
   });
+
+  it("rejects immediately and continuously when maxRequests is 0 or negative", () => {
+    const zeroConfig = { maxRequests: 0, windowMs: MINUTE };
+    const first = checkRateLimit("zero-op", zeroConfig);
+    expect(first.allowed).toBe(false);
+    expect(first.retryAfterMs).toBe(MINUTE);
+
+    const second = checkRateLimit("zero-op", zeroConfig);
+    expect(second.allowed).toBe(false);
+    expect(second.retryAfterMs).toBe(MINUTE);
+
+    const negativeConfig = { maxRequests: -5, windowMs: MINUTE };
+    expect(checkRateLimit("neg-op", negativeConfig).allowed).toBe(false);
+
+    const nanConfig = { maxRequests: Number.NaN, windowMs: MINUTE };
+    expect(checkRateLimit("nan-op", nanConfig).allowed).toBe(false);
+  });
 });

--- a/packages/agent/src/api/rate-limiter.ts
+++ b/packages/agent/src/api/rate-limiter.ts
@@ -74,10 +74,14 @@ export function checkRateLimit(
   const cutoff = now - config.windowMs;
   entry.timestamps = entry.timestamps.filter((t) => t > cutoff);
 
+  if (config.maxRequests <= 0 || !Number.isFinite(config.maxRequests)) {
+    return { allowed: false, retryAfterMs: Math.max(config.windowMs, 0) };
+  }
+
   if (entry.timestamps.length >= config.maxRequests) {
     const oldestInWindow = entry.timestamps[0];
     if (oldestInWindow === undefined) {
-      return { allowed: true, retryAfterMs: 0 };
+      return { allowed: false, retryAfterMs: Math.max(config.windowMs, 0) };
     }
     const retryAfterMs = oldestInWindow + config.windowMs - now;
     return { allowed: false, retryAfterMs: Math.max(retryAfterMs, 0) };


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Closes #28705

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low risk. Confined to `checkRateLimit` in `packages/agent/src/api/rate-limiter.ts`.

# Background

## What does this PR do?
`checkRateLimit()` in `packages/agent/src/api/rate-limiter.ts` implements a sliding-window rate limiter for API endpoints.

Previously, when `config.maxRequests` was configured as 0 (or negative), `entry.timestamps.length >= config.maxRequests` evaluated to `0 >= 0` (`true`). Then `oldestInWindow` was `entry.timestamps[0]` (`undefined`), causing the code to return `{ allowed: true, retryAfterMs: 0 }`. Because no timestamp was recorded, subsequent requests continued returning `allowed: true`, bypassing rate limiting completely.

This PR adds an explicit guard for `config.maxRequests <= 0 || !Number.isFinite(config.maxRequests)` to reject immediately and return `allowed: false` with the full window retry duration.

## What kind of change is this?
Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?
My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?
Review `packages/agent/src/api/rate-limiter.ts` lines 77-85 and the test cases in `packages/agent/src/api/rate-limiter.test.ts`.

## Detailed testing steps
Run:
```bash
bun test packages/agent/src/api/rate-limiter.test.ts
bun run --cwd packages/agent typecheck
```

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:6e2bcc3be772c95f7b11b0bec49ed70abb954496 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots: N/A - Non-UI server utility change.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots: N/A - Non-UI server utility change.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough: N/A - Non-UI server utility change.
<!-- evidence-row:backend-logs -->
- [x] Backend logs:
<details>
<summary>bun test packages/agent/src/api/rate-limiter.test.ts output</summary>

```
packages/agent/src/api/rate-limiter.test.ts:
✓ checkRateLimit > allows up to maxRequests then rejects with a retry hint [0.63ms]
✓ checkRateLimit > allows again once the window slides past the oldest request [0.09ms]
✓ checkRateLimit > does not let a short-window key's cleanup sweep wipe a longer-window bucket [0.14ms]
✓ checkRateLimit > rejects immediately and continuously when maxRequests is 0 or negative [0.10ms]

 4 pass
 0 fail
 18 expect() calls
Ran 4 tests across 1 file. [106.00ms]
```
</details>
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs: N/A - Backend-only utility with no frontend runtime execution.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory: N/A - Deterministic sliding-window algorithm with no AI model invocations.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts: N/A - In-memory data structures without persistent storage.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review: N/A - No UI rendered.

# Known gaps / failures
None.

# Maintainer CI exception record
N/A - no exception requested

---

AI provider/model: Google / Gemini 3.7 Flash
Client / agent tooling: Antigravity
Contribution skill revision: elizaOS/eliza@7d55350499b702ec4c979c3dcb6bb5e56d482939:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [antigravity-contrib]
<!-- eliza-computer-attribution:v1 {"provider":"google","model":"gemini-3.7-flash","client":"Antigravity","skill_revision":"elizaOS/eliza@7d55350499b702ec4c979c3dcb6bb5e56d482939:packages/skills/skills/contribute-to-eliza"} -->