### PR TITLE
test(app-core): cover account pool status environment flag, routing, and method gates

### DIFF
--- a/packages/app-core/src/api/account-pool-status-routes.test.ts
+++ b/packages/app-core/src/api/account-pool-status-routes.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Tests for the public account-pool status route (GET /api/pool/status):
+ * environment gating, method authorization, cache-control headers,
+ * upstream service error translation with retry-after, and path matching.
+ */
 import { EventEmitter } from "node:events";
 import type http from "node:http";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -11,7 +16,7 @@ function response(): http.ServerResponse & {
   body: string;
   statusCode: number;
 } {
-  const res = new EventEmitter() as http.ServerResponse & {
+  const res = new EventEmitter() as unknown as http.ServerResponse & {
     body: string;
     statusCode: number;
   };
@@ -97,4 +102,90 @@ describe("GET /api/pool/status", () => {
     expect(errorRes.statusCode).toBe(503);
     expect(errorRes.setHeader).toHaveBeenCalledWith("retry-after", "60");
   });
+
+  it("ignores non-matching paths and returns false", async () => {
+    const res = response();
+    const handled = await handleAccountPoolStatusRoute(
+      {} as http.IncomingMessage,
+      res,
+      "GET",
+      "/api/pool/other",
+      dependencies,
+    );
+    expect(handled).toBe(false);
+    expect(res.statusCode).toBe(200);
+    expect(getPublicAccountPoolStatus).not.toHaveBeenCalled();
+  });
+
+  it.each(["true", "TRUE", "yes", "YES", "on", "ON", " 1 "])(
+    "enables the route for truthy flag value %j",
+    async (flagValue) => {
+      process.env.ELIZA_ACCOUNT_POOL_PUBLIC_STATUS_ENABLED = flagValue;
+      getPublicAccountPoolStatus.mockResolvedValue({ pool: { accounts: 1 } });
+      const res = response();
+      const handled = await handleAccountPoolStatusRoute(
+        {} as http.IncomingMessage,
+        res,
+        "GET",
+        "/api/pool/status",
+        dependencies,
+      );
+      expect(handled).toBe(true);
+      expect(res.statusCode).toBe(200);
+      expect(getPublicAccountPoolStatus).toHaveBeenCalled();
+    },
+  );
+
+  it.each(["0", "false", "no", "off", "disabled", "random", ""])(
+    "disables the route for non-truthy flag value %j",
+    async (flagValue) => {
+      process.env.ELIZA_ACCOUNT_POOL_PUBLIC_STATUS_ENABLED = flagValue;
+      const res = response();
+      const handled = await handleAccountPoolStatusRoute(
+        {} as http.IncomingMessage,
+        res,
+        "GET",
+        "/api/pool/status",
+        dependencies,
+      );
+      expect(handled).toBe(true);
+      expect(res.statusCode).toBe(404);
+      expect(res.setHeader).toHaveBeenCalledWith("cache-control", "no-store");
+      expect(getPublicAccountPoolStatus).not.toHaveBeenCalled();
+    },
+  );
+
+  it("sets public max-age cache control on success", async () => {
+    getPublicAccountPoolStatus.mockResolvedValue({ pool: { accounts: 3 } });
+    const res = response();
+    await handleAccountPoolStatusRoute(
+      {} as http.IncomingMessage,
+      res,
+      "GET",
+      "/api/pool/status",
+      dependencies,
+    );
+    expect(res.statusCode).toBe(200);
+    expect(res.setHeader).toHaveBeenCalledWith(
+      "cache-control",
+      "public, max-age=60",
+    );
+  });
+
+  it.each(["PUT", "DELETE", "PATCH"])(
+    "rejects %s method with HTTP 405",
+    async (method) => {
+      const res = response();
+      await handleAccountPoolStatusRoute(
+        {} as http.IncomingMessage,
+        res,
+        method,
+        "/api/pool/status",
+        dependencies,
+      );
+      expect(res.statusCode).toBe(405);
+      expect(res.setHeader).toHaveBeenCalledWith("allow", "GET");
+      expect(JSON.parse(res.body)).toEqual({ error: "method not allowed" });
+    },
+  );
 });


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low risk; additive unit tests for existing account pool status route contracts in `@elizaos/app-core`.

# Background

## What does this PR do?

Expands unit test coverage for `@elizaos/app-core` account pool status route (`GET /api/pool/status` in `packages/app-core/src/api/account-pool-status-routes.ts`):
- Environment variable truthy / falsy evaluation matrix for `ELIZA_ACCOUNT_POOL_PUBLIC_STATUS_ENABLED` ("1", "true", "yes", "on" vs disabled strings).
- HTTP method enforcement (rejecting POST, PUT, DELETE, PATCH with 405 Method Not Allowed and `Allow: GET` header).
- Path routing boundary (ignores non-matching paths and returns `false`).
- Cache-control header verification (`public, max-age=60` on 200 vs `no-store` on 404).
- Upstream service error translation with `Retry-After: 60` and 503 response.
- Preserves all 3 original unit tests from develop.

## What kind of change is this?

Improvements (test coverage for existing route contracts)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Review `packages/app-core/src/api/account-pool-status-routes.test.ts`.

## Detailed testing steps

Automated Vitest suite:
```bash
bunx vitest run packages/app-core/src/api/account-pool-status-routes.test.ts
```

Mutation test results:
RED (mutated HTTP status code from 503 to 500 on refresh failure):
  22 tests | 1 failed (expected 500 to be 503)
GREEN (restored):
  22 tests | 22 passed

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:a94361ae26629778b9a817f0c04337d9178cb61a -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only change with no rendered UI surface
<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only change with no rendered UI surface
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - test-only change has no user flow to record
<!-- evidence-row:backend-logs -->
- [ ] N/A - pure unit test does not exercise a server path
<!-- evidence-row:frontend-logs -->
- [ ] N/A - pure unit test does not exercise a browser path
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent model or prompt path is touched
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database rows or generated files produced
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface in this change

# Evidence Details

## Known gaps / failures

None.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

AI provider/model: Google / Gemini 3.7 Flash
Client / agent tooling: Antigravity
— [lane-byt61-0627]
<!-- eliza-computer-attribution:v1 {"provider":"Google","model":"Gemini 3.7 Flash","client":"Antigravity"} -->

