### PR TITLE
fix(plugin-slack): keep UTF-16 surrogate pairs intact during text and message chunking

### DIFF
--- a/plugins/plugin-slack/src/formatting.test.ts
+++ b/plugins/plugin-slack/src/formatting.test.ts
@@ -525,3 +525,23 @@ describe("parseSlackMessageLink", () => {
     ).toBeNull();
   });
 });
+
+describe("chunkSlackText UTF-16 surrogate safety", () => {
+  it("preserves UTF-16 surrogate pairs during message chunking", () => {
+    // maxChars = 10 (hardLimit = 6). "a🔥🔥🔥🔥" (1 + 8 = 9 units).
+    // Raw break at hardLimit 6 lands on high surrogate of 3rd emoji.
+    // Surrogate safe back-off ensures we break at index 5 ("a🔥🔥"), keeping emojis whole.
+    const chunks = chunkSlackText("a🔥🔥🔥🔥🔥", 10);
+    expect(chunks).toEqual(["a🔥🔥", "🔥🔥🔥"]);
+    for (const chunk of chunks) {
+      for (const char of chunk) {
+        expect(
+          /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(
+            char,
+          ),
+        ).toBe(false);
+      }
+    }
+  });
+});
+

--- a/plugins/plugin-slack/src/formatting.ts
+++ b/plugins/plugin-slack/src/formatting.ts
@@ -1,3 +1,15 @@
+function truncateUtf16Safe(text: string, maxLength: number): string {
+  if (text.length <= maxLength) return text;
+  let end = maxLength;
+  if (end > 0 && end < text.length) {
+    const code = text.charCodeAt(end - 1);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      end -= 1;
+    }
+  }
+  return text.slice(0, end);
+}
+
 /**
  * Slack mrkdwn formatting utilities. Converts agent markdown to Slack's
  * `*bold*` / `_italic_` / `~strike~` mrkdwn and chunks it under the message
@@ -228,6 +240,12 @@ export function splitSlackText(
     }
 
     splitIndex = Math.min(splitIndex, maxChars);
+    if (splitIndex > 0 && splitIndex < remaining.length) {
+      const code = remaining.charCodeAt(splitIndex - 1);
+      if (code >= 0xd800 && code <= 0xdbff) {
+        splitIndex -= 1;
+      }
+    }
     messages.push(remaining.slice(0, splitIndex));
     remaining = remaining.slice(splitIndex);
   }
@@ -281,6 +299,12 @@ export function chunkSlackText(
     // exactly on hardLimit yields breakPoint = hardLimit + 1 and the reserved
     // fence budget is spent, pushing the emitted chunk to maxChars + 1.
     breakPoint = Math.min(breakPoint, hardLimit);
+    if (breakPoint > 0 && breakPoint < remaining.length) {
+      const code = remaining.charCodeAt(breakPoint - 1);
+      if (code >= 0xd800 && code <= 0xdbff) {
+        breakPoint -= 1;
+      }
+    }
 
     let chunk = remaining.slice(0, breakPoint);
 


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:cd8f80d12df1b9580ef5c4a9457bb6ec04780691 -->

## Summary
In `plugins/plugin-slack/src/formatting.ts`:
`splitSlackText` and `chunkSlackText` split long message text at character limits (`maxChars` / `hardLimit`). When a chunk break point lands between the high and low surrogate code units of a UTF-16 surrogate pair (such as emojis or complex astral symbols), slicing at that index bisects the surrogate pair across chunks, creating unpaired surrogate code points (`\uFFFD`).

## Proposed Changes
1. Added surrogate boundary check to `splitSlackText` and `chunkSlackText` in `plugins/plugin-slack/src/formatting.ts` to back off the split index by 1 character if the break lands inside a surrogate pair.
2. Added unit tests in `plugins/plugin-slack/src/formatting.test.ts`.

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-slack test src/formatting.test.ts` (64/64 passed).

<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-3-5-sonnet","client":"antigravity","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
