### PR TITLE
fix(plugin-x): keep UTF-16 surrogate pairs intact in XDmAdapter snippet and draft preview truncation

### DIFF
--- a/plugins/plugin-x/src/lifeops-message-adapter.test.ts
+++ b/plugins/plugin-x/src/lifeops-message-adapter.test.ts
@@ -194,4 +194,56 @@ describe("XDmAdapter", () => {
 
     expect(sendDirectMessageForAccount).not.toHaveBeenCalled();
   });
+
+  it("preserves UTF-16 surrogate pairs in snippet and draft preview truncation", async () => {
+    // "🔥" (2 code units * 120 = 240 units) -> > 200
+    const longEmoji = "🔥".repeat(120);
+    const memory: Memory = {
+      id: "memory-emoji",
+      agentId: "agent-1",
+      entityId: "entity-1",
+      roomId: "room-1",
+      createdAt: Date.parse("2026-05-08T00:00:00.000Z"),
+      content: { text: longEmoji },
+      metadata: {
+        messageIdFull: "native-emoji",
+        sender: { id: "sender-1", username: "alice" },
+        x: {
+          dmEventId: "dm-emoji",
+          conversationId: "conversation-1",
+          senderId: "x-user-1",
+          senderUsername: "alice_x",
+        },
+      },
+    } as Memory;
+    const fetchDirectMessagesForAccount = vi.fn(async () => [memory]);
+    const adapter = new XDmAdapter();
+    const runtime = runtimeWithXService({ fetchDirectMessagesForAccount });
+
+    const refs = await adapter.listMessages(runtime, { limit: 1 });
+    expect(refs).toHaveLength(1);
+    const snippet = refs[0]?.snippet;
+    expect(snippet?.length).toBe(200);
+    for (const char of snippet!) {
+      expect(
+        /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(
+          char,
+        ),
+      ).toBe(false);
+    }
+
+    const { preview } = await adapter.createDraft(runtime, {
+      to: [{ identifier: "x-user-2" }],
+      body: longEmoji,
+    });
+    expect(preview.endsWith("...")).toBe(true);
+    expect(preview.length).toBe(199);
+    for (const char of preview) {
+      expect(
+        /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(
+          char,
+        ),
+      ).toBe(false);
+    }
+  });
 });

--- a/plugins/plugin-x/src/lifeops-message-adapter.ts
+++ b/plugins/plugin-x/src/lifeops-message-adapter.ts
@@ -1,3 +1,15 @@
+function truncateUtf16Safe(text: string, maxLength: number): string {
+  if (text.length <= maxLength) return text;
+  let end = maxLength;
+  if (end > 0 && end < text.length) {
+    const code = text.charCodeAt(end - 1);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      end -= 1;
+    }
+  }
+  return text.slice(0, end);
+}
+
 /**
  * `XDmAdapter` — a LifeOps `BaseMessageAdapter` over the X connector's direct
  * messages, letting LifeOps list, draft, and send X DMs through `XService`. Maps
@@ -89,7 +101,7 @@ function memoryToMessageRef(memory: Memory): MessageRef {
       displayName: senderHandle,
     },
     to: [],
-    snippet: body.slice(0, 200),
+    snippet: truncateUtf16Safe(body, 200),
     body,
     receivedAtMs: Number.isFinite(receivedAtMs) ? receivedAtMs : Date.now(),
     hasAttachments: false,
@@ -203,7 +215,7 @@ export class XDmAdapter extends BaseMessageAdapter {
     }
     const draftId = `twitter:${encodeURIComponent(recipient)}:${Date.now()}:${encodeDraftBody(draft.body)}`;
     const preview =
-      draft.body.length > 200 ? `${draft.body.slice(0, 197)}...` : draft.body;
+      draft.body.length > 200 ? `${truncateUtf16Safe(draft.body, 197)}...` : draft.body;
     return { draftId, preview };
   }
 


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:9862ca32795e160b8f390f8787ec7245a6ef2b84 -->

## Summary
In `plugins/plugin-x/src/lifeops-message-adapter.ts`:
`XDmAdapter` creates message snippets using `body.slice(0, 200)` and draft previews using `${draft.body.slice(0, 197)}...`.

When direct message bodies contain multi-byte UTF-16 surrogate pairs (e.g. emojis or astral unicode characters), slicing at raw character indices can bisect a surrogate pair in half, producing orphaned surrogate characters (`\uFFFD`).

## Proposed Changes
1. Added `truncateUtf16Safe` helper with surrogate boundary back-off in `plugins/plugin-x/src/lifeops-message-adapter.ts`.
2. Applied `truncateUtf16Safe` across `snippet` and `createDraft` preview generation.
3. Added unit tests in `plugins/plugin-x/src/lifeops-message-adapter.test.ts`.

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-x test src/lifeops-message-adapter.test.ts` (8/8 passed).

<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-3-5-sonnet","client":"antigravity","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
