### PR TITLE
fix(voice): emit cancellable action progress heartbeats

### DIFF
--- a/packages/cloud/api/v1/voice/session/lib/session.ts
+++ b/packages/cloud/api/v1/voice/session/lib/session.ts
@@ -1254,6 +1254,24 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
             serverTiming: headers.serverTiming,
           });
         },
+        onProgress: (text: string) => {
+          if (this.currentVoiceTurnId !== traceId || abort.signal.aborted)
+            return;
+          // Progress cues are deliberately non-authoritative: they keep a slow
+          // action audible without entering the reply buffer or being persisted
+          // as an assistant answer. The next authoritative delta continues the
+          // same TTS context and normal terminal cleanup closes it.
+          const stream = ensureTts();
+          if (pendingPhrase !== null) {
+            stream.sendPhrase({ text: pendingPhrase, continueContext: true });
+            pendingPhrase = null;
+          }
+          stream.sendPhrase({ text, continueContext: true });
+          logger.info("[voice-session] action progress cue", {
+            traceId,
+            elapsedMs: this.now() - responseStartedAt,
+          });
+        },
       };
       const onDelta = (delta: string) => {
         if (this.currentVoiceTurnId !== traceId) return;

--- a/packages/cloud/shared/src/lib/voice-session/__tests__/eliza-sse-bridge.test.ts
+++ b/packages/cloud/shared/src/lib/voice-session/__tests__/eliza-sse-bridge.test.ts
@@ -221,6 +221,52 @@ describe("eliza sse bridge", () => {
     expect(result).toEqual({ completed: true, aborted: false });
   });
 
+  test("emits cancellable progress heartbeats while a provisional action waits", async () => {
+    const progress: string[] = [];
+    const encoder = new TextEncoder();
+    const fetchImpl = (async () => {
+      const body = new ReadableStream<Uint8Array>({
+        async start(controller) {
+          controller.enqueue(
+            encoder.encode(
+              `data: ${JSON.stringify({ type: "token", text: "On it.", provisional: true })}\n\n`,
+            ),
+          );
+          await new Promise((resolve) => setTimeout(resolve, 28));
+          controller.enqueue(
+            encoder.encode(
+              `data: ${JSON.stringify({ type: "token", fullText: "Bitcoin is $100." })}\n\n`,
+            ),
+          );
+          controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+          controller.close();
+        },
+      });
+      return new Response(body, { status: 200, headers: { "Content-Type": "text/event-stream" } });
+    }) as unknown as typeof fetch;
+
+    const result = await streamElizaConversation(
+      {
+        endpoint: "http://x",
+        authorization: "Bearer s",
+        model: "m",
+        transcript: "search bitcoin price",
+        agentId: "agent-1",
+        conversationId: "conv-1",
+        traceId: "trace-progress",
+        signal: new AbortController().signal,
+        fetchImpl,
+        progressIntervalMs: 10,
+        onProgress: (text) => progress.push(text),
+      },
+      () => undefined,
+    );
+
+    expect(progress.length).toBeGreaterThanOrEqual(2);
+    expect(progress.every((text) => text === "Still working on that.")).toBe(true);
+    expect(result).toEqual({ completed: true, aborted: false });
+  });
+
   test("speaks a provisional turnComplete acknowledgement once at terminal confirmation", async () => {
     const deltas: string[] = [];
     const fetchImpl = (async () =>

--- a/packages/cloud/shared/src/lib/voice-session/eliza-sse-bridge.ts
+++ b/packages/cloud/shared/src/lib/voice-session/eliza-sse-bridge.ts
@@ -56,6 +56,7 @@ const SERVER_TIMING_PROVIDERS = [
   "other",
   "unknown",
 ] as const;
+const ACTION_PROGRESS_TEXT = /^(?:on it\b|checking\b|fetching\b|gathering\b|looking\s+(?:up|into)\b|running\b|working\s+on\b|one\s+moment\b)/iu;
 
 export type ElizaServerTimingMetric = (typeof SERVER_TIMING_METRICS)[number];
 export type ElizaServerTimingProvider = (typeof SERVER_TIMING_PROVIDERS)[number];
@@ -137,6 +138,10 @@ export interface ElizaSseBridgeRequest {
   signal: AbortSignal;
   /** Reports canonical-route ingress timing as soon as response headers land. */
   onResponseHeaders?: (headers: ElizaSseBridgeResponseHeaders) => void | Promise<void>;
+  /** Emits a non-authoritative progress cue while an action-backed turn is pending. */
+  onProgress?: (text: string) => void | Promise<void>;
+  /** Test hook; production uses six seconds between progress cues. */
+  progressIntervalMs?: number;
   /** Injectable fetch for tests; defaults to global fetch. */
   fetchImpl?: typeof fetch;
 }
@@ -313,12 +318,55 @@ export async function streamElizaConversation(
   let eventType = "";
   let emittedText = "";
   let pendingProvisionalText: string | null = null;
+  let progressTimer: ReturnType<typeof setTimeout> | null = null;
+  let progressActive = false;
+  let progressInFlight = false;
+  const progressIntervalMs = request.progressIntervalMs ?? 6_000;
+  const clearProgress = (): void => {
+    progressActive = false;
+    if (progressTimer !== null) {
+      clearTimeout(progressTimer);
+      progressTimer = null;
+    }
+  };
+  const scheduleProgress = (): void => {
+    if (
+      !request.onProgress ||
+      progressActive ||
+      !Number.isFinite(progressIntervalMs) ||
+      progressIntervalMs <= 0
+    )
+      return;
+    progressActive = true;
+    const tick = async (): Promise<void> => {
+      if (!progressActive || request.signal.aborted) return;
+      if (!progressInFlight) {
+        progressInFlight = true;
+        try {
+          await request.onProgress?.("Still working on that.");
+        } catch (error) {
+          // error-policy:J7 progress telemetry/egress must not kill the canonical turn.
+          logger.warn("[eliza-sse-bridge] progress observer failed", {
+            traceId: request.traceId,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        } finally {
+          progressInFlight = false;
+        }
+      }
+      if (progressActive && !request.signal.aborted) {
+        progressTimer = setTimeout(() => void tick(), progressIntervalMs);
+      }
+    };
+    progressTimer = setTimeout(() => void tick(), progressIntervalMs);
+  };
   const emitDelta = (text: string): void => {
     if (!text) return;
     emittedText += text;
     onDelta(text);
   };
   const authorizeText = (authoritativeText: string): void => {
+    clearProgress();
     pendingProvisionalText = null;
     if (!authoritativeText.startsWith(emittedText)) {
       throw new ElizaSseBridgeError(
@@ -334,6 +382,7 @@ export async function streamElizaConversation(
         update.kind === "snapshot"
           ? update.text
           : `${pendingProvisionalText ?? emittedText}${update.text}`;
+      if (ACTION_PROGRESS_TEXT.test(update.text.trim())) scheduleProgress();
       return;
     }
 
@@ -406,6 +455,7 @@ export async function streamElizaConversation(
       }
     }
   } finally {
+    clearProgress();
     request.signal.removeEventListener("abort", cancelReaderOnAbort);
     if (abortCancellation) {
       await abortCancellation;


### PR DESCRIPTION
## Summary
- emit a non-authoritative “Still working on that.” heartbeat every 6s while a real action provisional acknowledgement is pending
- cancel heartbeats on authoritative output, abort, settlement, stream close, or interruption
- speak progress through the existing TTS context without persisting or duplicating the final reply

## Validation
- `bun run --cwd packages/cloud/shared test -- src/lib/voice-session/__tests__/eliza-sse-bridge.test.ts` (32/32)
- `bun run --cwd packages/cloud/api test -- v1/voice/session/__tests__/ws-lifecycle.test.ts` (68/68)
- targeted Biome check passes

Closes the observed silent slow-search voice turn while preserving canonical Eliza runtime parity.