### PR TITLE
test(cloud): cover html escape boundaries

### DIFF
--- a/packages/cloud/shared/src/lib/utils/html.test.ts
+++ b/packages/cloud/shared/src/lib/utils/html.test.ts
@@ -18,3 +18,112 @@ describe("html", () => {
     expect(() => serializeInlineScriptValue(undefined)).toThrow();
   });
 });
+
+/**
+ * escapeHtml guards Cloud response interpolation (oidc error pages, GitHub
+ * return pages) and serializeInlineScriptValue guards JSON values embedded in
+ * HTML <script> elements (app frontend hosting window globals). A regression
+ * here is an XSS class bug, so these assertions pin exact escaped bytes, the
+ * ampersand-first replacement order, and full script-terminator suppression.
+ */
+describe("escapeHtml edge contract", () => {
+  it("escapes each metacharacter to its exact replacement bytes", () => {
+    expect(escapeHtml("&")).toBe("&amp;");
+    expect(escapeHtml("<")).toBe("&lt;");
+    expect(escapeHtml(">")).toBe("&gt;");
+    expect(escapeHtml('"')).toBe("&quot;");
+    expect(escapeHtml("'")).toBe("&#039;");
+  });
+
+  it("replaces ampersands first so introduced entities are never double-escaped", () => {
+    // If `<` were replaced before `&`, the produced `&lt;` would itself be
+    // rewritten to `&amp;lt;`. Length pinning proves the ordering.
+    expect(escapeHtml("<")).toHaveLength(4);
+    // Pre-escaped input must survive as text, not be mangled into a new entity.
+    expect(escapeHtml("&lt;script&gt;")).toBe("&amp;lt;script&amp;gt;");
+    expect(escapeHtml("a & b")).toBe("a &amp; b");
+  });
+
+  it("leaves safe text untouched", () => {
+    expect(escapeHtml("")).toBe("");
+    expect(escapeHtml("plain text 123")).toBe("plain text 123");
+    expect(escapeHtml("café ☕")).toBe("café ☕");
+  });
+
+  it("neutralizes markup and attribute-context injection payloads", () => {
+    const escaped = escapeHtml('<script>alert("x")</script>');
+    expect(escaped).not.toMatch(/[<>"']/);
+    expect(escaped).toBe("&lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt;");
+
+    // Both quote styles must die so the value cannot break out of either a
+    // double-quoted or single-quoted HTML attribute.
+    const attr = escapeHtml("x' onclick='alert(1)");
+    expect(attr).toBe("x&#039; onclick=&#039;alert(1)");
+    expect(escapeHtml('"><svg onload=alert(1)>')).toBe("&quot;&gt;&lt;svg onload=alert(1)&gt;");
+  });
+});
+
+describe("serializeInlineScriptValue edge contract", () => {
+  it("escapes every angle bracket so no script terminator can survive", () => {
+    const serialized = serializeInlineScriptValue({
+      redirect: "</script><script>alert(1)</script>",
+      upper: "</SCRIPT>",
+      spaced: "</script >",
+      commentClose: "-->",
+    });
+    expect(serialized).not.toContain("<");
+    expect(serialized).not.toContain("</");
+    expect(serialized).not.toContain(">");
+    expect(serialized).toContain("--\\u003e");
+    expect(serialized).toContain("\\u003c/script\\u003e");
+    // Nested values get the escapes too: the transform runs on the whole
+    // serialized document, not only top-level strings.
+    expect(serialized).toContain("\\u003c/SCRIPT\\u003e");
+  });
+
+  it("escapes ampersands so entities cannot re-form during HTML re-parsing", () => {
+    expect(serializeInlineScriptValue("fish & chips")).toBe('"fish \\u0026 chips"');
+    expect(serializeInlineScriptValue({ query: "?a=1&b=2" })).toContain("?a=1\\u0026b=2");
+  });
+
+  it("escapes U+2028/U+2029 line separators into pure-ASCII output", () => {
+    const serialized = serializeInlineScriptValue({ note: "line para end" });
+    // Raw separators are legal JSON but terminate JS string literals in some
+    // parsers; both must leave as escape sequences.
+    expect(serialized).not.toContain(" ");
+    expect(serialized).not.toContain(" ");
+    expect(serialized).toContain("\\u2028");
+    expect(serialized).toContain("\\u2029");
+    expect(serialized).toMatch(/^[\x20-\x7e]*$/);
+  });
+
+  it("round-trips values through JSON.parse unchanged", () => {
+    for (const value of [
+      null,
+      true,
+      42,
+      -1.5,
+      "",
+      "plain",
+      "</script>&  ",
+      ["a", 1, null],
+      { nested: { deep: ["<b>", "&amp;"] } },
+      { unicode: "célestine 🌙" },
+    ]) {
+      expect(JSON.parse(serializeInlineScriptValue(value))).toEqual(value);
+    }
+  });
+
+  it("keeps the app-frontend-hosting window-global injection shape terminator-free", () => {
+    const attackerControlled = '</script><script>window.location="https://evil.test"';
+    const literal = `window.__ELIZA_APP_API_BASE__ = ${serializeInlineScriptValue(attackerControlled)};`;
+    expect(literal).not.toContain("</script");
+    expect(literal).toContain("\\u003c/script\\u003e");
+  });
+
+  it("throws TypeError for values JSON cannot represent", () => {
+    expect(() => serializeInlineScriptValue(undefined)).toThrow(TypeError);
+    expect(() => serializeInlineScriptValue(() => "fn")).toThrow(TypeError);
+    expect(() => serializeInlineScriptValue(Symbol("s"))).toThrow(TypeError);
+  });
+});


### PR DESCRIPTION
## test(cloud): cover html escape boundaries

test(cloud): cover html escape boundaries

### Summary

Strengthens the thin smoke suite for `packages/cloud/shared/src/lib/utils/html.ts` (authored by #26295: one combined-input escape check, a `toContain("a")` smoke test, one `toContain("\u003c")`, one throw check) into a contract-pinning regression guard. The module is the XSS boundary for Cloud response interpolation (`oidc/errors.ts` error pages, `agent-github-return.ts` return pages) and for JSON values embedded in HTML `<script>` elements (`app-frontend-hosting.ts` window globals); a regression here is an XSS-class bug, and the prior suite could not detect one.

Additive-only (+109 lines, 1 file): appends two `describe` blocks with 10 tests / 47 assertions total (file now 14/14 green under `bun test`, this package's lane).

### What the new tests pin

- exact escaped bytes for all five HTML metacharacters (`&` `<` `>` `"` `'`)
- ampersand-first replacement ordering — `&lt;` input survives as text (`&amp;lt;`), never double-escapes into a mangled entity
- full `</script>` suppression in serialized values including `</SCRIPT>` case-folded and `</script >` spaced variants, plus independent `>` proof via `--\u003e`
- ampersand escaping in serialized values so entities cannot re-form during HTML re-parsing
- U+2028/U+2029 line separators leaving as escape sequences; output is pure ASCII for that fixture
- JSON round-trip fidelity for nested/unicode values (escape layer never corrupts the value)
- the exact `window.__ELIZA_APP_API_BASE__ = <serialized>;` injection shape used by app-frontend-hosting stays terminator-free
- `TypeError` for `undefined` / functions / Symbols (fail-closed guard)

### Verification

- `bun test packages/cloud/shared/src/lib/utils/html.test.ts` — 14/14 pass, 47 assertions, 100% line coverage of `html.ts`
- Mutation matrix: 10/10 mutations caught (each `.replace` dropped in both functions, `&`/`<` order flipped, TypeError guard neutered) — every test is a real regression guard
- `biome check` clean on the changed file
- `bun run --cwd packages/cloud/shared typecheck` clean
- Control: the 7 failures in the full `lib/utils/` directory run are byte-identical on pristine develop at the same base (pre-existing cross-file pollution under the shared runner + one develop-red test in `default-eliza-character.test.ts`) — zero new failures introduced
- Independent review: RepoPrompt CE agent (gpt-5.6-sol) reviewed the module source + full diff + resulting file; verdict **APPROVE, zero must-fix** (4 nice-to-haves; #1 — independent `>` escaping proof — applied before push)

### Evidence

| Requirement | Evidence |
| --- | --- |
| backend-logs | N/A - test-only change; verification transcript: `bun test .../html.test.ts` → `14 pass / 0 fail / 47 expect() calls`; mutation harness output `10/10 mutations caught, target restored byte-identical`; `biome check` → `Checked 1 file. No fixes applied.`; `bun run --cwd packages/cloud/shared typecheck` → `Done!` exit 0 |
| frontend-screenshots | N/A - no UI change; cloud-shared server utility module only |
| mp4-walkthrough | N/A - test-only change, no user-visible behavior |
| live-model-trajectories | N/A - no model/agent behavior change; pure utility escape tests |
| native-target-captures | N/A - no native/device path touched |

AI provider/model: zai / glm-5.3 (manual) + GPT-5.6-sol (RepoPrompt CE review agent)
Client / agent tooling: Hermes Agent
Contribution skill revision: elizaOS/eliza@b447fe2f542af8f12c0c011c3bbf772c7c6b3f50:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [hermes/t3rpz]
<!-- eliza-computer-attribution:v1 {"provider":"zai","model":"glm-5.3","client":"Hermes Agent","skill_revision":"elizaOS/eliza@b447fe2f542af8f12c0c011c3bbf772c7c6b3f50:packages/skills/skills/contribute-to-eliza"} -->

<!-- evidence-head:052fcf0f54ab7ad3349cc372a9bcdf337ff38823 -->

<!-- evidence-row:backend-logs -->
- [ ] N/A - test-only change; verification transcript: bun test html.test.ts -> 14 pass / 0 fail / 47 expect() calls; mutation harness 10/10 mutations caught; biome check clean; typecheck exit 0

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only change; no UI surface touched

<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only change; no UI surface touched

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - test-only change; no user-visible behavior

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code path touched; cloud-shared server utility

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model/agent behavior change; pure escape-function tests

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no domain/DB/protocol artifacts; bun test output + mutation matrix in backend-logs row
