### PR TITLE
fix(plugin-wechat): keep UTF-16 surrogate pairs intact during reply message chunking

### DIFF
--- a/plugins/plugin-wechat/src/index.test.ts
+++ b/plugins/plugin-wechat/src/index.test.ts
@@ -358,4 +358,19 @@ describe("@elizaos/plugin-wechat", () => {
     expect(client.sendText).toHaveBeenNthCalledWith(1, "wxid_alice", "hello");
     expect(client.sendText).toHaveBeenNthCalledWith(2, "wxid_alice", "world");
   });
+
+  it("preserves UTF-16 surrogate pairs during message chunking", async () => {
+    const client = {
+      sendText: vi.fn(async () => undefined),
+    } as unknown as ProxyClient;
+    // Chunk size 4. "a🔥🔥" (1 char + 2 emojis = 5 code units).
+    // Raw break at index 4 lands on the high surrogate of the 2nd emoji.
+    // Surrogate safety backs off breakAt to 3, keeping emojis whole across chunks.
+    const dispatcher = new ReplyDispatcher({ client, chunkSize: 4 });
+
+    await dispatcher.sendText("wxid_alice", "a🔥🔥");
+
+    expect(client.sendText).toHaveBeenNthCalledWith(1, "wxid_alice", "a🔥");
+    expect(client.sendText).toHaveBeenNthCalledWith(2, "wxid_alice", "🔥");
+  });
 });

--- a/plugins/plugin-wechat/src/reply-dispatcher.ts
+++ b/plugins/plugin-wechat/src/reply-dispatcher.ts
@@ -69,6 +69,12 @@ export class ReplyDispatcher {
         // Hard break
         breakAt = this.chunkSize;
       }
+      if (breakAt > 0 && breakAt < remaining.length) {
+        const code = remaining.charCodeAt(breakAt - 1);
+        if (code >= 0xd800 && code <= 0xdbff) {
+          breakAt -= 1;
+        }
+      }
 
       chunks.push(remaining.slice(0, breakAt));
       remaining = remaining.slice(breakAt).trimStart();


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:77f87f026b9f7fad3cd364f9e993797debfb0c1c -->

## Summary
In `plugins/plugin-wechat/src/reply-dispatcher.ts`:
`splitIntoChunks` chunks long outgoing reply text into bounded chunks of size `chunkSize`. When a hard break at `this.chunkSize` is required, character index slicing at `this.chunkSize` could land between the high and low code units of a UTF-16 surrogate pair (such as emojis or astral plane unicode characters).

## Proposed Changes
1. Added surrogate boundary check to `splitIntoChunks` in `plugins/plugin-wechat/src/reply-dispatcher.ts` to back off `breakAt` by 1 character if the break lands inside a surrogate pair.
2. Added unit tests in `plugins/plugin-wechat/src/index.test.ts`.

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-wechat test src/index.test.ts` (12/12 passed).

<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-3-5-sonnet","client":"antigravity","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
