### PR TITLE
fix(discord): preserve long choice options

### DIFF
--- a/plugins/plugin-discord/__tests__/interactions.test.ts
+++ b/plugins/plugin-discord/__tests__/interactions.test.ts
@@ -1,7 +1,6 @@
 /**
- * Unit tests for `renderDiscordInteractions` — mapping neutral
- * `InteractionBlock` output to Discord action-row/button components.
- * Pure-function assertions.
+ * Tests Discord interaction rendering through the real discord.js component
+ * builder, including connector limits that must be enforced before delivery.
  */
 import type { Content } from "@elizaos/core";
 import {
@@ -14,6 +13,7 @@ import {
 	buildDiscordReplyPayload,
 	renderDiscordInteractions,
 } from "../interactions";
+import { buildDiscordComponents } from "../utils";
 
 describe("renderDiscordInteractions", () => {
 	it("passes plain replies through with no components", () => {
@@ -71,6 +71,35 @@ describe("renderDiscordInteractions", () => {
 			kind: "reply",
 			value: "yes",
 		});
+	});
+
+	it("keeps choice options reachable when labels exceed Discord's 80-character limit", () => {
+		const releaseLabel =
+			"Deploy the production release candidate to the primary cluster and notify the on-call team";
+		const cases = [
+			{
+				text: `Which release do you want?\n[CHOICE:deploy]\na=${releaseLabel}\nb=Cancel\n[/CHOICE]`,
+				expectedLabels: [releaseLabel.slice(0, 80), "Cancel"],
+			},
+			{
+				text: `Which release do you want?\n[CHOICE:deploy]\na=${"A".repeat(90)}\nb=${"B".repeat(90)}\n[/CHOICE]`,
+				expectedLabels: ["A".repeat(80), "B".repeat(80)],
+			},
+		];
+
+		for (const testCase of cases) {
+			const rendered = renderDiscordInteractions({
+				text: testCase.text,
+			} as Content);
+			const built = buildDiscordComponents(rendered.components);
+			const sentLabels =
+				built?.flatMap((row) =>
+					row.toJSON().components.map((component) => component.label),
+				) ?? [];
+
+			expect(sentLabels).toEqual(testCase.expectedLabels);
+			expect(rendered.needsFreeTextReply).toBe(false);
+		}
 	});
 
 	it("uses Discord's 100-byte custom_id budget for longer callback values", () => {

--- a/plugins/plugin-discord/interactions.ts
+++ b/plugins/plugin-discord/interactions.ts
@@ -20,6 +20,7 @@ import {
 	parseInteractionBlocks,
 	stripDashboardOnlyMarkers,
 	toNeutralLayout,
+	truncateWellFormed,
 } from "@elizaos/core";
 import type { DiscordActionRow, DiscordComponentOptions } from "./types";
 
@@ -27,6 +28,7 @@ import type { DiscordActionRow, DiscordComponentOptions } from "./types";
 const MAX_BUTTONS_PER_ROW = 5;
 const MAX_ROWS = 5;
 const MAX_CUSTOM_ID_BYTES = 100;
+const MAX_BUTTON_LABEL_LENGTH = 80;
 
 /** discord.js ButtonStyle numeric values. */
 const BUTTON_STYLE = { primary: 1, secondary: 2, danger: 4 } as const;
@@ -54,7 +56,7 @@ function toComponent(button: NeutralButton): DiscordComponentOptions | null {
 		return {
 			type: 2,
 			custom_id: "",
-			label: button.label,
+			label: truncateWellFormed(button.label, MAX_BUTTON_LABEL_LENGTH),
 			style: LINK_STYLE,
 			url: button.url,
 		};
@@ -63,7 +65,7 @@ function toComponent(button: NeutralButton): DiscordComponentOptions | null {
 		return {
 			type: 2,
 			custom_id: button.callbackData,
-			label: button.label,
+			label: truncateWellFormed(button.label, MAX_BUTTON_LABEL_LENGTH),
 			style: BUTTON_STYLE[button.style ?? "secondary"],
 		};
 	}


### PR DESCRIPTION
# Relates to

Discord choice buttons with labels longer than Discord's 80-character limit are dropped by `discord.js`, so the caller's option becomes unreachable. If every option is long, the user receives a bare question with no controls and no typed-reply fallback.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto `origin/develop` at `8c4f9ffa62aeb8598eff98a0e0ba7c56bf9ec2b1` with zero conflicts.
- [x] `bun run verify` was run after sync; its exact unrelated control failure is recorded below. Per the supplied workflow, the existing installation was used and `bun install` was not run.
- [x] A reviewer can confirm the change from the before/after reproduction and mutation proof below.

# Sync with develop

- [x] Rebased onto `origin/develop` at `8c4f9ffa62aeb8598eff98a0e0ba7c56bf9ec2b1`; zero conflicts.
- [x] `bun run verify` has the same unrelated failure on this branch and an untouched exact-base control, documented below.

# Risks

Low. The change only constrains Discord interaction button labels to the platform's documented builder limit before constructing Discord components. Callback values and URLs remain unchanged. The truncation helper preserves well-formed Unicode.

# Background

## What does this PR do?

`renderDiscordInteractions()` previously passed unbounded labels into the neutral layout. `buildDiscordComponents()` then called `ButtonBuilder.setLabel()`, which threw `Invalid string length`; its per-component catch converted the button to `null` and filtered it out. The message still sent, silently deleting an option.

This change applies Discord's 80-character label budget while creating neutral Discord components, before the native builder boundary. Both callback and link buttons use `truncateWellFormed`, so every option remains constructible without corrupting surrogate pairs. The regression test drives the rendered layout through the real `discord.js` component builder; it is evidence locking the production fix, not the purpose of the change.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No. This restores conformance to Discord's existing component contract without changing public APIs or documented behavior.

# Testing

## Where should a reviewer start?

- `plugins/plugin-discord/interactions.ts` — applies the platform label budget at layout time.
- `plugins/plugin-discord/__tests__/interactions.test.ts` — verifies mixed and all-long choice blocks survive the real builder path.

## Detailed testing steps

The handed-off scratch file was not repository state, so I reconstructed `/tmp/repro-discord-button-label.ts` exactly from the supplied mechanism. From `plugins/plugin-discord`, before the production change:

```console
$ bun /tmp/repro-discord-button-label.ts 2>&1 | grep -v '^ Info'
 Error      Error creating component: Error: Invalid string length
--- one option label > 80 chars
  neutral labels : [ "Deploy the production release candidate to the primary cluster and notify the on-call team",
  "Cancel"
]
  sent labels    : [ "Cancel" ]
  sent prose     : "Which release do you want?"
  needsFreeText  : false
 Error      Error creating component: Error: Invalid string length
 Error      Error creating component: Error: Invalid string length
--- every option label > 80 chars
  neutral labels : [ "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
  "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
]
  sent labels    : []
  sent prose     : "Which release do you want?"
  needsFreeText  : false
```

After the fix, the unchanged reproduction printed:

```console
$ bun /tmp/repro-discord-button-label.ts 2>&1 | grep -v '^ Info'
--- one option label > 80 chars
  neutral labels : [ "Deploy the production release candidate to the primary cluster and notify the on",
  "Cancel"
]
  sent labels    : [ "Deploy the production release candidate to the primary cluster and notify the on",
  "Cancel"
]
  sent prose     : "Which release do you want?"
  needsFreeText  : false
--- every option label > 80 chars
  neutral labels : [ "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
  "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
]
  sent labels    : [ "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
  "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
]
  sent prose     : "Which release do you want?"
  needsFreeText  : false
```

### Mutation proof

I reverted only the production import, constant, and two truncation calls while keeping the test. The focused test failed on the missing option:

```console
$ bunx vitest run --maxWorkers=2 plugins/plugin-discord/__tests__/interactions.test.ts -t "keeps choice options reachable when labels exceed Discord's 80-character limit"
 Error      Error creating component: Error: Invalid string length

AssertionError: expected [ 'Cancel' ] to deeply equal [ …(2) ]
- Expected
+ Received
[
- "Deploy the production release candidate to the primary cluster and notify the on",
  "Cancel",
]

Test Files  1 failed (1)
Tests  1 failed | 17 skipped (18)
```

After restoring the production fix:

```console
Test Files  1 passed (1)
Tests  1 passed | 17 skipped (18)
```

### Exact-head checks

```console
$ bunx biome check --write plugins/plugin-discord/interactions.ts plugins/plugin-discord/__tests__/interactions.test.ts
Checked 2 files in 12ms. No fixes applied.

$ bunx tsc --noEmit -p plugins/plugin-discord/tsconfig.json --pretty false
# exit 0; no output
```

The same TypeScript command on an untouched worktree at `8c4f9ffa62aeb8598eff98a0e0ba7c56bf9ec2b1` also exited 0 with no output.

The full owning-package command was run by full path with capped workers:

```console
$ bunx vitest run --maxWorkers=2 /Volumes/thescoho_1TB/Developer/worktrees/eliza-discord-choice-label-cap/plugins/plugin-discord --reporter=json --outputFile=/tmp/discord-label-suite-exact-head.json
Test suites: 279 total, 272 passed, 7 failed
Tests:       859 total, 854 passed, 5 failed
```

Untouched exact-base control:

```console
Test suites: 279 total, 272 passed, 7 failed
Tests:       858 total, 853 passed, 5 failed
```

Both runs had the same five pre-existing failed assertions in `inbound-envelope.test.ts`, `interaction-replay-render.test.ts`, and existing task-fallback cases in `interactions.test.ts`. The branch adds one passing regression test and no new failure.

# Evidence Gate

Evidence matches exact commit `4d99c6a2a0c2f4337dee5e9245b2e6bd4a1fb719`.
<!-- evidence-head:4d99c6a2a0c2f4337dee5e9245b2e6bd4a1fb719 -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - this is a server-side Discord payload transformation with no repository UI surface.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - this is a server-side Discord payload transformation with no repository UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - the deterministic production-path console reproduction above directly exposes the serialized Discord components.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: the verbatim before/after production-path output above shows the native builder rejection and the resulting sent labels.
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: N/A - no frontend request, response, or state changed.
<!-- evidence-row:llm-trajectory -->
- [x] LLM trajectory: N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: the serialized Discord action-row labels in the reproduction above are the affected domain artifact.
<!-- evidence-row:ocr-review -->
- [x] OCR review: N/A - no rendered visual surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - this change neither constructs nor modifies model-facing context and does not affect an agent/action/provider/prompt/model path.

## Backend + frontend logs

The before/after console blocks above are from the real `renderDiscordInteractions()` → `buildDiscordComponents()` path and include the `discord.js` builder failure before the fix. Frontend logs are N/A because this connector payload path has no frontend request or state transition.

## Screenshots (before / after) + video walkthrough

N/A - no UI code or rendered application surface changed. The affected artifact is the Discord component JSON, captured verbatim above.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or audio path changed.

## Known gaps / failures

`bun run verify` exited 1 on both the exact-head branch and an untouched control at the rebase SHA. Both printed the pre-existing `SwiftLint not found in PATH` warning. Both then terminated on the same unrelated `@elizaos/cloud-shared#lint:check` Biome formatting error in `packages/cloud/shared/src/lib/voice-session/eliza-sse-bridge.ts` and printed:

```console
@elizaos/cloud-shared:lint:check: Found 1 error.
Tasks: 141 successful, 146 total
Failed: @elizaos/cloud-shared#lint:check
ERROR run failed
error: script "verify" exited with code 1
```

The Discord package also has five existing failed assertions, identical on branch and exact-base control as quantified above. Neither unrelated failure was modified.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-eliza
Attribution status: self-reported
— [discord-choice-label-cap]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0XW0M4KVWC30RWRT3PMQMP7","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-26T01:47:34.419Z","completed_at":"2026-08-26T02:15:08.699Z","skill_sha256":"7d4db0c19ef1171c18744a11ec1aceb613e3f779a9c49953ef1a0018aa80e4fd","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-26T01:47:35.035Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"46d73e520cf37b186e612a4a7820970d5f1a33459f7389ef92c3609d7d5aa0cc","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"a3a65b32-1c77-4c35-a3c5-50145edd8522","object_id":"sha256:46d73e520cf37b186e612a4a7820970d5f1a33459f7389ef92c3609d7d5aa0cc","sha256":"46d73e520cf37b186e612a4a7820970d5f1a33459f7389ef92c3609d7d5aa0cc"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"9Puy63h-HgwUnDzsJES0qiAIMCGz9NB_vODdSh3oBjtKz0ufYHujy2avvoo_qg9fHvQ8XdcwuACiOVTlO3GKDQ"}} -->
