### PR TITLE
fix(core): cascade in-memory entity deletion

### DIFF
--- a/packages/core/src/database/inMemoryAdapter.test.ts
+++ b/packages/core/src/database/inMemoryAdapter.test.ts
@@ -3,7 +3,7 @@
  * for agents, caches, components, pending tasks, and room participants.
  */
 import { describe, expect, it } from "vitest";
-import type { Agent, Component, Task, UUID } from "../types";
+import type { Agent, Component, Entity, Room, Task, UUID } from "../types";
 import { InMemoryDatabaseAdapter } from "./inMemoryAdapter";
 
 const AGENT_ID = "00000000-0000-0000-0000-000000000001" as UUID;
@@ -177,6 +177,77 @@ describe("InMemoryDatabaseAdapter", () => {
 		await adapter.deleteComponents([MISSING_ID, COMPONENT_ID]);
 		await expect(adapter.getComponentsByIds([COMPONENT_ID])).resolves.toEqual(
 			[],
+		);
+	});
+
+	it("cascades entity deletion through components and room participation", async () => {
+		const adapter = new InMemoryDatabaseAdapter(AGENT_ID);
+		const entity = {
+			id: ENTITY_ID,
+			agentId: AGENT_ID,
+			names: ["Alice"],
+			metadata: {},
+		} satisfies Entity;
+		const otherEntity = {
+			id: OTHER_ENTITY_ID,
+			agentId: AGENT_ID,
+			names: ["Bob"],
+			metadata: {},
+		} satisfies Entity;
+		const room = {
+			id: ROOM_ID,
+			agentId: AGENT_ID,
+			worldId: WORLD_ID,
+			name: "contacts",
+			source: "test",
+			type: "GROUP",
+		} satisfies Room;
+		const ownedComponent = component({ sourceEntityId: ENTITY_ID });
+		const sourcedComponent = component({
+			id: "40000000-0000-0000-0000-000000000002" as UUID,
+			entityId: OTHER_ENTITY_ID,
+			sourceEntityId: ENTITY_ID,
+			type: "contact-profile",
+		});
+
+		await adapter.createEntities([entity, otherEntity]);
+		await adapter.createRooms([room]);
+		await adapter.createRoomParticipants([ENTITY_ID], ROOM_ID);
+		await adapter.updateParticipantUserStates([
+			{ roomId: ROOM_ID, entityId: ENTITY_ID, state: "MUTED" },
+		]);
+		await adapter.createComponents([ownedComponent, sourcedComponent]);
+
+		await adapter.deleteEntities([ENTITY_ID]);
+
+		await expect(adapter.getEntitiesByIds([ENTITY_ID])).resolves.toEqual([]);
+		await expect(
+			adapter.getComponentsForEntities([ENTITY_ID, OTHER_ENTITY_ID]),
+		).resolves.toEqual([]);
+		await expect(
+			adapter.getComponentsByIds([ownedComponent.id, sourcedComponent.id]),
+		).resolves.toEqual([]);
+		await expect(adapter.getRoomsForParticipants([ENTITY_ID])).resolves.toEqual(
+			[],
+		);
+		await expect(adapter.getParticipantsForRooms([ROOM_ID])).resolves.toEqual([
+			{ roomId: ROOM_ID, entityIds: [] },
+		]);
+		await expect(
+			adapter.getParticipantUserStates([
+				{ roomId: ROOM_ID, entityId: ENTITY_ID },
+			]),
+		).resolves.toEqual([null]);
+
+		await adapter.createEntities([{ ...entity, names: ["Alice recreated"] }]);
+		await adapter.createRoomParticipants([ENTITY_ID], ROOM_ID);
+		await expect(adapter.getEntitiesForRooms([ROOM_ID], true)).resolves.toEqual(
+			[
+				{
+					roomId: ROOM_ID,
+					entities: [{ ...entity, names: ["Alice recreated"] }],
+				},
+			],
 		);
 	});
 

--- a/packages/core/src/database/inMemoryAdapter.ts
+++ b/packages/core/src/database/inMemoryAdapter.ts
@@ -822,7 +822,31 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 
 	async deleteEntities(entityIds: UUID[]): Promise<void> {
 		for (const entityId of entityIds) {
-			this.entities.delete(String(entityId));
+			const entityKey = String(entityId);
+			for (const [componentId, component] of this.components.entries()) {
+				if (
+					String(component.entityId) === entityKey ||
+					String(component.sourceEntityId) === entityKey
+				) {
+					this.removeComponentIndexes(component);
+					this.components.delete(componentId);
+				}
+			}
+
+			const roomIds = this.roomsByParticipant.get(entityKey);
+			if (roomIds) {
+				for (const roomId of roomIds) {
+					const participants = this.participantsByRoom.get(roomId);
+					participants?.delete(entityKey);
+					if (participants?.size === 0) {
+						this.participantsByRoom.delete(roomId);
+					}
+					this.participantUserState.delete(`${roomId}:${entityKey}`);
+				}
+				this.roomsByParticipant.delete(entityKey);
+			}
+
+			this.entities.delete(entityKey);
 		}
 	}
 


### PR DESCRIPTION

`InMemoryDatabaseAdapter.deleteEntities` deleted only the entity row. Components linked through either entity foreign key and participant membership remained indexed, so deleting a contact reported success while its email/profile payload stayed readable and silently reattached when the deterministic entity id was created again.

This change makes the in-memory adapter honor the same cascade contract as SQL-backed adapters: entity deletion now removes matching component storage and indexes, both room-participant indexes, and participant user state before deleting the entity. A focused regression exercises the real adapter with an entity, room, participant state, owned component, source-linked component, deletion, and same-id recreation.

## Reproduction before the change

Command (run unchanged in the original checkout):

```text
cp /private/tmp/claude-501/-Users-thescoho-Developer-eliza-factory/9918b087-3e1d-4e51-a194-1ece5957e640/scratchpad/tmp-repro-deleteentity.test.ts /Volumes/thescoho_1TB/Developer/eliza/packages/core/src/database/tmp-repro-deleteentity.test.ts && cd /Volumes/thescoho_1TB/Developer/eliza && bunx vitest run packages/core/src/database/tmp-repro-deleteentity.test.ts --reporter=verbose --silent=false
```

Observed defect:

```text
entities: 0
componentsForEntities: [{"id":"00000000-0000-0000-0000-0000000000f1","entityId":"00000000-0000-0000-0000-0000000000d1","agentId":"00000000-0000-0000-0000-0000000000aa","roomId":"00000000-0000-0000-0000-0000000000b1","worldId":"00000000-0000-0000-0000-0000000000c1","sourceEntityId":"00000000-0000-0000-0000-0000000000d1","type":"profile","data":{"email":"alice@private.example"},"createdAt":1}]
componentsByIds: 1
roomsForParticipants: [ '00000000-0000-0000-0000-0000000000b1' ]
recreated entity components: [{"id":"00000000-0000-0000-0000-0000000000f1","entityId":"00000000-0000-0000-0000-0000000000d1","agentId":"00000000-0000-0000-0000-0000000000aa","roomId":"00000000-0000-0000-0000-0000000000b1","worldId":"00000000-0000-0000-0000-0000000000c1","sourceEntityId":"00000000-0000-0000-0000-0000000000d1","type":"profile","data":{"email":"alice@private.example"},"createdAt":1}]

Test Files  1 passed (1)
     Tests  1 passed (1)
```

The probe is observational, so its test status was green even while the printed state demonstrated the defect.

## Same production path after the change

The final diagnostic was made null-safe because the corrected participant cascade means the recreated entity is no longer in the old room. No production assertion or behavior was changed for this rerun.

```text
entities: 0
componentsForEntities: []
componentsByIds: 0
roomsForParticipants: []
recreated entity components: undefined

Test Files  1 passed (1)
     Tests  1 passed (1)
```

## Regression can fail

I reverted only `inMemoryAdapter.ts`, kept the new test, and ran:

```text
bunx vitest run /Volumes/thescoho_1TB/Developer/worktrees/eliza-delete-entities-cascade-20260825/packages/core/src/database/inMemoryAdapter.test.ts --reporter=verbose
```

It failed on the retained private components:

```text
FAIL  packages/core/src/database/inMemoryAdapter.test.ts > InMemoryDatabaseAdapter > cascades entity deletion through components and room participation
AssertionError: expected [ { …(9) }, { …(9) } ] to deeply equal []

Test Files  1 failed (1)
     Tests  1 failed | 6 passed (7)
```

After restoring the production change, the same command printed:

```text
Test Files  1 passed (1)
     Tests  7 passed (7)
```

## Package and hygiene verification

- Full owning-package suite, fixed tree: `33 failed | 857 passed | 2 skipped` files; `283 failed | 10502 passed | 209 skipped` tests.
- Same absolute-path suite on untouched `origin/develop` control: `33 failed | 857 passed | 2 skipped` files; `283 failed | 10501 passed | 209 skipped` tests. The branch adds exactly one passing test and zero failures.
- `bunx biome check --write packages/core/src/database/inMemoryAdapter.ts packages/core/src/database/inMemoryAdapter.test.ts` printed `Checked 2 files in 101ms. Fixed 1 file.`
- Direct `tsc --noEmit --pretty false -p <absolute packages/core/tsconfig.json>` exited 0 with no output in both the fixed and untouched control trees: zero new errors.
- `bun run verify` passed the repository preflight checks and the touched core lint (`Checked 1676 files ... No fixes applied.`), then stopped in unrelated native gateway lint because `/bin/bash: node-swiftlint: command not found` (exit 127).

## Risk

Low and limited to process-local in-memory deletion. The cascade intentionally matches declared component and participant foreign-key behavior. Rooms and unrelated entities/components remain intact.

## Evidence applicability

- UI screenshots, video, frontend logs, and OCR: N/A - no rendered UI files or behavior changed.
- Real-LLM trajectory: N/A - no model, prompt, provider, action-planning, or evaluator behavior changed.
- Backend logs: N/A - the affected path is a process-local adapter method; the verbatim adapter reproduction above is the direct runtime proof.
- Domain artifact: the before/after adapter output above is the deleted entity/component/participant state artifact.
- Audio/voice: N/A - no audio or voice path changed.
- Maintainer CI exception: N/A - no exception requested.


# Relates to

No issue is filed; this pull request is the standalone defect report.

- [x] Targets `develop` from current `origin/develop` with zero conflicts.
- [x] The exact unrelated `bun run verify` blocker is recorded above.
- [x] The before/after and revert proof let a reviewer verify behavior without reading the implementation.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - no rendered UI surface changed.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - no rendered UI surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no rendered or interactive UI surface changed.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - the direct process-local adapter reproduction above is the applicable runtime proof.
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: N/A - no frontend request, response, or state path changed.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent, prompt, model, provider, action-planning, or evaluator behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: the verbatim before/after entity, component, and participant state output is included above.
<!-- evidence-row:ocr-review -->
- [x] OCR review: N/A - no rendered visual surface changed.

## Documentation changes

N/A - the adapter now conforms to the existing schema cascade contract; no public API or operating instructions changed.

## Known gaps / failures

- No `bun install` was run because the supplied workflow explicitly required using the already-installed dependencies.
- `bun run verify` stopped at the unrelated missing `node-swiftlint` executable after the touched core lint passed.
- The full core suite has a pre-existing red baseline; the untouched control produced the same 283 failures and one fewer passing regression.
- No signed private trace is attached because this unattended session cannot finalize the interactive identity.slop.cash OAuth trace.

## Maintainer CI exception record

N/A - no exception requested.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: codex
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:0e268f616b84a6883c37a569e0ad428d5196f4fe -->

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-eliza
Attribution status: self-reported
— [codex-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-eliza"} -->
