### PR TITLE
fix(plugin-slack): keep UTF-16 surrogate pairs intact in truncateText

### DIFF
--- a/plugins/plugin-slack/src/formatting.test.ts
+++ b/plugins/plugin-slack/src/formatting.test.ts
@@ -525,3 +525,22 @@ describe("parseSlackMessageLink", () => {
     ).toBeNull();
   });
 });
+
+describe("truncateText", () => {
+  it("preserves UTF-16 surrogate pairs during truncation", () => {
+    // "🔥" is 2 code units. 20 repeats = 40 units
+    const longEmoji = "🔥".repeat(20);
+    // maxLength 10 -> maxLength - 1 (for ellipsis "…") = 9 (odd). Should truncate to 8 units (4 emojis) + "…" = 9 chars
+    const result = truncateText(longEmoji, 10);
+    expect(result.endsWith("…")).toBe(true);
+    expect(result.length).toBe(9);
+    for (const char of result) {
+      expect(
+        /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(
+          char,
+        ),
+      ).toBe(false);
+    }
+  });
+});
+

--- a/plugins/plugin-slack/src/formatting.ts
+++ b/plugins/plugin-slack/src/formatting.ts
@@ -479,6 +479,18 @@ export function isPrivateChannel(channel: SlackChannel): boolean {
 /**
  * Truncates text to a maximum length with an ellipsis
  */
+function truncateUtf16Safe(text: string, maxLength: number): string {
+  if (text.length <= maxLength) return text;
+  let end = maxLength;
+  if (end > 0 && end < text.length) {
+    const code = text.charCodeAt(end - 1);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      end -= 1;
+    }
+  }
+  return text.slice(0, end);
+}
+
 export function truncateText(
   text: string,
   maxLength: number,
@@ -487,7 +499,7 @@ export function truncateText(
   if (text.length <= maxLength) {
     return text;
   }
-  return text.slice(0, maxLength - ellipsis.length) + ellipsis;
+  return truncateUtf16Safe(text, maxLength - ellipsis.length) + ellipsis;
 }
 
 /**


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:e7c409f73bcc1e4f41e1facac0f69b72705f8053 -->

## Summary
In `plugins/plugin-slack/src/formatting.ts`:
`truncateText` shortens strings longer than `maxLength` with an ellipsis using `text.slice(0, maxLength - ellipsis.length) + ellipsis`.

When strings contain astral plane UTF-16 surrogate pairs (such as emojis or complex unicode characters), slicing at raw character index `maxLength - ellipsis.length` can bisect a surrogate pair in half, producing unpaired surrogate code points (`\uFFFD`).

## Proposed Changes
1. Added `truncateUtf16Safe` helper with surrogate boundary back-off in `plugins/plugin-slack/src/formatting.ts`.
2. Applied `truncateUtf16Safe` inside `truncateText`.
3. Added unit tests in `plugins/plugin-slack/src/formatting.test.ts`.

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-slack test src/formatting.test.ts` (64/64 passed).

<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-3-5-sonnet","client":"antigravity","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
