### PR TITLE
fix(cloud): route workflows through managed authority

### DIFF
--- a/packages/cloud/api/__tests__/workflow-proxy-capability.test.ts
+++ b/packages/cloud/api/__tests__/workflow-proxy-capability.test.ts
@@ -11,6 +11,7 @@ import {
   mock,
   test,
 } from "bun:test";
+import { createHash } from "node:crypto";
 import * as authActual from "@/lib/auth";
 import * as redisFactoryActual from "@/lib/cache/redis-factory";
 import * as billingGateActual from "@/lib/services/agent-billing-gate";
@@ -18,6 +19,20 @@ import * as elizaSandboxActual from "@/lib/services/eliza-sandbox";
 import * as provisioningJobsActual from "@/lib/services/provisioning-jobs";
 import * as workerHealthActual from "@/lib/services/provisioning-worker-health";
 import type { AppContext } from "@/types/cloud-worker-env";
+
+const MANAGED_AGENT_ID = "00000000-0000-4000-8000-0000000000a1";
+const RUNTIME_AGENT_ID = "00000000-0000-4000-8000-0000000000b2";
+const OTHER_RUNTIME_AGENT_ID = "00000000-0000-4000-8000-0000000000b3";
+const GENERATION = "00000000-0000-4000-8000-0000000000c3";
+const PUBLICATION_ID = "00000000-0000-4000-8000-0000000000d4";
+const MANAGED_SERVER_NAME = `sandbox-${GENERATION}`;
+const MANAGED_SERVER_URL = "https://sandbox.internal:3000/";
+const ACTIVATION_SNAPSHOT_SENTINEL = "activation-routing-snapshot:v1";
+const ACTIVATION_MISSING_SENTINEL = "activation-routing-missing:v1";
+const ACTIVATION_VALUE_PREFIX = "activation-routing:v1:";
+const ROUTING_VALUE_SNAPSHOT_SENTINEL = "agent-server-routing-value:v1";
+const ROUTING_VALUE_MISSING_SENTINEL = "agent-server-routing-missing:v1";
+const ROUTING_VALUE_PREFIX = "agent-server-routing:v1:";
 
 const requireAuth = mock(async () => ({
   user: { id: "user-1", organization_id: "org-1" },
@@ -29,6 +44,7 @@ type AgentExecutionTier =
   | "custom";
 type AgentFixture = {
   id: string;
+  character_id?: string | null;
   execution_tier: AgentExecutionTier;
   status?: string;
   bridge_url?: string | null;
@@ -36,8 +52,26 @@ type AgentFixture = {
 };
 const getAgent = mock<
   (_agentId: string, _organizationId: string) => Promise<AgentFixture | null>
->(async () => ({ id: "agent-1", execution_tier: "shared" }));
+>(async () => ({ id: MANAGED_AGENT_ID, execution_tier: "shared" }));
 const buildRedisClient = mock((_env: unknown) => null as unknown);
+const evalRedisReadOnly = mock(
+  async (
+    redis: {
+      evalRo?: (
+        script: string,
+        keys: string[],
+        args: Array<string | number>,
+      ) => Promise<unknown>;
+    },
+    scripts: { upstashRedis: string },
+    keys: string[],
+    args: Array<string | number>,
+  ) => {
+    if (!redis.evalRo)
+      throw new Error("read-only Redis evaluation unavailable");
+    return redis.evalRo(scripts.upstashRedis, keys, args);
+  },
+);
 const checkAgentCreditGate = mock(async (_organizationId: string) => ({
   allowed: true,
 }));
@@ -56,6 +90,7 @@ mock.module("@/lib/auth", () => ({
 mock.module("@/lib/cache/redis-factory", () => ({
   ...redisFactoryActual,
   buildRedisClient,
+  evalRedisReadOnly,
 }));
 
 mock.module("@/lib/services/eliza-sandbox", () => ({
@@ -102,8 +137,9 @@ beforeEach(() => {
   triggerImmediate.mockClear();
   buildRedisClient.mockReset();
   buildRedisClient.mockImplementation(() => null as unknown);
+  evalRedisReadOnly.mockClear();
   getAgent.mockImplementation(async () => ({
-    id: "agent-1",
+    id: MANAGED_AGENT_ID,
     execution_tier: "shared" as const,
   }));
   checkAgentCreditGate.mockImplementation(async () => ({ allowed: true }));
@@ -137,30 +173,109 @@ function context(env: Record<string, unknown> = {}): AppContext {
 
 function workflowRequest(headers?: HeadersInit): Request {
   return new Request(
-    "https://api.example.test/api/v1/eliza/agents/agent-1/workflows",
+    `https://api.example.test/api/v1/eliza/agents/${MANAGED_AGENT_ID}/workflows`,
     { headers },
   );
 }
 
-function installLiveRedisAssignment() {
-  const redisGet = mock(async (key: string) => {
-    if (key === "agent:agent-1:server") return "server-1";
-    if (key === "server:server-1:url") return "https://agent-server.test";
-    return null;
+function managedRoutingValues(
+  runtimeAgentId: string = RUNTIME_AGENT_ID,
+): Map<string, string> {
+  const endpoint = {
+    version: 1,
+    generation: GENERATION,
+    kind: "dedicated-sandbox",
+    serverName: MANAGED_SERVER_NAME,
+    runtimeAgentId,
+    registryUrl: MANAGED_SERVER_URL,
+    bridgeUrl: "http://100.64.0.3:3000",
+    healthUrl: "http://100.64.0.3:3000/health",
+  };
+  const endpointSha256 = createHash("sha256")
+    .update(JSON.stringify(endpoint), "utf8")
+    .digest("hex");
+  return new Map([
+    [
+      `agent:${MANAGED_AGENT_ID}:routing-managed`,
+      JSON.stringify({ version: 1, managed: true }),
+    ],
+    [
+      `agent:${MANAGED_AGENT_ID}:registration-authority`,
+      JSON.stringify({
+        version: 1,
+        state: "active",
+        generation: GENERATION,
+        publicationId: PUBLICATION_ID,
+        endpointSha256,
+      }),
+    ],
+    [
+      `agent:${MANAGED_AGENT_ID}:activation-route`,
+      JSON.stringify({
+        version: 1,
+        kind: "dedicated-sandbox",
+        generation: GENERATION,
+        publicationId: PUBLICATION_ID,
+        endpointSha256,
+        endpoint,
+      }),
+    ],
+    [`server:${MANAGED_SERVER_NAME}:url`, MANAGED_SERVER_URL],
+  ]);
+}
+
+function installRoutingRedis(values = managedRoutingValues()) {
+  const evalRo = mock(
+    async (_script: string, keys: string[], args: Array<string | number>) => {
+      if (args.length !== 0) throw new Error("unexpected routing script args");
+      if (keys.length === 3) {
+        return [
+          ACTIVATION_SNAPSHOT_SENTINEL,
+          ...keys.map((key) =>
+            values.has(key)
+              ? `${ACTIVATION_VALUE_PREFIX}${values.get(key)}`
+              : ACTIVATION_MISSING_SENTINEL,
+          ),
+        ];
+      }
+      if (keys.length === 1) {
+        const key = keys[0];
+        return [
+          ROUTING_VALUE_SNAPSHOT_SENTINEL,
+          key !== undefined && values.has(key)
+            ? `${ROUTING_VALUE_PREFIX}${values.get(key)}`
+            : ROUTING_VALUE_MISSING_SENTINEL,
+        ];
+      }
+      throw new Error("unexpected routing key count");
+    },
+  );
+  const evalWrite = mock(async () => {
+    throw new Error("mutating EVAL must not be used for workflow routing");
   });
-  buildRedisClient.mockImplementation(() => ({ get: redisGet }) as unknown);
-  return redisGet;
+  const get = mock(async () => {
+    throw new Error(
+      "auto-deserializing GET must not be used for workflow routing",
+    );
+  });
+  buildRedisClient.mockImplementation(
+    () => ({ evalRo, eval: evalWrite, get }) as unknown,
+  );
+  return { evalRo, evalWrite, get, values };
 }
 
 describe("workflow capability responses", () => {
   test("returns an explicit, non-automatic upgrade path for shared agents", async () => {
-    const redisGet = installLiveRedisAssignment();
-    const fetchRequest = mock(async () => Response.json({ ok: true }));
+    const routingRedis = installRoutingRedis();
+    const fetchRequest = mock(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        Response.json({ ok: true }),
+    );
     globalThis.fetch = fetchRequest as unknown as typeof fetch;
 
     const response = await handleWorkflowProxyRequest(
       workflowRequest(),
-      "agent-1",
+      MANAGED_AGENT_ID,
       "",
       context(),
     );
@@ -179,23 +294,23 @@ describe("workflow capability responses", () => {
       upgrade: {
         automatic: false,
         method: "POST",
-        endpoint: "/api/v1/eliza/agents/agent-1/upgrade-tier",
+        endpoint: `/api/v1/eliza/agents/${MANAGED_AGENT_ID}/upgrade-tier`,
       },
     });
     expect(buildRedisClient).not.toHaveBeenCalled();
-    expect(redisGet).not.toHaveBeenCalled();
+    expect(routingRedis.evalRo).not.toHaveBeenCalled();
     expect(fetchRequest).not.toHaveBeenCalled();
   });
 
   test("distinguishes a dedicated runtime outage from an upgrade requirement", async () => {
     getAgent.mockImplementation(async () => ({
-      id: "agent-1",
+      id: MANAGED_AGENT_ID,
       execution_tier: "dedicated-always" as const,
     }));
 
     const response = await handleWorkflowProxyRequest(
       workflowRequest(),
-      "agent-1",
+      MANAGED_AGENT_ID,
       "",
       context(),
     );
@@ -215,7 +330,7 @@ describe("workflow capability responses", () => {
 
   test("credit-gates and enqueues a scale-to-zero agent wake on workflow use", async () => {
     getAgent.mockImplementation(async () => ({
-      id: "agent-1",
+      id: MANAGED_AGENT_ID,
       execution_tier: "dedicated-lazy" as const,
       status: "sleeping",
       bridge_url: null,
@@ -224,7 +339,7 @@ describe("workflow capability responses", () => {
 
     const response = await handleWorkflowProxyRequest(
       workflowRequest(),
-      "agent-1",
+      MANAGED_AGENT_ID,
       "",
       context(),
     );
@@ -244,7 +359,7 @@ describe("workflow capability responses", () => {
     });
     expect(checkAgentCreditGate).toHaveBeenCalledWith("org-1");
     expect(enqueueAgentWakeOnce).toHaveBeenCalledWith({
-      agentId: "agent-1",
+      agentId: MANAGED_AGENT_ID,
       organizationId: "org-1",
       userId: "user-1",
     });
@@ -253,19 +368,19 @@ describe("workflow capability responses", () => {
 
   test("ignores a stale live assignment when a dedicated-lazy agent is stopped", async () => {
     getAgent.mockImplementation(async () => ({
-      id: "agent-1",
+      id: MANAGED_AGENT_ID,
       execution_tier: "dedicated-lazy" as const,
       status: "stopped",
       bridge_url: "https://stale-bridge.example.test",
       health_url: "https://stale-health.example.test",
     }));
-    const redisGet = installLiveRedisAssignment();
+    const routingRedis = installRoutingRedis();
     const fetchRequest = mock(async () => Response.json({ ok: true }));
     globalThis.fetch = fetchRequest as unknown as typeof fetch;
 
     const response = await handleWorkflowProxyRequest(
       workflowRequest(),
-      "agent-1",
+      MANAGED_AGENT_ID,
       "",
       context({ AGENT_SERVER_SHARED_SECRET: "server-secret" }),
     );
@@ -279,13 +394,13 @@ describe("workflow capability responses", () => {
     expect(checkAgentCreditGate).toHaveBeenCalledWith("org-1");
     expect(enqueueAgentWakeOnce).toHaveBeenCalledTimes(1);
     expect(buildRedisClient).not.toHaveBeenCalled();
-    expect(redisGet).not.toHaveBeenCalled();
+    expect(routingRedis.evalRo).not.toHaveBeenCalled();
     expect(fetchRequest).not.toHaveBeenCalled();
   });
 
   test("does not let a stale sleeping assignment bypass the credit gate", async () => {
     getAgent.mockImplementation(async () => ({
-      id: "agent-1",
+      id: MANAGED_AGENT_ID,
       execution_tier: "dedicated-lazy" as const,
       status: "sleeping",
       bridge_url: null,
@@ -296,13 +411,13 @@ describe("workflow capability responses", () => {
       balance: 0,
       error: "Insufficient credits",
     }));
-    const redisGet = installLiveRedisAssignment();
+    const routingRedis = installRoutingRedis();
     const fetchRequest = mock(async () => Response.json({ ok: true }));
     globalThis.fetch = fetchRequest as unknown as typeof fetch;
 
     const response = await handleWorkflowProxyRequest(
       workflowRequest(),
-      "agent-1",
+      MANAGED_AGENT_ID,
       "",
       context(),
     );
@@ -316,7 +431,7 @@ describe("workflow capability responses", () => {
     expect(enqueueAgentWakeOnce).not.toHaveBeenCalled();
     expect(triggerImmediate).not.toHaveBeenCalled();
     expect(buildRedisClient).not.toHaveBeenCalled();
-    expect(redisGet).not.toHaveBeenCalled();
+    expect(routingRedis.evalRo).not.toHaveBeenCalled();
     expect(fetchRequest).not.toHaveBeenCalled();
   });
 
@@ -346,18 +461,197 @@ describe("workflow proxy timeout budgets", () => {
   });
 });
 
+describe("workflow routing authority", () => {
+  test("fails before Redis when the sandbox has no canonical runtime identity", async () => {
+    getAgent.mockImplementation(async () => ({
+      id: MANAGED_AGENT_ID,
+      character_id: null,
+      execution_tier: "dedicated-always" as const,
+    }));
+    const fetchRequest = mock(async () => Response.json({ ok: true }));
+    globalThis.fetch = fetchRequest as unknown as typeof fetch;
+
+    const response = await handleWorkflowProxyRequest(
+      workflowRequest(),
+      MANAGED_AGENT_ID,
+      "",
+      context({ AGENT_SERVER_SHARED_SECRET: "server-secret" }),
+    );
+
+    expect(response.status).toBe(503);
+    expect(buildRedisClient).not.toHaveBeenCalled();
+    expect(fetchRequest).not.toHaveBeenCalled();
+  });
+
+  test("rejects a managed endpoint bound to another runtime before heartbeat or fetch", async () => {
+    getAgent.mockImplementation(async () => ({
+      id: MANAGED_AGENT_ID,
+      character_id: RUNTIME_AGENT_ID,
+      execution_tier: "dedicated-always" as const,
+    }));
+    const routingRedis = installRoutingRedis(
+      managedRoutingValues(OTHER_RUNTIME_AGENT_ID),
+    );
+    const fetchRequest = mock(async () => Response.json({ ok: true }));
+    globalThis.fetch = fetchRequest as unknown as typeof fetch;
+
+    const response = await handleWorkflowProxyRequest(
+      workflowRequest(),
+      MANAGED_AGENT_ID,
+      "",
+      context({ AGENT_SERVER_SHARED_SECRET: "server-secret" }),
+    );
+
+    expect(response.status).toBe(503);
+    expect(routingRedis.evalRo).toHaveBeenCalledTimes(1);
+    expect(routingRedis.evalRo.mock.calls[0]?.[1]).toEqual([
+      `agent:${MANAGED_AGENT_ID}:routing-managed`,
+      `agent:${MANAGED_AGENT_ID}:registration-authority`,
+      `agent:${MANAGED_AGENT_ID}:activation-route`,
+    ]);
+    expect(routingRedis.get).not.toHaveBeenCalled();
+    expect(fetchRequest).not.toHaveBeenCalled();
+  });
+
+  test("never consults legacy routing after a managed authority is revoked", async () => {
+    getAgent.mockImplementation(async () => ({
+      id: MANAGED_AGENT_ID,
+      character_id: RUNTIME_AGENT_ID,
+      execution_tier: "dedicated-always" as const,
+    }));
+    const values = managedRoutingValues();
+    values.set(
+      `agent:${MANAGED_AGENT_ID}:registration-authority`,
+      JSON.stringify({
+        version: 1,
+        state: "revoked",
+        generation: GENERATION,
+        publicationId: null,
+        endpointSha256: null,
+      }),
+    );
+    values.delete(`agent:${MANAGED_AGENT_ID}:activation-route`);
+    values.set(`agent:${RUNTIME_AGENT_ID}:server`, "stale-server");
+    values.set("server:stale-server:url", "https://stale.internal:3000");
+    const routingRedis = installRoutingRedis(values);
+    const fetchRequest = mock(async () => Response.json({ ok: true }));
+    globalThis.fetch = fetchRequest as unknown as typeof fetch;
+
+    const response = await handleWorkflowProxyRequest(
+      workflowRequest(),
+      MANAGED_AGENT_ID,
+      "",
+      context({ AGENT_SERVER_SHARED_SECRET: "server-secret" }),
+    );
+
+    expect(response.status).toBe(503);
+    const readKeys = routingRedis.evalRo.mock.calls.flatMap((call) => call[1]);
+    expect(readKeys).not.toContain(`agent:${RUNTIME_AGENT_ID}:server`);
+    expect(readKeys).not.toContain("server:stale-server:url");
+    expect(fetchRequest).not.toHaveBeenCalled();
+  });
+
+  test("keeps literal null distinct from a missing legacy pointer", async () => {
+    getAgent.mockImplementation(async () => ({
+      id: MANAGED_AGENT_ID,
+      character_id: RUNTIME_AGENT_ID,
+      execution_tier: "dedicated-always" as const,
+    }));
+    const routingRedis = installRoutingRedis(
+      new Map([[`agent:${RUNTIME_AGENT_ID}:server`, "null"]]),
+    );
+    const fetchRequest = mock(async () => Response.json({ ok: true }));
+    globalThis.fetch = fetchRequest as unknown as typeof fetch;
+
+    const response = await handleWorkflowProxyRequest(
+      workflowRequest(),
+      MANAGED_AGENT_ID,
+      "",
+      context({ AGENT_SERVER_SHARED_SECRET: "server-secret" }),
+    );
+
+    expect(response.status).toBe(503);
+    const readKeys = routingRedis.evalRo.mock.calls.flatMap((call) => call[1]);
+    expect(readKeys).toContain(`agent:${RUNTIME_AGENT_ID}:server`);
+    expect(readKeys).not.toContain(`agent:${MANAGED_AGENT_ID}:server`);
+    expect(readKeys).not.toContain("server:null:url");
+    expect(routingRedis.get).not.toHaveBeenCalled();
+    expect(fetchRequest).not.toHaveBeenCalled();
+  });
+
+  test("fails closed when read-only Redis evaluation is unavailable", async () => {
+    getAgent.mockImplementation(async () => ({
+      id: MANAGED_AGENT_ID,
+      character_id: RUNTIME_AGENT_ID,
+      execution_tier: "dedicated-always" as const,
+    }));
+    const routingRedis = installRoutingRedis();
+    routingRedis.evalRo.mockImplementation(async () => {
+      throw new Error("Redis unavailable");
+    });
+    const fetchRequest = mock(async () => Response.json({ ok: true }));
+    globalThis.fetch = fetchRequest as unknown as typeof fetch;
+
+    const response = await handleWorkflowProxyRequest(
+      workflowRequest(),
+      MANAGED_AGENT_ID,
+      "",
+      context({ AGENT_SERVER_SHARED_SECRET: "server-secret" }),
+    );
+
+    expect(response.status).toBe(503);
+    expect(routingRedis.evalRo).toHaveBeenCalledTimes(1);
+    expect(routingRedis.evalWrite).not.toHaveBeenCalled();
+    expect(routingRedis.get).not.toHaveBeenCalled();
+    expect(fetchRequest).not.toHaveBeenCalled();
+  });
+
+  test("uses only the runtime identity for an unmanaged legacy pointer", async () => {
+    getAgent.mockImplementation(async () => ({
+      id: MANAGED_AGENT_ID,
+      character_id: RUNTIME_AGENT_ID,
+      execution_tier: "dedicated-always" as const,
+    }));
+    const legacyServerUrl = "https://legacy-agent.internal:3000";
+    const routingRedis = installRoutingRedis(
+      new Map([
+        [`agent:${RUNTIME_AGENT_ID}:server`, "legacy-agent"],
+        ["server:legacy-agent:url", legacyServerUrl],
+      ]),
+    );
+    const fetchRequest = mock(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        Response.json({ ok: true }),
+    );
+    globalThis.fetch = fetchRequest as unknown as typeof fetch;
+
+    const response = await handleWorkflowProxyRequest(
+      workflowRequest(),
+      MANAGED_AGENT_ID,
+      "generate",
+      context({ AGENT_SERVER_SHARED_SECRET: "server-secret" }),
+    );
+
+    expect(response.status).toBe(200);
+    const readKeys = routingRedis.evalRo.mock.calls.flatMap((call) => call[1]);
+    expect(readKeys).toContain(`agent:${RUNTIME_AGENT_ID}:server`);
+    expect(readKeys).not.toContain(`agent:${MANAGED_AGENT_ID}:server`);
+    expect(String(fetchRequest.mock.calls[0]?.[0])).toBe(
+      `${legacyServerUrl}/agents/${RUNTIME_AGENT_ID}/workflows/generate`,
+    );
+    expect(routingRedis.evalWrite).not.toHaveBeenCalled();
+    expect(routingRedis.get).not.toHaveBeenCalled();
+  });
+});
+
 describe("workflow principal forwarding", () => {
   test("overwrites caller identity headers with the authenticated principal", async () => {
     getAgent.mockImplementation(async () => ({
-      id: "agent-1",
+      id: MANAGED_AGENT_ID,
+      character_id: RUNTIME_AGENT_ID,
       execution_tier: "dedicated-always" as const,
     }));
-    const redisGet = mock(async (key: string) => {
-      if (key === "agent:agent-1:server") return "server-1";
-      if (key === "server:server-1:url") return "https://agent-server.test";
-      return null;
-    });
-    buildRedisClient.mockImplementation(() => ({ get: redisGet }) as unknown);
+    const routingRedis = installRoutingRedis();
     const fetchRequest = mock(
       async (_input: RequestInfo | URL, _init?: RequestInit) =>
         Response.json({ ok: true }),
@@ -366,7 +660,7 @@ describe("workflow principal forwarding", () => {
 
     const response = await handleWorkflowProxyRequest(
       new Request(
-        "https://api.example.test/api/v1/eliza/agents/agent-1/workflows/resolve-clarification",
+        `https://api.example.test/api/v1/eliza/agents/${MANAGED_AGENT_ID}/workflows/resolve-clarification`,
         {
           method: "POST",
           headers: {
@@ -377,7 +671,7 @@ describe("workflow principal forwarding", () => {
           body: JSON.stringify({ draft: {}, resolutions: [] }),
         },
       ),
-      "agent-1",
+      MANAGED_AGENT_ID,
       "resolve-clarification",
       context({ AGENT_SERVER_SHARED_SECRET: "server-secret" }),
     );
@@ -388,8 +682,11 @@ describe("workflow principal forwarding", () => {
       [RequestInfo | URL, RequestInit]
     >;
     expect(String(call[0]?.[0])).toBe(
-      "https://agent-server.test/agents/agent-1/workflows/resolve-clarification",
+      `${MANAGED_SERVER_URL}agents/${RUNTIME_AGENT_ID}/workflows/resolve-clarification`,
     );
+    expect(routingRedis.evalRo).toHaveBeenCalledTimes(3);
+    expect(routingRedis.evalWrite).not.toHaveBeenCalled();
+    expect(routingRedis.get).not.toHaveBeenCalled();
     expect(call[0]?.[1].method).toBe("POST");
     expect(
       JSON.parse(new TextDecoder().decode(call[0]?.[1].body as ArrayBuffer)),
@@ -402,15 +699,11 @@ describe("workflow principal forwarding", () => {
 
   test("forwards the evaluation-samples suffix and query without a body", async () => {
     getAgent.mockImplementation(async () => ({
-      id: "agent-1",
+      id: MANAGED_AGENT_ID,
+      character_id: RUNTIME_AGENT_ID,
       execution_tier: "dedicated-always" as const,
     }));
-    const redisGet = mock(async (key: string) => {
-      if (key === "agent:agent-1:server") return "server-1";
-      if (key === "server:server-1:url") return "https://agent-server.test";
-      return null;
-    });
-    buildRedisClient.mockImplementation(() => ({ get: redisGet }) as unknown);
+    const routingRedis = installRoutingRedis();
     const fetchRequest = mock(
       async (_input: RequestInfo | URL, _init?: RequestInit) =>
         Response.json({ workflowId: "workflow-1" }),
@@ -419,9 +712,9 @@ describe("workflow principal forwarding", () => {
 
     const response = await handleWorkflowProxyRequest(
       new Request(
-        "https://api.example.test/api/v1/eliza/agents/agent-1/workflows/workflow-1/evaluation-samples?limit=7",
+        `https://api.example.test/api/v1/eliza/agents/${MANAGED_AGENT_ID}/workflows/workflow-1/evaluation-samples?limit=7`,
       ),
-      "agent-1",
+      MANAGED_AGENT_ID,
       "workflow-1/evaluation-samples",
       context({ AGENT_SERVER_SHARED_SECRET: "server-secret" }),
     );
@@ -431,8 +724,11 @@ describe("workflow principal forwarding", () => {
       [RequestInfo | URL, RequestInit]
     >;
     expect(String(call[0]?.[0])).toBe(
-      "https://agent-server.test/agents/agent-1/workflows/workflow-1/evaluation-samples?limit=7",
+      `${MANAGED_SERVER_URL}agents/${RUNTIME_AGENT_ID}/workflows/workflow-1/evaluation-samples?limit=7`,
     );
+    expect(routingRedis.evalRo).toHaveBeenCalledTimes(3);
+    expect(routingRedis.evalWrite).not.toHaveBeenCalled();
+    expect(routingRedis.get).not.toHaveBeenCalled();
     expect(call[0]?.[1].method).toBe("GET");
     expect(call[0]?.[1].body).toBeUndefined();
     const forwardedHeaders = new Headers(call[0]?.[1].headers);

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/workflows/_shared.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/workflows/_shared.ts
@@ -3,9 +3,17 @@
  * them to the assigned agent server. When no compatible runtime is assigned,
  * callers receive a typed dedicated-upgrade or retryable-unavailable response.
  */
+
+import {
+  ACTIVATION_ROUTING_REDIS_EVAL_RO_SCRIPT,
+  ACTIVATION_ROUTING_UPSTASH_READ_ONLY_SCRIPT,
+  type ActivationRoutingSnapshotKeys,
+  type AgentServerRoutingReader,
+  resolveAgentServerRouting,
+} from "@elizaos/cloud-services-common";
 import { errorToResponse } from "@/lib/api/errors";
 import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
-import { buildRedisClient } from "@/lib/cache/redis-factory";
+import { buildRedisClient, evalRedisReadOnly } from "@/lib/cache/redis-factory";
 import { checkAgentCreditGate } from "@/lib/services/agent-billing-gate";
 import { insufficientCredits402 } from "@/lib/services/agent-billing-gate-402";
 import { elizaSandboxService } from "@/lib/services/eliza-sandbox";
@@ -26,6 +34,21 @@ const DEDICATED_LAZY_INACTIVE_STATUSES = new Set([
   "sleeping",
   "disconnected",
 ]);
+const ROUTING_VALUE_SNAPSHOT_SENTINEL = "agent-server-routing-value:v1";
+const ROUTING_VALUE_MISSING_SENTINEL = "agent-server-routing-missing:v1";
+const ROUTING_VALUE_PREFIX = "agent-server-routing:v1:";
+const ROUTING_VALUE_READ_SCRIPT_BODY = `if #KEYS ~= 1 or #ARGV ~= 0 then
+  return redis.error_reply("agent-server routing read requires exactly 1 key and 0 args")
+end
+
+local value = redis.call("GET", KEYS[1])
+if value == false then
+  return {"${ROUTING_VALUE_SNAPSHOT_SENTINEL}", "${ROUTING_VALUE_MISSING_SENTINEL}"}
+end
+return {"${ROUTING_VALUE_SNAPSHOT_SENTINEL}", "${ROUTING_VALUE_PREFIX}" .. value}
+`;
+const ROUTING_VALUE_REDIS_EVAL_RO_SCRIPT = ROUTING_VALUE_READ_SCRIPT_BODY;
+const ROUTING_VALUE_UPSTASH_READ_ONLY_SCRIPT = `#!lua flags=no-writes,allow-key-locking\n${ROUTING_VALUE_READ_SCRIPT_BODY}`;
 
 type WorkflowAgentExecutionTier =
   | "shared"
@@ -77,20 +100,61 @@ function envString(c: AppContext | undefined, key: string): string | null {
   return typeof value === "string" && value.trim() ? value.trim() : null;
 }
 
-async function resolveAgentServerUrl(
-  c: AppContext,
-  agentId: string,
-): Promise<string | null> {
-  const redis = buildRedisClient(c.env);
-  if (!redis) return null;
+function decodeRoutingValueSnapshot(evaluated: unknown): string | null {
+  if (
+    !Array.isArray(evaluated) ||
+    evaluated.length !== 2 ||
+    evaluated[0] !== ROUTING_VALUE_SNAPSHOT_SENTINEL
+  ) {
+    throw new TypeError("Invalid agent-server routing value snapshot");
+  }
 
-  const serverName = await redis.get<string>(`agent:${agentId}:server`);
-  if (!serverName) return null;
+  const encoded = evaluated[1];
+  if (encoded === ROUTING_VALUE_MISSING_SENTINEL) return null;
+  if (
+    typeof encoded !== "string" ||
+    !encoded.startsWith(ROUTING_VALUE_PREFIX)
+  ) {
+    throw new TypeError("Invalid agent-server routing value envelope");
+  }
+  return encoded.slice(ROUTING_VALUE_PREFIX.length);
+}
 
-  const serverUrl = await redis.get<string>(`server:${serverName}:url`);
-  return typeof serverUrl === "string" && serverUrl.trim()
-    ? serverUrl.trim()
-    : null;
+function createWorkflowRoutingReader(c: AppContext): AgentServerRoutingReader {
+  let redis: ReturnType<typeof buildRedisClient> | undefined;
+  const requireRedis = (): NonNullable<ReturnType<typeof buildRedisClient>> => {
+    if (redis === undefined) redis = buildRedisClient(c.env);
+    if (!redis) throw new Error("Redis is not configured");
+    return redis;
+  };
+
+  return {
+    readActivationRoutingSnapshot(
+      keys: ActivationRoutingSnapshotKeys,
+    ): Promise<unknown> {
+      return evalRedisReadOnly(
+        requireRedis(),
+        {
+          directRedis: ACTIVATION_ROUTING_REDIS_EVAL_RO_SCRIPT,
+          upstashRedis: ACTIVATION_ROUTING_UPSTASH_READ_ONLY_SCRIPT,
+        },
+        [...keys],
+        [],
+      );
+    },
+    async readAgentServerRoutingValue(key: string): Promise<string | null> {
+      const evaluated = await evalRedisReadOnly(
+        requireRedis(),
+        {
+          directRedis: ROUTING_VALUE_REDIS_EVAL_RO_SCRIPT,
+          upstashRedis: ROUTING_VALUE_UPSTASH_READ_ONLY_SCRIPT,
+        },
+        [key],
+        [],
+      );
+      return decodeRoutingValueSnapshot(evaluated);
+    },
+  };
 }
 
 function buildTargetUrl(
@@ -186,6 +250,7 @@ async function forwardWorkflowToAgentServer(params: {
   ctx: AppContext;
   request: Request;
   agentId: string;
+  runtimeAgentId: string | null;
   suffix: string;
   user: { id: string; organization_id: string };
   executionTier: WorkflowAgentExecutionTier;
@@ -208,8 +273,14 @@ async function forwardWorkflowToAgentServer(params: {
     return wakeDedicatedLazyRuntime(params);
   }
 
-  const serverUrl = await resolveAgentServerUrl(params.ctx, params.agentId);
-  if (!serverUrl) {
+  const routing = await resolveAgentServerRouting(
+    createWorkflowRoutingReader(params.ctx),
+    {
+      managedAgentId: params.agentId,
+      runtimeAgentId: params.runtimeAgentId ?? "",
+    },
+  );
+  if (routing.kind !== "ready") {
     if (params.executionTier === "dedicated-lazy" && params.canWakeRuntime) {
       return wakeDedicatedLazyRuntime(params);
     }
@@ -248,9 +319,9 @@ async function forwardWorkflowToAgentServer(params: {
       : await params.request.arrayBuffer();
   return fetch(
     buildTargetUrl(
-      serverUrl,
+      routing.serverUrl,
       params.request.url,
-      params.agentId,
+      routing.runtimeAgentId,
       params.suffix,
     ),
     {
@@ -293,7 +364,8 @@ export async function handleWorkflowProxyRequest(
     const forwarded = await forwardWorkflowToAgentServer({
       ctx,
       request,
-      agentId,
+      agentId: agent.id,
+      runtimeAgentId: agent.character_id,
       suffix,
       user,
       executionTier: agent.execution_tier,

--- a/packages/cloud/shared/src/lib/cache/__tests__/redis-factory-selection.test.ts
+++ b/packages/cloud/shared/src/lib/cache/__tests__/redis-factory-selection.test.ts
@@ -1,13 +1,22 @@
 /** Verifies direct Redis transport selection without opening network connections. */
 
-import { describe, expect, test } from "bun:test";
+import { describe, expect, spyOn, test } from "bun:test";
 import { Redis as UpstashRedis } from "@upstash/redis";
-import { buildRedisClient, hasRedisConfig } from "../redis-factory";
+import {
+  buildRedisClient,
+  type CompatibleRedis,
+  evalRedisReadOnly,
+  hasRedisConfig,
+} from "../redis-factory";
 import { SocketRedis } from "../socket-redis";
 
 const TCP_URL = "redis://default:test@unreachable.example.test:6379";
 const REST_URL = "https://redis-rest.example.test";
 const REST_TOKEN = "test-token";
+const READ_ONLY_SCRIPTS = {
+  directRedis: "return 'direct'",
+  upstashRedis: "#!lua flags=no-writes\nreturn 'rest'",
+};
 
 describe("direct Redis transport selection", () => {
   test("missing or blank selection preserves automatic TCP-first behavior", () => {
@@ -166,5 +175,38 @@ describe("direct Redis transport selection", () => {
       expect(buildRedisClient(env)).toBeNull();
       expect(hasRedisConfig(env)).toBe(false);
     }
+  });
+
+  test("selects the exact read-only script for each known transport", async () => {
+    const direct = new SocketRedis(TCP_URL);
+    const directEvalRo = spyOn(direct, "evalRo").mockResolvedValue("direct");
+    const requestBodies: unknown[] = [];
+    const fetchMock = spyOn(globalThis, "fetch").mockImplementation(async (_input, init) => {
+      requestBodies.push(JSON.parse(String(init?.body)) as unknown);
+      return new Response(JSON.stringify([{ result: "cmVzdA==" }]), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    const rest = new UpstashRedis({ url: REST_URL, token: REST_TOKEN });
+
+    try {
+      expect(await evalRedisReadOnly(direct, READ_ONLY_SCRIPTS, ["key"], [])).toBe("direct");
+      expect(directEvalRo).toHaveBeenCalledWith(READ_ONLY_SCRIPTS.directRedis, ["key"], []);
+      expect(await evalRedisReadOnly(rest, READ_ONLY_SCRIPTS, ["key"], [])).toBe("rest");
+      expect(requestBodies).toEqual([[["eval_ro", READ_ONLY_SCRIPTS.upstashRedis, 1, "key"]]]);
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
+
+  test("rejects an unknown structural evalRo backend", () => {
+    const unknownBackend = {
+      evalRo: async () => "unexpected",
+    } as unknown as CompatibleRedis;
+
+    expect(() => evalRedisReadOnly(unknownBackend, READ_ONLY_SCRIPTS, ["key"], [])).toThrow(
+      "Unknown Redis backend for read-only Lua evaluation",
+    );
   });
 });

--- a/packages/cloud/shared/src/lib/cache/redis-factory.ts
+++ b/packages/cloud/shared/src/lib/cache/redis-factory.ts
@@ -46,15 +46,25 @@ export interface EvalCapableRedis {
   eval(script: string, keys: string[], args: Array<string | number>): Promise<unknown>;
 }
 
+export interface EvalRoCapableRedis {
+  evalRo(script: string, keys: string[], args: Array<string | number>): Promise<unknown>;
+}
+
+export interface RedisReadOnlyEvalScripts {
+  readonly directRedis: string;
+  readonly upstashRedis: string;
+}
+
 type CompatibleSocketRedis = Pick<
   SocketRedis,
-  Exclude<Extract<keyof SocketRedis, keyof MockSocketRedis>, "pipeline" | "eval">
+  Exclude<Extract<keyof SocketRedis, keyof MockSocketRedis>, "pipeline" | "eval" | "evalRo">
 > & {
   pipeline(): CompatibleRedisPipeline;
   // The in-memory factory client intentionally has no Lua support. Keeping the
   // capability optional makes that limitation visible instead of hiding it
   // behind a cast at the durable-store boundary.
   eval?: EvalCapableRedis["eval"];
+  evalRo?: EvalRoCapableRedis["evalRo"];
 };
 export type CompatibleRedis = CompatibleSocketRedis | UpstashRedis;
 
@@ -62,6 +72,34 @@ export function supportsRedisEval(
   redis: CompatibleRedis,
 ): redis is CompatibleRedis & EvalCapableRedis {
   return typeof redis.eval === "function";
+}
+
+export function supportsRedisEvalRo(
+  redis: CompatibleRedis,
+): redis is CompatibleRedis & EvalRoCapableRedis {
+  return typeof redis.evalRo === "function";
+}
+
+/**
+ * Execute a purpose-bound read-only script on either direct Redis or Upstash.
+ * There is deliberately no fallback to mutating EVAL.
+ */
+export function evalRedisReadOnly(
+  redis: CompatibleRedis,
+  scripts: RedisReadOnlyEvalScripts,
+  keys: string[],
+  args: Array<string | number>,
+): Promise<unknown> {
+  if (!supportsRedisEvalRo(redis)) {
+    throw new TypeError("Redis backend does not support read-only Lua evaluation");
+  }
+  if (redis instanceof SocketRedis) {
+    return redis.evalRo(scripts.directRedis, keys, args);
+  }
+  if (redis instanceof UpstashRedis) {
+    return redis.evalRo(scripts.upstashRedis, keys, args);
+  }
+  throw new TypeError("Unknown Redis backend for read-only Lua evaluation");
 }
 
 export interface RedisFactoryEnv {

--- a/packages/cloud/shared/src/lib/cache/socket-redis-resilience.test.ts
+++ b/packages/cloud/shared/src/lib/cache/socket-redis-resilience.test.ts
@@ -178,6 +178,23 @@ describe("SocketRedis connection resilience", () => {
     await redis.quit();
   });
 
+  test("serializes read-only Lua with EVAL_RO and never EVAL", async () => {
+    let request = "";
+    const server = createServer((socket: NetSocket) => {
+      socket.once("data", (chunk) => {
+        request = chunk.toString("utf8");
+        socket.write("*2\r\n$8\r\nsnapshot\r\n$-1\r\n");
+      });
+    });
+    const port = await listen(server);
+    const redis = new SocketRedis(`redis://127.0.0.1:${port}`);
+
+    expect(await redis.evalRo("return 1", ["agent"], [])).toEqual(["snapshot", null]);
+    expect(request).toBe("*4\r\n$7\r\nEVAL_RO\r\n$8\r\nreturn 1\r\n$1\r\n1\r\n$5\r\nagent\r\n");
+
+    await redis.quit();
+  });
+
   test("propagates an error nested inside an EVAL response", async () => {
     const server = createServer((socket: NetSocket) => {
       socket.once("data", () => socket.write("*2\r\n:1\r\n-ERR script failed\r\n"));

--- a/packages/cloud/shared/src/lib/cache/socket-redis.ts
+++ b/packages/cloud/shared/src/lib/cache/socket-redis.ts
@@ -835,6 +835,12 @@ export class SocketRedis {
     return unwrap(value);
   }
 
+  /** Execute a read-only Lua script without permitting a mutating fallback. */
+  async evalRo(script: string, keys: string[], args: Array<string | number>): Promise<unknown> {
+    const [value] = await this.conn.send([["EVAL_RO", script, keys.length, ...keys, ...args]]);
+    return unwrap(value);
+  }
+
   pipeline(): Pipeline {
     return new Pipeline(this.conn);
   }


### PR DESCRIPTION
# Relates to

- #20726
- Stacked on Draft #28657.

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] Built directly on PR12 head `efe88e3c054d8717ac70099bc776c9da6ca26c92`, without rebase or force-push.
- [ ] Full repository `bun run verify` remains pending before Ready.
- [x] Exact head `10d02496c6ca047b107b5f61429193c41ab6afec` received a fresh independent adversarial review with no P0-P3 findings.

# Sync with base

- [x] Clean stacked ancestry on `fix/20726-12-gateway-routing-redis-adapters`.
- [ ] Recheck after any base update and immediately before Ready.

# Risks

Medium — this switches the Cloud workflow proxy from sequential legacy GETs to the managed activation authority and adds a read-only Lua capability to the shared Redis client.

# Background

## What does this PR do?

Wires workflow proxy requests to the atomic managed/legacy routing resolver while preserving the existing tier and wake gates.

- Uses `agent_sandboxes.id` as the managed authority identity and `character_id` as the runtime identity.
- Proxies workflow paths with the validated runtime identity, never the managed sandbox ID.
- Prevents legacy fallback after any managed marker, including starting, revoked, conflict, mismatch, or unavailable authority states.
- Adds direct Redis `EVAL_RO` support with no fallback to mutating `EVAL`.
- Selects distinct direct-Redis and Upstash read-only scripts and fails closed for unknown transports.
- Reads legacy pointers and heartbeats through a prefixed presence envelope, preserving missing keys versus the literal value `"null"` despite Upstash JSON auto-deserialization.
- Builds the Redis client lazily, so invalid managed/runtime UUIDs are rejected before Redis is touched.

## What kind of change is this?

Bug fix and workflow routing consumer integration.

# Testing

Reviewer entry points:

- `packages/cloud/api/v1/eliza/agents/[agentId]/workflows/_shared.ts`
- `packages/cloud/api/__tests__/workflow-proxy-capability.test.ts`
- `packages/cloud/shared/src/lib/cache/redis-factory.ts`
- `packages/cloud/shared/src/lib/cache/socket-redis.ts`

Observed on the exact head:

- Cloud API workflow tests: 16/16 passed, 81 assertions;
- shared Redis transport/factory tests: 19/19 passed, 82 assertions;
- common activation/resolver tests: 103/103 passed, 222 assertions;
- Cloud API build and full typecheck/Worker dry-run: passed;
- shared and common typechecks: passed;
- targeted Biome and diff-check: passed;
- independent exact-head review: CLEAN, no P0-P3.

# Evidence Gate

<!-- evidence-head:10d02496c6ca047b107b5f61429193c41ab6afec -->

- [ ] Before/after screenshots: N/A — backend-only.
- [ ] Walkthrough video: N/A.
- [ ] Backend logs: Pending — no staging or production deployment is included.
- [ ] Frontend logs: N/A.
- [ ] Real-LLM trajectory: N/A.
- [x] Domain artifacts: hermetic Redis command tests, managed/legacy workflow routing tests, exact typechecks, Worker dry-run, and independent review above.

# Known gaps / failures

No live Redis or Upstash credential was used. Transport contracts and consumer behavior are covered hermetically, but a real-endpoint integration proof remains pending before Ready. Non-ready routing states retain the existing dedicated-lazy wake/unavailable response policy.

# Deploy Notes

No deploy is included or authorized by this Draft PR.
