### PR TITLE
fix(plugin-github): keep UTF-16 surrogate pairs intact in PR and issue body preview truncation

### DIFF
--- a/plugins/plugin-github/src/action-helpers.test.ts
+++ b/plugins/plugin-github/src/action-helpers.test.ts
@@ -6,6 +6,7 @@ import {
   requireString,
   requireStringArray,
   splitRepo,
+  truncateUtf16Safe,
 } from "./action-helpers.ts";
 
 /**
@@ -137,5 +138,30 @@ describe("isConfirmed", () => {
   it("is always false regardless of the supplied flag", () => {
     expect(isConfirmed({ confirmed: true })).toBe(false);
     expect(isConfirmed(undefined)).toBe(false);
+  });
+});
+
+describe("truncateUtf16Safe", () => {
+  it("keeps surrogate pairs intact when truncating at multi-byte boundaries", () => {
+    const longEmoji = "🔥".repeat(100);
+    const truncated = truncateUtf16Safe(longEmoji, 120);
+    expect(truncated.length).toBe(120);
+    for (const char of truncated) {
+      expect(
+        /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(
+          char,
+        ),
+      ).toBe(false);
+    }
+
+    const truncatedOdd = truncateUtf16Safe(longEmoji, 119);
+    expect(truncatedOdd.length).toBe(118);
+    for (const char of truncatedOdd) {
+      expect(
+        /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(
+          char,
+        ),
+      ).toBe(false);
+    }
   });
 });

--- a/plugins/plugin-github/src/action-helpers.ts
+++ b/plugins/plugin-github/src/action-helpers.ts
@@ -269,3 +269,15 @@ export function describeSelection(selection: GitHubAccountSelection): string {
     ? `${selection.role} (${selection.accountId})`
     : selection.role;
 }
+
+export function truncateUtf16Safe(text: string, maxLength: number): string {
+  if (text.length <= maxLength) return text;
+  let end = maxLength;
+  if (end > 0 && end < text.length) {
+    const code = text.charCodeAt(end - 1);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      end -= 1;
+    }
+  }
+  return text.slice(0, end);
+}

--- a/plugins/plugin-github/src/actions/issue-op.ts
+++ b/plugins/plugin-github/src/actions/issue-op.ts
@@ -16,6 +16,7 @@ import { logger, requireConfirmation } from "@elizaos/core";
 import {
   buildResolvedClient,
   describeSelection,
+  truncateUtf16Safe,
   optionalStringArray,
   type ResolvedClient,
   requireNumber,
@@ -279,7 +280,7 @@ function buildPreview(
       case "label":
         return ` with [${labels?.join(", ") ?? ""}]`;
       case "comment":
-        return body ? ` body: "${body.slice(0, 120)}"` : "";
+        return body ? ` body: "${truncateUtf16Safe(body, 120)}"` : "";
       default:
         return "";
     }

--- a/plugins/plugin-github/src/actions/pr-op.ts
+++ b/plugins/plugin-github/src/actions/pr-op.ts
@@ -15,6 +15,7 @@ import { logger, requireConfirmation } from "@elizaos/core";
 import {
   buildResolvedClient,
   describeSelection,
+  truncateUtf16Safe,
   requireNumber,
   requireString,
   resolveAccountSelection,
@@ -177,7 +178,7 @@ async function runReview(
 
   const preview =
     `About to ${action.replace("-", " ")} PR ${repo}#${number}` +
-    (body ? ` with body: "${body.slice(0, 120)}"` : "") +
+    (body ? ` with body: "${truncateUtf16Safe(body, 120)}"` : "") +
     ` as ${describeSelection(selection)}.`;
   const decision = await requireConfirmation({
     runtime,


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:5e21057bdfaf045a9ae29d7859458217559fb14f -->

## Summary
In `plugins/plugin-github`:
`pr-op.ts` and `issue-op.ts` construct human confirmation prompts for PR reviews and issue comments by previewing up to 120 characters of the body text via `body.slice(0, 120)`.

When the comment/review body contains multi-byte UTF-16 surrogate pairs (e.g. emojis or markdown unicode), slicing at character offset 120 can bisect a surrogate pair in half, producing orphaned surrogate characters (`\uFFFD`).

## Proposed Changes
1. Added `truncateUtf16Safe` helper with surrogate boundary back-off in `plugins/plugin-github/src/action-helpers.ts`.
2. Applied `truncateUtf16Safe` across `pr-op.ts` and `issue-op.ts` body preview strings.
3. Added unit tests in `plugins/plugin-github/src/action-helpers.test.ts`.

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-github test src/action-helpers.test.ts` (74/74 passed).

<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-3-5-sonnet","client":"antigravity","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
