### PR TITLE
fix(shared): widen custom brand asset base paths

### DIFF
--- a/packages/shared/src/brand-classic/index.ts
+++ b/packages/shared/src/brand-classic/index.ts
@@ -10,7 +10,10 @@ import {
 
 export const BRAND_ASSET_BASE_PATH = "/brand" as const;
 
-export function brandAssetPath(path: string, basePath = BRAND_ASSET_BASE_PATH) {
+export function brandAssetPath(
+  path: string,
+  basePath: string = BRAND_ASSET_BASE_PATH,
+) {
   const normalizedBase = trimEndCharacters(basePath, "/");
   const normalizedPath = trimStartCharacters(path, "/");
   return `${normalizedBase}/${normalizedPath}`;


### PR DESCRIPTION
Closes #28767.

`brandAssetPath` already normalizes arbitrary custom bases at runtime, but TypeScript inferred its defaulted `basePath` parameter as the literal `"/brand"`. Explicitly typing that public parameter as `string` restores the runtime contract and clears the shared typecheck blocker affecting unrelated PR admission.

Exact-head local evidence:
- shared typecheck: pass
- brand-classic focused suite: 7/7 pass, including default, normalized, and absolute CDN bases
- shared lint: pass (507 files)
- shared production build: pass
- full shared lane: 201 files / 2,405 assertions pass; 29 untouched suites fail collection because the standalone workspace cannot resolve the unbuilt `@elizaos/prompts` entry
- `git diff --check`: pass

No UI pixels, model behavior, network requests, persistence, or domain artifacts change.