### PR TITLE
fix(ci): build prompts before clean-install consumers

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -76,22 +76,23 @@ jobs:
         if: steps.frontend-scope.outputs.run != 'true'
         run: echo "Skipping consolidated frontend build; this PR does not touch its source or release surfaces."
 
+      # The install above uses --ignore-scripts, so no workspace dist exists.
+      # Homepage typechecking resolves @elizaos/ui's public dist subpaths, while
+      # both UI and app transitively resolve core's default-condition import of
+      # @elizaos/prompts. Build that dependency chain before either consumer.
+      - name: Build frontend workspace dependencies
+        if: steps.frontend-scope.outputs.run == 'true'
+        run: |
+          bun run --cwd packages/prompts build:package
+          bun run build:core
+          bun run --cwd packages/ui build
+
       - name: Validate homepage source contracts
         if: steps.frontend-scope.outputs.run == 'true'
         working-directory: packages/homepage
         run: bun run typecheck && bun run lint:check && bun run test && bun run check:snapshot-inventory
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      # The install above uses --ignore-scripts, so no workspace dist exists.
-      # packages/app/vite.config.ts imports ../shared/src/runtime-env.ts, whose
-      # barrels re-export from @elizaos/core, and Vite bundles the config with
-      # esbuild under default export conditions -- it cannot see core's
-      # eliza-source condition, so it needs core's real dist. cloud-cf-deploy.yml
-      # builds core the same way before the same build:web.
-      - name: Build linked elizaOS core workspace once
-        if: steps.frontend-scope.outputs.run == 'true'
-        run: bun run build:core
 
       - name: Build the only deployable frontend
         if: steps.frontend-scope.outputs.run == 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -692,6 +692,7 @@ jobs:
           bun-version: ${{ env.BUN_VERSION }}
           install-command: bun install --frozen-lockfile --ignore-scripts
           install-native-deps: "false"
+          run-postinstall: "true"
           skip-avatar-clone: "true"
           no-vision-deps: "true"
 

--- a/packages/core/src/features/trajectories/pricing.test.ts
+++ b/packages/core/src/features/trajectories/pricing.test.ts
@@ -105,24 +105,17 @@ describe("MODEL_PRICES_USD_PER_M_TOKENS", () => {
 		});
 	});
 
-	it("prices both routed Cerebras defaults from the authoritative snapshot", () => {
+	it("prices the pinned Cerebras default from the authoritative snapshot", () => {
 		expect(DEFAULT_ELIZA_CLOUD_TEXT_MODEL).toBe("gemma-4-31b");
-		expect(DEFAULT_ELIZA_CLOUD_LARGE_TEXT_MODEL).toBe("zai-glm-4.7");
+		expect(DEFAULT_ELIZA_CLOUD_LARGE_TEXT_MODEL).toBe(
+			DEFAULT_ELIZA_CLOUD_TEXT_MODEL,
+		);
 		expect(
 			MODEL_PRICES_USD_PER_M_TOKENS[DEFAULT_ELIZA_CLOUD_TEXT_MODEL],
 		).toEqual({
 			provider: "cerebras",
 			input: 0.99,
 			output: 1.49,
-			cacheRead: 0,
-			cacheWrite: 0,
-		});
-		expect(
-			MODEL_PRICES_USD_PER_M_TOKENS[DEFAULT_ELIZA_CLOUD_LARGE_TEXT_MODEL],
-		).toEqual({
-			provider: "cerebras",
-			input: 2.25,
-			output: 2.75,
 			cacheRead: 0,
 			cacheWrite: 0,
 		});

--- a/packages/prompts/package.json
+++ b/packages/prompts/package.json
@@ -60,6 +60,11 @@
   "gitHead": "cb192f7b21c441e9463d1af2f890c145814baad2",
   "elizaos": {
     "scripts": {
+      "buildOnInstall": {
+        "sentinel": "dist/index.js",
+        "order": 2,
+        "script": "build:package"
+      },
       "testLanes": [
         "server"
       ]

--- a/packages/scripts/__tests__/develop-full-workflow.test.ts
+++ b/packages/scripts/__tests__/develop-full-workflow.test.ts
@@ -34,6 +34,47 @@ const qualityWorkflow = readFileSync(
   ),
   "utf8",
 );
+const testWorkflow = Bun.YAML.parse(
+  readFileSync(
+    fileURLToPath(
+      new URL("../../../.github/workflows/test.yml", import.meta.url),
+    ),
+    "utf8",
+  ),
+) as {
+  jobs?: Record<
+    string,
+    {
+      steps?: Array<{
+        name?: string;
+        run?: string;
+        with?: Record<string, string>;
+      }>;
+    }
+  >;
+};
+const promptsPackage = JSON.parse(
+  readFileSync(
+    fileURLToPath(new URL("../../prompts/package.json", import.meta.url)),
+    "utf8",
+  ),
+) as {
+  elizaos?: {
+    scripts?: {
+      buildOnInstall?: { sentinel?: string; order?: number; script?: string };
+    };
+  };
+};
+const corePackage = JSON.parse(
+  readFileSync(
+    fileURLToPath(new URL("../../core/package.json", import.meta.url)),
+    "utf8",
+  ),
+) as {
+  elizaos?: {
+    scripts?: { buildOnInstall?: { sentinel?: string; order?: number } };
+  };
+};
 const surfaceGraph = JSON.parse(
   readFileSync(
     fileURLToPath(
@@ -164,5 +205,22 @@ describe("Develop Full workflow authority", () => {
     );
     expect(handoff?.steps?.[0]?.run).toContain("inputs[source_sha]");
     expect(handoff?.steps?.[0]?.run).toContain("inputs[source_run_id]");
+  });
+
+  test("builds prompts before core for Electrobun diagnostics", () => {
+    const steps = testWorkflow.jobs?.["zero-key-diagnostics"]?.steps ?? [];
+    const setupIndex = steps.findIndex(
+      (step) => step.name === "Setup workspace dependencies",
+    );
+    const diagnosticsIndex = steps.findIndex(
+      (step) => step.name === "Electrobun window and dynamic-view coverage",
+    );
+    const promptsBuild = promptsPackage.elizaos?.scripts?.buildOnInstall;
+    const coreBuild = corePackage.elizaos?.scripts?.buildOnInstall;
+    expect(steps[setupIndex]?.with?.["run-postinstall"]).toBe("true");
+    expect(promptsBuild?.sentinel).toBe("dist/index.js");
+    expect(promptsBuild?.script).toBe("build:package");
+    expect(coreBuild?.order).toBeGreaterThan(promptsBuild?.order ?? Infinity);
+    expect(diagnosticsIndex).toBeGreaterThan(setupIndex);
   });
 });

--- a/packages/scripts/__tests__/homepage-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/homepage-deploy-workflow.test.ts
@@ -167,16 +167,27 @@ describe("homepage deployment workflow", () => {
     );
   });
 
-  it("builds the core workspace before the quality frontend build", () => {
-    // packages/app/vite.config.ts reaches @elizaos/core through the
-    // packages/shared barrels, and Vite bundles the config with esbuild under
-    // default export conditions, so core's dist must exist first. Both
-    // workflows install with --ignore-scripts and therefore need the step.
+  it("builds the default-condition workspace chain before homepage validation", () => {
+    // Homepage resolves UI's public dist subpaths and the frontend reaches
+    // prompts through core. A clean --ignore-scripts install produces none of
+    // those dist artifacts, so the consumer gates must follow their builds.
     expect(workflow).toContain("run: bun run build:core");
-    expect(qualityWorkflow).toContain("run: bun run build:core");
-    const coreBuildIndex = qualityWorkflow.indexOf("run: bun run build:core");
+    const promptsBuildIndex = qualityWorkflow.indexOf(
+      "bun run --cwd packages/prompts build:package",
+    );
+    const coreBuildIndex = qualityWorkflow.indexOf("bun run build:core");
+    const uiBuildIndex = qualityWorkflow.indexOf(
+      "bun run --cwd packages/ui build",
+    );
+    const homepageValidationIndex = qualityWorkflow.indexOf(
+      "name: Validate homepage source contracts",
+    );
     const webBuildIndex = qualityWorkflow.indexOf("run: bun run build:web");
+    expect(promptsBuildIndex).toBeGreaterThan(-1);
+    expect(coreBuildIndex).toBeGreaterThan(promptsBuildIndex);
+    expect(uiBuildIndex).toBeGreaterThan(coreBuildIndex);
+    expect(homepageValidationIndex).toBeGreaterThan(uiBuildIndex);
     expect(coreBuildIndex).toBeGreaterThan(-1);
-    expect(webBuildIndex).toBeGreaterThan(coreBuildIndex);
+    expect(webBuildIndex).toBeGreaterThan(homepageValidationIndex);
   });
 });

--- a/packages/scripts/__tests__/plugin-discovery-zero-edit.test.ts
+++ b/packages/scripts/__tests__/plugin-discovery-zero-edit.test.ts
@@ -141,7 +141,11 @@ describe("plugin discovery is zero-edit", () => {
       name: "@fixture/dependency",
       elizaos: {
         scripts: {
-          buildOnInstall: { sentinel: "dist/index.js", order: 10 },
+          buildOnInstall: {
+            sentinel: "dist/index.js",
+            order: 10,
+            script: "build:package",
+          },
         },
       },
     });
@@ -151,6 +155,7 @@ describe("plugin discovery is zero-edit", () => {
         dir: "packages/dependency",
         name: "@fixture/dependency",
         order: 10,
+        script: "build:package",
         sentinel: "dist/index.js",
       },
       {

--- a/packages/scripts/build-private-workspace-packages.mjs
+++ b/packages/scripts/build-private-workspace-packages.mjs
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
 /**
- * Build private/internal workspace packages whose `dist/` is referenced by
+ * Build workspace packages whose `dist/` is referenced by
  * other workspace packages but not produced by any other install step.
  *
- * Why this exists: private workspace packages may ship dist artifacts that
+ * Why this exists: workspace packages may ship dist artifacts that
  * consumers import directly. On a fresh clone
  * neither npm fetch nor the workspace symlink step produces those dist files
- * — only the package's own `bun run build` does — and nothing wires that
+ * — only the package's configured build script does — and nothing wires that
  * build into install, so `git clone … && bun install && bun run dev` fails
  * with ERR_MODULE_NOT_FOUND on the missing dist entry. (See #8143 for the
  * original repro and root cause.)
@@ -27,13 +27,17 @@ const REPO_ROOT = path.resolve(
   "../..",
 );
 
-// Dependency-ordered set, resolved through the discovery seam. Each private
-// package declares `elizaos.scripts.buildOnInstall = { sentinel, order }` in its
-// own package.json — `order` builds leaves before dependents, and `sentinel`
-// is the dist file whose presence proves it is already built. No package
-// names live in this file.
+// Dependency-ordered set, resolved through the discovery seam. Each selected
+// package declares `elizaos.scripts.buildOnInstall` in its own package.json —
+// `order` builds leaves before dependents, `sentinel` proves readiness, and an
+// optional `script` narrows generation-heavy packages to their dist-only build.
+// No package names live in this file.
 const PACKAGES = resolveBuildOnInstallPackages({ repoRoot: REPO_ROOT }).map(
-  (pkg) => ({ dir: pkg.dir, freshnessSentinel: pkg.sentinel }),
+  (pkg) => ({
+    dir: pkg.dir,
+    freshnessSentinel: pkg.sentinel,
+    buildScript: pkg.script ?? "build",
+  }),
 );
 
 function log(msg) {
@@ -55,7 +59,7 @@ function buildPackage(pkg) {
   }
 
   log(`building ${pkg.dir} …`);
-  const result = spawnSync("bun", ["run", "build"], {
+  const result = spawnSync("bun", ["run", pkg.buildScript], {
     cwd: pkgDir,
     stdio: "inherit",
     // On Windows `bun` resolves through the npm shim — let the platform

--- a/packages/scripts/lib/script-metadata.mjs
+++ b/packages/scripts/lib/script-metadata.mjs
@@ -211,8 +211,9 @@ export function resolveDevHarnessBuildDirs(opts) {
 }
 
 /**
- * Private/internal packages to build on a fresh clone, in ascending `order`
- * (deps before dependents). Each entry is `{ dir, name, sentinel, order }`.
+ * Workspace packages to build on a fresh clone, in ascending `order`
+ * (deps before dependents). Each entry is `{ dir, name, sentinel, order }`
+ * plus an optional non-default `script`.
  * Replaces the hardcoded PACKAGES list in build-private-workspace-packages.mjs.
  */
 export function resolveBuildOnInstallPackages(opts) {
@@ -223,11 +224,15 @@ export function resolveBuildOnInstallPackages(opts) {
         typeof pkg.scripts.buildOnInstall === "object" &&
         typeof pkg.scripts.buildOnInstall.sentinel === "string",
     )
-    .map((pkg) => ({
-      dir: pkg.dir,
-      name: pkg.name,
-      sentinel: pkg.scripts.buildOnInstall.sentinel,
-      order: Number(pkg.scripts.buildOnInstall.order ?? 0),
-    }))
+    .map((pkg) => {
+      const script = pkg.scripts.buildOnInstall.script;
+      return {
+        dir: pkg.dir,
+        name: pkg.name,
+        sentinel: pkg.scripts.buildOnInstall.sentinel,
+        order: Number(pkg.scripts.buildOnInstall.order ?? 0),
+        ...(typeof script === "string" && script.length > 0 ? { script } : {}),
+      };
+    })
     .sort((a, b) => a.order - b.order || a.dir.localeCompare(b.dir));
 }


### PR DESCRIPTION
## Summary

- teach private workspace build-on-install metadata to select a package-specific build script
- build `@elizaos/prompts` with its dist-only `build:package` command before core/UI clean-install consumers
- make quality, homepage, and zero-key Electrobun workflow contracts enforce that order
- update the trajectory pricing regression for the intentionally identical small/large Cerebras `gemma-4-31b` pin merged in #28873

## Immutable checkpoint

- head: `57621e200956ea06ffce39cfad29ba960ed4b2e1`
- tree: `f953f95540feb39e25b6300120f5d0b87ddbfed8`
- pinned base: `5723e0964cca15996e1664ff74448897d4e288a7`
- branch: `codex/ci-clean-build-order-20260825`
- worktree clean; local head equals remote branch head

## Why draft

This overlaps the clean-install area of #28823 and should be composed deliberately. It does not replace the Vite/module-resolution contract in #28842 or the Cloud API prompts dependency in #28869. The package-specific dist-only build avoids unrelated generated action-doc churn when install-time recovery invokes the full prompts `build`.

No Pixel, mobile-auth, Cloud UI, deployment, credential, or provider configuration path is changed here. Pixel/mobile-auth remains owned by #28892.

## Completed gates

- 45 core trajectory pricing tests
- 17 Develop Full/homepage/plugin-discovery contract tests
- 23 prompts package tests
- prompts typecheck, Biome lint, and secret scan
- exact Biome on touched source/test/package files
- `git diff --check`
- workflow trigger policy audit
- script audit
- CLAUDE/AGENTS identity audit
- private workspace build helper idempotency

## Explicitly pending

- the first PR Static Smoke run was cancelled fleet-wide while its real jobs were in progress; the aggregate failure only reports those cancellations
- no merge or deployment from this draft
- no signed-in hosted Dedicated inventory/runtime acceptance
- no billable activation, provisioning, resume, or balance action

Focused issue: closes #28820.

Review visibility: @lalalune
