### PR TITLE
test(plugin-google-workspace): cover chat resource-name validation helpers

### DIFF
--- a/plugins/plugin-google-workspace/src/chat/types.test.ts
+++ b/plugins/plugin-google-workspace/src/chat/types.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Covers Google Chat resource-name validation and normalization helpers.
+ * Pins the regex contracts for space/user names and the target-to-resource
+ * coercion so malformed inputs never reach the Google Chat API.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  extractResourceId,
+  getSpaceDisplayName,
+  getUserDisplayName,
+  isDirectMessage,
+  isValidGoogleChatSpaceName,
+  isValidGoogleChatUserName,
+  normalizeSpaceTarget,
+  normalizeUserTarget,
+} from "./types";
+
+describe("isValidGoogleChatSpaceName", () => {
+  it("accepts canonical space names", () => {
+    expect(isValidGoogleChatSpaceName("spaces/abc123")).toBe(true);
+    expect(isValidGoogleChatSpaceName("spaces/ABC-123_def")).toBe(true);
+    expect(isValidGoogleChatSpaceName("spaces/1")).toBe(true);
+  });
+
+  it("rejects malformed space names", () => {
+    expect(isValidGoogleChatSpaceName("")).toBe(false);
+    expect(isValidGoogleChatSpaceName("spaces/")).toBe(false);
+    expect(isValidGoogleChatSpaceName("space/abc")).toBe(false);
+    expect(isValidGoogleChatSpaceName("spaces/abc/def")).toBe(false);
+    expect(isValidGoogleChatSpaceName("spaces/abc def")).toBe(false);
+    expect(isValidGoogleChatSpaceName("spaces/")).toBe(false);
+    expect(isValidGoogleChatSpaceName(" spaces/abc")).toBe(false);
+  });
+});
+
+describe("isValidGoogleChatUserName", () => {
+  it("accepts canonical user names", () => {
+    expect(isValidGoogleChatUserName("users/abc123")).toBe(true);
+    expect(isValidGoogleChatUserName("users/XYZ-789_def")).toBe(true);
+  });
+
+  it("rejects malformed user names", () => {
+    expect(isValidGoogleChatUserName("")).toBe(false);
+    expect(isValidGoogleChatUserName("users/")).toBe(false);
+    expect(isValidGoogleChatUserName("user/abc")).toBe(false);
+    expect(isValidGoogleChatUserName("users/abc/def")).toBe(false);
+    expect(isValidGoogleChatUserName("users/abc def")).toBe(false);
+  });
+});
+
+describe("normalizeSpaceTarget", () => {
+  it("returns already-canonical names unchanged", () => {
+    expect(normalizeSpaceTarget("spaces/abc123")).toBe("spaces/abc123");
+    expect(normalizeSpaceTarget("  spaces/abc123  ")).toBe("spaces/abc123");
+  });
+
+  it("coerces bare IDs to canonical form", () => {
+    expect(normalizeSpaceTarget("abc123")).toBe("spaces/abc123");
+    expect(normalizeSpaceTarget("  abc123  ")).toBe("spaces/abc123");
+    expect(normalizeSpaceTarget("ABC-123_def")).toBe("spaces/ABC-123_def");
+  });
+
+  it("rejects blank and malformed inputs", () => {
+    expect(normalizeSpaceTarget("")).toBeNull();
+    expect(normalizeSpaceTarget("   ")).toBeNull();
+    expect(normalizeSpaceTarget("spaces/abc def")).toBeNull();
+    expect(normalizeSpaceTarget("spaces/")).toBeNull();
+    expect(normalizeSpaceTarget("spaces/abc/def")).toBeNull();
+  });
+});
+
+describe("normalizeUserTarget", () => {
+  it("returns already-canonical user names unchanged", () => {
+    expect(normalizeUserTarget("users/abc123")).toBe("users/abc123");
+    expect(normalizeUserTarget("  users/abc123  ")).toBe("users/abc123");
+  });
+
+  it("coerces bare IDs to canonical form", () => {
+    expect(normalizeUserTarget("abc123")).toBe("users/abc123");
+    expect(normalizeUserTarget("XYZ-789")).toBe("users/XYZ-789");
+  });
+
+  it("rejects blank and malformed inputs", () => {
+    expect(normalizeUserTarget("")).toBeNull();
+    expect(normalizeUserTarget("   ")).toBeNull();
+    expect(normalizeUserTarget("users/abc def")).toBeNull();
+    expect(normalizeUserTarget("users/")).toBeNull();
+  });
+});
+
+describe("extractResourceId", () => {
+  it("returns the trailing segment after the last slash", () => {
+    expect(extractResourceId("spaces/abc123")).toBe("abc123");
+    expect(extractResourceId("users/xyz")).toBe("xyz");
+    expect(extractResourceId("spaces/a/b/c")).toBe("c");
+    expect(extractResourceId("single")).toBe("single");
+  });
+});
+
+describe("getUserDisplayName / getSpaceDisplayName", () => {
+  it("prefers displayName when present", () => {
+    expect(getUserDisplayName({ name: "users/123", displayName: "Alice" } as never)).toBe("Alice");
+    expect(getSpaceDisplayName({ name: "spaces/123", displayName: "General" } as never)).toBe(
+      "General"
+    );
+  });
+
+  it("falls back to resource ID when displayName is missing", () => {
+    expect(getUserDisplayName({ name: "users/123" } as never)).toBe("123");
+    expect(getSpaceDisplayName({ name: "spaces/abc" } as never)).toBe("abc");
+  });
+});
+
+describe("isDirectMessage", () => {
+  it("detects DM by type and singleUserBotDm", () => {
+    expect(isDirectMessage({ type: "DM" } as never)).toBe(true);
+    expect(isDirectMessage({ type: "ROOM", singleUserBotDm: true } as never)).toBe(true);
+    expect(isDirectMessage({ type: "ROOM" } as never)).toBe(false);
+    expect(isDirectMessage({ type: "SPACE" } as never)).toBe(false);
+  });
+});


### PR DESCRIPTION
# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Test-only addition: adds unit test coverage for Google Chat resource-name validation with no production code modifications.

# Background

## What does this PR do?

Adds mutation-sensitive unit tests for `isValidGoogleChatSpaceName`, `isValidGoogleChatUserName`, `normalizeSpaceTarget`, `normalizeUserTarget`, `extractResourceId`, `getUserDisplayName`, `getSpaceDisplayName`, and `isDirectMessage` in `plugins/plugin-google-workspace/src/chat/types.ts`.

## What kind of change is this?
Improvements (misc. changes to existing features)

# Documentation changes needed?
My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?
`plugins/plugin-google-workspace/src/chat/types.test.ts`

## Detailed testing steps
```bash
bunx vitest run plugins/plugin-google-workspace/src/chat/types.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.

<!-- evidence-head:3b60db11a1e575ead3f86aa2c743f25cf31af3bb -->

<!-- evidence-row:before-screenshots -->
- Before screenshots: N/A - no UI changes in unit tests (pure helper in plugins/plugin-google-workspace).

<!-- evidence-row:after-screenshots -->
- After screenshots: N/A - no UI changes in unit tests (pure helper in plugins/plugin-google-workspace).

<!-- evidence-row:walkthrough-video -->
- Walkthrough video: N/A - unit test execution only, no user flow.

<!-- evidence-row:backend-logs -->
- Backend logs: `bunx vitest run src/chat/types.test.ts` — 14 passed.

```
 RUN  v4.1.10 /Users/naynaingoo/.eliza-lanes/lane-byt61-4792/plugins/plugin-google-workspace

 Test Files  1 passed (1)
      Tests  14 passed (14)
   Start at  04:11:54
   Duration  3.22s (transform 2.48s, setup 0ms, import 3.16s, tests 2ms, environment 0ms)
```

<!-- evidence-row:frontend-logs -->
- Frontend logs: N/A - no frontend components touched (pure helper).

<!-- evidence-row:llm-trajectory -->
- LLM trajectory: N/A - deterministic unit tests with no model calls.

<!-- evidence-row:domain-artifacts -->
- Domain artifacts: N/A - unit test only, no domain side effects.

<!-- evidence-row:ocr-review -->
- OCR review: N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory
N/A - deterministic unit tests with no model calls.

## Backend + frontend logs
```
 RUN  v4.1.10 /Users/naynaingoo/.eliza-lanes/lane-byt61-4792/plugins/plugin-google-workspace

 Test Files  1 passed (1)
      Tests  14 passed (14)
```

## Screenshots (before / after) + video walkthrough
N/A - no UI change.

## Known gaps / failures
- `bun run typecheck` in `plugins/plugin-google-workspace` passes; `packages/shared` typecheck has 2 pre-existing brand-classic failures unrelated to this change.

## Maintainer CI exception record
N/A

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex desktop
— [lane-byt61-4792]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop"} -->
