### PR TITLE
test(cloud): cover verifyCronSecret in cloud-shared cron auth

### DIFF
--- a/packages/cloud/shared/src/lib/auth/cron.test.ts
+++ b/packages/cloud/shared/src/lib/auth/cron.test.ts
@@ -1,6 +1,21 @@
-// Exercises cron behavior with deterministic cloud-shared lib fixtures.
-import { describe, expect, it } from "vitest";
-import { timingSafeEqualSecret } from "./cron";
+/**
+ * Exercises cron-secret auth behavior with a deterministic harness: explicit
+ * env objects (with the ambient CRON_SECRET cleared around every case) and
+ * plain Request objects — no network, no timers, no logger assertions. The
+ * suite is real-unit (bun test via the package test lane).
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { timingSafeEqualSecret, verifyCronSecret } from "./cron";
+
+function cronRequest(headers: Record<string, string>): Request {
+  return new Request("https://cloud.example.com/api/cron/job", { headers });
+}
+
+async function expectJson(response: Response | null, status: number, error: string) {
+  expect(response, "rejected requests must resolve to an error Response").not.toBeNull();
+  expect(response!.status).toBe(status);
+  await expect(response!.json()).resolves.toEqual({ error });
+}
 
 describe("timingSafeEqualSecret", () => {
   it("returns true only for an exact match", () => {
@@ -24,5 +39,147 @@ describe("timingSafeEqualSecret", () => {
     // "é" is two UTF-8 bytes; the buffers differ in length from the ascii form
     expect(timingSafeEqualSecret("café", "cafe")).toBe(false);
     expect(timingSafeEqualSecret("café", "café")).toBe(true);
+  });
+});
+
+describe("verifyCronSecret", () => {
+  const originalSecret = process.env.CRON_SECRET;
+  const SECRET = "unit-test-cron-secret";
+
+  beforeEach(() => {
+    // verifyCronSecret falls back to process.env when the explicit env value
+    // is undefined, so the ambient variable must be cleared for every case
+    // to keep the explicit-env tests hermetic
+    delete process.env.CRON_SECRET;
+  });
+
+  afterEach(() => {
+    if (originalSecret === undefined) {
+      delete process.env.CRON_SECRET;
+    } else {
+      process.env.CRON_SECRET = originalSecret;
+    }
+  });
+
+  it("returns null when the Bearer token matches", () => {
+    const request = cronRequest({ authorization: `Bearer ${SECRET}` });
+    expect(verifyCronSecret(request, "[Cron]", { CRON_SECRET: SECRET })).toBeNull();
+  });
+
+  it("matches the Bearer scheme case-insensitively", () => {
+    // the header parser accepts "bearer"/"BEARER" like production cron schedulers emit
+    const request = cronRequest({ authorization: `BEARER ${SECRET}` });
+    expect(verifyCronSecret(request, "[Cron]", { CRON_SECRET: SECRET })).toBeNull();
+  });
+
+  it("falls back to the x-cron-secret header when Authorization is absent", () => {
+    const request = cronRequest({ "x-cron-secret": SECRET });
+    expect(verifyCronSecret(request, "[Cron]", { CRON_SECRET: SECRET })).toBeNull();
+  });
+
+  it("prefers the Authorization header over x-cron-secret when both are present", () => {
+    // a stale legacy header must not override the bearer credential
+    const request = cronRequest({
+      authorization: `Bearer ${SECRET}`,
+      "x-cron-secret": "wrong-legacy-secret",
+    });
+    expect(verifyCronSecret(request, "[Cron]", { CRON_SECRET: SECRET })).toBeNull();
+  });
+
+  it("returns 503 (server misconfiguration) when CRON_SECRET is not set", async () => {
+    await expectJson(
+      verifyCronSecret(cronRequest({}), "[Cron]", { CRON_SECRET: undefined }),
+      503,
+      "Server configuration error: CRON_SECRET not set",
+    );
+  });
+
+  it("treats an empty-string CRON_SECRET as unconfigured (503, not 401)", async () => {
+    // an empty configured secret must never be satisfiable by an empty client value
+    await expectJson(
+      verifyCronSecret(cronRequest({}), "[Cron]", { CRON_SECRET: "" }),
+      503,
+      "Server configuration error: CRON_SECRET not set",
+    );
+  });
+
+  it("returns 401 for a wrong same-length Bearer secret", async () => {
+    const request = cronRequest({ authorization: `Bearer ${SECRET.slice(0, -1)}X` });
+    await expectJson(
+      verifyCronSecret(request, "[Cron]", { CRON_SECRET: SECRET }),
+      401,
+      "Unauthorized",
+    );
+  });
+
+  it("returns 401 when no credential header is present at all", async () => {
+    await expectJson(
+      verifyCronSecret(cronRequest({}), "[Cron]", { CRON_SECRET: SECRET }),
+      401,
+      "Unauthorized",
+    );
+  });
+
+  it("strips the Bearer scheme even when separated by a tab", () => {
+    // Request header normalization collapses "Bearer " to "Bearer" (no
+    // whitespace left for the regex), but a tab separator survives — so the
+    // tab form is the reachable input that exercises prefix stripping
+    const request = cronRequest({ authorization: `Bearer\t${SECRET}` });
+    expect(verifyCronSecret(request, "[Cron]", { CRON_SECRET: SECRET })).toBeNull();
+  });
+
+  it("returns 401 for a bare scheme-only Authorization header", async () => {
+    // Request normalizes "Bearer " (trailing space) to "Bearer"; the regex
+    // does not match the bare scheme, so the whole header value remains the
+    // comparison candidate and must not equal the configured secret
+    const request = cronRequest({ authorization: "Bearer" });
+    await expectJson(
+      verifyCronSecret(request, "[Cron]", { CRON_SECRET: SECRET }),
+      401,
+      "Unauthorized",
+    );
+  });
+
+  it("returns 401 when x-cron-secret is wrong even if it matches in length", async () => {
+    const request = cronRequest({ "x-cron-secret": `${SECRET.slice(0, -1)}Y` });
+    await expectJson(
+      verifyCronSecret(request, "[Cron]", { CRON_SECRET: SECRET }),
+      401,
+      "Unauthorized",
+    );
+  });
+
+  it("does not accept a secret that is a strict prefix of the configured one", async () => {
+    const request = cronRequest({ "x-cron-secret": SECRET.slice(0, 6) });
+    await expectJson(
+      verifyCronSecret(request, "[Cron]", { CRON_SECRET: SECRET }),
+      401,
+      "Unauthorized",
+    );
+  });
+
+  it("falls back to process.env.CRON_SECRET when no env object is passed", () => {
+    process.env.CRON_SECRET = SECRET;
+    try {
+      const request = cronRequest({ authorization: `Bearer ${SECRET}` });
+      expect(verifyCronSecret(request)).toBeNull();
+    } finally {
+      delete process.env.CRON_SECRET;
+    }
+  });
+
+  it("returns 503 via process.env when the variable is unset and no env object is passed", async () => {
+    await expectJson(
+      verifyCronSecret(cronRequest({})),
+      503,
+      "Server configuration error: CRON_SECRET not set",
+    );
+  });
+
+  it("accepts the secret in Authorization even without the Bearer scheme", () => {
+    // the parser strips only the Bearer prefix, so the raw header value stays
+    // the comparison candidate and must still equal the configured secret
+    const request = cronRequest({ authorization: SECRET });
+    expect(verifyCronSecret(request, "[Cron]", { CRON_SECRET: SECRET })).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Adds direct test coverage for `verifyCronSecret` in `packages/cloud/shared/src/lib/auth/cron.ts` — previously covered only indirectly through `cloud/api` cron route suites; the module's own test file exercised just `timingSafeEqualSecret` (4 tests). This PR extends that suite to 19 tests (+172 lines), module source unchanged.

Covered behaviors:

- **Success paths**: Bearer token match; case-insensitive Bearer scheme (`BEARER`); Bearer-with-tab separator (the reachable input that exercises prefix stripping — Request header normalization collapses `"Bearer "` to `"Bearer"`, but tab survives); `x-cron-secret` fallback when Authorization is absent; Authorization preferred over a stale `x-cron-secret`; raw Authorization value accepted without the Bearer prefix (the parser strips only the scheme).
- **503 misconfiguration** (with exact error body): `CRON_SECRET` unset via explicit env object, empty-string secret, and unset `process.env` fallback — an empty configured secret is treated as unconfigured, never satisfiable by an empty client value.
- **401 rejection**: wrong same-length Bearer secret, missing headers entirely, bare scheme-only `Bearer` header, prefix-only secret, wrong `x-cron-secret`.
- **`process.env` fallback**: the path production `cloud/api` cron routes rely on, including save/restore of the ambient variable.

## Determinism / hermeticity

Every case that passes an explicit env object runs with the ambient `process.env.CRON_SECRET` cleared via `beforeEach` (restored in `afterEach`), because the implementation falls back to `process.env` when the explicit value is undefined. Verified: the full suite passes 19/19 under a hostile ambient `CRON_SECRET=ambient-secret`.

## Verification

- `bun test src/lib/auth/cron.test.ts` — 19/19 pass, 39 expect() calls (package `test` lane runs these via `bun test`; vitest config is a separate fixed allowlist, same as the pre-existing tests in this file).
- `bunx @biomejs/biome check src/lib/auth/cron.test.ts` — clean.
- Mutation matrix at the tested behaviors — all caught: length-guard flip in `timingSafeEqualSecret` (12 failures), Bearer regex `i`-flag removal (1), stripping regex replaced with a never-match pattern (5, including the tab test), 503→500 (3), `x-cron-secret` fallback removal (1), 401 body swap (5).
- Neighbor `src/lib/auth/` suite failures (steward-token-cached etc.) and the package's 21 typecheck errors were proven pre-existing via stash controls on pristine `origin/develop` (identical sets with/without this change; the typecheck deltas trace to a missing optional `@cloudflare/playwright` dependency in the dev environment).

## Evidence

| Evidence item | Status |
| --- | --- |
| backend-logs | N/A - test-only change; no runtime paths touched; inline verification transcript above |
| frontend-logs | N/A - no UI change |
| llm-trajectory | N/A - no model/trajectory change |
| screenshots | N/A - no visual change |
| recording | N/A - no interactive change |

<!-- evidence-head:381968b7b20d70ed307bd579ac2241a5213a03db -->

<!-- evidence-row:backend-logs -->
- [ ] N/A - test-only change; no runtime paths touched; inline verification transcript in PR body

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no UI change

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model/trajectory change

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no visual change

<!-- evidence-row:after-screenshots -->
- [ ] N/A - no visual change

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive change

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no domain integration change

AI provider/model: zai / glm-5.3
Client / agent tooling: Hermes Agent
Contribution skill revision: elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [hermes-t3rpz]
<!-- eliza-computer-attribution:v1 {"provider":"zai","model":"glm-5.3","client":"Hermes Agent","skill_revision":"elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza"} -->

