### PR TITLE
fix(core): keep UTF-16 surrogate pairs intact in trimDemonstrationInput

### DIFF
--- a/packages/core/src/services/optimized-prompt-resolver.test.ts
+++ b/packages/core/src/services/optimized-prompt-resolver.test.ts
@@ -269,3 +269,32 @@ describe("resolveOptimizedPromptForRuntime — per-task wiring", () => {
 		expect(out).toBe(BASELINE);
 	});
 });
+
+describe("trimDemonstrationInput UTF-16 surrogate safety", () => {
+	test("preserves UTF-16 surrogate pairs when trimming demonstration inputs", () => {
+		// 599 ASCII chars + "🔥" (2 code units) = 601.
+		// Truncating limit is 600. Index 600 lands on high surrogate of "🔥".
+		// Surrogate safe back-off ensures we take index 599, keeping emoji intact.
+		const longUser = "user: " + "a".repeat(599) + "🔥";
+		const service = {
+			getPrompt: () => ({
+				prompt: "OPTIMIZED",
+				fewShotExamples: [{ input: { user: longUser }, expectedOutput: "out" }],
+			}),
+		} as unknown as OptimizedPromptService;
+		const out = resolveOptimizedPromptForRuntime(
+			makeRuntime(service),
+			"response",
+			BASELINE,
+		);
+		expect(out).toContain("a".repeat(599));
+		for (const char of out) {
+			expect(
+				/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(
+					char,
+				),
+			).toBe(false);
+		}
+	});
+});
+

--- a/packages/core/src/services/optimized-prompt-resolver.ts
+++ b/packages/core/src/services/optimized-prompt-resolver.ts
@@ -1,3 +1,15 @@
+function truncateUtf16Safe(text: string, maxLength: number): string {
+	if (text.length <= maxLength) return text;
+	let end = maxLength;
+	if (end > 0 && end < text.length) {
+		const code = text.charCodeAt(end - 1);
+		if (code >= 0xd800 && code <= 0xdbff) {
+			end -= 1;
+		}
+	}
+	return text.slice(0, end);
+}
+
 /**
  * Helper that resolves the system prompt for one of the five core decision
  * tasks. Each runtime call site already constructs a baseline prompt; this
@@ -72,21 +84,22 @@ export function resolveOptimizedPrompt(
  * tool catalog (often ~30K chars); for ICL we only need the user's
  * current-turn request.
  */
-function trimDemonstrationInput(rawInput: string): string {
+function trimDemonstrationInput(rawInput: string | undefined): string {
+	const text = typeof rawInput === "string" ? rawInput : "";
 	const userMatch =
-		rawInput.match(
+		text.match(
 			/(?:^|\n)user(?:\s+message)?\s*:\s*([^\n]+(?:\n(?!\w+:)[^\n]+)*)/i,
 		) ??
-		rawInput.match(/(?:^|\n)user_message\s*:\s*([^\n]+(?:\n(?!\w+:)[^\n]+)*)/i);
+		text.match(/(?:^|\n)user_message\s*:\s*([^\n]+(?:\n(?!\w+:)[^\n]+)*)/i);
 	const candidate = userMatch?.[1]?.trim();
 	if (candidate && candidate.length > 0 && candidate.length <= 600) {
 		return candidate;
 	}
 	if (candidate && candidate.length > 0) {
-		return `${candidate.slice(0, 600).trimEnd()} …`;
+		return `${truncateUtf16Safe(candidate, 600).trimEnd()} …`;
 	}
-	if (rawInput.length <= 600) return rawInput;
-	return `${rawInput.slice(0, 400).trimEnd()}\n…\n${rawInput.slice(-200).trimStart()}`;
+	if (text.length <= 600) return text;
+	return `${truncateUtf16Safe(text, 400).trimEnd()}\n…\n${text.slice(-200).trimStart()}`;
 }
 
 function injectDemonstrations(


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:20bf40fd04d2a6f849002c4dda65e3243ed182ec -->

## Summary
In `packages/core/src/services/optimized-prompt-resolver.ts`:
`trimDemonstrationInput` trims recorded demonstration user inputs down to 600 or 400 characters using `candidate.slice(0, 600)` and `rawInput.slice(0, 400)`.

When few-shot example inputs contain multi-byte UTF-16 surrogate pairs (e.g. emojis or astral plane characters), string slicing at character boundaries can bisect a surrogate pair, causing corrupt/unpaired surrogate code points (`\uFFFD`) to be injected into system prompts.

## Proposed Changes
1. Added `truncateUtf16Safe` helper with surrogate boundary back-off in `packages/core/src/services/optimized-prompt-resolver.ts`.
2. Applied `truncateUtf16Safe` when trimming demonstration inputs in `trimDemonstrationInput`.
3. Handled optional/undefined inputs safely.
4. Added unit tests in `packages/core/src/services/optimized-prompt-resolver.test.ts`.

## Verification
- Ran vitest: `bun run --cwd packages/core test src/services/optimized-prompt-resolver.test.ts` (93/93 passed).

<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-3-5-sonnet","client":"antigravity","skill_revision":"8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"} -->
