### PR TITLE
fix(plugin-whatsapp): keep UTF-16 surrogate pairs intact in truncateText

### DIFF
--- a/plugins/plugin-whatsapp/src/normalize.test.ts
+++ b/plugins/plugin-whatsapp/src/normalize.test.ts
@@ -115,4 +115,19 @@ describe("text chunking", () => {
     expect(truncateText("short", 20)).toBe("short");
     expect(truncateText("abcdefghij", 5).length).toBeLessThanOrEqual(5);
   });
+
+  it("preserves UTF-16 surrogate pairs during truncateText", () => {
+    // "a" + "🔥".repeat(5) -> 1 + 10 = 11 chars. Truncate to 6 chars (limit 6 - 3 = 3 content chars).
+    // index 3 lands inside the second emoji "🔥".
+    // Surrogate safe back-off ensures we take index 2 ("a🔥"), producing "a🔥..." (5 chars <= 6).
+    const truncated = truncateText("a🔥🔥🔥🔥🔥", 6);
+    expect(truncated).toBe("a🔥...");
+    for (const char of truncated) {
+      expect(
+        /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(
+          char,
+        ),
+      ).toBe(false);
+    }
+  });
 });

--- a/plugins/plugin-whatsapp/src/normalize.ts
+++ b/plugins/plugin-whatsapp/src/normalize.ts
@@ -1,3 +1,15 @@
+function truncateUtf16Safe(text: string, maxLength: number): string {
+  if (text.length <= maxLength) return text;
+  let end = maxLength;
+  if (end > 0 && end < text.length) {
+    const code = text.charCodeAt(end - 1);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      end -= 1;
+    }
+  }
+  return text.slice(0, end);
+}
+
 /**
  * Phone/JID normalization and outbound-text chunking for the WhatsApp connector.
  * Parses E.164 numbers, recognizes user JIDs and LIDs, detects chat type, and
@@ -323,7 +335,7 @@ export function truncateText(text: string, maxLength: number): string {
   if (maxLength <= 3) {
     return "...".slice(0, maxLength);
   }
-  return `${text.slice(0, maxLength - 3)}...`;
+  return `${truncateUtf16Safe(text, maxLength - 3)}...`;
 }
 
 /**


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:676662cb3fdf454d0cd2ac38f140d659c12fbabc -->

## Summary
In `plugins/plugin-whatsapp/src/normalize.ts`:
`truncateText` truncates strings with an ellipsis using `${text.slice(0, maxLength - 3)}...`.

When text contains multi-byte UTF-16 surrogate pairs (e.g. emojis or astral plane characters), character slicing at index `maxLength - 3` could land between the high and low surrogate code units, producing unpaired surrogates (`\uFFFD`).

## Proposed Changes
1. Added `truncateUtf16Safe` helper with surrogate boundary back-off in `plugins/plugin-whatsapp/src/normalize.ts`.
2. Applied `truncateUtf16Safe` inside `truncateText`.
3. Added unit tests in `plugins/plugin-whatsapp/src/normalize.test.ts`.

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-whatsapp test src/normalize.test.ts` (12/12 passed).

<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-3-5-sonnet","client":"antigravity","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
