### PR TITLE
fix(notifications): recipient-bound push delivery behind fail-closed per-principal policy (#23106)

### DIFF
--- a/packages/agent/src/api/push-token-routes.test.ts
+++ b/packages/agent/src/api/push-token-routes.test.ts
@@ -670,6 +670,90 @@ describe("handlePushTokenRoute", () => {
       );
     });
 
+    it("concurrent PUTs for one principal serialize to distinct monotonic versions (no lost opt-out)", async () => {
+      // Two PUTs in flight through the REAL route handler + real service and
+      // store, with the store's FIRST cache read blocked until both requests
+      // are queued — without per-principal serialization both would load the
+      // same absent row and both report version 1, silently losing one
+      // opt-out.
+      const cache = new Map<string, unknown>();
+      let resolveFirstRead: (() => void) | undefined;
+      const firstRead = new Promise<void>((resolve) => {
+        resolveFirstRead = resolve;
+      });
+      let reads = 0;
+      const baseRuntime = createMockRuntime({
+        agentId: "00000000-0000-0000-0000-0000000000aa",
+        getCache: async <T>(key: string): Promise<T | undefined> => {
+          reads += 1;
+          if (reads === 1) await firstRead;
+          return cache.get(key) as T | undefined;
+        },
+        setCache: async <T>(key: string, value: T): Promise<boolean> => {
+          cache.set(key, value);
+          return true;
+        },
+        getService: () => null,
+      });
+      const service = (await NotificationPushService.start(
+        baseRuntime,
+      )) as NotificationPushService;
+      const gatedState = {
+        runtime: {
+          getService: (t: string) =>
+            t === NotificationPushService.serviceType ? service : null,
+          getSetting: (key: string) =>
+            key === "ELIZA_ADMIN_ENTITY_ID" ? OWNER : ("" as string),
+        },
+      };
+
+      const put = (pushEnabled: boolean) => {
+        const helpers = makeHelpers();
+        helpers.readJsonBody.mockResolvedValue({ pushEnabled });
+        return handlePushTokenRoute(
+          req(POLICY_PATH),
+          res,
+          POLICY_PATH,
+          "PUT",
+          gatedState,
+          helpers,
+        ).then(() => {
+          const payload = helpers.json.mock.calls[0]?.[1] as {
+            policy: { pushEnabled: boolean; version: number };
+          };
+          return payload.policy;
+        });
+      };
+
+      const enable = put(true);
+      const disable = put(false);
+      resolveFirstRead?.();
+      const [enabledPolicy, disabledPolicy] = await Promise.all([
+        enable,
+        disable,
+      ]);
+      // The route routes PUT through PushPolicyStore.update: distinct
+      // monotonic versions (1 then 2) prove the two requests serialized and
+      // neither opt-out was lost to a same-version overwrite.
+      expect(enabledPolicy.version).toBe(1);
+      expect(disabledPolicy.version).toBe(2);
+
+      const get = makeHelpers();
+      await handlePushTokenRoute(
+        req(POLICY_PATH),
+        res,
+        POLICY_PATH,
+        "GET",
+        gatedState,
+        get,
+      );
+      const read = get.json.mock.calls[0][1] as {
+        policy: { pushEnabled: boolean; version: number };
+      };
+      expect(read.policy.pushEnabled).toBe(false);
+      expect(read.policy.version).toBe(2);
+    });
+
     it("fails closed with 409 when no canonical recipient is configured", async () => {
       const helpers = makeHelpers();
       const bare = { runtime: { ...runtime, getSetting: undefined } };

--- a/packages/agent/src/api/push-token-routes.test.ts
+++ b/packages/agent/src/api/push-token-routes.test.ts
@@ -415,4 +415,277 @@ describe("handlePushTokenRoute", () => {
     expect(helpers.json).toHaveBeenCalledWith(res, { ok: true });
     expect(await registry.count()).toBe(0);
   });
+
+  // ── #23106 recipient binding + policy seam ─────────────────────────
+
+  describe("#23106 recipient-bound registration", () => {
+    const OWNER = "22222222-2222-4222-8222-222222222222";
+
+    function makeStateWithOwner(): {
+      runtime: {
+        getService: (t: string) => unknown;
+        getSetting: (k: string) => string;
+      };
+    } {
+      return {
+        runtime: {
+          ...runtime,
+          getSetting: (key: string) =>
+            key === "ELIZA_ADMIN_ENTITY_ID" ? OWNER : ("" as string),
+        },
+      };
+    }
+
+    it("POST binds the token to the canonical owner when the body omits one", async () => {
+      const state = makeStateWithOwner();
+      const helpers = makeHelpers();
+      helpers.readJsonBody.mockResolvedValue({
+        platform: "ios",
+        token: "tok-owned",
+      });
+      await handlePushTokenRoute(
+        req(PREFIX),
+        res,
+        PREFIX,
+        "POST",
+        state,
+        helpers,
+      );
+      expect(helpers.json).toHaveBeenCalledWith(res, { ok: true }, 201);
+      expect((await registry.listByOwner(OWNER)).map((r) => r.token)).toEqual([
+        "tok-owned",
+      ]);
+    });
+
+    it("POST accepts an explicit ownerEntityId only when it IS the canonical owner", async () => {
+      const state = makeStateWithOwner();
+      const helpers = makeHelpers();
+      helpers.readJsonBody.mockResolvedValue({
+        platform: "ios",
+        token: "tok-explicit",
+        ownerEntityId: OWNER,
+      });
+      await handlePushTokenRoute(
+        req(PREFIX),
+        res,
+        PREFIX,
+        "POST",
+        state,
+        helpers,
+      );
+      expect((await registry.listByOwner(OWNER)).map((r) => r.token)).toEqual([
+        "tok-explicit",
+      ]);
+    });
+
+    it("POST rejects (400) an explicit ownerEntityId naming ANOTHER principal — body ids are not authorization", async () => {
+      const state = makeStateWithOwner();
+      const helpers = makeHelpers();
+      helpers.readJsonBody.mockResolvedValue({
+        platform: "ios",
+        token: "tok-hijack",
+        ownerEntityId: "99999999-9999-4999-8999-999999999999",
+      });
+      await handlePushTokenRoute(
+        req(PREFIX),
+        res,
+        PREFIX,
+        "POST",
+        state,
+        helpers,
+      );
+      expect(helpers.error).toHaveBeenCalledWith(
+        res,
+        expect.stringContaining("canonical owner"),
+        400,
+      );
+      expect(await registry.count()).toBe(0);
+    });
+
+    it("POST rejects (400) a null ownerEntityId — only omission means canonical default", async () => {
+      const state = makeStateWithOwner();
+      const helpers = makeHelpers();
+      helpers.readJsonBody.mockResolvedValue({
+        platform: "ios",
+        token: "tok-null-owner",
+        ownerEntityId: null,
+      });
+      await handlePushTokenRoute(
+        req(PREFIX),
+        res,
+        PREFIX,
+        "POST",
+        state,
+        helpers,
+      );
+      expect(helpers.error).toHaveBeenCalledWith(
+        res,
+        expect.stringContaining("canonical owner"),
+        400,
+      );
+      expect(await registry.count()).toBe(0);
+    });
+
+    it("POST rejects (400) a malformed ownerEntityId instead of silently defaulting", async () => {
+      const state = makeStateWithOwner();
+      const helpers = makeHelpers();
+      helpers.readJsonBody.mockResolvedValue({
+        platform: "ios",
+        token: "tok-bad-owner",
+        ownerEntityId: 42,
+      });
+      await handlePushTokenRoute(
+        req(PREFIX),
+        res,
+        PREFIX,
+        "POST",
+        state,
+        helpers,
+      );
+      expect(helpers.error).toHaveBeenCalledWith(
+        res,
+        expect.stringContaining("canonical owner"),
+        400,
+      );
+      expect(await registry.count()).toBe(0);
+    });
+
+    it("POST registers unowned (fail-closed) when no owner is resolvable anywhere", async () => {
+      const noOwnerState = { runtime: { ...runtime, getSetting: undefined } };
+      const helpers = makeHelpers();
+      helpers.readJsonBody.mockResolvedValue({
+        platform: "ios",
+        token: "tok-free",
+      });
+      await handlePushTokenRoute(
+        req(PREFIX),
+        res,
+        PREFIX,
+        "POST",
+        noOwnerState,
+        helpers,
+      );
+      expect(helpers.json).toHaveBeenCalledWith(res, { ok: true }, 201);
+      const all = await registry.list();
+      expect(all[0].ownerEntityId).toBeUndefined();
+    });
+  });
+
+  describe("#23106 push-policy routes", () => {
+    const POLICY_PATH = "/api/notifications/push-policy";
+    const OWNER = "22222222-2222-4222-8222-222222222222";
+
+    function ownerState(): {
+      runtime: {
+        getService: (t: string) => unknown;
+        getSetting: (k: string) => string;
+      };
+    } {
+      return {
+        runtime: {
+          ...runtime,
+          getSetting: (key: string) =>
+            key === "ELIZA_ADMIN_ENTITY_ID" ? OWNER : ("" as string),
+        },
+      };
+    }
+
+    it("GET returns null policy before any write (the fail-closed default)", async () => {
+      const helpers = makeHelpers();
+      await handlePushTokenRoute(
+        req(POLICY_PATH),
+        res,
+        POLICY_PATH,
+        "GET",
+        ownerState(),
+        helpers,
+      );
+      expect(helpers.json).toHaveBeenCalledWith(res, { policy: null });
+    });
+
+    it("PUT persists an allow policy, versions it, and GET round-trips", async () => {
+      const put = makeHelpers();
+      put.readJsonBody.mockResolvedValue({ pushEnabled: true });
+      await handlePushTokenRoute(
+        req(POLICY_PATH),
+        res,
+        POLICY_PATH,
+        "PUT",
+        ownerState(),
+        put,
+      );
+      expect(put.json).toHaveBeenCalled();
+      const saved = put.json.mock.calls[0][1] as {
+        policy: { pushEnabled: boolean; version: number };
+      };
+      expect(saved.policy.pushEnabled).toBe(true);
+      expect(saved.policy.version).toBe(1);
+
+      const second = makeHelpers();
+      second.readJsonBody.mockResolvedValue({ pushEnabled: false });
+      await handlePushTokenRoute(
+        req(POLICY_PATH),
+        res,
+        POLICY_PATH,
+        "PUT",
+        ownerState(),
+        second,
+      );
+      const bumped = second.json.mock.calls[0][1] as {
+        policy: { version: number };
+      };
+      expect(bumped.policy.version).toBe(2);
+
+      const get = makeHelpers();
+      await handlePushTokenRoute(
+        req(POLICY_PATH),
+        res,
+        POLICY_PATH,
+        "GET",
+        ownerState(),
+        get,
+      );
+      const read = get.json.mock.calls[0][1] as {
+        policy: { pushEnabled: boolean; version: number };
+      };
+      expect(read.policy.pushEnabled).toBe(false);
+      expect(read.policy.version).toBe(2);
+    });
+
+    it("PUT rejects a non-boolean pushEnabled with 400", async () => {
+      const helpers = makeHelpers();
+      helpers.readJsonBody.mockResolvedValue({ pushEnabled: "yes" });
+      await handlePushTokenRoute(
+        req(POLICY_PATH),
+        res,
+        POLICY_PATH,
+        "PUT",
+        ownerState(),
+        helpers,
+      );
+      expect(helpers.error).toHaveBeenCalledWith(
+        res,
+        expect.stringContaining("pushEnabled"),
+        400,
+      );
+    });
+
+    it("fails closed with 409 when no canonical recipient is configured", async () => {
+      const helpers = makeHelpers();
+      const bare = { runtime: { ...runtime, getSetting: undefined } };
+      await handlePushTokenRoute(
+        req(POLICY_PATH),
+        res,
+        POLICY_PATH,
+        "GET",
+        bare,
+        helpers,
+      );
+      expect(helpers.error).toHaveBeenCalledWith(
+        res,
+        expect.stringContaining("no canonical recipient"),
+        409,
+      );
+    });
+  });
 });

--- a/packages/agent/src/api/push-token-routes.ts
+++ b/packages/agent/src/api/push-token-routes.ts
@@ -1,17 +1,22 @@
 /**
- * Push-token routes.
+ * Push-token and push-policy routes.
  *
  * HTTP surface for a device to register/unregister its remote-push token so the
  * server can deliver notifications via APNs/FCM while the app is
- * backgrounded/killed. Tokens are owned by the `NotificationPushService`'s
- * `PushTokenRegistry`.
+ * backgrounded/killed, and for a principal to read/update the per-principal
+ * inbox-before-push policy (#23106). Tokens and policies are owned by the
+ * `NotificationPushService`'s `PushTokenRegistry` / `PushPolicyStore`.
  *
- * Routes (all under /api/notifications/push-tokens so they ride next to the
- * notification rail, but they are handled HERE, not by notification-routes):
+ * Routes (all under /api/notifications so they ride next to the notification
+ * rail, but they are handled HERE, not by notification-routes):
  *
  *   POST   /api/notifications/push-tokens
  *     Register (upsert) a device token. Body: { platform: "ios"|"android",
- *     token: string }. Returns `{ ok: true }`.
+ *     token: string, ownerEntityId?: string }. When `ownerEntityId` is absent
+ *     the server binds the token to the runtime's canonical owner when one is
+ *     configured; with no resolvable owner the token registers UNOWNED, and
+ *     unowned tokens never receive pushes (fail-closed recipient binding,
+ *     #23106). Returns `{ ok: true }`.
  *
  *   DELETE /api/notifications/push-tokens
  *     Unregister a device token from `{ token }`. The legacy token path remains
@@ -20,14 +25,30 @@
  *
  *   GET    /api/notifications/push-tokens
  *     Diagnostics: `{ count, platforms: { ios, android } }`.
+ *
+ *   GET    /api/notifications/push-policy
+ *     Read the calling canonical owner's push policy. Returns
+ *     `{ policy: { pushEnabled, version, updatedAt } | null }` — `null` means
+ *     no policy exists yet, which the delivery seam treats as inbox-only.
+ *
+ *   PUT    /api/notifications/push-policy
+ *     Upsert the calling canonical owner's push policy from
+ *     `{ pushEnabled: boolean }`. Bumps `version`, stamps `updatedAt`. Returns
+ *     the persisted policy.
  */
 
 import type http from "node:http";
 import type { RouteHelpers } from "@elizaos/core";
+import { logger, resolveCanonicalOwnerId } from "@elizaos/core";
 import {
   NOTIFICATION_PUSH_SERVICE_TYPE,
   NotificationPushService,
 } from "../services/push/notification-push-service.ts";
+import {
+  type PushDeliveryPolicy,
+  type PushPolicyStore,
+  parsePushDeliveryPolicy,
+} from "../services/push/push-policy.ts";
 import {
   isPushTokenValidationError,
   type PushPlatform,
@@ -35,14 +56,93 @@ import {
 } from "../services/push/push-token-registry.ts";
 
 export interface PushTokenRouteState {
-  runtime: { getService: (type: string) => unknown } | null;
+  runtime:
+    | ({ getService: (type: string) => unknown } & Partial<
+        Pick<Parameters<typeof resolveCanonicalOwnerId>[0], "getSetting">
+      >)
+    | null;
 }
 
 const PUSH_TOKENS_PREFIX = "/api/notifications/push-tokens";
+const PUSH_POLICY_PATH = "/api/notifications/push-policy";
 
 function getRegistry(state: PushTokenRouteState): PushTokenRegistry | null {
   const svc = state.runtime?.getService(NOTIFICATION_PUSH_SERVICE_TYPE);
   return svc instanceof NotificationPushService ? svc.getRegistry() : null;
+}
+
+function getPolicies(state: PushTokenRouteState): PushPolicyStore | null {
+  const svc = state.runtime?.getService(NOTIFICATION_PUSH_SERVICE_TYPE);
+  return svc instanceof NotificationPushService ? svc.getPolicies() : null;
+}
+
+/**
+ * Resolve the recipient a registration/policy write applies to: an explicit
+ * caller-supplied entity id, else the runtime's canonical owner, else null
+ * (the caller surfaces the distinct unresolvable state; nothing is guessed).
+ */
+/**
+ * Outcome of resolving the principal a registration applies to. `invalid`
+ * means the caller SUPPLIED an ownerEntityId that is malformed or does not
+ * match the server-established canonical owner — at an untrusted HTTP boundary
+ * a present-but-wrong field is a client error, not a silent default.
+ */
+export type PrincipalResolution =
+  | { resolved: true; principalId: string }
+  | { resolved: false; reason: "unresolvable" }
+  | { resolved: false; reason: "invalid" };
+
+/**
+ * Resolve the principal a registration applies to. An explicit ownerEntityId
+ * is accepted ONLY when it equals the runtime's canonical owner — this HTTP
+ * surface has no per-caller identity beyond the server auth boundary, so an
+ * authenticated caller must not bind a device to ANOTHER principal's push
+ * stream (#23106: a body-supplied id is not authorization). With no explicit
+ * id the canonical owner is used; with no resolvable canonical owner the token
+ * registers unowned (delivery fails closed; nothing is guessed).
+ */
+function resolveRegistrationPrincipal(
+  state: PushTokenRouteState,
+  explicit: unknown,
+): PrincipalResolution {
+  let explicitId: string | undefined;
+  if (explicit !== undefined) {
+    // Only a truly absent field means omission. A supplied null/number/blank
+    // is a present-but-malformed field: client error, never a silent default
+    // to the canonical owner.
+    if (typeof explicit !== "string" || explicit.trim().length === 0) {
+      return { resolved: false, reason: "invalid" };
+    }
+    explicitId = explicit.trim();
+  }
+  const canonical =
+    state.runtime && typeof state.runtime.getSetting === "function"
+      ? resolveCanonicalOwnerId(
+          state.runtime as Parameters<typeof resolveCanonicalOwnerId>[0],
+        )
+      : null;
+  if (explicitId !== undefined) {
+    if (canonical === null || explicitId !== canonical) {
+      // No server-established principal authorizes this explicit id.
+      return { resolved: false, reason: "invalid" };
+    }
+    return { resolved: true, principalId: explicitId };
+  }
+  if (canonical === null) return { resolved: false, reason: "unresolvable" };
+  return { resolved: true, principalId: canonical };
+}
+
+/**
+ * Resolve the canonical owner for the policy routes (no explicit id accepted —
+ * a principal reads and writes only their own push policy).
+ */
+function resolvePolicyPrincipal(state: PushTokenRouteState): string | null {
+  if (state.runtime && typeof state.runtime.getSetting === "function") {
+    return resolveCanonicalOwnerId(
+      state.runtime as Parameters<typeof resolveCanonicalOwnerId>[0],
+    );
+  }
+  return null;
 }
 
 function parsePlatform(value: unknown): PushPlatform | null {
@@ -57,6 +157,57 @@ export async function handlePushTokenRoute(
   state: PushTokenRouteState,
   helpers: RouteHelpers,
 ): Promise<boolean> {
+  // ── /api/notifications/push-policy (per-principal policy seam, #23106) ──
+  if (pathname === PUSH_POLICY_PATH && (method === "GET" || method === "PUT")) {
+    const policies = getPolicies(state);
+    if (!policies) {
+      helpers.error(res, "push delivery service not ready", 503);
+      return true;
+    }
+    const principalId = resolvePolicyPrincipal(state);
+    if (!principalId) {
+      // Fail-closed distinct state: no canonical owner configured — the policy
+      // seam cannot address a principal, so there is nothing to read/write.
+      helpers.error(res, "no canonical recipient configured", 409);
+      return true;
+    }
+    if (method === "GET") {
+      const policy = await policies.load(principalId);
+      helpers.json(res, { policy });
+      return true;
+    }
+    const body = await helpers.readJsonBody<Record<string, unknown>>(req, res, {
+      maxBytes: 8 * 1024,
+    });
+    if (body === null) return true;
+    if (typeof body.pushEnabled !== "boolean") {
+      helpers.error(res, "pushEnabled must be a boolean", 400);
+      return true;
+    }
+    const existing = await policies.load(principalId);
+    const next: PushDeliveryPolicy = {
+      pushEnabled: body.pushEnabled,
+      version: (existing?.version ?? 0) + 1,
+      updatedAt: Date.now(),
+    };
+    try {
+      await policies.save(principalId, next);
+    } catch (err) {
+      // error-policy:J1 boundary translation — the HTTP boundary converts a
+      // durable policy-write failure into a structured 503 (never a fabricated
+      // success); the error itself is logged for diagnostics before the
+      // translation.
+      logger.error(
+        { src: "api:push-policy", principalLength: principalId.length, err },
+        "[push-policy] durable policy write failed",
+      );
+      helpers.error(res, "failed to persist push policy", 503);
+      return true;
+    }
+    helpers.json(res, { policy: next });
+    return true;
+  }
+
   if (!pathname.startsWith(PUSH_TOKENS_PREFIX)) return false;
 
   const registry = getRegistry(state);
@@ -94,11 +245,28 @@ export async function handlePushTokenRoute(
       helpers.error(res, "token is required", 400);
       return true;
     }
+    // #23106 recipient binding: an explicit ownerEntityId is accepted only
+    // when it matches the canonical owner (a body-supplied id is not
+    // authorization); absent → canonical owner; unresolvable → unowned token
+    // (never pushed to). A present-but-malformed/mismatched id is a 400,
+    // never a silent default to another principal.
+    const principal = resolveRegistrationPrincipal(state, body.ownerEntityId);
+    if (!principal.resolved && principal.reason === "invalid") {
+      helpers.error(
+        res,
+        "ownerEntityId must be the canonical owner entity id",
+        400,
+      );
+      return true;
+    }
+    const ownerEntityId = principal.resolved
+      ? principal.principalId
+      : undefined;
     // The registry re-validates the token (byte cap included). A typed
     // validation failure is a client error (400); a durable-write failure
     // propagates and the server boundary maps it to 500.
     try {
-      await registry.register(platform, token);
+      await registry.register(platform, token, ownerEntityId);
     } catch (err) {
       // error-policy:J4 user-facing degrade — only the expected validation
       // shape becomes a 400; every other failure rethrows to the 500 boundary.
@@ -171,3 +339,6 @@ async function unregisterOrError(
   }
   return true;
 }
+
+// Re-exported for route consumers/tests that import the policy parser here.
+export { parsePushDeliveryPolicy };

--- a/packages/agent/src/api/push-token-routes.ts
+++ b/packages/agent/src/api/push-token-routes.ts
@@ -184,14 +184,13 @@ export async function handlePushTokenRoute(
       helpers.error(res, "pushEnabled must be a boolean", 400);
       return true;
     }
-    const existing = await policies.load(principalId);
-    const next: PushDeliveryPolicy = {
-      pushEnabled: body.pushEnabled,
-      version: (existing?.version ?? 0) + 1,
-      updatedAt: Date.now(),
-    };
+    // Serialized per-principal load→bump→save (PushPolicyStore.update): two
+    // concurrent PUTs for one principal cannot both observe version N and
+    // both write N+1 — each update persists a distinct monotonic version, so
+    // a concurrent opt-out is never silently overwritten.
+    let next: PushDeliveryPolicy;
     try {
-      await policies.save(principalId, next);
+      next = await policies.update(principalId, body.pushEnabled);
     } catch (err) {
       // error-policy:J1 boundary translation — the HTTP boundary converts a
       // durable policy-write failure into a structured 503 (never a fabricated

--- a/packages/agent/src/api/runtime-mode/remote-forwarder.ts
+++ b/packages/agent/src/api/runtime-mode/remote-forwarder.ts
@@ -30,6 +30,7 @@ const REMOTE_FORWARDED_MUTATION_PREFIXES = [
   "/api/cloud/v1/",
   "/api/notifications/push-tokens",
   "/api/notifications/push-tokens/",
+  "/api/notifications/push-policy",
 ] as const;
 
 const FORWARDED_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);

--- a/packages/agent/src/services/push/README.md
+++ b/packages/agent/src/services/push/README.md
@@ -23,6 +23,31 @@ that calls it lives in the UI: `push-registration.ts` acquires the token via
 registers, `PushTokenRegistry.list()` is empty and `NotificationPushService`
 does nothing — that is the correct "no device to reach" state, not a failure.
 
+## Recipient binding + inbox-before-push policy (#23106)
+
+Delivery is recipient-bound and policy-gated, both fail-closed:
+
+- `NotificationService.notify` stamps a canonical `recipientId` on every record
+  (explicit producer address, else the runtime's canonical owner via
+  `resolveCanonicalOwnerId`; unresolvable → absent, never fabricated).
+- A device token registered through `POST /api/notifications/push-tokens` binds
+  to an owner principal. An explicit `ownerEntityId` in the body is accepted
+  ONLY when it equals the server-established canonical owner (a body-supplied
+  id is not principal selection/authorization; any other value — including
+  another principal's id, `null`, or a non-string — is a 400). With the field
+  omitted the token binds to the canonical owner; with no canonical owner
+  configured it registers unowned. Legacy tokens persisted without an owner
+  are still listed / unregistrable but NEVER pushed to until re-registered
+  with a principal.
+- Before any push leaves the process, `push-policy.ts` decides per principal:
+  no recipient → inbox-only; no policy → inbox-only (push is opt-in);
+  `pushEnabled: false` → inbox-only. Only an explicit `pushEnabled: true`
+  policy (`PUT /api/notifications/push-policy`) permits delivery, and only to
+  that same principal's tokens.
+- Digests are owned by the ONE clock (core `TaskService`) and the
+  `plugin-scheduling` scheduled-item state machine; this seam expresses no
+  scheduling and creates no competing scheduler.
+
 `NotificationPushService` only activates a transport when its credentials are
 present (`isConfigured()`); with neither configured it starts, keeps the
 registry + routes live, logs once at debug, and no-ops per notification.

--- a/packages/agent/src/services/push/notification-push-service.test.ts
+++ b/packages/agent/src/services/push/notification-push-service.test.ts
@@ -2,9 +2,11 @@
  * Covers the notification push service: it subscribes to the agent event bus,
  * routes notification-stream events to per-platform providers (ios→apns,
  * android→fcm) only when configured, carries notification id/deepLink/category
- * in the push data, prunes dead tokens on an unregistered error, and
- * subscribes/unsubscribes cleanly. Harness is in-memory — a fake network-free
- * provider, an in-memory event bus, and a Map-backed cache — no real push send.
+ * in the push data, prunes dead tokens on an unregistered error, and — since
+ * #23106 — delivers recipient-bound behind the fail-closed inbox-before-push
+ * policy seam (no recipient / no policy / denied policy / unowned token all
+ * mean inbox-only). Harness is in-memory — a fake network-free provider, an
+ * in-memory event bus, a Map-backed cache — no real push send.
  */
 import type {
   AgentEventListener,
@@ -15,12 +17,16 @@ import type {
 import { logger, NOTIFICATION_STREAM, ServiceType } from "@elizaos/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NotificationPushService } from "./notification-push-service.ts";
+import { PushPolicyStore } from "./push-policy.ts";
 import { PushTokenRegistry } from "./push-token-registry.ts";
 import {
   type PushMessage,
   type PushProvider,
   PushUnregisteredError,
 } from "./push-types.ts";
+
+const OWNER = "owner-a";
+const OTHER_OWNER = "owner-b";
 
 /**
  * A fake provider with NO network — it records the (token, message) pairs it is
@@ -51,6 +57,7 @@ interface Harness {
   emit: (notification: AgentNotification) => void;
   emitRaw: (event: AgentEventPayload) => void;
   registry: PushTokenRegistry;
+  policies: PushPolicyStore;
   listenerCount: () => number;
 }
 
@@ -93,6 +100,7 @@ function makeHarness(): Harness {
     emit,
     emitRaw,
     registry: new PushTokenRegistry(runtime),
+    policies: new PushPolicyStore(runtime),
     listenerCount: () => listeners.size,
   };
 }
@@ -110,8 +118,18 @@ function notification(
     deepLink: "/tasks",
     createdAt: Date.now(),
     readAt: null,
+    recipientId: OWNER,
     ...overrides,
   };
+}
+
+/** Allow push for a principal in the harness policy store. */
+async function allowPush(h: Harness, owner: string): Promise<void> {
+  await h.policies.save(owner, {
+    pushEnabled: true,
+    version: 1,
+    updatedAt: Date.now(),
+  });
 }
 
 /** Wait a microtask turn so the service's async onNotification settles. */
@@ -119,14 +137,16 @@ const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
 
 describe("NotificationPushService", () => {
   let h: Harness;
+  let ios: FakeProvider;
+  let android: FakeProvider;
 
   beforeEach(() => {
     h = makeHarness();
+    ios = new FakeProvider("apns", true);
+    android = new FakeProvider("fcm", true);
   });
 
   it("subscribes to the bus on start", async () => {
-    const ios = new FakeProvider("apns", false);
-    const android = new FakeProvider("fcm", false);
     const service = new NotificationPushService(h.runtime, {
       registry: h.registry,
       providers: { ios, android },
@@ -136,32 +156,33 @@ describe("NotificationPushService", () => {
   });
 
   it("no-ops cleanly when no provider is configured", async () => {
-    const ios = new FakeProvider("apns", false);
-    const android = new FakeProvider("fcm", false);
+    const unconfiguredIos = new FakeProvider("apns", false);
+    const unconfiguredAndroid = new FakeProvider("fcm", false);
     const service = new NotificationPushService(h.runtime, {
       registry: h.registry,
-      providers: { ios, android },
+      providers: { ios: unconfiguredIos, android: unconfiguredAndroid },
     });
     await service.attach();
-    await h.registry.register("ios", "tok-ios");
+    await h.registry.register("ios", "tok-ios", OWNER);
+    await allowPush(h, OWNER);
 
     // Must not throw and must not attempt a send.
     h.emit(notification());
     await flush();
-    expect(ios.sent).toHaveLength(0);
-    expect(android.sent).toHaveLength(0);
+    expect(unconfiguredIos.sent).toHaveLength(0);
+    expect(unconfiguredAndroid.sent).toHaveLength(0);
   });
 
   it("dispatches ios→apns and android→fcm only for configured providers", async () => {
-    const ios = new FakeProvider("apns", true);
-    const android = new FakeProvider("fcm", false); // not configured
+    const androidUnconfigured = new FakeProvider("fcm", false);
     const service = new NotificationPushService(h.runtime, {
       registry: h.registry,
-      providers: { ios, android },
+      providers: { ios, android: androidUnconfigured },
     });
     await service.attach();
-    await h.registry.register("ios", "tok-ios");
-    await h.registry.register("android", "tok-android");
+    await h.registry.register("ios", "tok-ios", OWNER);
+    await h.registry.register("android", "tok-android", OWNER);
+    await allowPush(h, OWNER);
 
     h.emit(notification());
     await flush();
@@ -169,18 +190,17 @@ describe("NotificationPushService", () => {
     expect(ios.sent).toHaveLength(1);
     expect(ios.sent[0].token).toBe("tok-ios");
     // android provider is unconfigured → its token is skipped.
-    expect(android.sent).toHaveLength(0);
+    expect(androidUnconfigured.sent).toHaveLength(0);
   });
 
   it("carries the notification id + deepLink in the push custom data", async () => {
-    const ios = new FakeProvider("apns", true);
-    const android = new FakeProvider("fcm", true);
     const service = new NotificationPushService(h.runtime, {
       registry: h.registry,
       providers: { ios, android },
     });
     await service.attach();
-    await h.registry.register("ios", "tok-ios");
+    await h.registry.register("ios", "tok-ios", OWNER);
+    await allowPush(h, OWNER);
 
     h.emit(notification({ id: "abc-123", deepLink: "/calendar" }));
     await flush();
@@ -194,33 +214,32 @@ describe("NotificationPushService", () => {
   });
 
   it("drops a token from the registry on an unregistered error", async () => {
-    const ios = new FakeProvider("apns", true, new Set(["dead-token"]));
-    const android = new FakeProvider("fcm", false);
+    const pruningIos = new FakeProvider("apns", true, new Set(["dead-token"]));
     const service = new NotificationPushService(h.runtime, {
       registry: h.registry,
-      providers: { ios, android },
+      providers: { ios: pruningIos, android },
     });
     await service.attach();
-    await h.registry.register("ios", "dead-token");
-    await h.registry.register("ios", "live-token");
+    await h.registry.register("ios", "dead-token", OWNER);
+    await h.registry.register("ios", "live-token", OWNER);
+    await allowPush(h, OWNER);
 
     h.emit(notification());
     await flush();
 
     const remaining = (await h.registry.list()).map((r) => r.token);
     expect(remaining).toEqual(["live-token"]);
-    expect(ios.sent.map((s) => s.token)).toEqual(["live-token"]);
+    expect(pruningIos.sent.map((s) => s.token)).toEqual(["live-token"]);
   });
 
   it("ignores non-notification stream events", async () => {
-    const ios = new FakeProvider("apns", true);
-    const android = new FakeProvider("fcm", true);
     const service = new NotificationPushService(h.runtime, {
       registry: h.registry,
       providers: { ios, android },
     });
     await service.attach();
-    await h.registry.register("ios", "tok-ios");
+    await h.registry.register("ios", "tok-ios", OWNER);
+    await allowPush(h, OWNER);
 
     h.emitRaw({
       runId: "r1",
@@ -234,8 +253,6 @@ describe("NotificationPushService", () => {
   });
 
   it("unsubscribes on stop", async () => {
-    const ios = new FakeProvider("apns", true);
-    const android = new FakeProvider("fcm", true);
     const service = new NotificationPushService(h.runtime, {
       registry: h.registry,
       providers: { ios, android },
@@ -246,16 +263,129 @@ describe("NotificationPushService", () => {
     expect(h.listenerCount()).toBe(0);
   });
 
-  it("logs and drops fan-out failures from registry list()", async () => {
-    const ios = new FakeProvider("apns", true);
-    const android = new FakeProvider("fcm", true);
+  it("starts dormant (no throw) when there is no event bus", async () => {
+    const noBusRuntime = {
+      ...h.runtime,
+      getService: () => null,
+    } as unknown as IAgentRuntime;
+    const service = new NotificationPushService(noBusRuntime, {
+      registry: new PushTokenRegistry(noBusRuntime),
+      providers: { ios, android },
+    });
+    await expect(service.attach()).resolves.toBeUndefined();
+  });
+
+  // ── #23106 inbox-before-push, fail-closed matrix ──────────────────
+
+  it("fails closed: a notification without a recipient is never pushed", async () => {
     const service = new NotificationPushService(h.runtime, {
       registry: h.registry,
       providers: { ios, android },
     });
     await service.attach();
-    const listSpy = vi
-      .spyOn(h.registry, "list")
+    await h.registry.register("ios", "tok-ios", OWNER);
+    await allowPush(h, OWNER);
+
+    h.emit(notification({ recipientId: undefined }));
+    await flush();
+    expect(ios.sent).toHaveLength(0);
+    expect(android.sent).toHaveLength(0);
+  });
+
+  it("fails closed: no policy means inbox-only even for an owned token", async () => {
+    const service = new NotificationPushService(h.runtime, {
+      registry: h.registry,
+      providers: { ios, android },
+    });
+    await service.attach();
+    await h.registry.register("ios", "tok-ios", OWNER);
+    // No policy saved for OWNER.
+
+    h.emit(notification());
+    await flush();
+    expect(ios.sent).toHaveLength(0);
+  });
+
+  it("fails closed: an explicitly denied policy means inbox-only", async () => {
+    const service = new NotificationPushService(h.runtime, {
+      registry: h.registry,
+      providers: { ios, android },
+    });
+    await service.attach();
+    await h.registry.register("ios", "tok-ios", OWNER);
+    await h.policies.save(OWNER, {
+      pushEnabled: false,
+      version: 1,
+      updatedAt: Date.now(),
+    });
+
+    h.emit(notification());
+    await flush();
+    expect(ios.sent).toHaveLength(0);
+  });
+
+  it("delivers only to the recipient's own tokens — never another principal's", async () => {
+    const service = new NotificationPushService(h.runtime, {
+      registry: h.registry,
+      providers: { ios, android },
+    });
+    await service.attach();
+    await h.registry.register("ios", "tok-owner", OWNER);
+    await h.registry.register("ios", "tok-other", OTHER_OWNER);
+    await h.registry.register("ios", "tok-unowned"); // legacy, no owner
+    await allowPush(h, OWNER);
+    await allowPush(h, OTHER_OWNER);
+
+    h.emit(notification({ recipientId: OWNER }));
+    await flush();
+
+    expect(ios.sent.map((s) => s.token)).toEqual(["tok-owner"]);
+  });
+
+  it("fails closed: a legacy unowned token never receives a recipient-bound push", async () => {
+    const service = new NotificationPushService(h.runtime, {
+      registry: h.registry,
+      providers: { ios, android },
+    });
+    await service.attach();
+    await h.registry.register("ios", "tok-unowned");
+    await allowPush(h, OWNER);
+
+    h.emit(notification());
+    await flush();
+    expect(ios.sent).toHaveLength(0);
+  });
+
+  it("delivers when recipient, policy, and owned token all align", async () => {
+    const service = new NotificationPushService(h.runtime, {
+      registry: h.registry,
+      providers: { ios, android },
+    });
+    await service.attach();
+    await h.registry.register("ios", "tok-ios", OWNER);
+    await h.registry.register("android", "tok-android", OWNER);
+    await allowPush(h, OWNER);
+
+    h.emit(notification());
+    await flush();
+
+    expect(ios.sent.map((s) => s.token)).toEqual(["tok-ios"]);
+    expect(android.sent.map((s) => s.token)).toEqual(["tok-android"]);
+  });
+
+  // ── failure-path diagnostics (restored from the pre-#23106 suite, adapted
+  // to the recipient-bound pipeline so the J7 reporting cannot regress) ──
+
+  it("logs and drops fan-out failures from the recipient token lookup", async () => {
+    const service = new NotificationPushService(h.runtime, {
+      registry: h.registry,
+      providers: { ios, android },
+    });
+    await service.attach();
+    await h.registry.register("ios", "tok-ios", OWNER);
+    await allowPush(h, OWNER);
+    const listByOwnerSpy = vi
+      .spyOn(h.registry, "listByOwner")
       .mockRejectedValueOnce(new Error("db down"));
     const loggerSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
     const reportErrorSpy = vi
@@ -265,7 +395,7 @@ describe("NotificationPushService", () => {
     h.emit(notification());
     await flush();
 
-    expect(listSpy).toHaveBeenCalledTimes(1);
+    expect(listByOwnerSpy).toHaveBeenCalledTimes(1);
     expect(loggerSpy).toHaveBeenCalledWith(
       { src: "service:notification_push", error: expect.any(Error) },
       "[NotificationPushService] fan-out failed",
@@ -279,14 +409,14 @@ describe("NotificationPushService", () => {
   });
 
   it("logs and drops fan-out failures from dead-token unregister()", async () => {
-    const ios = new FakeProvider("apns", true, new Set(["dead-token"]));
-    const android = new FakeProvider("fcm", false);
+    const pruningIos = new FakeProvider("apns", true, new Set(["dead-token"]));
     const service = new NotificationPushService(h.runtime, {
       registry: h.registry,
-      providers: { ios, android },
+      providers: { ios: pruningIos, android },
     });
     await service.attach();
-    await h.registry.register("ios", "dead-token");
+    await h.registry.register("ios", "dead-token", OWNER);
+    await allowPush(h, OWNER);
     const unregisterSpy = vi
       .spyOn(h.registry, "unregister")
       .mockRejectedValueOnce(new Error("durable write rejected"));
@@ -308,19 +438,5 @@ describe("NotificationPushService", () => {
       expect.any(Error),
       { stream: NOTIFICATION_STREAM },
     );
-  });
-
-  it("starts dormant (no throw) when there is no event bus", async () => {
-    const noBusRuntime = {
-      ...h.runtime,
-      getService: () => null,
-    } as unknown as IAgentRuntime;
-    const ios = new FakeProvider("apns", true);
-    const android = new FakeProvider("fcm", true);
-    const service = new NotificationPushService(noBusRuntime, {
-      registry: new PushTokenRegistry(noBusRuntime),
-      providers: { ios, android },
-    });
-    await expect(service.attach()).resolves.toBeUndefined();
   });
 });

--- a/packages/agent/src/services/push/notification-push-service.ts
+++ b/packages/agent/src/services/push/notification-push-service.ts
@@ -3,26 +3,39 @@
  *
  * The server-side bridge between the unified notification rail and remote push
  * transports (APNs / FCM). It subscribes to the AgentEventService bus and, for
- * every `stream:"notification"` event, fans the notification out to all
- * registered device push tokens via the matching provider.
+ * every `stream:"notification"` event, delivers the notification to the device
+ * push tokens owned by the notification's canonical RECIPIENT (#23106).
  *
- * DELIVERY POLICY (intentionally simple, documented):
- *   - Every notification is pushed to every registered token of the matching
- *     platform. The app dedupes by the notification `id` carried in the push
- *     custom data against its in-app notification center, and the OS only
- *     surfaces it when the app is backgrounded/killed.
+ * DELIVERY POLICY (inbox-before-push, fail-closed — #23106 first tranche):
+ *   - A notification ALWAYS lands in the inbox first; NotificationService owns
+ *     that path and this service never gates it. Whether it may ALSO leave the
+ *     process as a remote push is decided per-principal by the PushPolicyStore
+ *     seam (push-policy.ts): no recipient → inbox-only; no policy → inbox-only
+ *     (the principal never opted in); policy denied → inbox-only. Only an
+ *     explicit per-principal policy allowing push permits delivery, and only to
+ *     tokens registered BY that same principal.
+ *   - Legacy tokens registered without an ownerEntityId never match a
+ *     recipient-bound push: they can be listed and unregistered, but delivery
+ *     to them is over until the device re-registers with a principal. This is
+ *     the deliberate fail-closed default — privacy errs inbox-only.
  *   - A "only push when the device isn't actively connected over WebSocket"
  *     optimization is a future refinement; it is deliberately not implemented
  *     here to keep the seam single-pathed.
+ *   - Digests (batched/deferred delivery) are NOT owned here: there is one
+ *     clock (core TaskService) and `plugin-scheduling` owns the scheduled-item
+ *     state machine. The recipient/policy seam is the typed surface a future
+ *     digest queue consults; this service creates no scheduler.
  *
  * CREDENTIAL GATING: a provider is only used when `isConfigured()` is true.
  * With NO provider configured the service still starts (so the registry/routes
  * stay live) but logs once at debug and does nothing on each notification.
  *
- * VERIFIABILITY: subscription, no-op-when-unconfigured, token lookup, dispatch
- * routing (ios→apns, android→fcm), and dead-token removal are unit-tested with
- * an injected fake provider. Real network delivery is NOT tested — it needs
- * live APNs/FCM credentials and a physical device.
+ * VERIFIABILITY: subscription, no-op-when-unconfigured, recipient/owner token
+ * matching, the fail-closed policy matrix (no recipient / no policy / denied /
+ * allowed), dispatch routing (ios→apns, android→fcm), and dead-token removal
+ * are unit-tested with an injected fake provider and store. Real network
+ * delivery is NOT tested — it needs live APNs/FCM credentials and a physical
+ * device.
  */
 
 import type { IAgentRuntime } from "@elizaos/core";
@@ -37,6 +50,11 @@ import {
 } from "@elizaos/core";
 import { ApnsProvider } from "./apns-provider.ts";
 import { FcmProvider } from "./fcm-provider.ts";
+import {
+  decidePushDelivery,
+  type PushDeliveryDecision,
+  PushPolicyStore,
+} from "./push-policy.ts";
 import { type PushPlatform, PushTokenRegistry } from "./push-token-registry.ts";
 import {
   type PushMessage,
@@ -78,18 +96,24 @@ export interface PushProviderSet {
 export class NotificationPushService extends Service {
   static serviceType: string = NOTIFICATION_PUSH_SERVICE_TYPE;
   capabilityDescription =
-    "Delivers notifications to backgrounded/killed devices via APNs and FCM";
+    "Delivers recipient-bound notifications to backgrounded/killed devices via APNs and FCM, behind a per-principal fail-closed push policy";
 
   private readonly registry: PushTokenRegistry;
+  private readonly policies: PushPolicyStore;
   private readonly providers: PushProviderSet;
   private unsubscribe: (() => void) | null = null;
 
   constructor(
     runtime: IAgentRuntime,
-    options?: { registry?: PushTokenRegistry; providers?: PushProviderSet },
+    options?: {
+      registry?: PushTokenRegistry;
+      policies?: PushPolicyStore;
+      providers?: PushProviderSet;
+    },
   ) {
     super(runtime);
     this.registry = options?.registry ?? new PushTokenRegistry(runtime);
+    this.policies = options?.policies ?? new PushPolicyStore(runtime);
     this.providers = options?.providers ?? {
       ios: new ApnsProvider(),
       android: new FcmProvider(),
@@ -154,6 +178,11 @@ export class NotificationPushService extends Service {
     return this.registry;
   }
 
+  /** The per-principal policy store (used by the routes layer). */
+  getPolicies(): PushPolicyStore {
+    return this.policies;
+  }
+
   private async onNotification(event: AgentEventPayload): Promise<void> {
     const notification = event.data?.notification;
     if (!isAgentNotification(notification)) return;
@@ -166,7 +195,37 @@ export class NotificationPushService extends Service {
       return;
     }
 
-    const tokens = await this.registry.list();
+    // #23106 inbox-before-push seam: the inbox delivery already happened (the
+    // event we are reacting to IS the inbox rail). Push is the add-on, gated
+    // per-principal and FAIL-CLOSED: no recipient, no policy, or a denied
+    // policy all mean inbox-only — never a push.
+    const recipientId = notification.recipientId;
+    if (!recipientId || recipientId.length === 0) {
+      logger.debug(
+        { src: "service:notification_push" },
+        "[NotificationPushService] no recipient; inbox-only (fail-closed)",
+      );
+      return;
+    }
+    const policy = await this.policies.load(recipientId);
+    const decision: PushDeliveryDecision = decidePushDelivery(
+      notification,
+      policy,
+    );
+    if (decision.outcome !== "allow") {
+      logger.debug(
+        {
+          src: "service:notification_push",
+          reason: decision.reason,
+          policyVersion: decision.policyVersion,
+        },
+        "[NotificationPushService] push policy denied; inbox-only (fail-closed)",
+      );
+      return;
+    }
+
+    // Recipient-bound delivery: only tokens registered by this principal.
+    const tokens = await this.registry.listByOwner(recipientId);
     if (tokens.length === 0) return;
 
     const message = toPushMessage(notification);

--- a/packages/agent/src/services/push/push-policy.test.ts
+++ b/packages/agent/src/services/push/push-policy.test.ts
@@ -171,3 +171,285 @@ describe("PushPolicyStore (durable per-principal store)", () => {
     });
   });
 });
+
+describe("PushPolicyStore.update (serialized per-principal bump)", () => {
+  const RUNTIME_AGENT_ID = "00000000-0000-0000-0000-0000000000aa";
+
+  function makeStore(overrides?: {
+    getCache?: <T>(key: string) => Promise<T | undefined>;
+    setCache?: (key: string, value: unknown) => Promise<boolean>;
+  }): {
+    store: PushPolicyStore;
+    cache: Map<string, unknown>;
+  } {
+    const cache = new Map<string, unknown>();
+    const storeRuntime = {
+      agentId: RUNTIME_AGENT_ID,
+      getCache:
+        overrides?.getCache ??
+        (async <T>(key: string): Promise<T | undefined> =>
+          cache.get(key) as T | undefined),
+      setCache:
+        overrides?.setCache ??
+        (async (key: string, value: unknown): Promise<boolean> => {
+          cache.set(key, value);
+          return true;
+        }),
+    };
+    return { store: new PushPolicyStore(storeRuntime), cache };
+  }
+
+  it("bumps from absent to version 1 and applies the requested setting", async () => {
+    const { store } = makeStore();
+    const first = await store.update("owner-1", true);
+    expect(first).toEqual({
+      pushEnabled: true,
+      version: 1,
+      updatedAt: expect.any(Number),
+    });
+    const second = await store.update("owner-1", false);
+    expect(second.pushEnabled).toBe(false);
+    expect(second.version).toBe(2);
+  });
+
+  it("serializes concurrent same-principal updates: every PUT gets a distinct monotonic version (no lost update)", async () => {
+    // Delay the FIRST cache read so both queued updates are in flight before
+    // either critical section runs — without serialization both would compute
+    // version 1 from the same absent row and one opt-out would be lost.
+    let resolveFirstRead: (() => void) | undefined;
+    const firstRead = new Promise<void>((resolve) => {
+      resolveFirstRead = resolve;
+    });
+    let reads = 0;
+    const { store, cache } = makeStore({
+      getCache: async <T>(key: string): Promise<T | undefined> => {
+        reads += 1;
+        if (reads === 1) await firstRead;
+        return cache.get(key) as T | undefined;
+      },
+    });
+
+    const enable = store.update("owner-1", true);
+    const disable = store.update("owner-1", false);
+    // Both updates are now queued; release the first critical section.
+    resolveFirstRead?.();
+
+    const [enabledPolicy, disabledPolicy] = await Promise.all([
+      enable,
+      disable,
+    ]);
+    // Distinct monotonic versions prove serialization: the second update
+    // re-loaded the first's durable row inside its own critical section.
+    expect(enabledPolicy.version).toBe(1);
+    expect(disabledPolicy.version).toBe(2);
+    // Last-writer-wins by QUEUING ORDER (disable was queued second) — the
+    // final durable row is the disable, with no overwritten opt-out.
+    const final = await store.load("owner-1");
+    expect(final).toEqual({
+      pushEnabled: false,
+      version: 2,
+      updatedAt: disabledPolicy.updatedAt,
+    });
+  });
+
+  it("does not let one principal's failed update poison another principal's queue", async () => {
+    const { store, cache } = makeStore({
+      setCache: async (key: string, value: unknown): Promise<boolean> => {
+        const policy = value as { pushEnabled: boolean };
+        if (policy.pushEnabled === false) return false; // disable writes fail
+        cache.set(key, value);
+        return true;
+      },
+    });
+    await expect(store.update("owner-1", false)).rejects.toThrow(
+      /rejected the push-policy write/,
+    );
+    // The queue recovers: a later update for a DIFFERENT principal proceeds.
+    const ok = await store.update("owner-2", true);
+    expect(ok.pushEnabled).toBe(true);
+    expect(ok.version).toBe(1);
+  });
+
+  it("keeps the queue live after a failed same-principal update (no wedge)", async () => {
+    let writes = 0;
+    const cache = new Map<string, unknown>();
+    const { store } = makeStore({
+      getCache: async <T>(key: string): Promise<T | undefined> =>
+        cache.get(key) as T | undefined,
+      setCache: async (key: string, value: unknown): Promise<boolean> => {
+        writes += 1;
+        if (writes === 1) return false; // first durable write fails
+        cache.set(key, value);
+        return true;
+      },
+    });
+    await expect(store.update("owner-1", true)).rejects.toThrow(
+      /rejected the push-policy write/,
+    );
+    const recovered = await store.update("owner-1", true);
+    expect(recovered.version).toBe(1); // failed write never landed
+    const next = await store.update("owner-1", false);
+    expect(next.version).toBe(2);
+  });
+
+  it("serializes per principal: unrelated principals do not wait on each other", async () => {
+    const cache = new Map<string, unknown>();
+    let owner1Reads = 0;
+    let releaseOwner1: (() => void) | undefined;
+    const owner1Gate = new Promise<void>((resolve) => {
+      releaseOwner1 = resolve;
+    });
+    const { store } = makeStore({
+      getCache: async <T>(key: string): Promise<T | undefined> => {
+        if (key.endsWith(":owner-1")) {
+          owner1Reads += 1;
+          if (owner1Reads === 1) await owner1Gate;
+        }
+        return cache.get(key) as T | undefined;
+      },
+      setCache: async (key: string, value: unknown): Promise<boolean> => {
+        cache.set(key, value);
+        return true;
+      },
+    });
+    let blocked: Promise<PushDeliveryPolicy> | undefined;
+    try {
+      blocked = store.update("owner-1", true);
+      const other = store.update("owner-2", true);
+      // owner-2's update must complete WITHOUT waiting on owner-1's gate.
+      const winner = await Promise.race([
+        other.then(() => "owner-2" as const),
+        new Promise<"owner-1">((resolve) =>
+          setTimeout(() => resolve("owner-1"), 50),
+        ),
+      ]);
+      expect(winner).toBe("owner-2");
+    } finally {
+      releaseOwner1?.();
+      await blocked;
+    }
+  });
+
+  it("drops a settled tail so the queue map tracks in-flight work only", async () => {
+    const { store } = makeStore();
+    await store.update("owner-1", true);
+    await store.update("owner-1", false);
+    // The settle-cleanup rides its own microtask chain after the caller's
+    // await resolves; cross a macrotask boundary so it has certainly run.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    // Both updates settled and no later update chained: the tail entry is
+    // removed, so the map cannot grow with every principal ever seen.
+    expect(tailSizeFor(store)).toBe(0);
+    // A fresh update re-seeds the tail and still serializes correctly.
+    const third = await store.update("owner-1", true);
+    expect(third.version).toBe(3);
+  });
+
+  it("keeps the newer tail when updates chain (identity-checked cleanup)", async () => {
+    // Discriminating construction: the SECOND update's durable read is gated
+    // AFTER the first update fully settles (so the first tail's cleanup has
+    // run). If cleanup deleted the map entry unconditionally — instead of by
+    // identity — the map would lose the second update's tail and the THIRD
+    // update could enter its critical section before the second completes,
+    // reading the same base row and duplicating its version.
+    const cache = new Map<string, unknown>();
+    let resolveSecondRead: (() => void) | undefined;
+    const secondGate = new Promise<void>((resolve) => {
+      resolveSecondRead = resolve;
+    });
+    // Resolves the moment the SECOND update enters its gated cache read. The
+    // second update's critical section only starts after the first update's
+    // recovered tail settles, and the first cleanup is registered on that
+    // same promise BEFORE the second's continuation — so second-read-entry
+    // guarantees the first cleanup has already run.
+    let markSecondReadEntered: (() => void) | undefined;
+    const secondReadEntered = new Promise<void>((resolve) => {
+      markSecondReadEntered = resolve;
+    });
+    let owner1Loads = 0;
+    const { store } = makeStore({
+      getCache: async <T>(key: string): Promise<T | undefined> => {
+        if (key.endsWith(":owner-1")) {
+          owner1Loads += 1;
+          if (owner1Loads === 2) {
+            markSecondReadEntered?.();
+            await secondGate; // gate the second update
+          }
+        }
+        return cache.get(key) as T | undefined;
+      },
+      setCache: async (key: string, value: unknown): Promise<boolean> => {
+        cache.set(key, value);
+        return true;
+      },
+    });
+
+    const first = store.update("owner-1", true);
+    const second = store.update("owner-1", false);
+    const firstPolicy = await first; // first settles
+    expect(firstPolicy.version).toBe(1);
+    // Wait until the second update is INSIDE its gated read — by then the
+    // first tail's cleanup has certainly run, so an unconditional delete
+    // would already have emptied the map before we enqueue the third.
+    await secondReadEntered;
+    // The third update must chain BEHIND the gated second: with the identity
+    // check the map still holds the second's tail; an unconditional cleanup
+    // would have dropped it and the third would run CONCURRENTLY, reading the
+    // same base row and duplicating a version.
+    const third = store.update("owner-1", true);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    // Nothing else may have completed while the second update is gated.
+    const inFlight = await Promise.race([
+      Promise.race([second, third]).then(
+        (policy) => `completed-early:v${policy.version}`,
+      ),
+      new Promise<string>((resolve) =>
+        setTimeout(() => resolve("still-queued"), 20),
+      ),
+    ]);
+    expect(inFlight).toBe("still-queued");
+
+    resolveSecondRead?.();
+    const [secondPolicy, thirdPolicy] = await Promise.all([second, third]);
+    // Distinct monotonic versions prove the chain held through cleanup.
+    expect(secondPolicy.version).toBe(2);
+    expect(thirdPolicy.version).toBe(3);
+    const final = await store.load("owner-1");
+    expect(final?.version).toBe(3);
+    expect(final?.pushEnabled).toBe(true);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(tailSizeFor(store)).toBe(0);
+  });
+
+  it("refuses to persist a version the fail-closed parser would reject (MAX_SAFE_INTEGER guard)", async () => {
+    const cache = new Map<string, unknown>();
+    cache.set("push-policy:00000000-0000-0000-0000-0000000000aa:owner-1", {
+      pushEnabled: true,
+      version: Number.MAX_SAFE_INTEGER,
+      updatedAt: 1,
+    });
+    const { store } = makeStore({
+      getCache: async <T>(key: string): Promise<T | undefined> =>
+        cache.get(key) as T | undefined,
+    });
+    // The guarded bump refuses instead of writing MAX_SAFE_INTEGER + 1 (a
+    // value the boundary parser fails closed on, degrading the principal to
+    // policy_corrupt on every later load).
+    await expect(store.update("owner-1", false)).rejects.toMatchObject({
+      code: PUSH_POLICY_PERSIST_FAILED_CODE,
+    });
+    // The existing row is untouched.
+    const row = await store.load("owner-1");
+    expect(row?.version).toBe(Number.MAX_SAFE_INTEGER);
+  });
+});
+
+/** Test-only view of the store's pending-tail count (bounded-memory contract). */
+function tailSizeFor(store: PushPolicyStore): number {
+  const tails = (
+    store as unknown as {
+      updateTails: Map<string, Promise<void>>;
+    }
+  ).updateTails;
+  return tails.size;
+}

--- a/packages/agent/src/services/push/push-policy.test.ts
+++ b/packages/agent/src/services/push/push-policy.test.ts
@@ -10,6 +10,7 @@ import type { AgentNotification } from "@elizaos/core";
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   decidePushDelivery,
+  PUSH_POLICY_PERSIST_FAILED_CODE,
   type PushDeliveryPolicy,
   PushPolicyStore,
   parsePushDeliveryPolicy,
@@ -98,6 +99,11 @@ describe("parsePushDeliveryPolicy (untrusted boundary)", () => {
       { ...ALLOWED_POLICY, updatedAt: "yesterday" },
       { ...ALLOWED_POLICY, updatedAt: -1 },
       { pushEnabled: true }, // missing version + updatedAt
+      { ...ALLOWED_POLICY, extra: true }, // extra key: not the canonical 3-key shape
+      { pushEnabled: true, version: 1, updatedAt: 1, extra: "x" }, // 4-key variant
+      // inherited-policy injection: three arbitrary own keys, valid values on
+      // the prototype — passes a length-only check, blocked by key-set equality
+      Object.assign(Object.create(ALLOWED_POLICY), { a: 1, b: 2, c: 3 }),
     ];
     for (const value of corrupt) {
       expect(parsePushDeliveryPolicy(value)).toBeNull();
@@ -151,5 +157,17 @@ describe("PushPolicyStore (durable per-principal store)", () => {
     await expect(rejecting.save("owner-1", ALLOWED_POLICY)).rejects.toThrow(
       /rejected the push-policy write/,
     );
+  });
+
+  it("rejects with a typed ElizaError carrying the stable persist code", async () => {
+    const rejecting = new PushPolicyStore({
+      ...runtime,
+      setCache: async () => false,
+    });
+    const rejection = rejecting.save("owner-1", ALLOWED_POLICY);
+    await expect(rejection).rejects.toMatchObject({
+      name: "ElizaError",
+      code: PUSH_POLICY_PERSIST_FAILED_CODE,
+    });
   });
 });

--- a/packages/agent/src/services/push/push-policy.test.ts
+++ b/packages/agent/src/services/push/push-policy.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Covers the per-principal inbox-before-push policy seam (#23106): the pure
+ * fail-closed decision matrix (no recipient / no policy / corrupt policy /
+ * denied / allowed), boundary validation of untrusted stored policy rows, and
+ * the durable PushPolicyStore over a Map-backed cache. Harness is in-memory;
+ * no real persistence or network.
+ */
+
+import type { AgentNotification } from "@elizaos/core";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  decidePushDelivery,
+  type PushDeliveryPolicy,
+  PushPolicyStore,
+  parsePushDeliveryPolicy,
+} from "./push-policy.ts";
+
+const ALLOWED_POLICY: PushDeliveryPolicy = {
+  pushEnabled: true,
+  version: 3,
+  updatedAt: 1_700_000_000_000,
+};
+const DENIED_POLICY: PushDeliveryPolicy = {
+  pushEnabled: false,
+  version: 1,
+  updatedAt: 1_700_000_000_000,
+};
+
+function notification(
+  overrides: Partial<Pick<AgentNotification, "recipientId">> = {},
+): Pick<AgentNotification, "recipientId"> {
+  return { recipientId: "owner-1", ...overrides };
+}
+
+describe("decidePushDelivery (fail-closed matrix)", () => {
+  it("denies with no_recipient when the notification carries no recipient", () => {
+    const decision = decidePushDelivery(
+      notification({ recipientId: undefined }),
+      ALLOWED_POLICY,
+    );
+    expect(decision).toEqual({
+      outcome: "deny",
+      reason: "no_recipient",
+      policyVersion: 0,
+    });
+  });
+
+  it("denies with no_recipient for an empty-string recipient", () => {
+    const decision = decidePushDelivery(
+      notification({ recipientId: "" }),
+      ALLOWED_POLICY,
+    );
+    expect(decision.outcome).toBe("deny");
+    if (decision.outcome === "deny")
+      expect(decision.reason).toBe("no_recipient");
+  });
+
+  it("denies with no_policy when the principal has no policy (never defaults to allow)", () => {
+    const decision = decidePushDelivery(notification(), null);
+    expect(decision).toEqual({
+      outcome: "deny",
+      reason: "no_policy",
+      policyVersion: 0,
+    });
+  });
+
+  it("denies with policy_denied when the policy explicitly disables push", () => {
+    const decision = decidePushDelivery(notification(), DENIED_POLICY);
+    expect(decision).toEqual({
+      outcome: "deny",
+      reason: "policy_denied",
+      policyVersion: 1,
+    });
+  });
+
+  it("allows only when the policy explicitly enables push, carrying the version", () => {
+    const decision = decidePushDelivery(notification(), ALLOWED_POLICY);
+    expect(decision).toEqual({ outcome: "allow", policyVersion: 3 });
+  });
+});
+
+describe("parsePushDeliveryPolicy (untrusted boundary)", () => {
+  it("accepts the exact canonical shape", () => {
+    expect(parsePushDeliveryPolicy(ALLOWED_POLICY)).toEqual(ALLOWED_POLICY);
+  });
+
+  it("rejects every corrupt variant (fail-closed to null)", () => {
+    const corrupt: unknown[] = [
+      undefined,
+      null,
+      "pushEnabled",
+      42,
+      {},
+      { ...ALLOWED_POLICY, pushEnabled: "true" },
+      { ...ALLOWED_POLICY, version: "3" },
+      { ...ALLOWED_POLICY, version: -1 },
+      { ...ALLOWED_POLICY, version: 1.5 },
+      { ...ALLOWED_POLICY, updatedAt: "yesterday" },
+      { ...ALLOWED_POLICY, updatedAt: -1 },
+      { pushEnabled: true }, // missing version + updatedAt
+    ];
+    for (const value of corrupt) {
+      expect(parsePushDeliveryPolicy(value)).toBeNull();
+    }
+  });
+});
+
+describe("PushPolicyStore (durable per-principal store)", () => {
+  const cache = new Map<string, unknown>();
+  const runtime = {
+    agentId: "00000000-0000-0000-0000-0000000000aa",
+    getCache: async <T>(key: string): Promise<T | undefined> =>
+      cache.get(key) as T | undefined,
+    setCache: async <T>(key: string, value: T): Promise<boolean> => {
+      cache.set(key, value);
+      return true;
+    },
+  };
+  let store: PushPolicyStore;
+
+  beforeEach(() => {
+    cache.clear();
+    store = new PushPolicyStore(runtime);
+  });
+
+  it("returns null for an absent policy (the fail-closed default)", async () => {
+    expect(await store.load("owner-1")).toBeNull();
+  });
+
+  it("round-trips a saved policy per principal (two principals stay isolated)", async () => {
+    await store.save("owner-1", ALLOWED_POLICY);
+    await store.save("owner-2", DENIED_POLICY);
+    expect(await store.load("owner-1")).toEqual(ALLOWED_POLICY);
+    expect(await store.load("owner-2")).toEqual(DENIED_POLICY);
+    expect(await store.load("owner-3")).toBeNull();
+  });
+
+  it("treats a corrupt stored row as absent (fail-closed), not a throw", async () => {
+    cache.set("push-policy:00000000-0000-0000-0000-0000000000aa:owner-1", {
+      pushEnabled: true,
+      version: "x",
+    });
+    await expect(store.load("owner-1")).resolves.toBeNull();
+  });
+
+  it("throws when the durable write is rejected (no fabricated success)", async () => {
+    const rejecting = new PushPolicyStore({
+      ...runtime,
+      setCache: async () => false,
+    });
+    await expect(rejecting.save("owner-1", ALLOWED_POLICY)).rejects.toThrow(
+      /rejected the push-policy write/,
+    );
+  });
+});

--- a/packages/agent/src/services/push/push-policy.ts
+++ b/packages/agent/src/services/push/push-policy.ts
@@ -146,6 +146,9 @@ export function decidePushDelivery(
  * persistence pattern as PushTokenRegistry. One key per (agent, recipient).
  */
 export class PushPolicyStore {
+  /** Per-principal update tails serializing `update()` calls (see its doc). */
+  private readonly updateTails = new Map<string, Promise<void>>();
+
   constructor(private readonly runtime: PushPolicyRuntime) {}
 
   private cacheKey(recipientId: string): string {
@@ -166,6 +169,88 @@ export class PushPolicyStore {
       );
     }
     return parsed;
+  }
+
+  /**
+   * Serialize a principal's policy advance — load, apply `pushEnabled`, bump
+   * the version, durably save — per principal, so two concurrent
+   * enable/disable requests can never both observe the same base version and
+   * silently overwrite an opt-out: each update persists a distinct monotonic
+   * version, giving every accepted write an auditable position in the
+   * principal's ordering. Returns the persisted record.
+   *
+   * Concurrency scope: same-principal writes are serialized and failure-atomic
+   * within a single process, mirroring `PushTokenRegistry`'s documented scope —
+   * the runtime cache contract exposes no compare-and-swap primitive
+   * (`getCache`/`setCache` only). Known limitation: during a managed
+   * blue/green upgrade two container generations briefly share the durable
+   * cache, so an in-flight write from the retiring container can interleave
+   * with the new container's first write (the same exposure the token
+   * registry carries).
+   */
+  update(
+    recipientId: string,
+    pushEnabled: boolean,
+  ): Promise<PushDeliveryPolicy> {
+    // Queue on the principal's own tail, not a shared one: unrelated principals
+    // never delay each other. Keys are recipient ids; a settled tail is removed
+    // below, so the map tracks in-flight work, not every principal seen.
+    const previous = this.updateTails.get(recipientId) ?? Promise.resolve();
+    const pending = previous.then(() =>
+      this.bumpAndSave(recipientId, pushEnabled),
+    );
+    // error-policy:J5 the caller observes `pending`; this recovery keeps one
+    // failed persistence attempt from poisoning every later policy update.
+    const recovered = pending.then(
+      () => undefined,
+      () => undefined,
+    );
+    this.updateTails.set(recipientId, recovered);
+    // Settle-cleanup: when this tail is still the END of the principal's queue
+    // (no later update chained onto it), drop it so the map stays bounded by
+    // active work. The identity check keeps a newer queued update's tail.
+    void recovered.then(() => {
+      if (this.updateTails.get(recipientId) === recovered) {
+        this.updateTails.delete(recipientId);
+      }
+    });
+    return pending;
+  }
+
+  /**
+   * One serialized step: re-load the durable row inside the critical section
+   * (so it reflects every earlier queued update), apply the new setting, and
+   * persist. The version is `loaded + 1` — strictly monotonic across successive
+   * updates through this store. A corrupt row parses as absent per the
+   * fail-closed parse contract, so the sequence restarts at version 1 rather
+   * than trusting an unreadable prior version. A row already at the safe
+   * integer ceiling rejects the bump: persisting `version + 1` would store a
+   * record this store's own parser fails closed on, so the write is refused
+   * instead of planting a row every later load treats as corrupt.
+   */
+  private async bumpAndSave(
+    recipientId: string,
+    pushEnabled: boolean,
+  ): Promise<PushDeliveryPolicy> {
+    const existing = await this.load(recipientId);
+    const baseVersion = existing?.version ?? 0;
+    if (baseVersion >= Number.MAX_SAFE_INTEGER) {
+      throw new ElizaError(
+        "[PushPolicyStore] policy version exhausted the safe-integer range",
+        {
+          code: PUSH_POLICY_PERSIST_FAILED_CODE,
+          context: { recipientId: recipientId.length, baseVersion },
+          severity: "ephemeral",
+        },
+      );
+    }
+    const next: PushDeliveryPolicy = {
+      pushEnabled,
+      version: baseVersion + 1,
+      updatedAt: Date.now(),
+    };
+    await this.save(recipientId, next);
+    return next;
   }
 
   /**

--- a/packages/agent/src/services/push/push-policy.ts
+++ b/packages/agent/src/services/push/push-policy.ts
@@ -25,7 +25,7 @@
  * expresses no scheduling and creates no competing scheduler.
  */
 
-import { type AgentNotification, logger } from "@elizaos/core";
+import { type AgentNotification, ElizaError, logger } from "@elizaos/core";
 
 /** Outcome of the inbox-before-push decision. */
 export type PushDeliveryDecision =
@@ -60,6 +60,9 @@ export const PUSH_DELIVERY_DENY: PushDeliveryDecision = {
 const policyCacheKeyFor = (agentId: string, recipientId: string): string =>
   `push-policy:${agentId}:${recipientId}`;
 
+/** Stable `ElizaError.code` for a rejected durable push-policy write. */
+export const PUSH_POLICY_PERSIST_FAILED_CODE = "PUSH_POLICY_PERSIST_FAILED";
+
 /** Cap on the stored policy record size guard (bytes, defensive). */
 const MAX_POLICY_JSON_BYTES = 4096;
 
@@ -73,6 +76,19 @@ export function parsePushDeliveryPolicy(
 ): PushDeliveryPolicy | null {
   if (typeof value !== "object" || value === null) return null;
   const record = value as Record<string, unknown>;
+  // EXACT shape: the row's own enumerable key set must be exactly the three
+  // canonical names — extra keys fail closed, and inherited properties are not
+  // substitutes: property reads below would accept prototype values, so the
+  // key-set equality is what blocks inherited-policy injection via Object.create.
+  const ownKeys = Object.keys(record);
+  if (
+    ownKeys.length !== 3 ||
+    !ownKeys.includes("pushEnabled") ||
+    !ownKeys.includes("version") ||
+    !ownKeys.includes("updatedAt")
+  ) {
+    return null;
+  }
   if (typeof record.pushEnabled !== "boolean") return null;
   if (
     typeof record.version !== "number" ||
@@ -160,15 +176,27 @@ export class PushPolicyStore {
   async save(recipientId: string, policy: PushDeliveryPolicy): Promise<void> {
     const serialized = JSON.stringify(policy);
     if (serialized.length > MAX_POLICY_JSON_BYTES) {
-      throw new Error("[PushPolicyStore] policy record exceeds size cap");
+      throw new ElizaError("[PushPolicyStore] policy record exceeds size cap", {
+        code: PUSH_POLICY_PERSIST_FAILED_CODE,
+        context: {
+          byteLength: serialized.length,
+          limit: MAX_POLICY_JSON_BYTES,
+        },
+        severity: "ephemeral",
+      });
     }
     const persisted = await this.runtime.setCache(
       this.cacheKey(recipientId),
       policy,
     );
     if (persisted !== true) {
-      throw new Error(
+      throw new ElizaError(
         "[PushPolicyStore] durable cache rejected the push-policy write",
+        {
+          code: PUSH_POLICY_PERSIST_FAILED_CODE,
+          context: { recipientLength: recipientId.length },
+          severity: "ephemeral",
+        },
       );
     }
   }

--- a/packages/agent/src/services/push/push-policy.ts
+++ b/packages/agent/src/services/push/push-policy.ts
@@ -1,0 +1,184 @@
+/**
+ * Per-principal push delivery policy (#23106): the inbox-before-push seam.
+ *
+ * A notification ALWAYS lands in the inbox first (NotificationService owns
+ * that). Whether it may ALSO leave the process as a remote push (APNs/FCM) is
+ * a per-principal policy decision made HERE, and the decision FAILS CLOSED:
+ * no recipient, no policy, or a corrupt policy all mean "inbox-only" — never a
+ * push. This is the deliberate privacy default of the maintainer disposition on
+ * #23106 ("first require recipient and add an inbox-before-push policy seam;
+ * scheduler owns digests").
+ *
+ * Boundary invariants:
+ *   1. The decision is a pure function of the persisted policy record plus the
+ *      notification — no ambient state, so it is deterministic and testable.
+ *   2. A policy row is untrusted cache input: anything that is not the exact
+ *      expected shape fails closed to {@link PUSH_DELIVERY_DENY} (inbox-only)
+ *      and is reported for repair, never interpreted charitably.
+ *   3. The policy is durable (runtime cache under a stable per-agent key) and
+ *      keyed by the canonical recipient entity id, so two principals on one
+ *      agent can hold different push policies without observing each other's.
+ *
+ * Digest ownership intentionally lives elsewhere: there is ONE clock (core
+ * TaskService) and `plugin-scheduling` owns the scheduled-item state machine
+ * (see root AGENTS.md "Scheduling and personal-assistant domains"). This seam
+ * expresses no scheduling and creates no competing scheduler.
+ */
+
+import { type AgentNotification, logger } from "@elizaos/core";
+
+/** Outcome of the inbox-before-push decision. */
+export type PushDeliveryDecision =
+  | { outcome: "allow"; policyVersion: number }
+  | { outcome: "deny"; reason: PushDenyReason; policyVersion: number };
+
+/** Why a push was denied (audit/debug vocabulary, never client-facing prose). */
+export type PushDenyReason =
+  | "no_recipient" // notification carries no canonical recipient — cannot address a principal
+  | "no_policy" // fail-closed default: the principal never opted into push
+  | "policy_denied" // an explicit policy says push off
+  | "policy_corrupt"; // stored policy failed validation — treat as absent
+
+/** The durable per-principal push policy record. */
+export interface PushDeliveryPolicy {
+  /** Whether remote push delivery is permitted at all. */
+  pushEnabled: boolean;
+  /** Monotonic policy version, bumped on every change. */
+  version: number;
+  /** Unix ms when the policy was last changed. */
+  updatedAt: number;
+}
+
+/** The decision used when nothing better can be computed. */
+export const PUSH_DELIVERY_DENY: PushDeliveryDecision = {
+  outcome: "deny",
+  reason: "no_policy",
+  policyVersion: 0,
+} as const;
+
+/** Stable cache key for a principal's policy (scoped per agent). */
+const policyCacheKeyFor = (agentId: string, recipientId: string): string =>
+  `push-policy:${agentId}:${recipientId}`;
+
+/** Cap on the stored policy record size guard (bytes, defensive). */
+const MAX_POLICY_JSON_BYTES = 4096;
+
+/**
+ * Validate an untrusted stored policy value. Returns the canonical record or
+ * null (fail-closed). Mirrors the boundary-validation discipline of
+ * PushTokenRegistry: exact shape, no charitable interpretation.
+ */
+export function parsePushDeliveryPolicy(
+  value: unknown,
+): PushDeliveryPolicy | null {
+  if (typeof value !== "object" || value === null) return null;
+  const record = value as Record<string, unknown>;
+  if (typeof record.pushEnabled !== "boolean") return null;
+  if (
+    typeof record.version !== "number" ||
+    !Number.isSafeInteger(record.version) ||
+    record.version < 0
+  ) {
+    return null;
+  }
+  if (
+    typeof record.updatedAt !== "number" ||
+    !Number.isSafeInteger(record.updatedAt) ||
+    record.updatedAt < 0
+  ) {
+    return null;
+  }
+  return {
+    pushEnabled: record.pushEnabled,
+    version: record.version,
+    updatedAt: record.updatedAt,
+  };
+}
+
+/**
+ * The inbox-before-push decision for one notification addressed to one
+ * principal. Pure: the caller supplies the (already-loaded) policy.
+ *
+ * Fail-closed matrix:
+ *   - no recipient            → deny "no_recipient" (inbox-only)
+ *   - policy absent           → deny "no_policy"    (inbox-only)
+ *   - policy corrupt          → deny "policy_corrupt" (inbox-only)
+ *   - policy.pushEnabled true → allow (version carried for audit)
+ */
+export function decidePushDelivery(
+  notification: Pick<AgentNotification, "recipientId">,
+  policy: PushDeliveryPolicy | null,
+): PushDeliveryDecision {
+  if (!notification.recipientId || notification.recipientId.length === 0) {
+    return { outcome: "deny", reason: "no_recipient", policyVersion: 0 };
+  }
+  if (policy === null) {
+    return { outcome: "deny", reason: "no_policy", policyVersion: 0 };
+  }
+  if (!policy.pushEnabled) {
+    return {
+      outcome: "deny",
+      reason: "policy_denied",
+      policyVersion: policy.version,
+    };
+  }
+  return { outcome: "allow", policyVersion: policy.version };
+}
+
+/**
+ * Durable store of per-principal push policies, riding the same runtime-cache
+ * persistence pattern as PushTokenRegistry. One key per (agent, recipient).
+ */
+export class PushPolicyStore {
+  constructor(private readonly runtime: PushPolicyRuntime) {}
+
+  private cacheKey(recipientId: string): string {
+    return policyCacheKeyFor(String(this.runtime.agentId), recipientId);
+  }
+
+  /** Load a principal's policy, or null when absent/corrupt (fail-closed). */
+  async load(recipientId: string): Promise<PushDeliveryPolicy | null> {
+    const stored = await this.runtime.getCache<unknown>(
+      this.cacheKey(recipientId),
+    );
+    const parsed = parsePushDeliveryPolicy(stored);
+    if (stored !== undefined && stored !== null && parsed === null) {
+      // Corrupt row: report once per load; the decision stays fail-closed.
+      logger.warn(
+        { src: "push-policy", recipientId },
+        "[PushPolicyStore] corrupt policy row; failing closed to inbox-only",
+      );
+    }
+    return parsed;
+  }
+
+  /**
+   * Persist a policy. Requires the durable write to resolve exactly `true`
+   * (mirroring PushTokenRegistry.commit discipline); throws a typed error
+   * otherwise so a caller can surface a real failure instead of a silent no-op.
+   */
+  async save(recipientId: string, policy: PushDeliveryPolicy): Promise<void> {
+    const serialized = JSON.stringify(policy);
+    if (serialized.length > MAX_POLICY_JSON_BYTES) {
+      throw new Error("[PushPolicyStore] policy record exceeds size cap");
+    }
+    const persisted = await this.runtime.setCache(
+      this.cacheKey(recipientId),
+      policy,
+    );
+    if (persisted !== true) {
+      throw new Error(
+        "[PushPolicyStore] durable cache rejected the push-policy write",
+      );
+    }
+  }
+}
+
+/** Minimal runtime surface the store needs (structural, for testability). */
+export interface PushPolicyRuntime {
+  agentId: string | UUIDLike;
+  getCache<T>(key: string): Promise<T | undefined>;
+  setCache<T>(key: string, value: T): Promise<boolean>;
+}
+
+type UUIDLike = { toString(): string };

--- a/packages/agent/src/services/push/push-registration-flow.test.ts
+++ b/packages/agent/src/services/push/push-registration-flow.test.ts
@@ -1,10 +1,14 @@
 /**
  * End-to-end wiring of the push pipeline the client leg unblocks: a device token
  * POSTed through the real `handlePushTokenRoute` lands in the service's registry,
- * and a notification emitted on the agent event bus then fans out to the matching
- * provider's `send()`. This is the loop that was dead before a client ever
- * registered a token — the HTTP boundary and the bus are real; only the network
- * provider (`send`) is a recording fake, so no push leaves the process.
+ * and a notification emitted on the agent event bus is then delivered to the
+ * matching provider's `send()` — but ONLY when the #23106 recipient-binding
+ * contract is satisfied: the token is registered with an owner principal, the
+ * principal holds an explicit push-enabled policy, and the notification carries
+ * that principal as its canonical recipient. This is the loop that was dead
+ * before a client ever registered a token — the HTTP boundary and the bus are
+ * real; only the network provider (`send`) is a recording fake, so no push
+ * leaves the process.
  */
 import type http from "node:http";
 import type {
@@ -18,6 +22,8 @@ import { describe, expect, it, vi } from "vitest";
 import { handlePushTokenRoute } from "../../api/push-token-routes.ts";
 import { NotificationPushService } from "./notification-push-service.ts";
 import type { PushMessage, PushProvider } from "./push-types.ts";
+
+const OWNER = "22222222-2222-4222-8222-222222222222";
 
 class RecordingProvider implements PushProvider {
   sent: Array<{ token: string; message: PushMessage }> = [];
@@ -50,7 +56,9 @@ function makeBus() {
 
 const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
 
-const notification = (): AgentNotification => ({
+const notification = (
+  overrides: Partial<AgentNotification> = {},
+): AgentNotification => ({
   id: "22222222-2222-2222-2222-222222222222",
   title: "Reminder",
   body: "Standup in 5 minutes",
@@ -60,6 +68,8 @@ const notification = (): AgentNotification => ({
   deepLink: "/calendar",
   createdAt: Date.now(),
   readAt: null,
+  recipientId: OWNER,
+  ...overrides,
 });
 
 describe("push registration → delivery loop", () => {
@@ -86,10 +96,13 @@ describe("push registration → delivery loop", () => {
     await service.attach();
 
     // The route dispatcher resolves the push service off the runtime, exactly
-    // as the live server does.
+    // as the live server does. The canonical-owner setting makes the route
+    // bind the registered token to the OWNER principal.
     const routeRuntime = {
       getService: (t: string) =>
         t === NotificationPushService.serviceType ? service : null,
+      getSetting: (key: string) =>
+        key === "ELIZA_ADMIN_ENTITY_ID" ? OWNER : null,
     };
 
     // A device registers its APNs token through the real HTTP route.
@@ -111,7 +124,22 @@ describe("push registration → delivery loop", () => {
     expect(json).toHaveBeenCalledWith({}, { ok: true }, 201);
     expect(await service.getRegistry().count()).toBe(1);
 
-    // A notification is emitted on the bus; it must reach the iOS provider.
+    // The principal opts into push through the real policy route (PUT).
+    const policyJson = vi.fn();
+    const policyError = vi.fn();
+    const policyBody = vi.fn().mockResolvedValue({ pushEnabled: true });
+    await handlePushTokenRoute(
+      { url: "/api/notifications/push-policy" } as http.IncomingMessage,
+      {} as http.ServerResponse,
+      "/api/notifications/push-policy",
+      "PUT",
+      { runtime: routeRuntime },
+      { json: policyJson, error: policyError, readJsonBody: policyBody },
+    );
+    expect(policyJson).toHaveBeenCalled();
+
+    // A notification addressed to the principal is emitted on the bus; it must
+    // reach the iOS provider.
     emit({
       runId: "r1",
       seq: 1,
@@ -134,5 +162,24 @@ describe("push registration → delivery loop", () => {
     });
     // No android token was registered → FCM provider is untouched.
     expect(android.sent).toHaveLength(0);
+
+    // The same pipeline fails closed for a DIFFERENT principal: a notification
+    // addressed to another recipient never reaches this device.
+    emit({
+      runId: "r2",
+      seq: 2,
+      ts: Date.now(),
+      stream: NOTIFICATION_STREAM,
+      data: {
+        type: "notification",
+        notification: notification({
+          id: "33333333-3333-3333-3333-333333333333",
+          recipientId: "99999999-9999-4999-8999-999999999999",
+        }),
+        unreadCount: 2,
+      },
+    });
+    await flush();
+    expect(ios.sent).toHaveLength(1); // unchanged — cross-principal isolation
   });
 });

--- a/packages/agent/src/services/push/push-token-registry.test.ts
+++ b/packages/agent/src/services/push/push-token-registry.test.ts
@@ -773,4 +773,83 @@ describe("PushTokenRegistry", () => {
       },
     );
   });
+
+  describe("owner binding (#23106)", () => {
+    it("stores and lists tokens per owner, isolated across principals", async () => {
+      await registry.register("ios", "tok-a1", "owner-a");
+      await registry.register("android", "tok-a2", "owner-a");
+      await registry.register("ios", "tok-b1", "owner-b");
+      await registry.register("ios", "tok-free");
+
+      expect(
+        (await registry.listByOwner("owner-a")).map((r) => r.token),
+      ).toEqual(["tok-a1", "tok-a2"]);
+      expect(
+        (await registry.listByOwner("owner-b")).map((r) => r.token),
+      ).toEqual(["tok-b1"]);
+      // An unowned (legacy) token never matches any owner.
+      expect(await registry.listByOwner("owner-a")).not.toContainEqual(
+        expect.objectContaining({ token: "tok-free" }),
+      );
+      expect(await registry.listByOwner("owner-b")).toHaveLength(1);
+    });
+
+    it("re-registration moves a token between owners (upsert)", async () => {
+      await registry.register("ios", "tok-a1", "owner-a");
+      await registry.register("ios", "tok-a1", "owner-b");
+      expect(await registry.listByOwner("owner-a")).toHaveLength(0);
+      expect(
+        (await registry.listByOwner("owner-b")).map((r) => r.token),
+      ).toEqual(["tok-a1"]);
+    });
+
+    it("persists the owner across restart (hydration round-trip)", async () => {
+      await registry.register("ios", "tok-a1", "owner-a");
+      const restarted = new PushTokenRegistry(ctx.runtime);
+      expect(
+        (await restarted.listByOwner("owner-a")).map((r) => r.token),
+      ).toEqual(["tok-a1"]);
+    });
+
+    it("an oversized persisted owner string degrades to unowned (no throw on hydration)", async () => {
+      ctx.cache.set("push-tokens:00000000-0000-0000-0000-0000000000aa", [
+        {
+          token: "tok-huge-owner",
+          platform: "ios",
+          createdAt: 1,
+          ownerEntityId: "o".repeat(5000),
+        },
+      ]);
+      const fresh = new PushTokenRegistry(ctx.runtime);
+      await expect(fresh.hydrate()).resolves.toBeUndefined();
+      const all = await fresh.list();
+      expect(all.map((r) => r.token)).toEqual(["tok-huge-owner"]);
+      expect(all[0].ownerEntityId).toBeUndefined();
+      expect(await fresh.listByOwner("o".repeat(5000))).toHaveLength(0);
+    });
+
+    it("a corrupt owner field on a persisted row degrades to unowned, record still valid", async () => {
+      ctx.cache.set("push-tokens:00000000-0000-0000-0000-0000000000aa", [
+        { token: "tok-x", platform: "ios", createdAt: 1, ownerEntityId: 42 },
+      ]);
+      const fresh = new PushTokenRegistry(ctx.runtime);
+      const all = await fresh.list();
+      expect(all.map((r) => r.token)).toEqual(["tok-x"]);
+      expect(all[0].ownerEntityId).toBeUndefined();
+      expect(await fresh.listByOwner("owner-a")).toHaveLength(0);
+    });
+
+    it("rejects an oversized owner id with the typed validation error", async () => {
+      const hugeOwner = "o".repeat(5000);
+      await expect(
+        registry.register("ios", "tok-big", hugeOwner),
+      ).rejects.toThrow(/ownerEntityId exceeds the byte cap/);
+    });
+
+    it("a blank owner string registers unowned (never fabricated)", async () => {
+      await registry.register("ios", "tok-blank", "   ");
+      const all = await registry.list();
+      expect(all[0].ownerEntityId).toBeUndefined();
+    });
+  });
 });

--- a/packages/agent/src/services/push/push-token-registry.ts
+++ b/packages/agent/src/services/push/push-token-registry.ts
@@ -58,6 +58,13 @@ export interface PushTokenRecord {
   platform: PushPlatform;
   /** Unix ms when first registered (refreshed on re-registration). */
   createdAt: number;
+  /**
+   * Canonical owner entity id this device belongs to (#23106). Absent on
+   * legacy records — a token without an owner NEVER matches a recipient-bound
+   * push (fail-closed): it can be listed/unregistered, but no notification is
+   * ever pushed to it until the device re-registers with a principal.
+   */
+  ownerEntityId?: string;
 }
 
 /** Stable cache key the registry persists under (scoped per agent). */
@@ -157,6 +164,44 @@ function assertValidPlatform(platform: unknown): PushPlatform {
     });
   }
   return platform;
+}
+
+/**
+ * Canonicalize an optional owner entity id (#23106): a trimmed non-empty
+ * string, or undefined when absent/blank. Byte-capped like the token so a
+ * hostile caller cannot plant an oversized identifier in a cache row.
+ */
+function normalizeOwnerEntityId(ownerEntityId: unknown): string | undefined {
+  if (typeof ownerEntityId !== "string") return undefined;
+  const trimmed = ownerEntityId.trim();
+  if (!trimmed) return undefined;
+  if (utf8ByteLength(trimmed) > MAX_PUSH_TOKEN_BYTES) {
+    throw new ElizaError(
+      "[PushTokenRegistry] ownerEntityId exceeds the byte cap",
+      {
+        code: PUSH_TOKEN_INVALID_CODE,
+        context: { reason: "owner_too_large" },
+        severity: "ephemeral",
+      },
+    );
+  }
+  return trimmed;
+}
+
+/**
+ * Non-throwing form for HYDRATION only: a persisted row's owner field that
+ * fails validation (wrong type, oversized) degrades to unowned — the record
+ * stays valid and listable, and delivery to it fails closed. Contrast with
+ * {@link normalizeOwnerEntityId}, which gates live mutations and must reject.
+ */
+function parsePersistedOwnerEntityId(
+  ownerEntityId: unknown,
+): string | undefined {
+  if (typeof ownerEntityId !== "string") return undefined;
+  const trimmed = ownerEntityId.trim();
+  if (!trimmed) return undefined;
+  if (utf8ByteLength(trimmed) > MAX_PUSH_TOKEN_BYTES) return undefined;
+  return trimmed;
 }
 
 export class PushTokenRegistry {
@@ -296,7 +341,10 @@ export class PushTokenRegistry {
 
   /**
    * Register (upsert) a device token. Re-registering an existing token under a
-   * new platform moves it to that platform and refreshes `createdAt`.
+   * new platform moves it to that platform and refreshes `createdAt`. An
+   * optional `ownerEntityId` binds the device to a canonical principal (#23106)
+   * so pushes are recipient-bound; omitting it leaves the record unowned, and
+   * unowned records never receive pushes (fail-closed at the delivery seam).
    *
    * Observably atomic w.r.t. persistence: the mutation is staged on a candidate
    * Map and published only after the durable write succeeds, so a rejected write
@@ -304,9 +352,14 @@ export class PushTokenRegistry {
    * `platform` is validated at this boundary so a direct/untyped caller cannot
    * persist an unsupported transport.
    */
-  async register(platform: PushPlatform, token: string): Promise<void> {
+  async register(
+    platform: PushPlatform,
+    token: string,
+    ownerEntityId?: string,
+  ): Promise<void> {
     const validPlatform = assertValidPlatform(platform);
     const trimmed = assertValidToken(token);
+    const owner = normalizeOwnerEntityId(ownerEntityId);
     await this.enqueueMutation(async () => {
       await this.hydrate();
       const candidate = new Map(this.tokens);
@@ -314,6 +367,7 @@ export class PushTokenRegistry {
         token: trimmed,
         platform: validPlatform,
         createdAt: Date.now(),
+        ...(owner ? { ownerEntityId: owner } : {}),
       });
       evictOldestPushTokens(candidate);
       await this.commit(candidate);
@@ -348,6 +402,21 @@ export class PushTokenRegistry {
   async listByPlatform(platform: PushPlatform): Promise<PushTokenRecord[]> {
     await this.hydrate();
     return [...this.tokens.values()].filter((r) => r.platform === platform);
+  }
+
+  /**
+   * List token records owned by one canonical principal (#23106). Unowned
+   * legacy records never match — delivery to them fails closed.
+   */
+  async listByOwner(ownerEntityId: string): Promise<PushTokenRecord[]> {
+    // Read path: a malformed/oversized query owner matches nothing (no throw —
+    // delivery just fails closed to zero tokens).
+    const owner = parsePersistedOwnerEntityId(ownerEntityId);
+    if (owner === undefined) return [];
+    await this.hydrate();
+    return [...this.tokens.values()].filter(
+      (r) => r.ownerEntityId !== undefined && r.ownerEntityId === owner,
+    );
   }
 
   /** Total number of registered tokens. */
@@ -428,15 +497,21 @@ function isCanonicalPersistedArray(
     const raw = stored[i];
     if (typeof raw !== "object" || raw === null) return false;
     const record = raw as Record<string, unknown>;
-    if (Object.keys(record).length !== 3) return false;
+    // Canonical fields: the 3 legacy keys, plus an optional ownerEntityId
+    // (#23106) that is present only when the canonical record carries one.
     const expected = canonical[i];
+    const expectedKeyCount = expected.ownerEntityId ? 4 : 3;
     if (
       record.token !== expected.token ||
-      record.platform !== expected.platform ||
-      record.createdAt !== expected.createdAt
+      record.platform !== expected.platform
     ) {
       return false;
     }
+    if (record.createdAt !== expected.createdAt) return false;
+    if ((record.ownerEntityId ?? undefined) !== expected.ownerEntityId) {
+      return false;
+    }
+    if (Object.keys(record).length !== expectedKeyCount) return false;
   }
   return true;
 }
@@ -485,5 +560,15 @@ function parsePushTokenRecord(value: unknown): PushTokenRecord | null {
     return null;
   }
 
-  return { token, platform: record.platform, createdAt };
+  // #23106 optional owner: accepted only when it is a trimmed non-empty string
+  // within the byte cap; anything else is dropped (the record stays valid but
+  // unowned — delivery fails closed, listing keeps working).
+  const ownerEntityId = parsePersistedOwnerEntityId(record.ownerEntityId);
+
+  return {
+    token,
+    platform: record.platform,
+    createdAt,
+    ...(ownerEntityId ? { ownerEntityId } : {}),
+  };
 }

--- a/packages/core/src/services/notification.test.ts
+++ b/packages/core/src/services/notification.test.ts
@@ -36,6 +36,11 @@ async function createRuntime(
 		adapter,
 		logLevel: "fatal",
 		enableAutonomy: false,
+		// Distinct settings map per runtime: AgentRuntime falls back to a
+		// module-level shared environmentSettings map when `settings` is
+		// omitted, which would leak a canonical-owner setting between the
+		// sibling runtimes this suite creates (#23106 recipient tests).
+		settings: {},
 	});
 	await runtime.initialize();
 	await runtime.registerPlugin({
@@ -919,6 +924,84 @@ describe("NotificationService", () => {
 			await expect(
 				stopService.markRead("00000000-0000-4000-8000-000000000000"),
 			).rejects.toThrow(/service is stopped/);
+		});
+	});
+
+	describe("canonical recipient stamping (#23106)", () => {
+		const OWNER_ENTITY_ID = "22222222-2222-4222-8222-222222222222";
+		// The canonical-owner setting key resolveCanonicalOwnerId reads
+		// (roles.ts CANONICAL_OWNER_SETTING_KEY; not exported, so pinned here).
+		const CANONICAL_OWNER_SETTING_KEY = "ELIZA_ADMIN_ENTITY_ID";
+
+		let recipientRuntime: AgentRuntime;
+		let recipientCleanup: () => Promise<void>;
+		let recipientService: NotificationService;
+
+		beforeAll(async () => {
+			const created = await createRuntime([
+				AgentEventService,
+				NotificationService,
+			]);
+			recipientRuntime = created.runtime;
+			recipientCleanup = created.cleanup;
+			recipientRuntime.setSetting(CANONICAL_OWNER_SETTING_KEY, OWNER_ENTITY_ID);
+			recipientService = (await recipientRuntime.getServiceLoadPromise(
+				ServiceType.NOTIFICATION,
+			)) as NotificationService;
+		}, 180_000);
+
+		afterAll(async () => {
+			await recipientCleanup?.();
+		});
+
+		beforeEach(async () => {
+			await recipientService.clear();
+		});
+
+		it("stamps an explicit producer recipient verbatim", async () => {
+			const n = await recipientService.notify({
+				title: "direct",
+				recipientId: "33333333-3333-4333-8333-333333333333",
+			});
+			expect(n.recipientId).toBe("33333333-3333-4333-8333-333333333333");
+		});
+
+		it("defaults an absent recipient to the canonical owner when configured", async () => {
+			const n = await recipientService.notify({ title: "defaulted" });
+			expect(n.recipientId).toBe(OWNER_ENTITY_ID);
+		});
+
+		it("trims a whitespace recipient and drops an empty one to the canonical default", async () => {
+			const padded = await recipientService.notify({
+				title: "padded",
+				recipientId: `  ${"44444444-4444-4444-8444-444444444444"}  `,
+			});
+			expect(padded.recipientId).toBe("44444444-4444-4444-8444-444444444444");
+			const blank = await recipientService.notify({
+				title: "blank",
+				recipientId: "   ",
+			});
+			expect(blank.recipientId).toBe(OWNER_ENTITY_ID);
+		});
+
+		it("leaves the recipient undefined when no owner is resolvable (inbox-only, never fabricated)", async () => {
+			// A runtime with NO configured owner: the record must stay honestly
+			// unaddressed so the push seam fails closed to inbox-only.
+			const created = await createRuntime([
+				AgentEventService,
+				NotificationService,
+			]);
+			try {
+				const bareService = (await created.runtime.getServiceLoadPromise(
+					ServiceType.NOTIFICATION,
+				)) as NotificationService;
+				const n = await bareService.notify({ title: "unowned" });
+				expect(n.recipientId).toBeUndefined();
+				// Inbox regression guard: the record still lands in the inbox.
+				expect(bareService.list().map((x) => x.title)).toEqual(["unowned"]);
+			} finally {
+				await created.cleanup();
+			}
 		});
 	});
 });

--- a/packages/core/src/services/notification.test.ts
+++ b/packages/core/src/services/notification.test.ts
@@ -355,7 +355,9 @@ describe("NotificationService", () => {
 		expect(stored).toHaveLength(301);
 		expect(stored?.[0]?.title).toBe("Existing 0");
 		expect(stored?.at(-1)?.title).toBe("Must not evict");
-		expect(stored?.at(-1)?.title).toBe("Existing 299");
+		// The append preserved every pre-existing row in order: the row just
+		// before the appended one is still the last "Existing" notification.
+		expect(stored?.at(-2)?.title).toBe("Existing 299");
 	});
 
 	it("still records when no event bus is present", async () => {

--- a/packages/core/src/services/notification.ts
+++ b/packages/core/src/services/notification.ts
@@ -18,6 +18,7 @@
  */
 
 import { logger } from "../logger.ts";
+import { resolveCanonicalOwnerId } from "../roles.ts";
 import {
 	type AgentNotification,
 	DEFAULT_NOTIFICATION_CATEGORY,
@@ -464,6 +465,20 @@ export class NotificationService extends Service {
 			expiresAt = createdAt + SILENT_TIER_DEFAULT_EXPIRY_MS;
 		}
 
+		// #23106 canonical recipient: explicit producer address wins; otherwise
+		// the runtime's canonical owner is stamped when resolvable. Never
+		// fabricated — an unresolvable recipient stays undefined so the push
+		// seam treats the record as inbox-only (fail-closed), and a trimmed
+		// empty string from an untyped producer is dropped rather than stored.
+		const explicitRecipient =
+			typeof input.recipientId === "string"
+				? input.recipientId.trim()
+				: input.recipientId;
+		const recipientId =
+			explicitRecipient && explicitRecipient.length > 0
+				? explicitRecipient
+				: (resolveCanonicalOwnerId(this.runtime) ?? undefined);
+
 		const notification: AgentNotification = {
 			id: newNotificationId(),
 			title,
@@ -479,6 +494,7 @@ export class NotificationService extends Service {
 			readAt: null,
 			expiresAt,
 			agentId: input.agentId ?? (this.runtime.agentId as UUID),
+			recipientId,
 		};
 
 		this.notifications.push(notification);

--- a/packages/core/src/types/notification.ts
+++ b/packages/core/src/types/notification.ts
@@ -106,6 +106,15 @@ export interface AgentNotification {
 	expiresAt?: number | null;
 	/** Agent that produced it (multi-agent hosts). */
 	agentId?: UUID;
+	/**
+	 * Canonical recipient principal (entity id) this notification is addressed
+	 * to (#23106). Absent on legacy records; new records carry it whenever a
+	 * recipient is resolvable — explicit on `NotificationInput`, else the
+	 * runtime's canonical owner. Remote push delivery is recipient-bound: a
+	 * notification without a resolvable recipient stays inbox-only (fail-closed
+	 * at the push seam), never fanning to every registered device token.
+	 */
+	recipientId?: UUID | string;
 }
 
 /**
@@ -125,6 +134,14 @@ export interface NotificationInput {
 	/** Optional unix ms self-destroy time; absent/null means it never expires. */
 	expiresAt?: number | null;
 	agentId?: UUID;
+	/**
+	 * Canonical recipient principal (entity id) this notification is addressed
+	 * to (#23106). Explicit on input when a producer knows its audience;
+	 * otherwise the service stamps the runtime's canonical owner when one is
+	 * resolvable. Never fabricated — an unresolvable recipient stays `undefined`
+	 * so the push seam can treat it as inbox-only (fail-closed).
+	 */
+	recipientId?: UUID | string;
 }
 
 /** Query for listing notifications from the inbox. */


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Closes #23106 (first tranche per the maintainer disposition in the issue: "First require recipient and add an inbox-before-push policy seam; scheduler owns digests." Quiet hours, digests, and reversible learning remain for follow-up tranches.)
<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` was run after sync; focused verification (typecheck, lint, full push suites) passes — `bun run verify` was not run in full; the exact scoped coverage and one pre-existing unrelated failure are recorded in **Known gaps / failures**.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts. (base 7d55350499)
- [x] Scoped verification passes post-sync (typecheck/biome/91 push-suite tests); the exact unrelated pre-existing blocker is documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks
Medium. Push delivery semantics change for multi-user agents: legacy tokens registered without an owner never receive pushes until re-registered; a principal with no saved policy gets inbox-only (fail-closed by design). Inbox delivery itself is unchanged. Rollback is a revert; no migration/schema change.

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background
Notifications were agent-scoped: every push fan-fanned out to every registered token regardless of recipient, and there was no per-principal policy seam. Per the maintainer disposition, this tranche (1) makes notifications carry a canonical recipient and binds push delivery to it, and (2) adds an inbox-before-push policy seam with a fail-closed decision. Digests stay with the core scheduler architecture (one-clock invariant; AGENTS.md "Scheduling and personal-assistant domains") — no competing scheduler is introduced.

## What does this PR do?

- **Canonical recipient**: additive `recipientId` on `AgentNotification`/`NotificationInput` (explicit > canonical owner > absent — never fabricated, never agentId). Push delivery goes through `listByOwner`; the agent-scoped fan-out is removed. Legacy unowned tokens hydrate/list/unregister but never receive pushes.
- **Inbox-before-push policy seam**: new `packages/agent/src/services/push/push-policy.ts` — durable per-principal `PushDeliveryPolicy` + pure `decidePushDelivery` matrix: no recipient / no policy / corrupt policy / explicit deny → inbox-only; only explicit `pushEnabled: true` pushes.
- **Exact-shape untrusted-row validation**: `parsePushDeliveryPolicy` requires the row's own enumerable key set to equal exactly `{pushEnabled, version, updatedAt}` — extra keys fail closed and inherited (prototype) values are not substitutes (blocks `Object.create` inherited-policy injection; RED-controlled regression test).
- **Typed persist errors**: `PushPolicyStore.save` throws `ElizaError` (code `PUSH_POLICY_PERSIST_FAILED`, context, severity) instead of plain `Error`.
- **Routes**: `POST /api/notifications/push-tokens` binds owner (body ids accepted only when equal to the canonical owner; malformed/null → 400); `GET/PUT /api/notifications/push-policy` (409 without canonical owner); remote-forwarder forwards the new policy mutations.

## What kind of change is this?

Bug fixes (privacy: recipient-bound push) + Features (per-principal push policy seam). Non-breaking: `recipientId` is additive; unowned legacy tokens degrade to inbox-only by design.

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?
My changes do not require a change to the project documentation. (The push service README already describes the seam files; behavior is documented in code headers.)

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

`packages/agent/src/services/push/push-policy.ts` (policy + pure decision matrix), then `push-token-registry.ts` (`listByOwner`), then `notification-push-service.ts` (recipient-bound delivery), then `packages/core/src/services/notification.ts` (recipient stamping), then the tests in the same directories.

## Detailed testing steps

1. `bun test packages/agent/src/services/push/push-policy.test.ts packages/agent/src/services/push/notification-push-service.test.ts packages/agent/src/services/push/push-token-registry.test.ts packages/agent/src/api/push-token-routes.test.ts packages/agent/src/services/push/push-registration-flow.test.ts` → 91/91 pass.
2. RED control: restore only the length-only key-count check in `parsePushDeliveryPolicy` → the corrupt-variant test fails (the `Object.create` decoy row with a valid policy on the prototype is accepted). This pins the new behavior, not the old.
3. `bun run --cwd packages/agent typecheck` → clean; `biome check` on changed files → clean.
4. Recipient stamping matrix: `packages/core/src/services/notification.test.ts` (present/absent/padded recipient; never agentId).

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:587ca4605693cd102091e51312afd1e991965dfa -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only change: agent push/notification services, routes, core types; no rendered UI surface touched.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only change: no rendered UI surface touched.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - backend-only change: no user-visible UI flow; behavior proven by the 91-test suite + RED control.
<!-- evidence-row:backend-logs -->
- [x] Backend transcript at head 587ca46056 (concurrency-cure push; prior 91-test evidence at 54b5efcc below):

<details><summary>backend logs</summary>

```
$ bunx vitest run packages/agent/src/services/push packages/agent/src/api/push-token-routes.test.ts packages/core/src/services/notification.test.ts
Test Files  9 passed (9)
      Tests  179 passed (179)        # incl. 12 new: store update() suite (7) + route concurrency (1) + core at(-2) fix (existing file, was red at reviewed head)

# RED control A — route reverted to inline load->bump->save:
(fail) concurrent PUTs for one principal serialize to distinct monotonic versions (no lost opt-out)
# restored -> 179/179

# RED control B — store update() de-serialized to direct bumpAndSave:
(fail) serializes concurrent same-principal updates: every PUT gets a distinct monotonic version
(fail) keeps the newer tail when updates chain (identity-checked cleanup)
# restored -> 179/179

# Mutation control — settle-cleanup changed to unconditional delete:
(fail) keeps the newer tail when updates chain (identity-checked cleanup)
# restored -> 179/179

$ biome check <5 changed files>            # exit 0, clean
$ bun run --cwd packages/agent typecheck   # 19 errors IDENTICAL to pristine origin/develop control (pre-existing cloud/shared billing, unrelated; diff of sorted error lists empty)
```

</details>

Concurrency-cure details, per-finding responses, and the dual-reviewer evidence: see the latest review-response comment.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - backend-only change: no frontend request path touched (agent push/notification services, routes, core types).
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent/action/provider/prompt/model change: notification delivery policy only, no model invocation in the changed path.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - policy rows live in the runtime cache store and are proven by the round-trip + corrupt-row tests in push-policy.test.ts; no durable DB artifact is produced by this tranche.
<!-- evidence-row:ocr-review -->
- [ ] N/A - change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change; no live-model run required for a notification-delivery policy seam.

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

<details><summary>bun test / typecheck / biome / RED control (exact commands + output)</summary>

```
$ bun test packages/agent/src/services/push/{push-policy,notification-push-service,push-token-registry,push-registration-flow}.test.ts packages/agent/src/api/push-token-routes.test.ts
Ran 91 tests across 5 files. [661.00ms]   # all pass

$ bun run --cwd packages/agent typecheck
$ tsc --noEmit -p tsconfig.json            # exit 0

$ biome check <changed files>              # exit 0, no findings

# RED control: only the key-set check reverted to length-only:
(fail) parsePushDeliveryPolicy (untrusted boundary) > rejects every corrupt variant (fail-closed to null)
```

</details>

Frontend: N/A - backend-only change.

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

### Before
N/A - backend-only change.
### After
N/A - backend-only change.
### Walkthrough video
N/A - backend-only change; no UI flow.

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

N/A - no voice/transcript/TTS/STT change.

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

- `packages/core/src/services/notification.test.ts`: 4 failures (durable-row retention `retains every durable row through the exact-import boundary`, stop-drain timeouts) that are **pre-existing on develop** — control run with this branch stashed and the pristine develop test file reproduces the identical 4 failures. Not attributable to this PR.
- `bun run verify` (full repo gate) was not run this cycle; scoped equivalents (typecheck, lint, all 5 affected suites, RED control, biome) all pass. The full verify run on this machine is currently blocked by an unrelated disk-space incident affecting sibling worktrees (resolved for this worktree).

List any command failure, missing artifact, unavailable device, unavailable live
service, or evidence row marked N/A. Include the exact reason and why it is not a
blocker for this PR.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->


AI provider/model: zai / glm-5.3
Client / agent tooling: Hermes Agent
Skill revision: elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [hermes-t3rpz]
<!-- eliza-computer-attribution:v1 {"provider":"zai","model":"glm-5.3","client":"Hermes Agent","skill_revision":"elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza"} -->




