### PR TITLE
fix(capacitor-bridge): normalize full ASR grind report

### DIFF
--- a/plugins/plugin-capacitor-bridge/src/ios/model-grind.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/ios/model-grind.test.ts
@@ -171,4 +171,17 @@ describe("runModelGrind", () => {
 		);
 		expect(report.models.find((m) => m.model === "asr")?.ok).toBe(false);
 	});
+
+	it("preserves the complete ASR hypothesis while normalizing lone surrogates", async () => {
+		const transcript = `Eliza local voice end to end check one two three ${"x".repeat(2_100)}\uD800tail`;
+		const report = await runModelGrind(
+			baseDeps({ transcribeAsr: async () => transcript }),
+		);
+		const hypothesis = report.models.find((model) => model.model === "asr")
+			?.detail?.hypothesis;
+
+		expect(hypothesis).toBe(transcript.toWellFormed());
+		expect((hypothesis as string).length).toBe(transcript.length);
+		expect((hypothesis as string).isWellFormed()).toBe(true);
+	});
 });

--- a/plugins/plugin-capacitor-bridge/src/ios/model-grind.ts
+++ b/plugins/plugin-capacitor-bridge/src/ios/model-grind.ts
@@ -326,7 +326,11 @@ export async function runModelGrind(
 			r.inferMs = Math.round(now() - at);
 			const wer = wordErrorRate(GRIND_PHRASE, transcript);
 			r.throughput = { kind: "wer", value: Math.round(wer * 1000) / 1000 };
-			r.detail = { reference: GRIND_PHRASE, hypothesis: transcript, wer };
+			r.detail = {
+				reference: GRIND_PHRASE,
+				hypothesis: toWellFormedUnicode(transcript),
+				wer,
+			};
 			r.ok = transcript.trim().length > 0 && wer <= 0.5; // round-trip recognizable
 			if (!r.ok)
 				r.error = `ASR round-trip WER too high (${wer.toFixed(2)}) or empty`;


### PR DESCRIPTION
## Summary

Closes #28879.

The iOS model-grind report previously copied the native ASR transcript directly into its diagnostic detail. A lone UTF-16 surrogate could therefore survive into the stored/served JSON report.

This replacement for #28855 normalizes the complete hypothesis with `toWellFormedUnicode`. It deliberately does not retain that PR's arbitrary 2,000-unit cap: the diagnostic report has no demonstrated provider, transport, or storage boundary requiring truncation.

## Contract

- WER and pass/fail scoring still use the original transcript.
- The diagnostic hypothesis replaces lone surrogates before serialization.
- Every other code unit is retained; the report is not shortened.

## Verification

- `bun run --cwd plugins/plugin-capacitor-bridge test` — 31 files, 234 tests passed.
- focused `src/ios/model-grind.test.ts` — 14 tests passed.
- package typecheck — passed.
- package read-only lint — passed.

Root `bun run verify` was already exercised for the parent Unicode-boundary work and is blocked outside this package by the missing `node-swiftlint` executable in `@elizaos/capacitor-gateway`.

## Evidence

<!-- evidence-head:9bc6926ca5917685761e00159c9178ae6a3f4c7f -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI changes.
<!-- evidence-row:backend-logs -->
- [x] N/A - deterministic injected native dependencies exercise the production report builder.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model prompt or generation behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] The regression asserts a hypothesis longer than 2,000 units is preserved at full length and serializes as well-formed Unicode.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

