### PR TITLE
fix(elizaos): preserve complete migrated memories

### DIFF
--- a/packages/elizaos/src/commands/migrate-agent.ts
+++ b/packages/elizaos/src/commands/migrate-agent.ts
@@ -68,7 +68,6 @@ function printPlan(plan: MigratePlan, slug: string): void {
       `  SELF:          ${c.SELF}`,
       `  older marker:  ${c.MARKER}`,
       `  dedup dropped: ${plan.summary.duplicatesDropped}`,
-      `  clipped:       ${plan.summary.clipped} (truncated at maxChunkLen)`,
       "",
       `daily logs seen: ${plan.summary.dailyLogsTotal}`,
       `named memory:    ${plan.summary.namedMemoryTotal}`,

--- a/packages/elizaos/src/migrate/index.ts
+++ b/packages/elizaos/src/migrate/index.ts
@@ -48,8 +48,6 @@ export interface MigratePlan {
     hasSecretsDir: boolean;
     /** Cross-tier duplicate memories dropped during tiering. */
     duplicatesDropped: number;
-    /** Memory bodies clipped at maxChunkLen (content truncated). */
-    clipped: number;
     /** sqlite memory stores detected in the source home. */
     sqliteStores: number;
     /** True if sqlite memory was detected but NOT ingested (node:sqlite missing). */
@@ -78,7 +76,7 @@ export function buildMigrationPlan(opts: MigrateOptions): MigratePlan {
   const entityId = randomUUID() as UUID;
   const roomId = randomUUID() as UUID;
 
-  const { memories, counts, duplicatesDropped, clipped } = tierMemories(src, {
+  const { memories, counts, duplicatesDropped } = tierMemories(src, {
     memoryDays: opts.memoryDays ?? 14,
     roomId,
     entityId,
@@ -101,7 +99,6 @@ export function buildMigrationPlan(opts: MigrateOptions): MigratePlan {
       firewalled: firewall,
       hasSecretsDir: src.hasSecretsDir,
       duplicatesDropped,
-      clipped,
       sqliteStores: src.sqliteStores.length,
       sqliteUningested: src.sqliteUningested,
       warnings: src.warnings,

--- a/packages/elizaos/src/migrate/memory-tiering.ts
+++ b/packages/elizaos/src/migrate/memory-tiering.ts
@@ -29,8 +29,6 @@ export interface TieringOptions {
   agentId: UUID;
   /** Minimum chunk length to bother seeding. Default 20 chars. */
   minChunkLen?: number;
-  /** Max chars per memory (longer chunks are clipped). Default 6000. */
-  maxChunkLen?: number;
   /**
    * When true, the personal corpus (daily logs, awareness, curated MEMORY.md,
    * SELF journals) is NOT seeded into the result; a single marker is seeded
@@ -48,8 +46,6 @@ export interface TieringResult {
   counts: Record<MemoryTier, number>;
   /** How many memories were dropped as cross-tier duplicates. */
   duplicatesDropped: number;
-  /** How many memory bodies were clipped at maxChunkLen (content lost). */
-  clipped: number;
 }
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -72,29 +68,19 @@ function normalizeForDedup(text: string): string {
     .toLowerCase();
 }
 
-/** Mutable counter passed through mkMemory so we can tally clips. */
-interface ClipCounter {
-  n: number;
-}
-
 function mkMemory(
   text: string,
   tier: MemoryTier,
   opts: TieringOptions,
   createdAt: number,
-  clipCounter?: ClipCounter,
 ): Memory {
-  const max = opts.maxChunkLen ?? 6000;
-  const wasClipped = text.length > max;
-  if (wasClipped && clipCounter) clipCounter.n++;
-  const body = wasClipped ? text.slice(0, max) : text;
   return {
     id: randomUUID() as UUID,
     entityId: opts.entityId,
     agentId: opts.agentId,
     roomId: opts.roomId,
     createdAt,
-    content: { text: `[${tier}] ${body}` },
+    content: { text: `[${tier}] ${text}` },
     metadata: {
       type: "custom",
       // Provenance for downstream filtering / debugging.
@@ -141,7 +127,6 @@ export function tierMemories(
   };
   const now = Date.now();
   const cutoff = now - opts.memoryDays * DAY_MS;
-  const clip: ClipCounter = { n: 0 };
 
   // ---- FIREWALL: a portable archive carries the persona, NOT the personal corpus ----
   // Daily logs, <agent>-awareness.md, curated MEMORY.md, and SELF journals all
@@ -157,16 +142,15 @@ export function tierMemories(
         "MARKER",
         opts,
         now,
-        clip,
       ),
     );
     counts.MARKER++;
-    return { memories, counts, duplicatesDropped: 0, clipped: clip.n };
+    return { memories, counts, duplicatesDropped: 0 };
   }
 
   // ---- T1 CURRENT: awareness (highest signal) + last-N-day daily logs ----
   if (src.awareness?.trim()) {
-    memories.push(mkMemory(src.awareness.trim(), "CURRENT", opts, now, clip));
+    memories.push(mkMemory(src.awareness.trim(), "CURRENT", opts, now));
     counts.CURRENT++;
   }
   let olderCount = 0;
@@ -180,7 +164,6 @@ export function tierMemories(
             "CURRENT",
             opts,
             ts || now,
-            clip,
           ),
         );
         counts.CURRENT++;
@@ -193,7 +176,7 @@ export function tierMemories(
   // ---- T2 LONGTERM: curated MEMORY.md, chunked by section ----
   if (src.curatedMemory?.trim()) {
     for (const chunk of chunkBySection(src.curatedMemory, minLen)) {
-      memories.push(mkMemory(chunk, "LONGTERM", opts, now - 1, clip));
+      memories.push(mkMemory(chunk, "LONGTERM", opts, now - 1));
       counts.LONGTERM++;
     }
   }
@@ -203,7 +186,7 @@ export function tierMemories(
     if (!isSelfMemory(m.key)) continue;
     if (m.text.trim().length < minLen) continue;
     memories.push(
-      mkMemory(`${m.key}\n${m.text.trim()}`, "SELF", opts, now - 2, clip),
+      mkMemory(`${m.key}\n${m.text.trim()}`, "SELF", opts, now - 2),
     );
     counts.SELF++;
   }
@@ -229,7 +212,7 @@ export function tierMemories(
   // Hermes's normalize_text + seen-set dedup, but tier-priority-aware.) ----
   const { deduped, duplicatesDropped } = dedupeByTierPriority(memories, counts);
 
-  return { memories: deduped, counts, duplicatesDropped, clipped: clip.n };
+  return { memories: deduped, counts, duplicatesDropped };
 }
 
 /**

--- a/packages/elizaos/src/migrate/migrate.test.ts
+++ b/packages/elizaos/src/migrate/migrate.test.ts
@@ -230,6 +230,25 @@ describe("memory-tiering", () => {
     expect(all).not.toContain("old daily log that should NOT be flat-seeded");
     expect(all).toContain("Older history");
   });
+  it("preserves a complete memory beyond the former UTF-16 cap", () => {
+    const body = `${"x".repeat(5_999)}😀complete tail`;
+    const src = {
+      ...readOcAgentHome(FIXTURE, "tess"),
+      awareness: body,
+      curatedMemory: undefined,
+      dailyLogs: [],
+      namedMemory: [],
+    };
+
+    const { memories, counts } = tierMemories(src, {
+      memoryDays: 14,
+      ...ids,
+    });
+
+    expect(counts.CURRENT).toBe(1);
+    expect(memories).toHaveLength(1);
+    expect(memories[0].content.text).toBe(`[CURRENT] ${body}`);
+  });
   it("firewall excludes ALL personal-context memory (marker only)", () => {
     const src = readOcAgentHome(FIXTURE, "tess");
     const { memories, counts } = tierMemories(src, {


### PR DESCRIPTION
Closes #28899.

## Summary

- remove the arbitrary 6,000-UTF-16-code-unit cap from OpenClaw memory migration
- preserve each source memory as one complete record because the archive, importer, and storage path has no corresponding per-memory limit
- remove the obsolete `maxChunkLen` option and `clipped` result/CLI reporting
- prove a body crossing the former boundary with an emoji and trailing content survives exactly

This replaces #26561. That PR made the old cap lossless by adding chunks and reassembly metadata, but no external destination boundary justified fragmenting the record.

## Validation

- `bun run --cwd packages/elizaos test -- src/migrate/migrate.test.ts` — 25/25 passed
- `bun run --cwd packages/elizaos typecheck` — passed
- `bun run --cwd packages/elizaos lint:check` — passed across package, templates, and app template
- `bun run --cwd packages/elizaos build` — passed
- `bun run --cwd packages/elizaos test:packaged` — passed
- `git diff --check` — passed

The complete package suite reached 250 passing tests, then failed in the unchanged `src/commands/__tests__/cli-version.test.ts` because it imports a nonexistent sibling `./version.ts`; the focused owning suite above is green.

## Evidence

No visual or live-model surface changes. The focused regression feeds a 5,999-character prefix, an emoji spanning the former UTF-16 slice boundary, and a trailing suffix through the real tiering implementation and asserts exact complete output.
