### PR TITLE
fix(desktop): qualify persisted external runtime access

### DIFF
--- a/packages/app-core/platforms/electrobun/src/index.ts
+++ b/packages/app-core/platforms/electrobun/src/index.ts
@@ -132,7 +132,12 @@ import {
   resolveRendererAssetDir,
 } from "./runtime-layout";
 import { mergeRuntimePermissionStates } from "./runtime-permissions";
-import { resolveDesktopRuntimeForBoot } from "./runtime-preflight";
+import {
+  type DesktopRuntimeBootResolution,
+  resolveDesktopApiRequestToken,
+  resolveDesktopRuntimeForBoot,
+  resolveQualifiedExternalToken,
+} from "./runtime-preflight";
 import { startScreenCaptureBridgeServer } from "./screen-capture-bridge-server";
 import { startScreenshotDevServer } from "./screenshot-dev-server";
 import { registerShellSyncEndpoint } from "./shell-sync-relay";
@@ -241,13 +246,9 @@ onAgentReadyChange(() => setupApplicationMenu());
  * base resolves to `external` so the embedded agent is skipped; topology 1
  * (local agent → cloud inference) and topology 2 (all-local) keep `local`.
  */
-let preparedDesktopRuntime: ReturnType<
-  typeof resolveDesktopRuntimeModeWithDeployment
-> | null = null;
+let preparedDesktopRuntime: DesktopRuntimeBootResolution | null = null;
 
-function resolveDesktopRuntime(): ReturnType<
-  typeof resolveDesktopRuntimeModeWithDeployment
-> {
+function resolveDesktopRuntime(): DesktopRuntimeBootResolution {
   return (
     preparedDesktopRuntime ??
     resolveDesktopRuntimeModeWithDeployment(
@@ -264,17 +265,24 @@ function summarizeDesktopActionError(error: unknown, fallback: string): string {
   return trimmed.length > 80 ? `${trimmed.slice(0, 77)}...` : trimmed;
 }
 
-function buildApiRequestHeaders(contentType?: string): Record<string, string> {
+function buildApiRequestHeaders(
+  targetUrl: string,
+  contentType?: string,
+): Record<string, string> {
   const headers: Record<string, string> = {
     Accept: "application/json",
   };
   if (contentType) {
     headers["Content-Type"] = contentType;
   }
-  let apiToken = resolveApiToken(process.env);
+  const runtime = resolveDesktopRuntime();
+  let apiToken = resolveDesktopApiRequestToken({
+    resolution: runtime,
+    targetUrl,
+    configuredToken: resolveApiToken(process.env),
+  });
   if (!apiToken) {
-    const rt = resolveDesktopRuntime();
-    if (rt.mode === "local") {
+    if (runtime.mode === "local") {
       apiToken = configureDesktopLocalApiAuth().trim();
     }
   }
@@ -415,10 +423,11 @@ async function resetTheAppFromApplicationMenu(): Promise<void> {
       },
       getLocalApiAuthToken: () => configureDesktopLocalApiAuth(),
       postExternalAgentRestart: async () => {
+        const restartUrl = `${apiBase}/api/agent/restart`;
         try {
-          await fetch(`${apiBase}/api/agent/restart`, {
+          await fetch(restartUrl, {
             method: "POST",
-            headers: buildApiRequestHeaders(),
+            headers: buildApiRequestHeaders(restartUrl),
           });
         } catch {
           /* 409 / race while restarting — poll below */
@@ -848,7 +857,9 @@ async function startRendererServer(): Promise<string> {
   const initialApiToken =
     initialRuntime.mode === "local"
       ? configureDesktopLocalApiAuth()
-      : (resolveApiToken(process.env) ?? "");
+      : (resolveApiToken(process.env) ??
+        resolveQualifiedExternalToken(initialRuntime, initialApiBase) ??
+        "");
   apiBaseOwner.setCurrent(initialApiBase, initialApiToken);
 
   const resolveRendererCacheControl = (
@@ -1543,8 +1554,9 @@ async function exportConfigFromMenu(): Promise<void> {
   }
 
   try {
-    const response = await fetch(`${apiBase}/api/config`, {
-      headers: buildApiRequestHeaders(),
+    const configUrl = `${apiBase}/api/config`;
+    const response = await fetch(configUrl, {
+      headers: buildApiRequestHeaders(configUrl),
     });
     if (!response.ok) {
       throw new Error(`Config fetch failed (${response.status})`);
@@ -1611,9 +1623,10 @@ async function importConfigFromMenu(): Promise<void> {
       throw new Error("Config file must contain a JSON object");
     }
 
-    const response = await fetch(`${apiBase}/api/config`, {
+    const configUrl = `${apiBase}/api/config`;
+    const response = await fetch(configUrl, {
       method: "PUT",
-      headers: buildApiRequestHeaders("application/json"),
+      headers: buildApiRequestHeaders(configUrl, "application/json"),
       body: JSON.stringify(parsedConfig),
     });
     if (!response.ok) {
@@ -1846,9 +1859,14 @@ function injectApiBase(win: BrowserWindow): void {
     apiBaseOwner.notifyChange(
       win,
       runtimeResolution.externalApi.base,
-      resolveApiToken(process.env) ?? "",
+      resolveApiToken(process.env) ??
+        resolveQualifiedExternalToken(
+          runtimeResolution,
+          runtimeResolution.externalApi.base,
+        ) ??
+        "",
     );
-    setAgentReady(true);
+    setAgentReady(runtimeResolution.externalReachability !== "unavailable");
     return;
   }
 
@@ -2617,6 +2635,10 @@ async function main(): Promise<void> {
   ) {
     logger.warn(
       "[Main] Persisted external target is not a ready Eliza agent; using the embedded runtime for this launch without changing the saved deployment target.",
+    );
+  } else if (preparedDesktopRuntime.externalReachability === "unavailable") {
+    logger.warn(
+      "[Main] Persisted external target is unavailable and this package has no embedded runtime; keeping the external topology unavailable without exposing its credential.",
     );
   }
   // Start the static renderer server in parallel with the rest of pre-window

--- a/packages/app-core/platforms/electrobun/src/menu-reset-from-main.test.ts
+++ b/packages/app-core/platforms/electrobun/src/menu-reset-from-main.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Exercises the main-process reset transport with deterministic fetch fakes.
+ * The tests verify that authorization builders receive each actual request URL.
+ */
+import { describe, expect, it, vi } from "vitest";
+import {
+  pickReachableMenuResetApiBase,
+  runMainMenuResetAfterApiBaseResolved,
+} from "./menu-reset-from-main";
+
+describe("main-process reset target authorization", () => {
+  it("qualifies each reachability probe against its exact status URL", async () => {
+    const buildHeaders = vi.fn(() => ({ Accept: "application/json" }));
+    const fetchImpl = vi.fn(async (url: string) =>
+      Promise.resolve(
+        new Response("{}", {
+          status: url.startsWith("https://remote.example") ? 200 : 503,
+        }),
+      ),
+    );
+
+    await expect(
+      pickReachableMenuResetApiBase({
+        candidates: ["http://127.0.0.1:31337", "https://remote.example"],
+        fetchImpl,
+        buildHeaders,
+      }),
+    ).resolves.toBe("https://remote.example");
+    expect(buildHeaders.mock.calls).toEqual([
+      ["http://127.0.0.1:31337/api/status"],
+      ["https://remote.example/api/status"],
+    ]);
+  });
+
+  it("qualifies reset, poll, and verification against their exact URLs", async () => {
+    const buildHeaders = vi.fn(() => ({ Accept: "application/json" }));
+    const fetchImpl = vi.fn(async (url: string) => {
+      if (url.endsWith("/api/status")) {
+        return new Response('{"state":"running"}', { status: 200 });
+      }
+      if (url.endsWith("/api/first-run/status")) {
+        return new Response('{"complete":false}', { status: 200 });
+      }
+      return new Response("{}", { status: 200 });
+    });
+
+    await runMainMenuResetAfterApiBaseResolved({
+      apiBase: "https://remote.example",
+      fetchImpl,
+      buildHeaders,
+      useEmbeddedRestart: false,
+      restartEmbeddedClearingLocalDb: vi.fn(async () => ({})),
+      pushEmbeddedApiBaseToRenderer: vi.fn(),
+      getLocalApiAuthToken: vi.fn(() => ""),
+      postExternalAgentRestart: vi.fn(async () => undefined),
+      resolveApiBaseForStatusPoll: () => "https://remote.example",
+      sendMenuResetAppliedToRenderer: vi.fn(),
+    });
+
+    expect(buildHeaders.mock.calls).toEqual([
+      ["https://remote.example/api/agent/reset"],
+      ["https://remote.example/api/status"],
+      ["https://remote.example/api/first-run/status"],
+    ]);
+  });
+});

--- a/packages/app-core/platforms/electrobun/src/menu-reset-from-main.ts
+++ b/packages/app-core/platforms/electrobun/src/menu-reset-from-main.ts
@@ -20,6 +20,11 @@ export type FetchLike = (
   init?: RequestInit,
 ) => Promise<Response>;
 
+export type MainApiHeaderBuilder = (
+  targetUrl: string,
+  contentType?: string,
+) => Record<string, string>;
+
 export const MAIN_RESET_API_PROBE_TIMEOUT_MS = 4000;
 export const MENU_RESET_STATUS_POLL_MS = 1000;
 export const MENU_RESET_STATUS_MAX_MS = 120_000;
@@ -43,7 +48,7 @@ export function buildMainMenuResetApiCandidates(options: {
 export async function pickReachableMenuResetApiBase(options: {
   candidates: string[];
   fetchImpl: FetchLike;
-  buildHeaders: () => Record<string, string>;
+  buildHeaders: MainApiHeaderBuilder;
   probeTimeoutMs?: number;
 }): Promise<string | null> {
   if (options.candidates.length === 0) {
@@ -51,10 +56,11 @@ export async function pickReachableMenuResetApiBase(options: {
   }
   const timeoutMs = options.probeTimeoutMs ?? MAIN_RESET_API_PROBE_TIMEOUT_MS;
   for (const base of options.candidates) {
+    const statusUrl = `${base}/api/status`;
     try {
-      const res = await options.fetchImpl(`${base}/api/status`, {
+      const res = await options.fetchImpl(statusUrl, {
         method: "GET",
-        headers: options.buildHeaders(),
+        headers: options.buildHeaders(statusUrl),
         signal: AbortSignal.timeout(timeoutMs),
       });
       if (res.ok) {
@@ -70,7 +76,7 @@ export async function pickReachableMenuResetApiBase(options: {
 export async function pollMenuResetAgentStatusJson(options: {
   apiBase: string;
   fetchImpl: FetchLike;
-  buildHeaders: () => Record<string, string>;
+  buildHeaders: MainApiHeaderBuilder;
   pollMs?: number;
   maxMs?: number;
   sleep?: (ms: number) => Promise<void>;
@@ -82,10 +88,11 @@ export async function pollMenuResetAgentStatusJson(options: {
     options.sleep ?? ((ms: number) => new Promise((r) => setTimeout(r, ms)));
   const now = options.now ?? (() => Date.now());
   const deadline = now() + maxMs;
+  const statusUrl = `${options.apiBase}/api/status`;
   while (now() < deadline) {
     try {
-      const res = await options.fetchImpl(`${options.apiBase}/api/status`, {
-        headers: options.buildHeaders(),
+      const res = await options.fetchImpl(statusUrl, {
+        headers: options.buildHeaders(statusUrl),
       });
       if (res.ok) {
         const data = (await res.json()) as Record<string, unknown>;
@@ -99,8 +106,8 @@ export async function pollMenuResetAgentStatusJson(options: {
     await sleep(pollMs);
   }
   try {
-    const res = await options.fetchImpl(`${options.apiBase}/api/status`, {
-      headers: options.buildHeaders(),
+    const res = await options.fetchImpl(statusUrl, {
+      headers: options.buildHeaders(statusUrl),
     });
     if (res.ok) {
       return (await res.json()) as Record<string, unknown>;
@@ -114,7 +121,7 @@ export async function pollMenuResetAgentStatusJson(options: {
 export type MainMenuResetPostConfirmDeps = {
   apiBase: string;
   fetchImpl: FetchLike;
-  buildHeaders: () => Record<string, string>;
+  buildHeaders: MainApiHeaderBuilder;
   /** `true` when `resolveDesktopRuntimeMode(env).mode === "local"`. */
   useEmbeddedRestart: boolean;
   restartEmbeddedClearingLocalDb: () => Promise<{ port?: number }>;
@@ -141,9 +148,10 @@ export async function runMainMenuResetAfterApiBaseResolved(
   d: MainMenuResetPostConfirmDeps,
 ): Promise<void> {
   const executeResetAndRestart = async (): Promise<Record<string, unknown>> => {
-    const resetRes = await d.fetchImpl(`${d.apiBase}/api/agent/reset`, {
+    const resetUrl = `${d.apiBase}/api/agent/reset`;
+    const resetRes = await d.fetchImpl(resetUrl, {
       method: "POST",
-      headers: d.buildHeaders(),
+      headers: d.buildHeaders(resetUrl),
     });
     if (!resetRes.ok) {
       throw new Error(`Reset API failed (${resetRes.status})`);
@@ -172,10 +180,11 @@ export async function runMainMenuResetAfterApiBaseResolved(
   };
 
   const readOnboardingComplete = async (): Promise<boolean | null> => {
+    const statusUrl = `${d.apiBase}/api/first-run/status`;
     try {
-      const res = await d.fetchImpl(`${d.apiBase}/api/first-run/status`, {
+      const res = await d.fetchImpl(statusUrl, {
         method: "GET",
-        headers: d.buildHeaders(),
+        headers: d.buildHeaders(statusUrl),
       });
       if (!res.ok) {
         return null;

--- a/packages/app-core/platforms/electrobun/src/runtime-preflight.test.ts
+++ b/packages/app-core/platforms/electrobun/src/runtime-preflight.test.ts
@@ -3,7 +3,9 @@ import { createServer, type ServerResponse } from "node:http";
 import { describe, expect, it, vi } from "vitest";
 import {
   probeExternalAgent,
+  resolveDesktopApiRequestToken,
   resolveDesktopRuntimeForBoot,
+  resolveQualifiedExternalToken,
 } from "./runtime-preflight";
 
 const remoteDeployment = {
@@ -16,11 +18,13 @@ type EndpointResponse = {
   body: string;
   contentType?: string;
   requiredBearer?: string;
+  location?: string;
 };
 
 function sendResponse(res: ServerResponse, response: EndpointResponse): void {
   res.writeHead(response.status ?? 200, {
     "content-type": response.contentType ?? "application/json",
+    ...(response.location ? { location: response.location } : {}),
   });
   res.end(response.body);
 }
@@ -102,6 +106,31 @@ describe("probeExternalAgent", () => {
     );
   });
 
+  it("rejects redirects without forwarding the persisted bearer", async () => {
+    await withProbeServer(
+      { "/redirect-target": readyElizaEndpoints["/api/status"] },
+      async (redirectBase, redirectRequests) => {
+        await withProbeServer(
+          {
+            ...readyElizaEndpoints,
+            "/api/status": {
+              status: 302,
+              body: "",
+              location: `${redirectBase}/redirect-target`,
+            },
+          },
+          async (base, requests) => {
+            await expect(
+              probeExternalAgent(base, "remote-secret"),
+            ).resolves.toBe(false);
+            expect(requests).toEqual(["/api/health", "/api/status"]);
+            expect(redirectRequests).toEqual([]);
+          },
+        );
+      },
+    );
+  });
+
   it.each([
     [
       "authentication challenge",
@@ -160,8 +189,42 @@ describe("resolveDesktopRuntimeForBoot", () => {
     });
 
     expect(result.mode).toBe("external");
+    expect(result.externalReachability).toBe("verified");
     expect(result.externalApi.base).toBe("http://127.0.0.1:2250");
     expect(probe).toHaveBeenCalledOnce();
+  });
+
+  it("qualifies a configured external bearer against the actual request origin", () => {
+    const resolution = {
+      mode: "external" as const,
+      externalApi: {
+        base: "https://remote.example",
+        source: "ELIZA_DESKTOP_API_BASE" as const,
+        invalidSources: [],
+      },
+    };
+
+    expect(
+      resolveDesktopApiRequestToken({
+        resolution,
+        targetUrl: "https://remote.example/api/config",
+        configuredToken: " remote-secret ",
+      }),
+    ).toBe("remote-secret");
+    for (const targetUrl of [
+      "http://127.0.0.1:31337/api/agent/reset",
+      "http://localhost:31337/api/config",
+      "https://remote.example.evil.test/api/config",
+      "not a URL",
+    ]) {
+      expect(
+        resolveDesktopApiRequestToken({
+          resolution,
+          targetUrl,
+          configuredToken: "remote-secret",
+        }),
+      ).toBeUndefined();
+    }
   });
 
   it("passes only the persisted target token to the readiness probe", async () => {
@@ -176,9 +239,74 @@ describe("resolveDesktopRuntimeForBoot", () => {
     });
 
     expect(result.mode).toBe("external");
+    expect(result.externalReachability).toBe("verified");
     expect(probe).toHaveBeenCalledWith(
       "http://127.0.0.1:2250",
       "remote-secret",
+    );
+    expect(
+      resolveQualifiedExternalToken(result, "http://127.0.0.1:2250/api/chat"),
+    ).toBe("remote-secret");
+    expect(
+      resolveQualifiedExternalToken(result, "http://127.0.0.1:2251/api/chat"),
+    ).toBeUndefined();
+    expect(
+      resolveDesktopApiRequestToken({
+        resolution: result,
+        targetUrl: "http://127.0.0.1:2250/api/config",
+      }),
+    ).toBe("remote-secret");
+    expect(
+      resolveDesktopApiRequestToken({
+        resolution: result,
+        targetUrl: "http://127.0.0.1:2251/api/agent/reset",
+      }),
+    ).toBeUndefined();
+    expect(
+      resolveDesktopApiRequestToken({
+        resolution: result,
+        targetUrl: "not a URL",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("carries the qualified bearer from real preflight into a protected application request", async () => {
+    await withProbeServer(
+      {
+        ...readyElizaEndpoints,
+        "/api/status": {
+          ...readyElizaEndpoints["/api/status"],
+          requiredBearer: "remote-secret",
+        },
+        "/api/application": {
+          body: '{"ok":true}',
+          requiredBearer: "remote-secret",
+        },
+      },
+      async (base, requests) => {
+        const result = await resolveDesktopRuntimeForBoot({
+          env: {},
+          deployment: {
+            runtime: "remote",
+            remoteApiBase: base,
+            remoteAccessToken: "remote-secret",
+          },
+        });
+        const token = resolveQualifiedExternalToken(
+          result,
+          `${base}/api/application`,
+        );
+        const response = await fetch(`${base}/api/application`, {
+          headers: token ? { Authorization: `Bearer ${token}` } : {},
+        });
+
+        expect(response.status).toBe(200);
+        expect(requests).toEqual([
+          "/api/health",
+          "/api/status",
+          "/api/application",
+        ]);
+      },
     );
   });
 
@@ -193,16 +321,50 @@ describe("resolveDesktopRuntimeForBoot", () => {
     expect(result.externalApi.base).toBeNull();
   });
 
-  it("does not fabricate local runtime in a cloud-only package", async () => {
-    const probe = vi.fn(async () => false);
+  it("qualifies persisted access in a runtime-less external package", async () => {
+    const probe = vi.fn(async () => true);
     const result = await resolveDesktopRuntimeForBoot({
       env: { ELIZA_DESKTOP_SKIP_EMBEDDED_AGENT: "1" },
-      deployment: remoteDeployment,
+      deployment: {
+        ...remoteDeployment,
+        remoteAccessToken: " remote-secret ",
+      },
       probe,
     });
 
     expect(result.mode).toBe("external");
-    expect(probe).not.toHaveBeenCalled();
+    expect(result.externalReachability).toBe("verified");
+    expect(probe).toHaveBeenCalledWith(
+      "http://127.0.0.1:2250",
+      "remote-secret",
+    );
+    expect(
+      resolveQualifiedExternalToken(result, "http://127.0.0.1:2250/api/chat"),
+    ).toBe("remote-secret");
+  });
+
+  it("keeps a failed runtime-less probe external but unavailable", async () => {
+    const probe = vi.fn(async () => false);
+    const result = await resolveDesktopRuntimeForBoot({
+      env: { ELIZA_DESKTOP_SKIP_EMBEDDED_AGENT: "1" },
+      deployment: {
+        ...remoteDeployment,
+        remoteAccessToken: " remote-secret ",
+      },
+      probe,
+    });
+
+    expect(result.mode).toBe("external");
+    expect(result.externalApi.base).toBe("http://127.0.0.1:2250");
+    expect(result.externalReachability).toBe("unavailable");
+    expect(result.qualifiedAccess).toBeUndefined();
+    expect(probe).toHaveBeenCalledWith(
+      "http://127.0.0.1:2250",
+      "remote-secret",
+    );
+    expect(
+      resolveQualifiedExternalToken(result, "http://127.0.0.1:2250/api/chat"),
+    ).toBeUndefined();
   });
 
   it("preserves explicit env targets without probing persisted state", async () => {

--- a/packages/app-core/platforms/electrobun/src/runtime-preflight.ts
+++ b/packages/app-core/platforms/electrobun/src/runtime-preflight.ts
@@ -6,6 +6,7 @@
  */
 import {
   type DesktopRuntimeModeResolution,
+  normalizeApiBase,
   type PersistedDeployment,
   resolveDesktopRuntimeMode,
   resolveDesktopRuntimeModeWithDeployment,
@@ -17,6 +18,54 @@ export type ExternalReachabilityProbe = (
   base: string,
   accessToken?: string,
 ) => Promise<boolean>;
+
+export interface QualifiedExternalAccess {
+  origin: string;
+  token: string;
+}
+
+export interface DesktopRuntimeBootResolution
+  extends DesktopRuntimeModeResolution {
+  qualifiedAccess?: QualifiedExternalAccess;
+  externalReachability?: "verified" | "unavailable";
+}
+
+export function resolveQualifiedExternalToken(
+  resolution: DesktopRuntimeBootResolution,
+  targetBase: string | null | undefined,
+): string | undefined {
+  const targetOrigin = normalizeApiBase(targetBase ?? undefined);
+  return targetOrigin && resolution.qualifiedAccess?.origin === targetOrigin
+    ? resolution.qualifiedAccess.token
+    : undefined;
+}
+
+export function resolveDesktopApiRequestToken(options: {
+  resolution: DesktopRuntimeBootResolution;
+  targetUrl: string;
+  configuredToken?: string | null;
+}): string | undefined {
+  const configuredToken = options.configuredToken?.trim() || undefined;
+  if (options.resolution.mode === "local") {
+    return configuredToken;
+  }
+  if (options.resolution.mode !== "external") {
+    return undefined;
+  }
+
+  const targetOrigin = normalizeApiBase(options.targetUrl);
+  const externalOrigin = normalizeApiBase(
+    options.resolution.externalApi.base ?? undefined,
+  );
+  if (!targetOrigin || !externalOrigin || targetOrigin !== externalOrigin) {
+    return undefined;
+  }
+
+  return (
+    configuredToken ??
+    resolveQualifiedExternalToken(options.resolution, options.targetUrl)
+  );
+}
 
 function hasExplicitExternalTarget(
   env: Record<string, string | undefined>,
@@ -57,6 +106,7 @@ async function fetchJson(
   const response = await fetch(url, {
     method: "GET",
     headers,
+    redirect: "error",
     signal,
   });
   if (response.status !== 200) return null;
@@ -73,7 +123,7 @@ export async function probeExternalAgent(
     const health = await fetchJson(
       `${normalizedBase}/api/health`,
       signal,
-      accessToken,
+      undefined,
     );
     if (!isReadyHealth(health)) return false;
 
@@ -97,7 +147,7 @@ export async function resolveDesktopRuntimeForBoot(options: {
   env: Record<string, string | undefined>;
   deployment: PersistedDeployment | null;
   probe?: ExternalReachabilityProbe;
-}): Promise<DesktopRuntimeModeResolution> {
+}): Promise<DesktopRuntimeBootResolution> {
   const { env, deployment, probe = probeExternalAgent } = options;
   const resolved = resolveDesktopRuntimeModeWithDeployment(env, deployment);
 
@@ -109,19 +159,23 @@ export async function resolveDesktopRuntimeForBoot(options: {
     return resolved;
   }
 
-  // A runtime-less package cannot recover to an agent it does not ship.
   const envOnly = resolveDesktopRuntimeMode(env);
-  if (envOnly.mode === "disabled") {
-    return resolved;
+  const token = deployment?.remoteAccessToken?.trim() || undefined;
+  if (await probe(resolved.externalApi.base, token)) {
+    return token
+      ? {
+          ...resolved,
+          externalReachability: "verified",
+          qualifiedAccess: { origin: resolved.externalApi.base, token },
+        }
+      : { ...resolved, externalReachability: "verified" };
   }
 
-  if (
-    await probe(
-      resolved.externalApi.base,
-      deployment?.remoteAccessToken?.trim() || undefined,
-    )
-  ) {
-    return resolved;
+  // A runtime-less package cannot recover to an agent it does not ship. Keep
+  // the persisted topology external but unqualified so callers render an
+  // unavailable external runtime instead of silently inventing a local one.
+  if (envOnly.mode === "disabled") {
+    return { ...resolved, externalReachability: "unavailable" };
   }
 
   return envOnly;


### PR DESCRIPTION
## Summary

- restacks only the two unique desktop runtime-preflight follow-ups from #27221 onto current `develop`; none of that PR's ancient ancestry is included
- qualifies persisted external bearer tokens against the actual request target, so external credentials cannot be sent to loopback, reset, config import/export, or a different origin
- probes runtime-less persisted external targets with their persisted token and keeps failed probes explicitly external-but-unavailable instead of silently fabricating a local runtime
- passes the concrete request URL through main-process reset/status/config header construction

## Security behavior

- exact external origin: qualified token may be used
- loopback, different host/port, malformed target, or disabled runtime: no external bearer
- runtime-less probe failure: no qualified access, `externalReachability: unavailable`, no embedded fallback

## Evidence

- focused Electrobun runtime/reset contracts: 27/27 passed
- targeted TypeScript compile: passed
- scoped Biome check: passed
- `@elizaos/app-core` source build: passed
- `npm pack --dry-run`: 4,270,166 bytes packed estimate; 11,821,037 bytes unpacked
- `git diff --check`: passed
- gitleaks `origin/develop..HEAD`: no leaks
- full Electrobun lane: 1,424/1,425 passed; the sole failure is the untouched existing `shell-sync-relay.test.ts` 2,000-character expectation (this PR does not change that file or behavior)

## Evidence boundaries

- Native package launch: N/A - source/preflight PR only; no native ports or app were launched.
- UI screenshots/video: N/A - no rendered UI changes.
- Live external runtime credential: N/A - tests exercise the exact origin/token contract without exposing or using real credentials.

## Review focus

Please verify that request authorization is bound to the concrete target URL and that runtime-less external failures remain fail-closed and visibly unavailable.
