### PR TITLE
fix(ui): require usable audio recording capabilities

### DIFF
--- a/packages/ui/src/cloud-ui/components/voice/audio-utils.test.ts
+++ b/packages/ui/src/cloud-ui/components/voice/audio-utils.test.ts
@@ -140,4 +140,21 @@ describe("getSupportedMimeType", () => {
     vi.stubGlobal("window", { MediaRecorder: ThrowingMediaRecorder });
     expect(getSupportedMimeType()).toBe("");
   });
+
+  it("can probe the already-selected constructor without rereading browser globals", () => {
+    vi.stubGlobal(
+      "window",
+      Object.defineProperty({}, "MediaRecorder", {
+        get: () => {
+          throw new Error("global changed");
+        },
+      }),
+    );
+
+    expect(
+      getSupportedMimeType(
+        SupportedMediaRecorder as unknown as typeof MediaRecorder,
+      ),
+    ).toBe("audio/webm;codecs=opus");
+  });
 });

--- a/packages/ui/src/cloud-ui/components/voice/audio-utils.test.ts
+++ b/packages/ui/src/cloud-ui/components/voice/audio-utils.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Unit tests for the callable browser capabilities required by voice recording.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  getSupportedMimeType,
+  supportsGetUserMedia,
+  supportsMediaRecorder,
+} from "./audio-utils.ts";
+
+const SupportedMediaRecorder = Object.assign(
+  function SupportedMediaRecorder() {},
+  {
+    isTypeSupported: (type: string): boolean => type.includes("webm"),
+  },
+);
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("supportsMediaRecorder", () => {
+  it("rejects absent and partial MediaRecorder implementations", () => {
+    vi.stubGlobal("window", {});
+    expect(supportsMediaRecorder()).toBe(false);
+
+    vi.stubGlobal("window", { MediaRecorder: undefined });
+    expect(supportsMediaRecorder()).toBe(false);
+
+    vi.stubGlobal("window", { MediaRecorder: {} });
+    expect(supportsMediaRecorder()).toBe(false);
+
+    vi.stubGlobal("window", { MediaRecorder: class MediaRecorder {} });
+    expect(supportsMediaRecorder()).toBe(false);
+  });
+
+  it("accepts a callable recorder with MIME capability detection", () => {
+    vi.stubGlobal("window", { MediaRecorder: SupportedMediaRecorder });
+    expect(supportsMediaRecorder()).toBe(true);
+  });
+});
+
+describe("supportsGetUserMedia", () => {
+  it("rejects absent and non-callable getUserMedia implementations", () => {
+    vi.stubGlobal("window", {});
+    vi.stubGlobal("navigator", {});
+    expect(supportsGetUserMedia()).toBe(false);
+
+    vi.stubGlobal("navigator", { mediaDevices: {} });
+    expect(supportsGetUserMedia()).toBe(false);
+
+    vi.stubGlobal("navigator", { mediaDevices: { getUserMedia: true } });
+    expect(supportsGetUserMedia()).toBe(false);
+  });
+
+  it("accepts a callable getUserMedia implementation", () => {
+    vi.stubGlobal("window", {});
+    vi.stubGlobal("navigator", {
+      mediaDevices: { getUserMedia: vi.fn() },
+    });
+    expect(supportsGetUserMedia()).toBe(true);
+  });
+});
+
+describe("getSupportedMimeType", () => {
+  it("returns the first supported MIME type", () => {
+    vi.stubGlobal("MediaRecorder", SupportedMediaRecorder);
+    expect(getSupportedMimeType()).toBe("audio/webm;codecs=opus");
+  });
+
+  it("returns an empty string when capability detection is unavailable", () => {
+    vi.stubGlobal("MediaRecorder", class MediaRecorder {});
+    expect(getSupportedMimeType()).toBe("");
+  });
+
+  it("returns an empty string when no MIME type is supported", () => {
+    const UnsupportedMediaRecorder = Object.assign(
+      function UnsupportedMediaRecorder() {},
+      { isTypeSupported: (): boolean => false },
+    );
+
+    vi.stubGlobal("MediaRecorder", UnsupportedMediaRecorder);
+    expect(getSupportedMimeType()).toBe("");
+  });
+});

--- a/packages/ui/src/cloud-ui/components/voice/audio-utils.test.ts
+++ b/packages/ui/src/cloud-ui/components/voice/audio-utils.test.ts
@@ -8,12 +8,17 @@ import {
   supportsMediaRecorder,
 } from "./audio-utils.ts";
 
-const SupportedMediaRecorder = Object.assign(
-  function SupportedMediaRecorder() {},
-  {
-    isTypeSupported: (type: string): boolean => type.includes("webm"),
-  },
-);
+class SupportedMediaRecorder {
+  static isTypeSupported(type: string): boolean {
+    return type.includes("webm");
+  }
+
+  addEventListener(): void {}
+  start(): void {}
+  stop(): void {}
+  pause(): void {}
+  resume(): void {}
+}
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -38,6 +43,23 @@ describe("supportsMediaRecorder", () => {
     vi.stubGlobal("window", { MediaRecorder: SupportedMediaRecorder });
     expect(supportsMediaRecorder()).toBe(true);
   });
+
+  it("rejects hostile getters and non-constructible callables", () => {
+    const hostileWindow = Object.defineProperty({}, "MediaRecorder", {
+      get: () => {
+        throw new Error("blocked");
+      },
+    });
+    vi.stubGlobal("window", hostileWindow);
+    expect(supportsMediaRecorder()).toBe(false);
+
+    const nonConstructible = Object.assign(() => undefined, {
+      isTypeSupported: () => true,
+      prototype: SupportedMediaRecorder.prototype,
+    });
+    vi.stubGlobal("window", { MediaRecorder: nonConstructible });
+    expect(supportsMediaRecorder()).toBe(false);
+  });
 });
 
 describe("supportsGetUserMedia", () => {
@@ -60,11 +82,25 @@ describe("supportsGetUserMedia", () => {
     });
     expect(supportsGetUserMedia()).toBe(true);
   });
+
+  it("rejects a hostile mediaDevices getter", () => {
+    vi.stubGlobal("window", {});
+    vi.stubGlobal(
+      "navigator",
+      Object.defineProperty({}, "mediaDevices", {
+        get: () => {
+          throw new Error("blocked");
+        },
+      }),
+    );
+    expect(supportsGetUserMedia()).toBe(false);
+  });
 });
 
 describe("getSupportedMimeType", () => {
   it("returns the first supported MIME type", () => {
     vi.stubGlobal("MediaRecorder", SupportedMediaRecorder);
+    vi.stubGlobal("window", { MediaRecorder: SupportedMediaRecorder });
     expect(getSupportedMimeType()).toBe("audio/webm;codecs=opus");
   });
 
@@ -74,12 +110,34 @@ describe("getSupportedMimeType", () => {
   });
 
   it("returns an empty string when no MIME type is supported", () => {
-    const UnsupportedMediaRecorder = Object.assign(
-      function UnsupportedMediaRecorder() {},
-      { isTypeSupported: (): boolean => false },
-    );
+    class UnsupportedMediaRecorder extends SupportedMediaRecorder {
+      static isTypeSupported(): boolean {
+        return false;
+      }
+    }
 
     vi.stubGlobal("MediaRecorder", UnsupportedMediaRecorder);
+    vi.stubGlobal("window", { MediaRecorder: UnsupportedMediaRecorder });
+    expect(getSupportedMimeType()).toBe("");
+  });
+
+  it("requires an exact true result and fails closed when MIME probing throws", () => {
+    class TruthyMediaRecorder extends SupportedMediaRecorder {
+      static isTypeSupported(): boolean {
+        return 1 as unknown as boolean;
+      }
+    }
+    vi.stubGlobal("MediaRecorder", TruthyMediaRecorder);
+    vi.stubGlobal("window", { MediaRecorder: TruthyMediaRecorder });
+    expect(getSupportedMimeType()).toBe("");
+
+    class ThrowingMediaRecorder extends SupportedMediaRecorder {
+      static isTypeSupported(): boolean {
+        throw new Error("blocked");
+      }
+    }
+    vi.stubGlobal("MediaRecorder", ThrowingMediaRecorder);
+    vi.stubGlobal("window", { MediaRecorder: ThrowingMediaRecorder });
     expect(getSupportedMimeType()).toBe("");
   });
 });

--- a/packages/ui/src/cloud-ui/components/voice/audio-utils.test.ts
+++ b/packages/ui/src/cloud-ui/components/voice/audio-utils.test.ts
@@ -4,6 +4,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   getSupportedMimeType,
+  isUsableMediaRecorder,
   supportsGetUserMedia,
   supportsMediaRecorder,
 } from "./audio-utils.ts";
@@ -94,6 +95,29 @@ describe("supportsGetUserMedia", () => {
       }),
     );
     expect(supportsGetUserMedia()).toBe(false);
+  });
+});
+
+describe("isUsableMediaRecorder", () => {
+  it("requires a readable recorder state in addition to callable methods", () => {
+    const methods = {
+      addEventListener: vi.fn(),
+      start: vi.fn(),
+      stop: vi.fn(),
+      pause: vi.fn(),
+      resume: vi.fn(),
+    };
+    expect(isUsableMediaRecorder({ state: "inactive", ...methods })).toBe(true);
+    expect(isUsableMediaRecorder(methods)).toBe(false);
+    expect(
+      isUsableMediaRecorder(
+        Object.defineProperty({ ...methods }, "state", {
+          get: () => {
+            throw new Error("blocked");
+          },
+        }),
+      ),
+    ).toBe(false);
   });
 });
 

--- a/packages/ui/src/cloud-ui/components/voice/audio-utils.ts
+++ b/packages/ui/src/cloud-ui/components/voice/audio-utils.ts
@@ -47,6 +47,15 @@ export function isUsableMediaRecorder(
       return false;
     }
 
+    const state = (candidate as Record<string, unknown>).state;
+    if (
+      !(["inactive", "recording", "paused"] as const).includes(
+        state as RecordingState,
+      )
+    ) {
+      return false;
+    }
+
     return REQUIRED_RECORDER_METHODS.every(
       (method) =>
         typeof (candidate as Record<string, unknown>)[method] === "function",

--- a/packages/ui/src/cloud-ui/components/voice/audio-utils.ts
+++ b/packages/ui/src/cloud-ui/components/voice/audio-utils.ts
@@ -74,8 +74,9 @@ export function supportsGetUserMedia(): boolean {
   }
 }
 
-export function getSupportedMimeType(): string {
-  const recorder = getMediaRecorderConstructor();
+export function getSupportedMimeType(
+  recorder: typeof MediaRecorder | null = getMediaRecorderConstructor(),
+): string {
   if (!recorder) {
     return "";
   }

--- a/packages/ui/src/cloud-ui/components/voice/audio-utils.ts
+++ b/packages/ui/src/cloud-ui/components/voice/audio-utils.ts
@@ -1,27 +1,82 @@
 /**
  * Feature-detection and small audio helpers (MediaRecorder support) for the voice surface.
  */
+const REQUIRED_RECORDER_METHODS = [
+  "addEventListener",
+  "start",
+  "stop",
+  "pause",
+  "resume",
+] as const;
+
+export function getMediaRecorderConstructor(): typeof MediaRecorder | null {
+  try {
+    if (typeof window === "undefined") {
+      return null;
+    }
+
+    const candidate = window.MediaRecorder;
+    if (
+      typeof candidate !== "function" ||
+      typeof candidate.isTypeSupported !== "function" ||
+      !candidate.prototype
+    ) {
+      return null;
+    }
+
+    // Reflect.construct checks whether the candidate is a constructor without
+    // invoking browser code or requesting a real MediaStream.
+    Reflect.construct(Function, [], candidate);
+
+    return REQUIRED_RECORDER_METHODS.every(
+      (method) => typeof candidate.prototype[method] === "function",
+    )
+      ? candidate
+      : null;
+  } catch {
+    // error-policy:J3 Browser capability getters are untrusted input and fail closed.
+    return null;
+  }
+}
+
+export function isUsableMediaRecorder(
+  candidate: unknown,
+): candidate is MediaRecorder {
+  try {
+    if (typeof candidate !== "object" || candidate === null) {
+      return false;
+    }
+
+    return REQUIRED_RECORDER_METHODS.every(
+      (method) =>
+        typeof (candidate as Record<string, unknown>)[method] === "function",
+    );
+  } catch {
+    // error-policy:J3 Hostile recorder instances are rejected as invalid input.
+    return false;
+  }
+}
+
 export function supportsMediaRecorder(): boolean {
-  return (
-    typeof window !== "undefined" &&
-    typeof window.MediaRecorder === "function" &&
-    typeof window.MediaRecorder.isTypeSupported === "function"
-  );
+  return getMediaRecorderConstructor() !== null;
 }
 
 export function supportsGetUserMedia(): boolean {
-  return (
-    typeof window !== "undefined" &&
-    typeof navigator !== "undefined" &&
-    typeof navigator.mediaDevices?.getUserMedia === "function"
-  );
+  try {
+    return (
+      typeof window !== "undefined" &&
+      typeof navigator !== "undefined" &&
+      typeof navigator.mediaDevices?.getUserMedia === "function"
+    );
+  } catch {
+    // error-policy:J3 Browser capability getters are untrusted input and fail closed.
+    return false;
+  }
 }
 
 export function getSupportedMimeType(): string {
-  if (
-    typeof MediaRecorder === "undefined" ||
-    typeof MediaRecorder.isTypeSupported !== "function"
-  ) {
+  const recorder = getMediaRecorderConstructor();
+  if (!recorder) {
     return "";
   }
 
@@ -34,10 +89,15 @@ export function getSupportedMimeType(): string {
     "audio/wav",
   ];
 
-  for (const type of types) {
-    if (MediaRecorder.isTypeSupported(type)) {
-      return type;
+  try {
+    for (const type of types) {
+      if (recorder.isTypeSupported(type) === true) {
+        return type;
+      }
     }
+  } catch {
+    // error-policy:J3 MIME probing is browser input and fails closed.
+    return "";
   }
 
   return "";

--- a/packages/ui/src/cloud-ui/components/voice/audio-utils.ts
+++ b/packages/ui/src/cloud-ui/components/voice/audio-utils.ts
@@ -2,18 +2,29 @@
  * Feature-detection and small audio helpers (MediaRecorder support) for the voice surface.
  */
 export function supportsMediaRecorder(): boolean {
-  return typeof window !== "undefined" && "MediaRecorder" in window;
+  return (
+    typeof window !== "undefined" &&
+    typeof window.MediaRecorder === "function" &&
+    typeof window.MediaRecorder.isTypeSupported === "function"
+  );
 }
 
 export function supportsGetUserMedia(): boolean {
-  return !!(
+  return (
     typeof window !== "undefined" &&
-    navigator.mediaDevices &&
-    navigator.mediaDevices.getUserMedia
+    typeof navigator !== "undefined" &&
+    typeof navigator.mediaDevices?.getUserMedia === "function"
   );
 }
 
 export function getSupportedMimeType(): string {
+  if (
+    typeof MediaRecorder === "undefined" ||
+    typeof MediaRecorder.isTypeSupported !== "function"
+  ) {
+    return "";
+  }
+
   const types = [
     "audio/webm;codecs=opus",
     "audio/webm",

--- a/packages/ui/src/cloud-ui/components/voice/use-audio-recorder.test.tsx
+++ b/packages/ui/src/cloud-ui/components/voice/use-audio-recorder.test.tsx
@@ -1,0 +1,226 @@
+/**
+ * Deterministic hook tests verify recorder acquisition, cleanup, and teardown failure handling.
+ */
+// @vitest-environment jsdom
+
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAudioRecorder } from "./use-audio-recorder";
+
+const reportRendererDiagnostic = vi.hoisted(() => vi.fn());
+
+vi.mock("../../../utils/renderer-diagnostics", () => ({
+  reportRendererDiagnostic,
+}));
+
+type RecorderListener = (event: Event & { data?: Blob }) => void;
+
+class FakeMediaRecorder {
+  static isTypeSupported(): boolean {
+    return true;
+  }
+
+  static instances: FakeMediaRecorder[] = [];
+
+  state: RecordingState = "inactive";
+  readonly listeners = new Map<string, RecorderListener[]>();
+  readonly stopCall = vi.fn();
+
+  stop(): void {
+    this.stopCall();
+    if (this.state === "inactive") {
+      return;
+    }
+    this.state = "inactive";
+    for (const listener of this.listeners.get("stop") ?? []) {
+      listener(new Event("stop"));
+    }
+  }
+
+  constructor(_stream: MediaStream) {
+    FakeMediaRecorder.instances.push(this);
+  }
+
+  addEventListener(type: string, listener: EventListener): void {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener as RecorderListener);
+    this.listeners.set(type, listeners);
+  }
+
+  start(): void {
+    this.state = "recording";
+  }
+
+  pause(): void {
+    this.state = "paused";
+  }
+
+  resume(): void {
+    this.state = "recording";
+  }
+}
+
+function installRecorder(
+  getUserMedia: () => Promise<MediaStream>,
+  Recorder: typeof FakeMediaRecorder = FakeMediaRecorder,
+): void {
+  vi.stubGlobal("MediaRecorder", Recorder);
+  vi.stubGlobal("navigator", {
+    mediaDevices: { getUserMedia: vi.fn(getUserMedia) },
+  });
+}
+
+function createStream(...tracks: Array<{ stop: () => void }>): MediaStream {
+  return {
+    getTracks: () => tracks,
+  } as unknown as MediaStream;
+}
+
+afterEach(() => {
+  FakeMediaRecorder.instances = [];
+  reportRendererDiagnostic.mockReset();
+  vi.unstubAllGlobals();
+});
+
+describe("useAudioRecorder", () => {
+  it("stops a stream that resolves after the hook unmounts", async () => {
+    let resolveStream: ((stream: MediaStream) => void) | undefined;
+    const streamPromise = new Promise<MediaStream>((resolve) => {
+      resolveStream = resolve;
+    });
+    const stop = vi.fn();
+    installRecorder(() => streamPromise);
+
+    const { result, unmount } = renderHook(() => useAudioRecorder());
+    let startPromise: Promise<void> | undefined;
+    act(() => {
+      startPromise = result.current.startRecording();
+    });
+    unmount();
+
+    resolveStream?.(createStream({ stop }));
+    await act(async () => {
+      await startPromise;
+    });
+
+    expect(stop).toHaveBeenCalledOnce();
+    expect(FakeMediaRecorder.instances).toHaveLength(0);
+  });
+
+  it("rejects a constructor that returns a partial recorder and releases the stream", async () => {
+    const stop = vi.fn();
+    function PartialRecorder(): object {
+      return {
+        addEventListener: vi.fn(),
+        start: vi.fn(),
+      };
+    }
+    Object.assign(PartialRecorder, { isTypeSupported: () => true });
+    Object.assign(PartialRecorder.prototype, {
+      addEventListener: vi.fn(),
+      start: vi.fn(),
+      stop: vi.fn(),
+      pause: vi.fn(),
+      resume: vi.fn(),
+    });
+    installRecorder(
+      async () => createStream({ stop }),
+      PartialRecorder as unknown as typeof FakeMediaRecorder,
+    );
+
+    const { result } = renderHook(() => useAudioRecorder());
+    await act(async () => {
+      await result.current.startRecording();
+    });
+
+    expect(result.current.isRecording).toBe(false);
+    expect(result.current.error).toBe(
+      "Failed to start recording. Please try again.",
+    );
+    expect(stop).toHaveBeenCalledOnce();
+  });
+
+  it("releases every track when recorder startup and recorder teardown throw", async () => {
+    class ThrowingMediaRecorder extends FakeMediaRecorder {
+      override start(): void {
+        this.state = "recording";
+        throw new Error("start failed");
+      }
+
+      override stop(): void {
+        this.stopCall();
+        throw new Error("stop failed");
+      }
+    }
+    const firstStop = vi.fn(() => {
+      throw new Error("track failed");
+    });
+    const secondStop = vi.fn();
+    installRecorder(
+      async () => createStream({ stop: firstStop }, { stop: secondStop }),
+      ThrowingMediaRecorder,
+    );
+
+    const { result } = renderHook(() => useAudioRecorder());
+    await act(async () => {
+      await result.current.startRecording();
+    });
+
+    expect(result.current.isRecording).toBe(false);
+    expect(firstStop).toHaveBeenCalledOnce();
+    expect(secondStop).toHaveBeenCalledOnce();
+    expect(reportRendererDiagnostic).toHaveBeenCalledWith(
+      expect.objectContaining({ scope: "voice.recording.start.cleanup" }),
+    );
+  });
+
+  it("stops an active recorder once and makes repeated stop calls harmless", async () => {
+    const stopTrack = vi.fn();
+    installRecorder(async () => createStream({ stop: stopTrack }));
+
+    const { result } = renderHook(() => useAudioRecorder());
+    await act(async () => {
+      await result.current.startRecording();
+    });
+    expect(result.current.isRecording).toBe(true);
+
+    act(() => {
+      result.current.stopRecording();
+      result.current.stopRecording();
+    });
+
+    expect(FakeMediaRecorder.instances[0]?.stopCall).toHaveBeenCalledOnce();
+    expect(stopTrack).toHaveBeenCalledOnce();
+    expect(result.current.isRecording).toBe(false);
+  });
+
+  it("coalesces overlapping start calls into one microphone acquisition", async () => {
+    let resolveStream: ((stream: MediaStream) => void) | undefined;
+    const getUserMedia = vi.fn(
+      () =>
+        new Promise<MediaStream>((resolve) => {
+          resolveStream = resolve;
+        }),
+    );
+    const stopTrack = vi.fn();
+    installRecorder(getUserMedia);
+
+    const { result } = renderHook(() => useAudioRecorder());
+    let firstStart: Promise<void> | undefined;
+    let secondStart: Promise<void> | undefined;
+    act(() => {
+      firstStart = result.current.startRecording();
+      secondStart = result.current.startRecording();
+    });
+    expect(getUserMedia).toHaveBeenCalledOnce();
+
+    resolveStream?.(createStream({ stop: stopTrack }));
+    await act(async () => {
+      await Promise.all([firstStart, secondStart]);
+    });
+    expect(result.current.isRecording).toBe(true);
+
+    act(() => result.current.stopRecording());
+    expect(stopTrack).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/ui/src/cloud-ui/components/voice/use-audio-recorder.test.tsx
+++ b/packages/ui/src/cloud-ui/components/voice/use-audio-recorder.test.tsx
@@ -83,6 +83,22 @@ afterEach(() => {
 });
 
 describe("useAudioRecorder", () => {
+  it("remains usable across React Strict Mode's setup-cleanup replay", async () => {
+    const stopTrack = vi.fn();
+    installRecorder(async () => createStream({ stop: stopTrack }));
+
+    const { result } = renderHook(() => useAudioRecorder(), {
+      reactStrictMode: true,
+    });
+    await act(async () => {
+      await result.current.startRecording();
+    });
+
+    expect(result.current.isRecording).toBe(true);
+    act(() => result.current.stopRecording());
+    expect(stopTrack).toHaveBeenCalledOnce();
+  });
+
   it("stops a stream that resolves after the hook unmounts", async () => {
     let resolveStream: ((stream: MediaStream) => void) | undefined;
     const streamPromise = new Promise<MediaStream>((resolve) => {
@@ -222,5 +238,51 @@ describe("useAudioRecorder", () => {
 
     act(() => result.current.stopRecording());
     expect(stopTrack).toHaveBeenCalledOnce();
+  });
+
+  it("ignores a delayed stop event from an older recorder session", async () => {
+    class DelayedStopMediaRecorder extends FakeMediaRecorder {
+      override stop(): void {
+        this.stopCall();
+        this.state = "inactive";
+      }
+
+      emitStop(): void {
+        for (const listener of this.listeners.get("stop") ?? []) {
+          listener(new Event("stop"));
+        }
+      }
+    }
+    const firstTrackStop = vi.fn();
+    const secondTrackStop = vi.fn();
+    const streams = [
+      createStream({ stop: firstTrackStop }),
+      createStream({ stop: secondTrackStop }),
+    ];
+    installRecorder(async () => {
+      const stream = streams.shift();
+      if (!stream) throw new Error("unexpected acquisition");
+      return stream;
+    }, DelayedStopMediaRecorder);
+
+    const { result } = renderHook(() => useAudioRecorder());
+    await act(async () => {
+      await result.current.startRecording();
+    });
+    const firstRecorder = FakeMediaRecorder
+      .instances[0] as DelayedStopMediaRecorder;
+
+    act(() => result.current.stopRecording());
+    act(() => result.current.stopRecording());
+    expect(firstTrackStop).toHaveBeenCalledOnce();
+
+    await act(async () => {
+      await result.current.startRecording();
+    });
+    expect(result.current.isRecording).toBe(true);
+
+    act(() => firstRecorder.emitStop());
+    expect(result.current.isRecording).toBe(true);
+    expect(secondTrackStop).not.toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/cloud-ui/components/voice/use-audio-recorder.test.tsx
+++ b/packages/ui/src/cloud-ui/components/voice/use-audio-recorder.test.tsx
@@ -15,6 +15,11 @@ vi.mock("../../../utils/renderer-diagnostics", () => ({
 
 type RecorderListener = (event: Event & { data?: Blob }) => void;
 
+/**
+ * Spec-faithful fake: stop() flips state to "inactive" synchronously but, like
+ * a real MediaRecorder, delivers the final `dataavailable` and terminal `stop`
+ * events on a later microtask. `emitData` queues an interim chunk the same way.
+ */
 class FakeMediaRecorder {
   static isTypeSupported(): boolean {
     return true;
@@ -26,15 +31,30 @@ class FakeMediaRecorder {
   readonly listeners = new Map<string, RecorderListener[]>();
   readonly stopCall = vi.fn();
 
+  dispatch(type: string, data?: Blob): void {
+    const event = new Event(type) as Event & { data?: Blob };
+    if (data) {
+      event.data = data;
+    }
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener(event);
+    }
+  }
+
+  emitData(data: Blob): void {
+    queueMicrotask(() => this.dispatch("dataavailable", data));
+  }
+
   stop(): void {
     this.stopCall();
     if (this.state === "inactive") {
       return;
     }
     this.state = "inactive";
-    for (const listener of this.listeners.get("stop") ?? []) {
-      listener(new Event("stop"));
-    }
+    queueMicrotask(() => {
+      this.dispatch("dataavailable", new Blob(["-fin"]));
+      this.dispatch("stop");
+    });
   }
 
   constructor(_stream: MediaStream) {
@@ -95,7 +115,9 @@ describe("useAudioRecorder", () => {
     });
 
     expect(result.current.isRecording).toBe(true);
-    act(() => result.current.stopRecording());
+    await act(async () => {
+      result.current.stopRecording();
+    });
     expect(stopTrack).toHaveBeenCalledOnce();
   });
 
@@ -200,7 +222,7 @@ describe("useAudioRecorder", () => {
     });
     expect(result.current.isRecording).toBe(true);
 
-    act(() => {
+    await act(async () => {
       result.current.stopRecording();
       result.current.stopRecording();
     });
@@ -236,21 +258,22 @@ describe("useAudioRecorder", () => {
     });
     expect(result.current.isRecording).toBe(true);
 
-    act(() => result.current.stopRecording());
+    await act(async () => {
+      result.current.stopRecording();
+    });
     expect(stopTrack).toHaveBeenCalledOnce();
   });
 
   it("ignores a delayed stop event from an older recorder session", async () => {
-    class DelayedStopMediaRecorder extends FakeMediaRecorder {
+    class ThrowingStopMediaRecorder extends FakeMediaRecorder {
       override stop(): void {
         this.stopCall();
         this.state = "inactive";
+        throw new Error("stop failed");
       }
 
       emitStop(): void {
-        for (const listener of this.listeners.get("stop") ?? []) {
-          listener(new Event("stop"));
-        }
+        this.dispatch("stop");
       }
     }
     const firstTrackStop = vi.fn();
@@ -263,18 +286,18 @@ describe("useAudioRecorder", () => {
       const stream = streams.shift();
       if (!stream) throw new Error("unexpected acquisition");
       return stream;
-    }, DelayedStopMediaRecorder);
+    }, ThrowingStopMediaRecorder);
 
     const { result } = renderHook(() => useAudioRecorder());
     await act(async () => {
       await result.current.startRecording();
     });
     const firstRecorder = FakeMediaRecorder
-      .instances[0] as DelayedStopMediaRecorder;
+      .instances[0] as ThrowingStopMediaRecorder;
 
     act(() => result.current.stopRecording());
-    act(() => result.current.stopRecording());
     expect(firstTrackStop).toHaveBeenCalledOnce();
+    expect(result.current.isRecording).toBe(false);
 
     await act(async () => {
       await result.current.startRecording();
@@ -284,5 +307,71 @@ describe("useAudioRecorder", () => {
     act(() => firstRecorder.emitStop());
     expect(result.current.isRecording).toBe(true);
     expect(secondTrackStop).not.toHaveBeenCalled();
+  });
+
+  it("keeps a stale recorder's late dataavailable out of the next session's blob", async () => {
+    const streams = [
+      createStream({ stop: vi.fn() }),
+      createStream({ stop: vi.fn() }),
+    ];
+    installRecorder(async () => {
+      const stream = streams.shift();
+      if (!stream) throw new Error("unexpected acquisition");
+      return stream;
+    });
+
+    const { result } = renderHook(() => useAudioRecorder());
+    await act(async () => {
+      await result.current.startRecording();
+    });
+    const firstRecorder = FakeMediaRecorder.instances[0] as FakeMediaRecorder;
+    await act(async () => {
+      firstRecorder.emitData(new Blob(["r1"]));
+      result.current.stopRecording();
+    });
+    expect(result.current.audioBlob?.size).toBe(6); // "r1" + "-fin"
+
+    await act(async () => {
+      await result.current.startRecording();
+    });
+    const secondRecorder = FakeMediaRecorder.instances[1] as FakeMediaRecorder;
+    await act(async () => {
+      secondRecorder.emitData(new Blob(["r2!"]));
+      // A stale chunk from the retired recorder arrives mid-session.
+      firstRecorder.emitData(new Blob(["stale"]));
+    });
+    await act(async () => {
+      result.current.stopRecording();
+    });
+
+    expect(result.current.audioBlob?.size).toBe(7); // "r2!" + "-fin" only
+  });
+
+  it("preserves the recording when stop is clicked again before the async stop event", async () => {
+    const stopTrack = vi.fn();
+    installRecorder(async () => createStream({ stop: stopTrack }));
+
+    const { result } = renderHook(() => useAudioRecorder());
+    await act(async () => {
+      await result.current.startRecording();
+    });
+    const recorder = FakeMediaRecorder.instances[0] as FakeMediaRecorder;
+    await act(async () => {
+      recorder.emitData(new Blob(["take"]));
+    });
+
+    // Both clicks land inside the sync-inactive window: state is already
+    // "inactive" after the first stop() while its events are still queued.
+    act(() => {
+      result.current.stopRecording();
+      expect(recorder.state).toBe("inactive");
+      result.current.stopRecording();
+    });
+    await act(async () => {});
+
+    expect(recorder.stopCall).toHaveBeenCalledOnce();
+    expect(result.current.isRecording).toBe(false);
+    expect(result.current.audioBlob?.size).toBe(8); // "take" + "-fin"
+    expect(stopTrack).toHaveBeenCalledOnce();
   });
 });

--- a/packages/ui/src/cloud-ui/components/voice/use-audio-recorder.ts
+++ b/packages/ui/src/cloud-ui/components/voice/use-audio-recorder.ts
@@ -6,9 +6,10 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { reportRendererDiagnostic } from "../../../utils/renderer-diagnostics";
 import {
+  getMediaRecorderConstructor,
   getSupportedMimeType,
+  isUsableMediaRecorder,
   supportsGetUserMedia,
-  supportsMediaRecorder,
 } from "./audio-utils";
 
 export interface UseAudioRecorderReturn {
@@ -36,6 +37,8 @@ export function useAudioRecorder(): UseAudioRecorderReturn {
   const streamRef = useRef<MediaStream | null>(null);
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const mountedRef = useRef(true);
+  const startAttemptRef = useRef(0);
+  const startPendingRef = useRef(false);
 
   const clearTimer = useCallback(() => {
     if (timerRef.current) {
@@ -44,44 +47,99 @@ export function useAudioRecorder(): UseAudioRecorderReturn {
     }
   }, []);
 
-  const stopStream = useCallback(() => {
-    if (streamRef.current) {
-      streamRef.current.getTracks().forEach((track) => {
-        track.stop();
+  const stopTracks = useCallback((stream: MediaStream | null) => {
+    if (!stream) {
+      return;
+    }
+
+    try {
+      for (const track of stream.getTracks()) {
+        try {
+          track.stop();
+        } catch (error) {
+          // error-policy:J6 Media-track teardown is best effort during cleanup.
+          reportRendererDiagnostic({
+            scope: "voice.recording.track.stop",
+            error,
+          });
+        }
+      }
+    } catch (error) {
+      // error-policy:J6 A malformed stream must not prevent the remaining teardown.
+      reportRendererDiagnostic({
+        scope: "voice.recording.stream.cleanup",
+        error,
       });
-      streamRef.current = null;
     }
   }, []);
+
+  const stopStream = useCallback(() => {
+    const stream = streamRef.current;
+    streamRef.current = null;
+    stopTracks(stream);
+  }, [stopTracks]);
+
+  const resetRecorderState = useCallback(() => {
+    mediaRecorderRef.current = null;
+    clearTimer();
+    stopStream();
+    if (mountedRef.current) {
+      setIsRecording(false);
+      setIsPaused(false);
+    }
+  }, [clearTimer, stopStream]);
 
   useEffect(() => {
     return () => {
       mountedRef.current = false;
+      startAttemptRef.current += 1;
       clearTimer();
       const recorder = mediaRecorderRef.current;
-      if (recorder && recorder.state !== "inactive") {
-        recorder.stop();
+      mediaRecorderRef.current = null;
+      if (recorder) {
+        try {
+          if (recorder.state !== "inactive") {
+            recorder.stop();
+          }
+        } catch (error) {
+          // error-policy:J6 Recorder teardown is best effort during unmount.
+          reportRendererDiagnostic({
+            scope: "voice.recording.unmount.stop",
+            error,
+          });
+        }
       }
       stopStream();
     };
   }, [clearTimer, stopStream]);
 
   const startRecording = useCallback(async () => {
+    if (startPendingRef.current || mediaRecorderRef.current) {
+      return;
+    }
+
+    startPendingRef.current = true;
+    const attempt = ++startAttemptRef.current;
     setError(null);
     setAudioBlob(null);
     audioChunksRef.current = [];
 
-    if (!supportsGetUserMedia()) {
-      setError("Your browser doesn't support audio recording");
-      return;
-    }
-
-    if (!supportsMediaRecorder()) {
-      setError("Your browser doesn't support MediaRecorder");
-      return;
-    }
+    let acquiredStream: MediaStream | null = null;
+    let createdRecorder: MediaRecorder | null = null;
 
     try {
-      const stream = await navigator.mediaDevices.getUserMedia({
+      if (!supportsGetUserMedia()) {
+        setError("Your browser doesn't support audio recording");
+        return;
+      }
+
+      const MediaRecorderConstructor = getMediaRecorderConstructor();
+      if (!MediaRecorderConstructor) {
+        setError("Your browser doesn't support MediaRecorder");
+        return;
+      }
+
+      acquiredStream = await navigator.mediaDevices.getUserMedia({
         audio: {
           channelCount: 1,
           sampleRate: 16000,
@@ -92,40 +150,43 @@ export function useAudioRecorder(): UseAudioRecorderReturn {
         video: false,
       });
 
-      streamRef.current = stream;
+      if (!mountedRef.current || attempt !== startAttemptRef.current) {
+        stopTracks(acquiredStream);
+        return;
+      }
 
       const mimeType = getSupportedMimeType();
       if (!mimeType) {
         setError("No supported audio format found");
-        stopStream();
+        stopTracks(acquiredStream);
         return;
       }
 
-      const mediaRecorder = new MediaRecorder(stream, {
+      const recorderCandidate = new MediaRecorderConstructor(acquiredStream, {
         mimeType,
         audioBitsPerSecond: 128000,
       });
-      mediaRecorderRef.current = mediaRecorder;
+      if (!isUsableMediaRecorder(recorderCandidate)) {
+        throw new TypeError("MediaRecorder returned an unusable instance");
+      }
+      createdRecorder = recorderCandidate;
+      streamRef.current = acquiredStream;
+      mediaRecorderRef.current = createdRecorder;
 
-      mediaRecorder.addEventListener("dataavailable", (event) => {
+      createdRecorder.addEventListener("dataavailable", (event) => {
         if (event.data.size > 0) {
           audioChunksRef.current.push(event.data);
         }
       });
 
-      mediaRecorder.addEventListener("stop", () => {
+      createdRecorder.start(100);
+      createdRecorder.addEventListener("stop", () => {
         const audioBlob = new Blob(audioChunksRef.current, { type: mimeType });
         if (mountedRef.current) {
           setAudioBlob(audioBlob);
-          setIsRecording(false);
-          setIsPaused(false);
         }
-
-        stopStream();
-        clearTimer();
+        resetRecorderState();
       });
-
-      mediaRecorder.start(100);
       setIsRecording(true);
       setRecordingTime(0);
 
@@ -133,8 +194,38 @@ export function useAudioRecorder(): UseAudioRecorderReturn {
         setRecordingTime((prev) => prev + 1);
       }, 1000);
     } catch (err) {
+      // error-policy:J4 Recording failures become an explicit user-facing error state.
       reportRendererDiagnostic({ scope: "voice.recording.start", error: err });
 
+      if (createdRecorder) {
+        try {
+          if (createdRecorder.state !== "inactive") {
+            createdRecorder.stop();
+          }
+        } catch (stopError) {
+          // error-policy:J6 A failed partial recorder is cleaned up best effort.
+          reportRendererDiagnostic({
+            scope: "voice.recording.start.cleanup",
+            error: stopError,
+          });
+        }
+      }
+      if (mediaRecorderRef.current === createdRecorder) {
+        mediaRecorderRef.current = null;
+      }
+      if (streamRef.current === acquiredStream) {
+        streamRef.current = null;
+      }
+      stopTracks(acquiredStream);
+      clearTimer();
+      if (mountedRef.current) {
+        setIsRecording(false);
+        setIsPaused(false);
+      }
+
+      if (!mountedRef.current) {
+        return;
+      }
       if (err instanceof Error) {
         if (
           err.name === "NotAllowedError" ||
@@ -151,31 +242,70 @@ export function useAudioRecorder(): UseAudioRecorderReturn {
       } else {
         setError("Failed to start recording. Please try again.");
       }
+    } finally {
+      if (attempt === startAttemptRef.current) {
+        startPendingRef.current = false;
+      }
     }
-  }, [clearTimer, stopStream]);
+  }, [clearTimer, resetRecorderState, stopTracks]);
 
   const stopRecording = useCallback(() => {
-    if (mediaRecorderRef.current && isRecording) {
-      mediaRecorderRef.current.stop();
+    const recorder = mediaRecorderRef.current;
+    if (!recorder || !isRecording) {
+      return;
     }
-  }, [isRecording]);
+
+    try {
+      if (recorder.state === "inactive") {
+        resetRecorderState();
+        return;
+      }
+      recorder.stop();
+    } catch (stopError) {
+      // error-policy:J4 Stop failures become visible and still release resources.
+      reportRendererDiagnostic({
+        scope: "voice.recording.stop",
+        error: stopError,
+      });
+      setError("Failed to stop recording. Please try again.");
+      resetRecorderState();
+    }
+  }, [isRecording, resetRecorderState]);
 
   const pauseRecording = useCallback(() => {
     if (mediaRecorderRef.current && isRecording && !isPaused) {
-      mediaRecorderRef.current.pause();
-      setIsPaused(true);
-      clearTimer();
+      try {
+        mediaRecorderRef.current.pause();
+        setIsPaused(true);
+        clearTimer();
+      } catch (pauseError) {
+        // error-policy:J4 Pause failures become an explicit user-facing error state.
+        reportRendererDiagnostic({
+          scope: "voice.recording.pause",
+          error: pauseError,
+        });
+        setError("Failed to pause recording. Please try again.");
+      }
     }
   }, [clearTimer, isRecording, isPaused]);
 
   const resumeRecording = useCallback(() => {
     if (mediaRecorderRef.current && isRecording && isPaused) {
-      mediaRecorderRef.current.resume();
-      setIsPaused(false);
+      try {
+        mediaRecorderRef.current.resume();
+        setIsPaused(false);
 
-      timerRef.current = setInterval(() => {
-        setRecordingTime((prev) => prev + 1);
-      }, 1000);
+        timerRef.current = setInterval(() => {
+          setRecordingTime((prev) => prev + 1);
+        }, 1000);
+      } catch (resumeError) {
+        // error-policy:J4 Resume failures become an explicit user-facing error state.
+        reportRendererDiagnostic({
+          scope: "voice.recording.resume",
+          error: resumeError,
+        });
+        setError("Failed to resume recording. Please try again.");
+      }
     }
   }, [isRecording, isPaused]);
 

--- a/packages/ui/src/cloud-ui/components/voice/use-audio-recorder.ts
+++ b/packages/ui/src/cloud-ui/components/voice/use-audio-recorder.ts
@@ -2,6 +2,14 @@
 
 /**
  * Hook wrapping MediaRecorder capture for the voice-clone surface (start/stop, level, blob).
+ *
+ * Two lifecycle invariants matter here. Chunks are collected in an array local
+ * to each recorder generation, so a stale recorder's asynchronously queued
+ * `dataavailable` can never contaminate a later session's blob. And because
+ * MediaRecorder.stop() flips state to "inactive" synchronously while queueing
+ * its `dataavailable`/`stop` events asynchronously, an explicit stopping phase
+ * keeps `mediaRecorderRef` alive until the terminal `stop` event assembles the
+ * blob — a second stop click in that window is a no-op instead of a discard.
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { reportRendererDiagnostic } from "../../../utils/renderer-diagnostics";
@@ -33,12 +41,12 @@ export function useAudioRecorder(): UseAudioRecorderReturn {
   const [error, setError] = useState<string | null>(null);
 
   const mediaRecorderRef = useRef<MediaRecorder | null>(null);
-  const audioChunksRef = useRef<Blob[]>([]);
   const streamRef = useRef<MediaStream | null>(null);
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const mountedRef = useRef(true);
   const startAttemptRef = useRef(0);
   const startPendingRef = useRef(false);
+  const stoppingRef = useRef(false);
 
   const clearTimer = useCallback(() => {
     if (timerRef.current) {
@@ -81,6 +89,7 @@ export function useAudioRecorder(): UseAudioRecorderReturn {
 
   const resetRecorderState = useCallback(() => {
     mediaRecorderRef.current = null;
+    stoppingRef.current = false;
     clearTimer();
     stopStream();
     if (mountedRef.current) {
@@ -98,6 +107,7 @@ export function useAudioRecorder(): UseAudioRecorderReturn {
       clearTimer();
       const recorder = mediaRecorderRef.current;
       mediaRecorderRef.current = null;
+      stoppingRef.current = false;
       if (recorder) {
         try {
           if (recorder.state !== "inactive") {
@@ -124,7 +134,6 @@ export function useAudioRecorder(): UseAudioRecorderReturn {
     const attempt = ++startAttemptRef.current;
     setError(null);
     setAudioBlob(null);
-    audioChunksRef.current = [];
 
     let acquiredStream: MediaStream | null = null;
     let createdRecorder: MediaRecorder | null = null;
@@ -175,9 +184,12 @@ export function useAudioRecorder(): UseAudioRecorderReturn {
       streamRef.current = acquiredStream;
       mediaRecorderRef.current = createdRecorder;
 
+      // Chunks are scoped to this recorder generation so a stale recorder's
+      // async-queued dataavailable cannot contaminate a later session's blob.
+      const chunks: Blob[] = [];
       createdRecorder.addEventListener("dataavailable", (event) => {
         if (event.data.size > 0) {
-          audioChunksRef.current.push(event.data);
+          chunks.push(event.data);
         }
       });
 
@@ -186,7 +198,7 @@ export function useAudioRecorder(): UseAudioRecorderReturn {
         if (mediaRecorderRef.current !== createdRecorder) {
           return;
         }
-        const audioBlob = new Blob(audioChunksRef.current, { type: mimeType });
+        const audioBlob = new Blob(chunks, { type: mimeType });
         if (mountedRef.current) {
           setAudioBlob(audioBlob);
         }
@@ -256,15 +268,19 @@ export function useAudioRecorder(): UseAudioRecorderReturn {
 
   const stopRecording = useCallback(() => {
     const recorder = mediaRecorderRef.current;
-    if (!recorder || !isRecording) {
+    if (!recorder || !isRecording || stoppingRef.current) {
       return;
     }
 
     try {
       if (recorder.state === "inactive") {
+        // Fallback for a recorder that never started; a stopping recorder is
+        // also sync-inactive but is covered by the stoppingRef guard above so
+        // its queued stop event can still assemble the blob.
         resetRecorderState();
         return;
       }
+      stoppingRef.current = true;
       recorder.stop();
     } catch (stopError) {
       // error-policy:J4 Stop failures become visible and still release resources.
@@ -318,7 +334,6 @@ export function useAudioRecorder(): UseAudioRecorderReturn {
     setAudioBlob(null);
     setRecordingTime(0);
     setError(null);
-    audioChunksRef.current = [];
   }, []);
 
   return useMemo(

--- a/packages/ui/src/cloud-ui/components/voice/use-audio-recorder.ts
+++ b/packages/ui/src/cloud-ui/components/voice/use-audio-recorder.ts
@@ -155,7 +155,7 @@ export function useAudioRecorder(): UseAudioRecorderReturn {
         return;
       }
 
-      const mimeType = getSupportedMimeType();
+      const mimeType = getSupportedMimeType(MediaRecorderConstructor);
       if (!mimeType) {
         setError("No supported audio format found");
         stopTracks(acquiredStream);

--- a/packages/ui/src/cloud-ui/components/voice/use-audio-recorder.ts
+++ b/packages/ui/src/cloud-ui/components/voice/use-audio-recorder.ts
@@ -90,9 +90,11 @@ export function useAudioRecorder(): UseAudioRecorderReturn {
   }, [clearTimer, stopStream]);
 
   useEffect(() => {
+    mountedRef.current = true;
     return () => {
       mountedRef.current = false;
       startAttemptRef.current += 1;
+      startPendingRef.current = false;
       clearTimer();
       const recorder = mediaRecorderRef.current;
       mediaRecorderRef.current = null;
@@ -181,6 +183,9 @@ export function useAudioRecorder(): UseAudioRecorderReturn {
 
       createdRecorder.start(100);
       createdRecorder.addEventListener("stop", () => {
+        if (mediaRecorderRef.current !== createdRecorder) {
+          return;
+        }
         const audioBlob = new Blob(audioChunksRef.current, { type: mimeType });
         if (mountedRef.current) {
           setAudioBlob(audioBlob);


### PR DESCRIPTION
Closes #28763.

Repairs the follow-up left by #28760: keep failure-sensitive audio capability coverage and make the production probes require the callable browser APIs that `useAudioRecorder` actually invokes. MIME probing now fails closed when the static capability API is unavailable.

Exact-head local evidence before rebase produced commit-equivalent results; focused checks are being repeated on the rebased SHA:

- audio-utils production regression: 7/7 passed
- UI typecheck passed
- touched-file Biome passed with no diagnostics
- full UI lane: 1,215 files / 12,682 tests passed; 15 files / 22 unrelated tests failed in existing stale mocks/contracts outside this two-file diff
- `git diff --check` passed

No layout, styling, strings, network, persistent-domain, model, or audio encoding behavior changes. Visual output is unchanged; the behavior change is limited to failing closed before attempting unusable browser recording APIs.
