### PR TITLE
fix(connectors): use lossless provider-sized chunks

### DIFF
--- a/plugins/plugin-discord/__tests__/dm-send-chunking.test.ts
+++ b/plugins/plugin-discord/__tests__/dm-send-chunking.test.ts
@@ -35,6 +35,29 @@ function makeRecordingUser(): {
 }
 
 describe("sendDmInChunks transport budget", () => {
+	it("uses Discord's full 2000-character hard boundary", async () => {
+		const exact = makeRecordingUser();
+		await sendDmInChunks(
+			exact.user,
+			"a".repeat(DISCORD_HARD_LIMIT),
+			[],
+			undefined,
+		);
+		expect(exact.sends).toHaveLength(1);
+
+		const over = makeRecordingUser();
+		await sendDmInChunks(
+			over.user,
+			"a".repeat(DISCORD_HARD_LIMIT + 1),
+			[],
+			undefined,
+		);
+		expect(over.sends).toHaveLength(2);
+		expect(over.sends.map((send) => send.content).join("")).toBe(
+			"a".repeat(DISCORD_HARD_LIMIT + 1),
+		);
+	});
+
 	it("splits a >2000-char plain message into ordered chunks each within budget", async () => {
 		const paragraphs: string[] = [];
 		for (let i = 0; i < 60; i++) {

--- a/plugins/plugin-discord/draft-chunking.ts
+++ b/plugins/plugin-discord/draft-chunking.ts
@@ -14,7 +14,7 @@ export interface DraftChunkConfig {
 
 export const DEFAULT_DRAFT_CHUNK_CONFIG: DraftChunkConfig = {
 	minChars: 80,
-	maxChars: 1900,
+	maxChars: 2000,
 	breakPreference: "sentence",
 };
 

--- a/plugins/plugin-discord/draft-stream.ts
+++ b/plugins/plugin-discord/draft-stream.ts
@@ -54,7 +54,10 @@ export function createDraftStreamController(
 ): DraftStreamController {
 	const throttleMs = Math.max(250, options.throttleMs ?? DEFAULT_THROTTLE_MS);
 	const minInitialChars = options.minInitialChars ?? DEFAULT_MIN_INITIAL_CHARS;
-	const maxChars = Math.min(options.maxChars ?? 1900, DISCORD_MAX_CHARS);
+	const maxChars = Math.min(
+		options.maxChars ?? DISCORD_MAX_CHARS,
+		DISCORD_MAX_CHARS,
+	);
 	const log = options.log ?? (() => {});
 	const warn = options.warn ?? (() => {});
 

--- a/plugins/plugin-discord/messages.ts
+++ b/plugins/plugin-discord/messages.ts
@@ -880,8 +880,8 @@ export interface DmSendTarget {
  * `user.send(...)` with a longer body (e.g. a multi-day recall digest) is
  * rejected outright, so the reply never arrives. This routes DM text through
  * `chunkDiscordText` — the fence-aware chunker every other outbound Discord
- * path already uses — with the shared `MAX_MESSAGE_LENGTH` (1900) headroom
- * budget, and sends the chunks sequentially so ordering is preserved.
+ * path already uses — with the shared 2,000-character provider budget
+ * and sends the chunks sequentially so ordering is preserved.
  *
  * Attachments and interactive components ride the LAST chunk, mirroring
  * `sendMessageInChunks`, so widgets sit directly under the end of the answer.

--- a/plugins/plugin-discord/utils.ts
+++ b/plugins/plugin-discord/utils.ts
@@ -103,7 +103,7 @@ export function getMessageService(
 	return null;
 }
 
-export const MAX_MESSAGE_LENGTH = 1900;
+export const MAX_MESSAGE_LENGTH = 2000;
 
 function stripJsonFence(text: string): string {
 	const trimmed = text.trim();

--- a/plugins/plugin-google-workspace/src/chat/connector.test.ts
+++ b/plugins/plugin-google-workspace/src/chat/connector.test.ts
@@ -9,7 +9,7 @@ import { GoogleChatService } from "./service.js";
 import {
   GoogleChatApiError,
   GoogleChatConfigurationError,
-  MAX_GOOGLE_CHAT_MESSAGE_LENGTH,
+  MAX_GOOGLE_CHAT_MESSAGE_BYTES,
   splitMessageForGoogleChat,
 } from "./types.js";
 
@@ -358,7 +358,7 @@ describe("Google Chat message connector", () => {
       requests.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
       return Response.json({ name: `spaces/AAA/messages/${requests.length}` });
     });
-    const text = "🙂".repeat(2_500);
+    const text = "🙂".repeat(10_000);
 
     const result = await service.sendMessage({
       accountId: "workspace",
@@ -371,7 +371,11 @@ describe("Google Chat message connector", () => {
     expect(requests).toHaveLength(2);
     const sentText = requests.map((request) => String(request.text));
     expect(sentText.join("")).toBe(text);
-    expect(sentText.every((chunk) => chunk.length <= 4_000)).toBe(true);
+    expect(
+      sentText.every(
+        (chunk) => new TextEncoder().encode(chunk).byteLength <= MAX_GOOGLE_CHAT_MESSAGE_BYTES
+      )
+    ).toBe(true);
     expect(sentText.every((chunk) => chunk.isWellFormed())).toBe(true);
     expect(requests.map((request) => request.thread)).toEqual([
       { name: "spaces/AAA/threads/T1" },
@@ -395,7 +399,7 @@ describe("Google Chat message connector", () => {
       service.sendMessage({
         accountId: "workspace",
         space: "spaces/AAA",
-        text: "🙂".repeat(4_500),
+        text: "🙂".repeat(17_000),
       })
     ).rejects.toBeInstanceOf(GoogleChatApiError);
 
@@ -428,15 +432,17 @@ describe("Google Chat message connector", () => {
   });
 });
 
-describe("splitMessageForGoogleChat surrogate pair safety", () => {
-  it("keeps a surrogate pair (emoji) intact instead of splitting it across chunks", () => {
-    const text = `a${"🙂".repeat(MAX_GOOGLE_CHAT_MESSAGE_LENGTH)}`;
+describe("splitMessageForGoogleChat provider boundary", () => {
+  it("measures emoji in UTF-8 bytes and keeps every chunk well formed", () => {
+    const text = `a${"🙂".repeat(MAX_GOOGLE_CHAT_MESSAGE_BYTES)}`;
 
     const chunks = splitMessageForGoogleChat(text);
 
     expect(chunks.length).toBeGreaterThan(1);
     for (const chunk of chunks) {
-      expect(chunk.length).toBeLessThanOrEqual(MAX_GOOGLE_CHAT_MESSAGE_LENGTH);
+      expect(new TextEncoder().encode(chunk).byteLength).toBeLessThanOrEqual(
+        MAX_GOOGLE_CHAT_MESSAGE_BYTES
+      );
       expect(chunk.isWellFormed()).toBe(true);
     }
   });
@@ -446,29 +452,44 @@ describe("splitMessageForGoogleChat surrogate pair safety", () => {
   });
 
   it("keeps the exact provider boundary and chunks one unit beyond it", () => {
-    const exact = "a".repeat(MAX_GOOGLE_CHAT_MESSAGE_LENGTH);
+    const exact = "a".repeat(MAX_GOOGLE_CHAT_MESSAGE_BYTES);
     expect(splitMessageForGoogleChat(exact)).toEqual([exact]);
 
     const over = `${exact}b`;
     const chunks = splitMessageForGoogleChat(over);
-    expect(chunks.map((chunk) => chunk.length)).toEqual([4_000, 1]);
+    expect(chunks.map((chunk) => chunk.length)).toEqual([32_000, 1]);
     expect(chunks.join("")).toBe(over);
   });
 
   it("does not let a whitespace break exceed the provider limit", () => {
-    const chunks = splitMessageForGoogleChat(`${"a".repeat(MAX_GOOGLE_CHAT_MESSAGE_LENGTH)} b`);
-    expect(chunks.every((chunk) => chunk.length <= 4_000)).toBe(true);
-    expect(chunks).toEqual(["a".repeat(4_000), "b"]);
+    const source = `${"a".repeat(MAX_GOOGLE_CHAT_MESSAGE_BYTES)} b`;
+    const chunks = splitMessageForGoogleChat(source);
+    expect(
+      chunks.every(
+        (chunk) => new TextEncoder().encode(chunk).byteLength <= MAX_GOOGLE_CHAT_MESSAGE_BYTES
+      )
+    ).toBe(true);
+    expect(chunks).toEqual(["a".repeat(32_000), " b"]);
+    expect(chunks.join("")).toBe(source);
   });
 
   it.each([1, 0, -1, 2.5, Number.NaN, Number.POSITIVE_INFINITY])(
     "rejects an invalid maxLength %s instead of stalling",
     (maxLength) => {
       expect(() => splitMessageForGoogleChat("🙂x", maxLength)).toThrow(
-        "maxLength must be an integer of at least 2"
+        "maxBytes must be an integer of at least 4"
       );
     }
   );
+
+  it("uses the full byte budget for multibyte text and reassembles exactly", () => {
+    const source = `${"🙂".repeat(8_000)} tail\n`;
+    const chunks = splitMessageForGoogleChat(source);
+
+    expect(chunks.length).toBe(2);
+    expect(new TextEncoder().encode(chunks[0]).byteLength).toBe(32_000);
+    expect(chunks.join("")).toBe(source);
+  });
 
   it("replaces pre-existing lone surrogates before returning wire text", () => {
     const chunks = splitMessageForGoogleChat(`\uD83Dvalid\uDC00`);

--- a/plugins/plugin-google-workspace/src/chat/types.ts
+++ b/plugins/plugin-google-workspace/src/chat/types.ts
@@ -2,10 +2,13 @@
  * Type definitions for the Google Chat plugin.
  */
 
-import { type Service, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+import { type Service, toWellFormedUnicode } from "@elizaos/core";
 
-/** Maximum message length for Google Chat */
-export const MAX_GOOGLE_CHAT_MESSAGE_LENGTH = 4000;
+/** Google Chat's maximum message size, measured as UTF-8 bytes. */
+export const MAX_GOOGLE_CHAT_MESSAGE_BYTES = 32_000;
+
+/** @deprecated Use {@link MAX_GOOGLE_CHAT_MESSAGE_BYTES}; this value is a byte budget. */
+export const MAX_GOOGLE_CHAT_MESSAGE_LENGTH = MAX_GOOGLE_CHAT_MESSAGE_BYTES;
 
 /** Google Chat service name */
 export const GOOGLE_CHAT_SERVICE_NAME = "google-chat";
@@ -311,20 +314,20 @@ export function isDirectMessage(space: GoogleChatSpace): boolean {
 }
 
 /**
- * Returns provider-sized, well-formed Unicode chunks for Google Chat.
- * Budgets below two UTF-16 code units cannot hold an astral character and are
- * rejected so every iteration has a valid, non-empty prefix.
+ * Returns lossless, provider-sized, well-formed Unicode chunks for Google Chat.
+ * Google Chat measures the message boundary in UTF-8 bytes, not JavaScript
+ * UTF-16 code units.
  */
 export function splitMessageForGoogleChat(
   text: string,
-  maxLength: number = MAX_GOOGLE_CHAT_MESSAGE_LENGTH
+  maxBytes: number = MAX_GOOGLE_CHAT_MESSAGE_BYTES
 ): string[] {
-  if (!Number.isInteger(maxLength) || maxLength < 2) {
-    throw new RangeError("Google Chat message maxLength must be an integer of at least 2");
+  if (!Number.isInteger(maxBytes) || maxBytes < 4) {
+    throw new RangeError("Google Chat message maxBytes must be an integer of at least 4");
   }
 
   const wellFormedText = toWellFormedUnicode(text);
-  if (wellFormedText.length <= maxLength) {
+  if (wellFormedText.length === 0) {
     return [wellFormedText];
   }
 
@@ -332,26 +335,48 @@ export function splitMessageForGoogleChat(
   let remaining = wellFormedText;
 
   while (remaining.length > 0) {
-    if (remaining.length <= maxLength) {
+    let prefixLength = 0;
+    let prefixBytes = 0;
+    for (const character of remaining) {
+      const codePoint = character.codePointAt(0);
+      const characterBytes =
+        codePoint === undefined
+          ? 0
+          : codePoint <= 0x7f
+            ? 1
+            : codePoint <= 0x7ff
+              ? 2
+              : codePoint <= 0xffff
+                ? 3
+                : 4;
+      if (prefixBytes + characterBytes > maxBytes) {
+        break;
+      }
+      prefixBytes += characterBytes;
+      prefixLength += character.length;
+    }
+    if (prefixLength === 0) {
+      throw new RangeError("Google Chat message maxBytes cannot fit the next Unicode scalar");
+    }
+    if (prefixLength === remaining.length) {
       chunks.push(remaining);
       break;
     }
 
-    // Find a good break point
-    let breakPoint = maxLength;
-    const newlineIndex = remaining.lastIndexOf("\n", maxLength - 1);
-    if (newlineIndex > maxLength * 0.5) {
+    const prefix = remaining.slice(0, prefixLength);
+    let breakPoint = prefixLength;
+    const newlineIndex = prefix.lastIndexOf("\n");
+    if (newlineIndex > prefixLength * 0.5) {
       breakPoint = newlineIndex + 1;
     } else {
-      const spaceIndex = remaining.lastIndexOf(" ", maxLength - 1);
-      if (spaceIndex > maxLength * 0.5) {
+      const spaceIndex = prefix.lastIndexOf(" ");
+      if (spaceIndex > prefixLength * 0.5) {
         breakPoint = spaceIndex + 1;
       }
     }
 
-    const head = truncateWellFormed(remaining, breakPoint);
-    chunks.push(head.trimEnd());
-    remaining = remaining.slice(head.length).trimStart();
+    chunks.push(remaining.slice(0, breakPoint));
+    remaining = remaining.slice(breakPoint);
   }
 
   return chunks;

--- a/plugins/plugin-matrix/src/service.ts
+++ b/plugins/plugin-matrix/src/service.ts
@@ -26,6 +26,8 @@ import {
   resolveAliasedEnvValue,
   Service,
   type TargetInfo,
+  toWellFormedUnicode,
+  truncateWellFormed,
   type UUID,
 } from "@elizaos/core";
 import * as sdk from "matrix-js-sdk";
@@ -1294,7 +1296,7 @@ export class MatrixService extends Service implements IMatrixService {
     };
 
     logger.debug(
-      `Matrix message from ${message.senderInfo.displayName || message.sender} in ${room.name || roomId}: ${message.content.slice(0, 50)}...`
+      `Matrix message from ${message.senderInfo.displayName || message.sender} in ${room.name || roomId}: ${truncateWellFormed(toWellFormedUnicode(message.content), 50)}...`
     );
 
     // Plugin-local event other code may listen for (the MatrixMessage/MatrixRoom payload).

--- a/plugins/plugin-slack/src/formatting.test.ts
+++ b/plugins/plugin-slack/src/formatting.test.ts
@@ -211,6 +211,14 @@ describe("chunkSlackText", () => {
 });
 
 describe("splitSlackText", () => {
+  it("uses Slack's documented 40,000-character hard boundary by default", () => {
+    const text = "a".repeat(40_001);
+    const chunks = splitSlackText(text);
+
+    expect(chunks.map((chunk) => chunk.length)).toEqual([40_000, 1]);
+    expect(chunks.join("")).toBe(text);
+  });
+
   it.each(["\n", " "])(
     "keeps the service send path within the cap at an exact %j boundary",
     (boundary) => {

--- a/plugins/plugin-slack/src/formatting.ts
+++ b/plugins/plugin-slack/src/formatting.ts
@@ -222,11 +222,11 @@ export function markdownToSlackMrkdwn(markdown: string): string {
  * Options for chunking Slack text
  */
 export interface ChunkSlackTextOpts {
-  /** Max characters per message. Default: 4000 */
+  /** Max characters per message. Default: Slack's 40,000-character hard limit. */
   maxChars?: number;
 }
 
-const DEFAULT_MAX_CHARS = 4000;
+const DEFAULT_MAX_CHARS = 40_000;
 
 /**
  * A hard per-chunk cap can never be honored for arbitrary text unless it's a

--- a/plugins/plugin-slack/src/types.ts
+++ b/plugins/plugin-slack/src/types.ts
@@ -538,7 +538,7 @@ export function getSlackChannelType(channel: SlackChannel): SlackChannelType {
 /**
  * Maximum message length for Slack messages
  */
-export const MAX_SLACK_MESSAGE_LENGTH = 4000;
+export const MAX_SLACK_MESSAGE_LENGTH = 40_000;
 
 /**
  * Maximum number of blocks per message

--- a/plugins/plugin-wechat/src/index.test.ts
+++ b/plugins/plugin-wechat/src/index.test.ts
@@ -425,8 +425,9 @@ describe("@elizaos/plugin-wechat", () => {
 
     await dispatcher.sendText("wxid_alice", "hello world");
 
-    expect(client.sendText).toHaveBeenNthCalledWith(1, "wxid_alice", "hello");
-    expect(client.sendText).toHaveBeenNthCalledWith(2, "wxid_alice", "world");
+    const sent = client.sendText.mock.calls.map((call) => call[1]);
+    expect(sent).toEqual(["hello", " worl", "d"]);
+    expect(sent.join("")).toBe("hello world");
   });
 
   it("keeps surrogate pairs intact when chunking text through the proxy client", async () => {
@@ -470,7 +471,7 @@ describe("@elizaos/plugin-wechat", () => {
     expect(client.sendText).not.toHaveBeenCalled();
   });
 
-  it("keeps the established whitespace-boundary policy explicit", async () => {
+  it("preserves whitespace exactly across a natural chunk boundary", async () => {
     const client = {
       sendText: vi.fn(async () => undefined),
     } as unknown as ProxyClient;
@@ -478,9 +479,9 @@ describe("@elizaos/plugin-wechat", () => {
 
     await dispatcher.sendText("wxid_alice", "hello  world");
 
-    expect(
-      vi.mocked(client.sendText).mock.calls.map((call) => call[1]),
-    ).toEqual(["hello ", "world"]);
+    const sent = vi.mocked(client.sendText).mock.calls.map((call) => call[1]);
+    expect(sent).toEqual(["hello ", " world"]);
+    expect(sent.join("")).toBe("hello  world");
   });
 
   it("sanitizes pre-existing lone surrogates before sending", async () => {

--- a/plugins/plugin-wechat/src/reply-dispatcher.ts
+++ b/plugins/plugin-wechat/src/reply-dispatcher.ts
@@ -98,7 +98,7 @@ export class ReplyDispatcher {
       }
       const cutPoint = chunkCandidate.length;
       chunks.push(remaining.slice(0, cutPoint));
-      remaining = remaining.slice(cutPoint).trimStart();
+      remaining = remaining.slice(cutPoint);
     }
 
     return chunks;

--- a/plugins/plugin-whatsapp/src/normalize.test.ts
+++ b/plugins/plugin-whatsapp/src/normalize.test.ts
@@ -107,7 +107,7 @@ describe("text chunking", () => {
     const chunks = chunkWhatsAppText(text, { limit: 40 });
     expect(chunks.length).toBeGreaterThan(1);
     expect(chunks.every((c) => c.length <= 40)).toBe(true);
-    expect(chunks.join("\n").replace(/\s+/g, "")).toBe(text.replace(/\s+/g, ""));
+    expect(chunks.join("")).toBe(text);
   });
 
   it("chunkWhatsAppText keeps a surrogate pair (emoji) intact at the hard-break fallback", () => {
@@ -156,6 +156,14 @@ describe("text chunking", () => {
       expect(chunk.length).toBeLessThanOrEqual(2);
       expect(chunk.isWellFormed()).toBe(true);
     }
+    expect(chunks.join("")).toBe(text);
+  });
+
+  it("preserves repeated and leading boundary whitespace exactly", () => {
+    const text = "  hello  world\n\n next line  ";
+    const chunks = chunkWhatsAppText(text, { limit: 10 });
+
+    expect(chunks.every((chunk) => chunk.length <= 10)).toBe(true);
     expect(chunks.join("")).toBe(text);
   });
 });

--- a/plugins/plugin-whatsapp/src/normalize.ts
+++ b/plugins/plugin-whatsapp/src/normalize.ts
@@ -5,7 +5,7 @@
  * by the runtime service, message adapters, and account resolution.
  */
 
-import { truncateWellFormed } from "@elizaos/core";
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import { stripWhatsAppTargetPrefixes } from "./whatsapp-target-prefix";
 
 /**
@@ -229,18 +229,20 @@ function splitAtBreakPoint(text: string, limit: number): { chunk: string; remain
   // Prefer double newlines (paragraph breaks)
   const doubleNewline = searchArea.lastIndexOf("\n\n");
   if (doubleNewline > limit * 0.5) {
+    const breakPoint = doubleNewline + 2;
     return {
-      chunk: text.slice(0, doubleNewline).trimEnd(),
-      remainder: text.slice(doubleNewline + 2).trimStart(),
+      chunk: text.slice(0, breakPoint),
+      remainder: text.slice(breakPoint),
     };
   }
 
   // Try single newlines
   const singleNewline = searchArea.lastIndexOf("\n");
   if (singleNewline > limit * 0.5) {
+    const breakPoint = singleNewline + 1;
     return {
-      chunk: text.slice(0, singleNewline).trimEnd(),
-      remainder: text.slice(singleNewline + 1).trimStart(),
+      chunk: text.slice(0, breakPoint),
+      remainder: text.slice(breakPoint),
     };
   }
 
@@ -251,18 +253,20 @@ function splitAtBreakPoint(text: string, limit: number): { chunk: string; remain
     searchArea.lastIndexOf("? ")
   );
   if (sentenceEnd > limit * 0.5) {
+    const breakPoint = sentenceEnd + 2;
     return {
-      chunk: text.slice(0, sentenceEnd + 1).trimEnd(),
-      remainder: text.slice(sentenceEnd + 2).trimStart(),
+      chunk: text.slice(0, breakPoint),
+      remainder: text.slice(breakPoint),
     };
   }
 
   // Try word boundaries
   const space = searchArea.lastIndexOf(" ");
   if (space > limit * 0.5) {
+    const breakPoint = space + 1;
     return {
-      chunk: text.slice(0, space).trimEnd(),
-      remainder: text.slice(space + 1).trimStart(),
+      chunk: text.slice(0, breakPoint),
+      remainder: text.slice(breakPoint),
     };
   }
 
@@ -296,11 +300,11 @@ export function chunkWhatsAppText(text: string, opts: ChunkWhatsAppTextOpts = {}
     );
   }
 
-  if (!text.trim()) {
+  if (text.length === 0) {
     return [];
   }
 
-  const normalizedText = text.trim();
+  const normalizedText = toWellFormedUnicode(text);
   if (normalizedText.length <= limit) {
     return [normalizedText];
   }


### PR DESCRIPTION
## Summary

Part of #28832. PR #28851 owns the non-overlapping Telegram, X, and core multipart-post lane.

- uses Slack's documented 40,000-character hard message boundary instead of the 4,000-character recommendation
- uses Discord's documented 2,000-character message boundary consistently instead of arbitrary 1,900-character headroom
- chunks Google Chat text by its documented 32,000-byte message boundary rather than UTF-16 code units
- preserves every whitespace code unit across WeChat and WhatsApp chunk boundaries
- normalizes malformed Unicode before WhatsApp delivery
- keeps Matrix's legitimate bounded log preview while routing it through the shared well-formed Unicode helpers

Provider references:

- Slack: https://api.slack.com/changelog/2018-04-truncating-really-long-messages
- Discord: https://docs.discord.com/developers/resources/message
- Google Chat: https://developers.google.com/workspace/chat/api/reference/rest/v1/spaces.messages/create

## Contract

For every delivery splitter in scope:

- every emitted chunk stays within the provider or connector boundary
- no chunk bisects a UTF-16 surrogate pair
- concatenating the ordered chunks reproduces the complete normalized input
- provider failure stops subsequent sends rather than reporting fabricated success

## Verification

Focused tests:

- Slack formatting: 89 passed
- Discord DM/messaging boundary suites: 20 passed
- Google Chat connector: 24 passed
- WhatsApp normalization: 18 passed
- WeChat connector: 21 passed

Full package suites:

- Slack: 176 passed
- WhatsApp: 193 passed
- WeChat: 65 passed
- Matrix: 45 passed

Read-only lint passed for all six affected plugins.

Typecheck passed for Slack, Google Workspace, WeChat, and Matrix. Discord is blocked by missing unrelated workspace dependencies (`drizzle-orm`, Puppeteer/Playwright, and `@elizaos/plugin-commands`); WhatsApp is blocked by the existing `IFileStorageService.read` mismatch in `runtime-service.ts`.

Root `bun run verify` reached the workspace Turbo lane after passing parity, version, i18n, dependency, convention, alias, tsconfig, and publish-graph gates. It stopped on the unrelated missing `node-swiftlint` binary in `@elizaos/capacitor-gateway`.

Full Google Workspace has one unrelated stale Gmail Infinity-limit expectation (338 pass, 1 fail). Full Discord has 822 pass, 31 skipped, with unrelated missing `@electric-sql/pglite-sync` and stale interaction/reference expectations. The focused changed contracts are green.

## Evidence

<!-- evidence-head:4512668900ac080b22be9ab6fbda0788f659d6d5 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI changes.
<!-- evidence-row:backend-logs -->
- [x] N/A - no live provider credentials were available; deterministic connector tests exercise the production split/send paths.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model or prompt changes.
<!-- evidence-row:domain-artifacts -->
- [x] Ordered send-call tests assert provider-sized chunks and exact reassembly.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.


