### PR TITLE
test(ui): cover release-center shared helpers

### DIFF
--- a/packages/ui/src/components/release-center/shared.helpers.test.ts
+++ b/packages/ui/src/components/release-center/shared.helpers.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Unit coverage for the Release Center pure helpers: `summarizeError`
+ * (message extraction from unknown throwables), `normalizeReleaseNotesUrl`
+ * (validated URL with GitHub-releases fallback), and `partitionDescription`
+ * (localized label for desktop session partitions). No React; deterministic
+ * node-environment vitest against the real module.
+ */
+import { EXTERNAL_URLS } from "@elizaos/shared/brand";
+import { describe, expect, it } from "vitest";
+import {
+  normalizeReleaseNotesUrl,
+  partitionDescription,
+  summarizeError,
+} from "./shared.helpers";
+
+const DEFAULT_RELEASE_NOTES_URL = `${EXTERNAL_URLS.github}/releases`;
+
+describe("summarizeError", () => {
+  it("extracts the message from an Error instance", () => {
+    expect(summarizeError(new Error("release fetch failed"))).toBe(
+      "release fetch failed",
+    );
+  });
+
+  it("stringifies a non-Error thrown value", () => {
+    expect(summarizeError("plain string rejection")).toBe(
+      "plain string rejection",
+    );
+    expect(summarizeError(404)).toBe("404");
+  });
+
+  it("preserves the message of an Error subclass with empty message", () => {
+    class ReleaseError extends Error {}
+    const error = new ReleaseError("");
+    expect(summarizeError(error)).toBe("");
+  });
+
+  it("uses String() semantics for objects, not [object Object] guessing", () => {
+    // String({}) is "[object Object]" — the helper must match String(), so a
+    // payload carrying toString round-trips its custom representation.
+    const payload = { toString: () => "custom failure text" };
+    expect(summarizeError(payload)).toBe("custom failure text");
+  });
+
+  it("keeps a thrown null distinct from the string 'null' only by type", () => {
+    // String(null) === "null": the helper surfaces the raw value truthfully
+    // rather than substituting a generic placeholder.
+    expect(summarizeError(null)).toBe("null");
+    expect(summarizeError(undefined)).toBe("undefined");
+  });
+});
+
+describe("normalizeReleaseNotesUrl", () => {
+  it("returns a valid absolute URL unchanged modulo URL normalization", () => {
+    expect(normalizeReleaseNotesUrl("https://example.com/notes")).toBe(
+      "https://example.com/notes",
+    );
+  });
+
+  it("normalizes a whitespace-wrapped URL back to the bare form", () => {
+    // Observable contract: surrounding whitespace never leaks into the
+    // normalized value.
+    expect(normalizeReleaseNotesUrl("  https://example.com/notes  ")).toBe(
+      "https://example.com/notes",
+    );
+  });
+
+  it("falls back to the GitHub releases page for an unparseable value", () => {
+    expect(normalizeReleaseNotesUrl("not a url")).toBe(
+      DEFAULT_RELEASE_NOTES_URL,
+    );
+  });
+
+  it("falls back for empty, whitespace-only, null, and undefined inputs", () => {
+    expect(normalizeReleaseNotesUrl("")).toBe(DEFAULT_RELEASE_NOTES_URL);
+    expect(normalizeReleaseNotesUrl("   ")).toBe(DEFAULT_RELEASE_NOTES_URL);
+    expect(normalizeReleaseNotesUrl(null)).toBe(DEFAULT_RELEASE_NOTES_URL);
+    expect(normalizeReleaseNotesUrl(undefined)).toBe(DEFAULT_RELEASE_NOTES_URL);
+  });
+
+  it("accepts any URL the WHATWG parser accepts, adding a trailing slash for bare hosts", () => {
+    // new URL("example.com") throws (no scheme), so it must fall back;
+    // a scheme-qualified bare host normalizes with a trailing slash.
+    expect(normalizeReleaseNotesUrl("example.com")).toBe(
+      DEFAULT_RELEASE_NOTES_URL,
+    );
+    expect(normalizeReleaseNotesUrl("https://example.com")).toBe(
+      "https://example.com/",
+    );
+  });
+});
+
+describe("partitionDescription", () => {
+  it("labels the default renderer session via the default partition key", () => {
+    const calls: string[] = [];
+    const t = (key: string, options?: Record<string, unknown>) => {
+      calls.push(key);
+      return options?.defaultValue as string;
+    };
+    expect(partitionDescription("persist:default", t)).toBe(
+      "Renderer default session",
+    );
+    expect(calls).toEqual(["releasecenter.RendererDefaultSession"]);
+  });
+
+  it("labels every non-default partition as a sandboxed session", () => {
+    const calls: string[] = [];
+    const t = (_key: string, options?: Record<string, unknown>) => {
+      calls.push(_key);
+      return options?.defaultValue as string;
+    };
+    expect(partitionDescription("persist:release-notes-1.2.3", t)).toBe(
+      "Sandboxed release notes session",
+    );
+    expect(partitionDescription("", t)).toBe("Sandboxed release notes session");
+    expect(calls).toEqual([
+      "releasecenter.SandboxedReleaseNotesSession",
+      "releasecenter.SandboxedReleaseNotesSession",
+    ]);
+  });
+
+  it("passes the defaultValue option so a missing translation degrades visibly, not silently", () => {
+    const seen: Array<Record<string, unknown> | undefined> = [];
+    const t = (_key: string, options?: Record<string, unknown>) => {
+      seen.push(options);
+      return "translated";
+    };
+    expect(partitionDescription("persist:default", t)).toBe("translated");
+    expect(partitionDescription("other", t)).toBe("translated");
+    expect(seen[0]).toMatchObject({ defaultValue: "Renderer default session" });
+    expect(seen[1]).toMatchObject({
+      defaultValue: "Sandboxed release notes session",
+    });
+  });
+});


### PR DESCRIPTION
test(ui): cover release-center shared helpers

## Summary

Adds direct unit coverage for `packages/ui/src/components/release-center/shared.helpers.ts` — a pure (no-React) helper module that previously had zero direct test coverage anywhere in the repo, despite two production consumers:

- `summarizeError` — used by `ReleaseCenterView.tsx` to surface action failures
- `normalizeReleaseNotesUrl` — used by `ReleaseCenterView.tsx` to validate release-notes URLs with a GitHub-releases fallback
- `partitionDescription` — used by `release-center/sections.tsx` to label desktop session partitions

13 tests (+135 lines, 1 file) pinning the observable contracts: Error vs non-Error message extraction (incl. Error subclasses, custom `toString` objects, `null`/`undefined`), GitHub-releases fallback for unparseable/empty/whitespace/`null`/`undefined` inputs, WHATWG bare-host normalization (`https://example.com` → trailing slash; scheme-less `example.com` → fallback), default vs sandboxed partition labels including both i18n keys, and the i18n `defaultValue` pass-through.

## Verification

- `vitest run src/components/release-center/shared.helpers.test.ts` — 13/13 pass (node env, deterministic, no network/timers)
- Mutation matrix (each mutation applied to source, tests re-run, reverted):
  - message-swap (`error.message` → literal) → 2 tests fail
  - fallback-removed (`return candidate`) → 2 tests fail
  - partition-branch-swap (`===` → `!==`) → 3 tests fail
  - wrong default i18n key → 1 test fails; wrong sandboxed i18n key → caught by key-capture assertion
  - trim-removed → not observable (the WHATWG URL parser itself strips leading/trailing whitespace — verified by execution), so the test pins the observable contract only
- `biome check` on the new file — clean
- `tsc --noEmit -p packages/ui/tsconfig.json` — 0 errors
- Independent review (RepoPrompt agent, gpt-5.6-sol): round 1 REQUEST_CHANGES (2 must-fix: assert the sandboxed i18n key; remove a vacuous string-immutability test) → both fixed → round 2 APPROVE, zero findings at the exact head

## Evidence

| Item | Status |
| --- | --- |
| backend-logs | N/A - test-only PR, no server or model path touched |
| frontend-console | N/A - test-only PR, no UI behavior change |
| llm-trajectory | N/A - test-only PR, no model/agent code touched |
| screenshots | N/A - test-only PR, no visual change |
| walkthrough | N/A - test-only PR |

<!-- evidence-head:6bed2e1bb9f83c43ea2489fe6d2268803f4ab338 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only PR, no visual change

<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only PR, no visual change

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - test-only PR, no interactive surface changed

<!-- evidence-row:backend-logs -->
- [ ] N/A - test-only PR, no server or model path touched; inline verification transcript: 13/13 vitest pass at head 6bed2e1bb9, biome check clean, tsc -p packages/ui -> 0 errors, mutation matrix message-swap=2F fallback-removed=2F branch-swap=3F wrong-i18n-key=1F

<!-- evidence-row:frontend-logs -->
- [ ] N/A - test-only PR, no UI behavior change

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - test-only PR, no model/agent code touched

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - test-only PR, pure helper contracts

AI provider/model: zai / glm-5.3
Client / agent tooling: Hermes Agent
Contribution skill revision: elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [hermes-t3rpz]
<!-- eliza-computer-attribution:v1 {"provider":"zai","model":"glm-5.3","client":"Hermes Agent","skill_revision":"elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza"} -->


