### PR TITLE
fix(x): deliver complete text across connector egress

### DIFF
--- a/plugins/plugin-x/AGENTS.md
+++ b/plugins/plugin-x/AGENTS.md
@@ -137,7 +137,7 @@ All vars are read via `getSetting(runtime, key)` which checks `runtime.getSettin
 | `TWITTER_DISCOVERY_INTERVAL_MIN` | No | `15` | Minimum minutes between discovery cycles |
 | `TWITTER_DISCOVERY_INTERVAL_MAX` | No | `30` | Maximum minutes between discovery cycles |
 | `TWITTER_MAX_ENGAGEMENTS_PER_RUN` | No | `5` | Max interactions per engagement cycle |
-| `TWITTER_MAX_TWEET_LENGTH` | No | `280` | X-weighted post limit; oversized posts fail without rewriting |
+| `TWITTER_MAX_TWEET_LENGTH` | No | `280` | Legacy standard-post setting retained for compatibility; complete oversized text is sent as 280-weighted-unit posts |
 | `TWITTER_MIN_FOLLOWER_COUNT` | No | `100` | Min follower count for discovery follows |
 | `TWITTER_MAX_FOLLOWS_PER_CYCLE` | No | `5` | Max follows per discovery cycle |
 | `TWITTER_AUTO_RESPOND_MENTIONS` | No | `true` | Auto-respond to mentions |

--- a/plugins/plugin-x/CLAUDE.md
+++ b/plugins/plugin-x/CLAUDE.md
@@ -137,7 +137,7 @@ All vars are read via `getSetting(runtime, key)` which checks `runtime.getSettin
 | `TWITTER_DISCOVERY_INTERVAL_MIN` | No | `15` | Minimum minutes between discovery cycles |
 | `TWITTER_DISCOVERY_INTERVAL_MAX` | No | `30` | Maximum minutes between discovery cycles |
 | `TWITTER_MAX_ENGAGEMENTS_PER_RUN` | No | `5` | Max interactions per engagement cycle |
-| `TWITTER_MAX_TWEET_LENGTH` | No | `280` | X-weighted post limit; oversized posts fail without rewriting |
+| `TWITTER_MAX_TWEET_LENGTH` | No | `280` | Legacy standard-post setting retained for compatibility; complete oversized text is sent as 280-weighted-unit posts |
 | `TWITTER_MIN_FOLLOWER_COUNT` | No | `100` | Min follower count for discovery follows |
 | `TWITTER_MAX_FOLLOWS_PER_CYCLE` | No | `5` | Max follows per discovery cycle |
 | `TWITTER_AUTO_RESPOND_MENTIONS` | No | `true` | Auto-respond to mentions |

--- a/plugins/plugin-x/README.md
+++ b/plugins/plugin-x/README.md
@@ -57,7 +57,7 @@ TWITTER_DRY_RUN=false             # simulate writes, post nothing
 TWITTER_POST_IMMEDIATELY=false    # post once on startup
 TWITTER_TARGET_USERS=             # comma-separated usernames; empty or "*" = all
 TWITTER_NICKNAMES=                # comma-separated nicknames the agent answers to (TWITTER_IDENTITY provider)
-TWITTER_MAX_TWEET_LENGTH=280       # X-weighted units; oversized posts fail without rewriting
+TWITTER_MAX_TWEET_LENGTH=280       # Legacy standard-post compatibility setting
 TWITTER_RETRY_LIMIT=5
 TWITTER_DM_POLL_INTERVAL_SECONDS=60 # minimum 15 seconds
 

--- a/plugins/plugin-x/src/discovery.test.ts
+++ b/plugins/plugin-x/src/discovery.test.ts
@@ -225,8 +225,13 @@ function makeEngagementClient(): {
     nicknames: [],
   };
   const likeTweet = vi.fn(async () => {});
-  const sendTweet = vi.fn(async () => {});
-  const sendQuoteTweet = vi.fn(async () => {});
+  let nextTweetId = 200;
+  const sendTweet = vi.fn(async () => ({
+    data: { id: String(nextTweetId++) },
+  }));
+  const sendQuoteTweet = vi.fn(async () => ({
+    data: { id: String(nextTweetId++) },
+  }));
   const api = { likeTweet, sendTweet, sendQuoteTweet };
   const session = { client: api as never, profile, revision: 1 };
   return {
@@ -323,7 +328,8 @@ describe("TwitterDiscoveryClient engagement dedup (#22710)", () => {
   });
 
   it("replies to a discovered tweet once across cycles", async () => {
-    const { runtime } = makeEngagementRuntime("welcome to the timeline");
+    const completeReply = "welcome ".repeat(50);
+    const { runtime } = makeEngagementRuntime(completeReply);
     const useModel = runtime.useModel as ReturnType<typeof vi.fn>;
     const { client, session, sendTweet, likeTweet } = makeEngagementClient();
     const discovery = new TwitterDiscoveryClient(
@@ -339,11 +345,12 @@ describe("TwitterDiscoveryClient engagement dedup (#22710)", () => {
 
     expect(first).toBe(1);
     expect(second).toBe(0);
-    expect(sendTweet).toHaveBeenCalledTimes(1);
-    expect(sendTweet).toHaveBeenCalledWith(
-      "welcome to the timeline",
-      "1750000000000000001",
+    expect(sendTweet).toHaveBeenCalledTimes(2);
+    expect(sendTweet.mock.calls.map((call) => call[0]).join("")).toBe(
+      completeReply,
     );
+    expect(sendTweet.mock.calls[0]?.[1]).toBe("1750000000000000001");
+    expect(sendTweet.mock.calls[1]?.[1]).toBe("200");
     expect(useModel.mock.calls[0]?.[1]).toMatchObject({
       omitMaxTokens: true,
     });
@@ -434,26 +441,6 @@ describe("TwitterDiscoveryClient engagement dedup (#22710)", () => {
     });
     expect(sendTweet).not.toHaveBeenCalled();
     expect(memories).toHaveProperty("size", 0);
-  });
-
-  it("rejects a complete overlength draft instead of clipping it", async () => {
-    const completeDraft = "\u4f60".repeat(141);
-    const { runtime } = makeEngagementRuntime(completeDraft);
-    const useModel = runtime.useModel as ReturnType<typeof vi.fn>;
-    const { client } = makeEngagementClient();
-    const discovery = new TwitterDiscoveryClient(
-      client,
-      runtime,
-      {} as TwitterClientState,
-    ) as unknown as DiscoveryHarness;
-
-    await expect(
-      discovery.generateReply(scoredTweet("reply").tweet),
-    ).rejects.toMatchObject({
-      code: "X_DISCOVERY_DRAFT_LENGTH_EXCEEDED",
-      context: { weightedLength: 282, maxWeightedLength: 280 },
-    });
-    expect(useModel).toHaveBeenCalledTimes(1);
   });
 
   it("sorts discovered tweets safely when relevanceScore contains NaN", () => {

--- a/plugins/plugin-x/src/discovery.ts
+++ b/plugins/plugin-x/src/discovery.ts
@@ -17,11 +17,11 @@ import {
 import type { ClientBase, TwitterAccountSession } from "./base";
 import type { Client, Tweet } from "./client/index";
 import { SearchMode } from "./client/index";
-import { TWEET_MAX_LENGTH } from "./constants";
 import { getRandomInterval } from "./environment";
-import { countTwitterWeightedLength } from "./tweet-length";
 import type { TwitterClientState } from "./types";
+import { sendTextAsTweetThread } from "./utils";
 import { createMemorySafe, ensureTwitterContext } from "./utils/memory";
+import { extractXWriteReceiptId } from "./utils/provider-receipt";
 import { getSetting } from "./utils/settings";
 
 interface DiscoveryConfig {
@@ -79,23 +79,26 @@ function extractDraftText(result: string | GenerateTextResult): string {
 }
 
 function validateCompleteDraft(result: string | GenerateTextResult): string {
-  const text = extractDraftText(result).trim();
-  if (text.length === 0) {
+  const text = extractDraftText(result);
+  if (text.trim().length === 0) {
     throw new ElizaError("X draft generation returned no complete text", {
       code: "X_DISCOVERY_DRAFT_EMPTY",
     });
   }
-  const weightedLength = countTwitterWeightedLength(text);
-  if (weightedLength > TWEET_MAX_LENGTH) {
-    throw new ElizaError(
-      `Generated X draft exceeds ${TWEET_MAX_LENGTH} weighted characters; received ${weightedLength}`,
-      {
-        code: "X_DISCOVERY_DRAFT_LENGTH_EXCEEDED",
-        context: { weightedLength, maxWeightedLength: TWEET_MAX_LENGTH },
-      },
-    );
-  }
   return text;
+}
+
+async function requireDiscoveryWriteReceipt(result: unknown): Promise<{
+  id: string;
+}> {
+  const id = await extractXWriteReceiptId(result);
+  if (!id) {
+    throw new ElizaError("X returned no usable discovery post receipt", {
+      code: "X_POST_RECEIPT_INDETERMINATE",
+      context: { providerAccepted: true, retrySafe: false },
+    });
+  }
+  return { id };
 }
 
 interface ScoredTweet {
@@ -934,9 +937,15 @@ export class TwitterDiscoveryClient {
               );
             } else {
               this.assertCurrentSession(session);
-              await this.twitterClient.sendTweet(
+              await sendTextAsTweetThread(
                 replyText,
-                scoredTweet.tweet.id,
+                async (chunk, previousTweetId) =>
+                  requireDiscoveryWriteReceipt(
+                    await this.twitterClient.sendTweet(
+                      chunk,
+                      previousTweetId ?? scoredTweet.tweet.id,
+                    ),
+                  ),
               );
               logger.info(`Replied to tweet: ${scoredTweet.tweet.id}`);
             }
@@ -951,9 +960,20 @@ export class TwitterDiscoveryClient {
               );
             } else {
               this.assertCurrentSession(session);
-              await this.twitterClient.sendQuoteTweet(
+              await sendTextAsTweetThread(
                 quoteText,
-                scoredTweet.tweet.id,
+                async (chunk, previousTweetId, index) =>
+                  requireDiscoveryWriteReceipt(
+                    index === 0
+                      ? await this.twitterClient.sendQuoteTweet(
+                          chunk,
+                          scoredTweet.tweet.id,
+                        )
+                      : await this.twitterClient.sendTweet(
+                          chunk,
+                          previousTweetId,
+                        ),
+                  ),
               );
               logger.info(`Quoted tweet: ${scoredTweet.tweet.id}`);
             }

--- a/plugins/plugin-x/src/interactions-search-actions.test.ts
+++ b/plugins/plugin-x/src/interactions-search-actions.test.ts
@@ -55,6 +55,7 @@ interface TwitterClientMock {
   likeTweet: ReturnType<typeof vi.fn>;
   retweet: ReturnType<typeof vi.fn>;
   sendQuoteTweet: ReturnType<typeof vi.fn>;
+  sendTweet: ReturnType<typeof vi.fn>;
   getTweetsV2: ReturnType<typeof vi.fn>;
 }
 
@@ -142,6 +143,7 @@ function createTwitterClientMock(): TwitterClientMock {
     likeTweet: vi.fn(async () => undefined),
     retweet: vi.fn(async () => undefined),
     sendQuoteTweet: vi.fn(async () => ({ id: "quote-1" })),
+    sendTweet: vi.fn(async () => ({ id: "quote-2" })),
     getTweetsV2: vi.fn(async () => []),
   };
 }
@@ -195,6 +197,7 @@ describe("Twitter search engagement actions", () => {
   });
 
   it("quote tweets a search-discovered tweet with generated commentary", async () => {
+    const completeQuote = "sharp take, agreed ".repeat(20);
     const runtime = createRuntime("[QUOTE]", {
       TWITTER_ENABLE_REPLIES: "false",
       TWITTER_TARGET_USERS: "alice",
@@ -202,7 +205,7 @@ describe("Twitter search engagement actions", () => {
     // First useModel call returns the action decision; second returns the quote JSON.
     runtime.useModel
       .mockResolvedValueOnce("[QUOTE]")
-      .mockResolvedValueOnce('{"post":"sharp take, agreed"}');
+      .mockResolvedValueOnce(JSON.stringify({ post: completeQuote }));
     const twitterClient = createTwitterClientMock();
     const clientBase = createClient(twitterClient, runtime);
     const client = new TwitterInteractionClient(
@@ -213,14 +216,26 @@ describe("Twitter search engagement actions", () => {
 
     await runTargetUserEngagement(client, clientBase, tweet());
 
+    expect(
+      [
+        twitterClient.sendQuoteTweet.mock.calls[0]?.[0],
+        ...twitterClient.sendTweet.mock.calls.map((call) => call[0]),
+      ].join(""),
+    ).toBe(completeQuote);
     expect(twitterClient.sendQuoteTweet).toHaveBeenCalledWith(
-      "sharp take, agreed",
+      expect.any(String),
       "500",
     );
-    expect(clientBase.requestQueue.add).toHaveBeenCalledWith(
-      expect.any(Function),
-      NO_REQUEST_RETRY,
+    expect(twitterClient.sendTweet).toHaveBeenCalledWith(
+      expect.any(String),
+      "quote-1",
     );
+    expect(clientBase.requestQueue.add).toHaveBeenCalledTimes(2);
+    expect(
+      vi
+        .mocked(clientBase.requestQueue.add)
+        .mock.calls.every((call) => call[1] === NO_REQUEST_RETRY),
+    ).toBe(true);
     expect(twitterClient.likeTweet).not.toHaveBeenCalled();
     expect(twitterClient.retweet).not.toHaveBeenCalled();
     expect(runtime.reportError).not.toHaveBeenCalled();

--- a/plugins/plugin-x/src/interactions.ts
+++ b/plugins/plugin-x/src/interactions.ts
@@ -46,7 +46,11 @@ import type {
   TwitterRetweetReceivedPayload,
 } from "./types";
 import { TwitterEventTypes } from "./types";
-import { parseActionResponseFromText, sendTweet } from "./utils";
+import {
+  parseActionResponseFromText,
+  sendChunkedTweet,
+  sendTextAsTweetThread,
+} from "./utils";
 import { describeTweetPhotos } from "./utils/image-descriptions";
 import {
   buildTwitterMessageMetadata,
@@ -55,6 +59,7 @@ import {
   isTweetProcessed,
   reconcileTwitterWorld,
 } from "./utils/memory";
+import { extractXWriteReceiptId } from "./utils/provider-receipt";
 import { getSetting } from "./utils/settings";
 import { getEpochMs } from "./utils/time";
 
@@ -744,10 +749,26 @@ ${tweet.text}`;
         return true;
       }
 
-      this.assertCurrentSession(session);
-      await this.client.requestQueue.add(
-        () => this.client.twitterClient.sendQuoteTweet(post, tweet.id),
-        NO_REQUEST_RETRY,
+      await sendTextAsTweetThread(
+        post,
+        async (chunk, previousTweetId, index) => {
+          this.assertCurrentSession(session);
+          const result = await this.client.requestQueue.add(
+            () =>
+              index === 0
+                ? this.client.twitterClient.sendQuoteTweet(chunk, tweet.id)
+                : this.client.twitterClient.sendTweet(chunk, previousTweetId),
+            NO_REQUEST_RETRY,
+          );
+          const id = await extractXWriteReceiptId(result);
+          if (!id) {
+            throw new ElizaError("X returned no usable quote-thread receipt", {
+              code: "X_POST_RECEIPT_INDETERMINATE",
+              context: { providerAccepted: true, retrySafe: false },
+            });
+          }
+          return { id };
+        },
       );
       logger.info(`Quoted tweet ${tweet.id}`);
       return true;
@@ -1367,12 +1388,13 @@ ${tweet.text}`;
         deliveryError = error;
         throw error;
       }
-      let tweetResult: Awaited<ReturnType<typeof sendTweet>>;
+      let responseMemories: Memory[];
       try {
-        tweetResult = await sendTweet(
+        responseMemories = await sendChunkedTweet(
           this.client,
-          response.text,
-          [],
+          response,
+          message.roomId,
+          normalizedTweet.username,
           tweetToReplyTo,
         );
       } catch (error) {
@@ -1380,44 +1402,58 @@ ${tweet.text}`;
         throw error;
       }
 
-      if (!tweetResult) {
-        throw new Error("Failed to get tweet result from response");
+      if (responseMemories.length === 0) {
+        throw new Error("Failed to get X thread receipts from response");
       }
-      const responseId = createUniqueUuid(this.runtime, tweetResult.id);
-      const responseMemory: Memory = {
-        id: responseId,
-        entityId: this.runtime.agentId,
-        agentId: this.runtime.agentId,
-        roomId: message.roomId,
-        content: {
-          ...response,
-          source: "twitter",
-          inReplyTo: message.id,
-        },
-        metadata: {
-          type: "message",
-          source: "twitter",
-          accountId: this.client.accountId,
-          provider: "twitter",
-          fromBot: true,
-          messageIdFull: tweetResult.id,
-          twitter: {
-            accountId: this.client.accountId,
-            tweetId: tweetResult.id,
-            inReplyTo: tweetToReplyTo,
+      responseMemories = responseMemories.map((memory, index) => {
+        const tweetId =
+          typeof memory.metadata === "object"
+            ? (memory.metadata as { messageIdFull?: string }).messageIdFull
+            : undefined;
+        if (!tweetId) {
+          throw new Error("X thread memory is missing its provider receipt");
+        }
+        return {
+          ...memory,
+          content: {
+            ...response,
+            text: memory.content.text,
+            source: "twitter",
+            inReplyTo: responseMemories[index - 1]?.id ?? message.id,
           },
-        } satisfies Memory["metadata"],
-        createdAt: Date.now(),
-      };
+          metadata: {
+            type: "message",
+            source: "twitter",
+            accountId: this.client.accountId,
+            provider: "twitter",
+            fromBot: true,
+            messageIdFull: tweetId,
+            twitter: {
+              accountId: this.client.accountId,
+              tweetId,
+              inReplyTo:
+                index === 0
+                  ? tweetToReplyTo
+                  : (
+                      responseMemories[index - 1]?.metadata as
+                        | { messageIdFull?: string }
+                        | undefined
+                    )?.messageIdFull,
+            },
+          } satisfies Memory["metadata"],
+        } satisfies Memory;
+      });
 
       try {
-        await createMemorySafe(this.runtime, responseMemory, "messages");
+        for (const responseMemory of responseMemories) {
+          await createMemorySafe(this.runtime, responseMemory, "messages");
+        }
       } catch (error) {
         // error-policy:J7 X accepted the reply already, so persistence failure
         // is reported without retrying the external side effect.
         this.runtime.reportError("XInteractions.replyCallback", error);
       }
-      return [responseMemory];
+      return responseMemories;
     };
 
     const twitterUserId = normalizedTweet.userId;

--- a/plugins/plugin-x/src/services/x.service.test.ts
+++ b/plugins/plugin-x/src/services/x.service.test.ts
@@ -367,10 +367,15 @@ describe("XService trusted account routing", () => {
     );
   });
 
-  it("ignores spoofed content account metadata in the unscoped send handler", async () => {
+  it("ignores spoofed account metadata and delivers a complete oversized DM", async () => {
     const runtime = runtimeWithSettings({});
     const service = new XService(runtime);
-    const sendDmToParticipant = vi.fn(async () => ({ dm_event_id: "dm-1" }));
+    let nextDmId = 1;
+    const sendDmToParticipant = vi.fn(
+      async (_recipient: string, _payload: { text: string }) => ({
+        dm_event_id: `dm-${nextDmId++}`,
+      }),
+    );
     const session = dmSession("current-user", { sendDmToParticipant });
     const withAuthenticatedSession = vi.fn(
       async <T>(
@@ -394,20 +399,25 @@ describe("XService trusted account routing", () => {
       )
       .mockResolvedValue({ client: base });
 
+    const completeText = `${"a".repeat(10_000)}🙂`;
     await service.handleSendMessage(
       runtime,
       { source: "x", entityId: "123456" } as TargetInfo,
       {
-        text: "hello",
+        text: completeText,
         metadata: { accountId: "secondary" },
       } as Content,
     );
 
     expect(getClient).toHaveBeenCalledWith("default");
     expect(withAuthenticatedSession).toHaveBeenCalledOnce();
-    expect(sendDmToParticipant).toHaveBeenCalledWith("123456", {
-      text: "hello",
-    });
+    const sentChunks = sendDmToParticipant.mock.calls.map(
+      ([, payload]) => payload.text,
+    );
+    expect(sentChunks.map((chunk) => Array.from(chunk).length)).toEqual([
+      10_000, 1,
+    ]);
+    expect(sentChunks.join("")).toBe(completeText);
   });
 
   it("ignores spoofed content account metadata in the post handler", async () => {

--- a/plugins/plugin-x/src/services/x.service.ts
+++ b/plugins/plugin-x/src/services/x.service.ts
@@ -45,7 +45,7 @@ import { TwitterInteractionClient } from "../interactions";
 import { TwitterPostClient } from "../post";
 import { TwitterTimelineClient } from "../timeline";
 import type { ITwitterClient, TwitterClientState } from "../types";
-import { splitTweetContent } from "../utils";
+import { splitTweetContent, splitXDirectMessageContent } from "../utils";
 import { normalizeXReceiptId } from "../utils/provider-receipt";
 import { getSetting } from "../utils/settings";
 import { getEpochMs } from "../utils/time";
@@ -752,7 +752,12 @@ export class XService extends Service {
   async sendDirectMessageForAccount(
     accountId: string,
     params: { participantId: string; text: string },
-  ): Promise<{ ok: true; status: number; messageId: string | null }> {
+  ): Promise<{
+    ok: true;
+    status: number;
+    messageId: string | null;
+    messageIds: string[];
+  }> {
     const text = params.text;
     if (!text.trim()) {
       throw new Error("X DM connector requires non-empty text content.");
@@ -774,6 +779,7 @@ export class XService extends Service {
       ok: true,
       status: 201,
       messageId: sent.messageId,
+      messageIds: sent.messageIds,
     };
   }
 
@@ -1302,12 +1308,17 @@ export class XService extends Service {
     session: AuthenticatedTwitterSession,
     recipient: string,
     text: string,
-  ): Promise<{ messageId: string | null }> {
-    this.assertDmSessionCurrent(base, session);
-    const result = await session.client.v2.sendDmToParticipant(recipient, {
-      text,
-    });
-    return { messageId: normalizeXReceiptId(result.dm_event_id) ?? null };
+  ): Promise<{ messageId: string | null; messageIds: string[] }> {
+    const messageIds: string[] = [];
+    for (const chunk of splitXDirectMessageContent(text)) {
+      this.assertDmSessionCurrent(base, session);
+      const result = await session.client.v2.sendDmToParticipant(recipient, {
+        text: chunk,
+      });
+      const messageId = normalizeXReceiptId(result.dm_event_id);
+      if (messageId) messageIds.push(messageId);
+    }
+    return { messageId: messageIds[0] ?? null, messageIds };
   }
 
   private async withDmSession<T>(

--- a/plugins/plugin-x/src/timeline.ts
+++ b/plugins/plugin-x/src/timeline.ts
@@ -32,13 +32,18 @@ import {
   twitterActionTemplate,
 } from "./templates";
 import type { ActionResponse, TwitterClientState } from "./types";
-import { parseActionResponseFromText, sendTweet } from "./utils";
+import {
+  parseActionResponseFromText,
+  sendChunkedTweet,
+  sendTextAsTweetThread,
+} from "./utils";
 import {
   buildTwitterMessageMetadata,
   createMemorySafe,
   ensureTwitterContext,
   isTweetProcessed,
 } from "./utils/memory";
+import { extractXWriteReceiptId } from "./utils/provider-receipt";
 import { getSetting } from "./utils/settings";
 import { getEpochMs } from "./utils/time";
 
@@ -658,64 +663,64 @@ ${tweet.text}${mediaDescriptions}`;
           return true;
         }
 
-        const sendQuote = () =>
-          this.client.requestQueue.add(async () => {
-            if (session) this.assertCurrentSession(session);
-            return await this.twitterClient.sendQuoteTweet(
-              String(responseObject.post),
-              tweet.id,
-            );
-          }, NO_REQUEST_RETRY);
-        const result = await sendQuote();
+        const receipts = await sendTextAsTweetThread(
+          String(responseObject.post),
+          async (chunk, previousTweetId, index) => {
+            const result = await this.client.requestQueue.add(async () => {
+              if (session) this.assertCurrentSession(session);
+              return index === 0
+                ? await this.twitterClient.sendQuoteTweet(chunk, tweet.id)
+                : await this.twitterClient.sendTweet(chunk, previousTweetId);
+            }, NO_REQUEST_RETRY);
+            const id = await extractXWriteReceiptId(result);
+            if (!id) {
+              throw new ElizaError(
+                "X returned no usable quote-thread receipt",
+                {
+                  code: "X_POST_RECEIPT_INDETERMINATE",
+                  context: { providerAccepted: true, retrySafe: false },
+                },
+              );
+            }
+            return { id };
+          },
+        );
 
         try {
-          const resultWithJson = result as { json: () => Promise<unknown> };
-          const body = (await resultWithJson.json()) as {
-            id?: string;
-            data?: {
-              id?: string;
-              create_tweet?: {
-                tweet_results?: { result?: { id?: string } };
-              };
-            };
-          } | null;
-          const tweetResult =
-            body?.data?.create_tweet?.tweet_results?.result ||
-            body?.data ||
-            body;
-          const tweetId = tweetResult?.id;
-          if (!tweetId) {
-            throw new ElizaError("X returned no usable quote-tweet receipt", {
-              code: "X_POST_RESPONSE_INVALID",
-            });
-          }
-          logger.log("Successfully posted quote tweet");
-          const responseMemory: Memory = {
-            id: createUniqueUuid(this.runtime, tweetId),
-            entityId: this.runtime.agentId,
-            agentId: this.runtime.agentId,
-            roomId: message.roomId,
-            content: {
-              ...responseObject,
-              source: "twitter",
-              inReplyTo: message.id,
-            },
-            metadata: {
-              type: "message",
-              source: "twitter",
-              accountId: this.client.accountId,
-              provider: "twitter",
-              fromBot: true,
-              messageIdFull: tweetId,
-              twitter: {
-                accountId: this.client.accountId,
-                tweetId,
-                inReplyTo: tweet.id,
+          logger.log("Successfully posted quote thread");
+          const memoryIds = receipts.map((receipt) =>
+            createUniqueUuid(this.runtime, receipt.id),
+          );
+          for (const [index, receipt] of receipts.entries()) {
+            const responseMemory: Memory = {
+              id: memoryIds[index],
+              entityId: this.runtime.agentId,
+              agentId: this.runtime.agentId,
+              roomId: message.roomId,
+              content: {
+                ...responseObject,
+                text: receipt.text,
+                post: receipt.text,
+                source: "twitter",
+                inReplyTo: memoryIds[index - 1] ?? message.id,
               },
-            } satisfies Memory["metadata"],
-            createdAt: Date.now(),
-          };
-          await createMemorySafe(this.runtime, responseMemory, "messages");
+              metadata: {
+                type: "message",
+                source: "twitter",
+                accountId: this.client.accountId,
+                provider: "twitter",
+                fromBot: true,
+                messageIdFull: receipt.id,
+                twitter: {
+                  accountId: this.client.accountId,
+                  tweetId: receipt.id,
+                  inReplyTo: receipts[index - 1]?.id ?? tweet.id,
+                },
+              } satisfies Memory["metadata"],
+              createdAt: Date.now(),
+            };
+            await createMemorySafe(this.runtime, responseMemory, "messages");
+          }
         } catch (error) {
           // error-policy:J7 X already accepted the quote, so replaying the
           // action would duplicate an external effect. Report receipt loss and
@@ -779,47 +784,73 @@ ${tweet.text}${mediaDescriptions}`;
         }
 
         const sendReply = () =>
-          sendTweet(this.client, String(responseObject.post), [], tweet.id);
+          sendChunkedTweet(
+            this.client,
+            { text: String(responseObject.post) },
+            message.roomId,
+            tweet.username,
+            tweet.id,
+          );
         if (session) this.assertCurrentSession(session);
-        const result = await sendReply();
+        const responseMemories = await sendReply();
 
-        if (result) {
+        if (responseMemories.length > 0) {
           logger.log("Successfully posted reply tweet");
 
           try {
-            const responseMemory: Memory = {
-              id: createUniqueUuid(this.runtime, result.id),
-              entityId: this.runtime.agentId,
-              agentId: this.runtime.agentId,
-              roomId: message.roomId,
-              content: {
-                ...responseObject,
-                source: "twitter",
-                inReplyTo: message.id,
-              },
-              metadata: {
-                type: "message",
-                source: "twitter",
-                accountId: this.client.accountId,
-                provider: "twitter",
-                fromBot: true,
-                messageIdFull: result.id,
-                twitter: {
-                  accountId: this.client.accountId,
-                  tweetId: result.id,
-                  inReplyTo: tweet.id,
+            for (const [index, memory] of responseMemories.entries()) {
+              const tweetId =
+                typeof memory.metadata === "object"
+                  ? (memory.metadata as { messageIdFull?: string })
+                      .messageIdFull
+                  : undefined;
+              if (!tweetId) {
+                throw new Error(
+                  "X thread memory is missing its provider receipt",
+                );
+              }
+              const responseMemory: Memory = {
+                ...memory,
+                content: {
+                  ...responseObject,
+                  text: memory.content.text,
+                  source: "twitter",
+                  inReplyTo: responseMemories[index - 1]?.id ?? message.id,
                 },
-              } satisfies Memory["metadata"],
-              createdAt: Date.now(),
-            };
-            await createMemorySafe(this.runtime, responseMemory, "messages");
+                metadata: {
+                  type: "message",
+                  source: "twitter",
+                  accountId: this.client.accountId,
+                  provider: "twitter",
+                  fromBot: true,
+                  messageIdFull: tweetId,
+                  twitter: {
+                    accountId: this.client.accountId,
+                    tweetId,
+                    inReplyTo:
+                      index === 0
+                        ? tweet.id
+                        : (
+                            responseMemories[index - 1]?.metadata as
+                              | { messageIdFull?: string }
+                              | undefined
+                          )?.messageIdFull,
+                  },
+                } satisfies Memory["metadata"],
+              };
+              await createMemorySafe(this.runtime, responseMemory, "messages");
+            }
           } catch (error) {
             // error-policy:J7 X already accepted the reply; surface local
             // receipt loss without turning a successful egress into a retry.
             this.runtime.reportError("XTimeline.replyReceipt", error, {
               accountId: this.client.accountId,
               tweetId: tweet.id,
-              replyId: result.id,
+              replyId: (
+                responseMemories[0]?.metadata as
+                  | { messageIdFull?: string }
+                  | undefined
+              )?.messageIdFull,
             });
           }
           return true;

--- a/plugins/plugin-x/src/utils.test.ts
+++ b/plugins/plugin-x/src/utils.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 import { ClientBase, type TwitterProfile } from "./base";
 import { countTwitterWeightedLength } from "./tweet-length";
 import type { TwitterClientState } from "./types";
-import { sendChunkedTweet, sendTweet } from "./utils";
+import { sendChunkedTweet, sendTweet, splitTweetContent } from "./utils";
 
 function deferred<T>() {
   let resolve!: (value: T | PromiseLike<T>) => void;
@@ -25,6 +25,20 @@ function profile(id: string): TwitterProfile {
 }
 
 describe("sendTweet", () => {
+  it("keeps a weighted emoji grapheme intact when it fits the post boundary", () => {
+    const familyEmoji = "👨‍👩‍👧‍👦";
+    const prefix = "a".repeat(278);
+    const completeText = `${prefix}${familyEmoji}tail`;
+
+    const chunks = splitTweetContent(completeText, 280);
+
+    expect(chunks).toEqual([`${prefix}${familyEmoji}`, "tail"]);
+    expect(chunks.join("")).toBe(completeText);
+    expect(
+      chunks.every((chunk) => countTwitterWeightedLength(chunk) <= 280),
+    ).toBe(true);
+  });
+
   it("does not advance the mention cursor when publishing an outgoing tweet", async () => {
     // Regression for #22433: an outgoing post must never move the incoming
     // mention cursor (`lastCheckedTweetId`). The published tweet always carries

--- a/plugins/plugin-x/src/utils.test.ts
+++ b/plugins/plugin-x/src/utils.test.ts
@@ -2,6 +2,7 @@
 import type { IAgentRuntime, UUID } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { ClientBase, type TwitterProfile } from "./base";
+import { countTwitterWeightedLength } from "./tweet-length";
 import type { TwitterClientState } from "./types";
 import { sendChunkedTweet, sendTweet } from "./utils";
 
@@ -343,9 +344,10 @@ describe("sendTweet", () => {
       sendTweet: send,
     } as unknown as ClientBase["twitterClient"];
 
+    const completeText = `https://example.com${")".repeat(300)}`;
     const memories = await sendChunkedTweet(
       client,
-      { text: `${"a".repeat(280)}\n\n${"b".repeat(20)}` },
+      { text: completeText },
       "00000000-0000-0000-0000-000000000002" as UUID,
       "stale-caller-username",
       "parent",
@@ -360,8 +362,13 @@ describe("sendTweet", () => {
       "https://x.com/captured-a/status/202",
     ]);
     expect(memories.map((memory) => memory.content.text).join("")).toBe(
-      `${"a".repeat(280)}\n\n${"b".repeat(20)}`,
+      completeText,
     );
+    expect(
+      send.mock.calls.every(
+        (call) => countTwitterWeightedLength(String(call[0])) <= 280,
+      ),
+    ).toBe(true);
   });
 
   it("aborts a chunked thread before another egress when its captured session rotates", async () => {

--- a/plugins/plugin-x/src/utils.ts
+++ b/plugins/plugin-x/src/utils.ts
@@ -46,6 +46,21 @@ export interface TweetThreadReceipt {
 /** X direct-message text accepts at most 10,000 Unicode characters per send. */
 export const X_MAX_DM_LENGTH = 10_000;
 
+// The pinned runtimes provide Intl.Segmenter, while this package's ES2020
+// declaration library does not expose its type.
+const GraphemeSegmenter = (
+  Intl as unknown as {
+    Segmenter: new (
+      locale: string,
+      options: { granularity: "grapheme" },
+    ) => { segment(text: string): Iterable<{ segment: string }> };
+  }
+).Segmenter;
+
+const xGraphemeSegmenter = new GraphemeSegmenter("en", {
+  granularity: "grapheme",
+});
+
 /** Split direct-message text on Unicode scalar boundaries without dropping it. */
 export function splitXDirectMessageContent(text: string): string[] {
   const characters = Array.from(text);
@@ -390,7 +405,9 @@ export function splitTweetContent(
   const units: string[] = [];
   let cursor = 0;
   const appendTextUnits = (text: string) => {
-    units.push(...Array.from(text));
+    for (const { segment } of xGraphemeSegmenter.segment(text)) {
+      units.push(segment);
+    }
   };
   for (const entity of twitterText.extractUrlsWithIndices(content)) {
     const [start, end] = entity.indices;

--- a/plugins/plugin-x/src/utils.ts
+++ b/plugins/plugin-x/src/utils.ts
@@ -1,7 +1,6 @@
 /**
- * Shared tweet-sending and media helpers for the connector: `sendTweet` (publishes
- * text, splitting into threads and honoring the max length, returning the accepted
- * `SentTweet`), `fetchMediaData` (SSRF-guarded, size-capped attachment download), and
+ * Shared tweet-sending and media helpers for the connector: single-post and
+ * ordered-thread delivery, SSRF-guarded attachment loading, and
  * `parseActionResponseFromText` (extracts the model's like/retweet/quote/reply
  * choice). Re-exports the shared API error handler.
  */
@@ -18,6 +17,7 @@ import {
   type Memory,
   type UUID,
 } from "@elizaos/core";
+import twitterText from "twitter-text";
 import type { ClientBase } from "./base";
 import type { Tweet } from "./client";
 import { TWEET_MAX_LENGTH } from "./constants";
@@ -35,6 +35,43 @@ export interface SentTweet {
   text?: string;
   edit_history_tweet_ids?: string[];
   readonly [extra: string]: unknown;
+}
+
+/** Provider receipt paired with the exact chunk accepted for that post. */
+export interface TweetThreadReceipt {
+  id: string;
+  text: string;
+}
+
+/** X direct-message text accepts at most 10,000 Unicode characters per send. */
+export const X_MAX_DM_LENGTH = 10_000;
+
+/** Split direct-message text on Unicode scalar boundaries without dropping it. */
+export function splitXDirectMessageContent(text: string): string[] {
+  const characters = Array.from(text);
+  const chunks: string[] = [];
+  for (let index = 0; index < characters.length; index += X_MAX_DM_LENGTH) {
+    chunks.push(characters.slice(index, index + X_MAX_DM_LENGTH).join(""));
+  }
+  return chunks;
+}
+
+/** Send complete text through a caller-owned first/reply transport. */
+export async function sendTextAsTweetThread(
+  text: string,
+  sendChunk: (
+    chunk: string,
+    previousTweetId: string | undefined,
+    index: number,
+  ) => Promise<SentTweet>,
+  maxLength: number = TWEET_MAX_LENGTH,
+): Promise<TweetThreadReceipt[]> {
+  const receipts: TweetThreadReceipt[] = [];
+  for (const [index, chunk] of splitTweetContent(text, maxLength).entries()) {
+    const receipt = await sendChunk(chunk, receipts[index - 1]?.id, index);
+    receipts.push({ id: receipt.id, text: chunk });
+  }
+  return receipts;
 }
 
 function errorDetail(error: unknown): string {
@@ -279,74 +316,64 @@ export async function sendChunkedTweet(
   content: Content,
   roomId: UUID,
   _twitterUsername: string,
-  inReplyTo: string,
+  inReplyTo?: string,
 ): Promise<Memory[]> {
   return client.withAuthenticatedSession(async (session) => {
-    const messages: Memory[] = [];
-    const chunks = splitTweetContent(content.text ?? "", TWEET_MAX_LENGTH);
-    let previousTweetId = inReplyTo;
     const mediaData =
       content.attachments && content.attachments.length > 0
         ? await fetchMediaData(content.attachments)
         : [];
 
-    for (let i = 0; i < chunks.length; i++) {
-      const chunk = chunks[i];
-      if (chunk === undefined) continue;
-      const tweetContent = `${chunk}`;
-      logger.debug(`Sending tweet ${i + 1}/${chunks.length}: ${tweetContent}`);
-
-      try {
+    const receipts = await sendTextAsTweetThread(
+      content.text ?? "",
+      async (chunk, previousTweetId, index) => {
+        logger.debug(`Sending tweet chunk ${index + 1}: ${chunk}`);
         if (!client.isAuthenticatedSessionCurrent(session)) {
           throw new ElizaError("X credentials rotated during thread egress", {
             code: "X_AUTH_SESSION_ROTATED",
           });
         }
-        const result = await sendTweet(
-          client,
-          tweetContent,
-          i === 0 ? mediaData : [],
-          previousTweetId,
-        );
-        const tweetResult =
-          typeof result.data === "object" && result.data !== null
-            ? result.data
-            : result;
-
-        if (
-          typeof tweetResult === "object" &&
-          tweetResult !== null &&
-          "id" in tweetResult &&
-          typeof tweetResult.id === "string"
-        ) {
-          const tweetId = tweetResult.id;
-          messages.push({
-            id: createUniqueUuid(client.runtime, tweetId),
-            entityId: client.runtime.agentId,
-            content: {
-              text: chunk,
-              url: `https://x.com/${session.profile.username}/status/${tweetId}`,
-              source: "twitter",
-            },
-            agentId: client.runtime.agentId,
-            roomId,
-            createdAt: Date.now(),
-          });
-          previousTweetId = tweetId;
+        try {
+          return await sendTweet(
+            client,
+            chunk,
+            index === 0 ? mediaData : [],
+            previousTweetId ?? inReplyTo,
+          );
+        } catch (error) {
+          logger.error(`Error sending chunk ${index + 1}:`, errorDetail(error));
+          throw error;
         }
-      } catch (error) {
-        logger.error(`Error sending chunk ${i + 1}:`, errorDetail(error));
-        throw error;
-      }
-    }
+      },
+    );
 
-    return messages;
+    return receipts.map(({ id: tweetId, text }) => ({
+      id: createUniqueUuid(client.runtime, tweetId),
+      entityId: client.runtime.agentId,
+      content: {
+        text,
+        url: `https://x.com/${session.profile.username}/status/${tweetId}`,
+        source: "twitter",
+      },
+      metadata: {
+        type: "message",
+        source: "twitter",
+        accountId: client.accountId,
+        provider: "twitter",
+        messageIdFull: tweetId,
+        fromBot: true,
+      } satisfies Memory["metadata"],
+      agentId: client.runtime.agentId,
+      roomId,
+      createdAt: Date.now(),
+    }));
   });
 }
 
 /**
  * Split content into ordered posts without rewriting or dropping any text.
- * URLs stay indivisible because X gives each complete URL a fixed wire weight.
+ * URL boundaries come from twitter-text, the same parser used to enforce X's
+ * weighted limit, so trailing punctuation remains ordinary splittable text.
  */
 export function splitTweetContent(
   content: string,
@@ -361,19 +388,20 @@ export function splitTweetContent(
   if (!content) return [];
 
   const units: string[] = [];
-  const urlPattern = /https?:\/\/[^\s]+/gu;
   let cursor = 0;
-  for (const match of content.matchAll(urlPattern)) {
-    const index = match.index;
-    units.push(...Array.from(content.slice(cursor, index)));
-    units.push(match[0]);
-    cursor = index + match[0].length;
+  const appendTextUnits = (text: string) => {
+    units.push(...Array.from(text));
+  };
+  for (const entity of twitterText.extractUrlsWithIndices(content)) {
+    const [start, end] = entity.indices;
+    appendTextUnits(content.slice(cursor, start));
+    units.push(content.slice(start, end));
+    cursor = end;
   }
-  units.push(...Array.from(content.slice(cursor)));
+  appendTextUnits(content.slice(cursor));
 
   const chunks: string[] = [];
   let chunk = "";
-  let chunkWeight = 0;
   for (const unit of units) {
     const unitWeight = countTwitterWeightedLength(unit);
     if (unitWeight > maxLength) {
@@ -385,13 +413,12 @@ export function splitTweetContent(
         },
       );
     }
-    if (chunk && chunkWeight + unitWeight > maxLength) {
+    const candidate = `${chunk}${unit}`;
+    if (chunk && countTwitterWeightedLength(candidate) > maxLength) {
       chunks.push(chunk);
       chunk = unit;
-      chunkWeight = unitWeight;
     } else {
-      chunk += unit;
-      chunkWeight += unitWeight;
+      chunk = candidate;
     }
   }
   if (chunk) chunks.push(chunk);

--- a/plugins/plugin-x/src/utils/twitter-post-callback.test.ts
+++ b/plugins/plugin-x/src/utils/twitter-post-callback.test.ts
@@ -7,6 +7,7 @@ import {
 } from "@elizaos/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ClientBase } from "../base";
+import { countTwitterWeightedLength } from "../tweet-length";
 import { addToRecentTweets, getRecentTweets, isDuplicateTweet } from "./memory";
 import { createTwitterPostCallback } from "./twitter-post-callback";
 
@@ -61,6 +62,7 @@ function makeClient(): ClientBase {
     bio: "",
     nicknames: [],
   };
+  let nextTweetId = 123;
   return {
     accountId: "default",
     lastCheckedTweetId: null,
@@ -78,7 +80,7 @@ function makeClient(): ClientBase {
       sendTweet: vi.fn().mockImplementation(async (text: string) => ({
         data: {
           data: {
-            id: "123",
+            id: String(nextTweetId++),
             text,
           },
         },
@@ -152,7 +154,7 @@ describe("createTwitterPostCallback", () => {
       undefined,
       [],
       false,
-      [],
+      undefined,
     );
     expect(runtime.cache.get(RECENT_TWEETS_KEY)).toEqual(["new post text"]);
     expect(runtime.createMemory).toHaveBeenCalledTimes(1);
@@ -173,7 +175,7 @@ describe("createTwitterPostCallback", () => {
       undefined,
       [],
       false,
-      [],
+      undefined,
     );
     expect(runtime.cache.get(RECENT_TWEETS_KEY)).toEqual([text]);
     expect(memories[0]?.content?.text).toBe(text);
@@ -189,7 +191,7 @@ describe("createTwitterPostCallback", () => {
     const onPosted = vi.fn();
     const callback = makeCallback({ client, runtime, onPosted });
 
-    await expect(callback({ text: "new post text" })).resolves.toEqual([]);
+    await expect(callback({ text: "new post text" })).resolves.toHaveLength(1);
     const laterCallback = makeCallback({ client, runtime, onPosted });
     await expect(laterCallback({ text: "new post text" })).resolves.toEqual([]);
 
@@ -286,30 +288,24 @@ describe("createTwitterPostCallback", () => {
     expect(client.twitterClient.sendTweet).toHaveBeenCalledTimes(1);
   });
 
-  it("rejects overlong Latin text before duplicate tracking or egress", async () => {
+  it("delivers complete overlength generated text as an ordered thread", async () => {
     const runtime = makeRuntime();
     const client = makeClient();
     const callback = makeCallback({ client, runtime });
     const longText = "hello ".repeat(70);
 
-    await expect(callback({ text: longText })).rejects.toMatchObject({
-      code: "X_POST_LENGTH_EXCEEDED",
-      context: { weightedLength: 420, maxWeightedLength: 280 },
-    });
+    const memories = await callback({ text: longText });
+    const calls = vi.mocked(client.twitterClient.sendTweet).mock.calls;
 
-    expect(client.twitterClient.sendTweet).not.toHaveBeenCalled();
-    expect(runtime.cache.get(RECENT_TWEETS_KEY)).toBeUndefined();
-  });
-
-  it("rejects generated CJK text over the weighted cap without posting", async () => {
-    const runtime = makeRuntime();
-    const client = makeClient();
-    const callback = makeCallback({ client, runtime });
-    await expect(callback({ text: "你".repeat(141) })).rejects.toMatchObject({
-      code: "X_POST_LENGTH_EXCEEDED",
-      context: { weightedLength: 282, maxWeightedLength: 280 },
-    });
-    expect(client.twitterClient.sendTweet).not.toHaveBeenCalled();
+    expect(calls.map((call) => call[0]).join("")).toBe(longText);
+    expect(
+      calls.every((call) => countTwitterWeightedLength(call[0]) <= 280),
+    ).toBe(true);
+    expect(calls[1]?.[1]).toBe("123");
+    expect(memories.map((memory) => memory.content.text).join("")).toBe(
+      longText,
+    );
+    expect(runtime.cache.get(RECENT_TWEETS_KEY)).toEqual([longText]);
   });
 
   it("partitions recent-post duplicate state by account and profile identity", async () => {

--- a/plugins/plugin-x/src/utils/twitter-post-callback.ts
+++ b/plugins/plugin-x/src/utils/twitter-post-callback.ts
@@ -1,14 +1,12 @@
 /**
  * `createTwitterPostCallback` — the `HandlerCallback` the post loop hands the agent
- * for publishing a generated tweet: it normalizes text to the X length limit,
- * suppresses duplicate generations, honors `TWITTER_DRY_RUN`, publishes via the
- * client, and records the resulting memory (returning it even when the post-publish
- * persistence step fails).
+ * for publishing generated text: it suppresses duplicates, honors
+ * `TWITTER_DRY_RUN`, delivers complete text as an ordered thread, and records
+ * every provider receipt.
  */
 import {
   ChannelType,
   type Content,
-  createUniqueUuid,
   ElizaError,
   type HandlerCallback,
   type IAgentRuntime,
@@ -17,10 +15,8 @@ import {
   type UUID,
 } from "@elizaos/core";
 import type { ClientBase } from "../base";
-import { TWEET_MAX_LENGTH } from "../constants";
-import { countTwitterWeightedLength } from "../tweet-length";
 import type { TwitterClientState } from "../types";
-import { sendTweet } from "../utils";
+import { sendChunkedTweet } from "../utils";
 import {
   addToRecentTweets,
   createMemorySafe,
@@ -31,23 +27,6 @@ import { getSetting } from "./settings";
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
-}
-
-function normalizePostText(text: string): string {
-  const weightedLength = countTwitterWeightedLength(text);
-  if (weightedLength > TWEET_MAX_LENGTH) {
-    throw new ElizaError(
-      `Generated X post is limited to ${TWEET_MAX_LENGTH} weighted characters; received ${weightedLength}`,
-      {
-        code: "X_POST_LENGTH_EXCEEDED",
-        context: {
-          weightedLength,
-          maxWeightedLength: TWEET_MAX_LENGTH,
-        },
-      },
-    );
-  }
-  return text;
 }
 
 export function createTwitterPostCallback({
@@ -83,7 +62,7 @@ export function createTwitterPostCallback({
         return [];
       }
 
-      const postText = normalizePostText(generatedText);
+      const postText = generatedText;
       if (isDryRun) {
         runtime.logger.info(
           `[Twitter] [DRY RUN] Would post tweet: ${postText}`,
@@ -120,13 +99,24 @@ export function createTwitterPostCallback({
           runtime.logger.info("[Twitter] Skipping duplicate generated tweet");
           return [];
         }
-        const result = await sendTweet(client, postText, [], undefined, []);
-        const postedText =
-          typeof result.text === "string" && result.text.length > 0
-            ? result.text
-            : postText;
+        const deliveredMemories = await sendChunkedTweet(
+          client,
+          content,
+          roomId,
+          session.profile.username,
+        );
+        const firstTweetId =
+          typeof deliveredMemories[0]?.metadata === "object"
+            ? (deliveredMemories[0].metadata as { messageIdFull?: string })
+                .messageIdFull
+            : undefined;
+        if (!firstTweetId) {
+          throw new ElizaError("X thread delivery returned no usable receipt", {
+            code: "X_POST_RESPONSE_INVALID",
+          });
+        }
         runtime.logger.info(
-          `[Twitter] Tweet posted successfully! ID: ${result.id}`,
+          `[Twitter] Tweet thread posted successfully! First ID: ${firstTweetId}`,
         );
         try {
           onPosted?.();
@@ -135,18 +125,18 @@ export function createTwitterPostCallback({
           // notification callback must not convert delivery into a retry.
           runtime.reportError("XPostCallback.notificationReceipt", error, {
             accountId: client.accountId,
-            tweetId: result.id,
+            tweetId: firstTweetId,
           });
         }
 
         try {
-          await addToRecentTweets(runtime, cacheIdentity, postedText);
+          await addToRecentTweets(runtime, cacheIdentity, postText);
         } catch (error) {
           // error-policy:J7 X already accepted the post; local duplicate
           // history failure must be visible without replaying provider egress.
           runtime.reportError("XPostCallback.localReceipt", error, {
             accountId: client.accountId,
-            tweetId: result.id,
+            tweetId: firstTweetId,
           });
         }
 
@@ -158,46 +148,55 @@ export function createTwitterPostCallback({
             conversationId: `${session.profile.id}-home`,
           });
 
-          const postedMemory: Memory = {
-            id: createUniqueUuid(runtime, result.id),
-            entityId: runtime.agentId,
-            agentId: runtime.agentId,
-            roomId: context.roomId || roomId,
-            content: {
-              ...content,
-              text: postedText,
-              source: "twitter",
-              channelType: ChannelType.FEED,
-              type: "post",
-              metadata: {
-                accountId: client.accountId,
-                tweetId: result.id,
-                postedAt: Date.now(),
+          const postedMemories = deliveredMemories.map((memory) => {
+            const tweetId =
+              typeof memory.metadata === "object"
+                ? (memory.metadata as { messageIdFull?: string }).messageIdFull
+                : undefined;
+            if (!tweetId) {
+              throw new Error(
+                "X thread memory is missing its provider receipt",
+              );
+            }
+            return {
+              ...memory,
+              roomId: (context.roomId || roomId) as UUID,
+              content: {
+                ...content,
+                text: memory.content.text,
+                source: "twitter",
+                channelType: ChannelType.FEED,
+                type: "post",
+                metadata: {
+                  accountId: client.accountId,
+                  tweetId,
+                  postedAt: memory.createdAt,
+                },
               },
-            },
-            metadata: {
-              type: "message",
-              source: "twitter",
-              accountId: client.accountId,
-              provider: "twitter",
-              messageIdFull: result.id,
-              chatType: ChannelType.FEED,
-              fromBot: true,
-            } satisfies Memory["metadata"],
-            createdAt: Date.now(),
-          };
+              metadata: {
+                type: "message",
+                source: "twitter",
+                accountId: client.accountId,
+                provider: "twitter",
+                messageIdFull: tweetId,
+                chatType: ChannelType.FEED,
+                fromBot: true,
+              } satisfies Memory["metadata"],
+            } satisfies Memory;
+          });
 
-          await createMemorySafe(runtime, postedMemory, "messages");
-
-          return [postedMemory];
+          for (const postedMemory of postedMemories) {
+            await createMemorySafe(runtime, postedMemory, "messages");
+          }
+          return postedMemories;
         } catch (error) {
           // error-policy:J7 X already accepted the post; surface local memory
           // loss without returning an error that could cause duplicate egress.
           runtime.reportError("XPostCallback.memoryReceipt", error, {
             accountId: client.accountId,
-            tweetId: result.id,
+            tweetId: firstTweetId,
           });
-          return [];
+          return deliveredMemories;
         }
       });
     } catch (error) {


### PR DESCRIPTION
## Summary

Closes #28884.

This is the second-pass follow-up to #28851. The first pass removed surrogate-pair-aware truncation, but a real lossless-delivery defect remained: a post containing `https://example.com` followed by 300 closing parentheses was rejected as one indivisible token even though `twitter-text` recognizes only the URL as the URL entity and the punctuation can be split.

- use the official `twitter-text` URL entity boundaries and weighted-length parser for X post chunks
- deliver complete generated posts, replies, and quotes as ordered X threads across discovery, interactions, timeline, and callback paths
- split X direct messages losslessly at the provider's 10,000-Unicode-scalar boundary
- persist every provider receipt while retaining delivered receipts if local persistence fails
- remove high-level hard rejections and trimming that discarded otherwise deliverable output
- clarify the plugin contract: configured tweet length remains a compatibility setting, while complete text is threaded

The low-level `sendTweet` operation still rejects an oversized atomic provider request. All maintained high-level egress paths split before reaching that boundary.

## Verification

- `bun run --cwd plugins/plugin-x typecheck` — pass after rebasing onto current `develop`
- `bun run --cwd plugins/plugin-x lint` — pass after rebasing onto current `develop`
- `bun run --cwd plugins/plugin-x build` — pass
- five focused test files — 44 pass
- oversized-DM focused regression — pass (1 pass, 19 skipped by filter)
- `bun run check:agents-claude` — pass
- `git diff --check` — pass
- full plugin-X suite — 361 pass, 13 skip, with four pre-existing/stale expectation failures also present on `develop` (three PostService iterator/search expectations and one search-count expectation)
- `bun run verify` — reached 360/375 tasks before the host killed unrelated `@elizaos/corpus-tools#typecheck` for memory pressure (SIGKILL/exit 137); no source diagnostic was emitted

## Reproduction evidence

Before this change, `https://example.com` plus 300 `)` characters had a weighted length of 323 and the splitter threw an indivisible-token error. After this change, the exact original string reassembles from two chunks with weighted lengths 280 and 43.

<!-- evidence-gate -->
<!-- evidence-head:555f664d90418be731aaf8a82d77d3fbe23b9118 -->
<!-- evidence-row:before-screenshots -->
- [x] N/A — connector/runtime change with no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A — connector/runtime change with no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A — no visual interaction changed.
<!-- evidence-row:backend-logs -->
- [x] Deterministic production-handler tests exercise ordered provider calls and receipt persistence; live X credentials were not available.

<details><summary>Connector handler test transcript</summary>

```text
focused connector test files: 5 files, 44 tests passed with ordered provider-call assertions
oversized direct-message regression: 1 passed, 19 skipped by the focused name filter
provider receipts: every successfully delivered chunk is retained and persisted in delivery order
```

</details>
<!-- evidence-row:frontend-logs -->
- [x] N/A — no frontend code changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A — this changes deterministic connector delivery after model generation, not model prompting or inference behavior.
<!-- evidence-row:domain-artifacts -->
- [x] Exact reassembly and official weighted-length checks captured by the production splitter regression.

<details><summary>Lossless splitter transcript</summary>

```text
input: https://example.com followed by 300 closing-parenthesis characters; weighted length 323
before: throws because the broad URL tokenization treats the entire suffix as indivisible
after: 2 ordered chunks; weighted lengths [280, 43]; chunks.join("") === input
```

</details>

<!-- evidence-row:ocr-review -->
- [x] N/A — no screenshots or rendered text changed.
<!-- evidence-row:visual-review -->
- [x] N/A — no UI surface changed.
<!-- evidence-row:live-e2e -->
- [x] N/A for this submission — no live X credentials were available; deterministic tests exercise the real connector orchestration around mocked provider boundaries, and the PR does not claim live-provider proof.
