### PR TITLE
test(ui): cover view-event-bus

### DIFF
--- a/packages/ui/src/views/view-event-bus.test.ts
+++ b/packages/ui/src/views/view-event-bus.test.ts
@@ -1,10 +1,12 @@
 // @vitest-environment jsdom
 /**
- * view-event-bus unit tests: same-window delivery via the CustomEvent transport,
- * typed subscription filtering, unsubscribe semantics, and the cross-tab
- * BroadcastChannel transport (echo suppression, postMessage shape, and the
- * graceful-absence paths when BroadcastChannel is unavailable or throws).
- * Deterministic; jsdom environment, injected fake clock, no network.
+ * Unit tests for the cross-view pub-sub bus in the ui views layer: same-window
+ * delivery via the CustomEvent transport, typed subscription filtering,
+ * unsubscribe semantics, and the cross-tab BroadcastChannel transport
+ * (constructor name, postMessage shape, echo suppression, inbound delivery,
+ * unsubscribe identity, and the graceful-absence paths when BroadcastChannel
+ * or window are unavailable or construction throws).
+ * Deterministic; jsdom environment, frozen clock for shape assertions, no network.
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { emitViewEvent, onAnyViewEvent, onViewEvent } from "./view-event-bus";
@@ -12,57 +14,33 @@ import { emitViewEvent, onAnyViewEvent, onViewEvent } from "./view-event-bus";
 const CHANNEL_NAME = "elizaos-views";
 const WINDOW_EVENT_NAME = "elizaos-view-event";
 
-/** Captures every handler invocation across both transports for assertions. */
-function recorder() {
-  const calls: { channel: boolean; window: boolean; event: unknown }[] = [];
-  return {
-    calls,
-    onChannel(data: unknown) {
-      calls.push({ channel: true, window: false, event: data });
-    },
-    onWindow(event: Event) {
-      calls.push({
-        channel: false,
-        window: true,
-        event: (event as CustomEvent).detail,
-      });
-    },
-  };
-}
-
 describe("emitViewEvent / onAnyViewEvent (same-window transport)", () => {
   it("delivers the event object with type, payload, sourceViewId, and timestamp", () => {
-    const rec = recorder();
-    const unsub = onAnyViewEvent((event) =>
-      rec.onWindow({ detail: event } as CustomEvent),
-    );
-    const before = Date.now();
-    emitViewEvent("wallet:balance:updated", { balance: 42 }, "view-1");
-    expect(rec.calls).toHaveLength(1);
-    const event = rec.calls[0].event as {
+    const seen: {
       type: string;
       payload: Record<string, unknown>;
       sourceViewId?: string;
       timestamp: number;
-    };
-    expect(event.type).toBe("wallet:balance:updated");
-    expect(event.payload).toEqual({ balance: 42 });
-    expect(event.sourceViewId).toBe("view-1");
-    expect(event.timestamp).toBeGreaterThanOrEqual(before);
+    }[] = [];
+    const unsub = onAnyViewEvent((event) => seen.push(event));
+    const before = Date.now();
+    emitViewEvent("wallet:balance:updated", { balance: 42 }, "view-1");
+    expect(seen).toHaveLength(1);
+    expect(seen[0].type).toBe("wallet:balance:updated");
+    expect(seen[0].payload).toEqual({ balance: 42 });
+    expect(seen[0].sourceViewId).toBe("view-1");
+    expect(seen[0].timestamp).toBeGreaterThanOrEqual(before);
     unsub();
   });
 
   it("defaults the payload to an empty object and sourceViewId to undefined", () => {
-    const seen: unknown[] = [];
+    const seen: { payload: Record<string, unknown>; sourceViewId?: string }[] =
+      [];
     const unsub = onAnyViewEvent((event) => seen.push(event));
     emitViewEvent("ping");
     expect(seen).toHaveLength(1);
-    const event = seen[0] as {
-      payload: Record<string, unknown>;
-      sourceViewId?: string;
-    };
-    expect(event.payload).toEqual({});
-    expect(event.sourceViewId).toBeUndefined();
+    expect(seen[0].payload).toEqual({});
+    expect(seen[0].sourceViewId).toBeUndefined();
     unsub();
   });
 
@@ -157,6 +135,7 @@ describe("cross-tab BroadcastChannel transport", () => {
   const originalBC = globalThis.BroadcastChannel;
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.unstubAllGlobals();
     if (originalBC) {
       (
@@ -168,17 +147,22 @@ describe("cross-tab BroadcastChannel transport", () => {
     }
   });
 
-  it("posts the event to the elizaos-views channel and does not echo to the same tab", async () => {
-    const posts: { channel: string; data: unknown }[] = [];
+  it("posts the complete ViewEvent to a channel constructed with the exact name, without same-tab echo", async () => {
+    const posts: { constructorName: string; data: unknown }[] = [];
     class FakeChannel {
-      name = CHANNEL_NAME;
+      name: string;
+      constructor(name: string) {
+        this.name = name;
+      }
       postMessage(data: unknown) {
-        posts.push({ channel: this.name, data });
+        posts.push({ constructorName: this.name, data });
       }
       addEventListener() {}
       removeEventListener() {}
     }
     vi.stubGlobal("BroadcastChannel", FakeChannel);
+    vi.useFakeTimers();
+    vi.setSystemTime(1_724_612_345_678);
     // Re-import a fresh module copy so the lazy channel singleton rebinds to the fake.
     vi.resetModules();
     const bus = await import("./view-event-bus");
@@ -186,25 +170,39 @@ describe("cross-tab BroadcastChannel transport", () => {
     const unsub = bus.onAnyViewEvent((e) => seen.push(e.type));
     bus.emitViewEvent("cross:tab", { n: 1 }, "v");
     expect(posts).toHaveLength(1);
-    expect(posts[0].channel).toBe(CHANNEL_NAME);
-    expect(posts[0].data).toMatchObject({
+    expect(posts[0].constructorName).toBe(CHANNEL_NAME);
+    // Full ViewEvent shape on the cross-tab wire, with the frozen timestamp.
+    expect(posts[0].data).toEqual({
       type: "cross:tab",
       payload: { n: 1 },
+      sourceViewId: "v",
+      timestamp: 1_724_612_345_678,
     });
     // Same-window listener fired once (the module's own channel never echoes).
     expect(seen).toEqual(["cross:tab"]);
     unsub();
   });
 
-  it("delivers BroadcastChannel messages from other tabs to subscribers", async () => {
+  it("registers exactly one BroadcastChannel listener for the message event and delivers inbound events from other tabs", async () => {
     let channelListener: ((msg: { data: unknown }) => void) | undefined;
+    const added: {
+      type: string;
+      listener: (msg: { data: unknown }) => void;
+    }[] = [];
     class FakeChannel {
       name = CHANNEL_NAME;
-      addEventListener(_type: string, l: (msg: { data: unknown }) => void) {
-        channelListener = l;
+      addEventListener(
+        type: string,
+        listener: (msg: { data: unknown }) => void,
+      ) {
+        added.push({ type, listener });
+        channelListener = listener;
       }
-      removeEventListener() {
-        channelListener = undefined;
+      removeEventListener(
+        _type: string,
+        listener: (msg: { data: unknown }) => void,
+      ) {
+        if (channelListener === listener) channelListener = undefined;
       }
       postMessage() {}
     }
@@ -213,12 +211,50 @@ describe("cross-tab BroadcastChannel transport", () => {
     const bus = await import("./view-event-bus");
     const seen: unknown[] = [];
     const unsub = bus.onAnyViewEvent((e) => seen.push(e));
+    expect(added).toHaveLength(1);
+    expect(added[0].type).toBe("message");
     channelListener?.({
       data: { type: "other:tab", payload: { z: 1 }, timestamp: 5 },
     });
     expect(seen).toHaveLength(1);
     expect(seen[0]).toMatchObject({ type: "other:tab", payload: { z: 1 } });
     unsub();
+  });
+
+  it("removes the same BroadcastChannel listener identity on unsubscribe, so later cross-tab messages stop delivering", async () => {
+    let channelListener: ((msg: { data: unknown }) => void) | undefined;
+    const added: ((msg: { data: unknown }) => void)[] = [];
+    const removed: ((msg: { data: unknown }) => void)[] = [];
+    class FakeChannel {
+      name = CHANNEL_NAME;
+      addEventListener(
+        _type: string,
+        listener: (msg: { data: unknown }) => void,
+      ) {
+        added.push(listener);
+        channelListener = listener;
+      }
+      removeEventListener(
+        _type: string,
+        listener: (msg: { data: unknown }) => void,
+      ) {
+        removed.push(listener);
+        if (channelListener === listener) channelListener = undefined;
+      }
+      postMessage() {}
+    }
+    vi.stubGlobal("BroadcastChannel", FakeChannel);
+    vi.resetModules();
+    const bus = await import("./view-event-bus");
+    const seen: string[] = [];
+    const unsub = bus.onAnyViewEvent((e) => seen.push(e.type));
+    channelListener?.({ data: { type: "before:unsub", payload: {} } });
+    unsub();
+    // The exact listener identity registered is the identity removed.
+    expect(removed).toHaveLength(1);
+    expect(removed[0]).toBe(added[0]);
+    channelListener?.({ data: { type: "after:unsub", payload: {} } });
+    expect(seen).toEqual(["before:unsub"]);
   });
 
   it("falls back to same-window-only delivery when BroadcastChannel is undefined (SSR-like)", async () => {
@@ -232,23 +268,7 @@ describe("cross-tab BroadcastChannel transport", () => {
     unsub();
   });
 
-  it("falls back to same-window-only delivery when BroadcastChannel construction throws", async () => {
-    class ThrowingChannel {
-      constructor() {
-        throw new Error("restricted worker");
-      }
-    }
-    vi.stubGlobal("BroadcastChannel", ThrowingChannel);
-    vi.resetModules();
-    const bus = await import("./view-event-bus");
-    const seen: string[] = [];
-    const unsub = bus.onAnyViewEvent((e) => seen.push(e.type));
-    expect(() => bus.emitViewEvent("throw:bc")).not.toThrow();
-    expect(seen).toEqual(["throw:bc"]);
-    unsub();
-  });
-
-  it("keeps both transports after a throwing construction: postMessage never called", async () => {
+  it("falls back to same-window-only delivery when BroadcastChannel construction throws, never posting", async () => {
     const posts: unknown[] = [];
     class ThrowingChannel {
       constructor() {
@@ -265,9 +285,24 @@ describe("cross-tab BroadcastChannel transport", () => {
     const bus = await import("./view-event-bus");
     const seen: string[] = [];
     const unsub = bus.onAnyViewEvent((e) => seen.push(e.type));
-    expect(() => bus.emitViewEvent("throw2:bc")).not.toThrow();
+    expect(() => bus.emitViewEvent("throw:bc")).not.toThrow();
     expect(posts).toHaveLength(0);
-    expect(seen).toEqual(["throw2:bc"]);
+    expect(seen).toEqual(["throw:bc"]);
+    unsub();
+  });
+
+  it("skips the window transport entirely when window is undefined", async () => {
+    vi.stubGlobal("BroadcastChannel", undefined);
+    vi.stubGlobal("window", undefined);
+    vi.resetModules();
+    const bus = await import("./view-event-bus");
+    expect(() => bus.emitViewEvent("ssr:no-window", { x: 1 })).not.toThrow();
+    // Neither transport can exist; subscribing and emitting again must be a
+    // silent no-op, not a throw.
+    const unsub = bus.onAnyViewEvent(() => {
+      throw new Error("no transport can deliver here");
+    });
+    expect(() => bus.emitViewEvent("ssr:no-window-2")).not.toThrow();
     unsub();
   });
 });

--- a/packages/ui/src/views/view-event-bus.test.ts
+++ b/packages/ui/src/views/view-event-bus.test.ts
@@ -1,0 +1,273 @@
+// @vitest-environment jsdom
+/**
+ * view-event-bus unit tests: same-window delivery via the CustomEvent transport,
+ * typed subscription filtering, unsubscribe semantics, and the cross-tab
+ * BroadcastChannel transport (echo suppression, postMessage shape, and the
+ * graceful-absence paths when BroadcastChannel is unavailable or throws).
+ * Deterministic; jsdom environment, injected fake clock, no network.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { emitViewEvent, onAnyViewEvent, onViewEvent } from "./view-event-bus";
+
+const CHANNEL_NAME = "elizaos-views";
+const WINDOW_EVENT_NAME = "elizaos-view-event";
+
+/** Captures every handler invocation across both transports for assertions. */
+function recorder() {
+  const calls: { channel: boolean; window: boolean; event: unknown }[] = [];
+  return {
+    calls,
+    onChannel(data: unknown) {
+      calls.push({ channel: true, window: false, event: data });
+    },
+    onWindow(event: Event) {
+      calls.push({
+        channel: false,
+        window: true,
+        event: (event as CustomEvent).detail,
+      });
+    },
+  };
+}
+
+describe("emitViewEvent / onAnyViewEvent (same-window transport)", () => {
+  it("delivers the event object with type, payload, sourceViewId, and timestamp", () => {
+    const rec = recorder();
+    const unsub = onAnyViewEvent((event) =>
+      rec.onWindow({ detail: event } as CustomEvent),
+    );
+    const before = Date.now();
+    emitViewEvent("wallet:balance:updated", { balance: 42 }, "view-1");
+    expect(rec.calls).toHaveLength(1);
+    const event = rec.calls[0].event as {
+      type: string;
+      payload: Record<string, unknown>;
+      sourceViewId?: string;
+      timestamp: number;
+    };
+    expect(event.type).toBe("wallet:balance:updated");
+    expect(event.payload).toEqual({ balance: 42 });
+    expect(event.sourceViewId).toBe("view-1");
+    expect(event.timestamp).toBeGreaterThanOrEqual(before);
+    unsub();
+  });
+
+  it("defaults the payload to an empty object and sourceViewId to undefined", () => {
+    const seen: unknown[] = [];
+    const unsub = onAnyViewEvent((event) => seen.push(event));
+    emitViewEvent("ping");
+    expect(seen).toHaveLength(1);
+    const event = seen[0] as {
+      payload: Record<string, unknown>;
+      sourceViewId?: string;
+    };
+    expect(event.payload).toEqual({});
+    expect(event.sourceViewId).toBeUndefined();
+    unsub();
+  });
+
+  it("receives every event type on the any-channel, including unrelated types", () => {
+    const seen: string[] = [];
+    const unsub = onAnyViewEvent((event) => seen.push(event.type));
+    emitViewEvent("a:first");
+    emitViewEvent("b:second");
+    emitViewEvent("c:third");
+    expect(seen).toEqual(["a:first", "b:second", "c:third"]);
+    unsub();
+  });
+
+  it("delivers to multiple subscribers and preserves registration order", () => {
+    const order: string[] = [];
+    const unsubA = onAnyViewEvent(() => order.push("a"));
+    const unsubB = onAnyViewEvent(() => order.push("b"));
+    emitViewEvent("tick");
+    expect(order).toEqual(["a", "b"]);
+    unsubA();
+    unsubB();
+  });
+
+  it("stops delivery after the unsubscribe function runs", () => {
+    const seen: string[] = [];
+    const unsub = onAnyViewEvent((event) => seen.push(event.type));
+    emitViewEvent("before");
+    unsub();
+    emitViewEvent("after");
+    expect(seen).toEqual(["before"]);
+  });
+});
+
+describe("onViewEvent (typed subscription)", () => {
+  it("invokes the handler only for the subscribed type", () => {
+    const seen: string[] = [];
+    const unsub = onViewEvent("app:focus", (event) => seen.push(event.type));
+    emitViewEvent("app:blur");
+    emitViewEvent("app:focus");
+    emitViewEvent("app:focus:extra");
+    expect(seen).toEqual(["app:focus"]);
+    unsub();
+  });
+
+  it("still receives its type while an any-listener receives everything", () => {
+    const focused: string[] = [];
+    const everything: string[] = [];
+    const unsubFocus = onViewEvent("x", (e) => focused.push(e.type));
+    const unsubAny = onAnyViewEvent((e) => everything.push(e.type));
+    emitViewEvent("x");
+    emitViewEvent("y");
+    expect(focused).toEqual(["x"]);
+    expect(everything).toEqual(["x", "y"]);
+    unsubFocus();
+    unsubAny();
+  });
+
+  it("stops filtering after unsubscribe; other subscribers keep receiving", () => {
+    const focused: string[] = [];
+    const everything: string[] = [];
+    const unsubFocus = onViewEvent("x", (e) => focused.push(e.type));
+    const unsubAny = onAnyViewEvent((e) => everything.push(e.type));
+    emitViewEvent("x");
+    unsubFocus();
+    emitViewEvent("x");
+    expect(focused).toEqual(["x"]);
+    expect(everything).toEqual(["x", "x"]);
+    unsubAny();
+  });
+});
+
+describe("emitViewEvent window CustomEvent dispatch shape", () => {
+  it("dispatches a namespaced CustomEvent carrying the ViewEvent as detail", () => {
+    let captured: CustomEvent | undefined;
+    const listener = (e: Event) => {
+      captured = e as CustomEvent;
+    };
+    window.addEventListener(WINDOW_EVENT_NAME, listener);
+    emitViewEvent("shape:check", { k: "v" }, "src");
+    window.removeEventListener(WINDOW_EVENT_NAME, listener);
+    expect(captured).toBeDefined();
+    expect(captured?.type).toBe(WINDOW_EVENT_NAME);
+    expect(captured?.detail).toMatchObject({
+      type: "shape:check",
+      payload: { k: "v" },
+      sourceViewId: "src",
+    });
+  });
+});
+
+describe("cross-tab BroadcastChannel transport", () => {
+  const originalBC = globalThis.BroadcastChannel;
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    if (originalBC) {
+      (
+        globalThis as { BroadcastChannel?: typeof BroadcastChannel }
+      ).BroadcastChannel = originalBC;
+    } else {
+      delete (globalThis as { BroadcastChannel?: typeof BroadcastChannel })
+        .BroadcastChannel;
+    }
+  });
+
+  it("posts the event to the elizaos-views channel and does not echo to the same tab", async () => {
+    const posts: { channel: string; data: unknown }[] = [];
+    class FakeChannel {
+      name = CHANNEL_NAME;
+      postMessage(data: unknown) {
+        posts.push({ channel: this.name, data });
+      }
+      addEventListener() {}
+      removeEventListener() {}
+    }
+    vi.stubGlobal("BroadcastChannel", FakeChannel);
+    // Re-import a fresh module copy so the lazy channel singleton rebinds to the fake.
+    vi.resetModules();
+    const bus = await import("./view-event-bus");
+    const seen: string[] = [];
+    const unsub = bus.onAnyViewEvent((e) => seen.push(e.type));
+    bus.emitViewEvent("cross:tab", { n: 1 }, "v");
+    expect(posts).toHaveLength(1);
+    expect(posts[0].channel).toBe(CHANNEL_NAME);
+    expect(posts[0].data).toMatchObject({
+      type: "cross:tab",
+      payload: { n: 1 },
+    });
+    // Same-window listener fired once (the module's own channel never echoes).
+    expect(seen).toEqual(["cross:tab"]);
+    unsub();
+  });
+
+  it("delivers BroadcastChannel messages from other tabs to subscribers", async () => {
+    let channelListener: ((msg: { data: unknown }) => void) | undefined;
+    class FakeChannel {
+      name = CHANNEL_NAME;
+      addEventListener(_type: string, l: (msg: { data: unknown }) => void) {
+        channelListener = l;
+      }
+      removeEventListener() {
+        channelListener = undefined;
+      }
+      postMessage() {}
+    }
+    vi.stubGlobal("BroadcastChannel", FakeChannel);
+    vi.resetModules();
+    const bus = await import("./view-event-bus");
+    const seen: unknown[] = [];
+    const unsub = bus.onAnyViewEvent((e) => seen.push(e));
+    channelListener?.({
+      data: { type: "other:tab", payload: { z: 1 }, timestamp: 5 },
+    });
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toMatchObject({ type: "other:tab", payload: { z: 1 } });
+    unsub();
+  });
+
+  it("falls back to same-window-only delivery when BroadcastChannel is undefined (SSR-like)", async () => {
+    vi.stubGlobal("BroadcastChannel", undefined);
+    vi.resetModules();
+    const bus = await import("./view-event-bus");
+    const seen: string[] = [];
+    const unsub = bus.onAnyViewEvent((e) => seen.push(e.type));
+    expect(() => bus.emitViewEvent("no:bc", { ok: true })).not.toThrow();
+    expect(seen).toEqual(["no:bc"]);
+    unsub();
+  });
+
+  it("falls back to same-window-only delivery when BroadcastChannel construction throws", async () => {
+    class ThrowingChannel {
+      constructor() {
+        throw new Error("restricted worker");
+      }
+    }
+    vi.stubGlobal("BroadcastChannel", ThrowingChannel);
+    vi.resetModules();
+    const bus = await import("./view-event-bus");
+    const seen: string[] = [];
+    const unsub = bus.onAnyViewEvent((e) => seen.push(e.type));
+    expect(() => bus.emitViewEvent("throw:bc")).not.toThrow();
+    expect(seen).toEqual(["throw:bc"]);
+    unsub();
+  });
+
+  it("keeps both transports after a throwing construction: postMessage never called", async () => {
+    const posts: unknown[] = [];
+    class ThrowingChannel {
+      constructor() {
+        throw new Error("restricted worker");
+      }
+      addEventListener() {}
+      removeEventListener() {}
+      postMessage(d: unknown) {
+        posts.push(d);
+      }
+    }
+    vi.stubGlobal("BroadcastChannel", ThrowingChannel);
+    vi.resetModules();
+    const bus = await import("./view-event-bus");
+    const seen: string[] = [];
+    const unsub = bus.onAnyViewEvent((e) => seen.push(e.type));
+    expect(() => bus.emitViewEvent("throw2:bc")).not.toThrow();
+    expect(posts).toHaveLength(0);
+    expect(seen).toEqual(["throw2:bc"]);
+    unsub();
+  });
+});


### PR DESCRIPTION
## Summary

Adds direct unit tests for `packages/ui/src/views/view-event-bus.ts` — the cross-view pub-sub bus used by mounted views and agent-push updates — which previously had zero direct coverage:

- **Same-window transport** (`emitViewEvent` / `onAnyViewEvent`): delivered event shape (`type`, `payload`, `sourceViewId`, `timestamp`), payload/sourceViewId defaults, any-type delivery with order preservation across multiple subscribers, and unsubscribe stop semantics.
- **Typed subscription** (`onViewEvent`): handler invoked only for the subscribed type (exact match, not prefix), coexistence with any-listeners, and unsubscribe isolation.
- **CustomEvent dispatch contract**: the namespaced `elizaos-view-event` window event carrying the `ViewEvent` as `detail`.
- **Cross-tab BroadcastChannel transport**: constructor channel name, complete `ViewEvent` wire shape on `postMessage` (frozen clock, `sourceViewId` + `timestamp` included), no same-tab echo from the module's own channel, inbound delivery from other tabs via the `message` listener, listener-identity removal on unsubscribe with post-unsubscribe cross-tab silence.
- **Graceful degradation**: same-window-only fallback when `BroadcastChannel` is undefined (SSR-like) or its construction throws (restricted workers, no cross-tab posts), and full no-op emit when `window` is absent.

No production changes — test-only, 1 file (+371 lines net of the two commits).

## Testing

- [x] `npx vitest run --config ./vitest.config.ts src/views/view-event-bus.test.ts` — 15/15 passing (jsdom via per-file `@vitest-environment` docblock, per package convention)
- [x] `tsc --noEmit -p packages/ui/tsconfig.json` — clean
- [x] `npx biome check` on the new file — clean

## Evidence

| Evidence item | Location |
| --- | --- |
| backend-logs | N/A - test-only change; no runtime or model surface touched |
| screenshots | N/A - no UI rendering change |
| llm-trajectory | N/A - no model/agent behavior change |
| e2e capture | N/A - pure unit coverage of an event-bus module |

Reviewed by an independent RepoPrompt review agent (2 rounds; round-1 findings addressed: constructor-name capture, message-event listener assertions, unsubscribe identity, full wire-shape with frozen clock, window-less SSR path, header fix) — round 2 verdict: APPROVE.

<!-- evidence-head:9af2bcf22dba2653c5832067f472682d9cc34db3 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only change; no UI rendering change

<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only change; no UI rendering change

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - test-only change; no UI surface touched

<!-- evidence-row:backend-logs -->
- [ ] N/A - test-only change; no runtime surface touched (vitest 15/15, tsc, biome all green locally)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - test-only change; no UI surface touched

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model/agent behavior change

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - pure unit coverage of an event-bus module

AI provider/model: zai / glm-5.3 (implementation) + GPT-5.6-sol (RepoPrompt CE review agent)
Client / agent tooling: Hermes Agent
Skill revision: elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [hermes-t3rpz]
<!-- eliza-computer-attribution:v1 {"provider":"zai","model":"glm-5.3","client":"Hermes Agent","skill_revision":"elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza"} -->

