### PR TITLE
fix(skills): scan to the first valid frontmatter closer

### DIFF
--- a/packages/skills/src/frontmatter.ts
+++ b/packages/skills/src/frontmatter.ts
@@ -68,14 +68,29 @@ function extractFrontmatter(content: string): {
     return { yamlString: null, body: normalized };
   }
 
+  // Scan forward to the first line that actually closes the block. A `\n---`
+  // sequence can also occur inside a quoted multi-line YAML scalar (e.g. a
+  // description quoting a markdown rule); cutting there truncates the value
+  // and turns legal frontmatter into invalid YAML.
   const startOffset = openMatch[0].length;
-  const endIndex = normalized.indexOf("\n---", startOffset - 1);
+  // Start one character back so an immediately adjacent closer (an empty
+  // frontmatter block, `---\n---`) is still recognized as a candidate.
+  let cursor = startOffset - 1;
+  let endIndex = -1;
+  while (cursor < normalized.length) {
+    const candidate = normalized.indexOf("\n---", cursor);
+    if (candidate === -1) break;
+    if (/^---\s*(?:\n|$)/.test(normalized.slice(candidate + 1))) {
+      endIndex = candidate;
+      break;
+    }
+    cursor = candidate + 1;
+  }
   if (endIndex === -1) {
     return { yamlString: null, body: normalized };
   }
 
-  const afterClosing = normalized.slice(endIndex + 1);
-  const closeMatch = afterClosing.match(/^---\s*(?:\n|$)/);
+  const closeMatch = normalized.slice(endIndex + 1).match(/^---\s*(?:\n|$)/);
   const closingLength = closeMatch ? closeMatch[0].length : 4;
 
   return {

--- a/packages/skills/test/frontmatter.test.ts
+++ b/packages/skills/test/frontmatter.test.ts
@@ -72,6 +72,35 @@ Body`;
     assert.deepStrictEqual(result.frontmatter, {});
   });
 
+  it("rejects a typo'd ---- separator instead of swallowing frontmatter into the body", () => {
+    const content =
+      '---\ndescription: "A skill"\nname: my-skill\n----\nversion: 2\n---\nBody';
+    assert.throws(() => parseFrontmatter(content), (error: unknown) => {
+      assert.ok(error instanceof ElizaError);
+      assert.equal(error.code, INVALID_SKILL_FRONTMATTER_YAML);
+      return true;
+    });
+  });
+
+  it("preserves a dashes rule inside the body after a valid closer", () => {
+    const result = parseFrontmatter(
+      "---\nname: ok\n---\nRules\n----\nMore rules",
+    );
+    assert.deepStrictEqual(result.frontmatter, { name: "ok" });
+    assert.equal(result.body, "Rules\n----\nMore rules");
+  });
+
+  it("parses quoted scalars whose indented continuation contains ---", () => {
+    const result = parseFrontmatter(
+      '---\ndescription: "alpha\n  --- beta\n  gamma"\nname: quoted-skill\n---\nBody',
+    );
+    assert.deepStrictEqual(result.frontmatter, {
+      description: "alpha --- beta gamma",
+      name: "quoted-skill",
+    });
+    assert.equal(result.body, "Body");
+  });
+
   it("parses complex frontmatter with arrays", () => {
     const content = `---
 name: complex-skill


### PR DESCRIPTION
Supersedes #28404 because the contributor fork could not be rebased with the available maintainer OAuth scope. Preserves the original contributor as commit author.

Closes #28388.

This removes the parser’s first-`\n---` cut: it scans to the first delimiter that is actually valid, so a typoed `----` separator cannot silently swallow remaining frontmatter into the body. Invalid YAML now follows the existing typed `INVALID_SKILL_FRONTMATTER_YAML` path.

Validation on exact head `906fd1ea10f3aedc8be8ee55197f3696d754fae8` rebased onto `develop@3654ba0cff7e80e97d830e42e88b66af50581273`:

- `bun run --cwd packages/skills test` — 110 pass, 0 fail
- `bun run --cwd packages/skills build` — pass
- `bun run --cwd packages/skills lint:check` — pass
- `bun run verify` — 144/146 workspace tasks completed; failed only in `@elizaos/core#build` because this machine’s npm shell wrapper was invoked through Node (`set -euo pipefail` syntax error), outside this two-file diff

Evidence: the adversarial tests cover a typoed `----` candidate followed by a valid closer, a body rule after a valid closer, and an indented quoted scalar containing `---`. Existing tests cover empty/missing/valid closers and malformed YAML. No UI, model, network, persistent-domain, audio, or visual surface is changed, so those evidence categories are N/A.