### PR TITLE
fix(core): keep UTF-16 surrogate pairs intact in message relay and speaker name truncation

### DIFF
--- a/packages/core/src/services/message.preserved-tool-result.test.ts
+++ b/packages/core/src/services/message.preserved-tool-result.test.ts
@@ -317,6 +317,23 @@ describe("subAgentCompletionRelayBody parsing (#18208)", () => {
 		expect(capped).toMatch(/…$/);
 	});
 
+	
+	it("preserves UTF-16 surrogate pairs in subAgentCompletionRelayBody truncation", () => {
+		// "🔥" is 2 code units. 1000 repeats = 2000 units > 1500
+		// maxLength - 1 = 1499 (odd), bisecting a surrogate pair
+		const longEmoji = "🔥".repeat(1000);
+		const capped = subAgentCompletionRelayBody(`${RELAY_HEADER}\n${longEmoji}`);
+		expect(capped).toBeDefined();
+		expect(capped).toMatch(/…$/);
+		for (const char of capped as string) {
+			expect(
+				/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(
+					char,
+				),
+			).toBe(false);
+		}
+	});
+
 	it("a failed relay turn delivers the completed result instead of the canned line", async () => {
 		// Same failing-turn harness as above (tool result carries nothing
 		// user-facing, every later model call dies) — but the TRIGGERING message

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -1,3 +1,15 @@
+function truncateUtf16Safe(text: string, maxLength: number): string {
+	if (text.length <= maxLength) return text;
+	let end = maxLength;
+	if (end > 0 && end < text.length) {
+		const code = text.charCodeAt(end - 1);
+		if (code >= 0xd800 && code <= 0xdbff) {
+			end -= 1;
+		}
+	}
+	return text.slice(0, end);
+}
+
 /**
  * Built-in `DefaultMessageService` (the runtime's `IMessageService` singleton) and
  * the helpers it composes, implementing the full inbound-message pipeline: memory
@@ -1883,7 +1895,7 @@ export function subAgentCompletionRelayBody(
 	if (!body) return undefined;
 	const maxLength = 1500;
 	return body.length > maxLength
-		? `${body.slice(0, maxLength - 1).trimEnd()}…`
+		? `${truncateUtf16Safe(body, maxLength - 1).trimEnd()}…`
 		: body;
 }
 
@@ -2225,7 +2237,7 @@ function cleanPriorDialogueSpeakerName(value: unknown): string | undefined {
 	if (typeof value !== "string") return undefined;
 	const normalized = value.trim().split(/\s+/).join(" ");
 	if (!normalized) return undefined;
-	return normalized.length > 80 ? `${normalized.slice(0, 77)}...` : normalized;
+	return normalized.length > 80 ? `${truncateUtf16Safe(normalized, 77)}...` : normalized;
 }
 
 function senderIdentityName(value: unknown): string | undefined {


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:585ff7af19b6f566ce396f4bfba5955b96f4e4ea -->

## Summary
In `packages/core/src/services/message.ts`:
1. `subAgentCompletionRelayBody` caps runaway delegated task completion result bodies at 1500 characters using `${body.slice(0, maxLength - 1).trimEnd()}…`.
2. `cleanPriorDialogueSpeakerName` normalizes and limits speaker names longer than 80 characters using `${normalized.slice(0, 77)}...`.

When strings contain astral plane UTF-16 surrogate pairs (such as emojis or complex symbols), character slicing at odd index boundaries can split surrogate code points in half, resulting in malformed unicode containing unpaired surrogate code points (`\uFFFD`).

## Proposed Changes
1. Added `truncateUtf16Safe` with surrogate boundary back-off in `packages/core/src/services/message.ts`.
2. Applied `truncateUtf16Safe` inside `subAgentCompletionRelayBody` and `cleanPriorDialogueSpeakerName`.
3. Added unit tests in `packages/core/src/services/message.preserved-tool-result.test.ts`.

## Verification
- Ran vitest: `bun run --cwd packages/core test src/services/message.preserved-tool-result.test.ts` (15/15 passed).

<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-3-5-sonnet","client":"antigravity","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
