### PR TITLE
feat(cloud): atomically admit exact backup captures

### DIFF
--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-global-lock-order.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-global-lock-order.test.ts
@@ -117,4 +117,55 @@ describe("agent backup global lock order", () => {
       "scheduler reservation",
     );
   });
+
+  test("capture admission locks the global lane before its exact source authority", () => {
+    const admission = source("agent-backup-operation-admission.ts");
+    const sourceLockStart = admission.indexOf(
+      "async function lockExactSourceAuthorityInTransaction",
+    );
+    const sourceLockEnd = admission.indexOf("function assertCatalogueReplay", sourceLockStart);
+    expect(sourceLockStart).toBeGreaterThanOrEqual(0);
+    expect(sourceLockEnd).toBeGreaterThan(sourceLockStart);
+    const sourceLocks = admission.slice(sourceLockStart, sourceLockEnd);
+    const sourceAnchors = [
+      ".from(agentSandboxes)",
+      ".from(organizations)",
+      ".from(agentActivationPublications)",
+      ".from(dockerNodes)",
+      ".from(agentNodeIncarnationHistories)",
+    ];
+    let previous = -1;
+    for (const anchor of sourceAnchors) {
+      const index = sourceLocks.indexOf(anchor, previous + 1);
+      expect(index, `capture admission: missing ordered lock anchor ${anchor}`).toBeGreaterThan(
+        previous,
+      );
+      previous = index;
+    }
+    const publicationReadStart = sourceLocks.indexOf(".from(agentActivationPublications)");
+    const nodeLockStart = sourceLocks.indexOf(".from(dockerNodes)", publicationReadStart);
+    expect(
+      sourceLocks.slice(publicationReadStart, nodeLockStart),
+      "immutable activation publication must not be row-locked after the sandbox",
+    ).not.toContain('.for("');
+
+    const claim = exportedFunction(
+      admission,
+      "claimNextAgentBackupOperationAdmission",
+      "renewAgentBackupOperationAdmission",
+    );
+    expectOrder(
+      claim,
+      "lockAgentBackupOperationLaneInTransaction(tx)",
+      "lockNextDueBackupInTransaction(tx)",
+      "capture admission",
+    );
+    const renew = exportedFunction(admission, "renewAgentBackupOperationAdmission");
+    expectOrder(
+      renew,
+      "renewAgentBackupOperationLaneInTransaction(tx",
+      "lockBackupByTargetInTransaction(tx",
+      "capture admission renewal",
+    );
+  });
 });

--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-operation-admission.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-operation-admission.pglite.test.ts
@@ -1,0 +1,622 @@
+/** Real-PGlite proofs for atomic catalogue and provider-lane admission. */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { pushSchema } from "drizzle-kit/api";
+import { asc, eq } from "drizzle-orm";
+import { installAgentNodeOccurrenceTriggerForTests } from "../../agent-node-occurrence-test-support";
+import {
+  agentBackupOperationLane,
+  agentBackupOperationNodeWatermarks,
+  agentBackupOperationTenantWatermarks,
+} from "../../schemas/agent-backup-operation-lane";
+import { agentActivationPublications } from "../../schemas/agent-backup-restore-history";
+import { agentNodeIncarnationHistories } from "../../schemas/agent-node-incarnation-histories";
+import {
+  agentBackupCatalogAuthorities,
+  agentSandboxBackups,
+  agentSandboxes,
+} from "../../schemas/agent-sandboxes";
+import { dockerNodes } from "../../schemas/docker-nodes";
+import { organizations } from "../../schemas/organizations";
+import { userCharacters } from "../../schemas/user-characters";
+import { users } from "../../schemas/users";
+
+process.env.DATABASE_URL = "pglite://memory";
+process.env.DISABLE_LOCAL_PGLITE_FALLBACK = "1";
+process.env.NODE_ENV = "test";
+process.env.MOCK_REDIS = "1";
+process.env.SKIP_AGENT_SANDBOX_ENSURE = "1";
+
+const PGLITE_TIMEOUT = 60_000;
+const ORGANIZATION_ID = "10000000-0000-4000-8000-000000000001";
+const USER_ID = "20000000-0000-4000-8000-000000000001";
+const AGENT_ID = "30000000-0000-4000-8000-000000000001";
+const OPERATION_ID = "40000000-0000-4000-8000-000000000001";
+const OTHER_OPERATION_ID = "40000000-0000-4000-8000-000000000002";
+const ACTIVATION_GENERATION = "50000000-0000-4000-8000-000000000001";
+const NODE_RECORD_ID = "60000000-0000-4000-8000-000000000001";
+const POISON_NODE_RECORD_ID = "60000000-0000-4000-8000-000000000002";
+const NODE_INCARNATION_A = "70000000-0000-4000-8000-000000000001";
+const CALLER_GENERATION_A = "80000000-0000-4000-8000-000000000001";
+const CALLER_GENERATION_B = "80000000-0000-4000-8000-000000000002";
+const CALLER_GENERATION_C = "80000000-0000-4000-8000-000000000003";
+const ACTIVATION_PUBLICATION_ID = "90000000-0000-4000-8000-000000000001";
+const OWNER_A = "backup-admission-worker-a";
+const OWNER_B = "backup-admission-worker-b";
+const NODE_ID = "robot-backup-admission-a";
+const PROVIDER_HANDLE = "backup-admission-container";
+const CONTAINER_ID = "a".repeat(64);
+const IMAGE_DIGEST = `sha256:${"b".repeat(64)}`;
+const SHA_A = "c".repeat(64);
+const SHA_B = "d".repeat(64);
+const SHA_C = "e".repeat(64);
+const ACTIVATION_PUBLISHED_AT = new Date("2026-08-17T00:00:00.000Z");
+const ACTIVATION_RECEIPT = Object.freeze({
+  schemaVersion: 1 as const,
+  generation: ACTIVATION_GENERATION,
+  purpose: "provision" as const,
+  agentId: AGENT_ID,
+  organizationId: ORGANIZATION_ID,
+  lifecycleRevision: "0",
+  backupId: null,
+  backupHash: null,
+  manifestHash: null,
+  componentHashes: null,
+  freshAuthorization: null,
+  containerId: CONTAINER_ID,
+  imageDigest: IMAGE_DIGEST,
+  receiptId: NODE_INCARNATION_A,
+  receiptHash: SHA_A,
+  receiptMac: SHA_B,
+  appliedAt: "2026-08-17T00:00:00.000Z",
+  restored: true,
+  requiresRestart: false,
+});
+
+type ClientModule = typeof import("../../client");
+type AdmissionRepository = typeof import("../agent-backup-operation-admission");
+type CatalogRepository = typeof import("../agent-backup-catalog");
+type ClaimResult = Awaited<
+  ReturnType<AdmissionRepository["claimNextAgentBackupOperationAdmission"]>
+>;
+type SuccessfulClaim = Extract<ClaimResult, { kind: "claimed" | "replayed" }>;
+
+let dbWrite: ClientModule["dbWrite"];
+let closeDatabaseConnectionsForTests: ClientModule["closeDatabaseConnectionsForTests"];
+let repository: AdmissionRepository;
+let catalogRepository: CatalogRepository;
+let schemaFailure = "";
+
+const callerA = Object.freeze({ ownerId: OWNER_A, generation: CALLER_GENERATION_A });
+const callerB = Object.freeze({ ownerId: OWNER_B, generation: CALLER_GENERATION_B });
+
+function requireAdmission(result: ClaimResult): SuccessfulClaim {
+  if (result.kind === "empty" || result.kind === "busy") {
+    throw new Error(`Expected an admission, received ${result.kind}`);
+  }
+  return result;
+}
+
+function claimNext(
+  callerToken: Readonly<{ ownerId: string; generation: string }> = callerA,
+  leaseMs = 60_000,
+): Promise<ClaimResult> {
+  return repository.claimNextAgentBackupOperationAdmission({ callerToken, leaseMs });
+}
+
+async function reserveBackup(operationId = OPERATION_ID) {
+  return catalogRepository.reserveAgentBackupOperation({
+    organizationId: ORGANIZATION_ID,
+    agentId: AGENT_ID,
+    sandboxRecordId: AGENT_ID,
+    operationId,
+    activationGeneration: ACTIVATION_GENERATION,
+    lifecycleRevision: "0",
+    snapshotType: "auto",
+    backupKind: "full",
+    sourceProvider: "operator-onboarded",
+    sourceNodeRecordId: NODE_RECORD_ID,
+    sourceNodeId: NODE_ID,
+    sourceNodeIncarnation: NODE_INCARNATION_A,
+    sourceProviderServerId: null,
+    sourceProviderHandle: PROVIDER_HANDLE,
+    sourceContainerId: CONTAINER_ID,
+    retentionReason: "schedule",
+    retentionUntil: new Date("2026-09-17T00:00:00.000Z"),
+  });
+}
+
+async function readAuthorityState() {
+  const [lane] = await dbWrite
+    .select()
+    .from(agentBackupOperationLane)
+    .where(eq(agentBackupOperationLane.singleton, true));
+  return {
+    lane,
+    backups: await dbWrite.select().from(agentSandboxBackups).orderBy(asc(agentSandboxBackups.id)),
+    tenantWatermarks: await dbWrite
+      .select()
+      .from(agentBackupOperationTenantWatermarks)
+      .orderBy(asc(agentBackupOperationTenantWatermarks.organization_id)),
+    nodeWatermarks: await dbWrite
+      .select()
+      .from(agentBackupOperationNodeWatermarks)
+      .orderBy(asc(agentBackupOperationNodeWatermarks.source_node_history_id)),
+  };
+}
+
+async function expireAdmission(admission: SuccessfulClaim["admission"]): Promise<void> {
+  const claimedAt = new Date("2020-01-01T00:00:00.000Z");
+  const expiredAt = new Date("2020-01-01T00:00:01.000Z");
+  await dbWrite.transaction(async (tx) => {
+    await tx
+      .update(agentBackupOperationLane)
+      .set({
+        claimed_at: claimedAt,
+        lease_expires_at: expiredAt,
+        released_at: null,
+        updated_at: expiredAt,
+      })
+      .where(eq(agentBackupOperationLane.singleton, true));
+    await tx
+      .update(agentSandboxBackups)
+      .set({ catalog_lease_expires_at: expiredAt, catalog_updated_at: expiredAt })
+      .where(eq(agentSandboxBackups.id, admission.claim.backup.id));
+  });
+}
+
+beforeAll(async () => {
+  try {
+    const client = await import("../../client");
+    dbWrite = client.dbWrite;
+    closeDatabaseConnectionsForTests = client.closeDatabaseConnectionsForTests;
+    repository = await import("../agent-backup-operation-admission");
+    catalogRepository = await import("../agent-backup-catalog");
+
+    const { apply } = await pushSchema(
+      {
+        organizations,
+        users,
+        userCharacters,
+        agentNodeIncarnationHistories,
+        dockerNodes,
+        agentSandboxes,
+        agentSandboxBackups,
+        agentBackupCatalogAuthorities,
+        agentBackupOperationLane,
+        agentBackupOperationTenantWatermarks,
+        agentBackupOperationNodeWatermarks,
+        agentActivationPublications,
+      } as never,
+      dbWrite as never,
+    );
+    await apply();
+    await installAgentNodeOccurrenceTriggerForTests((statement) => dbWrite.execute(statement));
+  } catch (error) {
+    schemaFailure = error instanceof Error ? error.message : String(error);
+  }
+}, PGLITE_TIMEOUT);
+
+beforeEach(async () => {
+  expect(schemaFailure).toBe("");
+  await dbWrite.delete(agentBackupOperationNodeWatermarks);
+  await dbWrite.delete(agentBackupOperationTenantWatermarks);
+  await dbWrite.delete(agentBackupOperationLane);
+  await dbWrite.delete(agentActivationPublications);
+  await dbWrite.delete(agentSandboxBackups);
+  await dbWrite.delete(agentBackupCatalogAuthorities);
+  await dbWrite.delete(agentSandboxes);
+  await dbWrite.delete(dockerNodes);
+  await dbWrite.delete(agentNodeIncarnationHistories);
+  await dbWrite.delete(userCharacters);
+  await dbWrite.delete(users);
+  await dbWrite.delete(organizations);
+
+  await dbWrite.insert(organizations).values({
+    id: ORGANIZATION_ID,
+    name: "Backup admission organization",
+    slug: "backup-admission-organization",
+  });
+  await dbWrite.insert(users).values({
+    id: USER_ID,
+    steward_user_id: "backup-admission-user",
+    organization_id: ORGANIZATION_ID,
+  });
+  await dbWrite.insert(dockerNodes).values({
+    id: NODE_RECORD_ID,
+    node_id: NODE_ID,
+    hostname: "robot-backup-admission-a.example.test",
+    host_key_fingerprint: "sha256:backup-admission-host-key",
+    fleet_kind: "robot",
+    infrastructure_provider: "hetzner",
+    provider_server_id: null,
+    node_incarnation: NODE_INCARNATION_A,
+    status: "healthy",
+    enabled: true,
+  });
+  await dbWrite.insert(agentSandboxes).values({
+    id: AGENT_ID,
+    organization_id: ORGANIZATION_ID,
+    user_id: USER_ID,
+    agent_name: "Backup admission agent",
+    status: "running",
+    execution_tier: "dedicated-always",
+    sandbox_id: PROVIDER_HANDLE,
+    node_id: NODE_ID,
+    container_name: PROVIDER_HANDLE,
+    image_digest: IMAGE_DIGEST,
+    lifecycle_revision: 0,
+    activation_generation: ACTIVATION_GENERATION,
+    activation_lifecycle_revision: 0n,
+    activation_purpose: "provision",
+    activation_phase: "active",
+    activation_receipt: ACTIVATION_RECEIPT,
+    activation_receipt_hash: SHA_A,
+    activation_container_id: CONTAINER_ID,
+    activation_node_id: NODE_ID,
+    activation_image_digest: IMAGE_DIGEST,
+    activation_boot_id: NODE_INCARNATION_A,
+    activation_token_hash: SHA_B,
+    activation_token_ciphertext: "sealed-admission-token",
+    activation_funding_revision: 0n,
+    activation_authority_published_at: ACTIVATION_PUBLISHED_AT,
+    activation_dispatched_at: new Date("2026-08-17T00:00:01.000Z"),
+    activation_completed_at: new Date("2026-08-17T00:00:02.000Z"),
+  });
+  const [sourceNode] = await dbWrite
+    .select({ historyId: dockerNodes.current_node_history_id })
+    .from(dockerNodes)
+    .where(eq(dockerNodes.id, NODE_RECORD_ID));
+  if (!sourceNode?.historyId) throw new Error("Expected source-node occurrence during setup");
+  await dbWrite.insert(agentActivationPublications).values({
+    id: ACTIVATION_PUBLICATION_ID,
+    organization_id: ORGANIZATION_ID,
+    agent_id: AGENT_ID,
+    activation_generation: ACTIVATION_GENERATION,
+    previous_activation_generation: null,
+    lifecycle_revision: 0n,
+    purpose: "provision",
+    backup_id: null,
+    backup_manifest_sha256: null,
+    activation_receipt: ACTIVATION_RECEIPT,
+    activation_receipt_sha256: SHA_A,
+    container_id: CONTAINER_ID,
+    node_history_id: sourceNode.historyId,
+    docker_node_record_id: NODE_RECORD_ID,
+    node_id: NODE_ID,
+    node_incarnation: NODE_INCARNATION_A,
+    image_digest: IMAGE_DIGEST,
+    token_sha256: SHA_B,
+    funding_revision: 0n,
+    published_at: ACTIVATION_PUBLISHED_AT,
+  });
+  await dbWrite.insert(agentBackupOperationLane).values({ singleton: true });
+});
+
+afterAll(async () => {
+  await closeDatabaseConnectionsForTests?.();
+});
+
+describe("agent backup operation admission on primary PGlite", () => {
+  test("returns empty without mutating any authority or creating a node", async () => {
+    const before = await readAuthorityState();
+    const beforeNodes = await dbWrite.select().from(dockerNodes);
+    const beforeHistories = await dbWrite.select().from(agentNodeIncarnationHistories);
+
+    expect(await claimNext()).toEqual({ kind: "empty" });
+
+    expect(await readAuthorityState()).toEqual(before);
+    expect(await dbWrite.select().from(dockerNodes)).toEqual(beforeNodes);
+    expect(await dbWrite.select().from(agentNodeIncarnationHistories)).toEqual(beforeHistories);
+  });
+
+  test("atomically claims catalogue, global lane, and exact fairness watermarks", async () => {
+    const reserved = await reserveBackup();
+    const [sourceNode] = await dbWrite
+      .select()
+      .from(dockerNodes)
+      .where(eq(dockerNodes.id, NODE_RECORD_ID));
+    if (!sourceNode?.current_node_history_id) {
+      throw new Error("Expected the trigger-owned source-node occurrence");
+    }
+
+    const result = requireAdmission(await claimNext());
+    expect(result.kind).toBe("claimed");
+    expect(result.admission).toMatchObject({
+      claim: {
+        ownerId: OWNER_A,
+        generation: CALLER_GENERATION_A,
+        backup: {
+          id: reserved.id,
+          catalog_organization_id: ORGANIZATION_ID,
+          backup_operation_id: OPERATION_ID,
+          catalog_lease_owner: OWNER_A,
+          catalog_lease_generation: CALLER_GENERATION_A,
+        },
+      },
+      laneExecution: {
+        ownerId: OWNER_A,
+        generation: CALLER_GENERATION_A,
+        claimSequence: 1n,
+      },
+      sourceNodeHistoryId: sourceNode.current_node_history_id,
+    });
+
+    const state = await readAuthorityState();
+    expect(state.lane).toMatchObject({
+      owner_id: OWNER_A,
+      generation: CALLER_GENERATION_A,
+      organization_id: ORGANIZATION_ID,
+      backup_id: reserved.id,
+      operation_id: OPERATION_ID,
+      claim_sequence: 1n,
+      released_at: null,
+    });
+    const catalogueExpiry = state.backups[0]?.catalog_lease_expires_at;
+    expect(catalogueExpiry).toBeInstanceOf(Date);
+    expect(state.lane?.lease_expires_at?.getTime()).toBe(catalogueExpiry?.getTime());
+    expect(state.tenantWatermarks).toEqual([
+      expect.objectContaining({
+        organization_id: ORGANIZATION_ID,
+        last_backup_id: reserved.id,
+        last_operation_id: OPERATION_ID,
+        last_service_sequence: 1n,
+        service_count: 1n,
+      }),
+    ]);
+    expect(state.nodeWatermarks).toEqual([
+      expect.objectContaining({
+        source_node_history_id: sourceNode.current_node_history_id,
+        source_node_record_id: NODE_RECORD_ID,
+        source_node_incarnation: NODE_INCARNATION_A,
+        last_backup_id: reserved.id,
+        last_operation_id: OPERATION_ID,
+        last_service_sequence: 1n,
+        service_count: 1n,
+      }),
+    ]);
+    expect(await dbWrite.select().from(dockerNodes)).toHaveLength(1);
+    expect(await dbWrite.select().from(agentNodeIncarnationHistories)).toHaveLength(1);
+  });
+
+  test("replays the exact active caller without moving leases or counters", async () => {
+    await reserveBackup();
+    const first = requireAdmission(await claimNext());
+    const beforeReplay = await readAuthorityState();
+
+    const replay = requireAdmission(await claimNext());
+    expect(replay.kind).toBe("replayed");
+    expect(replay.admission).toEqual(first.admission);
+
+    const afterReplay = await readAuthorityState();
+    expect(afterReplay.lane?.claim_sequence).toBe(1n);
+    expect(afterReplay.lane?.claimed_at?.getTime()).toBe(beforeReplay.lane?.claimed_at?.getTime());
+    expect(afterReplay.lane?.lease_expires_at?.getTime()).toBe(
+      beforeReplay.lane?.lease_expires_at?.getTime(),
+    );
+    expect(afterReplay.backups[0]?.catalog_lease_expires_at?.getTime()).toBe(
+      beforeReplay.backups[0]?.catalog_lease_expires_at?.getTime(),
+    );
+    expect(afterReplay.backups[0]?.catalog_attempts).toBe(
+      beforeReplay.backups[0]?.catalog_attempts,
+    );
+    expect(afterReplay.tenantWatermarks[0]?.service_count).toBe(1n);
+    expect(afterReplay.nodeWatermarks[0]?.service_count).toBe(1n);
+  });
+
+  test("skips a poisoned earlier row and admits the next exact capture", async () => {
+    const poisoned = await reserveBackup();
+    await dbWrite
+      .update(agentSandboxBackups)
+      .set({ source_node_record_id: POISON_NODE_RECORD_ID })
+      .where(eq(agentSandboxBackups.id, poisoned.id));
+    const valid = await reserveBackup(OTHER_OPERATION_ID);
+
+    const result = requireAdmission(await claimNext());
+
+    expect(result.kind).toBe("claimed");
+    expect(result.admission.claim.backup.id).toBe(valid.id);
+    const state = await readAuthorityState();
+    expect(state.backups.find((backup) => backup.id === poisoned.id)).toMatchObject({
+      catalog_lease_owner: null,
+      catalog_lease_generation: null,
+      catalog_lease_expires_at: null,
+    });
+  });
+
+  test("returns busy before leasing another catalogue candidate", async () => {
+    await reserveBackup();
+    await reserveBackup(OTHER_OPERATION_ID);
+    const winner = requireAdmission(await claimNext());
+    const beforeBusy = await readAuthorityState();
+
+    const busy = await claimNext(callerB);
+    expect(busy.kind).toBe("busy");
+
+    const afterBusy = await readAuthorityState();
+    expect(afterBusy.lane).toEqual(beforeBusy.lane);
+    expect(afterBusy.tenantWatermarks).toEqual(beforeBusy.tenantWatermarks);
+    expect(afterBusy.nodeWatermarks).toEqual(beforeBusy.nodeWatermarks);
+    const unclaimed = afterBusy.backups.find(
+      (backup) => backup.id !== winner.admission.claim.backup.id,
+    );
+    expect(unclaimed).toMatchObject({
+      catalog_lease_owner: null,
+      catalog_lease_generation: null,
+      catalog_lease_expires_at: null,
+    });
+  });
+
+  test("uses claimSequence to fence an A/B/A caller-token cycle", async () => {
+    await reserveBackup();
+    const firstA = requireAdmission(await claimNext());
+    expect(firstA.admission.laneExecution.claimSequence).toBe(1n);
+    await expireAdmission(firstA.admission);
+
+    const middleB = requireAdmission(await claimNext(callerB));
+    expect(middleB).toMatchObject({
+      kind: "claimed",
+      admission: { laneExecution: { claimSequence: 2n } },
+    });
+    await expireAdmission(middleB.admission);
+
+    const currentA = requireAdmission(await claimNext());
+    expect(currentA).toMatchObject({
+      kind: "claimed",
+      admission: { laneExecution: { claimSequence: 3n } },
+    });
+    await expect(
+      repository.renewAgentBackupOperationAdmission({
+        admission: firstA.admission,
+        leaseMs: 60_000,
+      }),
+    ).rejects.toThrow();
+
+    const state = await readAuthorityState();
+    expect(state.lane).toMatchObject({
+      owner_id: OWNER_A,
+      generation: CALLER_GENERATION_A,
+      claim_sequence: 3n,
+    });
+    expect(state.backups[0]).toMatchObject({
+      catalog_lease_owner: OWNER_A,
+      catalog_lease_generation: CALLER_GENERATION_A,
+    });
+    expect(state.tenantWatermarks[0]).toMatchObject({
+      last_service_sequence: 3n,
+      service_count: 3n,
+    });
+    expect(state.nodeWatermarks[0]).toMatchObject({
+      last_service_sequence: 3n,
+      service_count: 3n,
+    });
+  });
+
+  test("fails closed across an A1-to-A2 occurrence ABA without partial admission", async () => {
+    const reserved = await reserveBackup();
+    const [original] = await dbWrite
+      .select()
+      .from(dockerNodes)
+      .where(eq(dockerNodes.id, NODE_RECORD_ID));
+    if (!original?.current_node_history_id) throw new Error("Expected original source occurrence");
+    await dbWrite
+      .update(dockerNodes)
+      .set({ node_incarnation: null })
+      .where(eq(dockerNodes.id, NODE_RECORD_ID));
+    await dbWrite
+      .update(dockerNodes)
+      .set({ node_incarnation: NODE_INCARNATION_A })
+      .where(eq(dockerNodes.id, NODE_RECORD_ID));
+    const [reattested] = await dbWrite
+      .select()
+      .from(dockerNodes)
+      .where(eq(dockerNodes.id, NODE_RECORD_ID));
+    expect(reattested?.current_node_history_id).not.toBeNull();
+    expect(reattested?.current_node_history_id).not.toBe(original.current_node_history_id);
+    expect(reattested?.node_incarnation).toBe(NODE_INCARNATION_A);
+    expect(await dbWrite.select().from(agentNodeIncarnationHistories)).toHaveLength(2);
+    const beforeClaim = await readAuthorityState();
+
+    expect(await claimNext()).toEqual({ kind: "empty" });
+
+    expect(await readAuthorityState()).toEqual(beforeClaim);
+    expect(beforeClaim.lane).toMatchObject({ owner_id: null, claim_sequence: 0n });
+    expect(beforeClaim.backups).toEqual([
+      expect.objectContaining({
+        id: reserved.id,
+        source_node_incarnation: NODE_INCARNATION_A,
+        catalog_lease_owner: null,
+        catalog_lease_generation: null,
+        catalog_lease_expires_at: null,
+      }),
+    ]);
+    expect(await dbWrite.select().from(dockerNodes)).toHaveLength(1);
+  });
+
+  test("skips a capture whose live sandbox authority drifted", async () => {
+    await reserveBackup();
+    await dbWrite
+      .update(agentSandboxes)
+      .set({ status: "stopped" })
+      .where(eq(agentSandboxes.id, AGENT_ID));
+    const beforeClaim = await readAuthorityState();
+
+    expect(await claimNext()).toEqual({ kind: "empty" });
+
+    expect(await readAuthorityState()).toEqual(beforeClaim);
+  });
+
+  test("skips mutable activation economics or token drift without partial admission", async () => {
+    await reserveBackup();
+    await dbWrite
+      .update(agentSandboxes)
+      .set({ activation_token_hash: SHA_C, activation_funding_revision: 1n })
+      .where(eq(agentSandboxes.id, AGENT_ID));
+    const beforeClaim = await readAuthorityState();
+
+    expect(await claimNext()).toEqual({ kind: "empty" });
+
+    expect(await readAuthorityState()).toEqual(beforeClaim);
+  });
+
+  test("rejects replay and renewal after an admitted live source drifts", async () => {
+    await reserveBackup();
+    const claimed = requireAdmission(await claimNext());
+    await dbWrite
+      .update(agentSandboxes)
+      .set({ status: "stopped" })
+      .where(eq(agentSandboxes.id, AGENT_ID));
+    const beforeRejectedUse = await readAuthorityState();
+
+    await expect(claimNext()).rejects.toThrow();
+    await expect(
+      repository.renewAgentBackupOperationAdmission({
+        admission: claimed.admission,
+        leaseMs: 60_000,
+      }),
+    ).rejects.toThrow();
+
+    expect(await readAuthorityState()).toEqual(beforeRejectedUse);
+  });
+
+  test("renews both leases atomically, never shortens, and rolls back on a stale catalogue", async () => {
+    await reserveBackup();
+    const claimed = requireAdmission(await claimNext(callerA, 1_000));
+    const initial = await readAuthorityState();
+    const initialExpiry = initial.lane?.lease_expires_at;
+    if (!initialExpiry) throw new Error("Expected an active admission lease");
+
+    const renewed = await repository.renewAgentBackupOperationAdmission({
+      admission: claimed.admission,
+      leaseMs: 60_000,
+    });
+    const afterRenew = await readAuthorityState();
+    expect(renewed.laneExecution).toEqual(claimed.admission.laneExecution);
+    expect(afterRenew.lane?.lease_expires_at?.getTime()).toBeGreaterThan(initialExpiry.getTime());
+    expect(afterRenew.lane?.lease_expires_at?.getTime()).toBe(
+      afterRenew.backups[0]?.catalog_lease_expires_at?.getTime(),
+    );
+
+    await repository.renewAgentBackupOperationAdmission({
+      admission: renewed,
+      leaseMs: 1,
+    });
+    const afterShortRenew = await readAuthorityState();
+    expect(afterShortRenew.lane?.lease_expires_at?.getTime()).toBe(
+      afterRenew.lane?.lease_expires_at?.getTime(),
+    );
+    expect(afterShortRenew.backups[0]?.catalog_lease_expires_at?.getTime()).toBe(
+      afterRenew.backups[0]?.catalog_lease_expires_at?.getTime(),
+    );
+
+    await dbWrite
+      .update(agentSandboxBackups)
+      .set({ catalog_lease_generation: CALLER_GENERATION_C })
+      .where(eq(agentSandboxBackups.id, renewed.claim.backup.id));
+    const beforeRejectedRenew = await readAuthorityState();
+    await expect(
+      repository.renewAgentBackupOperationAdmission({ admission: renewed, leaseMs: 120_000 }),
+    ).rejects.toThrow();
+    expect(await readAuthorityState()).toEqual(beforeRejectedRenew);
+  });
+});

--- a/packages/cloud/shared/src/db/repositories/agent-backup-operation-admission.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-backup-operation-admission.ts
@@ -1,0 +1,762 @@
+/** Atomic global-lane admission for one exact, live-source backup capture. */
+
+import { ElizaError } from "@elizaos/core";
+import { and, eq, gt, sql } from "drizzle-orm";
+import type { DbTransaction } from "../client";
+import { dbWrite } from "../helpers";
+import {
+  type AgentBackupOperationLane,
+  agentBackupOperationNodeWatermarks,
+  agentBackupOperationTenantWatermarks,
+} from "../schemas/agent-backup-operation-lane";
+import { agentActivationPublications } from "../schemas/agent-backup-restore-history";
+import { agentNodeIncarnationHistories } from "../schemas/agent-node-incarnation-histories";
+import {
+  agentSandboxBackups,
+  agentSandboxes,
+  type StoredAgentSandboxBackup,
+} from "../schemas/agent-sandboxes";
+import { dockerNodes } from "../schemas/docker-nodes";
+import { organizations } from "../schemas/organizations";
+import type { AgentBackupOperationClaim } from "./agent-backup-catalog";
+import {
+  type AgentBackupOperationLaneCallerToken,
+  type AgentBackupOperationLaneExecution,
+  type AgentBackupOperationLaneTarget,
+  claimAgentBackupOperationLaneInTransaction,
+  lockAgentBackupOperationLaneInTransaction,
+  normalizeAgentBackupOperationLaneCallerToken,
+  normalizeAgentBackupOperationLaneLeaseMs,
+  refreshAgentBackupOperationLaneProofInTransaction,
+  renewAgentBackupOperationLaneInTransaction,
+} from "./agent-backup-operation-lane";
+
+const CAPTURE_OWNED_STATES = ["scheduled", "capturing"] as const;
+
+export interface AgentBackupOperationAdmission {
+  readonly claim: Readonly<AgentBackupOperationClaim>;
+  readonly laneExecution: Readonly<AgentBackupOperationLaneExecution>;
+  readonly sourceNodeHistoryId: string;
+}
+
+export type AgentBackupOperationAdmissionResult =
+  | {
+      readonly kind: "claimed" | "replayed";
+      readonly admission: AgentBackupOperationAdmission;
+    }
+  | { readonly kind: "empty" }
+  | {
+      readonly kind: "busy";
+      readonly lane: Readonly<AgentBackupOperationLane>;
+      readonly databaseNow: Date;
+    };
+
+interface ExactSourceAuthority {
+  readonly sourceNodeHistoryId: string;
+  readonly sourceNodeRecordId: string;
+  readonly sourceNodeIncarnation: string;
+}
+
+function admissionLost(message: string): ElizaError {
+  return new ElizaError(message, {
+    code: "AGENT_BACKUP_OPERATION_ADMISSION_LOST",
+    severity: "fatal",
+  });
+}
+
+function laneIsActive(lane: AgentBackupOperationLane, databaseNow: Date): boolean {
+  return (
+    lane.released_at === null &&
+    lane.lease_expires_at !== null &&
+    lane.lease_expires_at.getTime() > databaseNow.getTime()
+  );
+}
+
+function observedLane(lane: AgentBackupOperationLane): Readonly<AgentBackupOperationLane> {
+  return Object.freeze({ ...lane });
+}
+
+function targetFor(backup: StoredAgentSandboxBackup): AgentBackupOperationLaneTarget {
+  if (!backup.catalog_organization_id || !backup.backup_operation_id) {
+    throw admissionLost("Backup operation is missing its exact catalogue target");
+  }
+  return Object.freeze({
+    organizationId: backup.catalog_organization_id,
+    backupId: backup.id,
+    operationId: backup.backup_operation_id,
+  });
+}
+
+function activeState(backup: StoredAgentSandboxBackup): boolean {
+  return (
+    CAPTURE_OWNED_STATES.some((state) => state === backup.catalog_state) ||
+    (backup.catalog_state === "failed_retryable" &&
+      CAPTURE_OWNED_STATES.some((state) => state === backup.catalog_resume_state))
+  );
+}
+
+function exactLeaseExpiry(lane: Readonly<AgentBackupOperationLane>, field: string): Date {
+  if (!(lane.lease_expires_at instanceof Date)) {
+    throw admissionLost(`${field} is missing its global-lane lease expiry`);
+  }
+  return new Date(lane.lease_expires_at.getTime());
+}
+
+function admissionFor(params: {
+  backup: StoredAgentSandboxBackup;
+  execution: AgentBackupOperationLaneExecution;
+  sourceNodeHistoryId: string;
+}): AgentBackupOperationAdmission {
+  const backup = Object.freeze({ ...params.backup });
+  const execution = Object.freeze({ ...params.execution });
+  return Object.freeze({
+    claim: Object.freeze({
+      backup,
+      ownerId: execution.ownerId,
+      generation: execution.generation,
+    }),
+    laneExecution: execution,
+    sourceNodeHistoryId: params.sourceNodeHistoryId,
+  });
+}
+
+async function lockBackupByTargetInTransaction(
+  tx: DbTransaction,
+  target: AgentBackupOperationLaneTarget,
+): Promise<StoredAgentSandboxBackup> {
+  const [backup] = await tx
+    .select()
+    .from(agentSandboxBackups)
+    .where(
+      and(
+        eq(agentSandboxBackups.id, target.backupId),
+        eq(agentSandboxBackups.catalog_organization_id, target.organizationId),
+        eq(agentSandboxBackups.backup_operation_id, target.operationId),
+      ),
+    )
+    .for("update")
+    .limit(1);
+  if (!backup || !activeState(backup)) {
+    throw admissionLost("Global lane target no longer names an executable backup operation");
+  }
+  return backup;
+}
+
+/**
+ * The global lane is already held before this function locks the backup row.
+ * Only live-source capture states are eligible here. Publication, verification,
+ * and GC must use a detached admission path that survives source-node loss.
+ */
+async function lockNextDueBackupInTransaction(
+  tx: DbTransaction,
+): Promise<StoredAgentSandboxBackup | null> {
+  const [candidate] = await tx
+    .select({ id: agentSandboxBackups.id })
+    .from(agentSandboxBackups)
+    .innerJoin(
+      agentSandboxes,
+      and(
+        eq(agentSandboxes.id, agentSandboxBackups.sandbox_record_id),
+        eq(agentSandboxes.id, agentSandboxBackups.catalog_agent_id),
+        eq(agentSandboxes.organization_id, agentSandboxBackups.catalog_organization_id),
+        eq(agentSandboxes.status, "running"),
+        eq(agentSandboxes.activation_phase, "active"),
+        eq(agentSandboxes.activation_generation, agentSandboxBackups.lifecycle_generation),
+        sql`${agentSandboxes.lifecycle_revision}::numeric
+          = ${agentSandboxBackups.lifecycle_revision}`,
+        sql`${agentSandboxes.activation_lifecycle_revision}::numeric
+          = ${agentSandboxBackups.lifecycle_revision}`,
+        eq(agentSandboxes.node_id, agentSandboxBackups.source_node_id),
+        eq(agentSandboxes.activation_node_id, agentSandboxBackups.source_node_id),
+        eq(agentSandboxes.sandbox_id, agentSandboxBackups.source_provider_handle),
+        eq(agentSandboxes.activation_container_id, agentSandboxBackups.source_container_id),
+        eq(agentSandboxes.activation_boot_id, agentSandboxBackups.source_node_incarnation),
+        sql`${agentSandboxes.activation_receipt} IS NOT NULL`,
+        sql`${agentSandboxes.activation_receipt_hash} IS NOT NULL`,
+        sql`${agentSandboxes.activation_image_digest} IS NOT NULL`,
+        sql`${agentSandboxes.activation_boot_id} IS NOT NULL`,
+        sql`${agentSandboxes.activation_token_hash} IS NOT NULL`,
+        sql`${agentSandboxes.activation_funding_revision} IS NOT NULL`,
+        sql`${agentSandboxes.activation_authority_published_at} IS NOT NULL`,
+        sql`${agentSandboxes.activation_dispatched_at} IS NOT NULL`,
+        sql`${agentSandboxes.activation_completed_at} IS NOT NULL`,
+      ),
+    )
+    .innerJoin(
+      agentActivationPublications,
+      and(
+        eq(
+          agentActivationPublications.organization_id,
+          agentSandboxBackups.catalog_organization_id,
+        ),
+        eq(agentActivationPublications.agent_id, agentSandboxBackups.catalog_agent_id),
+        eq(
+          agentActivationPublications.activation_generation,
+          agentSandboxBackups.lifecycle_generation,
+        ),
+        eq(agentActivationPublications.lifecycle_revision, agentSandboxBackups.lifecycle_revision),
+        eq(agentActivationPublications.purpose, agentSandboxes.activation_purpose),
+        sql`${agentActivationPublications.previous_activation_generation}
+          IS NOT DISTINCT FROM ${agentSandboxes.activation_previous_generation}`,
+        sql`${agentActivationPublications.backup_id}
+          IS NOT DISTINCT FROM ${agentSandboxes.activation_backup_id}`,
+        sql`${agentActivationPublications.backup_manifest_sha256}
+          IS NOT DISTINCT FROM ${agentSandboxes.activation_backup_hash}`,
+        sql`${agentActivationPublications.activation_receipt}
+          = ${agentSandboxes.activation_receipt}`,
+        eq(
+          agentActivationPublications.activation_receipt_sha256,
+          agentSandboxes.activation_receipt_hash,
+        ),
+        eq(agentActivationPublications.container_id, agentSandboxBackups.source_container_id),
+        eq(agentActivationPublications.image_digest, agentSandboxes.activation_image_digest),
+        eq(
+          agentActivationPublications.published_at,
+          agentSandboxes.activation_authority_published_at,
+        ),
+        eq(
+          agentActivationPublications.docker_node_record_id,
+          agentSandboxBackups.source_node_record_id,
+        ),
+        eq(agentActivationPublications.node_id, agentSandboxBackups.source_node_id),
+        eq(
+          agentActivationPublications.node_incarnation,
+          agentSandboxBackups.source_node_incarnation,
+        ),
+        eq(agentActivationPublications.node_incarnation, agentSandboxes.activation_boot_id),
+        eq(agentActivationPublications.token_sha256, agentSandboxes.activation_token_hash),
+        eq(
+          agentActivationPublications.funding_revision,
+          agentSandboxes.activation_funding_revision,
+        ),
+      ),
+    )
+    .innerJoin(
+      dockerNodes,
+      and(
+        eq(dockerNodes.id, agentSandboxBackups.source_node_record_id),
+        eq(dockerNodes.node_id, agentSandboxBackups.source_node_id),
+        eq(dockerNodes.node_incarnation, agentSandboxBackups.source_node_incarnation),
+        eq(dockerNodes.current_node_history_id, agentActivationPublications.node_history_id),
+      ),
+    )
+    .innerJoin(
+      agentNodeIncarnationHistories,
+      and(
+        eq(agentNodeIncarnationHistories.id, agentActivationPublications.node_history_id),
+        eq(agentNodeIncarnationHistories.docker_node_record_id, dockerNodes.id),
+        eq(agentNodeIncarnationHistories.node_id, dockerNodes.node_id),
+        eq(agentNodeIncarnationHistories.node_incarnation, dockerNodes.node_incarnation),
+        eq(agentNodeIncarnationHistories.fleet_kind, dockerNodes.fleet_kind),
+        eq(
+          agentNodeIncarnationHistories.infrastructure_provider,
+          dockerNodes.infrastructure_provider,
+        ),
+        sql`${agentNodeIncarnationHistories.provider_server_id}
+          IS NOT DISTINCT FROM ${dockerNodes.provider_server_id}`,
+        eq(agentNodeIncarnationHistories.host_key_fingerprint, dockerNodes.host_key_fingerprint),
+      ),
+    )
+    .leftJoin(
+      agentBackupOperationTenantWatermarks,
+      eq(
+        agentBackupOperationTenantWatermarks.organization_id,
+        agentSandboxBackups.catalog_organization_id,
+      ),
+    )
+    .leftJoin(
+      agentBackupOperationNodeWatermarks,
+      eq(
+        agentBackupOperationNodeWatermarks.source_node_history_id,
+        dockerNodes.current_node_history_id,
+      ),
+    )
+    .where(
+      and(
+        eq(agentSandboxBackups.catalog_version, 2),
+        sql`${agentSandboxBackups.sandbox_record_id} IS NOT NULL`,
+        sql`${agentSandboxBackups.catalog_organization_id} IS NOT NULL`,
+        sql`${agentSandboxBackups.backup_operation_id} IS NOT NULL`,
+        sql`${agentSandboxBackups.source_provider} IN ('operator-onboarded', 'hetzner-cloud')`,
+        sql`${agentSandboxBackups.source_node_record_id} IS NOT NULL`,
+        sql`${agentSandboxBackups.source_node_id} IS NOT NULL
+          AND ${agentSandboxBackups.source_node_id} <> ''`,
+        sql`${agentSandboxBackups.source_node_incarnation} IS NOT NULL`,
+        sql`${agentSandboxBackups.source_provider_handle} IS NOT NULL
+          AND ${agentSandboxBackups.source_provider_handle} <> ''`,
+        sql`${agentSandboxBackups.source_container_id} ~ '^[0-9a-f]{64}$'`,
+        eq(dockerNodes.infrastructure_provider, "hetzner"),
+        sql`(
+          (${agentSandboxBackups.source_provider} = 'operator-onboarded'
+            AND ${agentSandboxBackups.source_provider_server_id} IS NULL
+            AND ${dockerNodes.fleet_kind} = 'robot'
+            AND ${dockerNodes.provider_server_id} IS NULL)
+          OR
+          (${agentSandboxBackups.source_provider} = 'hetzner-cloud'
+            AND ${dockerNodes.fleet_kind} = 'cloud'
+            AND ${dockerNodes.provider_server_id}
+              = ${agentSandboxBackups.source_provider_server_id})
+        )`,
+        sql`(${agentSandboxBackups.catalog_state} IN ('scheduled', 'capturing')
+          OR (${agentSandboxBackups.catalog_state} = 'failed_retryable'
+            AND ${agentSandboxBackups.catalog_resume_state} IN ('scheduled', 'capturing')))`,
+        sql`(${agentSandboxBackups.catalog_next_attempt_at} IS NULL
+          OR ${agentSandboxBackups.catalog_next_attempt_at} <= clock_timestamp())`,
+        sql`(${agentSandboxBackups.catalog_lease_expires_at} IS NULL
+          OR ${agentSandboxBackups.catalog_lease_expires_at} <= clock_timestamp())`,
+      ),
+    )
+    .orderBy(
+      sql`COALESCE(${agentBackupOperationTenantWatermarks.service_count}, 0)`,
+      sql`COALESCE(${agentBackupOperationNodeWatermarks.service_count}, 0)`,
+      sql`COALESCE(${agentBackupOperationTenantWatermarks.last_served_at}, '-infinity'::timestamptz)`,
+      sql`COALESCE(${agentBackupOperationNodeWatermarks.last_served_at}, '-infinity'::timestamptz)`,
+      sql`COALESCE(${agentSandboxBackups.catalog_next_attempt_at}, ${agentSandboxBackups.created_at})`,
+      agentSandboxBackups.created_at,
+      agentSandboxBackups.id,
+    )
+    .for("update", { of: agentSandboxBackups, skipLocked: true })
+    .limit(1);
+  if (!candidate) return null;
+
+  const [backup] = await tx
+    .select()
+    .from(agentSandboxBackups)
+    .where(eq(agentSandboxBackups.id, candidate.id))
+    .for("update")
+    .limit(1);
+  if (!backup) throw admissionLost("Selected backup operation disappeared while locked");
+  return backup;
+}
+
+async function lockExactSourceAuthorityInTransaction(
+  tx: DbTransaction,
+  backup: StoredAgentSandboxBackup,
+): Promise<ExactSourceAuthority> {
+  if (
+    !backup.sandbox_record_id ||
+    !backup.catalog_organization_id ||
+    !backup.catalog_agent_id ||
+    !backup.source_node_record_id ||
+    !backup.source_node_id ||
+    !backup.source_node_incarnation ||
+    !backup.source_provider ||
+    !backup.source_provider_handle ||
+    !backup.source_container_id
+  ) {
+    throw admissionLost("Backup operation is missing its immutable source authority");
+  }
+
+  const [sandbox] = await tx
+    .select({
+      id: agentSandboxes.id,
+      status: agentSandboxes.status,
+      nodeId: agentSandboxes.node_id,
+      providerHandle: agentSandboxes.sandbox_id,
+      lifecycleRevision: sql<string>`${agentSandboxes.lifecycle_revision}::text`,
+      activationGeneration: agentSandboxes.activation_generation,
+      activationLifecycleRevision: sql<
+        string | null
+      >`${agentSandboxes.activation_lifecycle_revision}::text`,
+      activationPhase: agentSandboxes.activation_phase,
+      activationPurpose: agentSandboxes.activation_purpose,
+      activationPreviousGeneration: agentSandboxes.activation_previous_generation,
+      activationBackupId: agentSandboxes.activation_backup_id,
+      activationBackupHash: agentSandboxes.activation_backup_hash,
+      activationReceipt: agentSandboxes.activation_receipt,
+      activationReceiptHash: agentSandboxes.activation_receipt_hash,
+      activationContainerId: agentSandboxes.activation_container_id,
+      activationNodeId: agentSandboxes.activation_node_id,
+      activationImageDigest: agentSandboxes.activation_image_digest,
+      activationBootId: agentSandboxes.activation_boot_id,
+      activationTokenHash: agentSandboxes.activation_token_hash,
+      activationFundingRevision: agentSandboxes.activation_funding_revision,
+      activationAuthorityPublishedAt: agentSandboxes.activation_authority_published_at,
+      activationDispatchedAt: agentSandboxes.activation_dispatched_at,
+      activationCompletedAt: agentSandboxes.activation_completed_at,
+    })
+    .from(agentSandboxes)
+    .where(
+      and(
+        eq(agentSandboxes.id, backup.sandbox_record_id),
+        eq(agentSandboxes.organization_id, backup.catalog_organization_id),
+      ),
+    )
+    .for("update")
+    .limit(1);
+  if (!sandbox || sandbox.id !== backup.catalog_agent_id) {
+    throw admissionLost("Backup source sandbox authority disappeared or changed tenant");
+  }
+  if (
+    backup.lifecycle_revision === null ||
+    !backup.lifecycle_generation ||
+    sandbox.status !== "running" ||
+    sandbox.activationPhase !== "active" ||
+    sandbox.activationGeneration !== backup.lifecycle_generation ||
+    sandbox.lifecycleRevision !== backup.lifecycle_revision.toString() ||
+    sandbox.activationLifecycleRevision !== backup.lifecycle_revision.toString() ||
+    !sandbox.activationPurpose ||
+    !sandbox.activationReceipt ||
+    !sandbox.activationReceiptHash ||
+    !sandbox.activationImageDigest ||
+    sandbox.activationBootId !== backup.source_node_incarnation ||
+    !sandbox.activationTokenHash ||
+    sandbox.activationFundingRevision === null ||
+    !sandbox.activationAuthorityPublishedAt ||
+    !sandbox.activationDispatchedAt ||
+    !sandbox.activationCompletedAt ||
+    sandbox.nodeId !== backup.source_node_id ||
+    sandbox.activationNodeId !== backup.source_node_id ||
+    sandbox.providerHandle !== backup.source_provider_handle ||
+    sandbox.activationContainerId !== backup.source_container_id
+  ) {
+    throw admissionLost("Backup capture source is no longer the exact active sandbox generation");
+  }
+
+  const [organization] = await tx
+    .select({ id: organizations.id })
+    .from(organizations)
+    .where(eq(organizations.id, backup.catalog_organization_id))
+    .for("update")
+    .limit(1);
+  if (!organization) throw admissionLost("Backup organization authority disappeared");
+
+  const [publication] = await tx
+    .select({
+      lifecycleRevision: sql<string>`${agentActivationPublications.lifecycle_revision}::text`,
+      purpose: agentActivationPublications.purpose,
+      previousActivationGeneration: agentActivationPublications.previous_activation_generation,
+      backupId: agentActivationPublications.backup_id,
+      backupManifestHash: agentActivationPublications.backup_manifest_sha256,
+      activationReceipt: agentActivationPublications.activation_receipt,
+      activationReceiptHash: agentActivationPublications.activation_receipt_sha256,
+      containerId: agentActivationPublications.container_id,
+      nodeHistoryId: agentActivationPublications.node_history_id,
+      nodeRecordId: agentActivationPublications.docker_node_record_id,
+      nodeId: agentActivationPublications.node_id,
+      nodeIncarnation: agentActivationPublications.node_incarnation,
+      imageDigest: agentActivationPublications.image_digest,
+      tokenHash: agentActivationPublications.token_sha256,
+      fundingRevision: agentActivationPublications.funding_revision,
+      publishedAt: agentActivationPublications.published_at,
+    })
+    .from(agentActivationPublications)
+    .where(
+      and(
+        eq(agentActivationPublications.organization_id, backup.catalog_organization_id),
+        eq(agentActivationPublications.agent_id, backup.catalog_agent_id),
+        eq(agentActivationPublications.activation_generation, backup.lifecycle_generation),
+      ),
+    )
+    .limit(1);
+  if (
+    !publication ||
+    publication.lifecycleRevision !== backup.lifecycle_revision.toString() ||
+    publication.purpose !== sandbox.activationPurpose ||
+    publication.previousActivationGeneration !== sandbox.activationPreviousGeneration ||
+    publication.backupId !== sandbox.activationBackupId ||
+    publication.backupManifestHash !== sandbox.activationBackupHash ||
+    JSON.stringify(publication.activationReceipt) !== JSON.stringify(sandbox.activationReceipt) ||
+    publication.activationReceiptHash !== sandbox.activationReceiptHash ||
+    publication.containerId !== backup.source_container_id ||
+    publication.nodeRecordId !== backup.source_node_record_id ||
+    publication.nodeId !== backup.source_node_id ||
+    publication.nodeIncarnation !== backup.source_node_incarnation ||
+    publication.imageDigest !== sandbox.activationImageDigest ||
+    publication.tokenHash !== sandbox.activationTokenHash ||
+    publication.fundingRevision !== sandbox.activationFundingRevision ||
+    publication.publishedAt.getTime() !== sandbox.activationAuthorityPublishedAt.getTime()
+  ) {
+    throw admissionLost("Backup capture source lost its immutable activation publication");
+  }
+
+  const [node] = await tx
+    .select({
+      recordId: dockerNodes.id,
+      nodeId: dockerNodes.node_id,
+      incarnation: dockerNodes.node_incarnation,
+      historyId: dockerNodes.current_node_history_id,
+      fleetKind: dockerNodes.fleet_kind,
+      infrastructureProvider: dockerNodes.infrastructure_provider,
+      providerServerId: dockerNodes.provider_server_id,
+      hostKeyFingerprint: dockerNodes.host_key_fingerprint,
+    })
+    .from(dockerNodes)
+    .where(
+      and(
+        eq(dockerNodes.id, backup.source_node_record_id),
+        eq(dockerNodes.node_id, backup.source_node_id),
+        eq(dockerNodes.node_incarnation, backup.source_node_incarnation),
+        eq(dockerNodes.current_node_history_id, publication.nodeHistoryId),
+      ),
+    )
+    .for("update")
+    .limit(1);
+  if (!node?.incarnation || !node.historyId) {
+    throw admissionLost("Backup source node is no longer the reserved exact occurrence");
+  }
+  const expectedFleetKind =
+    backup.source_provider === "operator-onboarded"
+      ? "robot"
+      : backup.source_provider === "hetzner-cloud"
+        ? "cloud"
+        : null;
+  if (
+    !expectedFleetKind ||
+    node.fleetKind !== expectedFleetKind ||
+    node.infrastructureProvider !== "hetzner" ||
+    node.providerServerId !== backup.source_provider_server_id ||
+    !node.hostKeyFingerprint?.trim()
+  ) {
+    throw admissionLost("Backup source Robot/Cloud provider authority changed");
+  }
+
+  const [history] = await tx
+    .select({
+      id: agentNodeIncarnationHistories.id,
+      nodeId: agentNodeIncarnationHistories.node_id,
+      fleetKind: agentNodeIncarnationHistories.fleet_kind,
+      infrastructureProvider: agentNodeIncarnationHistories.infrastructure_provider,
+      providerServerId: agentNodeIncarnationHistories.provider_server_id,
+      hostKeyFingerprint: agentNodeIncarnationHistories.host_key_fingerprint,
+    })
+    .from(agentNodeIncarnationHistories)
+    .where(
+      and(
+        eq(agentNodeIncarnationHistories.id, publication.nodeHistoryId),
+        eq(agentNodeIncarnationHistories.docker_node_record_id, node.recordId),
+        eq(agentNodeIncarnationHistories.node_incarnation, node.incarnation),
+      ),
+    )
+    .for("share")
+    .limit(1);
+  if (
+    !history ||
+    history.nodeId !== node.nodeId ||
+    history.fleetKind !== node.fleetKind ||
+    history.infrastructureProvider !== node.infrastructureProvider ||
+    history.providerServerId !== node.providerServerId ||
+    history.hostKeyFingerprint !== node.hostKeyFingerprint
+  ) {
+    throw admissionLost("Backup source node-history occurrence disappeared or changed");
+  }
+
+  return Object.freeze({
+    sourceNodeHistoryId: history.id,
+    sourceNodeRecordId: node.recordId,
+    sourceNodeIncarnation: node.incarnation,
+  });
+}
+
+function assertCatalogueReplay(params: {
+  backup: StoredAgentSandboxBackup;
+  callerToken: Readonly<AgentBackupOperationLaneCallerToken>;
+  target: AgentBackupOperationLaneTarget;
+  laneExpiry: Date;
+  databaseNow: Date;
+}): void {
+  if (
+    params.backup.catalog_organization_id !== params.target.organizationId ||
+    params.backup.id !== params.target.backupId ||
+    params.backup.backup_operation_id !== params.target.operationId ||
+    params.backup.catalog_lease_owner !== params.callerToken.ownerId ||
+    params.backup.catalog_lease_generation !== params.callerToken.generation ||
+    !(params.backup.catalog_lease_expires_at instanceof Date) ||
+    params.backup.catalog_lease_expires_at.getTime() !== params.laneExpiry.getTime() ||
+    params.backup.catalog_lease_expires_at.getTime() <= params.databaseNow.getTime()
+  ) {
+    throw admissionLost("Catalogue lease does not replay the exact active global lane");
+  }
+}
+
+/**
+ * Lock the singleton first, then atomically claim one exact live-source capture
+ * and stamp both cross-tick fairness receipts. No provider runs here.
+ */
+export async function claimNextAgentBackupOperationAdmission(params: {
+  readonly callerToken: AgentBackupOperationLaneCallerToken;
+  readonly leaseMs: number;
+}): Promise<AgentBackupOperationAdmissionResult> {
+  const callerToken = normalizeAgentBackupOperationLaneCallerToken(params.callerToken);
+  const leaseMs = normalizeAgentBackupOperationLaneLeaseMs(params.leaseMs);
+
+  return dbWrite.transaction(async (tx) => {
+    const initial = await lockAgentBackupOperationLaneInTransaction(tx);
+    if (laneIsActive(initial.lane, initial.databaseNow)) {
+      if (
+        initial.lane.owner_id !== callerToken.ownerId ||
+        initial.lane.generation !== callerToken.generation
+      ) {
+        return Object.freeze({
+          kind: "busy" as const,
+          lane: observedLane(initial.lane),
+          databaseNow: new Date(initial.databaseNow.getTime()),
+        });
+      }
+      if (!initial.lane.organization_id || !initial.lane.backup_id || !initial.lane.operation_id) {
+        throw admissionLost("Active global lane is missing its exact catalogue target");
+      }
+      const target = Object.freeze({
+        organizationId: initial.lane.organization_id,
+        backupId: initial.lane.backup_id,
+        operationId: initial.lane.operation_id,
+      });
+      const backup = await lockBackupByTargetInTransaction(tx, target);
+      const source = await lockExactSourceAuthorityInTransaction(tx, backup);
+      const replay = await claimAgentBackupOperationLaneInTransaction(tx, {
+        ...target,
+        callerToken,
+        leaseMs,
+        fairness: source,
+      });
+      if (replay.kind === "busy") {
+        throw admissionLost("Exact active global lane unexpectedly became foreign");
+      }
+      const laneExpiry = exactLeaseExpiry(replay.proof.lane, "Replayed admission");
+      assertCatalogueReplay({
+        backup,
+        callerToken,
+        target,
+        laneExpiry,
+        databaseNow: replay.proof.databaseNow,
+      });
+      return Object.freeze({
+        kind: "replayed" as const,
+        admission: admissionFor({
+          backup,
+          execution: replay.execution,
+          sourceNodeHistoryId: source.sourceNodeHistoryId,
+        }),
+      });
+    }
+
+    const backup = await lockNextDueBackupInTransaction(tx);
+    if (!backup) return Object.freeze({ kind: "empty" as const });
+    const target = targetFor(backup);
+    const source = await lockExactSourceAuthorityInTransaction(tx, backup);
+    const laneClaim = await claimAgentBackupOperationLaneInTransaction(tx, {
+      ...target,
+      callerToken,
+      leaseMs,
+      fairness: source,
+    });
+    if (laneClaim.kind === "busy") {
+      return Object.freeze({
+        kind: "busy" as const,
+        lane: laneClaim.lane,
+        databaseNow: laneClaim.databaseNow,
+      });
+    }
+    if (laneClaim.kind !== "claimed") {
+      throw admissionLost("Fresh catalogue candidate unexpectedly replayed the global lane");
+    }
+    const laneExpiry = exactLeaseExpiry(laneClaim.proof.lane, "Claimed admission");
+    const [claimed] = await tx
+      .update(agentSandboxBackups)
+      .set({
+        catalog_lease_owner: callerToken.ownerId,
+        catalog_lease_generation: callerToken.generation,
+        catalog_lease_expires_at: laneExpiry,
+        catalog_updated_at: laneClaim.proof.databaseNow,
+      })
+      .where(
+        and(
+          eq(agentSandboxBackups.id, target.backupId),
+          eq(agentSandboxBackups.catalog_organization_id, target.organizationId),
+          eq(agentSandboxBackups.backup_operation_id, target.operationId),
+          sql`(${agentSandboxBackups.catalog_state} IN ('scheduled', 'capturing')
+            OR (${agentSandboxBackups.catalog_state} = 'failed_retryable'
+              AND ${agentSandboxBackups.catalog_resume_state} IN ('scheduled', 'capturing')))`,
+          sql`(${agentSandboxBackups.catalog_lease_expires_at} IS NULL
+            OR ${agentSandboxBackups.catalog_lease_expires_at} <= clock_timestamp())`,
+        ),
+      )
+      .returning();
+    if (!claimed) {
+      throw admissionLost("Catalogue operation changed after the global lane was claimed");
+    }
+    const finalProof = await refreshAgentBackupOperationLaneProofInTransaction(tx, laneClaim.proof);
+    if (
+      exactLeaseExpiry(finalProof.lane, "Committed admission").getTime() !== laneExpiry.getTime()
+    ) {
+      throw admissionLost("Catalogue lease diverged from the global lane before commit");
+    }
+    return Object.freeze({
+      kind: "claimed" as const,
+      admission: admissionFor({
+        backup: claimed,
+        execution: laneClaim.execution,
+        sourceNodeHistoryId: source.sourceNodeHistoryId,
+      }),
+    });
+  });
+}
+
+/** Renew the global and catalogue leases atomically; never shorten either. */
+export async function renewAgentBackupOperationAdmission(params: {
+  readonly admission: AgentBackupOperationAdmission;
+  readonly leaseMs: number;
+}): Promise<AgentBackupOperationAdmission> {
+  const input = params.admission;
+  if (!input?.claim?.backup || !input.laneExecution || !input.sourceNodeHistoryId) {
+    throw admissionLost("Admission is missing its exact catalogue and lane authorities");
+  }
+  const target = targetFor(input.claim.backup);
+  const execution = Object.freeze({
+    ownerId: input.laneExecution.ownerId,
+    generation: input.laneExecution.generation,
+    claimSequence: input.laneExecution.claimSequence,
+  });
+  const sourceNodeHistoryId = input.sourceNodeHistoryId;
+  const leaseMs = normalizeAgentBackupOperationLaneLeaseMs(params.leaseMs);
+
+  return dbWrite.transaction(async (tx) => {
+    const renewedProof = await renewAgentBackupOperationLaneInTransaction(tx, {
+      ...target,
+      execution,
+      leaseMs,
+    });
+    const backup = await lockBackupByTargetInTransaction(tx, target);
+    if (
+      backup.catalog_lease_owner !== execution.ownerId ||
+      backup.catalog_lease_generation !== execution.generation ||
+      !(backup.catalog_lease_expires_at instanceof Date) ||
+      backup.catalog_lease_expires_at.getTime() <= renewedProof.databaseNow.getTime()
+    ) {
+      throw admissionLost("Catalogue lease was lost before atomic admission renewal");
+    }
+    const source = await lockExactSourceAuthorityInTransaction(tx, backup);
+    if (source.sourceNodeHistoryId !== sourceNodeHistoryId) {
+      throw admissionLost("Backup source occurrence changed before admission renewal");
+    }
+    const currentProof = await refreshAgentBackupOperationLaneProofInTransaction(tx, renewedProof);
+    const laneExpiry = exactLeaseExpiry(currentProof.lane, "Renewed admission");
+    const [renewed] = await tx
+      .update(agentSandboxBackups)
+      .set({
+        catalog_lease_expires_at: laneExpiry,
+        catalog_updated_at: currentProof.databaseNow,
+      })
+      .where(
+        and(
+          eq(agentSandboxBackups.id, target.backupId),
+          eq(agentSandboxBackups.catalog_organization_id, target.organizationId),
+          eq(agentSandboxBackups.backup_operation_id, target.operationId),
+          eq(agentSandboxBackups.catalog_lease_owner, execution.ownerId),
+          eq(agentSandboxBackups.catalog_lease_generation, execution.generation),
+          gt(agentSandboxBackups.catalog_lease_expires_at, sql`clock_timestamp()`),
+          sql`(${agentSandboxBackups.catalog_state} IN ('scheduled', 'capturing')
+            OR (${agentSandboxBackups.catalog_state} = 'failed_retryable'
+              AND ${agentSandboxBackups.catalog_resume_state} IN ('scheduled', 'capturing')))`,
+        ),
+      )
+      .returning();
+    if (!renewed) throw admissionLost("Catalogue lease was lost during atomic admission renewal");
+    await refreshAgentBackupOperationLaneProofInTransaction(tx, currentProof);
+    return admissionFor({
+      backup: renewed,
+      execution,
+      sourceNodeHistoryId,
+    });
+  });
+}

--- a/packages/cloud/shared/src/db/repositories/agent-backup-operation-lane.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-backup-operation-lane.ts
@@ -270,6 +270,18 @@ function snapshotCallerToken(
   });
 }
 
+/** Validate and detach a caller token before a coordinator crosses an await. */
+export function normalizeAgentBackupOperationLaneCallerToken(
+  token: AgentBackupOperationLaneCallerToken,
+): Readonly<AgentBackupOperationLaneCallerToken> {
+  return snapshotCallerToken(token);
+}
+
+/** Share the lane's exact lease bounds with atomic admission coordinators. */
+export function normalizeAgentBackupOperationLaneLeaseMs(value: unknown): number {
+  return requireLeaseMs(value);
+}
+
 function snapshotExecution(
   execution: AgentBackupOperationLaneExecution,
 ): Readonly<AgentBackupOperationLaneExecution> {


### PR DESCRIPTION
Relates to #24407
Epic: #20726

Stacked on #28786 at exact parent `01a44833fd67bc2537d5d5454e80ba6bd07eaceb`.

## What this does

- Atomically admits the next capture operation through the singleton backup operation lane.
- Binds capture authority to the exact live sandbox generation and immutable activation publication, including its exact node-history occurrence.
- Stamps the catalogue lease plus tenant and node fairness watermarks with one database-clock expiry.
- Supports exact replay and non-shortening renewal while fencing A/B/A caller-token cycles with `claimSequence`.
- Fails closed on sandbox, activation, token, funding, provider, node, or history drift and can skip a poisoned earlier catalogue row.
- Preserves the global lock order and intentionally does not row-lock the immutable activation publication.

## Scope boundaries

This split covers capture admission only. It does not wire the runtime worker, enable feature gates, create nodes, call providers, autoscale, deploy, or touch staging/production. Detached publication, verification, garbage collection, cohort/fairness scheduling, restore, and failover remain follow-up splits.

## Validation

- Admission PGlite: 11/11 tests, 72 assertions
- Global lock-order: 6/6 tests, 54 assertions
- Parent lane lifecycle: 12/12 tests, 109 assertions
- Parent migration: 5/5 tests, 19 assertions
- Cloud shared TypeScript: pass
- Targeted Biome: pass
- `git diff --check`: pass
- Exact-head adversarial review: CLEAN, no P0-P3 findings

Exact head: `22376786a933480fb4bf3b453dc11e62dc7c5996`

## Known limitation

PGlite validates transactional behavior in one embedded session; it is not evidence of real PostgreSQL multi-connection interleavings. That proof remains required before runtime activation.

## Deployment

None. This PR remains Draft and no runtime/deployment gate is changed.