### PR TITLE
fix(plugin-instagram): keep UTF-16 surrogate pairs intact in comment truncation

### DIFF
--- a/plugins/plugin-instagram/src/__tests__/accounts.test.ts
+++ b/plugins/plugin-instagram/src/__tests__/accounts.test.ts
@@ -311,4 +311,38 @@ describe("Instagram connector accounts", () => {
       expect(postComment).not.toHaveBeenCalled();
     }
   );
+
+  it("preserves UTF-16 surrogate pairs in comment truncation", async () => {
+    const service = Object.create(InstagramService.prototype) as InstagramService;
+    let postedComment = "";
+    const postComment = vi.fn(async (_id: string, text: string) => {
+      postedComment = text;
+      return "123";
+    });
+    Object.assign(service, {
+      defaultAccountId: "default",
+      instagramConfig: { accountId: "default", username: "user", password: "password" },
+      isRunning: true,
+      postComment,
+    });
+
+    const runtime = { agentId: "00000000-0000-0000-0000-000000000001" } as IAgentRuntime;
+    // "🔥" is 2 code units. 600 repeats = 1200 code units > MAX_COMMENT_LENGTH (1000)
+    const longEmoji = "🔥".repeat(600);
+    await service.handleSendPost(runtime, {
+      text: longEmoji,
+      metadata: { mediaId: "123" },
+    } as Content);
+
+    expect(postComment).toHaveBeenCalled();
+    expect(postedComment.endsWith("...")).toBe(true);
+    expect(postedComment.length).toBe(999);
+    for (const char of postedComment) {
+      expect(
+        /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(
+          char,
+        ),
+      ).toBe(false);
+    }
+  });
 });

--- a/plugins/plugin-instagram/src/service.ts
+++ b/plugins/plugin-instagram/src/service.ts
@@ -138,8 +138,22 @@ function getInstagramTargetMetadata(target: TargetInfo): Record<string, unknown>
     : undefined;
 }
 
+function truncateUtf16Safe(text: string, maxLength: number): string {
+  if (text.length <= maxLength) return text;
+  let end = maxLength;
+  if (end > 0 && end < text.length) {
+    const code = text.charCodeAt(end - 1);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      end -= 1;
+    }
+  }
+  return text.slice(0, end);
+}
+
 function truncateInstagramComment(text: string): string {
-  return text.length > MAX_COMMENT_LENGTH ? `${text.slice(0, MAX_COMMENT_LENGTH - 3)}...` : text;
+  return text.length > MAX_COMMENT_LENGTH
+    ? `${truncateUtf16Safe(text, MAX_COMMENT_LENGTH - 3)}...`
+    : text;
 }
 
 function getInstagramPostMetadata(content: Content): Record<string, unknown> {


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:091f9ccdc5b1b124d9f5c24d4df092d4feef487b -->

## Summary
In `plugins/plugin-instagram/src/service.ts`:
`truncateInstagramComment` clamps long comments exceeding `MAX_COMMENT_LENGTH` (1000 characters) using `${text.slice(0, MAX_COMMENT_LENGTH - 3)}...`.

When comments contain multi-byte UTF-16 surrogate pairs (e.g. emojis or astral plane unicode characters), slicing at raw character offset 997 can split a surrogate pair in half, producing orphaned surrogate characters (`\uFFFD`).

## Proposed Changes
1. Added `truncateUtf16Safe` helper with surrogate boundary back-off in `plugins/plugin-instagram/src/service.ts`.
2. Applied `truncateUtf16Safe` in `truncateInstagramComment`.
3. Added unit tests in `plugins/plugin-instagram/src/__tests__/accounts.test.ts`.

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-instagram test src/__tests__/accounts.test.ts` (23/23 passed).

<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-3-5-sonnet","client":"antigravity","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
