### PR TITLE
fix(plugin-google-workspace): preserve trashed=false filter when literal text mentions trashed

### DIFF
--- a/plugins/plugin-google-workspace/src/drive.query.test.ts
+++ b/plugins/plugin-google-workspace/src/drive.query.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from "vitest";
+import { GoogleDriveClient } from "./drive.ts";
+
+function makeClient() {
+  const list = vi.fn(async () => ({ data: { files: [] } }));
+  const fakeDrive = { files: { list } };
+  const factory = { drive: vi.fn(async () => fakeDrive) };
+  return { client: new GoogleDriveClient(factory as never), list };
+}
+
+describe("searchDriveFiles trashed-filter preservation", () => {
+  it("existing: preserves an explicit top-level trashed predicate", async () => {
+    const { client, list } = makeClient();
+    await client.searchDriveFiles({
+      accountId: "acct",
+      query: "name contains 'Plan' and trashed = true",
+    } as never);
+    expect(list).toHaveBeenCalledWith(
+      expect.objectContaining({ q: "name contains 'Plan' and trashed = true" })
+    );
+  });
+
+  it("existing: appends trashed = false for a plain query", async () => {
+    const { client, list } = makeClient();
+    await client.searchDriveFiles({
+      accountId: "acct",
+      query: "name contains 'Plan'",
+    } as never);
+    expect(list).toHaveBeenCalledWith(
+      expect.objectContaining({ q: "(name contains 'Plan') and trashed = false" })
+    );
+  });
+
+  it("BUG: quoted-literal 'trashed =' text silently drops the trashed = false filter", async () => {
+    const { client, list } = makeClient();
+    await client.searchDriveFiles({
+      accountId: "acct",
+      query: "name contains 'trashed = report'",
+    } as never);
+    // Should append trashed = false; currently returns the raw query,
+    // exposing trashed (deleted) files in results.
+    expect(list).toHaveBeenCalledWith(
+      expect.objectContaining({
+        q: "(name contains 'trashed = report') and trashed = false",
+      })
+    );
+  });
+
+  it("BUG: quoted-literal 'trashed =' at the start of a fullText search", async () => {
+    const { client, list } = makeClient();
+    await client.searchDriveFiles({
+      accountId: "acct",
+      query: "fullText contains 'trashed = true'",
+    } as never);
+    expect(list).toHaveBeenCalledWith(
+      expect.objectContaining({
+        q: "(fullText contains 'trashed = true') and trashed = false",
+      })
+    );
+  });
+});
+
+describe("driveQuery quoted-literal edge cases", () => {
+  it("handles empty query", async () => {
+    const { client, list } = makeClient();
+    await client.searchDriveFiles({ accountId: "acct", query: "   " } as never);
+    expect(list).toHaveBeenCalledWith(expect.objectContaining({ q: "() and trashed = false" }));
+  });
+
+  it("handles escaped quote inside a literal", async () => {
+    const { client, list } = makeClient();
+    await client.searchDriveFiles({
+      accountId: "acct",
+      query: "name contains 'it\\'s trashed = here'",
+    } as never);
+    expect(list).toHaveBeenCalledWith(
+      expect.objectContaining({
+        q: "(name contains 'it\\'s trashed = here') and trashed = false",
+      })
+    );
+  });
+
+  it("strips trashed text only inside quoted literals in compound queries", async () => {
+    const { client, list } = makeClient();
+    await client.searchDriveFiles({
+      accountId: "acct",
+      query: "name contains 'a' and fullText contains 'trashed = b' and mimeType = 'text/plain'",
+    } as never);
+    expect(list).toHaveBeenCalledWith(
+      expect.objectContaining({
+        q: "(name contains 'a' and fullText contains 'trashed = b' and mimeType = 'text/plain') and trashed = false",
+      })
+    );
+  });
+});

--- a/plugins/plugin-google-workspace/src/drive.ts
+++ b/plugins/plugin-google-workspace/src/drive.ts
@@ -216,7 +216,12 @@ function escapeDriveQuery(value: string): string {
 
 function driveQuery(query: string): string {
   const trimmed = query.trim();
-  if (/\btrashed\s*=/.test(trimmed)) {
+  // Only honor an explicit trashed predicate when it appears outside a quoted
+  // string literal — otherwise a content search for the literal text
+  // "trashed = ..." (e.g. name contains 'trashed = report') would silently drop
+  // the trashed = false safety filter and expose deleted files.
+  const withoutQuoted = trimmed.replace(/'(?:\\.|[^'\\])*'/g, "");
+  if (/\btrashed\s*=/.test(withoutQuoted)) {
     return trimmed;
   }
   return `(${trimmed}) and trashed = false`;


### PR DESCRIPTION
<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance --> - AI assistance: `yes`
<!-- attribution-row:models --> - Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client --> - Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision --> - Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status --> - Provenance status: `self-reported`

## Summary

Fix + coverage for the Drive search query builder's trashed-file safety filter.

**Bug:** `driveQuery` treated any query containing the substring `trashed =` as an explicit user-supplied trashed predicate — including matches **inside quoted string literals**. A content search such as `name contains 'trashed = report'` therefore silently dropped the `trashed = false` safety filter and returned trashed (deleted) files in results.

**Fix:** the predicate scan now strips quoted literals (with backslash-escape support) before deciding whether the user supplied a real top-level `trashed =` clause.

## Evidence

| Requirement | Evidence |
| --- | --- |
| Focused unit tests (Concrete) | `plugins/plugin-google-workspace/src/drive.query.test.ts` — 7 tests, isolated vitest run, all passing; 2 regression tests fail against the pre-fix code (quoted-literal trashed text → filter dropped) |
| Provider/model disclosure (Concrete) | `deepseek/deepseek-v4-flash` via Hermes Agent |
| Manual end-to-end test (N/A) | Query string construction only; no Drive API wiring changed |

## Risks

- **Low** — real top-level `trashed =` predicates are still honored verbatim (existing behavior pinned by `index.test.ts`); only quoted-literal matches change.

## Definition of Done

- [x] Rebased onto fork/develop
- [x] Focused vitest run passes (7/7)
- [x] biome check clean
