### PR TITLE
fix(plugin-browser): keep UTF-16 surrogate pairs intact in BrowserBridgeAdapter summarizePage truncation

### DIFF
--- a/plugins/plugin-browser/src/message-adapter.test.ts
+++ b/plugins/plugin-browser/src/message-adapter.test.ts
@@ -83,4 +83,47 @@ describe("BrowserBridgeAdapter", () => {
       }),
     ).resolves.toEqual([]);
   });
+
+  it("preserves UTF-16 surrogate pairs when summarizing long page text", async () => {
+    // "🔥" (2 code units * 260 = 520 units) -> > 500
+    const longEmoji = "🔥".repeat(260);
+    const page = {
+      id: "page-emoji",
+      agentId: "agent-1",
+      browser: "chrome",
+      profileId: "default",
+      windowId: "window-1",
+      tabId: "tab-1",
+      url: "https://example.com/emoji",
+      title: "Emoji Page",
+      selectionText: null,
+      mainText: longEmoji,
+      headings: [],
+      links: [],
+      forms: [],
+      capturedAt: "2026-06-02T12:00:00.000Z",
+      metadata: {},
+    };
+    const routeService = {
+      getCurrentBrowserPage: vi.fn(async () => page),
+    };
+    const runtime = {
+      agentId: "agent-1",
+      getService: vi.fn(() => routeService),
+    } as unknown as IAgentRuntime;
+    const adapter = new BrowserBridgeAdapter();
+
+    const messages = await adapter.listMessages(runtime, { limit: 1 });
+    expect(messages).toHaveLength(1);
+    const snippet = messages[0]?.snippet;
+    expect(snippet?.endsWith("...")).toBe(true);
+    expect(snippet?.length).toBe(499);
+    for (const char of snippet!) {
+      expect(
+        /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(
+          char,
+        ),
+      ).toBe(false);
+    }
+  });
 });

--- a/plugins/plugin-browser/src/message-adapter.ts
+++ b/plugins/plugin-browser/src/message-adapter.ts
@@ -43,13 +43,25 @@ function browserPageMessageId(page: BrowserBridgePageContext): string {
   ].join(":");
 }
 
+function truncateUtf16Safe(text: string, maxLength: number): string {
+  if (text.length <= maxLength) return text;
+  let end = maxLength;
+  if (end > 0 && end < text.length) {
+    const code = text.charCodeAt(end - 1);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      end -= 1;
+    }
+  }
+  return text.slice(0, end);
+}
+
 function summarizePage(page: BrowserBridgePageContext): string {
   const text =
     page.selectionText?.trim() ||
     page.mainText?.trim() ||
     page.title.trim() ||
     page.url;
-  return text.length > 500 ? `${text.slice(0, 497)}...` : text;
+  return text.length > 500 ? `${truncateUtf16Safe(text, 497)}...` : text;
 }
 
 function pageToMessageRef(page: BrowserBridgePageContext): MessageRef {


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:d00dab8cd8b25d4612d6647da05ea6b0a8f22145 -->

## Summary
In `plugins/plugin-browser/src/message-adapter.ts`:
`summarizePage` creates message snippet previews for browser page context items by truncating strings longer than 500 characters using `${text.slice(0, 497)}...`.

When webpage text, selection text, or title contains multi-byte UTF-16 surrogate pairs (e.g. emojis or astral plane unicode symbols), slicing at character offset 497 can split a surrogate pair in half, producing orphaned surrogate characters (`\uFFFD`).

## Proposed Changes
1. Added `truncateUtf16Safe` helper with surrogate boundary back-off in `plugins/plugin-browser/src/message-adapter.ts`.
2. Applied `truncateUtf16Safe` across `summarizePage`.
3. Added unit tests in `plugins/plugin-browser/src/message-adapter.test.ts`.

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-browser test src/message-adapter.test.ts` (3/3 passed).

<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-3-5-sonnet","client":"antigravity","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
