### PR TITLE
feat(cloud): atomically admit detached backup publication

### DIFF
--- a/packages/cloud/shared/src/db/agent-backup-operation-lane-migration.pglite.test.ts
+++ b/packages/cloud/shared/src/db/agent-backup-operation-lane-migration.pglite.test.ts
@@ -4,9 +4,17 @@ import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { PGlite } from "@electric-sql/pglite";
 
-const migrationUrl = new URL("./migrations/0313_agent_backup_operation_lane.sql", import.meta.url);
+const baseMigrationUrl = new URL(
+  "./migrations/0313_agent_backup_operation_lane.sql",
+  import.meta.url,
+);
+const phaseMigrationUrl = new URL(
+  "./migrations/0314_agent_backup_detached_publication_lane.sql",
+  import.meta.url,
+);
 const journalUrl = new URL("./migrations/meta/_journal.json", import.meta.url);
-const migration = readFileSync(migrationUrl, "utf8");
+const baseMigration = readFileSync(baseMigrationUrl, "utf8");
+const phaseMigration = readFileSync(phaseMigrationUrl, "utf8");
 
 const ORGANIZATION_A = "00000000-0000-4000-8000-00000000f001";
 const ORGANIZATION_B = "00000000-0000-4000-8000-00000000f002";
@@ -43,17 +51,22 @@ async function createPrerequisites(database: PGlite): Promise<void> {
   `);
 }
 
-async function applyMigration(database: PGlite): Promise<void> {
+async function applyMigration(database: PGlite, migration: string): Promise<void> {
   for (const statement of migration.split("--> statement-breakpoint")) {
     if (statement.trim()) await database.exec(statement);
   }
 }
 
-async function withDatabase(run: (database: PGlite) => Promise<void>): Promise<void> {
+async function withDatabase(
+  run: (database: PGlite) => Promise<void>,
+  prepareBeforePhase?: (database: PGlite) => Promise<void>,
+): Promise<void> {
   const database = new PGlite();
   try {
     await createPrerequisites(database);
-    await applyMigration(database);
+    await applyMigration(database, baseMigration);
+    await prepareBeforePhase?.(database);
+    await applyMigration(database, phaseMigration);
     await run(database);
   } finally {
     await database.close();
@@ -65,25 +78,27 @@ describe("agent backup operation lane migration", () => {
     const journal = (await Bun.file(journalUrl).json()) as {
       entries: Array<{ idx: number; tag: string }>;
     };
-    expect(
-      journal.entries
-        .filter((entry) => entry.tag.includes("agent_backup_operation_lane"))
-        .map(({ idx, tag }) => ({ idx, tag })),
-    ).toEqual([{ idx: 296, tag: "0313_agent_backup_operation_lane" }]);
+    expect(journal.entries.slice(-2).map(({ idx, tag }) => ({ idx, tag }))).toEqual([
+      { idx: 296, tag: "0313_agent_backup_operation_lane" },
+      { idx: 297, tag: "0314_agent_backup_detached_publication_lane" },
+    ]);
   });
 
-  test("applies twice and preserves exactly one seeded singleton", async () => {
+  test("applies the phase migration twice and preserves one blank singleton", async () => {
     await withDatabase(async (database) => {
-      await applyMigration(database);
+      await applyMigration(database, phaseMigration);
       const rows = await database.query<{
         singleton: boolean;
         claim_sequence: string;
         owner_id: string | null;
+        operation_phase: string | null;
       }>(`
-        SELECT singleton, claim_sequence::text, owner_id
+        SELECT singleton, claim_sequence::text, owner_id, operation_phase
         FROM agent_backup_operation_lane
       `);
-      expect(rows.rows).toEqual([{ singleton: true, claim_sequence: "0", owner_id: null }]);
+      expect(rows.rows).toEqual([
+        { singleton: true, claim_sequence: "0", owner_id: null, operation_phase: null },
+      ]);
       await expect(
         database.exec(`INSERT INTO agent_backup_operation_lane (singleton) VALUES (false)`),
       ).rejects.toThrow(/singleton_check/);
@@ -91,6 +106,39 @@ describe("agent backup operation lane migration", () => {
         database.exec(`INSERT INTO agent_backup_operation_lane (singleton) VALUES (true)`),
       ).rejects.toThrow(/duplicate key|unique constraint/i);
     });
+  });
+
+  test("backfills active and released legacy ownership as capture", async () => {
+    for (const releasedAt of [null, "2026-08-25T10:03:00Z"]) {
+      await withDatabase(
+        async (database) => {
+          const lane = await database.query<{ operation_phase: string; released: boolean }>(`
+            SELECT operation_phase, released_at IS NOT NULL AS released
+            FROM agent_backup_operation_lane
+          `);
+          expect(lane.rows).toEqual([
+            { operation_phase: "capture", released: releasedAt !== null },
+          ]);
+
+          await database.exec(`
+            UPDATE agent_backup_operation_lane SET operation_phase = 'publication'
+          `);
+          await expect(
+            database.exec(`UPDATE agent_backup_operation_lane SET operation_phase = 'invalid'`),
+          ).rejects.toThrow(/shape_check/);
+        },
+        async (database) => {
+          await database.exec(`
+            UPDATE agent_backup_operation_lane SET
+              owner_id = 'legacy-worker', generation = '${GENERATION}',
+              organization_id = '${ORGANIZATION_A}', backup_id = '${BACKUP_ID}',
+              operation_id = '${OPERATION_ID}', claimed_at = '2026-08-25T10:00:00Z',
+              lease_expires_at = '2026-08-25T10:05:00Z',
+              released_at = ${releasedAt === null ? "NULL" : `'${releasedAt}'`}, claim_sequence = 1
+          `);
+        },
+      );
+    }
   });
 
   test("rejects partial claims and enforces the 255-byte canonical owner boundary", async () => {
@@ -103,7 +151,8 @@ describe("agent backup operation lane migration", () => {
         UPDATE agent_backup_operation_lane SET
           owner_id = '${"a".repeat(255)}', generation = '${GENERATION}',
           organization_id = '${ORGANIZATION_A}', backup_id = '${BACKUP_ID}',
-          operation_id = '${OPERATION_ID}', claimed_at = '2026-08-25T10:00:00Z',
+          operation_id = '${OPERATION_ID}', operation_phase = 'capture',
+          claimed_at = '2026-08-25T10:00:00Z',
           lease_expires_at = '2026-08-25T10:05:00Z', claim_sequence = 1
       `);
       await expect(
@@ -181,7 +230,7 @@ describe("agent backup operation lane migration", () => {
     });
   });
 
-  test("keys node fairness by exact history occurrence and cleans it with the live node", async () => {
+  test("keeps node fairness after live-node deletion and protects exact history", async () => {
     await withDatabase(async (database) => {
       await database.exec(`
         INSERT INTO agent_backup_operation_node_watermarks (
@@ -224,15 +273,25 @@ describe("agent backup operation lane migration", () => {
           )
         `),
       ).rejects.toThrow(/sequence_uidx|unique constraint/i);
-      await expect(
-        database.exec(`DELETE FROM agent_node_incarnation_histories WHERE id = '${HISTORY_A1}'`),
-      ).rejects.toThrow(/foreign key/i);
-
       await database.exec(`DELETE FROM docker_nodes WHERE id = '${NODE_A}'`);
       const remaining = await database.query<{ count: number }>(`
         SELECT count(*)::integer AS count FROM agent_backup_operation_node_watermarks
       `);
-      expect(remaining.rows).toEqual([{ count: 0 }]);
+      expect(remaining.rows).toEqual([{ count: 2 }]);
+
+      const foreignKeys = await database.query<{ conname: string }>(`
+        SELECT conname
+        FROM pg_constraint
+        WHERE conrelid = 'agent_backup_operation_node_watermarks'::regclass
+          AND contype = 'f'
+        ORDER BY conname
+      `);
+      expect(foreignKeys.rows).toEqual([
+        { conname: "agent_backup_op_node_watermarks_occurrence_fkey" },
+      ]);
+      await expect(
+        database.exec(`DELETE FROM agent_node_incarnation_histories WHERE id = '${HISTORY_A1}'`),
+      ).rejects.toThrow(/foreign key/i);
     });
   });
 });

--- a/packages/cloud/shared/src/db/migrations/0314_agent_backup_detached_publication_lane.sql
+++ b/packages/cloud/shared/src/db/migrations/0314_agent_backup_detached_publication_lane.sql
@@ -1,0 +1,41 @@
+ALTER TABLE "agent_backup_operation_lane"
+	ADD COLUMN IF NOT EXISTS "operation_phase" text;
+--> statement-breakpoint
+UPDATE "agent_backup_operation_lane"
+	SET "operation_phase" = 'capture'
+	WHERE "owner_id" IS NOT NULL AND "operation_phase" IS NULL;
+--> statement-breakpoint
+ALTER TABLE "agent_backup_operation_lane"
+	DROP CONSTRAINT IF EXISTS "agent_backup_operation_lane_shape_check";
+--> statement-breakpoint
+ALTER TABLE "agent_backup_operation_lane"
+	ADD CONSTRAINT "agent_backup_operation_lane_shape_check" CHECK ((
+		"claim_sequence" >= 0 AND ((
+			"owner_id" IS NULL
+			AND "generation" IS NULL
+			AND "organization_id" IS NULL
+			AND "backup_id" IS NULL
+			AND "operation_id" IS NULL
+			AND "operation_phase" IS NULL
+			AND "claimed_at" IS NULL
+			AND "lease_expires_at" IS NULL
+			AND "released_at" IS NULL
+		) OR (
+			"owner_id" IS NOT NULL
+			AND btrim("owner_id") = "owner_id"
+			AND octet_length("owner_id") BETWEEN 1 AND 255
+			AND "owner_id" !~ '[[:cntrl:]]'
+			AND "generation" IS NOT NULL
+			AND "organization_id" IS NOT NULL
+			AND "backup_id" IS NOT NULL
+			AND "operation_id" IS NOT NULL
+			AND "operation_phase" IN ('capture', 'publication')
+			AND "claimed_at" IS NOT NULL
+			AND "lease_expires_at" > "claimed_at"
+			AND ("released_at" IS NULL OR "released_at" >= "claimed_at")
+			AND "claim_sequence" >= 1
+		))
+	) IS TRUE);
+--> statement-breakpoint
+ALTER TABLE "agent_backup_operation_node_watermarks"
+	DROP CONSTRAINT IF EXISTS "agent_backup_op_node_watermarks_node_fkey";

--- a/packages/cloud/shared/src/db/migrations/meta/_journal.json
+++ b/packages/cloud/shared/src/db/migrations/meta/_journal.json
@@ -2080,6 +2080,13 @@
       "when": 1794254400004,
       "tag": "0313_agent_backup_operation_lane",
       "breakpoints": true
+    },
+    {
+      "idx": 297,
+      "version": "7",
+      "when": 1794254400005,
+      "tag": "0314_agent_backup_detached_publication_lane",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-global-lock-order.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-global-lock-order.test.ts
@@ -168,4 +168,68 @@ describe("agent backup global lock order", () => {
       "capture admission renewal",
     );
   });
+
+  test("detached publication admission locks the lane before immutable source authority", () => {
+    const admission = source("agent-backup-publication-admission.ts");
+    const sourceLockStart = admission.indexOf(
+      "async function lockDetachedSourceAuthorityInTransaction",
+    );
+    const sourceLockEnd = admission.indexOf("function assertCatalogueReplay", sourceLockStart);
+    expect(sourceLockStart).toBeGreaterThanOrEqual(0);
+    expect(sourceLockEnd).toBeGreaterThan(sourceLockStart);
+    const sourceLocks = admission.slice(sourceLockStart, sourceLockEnd);
+    const sourceAnchors = [
+      ".from(organizations)",
+      ".from(agentActivationPublications)",
+      ".from(agentNodeIncarnationHistories)",
+    ];
+    let previous = -1;
+    for (const anchor of sourceAnchors) {
+      const index = sourceLocks.indexOf(anchor, previous + 1);
+      expect(index, `publication admission: missing ordered authority ${anchor}`).toBeGreaterThan(
+        previous,
+      );
+      previous = index;
+    }
+
+    expect(admission, "detached publication must not read the mutable sandbox row").not.toContain(
+      ".from(agentSandboxes)",
+    );
+    expect(admission, "detached publication must not read the mutable node row").not.toContain(
+      ".from(dockerNodes)",
+    );
+
+    const publicationReadStart = sourceLocks.indexOf(".from(agentActivationPublications)");
+    const historyReadStart = sourceLocks.indexOf(
+      ".from(agentNodeIncarnationHistories)",
+      publicationReadStart,
+    );
+    expect(
+      sourceLocks.slice(publicationReadStart, historyReadStart),
+      "immutable activation publication must not be row-locked",
+    ).not.toContain('.for("');
+    expect(
+      sourceLocks.slice(historyReadStart),
+      "append-only node history must not be row-locked",
+    ).not.toContain('.for("');
+
+    const claim = exportedFunction(
+      admission,
+      "claimNextAgentBackupPublicationAdmission",
+      "renewAgentBackupPublicationAdmission",
+    );
+    expectOrder(
+      claim,
+      "lockAgentBackupOperationLaneInTransaction(tx)",
+      "lockNextDuePublicationInTransaction(tx)",
+      "publication admission",
+    );
+    const renew = exportedFunction(admission, "renewAgentBackupPublicationAdmission");
+    expectOrder(
+      renew,
+      "renewAgentBackupOperationLaneInTransaction(tx",
+      "lockBackupByTargetInTransaction(tx",
+      "publication admission renewal",
+    );
+  });
 });

--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-operation-admission.postgres.integration.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-operation-admission.postgres.integration.test.ts
@@ -454,6 +454,7 @@ realPostgres("backup operation admission contention", () => {
         organization_id: ORGANIZATION_ID,
         backup_id: winner.admission.claim.backup.id,
         operation_id: winner.admission.claim.backup.backup_operation_id,
+        operation_phase: "capture",
         released_at: null,
         claim_sequence: 1n,
       });

--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-operation-lane.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-operation-lane.pglite.test.ts
@@ -48,6 +48,7 @@ const target: AgentBackupOperationLaneTarget = {
   organizationId: ORGANIZATION_ID,
   backupId: BACKUP_ID,
   operationId: OPERATION_ID,
+  operationPhase: "capture",
 };
 
 const fairness: AgentBackupOperationLaneFairness = {
@@ -234,6 +235,7 @@ describe("agent backup operation lane lifecycle on primary PGlite", () => {
       organization_id: ORGANIZATION_ID,
       backup_id: BACKUP_ID,
       operation_id: OPERATION_ID,
+      operation_phase: "capture",
       claim_sequence: 1n,
       released_at: null,
     });
@@ -261,12 +263,44 @@ describe("agent backup operation lane lifecycle on primary PGlite", () => {
     ]);
   });
 
+  test("retains exact-node fairness after the mutable Docker node is deleted", async () => {
+    requireSuccessfulClaim(await claimCommitted());
+
+    await dbWrite.delete(dockerNodesTable).where(eq(dockerNodesTable.id, NODE_RECORD_ID));
+
+    expect(await dbWrite.select().from(dockerNodesTable)).toEqual([]);
+    expect((await readWatermarks()).nodes).toEqual([
+      expect.objectContaining({
+        source_node_history_id: NODE_HISTORY_ID,
+        source_node_record_id: NODE_RECORD_ID,
+        source_node_incarnation: NODE_INCARNATION,
+        last_service_sequence: 1n,
+      }),
+    ]);
+    await expect(
+      dbWrite
+        .delete(nodeHistoriesTable)
+        .where(eq(nodeHistoriesTable.id, NODE_HISTORY_ID))
+        .execute(),
+    ).rejects.toThrow();
+    expect(
+      await dbWrite
+        .select({ id: nodeHistoriesTable.id })
+        .from(nodeHistoriesTable)
+        .where(eq(nodeHistoriesTable.id, NODE_HISTORY_ID)),
+    ).toEqual([{ id: NODE_HISTORY_ID }]);
+  });
+
   test("requires an explicit transaction to turn the row lock into authority", async () => {
     await expectElizaError(
       repository.lockAgentBackupOperationLaneInTransaction(dbWrite as unknown as DbTransaction),
       "AGENT_BACKUP_OPERATION_LANE_TRANSACTION_REQUIRED",
     );
-    expect(await readLane()).toMatchObject({ owner_id: null, claim_sequence: 0n });
+    expect(await readLane()).toMatchObject({
+      owner_id: null,
+      operation_phase: null,
+      claim_sequence: 0n,
+    });
     expect(await readWatermarks()).toEqual({ tenants: [], nodes: [] });
   });
 
@@ -285,6 +319,7 @@ describe("agent backup operation lane lifecycle on primary PGlite", () => {
         mutableParams.organizationId = OTHER_BACKUP_ID;
         mutableParams.backupId = OTHER_BACKUP_ID;
         mutableParams.operationId = OTHER_OPERATION_ID;
+        mutableParams.operationPhase = "publication";
         mutableParams.callerToken.ownerId = OWNER_B;
         mutableParams.callerToken.generation = GENERATION_B;
         mutableParams.fairness.sourceNodeHistoryId = OTHER_BACKUP_ID;
@@ -303,6 +338,7 @@ describe("agent backup operation lane lifecycle on primary PGlite", () => {
       organization_id: ORGANIZATION_ID,
       backup_id: BACKUP_ID,
       operation_id: OPERATION_ID,
+      operation_phase: "capture",
     });
     const { tenants, nodes } = await readWatermarks();
     expect(tenants[0]).toMatchObject({ organization_id: ORGANIZATION_ID });
@@ -330,6 +366,66 @@ describe("agent backup operation lane lifecycle on primary PGlite", () => {
     const { tenants, nodes } = await readWatermarks();
     expect(tenants[0]?.service_count).toBe(1n);
     expect(nodes[0]?.service_count).toBe(1n);
+  });
+
+  test("persists publication phase and fences every operation against phase drift", async () => {
+    const publicationTarget: AgentBackupOperationLaneTarget = {
+      ...target,
+      operationPhase: "publication",
+    };
+    const claimed = requireSuccessfulClaim(await claimCommitted({ target: publicationTarget }));
+    expect(claimed.proof.lane.operation_phase).toBe("publication");
+
+    await expectElizaError(claimCommitted(), "AGENT_BACKUP_OPERATION_LANE_LOST");
+    await expectElizaError(
+      dbWrite.transaction((tx) =>
+        repository.assertAgentBackupOperationLaneInTransaction(tx, {
+          ...target,
+          execution: claimed.execution,
+        }),
+      ),
+      "AGENT_BACKUP_OPERATION_LANE_LOST",
+    );
+    await expectElizaError(
+      dbWrite.transaction((tx) =>
+        repository.renewAgentBackupOperationLaneInTransaction(tx, {
+          ...target,
+          execution: claimed.execution,
+          leaseMs: 60_000,
+        }),
+      ),
+      "AGENT_BACKUP_OPERATION_LANE_LOST",
+    );
+    await expectElizaError(
+      dbWrite.transaction((tx) =>
+        repository.releaseAgentBackupOperationLaneInTransaction(tx, {
+          ...target,
+          execution: claimed.execution,
+        }),
+      ),
+      "AGENT_BACKUP_OPERATION_LANE_LOST",
+    );
+
+    const beforeRelease = await readLane();
+    expect(beforeRelease.operation_phase).toBe("publication");
+    await expect(
+      dbWrite.transaction((tx) =>
+        repository.assertAgentBackupOperationLaneInTransaction(tx, {
+          ...publicationTarget,
+          execution: claimed.execution,
+        }),
+      ),
+    ).resolves.toMatchObject({ active: true });
+    const released = await dbWrite.transaction((tx) =>
+      repository.releaseAgentBackupOperationLaneInTransaction(tx, {
+        ...publicationTarget,
+        execution: claimed.execution,
+      }),
+    );
+    expect(released).toMatchObject({
+      kind: "released",
+      lane: { operation_phase: "publication" },
+    });
   });
 
   test("returns one active winner and a non-mutating busy result to another token", async () => {
@@ -602,6 +698,7 @@ describe("agent backup operation lane lifecycle on primary PGlite", () => {
       organization_id: null,
       backup_id: null,
       operation_id: null,
+      operation_phase: null,
       claim_sequence: 0n,
     });
     expect(await readWatermarks()).toEqual({ tenants: [], nodes: [] });
@@ -639,6 +736,7 @@ describe("agent backup operation lane lifecycle on primary PGlite", () => {
 
     for (const invalidClaim of [
       { target: { ...target, organizationId: UPPERCASE_UUID } },
+      { target: { ...target, operationPhase: "restore" as never } },
       { callerToken: { ...callerB, generation: UPPERCASE_UUID } },
       { fairness: { ...fairness, sourceNodeHistoryId: UPPERCASE_UUID } },
       { leaseMs: 0 },

--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-publication-admission.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-publication-admission.pglite.test.ts
@@ -1,0 +1,707 @@
+/** PGlite proofs for source-node-detached backup publication admission. */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { pushSchema } from "drizzle-kit/api";
+import { asc, eq } from "drizzle-orm";
+import { installAgentNodeOccurrenceTriggerForTests } from "../../agent-node-occurrence-test-support";
+import {
+  agentBackupOperationLane,
+  agentBackupOperationNodeWatermarks,
+  agentBackupOperationTenantWatermarks,
+} from "../../schemas/agent-backup-operation-lane";
+import { agentActivationPublications } from "../../schemas/agent-backup-restore-history";
+import { agentNodeIncarnationHistories } from "../../schemas/agent-node-incarnation-histories";
+import {
+  type AgentBackupCatalogState,
+  agentBackupCatalogAuthorities,
+  agentSandboxBackups,
+  agentSandboxes,
+} from "../../schemas/agent-sandboxes";
+import { dockerNodes } from "../../schemas/docker-nodes";
+import { organizations } from "../../schemas/organizations";
+import { userCharacters } from "../../schemas/user-characters";
+import { users } from "../../schemas/users";
+
+process.env.DATABASE_URL = "pglite://memory";
+process.env.DISABLE_LOCAL_PGLITE_FALLBACK = "1";
+process.env.NODE_ENV = "test";
+process.env.MOCK_REDIS = "1";
+process.env.SKIP_AGENT_SANDBOX_ENSURE = "1";
+
+const PGLITE_TIMEOUT = 60_000;
+const ORGANIZATION_ID = "10000000-0000-4000-8000-000000000201";
+const USER_ID = "20000000-0000-4000-8000-000000000201";
+const AGENT_ID = "30000000-0000-4000-8000-000000000201";
+const OPERATION_A = "40000000-0000-4000-8000-000000000201";
+const OPERATION_B = "40000000-0000-4000-8000-000000000202";
+const ACTIVATION_GENERATION = "50000000-0000-4000-8000-000000000201";
+const ACTIVATION_GENERATION_B = "50000000-0000-4000-8000-000000000202";
+const NODE_RECORD_ID = "60000000-0000-4000-8000-000000000201";
+const NODE_INCARNATION_A = "70000000-0000-4000-8000-000000000201";
+const NODE_INCARNATION_B = "70000000-0000-4000-8000-000000000202";
+const CALLER_GENERATION_A = "80000000-0000-4000-8000-000000000201";
+const CALLER_GENERATION_B = "80000000-0000-4000-8000-000000000202";
+const CALLER_GENERATION_C = "80000000-0000-4000-8000-000000000203";
+const ACTIVATION_PUBLICATION_ID = "90000000-0000-4000-8000-000000000201";
+const ACTIVATION_PUBLICATION_ID_B = "90000000-0000-4000-8000-000000000202";
+const OWNER_A = "backup-publication-admission-worker-a";
+const OWNER_B = "backup-publication-admission-worker-b";
+const NODE_ID = "robot-backup-publication-admission";
+const PROVIDER_HANDLE = "backup-publication-admission-container";
+const CONTAINER_ID = "a".repeat(64);
+const IMAGE_DIGEST = `sha256:${"b".repeat(64)}`;
+const OTHER_IMAGE_DIGEST = `sha256:${"c".repeat(64)}`;
+const SHA_A = "d".repeat(64);
+const SHA_B = "e".repeat(64);
+const SHA_C = "f".repeat(64);
+const ACTIVATION_PUBLISHED_AT = new Date("2026-08-17T00:00:00.000Z");
+const ACTIVATION_RECEIPT = Object.freeze({
+  schemaVersion: 1 as const,
+  generation: ACTIVATION_GENERATION,
+  purpose: "provision" as const,
+  agentId: AGENT_ID,
+  organizationId: ORGANIZATION_ID,
+  lifecycleRevision: "0",
+  backupId: null,
+  backupHash: null,
+  manifestHash: null,
+  componentHashes: null,
+  freshAuthorization: null,
+  containerId: CONTAINER_ID,
+  imageDigest: IMAGE_DIGEST,
+  receiptId: NODE_INCARNATION_A,
+  receiptHash: SHA_A,
+  receiptMac: SHA_B,
+  appliedAt: "2026-08-17T00:00:00.000Z",
+  restored: true,
+  requiresRestart: false,
+});
+
+type ClientModule = typeof import("../../client");
+type PublicationRepository = typeof import("../agent-backup-publication-admission");
+type CaptureRepository = typeof import("../agent-backup-operation-admission");
+type CatalogRepository = typeof import("../agent-backup-catalog");
+type ClaimResult = Awaited<
+  ReturnType<PublicationRepository["claimNextAgentBackupPublicationAdmission"]>
+>;
+type SuccessfulClaim = Extract<ClaimResult, { kind: "claimed" | "replayed" }>;
+
+let dbWrite: ClientModule["dbWrite"];
+let closeDatabaseConnectionsForTests: ClientModule["closeDatabaseConnectionsForTests"];
+let publicationRepository: PublicationRepository;
+let captureRepository: CaptureRepository;
+let catalogRepository: CatalogRepository;
+let schemaFailure = "";
+
+const callerA = Object.freeze({ ownerId: OWNER_A, generation: CALLER_GENERATION_A });
+const callerB = Object.freeze({ ownerId: OWNER_B, generation: CALLER_GENERATION_B });
+
+function requireAdmission(result: ClaimResult): SuccessfulClaim {
+  if (result.kind === "empty" || result.kind === "busy") {
+    throw new Error(`Expected publication admission, received ${result.kind}`);
+  }
+  return result;
+}
+
+function claimNext(
+  callerToken: Readonly<{ ownerId: string; generation: string }> = callerA,
+  leaseMs = 60_000,
+): Promise<ClaimResult> {
+  return publicationRepository.claimNextAgentBackupPublicationAdmission({
+    callerToken,
+    leaseMs,
+  });
+}
+
+async function reserveBackup(
+  operationId = OPERATION_A,
+  activationGeneration = ACTIVATION_GENERATION,
+) {
+  return catalogRepository.reserveAgentBackupOperation({
+    organizationId: ORGANIZATION_ID,
+    agentId: AGENT_ID,
+    sandboxRecordId: AGENT_ID,
+    operationId,
+    activationGeneration,
+    lifecycleRevision: "0",
+    snapshotType: "auto",
+    backupKind: "full",
+    sourceProvider: "operator-onboarded",
+    sourceNodeRecordId: NODE_RECORD_ID,
+    sourceNodeId: NODE_ID,
+    sourceNodeIncarnation: NODE_INCARNATION_A,
+    sourceProviderServerId: null,
+    sourceProviderHandle: PROVIDER_HANDLE,
+    sourceContainerId: CONTAINER_ID,
+    retentionReason: "schedule",
+    retentionUntil: new Date("2027-08-17T00:00:00.000Z"),
+  });
+}
+
+async function stampPublicationState(params: {
+  backupId: string;
+  state?: (typeof PUBLICATION_STATES)[number];
+  retryResumeState?: (typeof PUBLICATION_STATES)[number];
+  nextAttemptAt?: Date;
+}): Promise<void> {
+  const retry = params.retryResumeState !== undefined;
+  await dbWrite
+    .update(agentSandboxBackups)
+    .set({
+      catalog_state: retry ? "failed_retryable" : (params.state ?? "captured"),
+      catalog_resume_state: retry ? params.retryResumeState : null,
+      catalog_next_attempt_at: params.nextAttemptAt ?? new Date("2020-01-01T00:00:00.000Z"),
+      catalog_last_error_code: retry ? "PUBLICATION_RETRY" : null,
+      catalog_last_error: retry ? "retry fixture" : null,
+      manifest_format: "elizaos.agent-backup",
+      manifest_version: 2,
+      manifest_digest: SHA_A,
+      manifest_canonical_draft: "{}",
+      manifest_object_count: 1,
+      object_inventory_digest: SHA_B,
+      image_digest: IMAGE_DIGEST,
+      database_schema_version: "1",
+      plugin_set_digest: SHA_A,
+      watermark_digest: SHA_B,
+      raw_size_bytes: 1,
+      compressed_size_bytes: 1,
+      encrypted_size_bytes: 29,
+      kms_key_id: `org:${ORGANIZATION_ID}/dek/v1`,
+      kms_key_version: 1,
+      wrapped_dek_ref: `backup-dek:${params.backupId}`,
+      wrapped_dek_ciphertext_base64: "AQ==",
+      wrapped_dek_sha256: SHA_C,
+      wrapped_dek_size_bytes: 1,
+      wrapped_dek_receipt_digest: SHA_A,
+      catalog_updated_at: new Date(),
+    })
+    .where(eq(agentSandboxBackups.id, params.backupId));
+}
+
+async function reservePublication(
+  params: {
+    operationId?: string;
+    state?: (typeof PUBLICATION_STATES)[number];
+    retryResumeState?: (typeof PUBLICATION_STATES)[number];
+    nextAttemptAt?: Date;
+    activationGeneration?: string;
+  } = {},
+) {
+  const backup = await reserveBackup(params.operationId, params.activationGeneration);
+  await stampPublicationState({
+    backupId: backup.id,
+    state: params.state,
+    retryResumeState: params.retryResumeState,
+    nextAttemptAt: params.nextAttemptAt,
+  });
+  const [updated] = await dbWrite
+    .select()
+    .from(agentSandboxBackups)
+    .where(eq(agentSandboxBackups.id, backup.id));
+  if (!updated) throw new Error("Expected publication backup fixture");
+  return updated;
+}
+
+async function readAuthorityState() {
+  const [lane] = await dbWrite
+    .select()
+    .from(agentBackupOperationLane)
+    .where(eq(agentBackupOperationLane.singleton, true));
+  return {
+    lane,
+    backups: await dbWrite.select().from(agentSandboxBackups).orderBy(asc(agentSandboxBackups.id)),
+    tenantWatermarks: await dbWrite
+      .select()
+      .from(agentBackupOperationTenantWatermarks)
+      .orderBy(asc(agentBackupOperationTenantWatermarks.organization_id)),
+    nodeWatermarks: await dbWrite
+      .select()
+      .from(agentBackupOperationNodeWatermarks)
+      .orderBy(asc(agentBackupOperationNodeWatermarks.source_node_history_id)),
+  };
+}
+
+async function expireAdmission(admission: SuccessfulClaim["admission"]): Promise<void> {
+  const claimedAt = new Date("2020-01-01T00:00:00.000Z");
+  const expiredAt = new Date("2020-01-01T00:00:01.000Z");
+  await dbWrite.transaction(async (tx) => {
+    await tx
+      .update(agentBackupOperationLane)
+      .set({
+        claimed_at: claimedAt,
+        lease_expires_at: expiredAt,
+        released_at: null,
+        updated_at: expiredAt,
+      })
+      .where(eq(agentBackupOperationLane.singleton, true));
+    await tx
+      .update(agentSandboxBackups)
+      .set({ catalog_lease_expires_at: expiredAt, catalog_updated_at: expiredAt })
+      .where(eq(agentSandboxBackups.id, admission.claim.backup.id));
+  });
+}
+
+const PUBLICATION_STATES = [
+  "captured",
+  "uploading",
+  "primary_uploaded",
+  "primary_verified",
+  "secondary_pending",
+] as const satisfies readonly AgentBackupCatalogState[];
+
+beforeAll(async () => {
+  try {
+    const client = await import("../../client");
+    dbWrite = client.dbWrite;
+    closeDatabaseConnectionsForTests = client.closeDatabaseConnectionsForTests;
+    publicationRepository = await import("../agent-backup-publication-admission");
+    captureRepository = await import("../agent-backup-operation-admission");
+    catalogRepository = await import("../agent-backup-catalog");
+
+    const { apply } = await pushSchema(
+      {
+        organizations,
+        users,
+        userCharacters,
+        agentNodeIncarnationHistories,
+        dockerNodes,
+        agentSandboxes,
+        agentSandboxBackups,
+        agentBackupCatalogAuthorities,
+        agentBackupOperationLane,
+        agentBackupOperationTenantWatermarks,
+        agentBackupOperationNodeWatermarks,
+        agentActivationPublications,
+      } as never,
+      dbWrite as never,
+    );
+    await apply();
+    await installAgentNodeOccurrenceTriggerForTests((statement) => dbWrite.execute(statement));
+  } catch (error) {
+    schemaFailure = error instanceof Error ? error.message : String(error);
+  }
+}, PGLITE_TIMEOUT);
+
+beforeEach(async () => {
+  expect(schemaFailure).toBe("");
+  await dbWrite.delete(agentBackupOperationNodeWatermarks);
+  await dbWrite.delete(agentBackupOperationTenantWatermarks);
+  await dbWrite.delete(agentBackupOperationLane);
+  await dbWrite.delete(agentActivationPublications);
+  await dbWrite.delete(agentSandboxBackups);
+  await dbWrite.delete(agentBackupCatalogAuthorities);
+  await dbWrite.delete(agentSandboxes);
+  await dbWrite.delete(dockerNodes);
+  await dbWrite.delete(agentNodeIncarnationHistories);
+  await dbWrite.delete(userCharacters);
+  await dbWrite.delete(users);
+  await dbWrite.delete(organizations);
+
+  await dbWrite.insert(organizations).values({
+    id: ORGANIZATION_ID,
+    name: "Backup publication admission organization",
+    slug: "backup-publication-admission-organization",
+  });
+  await dbWrite.insert(users).values({
+    id: USER_ID,
+    steward_user_id: "backup-publication-admission-user",
+    organization_id: ORGANIZATION_ID,
+  });
+  await dbWrite.insert(dockerNodes).values({
+    id: NODE_RECORD_ID,
+    node_id: NODE_ID,
+    hostname: "robot-backup-publication-admission.example.test",
+    host_key_fingerprint: "sha256:backup-publication-admission-host-key",
+    fleet_kind: "robot",
+    infrastructure_provider: "hetzner",
+    provider_server_id: null,
+    node_incarnation: NODE_INCARNATION_A,
+    status: "healthy",
+    enabled: true,
+  });
+  await dbWrite.insert(agentSandboxes).values({
+    id: AGENT_ID,
+    organization_id: ORGANIZATION_ID,
+    user_id: USER_ID,
+    agent_name: "Backup publication admission agent",
+    status: "running",
+    execution_tier: "dedicated-always",
+    sandbox_id: PROVIDER_HANDLE,
+    node_id: NODE_ID,
+    container_name: PROVIDER_HANDLE,
+    image_digest: IMAGE_DIGEST,
+    lifecycle_revision: 0,
+    activation_generation: ACTIVATION_GENERATION,
+    activation_lifecycle_revision: 0n,
+    activation_purpose: "provision",
+    activation_phase: "active",
+    activation_receipt: ACTIVATION_RECEIPT,
+    activation_receipt_hash: SHA_A,
+    activation_container_id: CONTAINER_ID,
+    activation_node_id: NODE_ID,
+    activation_image_digest: IMAGE_DIGEST,
+    activation_boot_id: NODE_INCARNATION_A,
+    activation_token_hash: SHA_B,
+    activation_token_ciphertext: "sealed-publication-admission-token",
+    activation_funding_revision: 0n,
+    activation_authority_published_at: ACTIVATION_PUBLISHED_AT,
+    activation_dispatched_at: new Date("2026-08-17T00:00:01.000Z"),
+    activation_completed_at: new Date("2026-08-17T00:00:02.000Z"),
+  });
+  const [sourceNode] = await dbWrite
+    .select({ historyId: dockerNodes.current_node_history_id })
+    .from(dockerNodes)
+    .where(eq(dockerNodes.id, NODE_RECORD_ID));
+  if (!sourceNode?.historyId) throw new Error("Expected source occurrence during setup");
+  await dbWrite.insert(agentActivationPublications).values({
+    id: ACTIVATION_PUBLICATION_ID,
+    organization_id: ORGANIZATION_ID,
+    agent_id: AGENT_ID,
+    activation_generation: ACTIVATION_GENERATION,
+    previous_activation_generation: null,
+    lifecycle_revision: 0n,
+    purpose: "provision",
+    backup_id: null,
+    backup_manifest_sha256: null,
+    activation_receipt: ACTIVATION_RECEIPT,
+    activation_receipt_sha256: SHA_A,
+    container_id: CONTAINER_ID,
+    node_history_id: sourceNode.historyId,
+    docker_node_record_id: NODE_RECORD_ID,
+    node_id: NODE_ID,
+    node_incarnation: NODE_INCARNATION_A,
+    image_digest: IMAGE_DIGEST,
+    token_sha256: SHA_B,
+    funding_revision: 0n,
+    published_at: ACTIVATION_PUBLISHED_AT,
+  });
+  await dbWrite.insert(agentBackupOperationLane).values({ singleton: true });
+});
+
+afterAll(async () => {
+  await closeDatabaseConnectionsForTests?.();
+});
+
+describe("detached backup publication admission on primary PGlite", () => {
+  test("returns empty for capture work without mutating authority or creating a node", async () => {
+    await reserveBackup();
+    const before = await readAuthorityState();
+    const nodesBefore = await dbWrite.select().from(dockerNodes);
+    const historiesBefore = await dbWrite.select().from(agentNodeIncarnationHistories);
+
+    expect(await claimNext()).toEqual({ kind: "empty" });
+
+    expect(await readAuthorityState()).toEqual(before);
+    expect(await dbWrite.select().from(dockerNodes)).toEqual(nodesBefore);
+    expect(await dbWrite.select().from(agentNodeIncarnationHistories)).toEqual(historiesBefore);
+  });
+
+  test("atomically claims publication, phase, catalogue lease, and historical fairness", async () => {
+    const backup = await reservePublication();
+    const [publication] = await dbWrite.select().from(agentActivationPublications);
+    if (!publication) throw new Error("Expected activation publication fixture");
+
+    const result = requireAdmission(await claimNext());
+    expect(result.kind).toBe("claimed");
+    expect(result.admission).toMatchObject({
+      claim: {
+        ownerId: OWNER_A,
+        generation: CALLER_GENERATION_A,
+        backup: { id: backup.id, backup_operation_id: OPERATION_A },
+      },
+      laneExecution: {
+        ownerId: OWNER_A,
+        generation: CALLER_GENERATION_A,
+        claimSequence: 1n,
+      },
+      sourceNodeHistoryId: publication.node_history_id,
+    });
+    const authority = await readAuthorityState();
+    expect(authority.lane).toMatchObject({
+      owner_id: OWNER_A,
+      generation: CALLER_GENERATION_A,
+      organization_id: ORGANIZATION_ID,
+      backup_id: backup.id,
+      operation_id: OPERATION_A,
+      operation_phase: "publication",
+      claim_sequence: 1n,
+      released_at: null,
+    });
+    expect(authority.backups[0]?.catalog_lease_expires_at?.getTime()).toBe(
+      authority.lane?.lease_expires_at?.getTime(),
+    );
+    expect(authority.tenantWatermarks).toEqual([
+      expect.objectContaining({
+        organization_id: ORGANIZATION_ID,
+        last_backup_id: backup.id,
+        last_operation_id: OPERATION_A,
+        last_service_sequence: 1n,
+        service_count: 1n,
+      }),
+    ]);
+    expect(authority.nodeWatermarks).toEqual([
+      expect.objectContaining({
+        source_node_history_id: publication.node_history_id,
+        source_node_record_id: NODE_RECORD_ID,
+        source_node_incarnation: NODE_INCARNATION_A,
+        last_backup_id: backup.id,
+        last_operation_id: OPERATION_A,
+        last_service_sequence: 1n,
+        service_count: 1n,
+      }),
+    ]);
+  });
+
+  for (const state of PUBLICATION_STATES) {
+    test(`admits the exact ${state} publication state`, async () => {
+      const backup = await reservePublication({ state });
+      const result = requireAdmission(await claimNext());
+      expect(result.kind).toBe("claimed");
+      expect(result.admission.claim.backup).toMatchObject({
+        id: backup.id,
+        catalog_state: state,
+        catalog_resume_state: null,
+      });
+    });
+
+    test(`admits failed_retryable only when it resumes ${state}`, async () => {
+      const backup = await reservePublication({ retryResumeState: state });
+      const result = requireAdmission(await claimNext());
+      expect(result.kind).toBe("claimed");
+      expect(result.admission.claim.backup).toMatchObject({
+        id: backup.id,
+        catalog_state: "failed_retryable",
+        catalog_resume_state: state,
+      });
+    });
+  }
+
+  test("survives sandbox drift plus source-node reboot and deletion without recreating a node", async () => {
+    const backup = await reservePublication();
+    const [publication] = await dbWrite.select().from(agentActivationPublications);
+    if (!publication) throw new Error("Expected activation publication fixture");
+    await dbWrite
+      .update(agentSandboxes)
+      .set({
+        status: "stopped",
+        activation_token_hash: SHA_C,
+        activation_token_ciphertext: "sealed-drifted-publication-token",
+      })
+      .where(eq(agentSandboxes.id, AGENT_ID));
+    await dbWrite
+      .update(dockerNodes)
+      .set({ node_incarnation: NODE_INCARNATION_B })
+      .where(eq(dockerNodes.id, NODE_RECORD_ID));
+    await dbWrite.delete(dockerNodes).where(eq(dockerNodes.id, NODE_RECORD_ID));
+    expect(await dbWrite.select().from(dockerNodes)).toEqual([]);
+
+    const result = requireAdmission(await claimNext());
+    expect(result.kind).toBe("claimed");
+    expect(result.admission).toMatchObject({
+      claim: { backup: { id: backup.id } },
+      sourceNodeHistoryId: publication.node_history_id,
+    });
+    expect(await dbWrite.select().from(dockerNodes)).toEqual([]);
+    expect(await dbWrite.select().from(agentBackupOperationNodeWatermarks)).toEqual([
+      expect.objectContaining({ source_node_history_id: publication.node_history_id }),
+    ]);
+  });
+
+  test("skips an earlier poisoned immutable binding and admits the next publication", async () => {
+    const poisoned = await reservePublication({
+      operationId: OPERATION_A,
+      nextAttemptAt: new Date("2010-01-01T00:00:00.000Z"),
+    });
+    await dbWrite
+      .update(agentSandboxBackups)
+      .set({ image_digest: OTHER_IMAGE_DIGEST })
+      .where(eq(agentSandboxBackups.id, poisoned.id));
+    const valid = await reservePublication({
+      operationId: OPERATION_B,
+      nextAttemptAt: new Date("2011-01-01T00:00:00.000Z"),
+    });
+
+    const result = requireAdmission(await claimNext());
+    expect(result.admission.claim.backup.id).toBe(valid.id);
+    const [poisonedAfter] = await dbWrite
+      .select()
+      .from(agentSandboxBackups)
+      .where(eq(agentSandboxBackups.id, poisoned.id));
+    expect(poisonedAfter).toMatchObject({
+      catalog_lease_owner: null,
+      catalog_lease_generation: null,
+      catalog_lease_expires_at: null,
+    });
+  });
+
+  test("skips a semantically poisoned receipt without globally blocking later work", async () => {
+    const poisoned = await reservePublication({
+      operationId: OPERATION_A,
+      nextAttemptAt: new Date("2010-01-01T00:00:00.000Z"),
+    });
+    const [publication] = await dbWrite
+      .select()
+      .from(agentActivationPublications)
+      .where(eq(agentActivationPublications.id, ACTIVATION_PUBLICATION_ID));
+    if (!publication) throw new Error("Expected activation publication fixture");
+    await dbWrite
+      .update(agentActivationPublications)
+      .set({ activation_receipt: { ...ACTIVATION_RECEIPT, restored: false } })
+      .where(eq(agentActivationPublications.id, ACTIVATION_PUBLICATION_ID));
+
+    const validReceipt = Object.freeze({
+      ...ACTIVATION_RECEIPT,
+      generation: ACTIVATION_GENERATION_B,
+    });
+    await dbWrite.insert(agentActivationPublications).values({
+      ...publication,
+      id: ACTIVATION_PUBLICATION_ID_B,
+      activation_generation: ACTIVATION_GENERATION_B,
+      activation_receipt: validReceipt,
+    });
+    await dbWrite
+      .update(agentSandboxes)
+      .set({
+        activation_generation: ACTIVATION_GENERATION_B,
+        activation_receipt: validReceipt,
+      })
+      .where(eq(agentSandboxes.id, AGENT_ID));
+    const valid = await reservePublication({
+      operationId: OPERATION_B,
+      activationGeneration: ACTIVATION_GENERATION_B,
+      nextAttemptAt: new Date("2011-01-01T00:00:00.000Z"),
+    });
+
+    const result = requireAdmission(await claimNext());
+    expect(result.admission.claim.backup.id).toBe(valid.id);
+    const [poisonedAfter] = await dbWrite
+      .select()
+      .from(agentSandboxBackups)
+      .where(eq(agentSandboxBackups.id, poisoned.id));
+    expect(poisonedAfter).toMatchObject({
+      catalog_lease_owner: null,
+      catalog_lease_generation: null,
+      catalog_lease_expires_at: null,
+    });
+  });
+
+  test("returns busy without leasing a second publication", async () => {
+    const first = await reservePublication({ operationId: OPERATION_A });
+    const second = await reservePublication({ operationId: OPERATION_B });
+    const winner = requireAdmission(await claimNext(callerA));
+    expect([first.id, second.id]).toContain(winner.admission.claim.backup.id);
+
+    const blocked = await claimNext(callerB);
+    expect(blocked.kind).toBe("busy");
+    const backups = await dbWrite.select().from(agentSandboxBackups);
+    expect(backups.filter((backup) => backup.catalog_lease_owner !== null)).toHaveLength(1);
+    expect(backups.filter((backup) => backup.catalog_lease_owner === null)).toHaveLength(1);
+  });
+
+  test("does not replay one active capture as publication even with the same caller token", async () => {
+    const backup = await reserveBackup();
+    const capture = await captureRepository.claimNextAgentBackupOperationAdmission({
+      callerToken: callerA,
+      leaseMs: 60_000,
+    });
+    if (capture.kind === "empty" || capture.kind === "busy") {
+      throw new Error(`Expected capture admission, received ${capture.kind}`);
+    }
+    await stampPublicationState({ backupId: backup.id });
+
+    const publication = await claimNext(callerA);
+    expect(publication.kind).toBe("busy");
+    const authority = await readAuthorityState();
+    expect(authority.lane).toMatchObject({
+      operation_phase: "capture",
+      claim_sequence: 1n,
+    });
+    expect(authority.tenantWatermarks[0]).toMatchObject({
+      last_service_sequence: 1n,
+      service_count: 1n,
+    });
+    expect(authority.nodeWatermarks[0]).toMatchObject({
+      last_service_sequence: 1n,
+      service_count: 1n,
+    });
+  });
+
+  test("replays the exact publication without moving leases or counters", async () => {
+    await reservePublication();
+    const claimed = requireAdmission(await claimNext());
+    const before = await readAuthorityState();
+
+    const replayed = requireAdmission(await claimNext());
+    const after = await readAuthorityState();
+
+    expect(replayed.kind).toBe("replayed");
+    expect(replayed.admission).toEqual(claimed.admission);
+    expect(after).toEqual(before);
+  });
+
+  test("uses claimSequence to fence an A/B/A publication caller cycle", async () => {
+    await reservePublication();
+    const firstA = requireAdmission(await claimNext(callerA));
+    expect(firstA.admission.laneExecution.claimSequence).toBe(1n);
+    await expireAdmission(firstA.admission);
+
+    const claimB = requireAdmission(await claimNext(callerB));
+    expect(claimB.admission.laneExecution.claimSequence).toBe(2n);
+    await expireAdmission(claimB.admission);
+
+    const secondA = requireAdmission(await claimNext(callerA));
+    expect(secondA.admission.laneExecution).toEqual({
+      ...callerA,
+      claimSequence: 3n,
+    });
+  });
+
+  test("renews both leases without shortening and rolls back when catalogue ownership drifts", async () => {
+    await reservePublication();
+    const claimed = requireAdmission(await claimNext(callerA, 120_000));
+    const before = await readAuthorityState();
+    const renewed = await publicationRepository.renewAgentBackupPublicationAdmission({
+      admission: claimed.admission,
+      leaseMs: 1,
+    });
+    const afterRenew = await readAuthorityState();
+    expect(renewed.claim.backup.catalog_lease_expires_at?.getTime()).toBe(
+      before.lane?.lease_expires_at?.getTime(),
+    );
+    expect(afterRenew.lane?.lease_expires_at?.getTime()).toBe(
+      before.lane?.lease_expires_at?.getTime(),
+    );
+
+    await dbWrite
+      .update(agentSandboxBackups)
+      .set({ catalog_lease_generation: CALLER_GENERATION_C })
+      .where(eq(agentSandboxBackups.id, claimed.admission.claim.backup.id));
+    const beforeFailure = await readAuthorityState();
+    await expect(
+      publicationRepository.renewAgentBackupPublicationAdmission({
+        admission: renewed,
+        leaseMs: 120_000,
+      }),
+    ).rejects.toMatchObject({ code: "AGENT_BACKUP_PUBLICATION_ADMISSION_LOST" });
+    expect(await readAuthorityState()).toEqual(beforeFailure);
+  });
+
+  test("rejects replay and renewal after immutable publication drift", async () => {
+    await reservePublication();
+    const claimed = requireAdmission(await claimNext());
+    await dbWrite
+      .update(agentActivationPublications)
+      .set({ image_digest: OTHER_IMAGE_DIGEST })
+      .where(eq(agentActivationPublications.id, ACTIVATION_PUBLICATION_ID));
+
+    await expect(claimNext()).rejects.toMatchObject({
+      code: "AGENT_BACKUP_PUBLICATION_ADMISSION_LOST",
+    });
+    await expect(
+      publicationRepository.renewAgentBackupPublicationAdmission({
+        admission: claimed.admission,
+        leaseMs: 60_000,
+      }),
+    ).rejects.toMatchObject({ code: "AGENT_BACKUP_PUBLICATION_ADMISSION_LOST" });
+  });
+});

--- a/packages/cloud/shared/src/db/repositories/agent-backup-operation-lane.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-backup-operation-lane.ts
@@ -8,6 +8,7 @@ import { sqlRows } from "../execute-helpers";
 import { dbWrite } from "../helpers";
 import {
   type AgentBackupOperationLane,
+  type AgentBackupOperationLanePhase,
   agentBackupOperationLane,
   agentBackupOperationNodeWatermarks,
   agentBackupOperationTenantWatermarks,
@@ -32,6 +33,7 @@ export interface AgentBackupOperationLaneTarget {
   readonly organizationId: string;
   readonly backupId: string;
   readonly operationId: string;
+  readonly operationPhase: AgentBackupOperationLanePhase;
 }
 
 export interface AgentBackupOperationLaneFairness {
@@ -138,6 +140,7 @@ function authorityLost(
         organizationId: target.organizationId,
         backupId: target.backupId,
         operationId: target.operationId,
+        operationPhase: target.operationPhase,
         ...executionContext(execution),
       },
     },
@@ -162,6 +165,7 @@ function claimExpired(
       organizationId: target.organizationId,
       backupId: target.backupId,
       operationId: target.operationId,
+      operationPhase: target.operationPhase,
       ...executionContext(execution),
     },
   });
@@ -178,6 +182,7 @@ function fairnessMismatch(
       organizationId: target.organizationId,
       backupId: target.backupId,
       operationId: target.operationId,
+      operationPhase: target.operationPhase,
       ...executionContext(execution),
     },
   });
@@ -186,6 +191,13 @@ function fairnessMismatch(
 function requireCanonicalUuid(value: unknown, field: string): string {
   if (typeof value !== "string" || !isValidUUID(value) || value !== value.toLowerCase()) {
     throw invalidInput(`${field} must be a canonical lowercase UUID`, field);
+  }
+  return value;
+}
+
+function requireOperationPhase(value: unknown): AgentBackupOperationLanePhase {
+  if (value !== "capture" && value !== "publication") {
+    throw invalidInput("operationPhase must be capture or publication", "operationPhase");
   }
   return value;
 }
@@ -249,12 +261,16 @@ function snapshotTarget(
   target: AgentBackupOperationLaneTarget,
 ): Readonly<AgentBackupOperationLaneTarget> {
   if (!target || typeof target !== "object") {
-    throw invalidInput("target must identify an organization, backup, and operation", "target");
+    throw invalidInput(
+      "target must identify an organization, backup, operation, and operation phase",
+      "target",
+    );
   }
   return Object.freeze({
     organizationId: requireCanonicalUuid(target.organizationId, "organizationId"),
     backupId: requireCanonicalUuid(target.backupId, "backupId"),
     operationId: requireCanonicalUuid(target.operationId, "operationId"),
+    operationPhase: requireOperationPhase(target.operationPhase),
   });
 }
 
@@ -362,7 +378,8 @@ function callerTokenMatches(
     lane.generation === token.generation &&
     lane.organization_id === target.organizationId &&
     lane.backup_id === target.backupId &&
-    lane.operation_id === target.operationId
+    lane.operation_id === target.operationId &&
+    lane.operation_phase === target.operationPhase
   );
 }
 
@@ -569,6 +586,7 @@ export async function claimAgentBackupOperationLaneInTransaction(
       organization_id: target.organizationId,
       backup_id: target.backupId,
       operation_id: target.operationId,
+      operation_phase: target.operationPhase,
       claimed_at: databaseNow,
       lease_expires_at: leaseExpiresAt,
       released_at: null,
@@ -664,6 +682,7 @@ export async function renewAgentBackupOperationLaneInTransaction(
         eq(agentBackupOperationLane.organization_id, target.organizationId),
         eq(agentBackupOperationLane.backup_id, target.backupId),
         eq(agentBackupOperationLane.operation_id, target.operationId),
+        eq(agentBackupOperationLane.operation_phase, target.operationPhase),
         eq(agentBackupOperationLane.claim_sequence, execution.claimSequence),
         sql`${agentBackupOperationLane.released_at} IS NULL`,
         sql`${agentBackupOperationLane.lease_expires_at} > clock_timestamp()`,
@@ -718,6 +737,7 @@ export async function releaseAgentBackupOperationLaneInTransaction(
         eq(agentBackupOperationLane.organization_id, target.organizationId),
         eq(agentBackupOperationLane.backup_id, target.backupId),
         eq(agentBackupOperationLane.operation_id, target.operationId),
+        eq(agentBackupOperationLane.operation_phase, target.operationPhase),
         eq(agentBackupOperationLane.claim_sequence, execution.claimSequence),
         sql`${agentBackupOperationLane.released_at} IS NULL`,
         sql`${agentBackupOperationLane.lease_expires_at} > clock_timestamp()`,

--- a/packages/cloud/shared/src/db/repositories/agent-backup-publication-admission.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-backup-publication-admission.ts
@@ -1,4 +1,4 @@
-/** Atomic global-lane admission for one exact, live-source backup capture. */
+/** Atomic global-lane admission for source-node-detached backup publication. */
 
 import { ElizaError } from "@elizaos/core";
 import { and, eq, gt, sql } from "drizzle-orm";
@@ -11,12 +11,7 @@ import {
 } from "../schemas/agent-backup-operation-lane";
 import { agentActivationPublications } from "../schemas/agent-backup-restore-history";
 import { agentNodeIncarnationHistories } from "../schemas/agent-node-incarnation-histories";
-import {
-  agentSandboxBackups,
-  agentSandboxes,
-  type StoredAgentSandboxBackup,
-} from "../schemas/agent-sandboxes";
-import { dockerNodes } from "../schemas/docker-nodes";
+import { agentSandboxBackups, type StoredAgentSandboxBackup } from "../schemas/agent-sandboxes";
 import { organizations } from "../schemas/organizations";
 import type { AgentBackupOperationClaim } from "./agent-backup-catalog";
 import {
@@ -31,18 +26,24 @@ import {
   renewAgentBackupOperationLaneInTransaction,
 } from "./agent-backup-operation-lane";
 
-const CAPTURE_OWNED_STATES = ["scheduled", "capturing"] as const;
+const PUBLICATION_OWNED_STATES = [
+  "captured",
+  "uploading",
+  "primary_uploaded",
+  "primary_verified",
+  "secondary_pending",
+] as const;
 
-export interface AgentBackupOperationAdmission {
+export interface AgentBackupPublicationAdmission {
   readonly claim: Readonly<AgentBackupOperationClaim>;
   readonly laneExecution: Readonly<AgentBackupOperationLaneExecution>;
   readonly sourceNodeHistoryId: string;
 }
 
-export type AgentBackupOperationAdmissionResult =
+export type AgentBackupPublicationAdmissionResult =
   | {
       readonly kind: "claimed" | "replayed";
-      readonly admission: AgentBackupOperationAdmission;
+      readonly admission: AgentBackupPublicationAdmission;
     }
   | { readonly kind: "empty" }
   | {
@@ -51,7 +52,7 @@ export type AgentBackupOperationAdmissionResult =
       readonly databaseNow: Date;
     };
 
-interface ExactSourceAuthority {
+interface DetachedSourceAuthority {
   readonly sourceNodeHistoryId: string;
   readonly sourceNodeRecordId: string;
   readonly sourceNodeIncarnation: string;
@@ -59,7 +60,7 @@ interface ExactSourceAuthority {
 
 function admissionLost(message: string): ElizaError {
   return new ElizaError(message, {
-    code: "AGENT_BACKUP_OPERATION_ADMISSION_LOST",
+    code: "AGENT_BACKUP_PUBLICATION_ADMISSION_LOST",
     severity: "fatal",
   });
 }
@@ -78,21 +79,21 @@ function observedLane(lane: AgentBackupOperationLane): Readonly<AgentBackupOpera
 
 function targetFor(backup: StoredAgentSandboxBackup): AgentBackupOperationLaneTarget {
   if (!backup.catalog_organization_id || !backup.backup_operation_id) {
-    throw admissionLost("Backup operation is missing its exact catalogue target");
+    throw admissionLost("Backup publication is missing its exact catalogue target");
   }
   return Object.freeze({
     organizationId: backup.catalog_organization_id,
     backupId: backup.id,
     operationId: backup.backup_operation_id,
-    operationPhase: "capture" as const,
+    operationPhase: "publication" as const,
   });
 }
 
 function activeState(backup: StoredAgentSandboxBackup): boolean {
   return (
-    CAPTURE_OWNED_STATES.some((state) => state === backup.catalog_state) ||
+    PUBLICATION_OWNED_STATES.some((state) => state === backup.catalog_state) ||
     (backup.catalog_state === "failed_retryable" &&
-      CAPTURE_OWNED_STATES.some((state) => state === backup.catalog_resume_state))
+      PUBLICATION_OWNED_STATES.some((state) => state === backup.catalog_resume_state))
   );
 }
 
@@ -107,7 +108,7 @@ function admissionFor(params: {
   backup: StoredAgentSandboxBackup;
   execution: AgentBackupOperationLaneExecution;
   sourceNodeHistoryId: string;
-}): AgentBackupOperationAdmission {
+}): AgentBackupPublicationAdmission {
   const backup = Object.freeze({ ...params.backup });
   const execution = Object.freeze({ ...params.execution });
   return Object.freeze({
@@ -125,6 +126,9 @@ async function lockBackupByTargetInTransaction(
   tx: DbTransaction,
   target: AgentBackupOperationLaneTarget,
 ): Promise<StoredAgentSandboxBackup> {
+  if (target.operationPhase !== "publication") {
+    throw admissionLost("Global lane target is not a publication execution");
+  }
   const [backup] = await tx
     .select()
     .from(agentSandboxBackups)
@@ -138,51 +142,23 @@ async function lockBackupByTargetInTransaction(
     .for("update")
     .limit(1);
   if (!backup || !activeState(backup)) {
-    throw admissionLost("Global lane target no longer names an executable backup operation");
+    throw admissionLost("Global lane target no longer names an executable publication");
   }
   return backup;
 }
 
 /**
- * The global lane is already held before this function locks the backup row.
- * Only live-source capture states are eligible here. Publication, verification,
- * and GC must use a detached admission path that survives source-node loss.
+ * The singleton is already locked. Publication deliberately avoids mutable
+ * sandbox and docker-node rows: its source is the captured manifest plus the
+ * append-only activation publication and node-occurrence history.
  */
-async function lockNextDueBackupInTransaction(
+async function lockNextDuePublicationInTransaction(
   tx: DbTransaction,
 ): Promise<StoredAgentSandboxBackup | null> {
   const [candidate] = await tx
     .select({ id: agentSandboxBackups.id })
     .from(agentSandboxBackups)
-    .innerJoin(
-      agentSandboxes,
-      and(
-        eq(agentSandboxes.id, agentSandboxBackups.sandbox_record_id),
-        eq(agentSandboxes.id, agentSandboxBackups.catalog_agent_id),
-        eq(agentSandboxes.organization_id, agentSandboxBackups.catalog_organization_id),
-        eq(agentSandboxes.status, "running"),
-        eq(agentSandboxes.activation_phase, "active"),
-        eq(agentSandboxes.activation_generation, agentSandboxBackups.lifecycle_generation),
-        sql`${agentSandboxes.lifecycle_revision}::numeric
-          = ${agentSandboxBackups.lifecycle_revision}`,
-        sql`${agentSandboxes.activation_lifecycle_revision}::numeric
-          = ${agentSandboxBackups.lifecycle_revision}`,
-        eq(agentSandboxes.node_id, agentSandboxBackups.source_node_id),
-        eq(agentSandboxes.activation_node_id, agentSandboxBackups.source_node_id),
-        eq(agentSandboxes.sandbox_id, agentSandboxBackups.source_provider_handle),
-        eq(agentSandboxes.activation_container_id, agentSandboxBackups.source_container_id),
-        eq(agentSandboxes.activation_boot_id, agentSandboxBackups.source_node_incarnation),
-        sql`${agentSandboxes.activation_receipt} IS NOT NULL`,
-        sql`${agentSandboxes.activation_receipt_hash} IS NOT NULL`,
-        sql`${agentSandboxes.activation_image_digest} IS NOT NULL`,
-        sql`${agentSandboxes.activation_boot_id} IS NOT NULL`,
-        sql`${agentSandboxes.activation_token_hash} IS NOT NULL`,
-        sql`${agentSandboxes.activation_funding_revision} IS NOT NULL`,
-        sql`${agentSandboxes.activation_authority_published_at} IS NOT NULL`,
-        sql`${agentSandboxes.activation_dispatched_at} IS NOT NULL`,
-        sql`${agentSandboxes.activation_completed_at} IS NOT NULL`,
-      ),
-    )
+    .innerJoin(organizations, eq(organizations.id, agentSandboxBackups.catalog_organization_id))
     .innerJoin(
       agentActivationPublications,
       and(
@@ -196,25 +172,7 @@ async function lockNextDueBackupInTransaction(
           agentSandboxBackups.lifecycle_generation,
         ),
         eq(agentActivationPublications.lifecycle_revision, agentSandboxBackups.lifecycle_revision),
-        eq(agentActivationPublications.purpose, agentSandboxes.activation_purpose),
-        sql`${agentActivationPublications.previous_activation_generation}
-          IS NOT DISTINCT FROM ${agentSandboxes.activation_previous_generation}`,
-        sql`${agentActivationPublications.backup_id}
-          IS NOT DISTINCT FROM ${agentSandboxes.activation_backup_id}`,
-        sql`${agentActivationPublications.backup_manifest_sha256}
-          IS NOT DISTINCT FROM ${agentSandboxes.activation_backup_hash}`,
-        sql`${agentActivationPublications.activation_receipt}
-          = ${agentSandboxes.activation_receipt}`,
-        eq(
-          agentActivationPublications.activation_receipt_sha256,
-          agentSandboxes.activation_receipt_hash,
-        ),
         eq(agentActivationPublications.container_id, agentSandboxBackups.source_container_id),
-        eq(agentActivationPublications.image_digest, agentSandboxes.activation_image_digest),
-        eq(
-          agentActivationPublications.published_at,
-          agentSandboxes.activation_authority_published_at,
-        ),
         eq(
           agentActivationPublications.docker_node_record_id,
           agentSandboxBackups.source_node_record_id,
@@ -224,38 +182,57 @@ async function lockNextDueBackupInTransaction(
           agentActivationPublications.node_incarnation,
           agentSandboxBackups.source_node_incarnation,
         ),
-        eq(agentActivationPublications.node_incarnation, agentSandboxes.activation_boot_id),
-        eq(agentActivationPublications.token_sha256, agentSandboxes.activation_token_hash),
-        eq(
-          agentActivationPublications.funding_revision,
-          agentSandboxes.activation_funding_revision,
-        ),
-      ),
-    )
-    .innerJoin(
-      dockerNodes,
-      and(
-        eq(dockerNodes.id, agentSandboxBackups.source_node_record_id),
-        eq(dockerNodes.node_id, agentSandboxBackups.source_node_id),
-        eq(dockerNodes.node_incarnation, agentSandboxBackups.source_node_incarnation),
-        eq(dockerNodes.current_node_history_id, agentActivationPublications.node_history_id),
+        eq(agentActivationPublications.image_digest, agentSandboxBackups.image_digest),
+        sql`jsonb_typeof(${agentActivationPublications.activation_receipt}) = 'object'`,
+        sql`${agentActivationPublications.activation_receipt} -> 'schemaVersion' = '1'::jsonb`,
+        sql`${agentActivationPublications.activation_receipt} -> 'generation'
+          = to_jsonb(${agentSandboxBackups.lifecycle_generation}::text)`,
+        sql`${agentActivationPublications.activation_receipt} -> 'purpose'
+          = to_jsonb(${agentActivationPublications.purpose})`,
+        sql`${agentActivationPublications.activation_receipt} -> 'agentId'
+          = to_jsonb(${agentSandboxBackups.catalog_agent_id}::text)`,
+        sql`${agentActivationPublications.activation_receipt} -> 'organizationId'
+          = to_jsonb(${agentSandboxBackups.catalog_organization_id}::text)`,
+        sql`${agentActivationPublications.activation_receipt} -> 'lifecycleRevision'
+          = to_jsonb(${agentSandboxBackups.lifecycle_revision}::text)`,
+        sql`(
+          (${agentActivationPublications.backup_id} IS NULL
+            AND ${agentActivationPublications.activation_receipt} -> 'backupId' = 'null'::jsonb)
+          OR (${agentActivationPublications.backup_id} IS NOT NULL
+            AND ${agentActivationPublications.activation_receipt} -> 'backupId'
+              = to_jsonb(${agentActivationPublications.backup_id}::text))
+        )`,
+        sql`(
+          (${agentActivationPublications.backup_manifest_sha256} IS NULL
+            AND ${agentActivationPublications.activation_receipt} -> 'backupHash' = 'null'::jsonb)
+          OR (${agentActivationPublications.backup_manifest_sha256} IS NOT NULL
+            AND ${agentActivationPublications.activation_receipt} -> 'backupHash'
+              = to_jsonb(${agentActivationPublications.backup_manifest_sha256}))
+        )`,
+        sql`${agentActivationPublications.activation_receipt} -> 'containerId'
+          = to_jsonb(${agentSandboxBackups.source_container_id})`,
+        sql`${agentActivationPublications.activation_receipt} -> 'imageDigest'
+          = to_jsonb(${agentSandboxBackups.image_digest})`,
+        sql`${agentActivationPublications.activation_receipt} -> 'restored' = 'true'::jsonb`,
       ),
     )
     .innerJoin(
       agentNodeIncarnationHistories,
       and(
         eq(agentNodeIncarnationHistories.id, agentActivationPublications.node_history_id),
-        eq(agentNodeIncarnationHistories.docker_node_record_id, dockerNodes.id),
-        eq(agentNodeIncarnationHistories.node_id, dockerNodes.node_id),
-        eq(agentNodeIncarnationHistories.node_incarnation, dockerNodes.node_incarnation),
-        eq(agentNodeIncarnationHistories.fleet_kind, dockerNodes.fleet_kind),
         eq(
-          agentNodeIncarnationHistories.infrastructure_provider,
-          dockerNodes.infrastructure_provider,
+          agentNodeIncarnationHistories.docker_node_record_id,
+          agentSandboxBackups.source_node_record_id,
         ),
+        eq(agentNodeIncarnationHistories.node_id, agentSandboxBackups.source_node_id),
+        eq(
+          agentNodeIncarnationHistories.node_incarnation,
+          agentSandboxBackups.source_node_incarnation,
+        ),
+        eq(agentNodeIncarnationHistories.infrastructure_provider, "hetzner"),
         sql`${agentNodeIncarnationHistories.provider_server_id}
-          IS NOT DISTINCT FROM ${dockerNodes.provider_server_id}`,
-        eq(agentNodeIncarnationHistories.host_key_fingerprint, dockerNodes.host_key_fingerprint),
+          IS NOT DISTINCT FROM ${agentSandboxBackups.source_provider_server_id}`,
+        sql`btrim(${agentNodeIncarnationHistories.host_key_fingerprint}) <> ''`,
       ),
     )
     .leftJoin(
@@ -269,7 +246,7 @@ async function lockNextDueBackupInTransaction(
       agentBackupOperationNodeWatermarks,
       eq(
         agentBackupOperationNodeWatermarks.source_node_history_id,
-        dockerNodes.current_node_history_id,
+        agentActivationPublications.node_history_id,
       ),
     )
     .where(
@@ -277,7 +254,10 @@ async function lockNextDueBackupInTransaction(
         eq(agentSandboxBackups.catalog_version, 2),
         sql`${agentSandboxBackups.sandbox_record_id} IS NOT NULL`,
         sql`${agentSandboxBackups.catalog_organization_id} IS NOT NULL`,
+        sql`${agentSandboxBackups.catalog_agent_id} IS NOT NULL`,
         sql`${agentSandboxBackups.backup_operation_id} IS NOT NULL`,
+        sql`${agentSandboxBackups.lifecycle_generation} IS NOT NULL`,
+        sql`${agentSandboxBackups.lifecycle_revision} IS NOT NULL`,
         sql`${agentSandboxBackups.source_provider} IN ('operator-onboarded', 'hetzner-cloud')`,
         sql`${agentSandboxBackups.source_node_record_id} IS NOT NULL`,
         sql`${agentSandboxBackups.source_node_id} IS NOT NULL
@@ -286,21 +266,27 @@ async function lockNextDueBackupInTransaction(
         sql`${agentSandboxBackups.source_provider_handle} IS NOT NULL
           AND ${agentSandboxBackups.source_provider_handle} <> ''`,
         sql`${agentSandboxBackups.source_container_id} ~ '^[0-9a-f]{64}$'`,
-        eq(dockerNodes.infrastructure_provider, "hetzner"),
+        sql`${agentSandboxBackups.image_digest} ~ '^sha256:[0-9a-f]{64}$'`,
         sql`(
           (${agentSandboxBackups.source_provider} = 'operator-onboarded'
             AND ${agentSandboxBackups.source_provider_server_id} IS NULL
-            AND ${dockerNodes.fleet_kind} = 'robot'
-            AND ${dockerNodes.provider_server_id} IS NULL)
+            AND ${agentNodeIncarnationHistories.fleet_kind} = 'robot')
           OR
           (${agentSandboxBackups.source_provider} = 'hetzner-cloud'
-            AND ${dockerNodes.fleet_kind} = 'cloud'
-            AND ${dockerNodes.provider_server_id}
-              = ${agentSandboxBackups.source_provider_server_id})
+            AND ${agentNodeIncarnationHistories.fleet_kind} = 'cloud'
+            AND CASE
+              WHEN ${agentSandboxBackups.source_provider_server_id} ~ '^[1-9][0-9]{0,19}$'
+                THEN ${agentSandboxBackups.source_provider_server_id}::numeric
+                  <= 18446744073709551615
+              ELSE FALSE
+            END)
         )`,
-        sql`(${agentSandboxBackups.catalog_state} IN ('scheduled', 'capturing')
-          OR (${agentSandboxBackups.catalog_state} = 'failed_retryable'
-            AND ${agentSandboxBackups.catalog_resume_state} IN ('scheduled', 'capturing')))`,
+        sql`(${agentSandboxBackups.catalog_state} IN (
+            'captured', 'uploading', 'primary_uploaded', 'primary_verified', 'secondary_pending'
+          ) OR (${agentSandboxBackups.catalog_state} = 'failed_retryable'
+            AND ${agentSandboxBackups.catalog_resume_state} IN (
+              'captured', 'uploading', 'primary_uploaded', 'primary_verified', 'secondary_pending'
+            )))`,
         sql`(${agentSandboxBackups.catalog_next_attempt_at} IS NULL
           OR ${agentSandboxBackups.catalog_next_attempt_at} <= clock_timestamp())`,
         sql`(${agentSandboxBackups.catalog_lease_expires_at} IS NULL
@@ -326,92 +312,29 @@ async function lockNextDueBackupInTransaction(
     .where(eq(agentSandboxBackups.id, candidate.id))
     .for("update")
     .limit(1);
-  if (!backup) throw admissionLost("Selected backup operation disappeared while locked");
+  if (!backup) throw admissionLost("Selected backup publication disappeared while locked");
   return backup;
 }
 
-async function lockExactSourceAuthorityInTransaction(
+async function lockDetachedSourceAuthorityInTransaction(
   tx: DbTransaction,
   backup: StoredAgentSandboxBackup,
-): Promise<ExactSourceAuthority> {
+): Promise<DetachedSourceAuthority> {
   if (
     !backup.sandbox_record_id ||
     !backup.catalog_organization_id ||
     !backup.catalog_agent_id ||
+    !backup.lifecycle_generation ||
+    backup.lifecycle_revision === null ||
     !backup.source_node_record_id ||
     !backup.source_node_id ||
     !backup.source_node_incarnation ||
     !backup.source_provider ||
     !backup.source_provider_handle ||
-    !backup.source_container_id
+    !backup.source_container_id ||
+    !backup.image_digest
   ) {
-    throw admissionLost("Backup operation is missing its immutable source authority");
-  }
-
-  const [sandbox] = await tx
-    .select({
-      id: agentSandboxes.id,
-      status: agentSandboxes.status,
-      nodeId: agentSandboxes.node_id,
-      providerHandle: agentSandboxes.sandbox_id,
-      lifecycleRevision: sql<string>`${agentSandboxes.lifecycle_revision}::text`,
-      activationGeneration: agentSandboxes.activation_generation,
-      activationLifecycleRevision: sql<
-        string | null
-      >`${agentSandboxes.activation_lifecycle_revision}::text`,
-      activationPhase: agentSandboxes.activation_phase,
-      activationPurpose: agentSandboxes.activation_purpose,
-      activationPreviousGeneration: agentSandboxes.activation_previous_generation,
-      activationBackupId: agentSandboxes.activation_backup_id,
-      activationBackupHash: agentSandboxes.activation_backup_hash,
-      activationReceipt: agentSandboxes.activation_receipt,
-      activationReceiptHash: agentSandboxes.activation_receipt_hash,
-      activationContainerId: agentSandboxes.activation_container_id,
-      activationNodeId: agentSandboxes.activation_node_id,
-      activationImageDigest: agentSandboxes.activation_image_digest,
-      activationBootId: agentSandboxes.activation_boot_id,
-      activationTokenHash: agentSandboxes.activation_token_hash,
-      activationFundingRevision: agentSandboxes.activation_funding_revision,
-      activationAuthorityPublishedAt: agentSandboxes.activation_authority_published_at,
-      activationDispatchedAt: agentSandboxes.activation_dispatched_at,
-      activationCompletedAt: agentSandboxes.activation_completed_at,
-    })
-    .from(agentSandboxes)
-    .where(
-      and(
-        eq(agentSandboxes.id, backup.sandbox_record_id),
-        eq(agentSandboxes.organization_id, backup.catalog_organization_id),
-      ),
-    )
-    .for("update")
-    .limit(1);
-  if (!sandbox || sandbox.id !== backup.catalog_agent_id) {
-    throw admissionLost("Backup source sandbox authority disappeared or changed tenant");
-  }
-  if (
-    backup.lifecycle_revision === null ||
-    !backup.lifecycle_generation ||
-    sandbox.status !== "running" ||
-    sandbox.activationPhase !== "active" ||
-    sandbox.activationGeneration !== backup.lifecycle_generation ||
-    sandbox.lifecycleRevision !== backup.lifecycle_revision.toString() ||
-    sandbox.activationLifecycleRevision !== backup.lifecycle_revision.toString() ||
-    !sandbox.activationPurpose ||
-    !sandbox.activationReceipt ||
-    !sandbox.activationReceiptHash ||
-    !sandbox.activationImageDigest ||
-    sandbox.activationBootId !== backup.source_node_incarnation ||
-    !sandbox.activationTokenHash ||
-    sandbox.activationFundingRevision === null ||
-    !sandbox.activationAuthorityPublishedAt ||
-    !sandbox.activationDispatchedAt ||
-    !sandbox.activationCompletedAt ||
-    sandbox.nodeId !== backup.source_node_id ||
-    sandbox.activationNodeId !== backup.source_node_id ||
-    sandbox.providerHandle !== backup.source_provider_handle ||
-    sandbox.activationContainerId !== backup.source_container_id
-  ) {
-    throw admissionLost("Backup capture source is no longer the exact active sandbox generation");
+    throw admissionLost("Backup publication is missing its captured source authority");
   }
 
   const [organization] = await tx
@@ -420,13 +343,12 @@ async function lockExactSourceAuthorityInTransaction(
     .where(eq(organizations.id, backup.catalog_organization_id))
     .for("update")
     .limit(1);
-  if (!organization) throw admissionLost("Backup organization authority disappeared");
+  if (!organization) throw admissionLost("Backup publication organization disappeared");
 
   const [publication] = await tx
     .select({
       lifecycleRevision: sql<string>`${agentActivationPublications.lifecycle_revision}::text`,
       purpose: agentActivationPublications.purpose,
-      previousActivationGeneration: agentActivationPublications.previous_activation_generation,
       backupId: agentActivationPublications.backup_id,
       backupManifestHash: agentActivationPublications.backup_manifest_sha256,
       activationReceipt: agentActivationPublications.activation_receipt,
@@ -450,72 +372,41 @@ async function lockExactSourceAuthorityInTransaction(
       ),
     )
     .limit(1);
+  const receipt = publication?.activationReceipt;
   if (
     !publication ||
     publication.lifecycleRevision !== backup.lifecycle_revision.toString() ||
-    publication.purpose !== sandbox.activationPurpose ||
-    publication.previousActivationGeneration !== sandbox.activationPreviousGeneration ||
-    publication.backupId !== sandbox.activationBackupId ||
-    publication.backupManifestHash !== sandbox.activationBackupHash ||
-    JSON.stringify(publication.activationReceipt) !== JSON.stringify(sandbox.activationReceipt) ||
-    publication.activationReceiptHash !== sandbox.activationReceiptHash ||
     publication.containerId !== backup.source_container_id ||
     publication.nodeRecordId !== backup.source_node_record_id ||
     publication.nodeId !== backup.source_node_id ||
     publication.nodeIncarnation !== backup.source_node_incarnation ||
-    publication.imageDigest !== sandbox.activationImageDigest ||
-    publication.tokenHash !== sandbox.activationTokenHash ||
-    publication.fundingRevision !== sandbox.activationFundingRevision ||
-    publication.publishedAt.getTime() !== sandbox.activationAuthorityPublishedAt.getTime()
+    publication.imageDigest !== backup.image_digest ||
+    !publication.activationReceiptHash ||
+    !publication.tokenHash ||
+    publication.fundingRevision < 0n ||
+    !publication.publishedAt ||
+    !receipt ||
+    receipt.schemaVersion !== 1 ||
+    receipt.generation !== backup.lifecycle_generation ||
+    receipt.purpose !== publication.purpose ||
+    receipt.agentId !== backup.catalog_agent_id ||
+    receipt.organizationId !== backup.catalog_organization_id ||
+    receipt.lifecycleRevision !== backup.lifecycle_revision.toString() ||
+    receipt.backupId !== publication.backupId ||
+    receipt.backupHash !== publication.backupManifestHash ||
+    receipt.containerId !== backup.source_container_id ||
+    receipt.imageDigest !== backup.image_digest ||
+    receipt.restored !== true
   ) {
-    throw admissionLost("Backup capture source lost its immutable activation publication");
-  }
-
-  const [node] = await tx
-    .select({
-      recordId: dockerNodes.id,
-      nodeId: dockerNodes.node_id,
-      incarnation: dockerNodes.node_incarnation,
-      historyId: dockerNodes.current_node_history_id,
-      fleetKind: dockerNodes.fleet_kind,
-      infrastructureProvider: dockerNodes.infrastructure_provider,
-      providerServerId: dockerNodes.provider_server_id,
-      hostKeyFingerprint: dockerNodes.host_key_fingerprint,
-    })
-    .from(dockerNodes)
-    .where(
-      and(
-        eq(dockerNodes.id, backup.source_node_record_id),
-        eq(dockerNodes.node_id, backup.source_node_id),
-        eq(dockerNodes.node_incarnation, backup.source_node_incarnation),
-        eq(dockerNodes.current_node_history_id, publication.nodeHistoryId),
-      ),
-    )
-    .for("update")
-    .limit(1);
-  if (!node?.incarnation || !node.historyId) {
-    throw admissionLost("Backup source node is no longer the reserved exact occurrence");
-  }
-  const expectedFleetKind =
-    backup.source_provider === "operator-onboarded"
-      ? "robot"
-      : backup.source_provider === "hetzner-cloud"
-        ? "cloud"
-        : null;
-  if (
-    !expectedFleetKind ||
-    node.fleetKind !== expectedFleetKind ||
-    node.infrastructureProvider !== "hetzner" ||
-    node.providerServerId !== backup.source_provider_server_id ||
-    !node.hostKeyFingerprint?.trim()
-  ) {
-    throw admissionLost("Backup source Robot/Cloud provider authority changed");
+    throw admissionLost("Backup publication lost its immutable activation authority");
   }
 
   const [history] = await tx
     .select({
       id: agentNodeIncarnationHistories.id,
+      nodeRecordId: agentNodeIncarnationHistories.docker_node_record_id,
       nodeId: agentNodeIncarnationHistories.node_id,
+      nodeIncarnation: agentNodeIncarnationHistories.node_incarnation,
       fleetKind: agentNodeIncarnationHistories.fleet_kind,
       infrastructureProvider: agentNodeIncarnationHistories.infrastructure_provider,
       providerServerId: agentNodeIncarnationHistories.provider_server_id,
@@ -525,27 +416,35 @@ async function lockExactSourceAuthorityInTransaction(
     .where(
       and(
         eq(agentNodeIncarnationHistories.id, publication.nodeHistoryId),
-        eq(agentNodeIncarnationHistories.docker_node_record_id, node.recordId),
-        eq(agentNodeIncarnationHistories.node_incarnation, node.incarnation),
+        eq(agentNodeIncarnationHistories.docker_node_record_id, backup.source_node_record_id),
+        eq(agentNodeIncarnationHistories.node_incarnation, backup.source_node_incarnation),
       ),
     )
-    .for("share")
     .limit(1);
+  const expectedFleetKind =
+    backup.source_provider === "operator-onboarded"
+      ? "robot"
+      : backup.source_provider === "hetzner-cloud"
+        ? "cloud"
+        : null;
   if (
     !history ||
-    history.nodeId !== node.nodeId ||
-    history.fleetKind !== node.fleetKind ||
-    history.infrastructureProvider !== node.infrastructureProvider ||
-    history.providerServerId !== node.providerServerId ||
-    history.hostKeyFingerprint !== node.hostKeyFingerprint
+    history.nodeRecordId !== publication.nodeRecordId ||
+    history.nodeId !== publication.nodeId ||
+    history.nodeIncarnation !== publication.nodeIncarnation ||
+    !expectedFleetKind ||
+    history.fleetKind !== expectedFleetKind ||
+    history.infrastructureProvider !== "hetzner" ||
+    history.providerServerId !== backup.source_provider_server_id ||
+    !history.hostKeyFingerprint.trim()
   ) {
-    throw admissionLost("Backup source node-history occurrence disappeared or changed");
+    throw admissionLost("Backup publication node-history authority disappeared or changed");
   }
 
   return Object.freeze({
     sourceNodeHistoryId: history.id,
-    sourceNodeRecordId: node.recordId,
-    sourceNodeIncarnation: node.incarnation,
+    sourceNodeRecordId: history.nodeRecordId,
+    sourceNodeIncarnation: history.nodeIncarnation,
   });
 }
 
@@ -557,6 +456,7 @@ function assertCatalogueReplay(params: {
   databaseNow: Date;
 }): void {
   if (
+    params.target.operationPhase !== "publication" ||
     params.backup.catalog_organization_id !== params.target.organizationId ||
     params.backup.id !== params.target.backupId ||
     params.backup.backup_operation_id !== params.target.operationId ||
@@ -566,18 +466,15 @@ function assertCatalogueReplay(params: {
     params.backup.catalog_lease_expires_at.getTime() !== params.laneExpiry.getTime() ||
     params.backup.catalog_lease_expires_at.getTime() <= params.databaseNow.getTime()
   ) {
-    throw admissionLost("Catalogue lease does not replay the exact active global lane");
+    throw admissionLost("Catalogue lease does not replay the exact publication lane");
   }
 }
 
-/**
- * Lock the singleton first, then atomically claim one exact live-source capture
- * and stamp both cross-tick fairness receipts. No provider runs here.
- */
-export async function claimNextAgentBackupOperationAdmission(params: {
+/** Atomically claim one detached publication; no provider or mutable node runs here. */
+export async function claimNextAgentBackupPublicationAdmission(params: {
   readonly callerToken: AgentBackupOperationLaneCallerToken;
   readonly leaseMs: number;
-}): Promise<AgentBackupOperationAdmissionResult> {
+}): Promise<AgentBackupPublicationAdmissionResult> {
   const callerToken = normalizeAgentBackupOperationLaneCallerToken(params.callerToken);
   const leaseMs = normalizeAgentBackupOperationLaneLeaseMs(params.leaseMs);
 
@@ -587,7 +484,7 @@ export async function claimNextAgentBackupOperationAdmission(params: {
       if (
         initial.lane.owner_id !== callerToken.ownerId ||
         initial.lane.generation !== callerToken.generation ||
-        initial.lane.operation_phase !== "capture"
+        initial.lane.operation_phase !== "publication"
       ) {
         return Object.freeze({
           kind: "busy" as const,
@@ -596,16 +493,16 @@ export async function claimNextAgentBackupOperationAdmission(params: {
         });
       }
       if (!initial.lane.organization_id || !initial.lane.backup_id || !initial.lane.operation_id) {
-        throw admissionLost("Active global lane is missing its exact catalogue target");
+        throw admissionLost("Active publication lane is missing its exact catalogue target");
       }
       const target = Object.freeze({
         organizationId: initial.lane.organization_id,
         backupId: initial.lane.backup_id,
         operationId: initial.lane.operation_id,
-        operationPhase: "capture" as const,
+        operationPhase: "publication" as const,
       });
       const backup = await lockBackupByTargetInTransaction(tx, target);
-      const source = await lockExactSourceAuthorityInTransaction(tx, backup);
+      const source = await lockDetachedSourceAuthorityInTransaction(tx, backup);
       const replay = await claimAgentBackupOperationLaneInTransaction(tx, {
         ...target,
         callerToken,
@@ -613,9 +510,9 @@ export async function claimNextAgentBackupOperationAdmission(params: {
         fairness: source,
       });
       if (replay.kind === "busy") {
-        throw admissionLost("Exact active global lane unexpectedly became foreign");
+        throw admissionLost("Exact active publication lane unexpectedly became foreign");
       }
-      const laneExpiry = exactLeaseExpiry(replay.proof.lane, "Replayed admission");
+      const laneExpiry = exactLeaseExpiry(replay.proof.lane, "Replayed publication admission");
       assertCatalogueReplay({
         backup,
         callerToken,
@@ -633,10 +530,10 @@ export async function claimNextAgentBackupOperationAdmission(params: {
       });
     }
 
-    const backup = await lockNextDueBackupInTransaction(tx);
+    const backup = await lockNextDuePublicationInTransaction(tx);
     if (!backup) return Object.freeze({ kind: "empty" as const });
     const target = targetFor(backup);
-    const source = await lockExactSourceAuthorityInTransaction(tx, backup);
+    const source = await lockDetachedSourceAuthorityInTransaction(tx, backup);
     const laneClaim = await claimAgentBackupOperationLaneInTransaction(tx, {
       ...target,
       callerToken,
@@ -651,9 +548,9 @@ export async function claimNextAgentBackupOperationAdmission(params: {
       });
     }
     if (laneClaim.kind !== "claimed") {
-      throw admissionLost("Fresh catalogue candidate unexpectedly replayed the global lane");
+      throw admissionLost("Fresh publication candidate unexpectedly replayed the global lane");
     }
-    const laneExpiry = exactLeaseExpiry(laneClaim.proof.lane, "Claimed admission");
+    const laneExpiry = exactLeaseExpiry(laneClaim.proof.lane, "Claimed publication admission");
     const [claimed] = await tx
       .update(agentSandboxBackups)
       .set({
@@ -667,22 +564,26 @@ export async function claimNextAgentBackupOperationAdmission(params: {
           eq(agentSandboxBackups.id, target.backupId),
           eq(agentSandboxBackups.catalog_organization_id, target.organizationId),
           eq(agentSandboxBackups.backup_operation_id, target.operationId),
-          sql`(${agentSandboxBackups.catalog_state} IN ('scheduled', 'capturing')
-            OR (${agentSandboxBackups.catalog_state} = 'failed_retryable'
-              AND ${agentSandboxBackups.catalog_resume_state} IN ('scheduled', 'capturing')))`,
+          sql`(${agentSandboxBackups.catalog_state} IN (
+              'captured', 'uploading', 'primary_uploaded', 'primary_verified', 'secondary_pending'
+            ) OR (${agentSandboxBackups.catalog_state} = 'failed_retryable'
+              AND ${agentSandboxBackups.catalog_resume_state} IN (
+                'captured', 'uploading', 'primary_uploaded', 'primary_verified', 'secondary_pending'
+              )))`,
           sql`(${agentSandboxBackups.catalog_lease_expires_at} IS NULL
             OR ${agentSandboxBackups.catalog_lease_expires_at} <= clock_timestamp())`,
         ),
       )
       .returning();
     if (!claimed) {
-      throw admissionLost("Catalogue operation changed after the global lane was claimed");
+      throw admissionLost("Catalogue publication changed after the global lane was claimed");
     }
     const finalProof = await refreshAgentBackupOperationLaneProofInTransaction(tx, laneClaim.proof);
     if (
-      exactLeaseExpiry(finalProof.lane, "Committed admission").getTime() !== laneExpiry.getTime()
+      exactLeaseExpiry(finalProof.lane, "Committed publication admission").getTime() !==
+      laneExpiry.getTime()
     ) {
-      throw admissionLost("Catalogue lease diverged from the global lane before commit");
+      throw admissionLost("Catalogue publication lease diverged from the lane before commit");
     }
     return Object.freeze({
       kind: "claimed" as const,
@@ -695,14 +596,14 @@ export async function claimNextAgentBackupOperationAdmission(params: {
   });
 }
 
-/** Renew the global and catalogue leases atomically; never shorten either. */
-export async function renewAgentBackupOperationAdmission(params: {
-  readonly admission: AgentBackupOperationAdmission;
+/** Renew publication and catalogue leases atomically without a live source node. */
+export async function renewAgentBackupPublicationAdmission(params: {
+  readonly admission: AgentBackupPublicationAdmission;
   readonly leaseMs: number;
-}): Promise<AgentBackupOperationAdmission> {
+}): Promise<AgentBackupPublicationAdmission> {
   const input = params.admission;
   if (!input?.claim?.backup || !input.laneExecution || !input.sourceNodeHistoryId) {
-    throw admissionLost("Admission is missing its exact catalogue and lane authorities");
+    throw admissionLost("Publication admission is missing its catalogue and lane authorities");
   }
   const target = targetFor(input.claim.backup);
   const execution = Object.freeze({
@@ -726,14 +627,14 @@ export async function renewAgentBackupOperationAdmission(params: {
       !(backup.catalog_lease_expires_at instanceof Date) ||
       backup.catalog_lease_expires_at.getTime() <= renewedProof.databaseNow.getTime()
     ) {
-      throw admissionLost("Catalogue lease was lost before atomic admission renewal");
+      throw admissionLost("Catalogue publication lease was lost before atomic renewal");
     }
-    const source = await lockExactSourceAuthorityInTransaction(tx, backup);
+    const source = await lockDetachedSourceAuthorityInTransaction(tx, backup);
     if (source.sourceNodeHistoryId !== sourceNodeHistoryId) {
-      throw admissionLost("Backup source occurrence changed before admission renewal");
+      throw admissionLost("Publication source occurrence changed before admission renewal");
     }
     const currentProof = await refreshAgentBackupOperationLaneProofInTransaction(tx, renewedProof);
-    const laneExpiry = exactLeaseExpiry(currentProof.lane, "Renewed admission");
+    const laneExpiry = exactLeaseExpiry(currentProof.lane, "Renewed publication admission");
     const [renewed] = await tx
       .update(agentSandboxBackups)
       .set({
@@ -748,13 +649,16 @@ export async function renewAgentBackupOperationAdmission(params: {
           eq(agentSandboxBackups.catalog_lease_owner, execution.ownerId),
           eq(agentSandboxBackups.catalog_lease_generation, execution.generation),
           gt(agentSandboxBackups.catalog_lease_expires_at, sql`clock_timestamp()`),
-          sql`(${agentSandboxBackups.catalog_state} IN ('scheduled', 'capturing')
-            OR (${agentSandboxBackups.catalog_state} = 'failed_retryable'
-              AND ${agentSandboxBackups.catalog_resume_state} IN ('scheduled', 'capturing')))`,
+          sql`(${agentSandboxBackups.catalog_state} IN (
+              'captured', 'uploading', 'primary_uploaded', 'primary_verified', 'secondary_pending'
+            ) OR (${agentSandboxBackups.catalog_state} = 'failed_retryable'
+              AND ${agentSandboxBackups.catalog_resume_state} IN (
+                'captured', 'uploading', 'primary_uploaded', 'primary_verified', 'secondary_pending'
+              )))`,
         ),
       )
       .returning();
-    if (!renewed) throw admissionLost("Catalogue lease was lost during atomic admission renewal");
+    if (!renewed) throw admissionLost("Catalogue publication lease was lost during renewal");
     await refreshAgentBackupOperationLaneProofInTransaction(tx, currentProof);
     return admissionFor({
       backup: renewed,

--- a/packages/cloud/shared/src/db/schemas/agent-backup-operation-lane.ts
+++ b/packages/cloud/shared/src/db/schemas/agent-backup-operation-lane.ts
@@ -14,8 +14,9 @@ import {
   uuid,
 } from "drizzle-orm/pg-core";
 import { agentNodeIncarnationHistories } from "./agent-node-incarnation-histories";
-import { dockerNodes } from "./docker-nodes";
 import { organizations } from "./organizations";
+
+export type AgentBackupOperationLanePhase = "capture" | "publication";
 
 /**
  * The one database-serialized authority for backup provider mutations.
@@ -33,6 +34,7 @@ export const agentBackupOperationLane = pgTable(
     organization_id: uuid("organization_id"),
     backup_id: uuid("backup_id"),
     operation_id: uuid("operation_id"),
+    operation_phase: text("operation_phase").$type<AgentBackupOperationLanePhase>(),
     claimed_at: timestamp("claimed_at", { withTimezone: true }),
     lease_expires_at: timestamp("lease_expires_at", { withTimezone: true }),
     released_at: timestamp("released_at", { withTimezone: true }),
@@ -49,6 +51,7 @@ export const agentBackupOperationLane = pgTable(
         AND ${table.organization_id} IS NULL
         AND ${table.backup_id} IS NULL
         AND ${table.operation_id} IS NULL
+        AND ${table.operation_phase} IS NULL
         AND ${table.claimed_at} IS NULL
         AND ${table.lease_expires_at} IS NULL
         AND ${table.released_at} IS NULL
@@ -61,6 +64,7 @@ export const agentBackupOperationLane = pgTable(
         AND ${table.organization_id} IS NOT NULL
         AND ${table.backup_id} IS NOT NULL
         AND ${table.operation_id} IS NOT NULL
+        AND ${table.operation_phase} IN ('capture', 'publication')
         AND ${table.claimed_at} IS NOT NULL
         AND ${table.lease_expires_at} > ${table.claimed_at}
         AND (${table.released_at} IS NULL OR ${table.released_at} >= ${table.claimed_at})
@@ -111,11 +115,6 @@ export const agentBackupOperationNodeWatermarks = pgTable(
     last_served_at: timestamp("last_served_at", { withTimezone: true }).notNull(),
   },
   (table) => ({
-    source_node_fk: foreignKey({
-      name: "agent_backup_op_node_watermarks_node_fkey",
-      columns: [table.source_node_record_id],
-      foreignColumns: [dockerNodes.id],
-    }).onDelete("cascade"),
     node_occurrence_fk: foreignKey({
       name: "agent_backup_op_node_watermarks_occurrence_fkey",
       columns: [


### PR DESCRIPTION
## Summary

- add an explicit `capture | publication` phase to the singleton backup-operation lane and backfill legacy ownership as capture
- retain exact-node fairness after the mutable Docker-node row is deleted by anchoring the watermark only to append-only node history
- atomically admit publication work from captured catalogue rows using immutable activation-publication and node-occurrence authority
- keep publication detached from mutable sandbox/current-node reads, while fencing replay and renewal by owner, generation, phase, and claim sequence
- filter semantically poisoned immutable receipts before ordering so one corrupt row cannot head-of-line block later publication work

## Proof at `07b0e1dacbeb61621da09b5d03e369594acff238`

- publication admission PGlite: 21 passed, 80 assertions
- capture admission PGlite: 11 passed, 72 assertions
- lane lifecycle PGlite: 14 passed, 127 assertions
- lane migration PGlite: 6 passed, 24 assertions
- global lock-order contract: 7 passed, 71 assertions
- real PostgreSQL two-session contention: 1 passed, 13 assertions; exactly one claim and one busy result
- TypeScript, targeted Biome, and `git diff --check`: passed
- fresh adversarial review of the exact tree: CLEAN (no P0-P3)

## Stack

Depends on #28821.

## Deliberately out of scope

- no runtime/caller wiring, feature-gate change, deployment, staging, provider mutation, or autoscale
- no provider execution or catalogue state transition in the admission transaction
- lane settlement/handoff on capture completion, publication completion, and failure remains a following slice
- no V3 restorability verifier yet
- worker-spool loss/move resilience remains unresolved
- legacy captured rows without immutable activation-publication authority are skipped; cohort/backfill policy remains a following slice
