### PR TITLE
fix(plugin-whatsapp): keep UTF-16 surrogate pairs intact in truncateText

### DIFF
--- a/plugins/plugin-whatsapp/src/normalize.test.ts
+++ b/plugins/plugin-whatsapp/src/normalize.test.ts
@@ -115,4 +115,20 @@ describe("text chunking", () => {
     expect(truncateText("short", 20)).toBe("short");
     expect(truncateText("abcdefghij", 5).length).toBeLessThanOrEqual(5);
   });
+
+  it("preserves UTF-16 surrogate pairs in truncateText", () => {
+    // "🔥" is 2 code units. 20 repeats = 40 units
+    const longEmoji = "🔥".repeat(20);
+    // maxLength 10 -> maxLength - 3 = 7 (odd). Should truncate to 6 units (3 emojis) + "..." = 9 chars
+    const result = truncateText(longEmoji, 10);
+    expect(result.endsWith("...")).toBe(true);
+    expect(result.length).toBe(9);
+    for (const char of result) {
+      expect(
+        /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(
+          char,
+        ),
+      ).toBe(false);
+    }
+  });
 });

--- a/plugins/plugin-whatsapp/src/normalize.ts
+++ b/plugins/plugin-whatsapp/src/normalize.ts
@@ -316,6 +316,18 @@ export function chunkWhatsAppText(text: string, opts: ChunkWhatsAppTextOpts = {}
 /**
  * Truncates text to a maximum length with ellipsis
  */
+function truncateUtf16Safe(text: string, maxLength: number): string {
+  if (text.length <= maxLength) return text;
+  let end = maxLength;
+  if (end > 0 && end < text.length) {
+    const code = text.charCodeAt(end - 1);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      end -= 1;
+    }
+  }
+  return text.slice(0, end);
+}
+
 export function truncateText(text: string, maxLength: number): string {
   if (text.length <= maxLength) {
     return text;
@@ -323,7 +335,7 @@ export function truncateText(text: string, maxLength: number): string {
   if (maxLength <= 3) {
     return "...".slice(0, maxLength);
   }
-  return `${text.slice(0, maxLength - 3)}...`;
+  return `${truncateUtf16Safe(text, maxLength - 3)}...`;
 }
 
 /**


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:afcd1dd0e33789d5c16dae4be70254f4ca9d0a0e -->

## Summary
In `plugins/plugin-whatsapp/src/normalize.ts`:
`truncateText` shortens strings longer than `maxLength` with an ellipsis using `${text.slice(0, maxLength - 3)}...`.

When text contains multi-byte UTF-16 surrogate pairs (e.g. emojis or astral unicode characters), slicing at character index `maxLength - 3` can bisect a surrogate pair in half, producing orphaned surrogate characters (`\uFFFD`).

## Proposed Changes
1. Added `truncateUtf16Safe` helper with surrogate boundary back-off in `plugins/plugin-whatsapp/src/normalize.ts`.
2. Applied `truncateUtf16Safe` inside `truncateText`.
3. Added unit tests in `plugins/plugin-whatsapp/src/normalize.test.ts`.

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-whatsapp test src/normalize.test.ts` (12/12 passed).

<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-3-5-sonnet","client":"antigravity","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
