### PR TITLE
fix(plugin-telegram): keep UTF-16 surrogate pairs intact in command description clamping and reply truncation

### DIFF
--- a/plugins/plugin-telegram/src/command-registration.test.ts
+++ b/plugins/plugin-telegram/src/command-registration.test.ts
@@ -361,4 +361,26 @@ describe("applyTelegramSetMyCommands", () => {
     ).resolves.toBeUndefined();
     expect(setMyCommands).toHaveBeenCalledTimes(1);
   });
+
+  it("keeps surrogate pairs intact when clamping command descriptions", () => {
+    // "🔥" (2 code units * 150 = 300 units) -> > TELEGRAM_COMMAND_DESCRIPTION_MAX (256)
+    const longEmojiDesc = "🔥".repeat(150);
+    pluginCommandsMock.getConnectorCommands.mockReturnValueOnce([
+      {
+        name: "emoji_cmd",
+        description: longEmojiDesc,
+        target: { kind: "agent" },
+      },
+    ]);
+    const descriptors = buildTelegramCommandDescriptors();
+    expect(descriptors).toHaveLength(1);
+    expect(descriptors[0].description.length).toBeLessThanOrEqual(256);
+    for (const char of descriptors[0].description) {
+      expect(
+        /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(
+          char,
+        ),
+      ).toBe(false);
+    }
+  });
 });

--- a/plugins/plugin-telegram/src/command-registration.ts
+++ b/plugins/plugin-telegram/src/command-registration.ts
@@ -108,9 +108,21 @@ function sanitizeCommandName(name: string): string | null {
 }
 
 /** Clamp a description to Telegram's limit; a description is always required. */
+function truncateUtf16Safe(text: string, maxLength: number): string {
+  if (text.length <= maxLength) return text;
+  let end = maxLength;
+  if (end > 0 && end < text.length) {
+    const code = text.charCodeAt(end - 1);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      end -= 1;
+    }
+  }
+  return text.slice(0, end);
+}
+
 function clampDescription(description: string): string {
   const trimmed = description.trim();
-  return trimmed.slice(0, TELEGRAM_COMMAND_DESCRIPTION_MAX);
+  return truncateUtf16Safe(trimmed, TELEGRAM_COMMAND_DESCRIPTION_MAX);
 }
 
 /**
@@ -278,7 +290,7 @@ async function dispatchAgentCommand(
       ...(sender.senderName ? { senderName: sender.senderName } : {}),
     });
     if (resolved.handled && resolved.reply !== undefined) {
-      await ctx.reply(resolved.reply.slice(0, TELEGRAM_MESSAGE_MAX));
+      await ctx.reply(truncateUtf16Safe(resolved.reply, TELEGRAM_MESSAGE_MAX));
       return;
     }
   }


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:779f74d38bd797e48a3ee00ab0ca6e2524fc91ec -->

## Summary
In `plugins/plugin-telegram/src/command-registration.ts`:
`clampDescription` and `dispatchAgentCommand` truncate command descriptions and command replies using raw string slicing (`trimmed.slice(0, TELEGRAM_COMMAND_DESCRIPTION_MAX)` and `resolved.reply.slice(0, TELEGRAM_MESSAGE_MAX)`).

When command descriptions or replies contain multi-byte UTF-16 surrogate pairs (e.g. emojis or markdown unicode characters), slicing directly at maximum character boundaries can split a surrogate pair in half, producing orphaned surrogate characters (`\uFFFD`).

## Proposed Changes
1. Added `truncateUtf16Safe` helper with surrogate boundary back-off in `plugins/plugin-telegram/src/command-registration.ts`.
2. Applied `truncateUtf16Safe` across `clampDescription` and `dispatchAgentCommand`.
3. Added unit tests in `plugins/plugin-telegram/src/command-registration.test.ts`.

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-telegram test src/command-registration.test.ts` (14/14 passed).

<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-3-5-sonnet","client":"antigravity","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
