### PR TITLE
fix(scenario-runner): stop truncating trajectory reports at 500 files

### DIFF
--- a/packages/scenario-runner/src/reporter.test.ts
+++ b/packages/scenario-runner/src/reporter.test.ts
@@ -801,4 +801,35 @@ describe("trajectory cost aggregation", () => {
     expect(report.totalCostUsd).toBeCloseTo(0.0421, 10);
     expect(report.totals.costUsd).toBeCloseTo(0.0421, 10);
   });
+
+  it("includes every trajectory in aggregate cost and viewer data beyond 500 files", () => {
+    const runDir = makeTempDir("scenario-cost-many-");
+    for (let index = 0; index < 600; index += 1) {
+      writeTrajectory(runDir, `agent-1/trajectory-${index}.json`, {
+        trajectoryId: `trajectory-${index}`,
+        scenarioId: "todos.create-basic",
+        metrics: { totalCostUsd: 0.01 },
+        stages: [],
+      });
+    }
+
+    const report = buildAggregate(
+      [{ ...aggregateReport().scenarios[0] }],
+      "anthropic-claude",
+      "2026-05-23T00:00:00.000Z",
+      "2026-05-23T00:01:00.000Z",
+      "run-many-trajectories",
+      runDir,
+    );
+    const { viewerData } = writeScenarioRunViewer(report, runDir);
+    const data = readFileSync(viewerData, "utf-8");
+    const payload = JSON.parse(
+      data.replace(/^window\.SCENARIO_RUN_DATA = /, "").replace(/;\n?$/, ""),
+    );
+
+    expect(report.totalCostUsd).toBeCloseTo(6, 6);
+    expect(report.totals.costUsd).toBeCloseTo(6, 6);
+    expect(payload.trajectories.files).toHaveLength(600);
+    expect(payload.trajectories.summaries).toHaveLength(600);
+  });
 });

--- a/packages/scenario-runner/src/reporter.ts
+++ b/packages/scenario-runner/src/reporter.ts
@@ -1050,11 +1050,10 @@ function readJsonlFile(filePath: string, maxRows = 5_000): unknown[] {
   }
 }
 
-function collectFiles(rootDir: string, maxFiles = 500): string[] {
+function collectFiles(rootDir: string): string[] {
   if (!existsSync(rootDir)) return [];
   const out: string[] = [];
   const walk = (dir: string): void => {
-    if (out.length >= maxFiles) return;
     for (const name of readdirSync(dir).sort()) {
       const full = path.join(dir, name);
       let stat: ReturnType<typeof statSync>;
@@ -1068,7 +1067,6 @@ function collectFiles(rootDir: string, maxFiles = 500): string[] {
         continue;
       }
       if (stat.isFile()) out.push(full);
-      if (out.length >= maxFiles) return;
     }
   };
   walk(rootDir);


### PR DESCRIPTION
# Defect

Scenario reports silently stopped walking trajectory files after the first 500 entries. As a result, `matrix.json.totalCostUsd` and the run viewer presented partial data as complete: a 600-trajectory run costing $0.01 per trajectory reported about $5.00 instead of $6.00, and the viewer omitted 100 trajectories.

This removes the silent file-walk cap at the shared reporter boundary used by both cost aggregation and viewer payload construction. The regression creates 600 production-format trajectory files and locks both outputs: aggregate cost must be $6.00 and viewer files/summaries must each contain 600 entries.

No issue is linked; the operator supplied this independently reproduced defect directly.

# Sync with develop

- [x] Rebased onto `origin/develop` at `69c0291954942c9ae375fe5aacc82729a24bac6f`; zero conflicts.
- [x] Validated commit: `af2127bc95ea0abe1abfb8ef5d79cf6f9adb1f43`.
- [x] `bun run verify` was run post-sync; its untouched-control failure is documented below.

# Risks

Low. The change removes an undocumented completeness limit from a synchronous filesystem walk. Very large run viewers can now consume memory proportional to the complete trajectory set, which matches the existing contract that the viewer and cost totals represent the whole run.

# Background

## What does this PR do?

It changes `collectFiles` from a silently capped walk to a complete walk. That function feeds both `sumTrajectoryCostUsd` and `buildScenarioViewerPayload`, so the same minimal production change fixes the understated spend and missing viewer entries together.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No. This restores the documented behavior that report totals reflect the recorded run; it does not add or change an operator-facing contract.

# Testing

## Where should a reviewer start?

Run the reporter regression in `packages/scenario-runner/src/reporter.test.ts`, then inspect `collectFiles` in `packages/scenario-runner/src/reporter.ts`.

## Failing reproduction before the change

The handed-off scratch file was absent, so I reconstructed it at the named production boundary. It wrote 600 files under `trajectories/agent-1`, each with `metrics.totalCostUsd = 0.01`, and called `sumTrajectoryCostUsd`.

```text
$ bunx vitest run --config vitest.config.ts --maxWorkers=2 src/zzz-scratch-cost-cap.test.ts

 RUN  v4.1.10 [REDACTED:LOCAL_PATH]/packages/scenario-runner

stdout | src/zzz-scratch-cost-cap.test.ts > includes every trajectory when a run contains more than 500 files
observed totalCostUsd = 4.999999999999938 expected = 6

 ❯ src/zzz-scratch-cost-cap.test.ts (1 test | 1 failed) 82ms
   × includes every trajectory when a run contains more than 500 files 82ms

AssertionError: expected 4.999999999999938 to be close to 6, received difference is 1.0000000000000622, but expected 5e-7

 Test Files  1 failed (1)
      Tests  1 failed (1)
```

## Passing reproduction after the change

```text
$ bunx vitest run --config vitest.config.ts --maxWorkers=2 src/zzz-scratch-cost-cap.test.ts

 RUN  v4.1.10 [REDACTED:LOCAL_PATH]/packages/scenario-runner

 Test Files  1 passed (1)
      Tests  1 passed (1)
```

The scratch file was then removed; the equivalent guard remains in `reporter.test.ts`.

## Regression fails without only the production fix

I reverted only the `collectFiles` production change, retained the regression, and ran:

```text
$ bunx vitest run --config vitest.config.ts --maxWorkers=2 src/reporter.test.ts -t "includes every trajectory in aggregate cost and viewer data beyond 500 files"

AssertionError: expected 4.999999999999938 to be close to 6, received difference is 1.0000000000000622, but expected 5e-7

 Test Files  1 failed (1)
      Tests  1 failed | 20 skipped (21)
```

I restored the production fix afterward.

## Final focused result

```text
$ bunx vitest run --config vitest.config.ts --maxWorkers=2 [FULL_PATH]/packages/scenario-runner/src/reporter.test.ts

 Test Files  1 passed (1)
      Tests  21 passed (21)
```

## Owning-package suite and untouched control

The full source lane used the package config and absolute package path, capped at two workers. The fixed head added exactly one passing regression while preserving the same unrelated failures as the untouched base:

```text
fixed head:
 Test Files  5 failed | 61 passed (66)
      Tests  3 failed | 667 passed | 27 skipped (697)

untouched control at 69c0291954942c9ae375fe5aacc82729a24bac6f:
 Test Files  5 failed | 61 passed (66)
      Tests  3 failed | 666 passed | 27 skipped (696)
```

The mocks lane passed identically on both:

```text
 Test Files  4 passed (4)
      Tests  19 passed (19)
```

# Evidence Gate

Evidence matches commit `af2127bc95ea0abe1abfb8ef5d79cf6f9adb1f43`.
<!-- evidence-head:af2127bc95ea0abe1abfb8ef5d79cf6f9adb1f43 -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - no rendered UI files or visual surfaces changed.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - no rendered UI files or visual surfaces changed.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - this is a filesystem report-generation defect with no interactive UI flow.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - no server boundary is involved; the verbatim production reporter output is included above.
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: N/A - no frontend request or state path changed.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact: the inline before/after output above records the generated aggregate value for 600 persisted trajectory JSON files, and the retained test also inspects the generated viewer payload.
<!-- evidence-row:ocr-review -->
- [x] OCR review: N/A - no rendered visual surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no model-facing behavior changed.

## Backend + frontend logs

N/A - the affected boundary is synchronous report generation over persisted trajectory files. Verbatim command output is included in Testing.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, TTS, or STT change.

## Known gaps / failures

- `bun install` was not run because the operator explicitly stated dependencies were already installed and prohibited running it. Existing installed workspace dependency directories were linked into the isolated worktrees.
- `bunx tsc --noEmit` exits 1 with 133 errors on both the fixed head and untouched control. After normalizing checkout paths, `diff` exits 0: zero new TypeScript errors.
- The owning source suite has the identical five failing files / three failing tests on fixed and untouched heads. They are two suites blocked on missing `@radix-ui/react-radio-group`, plus stale assertions in `cerebras-judge`, `corpus-assertion-guard`, and `runtime-factory`. The fixed head has one additional passing test.
- `bun run verify` exits 1 on both fixed and untouched heads at `@elizaos/plugin-x#build`, whose declaration generation cannot resolve current `@elizaos/core` exports from the shared installed artifacts. The fixed run stopped after 157 of 189 tasks; the control reproduced the same failing package. The handed-off note predicted a later `node-swiftlint` failure, but this machine did not reach that gate, so this PR does not claim it.
- Signed trace finalization was attempted with the exact inspected 7,124-byte NDJSON file (SHA-256 `07282eb03bc578c36585d79e9feab25942e15b4f5e0d748c046b5264fdc2bc75`). It could not complete: `project run receipt failed: Slop identity poll returned HTTP 410`. This PR is therefore published unmeasured.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: codex
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-eliza
Attribution status: self-reported
— [codex-scenario-cost-cap]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-eliza"} -->
