### PR TITLE
fix(telegram): wire membership authority admission and revocation into the Telegram connector (#23101)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -846,6 +846,7 @@ jobs:
         run: |
           bun run --cwd plugins/plugin-anthropic test:real-runtime
           bun run --cwd plugins/plugin-discord test:real-runtime
+          bun run --cwd plugins/plugin-telegram test:real-runtime
 
   zero-key-e2e:
     name: Zero-Key Deterministic E2E

--- a/plugins/plugin-sql/src/services/sql-membership.ts
+++ b/plugins/plugin-sql/src/services/sql-membership.ts
@@ -49,7 +49,10 @@ const MAX_SNAPSHOT_MEMBERS = 100_000;
 const MAX_VALIDITY_MS = 24 * 60 * 60 * 1_000;
 const MAX_FUTURE_OBSERVATION_MS = 5 * 60 * 1_000;
 const ACTIVE_REASONS = new Set(["joined", "reconciled_present", "permission_restored"]);
-const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+// Canonical UUID shape (matches core's validateUuid): elizaOS derives many
+// runtime ids via stringToUuid, whose custom format zeroes the version nibble,
+// so restricting the nibble to [1-8] would reject the platform's own ids.
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const DEGRADE_REASON = {
   stale: "authority_stale",
   unavailable: "authority_unavailable",

--- a/plugins/plugin-telegram/README.md
+++ b/plugins/plugin-telegram/README.md
@@ -117,6 +117,10 @@ The plugin registers a `/eliza_pair <code>` bot command that lets the Telegram u
 
 The Telegram Bot API permits only one active long-poll connection per token. If two agent processes share the same token simultaneously, Telegram rejects the second with a 409 error. Full and standalone pollers share a process-local lock keyed by a fingerprint of the token; a live, starting, retrying, or merely quiet owner remains a hard launch failure. The lock becomes reclaimable only after that poller reaches an explicit terminal state. Across separate processes, operators must still ensure that only one process uses a given token at a time.
 
+## Membership recovery
+
+When the bot is kicked from a group, the scope's persisted health degrades to `unavailable` and group admission fails closed. Admission recovers automatically after a bot re-add: the re-add writes a durable, generation-fenced watermark, and the next join evidence restores the scope. If a re-add's `my_chat_member` / `new_chat_members` update is never delivered to the bot, the scope stays denied by design (fail closed) — the remedy is to kick and re-add the bot again rather than wait.
+
 ## Development
 
 ```bash

--- a/plugins/plugin-telegram/__tests__/core-test-mock.ts
+++ b/plugins/plugin-telegram/__tests__/core-test-mock.ts
@@ -34,6 +34,13 @@ vi.mock("@elizaos/core", async () => {
   );
   const { ElizaError } = await import("../../../packages/core/src/errors");
 
+  // The canonical env-truthiness contract (1/true/yes/y/on/enabled, trimmed
+  // and case-insensitive) is pure string logic; the gate's strict-mode branch
+  // must use the real implementation, so delegate rather than re-stub.
+  const { isTruthyEnvValue } = await import(
+    "../../../packages/core/src/env-utils"
+  );
+
   // The pairing integration is a pure service lookup plus reply formatting
   // over a duck-typed PairingService; the DM-policy suites exercise its real
   // fail-closed behavior (missing service, queue cap, reply claims), so it is
@@ -139,6 +146,7 @@ vi.mock("@elizaos/core", async () => {
     ChannelType,
     CommandRegistryService,
     ElizaError,
+    isTruthyEnvValue,
     EventType,
     checkPairingAllowed,
     getConfiguredOwnerEntityIds: () => [],

--- a/plugins/plugin-telegram/__tests__/membership-authority.real.test.ts
+++ b/plugins/plugin-telegram/__tests__/membership-authority.real.test.ts
@@ -1579,6 +1579,9 @@ describe("telegram membership authority vertical (real PGlite)", () => {
       runtime: unknown;
       defaultAccountId: string;
       membershipGates: Map<string, Promise<unknown>>;
+      settledMembershipGates: Map<string, unknown>;
+      pendingMembershipTransitions: Map<string, unknown[]>;
+      membershipGateFailures: Set<string>;
       handleMyChatMemberUpdate: (
         update: unknown,
         accountId?: string,
@@ -1586,9 +1589,17 @@ describe("telegram membership authority vertical (real PGlite)", () => {
     };
     service.runtime = harness.runtime;
     service.defaultAccountId = "default";
+    // The gate promise is already resolved, but the startup-window check
+    // consults the settled registry synchronously — mirror production state
+    // where the bootstrap completed before these dispatches run.
     service.membershipGates = new Map([
       ["default", Promise.resolve({ authority, botTelegramUserId: "900001" })],
     ]);
+    service.settledMembershipGates = new Map([
+      ["default", { authority, botTelegramUserId: "900001" }],
+    ]);
+    service.pendingMembershipTransitions = new Map();
+    service.membershipGateFailures = new Set();
     await service.handleMyChatMemberUpdate({
       chat: { id: CHAT_ID, type: "supergroup" },
       from: { id: 42, is_bot: false, first_name: "Admin" },

--- a/plugins/plugin-telegram/__tests__/membership-authority.real.test.ts
+++ b/plugins/plugin-telegram/__tests__/membership-authority.real.test.ts
@@ -63,7 +63,7 @@ async function bootMembershipHarness(options?: {
    * Fault injector for durable-overlay hydration failures: while true, the
    * runtime cache read throws, so authorize must fail closed.
    */
-  cacheFaults: { failGetCache: boolean };
+  cacheFaults: { failGetCache: boolean; setCacheResolvesFalse: boolean };
 }> {
   const harness = track(
     await createTestRuntimeWithModelProvider({
@@ -81,13 +81,24 @@ async function bootMembershipHarness(options?: {
   const faults = { failApplyMembership: false };
   // Fault injector #2: while true, runtime.getCache throws, exercising the
   // durable-overlay hydration failure path (must fail admission closed).
-  const cacheFaults = { failGetCache: false };
+  const cacheFaults = { failGetCache: false, setCacheResolvesFalse: false };
   const originalGetCache = harness.runtime.getCache.bind(harness.runtime);
   harness.runtime.getCache = (async (key: string) => {
     if (cacheFaults.failGetCache) {
       throw new Error("injected cache outage (test fault)");
     }
     return originalGetCache(key);
+  }) as never;
+  // Fault injector #3: while true, runtime.setCache RESOLVES FALSE (no
+  // throw) — the IAgentRuntime cache contract's non-throwing write failure.
+  // Exercises the durable-overlay persist path exactly like an adapter that
+  // confirms writes by polling would: the fence did not land.
+  const originalSetCache = harness.runtime.setCache.bind(harness.runtime);
+  harness.runtime.setCache = (async (key: string, value: unknown) => {
+    if (cacheFaults.setCacheResolvesFalse) {
+      return false;
+    }
+    return originalSetCache(key, value);
   }) as never;
   // Fault injector: override applyMembership ON THE REAL INSTANCE (instance
   // property shadows the prototype) and delegate to the bound original when
@@ -1205,6 +1216,318 @@ describe("telegram membership authority vertical (real PGlite)", () => {
       "an unrelated evidence commit during a cache outage must not erase principal A's durable revocation fence",
     ).toBe("denied");
     expect(aDecision.reason).toBe("membership_revoked");
+    cleanups.push(async () => {
+      await import("node:fs/promises").then((fs) =>
+        fs.rm(dir, { recursive: true, force: true }),
+      );
+    });
+  }, 120_000);
+
+  it("escalates to gate-broken (REVOCATION_UNSAFE) instead of claiming degraded when setCache resolves false on the revocation fence", async () => {
+    const { authority, harness, faults, cacheFaults } =
+      await bootMembershipHarness();
+    const entityId = await import("@elizaos/plugin-telegram").then((m) =>
+      m.resolveTelegramRuntimeEntityId(
+        harness.runtime,
+        "default",
+        String(MEMBER_TG_ID),
+      ),
+    );
+    await ensurePrincipal(harness, entityId);
+    const runtimeMap = { worldId: null, roomId: null, entityId };
+
+    // Principal admitted, then their revocation write FAILS while the
+    // durable-overlay persist path sees setCache resolve FALSE (the runtime
+    // cache contract's non-throwing write failure). The fence did NOT land,
+    // so the authority must NOT claim a durable fail-closed (DEGRADED)
+    // state: it must escalate so the connector marks the admission gate
+    // broken (every group admission fails closed) instead.
+    await authority.recordEvent({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+      state: "active",
+      reason: "joined",
+      messageId: 1,
+      telegramUserId: String(MEMBER_TG_ID),
+      runtime: runtimeMap,
+      observedAt: new Date(Date.now() - 10_000).toISOString(),
+    });
+    faults.failApplyMembership = true;
+    cacheFaults.setCacheResolvesFalse = true;
+    let escalated: unknown = null;
+    try {
+      await authority.recordEvent({
+        chatId: String(CHAT_ID),
+        chatRoomKey: String(CHAT_ID),
+        canonicalPrincipalId: entityId,
+        state: "revoked",
+        reason: "left",
+        messageId: 2,
+        telegramUserId: String(MEMBER_TG_ID),
+        runtime: runtimeMap,
+        observedAt: new Date(Date.now() - 5_000).toISOString(),
+      });
+    } catch (error) {
+      escalated = error;
+    }
+    faults.failApplyMembership = false;
+    cacheFaults.setCacheResolvesFalse = false;
+
+    expect(
+      escalated,
+      "recordEvent must throw on an unpersistable fence",
+    ).toBeTruthy();
+    expect((escalated as { code?: string }).code).toBe(
+      "TELEGRAM_MEMBERSHIP_REVOCATION_UNSAFE",
+    );
+
+    // The scope is still degraded stale in THIS process (the degrade landed
+    // before the persist), so admission denies here too — but the key
+    // assertion is the escalation above: the caller was told the truth.
+    const decision = await authority.authorize({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+    });
+    expect(decision.decision).toBe("denied");
+  }, 120_000);
+
+  it("keeps denying across a restart when setCache resolved false on the revocation fence (no durable overlay landed)", async () => {
+    const dir = await import("node:fs/promises").then((fs) =>
+      fs.mkdtemp("/tmp/tg-membership-false-restart-"),
+    );
+    const first = await bootMembershipHarness({ pgliteDir: dir });
+    const entityId = await import("@elizaos/plugin-telegram").then((m) =>
+      m.resolveTelegramRuntimeEntityId(
+        first.harness.runtime,
+        "default",
+        String(MEMBER_TG_ID),
+      ),
+    );
+    await ensurePrincipal(first.harness, entityId);
+    const runtimeMap = { worldId: null, roomId: null, entityId };
+
+    // Admitted; revocation write fails AND the overlay persist sees
+    // setCache resolve false: the fence never landed durably, and the
+    // authority escalated (previous test). Restart the process.
+    await first.authority.recordEvent({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+      state: "active",
+      reason: "joined",
+      messageId: 1,
+      telegramUserId: String(MEMBER_TG_ID),
+      runtime: runtimeMap,
+      observedAt: new Date(Date.now() - 10_000).toISOString(),
+    });
+    first.faults.failApplyMembership = true;
+    first.cacheFaults.setCacheResolvesFalse = true;
+    let escalated: unknown = null;
+    try {
+      await first.authority.recordEvent({
+        chatId: String(CHAT_ID),
+        chatRoomKey: String(CHAT_ID),
+        canonicalPrincipalId: entityId,
+        state: "revoked",
+        reason: "left",
+        messageId: 2,
+        telegramUserId: String(MEMBER_TG_ID),
+        runtime: runtimeMap,
+        observedAt: new Date(Date.now() - 5_000).toISOString(),
+      });
+    } catch (error) {
+      escalated = error;
+    }
+    first.faults.failApplyMembership = false;
+    first.cacheFaults.setCacheResolvesFalse = false;
+
+    // The fence never landed durably: the first process must have escalated
+    // gate-broken (the same contract as the non-restart test above), never
+    // claimed a durable degraded state.
+    expect(
+      escalated,
+      "setup must escalate on an unpersistable fence",
+    ).toBeTruthy();
+    expect((escalated as { code?: string }).code).toBe(
+      "TELEGRAM_MEMBERSHIP_REVOCATION_UNSAFE",
+    );
+
+    // Restart WITHOUT removing the PGlite dir. The revocation evidence
+    // itself never committed (applyMembership faulted), so without the fence
+    // the restarted process would fail OPEN on still-valid active evidence.
+    // What ACTUALLY protects the restarted process here is the durable
+    // scope degrade (setScopeHealth, an independent persistence path): this
+    // test pins exactly that division — the denial source must be the stale
+    // scope (authority_stale), NOT a hydrated pending-revocation fence
+    // (membership_revoked), proving no phantom durable overlay exists.
+    const cleanupIndex = cleanups.indexOf(first.harness.cleanup);
+    if (cleanupIndex >= 0) cleanups.splice(cleanupIndex, 1);
+    await first.harness.runtime.stop();
+    const second = await bootMembershipHarness({ pgliteDir: dir });
+
+    // Scope health must still show the stale degrade from the failed
+    // revocation — the degrade itself was a durable setScopeHealth write,
+    // independent of the cache overlay.
+    const health = await second.authority.scopeHealth({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+    });
+    expect(health?.health).toBe("stale");
+
+    // Admission for the departed principal denies, and — critically — the
+    // denial SOURCE is the durably-degraded scope (authority_stale), not a
+    // hydrated pending-revocation fence (membership_revoked): no overlay
+    // landed, so the restarted process must not report one.
+    const decision = await second.authority.authorize({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+    });
+    expect(decision.decision).toBe("denied");
+    expect(decision.reason).toBe("authority_stale");
+    cleanups.push(async () => {
+      await import("node:fs/promises").then((fs) =>
+        fs.rm(dir, { recursive: true, force: true }),
+      );
+    });
+  }, 120_000);
+
+  it("reports (but does not fail) the durable overlay clear when deleteCache resolves false on fresh evidence", async () => {
+    const dir = await import("node:fs/promises").then((fs) =>
+      fs.mkdtemp("/tmp/tg-membership-delcache-false-"),
+    );
+    const first = await bootMembershipHarness({ pgliteDir: dir });
+    const entityId = await import("@elizaos/plugin-telegram").then((m) =>
+      m.resolveTelegramRuntimeEntityId(
+        first.harness.runtime,
+        "default",
+        String(MEMBER_TG_ID),
+      ),
+    );
+    await ensurePrincipal(first.harness, entityId);
+    const runtimeMap = { worldId: null, roomId: null, entityId };
+
+    // Land a durable pending-revocation fence the normal way: revocation
+    // write fails, setCache(true) persists the overlay.
+    await first.authority.recordEvent({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+      state: "active",
+      reason: "joined",
+      messageId: 1,
+      telegramUserId: String(MEMBER_TG_ID),
+      runtime: runtimeMap,
+      observedAt: new Date(Date.now() - 10_000).toISOString(),
+    });
+    first.faults.failApplyMembership = true;
+    await first.authority.recordEvent({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+      state: "revoked",
+      reason: "left",
+      messageId: 2,
+      telegramUserId: String(MEMBER_TG_ID),
+      runtime: runtimeMap,
+      observedAt: new Date(Date.now() - 5_000).toISOString(),
+    });
+    first.faults.failApplyMembership = false;
+
+    // Restart: the durable overlay re-hydrates and denies the principal.
+    const cleanupIndex = cleanups.indexOf(first.harness.cleanup);
+    if (cleanupIndex >= 0) cleanups.splice(cleanupIndex, 1);
+    await first.harness.runtime.stop();
+    const second = await bootMembershipHarness({ pgliteDir: dir });
+    const deniedPreClear = await second.authority.authorize({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+    });
+    expect(deniedPreClear.decision).toBe("denied");
+    expect(deniedPreClear.reason).toBe("membership_revoked");
+
+    // Fresh evidence for the SAME principal commits; the in-memory overlay
+    // empties and the clear path calls deleteCache — which resolves FALSE.
+    // The commit itself must still succeed (evidence is authoritative); the
+    // failed clear is only REPORTED. A restart before any further persist
+    // re-hydrates the stale fence: fail-closed retention, self-healing on
+    // the next successful persist.
+    const reportCalls: Array<{ scope: string }> = [];
+    const originalReport = second.harness.runtime.reportError.bind(
+      second.harness.runtime,
+    );
+    second.harness.runtime.reportError = ((
+      ...args: Parameters<typeof originalReport>
+    ) => {
+      reportCalls.push({ scope: String(args[0]) });
+      return originalReport(...args);
+    }) as never;
+    // deleteCache false only (setCache stays healthy): fresh evidence runs
+    // the clear path, whose overlay is empty after removing this principal.
+    const originalDeleteCache = second.harness.runtime.deleteCache.bind(
+      second.harness.runtime,
+    );
+    second.harness.runtime.deleteCache = (async (key: string) => {
+      if (key.includes("pending-revocations")) {
+        return false;
+      }
+      return originalDeleteCache(key);
+    }) as never;
+
+    await second.authority.recordEvent({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+      state: "active",
+      reason: "joined",
+      messageId: 3,
+      telegramUserId: String(MEMBER_TG_ID),
+      runtime: runtimeMap,
+      observedAt: new Date().toISOString(),
+    });
+
+    // The failed durable clear was reported for diagnosis...
+    expect(
+      reportCalls.some((c) => c.scope === "telegram:membership-pending-clear"),
+      "a false deleteCache on the overlay clear must be reported",
+    ).toBe(true);
+    // ...and because authorize re-hydrates the overlay from the durable
+    // cache on every call, the uncleared fence keeps failing CLOSED in this
+    // process too (retention), even though the committed evidence is active
+    // and the in-memory overlay was emptied. Fail-closed retention until
+    // the durable clear actually lands — never fail-open.
+    const retained = await second.authority.authorize({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+    });
+    expect(retained.decision).toBe("denied");
+    expect(retained.reason).toBe("membership_revoked");
+
+    // Self-healing: once deleteCache is healthy again, the next evidence
+    // commit for this principal clears the durable overlay and admission
+    // resumes on the committed active record.
+    second.harness.runtime.deleteCache = originalDeleteCache;
+    await second.authority.recordEvent({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+      state: "active",
+      reason: "joined",
+      messageId: 4,
+      telegramUserId: String(MEMBER_TG_ID),
+      runtime: runtimeMap,
+      observedAt: new Date().toISOString(),
+    });
+    const admitted = await second.authority.authorize({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+    });
+    expect(admitted.decision).toBe("allowed");
     cleanups.push(async () => {
       await import("node:fs/promises").then((fs) =>
         fs.rm(dir, { recursive: true, force: true }),

--- a/plugins/plugin-telegram/__tests__/membership-authority.real.test.ts
+++ b/plugins/plugin-telegram/__tests__/membership-authority.real.test.ts
@@ -471,4 +471,175 @@ describe("telegram membership authority vertical (real PGlite)", () => {
       );
     });
   }, 120_000);
+
+  it("does not let an equal-second join redelivery resurrect a same-second revocation (strict tie-break)", async () => {
+    const { authority, harness } = await bootMembershipHarness();
+    const entityId = await import("@elizaos/plugin-telegram").then((m) =>
+      m.resolveTelegramRuntimeEntityId(
+        harness.runtime,
+        "default",
+        String(MEMBER_TG_ID),
+      ),
+    );
+    await ensurePrincipal(harness, entityId);
+    const runtimeMap = { worldId: null, roomId: null, entityId };
+    // Both observations carry the SAME second-resolution timestamp.
+    const sameSecond = new Date(Date.now() - 1_000).toISOString();
+
+    await authority.recordEvent({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+      state: "revoked",
+      reason: "left",
+      messageId: 10,
+      telegramUserId: String(MEMBER_TG_ID),
+      runtime: runtimeMap,
+      observedAt: sameSecond,
+    });
+    // A join redelivery stamped within the SAME second must not resurrect:
+    // Telegram dates are one-second resolution, so equal is not newer.
+    await authority.recordEvent({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+      state: "active",
+      reason: "joined",
+      messageId: 11,
+      telegramUserId: String(MEMBER_TG_ID),
+      runtime: runtimeMap,
+      observedAt: sameSecond,
+    });
+
+    const decision = await authority.authorize({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+    });
+    expect(decision.decision).toBe("denied");
+    expect((decision as { reason: string }).reason).toBe("membership_revoked");
+  }, 120_000);
+
+  it("tombstones a bot-removed scope: backlogged evidence cannot restore it, bot re-add clears it", async () => {
+    const { authority, harness } = await bootMembershipHarness();
+    const entityId = await import("@elizaos/plugin-telegram").then((m) =>
+      m.resolveTelegramRuntimeEntityId(
+        harness.runtime,
+        "default",
+        String(MEMBER_TG_ID),
+      ),
+    );
+    await ensurePrincipal(harness, entityId);
+    const runtimeMap = { worldId: null, roomId: null, entityId };
+
+    await authority.recordEvent({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+      state: "active",
+      reason: "joined",
+      messageId: 1,
+      telegramUserId: String(MEMBER_TG_ID),
+      runtime: runtimeMap,
+      observedAt: new Date(Date.now() - 5_000).toISOString(),
+    });
+    const beforeDecision = await authority.authorize({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+    });
+    expect(beforeDecision.decision).toBe("allowed");
+
+    // The bot is removed from the chat: the scope degrades to unavailable.
+    await authority.markScopeUnavailable({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      reason: "bot_removed",
+    });
+
+    // A backlogged join redelivery (observed AFTER the removal) must NOT
+    // advance the scope back to current — the tombstone holds.
+    await authority.recordEvent({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+      state: "active",
+      reason: "joined",
+      messageId: 2,
+      telegramUserId: String(MEMBER_TG_ID),
+      runtime: runtimeMap,
+      observedAt: new Date().toISOString(),
+    });
+    const tombstonedDecision = await authority.authorize({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+    });
+    expect(
+      tombstonedDecision.decision,
+      "backlogged evidence cannot restore a bot-removed scope",
+    ).toBe("denied");
+
+    // The bot is re-added: the tombstone clears and fresh evidence works.
+    authority.clearScopeRemoval({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+    });
+    await authority.recordEvent({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+      state: "active",
+      reason: "joined",
+      messageId: 3,
+      telegramUserId: String(MEMBER_TG_ID),
+      runtime: runtimeMap,
+      observedAt: new Date().toISOString(),
+    });
+    const readdedDecision = await authority.authorize({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+    });
+    expect(
+      readdedDecision.decision,
+      "after a bot re-add, fresh evidence re-establishes authority",
+    ).toBe("allowed");
+  }, 120_000);
+
+  it("rejects a reconcile response describing a different user than requested (subject mismatch)", async () => {
+    const { authority, harness } = await bootMembershipHarness();
+    const entityId = await import("@elizaos/plugin-telegram").then((m) =>
+      m.resolveTelegramRuntimeEntityId(
+        harness.runtime,
+        "default",
+        String(MEMBER_TG_ID),
+      ),
+    );
+    await ensurePrincipal(harness, entityId);
+    const runtimeMap = { worldId: null, roomId: null, entityId };
+
+    // Provider replies with member status but for user 999999, not 555001:
+    // the response must never become evidence for the requested principal.
+    const mismatched = await authority.reconcile({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+      telegramUserId: String(MEMBER_TG_ID),
+      runtime: runtimeMap,
+      getChatMember: async () => ({
+        status: "member",
+        user: { id: 999_999 },
+      }),
+      nonce: "mismatch-probe-1",
+    });
+    expect(mismatched).toBeNull();
+
+    const decision = await authority.authorize({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+    });
+    expect(decision.decision).toBe("denied");
+  }, 120_000);
 });

--- a/plugins/plugin-telegram/__tests__/membership-authority.real.test.ts
+++ b/plugins/plugin-telegram/__tests__/membership-authority.real.test.ts
@@ -366,6 +366,54 @@ describe("telegram membership authority vertical (real PGlite)", () => {
     expect(getChatMember).not.toHaveBeenCalled();
   }, 120_000);
 
+  it("does not let an older join (distinct message id) resurrect a newer revocation", async () => {
+    const { authority, harness } = await bootMembershipHarness();
+    const entityId = await import("@elizaos/plugin-telegram").then((m) =>
+      m.resolveTelegramRuntimeEntityId(
+        harness.runtime,
+        "default",
+        String(MEMBER_TG_ID),
+      ),
+    );
+    await ensurePrincipal(harness, entityId);
+    const runtimeMap = { worldId: null, roomId: null, entityId };
+
+    // Newer revocation lands first.
+    await authority.recordEvent({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+      state: "revoked",
+      reason: "left",
+      messageId: 50,
+      telegramUserId: String(MEMBER_TG_ID),
+      runtime: runtimeMap,
+      observedAt: new Date(Date.now() - 1_000).toISOString(),
+    });
+
+    // An OLDER join with a distinct message id redelivered out of order must
+    // not overwrite the newer revocation.
+    await authority.recordEvent({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+      state: "active",
+      reason: "joined",
+      messageId: 40,
+      telegramUserId: String(MEMBER_TG_ID),
+      runtime: runtimeMap,
+      observedAt: new Date(Date.now() - 60_000).toISOString(),
+    });
+
+    const decision = await authority.authorize({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+    });
+    expect(decision.decision).toBe("denied");
+    expect((decision as { reason: string }).reason).toBe("membership_revoked");
+  }, 120_000);
+
   it("continues the persisted publisher binding after a restart instead of re-registering", async () => {
     const dir = await import("node:fs/promises").then((fs) =>
       fs.mkdtemp("/tmp/tg-membership-restart-"),

--- a/plugins/plugin-telegram/__tests__/membership-authority.real.test.ts
+++ b/plugins/plugin-telegram/__tests__/membership-authority.real.test.ts
@@ -1534,4 +1534,156 @@ describe("telegram membership authority vertical (real PGlite)", () => {
       );
     });
   }, 120_000);
+
+  it("end-to-end through the my_chat_member delivery path: kick tombstones admission, backlogged evidence stays denied, re-add + fresh evidence restores it", async () => {
+    // This regression drives TelegramService.handleMyChatMemberUpdate — the
+    // poller's actual dispatch entry for the bot's own status updates — over
+    // the REAL authority + SqlMembershipService, pinning the security
+    // property the update delivery must provide (issue #23101 review: a
+    // kick/re-add cycle must not leave pre-removal evidence authorizing).
+    const { authority, harness, getChatMember } = await bootMembershipHarness();
+    const entityId = await import("@elizaos/plugin-telegram").then((m) =>
+      m.resolveTelegramRuntimeEntityId(
+        harness.runtime,
+        "default",
+        String(MEMBER_TG_ID),
+      ),
+    );
+    await ensurePrincipal(harness, entityId);
+    const runtimeMap = { worldId: null, roomId: null, entityId };
+
+    // Pre-removal membership: the member is admitted.
+    await authority.recordEvent({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+      state: "active",
+      reason: "joined",
+      messageId: 1,
+      telegramUserId: String(MEMBER_TG_ID),
+      runtime: runtimeMap,
+      observedAt: new Date(Date.now() - 10_000).toISOString(),
+    });
+    const before = await authority.authorize({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+    });
+    expect(before.decision).toBe("allowed");
+
+    // Drive the service-level dispatch exactly as the registered
+    // bot.on("my_chat_member") handler does for a kick update.
+    const service = Object.create(
+      (await import("@elizaos/plugin-telegram")).TelegramService.prototype,
+    ) as unknown as {
+      runtime: unknown;
+      defaultAccountId: string;
+      membershipGates: Map<string, Promise<unknown>>;
+      handleMyChatMemberUpdate: (
+        update: unknown,
+        accountId?: string,
+      ) => Promise<void>;
+    };
+    service.runtime = harness.runtime;
+    service.defaultAccountId = "default";
+    service.membershipGates = new Map([
+      ["default", Promise.resolve({ authority, botTelegramUserId: "900001" })],
+    ]);
+    await service.handleMyChatMemberUpdate({
+      chat: { id: CHAT_ID, type: "supergroup" },
+      from: { id: 42, is_bot: false, first_name: "Admin" },
+      date: Math.floor(Date.now() / 1000),
+      old_chat_member: {
+        status: "member",
+        user: { id: 900_001, is_bot: true },
+      },
+      new_chat_member: {
+        status: "kicked",
+        user: { id: 900_001, is_bot: true },
+      },
+    });
+
+    // Post-kick admission is denied even though the pre-removal evidence
+    // is still within its validity window.
+    const afterKick = await authority.authorize({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+    });
+    expect(afterKick.decision, "kick must tombstone admission").toBe("denied");
+
+    // A backlogged join redelivery (observed AFTER the removal) must not
+    // re-authorize the pre-removal member.
+    await authority.recordEvent({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+      state: "active",
+      reason: "joined",
+      messageId: 2,
+      telegramUserId: String(MEMBER_TG_ID),
+      runtime: runtimeMap,
+      observedAt: new Date().toISOString(),
+    });
+    const afterBacklog = await authority.authorize({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+    });
+    expect(
+      afterBacklog.decision,
+      "backlogged evidence cannot restore a bot-removed scope",
+    ).toBe("denied");
+
+    // Re-add through the same delivery path clears the tombstone...
+    await service.handleMyChatMemberUpdate({
+      chat: { id: CHAT_ID, type: "supergroup" },
+      from: { id: 42, is_bot: false, first_name: "Admin" },
+      date: Math.floor(Date.now() / 1000),
+      old_chat_member: {
+        status: "kicked",
+        user: { id: 900_001, is_bot: true },
+      },
+      new_chat_member: {
+        status: "member",
+        user: { id: 900_001, is_bot: true },
+      },
+    });
+
+    // ...but the re-add alone does NOT restore admission: the persisted
+    // scope health is still unavailable, so the pre-removal evidence must
+    // keep failing closed until FRESH evidence lands.
+    const afterReaddBeforeFresh = await authority.authorize({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+    });
+    expect(
+      afterReaddBeforeFresh.decision,
+      "re-add alone must not restore admission — fresh evidence is required",
+    ).toBe("denied");
+
+    // ...and FRESH evidence (stamped after the re-add) restores admission.
+    await authority.recordEvent({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+      state: "active",
+      reason: "joined",
+      messageId: 3,
+      telegramUserId: String(MEMBER_TG_ID),
+      runtime: runtimeMap,
+      observedAt: new Date().toISOString(),
+    });
+    const afterReadd = await authority.authorize({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+    });
+    expect(
+      afterReadd.decision,
+      "after re-add + fresh evidence, admission restores",
+    ).toBe("allowed");
+    expect(getChatMember).not.toHaveBeenCalled();
+  }, 120_000);
 });

--- a/plugins/plugin-telegram/__tests__/membership-authority.real.test.ts
+++ b/plugins/plugin-telegram/__tests__/membership-authority.real.test.ts
@@ -1,0 +1,426 @@
+/**
+ * Real-PGlite proof of the Telegram membership-authority vertical (#23101
+ * first lane): join/leave evidence through the canonical MembershipService,
+ * same-turn revocation, getChatMember backfill reconcile, duplicate-update
+ * non-resurrection, restart adoption with the stable publisher binding, and
+ * fail-closed admission when no fresh evidence exists.
+ *
+ * The harness boots a real AgentRuntime with the real SqlMembershipService
+ * (plugin-sql) and drives the REAL MessageManager.handleMessage admission
+ * gate with synthetic Telegram contexts; `getChatMember` is a captured
+ * provider seam (no network).
+ */
+import type { UUID } from "@elizaos/core";
+import {
+  createTestRuntimeWithModelProvider,
+  type ModelProviderTestRuntime,
+} from "@elizaos/core/testing";
+import { MessageManager } from "@elizaos/plugin-telegram";
+import type { Context } from "telegraf";
+import { Telegraf } from "telegraf";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const cleanups: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  while (cleanups.length > 0) {
+    const cleanup = cleanups.pop();
+    if (cleanup) await cleanup();
+  }
+});
+
+function track(harness: ModelProviderTestRuntime): ModelProviderTestRuntime {
+  cleanups.push(harness.cleanup);
+  return harness;
+}
+
+interface ChatMemberFixture {
+  status: string;
+  user: { id: number };
+}
+
+/**
+ * Boots a real runtime, resolves the membership service, and binds the
+ * authority-backed gate into a fresh MessageManager exactly the way
+ * TelegramService.finishBotStartup does.
+ */
+async function bootMembershipHarness(options?: {
+  pgliteDir?: string;
+}): Promise<{
+  harness: ModelProviderTestRuntime;
+  manager: MessageManager;
+  authority: import("@elizaos/plugin-telegram").TelegramMembershipAuthority;
+  getChatMember: ReturnType<typeof vi.fn>;
+  membershipService: import("@elizaos/core").MembershipService;
+}> {
+  const harness = track(
+    await createTestRuntimeWithModelProvider({
+      pgliteDir: options?.pgliteDir,
+      removePgliteDirOnCleanup: true,
+    }),
+  );
+  const membershipService = harness.runtime.getService(
+    "membership",
+  ) as import("@elizaos/core").MembershipService;
+  if (!membershipService) {
+    throw new Error("membership service missing from test runtime");
+  }
+
+  const { getConnectorAccountManager } = await import("@elizaos/core");
+  const manager$ = getConnectorAccountManager(harness.runtime);
+  const stored = await manager$.upsertAccount("telegram", {
+    id: "telegram-900001",
+    provider: "telegram",
+    label: "Telegram bot 900001",
+    role: "AGENT",
+    purpose: ["messaging"],
+    accessGate: "open",
+    status: "connected",
+    externalId: "900001",
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  });
+  if (!stored.id) throw new Error("connector account upsert returned no id");
+
+  const { TelegramMembershipAuthority } = await import(
+    "@elizaos/plugin-telegram"
+  );
+  const authority = new TelegramMembershipAuthority({
+    runtime: harness.runtime,
+    connectorAccountId: stored.id as UUID,
+    service: membershipService,
+  });
+
+  const bot = new Telegraf("123456:TEST_TOKEN", {
+    telegram: { apiRoot: "http://127.0.0.1:0/" },
+  });
+  const manager = new MessageManager(bot, harness.runtime, "default");
+  manager.bindMembershipGate({
+    authority,
+    botTelegramUserId: "900001",
+  });
+
+  const getChatMember = vi.fn(
+    async (): Promise<ChatMemberFixture> => ({
+      status: "member",
+      user: { id: 555001 },
+    }),
+  );
+
+  return {
+    harness,
+    manager,
+    authority,
+    getChatMember,
+    membershipService,
+  };
+}
+
+const CHAT_ID = -2001;
+const _BOT_ID = 900_001;
+const MEMBER_TG_ID = 555_001;
+
+/**
+ * The membership authority requires the principal's entity row to exist in the
+ * tenant before evidence can be applied (MEMBERSHIP_PRINCIPAL_NOT_FOUND
+ * otherwise). Production paths create it via ensureConnection; tests that
+ * drive recordEvent directly must create it the same way.
+ */
+async function ensurePrincipal(
+  harness: ModelProviderTestRuntime,
+  entityId: UUID,
+): Promise<void> {
+  const created = await harness.runtime.createEntity({
+    id: entityId,
+    agentId: harness.runtime.agentId,
+    names: ["Member Test User"],
+    metadata: {},
+  });
+  if (!created) {
+    throw new Error("test principal entity creation failed");
+  }
+}
+
+function groupMessageCtx(input: {
+  messageId: number;
+  fromId?: number;
+  date?: number;
+  text?: string;
+  getChatMember: ReturnType<typeof vi.fn>;
+}): Context {
+  const chat = { id: CHAT_ID, type: "group", title: "Membership Test Group" };
+  const from = {
+    id: input.fromId ?? MEMBER_TG_ID,
+    is_bot: false,
+    first_name: "Member",
+    username: "member",
+  };
+  return {
+    from,
+    chat,
+    message: {
+      message_id: input.messageId,
+      date: input.date ?? Math.floor(Date.now() / 1000),
+      text: input.text ?? "hello",
+      chat,
+      from,
+    },
+    telegram: {
+      getChatMember: input.getChatMember,
+      sendMessage: async () => ({}),
+      sendChatAction: async () => true,
+    },
+  } as unknown as Context;
+}
+
+describe("telegram membership authority vertical (real PGlite)", () => {
+  it("admits a member after join evidence and denies the same principal in the same turn after leave evidence", async () => {
+    const { manager, authority, getChatMember, harness } =
+      await bootMembershipHarness();
+    const entityId = await import("@elizaos/plugin-telegram").then((m) =>
+      m.resolveTelegramRuntimeEntityId(
+        harness.runtime,
+        "default",
+        String(MEMBER_TG_ID),
+      ),
+    );
+    await ensurePrincipal(harness, entityId);
+    const observedAt = new Date(Date.now() - 1_000).toISOString();
+    const runtimeMap = {
+      worldId: null as UUID | null,
+      roomId: null as UUID | null,
+      entityId,
+    };
+
+    // Join evidence
+    await authority.recordEvent({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+      state: "active",
+      reason: "joined",
+      runtime: runtimeMap,
+      messageId: 1,
+      telegramUserId: String(MEMBER_TG_ID),
+      observedAt,
+    });
+
+    // Admitted: message from the member creates a memory
+    await manager.handleMessage(
+      groupMessageCtx({ messageId: 100, getChatMember }),
+      { forceReply: false },
+    );
+    // The gate passed when getChatMember was NOT needed for this member
+    expect(getChatMember).not.toHaveBeenCalled();
+
+    // Leave evidence (same turn semantics: revocation lands before the next read)
+    await authority.recordEvent({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+      state: "revoked",
+      reason: "left",
+      runtime: runtimeMap,
+      messageId: 2,
+      telegramUserId: String(MEMBER_TG_ID),
+      observedAt: new Date().toISOString(),
+    });
+
+    // Denied: no memory created; but the reconcile seam IS consulted because
+    // the denial reason (membership_revoked) is not a reconcile-miss...
+    // revoked principals fail closed without a provider query.
+    const memorySpy = vi.fn();
+    harness.runtime.createMemory = memorySpy as never;
+    getChatMember.mockResolvedValueOnce({
+      status: "left",
+      user: { id: MEMBER_TG_ID },
+    });
+    await manager.handleMessage(
+      groupMessageCtx({ messageId: 101, getChatMember }),
+      { forceReply: false },
+    );
+    expect(getChatMember).not.toHaveBeenCalled();
+    expect(memorySpy).not.toHaveBeenCalled();
+  }, 120_000);
+
+  it("backfills a never-seen member via getChatMember reconcile and admits them; a kicked reconcile denies", async () => {
+    const { manager, getChatMember } = await bootMembershipHarness();
+
+    getChatMember.mockResolvedValue({
+      status: "member",
+      user: { id: MEMBER_TG_ID },
+    });
+    // Admission observability WITHOUT breaking the runtime: wrap the real
+    // createMemory so internal callers (ensureConnection etc.) keep working.
+    const harnessRuntime = (
+      manager as unknown as { runtime: { createMemory: unknown } }
+    ).runtime;
+    const originalCreateMemory = (
+      harnessRuntime.createMemory as (...args: unknown[]) => Promise<boolean>
+    ).bind(harnessRuntime);
+    let admissions = 0;
+    (harnessRuntime as { createMemory: unknown }).createMemory = async (
+      ...args: unknown[]
+    ) => {
+      admissions += 1;
+      return originalCreateMemory(
+        ...(args as Parameters<typeof originalCreateMemory>),
+      );
+    };
+
+    await manager.handleMessage(
+      groupMessageCtx({ messageId: 200, getChatMember }),
+      { forceReply: false },
+    );
+    expect(
+      getChatMember,
+      "never-seen member triggers a reconcile query",
+    ).toHaveBeenCalledTimes(1);
+    expect(admissions, "reconciled member is admitted").toBeGreaterThan(0);
+
+    // Kicked member: a SECOND never-seen principal whose getChatMember
+    // status is kicked — the reconcile applies revoked evidence and the
+    // message is denied. (The first principal is now an admitted member and
+    // would pass the gate without a provider query.)
+    getChatMember.mockClear();
+    admissions = 0;
+    getChatMember.mockResolvedValue({
+      status: "kicked",
+      user: { id: MEMBER_TG_ID },
+    });
+    await manager.handleMessage(
+      groupMessageCtx({
+        messageId: 201,
+        fromId: MEMBER_TG_ID + 1,
+        getChatMember,
+      }),
+      { forceReply: false },
+    );
+    expect(getChatMember).toHaveBeenCalledTimes(1);
+    expect(admissions, "kicked member is denied after reconcile").toBe(0);
+    (harnessRuntime as { createMemory: unknown }).createMemory =
+      originalCreateMemory;
+  }, 120_000);
+
+  it("does not resurrect membership on a duplicate join redelivery after a newer revocation", async () => {
+    const { authority, getChatMember, harness } = await bootMembershipHarness();
+    const entityId = await import("@elizaos/plugin-telegram").then((m) =>
+      m.resolveTelegramRuntimeEntityId(
+        harness.runtime,
+        "default",
+        String(MEMBER_TG_ID),
+      ),
+    );
+    await ensurePrincipal(harness, entityId);
+    const runtimeMap = { worldId: null, roomId: null, entityId };
+    const observedAt = new Date(Date.now() - 2_000).toISOString();
+
+    await authority.recordEvent({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+      state: "active",
+      reason: "joined",
+      messageId: 1,
+      telegramUserId: String(MEMBER_TG_ID),
+      runtime: runtimeMap,
+      observedAt,
+    });
+    await authority.recordEvent({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+      state: "revoked",
+      reason: "left",
+      messageId: 2,
+      telegramUserId: String(MEMBER_TG_ID),
+      runtime: runtimeMap,
+      observedAt: new Date(Date.now() - 1_000).toISOString(),
+    });
+
+    // Duplicate redelivery of the OLD join event (same message id): identical
+    // command bytes -> journal replay or benign-duplicate skip, never a
+    // resurrection over the newer revocation.
+    await authority.recordEvent({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+      state: "active",
+      reason: "joined",
+      messageId: 1,
+      telegramUserId: String(MEMBER_TG_ID),
+      runtime: runtimeMap,
+      observedAt,
+    });
+
+    const decision = await authority.authorize({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+    });
+    expect(decision.decision).toBe("denied");
+    expect(
+      (decision as { reason: string }).reason,
+      "the redelivered join did not resurrect the revoked membership",
+    ).toBe("membership_revoked");
+    expect(getChatMember).not.toHaveBeenCalled();
+  }, 120_000);
+
+  it("continues the persisted publisher binding after a restart instead of re-registering", async () => {
+    const dir = await import("node:fs/promises").then((fs) =>
+      fs.mkdtemp("/tmp/tg-membership-restart-"),
+    );
+    const first = await bootMembershipHarness({ pgliteDir: dir });
+    const entityId = await import("@elizaos/plugin-telegram").then((m) =>
+      m.resolveTelegramRuntimeEntityId(
+        first.harness.runtime,
+        "default",
+        String(MEMBER_TG_ID),
+      ),
+    );
+    await ensurePrincipal(first.harness, entityId);
+    const runtimeMap = { worldId: null, roomId: null, entityId };
+    await first.authority.recordEvent({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+      state: "active",
+      reason: "joined",
+      messageId: 1,
+      telegramUserId: String(MEMBER_TG_ID),
+      runtime: runtimeMap,
+      observedAt: new Date().toISOString(),
+    });
+    const before = await first.authority.scopeHealth({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+    });
+    expect(before?.health).toBe("current");
+    // Stop the first runtime WITHOUT removing the PGlite dir.
+    const cleanupIndex = cleanups.indexOf(first.harness.cleanup);
+    if (cleanupIndex >= 0) cleanups.splice(cleanupIndex, 1);
+    await first.harness.runtime.stop().catch(() => {});
+
+    // Second process over the same database: same stable publisher identity.
+    const second = await bootMembershipHarness({ pgliteDir: dir });
+    const decision = await second.authority.authorize({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+    });
+    expect(
+      decision.decision,
+      "a restarted process adopting the persisted binding does not strand the member fact",
+    ).toBe("allowed");
+    const after = await second.authority.scopeHealth({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+    });
+    expect(after?.publisherInstanceId).toBe(before?.publisherInstanceId);
+    cleanups.push(async () => {
+      await import("node:fs/promises").then((fs) =>
+        fs.rm(dir, { recursive: true, force: true }),
+      );
+    });
+  }, 120_000);
+});

--- a/plugins/plugin-telegram/__tests__/membership-authority.real.test.ts
+++ b/plugins/plugin-telegram/__tests__/membership-authority.real.test.ts
@@ -59,6 +59,11 @@ async function bootMembershipHarness(options?: {
    * real database outage would.
    */
   faults: { failApplyMembership: boolean };
+  /**
+   * Fault injector for durable-overlay hydration failures: while true, the
+   * runtime cache read throws, so authorize must fail closed.
+   */
+  cacheFaults: { failGetCache: boolean };
 }> {
   const harness = track(
     await createTestRuntimeWithModelProvider({
@@ -74,6 +79,16 @@ async function bootMembershipHarness(options?: {
   }
 
   const faults = { failApplyMembership: false };
+  // Fault injector #2: while true, runtime.getCache throws, exercising the
+  // durable-overlay hydration failure path (must fail admission closed).
+  const cacheFaults = { failGetCache: false };
+  const originalGetCache = harness.runtime.getCache.bind(harness.runtime);
+  harness.runtime.getCache = (async (key: string) => {
+    if (cacheFaults.failGetCache) {
+      throw new Error("injected cache outage (test fault)");
+    }
+    return originalGetCache(key);
+  }) as never;
   // Fault injector: override applyMembership ON THE REAL INSTANCE (instance
   // property shadows the prototype) and delegate to the bound original when
   // not faulted. The authority sees a genuine authority outage, not a mock
@@ -135,6 +150,7 @@ async function bootMembershipHarness(options?: {
     getChatMember,
     membershipService,
     faults,
+    cacheFaults,
   };
 }
 
@@ -1023,5 +1039,75 @@ describe("telegram membership authority vertical (real PGlite)", () => {
       "an authorization queued behind a failed revocation write must not overtake the fail-closed degrade",
     ).toBe("denied");
     expect(decision.reason).toBe("membership_revoked");
+  }, 120_000);
+
+  it("fails admission closed when the durable pending-revocation overlay cannot be read (cache outage)", async () => {
+    const { authority, harness, cacheFaults } = await bootMembershipHarness();
+    const entityId = await import("@elizaos/plugin-telegram").then((m) =>
+      m.resolveTelegramRuntimeEntityId(
+        harness.runtime,
+        "default",
+        String(MEMBER_TG_ID),
+      ),
+    );
+    await ensurePrincipal(harness, entityId);
+    const runtimeMap = { worldId: null, roomId: null, entityId };
+
+    // Principal admitted through committed evidence, scope current.
+    await authority.recordEvent({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+      state: "active",
+      reason: "joined",
+      messageId: 1,
+      telegramUserId: String(MEMBER_TG_ID),
+      runtime: runtimeMap,
+      observedAt: new Date().toISOString(),
+    });
+    const admitted = await authority.authorize({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+    });
+    expect(admitted.decision).toBe("allowed");
+
+    // Cache outage on the hydration read: the durable overlay state is
+    // UNKNOWN. Authorize must fail closed (deny) rather than consult the
+    // possibly-stale active evidence. The hydrated mark is NOT set, so the
+    // denial applies on every authorize while the outage lasts, and a later
+    // healthy read resumes normal decisions.
+    cacheFaults.failGetCache = true;
+    const duringOutage = await authority.authorize({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+    });
+    expect(
+      duringOutage.decision,
+      "an unreadable durable overlay must deny rather than trust active evidence",
+    ).toBe("denied");
+    expect(duringOutage.reason).toBe("membership_revoked");
+    // The fail-closed state is not sticky: a second authorize during the
+    // same outage still denies.
+    const duringOutage2 = await authority.authorize({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+    });
+    expect(duringOutage2.decision).toBe("denied");
+
+    // Cache recovers: hydration succeeds and the (empty) durable overlay no
+    // longer denies — the committed active evidence authorizes again.
+    cacheFaults.failGetCache = false;
+    const recovered = await authority.authorize({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+    });
+    expect(
+      recovered.decision,
+      "a healthy hydration read must restore normal authoritative decisions",
+    ).toBe("allowed");
   }, 120_000);
 });

--- a/plugins/plugin-telegram/__tests__/membership-authority.real.test.ts
+++ b/plugins/plugin-telegram/__tests__/membership-authority.real.test.ts
@@ -1581,6 +1581,7 @@ describe("telegram membership authority vertical (real PGlite)", () => {
       membershipGates: Map<string, Promise<unknown>>;
       settledMembershipGates: Map<string, unknown>;
       pendingMembershipTransitions: Map<string, unknown[]>;
+      replayingMembershipTransitions: Set<string>;
       membershipGateFailures: Set<string>;
       handleMyChatMemberUpdate: (
         update: unknown,
@@ -1599,6 +1600,7 @@ describe("telegram membership authority vertical (real PGlite)", () => {
       ["default", { authority, botTelegramUserId: "900001" }],
     ]);
     service.pendingMembershipTransitions = new Map();
+    service.replayingMembershipTransitions = new Set();
     service.membershipGateFailures = new Set();
     await service.handleMyChatMemberUpdate({
       chat: { id: CHAT_ID, type: "supergroup" },

--- a/plugins/plugin-telegram/__tests__/membership-authority.real.test.ts
+++ b/plugins/plugin-telegram/__tests__/membership-authority.real.test.ts
@@ -1110,4 +1110,105 @@ describe("telegram membership authority vertical (real PGlite)", () => {
       "a healthy hydration read must restore normal authoritative decisions",
     ).toBe("allowed");
   }, 120_000);
+
+  it("does not erase another principal's durable revocation fence when the overlay is unreadable", async () => {
+    const dir = await import("node:fs/promises").then((fs) =>
+      fs.mkdtemp("/tmp/tg-membership-erase-"),
+    );
+    const first = await bootMembershipHarness({ pgliteDir: dir });
+    const entityId = await import("@elizaos/plugin-telegram").then((m) =>
+      m.resolveTelegramRuntimeEntityId(
+        first.harness.runtime,
+        "default",
+        String(MEMBER_TG_ID),
+      ),
+    );
+    await ensurePrincipal(first.harness, entityId);
+    const runtimeMap = { worldId: null, roomId: null, entityId };
+
+    // Principal A: admitted, then their revocation write FAILS -> a durable
+    // pending-revocation fence lands in the cache.
+    await first.authority.recordEvent({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+      state: "active",
+      reason: "joined",
+      messageId: 1,
+      telegramUserId: String(MEMBER_TG_ID),
+      runtime: runtimeMap,
+      observedAt: new Date(Date.now() - 10_000).toISOString(),
+    });
+    first.faults.failApplyMembership = true;
+    await first.authority.recordEvent({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+      state: "revoked",
+      reason: "left",
+      messageId: 2,
+      telegramUserId: String(MEMBER_TG_ID),
+      runtime: runtimeMap,
+      observedAt: new Date(Date.now() - 5_000).toISOString(),
+    });
+    first.faults.failApplyMembership = false;
+
+    // Restart WITHOUT removing the PGlite dir, and fail the FIRST hydration
+    // read in the new process: the in-memory overlay stays empty and the
+    // persisted set is unknown.
+    const cleanupIndex = cleanups.indexOf(first.harness.cleanup);
+    if (cleanupIndex >= 0) cleanups.splice(cleanupIndex, 1);
+    await first.harness.runtime.stop().catch(() => {});
+    const second = await bootMembershipHarness({ pgliteDir: dir });
+    second.cacheFaults.failGetCache = true;
+
+    // Unrelated principal B joins DURING the outage: their evidence commits
+    // and the success path runs with an unhydrated overlay. It must NOT
+    // rewrite the persisted overlay — with an empty in-memory set the
+    // pre-fix code calls deleteCache, erasing A's durable fence.
+    const otherId = await import("@elizaos/plugin-telegram").then((m) =>
+      m.resolveTelegramRuntimeEntityId(
+        second.harness.runtime,
+        "default",
+        String(MEMBER_TG_ID + 11),
+      ),
+    );
+    await ensurePrincipal(second.harness, otherId);
+    await second.authority.recordEvent({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: otherId,
+      state: "active",
+      reason: "joined",
+      messageId: 3,
+      telegramUserId: String(MEMBER_TG_ID + 11),
+      runtime: { worldId: null, roomId: null, entityId: otherId },
+      observedAt: new Date().toISOString(),
+    });
+
+    // Cache recovers: A's durable fence must STILL be present — B's commit
+    // during the outage did not erase it.
+    second.cacheFaults.failGetCache = false;
+    const otherAdmitted = await second.authority.authorize({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: otherId,
+    });
+    expect(otherAdmitted.decision).toBe("allowed");
+    const aDecision = await second.authority.authorize({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+    });
+    expect(
+      aDecision.decision,
+      "an unrelated evidence commit during a cache outage must not erase principal A's durable revocation fence",
+    ).toBe("denied");
+    expect(aDecision.reason).toBe("membership_revoked");
+    cleanups.push(async () => {
+      await import("node:fs/promises").then((fs) =>
+        fs.rm(dir, { recursive: true, force: true }),
+      );
+    });
+  }, 120_000);
 });

--- a/plugins/plugin-telegram/__tests__/membership-authority.real.test.ts
+++ b/plugins/plugin-telegram/__tests__/membership-authority.real.test.ts
@@ -848,4 +848,180 @@ describe("telegram membership authority vertical (real PGlite)", () => {
       );
     });
   }, 120_000);
+
+  it("keeps an uncommitted revocation denying across a RESTART even after unrelated evidence restores scope health (durable overlay)", async () => {
+    const dir = await import("node:fs/promises").then((fs) =>
+      fs.mkdtemp("/tmp/tg-membership-pending-restart-"),
+    );
+    const first = await bootMembershipHarness({ pgliteDir: dir });
+    const entityId = await import("@elizaos/plugin-telegram").then((m) =>
+      m.resolveTelegramRuntimeEntityId(
+        first.harness.runtime,
+        "default",
+        String(MEMBER_TG_ID),
+      ),
+    );
+    await ensurePrincipal(first.harness, entityId);
+    const runtimeMap = { worldId: null, roomId: null, entityId };
+
+    // Principal is admitted, then their leave-revocation write FAILS (real
+    // authority outage): the scope degrades stale and the pending-revocation
+    // overlay installs — and must now be PERSISTED, not in-memory only.
+    await first.authority.recordEvent({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+      state: "active",
+      reason: "joined",
+      messageId: 1,
+      telegramUserId: String(MEMBER_TG_ID),
+      runtime: runtimeMap,
+      observedAt: new Date(Date.now() - 10_000).toISOString(),
+    });
+    first.faults.failApplyMembership = true;
+    await first.authority.recordEvent({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+      state: "revoked",
+      reason: "left",
+      messageId: 2,
+      telegramUserId: String(MEMBER_TG_ID),
+      runtime: runtimeMap,
+      observedAt: new Date(Date.now() - 5_000).toISOString(),
+    });
+    first.faults.failApplyMembership = false;
+
+    // Restart: stop the first runtime WITHOUT removing the PGlite dir.
+    const cleanupIndex = cleanups.indexOf(first.harness.cleanup);
+    if (cleanupIndex >= 0) cleanups.splice(cleanupIndex, 1);
+    await first.harness.runtime.stop().catch(() => {});
+    const second = await bootMembershipHarness({ pgliteDir: dir });
+
+    // In the restarted process, unrelated evidence for another principal
+    // restores scope health to current — the stale degrade is gone.
+    const otherId = await import("@elizaos/plugin-telegram").then((m) =>
+      m.resolveTelegramRuntimeEntityId(
+        second.harness.runtime,
+        "default",
+        String(MEMBER_TG_ID + 9),
+      ),
+    );
+    await ensurePrincipal(second.harness, otherId);
+    await second.authority.recordEvent({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: otherId,
+      state: "active",
+      reason: "joined",
+      messageId: 3,
+      telegramUserId: String(MEMBER_TG_ID + 9),
+      runtime: { worldId: null, roomId: null, entityId: otherId },
+      observedAt: new Date().toISOString(),
+    });
+    const health = await second.authority.scopeHealth({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+    });
+    expect(health?.health).toBe("current");
+
+    // The departed principal must STILL be denied: their revocation never
+    // committed and the durable overlay re-hydrated from the cache. Without
+    // persistence this authorize returns allowed (the fail-open path).
+    const decision = await second.authority.authorize({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+    });
+    expect(
+      decision.decision,
+      "a restarted process must keep denying a principal whose revocation could not be committed",
+    ).toBe("denied");
+    expect(decision.reason).toBe("membership_revoked");
+
+    // Fresh evidence for the SAME principal in the restarted process clears
+    // the durable overlay: the authority speaks again.
+    await second.authority.recordEvent({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+      state: "active",
+      reason: "joined",
+      messageId: 4,
+      telegramUserId: String(MEMBER_TG_ID),
+      runtime: runtimeMap,
+      observedAt: new Date().toISOString(),
+    });
+    const reAdmitted = await second.authority.authorize({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+    });
+    expect(reAdmitted.decision).toBe("allowed");
+    cleanups.push(async () => {
+      await import("node:fs/promises").then((fs) =>
+        fs.rm(dir, { recursive: true, force: true }),
+      );
+    });
+  }, 120_000);
+
+  it("does not let a queued authorization overtake the revocation failure degrade (atomic fence)", async () => {
+    const { authority, harness, faults } = await bootMembershipHarness();
+    const entityId = await import("@elizaos/plugin-telegram").then((m) =>
+      m.resolveTelegramRuntimeEntityId(
+        harness.runtime,
+        "default",
+        String(MEMBER_TG_ID),
+      ),
+    );
+    await ensurePrincipal(harness, entityId);
+    const runtimeMap = { worldId: null, roomId: null, entityId };
+
+    // Principal admitted; then the leave-revocation write fails while an
+    // authorization for the SAME principal is already queued behind it on
+    // the per-scope chain. The queued authorize must NOT observe the stale
+    // active record: the degrade + overlay land inside the SAME chain link.
+    await authority.recordEvent({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+      state: "active",
+      reason: "joined",
+      messageId: 1,
+      telegramUserId: String(MEMBER_TG_ID),
+      runtime: runtimeMap,
+      observedAt: new Date(Date.now() - 10_000).toISOString(),
+    });
+
+    faults.failApplyMembership = true;
+    // Queue the failing revocation and the authorize TOGETHER: the authorize
+    // enqueues on the per-scope chain while the revocation write is still
+    // pending/failed. Before the fix, the overlay installed only after the
+    // chain settled, so this authorize returned allowed (fail-open race).
+    const revocationPromise = authority.recordEvent({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+      state: "revoked",
+      reason: "left",
+      messageId: 2,
+      telegramUserId: String(MEMBER_TG_ID),
+      runtime: runtimeMap,
+      observedAt: new Date(Date.now() - 5_000).toISOString(),
+    });
+    const queuedAuthorize = authority.authorize({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+    });
+    await revocationPromise;
+    faults.failApplyMembership = false;
+
+    const decision = await queuedAuthorize;
+    expect(
+      decision.decision,
+      "an authorization queued behind a failed revocation write must not overtake the fail-closed degrade",
+    ).toBe("denied");
+    expect(decision.reason).toBe("membership_revoked");
+  }, 120_000);
 });

--- a/plugins/plugin-telegram/__tests__/membership-authority.real.test.ts
+++ b/plugins/plugin-telegram/__tests__/membership-authority.real.test.ts
@@ -52,6 +52,13 @@ async function bootMembershipHarness(options?: {
   authority: import("@elizaos/plugin-telegram").TelegramMembershipAuthority;
   getChatMember: ReturnType<typeof vi.fn>;
   membershipService: import("@elizaos/core").MembershipService;
+  /**
+   * Fault injector for evidence-write failures: while true, the NEXT
+   * applyMembership call (and every one until flipped back) throws a generic
+   * authority error, exercising the recordEvent failure path exactly like a
+   * real database outage would.
+   */
+  faults: { failApplyMembership: boolean };
 }> {
   const harness = track(
     await createTestRuntimeWithModelProvider({
@@ -65,6 +72,20 @@ async function bootMembershipHarness(options?: {
   if (!membershipService) {
     throw new Error("membership service missing from test runtime");
   }
+
+  const faults = { failApplyMembership: false };
+  // Fault injector: override applyMembership ON THE REAL INSTANCE (instance
+  // property shadows the prototype) and delegate to the bound original when
+  // not faulted. The authority sees a genuine authority outage, not a mock
+  // with fabricated responses; every other method keeps its real receiver.
+  const originalApplyMembership =
+    membershipService.applyMembership.bind(membershipService);
+  membershipService.applyMembership = ((command: never) => {
+    if (faults.failApplyMembership) {
+      throw new Error("injected authority outage (test fault)");
+    }
+    return originalApplyMembership(command);
+  }) as never;
 
   const { getConnectorAccountManager } = await import("@elizaos/core");
   const manager$ = getConnectorAccountManager(harness.runtime);
@@ -113,6 +134,7 @@ async function bootMembershipHarness(options?: {
     authority,
     getChatMember,
     membershipService,
+    faults,
   };
 }
 
@@ -286,7 +308,10 @@ describe("telegram membership authority vertical (real PGlite)", () => {
     admissions = 0;
     getChatMember.mockResolvedValue({
       status: "kicked",
-      user: { id: MEMBER_TG_ID },
+      // Subject must match the SENDER (555002): with the subject-mismatch
+      // guard, a reply describing a different user denies via mismatch and
+      // would mask the kicked-evidence path this test exists to prove.
+      user: { id: MEMBER_TG_ID + 1 },
     });
     await manager.handleMessage(
       groupMessageCtx({
@@ -447,6 +472,8 @@ describe("telegram membership authority vertical (real PGlite)", () => {
     // Stop the first runtime WITHOUT removing the PGlite dir.
     const cleanupIndex = cleanups.indexOf(first.harness.cleanup);
     if (cleanupIndex >= 0) cleanups.splice(cleanupIndex, 1);
+    // error-policy:J6 Best-effort teardown: a stop() rejection during test
+    // cleanup must not mask the assertions below.
     await first.harness.runtime.stop().catch(() => {});
 
     // Second process over the same database: same stable publisher identity.
@@ -641,5 +668,184 @@ describe("telegram membership authority vertical (real PGlite)", () => {
       canonicalPrincipalId: entityId,
     });
     expect(decision.decision).toBe("denied");
+  }, 120_000);
+
+  it("keeps a pending (uncommitted) revocation denying after unrelated evidence restores scope health", async () => {
+    const { authority, harness, faults } = await bootMembershipHarness();
+    const entityId = await import("@elizaos/plugin-telegram").then((m) =>
+      m.resolveTelegramRuntimeEntityId(
+        harness.runtime,
+        "default",
+        String(MEMBER_TG_ID),
+      ),
+    );
+    await ensurePrincipal(harness, entityId);
+    const runtimeMap = { worldId: null, roomId: null, entityId };
+
+    // Principal A is an admitted member.
+    await authority.recordEvent({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+      state: "active",
+      reason: "joined",
+      messageId: 1,
+      telegramUserId: String(MEMBER_TG_ID),
+      runtime: runtimeMap,
+      observedAt: new Date(Date.now() - 10_000).toISOString(),
+    });
+    const admitted = await authority.authorize({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+    });
+    expect(admitted.decision).toBe("allowed");
+
+    // REAL failure path: an authority outage makes the revocation evidence
+    // write throw; recordEvent degrades the scope stale and records the
+    // pending revocation.
+    faults.failApplyMembership = true;
+    await authority.recordEvent({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+      state: "revoked",
+      reason: "left",
+      messageId: 2,
+      telegramUserId: String(MEMBER_TG_ID),
+      runtime: runtimeMap,
+      observedAt: new Date(Date.now() - 5_000).toISOString(),
+    });
+    faults.failApplyMembership = false;
+    const staleDecision = await authority.authorize({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+    });
+    expect(staleDecision.decision).toBe("denied");
+
+    // Unrelated evidence (another principal's join observed NOW) restores
+    // scope health to current...
+    const otherId = await import("@elizaos/plugin-telegram").then((m) =>
+      m.resolveTelegramRuntimeEntityId(
+        harness.runtime,
+        "default",
+        String(MEMBER_TG_ID + 7),
+      ),
+    );
+    await ensurePrincipal(harness, otherId);
+    await authority.recordEvent({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: otherId,
+      state: "active",
+      reason: "joined",
+      messageId: 3,
+      telegramUserId: String(MEMBER_TG_ID + 7),
+      runtime: { worldId: null, roomId: null, entityId: otherId },
+      observedAt: new Date().toISOString(),
+    });
+
+    // ...but the FIRST principal must remain denied: their prior active
+    // fact is live and their revocation never committed. Without the
+    // pending-revocation overlay this authorize would return allowed.
+    const afterRestore = await authority.authorize({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+    });
+    expect(
+      afterRestore.decision,
+      "unrelated evidence restoring scope health must not re-authorize a principal with an uncommitted revocation",
+    ).toBe("denied");
+
+    // Fresh evidence for the FIRST principal (either direction) clears the
+    // overlay — here a later join re-admits them through the authority.
+    await authority.recordEvent({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+      state: "active",
+      reason: "joined",
+      messageId: 4,
+      telegramUserId: String(MEMBER_TG_ID),
+      runtime: runtimeMap,
+      observedAt: new Date().toISOString(),
+    });
+    const reAdmitted = await authority.authorize({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+    });
+    expect(reAdmitted.decision).toBe("allowed");
+  }, 120_000);
+
+  it("re-hydrates the bot-removal tombstone from persisted unavailable state after a restart", async () => {
+    const dir = await import("node:fs/promises").then((fs) =>
+      fs.mkdtemp("/tmp/tg-membership-tombstone-"),
+    );
+    const first = await bootMembershipHarness({ pgliteDir: dir });
+    const entityId = await import("@elizaos/plugin-telegram").then((m) =>
+      m.resolveTelegramRuntimeEntityId(
+        first.harness.runtime,
+        "default",
+        String(MEMBER_TG_ID),
+      ),
+    );
+    await ensurePrincipal(first.harness, entityId);
+    const runtimeMap = { worldId: null, roomId: null, entityId };
+    await first.authority.recordEvent({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+      state: "active",
+      reason: "joined",
+      messageId: 1,
+      telegramUserId: String(MEMBER_TG_ID),
+      runtime: runtimeMap,
+      observedAt: new Date().toISOString(),
+    });
+    await first.authority.markScopeUnavailable({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      reason: "bot_removed",
+    });
+
+    // Restart: stop the first runtime, boot a second over the same DB.
+    const cleanupIndex = cleanups.indexOf(first.harness.cleanup);
+    if (cleanupIndex >= 0) cleanups.splice(cleanupIndex, 1);
+    // error-policy:J6 Best-effort teardown: a stop() rejection during test
+    // cleanup must not mask the assertions below.
+    await first.harness.runtime.stop().catch(() => {});
+    const second = await bootMembershipHarness({ pgliteDir: dir });
+
+    // A backlogged join redelivery observed AFTER the removal must NOT
+    // restore the scope: the persisted unavailable state re-hydrates the
+    // tombstone in the restarted process.
+    await second.authority.recordEvent({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+      state: "active",
+      reason: "joined",
+      messageId: 2,
+      telegramUserId: String(MEMBER_TG_ID),
+      runtime: runtimeMap,
+      observedAt: new Date().toISOString(),
+    });
+    const decision = await second.authority.authorize({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+    });
+    expect(
+      decision.decision,
+      "a restarted process must not let backlogged evidence restore a bot-removed scope",
+    ).toBe("denied");
+    cleanups.push(async () => {
+      await import("node:fs/promises").then((fs) =>
+        fs.rm(dir, { recursive: true, force: true }),
+      );
+    });
   }, 120_000);
 });

--- a/plugins/plugin-telegram/__tests__/membership-authority.real.test.ts
+++ b/plugins/plugin-telegram/__tests__/membership-authority.real.test.ts
@@ -1849,4 +1849,177 @@ describe("telegram membership authority vertical (real PGlite)", () => {
     (harnessRuntime as { createMemory: unknown }).createMemory =
       originalCreateMemory;
   }, 120_000);
+
+  it.each([
+    // A bare UUID string iterates per character under the pre-fix code: the
+    // overlay never contains the principal's UUID and the empty-overlay
+    // outcome re-authorizes them off still-valid active evidence.
+    { label: "uuid-string", payload: "__OVERLAY__" },
+    // An empty string is falsy, so the pre-fix truthiness check skipped the
+    // merge entirely — corruption read as a definitive empty fence.
+    { label: "empty-string", payload: "" },
+    // An array containing one invalid entry must fail the WHOLE payload:
+    // keeping the valid prefix would under-deny the corrupted tail.
+    {
+      label: "array-with-invalid-entry",
+      payload: ["not-a-uuid", "__OVERLAY__"],
+    },
+    // A stored JSON null reaches hydration as JS null (present row, raw
+    // JSONB value — NOT the adapter's undefined cache miss). The SQL schema's
+    // value NOT NULL constraint only rejects SQL NULL; the JSONB literal
+    // 'null' lands fine via a direct write, so this case corrupts the row
+    // through drizzle sql, exactly like a migration or manual repair would.
+    { label: "stored-json-null", payload: "__JSON_NULL__" },
+  ])(
+    "fails admission closed when the persisted pending-revocation payload is malformed ($label)",
+    async ({ payload }) => {
+      const dir = await import("node:fs/promises").then((fs) =>
+        fs.mkdtemp("/tmp/tg-membership-pending-corrupt-"),
+      );
+      const first = await bootMembershipHarness({ pgliteDir: dir });
+      const entityId = await import("@elizaos/plugin-telegram").then((m) =>
+        m.resolveTelegramRuntimeEntityId(
+          first.harness.runtime,
+          "default",
+          String(MEMBER_TG_ID),
+        ),
+      );
+      await ensurePrincipal(first.harness, entityId);
+      const runtimeMap = { worldId: null, roomId: null, entityId };
+
+      // Land a durable pending-revocation fence the normal way (revocation
+      // write fails; setCache persists the overlay), then commit fresh
+      // active evidence for the SAME principal so the fence clears, the
+      // scope returns to current, and the principal is genuinely admitted —
+      // the exact preconditions under which only the durable overlay stands
+      // between a restarted process and a fail-open.
+      await first.authority.recordEvent({
+        chatId: String(CHAT_ID),
+        chatRoomKey: String(CHAT_ID),
+        canonicalPrincipalId: entityId,
+        state: "active",
+        reason: "joined",
+        messageId: 1,
+        telegramUserId: String(MEMBER_TG_ID),
+        runtime: runtimeMap,
+        observedAt: new Date(Date.now() - 10_000).toISOString(),
+      });
+      first.faults.failApplyMembership = true;
+      await first.authority.recordEvent({
+        chatId: String(CHAT_ID),
+        chatRoomKey: String(CHAT_ID),
+        canonicalPrincipalId: entityId,
+        state: "revoked",
+        reason: "left",
+        messageId: 2,
+        telegramUserId: String(MEMBER_TG_ID),
+        runtime: runtimeMap,
+        observedAt: new Date(Date.now() - 5_000).toISOString(),
+      });
+      first.faults.failApplyMembership = false;
+
+      // Restart: stop the first runtime WITHOUT removing the PGlite dir, so
+      // the durable overlay row survives into the restarted process.
+      const cleanupIndex = cleanups.indexOf(first.harness.cleanup);
+      if (cleanupIndex >= 0) cleanups.splice(cleanupIndex, 1);
+      await first.harness.runtime.stop().catch(() => {});
+      const second = await bootMembershipHarness({ pgliteDir: dir });
+
+      // Corrupt the REAL persisted overlay row (arbitrary JSON is legal
+      // under the SQL cache contract) with the class under test.
+      const { telegramMembershipScope } = await import(
+        "@elizaos/plugin-telegram"
+      );
+      const scope = telegramMembershipScope({
+        agentId: second.harness.runtime.agentId,
+        connectorAccountId: (
+          second.authority as unknown as {
+            connectorAccountId: UUID;
+          }
+        ).connectorAccountId,
+        chatId: String(CHAT_ID),
+        chatRoomKey: String(CHAT_ID),
+      });
+      const cacheKey = `telegram:membership:pending-revocations:${scope.connectorAccountId}:${scope.externalWorldId}:${scope.externalRoomId}`;
+      if (payload === "__JSON_NULL__") {
+        // The JSONB literal 'null' satisfies value NOT NULL (only SQL NULL
+        // violates it) but cannot pass setCache's JS-value path — write it
+        // through the raw drizzle connection, exactly like a direct
+        // migration or manual row repair would.
+        const db = (await second.harness.runtime.adapter.getConnection()) as {
+          execute: (query: string) => Promise<unknown>;
+        };
+        await db.execute(
+          `insert into cache (key, agent_id, value) values ('${cacheKey}', '${second.harness.runtime.agentId}', 'null'::jsonb) on conflict (key, agent_id) do update set value = 'null'::jsonb`,
+        );
+      } else {
+        const storedPayload =
+          typeof payload === "string"
+            ? payload === "__OVERLAY__"
+              ? entityId
+              : payload
+            : payload.map((entry) =>
+                entry === "__OVERLAY__" ? entityId : entry,
+              );
+        await second.harness.runtime.setCache(cacheKey, storedPayload);
+      }
+
+      // Restore scope health the way production would (unrelated evidence),
+      // so the overlay is the ONLY denial source: without validation the
+      // malformed payload reads as an empty/absent fence and authorize
+      // re-admits off still-valid active evidence (the fail-open bug).
+      const otherId = await import("@elizaos/plugin-telegram").then((m) =>
+        m.resolveTelegramRuntimeEntityId(
+          second.harness.runtime,
+          "default",
+          String(MEMBER_TG_ID + 9),
+        ),
+      );
+      await ensurePrincipal(second.harness, otherId);
+      await second.authority.recordEvent({
+        chatId: String(CHAT_ID),
+        chatRoomKey: String(CHAT_ID),
+        canonicalPrincipalId: otherId,
+        state: "active",
+        reason: "joined",
+        messageId: 3,
+        telegramUserId: String(MEMBER_TG_ID + 9),
+        runtime: { worldId: null, roomId: null, entityId: otherId },
+        observedAt: new Date().toISOString(),
+      });
+
+      // FAIL CLOSED: the corrupted overlay must deny the principal whose
+      // revocation could not be committed, exactly like an unreadable one.
+      const decision = await second.authority.authorize({
+        chatId: String(CHAT_ID),
+        chatRoomKey: String(CHAT_ID),
+        canonicalPrincipalId: entityId,
+      });
+      expect(
+        decision.decision,
+        "a malformed persisted overlay must fail closed, not read as an empty fence",
+      ).toBe("denied");
+      expect(decision.reason).toBe("membership_revoked");
+
+      // Recovery: repair the row to the honest empty overlay; hydration
+      // retries (the fail-closed state is not sticky) and the committed
+      // active evidence authorizes again.
+      await second.harness.runtime.deleteCache(cacheKey);
+      const recovered = await second.authority.authorize({
+        chatId: String(CHAT_ID),
+        chatRoomKey: String(CHAT_ID),
+        canonicalPrincipalId: entityId,
+      });
+      expect(
+        recovered.decision,
+        "a repaired overlay row must resume normal authoritative decisions",
+      ).toBe("allowed");
+      cleanups.push(async () => {
+        await import("node:fs/promises").then((fs) =>
+          fs.rm(dir, { recursive: true, force: true }),
+        );
+      });
+    },
+    120_000,
+  );
 });

--- a/plugins/plugin-telegram/__tests__/membership-authority.real.test.ts
+++ b/plugins/plugin-telegram/__tests__/membership-authority.real.test.ts
@@ -1012,6 +1012,121 @@ describe("telegram membership authority vertical (real PGlite)", () => {
     });
   }, 120_000);
 
+  it("fences a principal whose persisted pending-revocation entry uses UPPERCASE hex (case-consistent overlay)", async () => {
+    const dir = await import("node:fs/promises").then((fs) =>
+      fs.mkdtemp("/tmp/tg-membership-pending-case-"),
+    );
+    const first = await bootMembershipHarness({ pgliteDir: dir });
+    const entityId = await import("@elizaos/plugin-telegram").then((m) =>
+      m.resolveTelegramRuntimeEntityId(
+        first.harness.runtime,
+        "default",
+        String(MEMBER_TG_ID),
+      ),
+    );
+    await ensurePrincipal(first.harness, entityId);
+    const runtimeMap = { worldId: null, roomId: null, entityId };
+
+    // Principal admitted, then their leave-revocation write fails: the
+    // pending-revocation overlay installs and persists.
+    await first.authority.recordEvent({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+      state: "active",
+      reason: "joined",
+      messageId: 1,
+      telegramUserId: String(MEMBER_TG_ID),
+      runtime: runtimeMap,
+      observedAt: new Date(Date.now() - 10_000).toISOString(),
+    });
+    first.faults.failApplyMembership = true;
+    await first.authority.recordEvent({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+      state: "revoked",
+      reason: "left",
+      messageId: 2,
+      telegramUserId: String(MEMBER_TG_ID),
+      runtime: runtimeMap,
+      observedAt: new Date(Date.now() - 5_000).toISOString(),
+    });
+    first.faults.failApplyMembership = false;
+
+    // Corrupt the persisted overlay exactly the way the reviewer described:
+    // after the revocation-failure persist lands (lowercase), rewrite the
+    // durable value with the SAME UUID in uppercase hex. The interception
+    // happens at the getCache boundary in the restarted process so the REAL
+    // key format never needs reconstruction — hydration reads uppercase hex,
+    // which CANONICAL_UUID_PATTERN's `i` flag accepts while the admission
+    // path checks lowercase canonicalPrincipalId against a case-sensitive Set.
+    const cleanupIndex = cleanups.indexOf(first.harness.cleanup);
+    if (cleanupIndex >= 0) cleanups.splice(cleanupIndex, 1);
+    await first.harness.runtime.stop().catch(() => {});
+    const second = await bootMembershipHarness({ pgliteDir: dir });
+    const originalGet = second.harness.runtime.getCache.bind(
+      second.harness.runtime,
+    );
+    second.harness.runtime.getCache = (async (key: string) => {
+      const value = await originalGet(key);
+      if (
+        key.includes("pending-revocations") &&
+        Array.isArray(value) &&
+        value.every((v) => typeof v === "string")
+      ) {
+        return value.map((v) => v.toUpperCase());
+      }
+      return value;
+    }) as never;
+
+    // Unrelated evidence restores scope health to current.
+    const otherId = await import("@elizaos/plugin-telegram").then((m) =>
+      m.resolveTelegramRuntimeEntityId(
+        second.harness.runtime,
+        "default",
+        String(MEMBER_TG_ID + 9),
+      ),
+    );
+    await ensurePrincipal(second.harness, otherId);
+    await second.authority.recordEvent({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: otherId,
+      state: "active",
+      reason: "joined",
+      messageId: 3,
+      telegramUserId: String(MEMBER_TG_ID + 9),
+      runtime: { worldId: null, roomId: null, entityId: otherId },
+      observedAt: new Date().toISOString(),
+    });
+    const health = await second.authority.scopeHealth({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+    });
+    expect(health?.health).toBe("current");
+
+    // The uppercase entry must still fence the lowercase canonical principal.
+    // Before the normalization fix, hydration succeeded but Set.has never
+    // matched, silently re-authorizing the revoked principal.
+    const decision = await second.authority.authorize({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+    });
+    expect(
+      decision.decision,
+      "an uppercase persisted pending-revocation entry must still deny the lowercase canonical principal",
+    ).toBe("denied");
+    expect(decision.reason).toBe("membership_revoked");
+
+    cleanups.push(async () => {
+      await import("node:fs/promises").then((fs) =>
+        fs.rm(dir, { recursive: true, force: true }),
+      );
+    });
+  }, 120_000);
+
   it("does not let a queued authorization overtake the revocation failure degrade (atomic fence)", async () => {
     const { authority, harness, faults } = await bootMembershipHarness();
     const entityId = await import("@elizaos/plugin-telegram").then((m) =>

--- a/plugins/plugin-telegram/__tests__/membership-authority.real.test.ts
+++ b/plugins/plugin-telegram/__tests__/membership-authority.real.test.ts
@@ -60,6 +60,13 @@ async function bootMembershipHarness(options?: {
    */
   faults: { failApplyMembership: boolean };
   /**
+   * Fault injector for the fail-closed stale-degrade path: while true, every
+   * setScopeHealth call throws, so a failed revocation write ALSO cannot
+   * degrade the scope — the double-fault class where no durable fence can
+   * land and the connector admission gate must break instead.
+   */
+  degradeFaults: { failSetScopeHealth: boolean };
+  /**
    * Fault injector for durable-overlay hydration failures: while true, the
    * runtime cache read throws, so authorize must fail closed.
    */
@@ -79,6 +86,18 @@ async function bootMembershipHarness(options?: {
   }
 
   const faults = { failApplyMembership: false };
+  // Fault injector #4: while true, setScopeHealth throws on the real service
+  // instance — the stale-degrade path of a failed revocation write cannot
+  // land either, forcing the unsafe escalation class under test.
+  const degradeFaults = { failSetScopeHealth: false };
+  const originalSetScopeHealth =
+    membershipService.setScopeHealth.bind(membershipService);
+  membershipService.setScopeHealth = ((command: never) => {
+    if (degradeFaults.failSetScopeHealth) {
+      throw new Error("injected health-degrade outage (test fault)");
+    }
+    return originalSetScopeHealth(command);
+  }) as never;
   // Fault injector #2: while true, runtime.getCache throws, exercising the
   // durable-overlay hydration failure path (must fail admission closed).
   const cacheFaults = { failGetCache: false, setCacheResolvesFalse: false };
@@ -161,6 +180,7 @@ async function bootMembershipHarness(options?: {
     getChatMember,
     membershipService,
     faults,
+    degradeFaults,
     cacheFaults,
   };
 }
@@ -1698,5 +1718,135 @@ describe("telegram membership authority vertical (real PGlite)", () => {
       "after re-add + fresh evidence, admission restores",
     ).toBe("allowed");
     expect(getChatMember).not.toHaveBeenCalled();
+  }, 120_000);
+
+  it("breaks the connector admission gate when a revoked reconcile can neither commit nor degrade (REVOCATION_UNSAFE)", async () => {
+    const { manager, authority, getChatMember, faults, degradeFaults } =
+      await bootMembershipHarness();
+
+    // A never-seen principal in a group with no committed evidence: the
+    // first admission consults authorize (no_scope_evidence -> reconcile
+    // miss) and the gate issues the getChatMember point query.
+    getChatMember.mockResolvedValue({
+      status: "kicked",
+      user: { id: MEMBER_TG_ID },
+    });
+
+    // Admission observability: wrap the real createMemory so internal
+    // callers keep working while counting actual admissions.
+    const harnessRuntime = (
+      manager as unknown as { runtime: { createMemory: unknown } }
+    ).runtime;
+    const originalCreateMemory = (
+      harnessRuntime.createMemory as (...args: unknown[]) => Promise<boolean>
+    ).bind(harnessRuntime);
+    let admissions = 0;
+    (harnessRuntime as { createMemory: unknown }).createMemory = async (
+      ...args: unknown[]
+    ) => {
+      admissions += 1;
+      return originalCreateMemory(
+        ...(args as Parameters<typeof originalCreateMemory>),
+      );
+    };
+
+    // Double fault: the revoked evidence write fails AND the fail-closed
+    // stale-degrade fails — no durable fence can land. Before the fix the
+    // reconcile path swallowed this class and returned null, leaving the
+    // gate healthy with no overlay installed.
+    faults.failApplyMembership = true;
+    degradeFaults.failSetScopeHealth = true;
+    await manager.handleMessage(
+      groupMessageCtx({ messageId: 300, getChatMember }),
+      { forceReply: false },
+    );
+    expect(
+      getChatMember,
+      "never-seen principal triggers the reconcile query",
+    ).toHaveBeenCalledTimes(1);
+    expect(admissions, "the revoked reconcile's message is denied").toBe(0);
+
+    // The connector admission gate is now BROKEN: a later message from the
+    // SAME principal is denied at the broken short-circuit — no provider
+    // query, no authority consult, no reconciliation attempt at all.
+    await manager.handleMessage(
+      groupMessageCtx({ messageId: 301, getChatMember }),
+      { forceReply: false },
+    );
+    expect(
+      getChatMember,
+      "a broken gate must not reconsult the provider or the authority",
+    ).toHaveBeenCalledTimes(1);
+    expect(admissions).toBe(0);
+
+    // Refutation of "denied because of the fault": lift BOTH faults and
+    // answer "member" — the gate stays broken, so even a would-be-admissible
+    // reconcile result cannot restore admission. Only a later successful
+    // boot (rebind) can clear the broken state.
+    faults.failApplyMembership = false;
+    degradeFaults.failSetScopeHealth = false;
+    getChatMember.mockResolvedValue({
+      status: "member",
+      user: { id: MEMBER_TG_ID },
+    });
+    await manager.handleMessage(
+      groupMessageCtx({ messageId: 302, getChatMember }),
+      { forceReply: false },
+    );
+    expect(
+      getChatMember,
+      "the broken gate denies before any reconcile could admit",
+    ).toHaveBeenCalledTimes(1);
+    expect(
+      admissions,
+      "a healthy authority answer cannot restore a broken gate",
+    ).toBe(0);
+
+    // Recovery refutation, second leg: the broken gate itself — not residual
+    // runtime damage — is what denies. Rebinding a healthy gate (what a
+    // later successful boot does) restores normal admission FOR A CLEAN
+    // SCOPE: a never-seen principal in a DIFFERENT chat backfills through
+    // reconcile and is admitted. (The faulted scope itself stays denied
+    // until fresh evidence restores its health — covered by the
+    // tombstone/restart tests above — so the same-principal message above
+    // must remain denied regardless of gate state.)
+    manager.bindMembershipGate({
+      authority,
+      botTelegramUserId: "900001",
+    });
+    const otherChat = { id: CHAT_ID - 7, type: "group", title: "Other" };
+    const otherFrom = {
+      id: MEMBER_TG_ID + 9,
+      is_bot: false,
+      first_name: "Other",
+      username: "other",
+    };
+    const otherCtx = {
+      from: otherFrom,
+      chat: otherChat,
+      message: {
+        message_id: 310,
+        date: Math.floor(Date.now() / 1000),
+        text: "hello",
+        chat: otherChat,
+        from: otherFrom,
+      },
+      telegram: {
+        getChatMember: async () => ({
+          status: "member",
+          user: { id: MEMBER_TG_ID + 9 },
+        }),
+        sendMessage: async () => ({}),
+        sendChatAction: async () => true,
+      },
+    } as unknown as Context;
+    await manager.handleMessage(otherCtx, { forceReply: false });
+    expect(
+      admissions,
+      "a rebound healthy gate admits a clean-scope member via reconcile",
+    ).toBeGreaterThan(0);
+
+    (harnessRuntime as { createMemory: unknown }).createMemory =
+      originalCreateMemory;
   }, 120_000);
 });

--- a/plugins/plugin-telegram/__tests__/membership-poller-loop.real.test.ts
+++ b/plugins/plugin-telegram/__tests__/membership-poller-loop.real.test.ts
@@ -1,0 +1,1163 @@
+/**
+ * Real-poller Telegram membership lifecycle e2e (#28715 review evidence).
+ *
+ * Boots the REAL `TelegramService` long-poll loop against a local
+ * wire-compatible Telegram Bot API HTTP server (keyless — no BotFather token,
+ * no network) and drives the complete membership-authority lifecycle through
+ * the production path: Telegraf `getUpdates` long-poll → service middlewares →
+ * `MessageManager.handleMessage` admission gate → real `SqlMembershipService`
+ * over PGLite. Denial legs are classified on three independent dimensions
+ * (per-room memory writes, deterministic-provider model invocations, and the
+ * authority's own `authorize` decision), not on a single aggregate count.
+ *
+ * The `it.fails` tripwire at the bottom pins the KNOWN connector-path
+ * recovery deadlock; the first (green) test doubles as its companion proof
+ * that the shared harness itself admits messages, so a red tripwire is
+ * attributable to the deadlock rather than a broken boot. Deterministic;
+ * runs entirely on 127.0.0.1.
+ */
+import type { UUID } from "@elizaos/core";
+import { createUniqueUuid, ModelType } from "@elizaos/core";
+import {
+  benignExternalMessageFixture,
+  createTestRuntimeWithModelProvider,
+  type DeterministicModelFixture,
+  type ModelProviderTestRuntime,
+} from "@elizaos/core/testing";
+import {
+  DEFAULT_ACCOUNT_ID,
+  resolveTelegramRuntimeEntityId,
+  TelegramService,
+} from "@elizaos/plugin-telegram";
+import type { Chat, ChatMember, ChatMemberUpdated, User } from "telegraf/types";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+
+/** Local wire-server identity constants (never reach api.telegram.org). */
+const BOT_TOKEN = "111111:LOCAL_WIRE_EVIDENCE_TOKEN";
+const BOT_ID = 111_111;
+const CHAT_ID = -480_15;
+/**
+ * Deterministic update timestamps: strictly increasing with update_id, so
+ * the authority's out-of-order guard (Telegram dates are one-second
+ * resolution; EQUAL is not newer) can never silently skip an event for
+ * landing in the same wall-clock second as its predecessor.
+ */
+const BASE_DATE = Math.floor(Date.now() / 1000) - 10_000;
+const dateFor = (updateId: number): number => BASE_DATE + updateId;
+/** Membership chat-room key for the default account (`membershipChatRoomKey`). */
+const CHAT_KEY = String(CHAT_ID);
+const MEMBER_TG_ID = 480_151;
+const MEMBER2_TG_ID = 480_152;
+const HOST = "127.0.0.1";
+
+/**
+ * Bot-API `status` values the harness transitions the BOT through. The wire
+ * shapes below are the exact discriminated union members telegraf/types
+ * declares (`ChatMemberMember` / `ChatMemberLeft` / `ChatMemberBanned`), so
+ * typechecking pins the payload to the real contract.
+ */
+type BotMemberStatus = "member" | "left" | "kicked";
+
+interface QueuedUpdate {
+  update_id: number;
+  message?: Record<string, unknown>;
+  my_chat_member?: ChatMemberUpdated;
+}
+
+interface WireServer {
+  url: string;
+  close: () => Promise<void>;
+  /** Queue one raw Bot API update; resolves only once a poll CONSUMES it. */
+  push: (update: QueuedUpdate) => Promise<void>;
+  /** Resolves once every queued update has been consumed by getUpdates. */
+  waitForDrain: (timeoutMs?: number) => Promise<void>;
+  /** Resolves once the service's long-poll has actually queried getUpdates. */
+  waitForPoll: (timeoutMs?: number) => Promise<void>;
+  /** Mutable member status map served by getChatMember (reconcile seam). */
+  memberStatus: Map<string, string>;
+  /** Every outbound sendMessage the connector made ({chatId, text}). */
+  sentMessages: Array<{ chatId: number; text: string }>;
+  /** Every unknown Bot API method the connector called (fail-loud). */
+  unsupportedCalls: string[];
+  /** Methods the server answered (for assertions on the wire surface). */
+  handledMethods: Set<string>;
+}
+
+/**
+ * Minimal Bot API wire server emulating Telegram's LONG-POLL contract: an
+ * empty queue holds the getUpdates request open (50s timeout, like Telegram)
+ * instead of returning immediately, so the client never hot-loops. Offset
+ * acknowledgement drops consumed updates exactly like Telegram. The only seam
+ * replaced is Telegram itself; the Telegraf client on the other end is the
+ * production dependency.
+ */
+async function startWireServer(): Promise<WireServer> {
+  const { createServer } = await import("node:http");
+
+  const queue: QueuedUpdate[] = [];
+  let offset = 0;
+  let pollsServed = 0;
+  const pollWaiters: Array<() => void> = [];
+  const drainWaiters: Array<() => void> = [];
+  /** Held long-polls: each responds with a queue snapshot when woken. */
+  const heldPolls: Array<{
+    respond: (result: QueuedUpdate[]) => void;
+    timer: ReturnType<typeof setTimeout>;
+  }> = [];
+  const memberStatus = new Map<string, string>([
+    [`${CHAT_ID}:${MEMBER_TG_ID}`, "member"],
+    [`${CHAT_ID}:${MEMBER2_TG_ID}`, "member"],
+    [`${CHAT_ID}:${BOT_ID}`, "member"],
+  ]);
+  const sentMessages: Array<{ chatId: number; text: string }> = [];
+  const unsupportedCalls: string[] = [];
+  const handledMethods = new Set<string>();
+
+  const notifyDrain = (): void => {
+    if (queue.length === 0) {
+      for (const w of drainWaiters.splice(0)) w();
+    }
+  };
+
+  /** Wake every held long-poll with the current queue snapshot. */
+  const wakeHeldPolls = (): void => {
+    const snapshot = queue.slice(0, 100);
+    for (const held of heldPolls.splice(0)) {
+      clearTimeout(held.timer);
+      held.respond(snapshot);
+    }
+  };
+
+  const server = createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (c: Buffer) => chunks.push(c));
+    req.on("end", () => {
+      const url = new URL(req.url ?? "/", `http://${HOST}`);
+      if (process.env.WIRE_DEBUG) {
+        console.log(`[wire-server] ${req.method} ${req.url}`);
+      }
+      const tokenMatch = /\/bot[^/]+\/([A-Za-z]+)$/.exec(url.pathname);
+      const method =
+        req.method === "GET"
+          ? (tokenMatch?.[1] ?? url.pathname.slice(1))
+          : tokenMatch?.[1];
+      const body: Record<string, unknown> = chunks.length
+        ? (JSON.parse(Buffer.concat(chunks).toString("utf8")) as Record<
+            string,
+            unknown
+          >)
+        : Object.fromEntries(url.searchParams.entries());
+
+      const json = (payload: unknown): void => {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify(payload));
+      };
+      if (!method || !/^[A-Za-z]+$/.test(method)) {
+        json({ ok: false, error_code: 404, description: "Not Found" });
+        return;
+      }
+      handledMethods.add(method);
+
+      if (method === "getMe") {
+        json({
+          ok: true,
+          result: {
+            id: BOT_ID,
+            is_bot: true,
+            first_name: "EvidenceBot",
+            username: "evidence_local_bot",
+            can_join_groups: true,
+            can_read_all_group_messages: true,
+          },
+        });
+        return;
+      }
+      if (method === "getUpdates") {
+        pollsServed += 1;
+        const requestedOffset = Number(body.offset ?? 0);
+        if (requestedOffset > 0) {
+          offset = requestedOffset;
+          while (queue.length > 0 && queue[0].update_id < offset) {
+            queue.shift();
+          }
+          notifyDrain();
+        }
+        for (const w of pollWaiters.splice(0)) w();
+        if (queue.length === 0) {
+          // Hold the long poll open like Telegram does (bounded to 50s). A
+          // later push() wakes it with the then-current queue snapshot.
+          const timer = setTimeout(() => {
+            const index = heldPolls.findIndex((h) => h.timer === timer);
+            if (index >= 0) heldPolls.splice(index, 1);
+            json({ ok: true, result: [] });
+          }, 50_000);
+          heldPolls.push({
+            respond: (result) => json({ ok: true, result }),
+            timer,
+          });
+          return;
+        }
+        json({ ok: true, result: queue.slice(0, Number(body.limit ?? 100)) });
+        return;
+      }
+      if (
+        method === "setMyCommands" ||
+        method === "deleteMessage" ||
+        // Telegraf's polling launch clears any webhook FIRST; the long-poll
+        // loop never starts unless this succeeds.
+        method === "deleteWebhook"
+      ) {
+        json({ ok: true, result: true });
+        return;
+      }
+      if (method === "sendMessage") {
+        sentMessages.push({
+          chatId: Number(body.chat_id),
+          text: String(body.text ?? ""),
+        });
+        json({
+          ok: true,
+          result: {
+            message_id: 900_001,
+            from: { id: BOT_ID, is_bot: true, first_name: "EvidenceBot" },
+            chat: { id: Number(body.chat_id), type: "group" },
+            date: Math.floor(Date.now() / 1000),
+            text: String(body.text ?? ""),
+          },
+        });
+        return;
+      }
+      if (method === "getChatMember") {
+        const key = `${Number(body.chat_id)}:${Number(body.user_id)}`;
+        const status = memberStatus.get(key) ?? "left";
+        const user = {
+          id: Number(body.user_id),
+          is_bot: false,
+          first_name: "Member",
+        };
+        const result =
+          status === "kicked"
+            ? { status, user, until_date: 0 }
+            : status === "restricted"
+              ? { status, user, is_member: true, until_date: 0 }
+              : { status, user };
+        json({ ok: true, result });
+        return;
+      }
+      if (method === "getChat") {
+        json({
+          ok: true,
+          result: { id: CHAT_ID, type: "supergroup", title: "Evidence Group" },
+        });
+        return;
+      }
+      // Fail loud on anything outside the emulated surface: a fabricated
+      // success here could mask a production client change.
+      unsupportedCalls.push(method);
+      json({
+        ok: false,
+        error_code: 404,
+        description: `evidence wire server: ${method} not emulated`,
+      });
+    });
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, HOST, resolve));
+  const address = server.address();
+  if (!address || typeof address !== "object") {
+    throw new Error("wire server failed to bind");
+  }
+  const port = address.port;
+
+  return {
+    url: `http://${HOST}:${port}`,
+    close: () =>
+      new Promise<void>((resolve) => {
+        for (const held of heldPolls.splice(0)) {
+          clearTimeout(held.timer);
+          held.respond([]);
+        }
+        server.close(() => resolve());
+      }),
+    push: (update) =>
+      new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(
+          () => reject(new Error("queued update was never consumed by a poll")),
+          20_000,
+        );
+        drainWaiters.push(() => {
+          clearTimeout(timer);
+          resolve();
+        });
+        queue.push(update);
+        // Wake held long-polls so the update is delivered immediately.
+        wakeHeldPolls();
+        notifyDrain();
+      }),
+    waitForDrain: (timeoutMs = 15_000) =>
+      new Promise<void>((resolve, reject) => {
+        if (queue.length === 0) return resolve();
+        const timer = setTimeout(() => {
+          reject(new Error(`wire queue did not drain (${queue.length} left)`));
+        }, timeoutMs);
+        drainWaiters.push(() => {
+          clearTimeout(timer);
+          resolve();
+        });
+      }),
+    waitForPoll: (timeoutMs = 15_000) =>
+      new Promise<void>((resolve, reject) => {
+        const snapshot = pollsServed;
+        const timer = setTimeout(
+          () => reject(new Error("no getUpdates poll arrived")),
+          timeoutMs,
+        );
+        pollWaiters.push(() => {
+          clearTimeout(timer);
+          resolve();
+        });
+        // The poll may already have happened (e.g. during service boot).
+        if (snapshot > 0) {
+          clearTimeout(timer);
+          resolve();
+        }
+      }),
+    memberStatus,
+    sentMessages,
+    unsupportedCalls,
+    handledMethods,
+  };
+}
+
+const CHAT: Chat.SupergroupChat = {
+  id: CHAT_ID,
+  type: "supergroup",
+  title: "Evidence Group",
+};
+
+function fromUser(id: number): User {
+  return { id, is_bot: false, first_name: `Member${id}` };
+}
+
+/**
+ * The bot's own chat-member record, typed against the telegraf union so the
+ * compiler pins the exact wire shape: `kicked` carries the required
+ * `until_date` (`ChatMemberBanned`), `member`/`left` carry only status+user.
+ */
+function botMemberRecord(status: BotMemberStatus): ChatMember {
+  const user: User = {
+    id: BOT_ID,
+    is_bot: true,
+    first_name: "EvidenceBot",
+    username: "evidence_local_bot",
+  };
+  if (status === "kicked") {
+    return { status, user, until_date: 0 };
+  }
+  if (status === "left") {
+    return { status, user };
+  }
+  return { status, user };
+}
+
+function textMessage(
+  updateId: number,
+  fromId: number,
+  text: string,
+): QueuedUpdate {
+  return {
+    update_id: updateId,
+    message: {
+      message_id: updateId * 7,
+      from: fromUser(fromId),
+      chat: CHAT,
+      date: dateFor(updateId),
+      text,
+    },
+  };
+}
+
+function memberJoin(
+  updateId: number,
+  actorId: number,
+  joinedId: number,
+): QueuedUpdate {
+  return {
+    update_id: updateId,
+    message: {
+      message_id: updateId * 7,
+      from: fromUser(actorId),
+      chat: CHAT,
+      date: dateFor(updateId),
+      new_chat_members: [fromUser(joinedId)],
+    },
+  };
+}
+
+function memberLeft(updateId: number, leftId: number): QueuedUpdate {
+  return {
+    update_id: updateId,
+    message: {
+      message_id: updateId * 7,
+      from: fromUser(leftId),
+      chat: CHAT,
+      date: dateFor(updateId),
+      left_chat_member: fromUser(leftId),
+    },
+  };
+}
+
+/** `my_chat_member` transition of the BOT itself, typed against `ChatMemberUpdated`. */
+function myChatMember(
+  updateId: number,
+  fromStatus: BotMemberStatus,
+  toStatus: BotMemberStatus,
+): QueuedUpdate {
+  return {
+    update_id: updateId,
+    my_chat_member: {
+      chat: CHAT,
+      from: fromUser(MEMBER_TG_ID),
+      date: dateFor(updateId),
+      old_chat_member: botMemberRecord(fromStatus),
+      new_chat_member: botMemberRecord(toStatus),
+    },
+  };
+}
+
+/** Structural view of the production membership authority (introspection only). */
+interface AuthorityView {
+  authorize(input: {
+    chatId: string;
+    chatRoomKey: string;
+    canonicalPrincipalId: UUID;
+  }): Promise<{
+    decision: "allowed" | "denied";
+    reason: string;
+  }>;
+  scopeHealth(input: {
+    chatId: string;
+    chatRoomKey: string;
+  }): Promise<{ health: string; reason?: string } | null>;
+}
+
+interface RuntimeHandle {
+  harness: ModelProviderTestRuntime;
+  runtime: ModelProviderTestRuntime["runtime"];
+  service: TelegramService;
+  cleanup: () => Promise<void>;
+}
+
+const pgliteDirs: string[] = [];
+const savedEnv: Record<string, string | undefined> = {};
+
+const ENV_KEYS = [
+  "TELEGRAM_API_ROOT",
+  "TELEGRAM_BOT_TOKEN",
+  "TELEGRAM_AUTO_REPLY",
+  "TELEGRAM_MEMBERSHIP_ENFORCE",
+  "PGLITE_DATA_DIR",
+  "EMBEDDING_DIMENSION",
+  "LOCAL_EMBEDDING_DIMENSIONS",
+] as const;
+
+/**
+ * Boots a real PGLite runtime and starts the REAL TelegramService poller
+ * against the wire server. The connector resolves TELEGRAM_API_ROOT /
+ * TELEGRAM_BOT_TOKEN through runtime.getSetting's process.env fallback — the
+ * same production resolution chain, exercised end to end.
+ */
+async function bootRuntime(
+  pgliteDir: string,
+  apiRoot: string,
+  fixtures: DeterministicModelFixture[],
+): Promise<RuntimeHandle> {
+  process.env.TELEGRAM_API_ROOT = apiRoot;
+  process.env.TELEGRAM_BOT_TOKEN = BOT_TOKEN;
+  process.env.TELEGRAM_AUTO_REPLY = "true";
+  process.env.TELEGRAM_MEMBERSHIP_ENFORCE = "true";
+
+  const harness = await createTestRuntimeWithModelProvider({
+    pgliteDir,
+    removePgliteDirOnCleanup: false,
+    characterName: "TelegramEvidenceAgent",
+    fixtures: [
+      benignExternalMessageFixture("telegram-evidence-security"),
+      ...fixtures,
+    ],
+  });
+  const service = await TelegramService.start(harness.runtime);
+  const cleanup = async (): Promise<void> => {
+    await TelegramService.stop(harness.runtime).catch(() => undefined);
+    await service.stop().catch(() => undefined);
+    await harness.cleanup();
+  };
+  boots.push({ cleanup });
+  return { harness, runtime: harness.runtime, service, cleanup };
+}
+
+/** Live boots this test file; drained by afterEach so every Telegraf
+ * poller (and its process-local token claim) is stopped between tests. */
+const boots: Array<{ cleanup: () => Promise<void> }> = [];
+
+/**
+ * Resolves the settled membership authority for the default account, or null
+ * while the gate is still bootstrapping / settled-null (legacy mode).
+ */
+function getAuthority(handle: RuntimeHandle): AuthorityView | null {
+  const gate = (
+    handle.service as unknown as {
+      settledMembershipGates?: Map<string, { authority: AuthorityView } | null>;
+    }
+  ).settledMembershipGates?.get(DEFAULT_ACCOUNT_ID);
+  return gate ? gate.authority : null;
+}
+
+/** Canonical principal id the connector maps a Telegram user to. */
+async function principalIdOf(
+  handle: RuntimeHandle,
+  telegramUserId: number,
+): Promise<UUID> {
+  return resolveTelegramRuntimeEntityId(
+    handle.runtime,
+    DEFAULT_ACCOUNT_ID,
+    String(telegramUserId),
+  );
+}
+
+/** Polls `fn` until `ok` holds; throws with the description (and last
+ * observed value) on timeout. */
+async function until<T>(
+  description: string,
+  fn: () => Promise<T>,
+  ok: (value: T) => boolean,
+  timeoutMs = 20_000,
+): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const value = await fn();
+    if (ok(value)) return value;
+    if (Date.now() > deadline) {
+      throw new Error(
+        `${description}: condition unmet after ${timeoutMs}ms (last observed: ${JSON.stringify(value)})`,
+      );
+    }
+    await new Promise((r) => setTimeout(r, 250));
+  }
+}
+
+/**
+ * Resolves once the default account's membership gate has SETTLED with a
+ * live authority (not pending, not the legacy null), so a later denial is
+ * attributable to the authority, not a bootstrapping gate.
+ */
+async function waitForGateReady(
+  handle: RuntimeHandle,
+  wire: WireServer,
+  timeoutMs = 20_000,
+): Promise<void> {
+  await wire.waitForPoll(timeoutMs);
+  await until(
+    "membership gate settled with a live authority",
+    async () => getAuthority(handle),
+    (authority) => authority !== null,
+    timeoutMs,
+  );
+}
+
+/** How one delivered message was treated by the real connector path. */
+interface DeliveryOutcome {
+  /** Message rows in the chat room's memory table containing the exact inbound text. */
+  persistedInbound: number;
+  /** Outbound sendMessage calls to the chat during the delivery window. */
+  newOutboundReplies: number;
+  /** Deterministic-provider model calls during the delivery window. */
+  newModelCalls: number;
+  /** Room-participant membership state for the sender at delivery time
+   * (before the wire push) and after the settle window. Denial legs assert
+   * these directly: a revoked participant must remain listed unchanged (no
+   * re-add churn), and a never-admitted sender must never appear. */
+  wasParticipantBefore: boolean;
+  isParticipantAfter: boolean;
+  /** The authority's own decision for the sender at classify time. */
+  decision: "allowed" | "denied";
+  decisionReason: string;
+}
+
+/**
+ * Delivers one message through the REAL long-poll path and classifies the
+ * outcome on independent dimensions: whether the EXACT inbound text was
+ * persisted to the chat room's memory (the inbound mutation itself, immune
+ * to unrelated-room noise), whether any outbound reply was sent to the chat,
+ * deterministic-provider model invocations, and the authority's own
+ * authorization decision for the sender. The settle window is a bounded
+ * grace period for the middleware chain; event-driven `until` waits are
+ * used wherever an expected effect exists to wait for.
+ */
+async function deliverAndClassify(
+  handle: RuntimeHandle,
+  wire: WireServer,
+  roomId: UUID,
+  updateId: number,
+  fromId: number,
+  text: string,
+  settleMs = 6_000,
+): Promise<DeliveryOutcome> {
+  const authority = getAuthority(handle);
+  if (!authority) throw new Error("membership authority not settled");
+  const principalId = await principalIdOf(handle, fromId);
+  const persistedBefore = await countMemoriesWithText(
+    handle.runtime,
+    roomId,
+    text,
+  );
+  const callsBefore = modelCallCount(handle);
+  const outboundBefore = wire.sentMessages.length;
+  const wasParticipantBefore = (
+    await handle.runtime.getParticipantsForRoom(roomId)
+  ).includes(principalId);
+  await wire.push(textMessage(updateId, fromId, text));
+  await new Promise((r) => setTimeout(r, settleMs));
+  const persistedInbound =
+    (await countMemoriesWithText(handle.runtime, roomId, text)) -
+    persistedBefore;
+  const isParticipantAfter = (
+    await handle.runtime.getParticipantsForRoom(roomId)
+  ).includes(principalId);
+  const decision = await authority.authorize({
+    chatId: String(CHAT_ID),
+    chatRoomKey: CHAT_KEY,
+    canonicalPrincipalId: principalId,
+  });
+  return {
+    persistedInbound,
+    newOutboundReplies: wire.sentMessages.length - outboundBefore,
+    newModelCalls: modelCallCount(handle) - callsBefore,
+    wasParticipantBefore,
+    isParticipantAfter,
+    decision: decision.decision,
+    decisionReason: decision.reason,
+  };
+}
+
+/** Message rows in a room's memory whose content contains the exact text. */
+async function countMemoriesWithText(
+  runtime: RuntimeHandle["runtime"],
+  roomId: UUID,
+  text: string,
+): Promise<number> {
+  const memories = await runtime.getMemories({
+    tableName: "messages",
+    roomId,
+    count: 1000,
+  });
+  return memories.filter((m) => String(m.content.text ?? "").includes(text))
+    .length;
+}
+
+/** Model calls recorded by the deterministic provider since boot. */
+function modelCallCount(handle: RuntimeHandle): number {
+  return handle.harness.getFixtureDiagnostics().calls.length;
+}
+
+/**
+ * Single wire server per test (the afterEach drain closes exactly the ones
+ * still open; explicit closes mid-test are idempotent no-ops on their maps).
+ */
+let wireRef: WireServer | null = null;
+
+/**
+ * Throws a PRECISE error unless admission resumed for the given message:
+ * the EXACT inbound text is persisted AND the authority allows the sender.
+ * Used inside the `it.fails` tripwire, where the thrown message is the
+ * deadlock evidence.
+ */
+async function assertAdmissionResumedOrThrow(
+  handle: RuntimeHandle,
+  roomId: UUID,
+  fromId: number,
+  updateId: number,
+  text: string,
+): Promise<void> {
+  const wire = wireRef;
+  if (!wire) throw new Error("wire server not running");
+  await wire.push(textMessage(updateId, fromId, text));
+  const persisted = await until(
+    "admission resumption (expected to stay blocked at the PR head)",
+    async () => countMemoriesWithText(handle.runtime, roomId, text),
+    (count) => count > 0,
+    6_000,
+  ).catch(() => 0);
+  if (persisted > 0) return;
+  const authority = getAuthority(handle);
+  const principalId = await principalIdOf(handle, fromId);
+  const decision = authority
+    ? await authority.authorize({
+        chatId: String(CHAT_ID),
+        chatRoomKey: CHAT_KEY,
+        canonicalPrincipalId: principalId,
+      })
+    : null;
+  throw new Error(
+    `admission never resumed: "${text}" was never persisted, authority decision ${decision ? `${decision.decision}/${decision.reason}` : "unsettled"} (persisted scope health stays unavailable after bot re-add; the gate blocks the join evidence that would restore it)`,
+  );
+}
+
+beforeAll(() => {
+  for (const key of ENV_KEYS) savedEnv[key] = process.env[key];
+});
+
+afterEach(async () => {
+  // Drain EVERY live boot first: TelegramService.stop releases the
+  // process-local poller token claim, without which the next test's boot
+  // fails with a poller ownership conflict on the same bot token.
+  while (boots.length > 0) {
+    const boot = boots.pop();
+    if (boot) await boot.cleanup().catch(() => undefined);
+  }
+  if (wireRef) {
+    await wireRef.close().catch(() => undefined);
+    wireRef = null;
+  }
+});
+
+afterAll(async () => {
+  for (const key of ENV_KEYS) {
+    const value = savedEnv[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  // Remove PGLite fixture databases after runtimes have been cleaned up.
+  const { rm } = await import("node:fs/promises");
+  for (const dir of pgliteDirs.splice(0)) {
+    await rm(dir, { recursive: true, force: true }).catch(() => undefined);
+  }
+});
+
+describe("telegram membership lifecycle over the real long-poll connector (keyless wire server)", () => {
+  it("admits, revokes, denies pre-mutation, survives restart, and restores on re-add", async () => {
+    const { mkdtemp } = await import("node:fs/promises");
+    const { tmpdir } = await import("node:os");
+    const path = await import("node:path");
+    const pgliteDir = await mkdtemp(path.join(tmpdir(), "tg-poller-evidence-"));
+    pgliteDirs.push(pgliteDir);
+
+    wireRef = await startWireServer();
+    const wire = wireRef;
+
+    const replyFixture: DeterministicModelFixture = {
+      name: "evidence-reply",
+      match: { modelType: ModelType.RESPONSE_HANDLER },
+      response: {
+        contexts: ["simple"],
+        intents: [],
+        replyText: "evidence reply from the deterministic provider",
+        candidateActionNames: [],
+      },
+    };
+
+    // ── Boot #1: the REAL TelegramService long-polls our wire server. ──
+    const boot1 = await bootRuntime(pgliteDir, wire.url, [replyFixture]);
+    await waitForGateReady(boot1, wire);
+    // The production poller must subscribe to my_chat_member; nothing
+    // outside the emulated wire surface may ever be called.
+    expect(wire.unsupportedCalls).toEqual([]);
+    expect(wire.handledMethods.has("getUpdates")).toBe(true);
+
+    const authority1 = getAuthority(boot1);
+    if (!authority1) throw new Error("authority missing after gate ready");
+    const roomId = createUniqueUuid(boot1.runtime, `${CHAT_ID}`) as UUID;
+    const principal1 = await principalIdOf(boot1, MEMBER_TG_ID);
+    const principal2 = await principalIdOf(boot1, MEMBER2_TG_ID);
+
+    // ── 1. Admitted member message via REAL message-path evidence: a join
+    // update (carried by the still-valid member themselves — Telegram's
+    // actual self-join shape) lands join evidence first, then their text
+    // message is admitted by it (NOT by the reconcile fallback — the wire
+    // getChatMember map is only a point-query seam). ──
+    await wire.push(memberJoin(10_100, MEMBER_TG_ID, MEMBER_TG_ID));
+    await until(
+      "join evidence admitted the member in the authority",
+      async () =>
+        authority1.authorize({
+          chatId: String(CHAT_ID),
+          chatRoomKey: CHAT_KEY,
+          canonicalPrincipalId: principal1,
+        }),
+      (decision) => decision.decision === "allowed",
+    );
+    await wire.push(
+      textMessage(10_101, MEMBER_TG_ID, "hello from an admitted member"),
+    );
+    await until(
+      "admitted member message reached memory through the real connector",
+      async () =>
+        countMemoriesWithText(
+          boot1.runtime,
+          roomId,
+          "hello from an admitted member",
+        ),
+      (count) => count > 0,
+    );
+    // Non-vacuity guard for the participant dimension: while admitted, the
+    // sender IS a recorded participant of the room — so the cleared state
+    // asserted after revocation is a real transition, not a never-listed
+    // artifact.
+    await until(
+      "admitted member is a recorded room participant",
+      async () =>
+        (await boot1.runtime.getParticipantsForRoom(roomId)).includes(
+          principal1,
+        ),
+      (listed) => listed === true,
+    );
+
+    // ── 2. Removal/revocation: the member leaves the chat. The authority
+    // must flip to a durable denied BEFORE we test the message path, so
+    // the next denial is attributable to the persisted revocation. ──
+    await wire.push(memberLeft(10_102, MEMBER_TG_ID));
+    const revoked = await until(
+      "member-leave revocation landed in the authority",
+      async () =>
+        authority1.authorize({
+          chatId: String(CHAT_ID),
+          chatRoomKey: CHAT_KEY,
+          canonicalPrincipalId: principal1,
+        }),
+      (decision) =>
+        decision.decision === "denied" &&
+        decision.reason === "membership_revoked",
+    );
+    expect(revoked.decision).toBe("denied");
+
+    // Participation clear is part of the same leave handling as the durable
+    // revocation; wait for it explicitly so the denial leg below asserts a
+    // settled pre-state, not a race between the two writes.
+    await until(
+      "member-leave cleared the departed member's room participation",
+      async () =>
+        (await boot1.runtime.getParticipantsForRoom(roomId)).includes(
+          principal1,
+        ),
+      (stillListed) => stillListed === false,
+    );
+
+    // ── 3. Next message denied BEFORE any mutation: the exact inbound text
+    // must never be persisted, no outbound reply may be sent, the model
+    // must not run, and the authority itself must deny for exactly this
+    // reason. ──
+    const denied = await deliverAndClassify(
+      boot1,
+      wire,
+      roomId,
+      10_103,
+      MEMBER_TG_ID,
+      "message after revocation",
+    );
+    expect(
+      denied.persistedInbound,
+      "revoked sender's message never reached memory",
+    ).toBe(0);
+    expect(
+      denied.newOutboundReplies,
+      "no outbound reply for the denied message",
+    ).toBe(0);
+    expect(
+      denied.newModelCalls,
+      "the model provider was never invoked for the denied message",
+    ).toBe(0);
+    expect(denied.decision).toBe("denied");
+    expect(denied.decisionReason).toBe("membership_revoked");
+    // Participant dimension of "denied BEFORE participant/memory/model
+    // mutation": the revoked sender's cleared participation row must neither
+    // be re-added nor otherwise churned by the denied delivery itself.
+    expect(
+      denied.wasParticipantBefore,
+      "revocation had cleared the sender's participation before the message",
+    ).toBe(false);
+    expect(
+      denied.isParticipantAfter,
+      "the denied message did not re-add or mutate the sender's participation",
+    ).toBe(false);
+
+    // A second, still-valid member keeps working: the revocation is scoped.
+    await wire.push(textMessage(10_104, MEMBER2_TG_ID, "still a member here"));
+    await until(
+      "unrevoked member unaffected by the other member's revocation",
+      async () =>
+        countMemoriesWithText(boot1.runtime, roomId, "still a member here"),
+      (count) => count > 0,
+    );
+
+    // ── 4. Restart: stop the service + runtime, keep the PGLite dir. ──
+    await boot1.cleanup();
+
+    const boot2 = await bootRuntime(pgliteDir, wire.url, [replyFixture]);
+    await waitForGateReady(boot2, wire);
+    const authority2 = getAuthority(boot2);
+    if (!authority2) throw new Error("authority missing after restart");
+
+    // Durability pre-checks BEFORE the restart denial: the persisted scope
+    // must be current again, the still-valid member must be allowed, and
+    // the departed member's revocation must have survived — otherwise a
+    // denial could be blamed on a still-bootstrapping or stale scope.
+    await until(
+      "persisted scope health returned to current after restart",
+      async () =>
+        authority2.scopeHealth({
+          chatId: String(CHAT_ID),
+          chatRoomKey: CHAT_KEY,
+        }),
+      (health) => health?.health === "current",
+    );
+    const member2AfterRestart = await authority2.authorize({
+      chatId: String(CHAT_ID),
+      chatRoomKey: CHAT_KEY,
+      canonicalPrincipalId: principal2,
+    });
+    expect(
+      member2AfterRestart.decision,
+      "still-valid member allowed from persisted evidence after restart",
+    ).toBe("allowed");
+    const revokedAfterRestart = await authority2.authorize({
+      chatId: String(CHAT_ID),
+      chatRoomKey: CHAT_KEY,
+      canonicalPrincipalId: principal1,
+    });
+    expect(revokedAfterRestart.decision).toBe("denied");
+    expect(revokedAfterRestart.reason).toBe("membership_revoked");
+
+    const roomId2 = createUniqueUuid(boot2.runtime, `${CHAT_ID}`) as UUID;
+
+    // ── 5. Denial remains after restart (durable revocation). ──
+    const deniedRestart = await deliverAndClassify(
+      boot2,
+      wire,
+      roomId2,
+      10_105,
+      MEMBER_TG_ID,
+      "after restart, still revoked",
+    );
+    expect(
+      deniedRestart.persistedInbound,
+      "revocation survived the restart — still denied pre-mutation",
+    ).toBe(0);
+    expect(deniedRestart.newOutboundReplies).toBe(0);
+    expect(deniedRestart.newModelCalls).toBe(0);
+    expect(deniedRestart.decisionReason).toBe("membership_revoked");
+    // Participant dimension, post-restart leg: the durable revocation keeps
+    // the sender out of the room's participant set and the denied delivery
+    // still does not mutate participation.
+    expect(deniedRestart.isParticipantAfter).toBe(false);
+
+    // ── 6. Re-add + fresh evidence: a STILL-VALID member adds the departed
+    // member back (Telegram's actual shape: `from` is the adder). The
+    // authority must readmit from the join evidence BEFORE the message
+    // leg, proving restoration is evidence-driven, not message-driven. ──
+    await wire.push(memberJoin(10_106, MEMBER2_TG_ID, MEMBER_TG_ID));
+    await until(
+      "fresh join evidence readmitted the re-added principal",
+      async () =>
+        authority2.authorize({
+          chatId: String(CHAT_ID),
+          chatRoomKey: CHAT_KEY,
+          canonicalPrincipalId: principal1,
+        }),
+      (decision) => decision.decision === "allowed",
+    );
+
+    // ── 7. Admission restored: the exact inbound text is persisted again. ──
+    await wire.push(
+      textMessage(10_107, MEMBER_TG_ID, "fresh evidence, admit me again"),
+    );
+    await until(
+      "fresh post-re-add evidence restored admission through the real connector",
+      async () =>
+        countMemoriesWithText(
+          boot2.runtime,
+          roomId2,
+          "fresh evidence, admit me again",
+        ),
+      (count) => count > 0,
+    );
+
+    // The wire server must never have answered an unemulated method.
+    expect(wire.unsupportedCalls).toEqual([]);
+  }, 240_000);
+
+  it("tombstones the whole scope when the bot itself is kicked (fail-closed)", async () => {
+    const { mkdtemp } = await import("node:fs/promises");
+    const { tmpdir } = await import("node:os");
+    const path = await import("node:path");
+    const pgliteDir = await mkdtemp(
+      path.join(tmpdir(), "tg-poller-tombstone-"),
+    );
+    pgliteDirs.push(pgliteDir);
+
+    wireRef = await startWireServer();
+    const wire = wireRef;
+    const replyFixture: DeterministicModelFixture = {
+      name: "tombstone-reply",
+      match: { modelType: ModelType.RESPONSE_HANDLER },
+      response: {
+        contexts: ["simple"],
+        intents: [],
+        replyText: "tombstone proof reply",
+        candidateActionNames: [],
+      },
+    };
+
+    const boot = await bootRuntime(pgliteDir, wire.url, [replyFixture]);
+    await waitForGateReady(boot, wire);
+    const authority = getAuthority(boot);
+    if (!authority) throw new Error("authority missing after gate ready");
+
+    const roomId = createUniqueUuid(boot.runtime, `${CHAT_ID}`) as UUID;
+    const scopeArgs = { chatId: String(CHAT_ID), chatRoomKey: CHAT_KEY };
+
+    // Valid member establishes join evidence + speaks while the bot is
+    // present (message-path admission, not reconcile).
+    await wire.push(memberJoin(20_100, MEMBER_TG_ID, MEMBER_TG_ID));
+    await until(
+      "join evidence admitted the member before the kick",
+      async () =>
+        authority.authorize({
+          ...scopeArgs,
+          canonicalPrincipalId: await principalIdOf(boot, MEMBER_TG_ID),
+        }),
+      (decision) => decision.decision === "allowed",
+    );
+    await wire.push(
+      textMessage(20_101, MEMBER_TG_ID, "before the bot is kicked"),
+    );
+    await until(
+      "member message reached memory before the kick",
+      async () =>
+        countMemoriesWithText(boot.runtime, roomId, "before the bot is kicked"),
+      (count) => count > 0,
+    );
+
+    // The BOT is kicked: my_chat_member revoked transition → the persisted
+    // scope health must degrade to unavailable before the denial leg.
+    await wire.push(myChatMember(20_102, "member", "kicked"));
+    const degraded = await until(
+      "scope health degraded to unavailable after the bot kick",
+      async () => authority.scopeHealth(scopeArgs),
+      (health) => health?.health === "unavailable",
+    );
+    expect(degraded?.reason).toBe("bot_removed");
+
+    // Every member is now denied pre-mutation: the scope fails closed (a
+    // kicked bot cannot observe the chat, so stale evidence must not
+    // authorize). Classified on all four dimensions.
+    const denied = await deliverAndClassify(
+      boot,
+      wire,
+      roomId,
+      20_103,
+      MEMBER2_TG_ID,
+      "after the bot was kicked",
+    );
+    expect(denied.persistedInbound).toBe(0);
+    expect(denied.newOutboundReplies).toBe(0);
+    expect(denied.newModelCalls).toBe(0);
+    expect(denied.decision).toBe("denied");
+    expect(denied.decisionReason).toBe("authority_unavailable");
+    expect(wire.unsupportedCalls).toEqual([]);
+  }, 240_000);
+
+  it.fails("bot re-add + fresh join evidence restores admission for a still-valid member (KNOWN deadlock at the PR head)", async () => {
+    // KNOWN connector-path recovery deadlock, pinned so a fix flips this
+    // tripwire green: after a bot kick, `my_chat_member` revoked→present
+    // clears the IN-MEMORY tombstone, but the PERSISTED scope health stays
+    // `unavailable`. The middleware admission gate denies every group
+    // update while scope health is degraded — including the join updates
+    // that carry the fresh evidence which would advance the scope back to
+    // `current` — and `authority_unavailable` is not in the gate's
+    // reconcile-miss set (RECONCILE_MISS_REASONS). The scope can therefore
+    // never recover through the connector until something external resets
+    // it. Member-level revocation recovery (no bot kick) DOES work; see
+    // the lifecycle test above.
+    //
+    // Companion-test discipline: this file's first (green) test uses the
+    // SAME harness (same boot, same fixtures, same wire server) and
+    // proves it admits messages, so the throw below is attributable to
+    // the deadlock rather than a broken boot; if the harness breaks, the
+    // companion fails normally while this tripwire stays red.
+    const { mkdtemp } = await import("node:fs/promises");
+    const { tmpdir } = await import("node:os");
+    const path = await import("node:path");
+    const pgliteDir = await mkdtemp(path.join(tmpdir(), "tg-poller-botreadd-"));
+    pgliteDirs.push(pgliteDir);
+
+    wireRef = await startWireServer();
+    const wire = wireRef;
+    const replyFixture: DeterministicModelFixture = {
+      name: "botreadd-reply",
+      match: { modelType: ModelType.RESPONSE_HANDLER },
+      response: {
+        contexts: ["simple"],
+        intents: [],
+        replyText: "bot re-add proof reply",
+        candidateActionNames: [],
+      },
+    };
+
+    const boot = await bootRuntime(pgliteDir, wire.url, [replyFixture]);
+    await waitForGateReady(boot, wire);
+    const authority = getAuthority(boot);
+    if (!authority) throw new Error("authority missing after gate ready");
+
+    const roomId = createUniqueUuid(boot.runtime, `${CHAT_ID}`) as UUID;
+    const scopeArgs = { chatId: String(CHAT_ID), chatRoomKey: CHAT_KEY };
+
+    // Baseline: the member joins (message-path evidence) and speaks, so
+    // the final failure below cannot be blamed on a cold harness.
+    await wire.push(memberJoin(30_200, MEMBER_TG_ID, MEMBER_TG_ID));
+    await until(
+      "join evidence admitted the member before the kick",
+      async () =>
+        authority.authorize({
+          ...scopeArgs,
+          canonicalPrincipalId: await principalIdOf(boot, MEMBER_TG_ID),
+        }),
+      (decision) => decision.decision === "allowed",
+    );
+    await wire.push(textMessage(30_201, MEMBER_TG_ID, "admit me first"));
+    await until(
+      "baseline admission before the kick",
+      async () => countMemoriesWithText(boot.runtime, roomId, "admit me first"),
+      (count) => count > 0,
+    );
+
+    // Kick the bot (persisted scope degrades), then re-add it (clears the
+    // in-memory tombstone only, at the PR head).
+    await wire.push(myChatMember(30_202, "member", "kicked"));
+    await until(
+      "scope health degraded after the bot kick",
+      async () => authority.scopeHealth(scopeArgs),
+      (health) => health?.health === "unavailable",
+    );
+    await wire.push(myChatMember(30_203, "kicked", "member"));
+    await new Promise((r) => setTimeout(r, 1_500));
+
+    // A member join carried by a STILL-VALID adder should land fresh
+    // evidence and restore the scope — at the PR head the gate blocks it.
+    await wire.push(memberJoin(30_204, MEMBER_TG_ID, MEMBER2_TG_ID));
+    await new Promise((r) => setTimeout(r, 1_500));
+
+    // THE assertion: admission must have resumed on fresh evidence. At the
+    // PR head this throws with the precise deadlock signature (memory and
+    // model-call deltas flat, authority still denying).
+    await assertAdmissionResumedOrThrow(
+      boot,
+      roomId,
+      MEMBER2_TG_ID,
+      30_205,
+      "fresh evidence, admit me again",
+    );
+  }, 240_000);
+});

--- a/plugins/plugin-telegram/__tests__/membership-poller-loop.real.test.ts
+++ b/plugins/plugin-telegram/__tests__/membership-poller-loop.real.test.ts
@@ -10,11 +10,12 @@
  * (per-room memory writes, deterministic-provider model invocations, and the
  * authority's own `authorize` decision), not on a single aggregate count.
  *
- * The `it.fails` tripwire at the bottom pins the KNOWN connector-path
- * recovery deadlock; the first (green) test doubles as its companion proof
- * that the shared harness itself admits messages, so a red tripwire is
- * attributable to the deadlock rather than a broken boot. Deterministic;
- * runs entirely on 127.0.0.1.
+ * The final test pins the connector-path recovery path: after a bot kick
+ * (scope `unavailable`, admission denied) a durable, generation-fenced re-add
+ * watermark restores admission through the real long-poll path. The first
+ * (green) test doubles as its companion proof that the shared harness itself
+ * admits messages, so a failure there is attributable to the recovery path
+ * rather than a broken boot. Deterministic; runs entirely on 127.0.0.1.
  */
 import type { UUID } from "@elizaos/core";
 import { createUniqueUuid, ModelType } from "@elizaos/core";
@@ -669,8 +670,8 @@ let wireRef: WireServer | null = null;
 /**
  * Throws a PRECISE error unless admission resumed for the given message:
  * the EXACT inbound text is persisted AND the authority allows the sender.
- * Used inside the `it.fails` tripwire, where the thrown message is the
- * deadlock evidence.
+ * Used inside the recovery test, where the thrown message is the failure
+ * evidence when the re-add watermark fails to restore admission.
  */
 async function assertAdmissionResumedOrThrow(
   handle: RuntimeHandle,

--- a/plugins/plugin-telegram/__tests__/membership-poller-loop.real.test.ts
+++ b/plugins/plugin-telegram/__tests__/membership-poller-loop.real.test.ts
@@ -1069,24 +1069,16 @@ describe("telegram membership lifecycle over the real long-poll connector (keyle
     expect(wire.unsupportedCalls).toEqual([]);
   }, 240_000);
 
-  it("bot re-add + fresh join evidence restores admission for a still-valid member (KNOWN deadlock at the PR head)", async () => {
-    // KNOWN connector-path recovery deadlock, pinned so a fix flips this
-    // tripwire green: after a bot kick, `my_chat_member` revoked→present
-    // clears the IN-MEMORY tombstone, but the PERSISTED scope health stays
-    // `unavailable`. The middleware admission gate denies every group
-    // update while scope health is degraded — including the join updates
-    // that carry the fresh evidence which would advance the scope back to
-    // `current` — and `authority_unavailable` is not in the gate's
-    // reconcile-miss set (RECONCILE_MISS_REASONS). The scope can therefore
-    // never recover through the connector until something external resets
-    // it. Member-level revocation recovery (no bot kick) DOES work; see
-    // the lifecycle test above.
-    //
-    // Companion-test discipline: this file's first (green) test uses the
-    // SAME harness (same boot, same fixtures, same wire server) and
-    // proves it admits messages, so the throw below is attributable to
-    // the deadlock rather than a broken boot; if the harness breaks, the
-    // companion fails normally while this tripwire stays red.
+  it("bot re-add plus fresh join evidence restores admission for a still-valid member", async () => {
+    // Recovery invariant for the durable re-add design: after a bot kick the
+    // persisted scope health is `unavailable` and admission fails closed, but
+    // a durable, generation-fenced re-add watermark lets the gate reconcile
+    // through `getChatMember`, so the next join update carrying fresh
+    // evidence advances the scope back to `current` and admission resumes.
+    // The companion first test of this file uses the SAME harness (same
+    // boot, same fixtures, same wire server) and proves it admits messages,
+    // so a failure below is attributable to the recovery path rather than a
+    // broken boot; if the harness breaks, the companion fails normally.
     const { mkdtemp } = await import("node:fs/promises");
     const { tmpdir } = await import("node:os");
     const path = await import("node:path");
@@ -1133,8 +1125,8 @@ describe("telegram membership lifecycle over the real long-poll connector (keyle
       (count) => count > 0,
     );
 
-    // Kick the bot (persisted scope degrades), then re-add it (clears the
-    // in-memory tombstone only, at the PR head).
+    // Kick the bot (persisted scope degrades), then re-add it (writes the
+    // durable, generation-fenced re-add watermark the recovery below leans on).
     await wire.push(myChatMember(30_202, "member", "kicked"));
     await until(
       "scope health degraded after the bot kick",
@@ -1144,14 +1136,14 @@ describe("telegram membership lifecycle over the real long-poll connector (keyle
     await wire.push(myChatMember(30_203, "kicked", "member"));
     await new Promise((r) => setTimeout(r, 1_500));
 
-    // A member join carried by a STILL-VALID adder should land fresh
-    // evidence and restore the scope — at the PR head the gate blocks it.
+    // A member join carried by a STILL-VALID adder lands fresh evidence
+    // through the recovered connector path and restores the scope.
     await wire.push(memberJoin(30_204, MEMBER_TG_ID, MEMBER2_TG_ID));
     await new Promise((r) => setTimeout(r, 1_500));
 
-    // THE assertion: admission must have resumed on fresh evidence. At the
-    // PR head this throws with the precise deadlock signature (memory and
-    // model-call deltas flat, authority still denying).
+    // THE assertion: admission must have resumed on fresh evidence — flat
+    // memory and model-call deltas with the authority still denying would
+    // mean the recovery path regressed.
     await assertAdmissionResumedOrThrow(
       boot,
       roomId,

--- a/plugins/plugin-telegram/__tests__/membership-poller-loop.real.test.ts
+++ b/plugins/plugin-telegram/__tests__/membership-poller-loop.real.test.ts
@@ -1069,7 +1069,7 @@ describe("telegram membership lifecycle over the real long-poll connector (keyle
     expect(wire.unsupportedCalls).toEqual([]);
   }, 240_000);
 
-  it.fails("bot re-add + fresh join evidence restores admission for a still-valid member (KNOWN deadlock at the PR head)", async () => {
+  it("bot re-add + fresh join evidence restores admission for a still-valid member (KNOWN deadlock at the PR head)", async () => {
     // KNOWN connector-path recovery deadlock, pinned so a fix flips this
     // tripwire green: after a bot kick, `my_chat_member` revoked→present
     // clears the IN-MEMORY tombstone, but the PERSISTED scope health stays

--- a/plugins/plugin-telegram/__tests__/membership-readd-restart.real.test.ts
+++ b/plugins/plugin-telegram/__tests__/membership-readd-restart.real.test.ts
@@ -119,9 +119,9 @@ describe("bot re-add durability across restart", () => {
     // Restart: stop the first runtime, boot a second over the same DB.
     const cleanupIndex = cleanups.indexOf(first.harness.cleanup);
     if (cleanupIndex >= 0) cleanups.splice(cleanupIndex, 1);
-    // error-policy:J6 Best-effort teardown: a stop() rejection during test
-    // cleanup must not mask the assertions below.
-    await first.harness.runtime.stop().catch(() => {});
+    // Successful shutdown is part of the tested restart contract: the
+    // second runtime must not boot while the first still holds PGlite.
+    await first.harness.runtime.stop();
     const second = await bootAuthority(dir);
 
     // PRE-re-add evidence (backlogged, stamped before the re-add moment)
@@ -234,9 +234,9 @@ describe("bot re-add durability across restart", () => {
     // this distinction when both writes land in the same millisecond.
     const cleanupIndex = cleanups.indexOf(first.harness.cleanup);
     if (cleanupIndex >= 0) cleanups.splice(cleanupIndex, 1);
-    // error-policy:J6 Best-effort teardown: a stop() rejection during test
-    // cleanup must not mask the assertions below.
-    await first.harness.runtime.stop().catch(() => {});
+    // Successful shutdown is part of the tested restart contract: the
+    // second runtime must not boot while the first still holds PGlite.
+    await first.harness.runtime.stop();
     const second = await bootAuthority(dir);
 
     await recordJoin(second.authority, 2, new Date().toISOString());
@@ -305,9 +305,9 @@ describe("bot re-add durability across restart", () => {
     // hydration and fresh evidence recovers admission.
     const cleanupIndex = cleanups.indexOf(first.harness.cleanup);
     if (cleanupIndex >= 0) cleanups.splice(cleanupIndex, 1);
-    // error-policy:J6 Best-effort teardown: a stop() rejection during test
-    // cleanup must not mask the assertions below.
-    await first.harness.runtime.stop().catch(() => {});
+    // Successful shutdown is part of the tested restart contract: the
+    // second runtime must not boot while the first still holds PGlite.
+    await first.harness.runtime.stop();
     const second = await bootAuthority(dir);
 
     const realGetCache = second.harness.runtime.getCache.bind(
@@ -424,7 +424,11 @@ describe("bot re-add durability across restart", () => {
         chatRoomKey: String(CHAT_ID),
       }),
       "undurable re-add clear must throw to the caller",
-    ).rejects.toThrow();
+    ).rejects.toMatchObject({
+      name: "ElizaError",
+      code: "TELEGRAM_MEMBERSHIP_READD_WATERMARK_UNDURABLE",
+      cause: { message: "simulated persistent cache outage" },
+    });
 
     // THIS process is still protected: the in-memory watermark denies
     // backlogged pre-re-add evidence...

--- a/plugins/plugin-telegram/__tests__/membership-readd-restart.real.test.ts
+++ b/plugins/plugin-telegram/__tests__/membership-readd-restart.real.test.ts
@@ -1,15 +1,13 @@
 /**
- * Regression test for the re-add-then-restart durability gap in the
- * Telegram membership authority (PR #28715 review round, mashingaan
- * 2026-09-02): clearScopeRemoval persists a durable re-add watermark in the
- * runtime cache, so a process restart between the bot re-add and the next
- * fresh evidence write no longer re-hydrates the bot-removal tombstone from
- * the stale persisted "unavailable" scope health (the bot is already
- * present, so no second my_chat_member re-add transition would ever arrive
- * to clear it). Pre-re-add backlogged evidence stays denied through the
+ * Real-PGlite regression: a bot re-add followed by a process restart before
+ * the next fresh evidence write must not re-hydrate the bot-removal
+ * tombstone from the stale persisted "unavailable" scope health (the bot is
+ * already present, so no second my_chat_member re-add transition would ever
+ * arrive to clear it). Fresh post-re-add evidence recovers admission after
+ * re-instantiation; pre-re-add backlogged evidence stays denied through the
  * re-hydrated in-memory watermark.
  *
- * Real-PGlite harness identical to __tests__/membership-authority.real.test.ts:
+ * Harness identical to __tests__/membership-authority.real.test.ts:
  * real AgentRuntime + real SqlMembershipService; restart simulated by
  * stopping the first runtime and booting a second over the same PGlite dir.
  */
@@ -18,7 +16,7 @@ import {
   createTestRuntimeWithModelProvider,
   type ModelProviderTestRuntime,
 } from "@elizaos/core/testing";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 const cleanups: Array<() => Promise<void>> = [];
 
@@ -86,7 +84,8 @@ describe("bot re-add durability across restart", () => {
     );
 
     // Process 1: member joins, bot is removed (persists unavailable),
-    // then the bot is re-added (clearScopeRemoval — in-memory only).
+    // then the bot is re-added (clearScopeRemoval persists the re-add
+    // watermark durably).
     const first = await bootAuthority(dir);
     const entityId = (await resolveTelegramRuntimeEntityId(
       first.harness.runtime,
@@ -149,8 +148,7 @@ describe("bot re-add durability across restart", () => {
     ).toBe("denied");
 
     // FRESH evidence (stamped after the re-add) must recover admission
-    // even after the restart — this is the gap: today the re-hydrated
-    // tombstone rejects it indefinitely.
+    // even after the restart.
     await second.authority.recordEvent({
       chatId: String(CHAT_ID),
       chatRoomKey: String(CHAT_ID),
@@ -171,6 +169,303 @@ describe("bot re-add durability across restart", () => {
       freshDecision.decision,
       "fresh post-re-add evidence must recover admission after a restart",
     ).toBe("allowed");
+
+    cleanups.push(async () => {
+      await fs.rm(dir, { recursive: true, force: true });
+    });
+  }, 120_000);
+
+  it("a removal AFTER the re-add still re-hydrates the tombstone across restart (generation fence, no wall clock)", async () => {
+    const fs = await import("node:fs/promises");
+    const dir = await fs.mkdtemp("/tmp/tg-membership-readd-restart-");
+    const { resolveTelegramRuntimeEntityId } = await import(
+      "@elizaos/plugin-telegram"
+    );
+
+    // Cycle 1: join -> remove -> re-add (clear persists watermark for the
+    // removal generation it repaired). Cycle 2: the bot is removed AGAIN —
+    // the new unavailable row carries a strictly greater generation, so the
+    // persisted watermark must NOT suppress the tombstone after restart.
+    const first = await bootAuthority(dir);
+    const entityId = (await resolveTelegramRuntimeEntityId(
+      first.harness.runtime,
+      "default",
+      String(MEMBER_TG_ID),
+    )) as UUID;
+    await ensurePrincipal(first.harness, entityId);
+    const runtimeMap = { worldId: null, roomId: null, entityId };
+    const recordJoin = async (
+      authority: import("@elizaos/plugin-telegram").TelegramMembershipAuthority,
+      messageId: number,
+      observedAt: string,
+    ) => {
+      await authority.recordEvent({
+        chatId: String(CHAT_ID),
+        chatRoomKey: String(CHAT_ID),
+        canonicalPrincipalId: entityId,
+        state: "active",
+        reason: "joined",
+        messageId,
+        telegramUserId: String(MEMBER_TG_ID),
+        runtime: runtimeMap,
+        observedAt,
+      });
+    };
+
+    await recordJoin(first.authority, 1, new Date().toISOString());
+    await first.authority.markScopeUnavailable({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      reason: "bot_removed",
+    });
+    await first.authority.clearScopeRemoval({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+    });
+    await first.authority.markScopeUnavailable({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      reason: "bot_removed_again",
+    });
+
+    // Restart and try fresh evidence: the second removal's generation is
+    // strictly greater than the watermark's, so the tombstone re-hydrates
+    // and admission must stay denied — a wall-clock comparison cannot make
+    // this distinction when both writes land in the same millisecond.
+    const cleanupIndex = cleanups.indexOf(first.harness.cleanup);
+    if (cleanupIndex >= 0) cleanups.splice(cleanupIndex, 1);
+    // error-policy:J6 Best-effort teardown: a stop() rejection during test
+    // cleanup must not mask the assertions below.
+    await first.harness.runtime.stop().catch(() => {});
+    const second = await bootAuthority(dir);
+
+    await recordJoin(second.authority, 2, new Date().toISOString());
+    const decision = await second.authority.authorize({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+    });
+    expect(
+      decision.decision,
+      "evidence after a post-re-add removal must stay denied after restart",
+    ).toBe("denied");
+
+    cleanups.push(async () => {
+      await fs.rm(dir, { recursive: true, force: true });
+    });
+  }, 120_000);
+
+  it("a transient watermark cache READ failure denies that attempt without cementing the tombstone", async () => {
+    const fs = await import("node:fs/promises");
+    const dir = await fs.mkdtemp("/tmp/tg-membership-readd-restart-");
+    const { resolveTelegramRuntimeEntityId } = await import(
+      "@elizaos/plugin-telegram"
+    );
+
+    const first = await bootAuthority(dir);
+    const entityId = (await resolveTelegramRuntimeEntityId(
+      first.harness.runtime,
+      "default",
+      String(MEMBER_TG_ID),
+    )) as UUID;
+    await ensurePrincipal(first.harness, entityId);
+    const runtimeMap = { worldId: null, roomId: null, entityId };
+    const recordJoin = async (
+      observedAt: string,
+      messageId: number,
+    ): Promise<void> => {
+      await first.authority.recordEvent({
+        chatId: String(CHAT_ID),
+        chatRoomKey: String(CHAT_ID),
+        canonicalPrincipalId: entityId,
+        state: "active",
+        reason: "joined",
+        messageId,
+        telegramUserId: String(MEMBER_TG_ID),
+        runtime: runtimeMap,
+        observedAt,
+      });
+    };
+
+    await recordJoin(new Date().toISOString(), 1);
+    await first.authority.markScopeUnavailable({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      reason: "bot_removed",
+    });
+    await first.authority.clearScopeRemoval({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+    });
+
+    // Restart. First recordEvent after restart: the watermark cache read
+    // throws once — that attempt must fail closed (recordEvent returns
+    // false, no evidence write) WITHOUT setting the in-memory tombstone, so
+    // the next attempt (cache recovered) allows the watermark to suppress
+    // hydration and fresh evidence recovers admission.
+    const cleanupIndex = cleanups.indexOf(first.harness.cleanup);
+    if (cleanupIndex >= 0) cleanups.splice(cleanupIndex, 1);
+    // error-policy:J6 Best-effort teardown: a stop() rejection during test
+    // cleanup must not mask the assertions below.
+    await first.harness.runtime.stop().catch(() => {});
+    const second = await bootAuthority(dir);
+
+    const realGetCache = second.harness.runtime.getCache.bind(
+      second.harness.runtime,
+    );
+    let failNextWatermarkRead = true;
+    const watermarkKeyFragment = "telegram:membership:readd-watermark:";
+    vi.spyOn(second.harness.runtime, "getCache").mockImplementation(
+      async (key: string) => {
+        if (failNextWatermarkRead && key.startsWith(watermarkKeyFragment)) {
+          failNextWatermarkRead = false;
+          throw new Error("simulated transient cache outage");
+        }
+        return realGetCache(key);
+      },
+    );
+
+    const firstAttempt = await second.authority.recordEvent({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+      state: "active",
+      reason: "joined",
+      messageId: 2,
+      telegramUserId: String(MEMBER_TG_ID),
+      runtime: runtimeMap,
+      observedAt: new Date().toISOString(),
+    });
+    expect(firstAttempt).toBeUndefined();
+    const deniedDecision = await second.authority.authorize({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+    });
+    expect(
+      deniedDecision.decision,
+      "cache-read failure must fail this evidence attempt closed",
+    ).toBe("denied");
+
+    const secondAttempt = await second.authority.recordEvent({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+      state: "active",
+      reason: "joined",
+      messageId: 3,
+      telegramUserId: String(MEMBER_TG_ID),
+      runtime: runtimeMap,
+      observedAt: new Date().toISOString(),
+    });
+    expect(secondAttempt).toBeUndefined();
+    const decision = await second.authority.authorize({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+    });
+    expect(
+      decision.decision,
+      "recovered cache read must retry hydration, not replay a cemented tombstone",
+    ).toBe("allowed");
+
+    cleanups.push(async () => {
+      await fs.rm(dir, { recursive: true, force: true });
+    });
+  }, 120_000);
+
+  it("clearScopeRemoval THROWS when the watermark cannot be made durable; in-memory watermark still carries this process", async () => {
+    const fs = await import("node:fs/promises");
+    const dir = await fs.mkdtemp("/tmp/tg-membership-readd-restart-");
+    const { resolveTelegramRuntimeEntityId } = await import(
+      "@elizaos/plugin-telegram"
+    );
+
+    const first = await bootAuthority(dir);
+    const entityId = (await resolveTelegramRuntimeEntityId(
+      first.harness.runtime,
+      "default",
+      String(MEMBER_TG_ID),
+    )) as UUID;
+    await ensurePrincipal(first.harness, entityId);
+    const runtimeMap = { worldId: null, roomId: null, entityId };
+    await first.authority.recordEvent({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+      state: "active",
+      reason: "joined",
+      messageId: 1,
+      telegramUserId: String(MEMBER_TG_ID),
+      runtime: runtimeMap,
+      observedAt: new Date().toISOString(),
+    });
+    await first.authority.markScopeUnavailable({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      reason: "bot_removed",
+    });
+
+    // Every watermark write rejects: clearScopeRemoval must surface the
+    // durability failure to the re-add caller instead of silently
+    // succeeding.
+    const watermarkKeyFragment = "telegram:membership:readd-watermark:";
+    vi.spyOn(first.harness.runtime, "setCache").mockImplementation(
+      async (key: string) => {
+        if (key.startsWith(watermarkKeyFragment)) {
+          throw new Error("simulated persistent cache outage");
+        }
+        return true;
+      },
+    );
+    await expect(
+      first.authority.clearScopeRemoval({
+        chatId: String(CHAT_ID),
+        chatRoomKey: String(CHAT_ID),
+      }),
+      "undurable re-add clear must throw to the caller",
+    ).rejects.toThrow();
+
+    // THIS process is still protected: the in-memory watermark denies
+    // backlogged pre-re-add evidence...
+    await first.authority.recordEvent({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+      state: "active",
+      reason: "joined",
+      messageId: 2,
+      telegramUserId: String(MEMBER_TG_ID),
+      runtime: runtimeMap,
+      observedAt: new Date(Date.now() - 60_000).toISOString(),
+    });
+    const backlogged = await first.authority.authorize({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+    });
+    expect(
+      backlogged.decision,
+      "backlogged evidence stays denied in-process",
+    ).toBe("denied");
+    // ...and fresh post-re-add evidence recovers admission in-process.
+    await first.authority.recordEvent({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+      state: "active",
+      reason: "joined",
+      messageId: 3,
+      telegramUserId: String(MEMBER_TG_ID),
+      runtime: runtimeMap,
+      observedAt: new Date().toISOString(),
+    });
+    const decision = await first.authority.authorize({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+    });
+    expect(decision.decision).toBe("allowed");
 
     cleanups.push(async () => {
       await fs.rm(dir, { recursive: true, force: true });

--- a/plugins/plugin-telegram/__tests__/membership-readd-restart.real.test.ts
+++ b/plugins/plugin-telegram/__tests__/membership-readd-restart.real.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Regression test for the re-add-then-restart durability gap in the
+ * Telegram membership authority (PR #28715 review round, mashingaan
+ * 2026-09-02): clearScopeRemoval persists a durable re-add watermark in the
+ * runtime cache, so a process restart between the bot re-add and the next
+ * fresh evidence write no longer re-hydrates the bot-removal tombstone from
+ * the stale persisted "unavailable" scope health (the bot is already
+ * present, so no second my_chat_member re-add transition would ever arrive
+ * to clear it). Pre-re-add backlogged evidence stays denied through the
+ * re-hydrated in-memory watermark.
+ *
+ * Real-PGlite harness identical to __tests__/membership-authority.real.test.ts:
+ * real AgentRuntime + real SqlMembershipService; restart simulated by
+ * stopping the first runtime and booting a second over the same PGlite dir.
+ */
+import type { UUID } from "@elizaos/core";
+import {
+  createTestRuntimeWithModelProvider,
+  type ModelProviderTestRuntime,
+} from "@elizaos/core/testing";
+import { afterEach, describe, expect, it } from "vitest";
+
+const cleanups: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  while (cleanups.length > 0) {
+    const cleanup = cleanups.pop();
+    if (cleanup) await cleanup();
+  }
+});
+
+const CHAT_ID = -3101;
+const MEMBER_TG_ID = 655_001;
+
+async function bootAuthority(pgliteDir: string) {
+  const harness = await createTestRuntimeWithModelProvider({ pgliteDir });
+  cleanups.push(harness.cleanup);
+  const membershipService = harness.runtime.getService(
+    "membership",
+  ) as import("@elizaos/core").MembershipService;
+  const { getConnectorAccountManager } = await import("@elizaos/core");
+  const manager = await getConnectorAccountManager(harness.runtime);
+  const stored = await manager.upsertAccount("telegram", {
+    id: "telegram-910001",
+    provider: "telegram",
+    label: "Telegram bot 910001",
+    role: "AGENT",
+    purpose: ["messaging"],
+    accessGate: "open",
+    status: "connected",
+    externalId: "910001",
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  });
+  if (!stored.id) throw new Error("connector account upsert returned no id");
+  const { TelegramMembershipAuthority } = await import(
+    "@elizaos/plugin-telegram"
+  );
+  const authority = new TelegramMembershipAuthority({
+    runtime: harness.runtime,
+    connectorAccountId: stored.id as UUID,
+    service: membershipService,
+  });
+  return { harness, authority };
+}
+
+async function ensurePrincipal(
+  harness: ModelProviderTestRuntime,
+  entityId: UUID,
+): Promise<void> {
+  const created = await harness.runtime.createEntity({
+    id: entityId,
+    agentId: harness.runtime.agentId,
+    names: ["Re-add Restart Probe User"],
+    metadata: {},
+  });
+  if (!created) throw new Error("test principal entity creation failed");
+}
+
+describe("bot re-add durability across restart", () => {
+  it("fresh post-re-add evidence recovers admission after a restart, while pre-re-add evidence stays denied", async () => {
+    const fs = await import("node:fs/promises");
+    const dir = await fs.mkdtemp("/tmp/tg-membership-readd-restart-");
+    const { resolveTelegramRuntimeEntityId } = await import(
+      "@elizaos/plugin-telegram"
+    );
+
+    // Process 1: member joins, bot is removed (persists unavailable),
+    // then the bot is re-added (clearScopeRemoval — in-memory only).
+    const first = await bootAuthority(dir);
+    const entityId = (await resolveTelegramRuntimeEntityId(
+      first.harness.runtime,
+      "default",
+      String(MEMBER_TG_ID),
+    )) as UUID;
+    await ensurePrincipal(first.harness, entityId);
+    const runtimeMap = { worldId: null, roomId: null, entityId };
+
+    await first.authority.recordEvent({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+      state: "active",
+      reason: "joined",
+      messageId: 1,
+      telegramUserId: String(MEMBER_TG_ID),
+      runtime: runtimeMap,
+      observedAt: new Date().toISOString(),
+    });
+    await first.authority.markScopeUnavailable({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      reason: "bot_removed",
+    });
+    await first.authority.clearScopeRemoval({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+    });
+
+    // Restart: stop the first runtime, boot a second over the same DB.
+    const cleanupIndex = cleanups.indexOf(first.harness.cleanup);
+    if (cleanupIndex >= 0) cleanups.splice(cleanupIndex, 1);
+    // error-policy:J6 Best-effort teardown: a stop() rejection during test
+    // cleanup must not mask the assertions below.
+    await first.harness.runtime.stop().catch(() => {});
+    const second = await bootAuthority(dir);
+
+    // PRE-re-add evidence (backlogged, stamped before the re-add moment)
+    // must stay denied.
+    await second.authority.recordEvent({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+      state: "active",
+      reason: "joined",
+      messageId: 2,
+      telegramUserId: String(MEMBER_TG_ID),
+      runtime: runtimeMap,
+      observedAt: new Date(Date.now() - 60_000).toISOString(),
+    });
+    const backloggedDecision = await second.authority.authorize({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+    });
+    expect(
+      backloggedDecision.decision,
+      "backlogged pre-re-add evidence must not authorize after restart",
+    ).toBe("denied");
+
+    // FRESH evidence (stamped after the re-add) must recover admission
+    // even after the restart — this is the gap: today the re-hydrated
+    // tombstone rejects it indefinitely.
+    await second.authority.recordEvent({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+      state: "active",
+      reason: "joined",
+      messageId: 3,
+      telegramUserId: String(MEMBER_TG_ID),
+      runtime: runtimeMap,
+      observedAt: new Date().toISOString(),
+    });
+    const freshDecision = await second.authority.authorize({
+      chatId: String(CHAT_ID),
+      chatRoomKey: String(CHAT_ID),
+      canonicalPrincipalId: entityId,
+    });
+    expect(
+      freshDecision.decision,
+      "fresh post-re-add evidence must recover admission after a restart",
+    ).toBe("allowed");
+
+    cleanups.push(async () => {
+      await fs.rm(dir, { recursive: true, force: true });
+    });
+  }, 120_000);
+});

--- a/plugins/plugin-telegram/src/index.ts
+++ b/plugins/plugin-telegram/src/index.ts
@@ -99,6 +99,15 @@ export * from "./accounts";
 export * from "./connector-account-provider";
 export * from "./identity";
 export * from "./local-client";
+export {
+  TELEGRAM_MEMBERSHIP_TTL_MS,
+  TelegramMembershipAuthority,
+  type TelegramMembershipReason,
+  telegramMemberRoles,
+  telegramMembershipScope,
+  telegramObservedAt,
+  telegramStatusToMembership,
+} from "./membership";
 export * from "./poller-lock";
 export type { TelegramStandaloneContext } from "./standalone/handler";
 export { handleTelegramStandaloneMessage } from "./standalone/handler";

--- a/plugins/plugin-telegram/src/membership-gate-bootstrap.test.ts
+++ b/plugins/plugin-telegram/src/membership-gate-bootstrap.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Unit coverage for the bootstrap-failure contract of the Telegram
+ * membership gate factory: an absent authority service resolves to null
+ * (legacy degrade mode) while a connector-account bootstrap FAILURE throws
+ * (the service marks the admission gate broken; group admission fails
+ * closed). Deterministic mocked harness; the real-PGlite authority vertical
+ * lives in __tests__/membership-authority.real.test.ts.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { createTelegramMembershipGate } from "./membership-gate";
+
+const membershipLikeService = {
+  registerPublisher: vi.fn(),
+  authorize: vi.fn(),
+};
+
+function runtime(overrides?: {
+  getService?: () => unknown;
+  getConnectorAccountManager?: () => unknown;
+}): IAgentRuntime {
+  return {
+    agentId: "00000000-0000-0000-0000-0000000000aa",
+    getService: vi.fn(overrides?.getService ?? (() => membershipLikeService)),
+    getConnectorAccountManager:
+      overrides?.getConnectorAccountManager ??
+      (() => ({
+        upsertAccount: () =>
+          Promise.reject(new Error("connector store unavailable")),
+      })),
+  } as unknown as IAgentRuntime;
+}
+
+describe("createTelegramMembershipGate bootstrap failure contract", () => {
+  it("resolves null when the authority service is absent (legacy degrade mode)", async () => {
+    const gate = await createTelegramMembershipGate({
+      runtime: runtime({ getService: () => null }),
+      botTelegramUserId: "42",
+    });
+    expect(gate).toBeNull();
+  });
+
+  it("THROWS on connector-account bootstrap failure (fail-closed contract, not null)", async () => {
+    await expect(
+      createTelegramMembershipGate({
+        runtime: runtime(),
+        botTelegramUserId: "42",
+      }),
+    ).rejects.toThrow(/bootstrap failed/i);
+  });
+});

--- a/plugins/plugin-telegram/src/membership-gate.test.ts
+++ b/plugins/plugin-telegram/src/membership-gate.test.ts
@@ -7,6 +7,7 @@
  * lives in __tests__/membership-authority.real.test.ts.
  */
 import type { IAgentRuntime, UUID } from "@elizaos/core";
+import { logger } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { TelegramMembershipMessageGate } from "./membership-gate";
 
@@ -74,16 +75,49 @@ describe("TelegramMembershipMessageGate without an authority service", () => {
       authority: null,
       botTelegramUserId: null,
     });
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+    // Unique chat ids + message+context filtering: the structured logger
+    // flushes asynchronously, so calls buffered by earlier tests can land
+    // while this spy is attached and must not be counted.
+    const absentWarns = (chatId: string) =>
+      warnSpy.mock.calls.filter(
+        (call) =>
+          call[call.length - 1] ===
+            "Telegram group admission running without a membership authority service; membership checks disabled" &&
+          (call[0] as { chatId?: string })?.chatId === chatId,
+      );
     try {
-      await gate.authorizeMessage(decisionInput());
-      await gate.authorizeMessage(decisionInput());
+      const first = decisionInput();
+      first.chatId = "-9101";
+      first.chatRoomKey = "-9101";
+      const sameChatOtherSender = decisionInput({ telegramUserId: "43" });
+      sameChatOtherSender.chatId = "-9101";
+      sameChatOtherSender.chatRoomKey = "-9101";
+      await gate.authorizeMessage(first);
+      await gate.authorizeMessage(first);
+      await gate.authorizeMessage(sameChatOtherSender);
+      expect(absentWarns("-9101").length).toBe(1);
+      // A different chat warns independently.
+      const otherChat = decisionInput();
+      otherChat.chatId = "-9102";
+      otherChat.chatRoomKey = "-9102";
+      await gate.authorizeMessage(otherChat);
+      expect(absentWarns("-9102").length).toBe(1);
+      expect(absentWarns("-9101").length).toBe(1);
     } finally {
       warnSpy.mockRestore();
     }
-    // The once-per-chat contract is internal (this.warned); asserting on the
-    // observable behavior (both admissions allowed) plus no thrown errors.
-    expect(true).toBe(true);
+  });
+
+  it("fails closed after markBroken (authority configured but bootstrap failed)", async () => {
+    delete process.env.TELEGRAM_MEMBERSHIP_ENFORCE;
+    const gate = new TelegramMembershipMessageGate({
+      runtime: gateRuntime(),
+      authority: null,
+      botTelegramUserId: null,
+    });
+    gate.markBroken();
+    await expect(gate.authorizeMessage(decisionInput())).resolves.toBe(false);
   });
 
   it("admits the bot's own messages without consulting any authority", async () => {

--- a/plugins/plugin-telegram/src/membership-gate.test.ts
+++ b/plugins/plugin-telegram/src/membership-gate.test.ts
@@ -67,6 +67,42 @@ describe("TelegramMembershipMessageGate without an authority service", () => {
     await expect(gate.authorizeMessage(decisionInput())).resolves.toBe(false);
   });
 
+  it.each(["true", "yes", "y", "on", "enabled"])(
+    "fails closed for the canonical truthy spelling %s (isTruthyEnvValue parity)",
+    async (spelling) => {
+      process.env.TELEGRAM_MEMBERSHIP_ENFORCE = spelling;
+      const gate = new TelegramMembershipMessageGate({
+        runtime: gateRuntime(),
+        authority: null,
+        botTelegramUserId: null,
+      });
+      await expect(gate.authorizeMessage(decisionInput())).resolves.toBe(false);
+    },
+  );
+
+  it("fails closed for TELEGRAM_MEMBERSHIP_ENFORCE with surrounding whitespace or mixed case", async () => {
+    process.env.TELEGRAM_MEMBERSHIP_ENFORCE = "  TRUE \n";
+    const gate = new TelegramMembershipMessageGate({
+      runtime: gateRuntime(),
+      authority: null,
+      botTelegramUserId: null,
+    });
+    await expect(gate.authorizeMessage(decisionInput())).resolves.toBe(false);
+  });
+
+  it.each(["0", "false", "no", "off", "", "enable", "totally"])(
+    "degrades to allow for the non-truthy value %s (no strict opt-in)",
+    async (value) => {
+      process.env.TELEGRAM_MEMBERSHIP_ENFORCE = value;
+      const gate = new TelegramMembershipMessageGate({
+        runtime: gateRuntime(),
+        authority: null,
+        botTelegramUserId: null,
+      });
+      await expect(gate.authorizeMessage(decisionInput())).resolves.toBe(true);
+    },
+  );
+
   it("warns once per chat, not per message", async () => {
     delete process.env.TELEGRAM_MEMBERSHIP_ENFORCE;
     const runtime = gateRuntime();

--- a/plugins/plugin-telegram/src/membership-gate.test.ts
+++ b/plugins/plugin-telegram/src/membership-gate.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Unit coverage for the Telegram membership admission gate's degradation
+ * semantics: a deployment without a membership authority service degrades to
+ * allow with a once-per-chat warning (availability), while
+ * TELEGRAM_MEMBERSHIP_ENFORCE=1 opts into strict fail-closed admission
+ * (security). Deterministic unit harness; the real-PGlite authority vertical
+ * lives in __tests__/membership-authority.real.test.ts.
+ */
+import type { IAgentRuntime, UUID } from "@elizaos/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TelegramMembershipMessageGate } from "./membership-gate";
+
+function gateRuntime() {
+  return {
+    agentId: "agent-1",
+    reportError: vi.fn(),
+  } as unknown as IAgentRuntime;
+}
+
+function decisionInput(overrides?: {
+  telegramUserId?: string;
+}): Parameters<TelegramMembershipMessageGate["authorizeMessage"]>[0] {
+  return {
+    chatId: "-100",
+    chatRoomKey: "-100",
+    chatType: "group",
+    principalEntityId: "00000000-0000-0000-0000-000000000001" as UUID,
+    telegramUserId: overrides?.telegramUserId ?? "42",
+    runtimeMapping: {
+      worldId: null,
+      roomId: null,
+      entityId: null,
+    },
+    getChatMember: async () => ({ status: "member", user: { id: 42 } }),
+  };
+}
+
+const ORIGINAL_ENFORCE = process.env.TELEGRAM_MEMBERSHIP_ENFORCE;
+
+afterEach(() => {
+  if (ORIGINAL_ENFORCE === undefined) {
+    delete process.env.TELEGRAM_MEMBERSHIP_ENFORCE;
+  } else {
+    process.env.TELEGRAM_MEMBERSHIP_ENFORCE = ORIGINAL_ENFORCE;
+  }
+});
+
+describe("TelegramMembershipMessageGate without an authority service", () => {
+  it("degrades to allow group admission with a warning (availability)", async () => {
+    delete process.env.TELEGRAM_MEMBERSHIP_ENFORCE;
+    const gate = new TelegramMembershipMessageGate({
+      runtime: gateRuntime(),
+      authority: null,
+      botTelegramUserId: null,
+    });
+    await expect(gate.authorizeMessage(decisionInput())).resolves.toBe(true);
+  });
+
+  it("fails closed when TELEGRAM_MEMBERSHIP_ENFORCE=1 opts into strict mode", async () => {
+    process.env.TELEGRAM_MEMBERSHIP_ENFORCE = "1";
+    const gate = new TelegramMembershipMessageGate({
+      runtime: gateRuntime(),
+      authority: null,
+      botTelegramUserId: null,
+    });
+    await expect(gate.authorizeMessage(decisionInput())).resolves.toBe(false);
+  });
+
+  it("warns once per chat, not per message", async () => {
+    delete process.env.TELEGRAM_MEMBERSHIP_ENFORCE;
+    const runtime = gateRuntime();
+    const gate = new TelegramMembershipMessageGate({
+      runtime,
+      authority: null,
+      botTelegramUserId: null,
+    });
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      await gate.authorizeMessage(decisionInput());
+      await gate.authorizeMessage(decisionInput());
+    } finally {
+      warnSpy.mockRestore();
+    }
+    // The once-per-chat contract is internal (this.warned); asserting on the
+    // observable behavior (both admissions allowed) plus no thrown errors.
+    expect(true).toBe(true);
+  });
+
+  it("admits the bot's own messages without consulting any authority", async () => {
+    const gate = new TelegramMembershipMessageGate({
+      runtime: gateRuntime(),
+      authority: null,
+      botTelegramUserId: "900001",
+    });
+    await expect(
+      gate.authorizeMessage(decisionInput({ telegramUserId: "900001" })),
+    ).resolves.toBe(true);
+  });
+});

--- a/plugins/plugin-telegram/src/membership-gate.test.ts
+++ b/plugins/plugin-telegram/src/membership-gate.test.ts
@@ -166,4 +166,68 @@ describe("TelegramMembershipMessageGate without an authority service", () => {
       gate.authorizeMessage(decisionInput({ telegramUserId: "900001" })),
     ).resolves.toBe(true);
   });
+
+  it("breaks the gate (fail-closed thereafter) when a revoked reconcile escalates REVOCATION_UNSAFE", async () => {
+    delete process.env.TELEGRAM_MEMBERSHIP_ENFORCE;
+    const runtime = gateRuntime();
+    // A deterministic authority double whose authorize returns a
+    // reconcile-miss denial and whose revoked reconcile fails UNSAFE — the
+    // class the real authority throws when neither the evidence write nor
+    // the fail-closed stale-degrade can land.
+    const reconcile = vi.fn(async () => {
+      throw new (await import("@elizaos/core")).ElizaError(
+        "Telegram membership revocation could not be committed or degraded",
+        { code: "TELEGRAM_MEMBERSHIP_REVOCATION_UNSAFE" },
+      );
+    });
+    const authorize = vi.fn(async () => ({
+      decision: "denied",
+      reason: "no_scope_evidence",
+      generation: null,
+      health: null,
+    }));
+    const gate = new TelegramMembershipMessageGate({
+      runtime,
+      authority: { reconcile, authorize } as unknown as never,
+      botTelegramUserId: "900001",
+    });
+
+    // First message: denied through the UNSAFE escalation, gate marked broken.
+    await expect(gate.authorizeMessage(decisionInput())).resolves.toBe(false);
+    expect(reconcile).toHaveBeenCalledTimes(1);
+    expect(
+      runtime.reportError,
+      "the unsafe escalation is reported at the connector boundary",
+    ).toHaveBeenCalledTimes(1);
+
+    // Later messages from the same principal fail closed at the broken
+    // short-circuit — neither authorize nor reconcile runs again.
+    await expect(gate.authorizeMessage(decisionInput())).resolves.toBe(false);
+    expect(authorize).toHaveBeenCalledTimes(1);
+    expect(
+      reconcile,
+      "a broken gate must not reconsult reconcile",
+    ).toHaveBeenCalledTimes(1);
+
+    // A non-UNSAFE reconcile failure is NOT a gate-break: it propagates so
+    // the poll-loop boundary observes it (same boundary as authorize).
+    const propagating = new TelegramMembershipMessageGate({
+      runtime,
+      authority: {
+        reconcile: vi.fn(async () => {
+          throw new Error("provider transport failed");
+        }),
+        authorize,
+      } as unknown as never,
+      botTelegramUserId: "900001",
+    });
+    await expect(propagating.authorizeMessage(decisionInput())).rejects.toThrow(
+      "provider transport failed",
+    );
+    // The transport-failure gate was never marked broken: admission (which
+    // would hit reconcile again) still runs its authority path.
+    await expect(propagating.authorizeMessage(decisionInput())).rejects.toThrow(
+      "provider transport failed",
+    );
+  });
 });

--- a/plugins/plugin-telegram/src/membership-gate.test.ts
+++ b/plugins/plugin-telegram/src/membership-gate.test.ts
@@ -231,3 +231,72 @@ describe("TelegramMembershipMessageGate without an authority service", () => {
     );
   });
 });
+
+describe("TelegramMembershipMessageGate durable re-add recovery", () => {
+  function unavailableDenial() {
+    return {
+      decision: "denied" as const,
+      reason: "authority_unavailable",
+      generation: 3,
+      health: "unavailable",
+    };
+  }
+
+  it("an authority_unavailable denial without durable re-add proof stays denied and never reconciles", async () => {
+    delete process.env.TELEGRAM_MEMBERSHIP_ENFORCE;
+    const reconcile = vi.fn(async () => ({ state: "active", reason: "ok" }));
+    const readdedAfterUnavailable = vi.fn(async () => false);
+    const authorize = vi.fn(async () => unavailableDenial());
+    const gate = new TelegramMembershipMessageGate({
+      runtime: gateRuntime(),
+      authority: {
+        authorize,
+        reconcile,
+        readdedAfterUnavailable,
+      } as unknown as never,
+      botTelegramUserId: null,
+    });
+    const getChatMember = vi.fn(async () => ({
+      status: "member",
+      user: { id: 42 },
+    }));
+    const input = decisionInput();
+    input.getChatMember = getChatMember;
+    await expect(gate.authorizeMessage(input)).resolves.toBe(false);
+    expect(readdedAfterUnavailable).toHaveBeenCalledTimes(1);
+    expect(reconcile).not.toHaveBeenCalled();
+    expect(getChatMember).not.toHaveBeenCalled();
+  });
+
+  it("an authority_unavailable denial WITH durable re-add proof reconciles through getChatMember", async () => {
+    delete process.env.TELEGRAM_MEMBERSHIP_ENFORCE;
+    const reconcile = vi.fn(async () => ({ state: "active", reason: "ok" }));
+    const readdedAfterUnavailable = vi.fn(async () => true);
+    const authorize = vi.fn(async () => unavailableDenial());
+    const gate = new TelegramMembershipMessageGate({
+      runtime: gateRuntime(),
+      authority: {
+        authorize,
+        reconcile,
+        readdedAfterUnavailable,
+      } as unknown as never,
+      botTelegramUserId: null,
+    });
+    const getChatMember = vi.fn(async () => ({
+      status: "member",
+      user: { id: 42 },
+    }));
+    const input = decisionInput();
+    input.getChatMember = getChatMember;
+    // authorize is consulted a second time after the reconcile commits fresh
+    // evidence; keep returning the denial so the result stays deterministic.
+    await expect(gate.authorizeMessage(input)).resolves.toBe(false);
+    expect(readdedAfterUnavailable).toHaveBeenCalledTimes(1);
+    // The gate hands its getChatMember through to the authority's reconcile
+    // (the real authority performs the provider point query inside it).
+    expect(reconcile).toHaveBeenCalledTimes(1);
+    expect(reconcile).toHaveBeenCalledWith(
+      expect.objectContaining({ getChatMember }),
+    );
+  });
+});

--- a/plugins/plugin-telegram/src/membership-gate.ts
+++ b/plugins/plugin-telegram/src/membership-gate.ts
@@ -58,12 +58,13 @@ export async function bootstrapTelegramMembershipAccount(input: {
     }
     return stored.id as UUID;
   } catch (error) {
-    // error-policy:J4 Bootstrap failure is reported once; membership admission
-    // stays fail-closed until a later boot succeeds.
-    input.runtime.reportError("telegram:membership-bootstrap", error, {
-      botTelegramUserId: input.botTelegramUserId,
+    // error-policy:J2 Bootstrap failure must stay distinguishable from an
+    // absent connector-account manager: wrap and rethrow so the service
+    // records a BROKEN gate (fail-closed group admission) instead of
+    // silently degrading to the absent-authority legacy allow mode.
+    throw new Error("Telegram membership connector-account bootstrap failed", {
+      cause: error,
     });
-    return null;
   }
 }
 

--- a/plugins/plugin-telegram/src/membership-gate.ts
+++ b/plugins/plugin-telegram/src/membership-gate.ts
@@ -6,7 +6,7 @@
  * the provider query cannot produce fresh evidence.
  */
 import type { UUID } from "@elizaos/core";
-import { logger } from "@elizaos/core";
+import { ElizaError, logger } from "@elizaos/core";
 import type { TelegramMembershipAuthority } from "./membership";
 import {
   resolveMembershipService,
@@ -46,15 +46,20 @@ export async function bootstrapTelegramMembershipAccount(input: {
       account,
     );
     if (!stored.id || !isUuidLike(stored.id)) {
-      logger.warn(
-        {
-          src: "plugin:telegram",
-          agentId: input.agentId,
-          botTelegramUserId: input.botTelegramUserId,
-        },
+      // The authority service IS configured, but its connector-account store
+      // returned a malformed result. This must NOT degrade to the
+      // absent-authority legacy allow mode (null): throw so the caller marks
+      // the admission gate broken and every group admission fails closed.
+      throw new ElizaError(
         "Telegram membership bootstrap received a non-UUID connector account id",
+        {
+          code: "TELEGRAM_MEMBERSHIP_BOOTSTRAP_INVALID_ACCOUNT",
+          context: {
+            botTelegramUserId: input.botTelegramUserId,
+            storedId: stored.id ?? null,
+          },
+        },
       );
-      return null;
     }
     return stored.id as UUID;
   } catch (error) {
@@ -62,9 +67,13 @@ export async function bootstrapTelegramMembershipAccount(input: {
     // absent connector-account manager: wrap and rethrow so the service
     // records a BROKEN gate (fail-closed group admission) instead of
     // silently degrading to the absent-authority legacy allow mode.
-    throw new Error("Telegram membership connector-account bootstrap failed", {
-      cause: error,
-    });
+    throw new ElizaError(
+      "Telegram membership connector-account bootstrap failed",
+      {
+        code: "TELEGRAM_MEMBERSHIP_BOOTSTRAP_FAILED",
+        cause: error,
+      },
+    );
   }
 }
 

--- a/plugins/plugin-telegram/src/membership-gate.ts
+++ b/plugins/plugin-telegram/src/membership-gate.ts
@@ -1,0 +1,267 @@
+/**
+ * Membership admission gate for inbound Telegram group/supergroup messages:
+ * consults the canonical membership authority, reconciles via `getChatMember`
+ * on evidence-miss denials (backfill for never-seen members, refresh for
+ * quiet scopes), re-authorizes once, and fails closed when the authority or
+ * the provider query cannot produce fresh evidence.
+ */
+import type { UUID } from "@elizaos/core";
+import { logger } from "@elizaos/core";
+import type { TelegramMembershipAuthority } from "./membership";
+import {
+  resolveMembershipService,
+  telegramMembershipShouldReconcile,
+} from "./membership";
+
+const CONNECTOR_ACCOUNT_PROVIDER = "telegram";
+
+/**
+ * Durable connector-account bootstrap: upserts the (agent, "telegram",
+ * <bot telegram user id>) row through the ConnectorAccountManager so the
+ * membership authority's connector-account FK resolves to a stable UUID.
+ */
+export async function bootstrapTelegramMembershipAccount(input: {
+  agentId: UUID;
+  botTelegramUserId: string;
+  runtime: import("@elizaos/core").IAgentRuntime;
+}): Promise<UUID | null> {
+  try {
+    const { getConnectorAccountManager } = await import("@elizaos/core");
+    const manager = getConnectorAccountManager(input.runtime);
+    const now = Date.now();
+    const account: import("@elizaos/core").ConnectorAccount = {
+      id: `telegram-${input.botTelegramUserId}`,
+      provider: CONNECTOR_ACCOUNT_PROVIDER,
+      label: `Telegram bot ${input.botTelegramUserId}`,
+      role: "AGENT",
+      purpose: ["messaging"],
+      accessGate: "open",
+      status: "connected",
+      externalId: input.botTelegramUserId,
+      createdAt: now,
+      updatedAt: now,
+    };
+    const stored = await manager.upsertAccount(
+      CONNECTOR_ACCOUNT_PROVIDER,
+      account,
+    );
+    if (!stored.id || !isUuidLike(stored.id)) {
+      logger.warn(
+        {
+          src: "plugin:telegram",
+          agentId: input.agentId,
+          botTelegramUserId: input.botTelegramUserId,
+        },
+        "Telegram membership bootstrap received a non-UUID connector account id",
+      );
+      return null;
+    }
+    return stored.id as UUID;
+  } catch (error) {
+    // error-policy:J4 Bootstrap failure is reported once; membership admission
+    // stays fail-closed until a later boot succeeds.
+    input.runtime.reportError("telegram:membership-bootstrap", error, {
+      botTelegramUserId: input.botTelegramUserId,
+    });
+    return null;
+  }
+}
+
+function isUuidLike(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+    value,
+  );
+}
+
+export interface TelegramMembershipGate {
+  authority: TelegramMembershipAuthority;
+  connectorAccountId: UUID;
+  botTelegramUserId: string;
+}
+
+/** Builds the per-account authority gate, or null when the authority service is absent. */
+export async function createTelegramMembershipGate(input: {
+  runtime: import("@elizaos/core").IAgentRuntime;
+  botTelegramUserId: string;
+}): Promise<TelegramMembershipGate | null> {
+  const service = resolveMembershipService(input.runtime);
+  if (!service) {
+    return null;
+  }
+  const connectorAccountId = await bootstrapTelegramMembershipAccount({
+    agentId: input.runtime.agentId,
+    botTelegramUserId: input.botTelegramUserId,
+    runtime: input.runtime,
+  });
+  if (!connectorAccountId) {
+    return null;
+  }
+  const { TelegramMembershipAuthority: Authority } = await import(
+    "./membership"
+  );
+  return {
+    authority: new Authority({
+      runtime: input.runtime,
+      connectorAccountId,
+      service,
+    }),
+    connectorAccountId,
+    botTelegramUserId: input.botTelegramUserId,
+  };
+}
+
+export interface TelegramMembershipGateDecisionInput {
+  chatId: string;
+  chatRoomKey: string;
+  chatType: string;
+  principalEntityId: UUID;
+  telegramUserId: string;
+  runtimeMapping: {
+    worldId: UUID | null;
+    roomId: UUID | null;
+    entityId: UUID | null;
+  };
+  getChatMember: () => Promise<{
+    status: string;
+    custom_title?: string;
+    user: { id: number };
+  }>;
+}
+
+export class TelegramMembershipMessageGate {
+  private readonly runtime: import("@elizaos/core").IAgentRuntime;
+  private authority: TelegramMembershipAuthority | null;
+  private botTelegramUserId: string | null;
+  private readonly warned = new Set<string>();
+  private reconcileNonce = 0;
+
+  constructor(input: {
+    runtime: import("@elizaos/core").IAgentRuntime;
+    authority: TelegramMembershipAuthority | null;
+    botTelegramUserId: string | null;
+  }) {
+    this.runtime = input.runtime;
+    this.authority = input.authority;
+    this.botTelegramUserId = input.botTelegramUserId;
+  }
+
+  /** Late-binds the authority client and bot identity once bootstrapped. */
+  rebind(
+    authority: TelegramMembershipAuthority,
+    botTelegramUserId: string,
+  ): void {
+    this.authority = authority;
+    this.botTelegramUserId = botTelegramUserId;
+    this.warned.clear();
+  }
+
+  /** True when the message may proceed to memory creation. */
+  async authorizeMessage(
+    input: TelegramMembershipGateDecisionInput,
+  ): Promise<boolean> {
+    // The bot's own messages are not membership-gated (its membership is not
+    // tracked by the authority; outbound paths own their own discipline).
+    if (
+      this.botTelegramUserId &&
+      input.telegramUserId === this.botTelegramUserId
+    ) {
+      return true;
+    }
+    if (!this.authority) {
+      // The membership authority service was never registered (deployment
+      // without plugin-sql): admission degrades to allow with a once-per-chat
+      // structured warning — revoking every group message for deployments that
+      // never opted into membership authority would be a silent availability
+      // regression. TELEGRAM_MEMBERSHIP_ENFORCE opts into strict fail-closed.
+      // When the service IS present but scope evidence is stale or
+      // unavailable, the deny path below still fails closed.
+      if (process.env.TELEGRAM_MEMBERSHIP_ENFORCE === "1") {
+        this.warnOnce(
+          `authority-absent:${input.chatId}`,
+          "Telegram group admission denied: membership authority service is unavailable (TELEGRAM_MEMBERSHIP_ENFORCE=1)",
+          { chatId: input.chatId },
+        );
+        return false;
+      }
+      this.warnOnce(
+        `authority-absent:${input.chatId}`,
+        "Telegram group admission running without a membership authority service; membership checks disabled",
+        { chatId: input.chatId },
+      );
+      return true;
+    }
+    const decision = await this.authority.authorize({
+      chatId: input.chatId,
+      chatRoomKey: input.chatRoomKey,
+      canonicalPrincipalId: input.principalEntityId,
+    });
+    if (decision.decision === "allowed") {
+      return true;
+    }
+    if (telegramMembershipShouldReconcile(decision)) {
+      const reconciled = await this.authority.reconcile({
+        chatId: input.chatId,
+        chatRoomKey: input.chatRoomKey,
+        canonicalPrincipalId: input.principalEntityId,
+        telegramUserId: input.telegramUserId,
+        runtime: input.runtimeMapping,
+        getChatMember: input.getChatMember,
+        nonce: `${Date.now()}-${++this.reconcileNonce}`,
+      });
+      if (reconciled?.state === "active") {
+        const recheck = await this.authority.authorize({
+          chatId: input.chatId,
+          chatRoomKey: input.chatRoomKey,
+          canonicalPrincipalId: input.principalEntityId,
+        });
+        if (recheck.decision === "allowed") {
+          return true;
+        }
+        this.logDenial(input, recheck.reason, "post-reconcile");
+        return false;
+      }
+      this.logDenial(
+        input,
+        reconciled ? reconciled.reason : decision.reason,
+        reconciled ? "reconciled-revoked" : "reconcile-failed",
+      );
+      return false;
+    }
+    this.logDenial(input, decision.reason, "authority");
+    return false;
+  }
+
+  private logDenial(
+    input: TelegramMembershipGateDecisionInput,
+    reason: string,
+    stage: string,
+  ): void {
+    logger.warn(
+      {
+        src: "plugin:telegram",
+        agentId: this.runtime.agentId,
+        chatId: input.chatId,
+        chatType: input.chatType,
+        telegramUserId: input.telegramUserId,
+        reason,
+        stage,
+      },
+      "Telegram group message denied by membership authority",
+    );
+  }
+
+  private warnOnce(key: string, message: string, context: unknown): void {
+    if (this.warned.has(key)) return;
+    this.warned.add(key);
+    logger.warn(
+      {
+        src: "plugin:telegram",
+        agentId: this.runtime.agentId,
+        ...(context as {
+          chatId?: string;
+        }),
+      },
+      message,
+    );
+  }
+}

--- a/plugins/plugin-telegram/src/membership-gate.ts
+++ b/plugins/plugin-telegram/src/membership-gate.ts
@@ -6,7 +6,7 @@
  * the provider query cannot produce fresh evidence.
  */
 import type { UUID } from "@elizaos/core";
-import { ElizaError, logger } from "@elizaos/core";
+import { ElizaError, isTruthyEnvValue, logger } from "@elizaos/core";
 import type { TelegramMembershipAuthority } from "./membership";
 import {
   resolveMembershipService,
@@ -219,7 +219,8 @@ export class TelegramMembershipMessageGate {
     if (
       this.broken ||
       this.pending ||
-      (!this.authority && process.env.TELEGRAM_MEMBERSHIP_ENFORCE === "1")
+      (!this.authority &&
+        isTruthyEnvValue(process.env.TELEGRAM_MEMBERSHIP_ENFORCE))
     ) {
       // Broken bootstrap (authority configured but failed), pending
       // bootstrap (poller live before the gate settles — fail closed for

--- a/plugins/plugin-telegram/src/membership-gate.ts
+++ b/plugins/plugin-telegram/src/membership-gate.ts
@@ -143,6 +143,13 @@ export class TelegramMembershipMessageGate {
   private authority: TelegramMembershipAuthority | null;
   private botTelegramUserId: string | null;
   private broken = false;
+  /**
+   * True between manager construction and the first gate resolution: the
+   * poller is live before finishBotStartup settles, and admission must not
+   * degrade to the absent-authority allow mode during that window — a
+   * revoked sender could otherwise slip in before the authority binds.
+   */
+  private pending = false;
   private readonly warned = new Set<string>();
   private reconcileNonce = 0;
 
@@ -164,6 +171,24 @@ export class TelegramMembershipMessageGate {
     this.authority = authority;
     this.botTelegramUserId = botTelegramUserId;
     this.broken = false;
+    this.pending = false;
+    this.warned.clear();
+  }
+
+  /**
+   * Marks the gate pending: the authority's bootstrap is in flight, so
+   * group admission fails closed until rebind/markBroken/markAbsent settles
+   * it. Distinct from absent (legacy allow) and broken (fail closed).
+   */
+  markPending(): void {
+    this.pending = true;
+    this.warned.clear();
+  }
+
+  /** Settles a pending gate into the absent-authority legacy mode. */
+  markAbsent(): void {
+    this.pending = false;
+    this.authority = null;
     this.warned.clear();
   }
 
@@ -174,6 +199,7 @@ export class TelegramMembershipMessageGate {
    */
   markBroken(): void {
     this.broken = true;
+    this.pending = false;
     this.authority = null;
     this.warned.clear();
   }
@@ -192,12 +218,17 @@ export class TelegramMembershipMessageGate {
     }
     if (
       this.broken ||
+      this.pending ||
       (!this.authority && process.env.TELEGRAM_MEMBERSHIP_ENFORCE === "1")
     ) {
-      // Broken bootstrap (authority configured but failed) or explicit strict
-      // mode without an authority: admission fails closed.
+      // Broken bootstrap (authority configured but failed), pending
+      // bootstrap (poller live before the gate settles — fail closed for
+      // that window), or explicit strict mode without an authority:
+      // admission fails closed.
       this.warnOnce(
-        `authority-broken:${input.chatId}`,
+        this.pending
+          ? `authority-pending:${input.chatId}`
+          : `authority-broken:${input.chatId}`,
         "Telegram group admission denied: membership authority is unavailable",
         { chatId: input.chatId },
       );

--- a/plugins/plugin-telegram/src/membership-gate.ts
+++ b/plugins/plugin-telegram/src/membership-gate.ts
@@ -132,6 +132,7 @@ export class TelegramMembershipMessageGate {
   private readonly runtime: import("@elizaos/core").IAgentRuntime;
   private authority: TelegramMembershipAuthority | null;
   private botTelegramUserId: string | null;
+  private broken = false;
   private readonly warned = new Set<string>();
   private reconcileNonce = 0;
 
@@ -152,6 +153,18 @@ export class TelegramMembershipMessageGate {
   ): void {
     this.authority = authority;
     this.botTelegramUserId = botTelegramUserId;
+    this.broken = false;
+    this.warned.clear();
+  }
+
+  /**
+   * Marks the gate broken: the membership authority was configured but its
+   * bootstrap failed. Group admission fails closed until a later boot
+   * succeeds — this is distinct from the absent-authority legacy mode.
+   */
+  markBroken(): void {
+    this.broken = true;
+    this.authority = null;
     this.warned.clear();
   }
 
@@ -167,6 +180,19 @@ export class TelegramMembershipMessageGate {
     ) {
       return true;
     }
+    if (
+      this.broken ||
+      (!this.authority && process.env.TELEGRAM_MEMBERSHIP_ENFORCE === "1")
+    ) {
+      // Broken bootstrap (authority configured but failed) or explicit strict
+      // mode without an authority: admission fails closed.
+      this.warnOnce(
+        `authority-broken:${input.chatId}`,
+        "Telegram group admission denied: membership authority is unavailable",
+        { chatId: input.chatId },
+      );
+      return false;
+    }
     if (!this.authority) {
       // The membership authority service was never registered (deployment
       // without plugin-sql): admission degrades to allow with a once-per-chat
@@ -175,14 +201,6 @@ export class TelegramMembershipMessageGate {
       // regression. TELEGRAM_MEMBERSHIP_ENFORCE opts into strict fail-closed.
       // When the service IS present but scope evidence is stale or
       // unavailable, the deny path below still fails closed.
-      if (process.env.TELEGRAM_MEMBERSHIP_ENFORCE === "1") {
-        this.warnOnce(
-          `authority-absent:${input.chatId}`,
-          "Telegram group admission denied: membership authority service is unavailable (TELEGRAM_MEMBERSHIP_ENFORCE=1)",
-          { chatId: input.chatId },
-        );
-        return false;
-      }
       this.warnOnce(
         `authority-absent:${input.chatId}`,
         "Telegram group admission running without a membership authority service; membership checks disabled",

--- a/plugins/plugin-telegram/src/membership-gate.ts
+++ b/plugins/plugin-telegram/src/membership-gate.ts
@@ -9,6 +9,7 @@ import type { UUID } from "@elizaos/core";
 import { ElizaError, isTruthyEnvValue, logger } from "@elizaos/core";
 import type { TelegramMembershipAuthority } from "./membership";
 import {
+  authorityErrorCode,
   resolveMembershipService,
   telegramMembershipShouldReconcile,
 } from "./membership";
@@ -259,15 +260,42 @@ export class TelegramMembershipMessageGate {
       return true;
     }
     if (telegramMembershipShouldReconcile(decision)) {
-      const reconciled = await this.authority.reconcile({
-        chatId: input.chatId,
-        chatRoomKey: input.chatRoomKey,
-        canonicalPrincipalId: input.principalEntityId,
-        telegramUserId: input.telegramUserId,
-        runtime: input.runtimeMapping,
-        getChatMember: input.getChatMember,
-        nonce: `${Date.now()}-${++this.reconcileNonce}`,
-      });
+      let reconciled: Awaited<
+        ReturnType<TelegramMembershipAuthority["reconcile"]>
+      > = null;
+      try {
+        reconciled = await this.authority.reconcile({
+          chatId: input.chatId,
+          chatRoomKey: input.chatRoomKey,
+          canonicalPrincipalId: input.principalEntityId,
+          telegramUserId: input.telegramUserId,
+          runtime: input.runtimeMapping,
+          getChatMember: input.getChatMember,
+          nonce: `${Date.now()}-${++this.reconcileNonce}`,
+        });
+      } catch (error) {
+        // error-policy:J1 A revoked reconcile could be neither committed nor
+        // degraded fail-closed: no durable fence landed, so prior active
+        // evidence may still authorize the departed principal on a later
+        // message. Mark the connector gate broken — every group admission
+        // then fails closed until a later boot rebinds a healthy gate —
+        // mirroring the recordEvent failure path in TelegramService.
+        if (
+          authorityErrorCode(error) === "TELEGRAM_MEMBERSHIP_REVOCATION_UNSAFE"
+        ) {
+          this.runtime.reportError(
+            "telegram:membership-reconcile-unsafe",
+            error,
+            {
+              chatId: input.chatId,
+              telegramUserId: input.telegramUserId,
+            },
+          );
+          this.markBroken();
+          return false;
+        }
+        throw error;
+      }
       if (reconciled?.state === "active") {
         const recheck = await this.authority.authorize({
           chatId: input.chatId,

--- a/plugins/plugin-telegram/src/membership-gate.ts
+++ b/plugins/plugin-telegram/src/membership-gate.ts
@@ -259,63 +259,100 @@ export class TelegramMembershipMessageGate {
     if (decision.decision === "allowed") {
       return true;
     }
+    if (
+      decision.reason === "authority_unavailable" &&
+      (await this.authority.readdedAfterUnavailable({
+        chatId: input.chatId,
+        chatRoomKey: input.chatRoomKey,
+      }))
+    ) {
+      // Durable re-add recovery: the authority was consulted successfully
+      // and read a persisted "unavailable" row that a durable,
+      // generation-fenced re-add watermark PROVES stale (the bot was
+      // re-added — my_chat_member is Telegram-authoritative). The very
+      // next join evidence that would restore the scope is the update this
+      // gate is blocking, so fall through to the getChatMember reconcile,
+      // which commits fresh point-query evidence and advances the scope
+      // back to current. This is deliberately NOT a blanket
+      // authority_unavailable reconcile: without the watermark proof the
+      // denial below stands (fail closed), preserving the fail-open
+      // prohibition earlier review rounds established.
+      const recheck = await this.runReconcile(input, decision.reason);
+      if (recheck) return true;
+      return false;
+    }
     if (telegramMembershipShouldReconcile(decision)) {
-      let reconciled: Awaited<
-        ReturnType<TelegramMembershipAuthority["reconcile"]>
-      > = null;
-      try {
-        reconciled = await this.authority.reconcile({
-          chatId: input.chatId,
-          chatRoomKey: input.chatRoomKey,
-          canonicalPrincipalId: input.principalEntityId,
-          telegramUserId: input.telegramUserId,
-          runtime: input.runtimeMapping,
-          getChatMember: input.getChatMember,
-          nonce: `${Date.now()}-${++this.reconcileNonce}`,
-        });
-      } catch (error) {
-        // error-policy:J1 A revoked reconcile could be neither committed nor
-        // degraded fail-closed: no durable fence landed, so prior active
-        // evidence may still authorize the departed principal on a later
-        // message. Mark the connector gate broken — every group admission
-        // then fails closed until a later boot rebinds a healthy gate —
-        // mirroring the recordEvent failure path in TelegramService.
-        if (
-          authorityErrorCode(error) === "TELEGRAM_MEMBERSHIP_REVOCATION_UNSAFE"
-        ) {
-          this.runtime.reportError(
-            "telegram:membership-reconcile-unsafe",
-            error,
-            {
-              chatId: input.chatId,
-              telegramUserId: input.telegramUserId,
-            },
-          );
-          this.markBroken();
-          return false;
-        }
-        throw error;
-      }
-      if (reconciled?.state === "active") {
-        const recheck = await this.authority.authorize({
-          chatId: input.chatId,
-          chatRoomKey: input.chatRoomKey,
-          canonicalPrincipalId: input.principalEntityId,
-        });
-        if (recheck.decision === "allowed") {
-          return true;
-        }
-        this.logDenial(input, recheck.reason, "post-reconcile");
-        return false;
-      }
-      this.logDenial(
-        input,
-        reconciled ? reconciled.reason : decision.reason,
-        reconciled ? "reconciled-revoked" : "reconcile-failed",
-      );
+      const recheck = await this.runReconcile(input, decision.reason);
+      if (recheck) return true;
       return false;
     }
     this.logDenial(input, decision.reason, "authority");
+    return false;
+  }
+
+  /**
+   * Shared getChatMember reconcile + re-authorize. Returns true when the
+   * reconciled evidence re-authorizes the sender. THROWS through to the
+   * caller on non-revocation-unsafe errors (same contract as before).
+   */
+  private async runReconcile(
+    input: TelegramMembershipGateDecisionInput,
+    fallbackReason: string,
+  ): Promise<boolean> {
+    if (!this.authority) return false;
+    let reconciled: Awaited<
+      ReturnType<TelegramMembershipAuthority["reconcile"]>
+    > = null;
+    try {
+      reconciled = await this.authority.reconcile({
+        chatId: input.chatId,
+        chatRoomKey: input.chatRoomKey,
+        canonicalPrincipalId: input.principalEntityId,
+        telegramUserId: input.telegramUserId,
+        runtime: input.runtimeMapping,
+        getChatMember: input.getChatMember,
+        nonce: `${Date.now()}-${++this.reconcileNonce}`,
+      });
+    } catch (error) {
+      // error-policy:J1 A revoked reconcile could be neither committed nor
+      // degraded fail-closed: no durable fence landed, so prior active
+      // evidence may still authorize the departed principal on a later
+      // message. Mark the connector gate broken — every group admission
+      // then fails closed until a later boot rebinds a healthy gate —
+      // mirroring the recordEvent failure path in TelegramService.
+      if (
+        authorityErrorCode(error) === "TELEGRAM_MEMBERSHIP_REVOCATION_UNSAFE"
+      ) {
+        this.runtime.reportError(
+          "telegram:membership-reconcile-unsafe",
+          error,
+          {
+            chatId: input.chatId,
+            telegramUserId: input.telegramUserId,
+          },
+        );
+        this.markBroken();
+        return false;
+      }
+      throw error;
+    }
+    if (reconciled?.state === "active") {
+      const recheck = await this.authority.authorize({
+        chatId: input.chatId,
+        chatRoomKey: input.chatRoomKey,
+        canonicalPrincipalId: input.principalEntityId,
+      });
+      if (recheck.decision === "allowed") {
+        return true;
+      }
+      this.logDenial(input, recheck.reason, "post-reconcile");
+      return false;
+    }
+    this.logDenial(
+      input,
+      reconciled ? reconciled.reason : fallbackReason,
+      reconciled ? "reconciled-revoked" : "reconcile-failed",
+    );
     return false;
   }
 

--- a/plugins/plugin-telegram/src/membership.concurrent-clear.test.ts
+++ b/plugins/plugin-telegram/src/membership.concurrent-clear.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Regression for the concurrent removal/re-add race (PR #28715 review):
+ * Telegraf dispatches one polling batch concurrently
+ * (`Promise.all(updates.map(handleUpdate))`), so a re-add clear can run
+ * while an earlier removal is still awaiting its durable health write.
+ * Without serialization the clear observes no tombstone and returns; the
+ * removal resumes and installs the tombstone AFTER the clear, permanently
+ * denying a chat the bot is present in again. Deterministic unit harness:
+ * the REAL TelegramMembershipAuthority runs over an instrumented service
+ * double that can pause the health write; the observable is whether a
+ * post-re-add evidence write is accepted (recordEvent resolves) or
+ * tombstone-rejected.
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { TelegramMembershipAuthority } from "./membership";
+
+function makeAuthority(options?: {
+  pauseFirstHealthWrite?: () => Promise<void>;
+}) {
+  let healthWriteCalls = 0;
+  const service = {
+    getScopeHealth: vi.fn(async () => null),
+    setScopeHealth: vi.fn(async () => {
+      healthWriteCalls += 1;
+      if (healthWriteCalls === 1) {
+        await options?.pauseFirstHealthWrite?.();
+      }
+      return { operation: "health" };
+    }),
+    registerPublisher: vi.fn(async () => ({ operation: "publisher" })),
+    applyMembership: vi.fn(async () => ({ applied: true })),
+    getMembership: vi.fn(async () => null),
+  };
+  const runtime = {
+    agentId: "00000000-0000-0000-0000-0000000000a1",
+    reportError: vi.fn(),
+    getCache: vi.fn(async () => undefined),
+    setCache: vi.fn(async () => true),
+    deleteCache: vi.fn(async () => true),
+    createEntity: vi.fn(async () => true),
+    createWorld: vi.fn(async () => true),
+    createRoom: vi.fn(async () => true),
+  } as unknown as IAgentRuntime;
+  const authority = new TelegramMembershipAuthority({
+    runtime,
+    connectorAccountId: "00000000-0000-0000-0000-0000000000c1" as never,
+    service: service as never,
+  });
+  return { authority, service };
+}
+
+const SCOPE = { chatId: "-100999", chatRoomKey: "-100999" };
+const PRINCIPAL = "00000000-0000-0000-0000-000000000001" as never;
+
+async function recordJoin(authority: TelegramMembershipAuthority) {
+  return authority.recordEvent({
+    ...SCOPE,
+    canonicalPrincipalId: PRINCIPAL,
+    state: "active",
+    reason: "joined",
+    messageId: 1,
+    telegramUserId: "42",
+    runtime: { worldId: null, roomId: null, entityId: PRINCIPAL },
+    observedAt: new Date().toISOString(),
+  });
+}
+
+describe("concurrent removal/re-add serialization", () => {
+  it("re-add clear waits for an in-flight removal: fresh post-re-add evidence is not tombstoned", async () => {
+    // Pause the removal's durable health write until the re-add clear has
+    // been issued — the exact interleaving Telegraf's concurrent batch
+    // dispatch makes possible.
+    let releaseRemoval!: () => void;
+    const removalGate = new Promise<void>((resolve) => {
+      releaseRemoval = resolve;
+    });
+    const { authority, service } = makeAuthority({
+      pauseFirstHealthWrite: () => removalGate,
+    });
+
+    // Seed the scope so the removal's publisher bookkeeping resolves.
+    await recordJoin(authority);
+
+    const removal = authority.markScopeUnavailable({
+      ...SCOPE,
+      reason: "bot_removed",
+    });
+    // Let the removal enter its serialized chain and reach the paused write.
+    await new Promise((r) => setTimeout(r, 5));
+    // Re-add lands while the removal is still awaiting the health write.
+    // With the clear serialized behind the removal chain, it runs AFTER the
+    // tombstone is installed — and clears it. On the unfixed code the clear
+    // ran immediately (no tombstone yet), returned, and the removal then
+    // installed a tombstone that survives forever.
+    const clear = authority.clearScopeRemoval(SCOPE);
+    await new Promise((r) => setTimeout(r, 5));
+    releaseRemoval();
+    await Promise.all([removal, clear]);
+
+    // Fresh post-re-add evidence must be ACCEPTED: the evidence write
+    // reaches the membership service. On the unfixed code the clear ran
+    // before the tombstone existed and returned; the removal then installed
+    // a tombstone that survives forever, and this applyMembership call is
+    // SKIPPED (tombstone rejection).
+    const evidenceCalls = service.applyMembership.mock.calls.length;
+    await recordJoin(authority);
+    expect(service.applyMembership.mock.calls.length).toBe(evidenceCalls + 1);
+  });
+});

--- a/plugins/plugin-telegram/src/membership.test.ts
+++ b/plugins/plugin-telegram/src/membership.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Unit coverage for pure Telegram-membership mapping helpers and the
+ * out-of-order/restricted semantics fixed in review round 1. Deterministic
+ * unit harness; authority integration lives in
+ * __tests__/membership-authority.real.test.ts.
+ */
+import { describe, expect, it } from "vitest";
+import { telegramStatusToMembership } from "./membership";
+
+describe("telegramStatusToMembership", () => {
+  it("maps member statuses to active", () => {
+    for (const status of ["creator", "administrator", "member"]) {
+      expect(telegramStatusToMembership({ status })).toEqual({
+        state: "active",
+        reason: "reconciled_present",
+      });
+    }
+  });
+
+  it("maps restricted WITH is_member true to active", () => {
+    expect(
+      telegramStatusToMembership({ status: "restricted", is_member: true }),
+    ).toEqual({ state: "active", reason: "reconciled_present" });
+  });
+
+  it("maps restricted WITH is_member false to REVOKED (unbanned non-member must not admit)", () => {
+    expect(
+      telegramStatusToMembership({ status: "restricted", is_member: false }),
+    ).toEqual({ state: "revoked", reason: "left" });
+  });
+
+  it("maps restricted without is_member (unknown) to active (fail toward provider truth)", () => {
+    // Telegram always sends is_member on restricted; absence is treated as
+    // membership true to match the Bot API contract default.
+    expect(telegramStatusToMembership({ status: "restricted" })).toEqual({
+      state: "active",
+      reason: "reconciled_present",
+    });
+  });
+
+  it("maps left/kicked/unknown to revoked", () => {
+    expect(telegramStatusToMembership({ status: "left" })).toEqual({
+      state: "revoked",
+      reason: "left",
+    });
+    expect(telegramStatusToMembership({ status: "kicked" })).toEqual({
+      state: "revoked",
+      reason: "kicked",
+    });
+  });
+});

--- a/plugins/plugin-telegram/src/membership.test.ts
+++ b/plugins/plugin-telegram/src/membership.test.ts
@@ -29,12 +29,13 @@ describe("telegramStatusToMembership", () => {
     ).toEqual({ state: "revoked", reason: "left" });
   });
 
-  it("maps restricted without is_member (unknown) to active (fail toward provider truth)", () => {
-    // Telegram always sends is_member on restricted; absence is treated as
-    // membership true to match the Bot API contract default.
+  it("maps restricted WITHOUT is_member (incomplete provider response) to REVOKED (fail closed)", () => {
+    // Telegram always sends is_member on restricted; absence means an
+    // incomplete/untrusted provider response, which must not establish
+    // active membership at an external provider boundary.
     expect(telegramStatusToMembership({ status: "restricted" })).toEqual({
-      state: "active",
-      reason: "reconciled_present",
+      state: "revoked",
+      reason: "left",
     });
   });
 

--- a/plugins/plugin-telegram/src/membership.ts
+++ b/plugins/plugin-telegram/src/membership.ts
@@ -92,16 +92,22 @@ export function telegramMembershipScope(input: {
 }
 
 /** Telegram ChatMember status -> authority (state, reason). */
-export function telegramStatusToMembership(status: string): {
-  state: "active" | "revoked";
-  reason: TelegramMembershipReason;
-} {
-  switch (status) {
+export function telegramStatusToMembership(member: {
+  status: string;
+  is_member?: boolean;
+}): { state: "active" | "revoked"; reason: TelegramMembershipReason } {
+  switch (member.status) {
     case "creator":
     case "administrator":
     case "member":
-    case "restricted":
       return { state: "active", reason: "reconciled_present" };
+    case "restricted":
+      // A restricted user is only a member while is_member is true; Telegram
+      // reports restricted non-members (e.g. unbanned-but-not-rejoined) with
+      // is_member: false, which must NOT admit as active membership.
+      return member.is_member === false
+        ? { state: "revoked", reason: "left" }
+        : { state: "active", reason: "reconciled_present" };
     case "left":
       return { state: "revoked", reason: "left" };
     case "kicked":
@@ -235,22 +241,73 @@ export class TelegramMembershipAuthority {
     })();
   }
 
-  /** Re-reads persisted scope state after a pre-commit fencing failure. */
+  /**
+   * Re-reads persisted scope state after a pre-commit fencing failure. When
+   * the persisted publisher binding belongs to a different publisher
+   * instance, register OUR generation now so the evidence retry actually
+   * matches the registered publisher instead of mismatching again.
+   */
   private async readoptFromHealth(
     scope: MembershipScope,
   ): Promise<ScopeTracker> {
     const health = await this.service.getScopeHealth(scope);
+    if (health && health.publisherInstanceId !== this.publisherInstanceId) {
+      const publisherGeneration = (health.publisherGeneration ?? -1) + 1;
+      const receipt = await this.service.registerPublisher({
+        ...scope,
+        publisherInstanceId: this.publisherInstanceId,
+        publisherGeneration,
+        evidenceMode: "point_query",
+        expectedGeneration: health.generation,
+        idempotencyKey: `tg:${this.connectorAccountId}:publisher:${scope.externalWorldId}:${scope.externalRoomId}:${publisherGeneration}`,
+        observedAt: new Date().toISOString(),
+      });
+      if (receipt.operation !== "publisher") {
+        throw new Error(
+          `Telegram membership publisher takeover returned ${receipt.operation}`,
+        );
+      }
+      const tracker: ScopeTracker = {
+        generation: receipt.committedGeneration,
+        sourceVersion: -1,
+        sourceCursor: null,
+        publisherGeneration,
+      };
+      this.scopes.set(scopeKey(scope), tracker);
+      return tracker;
+    }
     const tracker: ScopeTracker = {
       generation: health?.generation ?? 0,
       sourceVersion: health?.sourceVersion ?? -1,
       sourceCursor: health?.sourceCursor ?? null,
-      publisherGeneration:
-        health?.publisherInstanceId === this.publisherInstanceId
-          ? (health.publisherGeneration ?? 0)
-          : (health?.publisherGeneration ?? -1) + 1,
+      publisherGeneration: health?.publisherGeneration ?? 0,
     };
     this.scopes.set(scopeKey(scope), tracker);
     return tracker;
+  }
+
+  /**
+   * Degrades the scope to stale so admission fails closed. Public degrade
+   * path for callers that observed a REVOCATION but could not commit the
+   * evidence itself (e.g. entity bootstrap failed): the safe representation
+   * of "we saw a leave but the authority did not record it" is a scope whose
+   * evidence can no longer authorize anyone until fresh evidence lands.
+   */
+  async markScopeStale(input: {
+    scope: MembershipScope;
+    reason: string;
+  }): Promise<void> {
+    const health = await this.service.getScopeHealth(input.scope);
+    const expectedGeneration = health?.generation ?? 0;
+    await this.service.setScopeHealth({
+      ...input.scope,
+      expectedGeneration,
+      idempotencyKey: `tg:${this.connectorAccountId}:${input.scope.externalWorldId}:stale:${input.reason}:${expectedGeneration}`,
+      health: "stale",
+      reason: input.reason,
+      observedAt: new Date().toISOString(),
+    });
+    this.scopes.delete(scopeKey(input.scope));
   }
 
   /**
@@ -278,6 +335,32 @@ export class TelegramMembershipAuthority {
       let tracker =
         (await this.ensureRegistered(input.scope)) ??
         (await this.readoptFromHealth(input.scope));
+
+      // Out-of-order guard: a fact older than the principal's committed
+      // evidence must never overwrite it (an old join with a distinct message
+      // id redelivered after a newer leave must not resurrect membership).
+      const committed = await this.service.getMembership(
+        input.scope,
+        input.canonicalPrincipalId,
+      );
+      if (
+        committed &&
+        Date.parse(input.observedAt) < Date.parse(committed.observedAt)
+      ) {
+        logger.debug(
+          {
+            src: "plugin:telegram",
+            agentId: this.runtime.agentId,
+            chatId: input.scope.externalWorldId,
+            telegramUserId: input.canonicalPrincipalId,
+            incomingObservedAt: input.observedAt,
+            committedObservedAt: committed.observedAt,
+          },
+          "Telegram membership fact is older than committed evidence; skipping",
+        );
+        return false;
+      }
+
       for (let attempt = 0; attempt < 2; attempt++) {
         const sourceVersion = tracker.sourceVersion + 1;
         const sourceCursor = `tg:${sourceVersion}`;
@@ -323,12 +406,11 @@ export class TelegramMembershipAuthority {
             tracker = await this.readoptFromHealth(input.scope);
             continue;
           }
-          if (
-            code === "MEMBERSHIP_IDEMPOTENCY_CONFLICT" ||
-            code === "MEMBERSHIP_COMMAND_INVALID"
-          ) {
-            // Replayed update rebuilt with different bytes, or a redelivery
-            // whose evidence window has passed: benign duplicates.
+          if (code === "MEMBERSHIP_IDEMPOTENCY_CONFLICT") {
+            // A redelivery of the same command bytes: benign duplicate.
+            // MEMBERSHIP_COMMAND_INVALID is NOT benign — it signals a
+            // malformed or rejected command that must surface (and for
+            // revocations, degrade the scope) rather than mask.
             logger.debug(
               {
                 src: "plugin:telegram",
@@ -390,8 +472,29 @@ export class TelegramMembershipAuthority {
         idempotencyKey: `tg:${this.connectorAccountId}:${input.chatId}:msg:${input.messageId}:${input.reason}:${input.telegramUserId}`,
       });
     } catch (error) {
-      // error-policy:J7 Authority diagnostics must not kill the poll loop;
-      // the principal stays denied-by-default until fresh evidence lands.
+      // error-policy:J7 Authority diagnostics must not kill the poll loop.
+      // For a REVOCATION we must not leave prior active evidence authorizing
+      // the departed principal: degrade the scope to stale (fail-closed
+      // admission) until fresh evidence lands.
+      if (input.state === "revoked") {
+        try {
+          await this.markScopeStale({
+            scope,
+            reason: `revocation_write_failed:${input.reason}`,
+          });
+        } catch (degradeError) {
+          this.runtime.reportError(
+            "telegram:membership-evidence",
+            degradeError,
+            {
+              chatId: input.chatId,
+              messageId: input.messageId,
+              telegramUserId: input.telegramUserId,
+              originalError: String(error),
+            },
+          );
+        }
+      }
       this.runtime.reportError("telegram:membership-evidence", error, {
         chatId: input.chatId,
         messageId: input.messageId,
@@ -442,7 +545,7 @@ export class TelegramMembershipAuthority {
       });
       return null;
     }
-    const mapped = telegramStatusToMembership(member.status);
+    const mapped = telegramStatusToMembership(member);
     const scope = telegramMembershipScope({
       agentId: this.runtime.agentId,
       connectorAccountId: this.connectorAccountId,
@@ -473,7 +576,13 @@ export class TelegramMembershipAuthority {
     return mapped;
   }
 
-  /** Fail-closed admission decision for a group/supergroup chat scope. */
+  /**
+   * Fail-closed admission decision for a group/supergroup chat scope. The
+   * read runs inside the per-scope serialization chain so it is ordered
+   * behind any evidence write already queued for the scope (e.g. a leave
+   * observed by the update handler cannot be jumped by a later message's
+   * authorization once its evidence command is enqueued).
+   */
   async authorize(input: {
     chatId: string;
     chatRoomKey: string;
@@ -485,7 +594,9 @@ export class TelegramMembershipAuthority {
       chatId: input.chatId,
       chatRoomKey: input.chatRoomKey,
     });
-    return this.service.authorize(scope, input.canonicalPrincipalId);
+    return this.serialized(scopeKey(scope), () =>
+      this.service.authorize(scope, input.canonicalPrincipalId),
+    );
   }
 
   /**

--- a/plugins/plugin-telegram/src/membership.ts
+++ b/plugins/plugin-telegram/src/membership.ts
@@ -267,30 +267,51 @@ export class TelegramMembershipAuthority {
     return this.pendingRevocations.get(key) ?? EMPTY_PENDING;
   }
 
-  /** Persists the in-memory pending-revocation set for one scope. */
+  /**
+   * Persists the in-memory pending-revocation set for one scope. Returns
+   * false when the durable write did NOT land: the runtime cache contract
+   * (`IAgentRuntime.setCache` / `deleteCache`) resolves `false` when the
+   * write failed without throwing — a false resolution is treated exactly
+   * like a thrown persistence failure, never as success.
+   */
   private async persistPendingRevocations(
     scope: MembershipScope,
   ): Promise<boolean> {
     const key = scopeKey(scope);
     const overlay = this.pendingRevocations.get(key);
+    const entries = overlay ? [...overlay] : [];
+    const writing = entries.length > 0;
     try {
-      if (overlay && overlay.size > 0) {
-        await this.runtime.setCache(this.pendingRevocationsCacheKey(scope), [
-          ...overlay,
-        ]);
-      } else {
-        await this.runtime.deleteCache(this.pendingRevocationsCacheKey(scope));
+      const persisted = writing
+        ? await this.runtime.setCache(
+            this.pendingRevocationsCacheKey(scope),
+            entries,
+          )
+        : await this.runtime.deleteCache(
+            this.pendingRevocationsCacheKey(scope),
+          );
+      if (persisted !== true) {
+        // error-policy:J4 The durable overlay write did not land: the cache
+        // adapter resolved false. For a fence WRITE (setCache) a restart
+        // would re-authorize the departed principal; for a fence CLEAR
+        // (deleteCache) the stale durable fence keeps denying that
+        // principal until a later clear lands. Either way the persisted
+        // overlay state is unconfirmed — return failure so the caller
+        // reports once with its fuller context (revocation path escalates
+        // REVOCATION_UNSAFE; clear path reports telegram:membership-pending-clear)
+        // instead of claiming a durable fail-closed state here.
+        return false;
       }
       return true;
-    } catch (error) {
-      // error-policy:J4 The durable fence did NOT land. The in-memory
-      // overlay still denies in THIS process, but a restart would
-      // re-authorize the departed principal. Report and surface failure so
-      // revocation callers escalate (gate broken) instead of claiming a
-      // durable fail-closed state.
-      this.runtime.reportError("telegram:membership-pending-persist", error, {
-        chatId: scope.externalWorldId,
-      });
+    } catch {
+      // error-policy:J4 The durable fence did NOT land (the cache call
+      // threw). The in-memory overlay still denies in THIS process, but a
+      // restart would re-authorize the departed principal. Surface failure
+      // so the caller reports ONCE with its fuller context — the revocation
+      // path escalates REVOCATION_UNSAFE (carrying the original authority
+      // error as cause); the clear path reports
+      // telegram:membership-pending-clear with principal context — instead
+      // of the helper emitting a second, lower-context report here.
       return false;
     }
   }
@@ -661,7 +682,27 @@ export class TelegramMembershipAuthority {
           // durable revocation fences from the cache.
           this.pendingRevocations.get(key)?.delete(input.canonicalPrincipalId);
           if (overlayHydrated) {
-            await this.persistPendingRevocations(input.scope);
+            const overlayCleared = await this.persistPendingRevocations(
+              input.scope,
+            );
+            if (!overlayCleared) {
+              // error-policy:J7 The committed evidence is authoritative in
+              // this process, but the durable overlay clear did not land: a
+              // restart would re-hydrate the stale fence and deny this
+              // principal until fresh evidence lands. That is fail-closed
+              // (denial), never fail-open — report so the persistence fault
+              // is diagnosable; the next successful persist self-heals it.
+              this.runtime.reportError(
+                "telegram:membership-pending-clear",
+                new Error(
+                  "durable pending-revocation overlay clear did not land (stale fence may deny after restart until fresh evidence)",
+                ),
+                {
+                  chatId: input.scope.externalWorldId,
+                  telegramUserId: input.canonicalPrincipalId,
+                },
+              );
+            }
           }
           return true;
         } catch (error) {

--- a/plugins/plugin-telegram/src/membership.ts
+++ b/plugins/plugin-telegram/src/membership.ts
@@ -1179,8 +1179,19 @@ export class TelegramMembershipAuthority {
    * from persisted health, so re-authorization requires fresh evidence —
    * pre-removal member facts alone stay non-authorizing because point-query
    * evidence carries a bounded validUntil.
+   *
+   * Runs inside the same per-scope serialized chain as markScopeUnavailable:
+   * Telegraf dispatches one polling batch concurrently
+   * (`Promise.all(updates.map(handleUpdate))`), so a re-add callback can
+   * interleave with an in-flight removal that is still awaiting its durable
+   * health write. Without serialization the clear observes no tombstone and
+   * returns; the removal then resumes and installs the tombstone AFTER the
+   * clear, permanently denying a chat the bot is present in again.
    */
-  clearScopeRemoval(input: { chatId: string; chatRoomKey: string }): void {
+  clearScopeRemoval(input: {
+    chatId: string;
+    chatRoomKey: string;
+  }): Promise<void> {
     const scope = telegramMembershipScope({
       agentId: this.runtime.agentId,
       connectorAccountId: this.connectorAccountId,
@@ -1188,12 +1199,15 @@ export class TelegramMembershipAuthority {
       chatRoomKey: input.chatRoomKey,
     });
     const key = scopeKey(scope);
-    this.removedScopes.delete(key);
-    // Watermark the re-add: backlogged evidence stamped BEFORE this moment
-    // (queued updates from while the bot was absent) must not re-authorize
-    // anything after the clear — only observations made while the bot was
-    // actually present may establish authority again.
-    this.scopeReaddWatermarks.set(key, Date.now());
+    // The chain swallows link rejections; only the mutation runs inside.
+    return this.serialized(key, async () => {
+      this.removedScopes.delete(key);
+      // Watermark the re-add: backlogged evidence stamped BEFORE this moment
+      // (queued updates from while the bot was absent) must not re-authorize
+      // anything after the clear — only observations made while the bot was
+      // actually present may establish authority again.
+      this.scopeReaddWatermarks.set(key, Date.now());
+    });
   }
 
   /** Read-only scope health accessor (used by tests and diagnostics). */

--- a/plugins/plugin-telegram/src/membership.ts
+++ b/plugins/plugin-telegram/src/membership.ts
@@ -172,6 +172,22 @@ export class TelegramMembershipAuthority {
    * the tombstone, and only after a fresh registration.
    */
   private readonly removedScopes = new Map<string, string>();
+  /**
+   * Re-add watermarks by scope key (epoch ms). After the bot is re-added,
+   * evidence observed BEFORE the re-add moment is backlogged and must not
+   * re-authorize anything: only observations made while the bot was actually
+   * present may establish authority again.
+   */
+  private readonly scopeReaddWatermarks = new Map<string, number>();
+  /**
+   * Principals whose REVOCATION could not be committed (evidence write
+   * failed; the scope was degraded stale instead). Their prior active
+   * evidence may still be live within its validity window, so admission
+   * denies them through this overlay until fresh evidence for the SAME
+   * principal commits (either direction) — a join/reconcile for an unrelated
+   * principal restoring scope health must not re-authorize them.
+   */
+  private readonly pendingRevocations = new Map<string, Set<UUID>>();
 
   constructor(input: {
     runtime: IAgentRuntime;
@@ -349,6 +365,9 @@ export class TelegramMembershipAuthority {
           ) {
             continue;
           }
+          // error-policy:J2 Generation moved persistently under us: wrap and
+          // rethrow so the caller can escalate (mark the gate broken) rather
+          // than treating the scope as successfully degraded.
           throw error;
         }
       }
@@ -381,6 +400,24 @@ export class TelegramMembershipAuthority {
   }): Promise<boolean> {
     const key = scopeKey(input.scope);
     return this.serialized(key, async () => {
+      // Restart hydration: if this process restarted, the in-memory
+      // bot-removal tombstone map is empty — but the persisted scope health
+      // still says unavailable. Hydrate BEFORE the tombstone check so a
+      // backlogged join redelivery after restart cannot register a fresh
+      // publisher generation and advance the scope back to current.
+      // A re-add watermark (this process cleared the tombstone after a bot
+      // re-add) suppresses hydration: the persisted unavailable state is
+      // stale by the explicit re-add.
+      if (
+        !this.removedScopes.has(key) &&
+        !this.scopes.has(key) &&
+        !this.scopeReaddWatermarks.has(key)
+      ) {
+        const health = await this.service.getScopeHealth(input.scope);
+        if (health?.health === "unavailable") {
+          this.removedScopes.set(key, health.reason || "bot_removed_persisted");
+        }
+      }
       // Bot-removal tombstone: once the bot has been removed from this chat,
       // no evidence (backlogged join redelivery, reconcile) may advance the
       // scope back to current — the bot cannot observe the chat anymore, so
@@ -397,6 +434,27 @@ export class TelegramMembershipAuthority {
             removalReason,
           },
           "Telegram membership evidence rejected for a bot-removed scope; skipping",
+        );
+        return false;
+      }
+      // Re-add watermark: after a bot re-add, only observations made WHILE
+      // the bot was present may (re)establish authority. Evidence stamped
+      // before the re-add moment is backlogged and must not authorize.
+      const readdWatermark = this.scopeReaddWatermarks.get(key);
+      if (
+        readdWatermark !== undefined &&
+        Date.parse(input.observedAt) < readdWatermark
+      ) {
+        logger.debug(
+          {
+            src: "plugin:telegram",
+            agentId: this.runtime.agentId,
+            chatId: input.scope.externalWorldId,
+            telegramUserId: input.canonicalPrincipalId,
+            observedAt: input.observedAt,
+            readdWatermark: new Date(readdWatermark).toISOString(),
+          },
+          "Telegram membership evidence predates the bot re-add; skipping",
         );
         return false;
       }
@@ -470,6 +528,10 @@ export class TelegramMembershipAuthority {
           tracker.generation += 1;
           tracker.sourceVersion = sourceVersion;
           tracker.sourceCursor = sourceCursor;
+          // Fresh evidence for this principal committed: any pending
+          // (uncommittable) revocation overlay for it is now superseded —
+          // the authoritative record speaks again.
+          this.pendingRevocations.get(key)?.delete(input.canonicalPrincipalId);
           return true;
         } catch (error) {
           const code = authorityErrorCode(error);
@@ -593,7 +655,15 @@ export class TelegramMembershipAuthority {
             scope,
             reason: `revocation_write_failed:${input.reason}`,
           });
-          // Degrade landed: admission now fails closed for the scope.
+          // Degrade landed: admission now fails closed for the scope. ALSO
+          // record the pending revocation: the stale degrade is not durable —
+          // unrelated evidence can restore scope health — so this principal
+          // must keep failing closed via the authorize overlay until fresh
+          // evidence for the SAME principal commits.
+          const key = scopeKey(scope);
+          const pending = this.pendingRevocations.get(key) ?? new Set<UUID>();
+          pending.add(input.canonicalPrincipalId);
+          this.pendingRevocations.set(key, pending);
           // error-policy:J7 Evidence-write failure must not kill the poll
           // loop; the failure is reported and the degraded scope carries the
           // security decision.
@@ -738,10 +808,10 @@ export class TelegramMembershipAuthority {
         });
       }
     } catch (error) {
-      // error-policy:J3 createEntity/createWorld/createRoom are idempotent
+      // error-policy:J7 createEntity/createWorld/createRoom are idempotent
       // for existing rows on the adapters in use; a genuine failure surfaces
       // below through applyEvidence's assert codes, so this only guards
-      // duplicate-create races.
+      // duplicate-create races and must not kill the reconcile attempt.
       this.runtime.reportError("telegram:membership-reconcile", error, {
         chatId: input.chatId,
         telegramUserId: input.telegramUserId,
@@ -790,9 +860,26 @@ export class TelegramMembershipAuthority {
       chatId: input.chatId,
       chatRoomKey: input.chatRoomKey,
     });
-    return this.serialized(scopeKey(scope), () =>
-      this.service.authorize(scope, input.canonicalPrincipalId),
-    );
+    const key = scopeKey(scope);
+    return this.serialized(key, async () => {
+      // Pending-revocation overlay: this principal's revocation could not be
+      // committed and the scope was degraded stale — but scope health may
+      // have been restored since by unrelated evidence. Their prior active
+      // fact must keep failing closed until fresh evidence for THIS
+      // principal lands.
+      if (this.pendingRevocations.get(key)?.has(input.canonicalPrincipalId)) {
+        // Reuse membership_revoked: a revocation WAS observed for this
+        // principal, it just could not be committed — admission must fail
+        // closed exactly as if it had.
+        return {
+          decision: "denied",
+          reason: "membership_revoked",
+          generation: null,
+          health: null,
+        } satisfies MembershipAuthorizationDecision;
+      }
+      return this.service.authorize(scope, input.canonicalPrincipalId);
+    });
   }
 
   /**
@@ -874,7 +961,13 @@ export class TelegramMembershipAuthority {
       chatId: input.chatId,
       chatRoomKey: input.chatRoomKey,
     });
-    this.removedScopes.delete(scopeKey(scope));
+    const key = scopeKey(scope);
+    this.removedScopes.delete(key);
+    // Watermark the re-add: backlogged evidence stamped BEFORE this moment
+    // (queued updates from while the bot was absent) must not re-authorize
+    // anything after the clear — only observations made while the bot was
+    // actually present may establish authority again.
+    this.scopeReaddWatermarks.set(key, Date.now());
   }
 
   /** Read-only scope health accessor (used by tests and diagnostics). */

--- a/plugins/plugin-telegram/src/membership.ts
+++ b/plugins/plugin-telegram/src/membership.ts
@@ -1,0 +1,543 @@
+/**
+ * Telegram-side client for the canonical membership authority
+ * (`MembershipService`, core contract + SqlMembershipService in plugin-sql).
+ *
+ * Owns the connector's publisher discipline for chat-granular group scopes:
+ * stable publisher identity adopted from persisted scope health, deterministic
+ * idempotency keys derived from Telegram message ids, point-query evidence
+ * from observed join/leave updates and `getChatMember` reconciles, and
+ * fail-closed admission decisions for group/supergroup chats. DMs are not
+ * membership-governed (the DM policy owns them) and channels have no inbound
+ * admission surface in this connector, so neither registers a scope.
+ */
+import type {
+  IAgentRuntime,
+  JsonObject,
+  MembershipAuthorizationDecision,
+  MembershipScope,
+  MembershipScopeHealth,
+  MembershipService,
+  UUID,
+} from "@elizaos/core";
+import { logger, ServiceType } from "@elizaos/core";
+
+/** Evidence freshness window for Telegram point proofs (under the authority's 24h cap). */
+export const TELEGRAM_MEMBERSHIP_TTL_MS = 60 * 60 * 1_000;
+
+export type TelegramMembershipReason =
+  | "joined"
+  | "reconciled_present"
+  | "left"
+  | "kicked"
+  | "banned";
+
+interface ScopeTracker {
+  generation: number;
+  sourceVersion: number;
+  sourceCursor: string | null;
+  publisherGeneration: number;
+}
+
+const RECONCILE_MISS_REASONS = new Set([
+  "no_scope_evidence",
+  "no_membership",
+  "membership_evidence_mismatch",
+  "membership_evidence_expired",
+  "authority_expired",
+]);
+
+/** Denied reasons that warrant a getChatMember reconcile before failing admission. */
+export function telegramMembershipShouldReconcile(
+  decision: MembershipAuthorizationDecision,
+): boolean {
+  return (
+    decision.decision === "denied" &&
+    RECONCILE_MISS_REASONS.has(decision.reason)
+  );
+}
+
+export function isMembershipService(
+  service: unknown,
+): service is MembershipService {
+  return (
+    typeof service === "object" &&
+    service !== null &&
+    typeof (service as MembershipService).registerPublisher === "function" &&
+    typeof (service as MembershipService).authorize === "function"
+  );
+}
+
+export function resolveMembershipService(
+  runtime: IAgentRuntime,
+): MembershipService | null {
+  const service = runtime.getService(ServiceType.MEMBERSHIP);
+  return isMembershipService(service) ? service : null;
+}
+
+/** Chat-granular scope: the chat's main room key, never a forum-topic room. */
+export function telegramMembershipScope(input: {
+  agentId: UUID;
+  connectorAccountId: UUID;
+  chatId: string;
+  chatRoomKey: string;
+}): MembershipScope {
+  return {
+    agentId: input.agentId,
+    // Must equal the connector_accounts row provider ("telegram").
+    connectorId: "telegram",
+    connectorAccountId: input.connectorAccountId,
+    externalWorldId: input.chatId,
+    externalRoomId: input.chatRoomKey,
+  };
+}
+
+/** Telegram ChatMember status -> authority (state, reason). */
+export function telegramStatusToMembership(status: string): {
+  state: "active" | "revoked";
+  reason: TelegramMembershipReason;
+} {
+  switch (status) {
+    case "creator":
+    case "administrator":
+    case "member":
+    case "restricted":
+      return { state: "active", reason: "reconciled_present" };
+    case "left":
+      return { state: "revoked", reason: "left" };
+    case "kicked":
+      return { state: "revoked", reason: "kicked" };
+    default:
+      return { state: "revoked", reason: "banned" };
+  }
+}
+
+/** Role snapshot from a Telegram ChatMember. */
+export function telegramMemberRoles(member: {
+  status: string;
+  custom_title?: string;
+}): readonly string[] {
+  if (member.status === "creator") return ["owner"];
+  if (member.status === "administrator") {
+    return member.custom_title
+      ? ["administrator", member.custom_title]
+      : ["administrator"];
+  }
+  return ["member"];
+}
+
+/** Deterministic observation time for an update-derived fact. */
+export function telegramObservedAt(dateSeconds: number): string {
+  return new Date(dateSeconds * 1_000).toISOString();
+}
+
+function scopeKey(scope: MembershipScope): string {
+  return `${scope.connectorAccountId}:${scope.externalWorldId}:${scope.externalRoomId}`;
+}
+
+function authorityErrorCode(error: unknown): string {
+  const code = (error as { code?: unknown } | null | undefined)?.code;
+  return typeof code === "string" ? code : "";
+}
+
+/**
+ * Per-(agent, Telegram account) client for the membership authority. Scope
+ * trackers are seeded from persisted scope health on first touch so a
+ * restarted process continues the persisted publisher binding instead of
+ * re-registering (which would strand every existing member fact with
+ * `membership_evidence_mismatch`).
+ */
+export class TelegramMembershipAuthority {
+  private readonly runtime: IAgentRuntime;
+  private readonly connectorAccountId: UUID;
+  private readonly service: MembershipService;
+  private readonly publisherInstanceId: string;
+  private readonly scopes = new Map<string, ScopeTracker>();
+  private readonly chains = new Map<string, Promise<unknown>>();
+
+  constructor(input: {
+    runtime: IAgentRuntime;
+    connectorAccountId: UUID;
+    service: MembershipService;
+  }) {
+    this.runtime = input.runtime;
+    this.connectorAccountId = input.connectorAccountId;
+    this.service = input.service;
+    this.publisherInstanceId = `telegram:${input.runtime.agentId}:${input.connectorAccountId}`;
+  }
+
+  /** Serializes authority command issuance per scope. */
+  private serialized<T>(key: string, fn: () => Promise<T>): Promise<T> {
+    const prior = this.chains.get(key) ?? Promise.resolve();
+    const run = prior.then(
+      () => fn(),
+      () => fn(),
+    );
+    this.chains.set(
+      key,
+      run.catch(() => {}),
+    );
+    return run;
+  }
+
+  /** Registers the scope publisher or adopts the persisted binding this publisher already owns. */
+  private async ensureRegistered(
+    scope: MembershipScope,
+  ): Promise<ScopeTracker | null> {
+    const key = scopeKey(scope);
+    const cached = this.scopes.get(key);
+    if (cached) return cached;
+    // Callers already hold the per-scope serialization lock (applyEvidence,
+    // markScopeUnavailable): do NOT re-enter serialized(key) here — the inner
+    // chain would queue behind the outer promise that is awaiting it.
+    return (async () => {
+      const seeded = this.scopes.get(key);
+      if (seeded) return seeded;
+      const health = await this.service.getScopeHealth(scope);
+      if (
+        health &&
+        health.publisherInstanceId === this.publisherInstanceId &&
+        health.evidenceMode === "point_query"
+      ) {
+        // Adoption: continue the persisted binding; generation CAS and cursor
+        // continuity provide dual-process fencing on top of the poller lock.
+        const tracker: ScopeTracker = {
+          generation: health.generation,
+          sourceVersion: health.sourceVersion,
+          sourceCursor: health.sourceCursor,
+          publisherGeneration: health.publisherGeneration ?? 0,
+        };
+        this.scopes.set(key, tracker);
+        return tracker;
+      }
+      const publisherGeneration = (health?.publisherGeneration ?? -1) + 1;
+      const receipt = await this.service.registerPublisher({
+        ...scope,
+        publisherInstanceId: this.publisherInstanceId,
+        publisherGeneration,
+        evidenceMode: "point_query",
+        expectedGeneration: health?.generation ?? 0,
+        idempotencyKey: `tg:${this.connectorAccountId}:publisher:${scope.externalWorldId}:${scope.externalRoomId}:${publisherGeneration}`,
+        observedAt: new Date().toISOString(),
+      });
+      if (receipt.operation !== "publisher") {
+        throw new Error(
+          `Telegram membership publisher registration returned ${receipt.operation}`,
+        );
+      }
+      const tracker: ScopeTracker = {
+        generation: receipt.committedGeneration,
+        sourceVersion: -1,
+        sourceCursor: null,
+        publisherGeneration,
+      };
+      this.scopes.set(key, tracker);
+      return tracker;
+    })();
+  }
+
+  /** Re-reads persisted scope state after a pre-commit fencing failure. */
+  private async readoptFromHealth(
+    scope: MembershipScope,
+  ): Promise<ScopeTracker> {
+    const health = await this.service.getScopeHealth(scope);
+    const tracker: ScopeTracker = {
+      generation: health?.generation ?? 0,
+      sourceVersion: health?.sourceVersion ?? -1,
+      sourceCursor: health?.sourceCursor ?? null,
+      publisherGeneration:
+        health?.publisherInstanceId === this.publisherInstanceId
+          ? (health.publisherGeneration ?? 0)
+          : (health?.publisherGeneration ?? -1) + 1,
+    };
+    this.scopes.set(scopeKey(scope), tracker);
+    return tracker;
+  }
+
+  /**
+   * Applies one point-query membership fact. On pre-commit fencing failures
+   * (cursor/generation) adopts persisted scope state and re-issues once under
+   * a fresh idempotency key (the request digest covers cursor fields).
+   */
+  private async applyEvidence(input: {
+    scope: MembershipScope;
+    canonicalPrincipalId: UUID;
+    state: "active" | "revoked";
+    reason: TelegramMembershipReason;
+    roles: readonly string[];
+    permissionSnapshot: JsonObject;
+    runtime: {
+      worldId: UUID | null;
+      roomId: UUID | null;
+      entityId: UUID | null;
+    };
+    observedAt: string;
+    idempotencyKey: string;
+  }): Promise<boolean> {
+    const key = scopeKey(input.scope);
+    return this.serialized(key, async () => {
+      let tracker =
+        (await this.ensureRegistered(input.scope)) ??
+        (await this.readoptFromHealth(input.scope));
+      for (let attempt = 0; attempt < 2; attempt++) {
+        const sourceVersion = tracker.sourceVersion + 1;
+        const sourceCursor = `tg:${sourceVersion}`;
+        try {
+          await this.service.applyMembership({
+            ...input.scope,
+            publisherInstanceId: this.publisherInstanceId,
+            publisherGeneration: tracker.publisherGeneration,
+            evidenceMode: "point_query",
+            expectedGeneration: tracker.generation,
+            sourceVersion,
+            previousSourceCursor: tracker.sourceCursor,
+            sourceCursor,
+            validUntil: new Date(
+              Date.parse(input.observedAt) + TELEGRAM_MEMBERSHIP_TTL_MS,
+            ).toISOString(),
+            canonicalPrincipalId: input.canonicalPrincipalId,
+            state: input.state,
+            reason: input.reason,
+            roles: [...input.roles],
+            permissionSnapshot: input.permissionSnapshot,
+            runtime: input.runtime,
+            idempotencyKey:
+              attempt === 0
+                ? input.idempotencyKey
+                : `${input.idempotencyKey}:retry${attempt}`,
+            observedAt: input.observedAt,
+          });
+          tracker.generation += 1;
+          tracker.sourceVersion = sourceVersion;
+          tracker.sourceCursor = sourceCursor;
+          return true;
+        } catch (error) {
+          const code = authorityErrorCode(error);
+          if (
+            attempt === 0 &&
+            (code === "MEMBERSHIP_CURSOR_DISCONTINUITY" ||
+              code === "MEMBERSHIP_GENERATION_MISMATCH" ||
+              code === "MEMBERSHIP_PUBLISHER_MISMATCH")
+          ) {
+            // error-policy:J4 Pre-commit fencing failure: adopt persisted
+            // scope state and re-issue once under a fresh idempotency key.
+            tracker = await this.readoptFromHealth(input.scope);
+            continue;
+          }
+          if (
+            code === "MEMBERSHIP_IDEMPOTENCY_CONFLICT" ||
+            code === "MEMBERSHIP_COMMAND_INVALID"
+          ) {
+            // Replayed update rebuilt with different bytes, or a redelivery
+            // whose evidence window has passed: benign duplicates.
+            logger.debug(
+              {
+                src: "plugin:telegram",
+                agentId: this.runtime.agentId,
+                chatId: input.scope.externalWorldId,
+                idempotencyKey: input.idempotencyKey,
+                code,
+              },
+              "Telegram membership evidence rejected as a duplicate; skipping",
+            );
+            return false;
+          }
+          throw error;
+        }
+      }
+      return false;
+    });
+  }
+
+  /**
+   * Records a join/leave/kick observation from a Telegram update.
+   * Deterministic idempotency key + observation time make duplicate and
+   * out-of-order redeliveries non-resurrecting: a replay either replays the
+   * identical journal entry or is skipped as a stale duplicate.
+   */
+  async recordEvent(input: {
+    chatId: string;
+    chatRoomKey: string;
+    canonicalPrincipalId: UUID;
+    state: "active" | "revoked";
+    reason: TelegramMembershipReason;
+    roles?: readonly string[];
+    permissionSnapshot?: JsonObject;
+    runtime: {
+      worldId: UUID | null;
+      roomId: UUID | null;
+      entityId: UUID | null;
+    };
+    messageId: number;
+    telegramUserId: string;
+    observedAt: string;
+  }): Promise<void> {
+    const scope = telegramMembershipScope({
+      agentId: this.runtime.agentId,
+      connectorAccountId: this.connectorAccountId,
+      chatId: input.chatId,
+      chatRoomKey: input.chatRoomKey,
+    });
+    try {
+      await this.applyEvidence({
+        scope,
+        canonicalPrincipalId: input.canonicalPrincipalId,
+        state: input.state,
+        reason: input.reason,
+        roles: input.roles ?? ["member"],
+        permissionSnapshot: input.permissionSnapshot ?? {},
+        runtime: input.runtime,
+        observedAt: input.observedAt,
+        idempotencyKey: `tg:${this.connectorAccountId}:${input.chatId}:msg:${input.messageId}:${input.reason}:${input.telegramUserId}`,
+      });
+    } catch (error) {
+      // error-policy:J7 Authority diagnostics must not kill the poll loop;
+      // the principal stays denied-by-default until fresh evidence lands.
+      this.runtime.reportError("telegram:membership-evidence", error, {
+        chatId: input.chatId,
+        messageId: input.messageId,
+        telegramUserId: input.telegramUserId,
+      });
+    }
+  }
+
+  /**
+   * getChatMember point-query reconcile. Returns the mapped
+   * (state, reason) and applies it as evidence, or null when the provider
+   * query itself failed (stay denied; report once per call).
+   */
+  async reconcile(input: {
+    chatId: string;
+    chatRoomKey: string;
+    canonicalPrincipalId: UUID;
+    telegramUserId: string;
+    runtime: {
+      worldId: UUID | null;
+      roomId: UUID | null;
+      entityId: UUID | null;
+    };
+    getChatMember: () => Promise<{
+      status: string;
+      custom_title?: string;
+      user: { id: number };
+    }>;
+    observedAt?: string;
+    nonce: string;
+  }): Promise<{
+    state: "active" | "revoked";
+    reason: TelegramMembershipReason;
+  } | null> {
+    let member: {
+      status: string;
+      custom_title?: string;
+      user: { id: number };
+    };
+    try {
+      member = await input.getChatMember();
+    } catch (error) {
+      // error-policy:J4 Reconcile transport failure: report and stay denied
+      // rather than fabricating an authoritative roster.
+      this.runtime.reportError("telegram:membership-reconcile", error, {
+        chatId: input.chatId,
+        telegramUserId: input.telegramUserId,
+      });
+      return null;
+    }
+    const mapped = telegramStatusToMembership(member.status);
+    const scope = telegramMembershipScope({
+      agentId: this.runtime.agentId,
+      connectorAccountId: this.connectorAccountId,
+      chatId: input.chatId,
+      chatRoomKey: input.chatRoomKey,
+    });
+    try {
+      await this.applyEvidence({
+        scope,
+        canonicalPrincipalId: input.canonicalPrincipalId,
+        state: mapped.state,
+        reason: mapped.reason,
+        roles: telegramMemberRoles(member),
+        permissionSnapshot: { status: member.status },
+        runtime: input.runtime,
+        observedAt: input.observedAt ?? new Date().toISOString(),
+        // Reconciles are provider queries, not update replays: keyed by the
+        // query nonce so repeated reconciles issue fresh evidence.
+        idempotencyKey: `tg:${this.connectorAccountId}:${input.chatId}:reconcile:${input.telegramUserId}:${input.nonce}`,
+      });
+    } catch (error) {
+      this.runtime.reportError("telegram:membership-reconcile", error, {
+        chatId: input.chatId,
+        telegramUserId: input.telegramUserId,
+      });
+      return null;
+    }
+    return mapped;
+  }
+
+  /** Fail-closed admission decision for a group/supergroup chat scope. */
+  async authorize(input: {
+    chatId: string;
+    chatRoomKey: string;
+    canonicalPrincipalId: UUID;
+  }): Promise<MembershipAuthorizationDecision> {
+    const scope = telegramMembershipScope({
+      agentId: this.runtime.agentId,
+      connectorAccountId: this.connectorAccountId,
+      chatId: input.chatId,
+      chatRoomKey: input.chatRoomKey,
+    });
+    return this.service.authorize(scope, input.canonicalPrincipalId);
+  }
+
+  /**
+   * Marks a chat scope unavailable (bot removed): every later admission for
+   * the scope fails closed with `authority_unavailable`.
+   */
+  async markScopeUnavailable(input: {
+    chatId: string;
+    chatRoomKey: string;
+    reason: string;
+  }): Promise<void> {
+    const scope = telegramMembershipScope({
+      agentId: this.runtime.agentId,
+      connectorAccountId: this.connectorAccountId,
+      chatId: input.chatId,
+      chatRoomKey: input.chatRoomKey,
+    });
+    const key = scopeKey(scope);
+    try {
+      await this.serialized(key, async () => {
+        const health = await this.service.getScopeHealth(scope);
+        const expectedGeneration = health?.generation ?? 0;
+        await this.service.setScopeHealth({
+          ...scope,
+          expectedGeneration,
+          idempotencyKey: `tg:${this.connectorAccountId}:${input.chatId}:${input.reason}:${expectedGeneration}`,
+          health: "unavailable",
+          reason: input.reason,
+          observedAt: new Date().toISOString(),
+        });
+        this.scopes.delete(key);
+      });
+    } catch (error) {
+      // error-policy:J7 Bot-removal bookkeeping must not kill the poll loop.
+      this.runtime.reportError("telegram:membership-scope-health", error, {
+        chatId: input.chatId,
+        reason: input.reason,
+      });
+    }
+  }
+
+  /** Read-only scope health accessor (used by tests and diagnostics). */
+  async scopeHealth(input: {
+    chatId: string;
+    chatRoomKey: string;
+  }): Promise<MembershipScopeHealth | null> {
+    const scope = telegramMembershipScope({
+      agentId: this.runtime.agentId,
+      connectorAccountId: this.connectorAccountId,
+      chatId: input.chatId,
+      chatRoomKey: input.chatRoomKey,
+    });
+    return this.service.getScopeHealth(scope);
+  }
+}

--- a/plugins/plugin-telegram/src/membership.ts
+++ b/plugins/plugin-telegram/src/membership.ts
@@ -19,7 +19,7 @@ import type {
   MembershipService,
   UUID,
 } from "@elizaos/core";
-import { ChannelType, logger, ServiceType } from "@elizaos/core";
+import { ChannelType, ElizaError, logger, ServiceType } from "@elizaos/core";
 
 /** Evidence freshness window for Telegram point proofs (under the authority's 24h cap). */
 export const TELEGRAM_MEMBERSHIP_TTL_MS = 60 * 60 * 1_000;
@@ -163,6 +163,15 @@ export class TelegramMembershipAuthority {
   private readonly publisherInstanceId: string;
   private readonly scopes = new Map<string, ScopeTracker>();
   private readonly chains = new Map<string, Promise<unknown>>();
+  /**
+   * Bot-removal tombstones by scope key. Once the bot itself has been removed
+   * from a chat, NO further evidence may advance that scope back to current:
+   * a backlogged join/leave/reconcile redelivery after the removal would
+   * otherwise re-authorize stale member facts for a chat the bot can no
+   * longer observe. Only an explicit bot re-add (my_chat_member join) clears
+   * the tombstone, and only after a fresh registration.
+   */
+  private readonly removedScopes = new Map<string, string>();
 
   constructor(input: {
     runtime: IAgentRuntime;
@@ -184,6 +193,9 @@ export class TelegramMembershipAuthority {
     );
     this.chains.set(
       key,
+      // error-policy:J5 The chain placeholder must never reject: the same
+      // rejection is already observed by the caller awaiting `run` (returned
+      // below); swallowing it here only keeps the chain link settled.
       run.catch(() => {}),
     );
     return run;
@@ -230,8 +242,9 @@ export class TelegramMembershipAuthority {
         observedAt: new Date().toISOString(),
       });
       if (receipt.operation !== "publisher") {
-        throw new Error(
+        throw new ElizaError(
           `Telegram membership publisher registration returned ${receipt.operation}`,
+          { code: "TELEGRAM_MEMBERSHIP_PUBLISHER_PROTOCOL" },
         );
       }
       const tracker: ScopeTracker = {
@@ -267,8 +280,9 @@ export class TelegramMembershipAuthority {
         observedAt: new Date().toISOString(),
       });
       if (receipt.operation !== "publisher") {
-        throw new Error(
+        throw new ElizaError(
           `Telegram membership publisher takeover returned ${receipt.operation}`,
+          { code: "TELEGRAM_MEMBERSHIP_PUBLISHER_PROTOCOL" },
         );
       }
       const tracker: ScopeTracker = {
@@ -338,8 +352,9 @@ export class TelegramMembershipAuthority {
           throw error;
         }
       }
-      throw new Error(
+      throw new ElizaError(
         `Telegram membership scope stale-degrade exhausted retries for ${input.scope.externalWorldId}`,
+        { code: "TELEGRAM_MEMBERSHIP_DEGRADE_EXHAUSTED" },
       );
     });
   }
@@ -366,6 +381,25 @@ export class TelegramMembershipAuthority {
   }): Promise<boolean> {
     const key = scopeKey(input.scope);
     return this.serialized(key, async () => {
+      // Bot-removal tombstone: once the bot has been removed from this chat,
+      // no evidence (backlogged join redelivery, reconcile) may advance the
+      // scope back to current — the bot cannot observe the chat anymore, so
+      // its stored member facts must stay non-authorizing until the bot is
+      // re-added (which clears the tombstone via clearScopeRemoval).
+      const removalReason = this.removedScopes.get(key);
+      if (removalReason !== undefined) {
+        logger.debug(
+          {
+            src: "plugin:telegram",
+            agentId: this.runtime.agentId,
+            chatId: input.scope.externalWorldId,
+            telegramUserId: input.canonicalPrincipalId,
+            removalReason,
+          },
+          "Telegram membership evidence rejected for a bot-removed scope; skipping",
+        );
+        return false;
+      }
       let tracker =
         (await this.ensureRegistered(input.scope)) ??
         (await this.readoptFromHealth(input.scope));
@@ -373,13 +407,23 @@ export class TelegramMembershipAuthority {
       // Out-of-order guard: a fact older than the principal's committed
       // evidence must never overwrite it (an old join with a distinct message
       // id redelivered after a newer leave must not resurrect membership).
+      // STRICT on the dangerous direction: Telegram update dates have
+      // one-second resolution, so an EQUAL timestamp is not newer — only a
+      // strictly newer active observation may replace a committed revocation
+      // (an equal-second join redelivery after a leave must not resurrect;
+      // equal-second revocations remain allowed — they only ever deny).
       const committed = await this.service.getMembership(
         input.scope,
         input.canonicalPrincipalId,
       );
+      const committedAt = committed ? Date.parse(committed.observedAt) : 0;
+      const observedAtMs = Date.parse(input.observedAt);
+      const wouldResurrect =
+        committed?.state === "revoked" && input.state === "active";
       if (
         committed &&
-        Date.parse(input.observedAt) < Date.parse(committed.observedAt)
+        (observedAtMs < committedAt ||
+          (observedAtMs === committedAt && wouldResurrect))
       ) {
         logger.debug(
           {
@@ -438,6 +482,39 @@ export class TelegramMembershipAuthority {
             // error-policy:J4 Pre-commit fencing failure: adopt persisted
             // scope state and re-issue once under a fresh idempotency key.
             tracker = await this.readoptFromHealth(input.scope);
+            // The competing write that broke our fence may have committed
+            // NEWER evidence for THIS principal (e.g. a revocation from
+            // another process): re-run the out-of-order guard against the
+            // now-committed record before retrying, or the retry would
+            // overwrite it and resurrect a revoked principal.
+            const recommitted = await this.service.getMembership(
+              input.scope,
+              input.canonicalPrincipalId,
+            );
+            const recommittedAt = recommitted
+              ? Date.parse(recommitted.observedAt)
+              : 0;
+            const nowResurrects =
+              recommitted?.state === "revoked" && input.state === "active";
+            if (
+              recommitted &&
+              (observedAtMs < recommittedAt ||
+                (observedAtMs === recommittedAt && nowResurrects))
+            ) {
+              logger.debug(
+                {
+                  src: "plugin:telegram",
+                  agentId: this.runtime.agentId,
+                  chatId: input.scope.externalWorldId,
+                  telegramUserId: input.canonicalPrincipalId,
+                  incomingObservedAt: input.observedAt,
+                  committedObservedAt: recommitted.observedAt,
+                  fenceRetry: true,
+                },
+                "Telegram membership retry would overwrite newer committed evidence; skipping",
+              );
+              return false;
+            }
             continue;
           }
           if (code === "MEMBERSHIP_IDEMPOTENCY_CONFLICT") {
@@ -531,9 +608,15 @@ export class TelegramMembershipAuthority {
           // degrade failed: propagate a typed error so the connector layer
           // can mark the admission gate broken (every group admission then
           // fails closed) instead of leaving active evidence authorizing.
-          throw new Error(
+          throw new ElizaError(
             "Telegram membership revocation could not be committed or degraded",
-            { cause: degradeError },
+            {
+              code: "TELEGRAM_MEMBERSHIP_REVOCATION_UNSAFE",
+              // Root cause is the original evidence failure; the degrade
+              // failure travels as context so both surfaces are diagnosable.
+              cause: error,
+              context: { degradeError: String(degradeError) },
+            },
           );
         }
       }
@@ -583,6 +666,31 @@ export class TelegramMembershipAuthority {
     } catch (error) {
       // error-policy:J4 Reconcile transport failure: report and stay denied
       // rather than fabricating an authoritative roster.
+      this.runtime.reportError("telegram:membership-reconcile", error, {
+        chatId: input.chatId,
+        telegramUserId: input.telegramUserId,
+      });
+      return null;
+    }
+    // Provider-boundary validation: the response must describe the SAME user
+    // we asked about. A mismatched getChatMember reply must never become
+    // evidence for the requested canonical principal (admitting the wrong
+    // principal, or a malformed upstream response fabricating membership).
+    if (
+      member.user?.id === undefined ||
+      String(member.user.id) !== input.telegramUserId
+    ) {
+      const error = new ElizaError(
+        "Telegram getChatMember returned a different user than requested",
+        {
+          code: "TELEGRAM_MEMBERSHIP_SUBJECT_MISMATCH",
+          context: {
+            chatId: input.chatId,
+            requestedTelegramUserId: input.telegramUserId,
+            returnedUserId: member.user?.id,
+          },
+        },
+      );
       this.runtime.reportError("telegram:membership-reconcile", error, {
         chatId: input.chatId,
         telegramUserId: input.telegramUserId,
@@ -723,6 +831,11 @@ export class TelegramMembershipAuthority {
           });
           if (receipt.operation === "health") {
             this.scopes.delete(key);
+            // Tombstone the scope: any further evidence write for this chat
+            // (backlogged redeliveries, reconciles) must NOT advance the
+            // scope back to current — it stays non-authorizing until the
+            // bot is explicitly re-added.
+            this.removedScopes.set(key, input.reason);
             return;
           }
         } catch (error) {
@@ -739,10 +852,29 @@ export class TelegramMembershipAuthority {
           throw error;
         }
       }
-      throw new Error(
+      throw new ElizaError(
         `Telegram membership scope unavailable-degrade exhausted retries for ${input.chatId}`,
+        { code: "TELEGRAM_MEMBERSHIP_DEGRADE_EXHAUSTED" },
       );
     });
+  }
+
+  /**
+   * Clears the bot-removal tombstone for a scope after the bot has been
+   * re-added to the chat (my_chat_member / new_chat_members join carrying
+   * the bot's own id). The next evidence write re-registers the publisher
+   * from persisted health, so re-authorization requires fresh evidence —
+   * pre-removal member facts alone stay non-authorizing because point-query
+   * evidence carries a bounded validUntil.
+   */
+  clearScopeRemoval(input: { chatId: string; chatRoomKey: string }): void {
+    const scope = telegramMembershipScope({
+      agentId: this.runtime.agentId,
+      connectorAccountId: this.connectorAccountId,
+      chatId: input.chatId,
+      chatRoomKey: input.chatRoomKey,
+    });
+    this.removedScopes.delete(scopeKey(scope));
   }
 
   /** Read-only scope health accessor (used by tests and diagnostics). */

--- a/plugins/plugin-telegram/src/membership.ts
+++ b/plugins/plugin-telegram/src/membership.ts
@@ -188,6 +188,13 @@ export class TelegramMembershipAuthority {
    * principal restoring scope health must not re-authorize them.
    */
   private readonly pendingRevocations = new Map<string, Set<UUID>>();
+  /**
+   * Scope keys whose persisted pending-revocation overlay has been hydrated
+   * from the runtime cache this process. Hydration is lazy (first authorize
+   * for the scope) so a restart denies principals whose revocation could not
+   * be committed even after unrelated evidence restored scope health.
+   */
+  private readonly pendingRevocationsHydrated = new Set<string>();
 
   constructor(input: {
     runtime: IAgentRuntime;
@@ -198,6 +205,72 @@ export class TelegramMembershipAuthority {
     this.connectorAccountId = input.connectorAccountId;
     this.service = input.service;
     this.publisherInstanceId = `telegram:${input.runtime.agentId}:${input.connectorAccountId}`;
+  }
+
+  /**
+   * Cache key for this scope's durable pending-revocation overlay. The
+   * runtime cache is database-backed, so the overlay survives a restart —
+   * without it, a failed revocation write followed by a restart would leave
+   * the departed principal's still-valid active evidence authorizing again.
+   */
+  private pendingRevocationsCacheKey(scope: MembershipScope): string {
+    return `telegram:membership:pending-revocations:${scope.connectorAccountId}:${scope.externalWorldId}:${scope.externalRoomId}`;
+  }
+
+  /**
+   * Loads the persisted pending-revocation set for a scope into memory
+   * (idempotent per scope per process). Callers on the per-scope chain may
+   * already hold the lock; cache reads are lock-free because they only ever
+   * merge persisted UUIDs into the in-memory overlay.
+   */
+  private async hydratePendingRevocations(
+    scope: MembershipScope,
+  ): Promise<void> {
+    const key = scopeKey(scope);
+    if (this.pendingRevocationsHydrated.has(key)) return;
+    this.pendingRevocationsHydrated.add(key);
+    try {
+      const persisted = await this.runtime.getCache<UUID[]>(
+        this.pendingRevocationsCacheKey(scope),
+      );
+      if (persisted) {
+        const overlay = this.pendingRevocations.get(key) ?? new Set<UUID>();
+        for (const id of persisted) overlay.add(id);
+        this.pendingRevocations.set(key, overlay);
+      }
+    } catch (error) {
+      // error-policy:J7 Cache hydration failure must not block admission:
+      // authorize falls through to the authoritative service decision, and
+      // the failure is reported for diagnosis.
+      this.runtime.reportError("telegram:membership-pending-hydration", error, {
+        chatId: scope.externalWorldId,
+      });
+    }
+  }
+
+  /** Persists the in-memory pending-revocation set for one scope. */
+  private async persistPendingRevocations(
+    scope: MembershipScope,
+  ): Promise<void> {
+    const key = scopeKey(scope);
+    const overlay = this.pendingRevocations.get(key);
+    try {
+      if (overlay && overlay.size > 0) {
+        await this.runtime.setCache(this.pendingRevocationsCacheKey(scope), [
+          ...overlay,
+        ]);
+      } else {
+        await this.runtime.deleteCache(this.pendingRevocationsCacheKey(scope));
+      }
+    } catch (error) {
+      // error-policy:J7 Persistence here is a durability enhancement: the
+      // in-memory overlay is already installed for this process and the
+      // scope was degraded stale; a cache write failure is reported, not
+      // fatal — authorize in THIS process still fails closed.
+      this.runtime.reportError("telegram:membership-pending-persist", error, {
+        chatId: scope.externalWorldId,
+      });
+    }
   }
 
   /** Serializes authority command issuance per scope. */
@@ -336,8 +409,22 @@ export class TelegramMembershipAuthority {
     scope: MembershipScope;
     reason: string;
   }): Promise<void> {
-    const key = scopeKey(input.scope);
-    await this.serialized(key, async () => {
+    await this.markScopeStaleLocked(input, false);
+  }
+
+  /**
+   * markScopeStale body. `alreadyLocked` must be true ONLY when the caller
+   * already holds this scope's serialized chain (applyEvidence's revocation
+   * failure path) — running the degrade inside the same chain link is what
+   * closes the overtake race: a queued authorize cannot run between the
+   * failed evidence write and the fail-closed degrade + overlay install.
+   */
+  private async markScopeStaleLocked(
+    input: { scope: MembershipScope; reason: string },
+    alreadyLocked: boolean,
+  ): Promise<void> {
+    const run = async () => {
+      const key = scopeKey(input.scope);
       for (let attempt = 0; attempt < 3; attempt++) {
         const health = await this.service.getScopeHealth(input.scope);
         const expectedGeneration = health?.generation ?? 0;
@@ -375,7 +462,12 @@ export class TelegramMembershipAuthority {
         `Telegram membership scope stale-degrade exhausted retries for ${input.scope.externalWorldId}`,
         { code: "TELEGRAM_MEMBERSHIP_DEGRADE_EXHAUSTED" },
       );
-    });
+    };
+    if (alreadyLocked) {
+      await run();
+      return;
+    }
+    await this.serialized(scopeKey(input.scope), run);
   }
 
   /**
@@ -400,6 +492,10 @@ export class TelegramMembershipAuthority {
   }): Promise<boolean> {
     const key = scopeKey(input.scope);
     return this.serialized(key, async () => {
+      // Restart hydration (see authorize): a restart-then-fresh-evidence
+      // commit must clear the persisted overlay for this principal, which
+      // requires the persisted set to be loaded first.
+      await this.hydratePendingRevocations(input.scope);
       // Restart hydration: if this process restarted, the in-memory
       // bot-removal tombstone map is empty — but the persisted scope health
       // still says unavailable. Hydrate BEFORE the tombstone check so a
@@ -530,8 +626,10 @@ export class TelegramMembershipAuthority {
           tracker.sourceCursor = sourceCursor;
           // Fresh evidence for this principal committed: any pending
           // (uncommittable) revocation overlay for it is now superseded —
-          // the authoritative record speaks again.
+          // the authoritative record speaks again. Persist the removal so a
+          // restart does not resurrect the overlay against committed state.
           this.pendingRevocations.get(key)?.delete(input.canonicalPrincipalId);
+          await this.persistPendingRevocations(input.scope);
           return true;
         } catch (error) {
           const code = authorityErrorCode(error);
@@ -596,6 +694,39 @@ export class TelegramMembershipAuthority {
             );
             return false;
           }
+          // A non-fencing failure (storage outage, assert). For REVOCATIONS
+          // the prior active evidence may still authorize the departed
+          // principal: install the fail-closed protections INSIDE this same
+          // serialized chain link (degrade the scope stale AND add the
+          // durable pending-revocation overlay) BEFORE the chain settles —
+          // an authorize queued while the write was pending must observe
+          // either the committed revocation or the fence, never the stale
+          // active record.
+          if (input.state === "revoked") {
+            await this.markScopeStaleLocked(
+              {
+                scope: input.scope,
+                reason: `revocation_write_failed:${input.reason}`,
+              },
+              true,
+            );
+            const key2 = scopeKey(input.scope);
+            const pending =
+              this.pendingRevocations.get(key2) ?? new Set<UUID>();
+            pending.add(input.canonicalPrincipalId);
+            this.pendingRevocations.set(key2, pending);
+            await this.persistPendingRevocations(input.scope);
+            // Surface a typed error so recordEvent's caller (the service)
+            // can log/report it; the security state itself is already
+            // fail-closed at this point.
+            throw new ElizaError(
+              "Telegram membership revocation could not be committed; scope degraded fail-closed",
+              {
+                code: "TELEGRAM_MEMBERSHIP_REVOCATION_DEGRADED",
+                cause: error,
+              },
+            );
+          }
           throw error;
         }
       }
@@ -646,49 +777,36 @@ export class TelegramMembershipAuthority {
       });
     } catch (error) {
       // error-policy:J7 Authority diagnostics must not kill the poll loop.
-      // For a REVOCATION we must not leave prior active evidence authorizing
-      // the departed principal: degrade the scope to stale (fail-closed
-      // admission) until fresh evidence lands.
+      // For a REVOCATION the fail-closed protections (scope stale degrade +
+      // durable pending-revocation overlay) are installed INSIDE
+      // applyEvidence's serialized chain link, atomically with the failed
+      // write: TELEGRAM_MEMBERSHIP_REVOCATION_DEGRADED arrives here only
+      // AFTER the fence landed, so reporting suffices.
+      if (
+        authorityErrorCode(error) === "TELEGRAM_MEMBERSHIP_REVOCATION_DEGRADED"
+      ) {
+        this.runtime.reportError("telegram:membership-evidence", error, {
+          chatId: input.chatId,
+          messageId: input.messageId,
+          telegramUserId: input.telegramUserId,
+          degraded: true,
+        });
+        return;
+      }
+      // For a raw revocation failure (no fence installed — e.g. the chain
+      // itself could not run) escalate so the connector layer can mark the
+      // admission gate broken: every group admission then fails closed.
       if (input.state === "revoked") {
-        try {
-          await this.markScopeStale({
-            scope,
-            reason: `revocation_write_failed:${input.reason}`,
-          });
-          // Degrade landed: admission now fails closed for the scope. ALSO
-          // record the pending revocation: the stale degrade is not durable —
-          // unrelated evidence can restore scope health — so this principal
-          // must keep failing closed via the authorize overlay until fresh
-          // evidence for the SAME principal commits.
-          const key = scopeKey(scope);
-          const pending = this.pendingRevocations.get(key) ?? new Set<UUID>();
-          pending.add(input.canonicalPrincipalId);
-          this.pendingRevocations.set(key, pending);
-          // error-policy:J7 Evidence-write failure must not kill the poll
-          // loop; the failure is reported and the degraded scope carries the
-          // security decision.
-          this.runtime.reportError("telegram:membership-evidence", error, {
-            chatId: input.chatId,
-            messageId: input.messageId,
-            telegramUserId: input.telegramUserId,
-          });
-          return;
-        } catch (degradeError) {
-          // error-policy:J2 BOTH the evidence write AND the fail-closed
-          // degrade failed: propagate a typed error so the connector layer
-          // can mark the admission gate broken (every group admission then
-          // fails closed) instead of leaving active evidence authorizing.
-          throw new ElizaError(
-            "Telegram membership revocation could not be committed or degraded",
-            {
-              code: "TELEGRAM_MEMBERSHIP_REVOCATION_UNSAFE",
-              // Root cause is the original evidence failure; the degrade
-              // failure travels as context so both surfaces are diagnosable.
-              cause: error,
-              context: { degradeError: String(degradeError) },
-            },
-          );
-        }
+        // error-policy:J2 Propagate a typed error so the connector layer can
+        // mark the admission gate broken instead of leaving active evidence
+        // authorizing.
+        throw new ElizaError(
+          "Telegram membership revocation could not be committed or degraded",
+          {
+            code: "TELEGRAM_MEMBERSHIP_REVOCATION_UNSAFE",
+            cause: error,
+          },
+        );
       }
       this.runtime.reportError("telegram:membership-evidence", error, {
         chatId: input.chatId,
@@ -862,6 +980,11 @@ export class TelegramMembershipAuthority {
     });
     const key = scopeKey(scope);
     return this.serialized(key, async () => {
+      // Restart hydration: the in-memory pending-revocation overlay is empty
+      // after a restart — load the persisted overlay so a principal whose
+      // revocation could not be committed keeps failing closed even if
+      // unrelated evidence restored scope health.
+      await this.hydratePendingRevocations(scope);
       // Pending-revocation overlay: this principal's revocation could not be
       // committed and the scope was degraded stale — but scope health may
       // have been restored since by unrelated evidence. Their prior active

--- a/plugins/plugin-telegram/src/membership.ts
+++ b/plugins/plugin-telegram/src/membership.ts
@@ -150,6 +150,18 @@ function authorityErrorCode(error: unknown): string {
 }
 
 /**
+ * Fail-closed sentinel for pending-revocation hydration: when the durable
+ * overlay cannot be read, membership decisions must deny rather than trust
+ * possibly-stale active evidence. `has()` always true — the unknown set is
+ * treated as containing every principal.
+ */
+const FAIL_CLOSED_PENDING: ReadonlySet<UUID> = {
+  has: () => true,
+} as unknown as ReadonlySet<UUID>;
+
+const EMPTY_PENDING: ReadonlySet<UUID> = new Set<UUID>();
+
+/**
  * Per-(agent, Telegram account) client for the membership authority. Scope
  * trackers are seeded from persisted scope health on first touch so a
  * restarted process continues the persisted publisher binding instead of
@@ -218,40 +230,47 @@ export class TelegramMembershipAuthority {
   }
 
   /**
-   * Loads the persisted pending-revocation set for a scope into memory
-   * (idempotent per scope per process). Callers on the per-scope chain may
-   * already hold the lock; cache reads are lock-free because they only ever
-   * merge persisted UUIDs into the in-memory overlay.
+   * Loads the persisted pending-revocation set for a scope into memory.
+   * FAIL CLOSED on a cache read failure: when the durable overlay cannot be
+   * read, the safe assumption is that uncommitted revocations exist, so the
+   * returned overlay-conservative fallback denies (below). The hydrated mark
+   * is only set after a successful read (or a definitive empty), so a
+   * transient cache outage never permanently suppresses hydration.
+   * Callers on the per-scope chain may already hold the lock; cache reads
+   * are lock-free because they only ever merge persisted UUIDs into the
+   * in-memory overlay.
    */
   private async hydratePendingRevocations(
     scope: MembershipScope,
-  ): Promise<void> {
+  ): Promise<ReadonlySet<UUID>> {
     const key = scopeKey(scope);
-    if (this.pendingRevocationsHydrated.has(key)) return;
-    this.pendingRevocationsHydrated.add(key);
+    let persisted: UUID[] | undefined;
     try {
-      const persisted = await this.runtime.getCache<UUID[]>(
+      persisted = await this.runtime.getCache<UUID[]>(
         this.pendingRevocationsCacheKey(scope),
       );
-      if (persisted) {
-        const overlay = this.pendingRevocations.get(key) ?? new Set<UUID>();
-        for (const id of persisted) overlay.add(id);
-        this.pendingRevocations.set(key, overlay);
-      }
     } catch (error) {
-      // error-policy:J7 Cache hydration failure must not block admission:
-      // authorize falls through to the authoritative service decision, and
-      // the failure is reported for diagnosis.
+      // error-policy:J4 A cache read failure leaves the durable overlay
+      // unknown: fail closed (deny via the conservative set below) rather
+      // than consult possibly-stale active evidence. Report for diagnosis.
       this.runtime.reportError("telegram:membership-pending-hydration", error, {
         chatId: scope.externalWorldId,
       });
+      return FAIL_CLOSED_PENDING;
     }
+    this.pendingRevocationsHydrated.add(key);
+    if (persisted) {
+      const overlay = this.pendingRevocations.get(key) ?? new Set<UUID>();
+      for (const id of persisted) overlay.add(id);
+      this.pendingRevocations.set(key, overlay);
+    }
+    return this.pendingRevocations.get(key) ?? EMPTY_PENDING;
   }
 
   /** Persists the in-memory pending-revocation set for one scope. */
   private async persistPendingRevocations(
     scope: MembershipScope,
-  ): Promise<void> {
+  ): Promise<boolean> {
     const key = scopeKey(scope);
     const overlay = this.pendingRevocations.get(key);
     try {
@@ -262,14 +281,17 @@ export class TelegramMembershipAuthority {
       } else {
         await this.runtime.deleteCache(this.pendingRevocationsCacheKey(scope));
       }
+      return true;
     } catch (error) {
-      // error-policy:J7 Persistence here is a durability enhancement: the
-      // in-memory overlay is already installed for this process and the
-      // scope was degraded stale; a cache write failure is reported, not
-      // fatal — authorize in THIS process still fails closed.
+      // error-policy:J4 The durable fence did NOT land. The in-memory
+      // overlay still denies in THIS process, but a restart would
+      // re-authorize the departed principal. Report and surface failure so
+      // revocation callers escalate (gate broken) instead of claiming a
+      // durable fail-closed state.
       this.runtime.reportError("telegram:membership-pending-persist", error, {
         chatId: scope.externalWorldId,
       });
+      return false;
     }
   }
 
@@ -494,7 +516,9 @@ export class TelegramMembershipAuthority {
     return this.serialized(key, async () => {
       // Restart hydration (see authorize): a restart-then-fresh-evidence
       // commit must clear the persisted overlay for this principal, which
-      // requires the persisted set to be loaded first.
+      // requires the persisted set to be loaded first. On a cache read
+      // failure the FAIL_CLOSED sentinel denies every principal — safe
+      // (evidence is only recorded, admission is gated in authorize).
       await this.hydratePendingRevocations(input.scope);
       // Restart hydration: if this process restarted, the in-memory
       // bot-removal tombstone map is empty — but the persisted scope health
@@ -715,7 +739,20 @@ export class TelegramMembershipAuthority {
               this.pendingRevocations.get(key2) ?? new Set<UUID>();
             pending.add(input.canonicalPrincipalId);
             this.pendingRevocations.set(key2, pending);
-            await this.persistPendingRevocations(input.scope);
+            const persisted = await this.persistPendingRevocations(input.scope);
+            if (!persisted) {
+              // The durable overlay did not land: a restart would
+              // re-authorize the departed principal. Escalate to gate-broken
+              // (every group admission fails closed) rather than claim a
+              // durable fail-closed state.
+              throw new ElizaError(
+                "Telegram membership revocation fence could not be persisted",
+                {
+                  code: "TELEGRAM_MEMBERSHIP_REVOCATION_UNSAFE",
+                  cause: error,
+                },
+              );
+            }
             // Surface a typed error so recordEvent's caller (the service)
             // can log/report it; the security state itself is already
             // fail-closed at this point.
@@ -983,14 +1020,16 @@ export class TelegramMembershipAuthority {
       // Restart hydration: the in-memory pending-revocation overlay is empty
       // after a restart — load the persisted overlay so a principal whose
       // revocation could not be committed keeps failing closed even if
-      // unrelated evidence restored scope health.
-      await this.hydratePendingRevocations(scope);
+      // unrelated evidence restored scope health. A cache read failure
+      // returns the FAIL_CLOSED sentinel: deny rather than consult
+      // possibly-stale active evidence.
+      const pendingOverlay = await this.hydratePendingRevocations(scope);
       // Pending-revocation overlay: this principal's revocation could not be
       // committed and the scope was degraded stale — but scope health may
       // have been restored since by unrelated evidence. Their prior active
       // fact must keep failing closed until fresh evidence for THIS
       // principal lands.
-      if (this.pendingRevocations.get(key)?.has(input.canonicalPrincipalId)) {
+      if (pendingOverlay.has(input.canonicalPrincipalId)) {
         // Reuse membership_revoked: a revocation WAS observed for this
         // principal, it just could not be committed — admission must fail
         // closed exactly as if it had.

--- a/plugins/plugin-telegram/src/membership.ts
+++ b/plugins/plugin-telegram/src/membership.ts
@@ -19,7 +19,7 @@ import type {
   MembershipService,
   UUID,
 } from "@elizaos/core";
-import { logger, ServiceType } from "@elizaos/core";
+import { ChannelType, logger, ServiceType } from "@elizaos/core";
 
 /** Evidence freshness window for Telegram point proofs (under the authority's 24h cap). */
 export const TELEGRAM_MEMBERSHIP_TTL_MS = 60 * 60 * 1_000;
@@ -101,13 +101,17 @@ export function telegramStatusToMembership(member: {
     case "administrator":
     case "member":
       return { state: "active", reason: "reconciled_present" };
-    case "restricted":
-      // A restricted user is only a member while is_member is true; Telegram
-      // reports restricted non-members (e.g. unbanned-but-not-rejoined) with
-      // is_member: false, which must NOT admit as active membership.
-      return member.is_member === false
-        ? { state: "revoked", reason: "left" }
-        : { state: "active", reason: "reconciled_present" };
+    case "restricted": {
+      // A restricted user is a member only while is_member is true. Telegram
+      // always reports is_member on restricted, so a missing field means an
+      // incomplete/untrusted provider response: fail CLOSED (treat as not a
+      // member) rather than fabricating active membership at an external
+      // provider boundary.
+      if (member.is_member !== true) {
+        return { state: "revoked", reason: "left" };
+      }
+      return { state: "active", reason: "reconciled_present" };
+    }
     case "left":
       return { state: "revoked", reason: "left" };
     case "kicked":
@@ -292,22 +296,52 @@ export class TelegramMembershipAuthority {
    * evidence itself (e.g. entity bootstrap failed): the safe representation
    * of "we saw a leave but the authority did not record it" is a scope whose
    * evidence can no longer authorize anyone until fresh evidence lands.
+   * Runs inside the per-scope serialized chain (ordered against evidence
+   * writes and admissions) and retries generation fencing so a concurrent
+   * write cannot starve the degrade. THROWS on persistent failure so callers
+   * can escalate (mark the gate broken) — failure is never silently
+   * converted back to an authorizing state.
    */
   async markScopeStale(input: {
     scope: MembershipScope;
     reason: string;
   }): Promise<void> {
-    const health = await this.service.getScopeHealth(input.scope);
-    const expectedGeneration = health?.generation ?? 0;
-    await this.service.setScopeHealth({
-      ...input.scope,
-      expectedGeneration,
-      idempotencyKey: `tg:${this.connectorAccountId}:${input.scope.externalWorldId}:stale:${input.reason}:${expectedGeneration}`,
-      health: "stale",
-      reason: input.reason,
-      observedAt: new Date().toISOString(),
+    const key = scopeKey(input.scope);
+    await this.serialized(key, async () => {
+      for (let attempt = 0; attempt < 3; attempt++) {
+        const health = await this.service.getScopeHealth(input.scope);
+        const expectedGeneration = health?.generation ?? 0;
+        try {
+          const receipt = await this.service.setScopeHealth({
+            ...input.scope,
+            expectedGeneration,
+            idempotencyKey: `tg:${this.connectorAccountId}:${input.scope.externalWorldId}:stale:${input.reason}:${expectedGeneration}:${attempt}`,
+            health: "stale",
+            reason: input.reason,
+            observedAt: new Date().toISOString(),
+          });
+          if (receipt.operation === "health") {
+            this.scopes.delete(key);
+            return;
+          }
+        } catch (error) {
+          // Generation moved under us (a concurrent write committed between
+          // the health read and the fenced update): re-read health and retry
+          // the fence so the degrade still lands.
+          if (
+            error instanceof Error &&
+            error.message.includes("MEMBERSHIP_GENERATION_MISMATCH") &&
+            attempt < 2
+          ) {
+            continue;
+          }
+          throw error;
+        }
+      }
+      throw new Error(
+        `Telegram membership scope stale-degrade exhausted retries for ${input.scope.externalWorldId}`,
+      );
     });
-    this.scopes.delete(scopeKey(input.scope));
   }
 
   /**
@@ -482,16 +516,24 @@ export class TelegramMembershipAuthority {
             scope,
             reason: `revocation_write_failed:${input.reason}`,
           });
+          // Degrade landed: admission now fails closed for the scope.
+          // error-policy:J7 Evidence-write failure must not kill the poll
+          // loop; the failure is reported and the degraded scope carries the
+          // security decision.
+          this.runtime.reportError("telegram:membership-evidence", error, {
+            chatId: input.chatId,
+            messageId: input.messageId,
+            telegramUserId: input.telegramUserId,
+          });
+          return;
         } catch (degradeError) {
-          this.runtime.reportError(
-            "telegram:membership-evidence",
-            degradeError,
-            {
-              chatId: input.chatId,
-              messageId: input.messageId,
-              telegramUserId: input.telegramUserId,
-              originalError: String(error),
-            },
+          // error-policy:J2 BOTH the evidence write AND the fail-closed
+          // degrade failed: propagate a typed error so the connector layer
+          // can mark the admission gate broken (every group admission then
+          // fails closed) instead of leaving active evidence authorizing.
+          throw new Error(
+            "Telegram membership revocation could not be committed or degraded",
+            { cause: degradeError },
           );
         }
       }
@@ -521,6 +563,7 @@ export class TelegramMembershipAuthority {
     getChatMember: () => Promise<{
       status: string;
       custom_title?: string;
+      is_member?: boolean;
       user: { id: number };
     }>;
     observedAt?: string;
@@ -532,6 +575,7 @@ export class TelegramMembershipAuthority {
     let member: {
       status: string;
       custom_title?: string;
+      is_member?: boolean;
       user: { id: number };
     };
     try {
@@ -552,6 +596,50 @@ export class TelegramMembershipAuthority {
       chatId: input.chatId,
       chatRoomKey: input.chatRoomKey,
     });
+    // The authority requires the principal's entity row AND the chat's world/
+    // room rows to exist before evidence can be applied
+    // (MEMBERSHIP_PRINCIPAL_NOT_FOUND / MEMBERSHIP_RUNTIME_MAPPING_INVALID
+    // otherwise). A never-seen principal reaching reconcile is the backfill
+    // case: create the ENTITY row for the principal and the WORLD/ROOM rows
+    // for the CHAT — all sender-membership-neutral. Room-participant
+    // association for the SENDER happens only AFTER admission in
+    // handleMessage, so a denied sender still mutates no participant state.
+    try {
+      await this.runtime.createEntity({
+        id: input.canonicalPrincipalId,
+        agentId: this.runtime.agentId,
+        names: [`telegram-${input.telegramUserId}`],
+        metadata: { source: "telegram", telegramUserId: input.telegramUserId },
+      });
+      if (input.runtime.worldId) {
+        await this.runtime.createWorld({
+          id: input.runtime.worldId,
+          name: input.chatId,
+          agentId: this.runtime.agentId,
+          metadata: { source: "telegram", chatId: input.chatId },
+        });
+      }
+      if (input.runtime.roomId && input.runtime.worldId) {
+        await this.runtime.createRoom({
+          id: input.runtime.roomId,
+          name: input.chatRoomKey,
+          source: "telegram",
+          type: ChannelType.GROUP,
+          channelId: input.chatId,
+          worldId: input.runtime.worldId,
+        });
+      }
+    } catch (error) {
+      // error-policy:J3 createEntity/createWorld/createRoom are idempotent
+      // for existing rows on the adapters in use; a genuine failure surfaces
+      // below through applyEvidence's assert codes, so this only guards
+      // duplicate-create races.
+      this.runtime.reportError("telegram:membership-reconcile", error, {
+        chatId: input.chatId,
+        telegramUserId: input.telegramUserId,
+        stage: "principal-bootstrap",
+      });
+    }
     try {
       await this.applyEvidence({
         scope,
@@ -615,27 +703,46 @@ export class TelegramMembershipAuthority {
       chatRoomKey: input.chatRoomKey,
     });
     const key = scopeKey(scope);
-    try {
-      await this.serialized(key, async () => {
+    // Runs inside the per-scope serialized chain and RETRIES generation
+    // fencing. THROWS on persistent failure: the bot-removal caller must be
+    // able to detect that the scope could NOT be marked unavailable and
+    // escalate (mark the message gate broken so admission fails closed)
+    // instead of continuing on an authorizable scope.
+    await this.serialized(key, async () => {
+      for (let attempt = 0; attempt < 3; attempt++) {
         const health = await this.service.getScopeHealth(scope);
         const expectedGeneration = health?.generation ?? 0;
-        await this.service.setScopeHealth({
-          ...scope,
-          expectedGeneration,
-          idempotencyKey: `tg:${this.connectorAccountId}:${input.chatId}:${input.reason}:${expectedGeneration}`,
-          health: "unavailable",
-          reason: input.reason,
-          observedAt: new Date().toISOString(),
-        });
-        this.scopes.delete(key);
-      });
-    } catch (error) {
-      // error-policy:J7 Bot-removal bookkeeping must not kill the poll loop.
-      this.runtime.reportError("telegram:membership-scope-health", error, {
-        chatId: input.chatId,
-        reason: input.reason,
-      });
-    }
+        try {
+          const receipt = await this.service.setScopeHealth({
+            ...scope,
+            expectedGeneration,
+            idempotencyKey: `tg:${this.connectorAccountId}:${input.chatId}:${input.reason}:${expectedGeneration}:${attempt}`,
+            health: "unavailable",
+            reason: input.reason,
+            observedAt: new Date().toISOString(),
+          });
+          if (receipt.operation === "health") {
+            this.scopes.delete(key);
+            return;
+          }
+        } catch (error) {
+          if (
+            error instanceof Error &&
+            error.message.includes("MEMBERSHIP_GENERATION_MISMATCH") &&
+            attempt < 2
+          ) {
+            continue;
+          }
+          // error-policy:J2 Degrade-bookkeeping failure propagates to the
+          // caller as a typed boundary decision (gate marked broken); the
+          // poll loop is protected by the update handler's own catch.
+          throw error;
+        }
+      }
+      throw new Error(
+        `Telegram membership scope unavailable-degrade exhausted retries for ${input.chatId}`,
+      );
+    });
   }
 
   /** Read-only scope health accessor (used by tests and diagnostics). */

--- a/plugins/plugin-telegram/src/membership.ts
+++ b/plugins/plugin-telegram/src/membership.ts
@@ -517,9 +517,13 @@ export class TelegramMembershipAuthority {
       // Restart hydration (see authorize): a restart-then-fresh-evidence
       // commit must clear the persisted overlay for this principal, which
       // requires the persisted set to be loaded first. On a cache read
-      // failure the FAIL_CLOSED sentinel denies every principal — safe
-      // (evidence is only recorded, admission is gated in authorize).
-      await this.hydratePendingRevocations(input.scope);
+      // failure hydration returns the FAIL_CLOSED sentinel: evidence is
+      // still recorded (the write path is independent of the overlay), but
+      // the success path below must NOT rewrite the persisted overlay from
+      // an incomplete in-memory set — that would erase other principals'
+      // durable revocation fences.
+      const hydration = await this.hydratePendingRevocations(input.scope);
+      const overlayHydrated = hydration !== FAIL_CLOSED_PENDING;
       // Restart hydration: if this process restarted, the in-memory
       // bot-removal tombstone map is empty — but the persisted scope health
       // still says unavailable. Hydrate BEFORE the tombstone check so a
@@ -651,9 +655,14 @@ export class TelegramMembershipAuthority {
           // Fresh evidence for this principal committed: any pending
           // (uncommittable) revocation overlay for it is now superseded —
           // the authoritative record speaks again. Persist the removal so a
-          // restart does not resurrect the overlay against committed state.
+          // restart does not resurrect the overlay against committed state —
+          // but ONLY when the overlay was successfully hydrated: persisting
+          // an incompletely-hydrated set could erase OTHER principals'
+          // durable revocation fences from the cache.
           this.pendingRevocations.get(key)?.delete(input.canonicalPrincipalId);
-          await this.persistPendingRevocations(input.scope);
+          if (overlayHydrated) {
+            await this.persistPendingRevocations(input.scope);
+          }
           return true;
         } catch (error) {
           const code = authorityErrorCode(error);
@@ -739,6 +748,20 @@ export class TelegramMembershipAuthority {
               this.pendingRevocations.get(key2) ?? new Set<UUID>();
             pending.add(input.canonicalPrincipalId);
             this.pendingRevocations.set(key2, pending);
+            if (!overlayHydrated) {
+              // The persisted set is unknown (cache read failed earlier):
+              // persisting the in-memory set could erase OTHER principals'
+              // durable fences. The in-memory overlay protects this process;
+              // escalate to gate-broken so a restart does not silently
+              // re-authorize.
+              throw new ElizaError(
+                "Telegram membership revocation fence could not be persisted (overlay unreadable)",
+                {
+                  code: "TELEGRAM_MEMBERSHIP_REVOCATION_UNSAFE",
+                  cause: error,
+                },
+              );
+            }
             const persisted = await this.persistPendingRevocations(input.scope);
             if (!persisted) {
               // The durable overlay did not land: a restart would

--- a/plugins/plugin-telegram/src/membership.ts
+++ b/plugins/plugin-telegram/src/membership.ts
@@ -1311,7 +1311,13 @@ export class TelegramMembershipAuthority {
             { code: "TELEGRAM_MEMBERSHIP_READD_WATERMARK_UNDURABLE" },
           );
         } catch (error) {
-          watermarkWriteError = error;
+          watermarkWriteError = new ElizaError(
+            `Telegram membership re-add watermark cache write failed for ${input.chatId}`,
+            {
+              code: "TELEGRAM_MEMBERSHIP_READD_WATERMARK_UNDURABLE",
+              cause: error,
+            },
+          );
         }
       }
       if (watermarkWriteError !== null) {

--- a/plugins/plugin-telegram/src/membership.ts
+++ b/plugins/plugin-telegram/src/membership.ts
@@ -572,48 +572,61 @@ export class TelegramMembershipAuthority {
       ) {
         const health = await this.service.getScopeHealth(input.scope);
         if (health?.health === "unavailable") {
-          // Durable re-add watermark: a persisted watermark NEWER than the
-          // unavailable observation proves the bot was re-added AFTER the
-          // removal that wrote this health row — the persisted unavailable
-          // state is stale, so do NOT re-hydrate the tombstone (the bot is
-          // already present; no second re-add transition will ever clear
-          // it). On a cache read failure or a watermark that does NOT
-          // postdate the observation, keep the tombstone (fail closed: an
-          // older/equal watermark belongs to an EARLIER re-add cycle, whose
-          // removal came after).
-          let persistedReaddMs: number | null = null;
+          // Durable re-add watermark: the watermark records the generation
+          // of the persisted health row it repaired. Hydration compares
+          // GENERATIONS, never wall clocks: a watermark whose generation is
+          // greater than or equal to the observed unavailable row's
+          // generation proves the clear already covered this removal cycle
+          // (the row is stale — the bot is present again, so no second
+          // re-add transition will ever arrive to clear it), while a
+          // strictly greater row generation means a NEWER removal landed
+          // after the re-add and the tombstone must stay. A cache READ
+          // failure denies this attempt WITHOUT memoizing the tombstone —
+          // hydration must retry on the next evidence once the cache is
+          // readable again, not strand the scope in-process.
+          let persistedReadd: { at: number; generation: number } | null = null;
+          let watermarkReadFailed = false;
           try {
-            const persisted = await this.runtime.getCache<number | null>(
-              this.readdWatermarkCacheKey(input.scope),
-            );
-            if (typeof persisted === "number") {
-              persistedReaddMs = persisted;
+            const persisted = await this.runtime.getCache<{
+              at: number;
+              generation: number;
+            }>(this.readdWatermarkCacheKey(input.scope));
+            if (
+              persisted !== undefined &&
+              persisted !== null &&
+              typeof persisted.at === "number" &&
+              typeof persisted.generation === "number"
+            ) {
+              persistedReadd = persisted;
             }
           } catch (error) {
-            // error-policy:J4 Durable re-add watermark unreadable: treat as
-            // absent and keep the tombstone (deny) — the stale-unavailable
-            // strand is repaired on the next re-add cycle, whereas wrongly
-            // clearing the tombstone would let backlogged evidence from
-            // while the bot was absent re-authorize members.
+            // error-policy:J4 Durable re-add watermark unreadable: fail
+            // closed for THIS attempt only (no evidence write below), but
+            // leave the tombstone unset so the next evidence attempt
+            // re-runs hydration against the recovered cache.
+            watermarkReadFailed = true;
             this.runtime.reportError(
               "telegram:membership-readd-watermark-read",
               error,
               { chatId: input.scope.externalWorldId },
             );
           }
+          if (watermarkReadFailed) {
+            return false;
+          }
           const readdAfterRemoval =
-            persistedReaddMs !== null &&
-            persistedReaddMs > Date.parse(health.observedAt);
+            persistedReadd !== null &&
+            persistedReadd.generation >= health.generation;
           if (!readdAfterRemoval) {
             this.removedScopes.set(
               key,
               health.reason || "bot_removed_persisted",
             );
-          } else if (persistedReaddMs !== null) {
+          } else if (persistedReadd !== null) {
             // Re-hydrate the in-memory watermark too: backlogged evidence
-            // stamped BEFORE the persisted re-add moment must stay denied in
-            // this process exactly as it would without the restart.
-            this.scopeReaddWatermarks.set(key, persistedReaddMs);
+            // stamped BEFORE the re-add moment must stay denied in this
+            // process exactly as it would without the restart.
+            this.scopeReaddWatermarks.set(key, persistedReadd.at);
           }
         }
       }
@@ -1262,40 +1275,56 @@ export class TelegramMembershipAuthority {
       // actually present may establish authority again.
       const watermark = Date.now();
       this.scopeReaddWatermarks.set(key, watermark);
-      // Persist the watermark durably: a restart between the re-add and the
-      // next fresh evidence write must not re-hydrate the tombstone from the
-      // stale persisted "unavailable" health (the bot is already present, so
-      // no second re-add transition would ever arrive to clear it). On a
-      // failed durable write the in-memory watermark still protects THIS
-      // process; a restart then fails closed (tombstone re-hydrates) until
-      // the next re-add cycle — reported for diagnosis.
-      try {
-        const persisted = await this.runtime.setCache(
-          this.readdWatermarkCacheKey(scope),
-          watermark,
-        );
-        if (persisted !== true) {
-          // error-policy:J4 The durable re-add watermark did not land (the
-          // cache adapter resolved false): admission still recovers in THIS
-          // process via the in-memory watermark, but a restart re-hydrates
-          // the tombstone and denies until the next re-add cycle.
-          this.runtime.reportError(
-            "telegram:membership-readd-watermark-write",
-            new ElizaError(
-              `Telegram membership re-add watermark cache write resolved false for ${input.chatId}`,
-              { code: "TELEGRAM_MEMBERSHIP_READD_WATERMARK_UNDURABLE" },
-            ),
-            { chatId: input.chatId },
+      // Persist the watermark durably, keyed to the health row's GENERATION
+      // rather than wall-clock time: generations are monotonic per scope and
+      // persisted by the membership service, so a same-millisecond re-add or
+      // a wall clock moving backward cannot make a legitimately later clear
+      // order before the removal it repaired. Hydration compares the
+      // persisted generation against the observed unavailable row's
+      // generation (>= means this clear already covered that removal). A
+      // restart between the re-add and the next fresh evidence write must
+      // not re-hydrate the tombstone from the stale persisted "unavailable"
+      // health (the bot is already present, so no second re-add transition
+      // would ever arrive to clear it). THROWS on persistent write failure,
+      // mirroring markScopeUnavailable: the re-add caller must be able to
+      // detect that the clear could NOT be made durable — otherwise a
+      // restart silently re-strands the scope. The in-memory watermark
+      // still protects THIS process in the meantime.
+      const healthAtClear = await this.service.getScopeHealth(scope);
+      const watermarkRecord = {
+        at: watermark,
+        generation: healthAtClear?.generation ?? 0,
+      };
+      let watermarkWriteError: unknown = null;
+      for (let attempt = 0; attempt < 3; attempt++) {
+        try {
+          const persisted = await this.runtime.setCache(
+            this.readdWatermarkCacheKey(scope),
+            watermarkRecord,
           );
+          if (persisted === true) {
+            watermarkWriteError = null;
+            break;
+          }
+          watermarkWriteError = new ElizaError(
+            `Telegram membership re-add watermark cache write resolved false for ${input.chatId}`,
+            { code: "TELEGRAM_MEMBERSHIP_READD_WATERMARK_UNDURABLE" },
+          );
+        } catch (error) {
+          watermarkWriteError = error;
         }
-      } catch (error) {
-        // error-policy:J4 Same contract as the resolved-false branch: the
-        // in-memory watermark carries this process; a restart fails closed.
+      }
+      if (watermarkWriteError !== null) {
+        // error-policy:J2 Durability failure of the re-add clear propagates
+        // to the caller as a typed error (the update handler's catch turns
+        // it into a logged, reported boundary decision); the in-memory
+        // watermark still carries this process.
         this.runtime.reportError(
           "telegram:membership-readd-watermark-write",
-          error,
+          watermarkWriteError,
           { chatId: input.chatId },
         );
+        throw watermarkWriteError;
       }
     });
   }

--- a/plugins/plugin-telegram/src/membership.ts
+++ b/plugins/plugin-telegram/src/membership.ts
@@ -144,7 +144,8 @@ function scopeKey(scope: MembershipScope): string {
   return `${scope.connectorAccountId}:${scope.externalWorldId}:${scope.externalRoomId}`;
 }
 
-function authorityErrorCode(error: unknown): string {
+/** Typed code of an authority/membership error, or "" for untyped errors. */
+export function authorityErrorCode(error: unknown): string {
   const code = (error as { code?: unknown } | null | undefined)?.code;
   return typeof code === "string" ? code : "";
 }
@@ -987,7 +988,11 @@ export class TelegramMembershipAuthority {
   /**
    * getChatMember point-query reconcile. Returns the mapped
    * (state, reason) and applies it as evidence, or null when the provider
-   * query itself failed (stay denied; report once per call).
+   * query itself failed (stay denied; report once per call). THROWS
+   * TELEGRAM_MEMBERSHIP_REVOCATION_UNSAFE when a revoked reconcile could be
+   * neither committed nor degraded fail-closed — the admission-gate caller
+   * must break the connector gate so later messages cannot be authorized by
+   * still-current prior active evidence (mirrors recordEvent's escalation).
    */
   async reconcile(input: {
     chatId: string;
@@ -1119,6 +1124,41 @@ export class TelegramMembershipAuthority {
         idempotencyKey: `tg:${this.connectorAccountId}:${input.chatId}:reconcile:${input.telegramUserId}:${input.nonce}`,
       });
     } catch (error) {
+      if (
+        authorityErrorCode(error) === "TELEGRAM_MEMBERSHIP_REVOCATION_DEGRADED"
+      ) {
+        // error-policy:J7 The fail-closed protections (scope stale degrade +
+        // durable pending-revocation overlay) landed INSIDE applyEvidence's
+        // serialized chain link, atomically with the failed write. The
+        // security state is already fail-closed; reporting suffices.
+        this.runtime.reportError("telegram:membership-reconcile", error, {
+          chatId: input.chatId,
+          telegramUserId: input.telegramUserId,
+          degraded: true,
+        });
+        return null;
+      }
+      if (mapped.state === "revoked") {
+        // error-policy:J2 The revocation could be neither committed nor
+        // degraded fail-closed (e.g. the stale-degrade itself failed): no
+        // durable fence landed, so prior active evidence may still authorize
+        // the departed principal on a later message. Propagate a typed error
+        // so the admission-gate caller marks the connector gate broken (every
+        // group admission then fails closed) — mirroring recordEvent's
+        // escalation path for the identical failure class.
+        throw new ElizaError(
+          "Telegram membership revocation could not be committed or degraded",
+          {
+            code: "TELEGRAM_MEMBERSHIP_REVOCATION_UNSAFE",
+            context: {
+              chatId: input.chatId,
+              telegramUserId: input.telegramUserId,
+              source: "reconcile",
+            },
+            cause: error,
+          },
+        );
+      }
       this.runtime.reportError("telegram:membership-reconcile", error, {
         chatId: input.chatId,
         telegramUserId: input.telegramUserId,

--- a/plugins/plugin-telegram/src/membership.ts
+++ b/plugins/plugin-telegram/src/membership.ts
@@ -162,6 +162,47 @@ const FAIL_CLOSED_PENDING: ReadonlySet<UUID> = {
 
 const EMPTY_PENDING: ReadonlySet<UUID> = new Set<UUID>();
 
+const CANONICAL_UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Runtime check for a canonical (8-4-4-4-12 lowercase-hex) UUID string. Used
+ * to validate durable cache payloads whose declared type is a compile-time
+ * cast only — the SQL cache contract stores arbitrary JSON.
+ */
+function isCanonicalUuid(value: unknown): value is UUID {
+  return typeof value === "string" && CANONICAL_UUID_PATTERN.test(value);
+}
+
+/**
+ * Validates a persisted pending-revocation overlay payload. The SQL cache
+ * contract stores arbitrary JSON and `getCache<UUID[]>` returns the raw
+ * stored value through a compile-time cast, so the shape must be proven at
+ * runtime: a bare string is iterable per character (never matching the
+ * revoked principal's UUID) and an empty string is falsy, either of which
+ * would silently re-authorize a principal whose revocation could not be
+ * committed. Only `undefined` (the typed cache miss — the adapter returns
+ * the raw JSONB value for a present row, so a stored JSON `null` arrives as
+ * `null`, not `undefined`) means no row exists: a definitive empty overlay.
+ * Everything else must prove it is an array of canonical UUIDs; anything
+ * else returns null so the caller fails closed instead of mistaking
+ * corruption for an empty fence.
+ */
+function parsePersistedPendingRevocations(value: unknown): UUID[] | null {
+  if (value === undefined) {
+    return [];
+  }
+  if (!Array.isArray(value)) {
+    return null;
+  }
+  for (const entry of value) {
+    if (!isCanonicalUuid(entry)) {
+      return null;
+    }
+  }
+  return value;
+}
+
 /**
  * Per-(agent, Telegram account) client for the membership authority. Scope
  * trackers are seeded from persisted scope health on first touch so a
@@ -257,7 +298,7 @@ export class TelegramMembershipAuthority {
     scope: MembershipScope,
   ): Promise<ReadonlySet<UUID>> {
     const key = scopeKey(scope);
-    let persisted: UUID[] | undefined;
+    let persisted: unknown;
     try {
       persisted = await this.runtime.getCache<UUID[]>(
         this.pendingRevocationsCacheKey(scope),
@@ -271,10 +312,35 @@ export class TelegramMembershipAuthority {
       });
       return FAIL_CLOSED_PENDING;
     }
+    const entries = parsePersistedPendingRevocations(persisted);
+    if (entries === null) {
+      // error-policy:J3 The persisted overlay payload is not the declared
+      // UUID[] shape (the SQL cache contract stores arbitrary JSON and the
+      // getCache type is a compile-time cast). Treat corruption exactly like
+      // an unreadable overlay: fail closed rather than let a malformed
+      // payload masquerade as an empty fence and re-authorize a principal
+      // whose revocation could not be committed. The hydrated mark is NOT
+      // set, so a later healthy payload resumes normal decisions.
+      this.runtime.reportError(
+        "telegram:membership-pending-hydration",
+        new ElizaError(
+          "Persisted pending-revocation overlay payload failed UUID[] validation",
+          {
+            code: "TELEGRAM_MEMBERSHIP_PENDING_PAYLOAD_INVALID",
+            context: {
+              chatId: scope.externalWorldId,
+              persistedType: typeof persisted,
+            },
+          },
+        ),
+        { chatId: scope.externalWorldId },
+      );
+      return FAIL_CLOSED_PENDING;
+    }
     this.pendingRevocationsHydrated.add(key);
-    if (persisted) {
+    if (entries.length > 0) {
       const overlay = this.pendingRevocations.get(key) ?? new Set<UUID>();
-      for (const id of persisted) overlay.add(id);
+      for (const id of entries) overlay.add(id);
       this.pendingRevocations.set(key, overlay);
     }
     return this.pendingRevocations.get(key) ?? EMPTY_PENDING;

--- a/plugins/plugin-telegram/src/membership.ts
+++ b/plugins/plugin-telegram/src/membership.ts
@@ -230,6 +230,18 @@ export class TelegramMembershipAuthority {
   }
 
   /**
+   * Cache key for this scope's durable bot re-add epoch (epoch ms). The
+   * runtime cache is database-backed, so the re-add watermark survives a
+   * restart — without it, a bot re-add followed by a restart re-hydrates the
+   * bot-removal tombstone from the persisted "unavailable" scope health, and
+   * because the bot is already present no second re-add transition ever
+   * arrives to clear it: fresh evidence is denied indefinitely.
+   */
+  private readdWatermarkCacheKey(scope: MembershipScope): string {
+    return `telegram:membership:readd-watermark:${scope.connectorAccountId}:${scope.externalWorldId}:${scope.externalRoomId}`;
+  }
+
+  /**
    * Loads the persisted pending-revocation set for a scope into memory.
    * FAIL CLOSED on a cache read failure: when the durable overlay cannot be
    * read, the safe assumption is that uncommitted revocations exist, so the
@@ -560,7 +572,49 @@ export class TelegramMembershipAuthority {
       ) {
         const health = await this.service.getScopeHealth(input.scope);
         if (health?.health === "unavailable") {
-          this.removedScopes.set(key, health.reason || "bot_removed_persisted");
+          // Durable re-add watermark: a persisted watermark NEWER than the
+          // unavailable observation proves the bot was re-added AFTER the
+          // removal that wrote this health row — the persisted unavailable
+          // state is stale, so do NOT re-hydrate the tombstone (the bot is
+          // already present; no second re-add transition will ever clear
+          // it). On a cache read failure or a watermark that does NOT
+          // postdate the observation, keep the tombstone (fail closed: an
+          // older/equal watermark belongs to an EARLIER re-add cycle, whose
+          // removal came after).
+          let persistedReaddMs: number | null = null;
+          try {
+            const persisted = await this.runtime.getCache<number | null>(
+              this.readdWatermarkCacheKey(input.scope),
+            );
+            if (typeof persisted === "number") {
+              persistedReaddMs = persisted;
+            }
+          } catch (error) {
+            // error-policy:J4 Durable re-add watermark unreadable: treat as
+            // absent and keep the tombstone (deny) — the stale-unavailable
+            // strand is repaired on the next re-add cycle, whereas wrongly
+            // clearing the tombstone would let backlogged evidence from
+            // while the bot was absent re-authorize members.
+            this.runtime.reportError(
+              "telegram:membership-readd-watermark-read",
+              error,
+              { chatId: input.scope.externalWorldId },
+            );
+          }
+          const readdAfterRemoval =
+            persistedReaddMs !== null &&
+            persistedReaddMs > Date.parse(health.observedAt);
+          if (!readdAfterRemoval) {
+            this.removedScopes.set(
+              key,
+              health.reason || "bot_removed_persisted",
+            );
+          } else if (persistedReaddMs !== null) {
+            // Re-hydrate the in-memory watermark too: backlogged evidence
+            // stamped BEFORE the persisted re-add moment must stay denied in
+            // this process exactly as it would without the restart.
+            this.scopeReaddWatermarks.set(key, persistedReaddMs);
+          }
         }
       }
       // Bot-removal tombstone: once the bot has been removed from this chat,
@@ -1206,7 +1260,43 @@ export class TelegramMembershipAuthority {
       // (queued updates from while the bot was absent) must not re-authorize
       // anything after the clear — only observations made while the bot was
       // actually present may establish authority again.
-      this.scopeReaddWatermarks.set(key, Date.now());
+      const watermark = Date.now();
+      this.scopeReaddWatermarks.set(key, watermark);
+      // Persist the watermark durably: a restart between the re-add and the
+      // next fresh evidence write must not re-hydrate the tombstone from the
+      // stale persisted "unavailable" health (the bot is already present, so
+      // no second re-add transition would ever arrive to clear it). On a
+      // failed durable write the in-memory watermark still protects THIS
+      // process; a restart then fails closed (tombstone re-hydrates) until
+      // the next re-add cycle — reported for diagnosis.
+      try {
+        const persisted = await this.runtime.setCache(
+          this.readdWatermarkCacheKey(scope),
+          watermark,
+        );
+        if (persisted !== true) {
+          // error-policy:J4 The durable re-add watermark did not land (the
+          // cache adapter resolved false): admission still recovers in THIS
+          // process via the in-memory watermark, but a restart re-hydrates
+          // the tombstone and denies until the next re-add cycle.
+          this.runtime.reportError(
+            "telegram:membership-readd-watermark-write",
+            new ElizaError(
+              `Telegram membership re-add watermark cache write resolved false for ${input.chatId}`,
+              { code: "TELEGRAM_MEMBERSHIP_READD_WATERMARK_UNDURABLE" },
+            ),
+            { chatId: input.chatId },
+          );
+        }
+      } catch (error) {
+        // error-policy:J4 Same contract as the resolved-false branch: the
+        // in-memory watermark carries this process; a restart fails closed.
+        this.runtime.reportError(
+          "telegram:membership-readd-watermark-write",
+          error,
+          { chatId: input.chatId },
+        );
+      }
     });
   }
 

--- a/plugins/plugin-telegram/src/membership.ts
+++ b/plugins/plugin-telegram/src/membership.ts
@@ -195,12 +195,19 @@ function parsePersistedPendingRevocations(value: unknown): UUID[] | null {
   if (!Array.isArray(value)) {
     return null;
   }
+  const normalized: UUID[] = [];
   for (const entry of value) {
     if (!isCanonicalUuid(entry)) {
       return null;
     }
+    // The admission path checks `pendingOverlay.has(canonicalPrincipalId)`
+    // and Set.has is case-sensitive, while CANONICAL_UUID_PATTERN accepts
+    // uppercase hex via its `i` flag. Normalize to the documented lowercase
+    // canonical form so an uppercase representation of a revoked principal
+    // still fences that principal instead of silently re-authorizing it.
+    normalized.push(entry.toLowerCase() as UUID);
   }
-  return value;
+  return normalized;
 }
 
 /**

--- a/plugins/plugin-telegram/src/membership.ts
+++ b/plugins/plugin-telegram/src/membership.ts
@@ -1448,6 +1448,66 @@ export class TelegramMembershipAuthority {
     });
   }
 
+  /**
+   * Durable re-add probe for `authority_unavailable` admission denials:
+   * true only when the persisted degraded row is PROVABLY stale — a durable
+   * re-add watermark persisted by clearScopeRemoval exists whose recorded
+   * generation covers the observed unavailable row's generation (the same
+   * generation comparison restart hydration uses). The my_chat_member
+   * re-add transition that wrote the watermark is itself
+   * Telegram-authoritative evidence the bot is present again, so gating a
+   * reconcile on this proof is NOT the fail-open "reconcile while the
+   * authority is down" shape: an authority that could not be consulted
+   * throws or is never reached, while this decision arrived FROM a
+   * successfully consulted authority that read a persisted degraded row.
+   * A cache read failure fails the probe closed (report + false): without
+   * the watermark the unavailable row cannot be proven stale, so the
+   * denial stands.
+   */
+  async readdedAfterUnavailable(input: {
+    chatId: string;
+    chatRoomKey: string;
+  }): Promise<boolean> {
+    const scope = telegramMembershipScope({
+      agentId: this.runtime.agentId,
+      connectorAccountId: this.connectorAccountId,
+      chatId: input.chatId,
+      chatRoomKey: input.chatRoomKey,
+    });
+    const health = await this.service.getScopeHealth(scope);
+    if (health?.health !== "unavailable") return false;
+    let persistedReadd: { at: number; generation: number } | null = null;
+    try {
+      const persisted = await this.runtime.getCache<{
+        at: number;
+        generation: number;
+      }>(this.readdWatermarkCacheKey(scope));
+      if (
+        persisted !== undefined &&
+        persisted !== null &&
+        typeof persisted.at === "number" &&
+        typeof persisted.generation === "number"
+      ) {
+        persistedReadd = persisted;
+      }
+    } catch (error) {
+      // error-policy:J4 Durable re-add watermark unreadable: the probe
+      // cannot prove the unavailable row stale, so it fails closed (the
+      // denial stands) and the read failure is reported for diagnostics;
+      // a later admission attempt re-runs the probe against the recovered
+      // cache.
+      this.runtime.reportError(
+        "telegram:membership-readd-watermark-read",
+        error,
+        { chatId: input.chatId },
+      );
+      return false;
+    }
+    return (
+      persistedReadd !== null && persistedReadd.generation >= health.generation
+    );
+  }
+
   /** Read-only scope health accessor (used by tests and diagnostics). */
   async scopeHealth(input: {
     chatId: string;

--- a/plugins/plugin-telegram/src/messageManager.channel-admission.test.ts
+++ b/plugins/plugin-telegram/src/messageManager.channel-admission.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Admission-surface boundary tests for MessageManager.handleMessage: the
+ * membership gate must run ONLY for raw Telegram `group`/`supergroup` chats —
+ * the same predicate as TelegramService.chatAndEntityMiddleware and the
+ * standalone handler. `channel` chats collapse to ChannelType.GROUP through
+ * getChannelType and must NOT consult or register a membership scope: the
+ * connector contract (membership.ts) gives channels no inbound admission
+ * surface. Deterministic unit harness: the REAL handleMessage admission path
+ * and the REAL TelegramMembershipMessageGate run over a fake runtime with a
+ * fail-closed stubbed authority; no network, no database.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { MessageManager } from "./messageManager";
+
+const CHAT_ID = -1002147483647;
+
+function makeRuntime(): IAgentRuntime & {
+  createMemory: ReturnType<typeof vi.fn>;
+  setCache: ReturnType<typeof vi.fn>;
+} {
+  return {
+    agentId: "00000000-0000-0000-0000-0000000000a1",
+    getSetting: () => undefined,
+    getCache: vi.fn(async () => undefined),
+    setCache: vi.fn(async () => undefined),
+    createMemory: vi.fn(async () => undefined),
+    ensureConnection: vi.fn(async () => undefined),
+    reportError: vi.fn(),
+  } as unknown as IAgentRuntime & {
+    createMemory: ReturnType<typeof vi.fn>;
+    setCache: ReturnType<typeof vi.fn>;
+  };
+}
+
+function makeManager(): {
+  manager: MessageManager;
+  runtime: ReturnType<typeof makeRuntime>;
+} {
+  const bot = {
+    telegram: {
+      getChatMember: vi.fn(async () => ({
+        status: "left",
+        user: { id: 424242 },
+      })),
+      sendMessage: vi.fn(async () => undefined),
+    },
+  };
+  const runtime = makeRuntime();
+  const manager = new MessageManager(bot as never, runtime as never, "default");
+  return { manager, runtime };
+}
+
+/**
+ * A gate whose authority denies EVERY authorization (fail-closed stub): if the
+ * channel-post path consults the authority, authorize() fires and admission
+ * is denied — the tripwire for the regression.
+ */
+function bindDenyAllGate(manager: MessageManager): ReturnType<typeof vi.fn> {
+  const authorize = vi.fn(async () => ({
+    decision: "denied" as const,
+    reason: "authority_expired" as const,
+  }));
+  const reconcile = vi.fn(async () => ({
+    state: "revoked" as const,
+    reason: "kicked" as const,
+  }));
+  manager.bindMembershipGate({
+    authority: {
+      authorize,
+      reconcile,
+    } as never,
+    botTelegramUserId: "777777",
+  });
+  return authorize;
+}
+
+function makeCtx(chatType: "channel" | "group" | "supergroup") {
+  return {
+    from: { id: 424242, is_bot: false, first_name: "Channel", username: "c" },
+    chat: { id: CHAT_ID, type: chatType, title: "Announcements" },
+    message: {
+      message_id: 101,
+      date: 1_774_000_000,
+      text: "broadcast post body",
+      chat: { id: CHAT_ID, type: chatType, title: "broadcasts" },
+    },
+    telegram: {
+      getChatMember: async () => ({ status: "left", user: { id: 424242 } }),
+    },
+  } as never;
+}
+
+describe("MessageManager admission gate scopes to group/supergroup chats", () => {
+  it("does not consult the membership authority for a channel post", async () => {
+    const { manager, runtime } = makeManager();
+    const authorize = bindDenyAllGate(manager);
+
+    await manager.handleMessage(makeCtx("channel"));
+
+    expect(authorize).not.toHaveBeenCalled();
+    // The channel post is still ingested: it must not be dropped by the gate.
+    expect(runtime.createMemory).toHaveBeenCalledTimes(1);
+    const memory = runtime.createMemory.mock.calls[0][0] as {
+      content: { channelType: string };
+      metadata: { chatType: string };
+    };
+    expect(memory.content.channelType).toBe("GROUP");
+    expect(memory.metadata.chatType).toBe("channel");
+  });
+
+  it("consults the membership authority for a group message and denies when evidence is stale", async () => {
+    const { manager, runtime } = makeManager();
+    const authorize = bindDenyAllGate(manager);
+
+    await manager.handleMessage(makeCtx("group"));
+
+    expect(authorize).toHaveBeenCalledTimes(1);
+    // Denied admission must not persist the message (fail-closed).
+    expect(runtime.createMemory).not.toHaveBeenCalled();
+  });
+
+  it("consults the membership authority for a supergroup message and denies when evidence is stale", async () => {
+    const { manager, runtime } = makeManager();
+    const authorize = bindDenyAllGate(manager);
+
+    await manager.handleMessage(makeCtx("supergroup"));
+
+    expect(authorize).toHaveBeenCalledTimes(1);
+    expect(runtime.createMemory).not.toHaveBeenCalled();
+  });
+
+  it("admits an allowed group sender and persists the memory", async () => {
+    const { manager, runtime } = makeManager();
+    const authorize = vi.fn(async () => ({
+      decision: "allowed" as const,
+    }));
+    manager.bindMembershipGate({
+      authority: { authorize, reconcile: vi.fn() } as never,
+      botTelegramUserId: "777777",
+    });
+
+    await manager.handleMessage(makeCtx("group"));
+
+    expect(authorize).toHaveBeenCalledTimes(1);
+    expect(runtime.createMemory).toHaveBeenCalledTimes(1);
+  });
+});

--- a/plugins/plugin-telegram/src/messageManager.channel-admission.test.ts
+++ b/plugins/plugin-telegram/src/messageManager.channel-admission.test.ts
@@ -2,10 +2,12 @@
  * Admission-surface boundary tests for MessageManager.handleMessage: the
  * membership gate must run ONLY for raw Telegram `group`/`supergroup` chats —
  * the same predicate as TelegramService.chatAndEntityMiddleware and the
- * standalone handler. `channel` chats collapse to ChannelType.GROUP through
- * getChannelType and must NOT consult or register a membership scope: the
- * connector contract (membership.ts) gives channels no inbound admission
- * surface. Deterministic unit harness: the REAL handleMessage admission path
+ * standalone handler's admission gate. `channel` chats collapse to
+ * ChannelType.GROUP through this file's getChannelType (the standalone
+ * mapping sends `channel` to FEED instead) and must NOT consult or register
+ * a membership scope: the connector contract (membership.ts) gives channels
+ * no inbound admission surface. Deterministic unit harness: the REAL
+ * handleMessage admission path
  * and the REAL TelegramMembershipMessageGate run over a fake runtime with a
  * fail-closed stubbed authority; no network, no database.
  */

--- a/plugins/plugin-telegram/src/messageManager.ts
+++ b/plugins/plugin-telegram/src/messageManager.ts
@@ -413,6 +413,14 @@ export class MessageManager {
     this.telegramMembershipGate.rebind(gate.authority, gate.botTelegramUserId);
   }
 
+  /**
+   * Marks the membership gate broken (authority configured but bootstrap
+   * failed): group admission fails closed until a later successful boot.
+   */
+  markMembershipGateBroken(): void {
+    this.telegramMembershipGate.markBroken();
+  }
+
   private telegramMessageMemoryKey(
     chatId: number | string,
     messageId: number | string,

--- a/plugins/plugin-telegram/src/messageManager.ts
+++ b/plugins/plugin-telegram/src/messageManager.ts
@@ -53,6 +53,7 @@ import {
   telegramIdentityMetadata,
 } from "./identity";
 import { renderTelegramInteractions } from "./interactions";
+import { TelegramMembershipMessageGate } from "./membership-gate";
 import {
   type TelegramContent,
   TelegramEventTypes,
@@ -390,10 +391,26 @@ export class MessageManager {
     this.bot = bot;
     this.runtime = runtime;
     this.accountId = accountId;
+    this.telegramMembershipGate = new TelegramMembershipMessageGate({
+      runtime,
+      authority: null,
+      botTelegramUserId: null,
+    });
   }
 
   private scopedTelegramKey(key: string): string {
     return this.accountId === "default" ? key : `${this.accountId}:${key}`;
+  }
+
+  /** Membership admission gate for group/supergroup messages; lazily bound by the owning TelegramService. */
+  public readonly telegramMembershipGate: TelegramMembershipMessageGate;
+
+  /** Binds the authority-backed membership gate once the service has bootstrapped it. */
+  bindMembershipGate(gate: {
+    authority: import("./membership").TelegramMembershipAuthority;
+    botTelegramUserId: string;
+  }): void {
+    this.telegramMembershipGate.rebind(gate.authority, gate.botTelegramUserId);
   }
 
   private telegramMessageMemoryKey(
@@ -1576,6 +1593,29 @@ export class MessageManager {
         worldId,
         worldName: telegramRoomid,
       });
+
+      // Membership admission gate: group/supergroup chats require canonical
+      // membership authority. DMs stay under the DM policy; channels have no
+      // inbound admission surface in this connector. The gate runs after
+      // ensureConnection so the principal entity row exists for reconciles.
+      if (channelType === ChannelType.GROUP) {
+        const admitted = await this.telegramMembershipGate.authorizeMessage({
+          chatId: telegramChatId,
+          chatRoomKey: this.scopedTelegramKey(telegramChatId),
+          chatType: chat.type,
+          principalEntityId: entityId,
+          telegramUserId,
+          runtimeMapping: { worldId, roomId, entityId },
+          getChatMember: async () =>
+            ctx.telegram.getChatMember(
+              Number(telegramChatId),
+              Number(telegramUserId),
+            ),
+        });
+        if (!admitted) {
+          return;
+        }
+      }
 
       // Create the memory object
       const memory: Memory = {

--- a/plugins/plugin-telegram/src/messageManager.ts
+++ b/plugins/plugin-telegram/src/messageManager.ts
@@ -1568,9 +1568,11 @@ export class MessageManager {
       // inbound admission surface in this connector — a channel post must not
       // register or consult a membership scope the connector does not own, so
       // the gate matches on the raw Telegram chat type (the same predicate as
-      // TelegramService.chatAndEntityMiddleware and the standalone handler)
-      // rather than the collapsed ChannelType mapping, which folds `channel`
-      // into GROUP. The gate runs BEFORE processMessage and ensureConnection
+      // TelegramService.chatAndEntityMiddleware and the standalone handler's
+      // admission gate) rather than this file's collapsed ChannelType mapping,
+      // which folds `channel` into GROUP — unlike the standalone
+      // getTelegramChannelType, which maps `channel` to FEED. The gate runs
+      // BEFORE processMessage and ensureConnection
       // so a denied sender can neither trigger media fetch/vision work nor
       // mutate room-participant state; the authority bootstraps the principal
       // entity itself when evidence needs the row.

--- a/plugins/plugin-telegram/src/messageManager.ts
+++ b/plugins/plugin-telegram/src/messageManager.ts
@@ -1559,6 +1559,36 @@ export class MessageManager {
         return;
       }
 
+      // Get chat type and determine channel type
+      const chat = message.chat as Chat;
+      const channelType = getChannelType(chat);
+
+      // Membership admission gate: group/supergroup chats require canonical
+      // membership authority. DMs stay under the DM policy; channels have no
+      // inbound admission surface in this connector. The gate runs BEFORE
+      // processMessage and ensureConnection so a denied sender can neither
+      // trigger media fetch/vision work nor mutate room-participant state;
+      // the authority bootstraps the principal entity itself when evidence
+      // needs the row.
+      if (channelType === ChannelType.GROUP) {
+        const admitted = await this.telegramMembershipGate.authorizeMessage({
+          chatId: telegramChatId,
+          chatRoomKey: this.scopedTelegramKey(telegramChatId),
+          chatType: chat.type,
+          principalEntityId: entityId,
+          telegramUserId,
+          runtimeMapping: { worldId, roomId, entityId },
+          getChatMember: async () =>
+            ctx.telegram.getChatMember(
+              Number(telegramChatId),
+              Number(telegramUserId),
+            ),
+        });
+        if (!admitted) {
+          return;
+        }
+      }
+
       // Process message content and attachments
       const { processedContent, attachments } =
         await this.processMessage(message);
@@ -1575,10 +1605,6 @@ export class MessageManager {
       if (!cleanedContent && cleanedAttachments.length === 0) {
         return;
       }
-
-      // Get chat type and determine channel type
-      const chat = message.chat as Chat;
-      const channelType = getChannelType(chat);
 
       await this.runtime.ensureConnection({
         entityId,
@@ -1601,29 +1627,6 @@ export class MessageManager {
         worldId,
         worldName: telegramRoomid,
       });
-
-      // Membership admission gate: group/supergroup chats require canonical
-      // membership authority. DMs stay under the DM policy; channels have no
-      // inbound admission surface in this connector. The gate runs after
-      // ensureConnection so the principal entity row exists for reconciles.
-      if (channelType === ChannelType.GROUP) {
-        const admitted = await this.telegramMembershipGate.authorizeMessage({
-          chatId: telegramChatId,
-          chatRoomKey: this.scopedTelegramKey(telegramChatId),
-          chatType: chat.type,
-          principalEntityId: entityId,
-          telegramUserId,
-          runtimeMapping: { worldId, roomId, entityId },
-          getChatMember: async () =>
-            ctx.telegram.getChatMember(
-              Number(telegramChatId),
-              Number(telegramUserId),
-            ),
-        });
-        if (!admitted) {
-          return;
-        }
-      }
 
       // Create the memory object
       const memory: Memory = {

--- a/plugins/plugin-telegram/src/messageManager.ts
+++ b/plugins/plugin-telegram/src/messageManager.ts
@@ -1565,12 +1565,16 @@ export class MessageManager {
 
       // Membership admission gate: group/supergroup chats require canonical
       // membership authority. DMs stay under the DM policy; channels have no
-      // inbound admission surface in this connector. The gate runs BEFORE
-      // processMessage and ensureConnection so a denied sender can neither
-      // trigger media fetch/vision work nor mutate room-participant state;
-      // the authority bootstraps the principal entity itself when evidence
-      // needs the row.
-      if (channelType === ChannelType.GROUP) {
+      // inbound admission surface in this connector — a channel post must not
+      // register or consult a membership scope the connector does not own, so
+      // the gate matches on the raw Telegram chat type (the same predicate as
+      // TelegramService.chatAndEntityMiddleware and the standalone handler)
+      // rather than the collapsed ChannelType mapping, which folds `channel`
+      // into GROUP. The gate runs BEFORE processMessage and ensureConnection
+      // so a denied sender can neither trigger media fetch/vision work nor
+      // mutate room-participant state; the authority bootstraps the principal
+      // entity itself when evidence needs the row.
+      if (chat.type === "group" || chat.type === "supergroup") {
         const admitted = await this.telegramMembershipGate.authorizeMessage({
           chatId: telegramChatId,
           chatRoomKey: this.scopedTelegramKey(telegramChatId),

--- a/plugins/plugin-telegram/src/service.launch-supervision.test.ts
+++ b/plugins/plugin-telegram/src/service.launch-supervision.test.ts
@@ -95,10 +95,16 @@ describe("TelegramService.launchPollerSupervised", () => {
     // The poll loop is still running (launch promise stays pending); the caller
     // must proceed off the connect callback, not off loop completion.
     expect(bot.launch).toHaveBeenCalledTimes(1);
-    expect(calls[0].config).toEqual({
-      dropPendingUpdates: false,
-      allowedUpdates: ["message", "message_reaction", "callback_query"],
-    });
+    // my_chat_member MUST be in allowedUpdates: it is Telegram's only update
+    // for the bot's own membership status, and the tombstone/clear paths in
+    // the membership authority depend on its delivery. This pins the
+    // membership-relevant entry rather than the full list shape (lockstep
+    // copies would stay green if a removal broke the delivery contract).
+    expect(calls[0].config.allowedUpdates).toContain("my_chat_member");
+    expect(calls[0].config.allowedUpdates).toContain("message");
+    expect(calls[0].config.allowedUpdates).toContain("message_reaction");
+    expect(calls[0].config.allowedUpdates).toContain("callback_query");
+    expect(calls[0].config.dropPendingUpdates).toBe(false);
 
     calls[0].onLaunch();
     await exposeStoppablePoller(bot);

--- a/plugins/plugin-telegram/src/service.membership-boundaries.test.ts
+++ b/plugins/plugin-telegram/src/service.membership-boundaries.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Boundary regressions for the review findings on #28715: (1) membership
+ * admission runs at the TOP of chatAndEntityMiddleware — ahead of any
+ * ensureConnection participant mutation; (2) a leave revocation removes the
+ * departed principal's room participation; (3) the pending admission state
+ * fails closed during the poller-before-gate startup window. Deterministic
+ * unit harness: the real middleware and gate run over fake runtimes; no
+ * network, no database.
+ */
+import type { IAgentRuntime, UUID } from "@elizaos/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TelegramMembershipMessageGate } from "./membership-gate";
+import { TelegramService } from "./service";
+
+function makeRuntime(): IAgentRuntime {
+  return {
+    agentId: "00000000-0000-0000-0000-0000000000a1",
+    reportError: vi.fn(),
+    getSetting: () => undefined,
+    getEntityById: vi.fn(async () => null),
+    updateEntity: vi.fn(async () => undefined),
+    createEntity: vi.fn(async () => true),
+    removeParticipant: vi.fn(async () => true),
+    ensureConnection: vi.fn(async () => undefined),
+    getWorld: vi.fn(async () => null),
+    getRoom: vi.fn(async () => null),
+    createWorld: vi.fn(async () => true),
+    createRoom: vi.fn(async () => true),
+    emitEvent: vi.fn(),
+  } as unknown as IAgentRuntime;
+}
+
+function middlewareService(options?: {
+  authorize?: (telegramUserId: string) => boolean;
+}) {
+  const runtime = makeRuntime();
+  const authorize = vi.fn(async (input: { telegramUserId: string }) =>
+    options?.authorize?.(input.telegramUserId)
+      ? { decision: "allowed" as const }
+      : { decision: "denied" as const, reason: "membership_revoked" },
+  );
+  const gate = new TelegramMembershipMessageGate({
+    runtime,
+    // Real gate; the authority double only records authorize calls.
+    authority: { authorize } as never,
+    botTelegramUserId: "900001",
+  });
+  const manager = { telegramMembershipGate: gate };
+  const service = Object.assign(
+    Object.create(TelegramService.prototype) as TelegramService,
+    {
+      runtime,
+      defaultAccountId: "default",
+      // The chat is already known so admitted updates take the
+      // existing-chat preprocessing path (no world bootstrap needed).
+      knownChats: new Map<string, unknown>([["-100123", {}]]),
+      syncedEntityIds: new Set<UUID>(),
+      messageManager: manager,
+    },
+  );
+  (service as unknown as { getAccountState: () => unknown }).getAccountState =
+    () => ({ messageManager: manager });
+  const chatAndEntityMiddleware = (
+    service as unknown as {
+      chatAndEntityMiddleware: (
+        ctx: unknown,
+        next: () => Promise<void>,
+        accountId?: string,
+      ) => Promise<void>;
+    }
+  ).chatAndEntityMiddleware.bind(service);
+  return { service, runtime, gate, authorize, chatAndEntityMiddleware };
+}
+
+function groupCtx(senderId = 42) {
+  return {
+    chat: { id: -100123, type: "supergroup" },
+    from: { id: senderId, is_bot: false, first_name: "Sender" },
+    message: {
+      message_id: 1,
+      date: 1_758_000_000,
+      text: "hello",
+      message_thread_id: undefined,
+    },
+    telegram: {
+      getChatMember: vi.fn(async () => ({
+        status: "member",
+        user: { id: senderId },
+      })),
+    },
+  } as never;
+}
+
+describe("chatAndEntityMiddleware membership admission ordering", () => {
+  afterEach(() => {
+    delete process.env.TELEGRAM_MEMBERSHIP_ENFORCE;
+    vi.restoreAllMocks();
+  });
+
+  it("runs the membership gate BEFORE any participant-state mutation (denied sender mutates nothing)", async () => {
+    const { chatAndEntityMiddleware, runtime } = middlewareService({
+      authorize: () => false,
+    });
+    const next = vi.fn(async () => undefined);
+
+    await chatAndEntityMiddleware(groupCtx(), next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(runtime.ensureConnection).not.toHaveBeenCalled();
+    expect(runtime.removeParticipant).not.toHaveBeenCalled();
+  });
+
+  it("admitted senders proceed to normal preprocessing", async () => {
+    const { chatAndEntityMiddleware } = middlewareService({
+      authorize: () => true,
+    });
+    const next = vi.fn(async () => undefined);
+
+    await chatAndEntityMiddleware(groupCtx(), next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not gate my_chat_member updates (a kicked bot must reach its tombstone handler)", async () => {
+    const { chatAndEntityMiddleware, authorize } = middlewareService({
+      authorize: () => false,
+    });
+    const next = vi.fn(async () => undefined);
+
+    // A my_chat_member update has no ctx.message — the gate must not fire.
+    await chatAndEntityMiddleware(
+      {
+        chat: { id: -100123, type: "supergroup" },
+        from: { id: 42, is_bot: false, first_name: "Admin" },
+        update: { my_chat_member: {} },
+      } as never,
+      next,
+    );
+
+    expect(authorize).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails closed while the admission gate is pending (startup window)", async () => {
+    const runtime = makeRuntime();
+    const gate = new TelegramMembershipMessageGate({
+      runtime,
+      authority: null,
+      botTelegramUserId: null,
+    });
+    gate.markPending();
+
+    await expect(
+      gate.authorizeMessage({
+        chatId: "-100",
+        chatRoomKey: "-100",
+        chatType: "group",
+        principalEntityId: "00000000-0000-0000-0000-000000000001" as UUID,
+        telegramUserId: "42",
+        runtimeMapping: { worldId: null, roomId: null, entityId: null },
+        getChatMember: async () => ({ status: "member", user: { id: 42 } }),
+      }),
+    ).resolves.toBe(false);
+
+    // Settles to the legacy allow mode once the bootstrap resolves absent.
+    gate.markAbsent();
+    await expect(
+      gate.authorizeMessage({
+        chatId: "-100",
+        chatRoomKey: "-100",
+        chatType: "group",
+        principalEntityId: "00000000-0000-0000-0000-000000000001" as UUID,
+        telegramUserId: "42",
+        runtimeMapping: { worldId: null, roomId: null, entityId: null },
+        getChatMember: async () => ({ status: "member", user: { id: 42 } }),
+      }),
+    ).resolves.toBe(true);
+  });
+});
+
+describe("leave revocation removes room participation", () => {
+  it("calls removeParticipant for the departed principal's observed and main rooms", async () => {
+    const runtime = makeRuntime();
+    const gate = {
+      authority: {
+        recordEvent: vi.fn(async () => undefined),
+        markScopeUnavailable: vi.fn(async () => undefined),
+      },
+      connectorAccountId: "connector-1",
+      botTelegramUserId: "900001",
+    };
+    const service = Object.assign(
+      Object.create(TelegramService.prototype) as TelegramService,
+      {
+        runtime,
+        defaultAccountId: "default",
+        knownChats: new Map<string, unknown>(),
+        syncedEntityIds: new Set<UUID>(),
+        membershipGateFailures: new Set<string>(),
+        settledMembershipGates: new Map<string, unknown>(),
+        membershipGates: new Map<string, unknown>(),
+        messageManager: { markMembershipGateBroken: vi.fn() },
+      },
+    );
+    (
+      service as unknown as { getMembershipGate: ReturnType<typeof vi.fn> }
+    ).getMembershipGate = vi.fn().mockResolvedValue(gate);
+    (service as unknown as { getAccountState: () => unknown }).getAccountState =
+      () => undefined;
+
+    const syncLeftChatMember = (
+      service as unknown as {
+        syncLeftChatMember: (
+          ctx: unknown,
+          worldId: UUID,
+          roomId: UUID,
+          accountId?: string,
+        ) => Promise<void>;
+      }
+    ).syncLeftChatMember.bind(service);
+
+    const roomId = "00000000-0000-0000-0000-0000000000aa" as UUID;
+    await syncLeftChatMember(
+      {
+        chat: { id: -100123, type: "supergroup" },
+        message: {
+          message_id: 5,
+          date: 1_758_000_000,
+          left_chat_member: { id: 42, is_bot: false, first_name: "Leaver" },
+        },
+      } as never,
+      "00000000-0000-0000-0000-0000000000bb" as UUID,
+      roomId,
+      "default",
+    );
+
+    expect(gate.authority.recordEvent).toHaveBeenCalledTimes(1);
+    expect(
+      (runtime.removeParticipant as ReturnType<typeof vi.fn>).mock.calls,
+    ).toEqual([
+      [expect.any(String), roomId],
+      [expect.any(String), expect.any(String)],
+    ]);
+    // A revocation must never (re)create participation: no ensureConnection.
+    expect(runtime.ensureConnection).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/plugin-telegram/src/service.membership-boundaries.test.ts
+++ b/plugins/plugin-telegram/src/service.membership-boundaries.test.ts
@@ -27,6 +27,7 @@ function makeRuntime(): IAgentRuntime {
     createWorld: vi.fn(async () => true),
     createRoom: vi.fn(async () => true),
     emitEvent: vi.fn(),
+    getRoomsForParticipant: vi.fn(async () => [] as UUID[]),
   } as unknown as IAgentRuntime;
 }
 
@@ -181,6 +182,27 @@ describe("chatAndEntityMiddleware membership admission ordering", () => {
 describe("leave revocation removes room participation", () => {
   it("calls removeParticipant for the departed principal's observed and main rooms", async () => {
     const runtime = makeRuntime();
+    // Forum-topic participation: the principal also sits in a topic room of
+    // the SAME chat world (plus an unrelated chat's world that must NOT be
+    // cleared). getRoom resolves worldId so the enumeration can filter.
+    const worldId = "00000000-0000-0000-0000-0000000000bb" as UUID;
+    const topicRoom = "00000000-0000-0000-0000-0000000000cc" as UUID;
+    const otherWorldRoom = "00000000-0000-0000-0000-0000000000dd" as UUID;
+    runtime.getRoomsForParticipant = vi.fn(async () => [
+      topicRoom,
+      otherWorldRoom,
+    ]);
+    runtime.getRoom = vi.fn(
+      async (id: UUID) =>
+        (id === topicRoom
+          ? { id, worldId }
+          : id === otherWorldRoom
+            ? {
+                id,
+                worldId: "00000000-0000-0000-0000-0000000000ee" as UUID,
+              }
+            : null) as never,
+    );
     const gate = {
       authority: {
         recordEvent: vi.fn(async () => undefined),
@@ -235,12 +257,14 @@ describe("leave revocation removes room participation", () => {
     );
 
     expect(gate.authority.recordEvent).toHaveBeenCalledTimes(1);
-    expect(
-      (runtime.removeParticipant as ReturnType<typeof vi.fn>).mock.calls,
-    ).toEqual([
-      [expect.any(String), roomId],
-      [expect.any(String), expect.any(String)],
-    ]);
+    const removedRooms = (
+      runtime.removeParticipant as ReturnType<typeof vi.fn>
+    ).mock.calls.map((call) => call[1]);
+    // Observed room, main room, AND the same-world topic room are cleared;
+    // the unrelated world's room is NOT.
+    expect(removedRooms).toContain(roomId);
+    expect(new Set(removedRooms)).toContain(topicRoom);
+    expect(removedRooms).not.toContain(otherWorldRoom);
     // A revocation must never (re)create participation: no ensureConnection.
     expect(runtime.ensureConnection).not.toHaveBeenCalled();
   });

--- a/plugins/plugin-telegram/src/service.my-chat-member.test.ts
+++ b/plugins/plugin-telegram/src/service.my-chat-member.test.ts
@@ -12,6 +12,30 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TelegramService } from "./service";
 
+// Controllable override for the gate factory: only the bootstrap-ordering
+// test below swaps it in (via gateFactory.create) so the REAL production
+// chain (beginMembershipGateBootstrap -> getMe -> factory -> replay) runs
+// against a deferred fake gate instead of the fake runtime's absent
+// authority service. Every other test stubs getMembershipGate directly and
+// never reaches the factory.
+const gateFactory = vi.hoisted(() => ({
+  create: null as
+    | null
+    | ((input: { botTelegramUserId: string }) => Promise<unknown>),
+}));
+vi.mock("./membership-gate", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./membership-gate")>();
+  return {
+    ...actual,
+    createTelegramMembershipGate: (
+      input: Parameters<typeof actual.createTelegramMembershipGate>[0],
+    ) =>
+      gateFactory.create
+        ? gateFactory.create(input)
+        : actual.createTelegramMembershipGate(input),
+  };
+});
+
 interface GateFake {
   authority: {
     markScopeUnavailable: ReturnType<typeof vi.fn>;
@@ -414,6 +438,73 @@ describe("my_chat_member delivery contract", () => {
     expect(
       settled.get("acct")?.authority.markScopeUnavailable,
     ).toHaveBeenCalledTimes(1);
+  });
+
+  it("installs the gate-bootstrap promise synchronously before the poller goes live (pre-getMe window)", async () => {
+    // The residual startup-window hole: ensureWiredOnce launches the poller
+    // BEFORE finishBotStartup's setMyCommands/getMe awaits resolve. A
+    // my_chat_member transition delivered in that window must find a PENDING
+    // gate promise to queue against — a missing promise reads as
+    // absent-authority legacy mode and silently drops the transition.
+    // beginMembershipGateBootstrap must therefore register the promise
+    // synchronously (its own getMe feeds it), before any update can arrive.
+    const { service } = makeService(null);
+    let resolveGetMe: (info: { id: number; username?: string }) => void =
+      () => {};
+    const getMe = vi.fn(
+      () =>
+        new Promise<{ id: number; username?: string }>((resolve) => {
+          resolveGetMe = resolve;
+        }),
+    );
+    const internals = service as unknown as {
+      membershipGates: Map<string, Promise<unknown>>;
+      settledMembershipGates: Map<string, unknown>;
+      pendingMembershipTransitions: Map<string, unknown[]>;
+      handleMyChatMemberUpdate: (
+        update: unknown,
+        accountId?: string,
+      ) => Promise<void>;
+      beginMembershipGateBootstrap: (bot: unknown, accountId: string) => void;
+    };
+    internals.pendingMembershipTransitions = new Map();
+    internals.beginMembershipGateBootstrap({ telegram: { getMe } }, "acct");
+
+    // Synchronous pin: the promise exists BEFORE getMe has resolved.
+    const gatePromise = internals.membershipGates.get("acct");
+    expect(gatePromise).toBeDefined();
+    expect(getMe).toHaveBeenCalledTimes(1);
+
+    // A transition arriving while the bootstrap is still pending queues
+    // (production dispatch path), instead of dropping on a missing promise.
+    await internals.handleMyChatMemberUpdate(botMemberUpdate("kicked"), "acct");
+    expect(internals.pendingMembershipTransitions.get("acct")?.length).toBe(1);
+
+    // Resolve the bootstrap: getMe resolves, the factory returns the fake
+    // gate, and the queued transition replays through the real dispatch
+    // path — the tombstone lands. Re-stub getMembershipGate BEFORE the
+    // resolution (the replay runs on the promise's microtask chain;
+    // makeService's null stub would read as absent authority and skip it).
+    const authority = {
+      markScopeUnavailable: vi.fn().mockResolvedValue(undefined),
+      clearScopeRemoval: vi.fn().mockResolvedValue(undefined),
+    };
+    const gate = {
+      authority,
+      connectorAccountId: "connector-1",
+      botTelegramUserId: "777",
+    };
+    gateFactory.create = async () => gate;
+    (
+      service as unknown as { getMembershipGate: ReturnType<typeof vi.fn> }
+    ).getMembershipGate = vi.fn().mockResolvedValue(gate);
+    resolveGetMe({ id: 777, username: "test_bot" });
+    await expect(gatePromise).resolves.toEqual(
+      expect.objectContaining({ botTelegramUserId: "777" }),
+    );
+    await new Promise((r) => setTimeout(r, 10));
+    expect(authority.markScopeUnavailable).toHaveBeenCalledTimes(1);
+    gateFactory.create = null;
   });
 
   it("registers a my_chat_member handler during message-handler setup", async () => {

--- a/plugins/plugin-telegram/src/service.my-chat-member.test.ts
+++ b/plugins/plugin-telegram/src/service.my-chat-member.test.ts
@@ -643,4 +643,117 @@ describe("my_chat_member delivery contract", () => {
       expect(gate.authority.markScopeUnavailable).toHaveBeenCalledTimes(1),
     );
   });
+
+  it("a failed bootstrap retry does not leave a stale settled null shadowing the fresh gate", async () => {
+    // RP R3 HIGH: when a queued transition's bootstrap promise REJECTS, the
+    // replay catch stores settled null; finishBotStartup's failure path
+    // then cleared only the identity/gate promise maps. A later successful
+    // retry created and bound a fresh gate, but getMembershipGate() kept
+    // returning the cached settled null — post-recovery transitions would
+    // silently skip authority writes while admission was live again. The
+    // failure catch must clear the settled registry too, and a successful
+    // retry must overwrite any stale settled entry with the fresh gate.
+    const { service, runtime } = makeService(null);
+    const internals = service as unknown as {
+      finishBotStartup: (
+        bot: { telegram: { getMe: () => Promise<unknown> } },
+        accountId: string,
+      ) => Promise<void>;
+    };
+    let getMeAttempts = 0;
+    const bot: { telegram: { getMe: () => Promise<unknown> } } = {
+      telegram: {
+        getMe: () => {
+          getMeAttempts += 1;
+          if (getMeAttempts === 1) {
+            // The runtime's absent authority service makes the gate factory
+            // resolve null (legacy mode); a REJECTED identity lookup is the
+            // failure path under test — reject the first attempt.
+            return Promise.reject(new Error("network down"));
+          }
+          return Promise.resolve({ id: 777, username: "test_bot" });
+        },
+      },
+    };
+
+    // First boot: identity lookup rejects inside the failure-observing try —
+    // the catch must clear ALL cached state including the settled registry.
+    await internals.finishBotStartup(bot, "acct");
+    const cleared = service as unknown as {
+      membershipBotIdentity: Map<string, unknown>;
+      membershipGates: Map<string, unknown>;
+      settledMembershipGates: Map<string, unknown>;
+      membershipGateFailures: Set<string>;
+    };
+    expect(cleared.membershipBotIdentity.has("acct")).toBe(false);
+    expect(cleared.membershipGates.has("acct")).toBe(false);
+    expect(cleared.settledMembershipGates.has("acct")).toBe(false);
+    expect(cleared.membershipGateFailures.has("acct")).toBe(true);
+    expect(
+      (
+        service as unknown as {
+          getAccountState: () => {
+            messageManager: {
+              markMembershipGateBroken: ReturnType<typeof vi.fn>;
+            };
+          };
+        }
+      ).getAccountState().messageManager.markMembershipGateBroken,
+    ).toHaveBeenCalledTimes(1);
+
+    // A stale settled null as a rejected replay could have stored BEFORE the
+    // catch ran (the ordering RP flagged): simulate it landing late.
+    cleared.settledMembershipGates.set("acct", null);
+
+    // Retry boot: the fresh identity resolves; with no authority service the
+    // factory resolves null and the manager settles to absent — but a REAL
+    // gate bootstrap would have set the fresh gate. Drive the real-gate path
+    // via the factory override to assert the overwrite contract.
+    const authority = {
+      markScopeUnavailable: vi.fn().mockResolvedValue(undefined),
+      clearScopeRemoval: vi.fn().mockResolvedValue(undefined),
+    };
+    // The real-gate path binds the manager; makeService's manager stub only
+    // covers the failure side. Replace it for the retry leg.
+    const retryManager = {
+      markMembershipGateBroken: vi.fn(),
+      bindMembershipGate: vi.fn(),
+      telegramMembershipGate: { markAbsent: vi.fn() },
+    };
+    (
+      service as unknown as {
+        getAccountState: () => {
+          messageManager: typeof retryManager;
+        };
+      }
+    ).getAccountState = () => ({ messageManager: retryManager });
+    gateFactory.create = async () => ({
+      authority,
+      connectorAccountId: "ca-1",
+      botTelegramUserId: "777",
+    });
+    try {
+      await internals.finishBotStartup(bot, "acct");
+      // The successful retry overwrites the stale settled null with the
+      // fresh gate — the REAL getMembershipGate (not makeService's stub,
+      // which is pinned to null) no longer short-circuits to null.
+      const resolved = await (
+        TelegramService.prototype as unknown as {
+          getMembershipGate: (
+            this: unknown,
+            accountId?: string,
+          ) => Promise<unknown>;
+        }
+      ).getMembershipGate.call(service, "acct");
+      expect(resolved).toEqual(
+        expect.objectContaining({ botTelegramUserId: "777" }),
+      );
+      expect(cleared.settledMembershipGates.get("acct")).toEqual(
+        expect.objectContaining({ botTelegramUserId: "777" }),
+      );
+      expect(runtime.reportError).toHaveBeenCalledTimes(1);
+    } finally {
+      gateFactory.create = null;
+    }
+  });
 });

--- a/plugins/plugin-telegram/src/service.my-chat-member.test.ts
+++ b/plugins/plugin-telegram/src/service.my-chat-member.test.ts
@@ -67,6 +67,9 @@ function makeService(gate: GateFake | null) {
     service as unknown as { membershipGates: Map<string, unknown> }
   ).membershipGates = new Map();
   (
+    service as unknown as { settledMembershipGates: Map<string, unknown> }
+  ).settledMembershipGates = new Map();
+  (
     service as unknown as {
       messageManager: { markMembershipGateBroken: ReturnType<typeof vi.fn> };
     }
@@ -334,7 +337,7 @@ describe("my_chat_member delivery contract", () => {
     });
   });
 
-  it("does nothing without a membership gate", async () => {
+  it("does nothing without a membership gate (absent authority: legacy mode)", async () => {
     const { service, getMembershipGate } = makeService(null);
     const dispatch = (
       service as unknown as {
@@ -348,6 +351,69 @@ describe("my_chat_member delivery contract", () => {
     await dispatch(botMemberUpdate("kicked"));
 
     expect(getMembershipGate).toHaveBeenCalledTimes(1);
+  });
+
+  it("queues a transition that arrives while the gate is bootstrapping and replays it once resolved", async () => {
+    // Startup window: the poller is live but finishBotStartup has not
+    // resolved the gate yet. A kick arriving here must be queued and
+    // replayed — discarding it would leave stale active authority
+    // untombstoned (and a re-add would leave a persisted tombstone
+    // denying the chat indefinitely).
+    let resolveGate: (gate: GateFake | null) => void = () => {};
+    const gatePromise = new Promise<GateFake | null>((resolve) => {
+      resolveGate = resolve;
+    });
+    const { service } = makeService(null);
+    const internals = service as unknown as {
+      membershipGates: Map<string, Promise<GateFake | null>>;
+      settledMembershipGates: Map<string, GateFake | null>;
+      pendingMembershipTransitions: Map<string, unknown[]>;
+      handleMyChatMemberUpdate: (
+        update: unknown,
+        accountId?: string,
+      ) => Promise<void>;
+    };
+    internals.membershipGates.set("acct", gatePromise);
+    // Object.assign harness: field initializers never ran, so provide the
+    // queue registry the production class declares.
+    internals.pendingMembershipTransitions = new Map();
+    // Production getMembershipGate: settled registry first, else the promise.
+    const settled = new Map<string, GateFake | null>();
+    (
+      service as unknown as {
+        getMembershipGate: ReturnType<typeof vi.fn>;
+      }
+    ).getMembershipGate = vi.fn(async () => {
+      if (settled.has("acct")) {
+        return settled.get("acct") ?? null;
+      }
+      return gatePromise.then((gate) => {
+        settled.set("acct", gate);
+        return gate;
+      });
+    });
+    internals.settledMembershipGates = settled as never;
+    const dispatch = internals.handleMyChatMemberUpdate.bind(service);
+
+    // Transition arrives while the gate promise is pending: queued, not dropped.
+    await dispatch(botMemberUpdate("kicked"));
+
+    // Once the gate resolves, the queued transition is replayed through the
+    // normal dispatch path — the tombstone lands.
+    resolveGate({
+      authority: {
+        markScopeUnavailable: vi.fn().mockResolvedValue(undefined),
+        clearScopeRemoval: vi.fn().mockResolvedValue(undefined),
+      },
+      connectorAccountId: "connector-1",
+      botTelegramUserId: "777",
+    });
+    await gatePromise;
+    // Let the replay microtask chain drain.
+    await new Promise((r) => setTimeout(r, 10));
+    expect(
+      settled.get("acct")?.authority.markScopeUnavailable,
+    ).toHaveBeenCalledTimes(1);
   });
 
   it("registers a my_chat_member handler during message-handler setup", async () => {

--- a/plugins/plugin-telegram/src/service.my-chat-member.test.ts
+++ b/plugins/plugin-telegram/src/service.my-chat-member.test.ts
@@ -94,6 +94,14 @@ function makeService(gate: GateFake | null) {
     service as unknown as { settledMembershipGates: Map<string, unknown> }
   ).settledMembershipGates = new Map();
   (
+    service as unknown as { replayingMembershipTransitions: Set<string> }
+  ).replayingMembershipTransitions = new Set();
+  (
+    service as unknown as {
+      membershipBotIdentity: Map<string, Promise<unknown>>;
+    }
+  ).membershipBotIdentity = new Map();
+  (
     service as unknown as {
       messageManager: { markMembershipGateBroken: ReturnType<typeof vi.fn> };
     }
@@ -505,6 +513,93 @@ describe("my_chat_member delivery contract", () => {
     await new Promise((r) => setTimeout(r, 10));
     expect(authority.markScopeUnavailable).toHaveBeenCalledTimes(1);
     gateFactory.create = null;
+  });
+
+  it("drains live arrivals behind the queued startup replay in arrival order", async () => {
+    // RP R1 finding (medium): the replay marks the gate settled and drains
+    // the queue while Telegraf may concurrently dispatch a NEWER live
+    // transition — the live one could serialize into the authority ahead of
+    // older queued entries (kick-then-re-add inverting). The replay fence
+    // re-queues live arrivals and drains them AFTER the queued ones.
+    let resolveGate: (gate: GateFake | null) => void = () => {};
+    const gatePromise = new Promise<GateFake | null>((resolve) => {
+      resolveGate = resolve;
+    });
+    // A genuine re-add: old status revoked (kicked) -> new status member.
+    const reAddUpdate = {
+      ...botMemberUpdate("member"),
+      old_chat_member: {
+        status: "kicked",
+        user: { id: 777, is_bot: true },
+      },
+    };
+    const { service } = makeService(null);
+    const internals = service as unknown as {
+      membershipGates: Map<string, Promise<GateFake | null>>;
+      settledMembershipGates: Map<string, GateFake | null>;
+      pendingMembershipTransitions: Map<string, unknown[]>;
+      replayingMembershipTransitions: Set<string>;
+      handleMyChatMemberUpdate: (
+        update: unknown,
+        accountId?: string,
+      ) => Promise<void>;
+      queuePendingMembershipTransition: (
+        update: unknown,
+        accountId: string,
+      ) => void;
+    };
+    internals.membershipGates.set("acct", gatePromise);
+    internals.pendingMembershipTransitions = new Map();
+    internals.replayingMembershipTransitions = new Set();
+    const order: string[] = [];
+    const authority = {
+      markScopeUnavailable: vi.fn(async () => {
+        // Simulate the live re-add arrival landing WHILE the queued kick's
+        // authority write is in flight. UNFENCED, this dispatch would run
+        // to completion first and log "clear" before "kick".
+        await internals.handleMyChatMemberUpdate(reAddUpdate, "acct");
+        order.push("kick");
+      }),
+      clearScopeRemoval: vi.fn(async () => {
+        order.push("clear");
+      }),
+    };
+    const settled = new Map<string, GateFake | null>();
+    internals.settledMembershipGates = settled as never;
+    (
+      service as unknown as { getMembershipGate: ReturnType<typeof vi.fn> }
+    ).getMembershipGate = vi.fn(async () => {
+      if (settled.has("acct")) {
+        return settled.get("acct") ?? null;
+      }
+      const gate = await gatePromise;
+      settled.set("acct", gate);
+      return gate;
+    });
+
+    // Queue a kick for chat -100999 while the gate bootstraps.
+    await internals.handleMyChatMemberUpdate(botMemberUpdate("kicked"), "acct");
+    expect(internals.pendingMembershipTransitions.get("acct")?.length).toBe(1);
+
+    // Resolve the gate: the replay starts and drains the queued kick. The
+    // kick's authority write triggers a LIVE re-add arrival for another
+    // chat; the fence must queue it behind the drain, not let it dispatch
+    // concurrently.
+    resolveGate({
+      authority,
+      connectorAccountId: "connector-1",
+      botTelegramUserId: "777",
+    });
+    await gatePromise;
+    await new Promise((r) => setTimeout(r, 20));
+
+    // The queued kick was tombstoned...
+    expect(authority.markScopeUnavailable).toHaveBeenCalledTimes(1);
+    // ...and the live re-add (which raced mid-drain) dispatched AFTER the
+    // queued kick — arrival order preserved across the replay/live boundary
+    // — and drained fully (queue empty).
+    expect(order).toEqual(["kick", "clear"]);
+    expect(internals.pendingMembershipTransitions.has("acct")).toBe(false);
   });
 
   it("registers a my_chat_member handler during message-handler setup", async () => {

--- a/plugins/plugin-telegram/src/service.my-chat-member.test.ts
+++ b/plugins/plugin-telegram/src/service.my-chat-member.test.ts
@@ -1,0 +1,394 @@
+/**
+ * Unit coverage for the `my_chat_member` delivery path: the poller's
+ * allowedUpdates wiring, the update handler registration, and the
+ * bot-removal tombstone / re-add clear dispatch. While polling, a kicked bot
+ * stops receiving the chat's messages entirely, so Telegram's
+ * `my_chat_member` update is the ONLY signal that reaches the runtime for the
+ * bot's own status transitions — without it the authority's tombstone paths
+ * (membership.ts removedScopes / scopeReaddWatermarks) are unreachable.
+ * Deterministic unit harness: runtime and gate are fakes; the real dispatch
+ * method runs.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TelegramService } from "./service";
+
+interface GateFake {
+  authority: {
+    markScopeUnavailable: ReturnType<typeof vi.fn>;
+    clearScopeRemoval: ReturnType<typeof vi.fn>;
+  };
+  connectorAccountId: string;
+  botTelegramUserId: string;
+}
+
+function makeMembershipChatRoomKey(
+  service: TelegramService,
+): (chatId: string) => string {
+  return (chatId: string) =>
+    (
+      service as unknown as {
+        membershipChatRoomKey: (chatId: string, accountId: string) => string;
+      }
+    ).membershipChatRoomKey(chatId, "acct");
+}
+
+function makeService(gate: GateFake | null) {
+  const runtime = {
+    agentId: "agent-test",
+    reportError: vi.fn(),
+  };
+  const service = Object.assign(
+    Object.create(TelegramService.prototype) as TelegramService,
+    {
+      runtime,
+      defaultAccountId: "acct",
+    },
+  );
+  const getMembershipGate = vi.fn().mockResolvedValue(gate);
+  const accountState = {
+    messageManager: { markMembershipGateBroken: vi.fn() },
+  };
+  (
+    service as unknown as {
+      getMembershipGate: typeof getMembershipGate;
+      getAccountState: () => typeof accountState;
+      membershipGateFailures: Set<string>;
+      membershipGates: Map<string, unknown>;
+      messageManager: { markMembershipGateBroken: ReturnType<typeof vi.fn> };
+    }
+  ).getMembershipGate = getMembershipGate;
+  (
+    service as unknown as { getAccountState: () => typeof accountState }
+  ).getAccountState = () => accountState;
+  (
+    service as unknown as { membershipGateFailures: Set<string> }
+  ).membershipGateFailures = new Set();
+  (
+    service as unknown as { membershipGates: Map<string, unknown> }
+  ).membershipGates = new Map();
+  (
+    service as unknown as {
+      messageManager: { markMembershipGateBroken: ReturnType<typeof vi.fn> };
+    }
+  ).messageManager = accountState.messageManager;
+  return { service, runtime, getMembershipGate, accountState };
+}
+
+function botMemberUpdate(
+  newStatus: string,
+  botId = 777,
+  chatId = -100999,
+): {
+  chat: { id: number; type: string };
+  from: { id: number; is_bot: boolean; first_name: string };
+  date: number;
+  old_chat_member: { status: string; user: { id: number; is_bot: boolean } };
+  new_chat_member: { status: string; user: { id: number; is_bot: boolean } };
+} {
+  return {
+    chat: { id: chatId, type: "supergroup" },
+    from: { id: 42, is_bot: false, first_name: "Admin" },
+    date: 1_758_000_000,
+    old_chat_member: {
+      status: "member",
+      user: { id: botId, is_bot: true },
+    },
+    new_chat_member: {
+      status: newStatus,
+      user: { id: botId, is_bot: true },
+    },
+  };
+}
+
+describe("my_chat_member delivery contract", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("tombstones the scope when the bot is kicked", async () => {
+    const gate: GateFake = {
+      authority: {
+        markScopeUnavailable: vi.fn().mockResolvedValue(undefined),
+        clearScopeRemoval: vi.fn(),
+      },
+      connectorAccountId: "ca-1",
+      botTelegramUserId: "777",
+    };
+    const { service } = makeService(gate);
+    const roomKey = makeMembershipChatRoomKey(service);
+    const dispatch = (
+      service as unknown as {
+        handleMyChatMemberUpdate: (
+          update: unknown,
+          accountId?: string,
+        ) => Promise<void>;
+      }
+    ).handleMyChatMemberUpdate.bind(service);
+
+    await dispatch(botMemberUpdate("kicked"));
+
+    expect(gate.authority.markScopeUnavailable).toHaveBeenCalledTimes(1);
+    expect(gate.authority.markScopeUnavailable).toHaveBeenCalledWith({
+      chatId: "-100999",
+      chatRoomKey: roomKey("-100999"),
+      reason: "bot_removed",
+    });
+    expect(gate.authority.clearScopeRemoval).not.toHaveBeenCalled();
+  });
+
+  it("clears the tombstone when the bot is re-added as a member", async () => {
+    const gate: GateFake = {
+      authority: {
+        markScopeUnavailable: vi.fn().mockResolvedValue(undefined),
+        clearScopeRemoval: vi.fn(),
+      },
+      connectorAccountId: "ca-1",
+      botTelegramUserId: "777",
+    };
+    const { service } = makeService(gate);
+    const roomKey = makeMembershipChatRoomKey(service);
+    const dispatch = (
+      service as unknown as {
+        handleMyChatMemberUpdate: (
+          update: unknown,
+          accountId?: string,
+        ) => Promise<void>;
+      }
+    ).handleMyChatMemberUpdate.bind(service);
+
+    const update = botMemberUpdate("member");
+    update.old_chat_member = {
+      status: "kicked",
+      user: { id: 777, is_bot: true },
+    };
+    await dispatch(update);
+
+    expect(gate.authority.clearScopeRemoval).toHaveBeenCalledTimes(1);
+    expect(gate.authority.clearScopeRemoval).toHaveBeenCalledWith({
+      chatId: "-100999",
+      chatRoomKey: roomKey("-100999"),
+    });
+    expect(gate.authority.markScopeUnavailable).not.toHaveBeenCalled();
+  });
+
+  it("ignores a present->present update (e.g. admin-rights edit, no re-add)", async () => {
+    const gate: GateFake = {
+      authority: {
+        markScopeUnavailable: vi.fn().mockResolvedValue(undefined),
+        clearScopeRemoval: vi.fn(),
+      },
+      connectorAccountId: "ca-1",
+      botTelegramUserId: "777",
+    };
+    const { service } = makeService(gate);
+    const dispatch = (
+      service as unknown as {
+        handleMyChatMemberUpdate: (
+          update: unknown,
+          accountId?: string,
+        ) => Promise<void>;
+      }
+    ).handleMyChatMemberUpdate.bind(service);
+
+    const update = botMemberUpdate("administrator");
+    update.old_chat_member = {
+      status: "member",
+      user: { id: 777, is_bot: true },
+    };
+    await dispatch(update);
+
+    // Not a re-add transition: neither tombstone nor clear may fire, or
+    // in-flight valid evidence would be spuriously invalidated.
+    expect(gate.authority.clearScopeRemoval).not.toHaveBeenCalled();
+    expect(gate.authority.markScopeUnavailable).not.toHaveBeenCalled();
+  });
+
+  it("treats a restricted bot with is_member false as removed (fail closed)", async () => {
+    const gate: GateFake = {
+      authority: {
+        markScopeUnavailable: vi.fn().mockResolvedValue(undefined),
+        clearScopeRemoval: vi.fn(),
+      },
+      connectorAccountId: "ca-1",
+      botTelegramUserId: "777",
+    };
+    const { service } = makeService(gate);
+    const dispatch = (
+      service as unknown as {
+        handleMyChatMemberUpdate: (
+          update: unknown,
+          accountId?: string,
+        ) => Promise<void>;
+      }
+    ).handleMyChatMemberUpdate.bind(service);
+
+    const update = botMemberUpdate("restricted");
+    (update.new_chat_member as { is_member?: boolean }).is_member = false;
+    await dispatch(update);
+
+    expect(gate.authority.markScopeUnavailable).toHaveBeenCalledTimes(1);
+    expect(gate.authority.clearScopeRemoval).not.toHaveBeenCalled();
+  });
+
+  it("ignores updates for a member other than the bot itself", async () => {
+    const gate: GateFake = {
+      authority: {
+        markScopeUnavailable: vi.fn().mockResolvedValue(undefined),
+        clearScopeRemoval: vi.fn(),
+      },
+      connectorAccountId: "ca-1",
+      botTelegramUserId: "777",
+    };
+    const { service } = makeService(gate);
+    const dispatch = (
+      service as unknown as {
+        handleMyChatMemberUpdate: (
+          update: unknown,
+          accountId?: string,
+        ) => Promise<void>;
+      }
+    ).handleMyChatMemberUpdate.bind(service);
+
+    await dispatch(botMemberUpdate("kicked", 12345));
+
+    expect(gate.authority.markScopeUnavailable).not.toHaveBeenCalled();
+    expect(gate.authority.clearScopeRemoval).not.toHaveBeenCalled();
+  });
+
+  it("breaks the admission gate when the tombstone write itself fails", async () => {
+    const gate: GateFake = {
+      authority: {
+        markScopeUnavailable: vi.fn().mockRejectedValue(new Error("db down")),
+        clearScopeRemoval: vi.fn(),
+      },
+      connectorAccountId: "ca-1",
+      botTelegramUserId: "777",
+    };
+    const { service, runtime, accountState } = makeService(gate);
+    const dispatch = (
+      service as unknown as {
+        handleMyChatMemberUpdate: (
+          update: unknown,
+          accountId?: string,
+        ) => Promise<void>;
+      }
+    ).handleMyChatMemberUpdate.bind(service);
+
+    await dispatch(botMemberUpdate("kicked"));
+
+    // Fail closed: the degrade write failed, so the admission gate must be
+    // marked broken and the failure reported rather than swallowed.
+    expect(
+      accountState.messageManager.markMembershipGateBroken,
+    ).toHaveBeenCalledTimes(1);
+    expect(runtime.reportError).toHaveBeenCalledTimes(1);
+    const reported = (
+      runtime.reportError as unknown as { mock: { calls: unknown[][] } }
+    ).mock.calls[0];
+    expect(reported[0]).toBe("telegram:membership-scope-health");
+    expect(reported[2]).toMatchObject({
+      chatId: "-100999",
+      reason: "bot_removed",
+      source: "my_chat_member",
+      degraded: "gate-broken",
+    });
+  });
+
+  it("degrades fail-closed when gate acquisition itself rejects", async () => {
+    // Production getMembershipGate cannot reject (it catches and resolves
+    // null), but this pins the fail-closed property the whole-body try
+    // provides: ANY pre-tombstone failure must break the admission gate
+    // rather than leak to the bot.on catch that only logs.
+    const { service, runtime, accountState } = makeService(null);
+    (
+      service as unknown as { getMembershipGate: ReturnType<typeof vi.fn> }
+    ).getMembershipGate = vi.fn().mockRejectedValue(new Error("gate blew up"));
+    const dispatch = (
+      service as unknown as {
+        handleMyChatMemberUpdate: (
+          update: unknown,
+          accountId?: string,
+        ) => Promise<void>;
+      }
+    ).handleMyChatMemberUpdate.bind(service);
+
+    await dispatch(botMemberUpdate("kicked"));
+
+    expect(
+      accountState.messageManager.markMembershipGateBroken,
+    ).toHaveBeenCalledTimes(1);
+    expect(runtime.reportError).toHaveBeenCalledTimes(1);
+    const reported = (
+      runtime.reportError as unknown as { mock: { calls: unknown[][] } }
+    ).mock.calls[0];
+    expect(reported[0]).toBe("telegram:membership-scope-health");
+    expect(reported[2]).toMatchObject({
+      chatId: "-100999",
+      reason: "bot_removed",
+      source: "my_chat_member",
+      degraded: "gate-broken",
+    });
+  });
+
+  it("does nothing without a membership gate", async () => {
+    const { service, getMembershipGate } = makeService(null);
+    const dispatch = (
+      service as unknown as {
+        handleMyChatMemberUpdate: (
+          update: unknown,
+          accountId?: string,
+        ) => Promise<void>;
+      }
+    ).handleMyChatMemberUpdate.bind(service);
+
+    await dispatch(botMemberUpdate("kicked"));
+
+    expect(getMembershipGate).toHaveBeenCalledTimes(1);
+  });
+
+  it("registers a my_chat_member handler during message-handler setup", async () => {
+    const { service } = makeService(null);
+    const registered: Array<{
+      event: string;
+      handler: (ctx: unknown) => Promise<void>;
+    }> = [];
+    const bot = {
+      on: vi.fn((event: string, handler: (ctx: unknown) => Promise<void>) => {
+        registered.push({ event, handler });
+      }),
+    };
+    (
+      service as unknown as { setupMessageHandlers: (state?: unknown) => void }
+    ).setupMessageHandlers({
+      bot,
+      messageManager: undefined,
+      accountId: "acct",
+      account: { botToken: "tok" },
+    });
+
+    const entry = registered.find((r) => r.event === "my_chat_member");
+    expect(entry).toBeDefined();
+
+    // Dispatching a kicked-bot update through the registered handler reaches
+    // the tombstone path (the handler catches and logs rather than throwing).
+    const gate: GateFake = {
+      authority: {
+        markScopeUnavailable: vi.fn().mockResolvedValue(undefined),
+        clearScopeRemoval: vi.fn(),
+      },
+      connectorAccountId: "ca-1",
+      botTelegramUserId: "777",
+    };
+    (
+      service as unknown as { getMembershipGate: ReturnType<typeof vi.fn> }
+    ).getMembershipGate = vi.fn().mockResolvedValue(gate);
+    entry?.handler({ update: { my_chat_member: botMemberUpdate("kicked") } });
+    await vi.waitFor(() =>
+      expect(gate.authority.markScopeUnavailable).toHaveBeenCalledTimes(1),
+    );
+  });
+});

--- a/plugins/plugin-telegram/src/service.start-retry.test.ts
+++ b/plugins/plugin-telegram/src/service.start-retry.test.ts
@@ -371,7 +371,9 @@ describe("TelegramService startup wiring", () => {
         eventRegistration.mock.calls.length +
         2,
     );
-    expect(eventRegistration).toHaveBeenCalledTimes(3);
+    // message, message_reaction, callback_query, and my_chat_member (the
+    // bot's own membership-status delivery contract).
+    expect(eventRegistration).toHaveBeenCalledTimes(4);
     expect(handleMessage).toHaveBeenCalledTimes(1);
     expect(process.listenerCount("SIGINT") - sigintBefore).toBe(1);
     expect(process.listenerCount("SIGTERM") - sigtermBefore).toBe(1);

--- a/plugins/plugin-telegram/src/service.start-retry.test.ts
+++ b/plugins/plugin-telegram/src/service.start-retry.test.ts
@@ -366,9 +366,9 @@ describe("TelegramService startup wiring", () => {
     });
     await deadline(handled.promise, "Expected the message handler to run");
 
-    // Deduplicated identity lookup: the failed call-3 attempt clears the
-    // cached rejection, and the successful retry boot reuses the fresh
-    // cached identity — 4 calls total, not 5.
+    // Deduplicated identity lookup: each successful boot issues exactly one
+    // getMe (the bootstrap lookup is cached and reused). Four calls total
+    // across the failing first boot and the successful retry.
     expect(api.getMeCalls()).toBe(4);
     expect(startRegistration).toHaveBeenCalledTimes(1);
     expect(commandRegistration).toHaveBeenCalledTimes(
@@ -427,8 +427,7 @@ describe("TelegramService poller lifecycle", () => {
     services.push(service);
     await api.waitForActiveGetUpdates(1);
 
-    // Same dedup accounting as above: one getMe per successful boot with the
-    // injected call-3 failure cleared and retried fresh.
+    // Same dedup accounting as above: one getMe per successful boot.
     expect(api.getMeCalls()).toBe(4);
     expect(api.activeGetUpdates()).toBe(1);
 

--- a/plugins/plugin-telegram/src/service.start-retry.test.ts
+++ b/plugins/plugin-telegram/src/service.start-retry.test.ts
@@ -327,6 +327,11 @@ describe("TelegramService startup wiring", () => {
     expect(handleMessage).toHaveBeenCalledTimes(1);
   });
 
+  // sanity guard for the counts below: finishBotStartup reuses the identity
+  // cached by beginMembershipGateBootstrap, so each successful boot issues
+  // exactly ONE getMe — a regression back to duplicate lookups shows up as
+  // an off-by-one in these expectations.
+
   it("registers commands, handlers, and shutdown hooks once across an injected retry", async () => {
     const api = await startStubBotApi(3);
     const runtime = makeRuntime(api.apiRoot);
@@ -361,7 +366,10 @@ describe("TelegramService startup wiring", () => {
     });
     await deadline(handled.promise, "Expected the message handler to run");
 
-    expect(api.getMeCalls()).toBe(5);
+    // Deduplicated identity lookup: the failed call-3 attempt clears the
+    // cached rejection, and the successful retry boot reuses the fresh
+    // cached identity — 4 calls total, not 5.
+    expect(api.getMeCalls()).toBe(4);
     expect(startRegistration).toHaveBeenCalledTimes(1);
     expect(commandRegistration).toHaveBeenCalledTimes(
       buildTelegramCommandDescriptors(runtime.agentId).length + 3,
@@ -419,7 +427,9 @@ describe("TelegramService poller lifecycle", () => {
     services.push(service);
     await api.waitForActiveGetUpdates(1);
 
-    expect(api.getMeCalls()).toBe(5);
+    // Same dedup accounting as above: one getMe per successful boot with the
+    // injected call-3 failure cleared and retried fresh.
+    expect(api.getMeCalls()).toBe(4);
     expect(api.activeGetUpdates()).toBe(1);
 
     await service.stop();

--- a/plugins/plugin-telegram/src/service.ts
+++ b/plugins/plugin-telegram/src/service.ts
@@ -1129,6 +1129,9 @@ export class TelegramService extends Service {
     try {
       return await promise;
     } catch {
+      // error-policy:J4 The gate seeding path already recorded the failure,
+      // marked the manager's gate broken, and reported it; callers treat null
+      // as "no gate" and the broken marker keeps group admission closed.
       return null;
     }
   }

--- a/plugins/plugin-telegram/src/service.ts
+++ b/plugins/plugin-telegram/src/service.ts
@@ -62,6 +62,7 @@ import { TELEGRAM_SERVICE_NAME } from "./constants";
 import { checkTelegramDmAccess, resolveTelegramDmPolicy } from "./dm-policy";
 import { resolveTelegramRuntimeEntityId } from "./identity";
 import type { TelegramMembershipReason } from "./membership";
+import { telegramMembershipScope } from "./membership";
 import {
   createTelegramMembershipGate,
   type TelegramMembershipGate,
@@ -396,12 +397,18 @@ export class TelegramService extends Service {
   private defaultAccountId = DEFAULT_ACCOUNT_ID;
   private accountStates: Map<string, TelegramAccountRuntime> = new Map();
   /**
-   * Lazily-created membership-authority gate for the default account: binds
-   * the durable connector-account row and the per-account authority client.
+   * Lazily-created membership-authority gates, keyed by account id: each
+   * binds that account's durable connector-account row and authority client
+   * (secondary accounts get their own gate keyed by their own bot identity).
    * Null until the bot's Telegram identity is known (getMe) or when the
-   * authority service is absent — group admission then fails closed.
+   * authority service is absent; bootstrap FAILURE is recorded distinctly so
+   * admission can fail closed instead of silently entering legacy allow mode.
    */
-  private membershipGate: Promise<TelegramMembershipGate | null> | null = null;
+  private membershipGates = new Map<
+    string,
+    Promise<TelegramMembershipGate | null>
+  >();
+  private membershipGateFailures = new Set<string>();
 
   /**
    * Constructor for TelegramService class.
@@ -1039,39 +1046,54 @@ export class TelegramService extends Service {
       "Bot info retrieved",
     );
 
-    // Seed the membership-authority gate once the bot identity is known. The
-    // default account is the only multi-account surface this vertical gates.
-    if (accountId === this.defaultAccountId && !this.membershipGate) {
-      this.membershipGate = createTelegramMembershipGate({
+    // Seed this account's membership-authority gate once its bot identity is
+    // known. Every account (default and secondary) gets its own gate.
+    if (!this.membershipGates.has(accountId)) {
+      const gatePromise = createTelegramMembershipGate({
         runtime: this.runtime,
         botTelegramUserId: String(botInfo.id),
       });
-      // error-policy:J4 Gate construction failure (absent authority service,
-      // bootstrap error) resolves to null; group admission fails closed.
+      this.membershipGates.set(accountId, gatePromise);
+      // error-policy:J4 Absent authority service resolves to null (legacy
+      // degrade-with-warning mode). A bootstrap FAILURE is recorded so
+      // admission can distinguish "never configured" from "broken" and fail
+      // closed on the latter.
+      // error-policy:J4 Absent authority service (null gate) means the
+      // deployment never registered the authority: the manager gate stays in
+      // documented legacy degrade-with-warning mode. A bootstrap FAILURE is
+      // different: the authority exists but is broken, so the manager gate is
+      // marked broken and every group admission fails closed.
       try {
-        const gate = await this.membershipGate;
+        const gate = await gatePromise;
         if (gate) {
           const manager =
             this.getAccountState(accountId)?.messageManager ??
             this.messageManager;
           manager?.bindMembershipGate(gate);
         }
-      } catch {
-        this.membershipGate = null;
+      } catch (error) {
+        this.membershipGateFailures.add(accountId);
+        (
+          this.getAccountState(accountId)?.messageManager ?? this.messageManager
+        )?.markMembershipGateBroken();
+        this.runtime.reportError("telegram:membership-bootstrap", error, {
+          accountId,
+        });
       }
     }
   }
 
-  /** Resolves the membership gate, or null when the authority is unavailable. */
-  private async getMembershipGate(): Promise<TelegramMembershipGate | null> {
-    if (!this.membershipGate) {
+  /** Resolves the account's membership gate, or null when absent/failed. */
+  private async getMembershipGate(
+    accountId = this.defaultAccountId,
+  ): Promise<TelegramMembershipGate | null> {
+    const promise = this.membershipGates.get(accountId);
+    if (!promise) {
       return null;
     }
     try {
-      return await this.membershipGate;
+      return await promise;
     } catch {
-      // error-policy:J4 a rejected bootstrap surfaces as an absent gate; the
-      // per-chat denial path reports the underlying error once per chat.
       return null;
     }
   }
@@ -1433,6 +1455,24 @@ export class TelegramService extends Service {
     if (!this.knownChats.has(this.scopedTelegramKey(chatId, accountId))) {
       // Process the new chat - creates world, room, topic room (if applicable) and entities
       await this.handleNewChat(ctx, accountId);
+      // The first update for a newly discovered chat still carries membership
+      // facts: record join/leave evidence before proceeding (a leave as the
+      // first observed update must not leave prior active evidence intact).
+      const worldId = createUniqueUuid(
+        this.runtime,
+        this.scopedTelegramKey(chatId, accountId),
+      ) as UUID;
+      const roomId = createUniqueUuid(
+        this.runtime,
+        this.scopedTelegramKey(
+          ctx.message && "message_thread_id" in ctx.message
+            ? `${chatId}-${ctx.message.message_thread_id}`
+            : chatId,
+          accountId,
+        ),
+      ) as UUID;
+      await this.syncNewChatMember(ctx, worldId, roomId, chatId, accountId);
+      await this.syncLeftChatMember(ctx, worldId, roomId, accountId);
       // Skip entity synchronization for new chats and proceed to the next middleware
       return next();
     }
@@ -1761,6 +1801,7 @@ export class TelegramService extends Service {
     ctx: Context,
     chatId: string,
     chatRoomKey: string,
+    accountId: string,
     event: {
       telegramUserId: string;
       canonicalPrincipalId: UUID;
@@ -1771,7 +1812,7 @@ export class TelegramService extends Service {
       observedAt: string;
     },
   ): Promise<void> {
-    const gate = await this.getMembershipGate();
+    const gate = await this.getMembershipGate(accountId);
     if (!gate) {
       // No authority service or bootstrap failed: nothing to record. Group
       // admission fails closed separately; this path only records evidence.
@@ -1793,7 +1834,28 @@ export class TelegramService extends Service {
       });
     } catch (error) {
       // error-policy:J7 Entity bootstrap failure must not kill the update
-      // handler; without the row the evidence would throw anyway, so skip.
+      // handler; without the row the evidence would throw anyway. For a
+      // REVOCATION we must not leave prior active evidence authorizing the
+      // departed principal: degrade the scope to stale (fail-closed
+      // admission) until fresh evidence lands.
+      if (event.state === "revoked") {
+        try {
+          await gate.authority.markScopeStale({
+            scope: telegramMembershipScope({
+              agentId: this.runtime.agentId,
+              connectorAccountId: gate.connectorAccountId,
+              chatId,
+              chatRoomKey,
+            }),
+            reason: `revocation_bootstrap_failed:${event.reason}`,
+          });
+        } catch (degradeError) {
+          this.runtime.reportError("telegram:membership-entity", degradeError, {
+            chatId,
+            telegramUserId: event.telegramUserId,
+          });
+        }
+      }
       this.runtime.reportError("telegram:membership-entity", error, {
         chatId,
         telegramUserId: event.telegramUserId,
@@ -1836,7 +1898,8 @@ export class TelegramService extends Service {
       const messageId = ctx.message.message_id;
       const observedAt = new Date(ctx.message.date * 1_000).toISOString();
       const chatRoomKey = this.membershipChatRoomKey(chatId, accountId);
-      const botId = (await this.getMembershipGate())?.botTelegramUserId;
+      const botId = (await this.getMembershipGate(accountId))
+        ?.botTelegramUserId;
       for (const newMember of ctx.message.new_chat_members) {
         const telegramId = newMember.id.toString();
         const entityId = await resolveTelegramRuntimeEntityId(
@@ -1849,15 +1912,21 @@ export class TelegramService extends Service {
         // cached entities: the syncedEntityIds guard exists to avoid repeated
         // ensureConnection work, not to gate membership facts.
         if (!botId || telegramId !== botId) {
-          await this.recordMembershipEvent(ctx, chatId, chatRoomKey, {
-            telegramUserId: telegramId,
-            canonicalPrincipalId: entityId,
-            state: "active",
-            reason: "joined",
-            runtime: { worldId, roomId, entityId },
-            messageId,
-            observedAt,
-          });
+          await this.recordMembershipEvent(
+            ctx,
+            chatId,
+            chatRoomKey,
+            accountId,
+            {
+              telegramUserId: telegramId,
+              canonicalPrincipalId: entityId,
+              state: "active",
+              reason: "joined",
+              runtime: { worldId, roomId, entityId },
+              messageId,
+              observedAt,
+            },
+          );
         }
 
         if (this.syncedEntityIds.has(entityId)) {
@@ -1926,16 +1995,19 @@ export class TelegramService extends Service {
       const messageId = ctx.message.message_id;
       const observedAt = new Date(ctx.message.date * 1_000).toISOString();
       const chatRoomKey = this.membershipChatRoomKey(chat, accountId);
-      const gate = await this.getMembershipGate();
+      const gate = await this.getMembershipGate(accountId);
 
       if (gate && telegramId === gate.botTelegramUserId) {
         // The bot itself was removed: it can no longer observe this chat, so
-        // the scope fails closed instead of fabricating stale authority.
+        // the scope fails closed instead of fabricating stale authority. Any
+        // further evidence write would advance the scope back to current and
+        // re-authorize stale member facts, so stop handling this update.
         await gate.authority.markScopeUnavailable({
           chatId: chat,
           chatRoomKey,
           reason: "bot_removed",
         });
+        return;
       }
 
       const entityId = await resolveTelegramRuntimeEntityId(
@@ -1947,7 +2019,7 @@ export class TelegramService extends Service {
       // Record the revocation for the canonical principal even when the
       // entity row is missing: recordMembershipEvent bootstraps it first so
       // the durable revocation exists (never-seen leavers included).
-      await this.recordMembershipEvent(ctx, chat, chatRoomKey, {
+      await this.recordMembershipEvent(ctx, chat, chatRoomKey, accountId, {
         telegramUserId: telegramId,
         canonicalPrincipalId: entityId,
         state: "revoked",

--- a/plugins/plugin-telegram/src/service.ts
+++ b/plugins/plugin-telegram/src/service.ts
@@ -61,6 +61,11 @@ import {
 import { TELEGRAM_SERVICE_NAME } from "./constants";
 import { checkTelegramDmAccess, resolveTelegramDmPolicy } from "./dm-policy";
 import { resolveTelegramRuntimeEntityId } from "./identity";
+import type { TelegramMembershipReason } from "./membership";
+import {
+  createTelegramMembershipGate,
+  type TelegramMembershipGate,
+} from "./membership-gate";
 import { MessageManager } from "./messageManager";
 import {
   claimTelegramPollerToken,
@@ -390,6 +395,13 @@ export class TelegramService extends Service {
   private botToken: string | null;
   private defaultAccountId = DEFAULT_ACCOUNT_ID;
   private accountStates: Map<string, TelegramAccountRuntime> = new Map();
+  /**
+   * Lazily-created membership-authority gate for the default account: binds
+   * the durable connector-account row and the per-account authority client.
+   * Null until the bot's Telegram identity is known (getMe) or when the
+   * authority service is absent — group admission then fails closed.
+   */
+  private membershipGate: Promise<TelegramMembershipGate | null> | null = null;
 
   /**
    * Constructor for TelegramService class.
@@ -1026,6 +1038,47 @@ export class TelegramService extends Service {
       },
       "Bot info retrieved",
     );
+
+    // Seed the membership-authority gate once the bot identity is known. The
+    // default account is the only multi-account surface this vertical gates.
+    if (accountId === this.defaultAccountId && !this.membershipGate) {
+      this.membershipGate = createTelegramMembershipGate({
+        runtime: this.runtime,
+        botTelegramUserId: String(botInfo.id),
+      });
+      // error-policy:J4 Gate construction failure (absent authority service,
+      // bootstrap error) resolves to null; group admission fails closed.
+      try {
+        const gate = await this.membershipGate;
+        if (gate) {
+          const manager =
+            this.getAccountState(accountId)?.messageManager ??
+            this.messageManager;
+          manager?.bindMembershipGate(gate);
+        }
+      } catch {
+        this.membershipGate = null;
+      }
+    }
+  }
+
+  /** Resolves the membership gate, or null when the authority is unavailable. */
+  private async getMembershipGate(): Promise<TelegramMembershipGate | null> {
+    if (!this.membershipGate) {
+      return null;
+    }
+    try {
+      return await this.membershipGate;
+    } catch {
+      // error-policy:J4 a rejected bootstrap surfaces as an absent gate; the
+      // per-chat denial path reports the underlying error once per chat.
+      return null;
+    }
+  }
+
+  /** Chat room key for membership scopes: the chat's main room, not a topic room. */
+  private membershipChatRoomKey(chatId: string, accountId: string): string {
+    return this.scopedTelegramKey(chatId, accountId);
   }
 
   /** Installs the process-level teardown hooks for one Telegraf instance. */
@@ -1648,7 +1701,7 @@ export class TelegramService extends Service {
     // Handle all three entity sync cases separately for clarity
     await this.syncMessageSender(ctx, worldId, roomId, chatId, accountId);
     await this.syncNewChatMember(ctx, worldId, roomId, chatId, accountId);
-    await this.syncLeftChatMember(ctx, accountId);
+    await this.syncLeftChatMember(ctx, worldId, roomId, accountId);
   }
 
   /**
@@ -1699,6 +1752,68 @@ export class TelegramService extends Service {
   }
 
   /**
+   * Applies one membership-evidence fact through the authority gate,
+   * ensuring the principal entity row exists first (the authority's FK
+   * requires it) and resolving the canonical principal the same way the
+   * message path does.
+   */
+  private async recordMembershipEvent(
+    ctx: Context,
+    chatId: string,
+    chatRoomKey: string,
+    event: {
+      telegramUserId: string;
+      canonicalPrincipalId: UUID;
+      state: "active" | "revoked";
+      reason: TelegramMembershipReason;
+      runtime: { worldId: UUID; roomId: UUID; entityId: UUID };
+      messageId: number;
+      observedAt: string;
+    },
+  ): Promise<void> {
+    const gate = await this.getMembershipGate();
+    if (!gate) {
+      // No authority service or bootstrap failed: nothing to record. Group
+      // admission fails closed separately; this path only records evidence.
+      return;
+    }
+    try {
+      // The authority requires an entity row for the principal before
+      // evidence can be applied; ensureConnection creates it when missing.
+      await this.runtime.ensureConnection({
+        entityId: event.canonicalPrincipalId,
+        roomId: event.runtime.roomId,
+        roomName: getTelegramChatDisplayName(ctx.chat, chatId),
+        userName: undefined,
+        name: "Unknown User",
+        source: "telegram",
+        channelId: chatId,
+        type: ChannelType.GROUP,
+        worldId: event.runtime.worldId,
+      });
+    } catch (error) {
+      // error-policy:J7 Entity bootstrap failure must not kill the update
+      // handler; without the row the evidence would throw anyway, so skip.
+      this.runtime.reportError("telegram:membership-entity", error, {
+        chatId,
+        telegramUserId: event.telegramUserId,
+      });
+      return;
+    }
+    await gate.authority.recordEvent({
+      chatId,
+      chatRoomKey,
+      canonicalPrincipalId: event.canonicalPrincipalId,
+      state: event.state,
+      reason: event.reason,
+      runtime: event.runtime,
+      messageId: event.messageId,
+      telegramUserId: event.telegramUserId,
+      observedAt: event.observedAt,
+    });
+  }
+
+  /**
    * Synchronizes a new chat member entity with the runtime system.
    * Triggered when a user joins the chat.
    *
@@ -1718,6 +1833,10 @@ export class TelegramService extends Service {
   ): Promise<void> {
     // Handle new chat member
     if (ctx.message && "new_chat_members" in ctx.message) {
+      const messageId = ctx.message.message_id;
+      const observedAt = new Date(ctx.message.date * 1_000).toISOString();
+      const chatRoomKey = this.membershipChatRoomKey(chatId, accountId);
+      const botId = (await this.getMembershipGate())?.botTelegramUserId;
       for (const newMember of ctx.message.new_chat_members) {
         const telegramId = newMember.id.toString();
         const entityId = await resolveTelegramRuntimeEntityId(
@@ -1725,6 +1844,21 @@ export class TelegramService extends Service {
           accountId,
           telegramId,
         );
+
+        // Membership evidence is applied for every observed join, including
+        // cached entities: the syncedEntityIds guard exists to avoid repeated
+        // ensureConnection work, not to gate membership facts.
+        if (!botId || telegramId !== botId) {
+          await this.recordMembershipEvent(ctx, chatId, chatRoomKey, {
+            telegramUserId: telegramId,
+            canonicalPrincipalId: entityId,
+            state: "active",
+            reason: "joined",
+            runtime: { worldId, roomId, entityId },
+            messageId,
+            observedAt,
+          });
+        }
 
         if (this.syncedEntityIds.has(entityId)) {
           continue;
@@ -1770,24 +1904,62 @@ export class TelegramService extends Service {
   }
 
   /**
-   * Updates entity status when a user leaves the chat.
-   *
-   * @param {Context} ctx - The context of the incoming update
-   * @returns {Promise<void>}
-   * @private
+   * Updates entity status when a user leaves the chat and records the
+   * revocation as membership evidence so the authority denies the principal
+   * from the same turn onward. The bot's own removal instead degrades the
+   * whole chat scope to `unavailable` (fail-closed admission for everyone).
    */
   private async syncLeftChatMember(
     ctx: Context,
+    worldId: UUID,
+    roomId: UUID,
     accountId = this.defaultAccountId,
   ): Promise<void> {
     // Handle left chat member
     if (ctx.message && "left_chat_member" in ctx.message) {
       const leftMember = ctx.message.left_chat_member;
       const telegramId = leftMember.id.toString();
-      const entityId = createUniqueUuid(
+      const chat = ctx.chat?.id.toString();
+      if (!chat) {
+        return;
+      }
+      const messageId = ctx.message.message_id;
+      const observedAt = new Date(ctx.message.date * 1_000).toISOString();
+      const chatRoomKey = this.membershipChatRoomKey(chat, accountId);
+      const gate = await this.getMembershipGate();
+
+      if (gate && telegramId === gate.botTelegramUserId) {
+        // The bot itself was removed: it can no longer observe this chat, so
+        // the scope fails closed instead of fabricating stale authority.
+        await gate.authority.markScopeUnavailable({
+          chatId: chat,
+          chatRoomKey,
+          reason: "bot_removed",
+        });
+      }
+
+      const entityId = await resolveTelegramRuntimeEntityId(
         this.runtime,
-        this.scopedTelegramKey(telegramId, accountId),
-      ) as UUID;
+        accountId,
+        telegramId,
+      );
+
+      // Record the revocation for the canonical principal even when the
+      // entity row is missing: recordMembershipEvent bootstraps it first so
+      // the durable revocation exists (never-seen leavers included).
+      await this.recordMembershipEvent(ctx, chat, chatRoomKey, {
+        telegramUserId: telegramId,
+        canonicalPrincipalId: entityId,
+        state: "revoked",
+        reason: "left",
+        runtime: { worldId, roomId, entityId },
+        messageId,
+        observedAt,
+      });
+
+      // A leaving member's cached sync state must not suppress the evidence
+      // for a later re-join in the same process.
+      this.syncedEntityIds.delete(entityId);
 
       const existingEntity = await this.runtime.getEntityById(entityId);
       if (existingEntity) {

--- a/plugins/plugin-telegram/src/service.ts
+++ b/plugins/plugin-telegram/src/service.ts
@@ -1465,7 +1465,10 @@ export class TelegramService extends Service {
       const roomId = createUniqueUuid(
         this.runtime,
         this.scopedTelegramKey(
-          ctx.message && "message_thread_id" in ctx.message
+          // Thread derivation must match syncEntity byte-for-byte so first-
+          // update evidence lands in the same scope the existing-chat path
+          // uses (truthiness gate: thread id 0 means "no thread" here too).
+          ctx.message?.message_thread_id
             ? `${chatId}-${ctx.message.message_thread_id}`
             : chatId,
           accountId,

--- a/plugins/plugin-telegram/src/service.ts
+++ b/plugins/plugin-telegram/src/service.ts
@@ -499,6 +499,9 @@ export class TelegramService extends Service {
 
   private setDefaultAccountState(state: TelegramAccountRuntime): void {
     this.accountStates.set(state.accountId, state);
+    // The manager for this account just became available: (re)bind any
+    // membership gate that resolved before the state was installed.
+    void this.bindAccountMembershipGates(state.accountId);
     if (state.accountId === this.defaultAccountId || !this.bot) {
       this.bot = state.bot;
       this.messageManager = state.messageManager;
@@ -1055,31 +1058,62 @@ export class TelegramService extends Service {
       });
       this.membershipGates.set(accountId, gatePromise);
       // error-policy:J4 Absent authority service resolves to null (legacy
-      // degrade-with-warning mode). A bootstrap FAILURE is recorded so
-      // admission can distinguish "never configured" from "broken" and fail
-      // closed on the latter.
-      // error-policy:J4 Absent authority service (null gate) means the
-      // deployment never registered the authority: the manager gate stays in
-      // documented legacy degrade-with-warning mode. A bootstrap FAILURE is
-      // different: the authority exists but is broken, so the manager gate is
-      // marked broken and every group admission fails closed.
+      // degrade-with-warning mode). A bootstrap FAILURE throws and is
+      // recorded here so admission can distinguish "never configured" from
+      // "broken" and fail closed on the latter.
       try {
         const gate = await gatePromise;
         if (gate) {
-          const manager =
-            this.getAccountState(accountId)?.messageManager ??
-            this.messageManager;
-          manager?.bindMembershipGate(gate);
+          // Bind ONLY this account's own manager: a fallback to the default
+          // manager would gate the wrong connector (and leave the secondary
+          // ungated) when the account state is not installed yet. If the
+          // manager is not ready, defer to bindAccountMembershipGates(),
+          // which runs at account-state installation.
+          this.getAccountState(accountId)?.messageManager?.bindMembershipGate(
+            gate,
+          );
         }
       } catch (error) {
         this.membershipGateFailures.add(accountId);
-        (
-          this.getAccountState(accountId)?.messageManager ?? this.messageManager
-        )?.markMembershipGateBroken();
+        this.getAccountState(
+          accountId,
+        )?.messageManager?.markMembershipGateBroken();
         this.runtime.reportError("telegram:membership-bootstrap", error, {
           accountId,
         });
       }
+    }
+  }
+
+  /**
+   * (Re)binds resolved membership gates to the account's own MessageManager.
+   * Called whenever an account state (with its manager) is installed so a
+   * gate that resolved BEFORE the manager existed still lands on the right
+   * manager — the bootstrap race can no longer strand a secondary account
+   * ungated or bind it to the default manager.
+   */
+  private async bindAccountMembershipGates(accountId: string): Promise<void> {
+    const promise = this.membershipGates.get(accountId);
+    if (!promise) {
+      return;
+    }
+    const manager = this.getAccountState(accountId)?.messageManager;
+    if (!manager) {
+      return;
+    }
+    if (this.membershipGateFailures.has(accountId)) {
+      manager.markMembershipGateBroken();
+      return;
+    }
+    try {
+      const gate = await promise;
+      if (gate) {
+        manager.bindMembershipGate(gate);
+      }
+    } catch {
+      // The seeding path already recorded the failure and marked whatever
+      // manager existed broken; this late-binding pass re-marks THIS manager.
+      manager.markMembershipGateBroken();
     }
   }
 
@@ -1865,17 +1899,37 @@ export class TelegramService extends Service {
       });
       return;
     }
-    await gate.authority.recordEvent({
-      chatId,
-      chatRoomKey,
-      canonicalPrincipalId: event.canonicalPrincipalId,
-      state: event.state,
-      reason: event.reason,
-      runtime: event.runtime,
-      messageId: event.messageId,
-      telegramUserId: event.telegramUserId,
-      observedAt: event.observedAt,
-    });
+    try {
+      await gate.authority.recordEvent({
+        chatId,
+        chatRoomKey,
+        canonicalPrincipalId: event.canonicalPrincipalId,
+        state: event.state,
+        reason: event.reason,
+        runtime: event.runtime,
+        messageId: event.messageId,
+        telegramUserId: event.telegramUserId,
+        observedAt: event.observedAt,
+      });
+    } catch (error) {
+      // error-policy:J2 recordEvent only throws when a REVOCATION could be
+      // neither committed nor degraded fail-closed (or the entity bootstrap
+      // above failed the same way): the authority can no longer be trusted
+      // for this account, so mark the admission gate broken — every group
+      // admission fails closed until a later boot rebinds a healthy gate.
+      // The poll loop survives; this update is dropped either way.
+      const manager =
+        this.getAccountState(accountId)?.messageManager ?? this.messageManager;
+      manager?.markMembershipGateBroken();
+      this.membershipGateFailures.add(accountId);
+      this.membershipGates.delete(accountId);
+      this.runtime.reportError("telegram:membership-evidence", error, {
+        chatId,
+        accountId,
+        telegramUserId: event.telegramUserId,
+        degraded: "gate-broken",
+      });
+    }
   }
 
   /**
@@ -2005,11 +2059,30 @@ export class TelegramService extends Service {
         // the scope fails closed instead of fabricating stale authority. Any
         // further evidence write would advance the scope back to current and
         // re-authorize stale member facts, so stop handling this update.
-        await gate.authority.markScopeUnavailable({
-          chatId: chat,
-          chatRoomKey,
-          reason: "bot_removed",
-        });
+        try {
+          await gate.authority.markScopeUnavailable({
+            chatId: chat,
+            chatRoomKey,
+            reason: "bot_removed",
+          });
+        } catch (error) {
+          // error-policy:J2 The unavailable-degrade itself failed: the scope
+          // may still authorize on stale evidence. Mark the admission gate
+          // broken so every group admission fails closed rather than
+          // continuing on an un-degraded scope.
+          (
+            this.getAccountState(accountId)?.messageManager ??
+            this.messageManager
+          )?.markMembershipGateBroken();
+          this.membershipGateFailures.add(accountId);
+          this.membershipGates.delete(accountId);
+          this.runtime.reportError("telegram:membership-scope-health", error, {
+            chatId: chat,
+            accountId,
+            reason: "bot_removed",
+            degraded: "gate-broken",
+          });
+        }
         return;
       }
 

--- a/plugins/plugin-telegram/src/service.ts
+++ b/plugins/plugin-telegram/src/service.ts
@@ -1111,8 +1111,9 @@ export class TelegramService extends Service {
         manager.bindMembershipGate(gate);
       }
     } catch {
-      // The seeding path already recorded the failure and marked whatever
-      // manager existed broken; this late-binding pass re-marks THIS manager.
+      // error-policy:J2 The seeding path already recorded this gate failure
+      // and reported it; this late-binding pass only re-marks THIS manager
+      // broken so the failure state follows the account's own manager.
       manager.markMembershipGateBroken();
     }
   }
@@ -1887,9 +1888,22 @@ export class TelegramService extends Service {
             reason: `revocation_bootstrap_failed:${event.reason}`,
           });
         } catch (degradeError) {
+          // error-policy:J2 BOTH the entity bootstrap AND the fail-closed
+          // degrade failed: the authority can no longer be trusted for this
+          // account — prior active evidence may still authorize the departed
+          // principal. Mark the admission gate broken so every group
+          // admission fails closed, mirroring the recordEvent failure path.
+          (
+            this.getAccountState(accountId)?.messageManager ??
+            this.messageManager
+          )?.markMembershipGateBroken();
+          this.membershipGateFailures.add(accountId);
+          this.membershipGates.delete(accountId);
           this.runtime.reportError("telegram:membership-entity", degradeError, {
             chatId,
+            accountId,
             telegramUserId: event.telegramUserId,
+            degraded: "gate-broken",
           });
         }
       }
@@ -1984,6 +1998,18 @@ export class TelegramService extends Service {
               observedAt,
             },
           );
+        } else {
+          // The bot itself was (re-)added to the chat: clear the bot-removal
+          // tombstone so fresh evidence can re-establish authority for this
+          // scope. Stored pre-removal facts alone still do not authorize —
+          // point-query evidence carries a bounded validUntil, so admission
+          // requires a fresh join/reconcile observation.
+          (
+            await this.getMembershipGate(accountId)
+          )?.authority.clearScopeRemoval({
+            chatId,
+            chatRoomKey,
+          });
         }
 
         if (this.syncedEntityIds.has(entityId)) {

--- a/plugins/plugin-telegram/src/service.ts
+++ b/plugins/plugin-telegram/src/service.ts
@@ -61,6 +61,7 @@ import { TELEGRAM_SERVICE_NAME } from "./constants";
 import { checkTelegramDmAccess, resolveTelegramDmPolicy } from "./dm-policy";
 import { resolveTelegramRuntimeEntityId } from "./identity";
 import type { TelegramMembershipReason } from "./membership";
+import { telegramMembershipScope } from "./membership";
 import {
   createTelegramMembershipGate,
   type TelegramMembershipGate,
@@ -402,12 +403,18 @@ export class TelegramService extends Service {
   private defaultAccountId = DEFAULT_ACCOUNT_ID;
   private accountStates: Map<string, TelegramAccountRuntime> = new Map();
   /**
-   * Lazily-created membership-authority gate for the default account: binds
-   * the durable connector-account row and the per-account authority client.
+   * Lazily-created membership-authority gates, keyed by account id: each
+   * binds that account's durable connector-account row and authority client
+   * (secondary accounts get their own gate keyed by their own bot identity).
    * Null until the bot's Telegram identity is known (getMe) or when the
-   * authority service is absent — group admission then fails closed.
+   * authority service is absent; bootstrap FAILURE is recorded distinctly so
+   * admission can fail closed instead of silently entering legacy allow mode.
    */
-  private membershipGate: Promise<TelegramMembershipGate | null> | null = null;
+  private membershipGates = new Map<
+    string,
+    Promise<TelegramMembershipGate | null>
+  >();
+  private membershipGateFailures = new Set<string>();
 
   /**
    * Constructor for TelegramService class.
@@ -1045,39 +1052,54 @@ export class TelegramService extends Service {
       "Bot info retrieved",
     );
 
-    // Seed the membership-authority gate once the bot identity is known. The
-    // default account is the only multi-account surface this vertical gates.
-    if (accountId === this.defaultAccountId && !this.membershipGate) {
-      this.membershipGate = createTelegramMembershipGate({
+    // Seed this account's membership-authority gate once its bot identity is
+    // known. Every account (default and secondary) gets its own gate.
+    if (!this.membershipGates.has(accountId)) {
+      const gatePromise = createTelegramMembershipGate({
         runtime: this.runtime,
         botTelegramUserId: String(botInfo.id),
       });
-      // error-policy:J4 Gate construction failure (absent authority service,
-      // bootstrap error) resolves to null; group admission fails closed.
+      this.membershipGates.set(accountId, gatePromise);
+      // error-policy:J4 Absent authority service resolves to null (legacy
+      // degrade-with-warning mode). A bootstrap FAILURE is recorded so
+      // admission can distinguish "never configured" from "broken" and fail
+      // closed on the latter.
+      // error-policy:J4 Absent authority service (null gate) means the
+      // deployment never registered the authority: the manager gate stays in
+      // documented legacy degrade-with-warning mode. A bootstrap FAILURE is
+      // different: the authority exists but is broken, so the manager gate is
+      // marked broken and every group admission fails closed.
       try {
-        const gate = await this.membershipGate;
+        const gate = await gatePromise;
         if (gate) {
           const manager =
             this.getAccountState(accountId)?.messageManager ??
             this.messageManager;
           manager?.bindMembershipGate(gate);
         }
-      } catch {
-        this.membershipGate = null;
+      } catch (error) {
+        this.membershipGateFailures.add(accountId);
+        (
+          this.getAccountState(accountId)?.messageManager ?? this.messageManager
+        )?.markMembershipGateBroken();
+        this.runtime.reportError("telegram:membership-bootstrap", error, {
+          accountId,
+        });
       }
     }
   }
 
-  /** Resolves the membership gate, or null when the authority is unavailable. */
-  private async getMembershipGate(): Promise<TelegramMembershipGate | null> {
-    if (!this.membershipGate) {
+  /** Resolves the account's membership gate, or null when absent/failed. */
+  private async getMembershipGate(
+    accountId = this.defaultAccountId,
+  ): Promise<TelegramMembershipGate | null> {
+    const promise = this.membershipGates.get(accountId);
+    if (!promise) {
       return null;
     }
     try {
-      return await this.membershipGate;
+      return await promise;
     } catch {
-      // error-policy:J4 a rejected bootstrap surfaces as an absent gate; the
-      // per-chat denial path reports the underlying error once per chat.
       return null;
     }
   }
@@ -1439,6 +1461,24 @@ export class TelegramService extends Service {
     if (!this.knownChats.has(this.scopedTelegramKey(chatId, accountId))) {
       // Process the new chat - creates world, room, topic room (if applicable) and entities
       await this.handleNewChat(ctx, accountId);
+      // The first update for a newly discovered chat still carries membership
+      // facts: record join/leave evidence before proceeding (a leave as the
+      // first observed update must not leave prior active evidence intact).
+      const worldId = createUniqueUuid(
+        this.runtime,
+        this.scopedTelegramKey(chatId, accountId),
+      ) as UUID;
+      const roomId = createUniqueUuid(
+        this.runtime,
+        this.scopedTelegramKey(
+          ctx.message && "message_thread_id" in ctx.message
+            ? `${chatId}-${ctx.message.message_thread_id}`
+            : chatId,
+          accountId,
+        ),
+      ) as UUID;
+      await this.syncNewChatMember(ctx, worldId, roomId, chatId, accountId);
+      await this.syncLeftChatMember(ctx, worldId, roomId, accountId);
       // Skip entity synchronization for new chats and proceed to the next middleware
       return next();
     }
@@ -1767,6 +1807,7 @@ export class TelegramService extends Service {
     ctx: Context,
     chatId: string,
     chatRoomKey: string,
+    accountId: string,
     event: {
       telegramUserId: string;
       canonicalPrincipalId: UUID;
@@ -1777,7 +1818,7 @@ export class TelegramService extends Service {
       observedAt: string;
     },
   ): Promise<void> {
-    const gate = await this.getMembershipGate();
+    const gate = await this.getMembershipGate(accountId);
     if (!gate) {
       // No authority service or bootstrap failed: nothing to record. Group
       // admission fails closed separately; this path only records evidence.
@@ -1799,7 +1840,28 @@ export class TelegramService extends Service {
       });
     } catch (error) {
       // error-policy:J7 Entity bootstrap failure must not kill the update
-      // handler; without the row the evidence would throw anyway, so skip.
+      // handler; without the row the evidence would throw anyway. For a
+      // REVOCATION we must not leave prior active evidence authorizing the
+      // departed principal: degrade the scope to stale (fail-closed
+      // admission) until fresh evidence lands.
+      if (event.state === "revoked") {
+        try {
+          await gate.authority.markScopeStale({
+            scope: telegramMembershipScope({
+              agentId: this.runtime.agentId,
+              connectorAccountId: gate.connectorAccountId,
+              chatId,
+              chatRoomKey,
+            }),
+            reason: `revocation_bootstrap_failed:${event.reason}`,
+          });
+        } catch (degradeError) {
+          this.runtime.reportError("telegram:membership-entity", degradeError, {
+            chatId,
+            telegramUserId: event.telegramUserId,
+          });
+        }
+      }
       this.runtime.reportError("telegram:membership-entity", error, {
         chatId,
         telegramUserId: event.telegramUserId,
@@ -1842,7 +1904,8 @@ export class TelegramService extends Service {
       const messageId = ctx.message.message_id;
       const observedAt = new Date(ctx.message.date * 1_000).toISOString();
       const chatRoomKey = this.membershipChatRoomKey(chatId, accountId);
-      const botId = (await this.getMembershipGate())?.botTelegramUserId;
+      const botId = (await this.getMembershipGate(accountId))
+        ?.botTelegramUserId;
       for (const newMember of ctx.message.new_chat_members) {
         const telegramId = newMember.id.toString();
         const entityId = await resolveTelegramRuntimeEntityId(
@@ -1855,15 +1918,21 @@ export class TelegramService extends Service {
         // cached entities: the syncedEntityIds guard exists to avoid repeated
         // ensureConnection work, not to gate membership facts.
         if (!botId || telegramId !== botId) {
-          await this.recordMembershipEvent(ctx, chatId, chatRoomKey, {
-            telegramUserId: telegramId,
-            canonicalPrincipalId: entityId,
-            state: "active",
-            reason: "joined",
-            runtime: { worldId, roomId, entityId },
-            messageId,
-            observedAt,
-          });
+          await this.recordMembershipEvent(
+            ctx,
+            chatId,
+            chatRoomKey,
+            accountId,
+            {
+              telegramUserId: telegramId,
+              canonicalPrincipalId: entityId,
+              state: "active",
+              reason: "joined",
+              runtime: { worldId, roomId, entityId },
+              messageId,
+              observedAt,
+            },
+          );
         }
 
         if (this.syncedEntityIds.has(entityId)) {
@@ -1932,16 +2001,19 @@ export class TelegramService extends Service {
       const messageId = ctx.message.message_id;
       const observedAt = new Date(ctx.message.date * 1_000).toISOString();
       const chatRoomKey = this.membershipChatRoomKey(chat, accountId);
-      const gate = await this.getMembershipGate();
+      const gate = await this.getMembershipGate(accountId);
 
       if (gate && telegramId === gate.botTelegramUserId) {
         // The bot itself was removed: it can no longer observe this chat, so
-        // the scope fails closed instead of fabricating stale authority.
+        // the scope fails closed instead of fabricating stale authority. Any
+        // further evidence write would advance the scope back to current and
+        // re-authorize stale member facts, so stop handling this update.
         await gate.authority.markScopeUnavailable({
           chatId: chat,
           chatRoomKey,
           reason: "bot_removed",
         });
+        return;
       }
 
       const entityId = await resolveTelegramRuntimeEntityId(
@@ -1953,7 +2025,7 @@ export class TelegramService extends Service {
       // Record the revocation for the canonical principal even when the
       // entity row is missing: recordMembershipEvent bootstraps it first so
       // the durable revocation exists (never-seen leavers included).
-      await this.recordMembershipEvent(ctx, chat, chatRoomKey, {
+      await this.recordMembershipEvent(ctx, chat, chatRoomKey, accountId, {
         telegramUserId: telegramId,
         canonicalPrincipalId: entityId,
         state: "revoked",

--- a/plugins/plugin-telegram/src/service.ts
+++ b/plugins/plugin-telegram/src/service.ts
@@ -436,6 +436,27 @@ export class TelegramService extends Service {
    * getMe resolves). Replayed — in arrival order — once the gate settles.
    */
   private pendingMembershipTransitions = new Map<string, ChatMemberUpdated[]>();
+  /**
+   * Accounts whose queued startup-window transitions are currently being
+   * replayed. While an account is in this set, a NEW live transition is
+   * appended to the replay queue instead of dispatching directly — the
+   * replay loop picks it up in arrival order once the earlier entries
+   * finish — so a concurrent live update cannot overtake older queued
+   * transitions into the authority's per-scope chain.
+   */
+  private replayingMembershipTransitions = new Set<string>();
+  /**
+   * Bot-identity lookups that back each account's gate bootstrap promise.
+   * beginMembershipGateBootstrap stores its own getMe here so
+   * finishBotStartup reuses the SAME identity instead of issuing a second
+   * network getMe — the two responses could otherwise diverge (identity
+   * mismatch between the gate and the logged startup identity) and a failed
+   * first lookup would be retried needlessly.
+   */
+  private membershipBotIdentity = new Map<
+    string,
+    Promise<{ id: number; username?: string }>
+  >();
 
   /**
    * Constructor for TelegramService class.
@@ -1074,8 +1095,13 @@ export class TelegramService extends Service {
     // crash boot.
     await applyTelegramSetMyCommands(bot, this.runtime, accountId);
 
-    // Get bot info for identification purposes
-    const botInfo = await bot.telegram.getMe();
+    // Reuse the cached bot-identity lookup when beginMembershipGateBootstrap
+    // already issued one — a second network getMe could diverge from the
+    // identity backing the gate (and retries a failed lookup needlessly).
+    const botInfoPromise =
+      this.membershipBotIdentity.get(accountId) ?? bot.telegram.getMe();
+    this.membershipBotIdentity.set(accountId, botInfoPromise);
+    const botInfo = await botInfoPromise;
     logger.debug(
       {
         src: "plugin:telegram",
@@ -1104,10 +1130,6 @@ export class TelegramService extends Service {
     const gatePromise = this.membershipGates.get(
       accountId,
     ) as Promise<TelegramMembershipGate | null>;
-    // error-policy:J4 Absent authority service resolves to null (legacy
-    // degrade-with-warning mode). A bootstrap FAILURE throws and is
-    // recorded here so admission can distinguish "never configured" from
-    // "broken" and fail closed on the latter.
     try {
       const gate = await gatePromise;
       const manager = this.getAccountState(accountId)?.messageManager;
@@ -1154,7 +1176,13 @@ export class TelegramService extends Service {
     if (this.membershipGates.has(accountId)) {
       return;
     }
-    const gatePromise = bot.telegram.getMe().then((botInfo) =>
+    const botInfoPromise = bot.telegram.getMe();
+    // Cache the identity lookup itself: finishBotStartup reuses the SAME
+    // promise instead of issuing a second network getMe (divergent
+    // identities between the gate and the startup log, needless retry
+    // after a first failure).
+    this.membershipBotIdentity.set(accountId, botInfoPromise);
+    const gatePromise = botInfoPromise.then((botInfo) =>
       createTelegramMembershipGate({
         runtime: this.runtime,
         botTelegramUserId: String(botInfo.id),
@@ -1162,8 +1190,8 @@ export class TelegramService extends Service {
     );
     this.membershipGates.set(accountId, gatePromise);
     // The promise may reject before finishBotStartup attaches its await;
-    // suppress that window's unhandled rejection (finishBotStartup's catch
-    // still records the failure and marks admission broken).
+    // suppress that window's unhandled rejection (finishBotStartup's await
+    // observes the same rejection and records the failure).
     void gatePromise.catch(() => {
       // error-policy:J5 observed and handled by finishBotStartup's await.
     });
@@ -1260,15 +1288,36 @@ export class TelegramService extends Service {
         }
         const pending = this.pendingMembershipTransitions.get(accountId);
         this.pendingMembershipTransitions.delete(accountId);
+        // Fence the replay: while queued transitions replay IN ARRIVAL
+        // ORDER, a newer LIVE transition must not enter the dispatch path
+        // and serialize ahead of older queued entries (Telegraf's polling
+        // batch dispatch runs updates concurrently, and the authority's
+        // per-scope chain only orders work that reaches it — a live re-add
+        // overtaking a queued kick would install the clear last and leave
+        // a chat the bot was kicked from admitted). Live arrivals during
+        // the drain append to the queue, which this loop re-reads each
+        // iteration, preserving global arrival order.
+        this.replayingMembershipTransitions.add(accountId);
         for (const pendingUpdate of pending ?? []) {
-          await this.handleMyChatMemberUpdate(pendingUpdate, accountId);
+          // Dispatch directly (fenced entries cannot re-queue — the live
+          // fence would bounce them back into the queue and loop forever).
+          await this.dispatchMembershipTransition(pendingUpdate, accountId);
         }
+        while (this.pendingMembershipTransitions.has(accountId)) {
+          const liveQueued = this.pendingMembershipTransitions.get(accountId);
+          this.pendingMembershipTransitions.delete(accountId);
+          for (const liveUpdate of liveQueued ?? []) {
+            await this.dispatchMembershipTransition(liveUpdate, accountId);
+          }
+        }
+        this.replayingMembershipTransitions.delete(accountId);
       })
       .catch(() => {
         // error-policy:J4 A failed bootstrap already marked the admission
         // gate broken; the queued transitions are dropped fail-closed.
         this.settledMembershipGates.set(accountId, null);
         this.pendingMembershipTransitions.delete(accountId);
+        this.replayingMembershipTransitions.delete(accountId);
       });
   }
 
@@ -2377,24 +2426,47 @@ export class TelegramService extends Service {
       // for a later re-join in the same process.
       this.syncedEntityIds.delete(entityId);
 
-      // Remove the departed principal's CURRENT room participation in the
-      // same logical leave operation: ensureConnection-created participants
-      // would otherwise keep resolving room-derived authorization (e.g.
-      // DocumentService grants via getRoomsForParticipants) for a principal
-      // the authority already revoked. The observed `roomId` (topic-aware)
-      // and the chat's main room are both cleared. The principal's ENTITY
-      // row stays (the authority's FK needs it) — only participation goes.
+      // Remove the departed principal's room participation across the WHOLE
+      // chat in the same logical leave operation: ensureConnection-created
+      // participants would otherwise keep resolving room-derived
+      // authorization (e.g. DocumentService grants via
+      // getRoomsForParticipants) for a principal the authority already
+      // revoked. The observed topic room and the chat's main room are
+      // cleared explicitly; every OTHER room under the chat's world (forum
+      // topics the principal joined through other messages) is cleared via
+      // getRoomsForParticipant filtered to this world, so no room of this
+      // chat keeps the departed principal. The principal's ENTITY row stays
+      // (the authority's FK needs it) — only participation goes.
       try {
-        await this.runtime.removeParticipant(entityId, roomId);
-        // The observed roomId is topic-aware; also clear the chat's MAIN room
-        // (same derivation syncEntity uses) when this leave arrived through a
-        // topic thread, so participation does not survive in the main room.
         const mainRoomId = createUniqueUuid(
           this.runtime,
           this.scopedTelegramKey(chat, accountId),
         ) as UUID;
-        if (mainRoomId !== roomId) {
-          await this.runtime.removeParticipant(entityId, mainRoomId);
+        const roomsToClear = new Set<UUID>([roomId, mainRoomId]);
+        // Enumerate the principal's participation and keep only rooms
+        // belonging to this chat's world — a principal may legitimately
+        // remain a participant in unrelated chats' worlds.
+        try {
+          const participantRooms =
+            await this.runtime.getRoomsForParticipant(entityId);
+          for (const candidateRoomId of participantRooms) {
+            const candidateRoom = await this.runtime.getRoom(candidateRoomId);
+            if (candidateRoom?.worldId === worldId) {
+              roomsToClear.add(candidateRoomId);
+            }
+          }
+        } catch (error) {
+          // error-policy:J7 Enumeration failure must not skip the explicit
+          // observed/main-room clears above; report and continue with what
+          // is known.
+          this.runtime.reportError(
+            "telegram:membership-participation-enumeration",
+            error,
+            { chatId: chat, accountId, entityId },
+          );
+        }
+        for (const roomToClear of roomsToClear) {
+          await this.runtime.removeParticipant(entityId, roomToClear);
         }
       } catch (error) {
         // error-policy:J7 Participation removal is a best-effort supplement:
@@ -2461,43 +2533,18 @@ export class TelegramService extends Service {
         this.queuePendingMembershipTransition(update, accountId);
         return;
       }
-      const gate = await this.getMembershipGate(accountId);
-      if (!gate) {
-        // An absent gate (no authority service) is the documented legacy
-        // mode: nothing to record. A FAILED bootstrap already marked the
-        // message gate broken, so group admission fails closed.
+      if (this.replayingMembershipTransitions.has(accountId)) {
+        // A replay is draining the startup queue; a transition arriving NOW
+        // is newer than everything queued, so append it to the queue the
+        // replay loop reads (it re-checks the queue each iteration) rather
+        // than dispatching concurrently — preserving arrival order across
+        // the replay/live boundary.
+        const queue = this.pendingMembershipTransitions.get(accountId) ?? [];
+        queue.push(update);
+        this.pendingMembershipTransitions.set(accountId, queue);
         return;
       }
-      const botId = update.new_chat_member.user.id.toString();
-      if (botId !== gate.botTelegramUserId) {
-        return;
-      }
-      const chatId = update.chat.id.toString();
-      const chatRoomKey = this.membershipChatRoomKey(chatId, accountId);
-      const membership = telegramStatusToMembership(update.new_chat_member);
-      const previous = telegramStatusToMembership(update.old_chat_member);
-      if (membership.state === "revoked") {
-        // Same fail-closed contract as the message-path bot removal: degrade
-        // the scope so admission for the whole chat fails closed. Repeated
-        // revoked transitions are idempotent.
-        await gate.authority.markScopeUnavailable({
-          chatId,
-          chatRoomKey,
-          reason: "bot_removed",
-        });
-        return;
-      }
-      // The bot is (again) a member of this chat. Only a revoked→present
-      // TRANSITION is a re-add: Telegram also emits my_chat_member for
-      // present→present changes (administrator-rights edits, restricted
-      // metadata), and clearing the tombstone / setting the re-add watermark
-      // on those would spuriously invalidate in-flight valid evidence.
-      // A present→present update must be a no-op.
-      if (previous.state === "revoked") {
-        // Awaits the per-scope serialized clear so a concurrently in-flight
-        // removal's tombstone install cannot land after this clear.
-        await gate.authority.clearScopeRemoval({ chatId, chatRoomKey });
-      }
+      await this.dispatchMembershipTransition(update, accountId);
     } catch (error) {
       // error-policy:J2 The tombstone/clear could not be applied: the scope
       // may still authorize on stale evidence. Mark the admission gate
@@ -2516,6 +2563,55 @@ export class TelegramService extends Service {
         source: "my_chat_member",
         degraded: "gate-broken",
       });
+    }
+  }
+
+  /**
+   * Core transition dispatch, WITHOUT the startup-queue and replay fences:
+   * the replay loop calls this directly so re-queued entries cannot bounce
+   * back into the queue. Live callers go through
+   * {@link handleMyChatMemberUpdate}, which applies the fences first.
+   */
+  private async dispatchMembershipTransition(
+    update: ChatMemberUpdated,
+    accountId: string,
+  ): Promise<void> {
+    const gate = await this.getMembershipGate(accountId);
+    if (!gate) {
+      // An absent gate (no authority service) is the documented legacy
+      // mode: nothing to record. A FAILED bootstrap already marked the
+      // message gate broken, so group admission fails closed.
+      return;
+    }
+    const botId = update.new_chat_member.user.id.toString();
+    if (botId !== gate.botTelegramUserId) {
+      return;
+    }
+    const chatId = update.chat.id.toString();
+    const chatRoomKey = this.membershipChatRoomKey(chatId, accountId);
+    const membership = telegramStatusToMembership(update.new_chat_member);
+    const previous = telegramStatusToMembership(update.old_chat_member);
+    if (membership.state === "revoked") {
+      // Same fail-closed contract as the message-path bot removal: degrade
+      // the scope so admission for the whole chat fails closed. Repeated
+      // revoked transitions are idempotent.
+      await gate.authority.markScopeUnavailable({
+        chatId,
+        chatRoomKey,
+        reason: "bot_removed",
+      });
+      return;
+    }
+    // The bot is (again) a member of this chat. Only a revoked→present
+    // TRANSITION is a re-add: Telegram also emits my_chat_member for
+    // present→present changes (administrator-rights edits, restricted
+    // metadata), and clearing the tombstone / setting the re-add watermark
+    // on those would spuriously invalidate in-flight valid evidence.
+    // A present→present update must be a no-op.
+    if (previous.state === "revoked") {
+      // Awaits the per-scope serialized clear so a concurrently in-flight
+      // removal's tombstone install cannot land after this clear.
+      await gate.authority.clearScopeRemoval({ chatId, chatRoomKey });
     }
   }
 

--- a/plugins/plugin-telegram/src/service.ts
+++ b/plugins/plugin-telegram/src/service.ts
@@ -60,6 +60,11 @@ import {
 import { TELEGRAM_SERVICE_NAME } from "./constants";
 import { checkTelegramDmAccess, resolveTelegramDmPolicy } from "./dm-policy";
 import { resolveTelegramRuntimeEntityId } from "./identity";
+import type { TelegramMembershipReason } from "./membership";
+import {
+  createTelegramMembershipGate,
+  type TelegramMembershipGate,
+} from "./membership-gate";
 import { MessageManager } from "./messageManager";
 import {
   claimTelegramPollerToken,
@@ -396,6 +401,13 @@ export class TelegramService extends Service {
   private botToken: string | null;
   private defaultAccountId = DEFAULT_ACCOUNT_ID;
   private accountStates: Map<string, TelegramAccountRuntime> = new Map();
+  /**
+   * Lazily-created membership-authority gate for the default account: binds
+   * the durable connector-account row and the per-account authority client.
+   * Null until the bot's Telegram identity is known (getMe) or when the
+   * authority service is absent — group admission then fails closed.
+   */
+  private membershipGate: Promise<TelegramMembershipGate | null> | null = null;
 
   /**
    * Constructor for TelegramService class.
@@ -1032,6 +1044,47 @@ export class TelegramService extends Service {
       },
       "Bot info retrieved",
     );
+
+    // Seed the membership-authority gate once the bot identity is known. The
+    // default account is the only multi-account surface this vertical gates.
+    if (accountId === this.defaultAccountId && !this.membershipGate) {
+      this.membershipGate = createTelegramMembershipGate({
+        runtime: this.runtime,
+        botTelegramUserId: String(botInfo.id),
+      });
+      // error-policy:J4 Gate construction failure (absent authority service,
+      // bootstrap error) resolves to null; group admission fails closed.
+      try {
+        const gate = await this.membershipGate;
+        if (gate) {
+          const manager =
+            this.getAccountState(accountId)?.messageManager ??
+            this.messageManager;
+          manager?.bindMembershipGate(gate);
+        }
+      } catch {
+        this.membershipGate = null;
+      }
+    }
+  }
+
+  /** Resolves the membership gate, or null when the authority is unavailable. */
+  private async getMembershipGate(): Promise<TelegramMembershipGate | null> {
+    if (!this.membershipGate) {
+      return null;
+    }
+    try {
+      return await this.membershipGate;
+    } catch {
+      // error-policy:J4 a rejected bootstrap surfaces as an absent gate; the
+      // per-chat denial path reports the underlying error once per chat.
+      return null;
+    }
+  }
+
+  /** Chat room key for membership scopes: the chat's main room, not a topic room. */
+  private membershipChatRoomKey(chatId: string, accountId: string): string {
+    return this.scopedTelegramKey(chatId, accountId);
   }
 
   /** Installs the process-level teardown hooks for one Telegraf instance. */
@@ -1654,7 +1707,7 @@ export class TelegramService extends Service {
     // Handle all three entity sync cases separately for clarity
     await this.syncMessageSender(ctx, worldId, roomId, chatId, accountId);
     await this.syncNewChatMember(ctx, worldId, roomId, chatId, accountId);
-    await this.syncLeftChatMember(ctx, accountId);
+    await this.syncLeftChatMember(ctx, worldId, roomId, accountId);
   }
 
   /**
@@ -1705,6 +1758,68 @@ export class TelegramService extends Service {
   }
 
   /**
+   * Applies one membership-evidence fact through the authority gate,
+   * ensuring the principal entity row exists first (the authority's FK
+   * requires it) and resolving the canonical principal the same way the
+   * message path does.
+   */
+  private async recordMembershipEvent(
+    ctx: Context,
+    chatId: string,
+    chatRoomKey: string,
+    event: {
+      telegramUserId: string;
+      canonicalPrincipalId: UUID;
+      state: "active" | "revoked";
+      reason: TelegramMembershipReason;
+      runtime: { worldId: UUID; roomId: UUID; entityId: UUID };
+      messageId: number;
+      observedAt: string;
+    },
+  ): Promise<void> {
+    const gate = await this.getMembershipGate();
+    if (!gate) {
+      // No authority service or bootstrap failed: nothing to record. Group
+      // admission fails closed separately; this path only records evidence.
+      return;
+    }
+    try {
+      // The authority requires an entity row for the principal before
+      // evidence can be applied; ensureConnection creates it when missing.
+      await this.runtime.ensureConnection({
+        entityId: event.canonicalPrincipalId,
+        roomId: event.runtime.roomId,
+        roomName: getTelegramChatDisplayName(ctx.chat, chatId),
+        userName: undefined,
+        name: "Unknown User",
+        source: "telegram",
+        channelId: chatId,
+        type: ChannelType.GROUP,
+        worldId: event.runtime.worldId,
+      });
+    } catch (error) {
+      // error-policy:J7 Entity bootstrap failure must not kill the update
+      // handler; without the row the evidence would throw anyway, so skip.
+      this.runtime.reportError("telegram:membership-entity", error, {
+        chatId,
+        telegramUserId: event.telegramUserId,
+      });
+      return;
+    }
+    await gate.authority.recordEvent({
+      chatId,
+      chatRoomKey,
+      canonicalPrincipalId: event.canonicalPrincipalId,
+      state: event.state,
+      reason: event.reason,
+      runtime: event.runtime,
+      messageId: event.messageId,
+      telegramUserId: event.telegramUserId,
+      observedAt: event.observedAt,
+    });
+  }
+
+  /**
    * Synchronizes a new chat member entity with the runtime system.
    * Triggered when a user joins the chat.
    *
@@ -1724,6 +1839,10 @@ export class TelegramService extends Service {
   ): Promise<void> {
     // Handle new chat member
     if (ctx.message && "new_chat_members" in ctx.message) {
+      const messageId = ctx.message.message_id;
+      const observedAt = new Date(ctx.message.date * 1_000).toISOString();
+      const chatRoomKey = this.membershipChatRoomKey(chatId, accountId);
+      const botId = (await this.getMembershipGate())?.botTelegramUserId;
       for (const newMember of ctx.message.new_chat_members) {
         const telegramId = newMember.id.toString();
         const entityId = await resolveTelegramRuntimeEntityId(
@@ -1731,6 +1850,21 @@ export class TelegramService extends Service {
           accountId,
           telegramId,
         );
+
+        // Membership evidence is applied for every observed join, including
+        // cached entities: the syncedEntityIds guard exists to avoid repeated
+        // ensureConnection work, not to gate membership facts.
+        if (!botId || telegramId !== botId) {
+          await this.recordMembershipEvent(ctx, chatId, chatRoomKey, {
+            telegramUserId: telegramId,
+            canonicalPrincipalId: entityId,
+            state: "active",
+            reason: "joined",
+            runtime: { worldId, roomId, entityId },
+            messageId,
+            observedAt,
+          });
+        }
 
         if (this.syncedEntityIds.has(entityId)) {
           continue;
@@ -1776,24 +1910,62 @@ export class TelegramService extends Service {
   }
 
   /**
-   * Updates entity status when a user leaves the chat.
-   *
-   * @param {Context} ctx - The context of the incoming update
-   * @returns {Promise<void>}
-   * @private
+   * Updates entity status when a user leaves the chat and records the
+   * revocation as membership evidence so the authority denies the principal
+   * from the same turn onward. The bot's own removal instead degrades the
+   * whole chat scope to `unavailable` (fail-closed admission for everyone).
    */
   private async syncLeftChatMember(
     ctx: Context,
+    worldId: UUID,
+    roomId: UUID,
     accountId = this.defaultAccountId,
   ): Promise<void> {
     // Handle left chat member
     if (ctx.message && "left_chat_member" in ctx.message) {
       const leftMember = ctx.message.left_chat_member;
       const telegramId = leftMember.id.toString();
-      const entityId = createUniqueUuid(
+      const chat = ctx.chat?.id.toString();
+      if (!chat) {
+        return;
+      }
+      const messageId = ctx.message.message_id;
+      const observedAt = new Date(ctx.message.date * 1_000).toISOString();
+      const chatRoomKey = this.membershipChatRoomKey(chat, accountId);
+      const gate = await this.getMembershipGate();
+
+      if (gate && telegramId === gate.botTelegramUserId) {
+        // The bot itself was removed: it can no longer observe this chat, so
+        // the scope fails closed instead of fabricating stale authority.
+        await gate.authority.markScopeUnavailable({
+          chatId: chat,
+          chatRoomKey,
+          reason: "bot_removed",
+        });
+      }
+
+      const entityId = await resolveTelegramRuntimeEntityId(
         this.runtime,
-        this.scopedTelegramKey(telegramId, accountId),
-      ) as UUID;
+        accountId,
+        telegramId,
+      );
+
+      // Record the revocation for the canonical principal even when the
+      // entity row is missing: recordMembershipEvent bootstraps it first so
+      // the durable revocation exists (never-seen leavers included).
+      await this.recordMembershipEvent(ctx, chat, chatRoomKey, {
+        telegramUserId: telegramId,
+        canonicalPrincipalId: entityId,
+        state: "revoked",
+        reason: "left",
+        runtime: { worldId, roomId, entityId },
+        messageId,
+        observedAt,
+      });
+
+      // A leaving member's cached sync state must not suppress the evidence
+      // for a later re-join in the same process.
+      this.syncedEntityIds.delete(entityId);
 
       const existingEntity = await this.runtime.getEntityById(entityId);
       if (existingEntity) {

--- a/plugins/plugin-telegram/src/service.ts
+++ b/plugins/plugin-telegram/src/service.ts
@@ -1135,6 +1135,9 @@ export class TelegramService extends Service {
     try {
       return await promise;
     } catch {
+      // error-policy:J4 The gate seeding path already recorded the failure,
+      // marked the manager's gate broken, and reported it; callers treat null
+      // as "no gate" and the broken marker keeps group admission closed.
       return null;
     }
   }

--- a/plugins/plugin-telegram/src/service.ts
+++ b/plugins/plugin-telegram/src/service.ts
@@ -1095,42 +1095,43 @@ export class TelegramService extends Service {
     // crash boot.
     await applyTelegramSetMyCommands(bot, this.runtime, accountId);
 
-    // Reuse the cached bot-identity lookup when beginMembershipGateBootstrap
-    // already issued one — a second network getMe could diverge from the
-    // identity backing the gate (and retries a failed lookup needlessly).
-    const botInfoPromise =
-      this.membershipBotIdentity.get(accountId) ?? bot.telegram.getMe();
-    this.membershipBotIdentity.set(accountId, botInfoPromise);
-    const botInfo = await botInfoPromise;
-    logger.debug(
-      {
-        src: "plugin:telegram",
-        agentId: this.runtime.agentId,
-        accountId,
-        botId: botInfo.id,
-        botUsername: botInfo.username,
-      },
-      "Bot info retrieved",
-    );
-
     // Seed this account's membership-authority gate once its bot identity is
     // known. Every account (default and secondary) gets its own gate. When
     // beginMembershipGateBootstrap already installed the promise ahead of the
     // poller, reuse it — only the manager binding and failure marking below
-    // still belong here.
-    if (!this.membershipGates.has(accountId)) {
-      this.membershipGates.set(
-        accountId,
-        createTelegramMembershipGate({
-          runtime: this.runtime,
-          botTelegramUserId: String(botInfo.id),
-        }),
-      );
-    }
-    const gatePromise = this.membershipGates.get(
-      accountId,
-    ) as Promise<TelegramMembershipGate | null>;
+    // still belong here. The identity lookup and gate await BOTH sit inside
+    // the failure-observing try: a rejected getMe must mark the gate failed
+    // (fail-closed admission) and clear the cached rejection so a startup
+    // retry issues a FRESH lookup instead of replaying the cached rejection.
     try {
+      let botInfoPromise = this.membershipBotIdentity.get(accountId);
+      if (!botInfoPromise) {
+        botInfoPromise = bot.telegram.getMe();
+        this.membershipBotIdentity.set(accountId, botInfoPromise);
+      }
+      const botInfo = await botInfoPromise;
+      logger.debug(
+        {
+          src: "plugin:telegram",
+          agentId: this.runtime.agentId,
+          accountId,
+          botId: botInfo.id,
+          botUsername: botInfo.username,
+        },
+        "Bot info retrieved",
+      );
+      if (!this.membershipGates.has(accountId)) {
+        this.membershipGates.set(
+          accountId,
+          createTelegramMembershipGate({
+            runtime: this.runtime,
+            botTelegramUserId: String(botInfo.id),
+          }),
+        );
+      }
+      const gatePromise = this.membershipGates.get(
+        accountId,
+      ) as Promise<TelegramMembershipGate | null>;
       const gate = await gatePromise;
       const manager = this.getAccountState(accountId)?.messageManager;
       if (gate) {
@@ -1153,6 +1154,10 @@ export class TelegramService extends Service {
       this.runtime.reportError("telegram:membership-bootstrap", error, {
         accountId,
       });
+      // Clear BOTH cached rejections so a startup retry issues FRESH
+      // lookups instead of replaying the cached failure forever.
+      this.membershipBotIdentity.delete(accountId);
+      this.membershipGates.delete(accountId);
     }
   }
 
@@ -1277,6 +1282,16 @@ export class TelegramService extends Service {
     if (!promise) {
       return;
     }
+    // Register the replay drain EXACTLY ONCE per settled promise: every
+    // queued arrival re-enters this method, and attaching another .then
+    // would start a SECOND concurrent drain — the second drain would see
+    // an empty queue, clear the replay fence below while the first drain
+    // is still replaying older entries, and let newer live transitions
+    // overtake them.
+    if (this.replayingMembershipTransitions.has(accountId)) {
+      return;
+    }
+    this.replayingMembershipTransitions.add(accountId);
     void promise
       .then(async (gate) => {
         // Prime the settled registry so the replayed dispatch takes the
@@ -1286,8 +1301,6 @@ export class TelegramService extends Service {
           this.pendingMembershipTransitions.delete(accountId);
           return;
         }
-        const pending = this.pendingMembershipTransitions.get(accountId);
-        this.pendingMembershipTransitions.delete(accountId);
         // Fence the replay: while queued transitions replay IN ARRIVAL
         // ORDER, a newer LIVE transition must not enter the dispatch path
         // and serialize ahead of older queued entries (Telegraf's polling
@@ -1295,22 +1308,29 @@ export class TelegramService extends Service {
         // per-scope chain only orders work that reaches it — a live re-add
         // overtaking a queued kick would install the clear last and leave
         // a chat the bot was kicked from admitted). Live arrivals during
-        // the drain append to the queue, which this loop re-reads each
-        // iteration, preserving global arrival order.
-        this.replayingMembershipTransitions.add(accountId);
-        for (const pendingUpdate of pending ?? []) {
-          // Dispatch directly (fenced entries cannot re-queue — the live
-          // fence would bounce them back into the queue and loop forever).
-          await this.dispatchMembershipTransition(pendingUpdate, accountId);
-        }
-        while (this.pendingMembershipTransitions.has(accountId)) {
-          const liveQueued = this.pendingMembershipTransitions.get(accountId);
-          this.pendingMembershipTransitions.delete(accountId);
-          for (const liveUpdate of liveQueued ?? []) {
-            await this.dispatchMembershipTransition(liveUpdate, accountId);
+        // the drain re-queue via the fence in handleMyChatMemberUpdate;
+        // this loop drains until quiet. Each drained entry dispatches
+        // through the LIVE handler (bypassing only the fence) so a failing
+        // authority write degrades admission fail-closed exactly like a
+        // live transition failure.
+        try {
+          for (;;) {
+            const pending = this.pendingMembershipTransitions.get(accountId);
+            this.pendingMembershipTransitions.delete(accountId);
+            if (!pending || pending.length === 0) {
+              break;
+            }
+            for (const pendingUpdate of pending) {
+              await this.handleMyChatMemberUpdate(
+                pendingUpdate,
+                accountId,
+                true,
+              );
+            }
           }
+        } finally {
+          this.replayingMembershipTransitions.delete(accountId);
         }
-        this.replayingMembershipTransitions.delete(accountId);
       })
       .catch(() => {
         // error-policy:J4 A failed bootstrap already marked the admission
@@ -2445,14 +2465,27 @@ export class TelegramService extends Service {
         const roomsToClear = new Set<UUID>([roomId, mainRoomId]);
         // Enumerate the principal's participation and keep only rooms
         // belonging to this chat's world — a principal may legitimately
-        // remain a participant in unrelated chats' worlds.
+        // remain a participant in unrelated chats' worlds. Per-room
+        // failures are isolated: one unreadable room must not abort the
+        // enumeration of the rest (the departed principal's authorization
+        // in the readable rooms is revoked regardless).
         try {
           const participantRooms =
             await this.runtime.getRoomsForParticipant(entityId);
           for (const candidateRoomId of participantRooms) {
-            const candidateRoom = await this.runtime.getRoom(candidateRoomId);
-            if (candidateRoom?.worldId === worldId) {
-              roomsToClear.add(candidateRoomId);
+            try {
+              const candidateRoom = await this.runtime.getRoom(candidateRoomId);
+              if (candidateRoom?.worldId === worldId) {
+                roomsToClear.add(candidateRoomId);
+              }
+            } catch (error) {
+              // error-policy:J7 One unreadable candidate room must not
+              // abort clearing the others.
+              this.runtime.reportError(
+                "telegram:membership-participation-enumeration",
+                error,
+                { chatId: chat, accountId, entityId, roomId: candidateRoomId },
+              );
             }
           }
         } catch (error) {
@@ -2466,12 +2499,25 @@ export class TelegramService extends Service {
           );
         }
         for (const roomToClear of roomsToClear) {
-          await this.runtime.removeParticipant(entityId, roomToClear);
+          try {
+            // removeParticipant resolves false when the row was absent;
+            // a throw is the only failure mode. Per-room isolation keeps
+            // one failed delete from aborting the remaining rooms.
+            await this.runtime.removeParticipant(entityId, roomToClear);
+          } catch (error) {
+            // error-policy:J7 A failed row delete must not abort the
+            // remaining rooms or the entity-status update below; the
+            // durable revocation above remains the authoritative deny.
+            this.runtime.reportError(
+              "telegram:membership-participation",
+              error,
+              { chatId: chat, accountId, entityId, roomId: roomToClear },
+            );
+          }
         }
       } catch (error) {
-        // error-policy:J7 Participation removal is a best-effort supplement:
-        // the durable revocation above is the authoritative deny, and a
-        // failed row delete must not kill the entity-status update below.
+        // error-policy:J7 Unreachable in practice (both inner loops catch
+        // their own); retained as a boundary guard for the Set setup.
         this.runtime.reportError("telegram:membership-participation", error, {
           chatId: chat,
           accountId,
@@ -2509,6 +2555,7 @@ export class TelegramService extends Service {
   private async handleMyChatMemberUpdate(
     update: ChatMemberUpdated | undefined,
     accountId = this.defaultAccountId,
+    replayDrain = false,
   ): Promise<void> {
     // Every failure in this method must land in the fail-closed degradation
     // below — never in a caller that only logs — so the entire body sits
@@ -2527,13 +2574,14 @@ export class TelegramService extends Service {
       // stays untombstoned) or a re-add (a persisted tombstone keeps denying
       // the chat indefinitely).
       if (
+        !replayDrain &&
         !this.settledMembershipGates.has(accountId) &&
         this.membershipGates.has(accountId)
       ) {
         this.queuePendingMembershipTransition(update, accountId);
         return;
       }
-      if (this.replayingMembershipTransitions.has(accountId)) {
+      if (!replayDrain && this.replayingMembershipTransitions.has(accountId)) {
         // A replay is draining the startup queue; a transition arriving NOW
         // is newer than everything queued, so append it to the queue the
         // replay loop reads (it re-checks the queue each iteration) rather

--- a/plugins/plugin-telegram/src/service.ts
+++ b/plugins/plugin-telegram/src/service.ts
@@ -419,6 +419,23 @@ export class TelegramService extends Service {
     Promise<TelegramMembershipGate | null>
   >();
   private membershipGateFailures = new Set<string>();
+  /**
+   * Settled gate outcomes keyed by account: once a bootstrap promise
+   * resolves, the concrete gate (or null-for-absent) is cached here so the
+   * startup-window path can check SYNCHRONOUSLY whether an account's gate
+   * is still bootstrapping — awaiting the pending promise inside the update
+   * handler would deadlock or delay poller dispatch instead of queueing.
+   */
+  private settledMembershipGates = new Map<
+    string,
+    TelegramMembershipGate | null
+  >();
+  /**
+   * my_chat_member transitions that arrived while the account's gate was
+   * still bootstrapping (the poller goes live before finishBotStartup's
+   * getMe resolves). Replayed — in arrival order — once the gate settles.
+   */
+  private pendingMembershipTransitions = new Map<string, ChatMemberUpdated[]>();
 
   /**
    * Constructor for TelegramService class.
@@ -493,6 +510,10 @@ export class TelegramService extends Service {
       this.runtime,
       account.accountId,
     );
+    // The poller goes live before finishBotStartup resolves the membership
+    // gate; group admission must fail closed (not degrade to the absent-
+    // authority allow mode) until the gate settles.
+    messageManager.telegramMembershipGate.markPending();
     return {
       accountId: account.accountId,
       account,
@@ -1073,15 +1094,18 @@ export class TelegramService extends Service {
       // "broken" and fail closed on the latter.
       try {
         const gate = await gatePromise;
+        const manager = this.getAccountState(accountId)?.messageManager;
         if (gate) {
           // Bind ONLY this account's own manager: a fallback to the default
           // manager would gate the wrong connector (and leave the secondary
           // ungated) when the account state is not installed yet. If the
           // manager is not ready, defer to bindAccountMembershipGates(),
           // which runs at account-state installation.
-          this.getAccountState(accountId)?.messageManager?.bindMembershipGate(
-            gate,
-          );
+          manager?.bindMembershipGate(gate);
+        } else {
+          // Gate settled absent (no authority service): settle the pending
+          // marker into the documented legacy allow mode.
+          manager?.telegramMembershipGate.markAbsent();
         }
       } catch (error) {
         this.membershipGateFailures.add(accountId);
@@ -1119,6 +1143,10 @@ export class TelegramService extends Service {
       const gate = await promise;
       if (gate) {
         manager.bindMembershipGate(gate);
+      } else {
+        // Gate settled absent (no authority service): settle the manager's
+        // pending marker into the documented legacy allow mode.
+        manager.telegramMembershipGate.markAbsent();
       }
     } catch {
       // error-policy:J2 The seeding path already recorded this gate failure
@@ -1132,18 +1160,66 @@ export class TelegramService extends Service {
   private async getMembershipGate(
     accountId = this.defaultAccountId,
   ): Promise<TelegramMembershipGate | null> {
+    const settled = this.settledMembershipGates.get(accountId);
+    if (settled !== undefined) {
+      return settled;
+    }
     const promise = this.membershipGates.get(accountId);
     if (!promise) {
       return null;
     }
     try {
-      return await promise;
+      const gate = await promise;
+      this.settledMembershipGates.set(accountId, gate);
+      return gate;
     } catch {
       // error-policy:J4 The gate seeding path already recorded the failure,
       // marked the manager's gate broken, and reported it; callers treat null
       // as "no gate" and the broken marker keeps group admission closed.
+      this.settledMembershipGates.set(accountId, null);
       return null;
     }
+  }
+
+  /**
+   * Queues a my_chat_member transition that arrived before the account's
+   * gate settled, then replays the queue once the gate promise resolves.
+   * Replayed transitions run the same dispatch path as live ones; on a null
+   * (absent) or failed gate the queue is dropped — absent is legacy
+   * no-authority mode, failed already fails admission closed.
+   */
+  private queuePendingMembershipTransition(
+    update: ChatMemberUpdated,
+    accountId: string,
+  ): void {
+    const queue = this.pendingMembershipTransitions.get(accountId) ?? [];
+    queue.push(update);
+    this.pendingMembershipTransitions.set(accountId, queue);
+    const promise = this.membershipGates.get(accountId);
+    if (!promise) {
+      return;
+    }
+    void promise
+      .then(async (gate) => {
+        // Prime the settled registry so the replayed dispatch takes the
+        // normal (non-queueing) path.
+        this.settledMembershipGates.set(accountId, gate);
+        if (!gate) {
+          this.pendingMembershipTransitions.delete(accountId);
+          return;
+        }
+        const pending = this.pendingMembershipTransitions.get(accountId);
+        this.pendingMembershipTransitions.delete(accountId);
+        for (const pendingUpdate of pending ?? []) {
+          await this.handleMyChatMemberUpdate(pendingUpdate, accountId);
+        }
+      })
+      .catch(() => {
+        // error-policy:J4 A failed bootstrap already marked the admission
+        // gate broken; the queued transitions are dropped fail-closed.
+        this.settledMembershipGates.set(accountId, null);
+        this.pendingMembershipTransitions.delete(accountId);
+      });
   }
 
   /** Chat room key for membership scopes: the chat's main room, not a topic room. */
@@ -1507,6 +1583,65 @@ export class TelegramService extends Service {
     }
 
     const chatId = ctx.chat.id.toString();
+
+    // Membership admission runs BEFORE any chat/entity preprocessing. The
+    // preprocessing below (handleNewChat, processExistingChat/syncEntity)
+    // mutates room-participant state via ensureConnection; running the
+    // membership authority only inside MessageManager.handleMessage (after
+    // next()) let an unauthorized or revoked sender create/attach an entity
+    // to the room first. Only ctx.message-bearing GROUP updates are gated:
+    // my_chat_member must pass through ungated or a kicked bot could never
+    // tombstone its own scope, and DMs/channels stay under the DM policy /
+    // have no inbound admission surface here. The authority bootstraps the
+    // principal entity itself (reconcile path), so a denied sender mutates
+    // no participant state; on admission the normal sync path runs.
+    if (
+      ctx.message &&
+      (ctx.chat.type === "group" || ctx.chat.type === "supergroup")
+    ) {
+      const manager =
+        this.getAccountState(accountId)?.messageManager ?? this.messageManager;
+      // Same canonical-principal derivation the message path uses, so the
+      // middleware gate and the manager gate agree on the principal.
+      const principalEntityId = ctx.from?.id
+        ? await resolveTelegramRuntimeEntityId(
+            this.runtime,
+            accountId,
+            ctx.from.id.toString(),
+          )
+        : null;
+      const admitted = await manager?.telegramMembershipGate.authorizeMessage({
+        chatId,
+        chatRoomKey: this.membershipChatRoomKey(chatId, accountId),
+        chatType: ctx.chat.type,
+        principalEntityId: principalEntityId as UUID,
+        telegramUserId: ctx.from?.id?.toString() ?? "",
+        runtimeMapping: {
+          worldId: createUniqueUuid(
+            this.runtime,
+            this.scopedTelegramKey(chatId, accountId),
+          ) as UUID,
+          roomId: createUniqueUuid(
+            this.runtime,
+            this.scopedTelegramKey(
+              ctx.message.message_thread_id
+                ? `${chatId}-${ctx.message.message_thread_id}`
+                : chatId,
+              accountId,
+            ),
+          ) as UUID,
+          entityId: principalEntityId as UUID,
+        },
+        getChatMember: async () =>
+          ctx.telegram.getChatMember(
+            (ctx.chat as { id: number }).id,
+            ctx.from?.id as number,
+          ),
+      });
+      if (!admitted) {
+        return;
+      }
+    }
 
     // If we haven't seen this chat before, process it as a new chat
     if (!this.knownChats.has(this.scopedTelegramKey(chatId, accountId))) {
@@ -1888,7 +2023,7 @@ export class TelegramService extends Service {
    * message path does.
    */
   private async recordMembershipEvent(
-    ctx: Context,
+    _ctx: Context,
     chatId: string,
     chatRoomKey: string,
     accountId: string,
@@ -1910,17 +2045,20 @@ export class TelegramService extends Service {
     }
     try {
       // The authority requires an entity row for the principal before
-      // evidence can be applied; ensureConnection creates it when missing.
-      await this.runtime.ensureConnection({
-        entityId: event.canonicalPrincipalId,
-        roomId: event.runtime.roomId,
-        roomName: getTelegramChatDisplayName(ctx.chat, chatId),
-        userName: undefined,
-        name: "Unknown User",
-        source: "telegram",
-        channelId: chatId,
-        type: ChannelType.GROUP,
-        worldId: event.runtime.worldId,
+      // evidence can be applied. Only the ENTITY row is bootstrapped here —
+      // NEVER room participation: a revocation must not (re)create a room
+      // participant for the departed principal, and room-derived
+      // authorization (e.g. DocumentService grants via
+      // getRoomsForParticipants) must stop resolving for them.
+      await this.runtime.createEntity({
+        id: event.canonicalPrincipalId,
+        agentId: this.runtime.agentId,
+        names: [`telegram-${event.telegramUserId}`],
+        metadata: {
+          accountId,
+          source: "telegram",
+          telegramUserId: event.telegramUserId,
+        },
       });
     } catch (error) {
       // error-policy:J7 Entity bootstrap failure must not kill the update
@@ -2055,8 +2193,10 @@ export class TelegramService extends Service {
           // tombstone so fresh evidence can re-establish authority for this
           // scope. Stored pre-removal facts alone still do not authorize —
           // point-query evidence carries a bounded validUntil, so admission
-          // requires a fresh join/reconcile observation.
-          (
+          // requires a fresh join/reconcile observation. The clear joins the
+          // per-scope serialized chain so it cannot interleave with an
+          // in-flight removal's durable health write.
+          await (
             await this.getMembershipGate(accountId)
           )?.authority.clearScopeRemoval({
             chatId,
@@ -2187,6 +2327,38 @@ export class TelegramService extends Service {
       // for a later re-join in the same process.
       this.syncedEntityIds.delete(entityId);
 
+      // Remove the departed principal's CURRENT room participation in the
+      // same logical leave operation: ensureConnection-created participants
+      // would otherwise keep resolving room-derived authorization (e.g.
+      // DocumentService grants via getRoomsForParticipants) for a principal
+      // the authority already revoked. The observed `roomId` (topic-aware)
+      // and the chat's main room are both cleared. The principal's ENTITY
+      // row stays (the authority's FK needs it) — only participation goes.
+      try {
+        await this.runtime.removeParticipant(entityId, roomId);
+        // The observed roomId is topic-aware; also clear the chat's MAIN room
+        // (same derivation syncEntity uses) when this leave arrived through a
+        // topic thread, so participation does not survive in the main room.
+        const mainRoomId = createUniqueUuid(
+          this.runtime,
+          this.scopedTelegramKey(chat, accountId),
+        ) as UUID;
+        if (mainRoomId !== roomId) {
+          await this.runtime.removeParticipant(entityId, mainRoomId);
+        }
+      } catch (error) {
+        // error-policy:J7 Participation removal is a best-effort supplement:
+        // the durable revocation above is the authoritative deny, and a
+        // failed row delete must not kill the entity-status update below.
+        this.runtime.reportError("telegram:membership-participation", error, {
+          chatId: chat,
+          accountId,
+          telegramUserId: telegramId,
+          entityId,
+          roomId,
+        });
+      }
+
       const existingEntity = await this.runtime.getEntityById(entityId);
       if (existingEntity) {
         existingEntity.metadata = {
@@ -2226,8 +2398,24 @@ export class TelegramService extends Service {
       if (!update?.chat || !update.new_chat_member) {
         return;
       }
+      // Startup-window check, SYNCHRONOUSLY: the poller goes live before
+      // finishBotStartup's getMe resolves. Awaiting a pending bootstrap here
+      // would stall poller dispatch; instead, queue the transition and
+      // return — discarding it would drop a kick (stale active authority
+      // stays untombstoned) or a re-add (a persisted tombstone keeps denying
+      // the chat indefinitely).
+      if (
+        !this.settledMembershipGates.has(accountId) &&
+        this.membershipGates.has(accountId)
+      ) {
+        this.queuePendingMembershipTransition(update, accountId);
+        return;
+      }
       const gate = await this.getMembershipGate(accountId);
       if (!gate) {
+        // An absent gate (no authority service) is the documented legacy
+        // mode: nothing to record. A FAILED bootstrap already marked the
+        // message gate broken, so group admission fails closed.
         return;
       }
       const botId = update.new_chat_member.user.id.toString();
@@ -2256,7 +2444,9 @@ export class TelegramService extends Service {
       // on those would spuriously invalidate in-flight valid evidence.
       // A present→present update must be a no-op.
       if (previous.state === "revoked") {
-        gate.authority.clearScopeRemoval({ chatId, chatRoomKey });
+        // Awaits the per-scope serialized clear so a concurrently in-flight
+        // removal's tombstone install cannot land after this clear.
+        await gate.authority.clearScopeRemoval({ chatId, chatRoomKey });
       }
     } catch (error) {
       // error-policy:J2 The tombstone/clear could not be applied: the scope

--- a/plugins/plugin-telegram/src/service.ts
+++ b/plugins/plugin-telegram/src/service.ts
@@ -43,6 +43,7 @@ import type {
   Chat,
   ChatMemberAdministrator,
   ChatMemberOwner,
+  ChatMemberUpdated,
   User,
 } from "telegraf/types";
 import {
@@ -61,7 +62,10 @@ import { TELEGRAM_SERVICE_NAME } from "./constants";
 import { checkTelegramDmAccess, resolveTelegramDmPolicy } from "./dm-policy";
 import { resolveTelegramRuntimeEntityId } from "./identity";
 import type { TelegramMembershipReason } from "./membership";
-import { telegramMembershipScope } from "./membership";
+import {
+  telegramMembershipScope,
+  telegramStatusToMembership,
+} from "./membership";
 import {
   createTelegramMembershipGate,
   type TelegramMembershipGate,
@@ -1345,7 +1349,16 @@ export class TelegramService extends Service {
           .launch(
             {
               dropPendingUpdates: false,
-              allowedUpdates: ["message", "message_reaction", "callback_query"],
+              // my_chat_member MUST be listed: it is Telegram's only update
+              // type for the bot's own chat-member status, and both the
+              // bot-removal tombstone and the re-add clear in membership.ts
+              // depend on it being delivered.
+              allowedUpdates: [
+                "message",
+                "message_reaction",
+                "callback_query",
+                "my_chat_member",
+              ],
             },
             () => {
               connectedAt = Date.now();
@@ -1647,6 +1660,36 @@ export class TelegramService extends Service {
             error: error instanceof Error ? error.message : String(error),
           },
           "Error handling callback query",
+        );
+      }
+    });
+
+    // Bot's own chat-member status transitions (kick/leave/re-add). This is
+    // the authoritative Telegram update for the bot's membership: the message
+    // path's new_chat_members/left_chat_member fallbacks do not fire while
+    // polling (a kicked bot stops receiving the chat's messages entirely), so
+    // without this handler the bot-removal tombstone in the membership
+    // authority would never be written and the scope's stale evidence would
+    // keep authorizing members of a chat the bot can no longer observe.
+    bot?.on("my_chat_member", async (ctx) => {
+      try {
+        const token = state?.account.botToken ?? this.botToken;
+        if (token) {
+          markTelegramPollerUpdate(token, bot);
+        }
+        await this.handleMyChatMemberUpdate(
+          ctx.update.my_chat_member,
+          accountId,
+        );
+      } catch (error) {
+        logger.error(
+          {
+            src: "plugin:telegram",
+            agentId: this.runtime.agentId,
+            accountId,
+            error: error instanceof Error ? error.message : String(error),
+          },
+          "Error handling my_chat_member update",
         );
       }
     });
@@ -2154,6 +2197,85 @@ export class TelegramService extends Service {
         };
         await this.runtime.updateEntity(existingEntity);
       }
+    }
+  }
+
+  /**
+   * Applies the bot's own chat-member status transition from a
+   * `my_chat_member` update — Telegram's designated (and, while polling,
+   * only reliable) signal that the bot was kicked, left, or was re-added to a
+   * chat. Kicked/left tombstones the scope (fail-closed admission for the
+   * whole chat, exactly like the `left_chat_member` message path); a re-add
+   * clears the tombstone so fresh evidence can re-establish authority. The
+   * status mapping reuses `telegramStatusToMembership` so a restricted bot
+   * with `is_member: false` is treated as removed, not present.
+   *
+   * @private
+   */
+  private async handleMyChatMemberUpdate(
+    update: ChatMemberUpdated | undefined,
+    accountId = this.defaultAccountId,
+  ): Promise<void> {
+    // Every failure in this method must land in the fail-closed degradation
+    // below — never in a caller that only logs — so the entire body sits
+    // inside one try. getMembershipGate itself cannot reject (it catches and
+    // resolves null), and a null gate is the documented legacy
+    // no-authority-service mode, not a failure; both properties are pinned
+    // by service.my-chat-member.test.ts.
+    try {
+      if (!update?.chat || !update.new_chat_member) {
+        return;
+      }
+      const gate = await this.getMembershipGate(accountId);
+      if (!gate) {
+        return;
+      }
+      const botId = update.new_chat_member.user.id.toString();
+      if (botId !== gate.botTelegramUserId) {
+        return;
+      }
+      const chatId = update.chat.id.toString();
+      const chatRoomKey = this.membershipChatRoomKey(chatId, accountId);
+      const membership = telegramStatusToMembership(update.new_chat_member);
+      const previous = telegramStatusToMembership(update.old_chat_member);
+      if (membership.state === "revoked") {
+        // Same fail-closed contract as the message-path bot removal: degrade
+        // the scope so admission for the whole chat fails closed. Repeated
+        // revoked transitions are idempotent.
+        await gate.authority.markScopeUnavailable({
+          chatId,
+          chatRoomKey,
+          reason: "bot_removed",
+        });
+        return;
+      }
+      // The bot is (again) a member of this chat. Only a revoked→present
+      // TRANSITION is a re-add: Telegram also emits my_chat_member for
+      // present→present changes (administrator-rights edits, restricted
+      // metadata), and clearing the tombstone / setting the re-add watermark
+      // on those would spuriously invalidate in-flight valid evidence.
+      // A present→present update must be a no-op.
+      if (previous.state === "revoked") {
+        gate.authority.clearScopeRemoval({ chatId, chatRoomKey });
+      }
+    } catch (error) {
+      // error-policy:J2 The tombstone/clear could not be applied: the scope
+      // may still authorize on stale evidence. Mark the admission gate
+      // broken so every group admission fails closed rather than continuing
+      // on an un-tombstoned scope; the my_chat_member handler's own catch
+      // only logs, so the degradation must happen here.
+      (
+        this.getAccountState(accountId)?.messageManager ?? this.messageManager
+      )?.markMembershipGateBroken();
+      this.membershipGateFailures.add(accountId);
+      this.membershipGates.delete(accountId);
+      this.runtime.reportError("telegram:membership-scope-health", error, {
+        chatId: update?.chat?.id?.toString() ?? "unknown",
+        accountId,
+        reason: "bot_removed",
+        source: "my_chat_member",
+        degraded: "gate-broken",
+      });
     }
   }
 

--- a/plugins/plugin-telegram/src/service.ts
+++ b/plugins/plugin-telegram/src/service.ts
@@ -1471,7 +1471,10 @@ export class TelegramService extends Service {
       const roomId = createUniqueUuid(
         this.runtime,
         this.scopedTelegramKey(
-          ctx.message && "message_thread_id" in ctx.message
+          // Thread derivation must match syncEntity byte-for-byte so first-
+          // update evidence lands in the same scope the existing-chat path
+          // uses (truthiness gate: thread id 0 means "no thread" here too).
+          ctx.message?.message_thread_id
             ? `${chatId}-${ctx.message.message_thread_id}`
             : chatId,
           accountId,

--- a/plugins/plugin-telegram/src/service.ts
+++ b/plugins/plugin-telegram/src/service.ts
@@ -505,6 +505,9 @@ export class TelegramService extends Service {
 
   private setDefaultAccountState(state: TelegramAccountRuntime): void {
     this.accountStates.set(state.accountId, state);
+    // The manager for this account just became available: (re)bind any
+    // membership gate that resolved before the state was installed.
+    void this.bindAccountMembershipGates(state.accountId);
     if (state.accountId === this.defaultAccountId || !this.bot) {
       this.bot = state.bot;
       this.messageManager = state.messageManager;
@@ -1061,31 +1064,62 @@ export class TelegramService extends Service {
       });
       this.membershipGates.set(accountId, gatePromise);
       // error-policy:J4 Absent authority service resolves to null (legacy
-      // degrade-with-warning mode). A bootstrap FAILURE is recorded so
-      // admission can distinguish "never configured" from "broken" and fail
-      // closed on the latter.
-      // error-policy:J4 Absent authority service (null gate) means the
-      // deployment never registered the authority: the manager gate stays in
-      // documented legacy degrade-with-warning mode. A bootstrap FAILURE is
-      // different: the authority exists but is broken, so the manager gate is
-      // marked broken and every group admission fails closed.
+      // degrade-with-warning mode). A bootstrap FAILURE throws and is
+      // recorded here so admission can distinguish "never configured" from
+      // "broken" and fail closed on the latter.
       try {
         const gate = await gatePromise;
         if (gate) {
-          const manager =
-            this.getAccountState(accountId)?.messageManager ??
-            this.messageManager;
-          manager?.bindMembershipGate(gate);
+          // Bind ONLY this account's own manager: a fallback to the default
+          // manager would gate the wrong connector (and leave the secondary
+          // ungated) when the account state is not installed yet. If the
+          // manager is not ready, defer to bindAccountMembershipGates(),
+          // which runs at account-state installation.
+          this.getAccountState(accountId)?.messageManager?.bindMembershipGate(
+            gate,
+          );
         }
       } catch (error) {
         this.membershipGateFailures.add(accountId);
-        (
-          this.getAccountState(accountId)?.messageManager ?? this.messageManager
-        )?.markMembershipGateBroken();
+        this.getAccountState(
+          accountId,
+        )?.messageManager?.markMembershipGateBroken();
         this.runtime.reportError("telegram:membership-bootstrap", error, {
           accountId,
         });
       }
+    }
+  }
+
+  /**
+   * (Re)binds resolved membership gates to the account's own MessageManager.
+   * Called whenever an account state (with its manager) is installed so a
+   * gate that resolved BEFORE the manager existed still lands on the right
+   * manager — the bootstrap race can no longer strand a secondary account
+   * ungated or bind it to the default manager.
+   */
+  private async bindAccountMembershipGates(accountId: string): Promise<void> {
+    const promise = this.membershipGates.get(accountId);
+    if (!promise) {
+      return;
+    }
+    const manager = this.getAccountState(accountId)?.messageManager;
+    if (!manager) {
+      return;
+    }
+    if (this.membershipGateFailures.has(accountId)) {
+      manager.markMembershipGateBroken();
+      return;
+    }
+    try {
+      const gate = await promise;
+      if (gate) {
+        manager.bindMembershipGate(gate);
+      }
+    } catch {
+      // The seeding path already recorded the failure and marked whatever
+      // manager existed broken; this late-binding pass re-marks THIS manager.
+      manager.markMembershipGateBroken();
     }
   }
 
@@ -1871,17 +1905,37 @@ export class TelegramService extends Service {
       });
       return;
     }
-    await gate.authority.recordEvent({
-      chatId,
-      chatRoomKey,
-      canonicalPrincipalId: event.canonicalPrincipalId,
-      state: event.state,
-      reason: event.reason,
-      runtime: event.runtime,
-      messageId: event.messageId,
-      telegramUserId: event.telegramUserId,
-      observedAt: event.observedAt,
-    });
+    try {
+      await gate.authority.recordEvent({
+        chatId,
+        chatRoomKey,
+        canonicalPrincipalId: event.canonicalPrincipalId,
+        state: event.state,
+        reason: event.reason,
+        runtime: event.runtime,
+        messageId: event.messageId,
+        telegramUserId: event.telegramUserId,
+        observedAt: event.observedAt,
+      });
+    } catch (error) {
+      // error-policy:J2 recordEvent only throws when a REVOCATION could be
+      // neither committed nor degraded fail-closed (or the entity bootstrap
+      // above failed the same way): the authority can no longer be trusted
+      // for this account, so mark the admission gate broken — every group
+      // admission fails closed until a later boot rebinds a healthy gate.
+      // The poll loop survives; this update is dropped either way.
+      const manager =
+        this.getAccountState(accountId)?.messageManager ?? this.messageManager;
+      manager?.markMembershipGateBroken();
+      this.membershipGateFailures.add(accountId);
+      this.membershipGates.delete(accountId);
+      this.runtime.reportError("telegram:membership-evidence", error, {
+        chatId,
+        accountId,
+        telegramUserId: event.telegramUserId,
+        degraded: "gate-broken",
+      });
+    }
   }
 
   /**
@@ -2011,11 +2065,30 @@ export class TelegramService extends Service {
         // the scope fails closed instead of fabricating stale authority. Any
         // further evidence write would advance the scope back to current and
         // re-authorize stale member facts, so stop handling this update.
-        await gate.authority.markScopeUnavailable({
-          chatId: chat,
-          chatRoomKey,
-          reason: "bot_removed",
-        });
+        try {
+          await gate.authority.markScopeUnavailable({
+            chatId: chat,
+            chatRoomKey,
+            reason: "bot_removed",
+          });
+        } catch (error) {
+          // error-policy:J2 The unavailable-degrade itself failed: the scope
+          // may still authorize on stale evidence. Mark the admission gate
+          // broken so every group admission fails closed rather than
+          // continuing on an un-degraded scope.
+          (
+            this.getAccountState(accountId)?.messageManager ??
+            this.messageManager
+          )?.markMembershipGateBroken();
+          this.membershipGateFailures.add(accountId);
+          this.membershipGates.delete(accountId);
+          this.runtime.reportError("telegram:membership-scope-health", error, {
+            chatId: chat,
+            accountId,
+            reason: "bot_removed",
+            degraded: "gate-broken",
+          });
+        }
         return;
       }
 

--- a/plugins/plugin-telegram/src/service.ts
+++ b/plugins/plugin-telegram/src/service.ts
@@ -1133,6 +1133,10 @@ export class TelegramService extends Service {
         accountId,
       ) as Promise<TelegramMembershipGate | null>;
       const gate = await gatePromise;
+      // Overwrite any stale settled entry (e.g. a null a rejected replay
+      // stored after an earlier failure's cleanup): a successful fresh
+      // bootstrap makes THIS gate the authoritative settled value.
+      this.settledMembershipGates.set(accountId, gate);
       const manager = this.getAccountState(accountId)?.messageManager;
       if (gate) {
         // Bind ONLY this account's own manager: a fallback to the default
@@ -1154,10 +1158,14 @@ export class TelegramService extends Service {
       this.runtime.reportError("telegram:membership-bootstrap", error, {
         accountId,
       });
-      // Clear BOTH cached rejections so a startup retry issues FRESH
-      // lookups instead of replaying the cached failure forever.
+      // Clear ALL cached state for this account so a startup retry issues
+      // FRESH lookups instead of replaying the cached failure forever —
+      // including the settled-null entry a rejected replay may have stored,
+      // which would otherwise short-circuit getMembershipGate() and make a
+      // successfully-retried gate look absent.
       this.membershipBotIdentity.delete(accountId);
       this.membershipGates.delete(accountId);
+      this.settledMembershipGates.delete(accountId);
     }
   }
 
@@ -1239,7 +1247,10 @@ export class TelegramService extends Service {
     }
   }
 
-  /** Resolves the account's membership gate, or null when absent/failed. */
+  /** Resolves the account's membership gate, or null when absent/failed.
+   * The settled-null short-circuit is safe because every failure path that
+   * clears the gate promise also clears the settled registry (see
+   * finishBotStartup's catch). */
   private async getMembershipGate(
     accountId = this.defaultAccountId,
   ): Promise<TelegramMembershipGate | null> {
@@ -1297,23 +1308,28 @@ export class TelegramService extends Service {
         // Prime the settled registry so the replayed dispatch takes the
         // normal (non-queueing) path.
         this.settledMembershipGates.set(accountId, gate);
-        if (!gate) {
-          this.pendingMembershipTransitions.delete(accountId);
-          return;
-        }
-        // Fence the replay: while queued transitions replay IN ARRIVAL
-        // ORDER, a newer LIVE transition must not enter the dispatch path
-        // and serialize ahead of older queued entries (Telegraf's polling
-        // batch dispatch runs updates concurrently, and the authority's
-        // per-scope chain only orders work that reaches it — a live re-add
-        // overtaking a queued kick would install the clear last and leave
-        // a chat the bot was kicked from admitted). Live arrivals during
-        // the drain re-queue via the fence in handleMyChatMemberUpdate;
-        // this loop drains until quiet. Each drained entry dispatches
-        // through the LIVE handler (bypassing only the fence) so a failing
-        // authority write degrades admission fail-closed exactly like a
-        // live transition failure.
+        // The ENTIRE callback body — including the absent-gate return —
+        // sits inside the try/finally so the replay fence is always
+        // cleared; an early return on !gate would otherwise leave the
+        // fence set forever and every later live transition would append
+        // to a queue nobody drains.
         try {
+          if (!gate) {
+            this.pendingMembershipTransitions.delete(accountId);
+            return;
+          }
+          // Fence the replay: while queued transitions replay IN ARRIVAL
+          // ORDER, a newer LIVE transition must not enter the dispatch path
+          // and serialize ahead of older queued entries (Telegraf's polling
+          // batch dispatch runs updates concurrently, and the authority's
+          // per-scope chain only orders work that reaches it — a live re-add
+          // overtaking a queued kick would install the clear last and leave
+          // a chat the bot was kicked from admitted). Live arrivals during
+          // the drain re-queue via the fence in handleMyChatMemberUpdate;
+          // this loop drains until quiet. Each drained entry dispatches
+          // through the LIVE handler (bypassing only the fence) so a failing
+          // authority write degrades admission fail-closed exactly like a
+          // live transition failure.
           for (;;) {
             const pending = this.pendingMembershipTransitions.get(accountId);
             this.pendingMembershipTransitions.delete(accountId);

--- a/plugins/plugin-telegram/src/service.ts
+++ b/plugins/plugin-telegram/src/service.ts
@@ -988,6 +988,13 @@ export class TelegramService extends Service {
     // A launch failure before polling becomes stoppable leaves the flag false,
     // so the startup retry can still relaunch.
     if (!wiring.poller) {
+      // Install the gate-bootstrap promise BEFORE the poller goes live so a
+      // my_chat_member transition delivered in the startup window finds a
+      // pending promise to queue against (never a silently-absent gate):
+      // the poller can deliver updates before finishBotStartup's getMe
+      // resolves, and the transition handler queues while this promise is
+      // pending rather than discarding the update.
+      this.beginMembershipGateBootstrap(bot, accountId);
       await this.launchPollerSupervised(bot, state.account.botToken, accountId);
       wiring.poller = true;
     }
@@ -1081,42 +1088,85 @@ export class TelegramService extends Service {
     );
 
     // Seed this account's membership-authority gate once its bot identity is
-    // known. Every account (default and secondary) gets its own gate.
+    // known. Every account (default and secondary) gets its own gate. When
+    // beginMembershipGateBootstrap already installed the promise ahead of the
+    // poller, reuse it — only the manager binding and failure marking below
+    // still belong here.
     if (!this.membershipGates.has(accountId)) {
-      const gatePromise = createTelegramMembershipGate({
+      this.membershipGates.set(
+        accountId,
+        createTelegramMembershipGate({
+          runtime: this.runtime,
+          botTelegramUserId: String(botInfo.id),
+        }),
+      );
+    }
+    const gatePromise = this.membershipGates.get(
+      accountId,
+    ) as Promise<TelegramMembershipGate | null>;
+    // error-policy:J4 Absent authority service resolves to null (legacy
+    // degrade-with-warning mode). A bootstrap FAILURE throws and is
+    // recorded here so admission can distinguish "never configured" from
+    // "broken" and fail closed on the latter.
+    try {
+      const gate = await gatePromise;
+      const manager = this.getAccountState(accountId)?.messageManager;
+      if (gate) {
+        // Bind ONLY this account's own manager: a fallback to the default
+        // manager would gate the wrong connector (and leave the secondary
+        // ungated) when the account state is not installed yet. If the
+        // manager is not ready, defer to bindAccountMembershipGates(),
+        // which runs at account-state installation.
+        manager?.bindMembershipGate(gate);
+      } else {
+        // Gate settled absent (no authority service): settle the pending
+        // marker into the documented legacy allow mode.
+        manager?.telegramMembershipGate.markAbsent();
+      }
+    } catch (error) {
+      this.membershipGateFailures.add(accountId);
+      this.getAccountState(
+        accountId,
+      )?.messageManager?.markMembershipGateBroken();
+      this.runtime.reportError("telegram:membership-bootstrap", error, {
+        accountId,
+      });
+    }
+  }
+
+  /**
+   * Installs the account's membership-gate bootstrap promise WITHOUT awaiting
+   * it, ahead of the poller going live. `ensureWiredOnce` launches the poller
+   * before `finishBotStartup`'s `setMyCommands`/`getMe` awaits resolve, so a
+   * `my_chat_member` transition delivered in that window would otherwise find
+   * no gate promise at all — the queueing path in
+   * `handleMyChatMemberUpdate` engages on a PENDING promise, and a missing
+   * promise is indistinguishable from absent-authority legacy mode, silently
+   * dropping the transition (an untombstoned kick, or a re-add that leaves a
+   * persisted tombstone denying the chat indefinitely). The bot identity comes
+   * from this method's own `getMe`; `finishBotStartup` later awaits the same
+   * promise for manager binding and failure marking.
+   */
+  private beginMembershipGateBootstrap(
+    bot: Telegraf<Context>,
+    accountId: string,
+  ): void {
+    if (this.membershipGates.has(accountId)) {
+      return;
+    }
+    const gatePromise = bot.telegram.getMe().then((botInfo) =>
+      createTelegramMembershipGate({
         runtime: this.runtime,
         botTelegramUserId: String(botInfo.id),
-      });
-      this.membershipGates.set(accountId, gatePromise);
-      // error-policy:J4 Absent authority service resolves to null (legacy
-      // degrade-with-warning mode). A bootstrap FAILURE throws and is
-      // recorded here so admission can distinguish "never configured" from
-      // "broken" and fail closed on the latter.
-      try {
-        const gate = await gatePromise;
-        const manager = this.getAccountState(accountId)?.messageManager;
-        if (gate) {
-          // Bind ONLY this account's own manager: a fallback to the default
-          // manager would gate the wrong connector (and leave the secondary
-          // ungated) when the account state is not installed yet. If the
-          // manager is not ready, defer to bindAccountMembershipGates(),
-          // which runs at account-state installation.
-          manager?.bindMembershipGate(gate);
-        } else {
-          // Gate settled absent (no authority service): settle the pending
-          // marker into the documented legacy allow mode.
-          manager?.telegramMembershipGate.markAbsent();
-        }
-      } catch (error) {
-        this.membershipGateFailures.add(accountId);
-        this.getAccountState(
-          accountId,
-        )?.messageManager?.markMembershipGateBroken();
-        this.runtime.reportError("telegram:membership-bootstrap", error, {
-          accountId,
-        });
-      }
-    }
+      }),
+    );
+    this.membershipGates.set(accountId, gatePromise);
+    // The promise may reject before finishBotStartup attaches its await;
+    // suppress that window's unhandled rejection (finishBotStartup's catch
+    // still records the failure and marks admission broken).
+    void gatePromise.catch(() => {
+      // error-policy:J5 observed and handled by finishBotStartup's await.
+    });
   }
 
   /**

--- a/plugins/plugin-telegram/src/service.ts
+++ b/plugins/plugin-telegram/src/service.ts
@@ -1117,8 +1117,9 @@ export class TelegramService extends Service {
         manager.bindMembershipGate(gate);
       }
     } catch {
-      // The seeding path already recorded the failure and marked whatever
-      // manager existed broken; this late-binding pass re-marks THIS manager.
+      // error-policy:J2 The seeding path already recorded this gate failure
+      // and reported it; this late-binding pass only re-marks THIS manager
+      // broken so the failure state follows the account's own manager.
       manager.markMembershipGateBroken();
     }
   }
@@ -1893,9 +1894,22 @@ export class TelegramService extends Service {
             reason: `revocation_bootstrap_failed:${event.reason}`,
           });
         } catch (degradeError) {
+          // error-policy:J2 BOTH the entity bootstrap AND the fail-closed
+          // degrade failed: the authority can no longer be trusted for this
+          // account — prior active evidence may still authorize the departed
+          // principal. Mark the admission gate broken so every group
+          // admission fails closed, mirroring the recordEvent failure path.
+          (
+            this.getAccountState(accountId)?.messageManager ??
+            this.messageManager
+          )?.markMembershipGateBroken();
+          this.membershipGateFailures.add(accountId);
+          this.membershipGates.delete(accountId);
           this.runtime.reportError("telegram:membership-entity", degradeError, {
             chatId,
+            accountId,
             telegramUserId: event.telegramUserId,
+            degraded: "gate-broken",
           });
         }
       }
@@ -1990,6 +2004,18 @@ export class TelegramService extends Service {
               observedAt,
             },
           );
+        } else {
+          // The bot itself was (re-)added to the chat: clear the bot-removal
+          // tombstone so fresh evidence can re-establish authority for this
+          // scope. Stored pre-removal facts alone still do not authorize —
+          // point-query evidence carries a bounded validUntil, so admission
+          // requires a fresh join/reconcile observation.
+          (
+            await this.getMembershipGate(accountId)
+          )?.authority.clearScopeRemoval({
+            chatId,
+            chatRoomKey,
+          });
         }
 
         if (this.syncedEntityIds.has(entityId)) {

--- a/plugins/plugin-telegram/src/standalone/handler.test.ts
+++ b/plugins/plugin-telegram/src/standalone/handler.test.ts
@@ -207,7 +207,7 @@ describe("standalone Telegram DM policy gate", () => {
     expect(handleMessage).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps group chats open when nothing is configured", async () => {
+  it("keeps group chats open when nothing is configured and no admission gate is supplied (legacy direct calls)", async () => {
     const { runtime, handleMessage } = makeRuntime({
       settings: { TELEGRAM_DM_POLICY: undefined },
     });
@@ -221,6 +221,62 @@ describe("standalone Telegram DM policy gate", () => {
     await handleTelegramStandaloneMessage(runtime, update as never);
 
     expect(handleMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("admits an active member and denies a revoked member through the membership authority gate", async () => {
+    // The standalone service passes its authority-backed admission gate for
+    // group chats; this replaces the old lockstep assertion that an
+    // unconfigured group is admitted unconditionally.
+    const { TelegramMembershipMessageGate } = await import(
+      "../membership-gate"
+    );
+    const authorize = vi.fn(async () => ({ decision: "allowed" as const }));
+    const markScopeUnavailable = vi.fn(async () => undefined);
+    const gate = new TelegramMembershipMessageGate({
+      runtime: {
+        agentId: "agent-1",
+        reportError: vi.fn(),
+      } as never,
+      authority: {
+        authorize,
+        markScopeUnavailable,
+      } as never,
+      botTelegramUserId: "900001",
+    });
+
+    // Positive control: an active member is admitted.
+    const allowed = context(111) as {
+      chat: { type: string };
+      message: { chat: { type: string } };
+    };
+    allowed.chat.type = "supergroup";
+    allowed.message.chat.type = "supergroup";
+    const { runtime, handleMessage } = makeRuntime({
+      settings: { TELEGRAM_DM_POLICY: undefined },
+    });
+    await handleTelegramStandaloneMessage(runtime, allowed as never, {
+      admissionGate: gate,
+    });
+    expect(handleMessage).toHaveBeenCalledTimes(1);
+    expect(authorize).toHaveBeenCalledTimes(1);
+
+    // Negative control: a revoked member is denied before any
+    // ensureConnection / handleMessage work.
+    authorize.mockResolvedValue({
+      decision: "denied",
+      reason: "membership_revoked",
+    } as never);
+    const denied = context(112) as {
+      chat: { type: string };
+      message: { chat: { type: string } };
+    };
+    denied.chat.type = "supergroup";
+    denied.message.chat.type = "supergroup";
+    await handleTelegramStandaloneMessage(runtime, denied as never, {
+      admissionGate: gate,
+    });
+    expect(handleMessage).toHaveBeenCalledTimes(1);
+    expect(runtime.ensureConnection).toHaveBeenCalledTimes(1);
   });
 
   it("still honors the allowlist before the DM policy", async () => {

--- a/plugins/plugin-telegram/src/standalone/handler.test.ts
+++ b/plugins/plugin-telegram/src/standalone/handler.test.ts
@@ -279,6 +279,75 @@ describe("standalone Telegram DM policy gate", () => {
     expect(runtime.ensureConnection).toHaveBeenCalledTimes(1);
   });
 
+  it("reconciles an evidence-missing active member through the live getChatMember provider", async () => {
+    // RP R1 finding: without a live provider, an ordinary active member with
+    // missing/expired scope evidence could never be admitted in standalone
+    // mode (the fallback throws and reconcile stays denied) — only
+    // principals with already-current durable evidence could pass. The
+    // service now passes ctx.telegram.getChatMember; this pins the
+    // reconcile path being REACHABLE and successful through the provider.
+    const { TelegramMembershipMessageGate } = await import(
+      "../membership-gate"
+    );
+    const authorize = vi.fn(async () => ({
+      decision: "denied" as const,
+      reason: "no_scope_evidence",
+    }));
+    const reconcile = vi.fn(
+      async (input: { getChatMember: () => Promise<unknown> }) => {
+        // Invoke the provider the handler passed (proving the LIVE provider —
+        // not the throwing fallback — reached the reconcile input).
+        await input.getChatMember();
+        return { state: "active" as const };
+      },
+    );
+    // After a successful reconcile the gate RE-AUTHORIZES; the recheck must
+    // now allow (the reconcile recorded fresh evidence).
+    authorize.mockResolvedValueOnce({
+      decision: "denied" as const,
+      reason: "no_scope_evidence",
+    });
+    authorize.mockResolvedValue({
+      decision: "allowed" as const,
+    } as never);
+    const gate = new TelegramMembershipMessageGate({
+      runtime: {
+        agentId: "agent-1",
+        reportError: vi.fn(),
+      } as never,
+      authority: {
+        authorize,
+        reconcile,
+      } as never,
+      botTelegramUserId: "900001",
+    });
+
+    const getChatMember = vi.fn(async () => ({
+      status: "member",
+      user: { id: 42 },
+    }));
+    const ctx = context(111, 21) as {
+      chat: { type: string };
+      message: { chat: { type: string } };
+    };
+    ctx.chat.type = "supergroup";
+    ctx.message.chat.type = "supergroup";
+    const { runtime, handleMessage } = makeRuntime({
+      settings: { TELEGRAM_DM_POLICY: undefined },
+    });
+    await handleTelegramStandaloneMessage(runtime, ctx as never, {
+      admissionGate: gate,
+      getChatMember,
+    });
+
+    expect(authorize).toHaveBeenCalledTimes(2);
+    // Reconcile ran with the LIVE provider (not the throwing fallback).
+    expect(reconcile).toHaveBeenCalledTimes(1);
+    expect(getChatMember).toHaveBeenCalledTimes(1);
+    // Reconciled-active admission reaches the message service.
+    expect(handleMessage).toHaveBeenCalledTimes(1);
+  });
+
   it("still honors the allowlist before the DM policy", async () => {
     const { runtime, handleMessage, pairingService } = makeRuntime({
       settings: {

--- a/plugins/plugin-telegram/src/standalone/handler.ts
+++ b/plugins/plugin-telegram/src/standalone/handler.ts
@@ -17,6 +17,7 @@ import {
 } from "@elizaos/core";
 import { checkTelegramDmAccess, resolveTelegramDmPolicy } from "../dm-policy";
 import { resolveTelegramRuntimeEntityId } from "../identity";
+import type { TelegramMembershipMessageGate } from "../membership-gate";
 
 function formatError(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
@@ -135,6 +136,16 @@ function telegramStandaloneDedupeKey(
 export async function handleTelegramStandaloneMessage(
   runtime: IAgentRuntime,
   ctx: TelegramStandaloneContext,
+  options?: {
+    /**
+     * Membership admission gate for group/supergroup chats. When omitted
+     * (legacy callers/tests) group admission falls back to the previous
+     * allow-by-default behavior; the standalone service always passes its
+     * authority-backed gate so group senders cannot bypass the membership
+     * authority in standalone mode.
+     */
+    admissionGate?: TelegramMembershipMessageGate;
+  },
 ): Promise<void> {
   try {
     const message = ctx.message;
@@ -198,6 +209,46 @@ export async function handleTelegramStandaloneMessage(
     logger.info(
       `[telegram-standalone] Telegram message from @${username} chat=${chatId} length=${text.length}`,
     );
+
+    // Membership admission for group/supergroup chats: the standalone
+    // poller must not bypass the membership authority. Runs BEFORE
+    // ensureConnection below so a denied sender mutates no participant
+    // state (the authority's reconcile path bootstraps the principal
+    // entity itself when evidence needs the row).
+    if (
+      options?.admissionGate &&
+      (chat.type === "group" || chat.type === "supergroup")
+    ) {
+      const entityId = await resolveTelegramRuntimeEntityId(
+        runtime,
+        accountId,
+        telegramUserId,
+      );
+      const roomId = createUniqueUuid(
+        runtime,
+        `telegram-room:${telegramRoomId}`,
+      ) as UUID;
+      const worldId = createUniqueUuid(runtime, `telegram-world:${chatId}`);
+      const admitted = await options.admissionGate.authorizeMessage({
+        chatId,
+        chatRoomKey: chatId,
+        chatType: chat.type,
+        principalEntityId: entityId,
+        telegramUserId,
+        runtimeMapping: { worldId, roomId, entityId },
+        getChatMember: async () => {
+          // The standalone context carries no telegram client; the gate's
+          // reconcile path handles a throwing provider query by staying
+          // denied (fail closed), which is the correct standalone default.
+          throw new Error(
+            "standalone handler has no getChatMember provider access",
+          );
+        },
+      });
+      if (!admitted) {
+        return;
+      }
+    }
 
     if (!runtime.messageService) {
       throw new ElizaError("Telegram runtime message service is unavailable", {

--- a/plugins/plugin-telegram/src/standalone/handler.ts
+++ b/plugins/plugin-telegram/src/standalone/handler.ts
@@ -145,6 +145,19 @@ export async function handleTelegramStandaloneMessage(
      * authority in standalone mode.
      */
     admissionGate?: TelegramMembershipMessageGate;
+    /**
+     * Live Telegram membership-status provider for the gate's reconcile
+     * path: without it an ordinary active member with missing/expired
+     * scope evidence can never be reconciled (the fallback below throws
+     * and admission stays denied), making authority-backed standalone
+     * groups unusable. The standalone service passes the Telegraf
+     * context's getChatMember; tests may omit it to pin the fail-closed
+     * fallback.
+     */
+    getChatMember?: (
+      chatId: string | number,
+      userId: string | number,
+    ) => Promise<{ status: string; user: { id: number } }>;
   },
 ): Promise<void> {
   try {
@@ -237,12 +250,16 @@ export async function handleTelegramStandaloneMessage(
         telegramUserId,
         runtimeMapping: { worldId, roomId, entityId },
         getChatMember: async () => {
-          // The standalone context carries no telegram client; the gate's
-          // reconcile path handles a throwing provider query by staying
-          // denied (fail closed), which is the correct standalone default.
-          throw new Error(
-            "standalone handler has no getChatMember provider access",
-          );
+          if (!options?.getChatMember) {
+            // No live provider (tests / legacy callers): the gate's
+            // reconcile path handles a throwing provider query by staying
+            // denied (fail closed), which is the correct fallback when no
+            // Telegram client is reachable.
+            throw new Error(
+              "standalone handler has no getChatMember provider access",
+            );
+          }
+          return await options.getChatMember(chat.id, telegramUserId);
         },
       });
       if (!admitted) {

--- a/plugins/plugin-telegram/src/standalone/service.test.ts
+++ b/plugins/plugin-telegram/src/standalone/service.test.ts
@@ -134,7 +134,9 @@ describe("TelegramStandaloneService lifecycle", () => {
     expect(launchMock).toHaveBeenCalledOnce();
     expect(launchMock.mock.calls[0][0]).toMatchObject({
       dropPendingUpdates: false,
-      allowedUpdates: ["message", "message_reaction"],
+      // my_chat_member is delivered so kick/re-add transitions reach the
+      // membership authority — the standalone poller must not bypass it.
+      allowedUpdates: ["message", "message_reaction", "my_chat_member"],
     });
 
     await service.stop();

--- a/plugins/plugin-telegram/src/standalone/service.ts
+++ b/plugins/plugin-telegram/src/standalone/service.ts
@@ -1,6 +1,12 @@
 /** Owns the opt-in standalone Telegram poller and its process-wide token lock. */
 import { ElizaError, type IAgentRuntime, logger, Service } from "@elizaos/core";
 import { type Context, Telegraf } from "telegraf";
+import { telegramStatusToMembership } from "../membership";
+import {
+  createTelegramMembershipGate,
+  type TelegramMembershipGate,
+  TelegramMembershipMessageGate,
+} from "../membership-gate";
 import {
   claimTelegramPollerToken,
   getTelegramPollerClaim,
@@ -64,6 +70,18 @@ export class TelegramStandaloneService extends Service {
 
   private bot: Telegraf<Context> | null = null;
   private botToken: string | null = null;
+  /**
+   * Membership admission gate for the standalone poller — the same
+   * authority the full TelegramService uses, so standalone group admission
+   * and bot kick/re-add tombstoning cannot bypass the membership authority.
+   * Null while bootstrap is pending; the message gate instance fails closed
+   * (pending) until the gate settles absent/failed.
+   */
+  private readonly admissionGate = new TelegramMembershipMessageGate({
+    runtime: null as unknown as IAgentRuntime,
+    authority: null,
+    botTelegramUserId: null,
+  });
 
   static async start(
     runtime: IAgentRuntime,
@@ -81,6 +99,111 @@ export class TelegramStandaloneService extends Service {
     if (existing) {
       await (existing as TelegramStandaloneService).stop();
     }
+  }
+
+  /**
+   * Bootstraps the standalone membership gate BEFORE polling can deliver
+   * updates: resolve bot identity, seed the authority gate, and bind the
+   * admission gate. A FAILED bootstrap marks the gate broken (group
+   * admission fails closed); an absent authority settles to the legacy
+   * allow mode.
+   */
+  private async bootstrapMembershipGate(bot: Telegraf<Context>): Promise<void> {
+    this.admissionGate.markPending();
+    try {
+      const botInfo = await bot.telegram.getMe();
+      const gate = await createTelegramMembershipGate({
+        runtime: this.runtime,
+        botTelegramUserId: String(botInfo.id),
+      });
+      if (gate) {
+        this.membershipGate = gate;
+        this.admissionGate.rebind(gate.authority, gate.botTelegramUserId);
+      } else {
+        this.admissionGate.markAbsent();
+      }
+    } catch (error) {
+      // error-policy:J2 Bootstrap failure must not degrade to the absent-
+      // authority allow mode: mark broken so group admission fails closed.
+      this.admissionGate.markBroken();
+      this.runtime.reportError(
+        "telegram-standalone:membership-bootstrap",
+        error,
+        {
+          accountId: "default",
+        },
+      );
+    }
+  }
+
+  /**
+   * Applies the bot's own chat-member status transition from a
+   * `my_chat_member` update — same contract as the full TelegramService:
+   * kicked/left tombstones the scope (fail-closed admission for the whole
+   * chat); a revoked→present transition clears the tombstone.
+   */
+  private async handleMyChatMemberUpdate(
+    update:
+      | {
+          chat?: { id: number | string };
+          new_chat_member?: { status: string; user: { id: number } };
+          old_chat_member?: { status: string; user: { id: number } };
+        }
+      | undefined,
+  ): Promise<void> {
+    const gate = this.membershipGate;
+    if (!gate || !update?.chat || !update.new_chat_member) {
+      return;
+    }
+    try {
+      if (
+        update.new_chat_member.user.id.toString() !== gate.botTelegramUserId
+      ) {
+        return;
+      }
+      const chatId = update.chat.id.toString();
+      const membership = telegramStatusToMembership(update.new_chat_member);
+      const previous = telegramStatusToMembership(
+        update.old_chat_member ?? update.new_chat_member,
+      );
+      if (membership.state === "revoked") {
+        await gate.authority.markScopeUnavailable({
+          chatId,
+          chatRoomKey: chatId,
+          reason: "bot_removed",
+        });
+        return;
+      }
+      if (previous.state === "revoked") {
+        await gate.authority.clearScopeRemoval({
+          chatId,
+          chatRoomKey: chatId,
+        });
+      }
+    } catch (error) {
+      // error-policy:J2 The tombstone/clear could not be applied; the scope
+      // may still authorize on stale evidence. Mark the admission gate
+      // broken so every group admission fails closed.
+      this.admissionGate.markBroken();
+      this.membershipGate = null;
+      this.runtime.reportError(
+        "telegram-standalone:membership-scope-health",
+        error,
+        {
+          chatId: update?.chat?.id?.toString() ?? "unknown",
+          accountId: "default",
+          reason: "bot_removed",
+          source: "my_chat_member",
+        },
+      );
+    }
+  }
+
+  private membershipGate: TelegramMembershipGate | null = null;
+
+  /** The admission gate consulted for standalone group admission. */
+  private gate(): TelegramMembershipMessageGate {
+    return this.admissionGate;
   }
 
   private async launch(): Promise<void> {
@@ -108,7 +231,19 @@ export class TelegramStandaloneService extends Service {
 
       bot.on("message", async (ctx) => {
         markTelegramPollerUpdate(botToken, bot);
-        await handleTelegramStandaloneMessage(this.runtime, ctx);
+        await handleTelegramStandaloneMessage(this.runtime, ctx, {
+          admissionGate: this.gate(),
+        });
+      });
+
+      // The bot's own chat-member status transitions (kick/leave/re-add):
+      // while polling, my_chat_member is the ONLY signal that the bot was
+      // removed from a chat — without it the standalone poller could never
+      // tombstone a scope and stale evidence would keep authorizing members
+      // of a chat the bot can no longer observe.
+      bot.on("my_chat_member", async (ctx) => {
+        markTelegramPollerUpdate(botToken, bot);
+        await this.handleMyChatMemberUpdate(ctx.update.my_chat_member);
       });
 
       bot.catch((err: unknown) => {
@@ -122,12 +257,19 @@ export class TelegramStandaloneService extends Service {
         );
       });
 
+      // Membership gate must settle BEFORE polling can deliver updates:
+      // getMe + authority bootstrap happen here, ahead of bot.launch(). A
+      // kick/re-add delivered before the gate existed would otherwise be
+      // dropped (or admitted through the pending window) — this is the
+      // standalone mirror of the full service's startup-window contract.
+      await this.bootstrapMembershipGate(bot);
+
       // Fire-and-forget — bot.launch() only resolves on stop().
       bot
         .launch(
           {
             dropPendingUpdates: false,
-            allowedUpdates: ["message", "message_reaction"],
+            allowedUpdates: ["message", "message_reaction", "my_chat_member"],
           },
           () => {
             markTelegramPollerConnected(botToken, bot);

--- a/plugins/plugin-telegram/src/standalone/service.ts
+++ b/plugins/plugin-telegram/src/standalone/service.ts
@@ -75,13 +75,13 @@ export class TelegramStandaloneService extends Service {
    * authority the full TelegramService uses, so standalone group admission
    * and bot kick/re-add tombstoning cannot bypass the membership authority.
    * Null while bootstrap is pending; the message gate instance fails closed
-   * (pending) until the gate settles absent/failed.
+   * (pending) until the gate settles absent/failed. Constructed lazily in
+   * launch() with the REAL runtime: every warning/denial path in
+   * TelegramMembershipMessageGate dereferences runtime.agentId, so a
+   * null-runtime gate would throw instead of denying (and throw instead of
+   * the documented absent-authority allow mode).
    */
-  private readonly admissionGate = new TelegramMembershipMessageGate({
-    runtime: null as unknown as IAgentRuntime,
-    authority: null,
-    botTelegramUserId: null,
-  });
+  private admissionGate: TelegramMembershipMessageGate | null = null;
 
   static async start(
     runtime: IAgentRuntime,
@@ -109,7 +109,7 @@ export class TelegramStandaloneService extends Service {
    * allow mode.
    */
   private async bootstrapMembershipGate(bot: Telegraf<Context>): Promise<void> {
-    this.admissionGate.markPending();
+    this.gate().markPending();
     try {
       const botInfo = await bot.telegram.getMe();
       const gate = await createTelegramMembershipGate({
@@ -118,14 +118,14 @@ export class TelegramStandaloneService extends Service {
       });
       if (gate) {
         this.membershipGate = gate;
-        this.admissionGate.rebind(gate.authority, gate.botTelegramUserId);
+        this.gate().rebind(gate.authority, gate.botTelegramUserId);
       } else {
-        this.admissionGate.markAbsent();
+        this.gate().markAbsent();
       }
     } catch (error) {
       // error-policy:J2 Bootstrap failure must not degrade to the absent-
       // authority allow mode: mark broken so group admission fails closed.
-      this.admissionGate.markBroken();
+      this.gate().markBroken();
       this.runtime.reportError(
         "telegram-standalone:membership-bootstrap",
         error,
@@ -184,7 +184,7 @@ export class TelegramStandaloneService extends Service {
       // error-policy:J2 The tombstone/clear could not be applied; the scope
       // may still authorize on stale evidence. Mark the admission gate
       // broken so every group admission fails closed.
-      this.admissionGate.markBroken();
+      this.gate().markBroken();
       this.membershipGate = null;
       this.runtime.reportError(
         "telegram-standalone:membership-scope-health",
@@ -201,9 +201,14 @@ export class TelegramStandaloneService extends Service {
 
   private membershipGate: TelegramMembershipGate | null = null;
 
-  /** The admission gate consulted for standalone group admission. */
+  /**
+   * The admission gate consulted for standalone group admission. Never null
+   * once launch() begins (constructed with the real runtime there); the
+   * non-null assertion documents that bot.on("message") handlers only run
+   * after launch() has created it.
+   */
   private gate(): TelegramMembershipMessageGate {
-    return this.admissionGate;
+    return this.admissionGate as TelegramMembershipMessageGate;
   }
 
   private async launch(): Promise<void> {
@@ -222,6 +227,15 @@ export class TelegramStandaloneService extends Service {
       const bot = new Telegraf(botToken, { telegram: { apiRoot } });
       this.bot = bot;
       this.botToken = botToken;
+      // Construct the admission gate with the REAL runtime BEFORE any
+      // handler can consult it: the gate's warning/denial paths
+      // dereference runtime.agentId, so a null-runtime gate would throw
+      // instead of returning a decision.
+      this.admissionGate = new TelegramMembershipMessageGate({
+        runtime: this.runtime,
+        authority: null,
+        botTelegramUserId: null,
+      });
       claimTelegramPollerToken(botToken, {
         bot,
         mode: "standalone",
@@ -233,6 +247,12 @@ export class TelegramStandaloneService extends Service {
         markTelegramPollerUpdate(botToken, bot);
         await handleTelegramStandaloneMessage(this.runtime, ctx, {
           admissionGate: this.gate(),
+          // Live membership-status provider so the gate's reconcile path can
+          // admit an ordinary active member whose scope evidence is missing
+          // or expired — without it authority-backed standalone groups could
+          // only admit principals with already-current durable evidence.
+          getChatMember: async (chatId, userId) =>
+            await ctx.telegram.getChatMember(chatId, Number(userId)),
         });
       });
 


### PR DESCRIPTION
## Summary

Telegram membership-authority vertical slice for #23101: the Telegram connector's join (`new_chat_members`) / leave (`left_chat_member`) / kick event paths and inbound group-message admission are wired into the canonical `MembershipService` authority (landed in #25379/#25474/#25514), proving same-turn revocation and fail-closed admission when the authority is stale, unavailable, or its writes fail.

Refs #23101 (kept open — this is the first connector slice of the multi-connector security architecture).

## What this PR does

- **`plugins/plugin-telegram/src/membership.ts`** — `TelegramMembershipAuthority`: per-(agent, account) authority client. Typed idempotent evidence commands from Telegram updates (deterministic idempotency keys, point-query evidence mode, TTL validity), out-of-order protection (strict same-second tie-break against resurrection), publisher fencing with adopt-and-retry on cursor/generation mismatches, bot-removal tombstones + re-add watermarks, restart hydration of persisted scope state, and a durable pending-revocation overlay for revocations whose evidence write failed.
- **`plugins/plugin-telegram/src/membership-gate.ts`** — the admission gate bound into `MessageManager`: every group message is gated BEFORE `processMessage`; denied principals reconcile via `getChatMember` and are re-checked; authority unavailability fails closed (`TELEGRAM_MEMBERSHIP_ENFORCE=1` strict, default degrade-allow+warn for non-sql deployments).
- **`plugins/plugin-telegram/src/service.ts` / `messageManager.ts`** — event wiring for join/leave/kick/bot-removal, connector-removal suspension, and the gate-before-processing ordering.
- **`plugins/plugin-sql/src/services/sql-membership.ts`** — one-line subject-scope fix in the reconcile path.

## Security invariants (all execution-proven, see tests)

1. **Same-turn revocation**: read → leave evidence → read denies (`membership_revoked`).
2. **Out-of-order/duplicate redelivery cannot resurrect** a committed revocation (strict same-second tie-break; distinct-message-id old joins skipped).
3. **Failed revocation writes fail closed**: the scope degrades stale AND a per-principal overlay fence installs atomically inside the same per-scope serialized chain link — a queued authorize cannot overtake the fence. The fence is durable (runtime cache) and survives restart even after unrelated evidence restores scope health.
4. **Cache outages fail closed**: an unreadable durable overlay denies admission (never consults possibly-stale active evidence); an unwritable fence escalates to gate-broken (every group admission fails closed).
5. **Never rewrites the durable overlay from an unhydrated set** — an unrelated evidence commit during a cache outage cannot erase other principals' revocation fences.
6. **Bot removal tombstones** the scope: backlogged evidence after removal cannot restore authority; only an explicit re-add (with a watermark suppressing pre-re-add observations) can.
7. **Reconcile subject-mismatch** (provider response describing a different user than requested) is rejected.

## Testing

Real-runtime PGlite suite (`vitest.real-runtime.config.ts`, real `AgentRuntime` + real `SqlMembershipService`, fault-injected outages on the real instances): **14/14 pass**, including:
- join/leave admission, getChatMember backfill reconcile, kicked reconcile deny
- duplicate redelivery + older-join non-resurrection + same-second tie-break
- restart publisher-binding continuation, restart tombstone hydration
- fault-injected pending revocation: overlay deny across unrelated-evidence health restore, **restart durability** (RED on parent: re-authorized), **queued-authorize overtake race** (RED on parent: admitted), **cache-outage fail-closed + recovery**, **unhydrated-set fence erasure** (restart scenario, RED on parent: fence erased).
- Every new regression was RED-control-proven on the parent commit (fix stashed) before being claimed as coverage.

Unit suites: membership gate/membership/bootstrap tests all pass; full `plugins/plugin-telegram` `bun test` shows only two failures, both proven identical at `origin/develop` control (pre-existing, untouched files).

Typecheck (`tsc -p`) clean; `biome check` clean.

## Evidence

### backend-logs
Real PGlite suite run at exact head 2147ed4cbf48:
```
$ bunx vitest run --config vitest.real-runtime.config.ts --root plugins/plugin-telegram __tests__/membership-authority.real.test.ts
 Test Files  1 passed (1)
      Tests  14 passed (14)
   Duration  22.18s
$ bun run --cwd plugins/plugin-telegram typecheck
$ tsc --noEmit -p tsconfig.json   (clean)
$ bunx biome check <changed files> (clean)
```
RED controls (fix stashed, parent commit a321314cd9): "durable revocation fence" test FAILS (A re-authorized); restore fix → 14/14 pass. Earlier rounds: restart-durability and overtake tests FAIL on pre-fix parent; pass at head.

### unit-tests
See backend-logs above: 14/14 real-runtime PGlite tests + unit membership suites green; 2 remaining full-suite failures proven identical at origin/develop control (poller-lock, launch-supervision — untouched files).

### llm-trajectory
N/A - no model/provider behavior changed; this PR gates connector admission paths (no LLM call sites touched).

### screenshots / video
N/A - connector backend slice; no UI surfaces changed (packages/app untouched).

## Review

Dual-reviewer convergence: 7 RepoPrompt review rounds (Codex gpt-5.6-sol) over the full embedded diff — rounds 1-3 fixed 16 findings (ordering race, out-of-order resurrection, fail-open revocation writes, tombstone bypass, restricted/is_member, secondary-account bypass, strict tie-break, subject mismatch...), round 4 found 2 (restart durability, overtake race), round 5 found 1 (cache-error fail-open), round 6 found 1 (unhydrated-set erasure), round 7: **APPROVE — "No must-fix findings"**. Every finding was independently verified against the code before fixing, and every fix is regression-tested with a RED control.

<!-- evidence-head:f709386cbcf38b5dc24eb11c8b7cf42da24117c3 -->

<!-- evidence-row:after-screenshots -->
- [ ] N/A - connector backend slice, no UI surfaces changed (packages/app untouched)

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no UI surface changed; behavior proven by the 14-test real-runtime PGlite transcript in backend-logs

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code touched

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model/provider behavior changed; connector admission gating only

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no domain artifact surface (documents/media/etc) changed


### backend-logs (update: my_chat_member delivery fix at 29cb5e99e9)
Responding to the ss251 2026-08-28 review. RED control — with ONLY service.ts + launch-supervision.test.ts reverted to parent d4dea8bbed (new test file kept), the new suite fails 7/7; with the fix:
```
$ npx vitest run src/service.my-chat-member.test.ts src/service.launch-supervision.test.ts src/service.start-retry.test.ts
 Test Files  3 passed (3)      Tests  21 passed (21)
$ npx vitest run --config vitest.real-runtime.config.ts __tests__/membership-authority.real.test.ts
 Test Files  1 passed (1)      Tests  18 passed (18)   (real PGlite; incl. new delivery-path regression)
$ npx vitest run   (full plugin-telegram)
 Test Files  1 failed | 32 passed (33)   Tests  2 failed | 314 passed (316)
   # the 2 messageConnector failures are byte-identical at the pristine parent head (git stash control) — pre-existing, documented above
$ npx tsc --noEmit -p tsconfig.json    # error set IDENTICAL to pristine-parent control (5 pre-existing stale-core-dist errors in untouched membership.ts)
$ biome check <5 touched files>        # clean
```
Delivery-path regression (real PGlite): pre-removal member allowed → kick update via handleMyChatMemberUpdate → authorize denied → backlogged join redelivery stays denied → re-add update → still denied (fresh evidence required) → fresh evidence → allowed.


<!-- evidence-row:backend-logs -->
- [ ] N/A - test-only increments: real-runtime 33/33 and unit 331/331 at head 1335663199 (2 new fail-closed gate pins, both fail-open mutants flip them red); typecheck + biome clean

```
# Fresh run at current head af55c4a672 (2026-09-01, worktree, real install + core build, pinned bun):
RUN  v4.1.10 /Users/t3rpz/.cache/e-lane/repair-wt/plugins/plugin-telegram


 Test Files  1 passed (1)
      Tests  18 passed (18)
   Start at  05:56:33
   Duration  29.71s (transform 5.41s, setup 0ms, import 5.00s, tests 24.62s, environment 0ms)
```
<!-- evidence-row:before-screenshots -->
- [ ] N/A - connector backend slice, no UI surfaces changed (packages/app untouched)

AI provider/model: zai / glm-5.3 (manual) + GPT-5.6-sol (RepoPrompt CE review agent)
Client / agent tooling: Hermes Agent
Contribution skill revision: elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [hermes-t3rpz]
<!-- eliza-computer-attribution:v1 {"provider":"zai","model":"glm-5.3","client":"Hermes Agent","skill_revision":"elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza"} -->










## Real-runtime suite determinism (2026-08-29)

The `plugin-telegram test:real-runtime` suite promoted to the post-merge CI lane by `defc15e1` was run 10 consecutive times at head `defc15e162` in a properly built workspace (fresh `bun run build:core` exit 0, pinned bun 1.3.14). All 9 valid runs were byte-identical: exit 0, `Test Files 3 passed (3)`, `Tests 22 passed | 1 expected fail (23)`, same three files (`connector-loop.real.test.ts`, `membership-authority.real.test.ts`, `membership-poller-loop.real.test.ts`). The single non-green run (run 6) is disclosed in [the determinism comment](https://github.com/elizaOS/eliza/pull/28715#issuecomment-5462005113): the worktree directory was removed by an unrelated local cleanup mid-series (`Script not found`, zero tests collected) — infrastructure below the suite, not suite variance. Full table and raw log paths are in that comment.










