### PR TITLE
test(plugin-health): cover mobile signal setup badge and permission helpers

### DIFF
--- a/plugins/plugin-health/src/screen-time/mobile-signal-setup.test.ts
+++ b/plugins/plugin-health/src/screen-time/mobile-signal-setup.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Covers mobile signal setup badge and label helpers.
+ * Pins the status-to-variant mapping and permission-target resolution so the
+ * screen-time UI never shows the wrong badge or requests the wrong permission.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  mobileSignalPermissionTargetForAction,
+  mobileSignalSetupActionBadge,
+  mobileSignalSetupPrimaryActionLabel,
+} from "./mobile-signal-setup";
+
+function t(key: string, opts?: { defaultValue?: string }): string {
+  return opts?.defaultValue ?? key;
+}
+
+describe("mobileSignalSetupActionBadge", () => {
+  it("returns secondary Ready for ready status", () => {
+    const res = mobileSignalSetupActionBadge(
+      { id: "a", label: "x", status: "ready", canRequest: false },
+      t,
+    );
+    expect(res.variant).toBe("secondary");
+    expect(res.label).toBe("Ready");
+  });
+
+  it("returns outline Unavailable for unavailable status", () => {
+    const res = mobileSignalSetupActionBadge(
+      { id: "a", label: "x", status: "unavailable", canRequest: false },
+      t,
+    );
+    expect(res.variant).toBe("outline");
+    expect(res.label).toBe("Unavailable");
+  });
+
+  it("returns outline Needs action for other statuses", () => {
+    const res = mobileSignalSetupActionBadge(
+      { id: "a", label: "x", status: "needs_action", canRequest: false },
+      t,
+    );
+    expect(res.variant).toBe("outline");
+    expect(res.label).toBe("Needs action");
+  });
+
+  it("handles unknown string status as Needs action", () => {
+    const res = mobileSignalSetupActionBadge(
+      { id: "a", label: "x", status: "custom", canRequest: false },
+      t,
+    );
+    expect(res.label).toBe("Needs action");
+    expect(res.variant).toBe("outline");
+  });
+
+  it("calls translator with correct keys", () => {
+    const spy = vi.fn(
+      (k: string, o?: { defaultValue?: string }) => o?.defaultValue ?? k,
+    );
+    mobileSignalSetupActionBadge(
+      { id: "a", label: "x", status: "ready", canRequest: false },
+      spy,
+    );
+    expect(spy).toHaveBeenCalledWith(
+      "lifeopssettings.deviceSetupReady",
+      expect.any(Object),
+    );
+    spy.mockClear();
+    mobileSignalSetupActionBadge(
+      { id: "a", label: "x", status: "unavailable", canRequest: false },
+      spy,
+    );
+    expect(spy).toHaveBeenCalledWith(
+      "lifeopssettings.deviceSetupUnavailable",
+      expect.any(Object),
+    );
+    spy.mockClear();
+    mobileSignalSetupActionBadge(
+      { id: "a", label: "x", status: "other", canRequest: false },
+      spy,
+    );
+    expect(spy).toHaveBeenCalledWith(
+      "lifeopssettings.deviceSetupNeedsAction",
+      expect.any(Object),
+    );
+  });
+});
+
+describe("mobileSignalSetupPrimaryActionLabel", () => {
+  it("returns Grant when canRequest is true", () => {
+    expect(
+      mobileSignalSetupPrimaryActionLabel(
+        { id: "a", label: "x", status: "ready", canRequest: true },
+        t,
+      ),
+    ).toBe("Grant");
+  });
+
+  it("returns Open Settings when canRequest is false", () => {
+    expect(
+      mobileSignalSetupPrimaryActionLabel(
+        { id: "a", label: "x", status: "ready", canRequest: false },
+        t,
+      ),
+    ).toBe("Open Settings");
+  });
+
+  it("uses translator keys", () => {
+    const spy = vi.fn(
+      (k: string, o?: { defaultValue?: string }) => o?.defaultValue ?? k,
+    );
+    mobileSignalSetupPrimaryActionLabel(
+      { id: "a", label: "x", status: "ready", canRequest: true },
+      spy,
+    );
+    expect(spy).toHaveBeenCalledWith(
+      "lifeopssettings.deviceSetupGrant",
+      expect.any(Object),
+    );
+    spy.mockClear();
+    mobileSignalSetupPrimaryActionLabel(
+      { id: "a", label: "x", status: "ready", canRequest: false },
+      spy,
+    );
+    expect(spy).toHaveBeenCalledWith(
+      "lifeopssettings.deviceSetupOpenSettings",
+      expect.any(Object),
+    );
+  });
+});
+
+describe("mobileSignalPermissionTargetForAction", () => {
+  it("maps known action IDs to permission targets", () => {
+    expect(
+      mobileSignalPermissionTargetForAction({ id: "health_permissions" }),
+    ).toBe("health");
+    expect(
+      mobileSignalPermissionTargetForAction({
+        id: "screen_time_authorization",
+      }),
+    ).toBe("screenTime");
+    expect(
+      mobileSignalPermissionTargetForAction({ id: "notification_settings" }),
+    ).toBe("notifications");
+  });
+
+  it("returns null for unknown IDs", () => {
+    expect(mobileSignalPermissionTargetForAction({ id: "unknown" })).toBeNull();
+    expect(mobileSignalPermissionTargetForAction({ id: "" })).toBeNull();
+    expect(mobileSignalPermissionTargetForAction({ id: "health" })).toBeNull();
+  });
+});


### PR DESCRIPTION
# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Test-only addition: adds unit test coverage for mobile signal setup helpers with no production code modifications.

# Background

## What does this PR do?

Adds mutation-sensitive unit tests for `mobileSignalSetupActionBadge`, `mobileSignalSetupPrimaryActionLabel`, and `mobileSignalPermissionTargetForAction` in `plugins/plugin-health/src/screen-time/mobile-signal-setup.ts`.

## What kind of change is this?
Improvements (misc. changes to existing features)

# Documentation changes needed?
My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?
`plugins/plugin-health/src/screen-time/mobile-signal-setup.test.ts`

## Detailed testing steps
```bash
bunx vitest run plugins/plugin-health/src/screen-time/mobile-signal-setup.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.

<!-- evidence-head:c4f992c695ebeafdc11b6c31bbc7df35626fcad0 -->

<!-- evidence-row:before-screenshots -->
- Before screenshots: N/A - no UI changes in unit tests (pure helper in plugins/plugin-health).

<!-- evidence-row:after-screenshots -->
- After screenshots: N/A - no UI changes in unit tests (pure helper in plugins/plugin-health).

<!-- evidence-row:walkthrough-video -->
- Walkthrough video: N/A - unit test execution only, no user flow.

<!-- evidence-row:backend-logs -->
- Backend logs: `bunx vitest run src/screen-time/mobile-signal-setup.test.ts` — 10 passed.

```
 RUN  v4.1.10 /Users/naynaingoo/.eliza-lanes/lane-byt61-4792/plugins/plugin-health

 Test Files  1 passed (1)
      Tests  10 passed (10)
   Start at  04:16:10
   Duration  108ms (transform 23ms, setup 0ms, import 42ms, tests 3ms, environment 0ms)
```

<!-- evidence-row:frontend-logs -->
- Frontend logs: N/A - no frontend components touched (pure helper).

<!-- evidence-row:llm-trajectory -->
- LLM trajectory: N/A - deterministic unit tests with no model calls.

<!-- evidence-row:domain-artifacts -->
- Domain artifacts: N/A - unit test only, no domain side effects.

<!-- evidence-row:ocr-review -->
- OCR review: N/A - no rendered visual surface.

# Evidence Details

## Backend + frontend logs
```
 RUN  v4.1.10 /Users/naynaingoo/.eliza-lanes/lane-byt61-4792/plugins/plugin-health

 Test Files  1 passed (1)
      Tests  10 passed (10)
```

## Known gaps / failures
None.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex desktop
— [lane-byt61-4792]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop"} -->
