### PR TITLE
fix(ci): stop superseded develop child jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -349,7 +349,7 @@ jobs:
   android_aab:
     name: Android release AAB
     needs: changes
-    if: always()
+    if: ${{ always() && !cancelled() }}
     runs-on: ubuntu-24.04
     timeout-minutes: 70
     steps:
@@ -434,7 +434,7 @@ jobs:
 
       - name: Verify release AAB audit evidence
         id: release-aab-evidence
-        if: ${{ always() && steps.selection.outputs.selected == 'true' }}
+        if: ${{ always() && !cancelled() && steps.selection.outputs.selected == 'true' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -474,7 +474,7 @@ jobs:
           test -s "$SHA256"
 
       - name: Upload verified release AAB evidence
-        if: ${{ always() && steps.release-aab-evidence.outcome == 'success' }}
+        if: ${{ always() && !cancelled() && steps.release-aab-evidence.outcome == 'success' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: android-cloud-release-aab-audit
@@ -487,7 +487,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload Android failure diagnostics
-        if: ${{ always() && steps.selection.outputs.selected == 'true' && steps.release-aab-evidence.outcome != 'success' }}
+        if: ${{ always() && !cancelled() && steps.selection.outputs.selected == 'true' && steps.release-aab-evidence.outcome != 'success' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: android-cloud-release-aab-failure-diagnostics
@@ -540,7 +540,7 @@ jobs:
 
   required:
     name: All Tests Passed
-    if: always()
+    if: ${{ always() && !cancelled() }}
     needs:
       [
         changes,

--- a/.github/workflows/develop-full.yml
+++ b/.github/workflows/develop-full.yml
@@ -258,7 +258,7 @@ jobs:
 
   complete:
     name: Complete manifest
-    if: ${{ always() && needs.plan.result == 'success' }}
+    if: ${{ always() && !cancelled() && needs.plan.result == 'success' }}
     needs:
       - plan
       - canonical

--- a/.github/workflows/ui-story-gate.yml
+++ b/.github/workflows/ui-story-gate.yml
@@ -43,7 +43,7 @@ jobs:
         run: bun run --cwd packages/ui build-storybook --output-dir storybook-static --quiet
 
       - name: Upload static Storybook catalog
-        if: always()
+        if: ${{ always() && !cancelled() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: storybook-static
@@ -54,7 +54,7 @@ jobs:
   story-shard:
     name: Story shard ${{ matrix.shard }}/8
     needs: build-catalog
-    if: ${{ always() }}
+    if: ${{ always() && !cancelled() }}
     runs-on: ubuntu-24.04
     timeout-minutes: 35
     strategy:
@@ -94,7 +94,7 @@ jobs:
           --concurrency 6
 
       - name: Upload shard report and evidence
-        if: ${{ always() }}
+        if: ${{ always() && !cancelled() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: story-gate-shard-${{ matrix.shard }}-of-8
@@ -105,7 +105,7 @@ jobs:
   aggregate:
     name: Aggregate Story Gate verdict
     needs: [build-catalog, story-shard]
-    if: ${{ always() }}
+    if: ${{ always() && !cancelled() }}
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
@@ -129,7 +129,7 @@ jobs:
           merge-multiple: false
 
       - name: Merge and validate complete catalog coverage
-        if: ${{ always() }}
+        if: ${{ always() && !cancelled() }}
         run: >-
           node packages/ui/test/story-gate/merge-story-gate.mjs
           --catalog packages/ui/storybook-static/index.json
@@ -138,7 +138,7 @@ jobs:
           --shards 8
 
       - name: Upload aggregate Story Gate output
-        if: ${{ always() }}
+        if: ${{ always() && !cancelled() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: story-gate-output

--- a/packages/scripts/__tests__/ci-android-aab-workflow.test.ts
+++ b/packages/scripts/__tests__/ci-android-aab-workflow.test.ts
@@ -148,10 +148,13 @@ describe("consolidated Android release AAB authority", () => {
     expect(changes.uses).toContain("classify-paths.yml");
     expect(android.name).toBe("Android release AAB");
     expect(android.needs).toBe("changes");
-    expect(android.if).toBe("always()");
+    expect(android.if).toContain("always()");
+    expect(android.if).toContain("!cancelled()");
     expect(android["runs-on"]).toBe("ubuntu-24.04");
     expect(android["runs-on"]).not.toContain("self-hosted");
     expect(required.needs).toContain("android_aab");
+    expect(required.if).toContain("always()");
+    expect(required.if).toContain("!cancelled()");
     expect(
       requireStep(required, "Require every CI job to succeed").env?.RESULTS,
     ).toContain("needs.android_aab.result");
@@ -229,12 +232,15 @@ describe("consolidated Android release AAB authority", () => {
 
     expect(verify.id).toBe("release-aab-evidence");
     expect(verify.if).toContain("always()");
+    expect(verify.if).toContain("!cancelled()");
     expect(upload.if).toContain("release-aab-evidence.outcome == 'success'");
+    expect(upload.if).toContain("!cancelled()");
     expect(upload.with?.["if-no-files-found"]).toBe("error");
     expect(String(upload.with?.path).trim().split(/\r?\n/)).toHaveLength(4);
     expect(diagnostics.if).toContain(
       "release-aab-evidence.outcome != 'success'",
     );
+    expect(diagnostics.if).toContain("!cancelled()");
     expect(diagnostics.with?.["if-no-files-found"]).toBe("warn");
 
     if (!verify.run) throw new Error("AAB verifier has no executable body");

--- a/packages/scripts/__tests__/develop-full-workflow.test.ts
+++ b/packages/scripts/__tests__/develop-full-workflow.test.ts
@@ -158,7 +158,7 @@ describe("Develop Full workflow authority", () => {
     expect(surfaceGraph.reusePolicy).toBe("current-run-only");
     const complete = workflow.jobs?.complete;
     expect(complete?.if).toBe(
-      `\${{ always() && needs.plan.result == 'success' }}`,
+      `\${{ always() && !cancelled() && needs.plan.result == 'success' }}`,
     );
     expect(complete?.needs).toEqual(["plan", ...delegatedJobs]);
     expect(
@@ -166,6 +166,125 @@ describe("Develop Full workflow authority", () => {
         step.run?.includes("develop-impact-evidence.mjs record"),
       ),
     ).toBe(true);
+  });
+
+  test("guards every develop-reachable always job against cancellation", () => {
+    const nonPushOnlyAlwaysJobs = new Map([
+      [
+        ".github/workflows/test.yml#github-live-artifact-validate",
+        "always() && (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && (needs.cloud-live-e2e.outputs.capability_skip != 'true' || needs.provider-live-e2e.outputs.skip != 'true')",
+      ],
+    ]);
+    const expressionBody = (condition: string) =>
+      condition
+        .replace(/^\$\{\{\s*/, "")
+        .replace(/\s*\}\}$/, "")
+        .trim();
+    const canonicalExpression = (condition: string) =>
+      expressionBody(condition).replace(
+        /\b(?:always|cancelled)\s*\(\s*\)/gi,
+        (statusCall) => statusCall.replace(/\s/g, "").toLowerCase(),
+      );
+    const mentionsAlways = (condition: string) =>
+      canonicalExpression(condition).includes("always()");
+    const hasTopLevelDisjunction = (expression: string) => {
+      let depth = 0;
+      let quote: "'" | '"' | null = null;
+
+      for (let index = 0; index < expression.length; index += 1) {
+        const character = expression[index];
+        if (quote) {
+          if (character === quote) {
+            if (quote === "'" && expression[index + 1] === "'") {
+              index += 1;
+            } else {
+              quote = null;
+            }
+          }
+          continue;
+        }
+        if (character === "'" || character === '"') {
+          quote = character;
+        } else if (character === "(") {
+          depth += 1;
+        } else if (character === ")") {
+          depth -= 1;
+          if (depth < 0) return true;
+        } else if (
+          depth === 0 &&
+          character === "|" &&
+          expression[index + 1] === "|"
+        ) {
+          return true;
+        }
+      }
+
+      return depth !== 0 || quote !== null;
+    };
+    const isCancellationAwareAlways = (condition: string) => {
+      const expression = canonicalExpression(condition);
+      return (
+        !hasTopLevelDisjunction(expression) &&
+        /^(?:always\(\)\s*&&\s*!cancelled\(\)|!cancelled\(\)\s*&&\s*always\(\))(?:\s*&&|$)/.test(
+          expression,
+        )
+      );
+    };
+
+    for (const unsafe of [
+      "always() && cancelled()",
+      "always() || !cancelled()",
+      "always() && !cancelled() || github.event_name == 'push'",
+      "always() && !cancelled() && needs.plan.result == 'success' || github.event_name == 'push'",
+      "!cancelled() && always() && needs.plan.result == 'success' || github.event_name == 'push'",
+      "always() && !cancelled() && true || cancelled()",
+      "always( )",
+      "ALWAYS()",
+    ]) {
+      expect(mentionsAlways(unsafe), unsafe).toBe(true);
+      expect(isCancellationAwareAlways(unsafe), unsafe).toBe(false);
+    }
+    expect(
+      isCancellationAwareAlways(
+        "!cancelled() && always() && (github.event_name != 'pull_request' || needs.changes.outputs.zero_key == 'true')",
+      ),
+    ).toBe(true);
+    expect(isCancellationAwareAlways("ALWAYS( ) && !cancelled( )")).toBe(true);
+    const visited = new Set<string>();
+    const pending = [".github/workflows/develop-full.yml"];
+    const offenders: string[] = [];
+
+    while (pending.length > 0) {
+      const relativePath = pending.shift();
+      if (!relativePath || visited.has(relativePath)) continue;
+      visited.add(relativePath);
+
+      const candidate = Bun.YAML.parse(
+        readFileSync(
+          fileURLToPath(new URL(`../../../${relativePath}`, import.meta.url)),
+          "utf8",
+        ),
+      ) as typeof workflow;
+
+      for (const [jobId, job] of Object.entries(candidate.jobs ?? {})) {
+        const key = `${relativePath}#${jobId}`;
+        const condition = job.if ?? "";
+        if (
+          mentionsAlways(condition) &&
+          !isCancellationAwareAlways(condition)
+        ) {
+          if (expressionBody(condition) !== nonPushOnlyAlwaysJobs.get(key)) {
+            offenders.push(key);
+          }
+        }
+
+        if (job.uses?.startsWith("./.github/workflows/")) {
+          pending.push(job.uses.slice(2));
+        }
+      }
+    }
+
+    expect(offenders).toEqual([]);
   });
 
   test("uses exact digest cache keys and publishes the manifest artifact", () => {

--- a/packages/ui/test/story-gate/story-gate-workflow.test.mjs
+++ b/packages/ui/test/story-gate/story-gate-workflow.test.mjs
@@ -5,7 +5,7 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import { parse } from "yaml";
 
-const ALWAYS_EXPRESSION = "$" + "{{ always() }}";
+const CANCELLATION_AWARE_EXPRESSION = "$" + "{{ always() && !cancelled() }}";
 const PUSH_EVENT_EXPRESSION = "$" + "{{ github.event_name == 'push' }}";
 const MATRIX_SHARD_EXPRESSION = "$" + "{{ matrix.shard }}";
 const workflow = readFileSync(
@@ -13,8 +13,12 @@ const workflow = readFileSync(
   "utf8",
 );
 const config = parse(workflow);
+const buildCatalogJob = config.jobs["build-catalog"];
 const shardJob = config.jobs["story-shard"];
 const aggregateJob = config.jobs.aggregate;
+const catalogUpload = buildCatalogJob.steps.find((step) =>
+  step.name?.startsWith("Upload static Storybook"),
+);
 const shardUpload = shardJob.steps.find((step) =>
   step.name?.startsWith("Upload shard report"),
 );
@@ -30,6 +34,8 @@ describe("UI Story Gate workflow", () => {
   });
 
   it("runs eight shards and uploads shard evidence", () => {
+    expect(catalogUpload.if).toBe(CANCELLATION_AWARE_EXPRESSION);
+    expect(shardJob.if).toBe(CANCELLATION_AWARE_EXPRESSION);
     expect(shardJob["timeout-minutes"]).toBe(35);
     expect(
       shardJob.steps.find(
@@ -41,7 +47,7 @@ describe("UI Story Gate workflow", () => {
       matrix: { shard: [1, 2, 3, 4, 5, 6, 7, 8] },
     });
     expect(shardUpload).toMatchObject({
-      if: ALWAYS_EXPRESSION,
+      if: CANCELLATION_AWARE_EXPRESSION,
       with: {
         name: `story-gate-shard-${MATRIX_SHARD_EXPRESSION}-of-8`,
         path: "packages/ui/test/story-gate/output",
@@ -51,8 +57,8 @@ describe("UI Story Gate workflow", () => {
 
   it("has an aggregate job that preserves fail-closed evidence", () => {
     expect(aggregateJob.needs).toEqual(["build-catalog", "story-shard"]);
-    expect(aggregateJob.if).toBe(ALWAYS_EXPRESSION);
-    expect(aggregateMerge.if).toBe(ALWAYS_EXPRESSION);
+    expect(aggregateJob.if).toBe(CANCELLATION_AWARE_EXPRESSION);
+    expect(aggregateMerge.if).toBe(CANCELLATION_AWARE_EXPRESSION);
     expect(aggregateMerge.run).toContain("--shards 8");
 
     const catalogDownload = aggregateJob.steps.find(
@@ -71,7 +77,7 @@ describe("UI Story Gate workflow", () => {
         (step) => step.name === "Upload aggregate Story Gate output",
       ),
     ).toMatchObject({
-      if: ALWAYS_EXPRESSION,
+      if: CANCELLATION_AWARE_EXPRESSION,
       with: { name: "story-gate-output" },
     });
   });


### PR DESCRIPTION
# Relates to

Fixes #24245.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on the latest `origin/develop` (`325784c56ba8bdfdb162273b64642076b4d8cd91`) with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync; the exact unrelated `@elizaos/prompts` blocker is recorded below.
- [x] A reviewer can confirm the change from the live cancellation evidence and deterministic workflow-contract tests below.

# Sync with develop

- [x] Based on the latest `origin/develop`; zero conflicts, with the effective diff limited to the six intended files.
- [x] `bun run verify` was run post-sync; its exact unrelated blocker is documented in **Known gaps / failures**.

# Risks

Medium, limited to GitHub Actions scheduling on cancelled/superseded validation runs. Ordinary test failures still run the fail-closed evidence and aggregate jobs because `always()` remains present; only an actual cancellation suppresses obsolete children. No permissions, secrets, effect handoff, deployment, application runtime, or billing behavior changes.

# Background

Rapid consecutive pushes to `develop` cancel the older top-level Develop Full run, but downstream reusable-workflow children containing bare job-level `always()` were re-evaluated as true and kept the shared concurrency group alive. The newer tip then remained queued behind obsolete Story Gate/aggregate work.

Live reproductions and root-cause evidence:

- [Initial obsolete-child evidence](https://github.com/elizaOS/eliza/issues/24245#issuecomment-5416752281)
- [Cancellation root cause](https://github.com/elizaOS/eliza/issues/24245#issuecomment-5416840546)
- [Second rapid-push reproduction](https://github.com/elizaOS/eliza/issues/24245#issuecomment-5417051032)
- [Latest live reproduction: a cancelled old tip retained Complete manifest until the new tip was released](https://github.com/elizaOS/eliza/actions/runs/32901059191/job/97981514694)

## What does this PR do?

- Makes Develop Full's final manifest job cancellation-aware.
- Makes Story Gate catalog uploads, shard/aggregate jobs, and evidence uploads cancellation-aware.
- Makes the canonical CI Android release job, its evidence steps, and the final required aggregate cancellation-aware.
- Adds a recursive contract over all reusable workflows reachable from Develop Full. It rejects bare or malformed `always()` guards, top-level disjunction bypasses, and case/whitespace variants while retaining one exact manual/schedule-only exception.

## What kind of change is this?

Bug fix (non-breaking CI control-plane correction).

# Documentation changes needed?

No project documentation change is needed. The invariant and its exception are encoded in the workflow-contract tests, and the operational history remains on #24245.

# Testing

## Where should a reviewer start?

Start with `.github/workflows/develop-full.yml`, then `.github/workflows/ui-story-gate.yml`, `.github/workflows/ci.yml`, and the recursive guard in `packages/scripts/__tests__/develop-full-workflow.test.ts`.

## Detailed testing steps

Exact head: `648b17eb243bf026ed46d57aaec254a0e6557464`

Pre-patch structural RED offenders:

- `.github/workflows/develop-full.yml#complete`
- `.github/workflows/ci.yml#android_aab`
- `.github/workflows/ci.yml#required`
- `.github/workflows/ui-story-gate.yml#story-shard`
- `.github/workflows/ui-story-gate.yml#aggregate`

Post-patch validation:

- `bun test packages/scripts/__tests__/develop-full-workflow.test.ts packages/scripts/__tests__/ci-android-aab-workflow.test.ts packages/scripts/__tests__/ci-workflow-concurrency.test.ts packages/scripts/__tests__/workflow-call-permissions.test.ts packages/scripts/__tests__/workflow-trigger-policy.test.ts` — 35 passed, 0 failed, 311 assertions.
- `bun run --cwd packages/ui test -- test/story-gate/story-gate-workflow.test.mjs` — 3 passed, 0 failed.
- `actionlint .github/workflows/ui-story-gate.yml .github/workflows/develop-full.yml .github/workflows/ci.yml` — passed.
- `bun run audit:workflow-triggers` — verified 61 workflows and exactly one `develop` push surface.
- Biome on all changed test files — passed.
- YAML parsing for all three changed workflows — passed.
- `git diff --check origin/develop...HEAD` — passed.
- Two independent adversarial reviews of this exact head — no P0-P3 findings.

# Evidence Gate

Evidence matches the exact commit reviewed.
<!-- evidence-head:648b17eb243bf026ed46d57aaec254a0e6557464 -->

This diff changes GitHub Actions YAML and static contract tests only; it has no rendered frontend surface.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI surface; workflow YAML/test-only change.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI surface; workflow YAML/test-only change.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user flow or rendered UI surface.
<!-- evidence-row:backend-logs -->
- [ ] N/A - no application backend code path; live GitHub Actions cancellation evidence is linked in Background.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code, request, or state change.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, provider, prompt, or model change.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no DB, memory, task, wallet, generated-file, audio, or other domain artifact.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface or visual text.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model change.

## Backend + frontend logs

N/A - no application backend or frontend runtime path. The affected runtime is GitHub Actions scheduling; live run evidence is linked in **Background**.

## Screenshots (before / after) + video walkthrough

### Before

N/A - no rendered UI surface.

### After

N/A - no rendered UI surface.

### Walkthrough video

N/A - no rendered UI surface or interactive user flow.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or omnivoice change.

## Known gaps / failures

- Post-sync root `bun run verify` on `origin/develop@69c02919` reached 213 successful tasks out of 215 before `@elizaos/cloud-api#typecheck` failed with `TS2307: Cannot find module '@elizaos/prompts'` in `packages/cloud/api/__tests__/elizaos-core-stub.test.ts`. This is the known current-`develop` regression introduced by merged #27316 and reproduced outside this diff; [baseline evidence](https://github.com/elizaOS/eliza/pull/27316#issuecomment-5416971373). All affected-path and workflow-contract checks above pass.
- No synthetic workflow dispatch or forced rapid-push canary was launched. This PR does not request authority to dispatch or mutate protected CI state; normal future consecutive `develop` pushes provide the final hosted-runtime canary.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

# Deploy Notes

No deployment, migration, external-provider mutation, or manual workflow dispatch is part of this PR.

## Database changes

None.

## Deployment instructions

None. Merge remains maintainer-controlled and is not requested by this automation.