### PR TITLE
fix(plugin-browser): keep UTF-16 surrogate pairs intact in summarizePage

### DIFF
--- a/plugins/plugin-browser/src/message-adapter.test.ts
+++ b/plugins/plugin-browser/src/message-adapter.test.ts
@@ -83,4 +83,39 @@ describe("BrowserBridgeAdapter", () => {
       }),
     ).resolves.toEqual([]);
   });
+
+  it("preserves UTF-16 surrogate pairs when summarizing long pages", async () => {
+    // 496 ASCII chars + "🔥" (2 units) = 498 total chars > 500 when repeated
+    const mainText = "a".repeat(496) + "🔥".repeat(10);
+    const page = {
+      id: "page-surrogate",
+      agentId: "agent-1",
+      browser: "chrome",
+      profileId: "default",
+      windowId: "window-1",
+      tabId: "tab-1",
+      url: "https://example.com/article",
+      title: "Article",
+      selectionText: null,
+      mainText,
+      headings: [],
+      links: [],
+      forms: [],
+      capturedAt: "2026-06-02T12:00:00.000Z",
+      metadata: {},
+    };
+    const routeService = {
+      getCurrentBrowserPage: vi.fn(async () => page),
+    };
+    const runtime = {
+      agentId: "agent-1",
+      getService: vi.fn(() => routeService),
+    } as unknown as IAgentRuntime;
+    const adapter = new BrowserBridgeAdapter();
+
+    const messages = await adapter.listMessages(runtime, { limit: 1 });
+    expect(messages[0]?.snippet).toBeDefined();
+    // 496 "a"s + "..." = 499 total chars, without a broken surrogate
+    expect(messages[0]?.snippet).toBe(`${"a".repeat(496)}...`);
+  });
 });

--- a/plugins/plugin-browser/src/message-adapter.ts
+++ b/plugins/plugin-browser/src/message-adapter.ts
@@ -1,3 +1,15 @@
+function truncateUtf16Safe(text: string, maxLength: number): string {
+  if (text.length <= maxLength) return text;
+  let end = maxLength;
+  if (end > 0 && end < text.length) {
+    const code = text.charCodeAt(end - 1);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      end -= 1;
+    }
+  }
+  return text.slice(0, end);
+}
+
 /**
  * MessageAdapter implementation backed by browser bridge page-context records.
  */
@@ -49,7 +61,7 @@ function summarizePage(page: BrowserBridgePageContext): string {
     page.mainText?.trim() ||
     page.title.trim() ||
     page.url;
-  return text.length > 500 ? `${text.slice(0, 497)}...` : text;
+  return text.length > 500 ? `${truncateUtf16Safe(text, 497)}...` : text;
 }
 
 function pageToMessageRef(page: BrowserBridgePageContext): MessageRef {


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:16cf0056109d096accfbde373ea0a62962407643 -->

## Summary
In `plugins/plugin-browser/src/message-adapter.ts`:
`summarizePage` truncates long page context text at 497 characters using `${text.slice(0, 497)}...`.

When the page text contains multi-byte UTF-16 surrogate pairs (e.g. emojis or astral plane characters), slicing at index 497 could land between surrogate pair code units, creating unpaired surrogates (`\uFFFD`).

## Proposed Changes
1. Added `truncateUtf16Safe` helper with surrogate boundary back-off in `plugins/plugin-browser/src/message-adapter.ts`.
2. Used `truncateUtf16Safe` in `summarizePage`.
3. Added unit tests in `plugins/plugin-browser/src/message-adapter.test.ts`.

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-browser test src/message-adapter.test.ts` (3/3 passed).

<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-3-5-sonnet","client":"antigravity","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
