### PR TITLE
fix(core): preserve extracted args over empty planner values

### DIFF
--- a/packages/core/src/actions/resolve-action-args.test.ts
+++ b/packages/core/src/actions/resolve-action-args.test.ts
@@ -106,6 +106,41 @@ describe("resolveActionArgs", () => {
 		expect(runtime.useModel).toHaveBeenCalled();
 	});
 
+	it.each([null, ""])(
+		"uses extracted parameters when the planner supplied an absent value (%j)",
+		async (plannerTitle) => {
+			const modelOutput = JSON.stringify({
+				action: "CREATE",
+				params: { title: "Buy groceries" },
+				missing: [],
+				confidence: 0.95,
+			});
+
+			const runtime = makeMockRuntime(modelOutput);
+			const message = makeMessage("create a task to buy groceries");
+
+			const result = await resolveActionArgs<TaskSubactions>({
+				runtime,
+				message,
+				actionName: "TASK",
+				subactions: taskSubactions,
+				options: {
+					parameters: {
+						action: "CREATE",
+						title: plannerTitle,
+					},
+				},
+			});
+
+			expect(result).toEqual({
+				ok: true,
+				subaction: "CREATE",
+				params: { title: "Buy groceries" },
+			});
+			expect(runtime.useModel).toHaveBeenCalled();
+		},
+	);
+
 	it("returns clarification failure when required parameters cannot be extracted", async () => {
 		const modelOutput = JSON.stringify({
 			action: "DELETE",

--- a/packages/core/src/actions/resolve-action-args.test.ts
+++ b/packages/core/src/actions/resolve-action-args.test.ts
@@ -48,6 +48,36 @@ function makeMessage(text: string): Memory {
 }
 
 describe("resolveActionArgs", () => {
+	it("preserves an explicit description clear while extracting a missing goal ID", async () => {
+		const runtime = makeMockRuntime(
+			JSON.stringify({
+				action: "UPDATE",
+				params: { id: "goal-1", description: "Old description" },
+				missing: [],
+				confidence: 0.95,
+			}),
+		);
+		const result = await resolveActionArgs({
+			runtime,
+			message: makeMessage("clear the description of my goal"),
+			actionName: "OWNER_GOALS",
+			subactions: {
+				UPDATE: {
+					description: "Update an owner goal by ID",
+					descriptionCompressed: "update goal",
+					required: ["id"],
+					optional: ["description"],
+				},
+			},
+			options: { parameters: { action: "UPDATE", id: null, description: "" } },
+		});
+		expect(result).toEqual({
+			ok: true,
+			subaction: "UPDATE",
+			params: { id: "goal-1", description: "" },
+		});
+	});
+
 	it("trusts complete planner-supplied parameters without invoking model extraction", async () => {
 		const runtime = makeMockRuntime();
 		const message = makeMessage("create a task");

--- a/packages/core/src/actions/resolve-action-args.ts
+++ b/packages/core/src/actions/resolve-action-args.ts
@@ -137,7 +137,7 @@ function pickKnownParams<TSubaction extends string>(
 	]);
 	const result: Record<string, unknown> = {};
 	for (const [key, value] of Object.entries(params)) {
-		if (allowed.has(key) && value !== undefined) {
+		if (allowed.has(key) && valueIsPresent(value)) {
 			result[key] = value;
 		}
 	}

--- a/packages/core/src/actions/resolve-action-args.ts
+++ b/packages/core/src/actions/resolve-action-args.ts
@@ -137,7 +137,12 @@ function pickKnownParams<TSubaction extends string>(
 	]);
 	const result: Record<string, unknown> = {};
 	for (const [key, value] of Object.entries(params)) {
-		if (allowed.has(key) && valueIsPresent(value)) {
+		// Optional empty values can intentionally clear a field in update actions.
+		if (
+			allowed.has(key) &&
+			value !== undefined &&
+			(!spec.required.includes(key) || valueIsPresent(value))
+		) {
 			result[key] = value;
 		}
 	}


### PR DESCRIPTION
Fix missing required action arguments while preserving explicit optional-field clears. An absent planner value such as `title: null` previously overwrote successful extraction. The original proposed filter also discarded `description: ""`, preventing an update from clearing that field. Required parameters now use the resolver's presence rule; optional values retain caller intent.

Supports #24299's single-request completion work. This does not close the broader workflow/coding-agent epic.

Validation on `develop` base `3a7f438a9e9d5ba10ea905198723012667bd785d`, with Bun 1.3.14 and Node 24.15.0:

- Reproduced the optional-clear regression against the original proposed fix: 7 passing / 1 failing resolver cases. The missing ID was extracted, but the empty description was replaced with the old description.
- Repaired resolver suite: 8/8 pass. Core typecheck and read-only lint: exit 0 (existing lint warnings remain).
- Normal `bun install`: exit 0. Root `bun run verify`: exit 0, 373/373 tasks including cached tasks; all final repository audits passed.
- Independent source review found no blocker. Complete synthetic live request, response, and resolver result were independently inspected.
- Full owning core suite: 930 passed / 2 skipped files; 12,085 passed / 3 skipped tests, exit 0. The repository audit confirms no untracked skips. Merge remains held for final hosted checks.

The live run uses a real AgentRuntime, PGlite, production OpenAI-compatible plugin, and Cerebras qwen-3.8-27b. It resolves the requested goal ID and preserves the explicit empty description. This proves the extraction boundary, not a persisted goal update or a mounted calendar/application flow.

<!-- evidence-head:ddd968b5f9534d3c45dc0809564938599c4a3e6a -->

| Evidence | Result |
|---|---|
| Before/after screenshots, video, OCR | N/A — no rendered surface changes |
| Frontend logs | N/A — no frontend path changes |
| Backend and domain result | Complete resolver result below; eight focused cases pass |
| Live-model trajectory | Complete synthetic provider request and response below |
| Native/audio capture | N/A — no device/audio path changes |

<details><summary>Complete live extraction evidence</summary>

```json
{
  "result": {
    "ok": true,
    "subaction": "UPDATE",
    "params": {
      "id": "goal-1",
      "description": ""
    }
  },
  "calls": [
    {
      "url": "https://api.cerebras.ai/v1/chat/completions",
      "request": {
        "model": "qwen-3.8-27b",
        "reasoning_effort": "none",
        "messages": [
          {
            "role": "user",
            "content": "Pick the correct action value for the OWNER_GOALS umbrella and extract its parameters.\nAction values (with their required + optional parameter keys):\n- UPDATE: Update an existing goal. Extract the exact id and description. An empty description clears it.\n  required: id\n  optional: description\n\nReturn ONLY a JSON object with these fields:\n  action: one of the action keys above, or null if the request does not match any action\n  params: record containing the required and any obvious optional parameter values you extracted\n  missing: list of required parameter keys you could NOT extract from the request or context\n  confidence: number from 0.0 to 1.0 reflecting how confident you are in the subaction choice\n\nRules:\n- Use null for params you cannot determine; do not invent values.\n- Only include parameter keys that appear in the chosen subaction's required or optional list.\n- If the request does not match any subaction, set subaction=null and confidence < 0.5.\n\nUser request: Update goal ID goal-1 and clear its description.\nRecent conversation (most recent last):\n(none)\n\nReturn ONLY the JSON object. Example: {\"action\":null,\"params\":{},\"missing\":[\"action\"],\"confidence\":0.0}. No prose, markdown, or code fences."
          }
        ]
      },
      "status": 200,
      "response": "{\"id\":\"chatcmpl-f72605d3-35c5-4bcb-9069-b612469f7d15\",\"choices\":[{\"finish_reason\":\"stop\",\"index\":0,\"message\":{\"content\":\"{\\\"action\\\":\\\"UPDATE\\\",\\\"params\\\":{\\\"id\\\":\\\"goal-1\\\",\\\"description\\\":\\\"\\\"},\\\"missing\\\":[],\\\"confidence\\\":1.0}\",\"role\":\"assistant\"}}],\"created\":1788994719,\"model\":\"qwen-3.8-27b\",\"system_fingerprint\":\"fp_c09e1a821fa613148d4b\",\"object\":\"chat.completion\",\"usage\":{\"total_tokens\":313,\"completion_tokens\":26,\"completion_tokens_details\":{\"reasoning_tokens\":0},\"prompt_tokens\":287,\"prompt_tokens_details\":{\"cached_tokens\":0,\"image_tokens\":0}},\"time_info\":{\"created\":1788994719.86951,\"queue_time\":0.010844679,\"prompt_time\":0.009610261,\"completion_time\":0.023531996,\"total_time\":0.0455327033996582}}"
    }
  ]
}
```
</details>
