### PR TITLE
fix(prompts): restore clean Vite resolution

### DIFF
--- a/packages/prompts/AGENTS.md
+++ b/packages/prompts/AGENTS.md
@@ -17,10 +17,12 @@ root [`CLAUDE.md`](../../CLAUDE.md).
   backward compatibility. Runtime and codegen paths use complete authored
   descriptions directly; the alias must never rewrite text.
 - Also owns the action/provider **specs** under `specs/` and the generators in `scripts/` that build a merged plugin action spec and emit `packages/core/src/generated/action-docs.ts`.
-- Bun and `eliza-source` workspace consumers load the maintained TypeScript
-  source directly, and workspace TypeScript consumers resolve source types
-  before `dist/` exists. The generated publish manifest rewrites those type
-  paths so native Node and published-package consumers load compiled `dist/`
+- Bun, Vite's `module` condition, explicitly configured `eliza-source`
+  consumers, and targeted Vitest source aliases load the maintained TypeScript
+  source directly. Workspace TypeScript consumers resolve source types before
+  `dist/` exists. Normal native Node workspace consumers continue to load
+  compiled `dist/` JavaScript. The generated publish manifest rewrites every
+  source-facing condition so published-package consumers load compiled
   JavaScript and declarations. Both manifests expose only the package root.
   Internal source imports use explicit `.js` specifiers so NodeNext typechecking
   and emitted native ESM resolve the same sibling modules.
@@ -72,9 +74,11 @@ bun run --cwd packages/prompts clean                    # rm -rf dist
 maintained source modules. The package test lane builds and packs `dist/`
 exactly as the release path does, verifies that the tarball contains the
 compiled `dist/` contract rather than TypeScript runtime source, installs it
-into an isolated native Node consumer, separately exercises Bun's workspace
-package resolution, and emits the core prompt declarations after removing
-`dist/`; either path failing is a package-contract error.
+into an isolated native Node consumer, and proves that all published
+source-facing conditions still load compiled JavaScript. It separately
+exercises Bun's workspace resolution, native Node's compiled workspace entry,
+Vitest-compatible Vite resolution of core with `dist/` removed, and clean core
+declaration emission; any path failing is a package-contract error.
 
 ## Config / env vars
 

--- a/packages/prompts/CLAUDE.md
+++ b/packages/prompts/CLAUDE.md
@@ -17,10 +17,12 @@ root [`CLAUDE.md`](../../CLAUDE.md).
   backward compatibility. Runtime and codegen paths use complete authored
   descriptions directly; the alias must never rewrite text.
 - Also owns the action/provider **specs** under `specs/` and the generators in `scripts/` that build a merged plugin action spec and emit `packages/core/src/generated/action-docs.ts`.
-- Bun and `eliza-source` workspace consumers load the maintained TypeScript
-  source directly, and workspace TypeScript consumers resolve source types
-  before `dist/` exists. The generated publish manifest rewrites those type
-  paths so native Node and published-package consumers load compiled `dist/`
+- Bun, Vite's `module` condition, explicitly configured `eliza-source`
+  consumers, and targeted Vitest source aliases load the maintained TypeScript
+  source directly. Workspace TypeScript consumers resolve source types before
+  `dist/` exists. Normal native Node workspace consumers continue to load
+  compiled `dist/` JavaScript. The generated publish manifest rewrites every
+  source-facing condition so published-package consumers load compiled
   JavaScript and declarations. Both manifests expose only the package root.
   Internal source imports use explicit `.js` specifiers so NodeNext typechecking
   and emitted native ESM resolve the same sibling modules.
@@ -72,9 +74,11 @@ bun run --cwd packages/prompts clean                    # rm -rf dist
 maintained source modules. The package test lane builds and packs `dist/`
 exactly as the release path does, verifies that the tarball contains the
 compiled `dist/` contract rather than TypeScript runtime source, installs it
-into an isolated native Node consumer, separately exercises Bun's workspace
-package resolution, and emits the core prompt declarations after removing
-`dist/`; either path failing is a package-contract error.
+into an isolated native Node consumer, and proves that all published
+source-facing conditions still load compiled JavaScript. It separately
+exercises Bun's workspace resolution, native Node's compiled workspace entry,
+Vitest-compatible Vite resolution of core with `dist/` removed, and clean core
+declaration emission; any path failing is a package-contract error.
 
 ## Config / env vars
 

--- a/packages/prompts/README.md
+++ b/packages/prompts/README.md
@@ -47,11 +47,14 @@ bun run build:package
 ```
 
 Bun workspace tooling resolves the maintained TypeScript source through the
-`bun` export condition, and workspace TypeScript consumers resolve source types
-before `dist/` exists. The generated publish manifest rewrites those type paths
-to declarations in `dist/`; native Node and the release path resolve compiled
-JavaScript from the tarball packed out of that publish directory. TypeScript
-source is not published as runtime code.
+`bun` export condition, and Vite resolves it through `module`. Vitest removes
+that condition in Node mode, so clean-workspace Vitest configs must use the
+explicit `eliza-source` condition or a targeted source alias. Workspace
+TypeScript consumers resolve source types before `dist/` exists, while normal
+native Node workspace consumers continue to use the compiled `dist/` entry.
+The generated publish manifest rewrites every source-facing condition to
+compiled JavaScript and declarations in `dist/`, so the release tarball never
+publishes TypeScript source as runtime code.
 
 ## Usage
 

--- a/packages/prompts/package.json
+++ b/packages/prompts/package.json
@@ -22,6 +22,11 @@
         "import": "./src/index.ts",
         "default": "./src/index.ts"
       },
+      "module": {
+        "types": "./src/index.ts",
+        "import": "./src/index.ts",
+        "default": "./src/index.ts"
+      },
       "import": "./dist/index.js",
       "default": "./dist/index.js"
     },

--- a/packages/prompts/test/package-contract.test.js
+++ b/packages/prompts/test/package-contract.test.js
@@ -9,13 +9,14 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  realpathSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, dirname, join } from "node:path";
 import { describe, it } from "node:test";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
 const repositoryRoot = join(packageRoot, "../..");
@@ -25,6 +26,72 @@ describe("package consumer contract", () => {
     const { compressPromptDescription } = await import("@elizaos/prompts");
     const payload = "  Bun keeps this complete.\nAnd this line too.  ";
     assert.strictEqual(compressPromptDescription(payload), payload);
+  });
+
+  it("keeps native Node mode conditions on executable dist while module resolves source", () => {
+    const coreRoot = join(repositoryRoot, "packages/core");
+    const resolveProbe =
+      'process.stdout.write(import.meta.resolve("@elizaos/prompts"));';
+    const normalResolution = execFileSync(
+      "node",
+      ["--input-type=module", "--eval", resolveProbe],
+      { cwd: coreRoot, encoding: "utf8" },
+    );
+    const moduleResolution = execFileSync(
+      "node",
+      ["--conditions=module", "--input-type=module", "--eval", resolveProbe],
+      { cwd: coreRoot, encoding: "utf8" },
+    );
+    const developmentResolution = execFileSync(
+      "node",
+      [
+        "--conditions=development",
+        "--input-type=module",
+        "--eval",
+        resolveProbe,
+      ],
+      { cwd: coreRoot, encoding: "utf8" },
+    );
+    const productionResolution = execFileSync(
+      "node",
+      [
+        "--conditions=production",
+        "--input-type=module",
+        "--eval",
+        resolveProbe,
+      ],
+      { cwd: coreRoot, encoding: "utf8" },
+    );
+
+    assert.strictEqual(
+      normalResolution,
+      pathToFileURL(join(publishRoot, "index.js")).href,
+    );
+    assert.strictEqual(
+      moduleResolution,
+      pathToFileURL(join(packageRoot, "src/index.ts")).href,
+    );
+    assert.strictEqual(developmentResolution, normalResolution);
+    assert.strictEqual(productionResolution, normalResolution);
+
+    const runtimeProbe = [
+      'const { compressPromptDescription } = await import("@elizaos/prompts");',
+      'process.stdout.write(compressPromptDescription("native-node-dist"));',
+    ].join("\n");
+    for (const args of [
+      [],
+      ["--conditions=development"],
+      ["--conditions=production"],
+    ]) {
+      assert.strictEqual(
+        execFileSync(
+          "node",
+          [...args, "--input-type=module", "--eval", runtimeProbe],
+          { cwd: coreRoot, encoding: "utf8" },
+        ),
+        "native-node-dist",
+      );
+    }
   });
 
   it("loads the packed build in an isolated native Node consumer", {
@@ -78,6 +145,16 @@ describe("package consumer contract", () => {
       );
       assert.strictEqual(installedManifest.types, "./index.d.ts");
       assert.strictEqual(installedManifest.exports["."].types, "./index.d.ts");
+      assert.deepStrictEqual(installedManifest.exports["."].module, {
+        types: "./index.d.ts",
+        import: "./index.js",
+        default: "./index.js",
+      });
+      assert.deepStrictEqual(installedManifest.exports["."]["eliza-source"], {
+        types: "./index.d.ts",
+        import: "./index.js",
+        default: "./index.js",
+      });
 
       const probe = join(consumerDir, "probe.mjs");
       const payload =
@@ -92,18 +169,37 @@ describe("package consumer contract", () => {
           'if (process.release.name !== "node") process.exit(70);',
           "const value = process.env.ELIZA_PROMPTS_PROBE;",
           "if (compressPromptDescription(value) !== value) process.exit(71);",
-          "process.stdout.write(JSON.stringify({ replyTemplate, value }));",
+          'const resolved = import.meta.resolve("@elizaos/prompts");',
+          "process.stdout.write(JSON.stringify({ replyTemplate, resolved, value }));",
         ].join("\n"),
       );
 
-      const probeOutput = execFileSync("node", [probe], {
-        cwd: consumerDir,
-        encoding: "utf8",
-        env: { ...process.env, ELIZA_PROMPTS_PROBE: payload },
-      });
-      const result = JSON.parse(probeOutput);
-      assert.strictEqual(result.value, payload);
-      assert.strictEqual(result.replyTemplate, workspacePrompts.replyTemplate);
+      const runProbe = (args) =>
+        JSON.parse(
+          execFileSync("node", [...args, probe], {
+            cwd: consumerDir,
+            encoding: "utf8",
+            env: { ...process.env, ELIZA_PROMPTS_PROBE: payload },
+          }),
+        );
+      const expectedResolution = realpathSync(
+        join(sandbox, "node_modules/@elizaos/prompts/index.js"),
+      );
+      const normalResult = runProbe([]);
+      const moduleResult = runProbe(["--conditions=module"]);
+      const sourceConditionResult = runProbe(["--conditions=eliza-source"]);
+      for (const result of [
+        normalResult,
+        moduleResult,
+        sourceConditionResult,
+      ]) {
+        assert.strictEqual(result.value, payload);
+        assert.strictEqual(
+          result.replyTemplate,
+          workspacePrompts.replyTemplate,
+        );
+        assert.strictEqual(fileURLToPath(result.resolved), expectedResolution);
+      }
     } finally {
       rmSync(sandbox, { force: true, recursive: true });
     }
@@ -147,6 +243,43 @@ describe("package consumer contract", () => {
         stdio: "pipe",
       });
       rmSync(sandbox, { force: true, recursive: true });
+    }
+  });
+
+  it("loads core prompt re-exports through Vite without a prebuilt prompts dist", {
+    timeout: 60_000,
+  }, async () => {
+    const sandbox = mkdtempSync(join(tmpdir(), "eliza-prompts-vite-"));
+    let server;
+    try {
+      const { createServer, normalizePath } = await import("vite");
+      rmSync(join(packageRoot, "dist"), { force: true, recursive: true });
+      server = await createServer({
+        appType: "custom",
+        cacheDir: join(sandbox, "cache"),
+        configFile: false,
+        logLevel: "silent",
+        root: repositoryRoot,
+        server: { middlewareMode: true },
+      });
+      const corePrompts = await server.ssrLoadModule(
+        `/@fs/${normalizePath(join(repositoryRoot, "packages/core/src/prompts.ts"))}`,
+      );
+      const payload = "  Vite keeps this complete.\nAnd this line too.  ";
+      assert.strictEqual(
+        corePrompts.compressPromptDescription(payload),
+        payload,
+      );
+    } finally {
+      try {
+        await server?.close();
+      } finally {
+        execFileSync("bun", ["run", "build:package"], {
+          cwd: packageRoot,
+          stdio: "pipe",
+        });
+        rmSync(sandbox, { force: true, recursive: true });
+      }
     }
   });
 });

--- a/packages/scripts/__tests__/prepare-package-dist.test.ts
+++ b/packages/scripts/__tests__/prepare-package-dist.test.ts
@@ -38,6 +38,68 @@ afterEach(() => {
 });
 
 describe("prepare-package-dist", () => {
+  test("recursively rewrites nested module export conditions for dist", () => {
+    const root = temporaryRepository();
+    writeJson(root, "package.json", {
+      name: "workspace-fixture",
+      private: true,
+      workspaces: ["packages/*"],
+    });
+    writeJson(root, "packages/prompts/package.json", {
+      name: "@fixture/prompts",
+      version: "1.0.0",
+      main: "./src/index.ts",
+      types: "./src/index.ts",
+      exports: {
+        ".": {
+          types: "./src/index.ts",
+          module: {
+            types: "./src/index.ts",
+            development: {
+              types: "./src/development.ts",
+              import: "./src/development.ts",
+              default: "./src/development.ts",
+            },
+            import: "./src/index.ts",
+            default: "./src/index.ts",
+          },
+          import: "./src/index.ts",
+          default: "./src/index.ts",
+        },
+      },
+    });
+
+    const prepared = preparePackageDist({
+      repositoryRoot: root,
+      packageDirectory: "packages/prompts",
+      optionalPluginFallbackVersions: new Map(),
+    });
+    const expectedExports = {
+      ".": {
+        types: "./index.d.ts",
+        module: {
+          types: "./index.d.ts",
+          development: {
+            types: "./development.d.ts",
+            import: "./development.js",
+            default: "./development.js",
+          },
+          import: "./index.js",
+          default: "./index.js",
+        },
+        import: "./index.js",
+        default: "./index.js",
+      },
+      "./package.json": "./package.json",
+    };
+
+    expect(prepared.exports).toEqual(expectedExports);
+    const written = JSON.parse(
+      readFileSync(join(root, "packages/prompts/dist/package.json"), "utf8"),
+    );
+    expect(written.exports).toEqual(expectedExports);
+  });
+
   test("ignores a stale nested manifest that repeats a workspace name", () => {
     const root = temporaryRepository();
     writeJson(root, "package.json", {

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -11,6 +11,7 @@ const monorepoRoot = resolve(packageRoot, "../..");
 const uiSrc = resolve(packageRoot, "src");
 const sharedSrc = resolve(monorepoRoot, "packages/shared/src");
 const coreSrc = resolve(monorepoRoot, "packages/core/src");
+const promptsSrc = resolve(monorepoRoot, "packages/prompts/src");
 const cloudRoutingSrc = resolve(monorepoRoot, "packages/cloud/routing/src");
 const cloudSharedSrc = resolve(monorepoRoot, "packages/cloud/shared/src");
 const loggerSrc = resolve(monorepoRoot, "packages/logger/src");
@@ -112,6 +113,12 @@ export default defineConfig({
       {
         find: /^@elizaos\/core\/(.+)$/,
         replacement: resolve(coreSrc, "$1"),
+      },
+      {
+        // Vitest deliberately omits Vite's `module` condition. Resolve this
+        // workspace package explicitly so clean CI does not require dist/.
+        find: /^@elizaos\/prompts$/,
+        replacement: resolve(promptsSrc, "index.ts"),
       },
       {
         find: /^@elizaos\/app-core(?:\/browser|\/ui-compat)?$/,


### PR DESCRIPTION
## Summary

- expose the maintained prompts source to Vite through the workspace-only `module` export while keeping native Node on compiled `dist`
- add a targeted prompts source alias to the UI Vitest config because Vitest 4 intentionally removes Vite's `module` condition in Node mode
- prove native Node default/development/production execution, Vite clean-workspace loading, Bun workspace loading, and published tarball resolution under `module` and `eliza-source`
- cover recursive publish-manifest rewriting and synchronize package documentation

Closes #28803.

## Regression boundary

Merged #27316 moved normal runtime exports to `./dist/index.js`. Clean CI installs do not prebuild `packages/prompts/dist`, so the chat render-parity lane failed while importing `packages/core/src/prompts.ts`.

The repair preserves the published/native-Node contract: only workspace-aware bundlers or explicit test aliases reach source; the generated publish manifest rewrites every conditional runtime path to compiled JavaScript.

## Validation

Exact head: `23f15db507018e4fd70e54c072cc28aa78695c7a`
Exact base: `4eaf54db749ece00d2c3860a3239db13891a9c30`
Bun: `1.3.14`

- clean `packages/prompts/dist` + exact render-parity command: 13/13 pass
- `bun run --cwd packages/prompts test`: 25/25 pass
- `bun test packages/scripts/__tests__/prepare-package-dist.test.ts`: 5/5 pass
- prompts typecheck, lint, format, and secret scanner: pass (existing review-only wallet warning)
- AGENTS/CLAUDE byte-identity guard: 160 pairs pass
- publish graph, dependency declaration, and tsconfig workspace-resolution audits: pass
- `git diff --check`: pass
- independent adversarial re-review of the final diff: no P0-P3 findings

A full clean-dist UI typecheck is not claimed: this install topology stops earlier on the unrelated existing `@elizaos/cloud-routing` compiled-entry baseline. The exact Vite regression lane above passes from `prompts/dist` absent.

## Safety

No prompt content, provider/model call, workflow behavior, deployment, package publication, production state, payment, Stripe state, or database state is changed.
