### PR TITLE
fix(plugin-google-workspace): keep UTF-16 surrogate pairs intact in meet summary and gmail subject truncation

### DIFF
--- a/plugins/plugin-google-workspace/src/gmail-message-connector.test.ts
+++ b/plugins/plugin-google-workspace/src/gmail-message-connector.test.ts
@@ -358,4 +358,33 @@ describe("isEmailAddress", () => {
     expect(isEmailAddress("shadow@localhost")).toBe(false);
     expect(isEmailAddress(42)).toBe(false);
   });
+
+  it("preserves UTF-16 surrogate pairs in derived subject truncation", async () => {
+    const { runtime, sendGmailMessage } = runtimeStub({
+      accounts: [CONNECTED_ACCOUNT],
+    });
+    const registration = createGmailMessageConnector(runtime);
+
+    // "🔥" is 2 code units. 70 repeats = 140 units > SUBJECT_MAX_LENGTH (120)
+    const longEmoji = "🔥".repeat(70);
+    await invokeSend(
+      registration,
+      runtime,
+      { channelId: "shadow@example.com" },
+      { text: longEmoji }
+    );
+
+    expect(sendGmailMessage).toHaveBeenCalled();
+    const callArgs = sendGmailMessage.mock.calls[0][0];
+    const subject = callArgs.subject;
+    expect(subject.endsWith("...")).toBe(true);
+    expect(subject.length).toBe(77);
+    for (const char of subject) {
+      expect(
+        /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(
+          char,
+        ),
+      ).toBe(false);
+    }
+  });
 });

--- a/plugins/plugin-google-workspace/src/gmail-message-connector.ts
+++ b/plugins/plugin-google-workspace/src/gmail-message-connector.ts
@@ -1,3 +1,15 @@
+function truncateUtf16Safe(text: string, maxLength: number): string {
+  if (text.length <= maxLength) return text;
+  let end = maxLength;
+  if (end > 0 && end < text.length) {
+    const code = text.charCodeAt(end - 1);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      end -= 1;
+    }
+  }
+  return text.slice(0, end);
+}
+
 /**
  * Gmail send-target MessageConnector: advertises Gmail as a cross-connector
  * send surface so `MESSAGE op=send source=gmail` (aliases "email"/"mail") and
@@ -170,7 +182,7 @@ function subjectFromContent(content: Content): string {
     .trim();
   return firstLine.length <= SUBJECT_MAX_LENGTH
     ? firstLine
-    : `${firstLine.slice(0, SUBJECT_MAX_LENGTH - 3)}...`;
+    : `${truncateUtf16Safe(firstLine, SUBJECT_MAX_LENGTH - 3)}...`;
 }
 
 async function sendGmailFromTarget(

--- a/plugins/plugin-google-workspace/src/meet.canonical-artifact.test.ts
+++ b/plugins/plugin-google-workspace/src/meet.canonical-artifact.test.ts
@@ -8,6 +8,7 @@ import {
   buildGoogleMeetCanonicalArtifact,
   classifyGoogleMeetImportError,
   GoogleMeetClient,
+  summarizeTranscript,
 } from "./meet.js";
 
 const CONFERENCE_RECORD = "conferenceRecords/conf_1";
@@ -375,5 +376,31 @@ describe("Google Meet canonical artifact mapping", () => {
       })
     ).rejects.toMatchObject({ code: "GOOGLE_MEET_PAGE_LIMIT_EXCEEDED" });
     expect(list).toHaveBeenCalledTimes(1_000);
+  });
+
+
+  it("preserves UTF-16 surrogate pairs in meet fallback summary truncation", () => {
+    // "🔥" is 2 code units. 300 repeats without punctuation is 600 units > 500
+    const longEmoji = "🔥".repeat(300);
+    const result = summarizeTranscript([
+      {
+        id: "entry-1",
+        speakerName: "Alice",
+        speakerId: PARTICIPANT,
+        text: longEmoji,
+        startTime: "2026-07-04T14:02:00.000Z",
+        endTime: "2026-07-04T14:02:05.000Z",
+        languageCode: "en-US",
+      },
+    ]);
+
+    expect(result.summary.length).toBe(500);
+    for (const char of result.summary) {
+      expect(
+        /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(
+          char,
+        ),
+      ).toBe(false);
+    }
   });
 });

--- a/plugins/plugin-google-workspace/src/meet.ts
+++ b/plugins/plugin-google-workspace/src/meet.ts
@@ -1,3 +1,15 @@
+function truncateUtf16Safe(text: string, maxLength: number): string {
+  if (text.length <= maxLength) return text;
+  let end = maxLength;
+  if (end > 0 && end < text.length) {
+    const code = text.charCodeAt(end - 1);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      end -= 1;
+    }
+  }
+  return text.slice(0, end);
+}
+
 /**
  * `GoogleMeetClient` — Meet space management and conference-artifact reads
  * behind the workspace service: create/get/end spaces, and list participants,
@@ -562,7 +574,7 @@ function durationMinutes(conference: GoogleMeetConferenceRecord): number {
   return Math.max(0, Math.round((end - start) / 60000));
 }
 
-function summarizeTranscript(entries: readonly GoogleMeetTranscript[]): {
+export function summarizeTranscript(entries: readonly GoogleMeetTranscript[]): {
   summary: string;
   keyPoints: string[];
   actionItems: GoogleMeetReport["actionItems"];
@@ -581,7 +593,7 @@ function summarizeTranscript(entries: readonly GoogleMeetTranscript[]): {
     .split(/(?<=[.!?])\s+/)
     .map((sentence) => sentence.trim())
     .filter(Boolean);
-  const summary = sentences.slice(0, 3).join(" ") || plainText.slice(0, 500);
+  const summary = sentences.slice(0, 3).join(" ") || truncateUtf16Safe(plainText, 500);
   const keyPoints = lines.filter((line) => line.length >= 20).slice(0, 6);
   const actionItems = lines
     .filter((line) => /\b(action item|to[- ]?do|follow up|need to|will|should)\b/i.test(line))


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:d5411a7b740b92b3d1f46ff74cc379546ec26ef6 -->

## Summary
In `plugins/plugin-google-workspace`:
1. `meet.ts`: `summarizeTranscript` creates a plain text fallback summary by truncating unformatted transcripts longer than 500 characters using `plainText.slice(0, 500)`.
2. `gmail-message-connector.ts`: `subjectFromContent` derives email subjects from message text by truncating strings longer than `SUBJECT_MAX_LENGTH` (78 characters) using `${firstLine.slice(0, SUBJECT_MAX_LENGTH - 3)}...`.

When text contains multi-byte UTF-16 surrogate pairs (e.g. emojis or astral unicode symbols), raw character slicing can split a surrogate pair in half, producing orphaned surrogate characters (`\uFFFD`).

## Proposed Changes
1. Added `truncateUtf16Safe` helper with surrogate boundary back-off in `plugins/plugin-google-workspace/src/meet.ts` and `plugins/plugin-google-workspace/src/gmail-message-connector.ts`.
2. Applied `truncateUtf16Safe` across `summarizeTranscript` and `subjectFromContent`.
3. Added unit tests in `src/meet.canonical-artifact.test.ts` and `src/gmail-message-connector.test.ts`.

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-google-workspace test src/meet.canonical-artifact.test.ts` (7/7 passed).
- Ran vitest: `bun run --cwd plugins/plugin-google-workspace test src/gmail-message-connector.test.ts` (13/13 passed).

<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-3-5-sonnet","client":"antigravity","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
