### PR TITLE
test(local-inference): cover TTS voice id normalization and alias resolution

### DIFF
--- a/plugins/plugin-local-inference/src/services/voice/requested-voice.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/requested-voice.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Unit tests for `requested-voice`: validates normalization of voice parameter
+ * inputs across canonical `voice` and legacy `voiceId` properties, whitespace
+ * trimming, and Kokoro alias translation for historical Piper and OpenAI voice ids.
+ */
+import type { TextToSpeechParams } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import {
+	extractRequestedKokoroVoiceId,
+	extractRequestedVoiceId,
+} from "./requested-voice.ts";
+
+describe("requested-voice", () => {
+	describe("extractRequestedVoiceId", () => {
+		it("returns undefined for string inputs or non-object primitives", () => {
+			expect(extractRequestedVoiceId("hello world")).toBeUndefined();
+			expect(
+				extractRequestedVoiceId(null as unknown as TextToSpeechParams),
+			).toBeUndefined();
+			expect(
+				extractRequestedVoiceId(undefined as unknown as TextToSpeechParams),
+			).toBeUndefined();
+		});
+
+		it("extracts explicit voice parameter from object", () => {
+			expect(extractRequestedVoiceId({ text: "hi", voice: "af_bella" })).toBe(
+				"af_bella",
+			);
+		});
+
+		it("extracts legacy voiceId when voice is not specified", () => {
+			expect(
+				extractRequestedVoiceId({
+					text: "hi",
+					voiceId: "en_us-male-medium",
+				} as unknown as TextToSpeechParams),
+			).toBe("en_us-male-medium");
+		});
+
+		it("prioritizes canonical voice over legacy voiceId when both exist", () => {
+			expect(
+				extractRequestedVoiceId({
+					text: "hi",
+					voice: "af_nicole",
+					voiceId: "en_us-male-medium",
+				} as unknown as TextToSpeechParams),
+			).toBe("af_nicole");
+		});
+
+		it("trims whitespace from voice string and ignores empty whitespace-only values", () => {
+			expect(
+				extractRequestedVoiceId({ text: "hi", voice: "  af_sarah  " }),
+			).toBe("af_sarah");
+			expect(
+				extractRequestedVoiceId({ text: "hi", voice: "   \t\n  " }),
+			).toBeUndefined();
+			expect(
+				extractRequestedVoiceId({
+					text: "hi",
+					voiceId: "   ",
+				} as unknown as TextToSpeechParams),
+			).toBeUndefined();
+		});
+
+		it("ignores non-string voice or voiceId fields", () => {
+			expect(
+				extractRequestedVoiceId({
+					text: "hi",
+					voice: 12345,
+				} as unknown as TextToSpeechParams),
+			).toBeUndefined();
+			expect(
+				extractRequestedVoiceId({
+					text: "hi",
+					voiceId: { id: "voice" },
+				} as unknown as TextToSpeechParams),
+			).toBeUndefined();
+		});
+	});
+
+	describe("extractRequestedKokoroVoiceId", () => {
+		it("returns undefined when no voice is requested", () => {
+			expect(extractRequestedKokoroVoiceId("raw text")).toBeUndefined();
+			expect(extractRequestedKokoroVoiceId({ text: "hi" })).toBeUndefined();
+			expect(
+				extractRequestedKokoroVoiceId({ text: "hi", voice: "   " }),
+			).toBeUndefined();
+		});
+
+		it.each([
+			["en_us-female-medium", "af_nicole"],
+			["EN_US-FEMALE-MEDIUM", "af_nicole"],
+			["en_us-female", "af_bella"],
+			["En_Us-Female", "af_bella"],
+			["en_us-male-medium", "am_michael"],
+			["EN_US-MALE-MEDIUM", "am_michael"],
+			["nova", "af_nova"],
+			["NOVA", "af_nova"],
+			["Nova", "af_nova"],
+			["alloy", "af_alloy"],
+			["ALLOY", "af_alloy"],
+			["Alloy", "af_alloy"],
+		])("maps alias %s to canonical Kokoro voice %s", (alias, expected) => {
+			expect(extractRequestedKokoroVoiceId({ text: "hi", voice: alias })).toBe(
+				expected,
+			);
+			expect(
+				extractRequestedKokoroVoiceId({
+					text: "hi",
+					voiceId: alias,
+				} as unknown as TextToSpeechParams),
+			).toBe(expected);
+		});
+
+		it("preserves unaliased native Kokoro voice identifiers without modification", () => {
+			expect(
+				extractRequestedKokoroVoiceId({ text: "hi", voice: "af_sky" }),
+			).toBe("af_sky");
+			expect(
+				extractRequestedKokoroVoiceId({ text: "hi", voice: "am_adam" }),
+			).toBe("am_adam");
+			expect(
+				extractRequestedKokoroVoiceId({ text: "hi", voice: "bf_emma" }),
+			).toBe("bf_emma");
+			expect(
+				extractRequestedKokoroVoiceId({
+					text: "hi",
+					voiceId: "bm_george",
+				} as unknown as TextToSpeechParams),
+			).toBe("bm_george");
+		});
+	});
+});


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Test-only change adding unit test coverage for `extractRequestedVoiceId` and `extractRequestedKokoroVoiceId` in `@elizaos/plugin-local-inference`. No runtime logic or contracts are modified.

# Background

## What does this PR do?

Adds unit test coverage for text-to-speech voice parameter extraction and alias resolution:
- Tests canonical `voice` and fallback `voiceId` parameter reading from input parameter objects.
- Verifies priority resolution when both fields are provided.
- Tests whitespace trimming and rejection of whitespace-only / non-string / primitive string inputs.
- Validates translation of historical Piper and OpenAI voice aliases (`en_us-female-medium`, `en_us-female`, `en_us-male-medium`, `nova`, `alloy`) across case variants to bundled Kokoro voice names.
- Verifies pass-through preservation for unaliased native Kokoro voices.

## What kind of change is this?

- Improvements (misc. changes to existing features / unit test coverage)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Review `plugins/plugin-local-inference/src/services/voice/requested-voice.test.ts`.

## Detailed testing steps

Run:
```bash
npx vitest run plugins/plugin-local-inference/src/services/voice/requested-voice.test.ts
```

```
RED (mutating KOKORO_VOICE_ALIASES lookup to bypass alias translation):
  20 tests | 12 failed — alias resolution tests fail across all historical voice names

GREEN (restored):
  20 tests | 20 passed
```

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:84ab304bd64a2ee067e2d982ab3bdf2321bf4a34 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only change with no rendered UI surface
<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only change with no rendered UI surface
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - test-only change has no user flow to record
<!-- evidence-row:backend-logs -->
- [ ] N/A - pure unit test does not exercise a server path
<!-- evidence-row:frontend-logs -->
- [ ] N/A - pure unit test does not exercise a browser path
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent model or prompt path is touched
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database rows or generated files produced
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface in this change

# Evidence Details

## Real LLM-call trajectory

N/A - no agent model or prompt path is touched

## Backend + frontend logs

N/A - pure unit test does not exercise a server path

## Screenshots (before / after) + video walkthrough

N/A - test-only change with no rendered UI surface

### Before

N/A - test-only change with no rendered UI surface

### After

N/A - test-only change with no rendered UI surface

### Walkthrough video

N/A - test-only change has no user flow to record

## Audio / voice walkthrough

N/A - pure unit test of voice name string mapping

## Known gaps / failures

None.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: Claude Code
— [lane-byt61-3179]

