### PR TITLE
fix(plugin-github): keep UTF-16 surrogate pairs intact in PR and issue body previews

### DIFF
--- a/plugins/plugin-github/src/action-helpers.test.ts
+++ b/plugins/plugin-github/src/action-helpers.test.ts
@@ -6,6 +6,7 @@ import {
   requireString,
   requireStringArray,
   splitRepo,
+  truncateUtf16Safe,
 } from "./action-helpers.ts";
 
 /**
@@ -139,3 +140,21 @@ describe("isConfirmed", () => {
     expect(isConfirmed(undefined)).toBe(false);
   });
 });
+
+describe("truncateUtf16Safe", () => {
+  it("preserves UTF-16 surrogate pairs during truncation", () => {
+    // "🔥" is 2 code units. 70 repeats = 140 units > 120
+    // Slicing at odd offset e.g. 119 will back off to 118
+    const longEmoji = "🔥".repeat(70);
+    const result = truncateUtf16Safe(longEmoji, 119);
+    expect(result.length).toBe(118);
+    for (const char of result) {
+      expect(
+        /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(
+          char,
+        ),
+      ).toBe(false);
+    }
+  });
+});
+

--- a/plugins/plugin-github/src/action-helpers.ts
+++ b/plugins/plugin-github/src/action-helpers.ts
@@ -269,3 +269,15 @@ export function describeSelection(selection: GitHubAccountSelection): string {
     ? `${selection.role} (${selection.accountId})`
     : selection.role;
 }
+
+export function truncateUtf16Safe(text: string, maxLength: number): string {
+  if (text.length <= maxLength) return text;
+  let end = maxLength;
+  if (end > 0 && end < text.length) {
+    const code = text.charCodeAt(end - 1);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      end -= 1;
+    }
+  }
+  return text.slice(0, end);
+}

--- a/plugins/plugin-github/src/actions/issue-op.ts
+++ b/plugins/plugin-github/src/actions/issue-op.ts
@@ -279,7 +279,7 @@ function buildPreview(
       case "label":
         return ` with [${labels?.join(", ") ?? ""}]`;
       case "comment":
-        return body ? ` body: "${body.slice(0, 120)}"` : "";
+        return body ? ` body: "${truncateUtf16Safe(body, 120)}"` : "";
       default:
         return "";
     }

--- a/plugins/plugin-github/src/actions/pr-op.ts
+++ b/plugins/plugin-github/src/actions/pr-op.ts
@@ -177,7 +177,7 @@ async function runReview(
 
   const preview =
     `About to ${action.replace("-", " ")} PR ${repo}#${number}` +
-    (body ? ` with body: "${body.slice(0, 120)}"` : "") +
+    (body ? ` with body: "${truncateUtf16Safe(body, 120)}"` : "") +
     ` as ${describeSelection(selection)}.`;
   const decision = await requireConfirmation({
     runtime,


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:3abf6dd085797d98400ec91b4b0cadc1774f3496 -->

## Summary
In `plugins/plugin-github`:
1. `src/actions/pr-op.ts`: `runReview` generates interactive confirmation prompts for pull request review actions using `body.slice(0, 120)`.
2. `src/actions/issue-op.ts`: `buildPreview` formats confirmation previews for issue comments using `body.slice(0, 120)`.

When pull request or issue comment bodies contain multi-byte UTF-16 surrogate pairs (e.g. emojis or astral unicode characters), slicing at index 120 can bisect a surrogate pair in half, producing orphaned surrogate characters (`\uFFFD`).

## Proposed Changes
1. Exported `truncateUtf16Safe` helper with surrogate boundary back-off in `plugins/plugin-github/src/action-helpers.ts`.
2. Applied `truncateUtf16Safe` in `plugins/plugin-github/src/actions/pr-op.ts` and `plugins/plugin-github/src/actions/issue-op.ts`.
3. Added unit tests in `plugins/plugin-github/src/action-helpers.test.ts`.

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-github test src/action-helpers.test.ts` (74/74 passed).

<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-3-5-sonnet","client":"antigravity","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
