### PR TITLE
fix(computeruse): report only implemented Linux a11y capability

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -711,7 +711,7 @@ jobs:
         run: bun run --cwd plugins/plugin-app-control test -- src/services/__tests__/app-verification.integration.test.ts src/services/__tests__/verification-room-bridge.test.ts
 
       - name: Computer-use screenshot quality diagnostics coverage
-        run: bun run --cwd plugins/plugin-computeruse test -- test/helpers/screenshot-quality.test.ts src/__tests__/browser-auto-open.test.ts
+        run: bun run --cwd plugins/plugin-computeruse test -- test/helpers/screenshot-quality.test.ts src/__tests__/browser-auto-open.test.ts src/platform/a11y.test.ts
 
       - name: App screenshot quality diagnostics coverage
         run: bunx vitest run --config packages/app/vitest.config.ts packages/app/test/screenshot-quality.test.ts

--- a/plugins/plugin-computeruse/src/platform/a11y.test.ts
+++ b/plugins/plugin-computeruse/src/platform/a11y.test.ts
@@ -45,14 +45,14 @@ describe("isA11yAvailable", () => {
     expect(isA11yAvailable()).toBe(true);
   });
 
-  it("requires python3 or gdbus on Linux", () => {
+  it("requires the implemented python3 AT-SPI lane on Linux", () => {
     mocks.currentPlatform.mockReturnValue("linux");
     mocks.commandExists.mockReturnValue(false);
     expect(isA11yAvailable()).toBe(false);
     mocks.commandExists.mockImplementation((cmd: string) => cmd === "python3");
     expect(isA11yAvailable()).toBe(true);
     mocks.commandExists.mockImplementation((cmd: string) => cmd === "gdbus");
-    expect(isA11yAvailable()).toBe(true);
+    expect(isA11yAvailable()).toBe(false);
   });
 
   it("is unavailable on unsupported platforms", () => {

--- a/plugins/plugin-computeruse/src/platform/a11y.ts
+++ b/plugins/plugin-computeruse/src/platform/a11y.ts
@@ -89,7 +89,11 @@ export function isA11yAvailable(): boolean {
     return true;
   }
   if (os === "linux") {
-    return commandExists("python3") || commandExists("gdbus");
+    // The extractor below has a single executable implementation: Python
+    // AT-SPI. `gdbus` may be present on a host without providing any tree
+    // extraction path, so advertising it here would create a false-positive
+    // capability and a guaranteed null scene.
+    return commandExists("python3");
   }
   if (os === "win32") {
     // PowerShell UIAutomation always available on modern Windows


### PR DESCRIPTION
The merged a11y coverage incorrectly advertised gdbus-only Linux hosts as available, but the legacy extractor has no gdbus implementation and returns null there.

This patch makes capability detection match the implemented python3 AT-SPI lane, updates the regression test, and adds the test to the existing computer-use CI coverage command.

Validation: focused a11y suite 10/10, plugin typecheck after building cloud-routing dependency, Biome, and diff check.