### PR TITLE
feat(cloud): add backup operation lane authority

### DIFF
--- a/packages/cloud/shared/src/db/agent-backup-operation-lane-migration.pglite.test.ts
+++ b/packages/cloud/shared/src/db/agent-backup-operation-lane-migration.pglite.test.ts
@@ -1,0 +1,238 @@
+/** Real-Postgres proof for the expand-only global backup-operation lane. */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { PGlite } from "@electric-sql/pglite";
+
+const migrationUrl = new URL("./migrations/0313_agent_backup_operation_lane.sql", import.meta.url);
+const journalUrl = new URL("./migrations/meta/_journal.json", import.meta.url);
+const migration = readFileSync(migrationUrl, "utf8");
+
+const ORGANIZATION_A = "00000000-0000-4000-8000-00000000f001";
+const ORGANIZATION_B = "00000000-0000-4000-8000-00000000f002";
+const BACKUP_ID = "00000000-0000-4000-8000-00000000f003";
+const OPERATION_ID = "00000000-0000-4000-8000-00000000f004";
+const GENERATION = "00000000-0000-4000-8000-00000000f005";
+const NODE_A = "00000000-0000-4000-8000-00000000f006";
+const NODE_B = "00000000-0000-4000-8000-00000000f007";
+const HISTORY_A1 = "00000000-0000-4000-8000-00000000f008";
+const HISTORY_A2 = "00000000-0000-4000-8000-00000000f009";
+const HISTORY_B = "00000000-0000-4000-8000-00000000f00a";
+const INCARNATION_A = "00000000-0000-4000-8000-00000000f00b";
+const INCARNATION_B = "00000000-0000-4000-8000-00000000f00c";
+
+async function createPrerequisites(database: PGlite): Promise<void> {
+  await database.exec(`
+    CREATE TABLE organizations (id uuid PRIMARY KEY);
+    CREATE TABLE docker_nodes (id uuid PRIMARY KEY);
+    CREATE TABLE agent_node_incarnation_histories (
+      id uuid PRIMARY KEY,
+      docker_node_record_id uuid NOT NULL,
+      node_incarnation uuid NOT NULL,
+      CONSTRAINT agent_node_incarnation_histories_receipt_authority_unique
+        UNIQUE (id, docker_node_record_id, node_incarnation)
+    );
+    INSERT INTO organizations (id) VALUES ('${ORGANIZATION_A}'), ('${ORGANIZATION_B}');
+    INSERT INTO docker_nodes (id) VALUES ('${NODE_A}'), ('${NODE_B}');
+    INSERT INTO agent_node_incarnation_histories (
+      id, docker_node_record_id, node_incarnation
+    ) VALUES
+      ('${HISTORY_A1}', '${NODE_A}', '${INCARNATION_A}'),
+      ('${HISTORY_A2}', '${NODE_A}', '${INCARNATION_A}'),
+      ('${HISTORY_B}', '${NODE_B}', '${INCARNATION_B}');
+  `);
+}
+
+async function applyMigration(database: PGlite): Promise<void> {
+  for (const statement of migration.split("--> statement-breakpoint")) {
+    if (statement.trim()) await database.exec(statement);
+  }
+}
+
+async function withDatabase(run: (database: PGlite) => Promise<void>): Promise<void> {
+  const database = new PGlite();
+  try {
+    await createPrerequisites(database);
+    await applyMigration(database);
+    await run(database);
+  } finally {
+    await database.close();
+  }
+}
+
+describe("agent backup operation lane migration", () => {
+  test("is journaled in the next append-only slot", async () => {
+    const journal = (await Bun.file(journalUrl).json()) as {
+      entries: Array<{ idx: number; tag: string }>;
+    };
+    expect(
+      journal.entries
+        .filter((entry) => entry.tag.includes("agent_backup_operation_lane"))
+        .map(({ idx, tag }) => ({ idx, tag })),
+    ).toEqual([{ idx: 296, tag: "0313_agent_backup_operation_lane" }]);
+  });
+
+  test("applies twice and preserves exactly one seeded singleton", async () => {
+    await withDatabase(async (database) => {
+      await applyMigration(database);
+      const rows = await database.query<{
+        singleton: boolean;
+        claim_sequence: string;
+        owner_id: string | null;
+      }>(`
+        SELECT singleton, claim_sequence::text, owner_id
+        FROM agent_backup_operation_lane
+      `);
+      expect(rows.rows).toEqual([{ singleton: true, claim_sequence: "0", owner_id: null }]);
+      await expect(
+        database.exec(`INSERT INTO agent_backup_operation_lane (singleton) VALUES (false)`),
+      ).rejects.toThrow(/singleton_check/);
+      await expect(
+        database.exec(`INSERT INTO agent_backup_operation_lane (singleton) VALUES (true)`),
+      ).rejects.toThrow(/duplicate key|unique constraint/i);
+    });
+  });
+
+  test("rejects partial claims and enforces the 255-byte canonical owner boundary", async () => {
+    await withDatabase(async (database) => {
+      await expect(
+        database.exec(`UPDATE agent_backup_operation_lane SET owner_id = 'worker-a'`),
+      ).rejects.toThrow(/shape_check/);
+
+      await database.exec(`
+        UPDATE agent_backup_operation_lane SET
+          owner_id = '${"a".repeat(255)}', generation = '${GENERATION}',
+          organization_id = '${ORGANIZATION_A}', backup_id = '${BACKUP_ID}',
+          operation_id = '${OPERATION_ID}', claimed_at = '2026-08-25T10:00:00Z',
+          lease_expires_at = '2026-08-25T10:05:00Z', claim_sequence = 1
+      `);
+      await expect(
+        database.query(`UPDATE agent_backup_operation_lane SET owner_id = $1`, ["é".repeat(128)]),
+      ).rejects.toThrow(/shape_check/);
+      await database.query(`UPDATE agent_backup_operation_lane SET owner_id = $1`, [
+        `${"é".repeat(127)}a`,
+      ]);
+      const owner = await database.query<{ bytes: number }>(`
+        SELECT octet_length(owner_id)::integer AS bytes FROM agent_backup_operation_lane
+      `);
+      expect(owner.rows).toEqual([{ bytes: 255 }]);
+      await expect(
+        database.query(`UPDATE agent_backup_operation_lane SET owner_id = $1`, ["worker\ncontrol"]),
+      ).rejects.toThrow(/shape_check/);
+      await expect(
+        database.exec(`UPDATE agent_backup_operation_lane SET claim_sequence = 0`),
+      ).rejects.toThrow(/shape_check/);
+      await expect(
+        database.exec(`
+          UPDATE agent_backup_operation_lane
+          SET released_at = '2026-08-25T09:59:59Z'
+        `),
+      ).rejects.toThrow(/shape_check/);
+    });
+  });
+
+  test("enforces tenant fairness counters, sequence uniqueness, foreign keys, and cascade", async () => {
+    await withDatabase(async (database) => {
+      await database.exec(`
+        INSERT INTO agent_backup_operation_tenant_watermarks (
+          organization_id, last_backup_id, last_operation_id,
+          last_service_sequence, service_count, last_served_at
+        ) VALUES (
+          '${ORGANIZATION_A}', '${BACKUP_ID}', '${OPERATION_ID}', 1, 1, NOW()
+        )
+      `);
+      await expect(
+        database.exec(`
+          INSERT INTO agent_backup_operation_tenant_watermarks (
+            organization_id, last_backup_id, last_operation_id,
+            last_service_sequence, service_count, last_served_at
+          ) VALUES (
+            '${ORGANIZATION_B}', '${BACKUP_ID}', '${OPERATION_ID}', 1, 1, NOW()
+          )
+        `),
+      ).rejects.toThrow(/sequence_uidx|unique constraint/i);
+      await expect(
+        database.exec(`
+          INSERT INTO agent_backup_operation_tenant_watermarks (
+            organization_id, last_backup_id, last_operation_id,
+            last_service_sequence, service_count, last_served_at
+          ) VALUES (
+            '${ORGANIZATION_B}', '${BACKUP_ID}', '${OPERATION_ID}', 2, 0, NOW()
+          )
+        `),
+      ).rejects.toThrow(/counters_check/);
+      await expect(
+        database.exec(`
+          INSERT INTO agent_backup_operation_tenant_watermarks (
+            organization_id, last_backup_id, last_operation_id,
+            last_service_sequence, service_count, last_served_at
+          ) VALUES (
+            '00000000-0000-4000-8000-00000000ffff', '${BACKUP_ID}',
+            '${OPERATION_ID}', 2, 1, NOW()
+          )
+        `),
+      ).rejects.toThrow(/foreign key/i);
+
+      await database.exec(`DELETE FROM organizations WHERE id = '${ORGANIZATION_A}'`);
+      const remaining = await database.query<{ count: number }>(`
+        SELECT count(*)::integer AS count FROM agent_backup_operation_tenant_watermarks
+      `);
+      expect(remaining.rows).toEqual([{ count: 0 }]);
+    });
+  });
+
+  test("keys node fairness by exact history occurrence and cleans it with the live node", async () => {
+    await withDatabase(async (database) => {
+      await database.exec(`
+        INSERT INTO agent_backup_operation_node_watermarks (
+          source_node_history_id, source_node_record_id, source_node_incarnation,
+          last_backup_id, last_operation_id, last_service_sequence, service_count, last_served_at
+        ) VALUES
+          ('${HISTORY_A1}', '${NODE_A}', '${INCARNATION_A}', '${BACKUP_ID}', '${OPERATION_ID}', 1, 1, NOW()),
+          ('${HISTORY_A2}', '${NODE_A}', '${INCARNATION_A}', '${BACKUP_ID}', '${OPERATION_ID}', 2, 1, NOW())
+      `);
+      await expect(
+        database.exec(`
+          INSERT INTO agent_backup_operation_node_watermarks (
+            source_node_history_id, source_node_record_id, source_node_incarnation,
+            last_backup_id, last_operation_id, last_service_sequence, service_count, last_served_at
+          ) VALUES (
+            '${HISTORY_B}', '${NODE_A}', '${INCARNATION_B}', '${BACKUP_ID}',
+            '${OPERATION_ID}', 3, 1, NOW()
+          )
+        `),
+      ).rejects.toThrow(/occurrence_fkey|foreign key/i);
+      await expect(
+        database.exec(`
+          INSERT INTO agent_backup_operation_node_watermarks (
+            source_node_history_id, source_node_record_id, source_node_incarnation,
+            last_backup_id, last_operation_id, last_service_sequence, service_count, last_served_at
+          ) VALUES (
+            '${HISTORY_B}', '${NODE_B}', '${INCARNATION_B}', '${BACKUP_ID}',
+            '${OPERATION_ID}', 3, 0, NOW()
+          )
+        `),
+      ).rejects.toThrow(/counters_check/);
+      await expect(
+        database.exec(`
+          INSERT INTO agent_backup_operation_node_watermarks (
+            source_node_history_id, source_node_record_id, source_node_incarnation,
+            last_backup_id, last_operation_id, last_service_sequence, service_count, last_served_at
+          ) VALUES (
+            '${HISTORY_B}', '${NODE_B}', '${INCARNATION_B}', '${BACKUP_ID}',
+            '${OPERATION_ID}', 1, 1, NOW()
+          )
+        `),
+      ).rejects.toThrow(/sequence_uidx|unique constraint/i);
+      await expect(
+        database.exec(`DELETE FROM agent_node_incarnation_histories WHERE id = '${HISTORY_A1}'`),
+      ).rejects.toThrow(/foreign key/i);
+
+      await database.exec(`DELETE FROM docker_nodes WHERE id = '${NODE_A}'`);
+      const remaining = await database.query<{ count: number }>(`
+        SELECT count(*)::integer AS count FROM agent_backup_operation_node_watermarks
+      `);
+      expect(remaining.rows).toEqual([{ count: 0 }]);
+    });
+  });
+});

--- a/packages/cloud/shared/src/db/migrations/0313_agent_backup_operation_lane.sql
+++ b/packages/cloud/shared/src/db/migrations/0313_agent_backup_operation_lane.sql
@@ -1,0 +1,81 @@
+CREATE TABLE IF NOT EXISTS "agent_backup_operation_lane" (
+	"singleton" boolean PRIMARY KEY DEFAULT true NOT NULL,
+	"owner_id" text,
+	"generation" uuid,
+	"organization_id" uuid,
+	"backup_id" uuid,
+	"operation_id" uuid,
+	"claimed_at" timestamp with time zone,
+	"lease_expires_at" timestamp with time zone,
+	"released_at" timestamp with time zone,
+	"claim_sequence" bigint DEFAULT 0 NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "agent_backup_operation_lane_singleton_check" CHECK ("agent_backup_operation_lane"."singleton"),
+	CONSTRAINT "agent_backup_operation_lane_shape_check" CHECK (("agent_backup_operation_lane"."claim_sequence" >= 0 AND ((
+		"agent_backup_operation_lane"."owner_id" IS NULL
+		AND "agent_backup_operation_lane"."generation" IS NULL
+		AND "agent_backup_operation_lane"."organization_id" IS NULL
+		AND "agent_backup_operation_lane"."backup_id" IS NULL
+		AND "agent_backup_operation_lane"."operation_id" IS NULL
+		AND "agent_backup_operation_lane"."claimed_at" IS NULL
+		AND "agent_backup_operation_lane"."lease_expires_at" IS NULL
+		AND "agent_backup_operation_lane"."released_at" IS NULL
+	) OR (
+		"agent_backup_operation_lane"."owner_id" IS NOT NULL
+		AND btrim("agent_backup_operation_lane"."owner_id") = "agent_backup_operation_lane"."owner_id"
+		AND octet_length("agent_backup_operation_lane"."owner_id") BETWEEN 1 AND 255
+		AND "agent_backup_operation_lane"."owner_id" !~ '[[:cntrl:]]'
+		AND "agent_backup_operation_lane"."generation" IS NOT NULL
+		AND "agent_backup_operation_lane"."organization_id" IS NOT NULL
+		AND "agent_backup_operation_lane"."backup_id" IS NOT NULL
+		AND "agent_backup_operation_lane"."operation_id" IS NOT NULL
+		AND "agent_backup_operation_lane"."claimed_at" IS NOT NULL
+		AND "agent_backup_operation_lane"."lease_expires_at" > "agent_backup_operation_lane"."claimed_at"
+		AND ("agent_backup_operation_lane"."released_at" IS NULL
+			OR "agent_backup_operation_lane"."released_at" >= "agent_backup_operation_lane"."claimed_at")
+		AND "agent_backup_operation_lane"."claim_sequence" >= 1
+	))) IS TRUE)
+);
+--> statement-breakpoint
+INSERT INTO "agent_backup_operation_lane" ("singleton") VALUES (true)
+ON CONFLICT ("singleton") DO NOTHING;
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "agent_backup_operation_tenant_watermarks" (
+	"organization_id" uuid PRIMARY KEY NOT NULL,
+	"last_backup_id" uuid NOT NULL,
+	"last_operation_id" uuid NOT NULL,
+	"last_service_sequence" bigint NOT NULL,
+	"service_count" bigint DEFAULT 1 NOT NULL,
+	"last_served_at" timestamp with time zone NOT NULL,
+	CONSTRAINT "agent_backup_operation_tenant_watermarks_counters_check"
+		CHECK ("last_service_sequence" >= 1 AND "service_count" >= 1),
+	CONSTRAINT "agent_backup_op_tenant_watermarks_org_fkey"
+		FOREIGN KEY ("organization_id") REFERENCES "public"."organizations"("id")
+		ON DELETE cascade ON UPDATE no action
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "agent_backup_operation_node_watermarks" (
+	"source_node_history_id" uuid PRIMARY KEY NOT NULL,
+	"source_node_record_id" uuid NOT NULL,
+	"source_node_incarnation" uuid NOT NULL,
+	"last_backup_id" uuid NOT NULL,
+	"last_operation_id" uuid NOT NULL,
+	"last_service_sequence" bigint NOT NULL,
+	"service_count" bigint DEFAULT 1 NOT NULL,
+	"last_served_at" timestamp with time zone NOT NULL,
+	CONSTRAINT "agent_backup_operation_node_watermarks_counters_check"
+		CHECK ("last_service_sequence" >= 1 AND "service_count" >= 1),
+	CONSTRAINT "agent_backup_op_node_watermarks_node_fkey"
+		FOREIGN KEY ("source_node_record_id") REFERENCES "public"."docker_nodes"("id")
+		ON DELETE cascade ON UPDATE no action,
+	CONSTRAINT "agent_backup_op_node_watermarks_occurrence_fkey"
+		FOREIGN KEY ("source_node_history_id", "source_node_record_id", "source_node_incarnation")
+		REFERENCES "public"."agent_node_incarnation_histories"("id", "docker_node_record_id", "node_incarnation")
+		ON DELETE restrict ON UPDATE no action
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "agent_backup_operation_tenant_watermarks_sequence_uidx"
+	ON "agent_backup_operation_tenant_watermarks" USING btree ("last_service_sequence");
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "agent_backup_operation_node_watermarks_sequence_uidx"
+	ON "agent_backup_operation_node_watermarks" USING btree ("last_service_sequence");

--- a/packages/cloud/shared/src/db/migrations/meta/_journal.json
+++ b/packages/cloud/shared/src/db/migrations/meta/_journal.json
@@ -2073,6 +2073,13 @@
       "when": 1794254400003,
       "tag": "0312_personal_shared_group_delivery_attempts",
       "breakpoints": true
+    },
+    {
+      "idx": 296,
+      "version": "7",
+      "when": 1794254400004,
+      "tag": "0313_agent_backup_operation_lane",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/cloud/shared/src/db/schemas/agent-backup-operation-lane.ts
+++ b/packages/cloud/shared/src/db/schemas/agent-backup-operation-lane.ts
@@ -1,0 +1,149 @@
+/** Global provider-execution lane and explicit tenant/node fairness watermarks. */
+
+import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { sql } from "drizzle-orm";
+import {
+  bigint,
+  boolean,
+  check,
+  foreignKey,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+} from "drizzle-orm/pg-core";
+import { agentNodeIncarnationHistories } from "./agent-node-incarnation-histories";
+import { dockerNodes } from "./docker-nodes";
+import { organizations } from "./organizations";
+
+/**
+ * The one database-serialized authority for backup provider mutations.
+ *
+ * Scheduler admission can remain concurrent, but a provider call must own this
+ * row under `SELECT ... FOR UPDATE` and the exact generation stored here. The
+ * row is seeded by the migration and is never deleted.
+ */
+export const agentBackupOperationLane = pgTable(
+  "agent_backup_operation_lane",
+  {
+    singleton: boolean("singleton").primaryKey().notNull().default(true),
+    owner_id: text("owner_id"),
+    generation: uuid("generation"),
+    organization_id: uuid("organization_id"),
+    backup_id: uuid("backup_id"),
+    operation_id: uuid("operation_id"),
+    claimed_at: timestamp("claimed_at", { withTimezone: true }),
+    lease_expires_at: timestamp("lease_expires_at", { withTimezone: true }),
+    released_at: timestamp("released_at", { withTimezone: true }),
+    claim_sequence: bigint("claim_sequence", { mode: "bigint" }).notNull().default(sql`0`),
+    updated_at: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    singleton_check: check("agent_backup_operation_lane_singleton_check", sql`${table.singleton}`),
+    shape_check: check(
+      "agent_backup_operation_lane_shape_check",
+      sql`(${table.claim_sequence} >= 0 AND ((
+        ${table.owner_id} IS NULL
+        AND ${table.generation} IS NULL
+        AND ${table.organization_id} IS NULL
+        AND ${table.backup_id} IS NULL
+        AND ${table.operation_id} IS NULL
+        AND ${table.claimed_at} IS NULL
+        AND ${table.lease_expires_at} IS NULL
+        AND ${table.released_at} IS NULL
+      ) OR (
+        ${table.owner_id} IS NOT NULL
+        AND btrim(${table.owner_id}) = ${table.owner_id}
+        AND octet_length(${table.owner_id}) BETWEEN 1 AND 255
+        AND ${table.owner_id} !~ '[[:cntrl:]]'
+        AND ${table.generation} IS NOT NULL
+        AND ${table.organization_id} IS NOT NULL
+        AND ${table.backup_id} IS NOT NULL
+        AND ${table.operation_id} IS NOT NULL
+        AND ${table.claimed_at} IS NOT NULL
+        AND ${table.lease_expires_at} > ${table.claimed_at}
+        AND (${table.released_at} IS NULL OR ${table.released_at} >= ${table.claimed_at})
+        AND ${table.claim_sequence} >= 1
+      ))) IS TRUE`,
+    ),
+  }),
+);
+
+/** Last globally serialized service received by an organization. */
+export const agentBackupOperationTenantWatermarks = pgTable(
+  "agent_backup_operation_tenant_watermarks",
+  {
+    organization_id: uuid("organization_id").primaryKey(),
+    last_backup_id: uuid("last_backup_id").notNull(),
+    last_operation_id: uuid("last_operation_id").notNull(),
+    last_service_sequence: bigint("last_service_sequence", { mode: "bigint" }).notNull(),
+    service_count: bigint("service_count", { mode: "bigint" }).notNull().default(sql`1`),
+    last_served_at: timestamp("last_served_at", { withTimezone: true }).notNull(),
+  },
+  (table) => ({
+    organization_fk: foreignKey({
+      name: "agent_backup_op_tenant_watermarks_org_fkey",
+      columns: [table.organization_id],
+      foreignColumns: [organizations.id],
+    }).onDelete("cascade"),
+    sequence_uidx: uniqueIndex("agent_backup_operation_tenant_watermarks_sequence_uidx").on(
+      table.last_service_sequence,
+    ),
+    counters_check: check(
+      "agent_backup_operation_tenant_watermarks_counters_check",
+      sql`${table.last_service_sequence} >= 1 AND ${table.service_count} >= 1`,
+    ),
+  }),
+);
+
+/** Last globally serialized service received by one exact source-node occurrence. */
+export const agentBackupOperationNodeWatermarks = pgTable(
+  "agent_backup_operation_node_watermarks",
+  {
+    source_node_history_id: uuid("source_node_history_id").primaryKey(),
+    source_node_record_id: uuid("source_node_record_id").notNull(),
+    source_node_incarnation: uuid("source_node_incarnation").notNull(),
+    last_backup_id: uuid("last_backup_id").notNull(),
+    last_operation_id: uuid("last_operation_id").notNull(),
+    last_service_sequence: bigint("last_service_sequence", { mode: "bigint" }).notNull(),
+    service_count: bigint("service_count", { mode: "bigint" }).notNull().default(sql`1`),
+    last_served_at: timestamp("last_served_at", { withTimezone: true }).notNull(),
+  },
+  (table) => ({
+    source_node_fk: foreignKey({
+      name: "agent_backup_op_node_watermarks_node_fkey",
+      columns: [table.source_node_record_id],
+      foreignColumns: [dockerNodes.id],
+    }).onDelete("cascade"),
+    node_occurrence_fk: foreignKey({
+      name: "agent_backup_op_node_watermarks_occurrence_fkey",
+      columns: [
+        table.source_node_history_id,
+        table.source_node_record_id,
+        table.source_node_incarnation,
+      ],
+      foreignColumns: [
+        agentNodeIncarnationHistories.id,
+        agentNodeIncarnationHistories.docker_node_record_id,
+        agentNodeIncarnationHistories.node_incarnation,
+      ],
+    }).onDelete("restrict"),
+    sequence_uidx: uniqueIndex("agent_backup_operation_node_watermarks_sequence_uidx").on(
+      table.last_service_sequence,
+    ),
+    counters_check: check(
+      "agent_backup_operation_node_watermarks_counters_check",
+      sql`${table.last_service_sequence} >= 1 AND ${table.service_count} >= 1`,
+    ),
+  }),
+);
+
+export type AgentBackupOperationLane = InferSelectModel<typeof agentBackupOperationLane>;
+export type NewAgentBackupOperationLane = InferInsertModel<typeof agentBackupOperationLane>;
+export type AgentBackupOperationTenantWatermark = InferSelectModel<
+  typeof agentBackupOperationTenantWatermarks
+>;
+export type AgentBackupOperationNodeWatermark = InferSelectModel<
+  typeof agentBackupOperationNodeWatermarks
+>;

--- a/packages/cloud/shared/src/db/schemas/index.ts
+++ b/packages/cloud/shared/src/db/schemas/index.ts
@@ -17,6 +17,7 @@ export * from "./admin-users";
 export * from "./affiliate-payout-outbox";
 export * from "./affiliates";
 export * from "./agent-backup-catalog";
+export * from "./agent-backup-operation-lane";
 export * from "./agent-backup-restore-history";
 export * from "./agent-budgets";
 export * from "./agent-compute-stop-intents";


### PR DESCRIPTION
# Relates to

- #24407
- Parent epic: #20726
- First scheduler-admission split, based directly on `develop@7883d65a44ce2febeea6893e6f83baf181003066`.

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] Exact head `198f3e4d34a4eb6a47b418a533d67d1b3057ba40` received an independent adversarial review with no P0-P3 findings.
- [ ] Full repository `bun run verify` remains pending before Ready.
- [ ] Scheduler admission, provider execution, and feature activation remain outside this foundation PR.

# Sync with base

- [x] Rebased onto current `origin/develop@7883d65a44ce2febeea6893e6f83baf181003066` after upstream #28770 fixed the unrelated shared-package type failure seen by the first CI run.
- [x] Stable patch-id is unchanged from pre-rebase head `a6a2740729b9a971e8df797cbc3ff4c6fb58c7b4`; all five PR-owned blobs are identical.
- [ ] Recheck migration ordinal and exact-head evidence after any later base update and immediately before Ready.

# Risks

Low to medium — additive database authority only. This creates one seeded singleton lease row plus tenant and exact node-occurrence fairness watermarks. No caller is wired in this PR.

# Background

## What does this PR do?

Adds the expand-only database foundation that later scheduler/provider slices will use to serialize backup provider effects and enforce fair service.

- Seeds one global singleton authority row for exact owner/generation/tenant/backup/operation lease identity.
- Rejects partial claims, invalid lease intervals, non-positive active claim sequences, control characters, and owner IDs outside 1–255 UTF-8 bytes.
- Adds tenant watermarks with monotone global service-sequence uniqueness.
- Keys node watermarks by immutable `source_node_history_id`, with a composite FK to the exact `(history, record, incarnation)` occurrence so an ABA reuse of record/incarnation cannot collapse two boots.
- Cascades derived fairness state with organization/live-node removal while refusing direct deletion of a referenced immutable occurrence.
- Registers idempotent migration `0313_agent_backup_operation_lane` in journal slot 296.

## What kind of change is this?

Database foundation for the backup scheduler admission flow. It is intentionally expand-only and behavior-dormant.

# Testing

Reviewer entry points:

- `packages/cloud/shared/src/db/schemas/agent-backup-operation-lane.ts`
- `packages/cloud/shared/src/db/migrations/0313_agent_backup_operation_lane.sql`
- `packages/cloud/shared/src/db/agent-backup-operation-lane-migration.pglite.test.ts`

Observed on exact head `198f3e4d34a4eb6a47b418a533d67d1b3057ba40` with Bun 1.3.14:

- real PGlite migration/invariant proof: 5/5 passed;
- global migration journal gate: 5/5 passed;
- Cloud shared TypeScript typecheck: passed;
- targeted Biome and diff-check: passed;
- `drizzle-kit check`: passed;
- independent exact-head review: CLEAN, no P0-P3.

The PGlite proof applies migration 0313 twice and exercises singleton uniqueness, partial-shape rejection, the 255-byte UTF-8 boundary, control-character rejection, tenant/node FKs, ABA-distinct node histories, counters, unique service sequences, cascade behavior, and direct history deletion fencing.

# Evidence Gate

<!-- evidence-head:198f3e4d34a4eb6a47b418a533d67d1b3057ba40 -->

- [ ] Before/after screenshots: N/A — database-only.
- [ ] Walkthrough video: N/A.
- [ ] Backend logs: Pending — no staging or production deployment is included.
- [ ] Frontend logs: N/A.
- [ ] Real-LLM trajectory: N/A.
- [x] Domain artifacts: real PGlite migration replay/constraint proof, journal integrity gate, typecheck, migration check, and independent review above.

# Known gaps / failures

This PR deliberately does not add claim/renew/release repositories, scheduler admission, provider calls, table-hot backfills, active catalogue indexes, runtime configuration, or the 10,000-agent load proof. Those remain separate stacked Draft slices under #24407.

# Deploy Notes

No deploy, migration execution, scheduler activation, provider call, node creation, or autoscale is included or authorized by this Draft PR.
