### PR TITLE
fix(plugin-x): short-circuit non-positive profile fetch budgets

### DIFF
--- a/plugins/plugin-x/src/client/relationships.test.ts
+++ b/plugins/plugin-x/src/client/relationships.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  fetchProfileFollowers,
+  fetchProfileFollowing,
+  getFollowers,
+  getFollowing,
+} from "./relationships";
+
+const USER = (id: string, username: string) => ({
+  id,
+  username,
+  name: `Name ${username}`,
+  description: "desc",
+  profile_image_url: "https://example.com/normal.jpg",
+  public_metrics: {
+    followers_count: 10,
+    following_count: 5,
+    tweet_count: 3,
+    like_count: 2,
+    listed_count: 1,
+  },
+  verified: false,
+  verified_type: "none",
+  created_at: "2026-01-01T00:00:00.000Z",
+  protected: false,
+});
+
+function makeAuth(impl: Record<string, unknown>) {
+  const auth = {
+    getV2Client: vi.fn(async () => ({ v2: impl })),
+  };
+  return auth;
+}
+
+describe("fetchProfileFollowing maxProfiles boundary", () => {
+  it("returns an empty page without calling the API for maxProfiles 0", async () => {
+    const following = vi.fn();
+    const auth = makeAuth({ following });
+    const result = await fetchProfileFollowing("user-1", 0, auth);
+    expect(result).toEqual({ profiles: [], next: undefined });
+    expect(following).not.toHaveBeenCalled();
+  });
+
+  it("returns an empty page without calling the API for negative maxProfiles", async () => {
+    const following = vi.fn();
+    const auth = makeAuth({ following });
+    const result = await fetchProfileFollowing("user-1", -3, auth);
+    expect(result).toEqual({ profiles: [], next: undefined });
+    expect(following).not.toHaveBeenCalled();
+  });
+
+  it("passes a positive maxProfiles through to the API and parses profiles", async () => {
+    const following = vi.fn(async () => ({
+      data: [USER("u1", "alice"), USER("u2", "bob")],
+      meta: { next_token: "tok-9" },
+    }));
+    const auth = makeAuth({ following });
+    const result = await fetchProfileFollowing("user-1", 5, auth, "tok-8");
+    expect(following).toHaveBeenCalledWith(
+      "user-1",
+      expect.objectContaining({
+        max_results: 5,
+        pagination_token: "tok-8",
+      }),
+    );
+    expect(result.profiles.length).toBe(2);
+    expect(result.next).toBe("tok-9");
+    expect(result.profiles[0].username).toBe("alice");
+  });
+});
+
+describe("fetchProfileFollowers maxProfiles boundary", () => {
+  it("returns an empty page without calling the API for maxProfiles 0", async () => {
+    const followers = vi.fn();
+    const auth = makeAuth({ followers });
+    const result = await fetchProfileFollowers("user-1", 0, auth);
+    expect(result).toEqual({ profiles: [], next: undefined });
+    expect(followers).not.toHaveBeenCalled();
+  });
+
+  it("passes a positive maxProfiles through to the API", async () => {
+    const followers = vi.fn(async () => ({
+      data: [USER("u3", "carol")],
+      meta: {},
+    }));
+    const auth = makeAuth({ followers });
+    const result = await fetchProfileFollowers("user-1", 10, auth);
+    expect(followers).toHaveBeenCalledWith(
+      "user-1",
+      expect.objectContaining({ max_results: 10 }),
+    );
+    expect(result.profiles.length).toBe(1);
+  });
+});
+
+describe("getFollowing / getFollowers zero-request semantics", () => {
+  it("yields nothing and never calls the API when maxProfiles is 0", async () => {
+    const following = vi.fn();
+    const auth = makeAuth({ following });
+    const collected = [];
+    for await (const p of getFollowing("user-1", 0, auth)) {
+      collected.push(p);
+    }
+    expect(collected).toEqual([]);
+    expect(following).not.toHaveBeenCalled();
+  });
+
+  it("pages with the remaining budget until maxProfiles is reached", async () => {
+    const following = vi
+      .fn()
+      .mockResolvedValueOnce({
+        data: [USER("u1", "alice"), USER("u2", "bob")],
+        meta: { next_token: "tok-1" },
+      })
+      .mockResolvedValueOnce({
+        data: [USER("u3", "carol")],
+        meta: { next_token: "tok-2" },
+      })
+      .mockResolvedValueOnce({
+        data: [USER("u4", "dave")],
+        meta: {},
+      });
+    const auth = makeAuth({ following });
+    const collected = [];
+    for await (const p of getFollowing("user-1", 3, auth)) {
+      collected.push(p);
+    }
+    expect(collected.length).toBe(3);
+    expect(following).toHaveBeenCalledTimes(2);
+    // second page asks for the remaining budget
+    const secondCallOpts = following.mock.calls[1][1];
+    expect(secondCallOpts.max_results).toBe(1);
+    expect(secondCallOpts.pagination_token).toBe("tok-1");
+  });
+
+  it("yields nothing for maxProfiles 0 in getFollowers", async () => {
+    const followers = vi.fn();
+    const auth = makeAuth({ followers });
+    const collected = [];
+    for await (const p of getFollowers("user-1", 0, auth)) {
+      collected.push(p);
+    }
+    expect(collected).toEqual([]);
+    expect(followers).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/plugin-x/src/client/relationships.ts
+++ b/plugins/plugin-x/src/client/relationships.ts
@@ -182,6 +182,12 @@ export async function fetchProfileFollowing(
     throw new Error("Not authenticated");
   }
 
+  // The v2 following endpoint rejects max_results below 1 with HTTP 400;
+  // a non-positive budget is an empty result, not an API request.
+  if (maxProfiles <= 0) {
+    return { profiles: [], next: undefined };
+  }
+
   const client = await auth.getV2Client();
 
   try {
@@ -239,6 +245,12 @@ export async function fetchProfileFollowers(
 ): Promise<QueryProfilesResponse> {
   if (!auth) {
     throw new Error("Not authenticated");
+  }
+
+  // The v2 followers endpoint rejects max_results below 1 with HTTP 400;
+  // a non-positive budget is an empty result, not an API request.
+  if (maxProfiles <= 0) {
+    return { profiles: [], next: undefined };
   }
 
   const client = await auth.getV2Client();


### PR DESCRIPTION
# Relates to

<!-- No issue; boundary fix in the X client profile-fetch helpers. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Two additive early-return guards in `fetchProfileFollowing` /
`fetchProfileFollowers`: when the requested profile budget is non-positive the
helpers return an empty page instead of issuing an API request that the X API
v2 would reject (max_results below 1 → HTTP 400). Positive-budget behavior is
unchanged and pinned by the new tests.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: 16 passed (see log below) |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: source + test diffs in this PR |

Focused vitest run (isolated, at PR head):

```log
Test Files  2 passed (2)
     Tests  16 passed (16)
```

- Command: `npx vitest run plugins/plugin-x/src/client/relationships.test.ts plugins/plugin-x/src/client/search.test.ts`
- Result: all passed (8 relationship tests; the search suite shares the same
  stubbed auth harness)

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: N/A - no contribution skill used
