### PR TITLE
fix(plugin-inbox): keep UTF-16 surrogate pairs intact in formatPromptScalar

### DIFF
--- a/plugins/plugin-inbox/src/inbox/triage-classifier.ts
+++ b/plugins/plugin-inbox/src/inbox/triage-classifier.ts
@@ -1,3 +1,15 @@
+function truncateUtf16Safe(text: string, maxLength: number): string {
+  if (text.length <= maxLength) return text;
+  let end = maxLength;
+  if (end > 0 && end < text.length) {
+    const code = text.charCodeAt(end - 1);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      end -= 1;
+    }
+  }
+  return text.slice(0, end);
+}
+
 /**
  * LLM classification of inbound cross-channel messages for the triage queue.
  *
@@ -43,7 +55,8 @@ function formatPromptScalar(value: unknown, maxLength = 600): string {
   if (value === null || value === undefined) {
     return "";
   }
-  return String(value).replace(/\s+/g, " ").trim().slice(0, maxLength);
+  const clean = String(value).replace(/\s+/g, " ").trim();
+  return truncateUtf16Safe(clean, maxLength);
 }
 
 /**

--- a/plugins/plugin-inbox/test/triage-optimized-prompt.test.ts
+++ b/plugins/plugin-inbox/test/triage-optimized-prompt.test.ts
@@ -87,3 +87,34 @@ describe("inbox triage — OptimizedPromptService routing", () => {
     expect(prompt).toContain("Sam Rivera");
   });
 });
+
+describe("buildTriagePrompt UTF-16 surrogate safety", () => {
+  it("preserves UTF-16 surrogate pairs in message scalars", () => {
+    // 499 ASCII chars + "🔥" (2 code units) = 501 chars.
+    // Truncating limit for text is 500. Index 500 lands on high surrogate of "🔥".
+    // Surrogate safe back-off ensures we take index 499, keeping emoji intact.
+    const longText = "a".repeat(499) + "🔥";
+    const prompt = buildTriagePrompt(
+      [
+        {
+          id: "msg-emoji",
+          source: "gmail",
+          senderName: "Alice",
+          channelName: "Inbox",
+          channelType: "dm",
+          text: longText,
+        },
+      ],
+      {},
+    );
+    expect(prompt).toContain("a".repeat(499));
+    for (const char of prompt) {
+      expect(
+        /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(
+          char,
+        ),
+      ).toBe(false);
+    }
+  });
+});
+


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:85b83ecfbf1a3925845f5deef7137afa40b8c0e3 -->

## Summary
In `plugins/plugin-inbox/src/inbox/triage-classifier.ts`:
`formatPromptScalar` formats message fields (sender name, channel name, text) for LLM prompts and sliced strings at `maxLength` characters.

When a message contains multi-byte UTF-16 surrogate pairs (e.g. emojis or astral plane characters), string slicing at character count limits can bisect a surrogate pair, injecting unpaired surrogate code points (`\uFFFD`) into prompt construction.

## Proposed Changes
1. Added `truncateUtf16Safe` helper with surrogate boundary back-off in `plugins/plugin-inbox/src/inbox/triage-classifier.ts`.
2. Applied `truncateUtf16Safe` inside `formatPromptScalar`.
3. Added unit tests in `plugins/plugin-inbox/test/triage-optimized-prompt.test.ts`.

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-inbox test test/triage-optimized-prompt.test.ts` (5/5 passed).

<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-3-5-sonnet","client":"antigravity","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
