### PR TITLE
fix(plugin-discord): delegate truncateText to truncateUtf16Safe to prevent surrogate splitting

### DIFF
--- a/plugins/plugin-discord/__tests__/messaging-format.test.ts
+++ b/plugins/plugin-discord/__tests__/messaging-format.test.ts
@@ -14,6 +14,7 @@ import {
 	parseMessageLink,
 	sanitizeThreadName,
 	stripDiscordFormatting,
+	truncateText,
 	truncateUtf16Safe,
 } from "../messaging.ts";
 
@@ -93,3 +94,23 @@ describe("message link build/parse round-trip", () => {
 		expect(parseMessageLink("https://example.com/x")).toBeNull();
 	});
 });
+
+describe("truncateText", () => {
+	it("preserves UTF-16 surrogate pairs and delegates to truncateUtf16Safe", () => {
+		const text = `abc${"😀".repeat(5)}`;
+		const out = truncateText(text, 6, "…");
+		expect(out.length).toBeLessThanOrEqual(6);
+		for (const char of out) {
+			expect(
+				/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(
+					char,
+				),
+			).toBe(false);
+		}
+	});
+
+	it("returns text unchanged when within maxLength", () => {
+		expect(truncateText("hello", 10)).toBe("hello");
+	});
+});
+

--- a/plugins/plugin-discord/messaging.ts
+++ b/plugins/plugin-discord/messaging.ts
@@ -495,7 +495,7 @@ export function truncateText(
 	if (text.length <= maxLength) {
 		return text;
 	}
-	return text.slice(0, maxLength - ellipsis.length) + ellipsis;
+	return truncateUtf16Safe(text, maxLength, ellipsis);
 }
 
 /**


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:4ff9d3e73c9b2d7f19731a2a660ee6642e8625de -->

## Summary
In `plugins/plugin-discord/messaging.ts`:
`truncateText` truncated strings using `text.slice(0, maxLength - ellipsis.length) + ellipsis` without surrogate boundary checking, whereas `truncateUtf16Safe` was implemented right below it with surrogate back-off logic.

## Proposed Changes
1. Delegated `truncateText` to `truncateUtf16Safe` in `plugins/plugin-discord/messaging.ts`.
2. Added unit tests in `plugins/plugin-discord/__tests__/messaging-format.test.ts`.

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-discord test __tests__/messaging-format.test.ts` (10/10 passed).

<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-3-5-sonnet","client":"antigravity","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
