### PR TITLE
fix(homepage): fail closed when staging Discord CTA uses production

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -338,6 +338,19 @@ post-deploy inventories fail closed if a required binding is absent. This proves
 presence, not byte-for-byte parity, so parity still requires an intentional
 rotation to one newly generated environment-owned value.
 
+The public homepage Discord CTA is compiled into the Pages Vite artifact as
+`VITE_DISCORD_CLIENT_ID`. Git records only that variable name. Staging and
+pull-request preview builds fail closed when the value is absent, blank,
+malformed, or equal to the production application `1468649258654630063`.
+Production may omit it and uses that canonical id. Pull-request previews have no
+GitHub Environment, so they read the repository variable; `staging` and
+`production` Environments supply the develop and main deploys. If the repository
+variable is the staging snowflake, the production Environment must set the
+canonical production id. Cloudflare injects the value at
+`bun run --cwd packages/app build:web`; Railway does not own this CTA. Deploy
+step summaries redact the snowflake and record that staging is distinct from
+production.
+
 The protected `TUNNEL_HOSTNAME_SIGNING_SECRET` is intentionally shared by the
 Cloud Worker and Railway tunnel proxy. Configure one environment-owned value
 per environment; `cloud-cf-deploy.yml` publishes it to the Worker and

--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -471,6 +471,7 @@ jobs:
       telegram_bot_id: ${{ steps.telegram.outputs.bot_id }}
       telegram_bot_username: ${{ steps.telegram.outputs.bot_username }}
       whatsapp_phone_number: ${{ steps.whatsapp.outputs.phone_number }}
+      discord_client_id: ${{ steps.discord.outputs.client_id }}
     steps:
       - name: Resolve public preview defaults
         id: telegram
@@ -518,6 +519,44 @@ jobs:
               exit 1
               ;;
           esac
+
+      - name: Resolve public Discord application
+        id: discord
+        env:
+          TARGET_ENVIRONMENT: staging
+          DISCORD_CLIENT_ID: ${{ vars.VITE_DISCORD_CLIENT_ID }}
+          PRODUCTION_DISCORD_APPLICATION_ID: "1468649258654630063"
+        run: |
+          set -euo pipefail
+          configured="$(printf '%s' "$DISCORD_CLIENT_ID" | tr -d '[:space:]')"
+          if [[ "$TARGET_ENVIRONMENT" == "staging" ]]; then
+            if [[ ! "$configured" =~ ^[0-9]{17,20}$ ]]; then
+              echo "::error::Staging homepage Discord CTA requires VITE_DISCORD_CLIENT_ID for a distinct staging application"
+              exit 1
+            fi
+            if [[ "$configured" == "$PRODUCTION_DISCORD_APPLICATION_ID" ]]; then
+              echo "::error::Staging VITE_DISCORD_CLIENT_ID must not equal the production Discord application"
+              exit 1
+            fi
+            echo "client_id=$configured" >> "$GITHUB_OUTPUT"
+            echo "Resolved public Discord application for staging (value redacted)." >> "$GITHUB_STEP_SUMMARY"
+            echo "staging_discord_distinct_from_production=true" >> "$GITHUB_STEP_SUMMARY"
+          elif [[ "$TARGET_ENVIRONMENT" == "production" ]]; then
+            if [[ -z "$configured" ]]; then
+              configured="$PRODUCTION_DISCORD_APPLICATION_ID"
+            elif [[ ! "$configured" =~ ^[0-9]{17,20}$ ]]; then
+              echo "::error::VITE_DISCORD_CLIENT_ID must be a Discord application snowflake"
+              exit 1
+            elif [[ "$configured" != "$PRODUCTION_DISCORD_APPLICATION_ID" ]]; then
+              echo "::error::Production VITE_DISCORD_CLIENT_ID must be the canonical production Discord application"
+              exit 1
+            fi
+            echo "client_id=$configured" >> "$GITHUB_OUTPUT"
+            echo "Resolved public Discord application for production (value redacted)." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "::error::Unknown Pages target environment"
+            exit 1
+          fi
 
   build-pages:
     name: Build Pages artifacts
@@ -589,6 +628,7 @@ jobs:
           VITE_TELEGRAM_BOT_ID: ${{ needs.resolve-pages-preview-config.outputs.telegram_bot_id }}
           VITE_TELEGRAM_BOT_USERNAME: ${{ needs.resolve-pages-preview-config.outputs.telegram_bot_username }}
           VITE_WHATSAPP_PHONE_NUMBER: ${{ needs.resolve-pages-preview-config.outputs.whatsapp_phone_number }}
+          VITE_DISCORD_CLIENT_ID: ${{ needs.resolve-pages-preview-config.outputs.discord_client_id }}
           VITE_API_URL: https://api-staging.eliza.app
           NEXT_PUBLIC_API_URL: https://api-staging.eliza.app
           VITE_OIDC_ISSUER_URL: https://api-staging.eliza.app

--- a/.github/workflows/cloud-cf-release.yml
+++ b/.github/workflows/cloud-cf-release.yml
@@ -1736,6 +1736,7 @@ jobs:
       telegram_bot_id: ${{ steps.telegram.outputs.bot_id }}
       telegram_bot_username: ${{ steps.telegram.outputs.bot_username }}
       whatsapp_phone_number: ${{ steps.whatsapp.outputs.phone_number }}
+      discord_client_id: ${{ steps.discord.outputs.client_id }}
     steps:
       - name: Validate Telegram configuration
         id: telegram
@@ -1784,6 +1785,44 @@ jobs:
               ;;
           esac
 
+      - name: Resolve public Discord application
+        id: discord
+        env:
+          TARGET_ENVIRONMENT: ${{ inputs.target_environment }}
+          DISCORD_CLIENT_ID: ${{ vars.VITE_DISCORD_CLIENT_ID }}
+          PRODUCTION_DISCORD_APPLICATION_ID: "1468649258654630063"
+        run: |
+          set -euo pipefail
+          configured="$(printf '%s' "$DISCORD_CLIENT_ID" | tr -d '[:space:]')"
+          if [[ "$TARGET_ENVIRONMENT" == "staging" ]]; then
+            if [[ ! "$configured" =~ ^[0-9]{17,20}$ ]]; then
+              echo "::error::Staging homepage Discord CTA requires VITE_DISCORD_CLIENT_ID for a distinct staging application"
+              exit 1
+            fi
+            if [[ "$configured" == "$PRODUCTION_DISCORD_APPLICATION_ID" ]]; then
+              echo "::error::Staging VITE_DISCORD_CLIENT_ID must not equal the production Discord application"
+              exit 1
+            fi
+            echo "client_id=$configured" >> "$GITHUB_OUTPUT"
+            echo "Resolved public Discord application for staging (value redacted)." >> "$GITHUB_STEP_SUMMARY"
+            echo "staging_discord_distinct_from_production=true" >> "$GITHUB_STEP_SUMMARY"
+          elif [[ "$TARGET_ENVIRONMENT" == "production" ]]; then
+            if [[ -z "$configured" ]]; then
+              configured="$PRODUCTION_DISCORD_APPLICATION_ID"
+            elif [[ ! "$configured" =~ ^[0-9]{17,20}$ ]]; then
+              echo "::error::VITE_DISCORD_CLIENT_ID must be a Discord application snowflake"
+              exit 1
+            elif [[ "$configured" != "$PRODUCTION_DISCORD_APPLICATION_ID" ]]; then
+              echo "::error::Production VITE_DISCORD_CLIENT_ID must be the canonical production Discord application"
+              exit 1
+            fi
+            echo "client_id=$configured" >> "$GITHUB_OUTPUT"
+            echo "Resolved public Discord application for production (value redacted)." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "::error::Unknown Pages target environment"
+            exit 1
+          fi
+
   build-pages:
     name: Build Pages artifacts
     needs: [migrate-db, resolve-pages-environment-config]
@@ -1801,6 +1840,7 @@ jobs:
       telegram_bot_id: ${{ needs.resolve-pages-environment-config.outputs.telegram_bot_id }}
       telegram_bot_username: ${{ needs.resolve-pages-environment-config.outputs.telegram_bot_username }}
       whatsapp_phone_number: ${{ needs.resolve-pages-environment-config.outputs.whatsapp_phone_number }}
+      discord_client_id: ${{ needs.resolve-pages-environment-config.outputs.discord_client_id }}
     steps:
       - name: Validate PR preview identity
         if: github.event_name == 'pull_request'
@@ -1855,6 +1895,7 @@ jobs:
           VITE_TELEGRAM_BOT_ID: ${{ needs.resolve-pages-environment-config.outputs.telegram_bot_id }}
           VITE_TELEGRAM_BOT_USERNAME: ${{ needs.resolve-pages-environment-config.outputs.telegram_bot_username }}
           VITE_WHATSAPP_PHONE_NUMBER: ${{ needs.resolve-pages-environment-config.outputs.whatsapp_phone_number }}
+          VITE_DISCORD_CLIENT_ID: ${{ needs.resolve-pages-environment-config.outputs.discord_client_id }}
           VITE_API_URL: ${{ (inputs.target_environment == 'production') && 'https://api.eliza.app' || 'https://api-staging.eliza.app' }}
           NEXT_PUBLIC_API_URL: ${{ (inputs.target_environment == 'production') && 'https://api.eliza.app' || 'https://api-staging.eliza.app' }}
           VITE_OIDC_ISSUER_URL: ${{ (inputs.target_environment == 'production') && 'https://api.eliza.app' || 'https://api-staging.eliza.app' }}
@@ -2139,6 +2180,7 @@ jobs:
           VITE_TELEGRAM_BOT_ID: ${{ needs.build-pages.outputs.telegram_bot_id }}
           VITE_TELEGRAM_BOT_USERNAME: ${{ needs.build-pages.outputs.telegram_bot_username }}
           VITE_WHATSAPP_PHONE_NUMBER: ${{ needs.build-pages.outputs.whatsapp_phone_number }}
+          VITE_DISCORD_CLIENT_ID: ${{ needs.build-pages.outputs.discord_client_id }}
           VITE_API_URL: ${{ (inputs.target_environment == 'production') && 'https://api.eliza.app' || 'https://api-staging.eliza.app' }}
           NEXT_PUBLIC_API_URL: ${{ (inputs.target_environment == 'production') && 'https://api.eliza.app' || 'https://api-staging.eliza.app' }}
           VITE_OIDC_ISSUER_URL: ${{ (inputs.target_environment == 'production') && 'https://api.eliza.app' || 'https://api-staging.eliza.app' }}

--- a/packages/app/.env.example
+++ b/packages/app/.env.example
@@ -16,9 +16,12 @@ VITE_ELIZA_IOS_API_TOKEN=
 VITE_ELIZA_DEVICE_BRIDGE_URL=
 VITE_ELIZA_DEVICE_BRIDGE_TOKEN=
 
-# Optional public marketing-channel overrides. The canonical Eliza bot/app
-# identifiers are source defaults, so ordinary builds remain functional when
-# these are unset.
+# Public marketing-channel identities for the packages/app Vite build.
+# Staging and pull-request preview Discord builds must set
+# VITE_DISCORD_CLIENT_ID to a distinct staging application together with
+# VITE_ENVIRONMENT=staging; they never inherit production
+# 1468649258654630063. Production may omit Discord and uses that canonical id.
+# Telegram remains optional with source defaults.
 VITE_TELEGRAM_BOT_ID=
 VITE_TELEGRAM_BOT_USERNAME=
 VITE_DISCORD_CLIENT_ID=

--- a/packages/homepage/.env.example
+++ b/packages/homepage/.env.example
@@ -20,9 +20,12 @@ VITE_TELEGRAM_BOT_ID=
 # This must match the bot configured in eliza-cloud-v2 ELIZA_APP_TELEGRAM_BOT_TOKEN
 VITE_TELEGRAM_BOT_USERNAME=
 
-# Discord Application ID (from Discord Developer Portal > General Information)
-# This is also the OAuth2 Client ID
+# Discord Application ID (from Discord Developer Portal > General Information).
+# This is also the OAuth2 Client ID. Staging homepage builds must set a distinct
+# snowflake and VITE_ENVIRONMENT=staging; never use the production application
+# 1468649258654630063 on staging.
 VITE_DISCORD_CLIENT_ID=
+# VITE_ENVIRONMENT=staging
 
 # WhatsApp Business phone number displayed to users (E.164 format)
 VITE_WHATSAPP_PHONE_NUMBER=

--- a/packages/homepage/AGENTS.md
+++ b/packages/homepage/AGENTS.md
@@ -124,7 +124,8 @@ isolated visual harness.
 | `VITE_ELIZACLOUD_API_URL` | `https://api.eliza.app` | Eliza Cloud backend base URL |
 | `VITE_TELEGRAM_BOT_USERNAME` | `ElizaIsNotABot` | Optional Telegram bot username override |
 | `VITE_TELEGRAM_BOT_ID` | `8931353359` | Optional numeric Telegram bot ID override |
-| `VITE_DISCORD_CLIENT_ID` | `1468649258654630063` | Optional Discord Application ID override |
+| `VITE_DISCORD_CLIENT_ID` | production: `1468649258654630063` | Discord application snowflake for the public CTA. Staging and preview builds fail closed unless this is a distinct staging application. Never fall back to production on staging. |
+| `VITE_ENVIRONMENT` | unset locally | `staging` or `production` on Pages builds. Staging requires a distinct `VITE_DISCORD_CLIENT_ID`. |
 | `WHATSAPP_PUBLIC_ENABLED` | disabled | Deployment-only switch that admits the public WhatsApp CTA |
 | `VITE_WHATSAPP_PHONE_NUMBER` | — | Admitted Blooio WhatsApp sender (E.164); production uses the shared `+18087881821` number only after its WhatsApp channel passes live proof |
 

--- a/packages/homepage/CLAUDE.md
+++ b/packages/homepage/CLAUDE.md
@@ -124,7 +124,8 @@ isolated visual harness.
 | `VITE_ELIZACLOUD_API_URL` | `https://api.eliza.app` | Eliza Cloud backend base URL |
 | `VITE_TELEGRAM_BOT_USERNAME` | `ElizaIsNotABot` | Optional Telegram bot username override |
 | `VITE_TELEGRAM_BOT_ID` | `8931353359` | Optional numeric Telegram bot ID override |
-| `VITE_DISCORD_CLIENT_ID` | `1468649258654630063` | Optional Discord Application ID override |
+| `VITE_DISCORD_CLIENT_ID` | production: `1468649258654630063` | Discord application snowflake for the public CTA. Staging and preview builds fail closed unless this is a distinct staging application. Never fall back to production on staging. |
+| `VITE_ENVIRONMENT` | unset locally | `staging` or `production` on Pages builds. Staging requires a distinct `VITE_DISCORD_CLIENT_ID`. |
 | `WHATSAPP_PUBLIC_ENABLED` | disabled | Deployment-only switch that admits the public WhatsApp CTA |
 | `VITE_WHATSAPP_PHONE_NUMBER` | — | Admitted Blooio WhatsApp sender (E.164); production uses the shared `+18087881821` number only after its WhatsApp channel passes live proof |
 

--- a/packages/homepage/README.md
+++ b/packages/homepage/README.md
@@ -23,13 +23,36 @@ cp .env.example .env.local
 | `VITE_ELIZACLOUD_API_URL` | Eliza Cloud backend URL (defaults to `https://api.eliza.app`) |
 | `VITE_TELEGRAM_BOT_USERNAME` | Optional Telegram bot username override (default `ElizaIsNotABot`) |
 | `VITE_TELEGRAM_BOT_ID` | Optional numeric Telegram bot ID override (default `8931353359`) |
-| `VITE_DISCORD_CLIENT_ID` | Optional Discord Application ID override (default `1468649258654630063`) |
+| `VITE_DISCORD_CLIENT_ID` | Discord application snowflake for the public CTA. Staging and pull-request preview builds require a distinct staging application and fail closed if this is absent, blank, malformed, or equal to production `1468649258654630063`. Production may omit it and uses that canonical id. |
+| `VITE_ENVIRONMENT` | Pages deploy identity (`staging` or `production`). Staging never inherits the production Discord fallback. Unset locally. |
 | `WHATSAPP_PUBLIC_ENABLED` | Deployment switch that must be true before the public WhatsApp CTA is built |
 | `VITE_WHATSAPP_PHONE_NUMBER` | Admitted Blooio WhatsApp sender in E.164 format; set to the shared `+18087881821` number |
 
 OAuth provider callback configuration belongs to the unified Cloud auth routes
 and API deployment. Do not register a callback against this source package or
 its optional test-harness port.
+
+### Discord application authority (names only)
+
+The public "Message Eliza on Discord" CTA is a user-install OAuth URL for a
+team-maintained Eliza application. Users do not create their own bot. Git never
+stores the staging snowflake.
+
+Set the GitHub variable **name** `VITE_DISCORD_CLIENT_ID` only:
+
+| Authority | Visibility | Required value |
+| --- | --- | --- |
+| Repository variable | Pull-request Pages previews (`cloud-cf-deploy.yml` has no GitHub Environment) | Staging Discord application snowflake, never `1468649258654630063` |
+| GitHub Environment `staging` | `develop` Pages deploys | Same staging snowflake |
+| GitHub Environment `production` | `main` Pages deploys | Canonical production id `1468649258654630063`, or omit to use that fallback |
+| Cloudflare Pages / Vite | `bun run --cwd packages/app build:web` | Injected as `VITE_DISCORD_CLIENT_ID`; not a Cloudflare dashboard secret |
+| Railway | Not used | This CTA is compiled into the Cloudflare Pages artifact |
+
+If the repository variable is the staging snowflake, the production Environment
+must set `VITE_DISCORD_CLIENT_ID` to the canonical production id. GitHub merges
+repository variables into Environment jobs, and a staging id in production fails
+closed. Deploy logs and step summaries redact the snowflake; the built public
+OAuth `client_id` is the user-visible identity.
 
 ### WhatsApp production activation
 

--- a/packages/homepage/src/lib/contact.ts
+++ b/packages/homepage/src/lib/contact.ts
@@ -1,12 +1,25 @@
 /**
  * Contact constants and link builders for homepage messaging entrypoints.
+ *
+ * Discord application IDs are public OAuth client identifiers. Staging builds
+ * must receive an explicit snowflake that is distinct from production; they
+ * never inherit the production fallback.
  */
 export const ELIZA_PHONE_NUMBER = "+18087881821";
 export const ELIZA_TELEGRAM_BOT_USERNAME = "ElizaIsNotABot";
 export const ELIZA_TELEGRAM_BOT_ID = "8931353359";
 export const ELIZA_DISCORD_APPLICATION_ID = "1468649258654630063";
+export const DISCORD_APPLICATION_ID_PATTERN = /^[0-9]{17,20}$/;
 const DEFAULT_WHATSAPP_PHONE_NUMBER = "+14159611510";
 const IMESSAGE_GREETING = "Hey Eliza, what can you do?";
+export const STAGING_DISCORD_REQUIRED_ERROR =
+  "Staging homepage Discord CTA requires VITE_DISCORD_CLIENT_ID for a distinct staging application";
+export const STAGING_DISCORD_PRODUCTION_COLLISION_ERROR =
+  "Staging VITE_DISCORD_CLIENT_ID must not equal the production Discord application";
+export const DISCORD_APPLICATION_SNOWFLAKE_ERROR =
+  "VITE_DISCORD_CLIENT_ID must be a Discord application snowflake";
+export const PRODUCTION_DISCORD_CANONICAL_ERROR =
+  "Production VITE_DISCORD_CLIENT_ID must be the canonical production Discord application";
 
 interface ContactNavigator {
   clipboard?: Pick<Clipboard, "writeText">;
@@ -52,10 +65,74 @@ export function getTelegramBotId(): string {
   return (import.meta.env.VITE_TELEGRAM_BOT_ID || ELIZA_TELEGRAM_BOT_ID).trim();
 }
 
+function normalizeDiscordApplicationId(
+  value: string | undefined,
+): string | null {
+  const normalized = (value ?? "").trim();
+  return DISCORD_APPLICATION_ID_PATTERN.test(normalized) ? normalized : null;
+}
+
+function homepageDeployEnvironment(
+  environment: string | undefined,
+): "staging" | "production" | "local" {
+  const normalized = (environment ?? "").trim().toLowerCase();
+  if (normalized === "staging") return "staging";
+  if (normalized === "production") return "production";
+  return "local";
+}
+
+/**
+ * Resolve the public Discord application for a homepage build.
+ *
+ * Staging never falls back to production. Production may omit the override and
+ * uses the canonical shared application. Local builds may set any valid
+ * snowflake for harness work.
+ */
+export function resolveDiscordApplicationId(
+  configuredValue: string | undefined,
+  environment: string | undefined,
+): string {
+  const configured = (configuredValue ?? "").trim();
+  const deployEnvironment = homepageDeployEnvironment(environment);
+  const normalized = normalizeDiscordApplicationId(configured);
+
+  if (deployEnvironment === "staging") {
+    if (!normalized) {
+      throw new Error(STAGING_DISCORD_REQUIRED_ERROR);
+    }
+    if (normalized === ELIZA_DISCORD_APPLICATION_ID) {
+      throw new Error(STAGING_DISCORD_PRODUCTION_COLLISION_ERROR);
+    }
+    return normalized;
+  }
+
+  if (deployEnvironment === "production") {
+    if (!configured) {
+      return ELIZA_DISCORD_APPLICATION_ID;
+    }
+    if (!normalized) {
+      throw new Error(DISCORD_APPLICATION_SNOWFLAKE_ERROR);
+    }
+    if (normalized !== ELIZA_DISCORD_APPLICATION_ID) {
+      throw new Error(PRODUCTION_DISCORD_CANONICAL_ERROR);
+    }
+    return normalized;
+  }
+
+  if (!configured) {
+    return ELIZA_DISCORD_APPLICATION_ID;
+  }
+  if (!normalized) {
+    throw new Error(DISCORD_APPLICATION_SNOWFLAKE_ERROR);
+  }
+  return normalized;
+}
+
 export function getDiscordBotApplicationId(): string {
-  return (
-    import.meta.env.VITE_DISCORD_CLIENT_ID || ELIZA_DISCORD_APPLICATION_ID
-  ).trim();
+  return resolveDiscordApplicationId(
+    import.meta.env.VITE_DISCORD_CLIENT_ID,
+    import.meta.env.VITE_ENVIRONMENT,
+  );
 }
 
 export function buildElizaSmsHref(message: string = IMESSAGE_GREETING): string {
@@ -120,11 +197,17 @@ export function buildElizaTelegramHref(): string {
   return `https://t.me/${getTelegramBotUsername()}`;
 }
 
-export function buildElizaDiscordHref(): string {
+export function buildElizaDiscordHrefForApplicationId(
+  applicationId: string,
+): string {
   const params = new URLSearchParams({
-    client_id: getDiscordBotApplicationId(),
+    client_id: applicationId,
     integration_type: "1",
     scope: "applications.commands",
   });
   return `https://discord.com/oauth2/authorize?${params.toString()}`;
+}
+
+export function buildElizaDiscordHref(): string {
+  return buildElizaDiscordHrefForApplicationId(getDiscordBotApplicationId());
 }

--- a/packages/homepage/src/vite-env.d.ts
+++ b/packages/homepage/src/vite-env.d.ts
@@ -9,6 +9,7 @@ interface ImportMetaEnv {
   readonly VITE_TELEGRAM_BOT_ID?: string;
   readonly VITE_WHATSAPP_PHONE_NUMBER?: string;
   readonly VITE_DISCORD_CLIENT_ID?: string;
+  readonly VITE_ENVIRONMENT?: string;
 }
 
 interface ImportMeta {

--- a/packages/homepage/tests/contact.test.ts
+++ b/packages/homepage/tests/contact.test.ts
@@ -1,15 +1,18 @@
 /**
- * Tests homepage SMS contact link constants and href generation for the shared Eliza gateway.
+ * Tests homepage contact link constants, href generation, and Discord
+ * environment fail-closed resolution for the shared Eliza gateway.
  */
 
 import { describe, expect, test } from "bun:test";
 import {
   buildElizaDiscordHref,
+  buildElizaDiscordHrefForApplicationId,
   buildElizaSmsHref,
   buildElizaTelegramHref,
   buildElizaTelHref,
   buildElizaWhatsAppHref,
   canOpenElizaSmsLink,
+  DISCORD_APPLICATION_SNOWFLAKE_ERROR,
   ELIZA_DISCORD_APPLICATION_ID,
   ELIZA_PHONE_NUMBER,
   ELIZA_TELEGRAM_BOT_ID,
@@ -19,8 +22,14 @@ import {
   getWhatsAppNumber,
   openOrCopyElizaCall,
   openOrCopyElizaMessage,
+  PRODUCTION_DISCORD_CANONICAL_ERROR,
+  resolveDiscordApplicationId,
   resolveWhatsAppNumber,
+  STAGING_DISCORD_PRODUCTION_COLLISION_ERROR,
+  STAGING_DISCORD_REQUIRED_ERROR,
 } from "../src/lib/contact";
+
+const STAGING_DISCORD_APPLICATION_ID = "1111111111111111111";
 
 describe("Eliza contact links", () => {
   test("builds an SMS link to the hosted Blooio number", () => {
@@ -65,6 +74,79 @@ describe("Eliza contact links", () => {
     expect(discordUrl.searchParams.get("scope")).toBe("applications.commands");
     expect(getTelegramBotId()).toBe(ELIZA_TELEGRAM_BOT_ID);
     expect(getDiscordBotApplicationId()).toBe(ELIZA_DISCORD_APPLICATION_ID);
+  });
+
+  test("builds environment-specific Discord OAuth URLs from the resolved application", () => {
+    const stagingHref = buildElizaDiscordHrefForApplicationId(
+      resolveDiscordApplicationId(STAGING_DISCORD_APPLICATION_ID, "staging"),
+    );
+    const productionHref = buildElizaDiscordHrefForApplicationId(
+      resolveDiscordApplicationId(undefined, "production"),
+    );
+    const stagingUrl = new URL(stagingHref);
+    const productionUrl = new URL(productionHref);
+
+    expect(stagingUrl.searchParams.get("client_id")).toBe(
+      STAGING_DISCORD_APPLICATION_ID,
+    );
+    expect(productionUrl.searchParams.get("client_id")).toBe(
+      ELIZA_DISCORD_APPLICATION_ID,
+    );
+    expect(stagingHref).not.toContain(ELIZA_DISCORD_APPLICATION_ID);
+    expect(productionHref).not.toContain(STAGING_DISCORD_APPLICATION_ID);
+    expect(stagingUrl.searchParams.get("integration_type")).toBe("1");
+    expect(stagingUrl.searchParams.get("scope")).toBe("applications.commands");
+  });
+
+  test("rejects a missing, blank, malformed, or production Discord id on staging", () => {
+    expect(() => resolveDiscordApplicationId(undefined, "staging")).toThrow(
+      STAGING_DISCORD_REQUIRED_ERROR,
+    );
+    expect(() => resolveDiscordApplicationId("", "staging")).toThrow(
+      STAGING_DISCORD_REQUIRED_ERROR,
+    );
+    expect(() => resolveDiscordApplicationId("   ", "staging")).toThrow(
+      STAGING_DISCORD_REQUIRED_ERROR,
+    );
+    expect(() =>
+      resolveDiscordApplicationId("not-a-snowflake", "staging"),
+    ).toThrow(STAGING_DISCORD_REQUIRED_ERROR);
+    expect(() => resolveDiscordApplicationId("12345", "staging")).toThrow(
+      STAGING_DISCORD_REQUIRED_ERROR,
+    );
+    expect(() =>
+      resolveDiscordApplicationId(ELIZA_DISCORD_APPLICATION_ID, "staging"),
+    ).toThrow(STAGING_DISCORD_PRODUCTION_COLLISION_ERROR);
+    expect(
+      resolveDiscordApplicationId(STAGING_DISCORD_APPLICATION_ID, "staging"),
+    ).toBe(STAGING_DISCORD_APPLICATION_ID);
+  });
+
+  test("keeps production on the canonical Discord application", () => {
+    expect(resolveDiscordApplicationId(undefined, "production")).toBe(
+      ELIZA_DISCORD_APPLICATION_ID,
+    );
+    expect(
+      resolveDiscordApplicationId(ELIZA_DISCORD_APPLICATION_ID, "production"),
+    ).toBe(ELIZA_DISCORD_APPLICATION_ID);
+    expect(() =>
+      resolveDiscordApplicationId("not-a-snowflake", "production"),
+    ).toThrow(DISCORD_APPLICATION_SNOWFLAKE_ERROR);
+    expect(() =>
+      resolveDiscordApplicationId(STAGING_DISCORD_APPLICATION_ID, "production"),
+    ).toThrow(PRODUCTION_DISCORD_CANONICAL_ERROR);
+  });
+
+  test("allows a local Discord override without using the staging production fallback", () => {
+    expect(resolveDiscordApplicationId(undefined, undefined)).toBe(
+      ELIZA_DISCORD_APPLICATION_ID,
+    );
+    expect(
+      resolveDiscordApplicationId(STAGING_DISCORD_APPLICATION_ID, undefined),
+    ).toBe(STAGING_DISCORD_APPLICATION_ID);
+    expect(() =>
+      resolveDiscordApplicationId("not-a-snowflake", undefined),
+    ).toThrow(DISCORD_APPLICATION_SNOWFLAKE_ERROR);
   });
 
   test("opens the native SMS handler only on supported platforms", async () => {

--- a/packages/homepage/tsconfig.app.json
+++ b/packages/homepage/tsconfig.app.json
@@ -32,6 +32,13 @@
         "../ui/src/components/ui/dropdown-menu.tsx"
       ],
       "@elizaos/ui/input": ["../ui/src/components/ui/input.tsx"],
+      "@elizaos/ui/native-dialog": [
+        "../ui/src/components/ui/native-dialog.tsx"
+      ],
+      "@elizaos/ui/native-select": [
+        "../ui/src/components/ui/native-select.tsx"
+      ],
+      "@elizaos/ui/textarea": ["../ui/src/components/ui/textarea.tsx"],
       "@elizaos/ui/i18n/region": ["../ui/src/i18n/region.ts"],
       "@elizaos/ui/product-switcher": [
         "../ui/src/cloud-ui/components/product-switcher.tsx"

--- a/packages/scripts/__tests__/homepage-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/homepage-deploy-workflow.test.ts
@@ -149,6 +149,52 @@ describe("homepage deployment workflow", () => {
     );
   });
 
+  it("fails closed when staging Discord uses the production application", () => {
+    for (const source of [workflow, releaseWorkflow]) {
+      expect(source).toContain("Resolve public Discord application");
+      expect(source).toContain(
+        "Staging homepage Discord CTA requires VITE_DISCORD_CLIENT_ID for a distinct staging application",
+      );
+      expect(source).toContain(
+        "Staging VITE_DISCORD_CLIENT_ID must not equal the production Discord application",
+      );
+      expect(source).toContain(
+        "VITE_DISCORD_CLIENT_ID must be a Discord application snowflake",
+      );
+      expect(source).toContain(
+        "Production VITE_DISCORD_CLIENT_ID must be the canonical production Discord application",
+      );
+      expect(source).toContain(
+        "Resolved public Discord application for staging (value redacted).",
+      );
+      expect(source).toContain("staging_discord_distinct_from_production=true");
+      expect(source).toContain(
+        'PRODUCTION_DISCORD_APPLICATION_ID: "1468649258654630063"',
+      );
+      expect(
+        source.match(
+          /PRODUCTION_DISCORD_APPLICATION_ID: "1468649258654630063"/g,
+        ),
+      ).toHaveLength(1);
+    }
+    expect(workflow).toContain("TARGET_ENVIRONMENT: staging");
+    expect(workflow).toContain(
+      "VITE_DISCORD_CLIENT_ID: $" +
+        "{{ needs.resolve-pages-preview-config.outputs.discord_client_id }}",
+    );
+    expect(releaseWorkflow).toContain(
+      "TARGET_ENVIRONMENT: $" + "{{ inputs.target_environment }}",
+    );
+    expect(releaseWorkflow).toContain(
+      "VITE_DISCORD_CLIENT_ID: $" +
+        "{{ needs.resolve-pages-environment-config.outputs.discord_client_id }}",
+    );
+    expect(releaseWorkflow).toContain(
+      "VITE_DISCORD_CLIENT_ID: $" +
+        "{{ needs.build-pages.outputs.discord_client_id }}",
+    );
+  });
+
   it("validates homepage source while building only packages/app in quality CI", () => {
     expect(qualityWorkflow).toContain("consolidated-frontend-build:");
     expect(qualityWorkflow).toContain("Validate homepage source contracts");


### PR DESCRIPTION
# Relates to

Fixes #28741

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

`origin/develop` SHA at rebase: `8bd5db316cc1f03abfbec6249657e0e867e5bd12`
PR head: `4a2afb27279b55d9b6f8da620e779cf58c1a76c8`

`bun run verify` failed on this head because `@elizaos/plugin-coding-tools#build`
cannot resolve `minimatch`. This PR does not touch that package; the same
command fails on the current tree independently of the Discord CTA change.

# Risks

Medium. Staging and pull-request Pages builds fail closed until maintainers set
protected GitHub variable `VITE_DISCORD_CLIENT_ID` to a distinct staging
Discord application snowflake. That is the requested invariant, not a
regression. Production continues to use canonical application
`1468649258654630063` when the production Environment omits the variable, and
rejects a non-canonical override.

If the repository variable is the staging snowflake, the production Environment
must set the canonical production id. GitHub merges repository variables into
Environment jobs.

# Background

## What does this PR do?

Stops `staging.eliza.app` from compiling the production Discord OAuth
`client_id`. Staging homepage builds now require `VITE_DISCORD_CLIENT_ID` and
refuse a missing, blank, malformed, or production snowflake. Production keeps
the canonical shared application. The public CTA copy stays "Message Eliza on
Discord".

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue)

# Documentation changes needed?

Updated homepage and workflow names-only authority for `VITE_DISCORD_CLIENT_ID`
(GitHub variable name, Cloudflare Pages Vite inject, Railway not used).

# Testing

## Where should a reviewer start?

1. Live current bug: both public sites compile production application
   `1468649258654630063`.
2. `packages/homepage/src/lib/contact.ts` `resolveDiscordApplicationId`.
3. Pages resolvers in `cloud-cf-deploy.yml` and `cloud-cf-release.yml`.

## Detailed testing steps

- `bun --conditions=eliza-source test packages/homepage/tests/contact.test.ts`
- `bun test packages/scripts/__tests__/homepage-deploy-workflow.test.ts`
- `bun run --cwd packages/homepage typecheck`
- `bun run --cwd packages/homepage lint:check`
- After maintainers set the staging snowflake and this lands on `develop`:
  confirm `staging.eliza.app` OAuth `client_id` is not
  `1468649258654630063`, and `eliza.app` stays that production id.
- Do not complete Discord user-install/DM OAuth in this PR. That remains a
  separate action-time authorization.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:4a2afb27279b55d9b6f8da620e779cf58c1a76c8 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered visual change; Discord CTA copy is unchanged. The defect is the compiled OAuth client_id, captured in domain artifacts.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - live staging cannot show a distinct application until maintainers set VITE_DISCORD_CLIENT_ID and deploy this revision.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no visual interaction change. Completing Discord OAuth is a separate maintainer-authorized action and was not performed.
<!-- evidence-row:backend-logs -->
- [ ] N/A - Discord CTA identity is a Vite build-time value, not an API/runtime log path.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no request/response change. The public identity is the compiled homepage chunk client_id shown in domain artifacts.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - live compiled Discord snowflake from eliza.app and staging.eliza.app embedded-home chunks is 1468649258654630063 on both; homepage contact tests and Pages workflow contract tests passed on this head. JS identity is public source, not a binary upload.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface change.

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

`N/A - Vite build-time public identity, not a backend/frontend request path.`

## Screenshots (before / after) + video walkthrough

`N/A - see evidence rows. Live current-bug identity is in domain artifacts.`

### Before

Live `origin/develop` Pages artifacts both compile production Discord
application `1468649258654630063`:

- `https://eliza.app/assets/embedded-home-Cxm_X7VG.js` contains
  `ve="1468649258654630063"` next to the Discord OAuth authorize builder.
- `https://staging.eliza.app/assets/embedded-home-CP6eCnfR.js` contains
  `Ee="1468649258654630063"` next to the same builder.

No other 17–20 digit Discord snowflake is present in those chunks.

### After

`N/A - staging cannot compile a distinct application until the protected
variable is set and this revision is deployed.`

### Walkthrough video

`N/A - no visual flow change; Discord OAuth was not completed.`

## Audio / voice walkthrough

`N/A - not a voice change.`

## Known gaps / failures

- `bun run verify` failed on head `4a2afb27279b55d9b6f8da620e779cf58c1a76c8`:
  `@elizaos/plugin-coding-tools#build` exits 1 with `Could not resolve: "minimatch"`
  from `plugins/plugin-coding-tools/src/actions/glob.ts:17`. This PR does not
  change that package. Reproduced with `bun run --cwd plugins/plugin-coding-tools build`.
- Local `bun run --cwd packages/homepage test` hit a pre-existing load failure
  in `get-started-continuation-render.test.tsx` (`@elizaos/ui/native-select`
  requires `packages/ui/dist` after `--ignore-scripts`). Contact tests,
  typecheck, and lint for this change passed. Vite already aliases that module
  to source; this PR only added the matching `tsconfig.app.json` paths.
- Live staging/production identity split after deploy requires maintainer
  `VITE_DISCORD_CLIENT_ID`.
- Staging user-install/DM receipt is not in this PR. Needs separate action-time
  authorization after the variable exists.
- This PR's Pages preview job will fail closed until the repository variable
  is set. That is the intended gate.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

# Deploy Notes

Before or with merge, set GitHub variable **name** `VITE_DISCORD_CLIENT_ID`:

- Repository variable: staging Discord application snowflake (PR Pages
  previews have no GitHub Environment).
- Environment `staging`: same staging snowflake.
- Environment `production`: canonical `1468649258654630063`, or omit for that
  fallback. If the repository variable is the staging snowflake, production
  must set the canonical id explicitly.

Do not put the snowflake in git. Deploy step summaries redact it and record
`staging_discord_distinct_from_production=true`.

AI provider/model: spacexai / grok-4.6
Client / agent tooling: cursor
Contribution skill revision: elizaOS/eliza@8bd5db316cc1f03abfbec6249657e0e867e5bd12:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [nicolasdmolina]
<!-- eliza-computer-attribution:v1 {"provider":"spacexai","model":"grok-4.6","client":"cursor","skill_revision":"elizaOS/eliza@8bd5db316cc1f03abfbec6249657e0e867e5bd12:packages/skills/skills/contribute-to-eliza"} -->


