### PR TITLE
test(agent): cover message-corpus edge contracts and seeding lifecycle

### DIFF
--- a/packages/agent/src/api/message-corpus.test.ts
+++ b/packages/agent/src/api/message-corpus.test.ts
@@ -111,4 +111,86 @@ describe("message-corpus", () => {
         .every(({ memory }) => memory.entityId === ownerEntityId),
     ).toBe(true);
   });
+
+  it("handles empty corpus shape without timestamps", () => {
+    const fixedNow = 1700000000000;
+    const corpus = generateMessageCorpus({
+      conversationCount: 0,
+      messagesPerConversation: 0,
+      seed: 1,
+      now: fixedNow,
+    });
+    expect(corpus.conversations).toHaveLength(0);
+    expect(corpus.oldestMessageAt).toBeNull();
+    expect(corpus.newestMessageAt).toBeNull();
+    expect(corpus.sampleQueries).toHaveLength(0);
+  });
+
+  it("produces varying output across seeds and stable ordering", () => {
+    const fixedNow = 1700000000000;
+    const a = generateMessageCorpus({ conversationCount: 2, messagesPerConversation: 3, seed: 1, now: fixedNow });
+    const b = generateMessageCorpus({ conversationCount: 2, messagesPerConversation: 3, seed: 2, now: fixedNow });
+    expect(a).not.toEqual(b);
+    // messages within a conversation are strictly increasing in time
+    for (const conv of a.conversations) {
+      for (let i = 1; i < conv.messages.length; i++) {
+        expect(conv.messages[i].createdAt).toBeGreaterThan(conv.messages[i - 1].createdAt);
+      }
+      expect(conv.messages.filter((m) => m.role === "user")).toHaveLength(Math.ceil(conv.messages.length / 2));
+      expect(conv.title).toMatch(/\(.+ \d{4}\)$/);
+    }
+    // sampleQueries bounded by conversationCount and pack size
+    expect(a.sampleQueries.length).toBeLessThanOrEqual(a.conversations.length);
+  });
+
+  it("propagates scope and timestamps through seedSummary lifecycle", async () => {
+    const fixedNow = 1700000000000;
+    const corpus = generateMessageCorpus({
+      conversationCount: 1,
+      messagesPerConversation: 3,
+      factsPerConversation: 2,
+      seed: 77,
+      now: fixedNow,
+    });
+    const mockRuntime: MessageCorpusRuntime = {
+      agentId: "12345678-1234-1234-1234-123456789abc" as UUID,
+      character: {},
+      ensureConnection: vi.fn().mockResolvedValue(undefined),
+      createMemory: vi.fn().mockResolvedValue("id" as UUID),
+    };
+    const summary = await seedMessageCorpus(mockRuntime, corpus);
+    expect(summary.messagesCreated).toBe(3);
+    expect(summary.factsCreated).toBe(2);
+    expect(summary.oldestMessageAt).toBe(corpus.oldestMessageAt);
+    expect(summary.newestMessageAt).toBe(corpus.newestMessageAt);
+    expect(summary.sampleQueries).toEqual(corpus.sampleQueries);
+    expect(summary.conversations[0].lastMessageAt).toBe(corpus.conversations[0].messages.at(-1)?.createdAt ?? null);
+  });
+
+  it("defaults to synthetic owner when no explicit owner is supplied", async () => {
+    const corpus = generateMessageCorpus({ conversationCount: 1, messagesPerConversation: 1, seed: 5 });
+    const ensureCalls: Array<Record<string, unknown>> = [];
+    const mockRuntime: MessageCorpusRuntime = {
+      agentId: "12345678-1234-1234-1234-123456789abc" as UUID,
+      character: { name: "TestAgent" },
+      ensureConnection: vi.fn().mockImplementation(async (params) => { ensureCalls.push(params as Record<string, unknown>); }),
+      createMemory: vi.fn().mockResolvedValue("id" as UUID),
+    };
+    const summary = await seedMessageCorpus(mockRuntime, corpus);
+    expect(ensureCalls).toHaveLength(1);
+    expect(ensureCalls[0].roomName).toBe(corpus.conversations[0].title);
+    expect(summary.conversations).toHaveLength(1);
+  });
+
+  it("respects spanMonths zero as immediate window", () => {
+    const fixedNow = 1700000000000;
+    const corpus = generateMessageCorpus({ conversationCount: 1, messagesPerConversation: 2, spanMonths: 0, seed: 9, now: fixedNow });
+    expect(corpus.conversations).toHaveLength(1);
+    expect(corpus.oldestMessageAt).not.toBeNull();
+    expect(corpus.newestMessageAt).not.toBeNull();
+    for (const msg of corpus.conversations[0].messages) {
+      expect(msg.createdAt).toBeLessThanOrEqual(fixedNow);
+    }
+  });
+
 });


### PR DESCRIPTION
## Summary
Expands `packages/agent/src/api/message-corpus` coverage to exercise deterministic generation boundaries and the `seedMessageCorpus` lifecycle without duplicating existing success-path tests.

## Changes
- `packages/agent/src/api/message-corpus.test.ts`: +5 tests — empty corpus (0 conversations ⇒ null timestamps, 0 queries), seed variation and monotonic ordering/role alternation/title shape, propagated `oldest/newest/sampleQueries` and `lastMessageAt` through `seedMessageCorpus`, synthetic-owner defaulting (roomName binding), and `spanMonths:0` immediate-window handling.

## Verification
- `bun x vitest run --config packages/agent/vitest.config.ts src/api/message-corpus.test.ts` — **before**: 3 tests (existing), **after**: 8 passed / 8.
- Mutation check: forcing `oldestMessageAt: null` causes 2 failures (determinism and immediate-window), proving the new tests are coupled to source.
- Production callers: `packages/agent/src/api/conversation-routes.ts` (`generateMessageCorpus`/`seedMessageCorpus` via dev seed route) and scenario-runner seed step.
- Diff stat matches body: `message-corpus.test.ts` only.

## Claim
File `packages/agent/src/api/message-corpus.ts` CLEAR, symbols `generateMessageCorpus`/`seedMessageCorpus` CLEAR per `collision_map.py` at claim time.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:d0da5830bd1cb9fb6935e5e97a1104bb5df7da0a -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] N/A - test-only / core utility, no rendered UI surface
<!-- evidence-row:after-screenshots -->
- [x] N/A - test-only / core utility, no rendered UI surface
<!-- evidence-row:walkthrough-video -->
- [x] N/A - test-only / core utility, no user flow to record
<!-- evidence-row:backend-logs -->
- [x] N/A - pure unit test / core utility does not exercise a server path (or see Verification logs above)
<!-- evidence-row:frontend-logs -->
- [x] N/A - pure unit test / core utility does not exercise a browser path
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent model or prompt path is touched
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database rows or generated files produced

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
— [lane-byt61-5782]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@d0da5830bd1cb9fb6935e5e97a1104bb5df7da0a:packages/skills/skills/contribute-to-eliza"} -->
