### PR TITLE
fix(plugin-meetings): keep UTF-16 surrogate pairs intact in get-meeting-transcript clipping

### DIFF
--- a/plugins/plugin-meetings/src/actions/actions.test.ts
+++ b/plugins/plugin-meetings/src/actions/actions.test.ts
@@ -430,4 +430,52 @@ describe("GET_MEETING_TRANSCRIPT", () => {
     expect(await v(has.runtime, msg("hello there"), NO_STATE)).toBe(false);
     expect(await v(has.runtime, msg("show me the notes"), NO_STATE)).toBe(true);
   });
+
+  it("preserves UTF-16 surrogate pairs when clipping long transcripts", async () => {
+    // "🔥" is 2 code units. 2000 repeats = 4000 code units > MAX_REPLY_CHARS (3500)
+    // MAX_REPLY_CHARS is 3500 (even), but if text starts with an offset or emoji boundary
+    // let us use an odd prefix "a" + 2000 emojis so index 3500 lands inside a pair
+    const longEmoji = "a" + "🔥".repeat(2000);
+    const row = {
+      id: "trans-emoji",
+      content: {
+        text: "Alice: " + longEmoji,
+        transcript: JSON.stringify({
+          id: "trans-emoji",
+          status: "ready",
+          segments: [
+            {
+              id: "s1",
+              speakerLabel: "Alice",
+              startMs: 0,
+              endMs: 1000,
+              text: longEmoji,
+              words: [],
+            },
+          ],
+        }),
+      },
+      metadata: { type: "custom", source: "transcript" },
+    } as unknown as Memory;
+    const h = harness({
+      service: svc([session({ transcriptId: "trans-emoji" })]),
+      memories: { "trans-emoji": row },
+    });
+    const res = await getMeetingTranscriptAction.handler(
+      h.runtime,
+      msg("show the transcript"),
+      NO_STATE,
+      {},
+      h.cb,
+    );
+    expect(res.success).toBe(true);
+    expect(res.text).toContain("truncated");
+    for (const char of res.text) {
+      expect(
+        /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(
+          char,
+        ),
+      ).toBe(false);
+    }
+  });
 });

--- a/plugins/plugin-meetings/src/actions/get-meeting-transcript.ts
+++ b/plugins/plugin-meetings/src/actions/get-meeting-transcript.ts
@@ -1,3 +1,15 @@
+function truncateUtf16Safe(text: string, maxLength: number): string {
+  if (text.length <= maxLength) return text;
+  let end = maxLength;
+  if (end > 0 && end < text.length) {
+    const code = text.charCodeAt(end - 1);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      end -= 1;
+    }
+  }
+  return text.slice(0, end);
+}
+
 /**
  * `GET_MEETING_TRANSCRIPT` — return the (live or final) transcript text of a
  * meeting the bot attended. Targets the session named by URL/sessionId when
@@ -72,7 +84,7 @@ async function handler(
   }
   const clipped =
     text.length > MAX_REPLY_CHARS
-      ? `${text.slice(0, MAX_REPLY_CHARS)}\n… (truncated — open transcript ${transcript.id} in the Transcripts view for the full record)`
+      ? `${truncateUtf16Safe(text, MAX_REPLY_CHARS)}\n… (truncated — open transcript ${transcript.id} in the Transcripts view for the full record)`
       : text;
   return reply(
     callback,


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:873e6e7a0d888e77910b8c460d4aede2eb57b823 -->

## Summary
In `plugins/plugin-meetings/src/actions/get-meeting-transcript.ts`:
`handler` truncates long transcripts exceeding `MAX_REPLY_CHARS` (3500 characters) using `${text.slice(0, MAX_REPLY_CHARS)}\n… (truncated — open transcript ${transcript.id} in the Transcripts view for the full record)`.

When meeting transcripts contain multi-byte UTF-16 surrogate pairs (e.g. emojis or astral unicode characters), slicing at raw character index 3500 can bisect a surrogate pair in half, producing orphaned surrogate characters (`\uFFFD`).

## Proposed Changes
1. Added `truncateUtf16Safe` helper with surrogate boundary back-off in `plugins/plugin-meetings/src/actions/get-meeting-transcript.ts`.
2. Applied `truncateUtf16Safe` across transcript reply clipping.
3. Added unit tests in `plugins/plugin-meetings/src/actions/actions.test.ts`.

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-meetings test src/actions/actions.test.ts` (21/21 passed).

<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-3-5-sonnet","client":"antigravity","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
