### PR TITLE
fix(remote): close the connection-mode allowlist for secure remote hosts

### DIFF
--- a/packages/cloud/api/v1/remote/hosts/route.ts
+++ b/packages/cloud/api/v1/remote/hosts/route.ts
@@ -14,7 +14,10 @@ import { remoteHostsRepository } from "@/db/repositories/remote-hosts";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import type { AppEnv } from "@/types/cloud-worker-env";
-import { isRemoteControlIdentifier } from "../validation";
+import {
+  isRemoteConnectionMode,
+  isRemoteControlIdentifier,
+} from "../validation";
 
 const app = new Hono<AppEnv>();
 const REMOTE_HOST_ONLINE_WINDOW_MS = 15_000;
@@ -103,7 +106,7 @@ app.post("/", async (c) => {
     };
     if (
       !isRemoteControlIdentifier(body.deviceId) ||
-      !isRemoteControlIdentifier(connectionMode) ||
+      !isRemoteConnectionMode(connectionMode) ||
       !isRemoteTargetPublicIdentity(identity)
     ) {
       return c.json(
@@ -122,7 +125,7 @@ app.post("/", async (c) => {
           deviceId: body.deviceId as string,
           displayName: identity.displayName,
           platform: identity.platform,
-          connectionMode: connectionMode as string,
+          connectionMode,
           runtimeKeyId: identity.keyId,
           signingPublicJwk: identity.signingPublicKeyJwk,
           encryptionPublicJwk: identity.encryptionPublicKeyJwk,

--- a/packages/cloud/api/v1/remote/relay-routes.test.ts
+++ b/packages/cloud/api/v1/remote/relay-routes.test.ts
@@ -236,6 +236,26 @@ describe("secure remote relay routes", () => {
     );
   });
 
+  test("rejects a non-relay connection mode before any host state is created", async () => {
+    for (const connectionMode of ["headscale", "tunnel", "direct", "RELAY"]) {
+      createOwned.mockReset();
+      recoverHostCredential.mockReset();
+      const response = await request("/api/v1/remote/hosts", {
+        ownerId,
+        deviceId: "linux-one",
+        displayName: "Linux One",
+        platform: "linux",
+        connectionMode,
+        runtimeKeyId: targetKeyId,
+        signingPublicKeyJwk: publicJwk,
+        encryptionPublicKeyJwk: publicJwk,
+      });
+      expect(response.status).toBe(400);
+      expect(createOwned).not.toHaveBeenCalled();
+      expect(recoverHostCredential).not.toHaveBeenCalled();
+    }
+  });
+
   test("bootstraps the authenticated owner and target public keys without leaking host credentials", async () => {
     const staleHostId = "40000000-0000-4000-8000-000000000002";
     listOwned.mockResolvedValue([

--- a/packages/cloud/api/v1/remote/validation.ts
+++ b/packages/cloud/api/v1/remote/validation.ts
@@ -1,3 +1,6 @@
 /** Validates untrusted remote relay identities and public enrollment keys. */
 
-export { isRemoteControlIdentifier } from "@elizaos/shared/contracts/remote-control";
+export {
+  isRemoteConnectionMode,
+  isRemoteControlIdentifier,
+} from "@elizaos/shared/contracts/remote-control";

--- a/packages/cloud/shared/src/db/migrations/0313_remote_host_connection_mode_check.sql
+++ b/packages/cloud/shared/src/db/migrations/0313_remote_host_connection_mode_check.sql
@@ -1,0 +1,21 @@
+-- Make the remote-host connection-mode allowlist honest in storage. Rows
+-- enrolled before the endpoint validator could carry any free-form mode, so
+-- first fail closed: every non-relay row is revoked (audit history retained,
+-- current capability removed), then the constraint pins active rows to relay.
+-- Revoked rows may keep their legacy mode value for audit.
+
+UPDATE "remote_hosts"
+SET
+  "status" = 'revoked',
+  "revoked_at" = COALESCE("revoked_at", NOW()),
+  "updated_at" = NOW()
+WHERE
+  "connection_mode" <> 'relay';
+
+--> statement-breakpoint
+ALTER TABLE "remote_hosts"
+  DROP CONSTRAINT IF EXISTS "remote_hosts_connection_mode_check";
+--> statement-breakpoint
+ALTER TABLE "remote_hosts"
+  ADD CONSTRAINT "remote_hosts_connection_mode_check"
+  CHECK ("connection_mode" = 'relay' OR "status" = 'revoked');

--- a/packages/cloud/shared/src/db/migrations/meta/_journal.json
+++ b/packages/cloud/shared/src/db/migrations/meta/_journal.json
@@ -2073,6 +2073,13 @@
       "when": 1794254400003,
       "tag": "0312_personal_shared_group_delivery_attempts",
       "breakpoints": true
+    },
+    {
+      "idx": 296,
+      "version": "7",
+      "when": 1794254400004,
+      "tag": "0313_remote_host_connection_mode_check",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/cloud/shared/src/db/migrations/remote-host-connection-mode-check.test.ts
+++ b/packages/cloud/shared/src/db/migrations/remote-host-connection-mode-check.test.ts
@@ -1,0 +1,204 @@
+/** Applies the remote-host connection-mode CHECK migration to real PGlite and proves the backfill fails closed. */
+import { afterEach, describe, expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { PGlite } from "@electric-sql/pglite";
+
+const migration = await readFile(
+  new URL("./0313_remote_host_connection_mode_check.sql", import.meta.url),
+  "utf8",
+);
+
+const databases: PGlite[] = [];
+
+async function database(): Promise<PGlite> {
+  const db = new PGlite();
+  databases.push(db);
+  await db.exec(`
+    CREATE TABLE remote_hosts (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      organization_id uuid NOT NULL,
+      user_id uuid NOT NULL,
+      device_id text NOT NULL,
+      display_name text NOT NULL,
+      platform text NOT NULL,
+      connection_mode text NOT NULL,
+      runtime_key_id text NOT NULL,
+      signing_public_jwk jsonb NOT NULL,
+      encryption_public_jwk jsonb NOT NULL,
+      host_token_hash text NOT NULL,
+      status text DEFAULT 'active' NOT NULL,
+      last_seen_at timestamp,
+      created_at timestamp DEFAULT now() NOT NULL,
+      updated_at timestamp DEFAULT now() NOT NULL,
+      revoked_at timestamp,
+      CONSTRAINT remote_hosts_status_check CHECK (
+        (status = 'active' AND revoked_at IS NULL)
+        OR (status = 'revoked' AND revoked_at IS NOT NULL)
+      )
+    )
+  `);
+  return db;
+}
+
+afterEach(async () => {
+  await Promise.all(databases.splice(0).map((db) => db.close()));
+});
+
+describe("0313 remote host connection-mode check", () => {
+  test("revokes non-relay legacy rows, preserves relay rows and their status", async () => {
+    const db = await database();
+    await db.exec(`
+      INSERT INTO remote_hosts
+        (organization_id, user_id, device_id, display_name, platform, connection_mode,
+         runtime_key_id, signing_public_jwk, encryption_public_jwk, host_token_hash, status, revoked_at)
+      VALUES
+        ('00000000-0000-4000-8000-000000000001', '00000000-0000-4000-8000-000000000002',
+         'relay-host', 'Relay Host', 'linux', 'relay', 'key-r', '{}', '{}', 'hash-r', 'active', NULL),
+        ('00000000-0000-4000-8000-000000000001', '00000000-0000-4000-8000-000000000002',
+         'legacy-ssh', 'Legacy SSH', 'linux', 'ssh', 'key-s', '{}', '{}', 'hash-s', 'active', NULL),
+        ('00000000-0000-4000-8000-000000000001', '00000000-0000-4000-8000-000000000002',
+         'relay-revoked', 'Already Revoked', 'linux', 'relay', 'key-x', '{}', '{}',
+         'hash-x', 'revoked', '2026-01-01T00:00:00Z')
+    `);
+
+    await db.exec(migration);
+
+    const result = await db.query<{
+      device_id: string;
+      connection_mode: string;
+      status: string;
+      revoked_at: string | null;
+    }>(`
+      SELECT device_id, connection_mode, status, revoked_at
+      FROM remote_hosts
+      ORDER BY device_id
+    `);
+
+    const rows = result.rows;
+    expect(rows).toHaveLength(3);
+    const relayHost = rows.find((row) => row.device_id === "relay-host");
+    expect(relayHost?.status).toBe("active");
+    expect(relayHost?.revoked_at).toBeNull();
+    const legacySsh = rows.find((row) => row.device_id === "legacy-ssh");
+    expect(legacySsh?.status).toBe("revoked");
+    expect(legacySsh?.revoked_at).not.toBeNull();
+    const relayRevoked = rows.find((row) => row.device_id === "relay-revoked");
+    expect(relayRevoked?.status).toBe("revoked");
+    expect(relayRevoked?.revoked_at).not.toBeNull();
+    // The already-revoked row keeps its original revoked_at (COALESCE preserved it).
+    expect(relayRevoked?.revoked_at === legacySsh?.revoked_at).toBe(false);
+  });
+
+  test("enforces the CHECK constraint against new and updated rows", async () => {
+    const db = await database();
+    await db.exec(migration);
+
+    await db.exec(`
+      INSERT INTO remote_hosts
+        (organization_id, user_id, device_id, display_name, platform, connection_mode,
+         runtime_key_id, signing_public_jwk, encryption_public_jwk, host_token_hash)
+      VALUES
+        ('00000000-0000-4000-8000-000000000001', '00000000-0000-4000-8000-000000000002',
+         'relay-ok', 'Relay OK', 'linux', 'relay', 'key-r', '{}', '{}', 'hash-r')
+    `);
+    await db.exec("UPDATE remote_hosts SET connection_mode = 'relay' WHERE device_id = 'relay-ok'");
+
+    let insertRejected = false;
+    try {
+      await db.exec(`
+        INSERT INTO remote_hosts
+          (organization_id, user_id, device_id, display_name, platform, connection_mode,
+           runtime_key_id, signing_public_jwk, encryption_public_jwk, host_token_hash)
+        VALUES
+          ('00000000-0000-4000-8000-000000000001', '00000000-0000-4000-8000-000000000002',
+           'bad-mode', 'Bad Mode', 'linux', 'ssh', 'key-b', '{}', '{}', 'hash-b')
+      `);
+    } catch {
+      insertRejected = true;
+    }
+    expect(insertRejected).toBe(true);
+
+    let updateRejected = false;
+    try {
+      await db.exec(
+        "UPDATE remote_hosts SET connection_mode = 'tunnel' WHERE device_id = 'relay-ok'",
+      );
+    } catch {
+      updateRejected = true;
+    }
+    expect(updateRejected).toBe(true);
+
+    const result = await db.query<{ connection_mode: string }>(
+      "SELECT connection_mode FROM remote_hosts WHERE device_id = 'relay-ok'",
+    );
+    expect(result.rows[0]?.connection_mode).toBe("relay");
+  });
+
+  test("is idempotent: re-applying preserves the constraint and existing rows", async () => {
+    const db = await database();
+    await db.exec(`
+      INSERT INTO remote_hosts
+        (organization_id, user_id, device_id, display_name, platform, connection_mode,
+         runtime_key_id, signing_public_jwk, encryption_public_jwk, host_token_hash)
+      VALUES
+        ('00000000-0000-4000-8000-000000000001', '00000000-0000-4000-8000-000000000002',
+         'legacy-ssh', 'Legacy SSH', 'linux', 'ssh', 'key-s', '{}', '{}', 'hash-s')
+    `);
+    await db.exec(migration);
+    await db.exec(migration);
+
+    const result = await db.query<{ status: string; revoked_at: string | null }>(
+      "SELECT status, revoked_at FROM remote_hosts WHERE device_id = 'legacy-ssh'",
+    );
+    expect(result.rows[0]?.status).toBe("revoked");
+    expect(result.rows[0]?.revoked_at).not.toBeNull();
+
+    let rejected = false;
+    try {
+      await db.exec(
+        "UPDATE remote_hosts SET connection_mode = 'headscale' WHERE device_id = 'legacy-ssh'",
+      );
+    } catch {
+      rejected = true;
+    }
+    // The legacy row is revoked, so retaining 'ssh' is allowed (audit history).
+    expect(rejected).toBe(false);
+    // But flipping an active row's mode away from relay is rejected.
+    await db.exec(`
+      INSERT INTO remote_hosts
+        (organization_id, user_id, device_id, display_name, platform, connection_mode,
+         runtime_key_id, signing_public_jwk, encryption_public_jwk, host_token_hash)
+      VALUES
+        ('00000000-0000-4000-8000-000000000001', '00000000-0000-4000-8000-000000000002',
+         'relay-live', 'Relay Live', 'linux', 'relay', 'key-l', '{}', '{}', 'hash-l')
+    `);
+    let activeRejected = false;
+    try {
+      await db.exec(
+        "UPDATE remote_hosts SET connection_mode = 'headscale' WHERE device_id = 'relay-live'",
+      );
+    } catch {
+      activeRejected = true;
+    }
+    expect(activeRejected).toBe(true);
+
+    // The only path where a brand-new non-relay value can legally enter the
+    // table: an INSERT that is already revoked (audit-style), per the CHECK's
+    // (relay OR revoked) carve-out.
+    await db.exec(`
+      INSERT INTO remote_hosts
+        (organization_id, user_id, device_id, display_name, platform, connection_mode,
+         runtime_key_id, signing_public_jwk, encryption_public_jwk, host_token_hash,
+         status, revoked_at)
+      VALUES
+        ('00000000-0000-4000-8000-000000000001', '00000000-0000-4000-8000-000000000002',
+         'legacy-audit', 'Legacy Audit', 'linux', 'ssh', 'key-a', '{}', '{}', 'hash-a',
+         'revoked', '2026-01-01T00:00:00Z')
+    `);
+    const auditRow = await db.query<{ status: string; connection_mode: string }>(
+      "SELECT status, connection_mode FROM remote_hosts WHERE device_id = 'legacy-audit'",
+    );
+    expect(auditRow.rows[0]?.status).toBe("revoked");
+    expect(auditRow.rows[0]?.connection_mode).toBe("ssh");
+  });
+});

--- a/packages/cloud/shared/src/db/repositories/remote-hosts.ts
+++ b/packages/cloud/shared/src/db/repositories/remote-hosts.ts
@@ -5,7 +5,10 @@
  */
 
 import { ElizaError } from "@elizaos/core";
-import { canonicalizeRemoteControlValue } from "@elizaos/shared/contracts/remote-control";
+import {
+  canonicalizeRemoteControlValue,
+  type RemoteConnectionMode,
+} from "@elizaos/shared/contracts/remote-control";
 import { and, asc, desc, eq, inArray, type SQL } from "drizzle-orm";
 import type { Database } from "../client";
 import { hashRemoteHostToken } from "../crypto/remote-host-token";
@@ -27,7 +30,7 @@ export interface RecoverRemoteHostCredentialInput {
   deviceId: string;
   displayName: string;
   platform: string;
-  connectionMode: string;
+  connectionMode: RemoteConnectionMode;
   runtimeKeyId: string;
   signingPublicJwk: JsonWebKey;
   encryptionPublicJwk: JsonWebKey;

--- a/packages/cloud/shared/src/db/repositories/remote-hosts.ts
+++ b/packages/cloud/shared/src/db/repositories/remote-hosts.ts
@@ -168,6 +168,10 @@ export class RemoteHostsRepository {
         .for("update");
       if (!current) return { kind: "not_found" };
       if (current.status !== "active") return { kind: "revoked" };
+      // connection_mode is only guaranteed to be a RemoteConnectionMode for
+      // active rows (migration 0313 + schema check); revoked legacy rows may
+      // retain other values for audit, so never narrow the read type without
+      // filtering on status.
       if (
         current.device_id !== input.deviceId ||
         current.display_name !== input.displayName ||

--- a/packages/cloud/shared/src/db/schemas/remote-hosts.ts
+++ b/packages/cloud/shared/src/db/schemas/remote-hosts.ts
@@ -5,7 +5,17 @@
  */
 
 import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
-import { index, jsonb, pgTable, text, timestamp, uniqueIndex, uuid } from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
+import {
+  check,
+  index,
+  jsonb,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+} from "drizzle-orm/pg-core";
 import { organizations } from "./organizations";
 import { users } from "./users";
 
@@ -49,6 +59,15 @@ export const remoteHosts = pgTable(
       table.runtime_key_id,
     ),
     statusIdx: index("remote_hosts_status_idx").on(table.status),
+    // Mirrors migration 0313: an active remote host must declare a
+    // REMOTE_CONNECTION_MODES member; revoked rows may retain legacy values
+    // for audit. The closed TS allowlist and the database constraint stay
+    // honest about each other. Widening requires a lane that owns
+    // schema+migration.
+    connectionModeCheck: check(
+      "remote_hosts_connection_mode_check",
+      sql`${table.connection_mode} = 'relay' OR ${table.status} = 'revoked'`,
+    ),
   }),
 );
 

--- a/packages/shared/src/contracts/remote-control.test.ts
+++ b/packages/shared/src/contracts/remote-control.test.ts
@@ -4,8 +4,10 @@ import { describe, expect, it } from "vitest";
 import {
   canonicalizeRemoteControlValue,
   isEncryptedRemoteControlEnvelope,
+  isRemoteConnectionMode,
   isRemoteControlIdentifier,
   isSignedRemoteCommand,
+  REMOTE_CONNECTION_MODES,
   REMOTE_CONTROL_ENVELOPE_ALGORITHM,
   REMOTE_CONTROL_PROTOCOL_VERSION,
   REMOTE_CONTROL_SIGNATURE_ALGORITHM,
@@ -115,5 +117,31 @@ describe("remote-control contract", () => {
     expect(isEncryptedRemoteControlEnvelope({ ...envelope, sequence: 0 })).toBe(
       false,
     );
+  });
+});
+
+describe("remote connection-mode allowlist", () => {
+  it("admits relay and only relay without normalization", () => {
+    expect(isRemoteConnectionMode("relay")).toBe(true);
+    for (const rejected of [
+      "RELAY",
+      "relay ",
+      " relay",
+      "headscale",
+      "tunnel",
+      "direct",
+      "ssh",
+      "",
+      0,
+      null,
+      undefined,
+      {},
+    ]) {
+      expect(isRemoteConnectionMode(rejected)).toBe(false);
+    }
+  });
+
+  it("pins the closed union so widening requires a reviewed lane", () => {
+    expect([...REMOTE_CONNECTION_MODES]).toStrictEqual(["relay"]);
   });
 });

--- a/packages/shared/src/contracts/remote-control.ts
+++ b/packages/shared/src/contracts/remote-control.ts
@@ -18,6 +18,24 @@ export const REMOTE_CONTROL_MAX_CANONICAL_BYTES = 1_048_576 as const;
 export const REMOTE_CONTROL_MAX_REPLAY_ENTRIES_PER_SESSION = 4_096 as const;
 export const REMOTE_CONTROL_MAX_ACTIVE_SESSIONS = 256 as const;
 
+/**
+ * Closed allowlist of connection modes a secure remote host may declare.
+ * Relay is the only transport v1 admits; adding a member requires a reviewed
+ * lane that also owns the schema, migration, and transport cleanup contract.
+ */
+export const REMOTE_CONNECTION_MODES = ["relay"] as const;
+
+export type RemoteConnectionMode = (typeof REMOTE_CONNECTION_MODES)[number];
+
+export function isRemoteConnectionMode(
+  value: unknown,
+): value is RemoteConnectionMode {
+  return (
+    typeof value === "string" &&
+    (REMOTE_CONNECTION_MODES as readonly string[]).includes(value)
+  );
+}
+
 export const REMOTE_CONTROLLER_PLATFORMS = [
   "ios",
   "macos",


### PR DESCRIPTION
## Summary

Part of #23271 (staged rebuild). Defensive relay-only v1 slice: the secure host enrollment write path validated `connectionMode` with the generic `isRemoteControlIdentifier` check, so any 1–256 character trimmed string was persisted to `remote_hosts.connection_mode`, while the UI read path (`remote-control-cloud-client.ts`) accepts exactly `["relay"]` via `exactEnum`. A host enrolled with a foreign/future mode would be persisted by Cloud but rejected by the client that owns it — and any future transport dispatch keyed on this column would inherit an unvalidated discriminator.

This PR pins a closed `RemoteConnectionMode = "relay"` union (`REMOTE_CONNECTION_MODES`) in `@elizaos/shared/contracts/remote-control`, gates both enrollment and credential recovery on `isRemoteConnectionMode` (400 before any repository call), and narrows `RecoverRemoteHostCredentialInput.connectionMode` from `string` to `RemoteConnectionMode` so a non-relay value is unrepresentable at the repository input type.

Per the maintainer disposition this slice deliberately adds no managed-network transport, no migration (journal stays at 296 entries), and no staging mutation: it makes a non-relay connection mode impossible-by-construction until a reviewed lane adds the transport deliberately (new enum member + schema + migration together).

### Severity framing (added in response to review)

This is **defense-in-depth and data integrity, not a live transport-selection bypass**. Two independent reasons (both verified by @sarah-pump-ai and re-checked here):

- The cloud client validates on read: `remote-control-cloud-client.ts:200` parses the host list with `exactEnum(item.connectionMode, "connection mode", ["relay"])`, so a non-relay value coming back from the server is rejected at parse time — it never reaches transport selection.
- The SSH transport selector (`ssh-runtime-transport.ts:22`) reads `loadAgentProfileRegistry().profiles` — the **local agent profile registry**, a different collection from cloud-enrolled remote hosts. A host enrolled through this endpoint does not land there.

### Round 2: storage backstop (responds to "the narrowed type isn't backed by storage")

The reviewer correctly noted the column was plain `text NOT NULL` with no CHECK and no read validation, so the narrowed `RemoteConnectionMode` type asserted an invariant storage didn't enforce, and pre-validator rows could hold values the type says are impossible. Round 2 makes the type honest in storage:

- **Migration 0313** fail-closed backfill first: every non-relay row is revoked (`status='revoked'`, `revoked_at = COALESCE(revoked_at, NOW())` — audit history preserved, current capability removed, matching the existing `remote_hosts_status_check` semantics), then `CHECK (connection_mode = 'relay' OR status = 'revoked')` pins **active** rows to relay. Revoked legacy rows may retain their historical mode value for audit; a revoked row can never be reactivated without also fixing its mode (`SET status='active'` on a non-relay row evaluates false OR false and is rejected by the CHECK). The constraint also catches any future write path that bypasses the endpoint validator, and fails closed an old-code replica still admitting free-form modes mid-rollout.
- **Drizzle schema mirror**: the same `check()` constraint is declared on the `remote_hosts` table so schema tooling sees it.
- **PGlite migration test** (3 tests): backfill revokes non-relay rows while preserving relay rows and already-revoked rows' original `revoked_at`; CHECK rejects non-relay INSERTs and active-row UPDATEs while allowing the audit carve-out (revoked row keeps `'ssh'`, direct revoked INSERT allowed); idempotent re-application.
- **Read-site caveat** documented at `remote-hosts.ts` recovery comparison: `connection_mode` is only guaranteed to be a `RemoteConnectionMode` for active rows — never narrow the read type without filtering on status.

The journal moves from 296 to 297 entries with `0313_remote_host_connection_mode_check` (this supersedes the original no-migration framing; the reviewer's CHECK ask makes the migration the right call now).

## Root-cause evidence

- Sole-writer grep at base `fb2326972c`: only `packages/cloud/api/v1/remote/hosts/route.ts:138` writes `connection_mode` in the entire cloud tree (`git grep -n "connection_mode" fb2326972c -- 'packages/cloud/**'` — remaining hits are the schema/migration definitions and a read-side change detector).
- Route derivation is raw: `const connectionMode = body.connectionMode ?? "relay";` — no trim/canonicalization, so `" relay"` / `"RELAY"` are rejected at the boundary, matching the contract-test claim of no normalization.
- RED control: with the route change stashed (develop behavior), the new route test fails — non-relay modes (`headscale`, `tunnel`, `direct`, `RELAY`) were accepted with 201 and `createOwned` invoked. With the fix: 400 and neither `createOwned` nor `recoverCredential` called.

## Test evidence

Round-1 suites run at `2de0eb2d21`; round-2 suites (migration backstop) run at `3e3a987680` in a fresh worktree, pinned Bun 1.3.14:

| Suite | Result |
|---|---|
| `packages/shared/src/contracts/remote-control.test.ts` (incl. 2 new) | 7/7 pass |
| `packages/cloud/api/v1/remote/relay-routes.test.ts` (incl. 1 new) | 16/16 pass |
| `packages/cloud/api/v1/remote/pair/route.test.ts` | 8/8 pass |
| `packages/cloud/api/v1/remote/sessions/owner-boundary.test.ts` | 5/5 pass |
| `packages/cloud/shared/src/db/repositories/remote-command-envelopes.pglite.test.ts` | 12/12 pass |
| `packages/cloud/shared/src/db/crypto/remote-pairing-code.test.ts` | pass |
| `packages/app-core/src/security/remote-control-crypto.test.ts` | 6/6 pass |
| `packages/app-core/src/security/remote-control-journal.test.ts` | 7/7 pass |
| `packages/app-core/platforms/electrobun/src/ssh-runtime-rpc.test.ts` | 6/6 pass |
| Typecheck `shared` / `cloud-shared` / `cloud-api` | exit 0 each |
| `packages/cloud/shared/src/db/migrations/remote-host-connection-mode-check.test.ts` (new, round 2) | 3/3 pass (17 assertions) |
| `drizzle-kit check` (cloud/shared, round 2) | clean |
| Typecheck `shared` / `cloud-shared` / `cloud-api` | exit 0 each (pre-existing cloud/shared errors verified identical on pristine origin/develop control) |
| Biome check (6 changed files) | clean |

New tests:
- Contract: `admits relay and only relay without normalization` (rejects `RELAY`, `"relay "`, `" relay"`, `headscale`, `tunnel`, `direct`, `ssh`, `""`, non-strings) and `pins the closed union so widening requires a reviewed lane` (`[...REMOTE_CONNECTION_MODES]` === `["relay"]` — decision-record against silent widening).
- Route: `rejects a non-relay connection mode before any host state is created` — per-mode 400 + repository mocks never called.

## Independent review

**Round 1** — RepoPrompt CE review agent (opus) reviewed the full embedded diff with surrounding develop bytes: **APPROVE**, zero must-fix items, after both of its blocking gates were closed by execution (typechecks green; sole-writer grep + raw-derivation confirmation above). It flagged the storage backstop as a follow-up; that follow-up is now delivered in round 2.

**Round 2** — RepoPrompt CE review agent (opus) reviewed the round-2 delta (migration 0313 + schema check + PGlite tests) with exact bytes embedded: **APPROVE**, zero must-fix items. One SHOULD-FIX (missing `--> statement-breakpoint` between the two ALTER statements — the migration runner at `packages/cloud/scripts/admin/migrate-with-diagnostics.ts:146` splits on exactly that token) was verified against the real runner source and fixed before push; the runner's multi-statement PGlite fallback was confirmed in the same file. Its NOTE-level suggestions (read-site caveat comment, INSERT-time carve-out test) are also included. Deploy-order note from the review: with the constraint in place, an old-code replica still admitting free-form modes gets a DB error (fail-closed) instead of the new 400 — acceptable and expected.

## Evidence

| Row | Value |
|---|---|
| backend-logs | See inline transcript above: RED control (`(fail) secure remote relay routes > rejects a non-relay connection mode before any host state is created` with route fix stashed) → green `(pass)` with fix; `grep -cE "^\(pass\)"` = 79 across the 9 remote-surface suites; typecheck exit codes 0/0/0; biome clean at rebased head. Round 2 at `3e3a987680`: `bun test src/db/migrations/remote-host-connection-mode-check.test.ts` → 3 pass / 0 fail / 17 assertions; `drizzle-kit check` → "Everything's fine"; relay-routes 15/15; biome clean on changed files. |
| screenshots | N/A - pure contract/HTTP-boundary change with no UI surface; behavior is asserted by execution, not pixels. |
| mp4-walkthrough | N/A - no user-visible surface changes; the changed path is a Cloudflare Worker route + shared contract. |
| llm-trajectory | N/A - no model/trajectory changes; slice touches validation plumbing only. |

AI provider/model: zai / glm-5.3
Client / agent tooling: Hermes Agent
Skill revision: elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [hermes-t3rpz]
<!-- eliza-computer-attribution:v1 {"provider":"zai","model":"glm-5.3","client":"Hermes Agent","skill_revision":"elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza"} -->

<!-- evidence-head:4638c1365bbb626a3a907e3b9145e3219dca3f1c -->
<!-- evidence-row:backend-logs -->
<details>
<summary>bun test output — RED control and green battery (real run)</summary>

```
# RED control (route fix stashed at base fb2326972c):
$ bun test packages/cloud/api/v1/remote/relay-routes.test.ts
(fail) secure remote relay routes > rejects a non-relay connection mode before any host state is created [0.56ms]
# develop accepted connectionMode=headscale/tunnel/direct/RELAY with 201 and invoked createOwned.

# Fix applied (branch head):
$ bun test packages/cloud/api/v1/remote/relay-routes.test.ts packages/shared/src/contracts/remote-control.test.ts
(pass) secure remote relay routes > rejects a non-relay connection mode before any host state is created [0.20ms]
(pass) remote connection-mode allowlist > admits relay and only relay without normalization [0.03ms]
(pass) remote connection-mode allowlist > pins the closed union so widening requires a reviewed lane [0.01ms]

# Full battery at rebased head 2de0eb2d21 (79 pass / 0 fail across 9 suites):
$ bun test <9 remote suites> | grep -cE "^\(pass\)"
79
$ bun run --cwd packages/cloud/api typecheck && bun run --cwd packages/cloud/shared typecheck
exit 0 / exit 0
```
</details>
<!-- evidence-row:before-screenshots -->
N/A - no UI surface changed; validation-boundary slice only
<!-- evidence-row:after-screenshots -->
N/A - no UI surface changed; validation-boundary slice only
<!-- evidence-row:walkthrough-video -->
N/A - Cloudflare Worker route plus shared contract only; no user-visible surface to walk through
<!-- evidence-row:frontend-logs -->
N/A - no frontend code touched
<!-- evidence-row:llm-trajectory -->
N/A - no model or trajectory changes; validation plumbing only
<!-- evidence-row:domain-artifacts -->
N/A - no domain artifact produced by this change





