### PR TITLE
fix(shared): preserve single-character streaming deltas

### DIFF
--- a/packages/shared/src/utils/streaming-text.test.ts
+++ b/packages/shared/src/utils/streaming-text.test.ts
@@ -91,6 +91,53 @@ describe("streaming text named regressions", () => {
     });
   });
 
+  it("preserves leading repeated-character runs streamed one token at a time", () => {
+    // Regression for #28041: the regressive-snapshot guard used to fire on a
+    // single-char delta whose char equals the buffer's leading char, dropping
+    // every char after the second. A run of >=3 identical chars anchored at the
+    // string start ("...", "!!!", "---", the "```" code fence) must survive.
+    const stream = (tokens: string[]) =>
+      tokens.reduce((acc, token) => mergeStreamingText(acc, token), "");
+    expect(stream([".", ".", "."])).toBe("...");
+    expect(stream(["!", "!", "!"])).toBe("!!!");
+    expect(stream(["-", "-", "-"])).toBe("---");
+    expect(stream(["#", "#", "#", " ", "H"])).toBe("### H");
+
+    // A markdown code fence followed by a language tag: the third backtick used
+    // to be swallowed, corrupting code-block rendering in the legacy per-token
+    // chat path.
+    let fence = "";
+    for (const token of ["`", "`", "`", "j", "s"]) {
+      fence = mergeStreamingText(fence, token);
+    }
+    expect(fence).toBe("```js");
+
+    // Step-level classification: the third "." is a real append, not unchanged.
+    expect(resolveStreamingUpdate("..", ".")).toEqual({
+      kind: "append",
+      nextText: "...",
+      emittedText: ".",
+    });
+    expect(computeStreamingDelta("``", "`")).toBe("`");
+  });
+
+  it("still ignores genuine regressive snapshots and non-tail single chars", () => {
+    // A multi-char prefix of the buffer is a stale snapshot, not an append.
+    expect(mergeStreamingText("hello world", "hello")).toBe("hello world");
+    expect(resolveStreamingUpdate("hello world", "hello")).toEqual({
+      kind: "unchanged",
+      nextText: "hello world",
+      emittedText: "",
+    });
+    // A single char that is the leading char but does NOT match the tail stays
+    // a regressive no-op (buffer "ab" already advanced past the leading "a").
+    expect(mergeStreamingText("ab", "a")).toBe("ab");
+    // A single whitespace delta remains regressive, matching the equality path.
+    expect(mergeStreamingText("  x", " ")).toBe("  x");
+    // Full-snapshot growth (incoming starts with existing) is unchanged.
+    expect(mergeStreamingText(".", "...")).toBe("...");
+  });
+
   it("deduplicates overlapping suffix/prefix fragments", () => {
     expect(mergeStreamingText("Hello wor", "world")).toBe("Hello world");
     expect(computeStreamingDelta("Hello wor", "world")).toBe("ld");
@@ -156,7 +203,18 @@ describe("streaming text fuzz invariants", () => {
   it("ignores regressive snapshots that are prefixes of existing text", () => {
     fc.assert(
       fc.property(textArbitrary, textArbitrary, (prefix, suffix) => {
-        fc.pre(!(suffix === "" && prefix.length === 1 && /\S/u.test(prefix)));
+        // A single non-whitespace char that also matches the buffer's tail is a
+        // repeated-character append (#28041), not a regressive snapshot, so it
+        // is excluded here alongside the existing equality carve-out.
+        fc.pre(
+          !(
+            prefix.length === 1 &&
+            /\S/u.test(prefix) &&
+            `${prefix}${suffix}`
+              .normalize("NFC")
+              .endsWith(prefix.normalize("NFC"))
+          ),
+        );
         const existing = `${prefix}${suffix}`;
 
         expect(mergeStreamingText(existing, prefix)).toBe(existing);

--- a/packages/shared/src/utils/streaming-text.test.ts
+++ b/packages/shared/src/utils/streaming-text.test.ts
@@ -132,6 +132,16 @@ describe("streaming text named regressions", () => {
     // appends instead of being dropped.
     expect(mergeStreamingText("ab", "a")).toBe("aba");
     expect(mergeStreamingText("ahbbh", "a")).toBe("ahbbha");
+
+    // Unicode code points outside the BMP occupy two UTF-16 code units but
+    // remain one streamed character. They follow the same append contract.
+    expect(stream([..."😀😀"])).toBe("😀😀");
+    expect(stream([..."😀a😀"])).toBe("😀a😀");
+    expect(resolveStreamingUpdate("😀a", "😀")).toEqual({
+      kind: "append",
+      nextText: "😀a😀",
+      emittedText: "😀",
+    });
   });
 
   it("still ignores genuine multi-character regressive snapshots", () => {
@@ -202,7 +212,7 @@ describe("streaming text fuzz invariants", () => {
   it("treats cumulative snapshots as replacements, not duplicated appends", () => {
     fc.assert(
       fc.property(textArbitrary, textArbitrary, (prefix, suffix) => {
-        fc.pre(!(suffix === "" && prefix.length === 1 && /\S/u.test(prefix)));
+        fc.pre(!(suffix === "" && /^\S$/u.test(prefix)));
         const incoming = `${prefix}${suffix}`;
 
         expect(mergeStreamingText(prefix, incoming)).toBe(incoming);
@@ -219,7 +229,7 @@ describe("streaming text fuzz invariants", () => {
         // not a regressive snapshot, so it is excluded here alongside the
         // existing equality carve-out. Multi-character prefixes remain
         // regressive and are still asserted below.
-        fc.pre(!(prefix.length === 1 && /\S/u.test(prefix)));
+        fc.pre(!/^\S$/u.test(prefix));
         const existing = `${prefix}${suffix}`;
 
         expect(mergeStreamingText(existing, prefix)).toBe(existing);

--- a/packages/shared/src/utils/streaming-text.test.ts
+++ b/packages/shared/src/utils/streaming-text.test.ts
@@ -91,26 +91,35 @@ describe("streaming text named regressions", () => {
     });
   });
 
-  it("preserves leading repeated-character runs streamed one token at a time", () => {
+  it("reconstructs any non-whitespace stream one token at a time", () => {
     // Regression for #28041: the regressive-snapshot guard used to fire on a
-    // single-char delta whose char equals the buffer's leading char, dropping
-    // every char after the second. A run of >=3 identical chars anchored at the
-    // string start ("...", "!!!", "---", the "```" code fence) must survive.
+    // single-char delta equal to the buffer's leading char, dropping every
+    // occurrence of that char after the first. A one-char snapshot of a longer
+    // buffer carries no information, so all non-whitespace single-char deltas
+    // must append -- character-by-character streaming is lossless.
     const stream = (tokens: string[]) =>
       tokens.reduce((acc, token) => mergeStreamingText(acc, token), "");
+    // Leading runs of identical chars ("...", "!!!", "---", the "```" fence).
     expect(stream([".", ".", "."])).toBe("...");
     expect(stream(["!", "!", "!"])).toBe("!!!");
     expect(stream(["-", "-", "-"])).toBe("---");
     expect(stream(["#", "#", "#", " ", "H"])).toBe("### H");
 
-    // A markdown code fence followed by a language tag: the third backtick used
-    // to be swallowed, corrupting code-block rendering in the legacy per-token
-    // chat path.
-    let fence = "";
-    for (const token of ["`", "`", "`", "j", "s"]) {
-      fence = mergeStreamingText(fence, token);
-    }
-    expect(fence).toBe("```js");
+    // Interior chars equal to the leading char used to be swallowed too: the
+    // guard only tested `buffer[0] === incoming`. Streaming "aba" dropped the
+    // final "a", and code identifiers lost repeated letters.
+    expect(stream([..."aba"])).toBe("aba");
+    expect(stream([..."const c = 1"])).toBe("const c = 1");
+    expect(stream([..."- item one\n- item two"])).toBe(
+      "- item one\n- item two",
+    );
+
+    // The PR's own motivating example: a full markdown code block streamed one
+    // char at a time must round-trip, including the CLOSING fence -- which the
+    // narrower tail-only fix still dropped (buffer started with a backtick but
+    // ended with a newline by then).
+    const codeBlock = "```js\nconst x = 1\n```";
+    expect(stream([...codeBlock])).toBe(codeBlock);
 
     // Step-level classification: the third "." is a real append, not unchanged.
     expect(resolveStreamingUpdate("..", ".")).toEqual({
@@ -119,19 +128,22 @@ describe("streaming text named regressions", () => {
       emittedText: ".",
     });
     expect(computeStreamingDelta("``", "`")).toBe("`");
+    // A single char equal to the buffer's leading char but not its tail now
+    // appends instead of being dropped.
+    expect(mergeStreamingText("ab", "a")).toBe("aba");
+    expect(mergeStreamingText("ahbbh", "a")).toBe("ahbbha");
   });
 
-  it("still ignores genuine regressive snapshots and non-tail single chars", () => {
-    // A multi-char prefix of the buffer is a stale snapshot, not an append.
+  it("still ignores genuine multi-character regressive snapshots", () => {
+    // A multi-char prefix of the buffer is a stale snapshot, not an append; the
+    // single-char carve-out does not widen to multi-character deltas.
     expect(mergeStreamingText("hello world", "hello")).toBe("hello world");
     expect(resolveStreamingUpdate("hello world", "hello")).toEqual({
       kind: "unchanged",
       nextText: "hello world",
       emittedText: "",
     });
-    // A single char that is the leading char but does NOT match the tail stays
-    // a regressive no-op (buffer "ab" already advanced past the leading "a").
-    expect(mergeStreamingText("ab", "a")).toBe("ab");
+    expect(mergeStreamingText("abcdef", "abc")).toBe("abcdef");
     // A single whitespace delta remains regressive, matching the equality path.
     expect(mergeStreamingText("  x", " ")).toBe("  x");
     // Full-snapshot growth (incoming starts with existing) is unchanged.
@@ -203,18 +215,11 @@ describe("streaming text fuzz invariants", () => {
   it("ignores regressive snapshots that are prefixes of existing text", () => {
     fc.assert(
       fc.property(textArbitrary, textArbitrary, (prefix, suffix) => {
-        // A single non-whitespace char that also matches the buffer's tail is a
-        // repeated-character append (#28041), not a regressive snapshot, so it
-        // is excluded here alongside the existing equality carve-out.
-        fc.pre(
-          !(
-            prefix.length === 1 &&
-            /\S/u.test(prefix) &&
-            `${prefix}${suffix}`
-              .normalize("NFC")
-              .endsWith(prefix.normalize("NFC"))
-          ),
-        );
+        // Every non-whitespace single-char delta is a token append (#28041),
+        // not a regressive snapshot, so it is excluded here alongside the
+        // existing equality carve-out. Multi-character prefixes remain
+        // regressive and are still asserted below.
+        fc.pre(!(prefix.length === 1 && /\S/u.test(prefix)));
         const existing = `${prefix}${suffix}`;
 
         expect(mergeStreamingText(existing, prefix)).toBe(existing);

--- a/packages/shared/src/utils/streaming-text.test.ts
+++ b/packages/shared/src/utils/streaming-text.test.ts
@@ -150,6 +150,27 @@ describe("streaming text named regressions", () => {
     expect(stream([decomposedAcute, decomposedAcute])).toBe(
       `${decomposedAcute}${decomposedAcute}`,
     );
+
+    // Some Unicode composition exclusions expand under NFC. They are still
+    // one raw streamed code point and must not enter snapshot heuristics.
+    const bmpCompositionExclusion = "\u0958";
+    const astralCompositionExclusion = "\u{1d1bb}";
+    expect(stream([bmpCompositionExclusion, bmpCompositionExclusion])).toBe(
+      `${bmpCompositionExclusion}${bmpCompositionExclusion}`,
+    );
+    expect(
+      stream([astralCompositionExclusion, "x", astralCompositionExclusion]),
+    ).toBe(`${astralCompositionExclusion}x${astralCompositionExclusion}`);
+    expect(
+      resolveStreamingUpdate(
+        `${bmpCompositionExclusion}a`,
+        bmpCompositionExclusion,
+      ),
+    ).toEqual({
+      kind: "append",
+      nextText: `${bmpCompositionExclusion}a${bmpCompositionExclusion}`,
+      emittedText: bmpCompositionExclusion,
+    });
   });
 
   it("still ignores genuine multi-character regressive snapshots", () => {

--- a/packages/shared/src/utils/streaming-text.test.ts
+++ b/packages/shared/src/utils/streaming-text.test.ts
@@ -142,6 +142,14 @@ describe("streaming text named regressions", () => {
       nextText: "😀a😀",
       emittedText: "😀",
     });
+
+    // Canonically equivalent decomposed graphemes are normalized before the
+    // single-code-point decision, so a repeated streamed token is not mistaken
+    // for an unchanged snapshot.
+    const decomposedAcute = "e\u0301";
+    expect(stream([decomposedAcute, decomposedAcute])).toBe(
+      `${decomposedAcute}${decomposedAcute}`,
+    );
   });
 
   it("still ignores genuine multi-character regressive snapshots", () => {

--- a/packages/shared/src/utils/streaming-text.ts
+++ b/packages/shared/src/utils/streaming-text.ts
@@ -131,8 +131,18 @@ export function mergeStreamingText(existing: string, incoming: string): string {
     return incoming;
   }
 
-  // Ignore clearly regressive snapshots.
-  if (existingNorm.startsWith(incomingNorm)) {
+  // Ignore clearly regressive snapshots, but never let this guard swallow a
+  // plausible repeated single-character append. When the buffer already starts
+  // with the same char as an incoming one-char delta, the guard would fire
+  // before the overlap loop and drop every char after the second, so a leading
+  // run of identical chars streamed one token at a time ("...", "!!!", the
+  // "```" of a code fence) rendered truncated. Defer to the overlap loop, which
+  // already appends a single-char delta that matches the tail of the buffer.
+  const isRepeatedCharAppend =
+    incoming.length === 1 &&
+    /\S/u.test(incoming) &&
+    existingNorm.endsWith(incomingNorm);
+  if (existingNorm.startsWith(incomingNorm) && !isRepeatedCharAppend) {
     return existing;
   }
 

--- a/packages/shared/src/utils/streaming-text.ts
+++ b/packages/shared/src/utils/streaming-text.ts
@@ -82,6 +82,10 @@ function commonSuffixLength(
   return length;
 }
 
+function isSingleNonWhitespaceCodePoint(value: string): boolean {
+  return /^\S$/u.test(value);
+}
+
 function isLikelySnapshotReplacement(
   existing: string,
   incoming: string,
@@ -114,11 +118,10 @@ export function mergeStreamingText(existing: string, incoming: string): string {
   // Normalize unicode for comparison, but return original incoming when selected.
   const existingNorm = existing.normalize("NFC");
   const incomingNorm = incoming.normalize("NFC");
+  const isSingleCodePointDelta = isSingleNonWhitespaceCodePoint(incoming);
 
   if (incomingNorm === existingNorm) {
-    return incoming.length === 1 && /\S/u.test(incoming)
-      ? `${existing}${incoming}`
-      : incoming;
+    return isSingleCodePointDelta ? `${existing}${incoming}` : incoming;
   }
 
   // Common case: the stream sends the full text-so-far.
@@ -141,9 +144,16 @@ export function mergeStreamingText(existing: string, incoming: string): string {
   // the first). Defer all non-whitespace single-char deltas to the overlap
   // loop, which appends them; genuine regressive snapshots are multi-character
   // and still caught here.
-  const isSingleCharDelta = incoming.length === 1 && /\S/u.test(incoming);
-  if (existingNorm.startsWith(incomingNorm) && !isSingleCharDelta) {
+  if (existingNorm.startsWith(incomingNorm) && !isSingleCodePointDelta) {
     return existing;
+  }
+
+  // Legacy frames cannot distinguish a one-code-point snapshot from a delta.
+  // Once the cumulative and regressive cases above are excluded, preserve the
+  // documented lossless-delta contract before UTF-16 overlap heuristics can
+  // misclassify astral characters as multi-character snapshot replacements.
+  if (isSingleCodePointDelta) {
+    return `${existing}${incoming}`;
   }
 
   // Use trimmed existing for overlap detection so trailing whitespace
@@ -167,9 +177,9 @@ export function mergeStreamingText(existing: string, incoming: string): string {
     if (!match) continue;
 
     if (overlap === incomingNorm.length) {
-      // Preserve repeated single-character deltas like "l" + "l", but avoid
-      // replaying larger suffix fragments already present in the buffer.
-      return incoming.length === 1 ? `${existing}${incoming}` : existing;
+      // Single-code-point deltas returned above; a larger suffix fragment
+      // already present in the buffer is a replay.
+      return existing;
     }
 
     const suffix = sliceAfterNormalizedOverlap(incoming, incomingNorm, overlap);

--- a/packages/shared/src/utils/streaming-text.ts
+++ b/packages/shared/src/utils/streaming-text.ts
@@ -132,17 +132,17 @@ export function mergeStreamingText(existing: string, incoming: string): string {
   }
 
   // Ignore clearly regressive snapshots, but never let this guard swallow a
-  // plausible repeated single-character append. When the buffer already starts
-  // with the same char as an incoming one-char delta, the guard would fire
-  // before the overlap loop and drop every char after the second, so a leading
-  // run of identical chars streamed one token at a time ("...", "!!!", the
-  // "```" of a code fence) rendered truncated. Defer to the overlap loop, which
-  // already appends a single-char delta that matches the tail of the buffer.
-  const isRepeatedCharAppend =
-    incoming.length === 1 &&
-    /\S/u.test(incoming) &&
-    existingNorm.endsWith(incomingNorm);
-  if (existingNorm.startsWith(incomingNorm) && !isRepeatedCharAppend) {
+  // single-character delta. A one-char snapshot of a longer buffer carries no
+  // information, so it is never a real regressive snapshot; under delta framing
+  // it is the next token and must append. The guard fires on
+  // `existingNorm.startsWith(incomingNorm)`, which for a one-char delta is just
+  // `buffer[0] === incoming` -- swallowing every occurrence of the buffer's
+  // leading char ("...", "!!!", the "```" fence, and any interior char equal to
+  // the first). Defer all non-whitespace single-char deltas to the overlap
+  // loop, which appends them; genuine regressive snapshots are multi-character
+  // and still caught here.
+  const isSingleCharDelta = incoming.length === 1 && /\S/u.test(incoming);
+  if (existingNorm.startsWith(incomingNorm) && !isSingleCharDelta) {
     return existing;
   }
 

--- a/packages/shared/src/utils/streaming-text.ts
+++ b/packages/shared/src/utils/streaming-text.ts
@@ -118,7 +118,9 @@ export function mergeStreamingText(existing: string, incoming: string): string {
   // Normalize unicode for comparison, but return original incoming when selected.
   const existingNorm = existing.normalize("NFC");
   const incomingNorm = incoming.normalize("NFC");
-  const isSingleCodePointDelta = isSingleNonWhitespaceCodePoint(incomingNorm);
+  const isSingleCodePointDelta =
+    isSingleNonWhitespaceCodePoint(incoming) ||
+    isSingleNonWhitespaceCodePoint(incomingNorm);
 
   if (incomingNorm === existingNorm) {
     return isSingleCodePointDelta ? `${existing}${incoming}` : incoming;

--- a/packages/shared/src/utils/streaming-text.ts
+++ b/packages/shared/src/utils/streaming-text.ts
@@ -118,7 +118,7 @@ export function mergeStreamingText(existing: string, incoming: string): string {
   // Normalize unicode for comparison, but return original incoming when selected.
   const existingNorm = existing.normalize("NFC");
   const incomingNorm = incoming.normalize("NFC");
-  const isSingleCodePointDelta = isSingleNonWhitespaceCodePoint(incoming);
+  const isSingleCodePointDelta = isSingleNonWhitespaceCodePoint(incomingNorm);
 
   if (incomingNorm === existingNorm) {
     return isSingleCodePointDelta ? `${existing}${incoming}` : incoming;


### PR DESCRIPTION
Supersedes #28054 after exact-head review and rebase; preserves the original contributor as commit author.

Closes #28041.

`mergeStreamingText` treated a one-character delta equal to the first buffered character as a regressive snapshot and silently dropped it. This routes non-whitespace single-character deltas through the existing append/overlap path, preserving repeated leading characters, interior repeated characters, and closing Markdown fences while retaining the multi-character regressive-snapshot guard.

Validation on exact head `4bbf12019d74ab23fd3cedbb12d346f57469a97f` rebased onto `develop@3654ba0cff7e80e97d830e42e88b66af50581273`:

- focused streaming-text suite: 16/16 pass
- shared lint: pass
- shared build: pass
- full shared lane: 201 files / 2,407 tests pass; 29 untouched suites fail collection because the incomplete workspace install cannot resolve `@elizaos/prompts`
- shared typecheck reaches two pre-existing untouched `brand-classic` literal-type errors
- root install/verify on this machine is blocked by the existing npm shell-wrapper packaging error documented in #28756

The focused suite includes named regressions for `...`, `!!!`, interior characters, streamed Markdown closing fences, update classification, and property checks for multi-character snapshot behavior. No UI layout, network, persistent-domain, audio, or visual surface changes; those evidence categories are N/A.