### PR TITLE
fix(agent): paginate oversized natural recall losslessly

### DIFF
--- a/packages/agent/src/actions/memories.test.ts
+++ b/packages/agent/src/actions/memories.test.ts
@@ -7,7 +7,11 @@
 import type { ActionResult, IAgentRuntime, Memory, UUID } from "@elizaos/core";
 import { normalizeActionIdentifier } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
-import { memoryAction } from "./memories";
+import {
+  MAX_MEMORY_ACTION_RESULT_CHARS,
+  MAX_MEMORY_PAGE_ITEMS,
+  memoryAction,
+} from "./memories";
 
 const AGENT_ID = "00000000-0000-0000-0000-0000000000aa" as UUID;
 const USER_ID = "00000000-0000-0000-0000-0000000000bb" as UUID;
@@ -869,6 +873,83 @@ describe("MEMORY op:search complete traversal", () => {
     });
   });
 
+  it("rejects a caller page size above the enforced maximum", async () => {
+    const { runtime } = makeRuntime();
+    const result = await runAction(runtime, makeMessage(), {
+      action: "search",
+      query: "invoice number",
+      limit: MAX_MEMORY_PAGE_ITEMS + 1,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.data).toMatchObject({
+      error: "MEMORY_PAGE_LIMIT_EXCEEDED",
+      requestedLimit: MAX_MEMORY_PAGE_ITEMS + 1,
+      maxLimit: MAX_MEMORY_PAGE_ITEMS,
+    });
+  });
+
+  it("requires pagination instead of rendering an oversized complete result", async () => {
+    const { runtime, rows } = makeRuntime();
+    for (let i = 0; i <= MAX_MEMORY_PAGE_ITEMS; i++) {
+      seedFact(rows, { text: `invoice number ${i}`, entityId: USER_ID });
+    }
+
+    const result = await runAction(runtime, makeMessage(), {
+      action: "search",
+      query: "invoice number",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.data).toMatchObject({
+      error: "MEMORY_SEARCH_REQUIRES_PAGINATION",
+      totalMatches: MAX_MEMORY_PAGE_ITEMS + 1,
+      maxLimit: MAX_MEMORY_PAGE_ITEMS,
+    });
+    expect(result.text).not.toContain("- [facts]");
+  });
+
+  it("rejects one indivisible memory that exceeds the page character budget", async () => {
+    const { runtime, rows } = makeRuntime();
+    const memoryId = seedFact(rows, {
+      text: `invoice ${"x".repeat(MAX_MEMORY_ACTION_RESULT_CHARS)}`,
+      entityId: USER_ID,
+    });
+
+    const result = await runAction(runtime, makeMessage(), {
+      action: "search",
+      query: "invoice",
+      limit: 1,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.data).toMatchObject({
+      error: "MEMORY_RECORD_EXCEEDS_PAGE_BUDGET",
+      memoryId,
+      maxResultChars: MAX_MEMORY_ACTION_RESULT_CHARS,
+    });
+    expect(JSON.stringify(result).length).toBeLessThan(1_048_576);
+  });
+
+  it("keeps the maximum accepted page below the Codex input boundary", async () => {
+    const { runtime, rows } = makeRuntime();
+    for (let i = 0; i < MAX_MEMORY_PAGE_ITEMS; i++) {
+      seedFact(rows, { text: `invoice number ${i}`, entityId: USER_ID });
+    }
+
+    const result = await runAction(runtime, makeMessage(), {
+      action: "search",
+      query: "invoice number",
+      limit: MAX_MEMORY_PAGE_ITEMS,
+    });
+
+    expect(result.success).toBe(true);
+    expect(JSON.stringify(result).length).toBeLessThanOrEqual(
+      MAX_MEMORY_ACTION_RESULT_CHARS,
+    );
+    expect(JSON.stringify(result).length).toBeLessThan(1_048_576);
+  });
+
   it("rejects an offset without an explicit page size", async () => {
     const { runtime } = makeRuntime();
     const result = await runAction(runtime, makeMessage(), {
@@ -892,6 +973,32 @@ describe("MEMORY op:search complete traversal", () => {
       limit: 3,
     });
     seedFact(rows, { text: "invoice number 6", entityId: USER_ID });
+
+    const continuation = await runAction(runtime, makeMessage(), {
+      action: "search",
+      query: "invoice number",
+      limit: 3,
+      offset: 3,
+      snapshot: String(first.values?.snapshot),
+    });
+
+    expect(continuation.success).toBe(false);
+    expect(continuation.data).toMatchObject({
+      error: "MEMORY_PAGE_SNAPSHOT_CHANGED",
+    });
+  });
+
+  it("rejects a continuation when a matched record changes under the same id", async () => {
+    const { runtime, rows } = makeRuntime();
+    for (let i = 0; i < 6; i++) {
+      seedFact(rows, { text: `invoice number ${i}`, entityId: USER_ID });
+    }
+    const first = await runAction(runtime, makeMessage(), {
+      action: "search",
+      query: "invoice number",
+      limit: 3,
+    });
+    rows[0].memory.content.text = "invoice number corrected in place";
 
     const continuation = await runAction(runtime, makeMessage(), {
       action: "search",

--- a/packages/agent/src/actions/memories.test.ts
+++ b/packages/agent/src/actions/memories.test.ts
@@ -819,14 +819,177 @@ describe("MEMORY op:search complete traversal", () => {
     expect(result.values).toMatchObject({ rendered: 30, totalMatches: 30 });
   });
 
+  it("returns an explicit lossless continuation when the caller requests a page", async () => {
+    const { runtime, rows } = makeRuntime();
+    for (let i = 0; i < 12; i++) {
+      seedFact(rows, { text: `invoice number ${i}`, entityId: USER_ID });
+    }
+
+    const first = await runAction(runtime, makeMessage(), {
+      action: "search",
+      query: "invoice number",
+      limit: 5,
+    });
+    const snapshot = String(first.values?.snapshot);
+    const second = await runAction(runtime, makeMessage(), {
+      action: "search",
+      query: "invoice number",
+      limit: 5,
+      offset: 5,
+      snapshot,
+    });
+    const third = await runAction(runtime, makeMessage(), {
+      action: "search",
+      query: "invoice number",
+      limit: 5,
+      offset: 10,
+      snapshot,
+    });
+
+    const pageTexts = [first, second, third].flatMap((result) => {
+      const data = result.data as { memories: Array<{ text: string }> };
+      return data.memories.map((memory) => memory.text);
+    });
+    expect(new Set(pageTexts)).toEqual(
+      new Set(Array.from({ length: 12 }, (_, i) => `invoice number ${i}`)),
+    );
+    expect(first.values).toMatchObject({
+      rendered: 5,
+      totalMatches: 12,
+      offset: 0,
+      nextOffset: 5,
+      snapshot,
+    });
+    expect(first.text).toContain("continue losslessly");
+    expect(second.values).toMatchObject({ offset: 5, nextOffset: 10 });
+    expect(third.values).toMatchObject({
+      rendered: 2,
+      offset: 10,
+      nextOffset: null,
+    });
+  });
+
+  it("rejects an offset without an explicit page size", async () => {
+    const { runtime } = makeRuntime();
+    const result = await runAction(runtime, makeMessage(), {
+      action: "search",
+      query: "invoice number",
+      offset: 5,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.data).toMatchObject({ error: "MEMORY_INVALID_PAGE" });
+  });
+
+  it("rejects a continuation when the ordered matches changed", async () => {
+    const { runtime, rows } = makeRuntime();
+    for (let i = 0; i < 6; i++) {
+      seedFact(rows, { text: `invoice number ${i}`, entityId: USER_ID });
+    }
+    const first = await runAction(runtime, makeMessage(), {
+      action: "search",
+      query: "invoice number",
+      limit: 3,
+    });
+    seedFact(rows, { text: "invoice number 6", entityId: USER_ID });
+
+    const continuation = await runAction(runtime, makeMessage(), {
+      action: "search",
+      query: "invoice number",
+      limit: 3,
+      offset: 3,
+      snapshot: String(first.values?.snapshot),
+    });
+
+    expect(continuation.success).toBe(false);
+    expect(continuation.data).toMatchObject({
+      error: "MEMORY_PAGE_SNAPSHOT_CHANGED",
+    });
+  });
+
+  it("does not treat one weak token as a multi-word query match", async () => {
+    const { runtime, rows } = makeRuntime();
+    for (let i = 0; i < 100; i++) {
+      seedFact(rows, {
+        text: `Would you like to revisit the reading list item ${i}?`,
+        entityId: USER_ID,
+      });
+    }
+    seedFact(rows, {
+      text: "The owner's newest archival project codename is Silver Falcon 2042.",
+      entityId: USER_ID,
+    });
+
+    const result = await runAction(runtime, makeMessage(), {
+      action: "search",
+      query: "newest archival project codename told you",
+    });
+
+    expect(result.success).toBe(true);
+    const data = result.data as { memories: Array<{ text: string }> };
+    expect(data.memories).toHaveLength(1);
+    expect(data.memories[0].text).toContain("Silver Falcon 2042");
+    expect(result.values).toMatchObject({ totalMatches: 1, scanned: 101 });
+  });
+
+  it("matches separate rows for a natural cross-topic query", async () => {
+    const { runtime, rows } = makeRuntime();
+    seedFact(rows, {
+      text: "The tomato variety that ripened first was Sungold.",
+      entityId: USER_ID,
+    });
+    seedFact(rows, {
+      text: "The Kyoto booking is at Kumo Ryokan.",
+      entityId: USER_ID,
+    });
+    seedFact(rows, {
+      text: "The first ten minutes of the recording were silent.",
+      entityId: USER_ID,
+    });
+
+    const result = await runAction(runtime, makeMessage(), {
+      action: "search",
+      query: "which tomato ripened first and where is the Kyoto booking",
+    });
+
+    expect(result.success).toBe(true);
+    const data = result.data as { memories: Array<{ text: string }> };
+    expect(data.memories.map((memory) => memory.text)).toEqual([
+      "The tomato variety that ripened first was Sungold.",
+      "The Kyoto booking is at Kumo Ryokan.",
+    ]);
+  });
+
+  it("keeps a single exact anchor for a two-term query", async () => {
+    const { runtime, rows } = makeRuntime();
+    seedFact(rows, {
+      text: "The owner is allergic to pistachios, not almonds.",
+      entityId: USER_ID,
+    });
+    seedFact(rows, {
+      text: "The first ten minutes of the recording were silent.",
+      entityId: USER_ID,
+    });
+
+    const result = await runAction(runtime, makeMessage(), {
+      action: "search",
+      query: "nut allergic",
+    });
+
+    expect(result.success).toBe(true);
+    const data = result.data as { memories: Array<{ text: string }> };
+    expect(data.memories).toHaveLength(1);
+    expect(data.memories[0].text).toContain("pistachios");
+  });
+
   it("rejects a repeated full page instead of returning partial memories", async () => {
     const { runtime, rows } = makeRuntime();
-    for (let i = 0; i < 500; i++) {
+    for (let i = 0; i < 10_000; i++) {
       seedFact(rows, { text: `memory ${i}`, entityId: USER_ID });
     }
     const firstPage = await runtime.getMemories({
       tableName: "facts",
-      limit: 500,
+      limit: 10_000,
     });
     runtime.getMemories = async ({ tableName }) =>
       tableName === "facts" ? firstPage : [];

--- a/packages/agent/src/actions/memories.ts
+++ b/packages/agent/src/actions/memories.ts
@@ -6,6 +6,7 @@
  * All model-supplied ids are parsed before touching the database so a bad
  * id becomes a clean handled result, never a raw SQL error in model context.
  */
+import { createHash } from "node:crypto";
 import type {
   Action,
   ActionResult,
@@ -44,6 +45,9 @@ interface MemoryParams {
   entityId?: string;
   roomId?: string;
   query?: string;
+  limit?: number;
+  offset?: number;
+  snapshot?: string;
   memoryId?: string;
   confirm?: boolean;
 }
@@ -57,6 +61,53 @@ interface MemoryListItem {
   agentId: string | null;
   createdAt: number;
 }
+
+const SEARCH_QUERY_STOP_WORDS = new Set([
+  "a",
+  "am",
+  "an",
+  "and",
+  "are",
+  "as",
+  "at",
+  "be",
+  "by",
+  "did",
+  "do",
+  "does",
+  "for",
+  "from",
+  "had",
+  "has",
+  "have",
+  "how",
+  "i",
+  "in",
+  "is",
+  "it",
+  "me",
+  "my",
+  "of",
+  "on",
+  "or",
+  "our",
+  "that",
+  "the",
+  "this",
+  "to",
+  "was",
+  "we",
+  "were",
+  "what",
+  "when",
+  "where",
+  "which",
+  "who",
+  "why",
+  "with",
+  "you",
+  "your",
+]);
 
 function fail(text: string, error: string): ActionResult {
   return { success: false, text, data: { error } };
@@ -99,14 +150,22 @@ function scoreText(text: string, query: string): number {
   const t = text.toLowerCase();
   const q = query.toLowerCase();
   if (!t || !q) return 0;
-  const terms = q
-    .split(/\s+/)
-    .map((s) => s.trim())
-    .filter((s) => s.length >= 2);
+  const terms = [
+    ...new Set(
+      q
+        .split(/[^\p{L}\p{N}]+/u)
+        .filter(
+          (term) => term.length >= 2 && !SEARCH_QUERY_STOP_WORDS.has(term),
+        ),
+    ),
+  ];
   const whole = t.includes(q) ? 1 : 0;
   if (terms.length === 0) return whole;
+  const textTerms = new Set(t.split(/[^\p{L}\p{N}]+/u).filter(Boolean));
   let matches = 0;
-  for (const term of terms) if (t.includes(term)) matches += 1;
+  for (const term of terms) if (textTerms.has(term)) matches += 1;
+  const requiredMatches = terms.length >= 3 ? 2 : 1;
+  if (whole === 0 && matches < requiredMatches) return 0;
   return whole + matches / terms.length;
 }
 
@@ -219,7 +278,7 @@ interface CandidateScan {
   scanned: number;
 }
 
-const COMPLETE_MEMORY_PAGE_SIZE = 500;
+const COMPLETE_MEMORY_PAGE_SIZE = 10_000;
 
 function traversalError(
   code: string,
@@ -252,6 +311,17 @@ function compareMemoryTuple(left: Memory, right: Memory): number {
   return String(right.id)
     .toLowerCase()
     .localeCompare(String(left.id).toLowerCase());
+}
+
+function memoryPageSnapshot(matches: readonly MemoryCandidate[]): string {
+  const hash = createHash("sha256");
+  for (const candidate of matches) {
+    hash.update(candidate.type);
+    hash.update("\0");
+    hash.update(String(candidate.memory.id));
+    hash.update("\0");
+  }
+  return hash.digest("hex");
 }
 
 async function scanCompleteMemoryTable(
@@ -488,6 +558,21 @@ async function doSearch(
     );
   }
   const query = params.query?.trim();
+  const limit = params.limit;
+  const offset = params.offset ?? 0;
+  const requestedSnapshot = params.snapshot?.trim();
+  if (
+    (limit !== undefined && (!Number.isSafeInteger(limit) || limit < 1)) ||
+    !Number.isSafeInteger(offset) ||
+    offset < 0 ||
+    (limit === undefined && offset !== 0) ||
+    (offset > 0 && !requestedSnapshot)
+  ) {
+    return fail(
+      "search limit must be a positive integer, and a continuation offset requires limit and snapshot.",
+      "MEMORY_INVALID_PAGE",
+    );
+  }
 
   const scope = {
     type,
@@ -498,7 +583,22 @@ async function doSearch(
   const scan = await collectCandidates(runtime, scope);
 
   const totalMatches = scan.matches.length;
-  const items = scan.matches.map((c) => toListItem(c.memory, c.type));
+  const snapshot = memoryPageSnapshot(scan.matches);
+  if (requestedSnapshot && requestedSnapshot !== snapshot) {
+    return fail(
+      "The ordered memory matches changed after the previous page. Restart this search at offset 0.",
+      "MEMORY_PAGE_SNAPSHOT_CHANGED",
+    );
+  }
+  const pageMatches =
+    limit === undefined
+      ? scan.matches
+      : scan.matches.slice(offset, offset + limit);
+  const items = pageMatches.map((c) => toListItem(c.memory, c.type));
+  const nextOffset =
+    limit !== undefined && offset + items.length < totalMatches
+      ? offset + items.length
+      : undefined;
   // The text projection carries enough of each hit for model reasoning; the
   // complete records remain machine data for state and trajectory consumers.
   const lines = items.map(
@@ -515,7 +615,16 @@ async function doSearch(
       ].join("\n")
     : undefined;
 
-  const renderNote = `Showing all ${lines.length} match(es) found in the complete scan`;
+  const renderNote =
+    limit === undefined
+      ? `Showing all ${lines.length} match(es) found in the complete scan`
+      : `Showing ${lines.length} match(es) at offset ${offset} of ${totalMatches} found in the complete scan`;
+  const continuationNote =
+    nextOffset === undefined
+      ? []
+      : [
+          `More matches remain. To continue losslessly, call MEMORY_SEARCH with the same filters, limit=${limit}, offset=${nextOffset}, snapshot=${snapshot}.`,
+        ];
 
   return {
     success: true,
@@ -526,8 +635,11 @@ async function doSearch(
         : []),
       describeCompleteScan(scan),
       ...lines,
+      ...continuationNote,
     ].join("\n"),
-    ...(userFacingText && recallTerminalEnabled(runtime)
+    ...(userFacingText &&
+    nextOffset === undefined &&
+    recallTerminalEnabled(runtime)
       ? {
           userFacingText,
           verifiedUserFacing: true,
@@ -539,6 +651,9 @@ async function doSearch(
       rendered: lines.length,
       totalMatches,
       scanned: scan.scanned,
+      offset,
+      nextOffset: nextOffset ?? null,
+      snapshot,
     },
     data: {
       actionName: "MEMORY",
@@ -546,6 +661,9 @@ async function doSearch(
       memories: items,
       totalMatches,
       scanned: scan.scanned,
+      offset,
+      nextOffset: nextOffset ?? null,
+      snapshot,
     },
     promptData: {
       actionName: "MEMORY",
@@ -553,6 +671,9 @@ async function doSearch(
       totalMatches,
       rendered: lines.length,
       scanned: scan.scanned,
+      offset,
+      nextOffset: nextOffset ?? null,
+      snapshot,
     },
   };
 }
@@ -952,6 +1073,27 @@ export const memoryAction: Action = {
         "search/update/delete: case-insensitive text match against memory content. update/delete: resolves the memory to mutate when memoryId is unknown; scoped to the requesting user's own memories.",
       required: false,
       schema: { type: "string" as const },
+    },
+    {
+      name: "limit",
+      description:
+        "search: optional positive page size. When supplied, the result reports totalMatches and nextOffset so every ordered match remains retrievable.",
+      required: false,
+      schema: { type: "integer" as const, minimum: 1 },
+    },
+    {
+      name: "offset",
+      description:
+        "search: zero-based continuation offset from a previous paginated result. Requires the same filters and limit.",
+      required: false,
+      schema: { type: "integer" as const, minimum: 0 },
+    },
+    {
+      name: "snapshot",
+      description:
+        "search: continuation fingerprint returned by the previous page. Required with a positive offset so changed results reject instead of shifting pages.",
+      required: false,
+      schema: { type: "string" as const, pattern: "^[0-9a-f]{64}$" },
     },
     {
       name: "memoryId",

--- a/packages/agent/src/actions/memories.ts
+++ b/packages/agent/src/actions/memories.ts
@@ -109,8 +109,12 @@ const SEARCH_QUERY_STOP_WORDS = new Set([
   "your",
 ]);
 
-function fail(text: string, error: string): ActionResult {
-  return { success: false, text, data: { error } };
+function fail(
+  text: string,
+  error: string,
+  context?: Record<string, unknown>,
+): ActionResult {
+  return { success: false, text, data: { error, ...context } };
 }
 
 type UuidParamName = "entityId" | "roomId" | "memoryId";
@@ -279,6 +283,8 @@ interface CandidateScan {
 }
 
 const COMPLETE_MEMORY_PAGE_SIZE = 10_000;
+export const MAX_MEMORY_PAGE_ITEMS = 50;
+export const MAX_MEMORY_ACTION_RESULT_CHARS = 256 * 1024;
 
 function traversalError(
   code: string,
@@ -313,13 +319,21 @@ function compareMemoryTuple(left: Memory, right: Memory): number {
     .localeCompare(String(left.id).toLowerCase());
 }
 
-function memoryPageSnapshot(matches: readonly MemoryCandidate[]): string {
+function memoryPageSnapshot(items: readonly MemoryListItem[]): string {
   const hash = createHash("sha256");
-  for (const candidate of matches) {
-    hash.update(candidate.type);
-    hash.update("\0");
-    hash.update(String(candidate.memory.id));
-    hash.update("\0");
+  for (const item of items) {
+    const canonical = JSON.stringify([
+      item.id,
+      item.type,
+      item.text,
+      item.entityId,
+      item.roomId,
+      item.agentId,
+      item.createdAt,
+    ]);
+    hash.update(String(Buffer.byteLength(canonical)));
+    hash.update(":");
+    hash.update(canonical);
   }
   return hash.digest("hex");
 }
@@ -573,6 +587,13 @@ async function doSearch(
       "MEMORY_INVALID_PAGE",
     );
   }
+  if (limit !== undefined && limit > MAX_MEMORY_PAGE_ITEMS) {
+    return fail(
+      `search limit ${limit} exceeds the maximum page size of ${MAX_MEMORY_PAGE_ITEMS}. Retry with a smaller limit.`,
+      "MEMORY_PAGE_LIMIT_EXCEEDED",
+      { requestedLimit: limit, maxLimit: MAX_MEMORY_PAGE_ITEMS },
+    );
+  }
 
   const scope = {
     type,
@@ -582,19 +603,31 @@ async function doSearch(
   };
   const scan = await collectCandidates(runtime, scope);
 
-  const totalMatches = scan.matches.length;
-  const snapshot = memoryPageSnapshot(scan.matches);
+  const allItems = scan.matches.map((candidate) =>
+    toListItem(candidate.memory, candidate.type),
+  );
+  const totalMatches = allItems.length;
+  const snapshot = memoryPageSnapshot(allItems);
   if (requestedSnapshot && requestedSnapshot !== snapshot) {
     return fail(
       "The ordered memory matches changed after the previous page. Restart this search at offset 0.",
       "MEMORY_PAGE_SNAPSHOT_CHANGED",
     );
   }
-  const pageMatches =
-    limit === undefined
-      ? scan.matches
-      : scan.matches.slice(offset, offset + limit);
-  const items = pageMatches.map((c) => toListItem(c.memory, c.type));
+  if (limit === undefined && totalMatches > MAX_MEMORY_PAGE_ITEMS) {
+    return fail(
+      `The complete search has ${totalMatches} matches, which exceeds the maximum safe result size of ${MAX_MEMORY_PAGE_ITEMS} records. Retry with limit at most ${MAX_MEMORY_PAGE_ITEMS}.`,
+      "MEMORY_SEARCH_REQUIRES_PAGINATION",
+      {
+        totalMatches,
+        maxLimit: MAX_MEMORY_PAGE_ITEMS,
+        suggestedLimit: Math.min(20, MAX_MEMORY_PAGE_ITEMS),
+        snapshot,
+      },
+    );
+  }
+  const items =
+    limit === undefined ? allItems : allItems.slice(offset, offset + limit);
   const nextOffset =
     limit !== undefined && offset + items.length < totalMatches
       ? offset + items.length
@@ -626,7 +659,7 @@ async function doSearch(
           `More matches remain. To continue losslessly, call MEMORY_SEARCH with the same filters, limit=${limit}, offset=${nextOffset}, snapshot=${snapshot}.`,
         ];
 
-  return {
+  const result: ActionResult = {
     success: true,
     text: [
       `${renderNote} (filters: ${describeSearchScope(scope)}).`,
@@ -676,6 +709,54 @@ async function doSearch(
       snapshot,
     },
   };
+  const serializedChars = JSON.stringify(result).length;
+  if (serializedChars > MAX_MEMORY_ACTION_RESULT_CHARS) {
+    if (limit === undefined) {
+      return fail(
+        `The complete search result requires ${serializedChars} characters, exceeding the safe action-result budget of ${MAX_MEMORY_ACTION_RESULT_CHARS}. Retry with an explicit page limit.`,
+        "MEMORY_SEARCH_REQUIRES_PAGINATION",
+        {
+          totalMatches,
+          renderedChars: serializedChars,
+          maxResultChars: MAX_MEMORY_ACTION_RESULT_CHARS,
+          suggestedLimit: Math.min(20, MAX_MEMORY_PAGE_ITEMS),
+          snapshot,
+        },
+      );
+    }
+    if (items.length === 1) {
+      return fail(
+        `Memory ${items[0].id} alone requires ${serializedChars} action-result characters, exceeding the safe budget of ${MAX_MEMORY_ACTION_RESULT_CHARS}. Narrow the search or use a provider with a larger input boundary.`,
+        "MEMORY_RECORD_EXCEEDS_PAGE_BUDGET",
+        {
+          memoryId: items[0].id,
+          renderedChars: serializedChars,
+          maxResultChars: MAX_MEMORY_ACTION_RESULT_CHARS,
+        },
+      );
+    }
+    const suggestedLimit = Math.max(
+      1,
+      Math.min(
+        items.length - 1,
+        Math.floor(
+          (items.length * MAX_MEMORY_ACTION_RESULT_CHARS) / serializedChars,
+        ),
+      ),
+    );
+    return fail(
+      `The requested page requires ${serializedChars} action-result characters, exceeding the safe budget of ${MAX_MEMORY_ACTION_RESULT_CHARS}. Retry with limit=${suggestedLimit}.`,
+      "MEMORY_PAGE_RESULT_TOO_LARGE",
+      {
+        requestedLimit: limit,
+        suggestedLimit,
+        renderedChars: serializedChars,
+        maxResultChars: MAX_MEMORY_ACTION_RESULT_CHARS,
+        snapshot,
+      },
+    );
+  }
+  return result;
 }
 
 async function doUpdate(
@@ -1076,10 +1157,13 @@ export const memoryAction: Action = {
     },
     {
       name: "limit",
-      description:
-        "search: optional positive page size. When supplied, the result reports totalMatches and nextOffset so every ordered match remains retrievable.",
+      description: `search: optional positive page size up to ${MAX_MEMORY_PAGE_ITEMS}. Large complete results reject with a typed instruction to retry using this lossless pagination contract.`,
       required: false,
-      schema: { type: "integer" as const, minimum: 1 },
+      schema: {
+        type: "integer" as const,
+        minimum: 1,
+        maximum: MAX_MEMORY_PAGE_ITEMS,
+      },
     },
     {
       name: "offset",


### PR DESCRIPTION
Fixes #28739

## Summary

- replace substring-heavy memory scoring with Unicode token matching and stop-word filtering
- require multiple anchors for broad multi-term questions while preserving focused one-anchor recall
- enforce lossless pagination with a maximum of 50 records and a 256 KiB serialized action-result boundary
- reject oversized complete results, pages, and indivisible records with typed retry guidance instead of truncating or clamping
- bind continuation snapshots to every model-facing record field, so in-place edits reject stale continuations
- scan complete memory in 10,000-row storage batches; each continuation deliberately repeats the complete stability scan

## Verification

Exact head: 9955afcb5e5c7ec06b44cd4030b19946e722a556
Validated base: 1d3705dad2a76fd06fcfa4bf9f776c18a4a22b79

- Focused memories suite: 47 passed
- Agent typecheck: passed
- Biome on changed files: passed
- Prompt-integrity policy suite: 8 passed
- git diff check: passed
- Root verify: 144 of 146 workspace tasks completed, then the unrelated current-develop stale packages/ui/duplicate-molecular-components-report.md gate failed

The pagination and scoring path previously passed one natural-language Codex SDK question over 100,000 stored messages in run cadb2afd-9647-42a4-90da-1e477a74a76f. That trajectory predates the exact-head typed-boundary follow-up. The new boundary and content-snapshot behavior is verified deterministically at the exact head, not by a new full live matrix.

The complete 20-question live matrix remains the issue acceptance run. Each local 100k Codex question was taking about 19.5 minutes. Deterministic coverage now exercises lossless multi-page reassembly, invalid continuation input, maximum page rejection, oversized complete-result rejection, indivisible-record rejection, serialized output below the Codex character boundary, content-bound snapshot drift, stop-word fanout, cross-topic matching, and exact-token matching.

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] N/A - headless memory retrieval change with no rendered UI.

<!-- evidence-row:after-screenshots -->
- [x] N/A - headless memory retrieval change with no rendered UI.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no visual workflow changed.

<!-- evidence-row:backend-logs -->
- [x] Earlier live backend transcript:
~~~text
Corpus: 100000 stored messages across 10 authorized rooms
Provider: Codex SDK CLI inference with a fresh inference thread
Result: natural recall passed without the previous 1048576-character input rejection
Run: cadb2afd-9647-42a4-90da-1e477a74a76f, before the typed-boundary follow-up
~~~

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or browser surface changed.

<!-- evidence-row:llm-trajectory -->
- [x] Reviewed earlier real-model trajectory:
~~~json
{"runId":"cadb2afd-9647-42a4-90da-1e477a74a76f","provider":"codex-sdk","model":"installed Codex CLI inference","input":"What is the oldest archival project codename I told you?","output":"Copper Heron 9184","corpusMessages":100000,"result":"pass","exactHeadEvidence":false}
~~~

<!-- evidence-row:domain-artifacts -->
- [x] Exact-head domain and boundary inspection:
~~~text
MEMORY_SEARCH calculates the complete stable match set before returning a page.
Pages are limited to 50 records and 262144 serialized ActionResult characters.
Snapshots cover id, type, text, entityId, roomId, agentId, and createdAt for every ordered match.
Oversized requests return typed failures with retry guidance and no partial memory prefix.
~~~

## Prompt-integrity contract

Results are never silently truncated, compacted, summarized, or clamped. A complete result is returned only when it fits the explicit action boundary. Larger results reject with MEMORY_SEARCH_REQUIRES_PAGINATION. Explicit pages retain stable ordering and continuation metadata; pages above the count or character boundary reject with typed errors. A changed model-facing record invalidates the snapshot before any continuation data is returned.