### PR TITLE
fix(core): keep UTF-16 surrogate pairs intact in trajectory JSON string truncation

### DIFF
--- a/packages/core/src/services/trajectory-json.test.ts
+++ b/packages/core/src/services/trajectory-json.test.ts
@@ -21,4 +21,23 @@ describe("trajectory JSON normalization", () => {
 		);
 		expect(serialized).toContain('"reason":"global_budget"');
 	});
+
+	it("preserves UTF-16 surrogate pairs when truncating large strings", () => {
+		// "🔥" is 2 code units. 40,000 repeats = 80,000 units > 64 * 1024 (65536)
+		// TRAJECTORY_JSON_MAX_STRING_CHARS = 65536
+		// TRAJECTORY_JSON_TRUNCATION_SUFFIX = "...[truncated]" (15 chars)
+		// previewLength = 65536 - 15 = 65521 (odd). Slicing at 65521 bisects a surrogate pair.
+		const longEmoji = "🔥".repeat(40_000);
+		const sanitized = sanitizeTrajectoryJsonObject({ text: longEmoji });
+		expect(sanitized).toBeDefined();
+		const result = sanitized!.text as string;
+		expect(result.endsWith("...[truncated]")).toBe(true);
+		for (const char of result) {
+			expect(
+				/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(
+					char,
+				),
+			).toBe(false);
+		}
+	});
 });

--- a/packages/core/src/services/trajectory-json.ts
+++ b/packages/core/src/services/trajectory-json.ts
@@ -24,13 +24,25 @@ export type SanitizationState = {
 	exhausted: boolean;
 };
 
+function truncateUtf16Safe(text: string, maxLength: number): string {
+	if (text.length <= maxLength) return text;
+	let end = maxLength;
+	if (end > 0 && end < text.length) {
+		const code = text.charCodeAt(end - 1);
+		if (code >= 0xd800 && code <= 0xdbff) {
+			end -= 1;
+		}
+	}
+	return text.slice(0, end);
+}
+
 function truncateTrajectoryString(value: string): string {
 	if (value.length <= TRAJECTORY_JSON_MAX_STRING_CHARS) return value;
 	const previewLength = Math.max(
 		0,
 		TRAJECTORY_JSON_MAX_STRING_CHARS - TRAJECTORY_JSON_TRUNCATION_SUFFIX.length,
 	);
-	return `${value.slice(0, previewLength)}${TRAJECTORY_JSON_TRUNCATION_SUFFIX}`;
+	return `${truncateUtf16Safe(value, previewLength)}${TRAJECTORY_JSON_TRUNCATION_SUFFIX}`;
 }
 
 function jsonByteLength(value: JsonValue): number {


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:3002bda141998647f48915d05d33870b4835aba6 -->

## Summary
In `packages/core/src/services/trajectory-json.ts`:
`truncateTrajectoryString` truncates large string values exceeding `TRAJECTORY_JSON_MAX_STRING_CHARS` (64 KB) using `${value.slice(0, previewLength)}${TRAJECTORY_JSON_TRUNCATION_SUFFIX}`.

Because `previewLength = 65536 - 15 = 65521` is an odd index, slicing at character offset 65521 bisects UTF-16 surrogate pairs (e.g. emojis or astral symbols) in half, resulting in malformed unicode containing unpaired surrogate code points (`\uFFFD`).

## Proposed Changes
1. Added `truncateUtf16Safe` with surrogate boundary back-off in `packages/core/src/services/trajectory-json.ts`.
2. Applied `truncateUtf16Safe` inside `truncateTrajectoryString`.
3. Added unit tests in `packages/core/src/services/trajectory-json.test.ts`.

## Verification
- Ran vitest: `bun run --cwd packages/core test src/services/trajectory-json.test.ts` (2/2 passed).

<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-3-5-sonnet","client":"antigravity","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
