### PR TITLE
test(plugin-dropbox): cover bounded response reader gates and deadlines

### DIFF
--- a/plugins/plugin-dropbox/src/bounded-response.test.ts
+++ b/plugins/plugin-dropbox/src/bounded-response.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Covers the bounded HTTP body reader — declarative size gate, live size gate,
+ * deadline cancellation, and error mapping — so oversized or hanging Dropbox
+ * responses never allocate unbounded memory.
+ */
+import { describe, expect, it } from "vitest";
+
+import { type BoundedResponseErrors, readBoundedResponse } from "./bounded-response";
+
+function errors(): BoundedResponseErrors & { calls: string[] } {
+  const calls: string[] = [];
+  return {
+    calls,
+    tooLarge: (declaredBytes: number | null) => {
+      calls.push(`tooLarge:${declaredBytes}`);
+      return new Error(`tooLarge:${declaredBytes}`);
+    },
+    timedOut: () => {
+      calls.push("timedOut");
+      return new Error("timedOut");
+    },
+    readFailed: (cause: unknown) => {
+      calls.push(`readFailed:${String(cause)}`);
+      return new Error(`readFailed:${String(cause)}`);
+    },
+  };
+}
+
+function responseFromChunks(chunks: Uint8Array[], headers: Record<string, string> = {}): Response {
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const c of chunks) controller.enqueue(c);
+      controller.close();
+    },
+  });
+  return new Response(stream, { headers });
+}
+
+function hangingResponse(): Response {
+  const stream = new ReadableStream<Uint8Array>({
+    start() {
+      // never enqueue or close — hangs until timeout cancels
+    },
+  });
+  return new Response(stream);
+}
+
+function failingResponse(cause: unknown): Response {
+  const stream = new ReadableStream<Uint8Array>({
+    start(_controller) {
+      // throw synchronously on read: simulate underlying stream error
+    },
+    pull() {
+      throw cause;
+    },
+  });
+  // wrap to ensure body exists
+  const response = new Response(stream);
+  // override getReader to throw
+  const body = response.body;
+  if (body) void body.getReader.bind(body);
+  // Instead construct a custom stream that fails on read
+  const failStream = new ReadableStream<Uint8Array>({
+    pull() {
+      throw cause;
+    },
+  });
+  return new Response(failStream);
+}
+
+describe("readBoundedResponse", () => {
+  it("rejects when declared Content-Length exceeds maxBytes without consuming body", async () => {
+    const response = responseFromChunks([new Uint8Array([1, 2, 3])], {
+      "Content-Length": "100",
+    });
+    const e = errors();
+    await expect(readBoundedResponse(response, 10, 1000, e)).rejects.toThrow("tooLarge:100");
+    expect(e.calls).toContain("tooLarge:100");
+  });
+
+  it("returns empty Uint8Array when response has no body", async () => {
+    const response = new Response(null);
+    const e = errors();
+    const bytes = await readBoundedResponse(response, 10, 1000, e);
+    expect(bytes).toEqual(new Uint8Array());
+  });
+
+  it("reads and concatenates chunks within bounds", async () => {
+    const response = responseFromChunks([new Uint8Array([1, 2]), new Uint8Array([3, 4, 5])]);
+    const e = errors();
+    const bytes = await readBoundedResponse(response, 10, 1000, e);
+    expect(Array.from(bytes)).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it("rejects when live total exceeds maxBytes and cancels reader", async () => {
+    const response = responseFromChunks([new Uint8Array([1, 2, 3]), new Uint8Array([4, 5, 6])]);
+    const e = errors();
+    await expect(readBoundedResponse(response, 4, 1000, e)).rejects.toThrow("tooLarge");
+    expect(e.calls.some((c) => c.startsWith("tooLarge:"))).toBe(true);
+  });
+
+  it("treats missing or non-numeric Content-Length as no declarative gate", async () => {
+    const r1 = responseFromChunks([new Uint8Array([1])], { "Content-Length": "not-a-number" });
+    const e1 = errors();
+    await expect(readBoundedResponse(r1, 10, 1000, e1)).resolves.toEqual(new Uint8Array([1]));
+
+    const r2 = responseFromChunks([new Uint8Array([1])], {});
+    const e2 = errors();
+    await expect(readBoundedResponse(r2, 10, 1000, e2)).resolves.toEqual(new Uint8Array([1]));
+  });
+
+  it("treats non-safe-integer Content-Length as no declarative gate", async () => {
+    // Number.MAX_SAFE_INTEGER + 1 is not safe
+    const big = String(Number.MAX_SAFE_INTEGER + 2);
+    const r = responseFromChunks([new Uint8Array([1])], { "Content-Length": big });
+    const e = errors();
+    await expect(readBoundedResponse(r, 10, 1000, e)).resolves.toEqual(new Uint8Array([1]));
+  });
+
+  it("times out when stream hangs past deadline", async () => {
+    const response = hangingResponse();
+    const e = errors();
+    await expect(readBoundedResponse(response, 10, 50, e)).rejects.toThrow("timedOut");
+    expect(e.calls).toContain("timedOut");
+  });
+
+  it("immediately times out when timeoutMs is 0 or negative", async () => {
+    const response = responseFromChunks([new Uint8Array([1, 2])]);
+    const e = errors();
+    await expect(readBoundedResponse(response, 10, 0, e)).rejects.toThrow("timedOut");
+  });
+
+  it("maps stream read failure to readFailed", async () => {
+    const cause = new Error("underlying failure");
+    const response = failingResponse(cause);
+    const e = errors();
+    await expect(readBoundedResponse(response, 10, 1000, e)).rejects.toThrow("readFailed");
+    expect(e.calls.some((c) => c.startsWith("readFailed:"))).toBe(true);
+  });
+
+  it("respects exact maxBytes boundary (total == maxBytes succeeds)", async () => {
+    const response = responseFromChunks([new Uint8Array([1, 2, 3])]);
+    const e = errors();
+    await expect(readBoundedResponse(response, 3, 1000, e)).resolves.toEqual(
+      new Uint8Array([1, 2, 3])
+    );
+  });
+
+  it("admits declared Content-Length equal to maxBytes", async () => {
+    const response = responseFromChunks([new Uint8Array([1])], { "Content-Length": "5" });
+    const e = errors();
+    await expect(readBoundedResponse(response, 5, 1000, e)).resolves.toEqual(new Uint8Array([1]));
+  });
+});


### PR DESCRIPTION
# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Test-only addition: adds unit test coverage for bounded-response helper with no production code modifications.

# Background

## What does this PR do?

Adds mutation-sensitive unit tests for `readBoundedResponse` in `plugins/plugin-dropbox/src/bounded-response.ts`, pinning declarative Content-Length rejection, live byte accounting, deadline cancellation, and stream error mapping so untrusted Dropbox responses cannot allocate unbounded memory.

## What kind of change is this?
Improvements (misc. changes to existing features)

# Documentation changes needed?
My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?
`plugins/plugin-dropbox/src/bounded-response.test.ts`

## Detailed testing steps
```bash
bunx vitest run plugins/plugin-dropbox/src/bounded-response.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.

<!-- evidence-head:276556faf4fb5329999e4c538b2fcc113c0f4558 -->

<!-- evidence-row:before-screenshots -->
- Before screenshots: N/A - no UI changes in unit tests (pure helper in plugins/plugin-dropbox).

<!-- evidence-row:after-screenshots -->
- After screenshots: N/A - no UI changes in unit tests (pure helper in plugins/plugin-dropbox).

<!-- evidence-row:walkthrough-video -->
- Walkthrough video: N/A - unit test execution only, no user flow.

<!-- evidence-row:backend-logs -->
- Backend logs: `bunx vitest run src/bounded-response.test.ts` — 11 passed.

```
 RUN  v4.1.10 /Users/naynaingoo/.eliza-lanes/lane-byt61-4792/plugins/plugin-dropbox

 Test Files  1 passed (1)
      Tests  11 passed (11)
   Start at  04:25:08
   Duration  181ms (transform 24ms, setup 0ms, import 45ms, tests 63ms, environment 0ms)
```

<!-- evidence-row:frontend-logs -->
- Frontend logs: N/A - no frontend components touched (pure helper).

<!-- evidence-row:llm-trajectory -->
- LLM trajectory: N/A - deterministic unit tests with no model calls.

<!-- evidence-row:domain-artifacts -->
- Domain artifacts: N/A - unit test only, no domain side effects.

<!-- evidence-row:ocr-review -->
- OCR review: N/A - no rendered visual surface.

# Evidence Details

## Backend + frontend logs
```
 RUN  v4.1.10 /Users/naynaingoo/.eliza-lanes/lane-byt61-4792/plugins/plugin-dropbox

 Test Files  1 passed (1)
      Tests  11 passed (11)
```

## Known gaps / failures
None.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex desktop
— [lane-byt61-4792]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop"} -->