### PR TITLE
feat(app): add an explicit cloud-only development lane

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "dev:prepare": "node packages/scripts/run-turbo.mjs run build --filter=@elizaos/app... --filter=!@elizaos/app",
     "dev": "node packages/app-core/scripts/ensure-shared-i18n-data.mjs && bun --no-install --conditions=eliza-source packages/app-core/scripts/dev-ui.mjs",
     "dev:ui": "node packages/app-core/scripts/ensure-shared-i18n-data.mjs && bun --no-install --conditions=eliza-source packages/app-core/scripts/dev-ui.mjs --ui-only",
+    "dev:cloud-only": "node packages/app-core/scripts/ensure-shared-i18n-data.mjs && bun run --cwd packages/app dev:cloud-only",
     "dev:desktop": "ELIZA_DEV_SOURCE=1 ELIZA_NAMESPACE=eliza bun --conditions=eliza-source packages/app-core/scripts/dev-platform.mjs",
     "dev:desktop:watch": "ELIZA_DEV_SOURCE=1 ELIZA_NAMESPACE=eliza ELIZA_DESKTOP_VITE_WATCH=1 bun --conditions=eliza-source packages/app-core/scripts/dev-platform.mjs",
     "desktop:stack-status": "bun --conditions=eliza-source packages/app-core/scripts/desktop-stack-status.mjs",

--- a/packages/app/.env.example
+++ b/packages/app/.env.example
@@ -3,12 +3,24 @@
 # Set to https://blob.eliza.app for production or a custom CDN domain.
 VITE_ASSET_BASE_URL=https://blob.eliza.app
 
+# Hosted Cloud renderer configuration. These values select public endpoints and
+# tenant metadata only; never put credentials or session tokens in VITE_* vars.
+VITE_ELIZA_CLOUD_BASE=https://cloud.eliza.app
+VITE_STEWARD_API_URL=
+VITE_STEWARD_TENANT_ID=
+
+# Desktop renderer policy. `bun run dev:cloud-only` sets the runtime mode to
+# `cloud` automatically. Ordinary `bun run dev` retains the runtime chooser.
+VITE_ELIZA_DESKTOP_RUNTIME_MODE=
+# Production/test builds may opt into the local/cloud/remote chooser with `1`.
+# The ordinary Vite development server already enables it by default.
+VITE_ELIZA_ENABLE_RUNTIME_CHOOSER=
+
 # iOS runtime modes:
 # - cloud: use bundled web assets and Eliza Cloud
 # - remote-mac: connect the phone build to a Mac-hosted Eliza API
 # - cloud-hybrid: use cloud runtime and connect the device bridge for local compute
 VITE_ELIZA_IOS_RUNTIME_MODE=
-VITE_ELIZA_CLOUD_BASE=https://cloud.eliza.app
 VITE_ELIZA_IOS_API_BASE=
 # Build-time API tokens are embedded in the web bundle. Use only for dev
 # builds or short-lived test credentials.

--- a/packages/app/AGENTS.md
+++ b/packages/app/AGENTS.md
@@ -94,6 +94,7 @@ Common scripts from this package's `package.json`:
 
 ```bash
 bun run --cwd packages/app dev                        # Vite dev server (renderer only; UI port from ELIZA_UI_PORT, default 2138)
+bun run --cwd packages/app dev:cloud-only             # Vite renderer with hosted Cloud onboarding policy
 bun run --cwd packages/app dev:shared                 # Shared long-lived Vite server on deterministic worktree port
 bun run --cwd packages/app dev:status                 # List running shared dev servers (port, worktree, pid)
 bun run --cwd packages/app dev:rebuild                # Trigger explicit Vite full reload for this worktree
@@ -274,7 +275,11 @@ All env vars use the `ELIZA_` prefix (set in `app.config.ts` → `envPrefix: "EL
 | `ELIZA_TTS_DEBUG` | Enable TTS trace logs |
 | `ELIZA_SETTINGS_DEBUG` | Enable settings debug panel |
 | `VITE_ASSET_BASE_URL` | Override asset base URL for CDN hosting |
-| `VITE_ELIZA_DESKTOP_RUNTIME_MODE` | `"cloud"` forces cloud-only branding on desktop |
+| `VITE_ELIZA_CLOUD_BASE` | Hosted Cloud origin used by public-web boot and Cloud runtime configuration |
+| `VITE_ELIZA_DESKTOP_RUNTIME_MODE` | `"cloud"` forces hosted Cloud sign-in policy; `dev:cloud-only` sets it automatically |
+| `VITE_ELIZA_ENABLE_RUNTIME_CHOOSER` | `"1"` opts production/test builds into the local/cloud/remote chooser; ordinary Vite dev enables it by default |
+| `VITE_STEWARD_API_URL` | Optional public Steward API base URL override |
+| `VITE_STEWARD_TENANT_ID` | Steward tenant identifier for the selected Cloud environment |
 | `ELIZA_CAPACITOR_BUILD_TARGET` | `"ios"` or `"android"` — set during mobile builds |
 | `ELIZA_BUILD_VARIANT` | `"store"` for App Store / Play Store builds |
 | `ELIZA_RELEASE_AUTHORITY` | `"apple-app-store"` for iOS store builds (tightens CSP) |

--- a/packages/app/CLAUDE.md
+++ b/packages/app/CLAUDE.md
@@ -94,6 +94,7 @@ Common scripts from this package's `package.json`:
 
 ```bash
 bun run --cwd packages/app dev                        # Vite dev server (renderer only; UI port from ELIZA_UI_PORT, default 2138)
+bun run --cwd packages/app dev:cloud-only             # Vite renderer with hosted Cloud onboarding policy
 bun run --cwd packages/app dev:shared                 # Shared long-lived Vite server on deterministic worktree port
 bun run --cwd packages/app dev:status                 # List running shared dev servers (port, worktree, pid)
 bun run --cwd packages/app dev:rebuild                # Trigger explicit Vite full reload for this worktree
@@ -274,7 +275,11 @@ All env vars use the `ELIZA_` prefix (set in `app.config.ts` → `envPrefix: "EL
 | `ELIZA_TTS_DEBUG` | Enable TTS trace logs |
 | `ELIZA_SETTINGS_DEBUG` | Enable settings debug panel |
 | `VITE_ASSET_BASE_URL` | Override asset base URL for CDN hosting |
-| `VITE_ELIZA_DESKTOP_RUNTIME_MODE` | `"cloud"` forces cloud-only branding on desktop |
+| `VITE_ELIZA_CLOUD_BASE` | Hosted Cloud origin used by public-web boot and Cloud runtime configuration |
+| `VITE_ELIZA_DESKTOP_RUNTIME_MODE` | `"cloud"` forces hosted Cloud sign-in policy; `dev:cloud-only` sets it automatically |
+| `VITE_ELIZA_ENABLE_RUNTIME_CHOOSER` | `"1"` opts production/test builds into the local/cloud/remote chooser; ordinary Vite dev enables it by default |
+| `VITE_STEWARD_API_URL` | Optional public Steward API base URL override |
+| `VITE_STEWARD_TENANT_ID` | Steward tenant identifier for the selected Cloud environment |
 | `ELIZA_CAPACITOR_BUILD_TARGET` | `"ios"` or `"android"` — set during mobile builds |
 | `ELIZA_BUILD_VARIANT` | `"store"` for App Store / Play Store builds |
 | `ELIZA_RELEASE_AUTHORITY` | `"apple-app-store"` for iOS store builds (tightens CSP) |

--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -43,6 +43,7 @@ Run from the repo root with `--cwd packages/app`, or from inside the package dir
 
 ```bash
 bun run dev            # Vite dev server (renderer only; UI port from ELIZA_UI_PORT, default 2138)
+bun run dev:cloud-only # Vite renderer with hosted Cloud onboarding policy
 bun run build          # Full app build (scripts/build.mjs)
 bun run build:web      # Vite build only (no Capacitor sync)
 bun run plugin:build   # Plugin-only build
@@ -77,6 +78,25 @@ grants still cover the target instead of minting another profile.
 
 The desktop shell is built by Electrobun from the repo root (`bun run dev:desktop`),
 not from inside this package â `packages/app` only produces the renderer.
+
+### Cloud-only renderer development
+
+The ordinary `bun run dev` command intentionally retains the local/cloud/remote
+runtime chooser for local-agent development. Use `bun run dev:cloud-only` when
+you need the same hosted Cloud sign-in policy as a production Cloud surface.
+This explicit lane starts the canonical Vite development server with the
+existing `VITE_ELIZA_DESKTOP_RUNTIME_MODE=cloud` policy; it does not introduce a
+separate renderer or change the default development experience.
+
+To compose the lane against staging, provide the public Cloud and Steward
+configuration without embedding credentials:
+
+```bash
+VITE_ELIZA_CLOUD_BASE=https://cloud-staging.eliza.app \
+VITE_STEWARD_API_URL=https://staging.eliza.app/steward \
+VITE_STEWARD_TENANT_ID=elizacloud-staging \
+bun run --cwd packages/app dev:cloud-only
+```
 
 ## Config
 

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "node scripts/dev.mjs",
+    "dev:cloud-only": "node scripts/dev-cloud-only.mjs",
     "dev:chat-harness": "ELIZA_CHAT_UI_HARNESS=1 node scripts/dev.mjs",
     "preview": "bun --bun vite preview",
     "design-review": "node --import tsx test/design-review/run-design-review.ts",
@@ -20,6 +21,7 @@
     "perf:login-transfer-budget": "node scripts/check-login-transfer-budget.mjs",
     "analyze:login-eager-chunks": "node scripts/list-eager-login-chunks.mjs",
     "test:dev-smoke": "node scripts/run-ui-playwright.mjs --config playwright.dev-smoke.config.ts",
+    "test:dev-smoke:cloud-only": "ELIZA_DEV_SMOKE_CLOUD_ONLY=1 node scripts/run-ui-playwright.mjs --config playwright.dev-smoke.config.ts test/dev-smoke/cloud-only-mode.spec.ts",
     "test:hmr": "node scripts/run-ui-playwright.mjs --config playwright.hmr.config.ts",
     "test:e2e": "node scripts/run-ui-playwright.mjs --config playwright.ui-smoke.config.ts",
     "test:e2e:chat-stream-real": "ELIZA_UI_SMOKE_REAL_LOCAL_STACK=1 ELIZA_UI_SMOKE_DISABLE_VIDEO=1 node scripts/run-ui-playwright.mjs --config playwright.ui-smoke.config.ts --project=chromium test/ui-smoke/chat-stream-real-runtime-perf.spec.ts",

--- a/packages/app/playwright.dev-smoke.config.ts
+++ b/packages/app/playwright.dev-smoke.config.ts
@@ -24,6 +24,7 @@ const uiPort = resolvePlaywrightPortEnv(
 const stateDir =
   process.env.ELIZA_DEV_SMOKE_STATE_DIR ||
   path.join(os.tmpdir(), `eliza-dev-smoke-${process.pid}`);
+const cloudOnlyLane = process.env.ELIZA_DEV_SMOKE_CLOUD_ONLY === "1";
 
 process.env.ELIZA_API_PORT = String(apiPort);
 process.env.ELIZA_UI_PORT = String(uiPort);
@@ -54,7 +55,9 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: "bun run dev",
+    command: cloudOnlyLane
+      ? "bun run --cwd packages/app dev:cloud-only"
+      : "bun run dev",
     cwd: repoRoot,
     env: {
       ...process.env,

--- a/packages/app/scripts/dev-cloud-only.mjs
+++ b/packages/app/scripts/dev-cloud-only.mjs
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+
+/**
+ * Starts the ordinary Vite renderer with the hosted Cloud onboarding policy.
+ * The default dev command intentionally keeps the local/cloud/remote chooser;
+ * this explicit lane mirrors production Cloud sign-in without changing it.
+ */
+
+process.env.VITE_ELIZA_DESKTOP_RUNTIME_MODE = "cloud";
+await import("./dev.mjs");

--- a/packages/app/test/dev-smoke/cloud-only-mode.spec.ts
+++ b/packages/app/test/dev-smoke/cloud-only-mode.spec.ts
@@ -1,0 +1,116 @@
+/**
+ * Proves the explicit cloud-only development lane through the real Vite
+ * transform and renderer, without changing the ordinary development default.
+ */
+
+import { mkdir } from "node:fs/promises";
+import { expect, type Page, type Route, test } from "@playwright/test";
+import {
+  expectNoRenderTelemetryErrors,
+  installDefaultAppRoutes,
+  installRenderTelemetryGuard,
+  seedAppStorage,
+} from "../ui-smoke/helpers";
+
+test.skip(
+  process.env.ELIZA_DEV_SMOKE_CLOUD_ONLY !== "1",
+  "runs only through test:dev-smoke:cloud-only",
+);
+
+async function fulfillJson(
+  route: Route,
+  status: number,
+  body: Record<string, unknown>,
+): Promise<void> {
+  await route.fulfill({
+    status,
+    contentType: "application/json",
+    body: JSON.stringify(body),
+  });
+}
+
+async function routeFreshFirstRun(page: Page): Promise<void> {
+  await page.route("**/api/auth/status", async (route) => {
+    if (route.request().method() !== "GET") return route.fallback();
+    await fulfillJson(route, 200, {
+      required: false,
+      authenticated: true,
+      loginRequired: false,
+      localAccess: true,
+      passwordConfigured: false,
+      pairingEnabled: false,
+      expiresAt: null,
+    });
+  });
+  await page.route("**/api/first-run/status", async (route) => {
+    if (route.request().method() !== "GET") return route.fallback();
+    await fulfillJson(route, 200, { complete: false, cloudProvisioned: false });
+  });
+}
+
+async function expectCloudOnlyGreeting(page: Page): Promise<void> {
+  await expect(
+    page.getByText("Sign in to Eliza Cloud", { exact: true }),
+  ).toBeVisible({ timeout: 20_000 });
+  await expect(
+    page.getByTestId("choice-__first_run__:runtime:cloud"),
+  ).toBeVisible();
+  await expect(page.getByTestId("first-run-runtime-chooser")).toHaveCount(0);
+  for (const runtime of ["local", "remote"]) {
+    await expect(
+      page.getByTestId(`choice-__first_run__:runtime:${runtime}`),
+    ).toHaveCount(0);
+  }
+}
+
+async function capture(page: Page, outputPath: string): Promise<void> {
+  await page.screenshot({ path: outputPath, fullPage: true });
+}
+
+test("explicit cloud-only Vite development skips the runtime chooser", async ({
+  page,
+}, testInfo) => {
+  await installRenderTelemetryGuard(page);
+  await installDefaultAppRoutes(page);
+  await routeFreshFirstRun(page);
+  await page.addInitScript(() => {
+    const win = window as unknown as Record<string, unknown>;
+    win.__ELIZA_APP_API_BASE__ = window.location.origin;
+    win.__ELIZAOS_APP_BOOT_CONFIG__ = { apiBase: window.location.origin };
+    win.__electrobunWindowId = 1;
+  });
+  await seedAppStorage(page, {
+    "eliza:first-run-complete": "",
+  });
+
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+  await expectCloudOnlyGreeting(page);
+  expect(
+    await page.evaluate(() =>
+      localStorage.getItem("eliza:enable-runtime-chooser"),
+    ),
+  ).toBeNull();
+  await expectNoRenderTelemetryErrors(page, "cloud-only Vite development");
+
+  await mkdir(testInfo.outputDir, { recursive: true });
+  const desktopPath = testInfo.outputPath("cloud-only-dev-desktop.png");
+  await capture(page, desktopPath);
+  await testInfo.attach("cloud-only-dev-desktop", {
+    path: desktopPath,
+    contentType: "image/png",
+  });
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.reload({ waitUntil: "domcontentloaded" });
+  await expectCloudOnlyGreeting(page);
+  await expectNoRenderTelemetryErrors(
+    page,
+    "cloud-only Vite development mobile reload",
+  );
+  const mobilePath = testInfo.outputPath("cloud-only-dev-mobile.png");
+  await capture(page, mobilePath);
+  await testInfo.attach("cloud-only-dev-mobile", {
+    path: mobilePath,
+    contentType: "image/png",
+  });
+});

--- a/packages/app/test/dev-smoke/cloud-only-mode.spec.ts
+++ b/packages/app/test/dev-smoke/cloud-only-mode.spec.ts
@@ -19,20 +19,22 @@ test.skip(
 
 async function fulfillJson(
   route: Route,
-  status: number,
   body: Record<string, unknown>,
 ): Promise<void> {
   await route.fulfill({
-    status,
+    status: 200,
     contentType: "application/json",
     body: JSON.stringify(body),
   });
 }
 
-async function routeFreshFirstRun(page: Page): Promise<void> {
+async function routeFreshFirstRun(
+  page: Page,
+): Promise<{ loginStarts: number }> {
+  const state = { loginStarts: 0 };
   await page.route("**/api/auth/status", async (route) => {
     if (route.request().method() !== "GET") return route.fallback();
-    await fulfillJson(route, 200, {
+    await fulfillJson(route, {
       required: false,
       authenticated: true,
       loginRequired: false,
@@ -44,17 +46,41 @@ async function routeFreshFirstRun(page: Page): Promise<void> {
   });
   await page.route("**/api/first-run/status", async (route) => {
     if (route.request().method() !== "GET") return route.fallback();
-    await fulfillJson(route, 200, { complete: false, cloudProvisioned: false });
+    await fulfillJson(route, { complete: false, cloudProvisioned: false });
   });
+  await page.route("**/api/first-run/options", async (route) => {
+    if (route.request().method() !== "GET") return route.fallback();
+    await fulfillJson(route, {
+      names: [],
+      styles: [],
+      providers: [],
+      cloudProviders: [],
+      models: [],
+      inventoryProviders: [],
+      sharedStyleRules: "",
+      githubOAuthAvailable: false,
+    });
+  });
+  await page.route("**/api/cloud/login", async (route) => {
+    if (route.request().method() !== "POST") return route.fallback();
+    state.loginStarts += 1;
+    await fulfillJson(route, {
+      ok: true,
+      sessionId: "cloud-only-dev-smoke",
+      browserUrl: "https://www.elizacloud.ai/device/cloud-only-dev-smoke",
+    });
+  });
+  await page.route("**/api/cloud/login/status**", async (route) => {
+    if (route.request().method() !== "GET") return route.fallback();
+    await fulfillJson(route, { status: "pending" });
+  });
+  return state;
 }
 
-async function expectCloudOnlyGreeting(page: Page): Promise<void> {
-  await expect(
-    page.getByText("Sign in to Eliza Cloud", { exact: true }),
-  ).toBeVisible({ timeout: 20_000 });
-  await expect(
-    page.getByTestId("choice-__first_run__:runtime:cloud"),
-  ).toBeVisible();
+async function expectCloudOnlyAuth(page: Page): Promise<void> {
+  await expect(page.getByText("Opening secure sign in…")).toBeVisible({
+    timeout: 20_000,
+  });
   await expect(page.getByTestId("first-run-runtime-chooser")).toHaveCount(0);
   for (const runtime of ["local", "remote"]) {
     await expect(
@@ -72,19 +98,14 @@ test("explicit cloud-only Vite development skips the runtime chooser", async ({
 }, testInfo) => {
   await installRenderTelemetryGuard(page);
   await installDefaultAppRoutes(page);
-  await routeFreshFirstRun(page);
-  await page.addInitScript(() => {
-    const win = window as unknown as Record<string, unknown>;
-    win.__ELIZA_APP_API_BASE__ = window.location.origin;
-    win.__ELIZAOS_APP_BOOT_CONFIG__ = { apiBase: window.location.origin };
-    win.__electrobunWindowId = 1;
-  });
+  const routeState = await routeFreshFirstRun(page);
   await seedAppStorage(page, {
     "eliza:first-run-complete": "",
   });
 
   await page.goto("/", { waitUntil: "domcontentloaded" });
-  await expectCloudOnlyGreeting(page);
+  await expectCloudOnlyAuth(page);
+  expect(routeState.loginStarts).toBeGreaterThan(0);
   expect(
     await page.evaluate(() =>
       localStorage.getItem("eliza:enable-runtime-chooser"),
@@ -102,7 +123,7 @@ test("explicit cloud-only Vite development skips the runtime chooser", async ({
 
   await page.setViewportSize({ width: 390, height: 844 });
   await page.reload({ waitUntil: "domcontentloaded" });
-  await expectCloudOnlyGreeting(page);
+  await expectCloudOnlyAuth(page);
   await expectNoRenderTelemetryErrors(
     page,
     "cloud-only Vite development mobile reload",


### PR DESCRIPTION
# Relates to

Fixes #28850

## Summary

Adds an explicit opt-in `dev:cloud-only` command at the repository and app-package roots. It reuses the existing hosted-Cloud runtime policy and canonical Vite launcher; ordinary `bun run dev` remains unchanged.

The branch was rebased onto current `develop`. Its real-Vite smoke was updated for the current zero-interaction Cloud authentication startup: it proves Cloud auth begins, local/remote chooser choices never render, no chooser override is persisted, and desktop plus 390x844 mobile reloads remain clean.

## Risk

Low and non-breaking. This changes developer launch configuration, documentation, and its dedicated smoke only. Production builds, backend behavior, and the ordinary development chooser are untouched.

## Validation

Exact PR head: `a03f3f264f78e1c06ca19ac72ffbe7448b88d2d3`

- [x] Pinned Bun install and full app dependency build: 97/97 packages.
- [x] `bun run --cwd packages/app typecheck`.
- [x] Exact-head real-Vite cloud-only desktop/mobile smoke: 1/1 passed.
- [x] `bun run check:agents-claude`.
- [x] Biome on changed executable/config/test files.
- [x] `git diff --check`.

## Evidence gate

<!-- evidence-head:a03f3f264f78e1c06ca19ac72ffbe7448b88d2d3 -->

- [x] Screenshots/video: N/A — opt-in developer command only; the dedicated real-browser test exercises desktop and mobile rendering and captures failures.
- [x] Backend logs: N/A — no backend path changes.
- [x] Frontend logs: covered by the real-Vite Playwright telemetry guard.
- [x] LLM trajectory: N/A — no model, prompt, provider, or agent behavior changes.
- [x] OCR review: N/A — no production copy or visual design change.