### PR TITLE
registry: add @openrelay999/eliza-plugin (x402-paid LLM inference)

### DIFF
--- a/packages/registry/entries/third-party/openrelay999__eliza-plugin.json
+++ b/packages/registry/entries/third-party/openrelay999__eliza-plugin.json
@@ -4,7 +4,7 @@
   "kind": "plugin",
   "description": "OpenAI-compatible LLM inference (DeepSeek V4 Flash, Kimi K2.6, MiniMax M2.7) paid per request in USDC via x402 on Solana + Base. Agent's wallet signs micropayment per call — no signup, no API keys, no subscriptions.",
   "homepage": "https://github.com/GitVova999/openrelay-eliza-plugin",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "tags": [
     "x402",
     "model-provider",

--- a/packages/registry/entries/third-party/openrelay999__eliza-plugin.json
+++ b/packages/registry/entries/third-party/openrelay999__eliza-plugin.json
@@ -4,7 +4,7 @@
   "kind": "plugin",
   "description": "OpenAI-compatible LLM inference (DeepSeek V4 Flash, Kimi K2.6, MiniMax M2.7) paid per request in USDC via x402 on Solana + Base. Agent's wallet signs micropayment per call — no signup, no API keys, no subscriptions.",
   "homepage": "https://github.com/GitVova999/openrelay-eliza-plugin",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "tags": [
     "x402",
     "model-provider",

--- a/packages/registry/entries/third-party/openrelay999__eliza-plugin.json
+++ b/packages/registry/entries/third-party/openrelay999__eliza-plugin.json
@@ -1,0 +1,23 @@
+{
+  "package": "@openrelay999/eliza-plugin",
+  "repository": "github:GitVova999/openrelay-eliza-plugin",
+  "kind": "plugin",
+  "description": "OpenAI-compatible LLM inference (DeepSeek V4 Flash, Kimi K2.6, MiniMax M2.7) paid per request in USDC via x402 on Solana + Base. Agent's wallet signs micropayment per call — no signup, no API keys, no subscriptions.",
+  "homepage": "https://github.com/GitVova999/openrelay-eliza-plugin",
+  "version": "0.1.0",
+  "tags": [
+    "x402",
+    "model-provider",
+    "openai-compatible",
+    "inference",
+    "llm",
+    "usdc",
+    "base",
+    "solana",
+    "payai",
+    "micropayments",
+    "deepseek",
+    "kimi",
+    "minimax"
+  ]
+}

--- a/packages/registry/entries/third-party/openrelay999__eliza-plugin.json
+++ b/packages/registry/entries/third-party/openrelay999__eliza-plugin.json
@@ -4,7 +4,7 @@
   "kind": "plugin",
   "description": "OpenAI-compatible LLM inference (DeepSeek V4 Flash, Kimi K2.6, MiniMax M2.7) paid per request in USDC via x402 on Solana + Base. Agent's wallet signs micropayment per call — no signup, no API keys, no subscriptions.",
   "homepage": "https://github.com/GitVova999/openrelay-eliza-plugin",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "tags": [
     "x402",
     "model-provider",

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -386,7 +386,7 @@
         "repo": "@openrelay999/eliza-plugin",
         "v0": null,
         "v1": null,
-        "v2": "0.1.3"
+        "v2": "0.1.4"
       },
       "supports": {
         "v0": false,

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -386,7 +386,7 @@
         "repo": "@openrelay999/eliza-plugin",
         "v0": null,
         "v1": null,
-        "v2": "0.1.2"
+        "v2": "0.1.3"
       },
       "supports": {
         "v0": false,

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -369,6 +369,59 @@
       "registryKind": "plugin",
       "directory": null
     },
+    "@openrelay999/eliza-plugin": {
+      "git": {
+        "repo": "GitVova999/openrelay-eliza-plugin",
+        "v0": {
+          "branch": null
+        },
+        "v1": {
+          "branch": null
+        },
+        "v2": {
+          "branch": "main"
+        }
+      },
+      "npm": {
+        "repo": "@openrelay999/eliza-plugin",
+        "v0": null,
+        "v1": null,
+        "v2": "0.1.2"
+      },
+      "supports": {
+        "v0": false,
+        "v1": false,
+        "v2": true
+      },
+      "description": "OpenAI-compatible LLM inference (DeepSeek V4 Flash, Kimi K2.6, MiniMax M2.7) paid per request in USDC via x402 on Solana + Base. Agent's wallet signs micropayment per call — no signup, no API keys, no subscriptions.",
+      "homepage": "https://github.com/GitVova999/openrelay-eliza-plugin",
+      "topics": [
+        "x402",
+        "model-provider",
+        "openai-compatible",
+        "inference",
+        "llm",
+        "usdc",
+        "base",
+        "solana",
+        "payai",
+        "micropayments",
+        "deepseek",
+        "kimi",
+        "minimax"
+      ],
+      "stargazers_count": 0,
+      "language": "TypeScript",
+      "origin": "third-party",
+      "source": "community",
+      "support": "community",
+      "builtIn": false,
+      "firstParty": false,
+      "thirdParty": true,
+      "kind": "plugin",
+      "registryKind": "plugin",
+      "directory": null
+    },
     "@ophis/plugin-elizaos": {
       "git": {
         "repo": "ophis-fi/ophis",


### PR DESCRIPTION
## What

Adds a third-party registry entry for [`@openrelay999/eliza-plugin`](https://www.npmjs.com/package/@openrelay999/eliza-plugin) — an OpenAI-compatible LLM inference model-provider that pays per request in USDC via [x402](https://x402.org).

## Why

x402 is the emerging Coinbase-championed standard for agent-native payments (HTTP 402 + on-chain USDC settlement). This plugin lets any ElizaOS agent get LLM inference **without an API key or human signup** — the agent's own wallet signs a stablecoin micropayment per call. Models: DeepSeek V4 Flash (400k ctx), Kimi K2.6, MiniMax M2.7.

Fits the same slot as `@elizaos/plugin-openai` — but the auth is a Base or Solana wallet, not a Bearer token.

## Entry

- **Package:** [`@openrelay999/eliza-plugin`](https://www.npmjs.com/package/@openrelay999/eliza-plugin) — v0.1.0, MIT
- **Source:** https://github.com/GitVova999/openrelay-eliza-plugin
- **Backend / discovery:** https://x402scan.com/server/2ed5dcb1-e941-411f-927f-bf221729a62e
- **Kind:** `plugin` (model-provider)

## Security & scope

- Trusted-host allow-list (default: the OpenRelay production URL only)
- Hard cap per request (`OPENRELAY_MAX_USD_PER_REQUEST`, default `$0.05`)
- `resource.url` mismatch check + amount/address regex validation
- No streaming yet — chat-completions only (SSE support planned in 0.2)

Happy to fix anything reviewers flag. Thanks for looking. 🙏