### PR TITLE
fix(core): preserve compaction content refs beside falsy values

### DIFF
--- a/packages/core/src/runtime/content-access-manifest.test.ts
+++ b/packages/core/src/runtime/content-access-manifest.test.ts
@@ -101,6 +101,33 @@ describe("deriveCompactionContentManifest", () => {
 		]);
 	});
 
+	it.each([
+		["null field", { view: readView(0, 20), nextCursor: null }],
+		["empty-string field", { view: readView(0, 20), note: "" }],
+		["zero array element", { items: [readView(0, 20), 0] }],
+	])("keeps references next to a falsy %s", (_case, promptData) => {
+		const manifest = deriveCompactionContentManifest(
+			{
+				archivedSteps: [],
+				steps: [
+					{
+						iteration: 1,
+						toolCall: { name: "FILE" },
+						result: { success: true, promptData },
+					},
+				],
+			},
+			{ lastUsedAt: "2026-08-22T12:00:00.000Z" },
+		);
+
+		expect(manifest.contentRefs).toMatchObject([
+			{
+				reference: { ref: "opaque-file" },
+				rangesUsed: [{ unit: "byte", start: 0, end: 20 }],
+			},
+		]);
+	});
+
 	it("fails explicitly instead of silently truncating the manifest", () => {
 		expect(() =>
 			deriveCompactionContentManifest(

--- a/packages/core/src/runtime/content-access-manifest.ts
+++ b/packages/core/src/runtime/content-access-manifest.ts
@@ -161,7 +161,7 @@ export function deriveCompactionContentManifest(
 		const visited = new WeakSet<object>();
 		while (pending.length > 0) {
 			const current = pending.pop();
-			if (!current) break;
+			if (!current) continue;
 			if (isReadView(current)) {
 				addReference(current.reference, reason, {
 					unit: current.slice.range.unit,


### PR DESCRIPTION
# Defect

`deriveCompactionContentManifest` stopped scanning an entire tool result whenever its stack popped any falsy value. A common result such as `{ view: <ReadView>, nextCursor: null }` therefore returned `contentRefs: []` even though the result referenced retained native content. At the archive/compaction seam, that silently makes live continuation content look unreferenced and allows paged read state to be lost.

This changes the walker from `break` to `continue` for a falsy popped node. The traversal now skips that value and continues visiting the remaining stack. The regression cases are evidence for the production correction; they are not the purpose of the PR.

# Relates to

No issue. This pull request is the standalone defect report and fix.

Definition of Done: full standard in [`CONTRIBUTING.md`](CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` was intentionally not run because the handoff stated dependencies were already installed. `bun run verify` was run after sync; its exact control-reproduced blocker is recorded below.
- [x] A reviewer can confirm the change works without reading the code from the failing-before, passing-after, mutant, control, and manifest evidence below.

# Sync with develop

- [x] Rebased onto `origin/develop` at `6941532900d691b674ed0c0462985f1faab360d7`; zero conflicts.
- [x] `bun run verify` was run post-sync. It fails identically on the fix and untouched control because `node-swiftlint` is absent; see **Known gaps / failures**.

# Risks

Low. The production change is one control-flow word in the cycle-safe value walker. It broadens traversal only after falsy values that previously aborted the stack; existing reference bounds, range bounds, cycle detection, validation, and error behavior are unchanged.

# Background

## What does this PR do?

It preserves content references and byte ranges when `result.data` or `result.promptData` contains a falsy sibling before a `ReadView` is visited in LIFO order. It covers object siblings (`null`, `""`) and an array sibling (`0`).

## What kind of change is this?

Bug fix (non-breaking).

## Why are we doing this? Any context or related work?

The compaction manifest is the retention ledger for native content referenced by settled planner steps. Returning an empty or partial ledger causes archive/compaction to discard continuation state without an error or warning.

# Documentation changes needed?

No documentation change. The module already promises complete, cycle-safe traversal and archive-boundary continuity; this fix makes the implementation honor that existing contract.

# Testing

## Where should a reviewer start?

Start with `packages/core/src/runtime/content-access-manifest.ts` at the stack walker, then inspect the three real-contract cases in `packages/core/src/runtime/content-access-manifest.test.ts`.

## Detailed testing steps

### 1. Reconstructed failing reproduction before the production change

The handed-off scratch file was absent, so I reconstructed its three specified cases at `packages/core/src/runtime/zz-repro.test.ts`. I added `--maxWorkers=2` as required by the handoff's machine-safety rule.

```console
$ bunx vitest run --maxWorkers=2 packages/core/src/runtime/zz-repro.test.ts

 RUN  v4.1.10 /Volumes/thescoho_1TB/Developer/worktrees/eliza-compaction-manifest-falsy-values

 ❯ packages/core/src/runtime/zz-repro.test.ts (3 tests | 3 failed) 6ms
     × keeps the reference when a sibling field is null 5ms
     × keeps the reference when a sibling field is an empty string 0ms
     × keeps the reference when an array sibling element is 0 0ms

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 3 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  packages/core/src/runtime/zz-repro.test.ts > falsy sibling truncation > keeps the reference when a sibling field is null
AssertionError: expected [] to have a length of 1 but got +0

- Expected
+ Received

- 1
+ 0

 ❯ packages/core/src/runtime/zz-repro.test.ts:40:32
     38|    { lastUsedAt: "2026-08-22T12:00:00.000Z" },
     39|   );
     40|   expect(manifest.contentRefs).toHaveLength(1);
       |                                ^
     41|  });
     42|

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/3]⎯

 FAIL  packages/core/src/runtime/zz-repro.test.ts > falsy sibling truncation > keeps the reference when a sibling field is an empty string
AssertionError: expected [] to have a length of 1 but got +0

- Expected
+ Received

- 1
+ 0

 ❯ packages/core/src/runtime/zz-repro.test.ts:60:32
     58|    { lastUsedAt: "2026-08-22T12:00:00.000Z" },
     59|   );
     60|   expect(manifest.contentRefs).toHaveLength(1);
       |                                ^
     61|  });
     62|

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/3]⎯

 FAIL  packages/core/src/runtime/zz-repro.test.ts > falsy sibling truncation > keeps the reference when an array sibling element is 0
AssertionError: expected [] to have a length of 1 but got +0

- Expected
+ Received

- 1
+ 0

 ❯ packages/core/src/runtime/zz-repro.test.ts:80:32
     78|    { lastUsedAt: "2026-08-22T12:00:00.000Z" },
     79|   );
     80|   expect(manifest.contentRefs).toHaveLength(1);
       |                                ^
     81|  });
     82| });

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[3/3]⎯


 Test Files  1 failed (1)
      Tests  3 failed (3)
   Start at  04:57:00
   Duration  144ms (transform 45ms, setup 0ms, import 53ms, tests 6ms, environment 0ms)
```

### 2. Same reconstruction after the production fix

```console
$ bunx vitest run --maxWorkers=2 packages/core/src/runtime/zz-repro.test.ts

 RUN  v4.1.10 /Volumes/thescoho_1TB/Developer/worktrees/eliza-compaction-manifest-falsy-values


 Test Files  1 passed (1)
      Tests  3 passed (3)
   Start at  04:57:13
   Duration  127ms (transform 44ms, setup 0ms, import 52ms, tests 3ms, environment 0ms)
```

### 3. Permanent regression guard on the final rebased head

```console
$ bunx vitest run --maxWorkers=2 packages/core/src/runtime/content-access-manifest.test.ts

 RUN  v4.1.10 /Volumes/thescoho_1TB/Developer/worktrees/eliza-compaction-manifest-falsy-values


 Test Files  1 passed (1)
      Tests  8 passed (8)
   Start at  05:08:18
   Duration  139ms (transform 46ms, setup 0ms, import 55ms, tests 12ms, environment 0ms)
```

### 4. Mutant proof: regression guard with only the production fix reverted

```console
$ bunx vitest run --maxWorkers=2 packages/core/src/runtime/content-access-manifest.test.ts

 RUN  v4.1.10 /Volumes/thescoho_1TB/Developer/worktrees/eliza-compaction-manifest-falsy-values

 ❯ packages/core/src/runtime/content-access-manifest.test.ts (8 tests | 3 failed) 16ms
     × keeps references next to a falsy null field 4ms
     × keeps references next to a falsy empty-string field 1ms
     × keeps references next to a falsy zero array element 0ms

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 3 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  packages/core/src/runtime/content-access-manifest.test.ts > deriveCompactionContentManifest > keeps references next to a falsy null field
 FAIL  packages/core/src/runtime/content-access-manifest.test.ts > deriveCompactionContentManifest > keeps references next to a falsy empty-string field
 FAIL  packages/core/src/runtime/content-access-manifest.test.ts > deriveCompactionContentManifest > keeps references next to a falsy zero array element
AssertionError: expected [] to match object [ { …(2) } ]

- Expected
+ Received

- [
-   {
-     "rangesUsed": [
-       {
-         "end": 20,
-         "start": 0,
-         "unit": "byte",
-       },
-     ],
-     "reference": {
-       "ref": "opaque-file",
-     },
-   },
- ]
+ []

 ❯ packages/core/src/runtime/content-access-manifest.test.ts:123:32
    121|   );
    122|
    123|   expect(manifest.contentRefs).toMatchObject([
       |                                ^
    124|    {
    125|     reference: { ref: "opaque-file" },

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/3]⎯


 Test Files  1 failed (1)
      Tests  3 failed | 5 passed (8)
   Start at  04:57:48
   Duration  151ms (transform 45ms, setup 0ms, import 54ms, tests 16ms, environment 0ms)
```

After restoring `continue`, the same permanent suite returned `1 passed (1)` file and `8 passed (8)` tests.

### 5. Package suite and untouched exact-SHA control

Both commands used `bunx vitest run --maxWorkers=2 packages/core/src` after generating the package's ignored keyword source. The failure set and count were identical; the fix tree adds exactly the three passing regression cases.

```text
Fix head d101c4303540f49a64be6c3e46f9735e2d1d78e3:
Test Files  28 failed | 863 passed | 2 skipped (893)
Tests       285 failed | 10801 passed | 3 skipped (11089)

Untouched control at 6941532900d691b674ed0c0462985f1faab360d7:
Test Files  28 failed | 863 passed | 2 skipped (893)
Tests       285 failed | 10798 passed | 3 skipped (11086)
```

### 6. Format and typecheck

```console
$ bunx biome check --write packages/core/src/runtime/content-access-manifest.ts packages/core/src/runtime/content-access-manifest.test.ts
Checked 2 files in 61ms. No fixes applied.

$ bunx tsc --noEmit -p packages/core/tsconfig.json
# exit 0 on fix head; exit 0 on untouched exact-SHA control
```

# Evidence Gate

Evidence matches exact head `d101c4303540f49a64be6c3e46f9735e2d1d78e3`.
<!-- evidence-head:d101c4303540f49a64be6c3e46f9735e2d1d78e3 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - this two-file core-runtime change has no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - this two-file core-runtime change has no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - this is a deterministic archive-ledger function with no interactive user flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - the affected pure manifest derivation function has no logger, transport, service, or persistence boundary; its returned artifact is shown inline below.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or request path changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, action, evaluator, or agent-loop behavior changes; this fixes deterministic traversal of an already-settled tool result.
<!-- evidence-row:domain-artifacts -->
- [x] The returned compaction manifest artifact is shown inline below for the real `ReadView + nextCursor: null` path.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface or text.

# Evidence Details

## Domain artifact: retained native content reference

The final production code was invoked directly with Bun, outside Vitest, using the real `buildReadView`, `buildReadSlice`, and `deriveCompactionContentManifest` contracts. It returned:

```json
{
  "schemaVersion": 1,
  "contentRefs": [
    {
      "reference": {
        "kind": "file",
        "ref": "opaque-file",
        "revision": "rev-1"
      },
      "revision": "rev-1",
      "reason": "tool:FILE",
      "rangesUsed": [
        {
          "unit": "byte",
          "start": 0,
          "end": 20
        }
      ],
      "lastUsedAt": "2026-08-22T12:00:00.000Z",
      "retained": true
    }
  ],
  "modifiedFiles": [],
  "pendingProcesses": []
}
```

## Real LLM-call trajectory

N/A - the change does not touch a model-facing prompt, provider, action, evaluator, or agent call. It repairs deterministic retention-ledger traversal after a tool result has already settled.

## Backend + frontend logs

N/A - the affected pure function produces a returned manifest and no structured logs; there is no frontend path. The returned manifest artifact and direct command results are inline above.

## Screenshots (before / after) + video walkthrough

### Before

N/A - no rendered UI.

### After

N/A - no rendered UI.

### Walkthrough video

N/A - no interactive UI or user flow.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, TTS, or STT behavior.

## Known gaps / failures

- `bun run verify` exits 127 on both the fix head and the untouched exact-SHA control at the same pre-existing host dependency:

  ```text
  @elizaos/capacitor-gateway:lint:check: $ node-swiftlint lint
  @elizaos/capacitor-gateway:lint:check: /bin/bash: node-swiftlint: command not found
  @elizaos/capacitor-gateway:lint:check: error: script "swiftlint" exited with code 127
  @elizaos/capacitor-gateway:lint:check: error: script "lint:check" exited with code 127
  Failed:    @elizaos/capacitor-gateway#lint:check
  error: script "verify" exited with code 127
  ```

- The package-wide Vitest lane has 285 failures on both the fix and control. The exact aggregate comparison is above; the fix introduces no new failure and adds three passing tests.
- The signed private trace could not be finalized because `trace` blocked after printing the interactive identity authorization URL and no browser authorization tooling was available in this session. The PR is published unmeasured under the factory's explicit evidence waiver.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: codex
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-eliza
Attribution status: self-reported
— [core-runtime]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-eliza"} -->
