### PR TITLE
fix(plugin-x): keep UTF-16 surrogate pairs intact in XDmAdapter snippet and preview

### DIFF
--- a/plugins/plugin-x/src/lifeops-message-adapter.test.ts
+++ b/plugins/plugin-x/src/lifeops-message-adapter.test.ts
@@ -194,4 +194,25 @@ describe("XDmAdapter", () => {
 
     expect(sendDirectMessageForAccount).not.toHaveBeenCalled();
   });
+
+  it("preserves UTF-16 surrogate pairs during createDraft preview truncation", async () => {
+    const adapter = new XDmAdapter();
+    const runtime = runtimeWithXService({ sendDirectMessageForAccount: vi.fn() });
+    // 196 ASCII chars + "🔥" (2 code units) = 198 chars.
+    // Truncating limit is 197. Index 197 lands inside "🔥".
+    // Surrogate safe back-off ensures we take index 196, avoiding splitting the emoji.
+    const longBody = "a".repeat(196) + "🔥".repeat(10);
+    const draft = await adapter.createDraft(runtime, {
+      to: [{ identifier: "alice" }],
+      body: longBody,
+    });
+    expect(draft.preview).toBe(`${"a".repeat(196)}...`);
+    for (const char of draft.preview) {
+      expect(
+        /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(
+          char,
+        ),
+      ).toBe(false);
+    }
+  });
 });

--- a/plugins/plugin-x/src/lifeops-message-adapter.ts
+++ b/plugins/plugin-x/src/lifeops-message-adapter.ts
@@ -1,3 +1,15 @@
+function truncateUtf16Safe(text: string, maxLength: number): string {
+  if (text.length <= maxLength) return text;
+  let end = maxLength;
+  if (end > 0 && end < text.length) {
+    const code = text.charCodeAt(end - 1);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      end -= 1;
+    }
+  }
+  return text.slice(0, end);
+}
+
 /**
  * `XDmAdapter` — a LifeOps `BaseMessageAdapter` over the X connector's direct
  * messages, letting LifeOps list, draft, and send X DMs through `XService`. Maps
@@ -89,7 +101,7 @@ function memoryToMessageRef(memory: Memory): MessageRef {
       displayName: senderHandle,
     },
     to: [],
-    snippet: body.slice(0, 200),
+    snippet: truncateUtf16Safe(body, 200),
     body,
     receivedAtMs: Number.isFinite(receivedAtMs) ? receivedAtMs : Date.now(),
     hasAttachments: false,
@@ -203,7 +215,7 @@ export class XDmAdapter extends BaseMessageAdapter {
     }
     const draftId = `twitter:${encodeURIComponent(recipient)}:${Date.now()}:${encodeDraftBody(draft.body)}`;
     const preview =
-      draft.body.length > 200 ? `${draft.body.slice(0, 197)}...` : draft.body;
+      draft.body.length > 200 ? `${truncateUtf16Safe(draft.body, 197)}...` : draft.body;
     return { draftId, preview };
   }
 


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:5944489946d3eae1e28f49fc7f46ad226d296c3c -->

## Summary
In `plugins/plugin-x/src/lifeops-message-adapter.ts`:
`memoryToMessageRef` extracts message snippets with `body.slice(0, 200)` and `createDraft` creates previews with `${draft.body.slice(0, 197)}...`.

When text contains multi-byte UTF-16 surrogate pairs (e.g. emojis or astral plane characters), string slicing at character boundaries can bisect a surrogate pair, causing corrupt/unpaired surrogate code points (`\uFFFD`).

## Proposed Changes
1. Added `truncateUtf16Safe` helper with surrogate boundary back-off in `plugins/plugin-x/src/lifeops-message-adapter.ts`.
2. Applied `truncateUtf16Safe` inside `memoryToMessageRef` (snippet) and `createDraft` (preview).
3. Added unit tests in `plugins/plugin-x/src/lifeops-message-adapter.test.ts`.

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-x test src/lifeops-message-adapter.test.ts` (8/8 passed).

<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-3-5-sonnet","client":"antigravity","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
