### PR TITLE
fix(plugin-discord): keep UTF-16 surrogate pairs intact in triage draft previews and draft stream display

### DIFF
--- a/plugins/plugin-discord/__tests__/triage-adapter.test.ts
+++ b/plugins/plugin-discord/__tests__/triage-adapter.test.ts
@@ -354,4 +354,34 @@ describe("DiscordTriageAdapter", () => {
 			),
 		).rejects.toThrow(/no cached draft/);
 	});
+
+	it("preserves UTF-16 surrogate pairs in draft preview clipping", async () => {
+		const service = createFakeDiscordService({
+			channels: [{ channelId: "c1" }],
+			messagesByChannel: {
+				c1: [discordMemory({ messageId: "88", channelId: "c1" })],
+			},
+		});
+		const adapter = new DiscordTriageAdapter();
+		const runtime = createRuntime(service);
+		await adapter.listMessages(runtime, {});
+
+		// "🔥" is 2 code units. 200 repeats = 400 units > 120
+		const longEmoji = "🔥".repeat(200);
+		const { preview } = await adapter.createDraft(runtime, {
+			source: "discord",
+			inReplyToId: "discord:88",
+			to: [{ identifier: "111222333444555666" }],
+			body: longEmoji,
+		});
+
+		expect(preview.endsWith("...")).toBe(true);
+		for (const char of preview) {
+			expect(
+				/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(
+					char,
+				),
+			).toBe(false);
+		}
+	});
 });

--- a/plugins/plugin-discord/draft-stream.ts
+++ b/plugins/plugin-discord/draft-stream.ts
@@ -1,3 +1,15 @@
+function truncateUtf16Safe(text: string, maxLength: number): string {
+	if (text.length <= maxLength) return text;
+	let end = maxLength;
+	if (end > 0 && end < text.length) {
+		const code = text.charCodeAt(end - 1);
+		if (code >= 0xd800 && code <= 0xdbff) {
+			end -= 1;
+		}
+	}
+	return text.slice(0, end);
+}
+
 /**
  * Streams an in-progress agent reply to Discord by editing a single message as
  * draft chunks arrive, using the draft-chunking break logic.
@@ -88,7 +100,7 @@ export function createDraftStreamController(
 
 		const displayText =
 			trimmed.length > maxChars
-				? `${trimmed.slice(0, maxChars - 3)}...`
+				? `${truncateUtf16Safe(trimmed, maxChars - 3)}...`
 				: trimmed;
 		if (displayText === lastSentText) {
 			if (components && components.length > 0 && lastSentMessage) {

--- a/plugins/plugin-discord/triage-adapter.ts
+++ b/plugins/plugin-discord/triage-adapter.ts
@@ -104,9 +104,21 @@ function metaString(
 	return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 
+function truncateUtf16Safe(text: string, maxLength: number): string {
+	if (text.length <= maxLength) return text;
+	let end = maxLength;
+	if (end > 0 && end < text.length) {
+		const code = text.charCodeAt(end - 1);
+		if (code >= 0xd800 && code <= 0xdbff) {
+			end -= 1;
+		}
+	}
+	return text.slice(0, end);
+}
+
 function clip(value: string, maxLength: number): string {
 	return value.length > maxLength
-		? `${value.slice(0, maxLength - 3)}...`
+		? `${truncateUtf16Safe(value, maxLength - 3)}...`
 		: value;
 }
 


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:bb2ce0f8e6163ba20f19c12c3ec533d78b1c330a -->

## Summary
In `plugins/plugin-discord`:
1. `triage-adapter.ts`: `clip` generates draft preview snippets by truncating bodies longer than `maxLength` (120 characters) using `${value.slice(0, maxLength - 3)}...`.
2. `draft-stream.ts`: `createDraftStreamController` formats in-progress draft replies longer than `maxChars` using `${trimmed.slice(0, maxChars - 3)}...`.

When message content contains multi-byte UTF-16 surrogate pairs (such as emojis or complex unicode characters), character slicing at index `maxLength - 3` can split a surrogate pair in half, producing orphaned surrogate characters (`\uFFFD`).

## Proposed Changes
1. Added `truncateUtf16Safe` helper with surrogate boundary back-off in `plugins/plugin-discord/triage-adapter.ts` and `plugins/plugin-discord/draft-stream.ts`.
2. Applied `truncateUtf16Safe` inside `clip` and `createDraftStreamController`.
3. Added unit tests in `plugins/plugin-discord/__tests__/triage-adapter.test.ts`.

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-discord test __tests__/triage-adapter.test.ts` (16/16 passed).

<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-3-5-sonnet","client":"antigravity","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
