### PR TITLE
fix(core): preserve zero-leading batch embeddings

### DIFF
--- a/packages/core/src/features/documents/document-processor.test.ts
+++ b/packages/core/src/features/documents/document-processor.test.ts
@@ -210,6 +210,39 @@ describe("processFragmentsSynchronously", () => {
 			source: "upload",
 		});
 	});
+
+	it("persists a batch embedding whose first component is zero", async () => {
+		const embedding = [0, 0.51, -0.32, 0.77];
+		const writes: Memory[] = [];
+		const runtime = runtimeWith({
+			getSetting: (key: string) => {
+				if (key === "BATCH_EMBEDDINGS") return "true";
+				if (key === "RATE_LIMIT_ENABLED") return "false";
+				return null;
+			},
+			getModel: (type: string) =>
+				type === ModelType.TEXT_EMBEDDING ? async () => embedding : undefined,
+			useModel: (async (type: string) => {
+				if (type === ModelType.TEXT_EMBEDDING) return [embedding];
+				throw new Error(`Unexpected model: ${type}`);
+			}) as IAgentRuntime["useModel"],
+			createMemory: async (memory: Memory) => {
+				writes.push(memory);
+				return memory.id as UUID;
+			},
+		});
+
+		const saved = await processFragmentsSynchronously({
+			runtime,
+			documentId: DOCUMENT_ID,
+			fullDocumentText: "batch vector searchable text",
+			agentId: MOCK_AGENT_ID,
+		});
+
+		expect(saved).toBe(1);
+		expect(writes).toHaveLength(1);
+		expect(writes[0]?.embedding).toEqual(embedding);
+	});
 });
 
 describe("extractTextFromDocument", () => {

--- a/packages/core/src/features/documents/document-processor.ts
+++ b/packages/core/src/features/documents/document-processor.ts
@@ -741,7 +741,7 @@ async function generateEmbeddingsBatch(
 				const chunk = batch[i];
 				const embedding = embeddings[i];
 
-				if (embedding && embedding.length > 0 && embedding[0] !== 0) {
+				if (embedding && embedding.length > 0) {
 					results.push({
 						embedding,
 						success: true,


### PR DESCRIPTION
# Defect

With `BATCH_EMBEDDINGS=true`, document ingestion drops any otherwise valid embedding whose first component is exactly zero. The caller receives a lower saved count and the fragment is absent from `document_fragments`, so semantic search cannot retrieve content that ingests successfully through the non-batch path.

The batch validator treated `embedding[0] !== 0` as a validity test. This PR removes that first-component heuristic and uses the same non-empty-vector contract as individual ingestion. A regression test locks the public `processFragmentsSynchronously` path with `[0, 0.51, -0.32, 0.77]` and verifies one persisted fragment.

# Relates to

No issue. This PR is the standalone report for the explicitly assigned, reproduced defect.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] The operator explicitly prohibited `bun install`; `bun run verify` was run after sync and its untouched-control failure is recorded below.
- [x] A reviewer can confirm the defect and fix from the before/after output below without reading the implementation.

# Sync with develop

- [x] Rebased onto `origin/develop` at `8c4f9ffa62aeb8598eff98a0e0ba7c56bf9ec2b1`; zero conflicts.
- [x] `bun run verify` was attempted post-sync; the exact unrelated control failure is documented under **Known gaps / failures**.

# Risks

Low. The change only removes a bogus first-dimension predicate from batch-result validation. Empty and missing vectors remain rejected. The affected behavior is limited to document fragment embeddings returned by the batch path.

# Background

## What does this PR do?

It makes batch document ingestion accept every non-empty embedding vector, including sparse, quantized, or Matryoshka vectors whose first dimension is `0`. It also adds a regression guard at the public ingestion boundary.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No. The existing intended contract already accepts non-empty vectors; this restores the batch implementation to that contract.

# Testing

## Where should a reviewer start?

Run the focused test, then inspect the one-line production diff:

```bash
bunx vitest run --maxWorkers=2 packages/core/src/features/documents/document-processor.test.ts
```

## Reproduction before the fix

The handed-off scratch file was absent, so I reconstructed the minimal test at the named public boundary. It runs the same runtime and vector in individual and batch modes.

```text
$ cd packages/core && ./node_modules/.bin/vitest run --root /tmp/eliza-repro --config packages/core/vitest.config.ts zero-first-dim.test.ts

 RUN  v4.1.10 /tmp/eliza-repro

stdout | zero-first-dim.test.ts > zero-leading document embeddings > batch ingestion persists the fragment
 Info       Split into 1 chunks

stderr | zero-first-dim.test.ts > zero-leading document embeddings > batch ingestion persists the fragment
 Warn       Failed to process chunk 0 for document 00000000-0000-0000-0000-0000000000aa

stderr | zero-first-dim.test.ts > zero-leading document embeddings > batch ingestion persists the fragment
 Warn       1/1 chunks failed processing

stdout | zero-first-dim.test.ts > zero-leading document embeddings > batch ingestion persists the fragment
BATCH_EMBEDDINGS=true { count: 0, saved: 0 }

 ❯ zero-first-dim.test.ts (2 tests | 1 failed) 9ms
     × batch ingestion persists the fragment 4ms

 FAIL  zero-first-dim.test.ts > zero-leading document embeddings > batch ingestion persists the fragment
AssertionError: expected { count: +0, saved: +0 } to deeply equal { count: 1, saved: 1 }

- Expected
+ Received

  {
-   "count": 1,
-   "saved": 1,
+   "count": 0,
+   "saved": 0,
  }

 Test Files  1 failed (1)
      Tests  1 failed | 1 passed (2)
```

## Reproduction after the fix

The unchanged assertion passes, and the supplementary console-visible run shows the resulting persistence artifact for both settings:

```text
$ ./node_modules/.bin/vitest run --maxWorkers=2 --disableConsoleIntercept --root /tmp/eliza-repro --config packages/core/vitest.config.ts zero-first-dim.test.ts

 RUN  v4.1.10 /tmp/eliza-repro

 Info       Split into 1 chunks
BATCH_EMBEDDINGS=false { count: 1, saved: 1 }
 Info       Split into 1 chunks
BATCH_EMBEDDINGS=true { count: 1, saved: 1 }

 Test Files  1 passed (1)
      Tests  2 passed (2)
   Start at  07:48:15
   Duration  572ms (transform 353ms, setup 0ms, import 483ms, tests 6ms, environment 0ms)
```

## Regression mutation proof

After the fix, I restored only `embedding[0] !== 0`, kept the new test, and reran it:

```text
$ bunx vitest run --maxWorkers=2 packages/core/src/features/documents/document-processor.test.ts

 RUN  v4.1.10

stderr | packages/core/src/features/documents/document-processor.test.ts > processFragmentsSynchronously > persists a batch embedding whose first component is zero
 Warn       Failed to process chunk 0 for document 11111111-1111-1111-1111-111111111111
 Warn       1/1 chunks failed processing

 FAIL  packages/core/src/features/documents/document-processor.test.ts > processFragmentsSynchronously > persists a batch embedding whose first component is zero
AssertionError: expected +0 to be 1 // Object.is equality

- Expected
+ Received

- 1
+ 0

 Test Files  1 failed (1)
      Tests  1 failed | 30 passed (31)
```

I then restored the fix. The final exact-head focused result was:

```text
 Test Files  1 passed (1)
      Tests  31 passed (31)
```

## Package and static validation

```text
$ bunx biome check --write packages/core/src/features/documents/document-processor.ts packages/core/src/features/documents/document-processor.test.ts
Checked 2 files in 46ms. No fixes applied.

$ bun run --cwd packages/core typecheck
$ node ../shared/scripts/generate-keywords.mjs && tsc --noEmit -p ./tsconfig.json
Done!
```

The same typecheck exited 0 on untouched control `8c4f9ffa62aeb8598eff98a0e0ba7c56bf9ec2b1`.

The final full owning-package command was run on branch and untouched control:

```text
$ bunx vitest run --maxWorkers=2 packages/core/src

branch:
 Test Files  34 failed | 857 passed | 2 skipped (893)
      Tests  282 failed | 10614 passed | 209 skipped (11105)

untouched control:
 Test Files  34 failed | 857 passed | 2 skipped (893)
      Tests  282 failed | 10613 passed | 209 skipped (11104)
```

The branch adds exactly one passing regression test and no failing or skipped tests relative to control. The shared preinstalled workspace links cause the common unrelated failures described below.

# Evidence Gate

Evidence matches exact PR head `9d7bb98598973ab4a137aa1467f86ede7ad12a70`.
<!-- evidence-head:9d7bb98598973ab4a137aa1467f86ede7ad12a70 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - this is a core ingestion predicate with no interactive UI flow.
<!-- evidence-row:backend-logs -->
- [x] The verbatim production logger warnings from the failing ingestion path are included above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, response, or state changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent prompt, action, provider, or live-model behavior changed; the embedding vectors are deterministic test inputs.
<!-- evidence-row:domain-artifacts -->
- [x] The console-visible before/after `{ count, saved }` fragment-persistence results are included above.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - the change is deterministic validation of an already-returned embedding vector and does not alter an LLM call.

## Backend + frontend logs

Backend: the failing fragment-drop warnings and passing `{ count, saved }` artifact are included verbatim above.

Frontend: N/A - no frontend surface changed.

## Screenshots (before / after) + video walkthrough

N/A - no UI changed.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT path changed.

## Known gaps / failures

- `bun run verify` does not complete on either branch or untouched control. Turbo may surface a different first unrelated task depending on scheduling, but the handed-off known gate reproduces identically on both:

  ```text
  $ bun run --cwd plugins/plugin-native-gateway lint:check
  $ bunx @biomejs/biome check . && bun run swiftlint -- lint
  Checked 7 files in 17ms. No fixes applied.
  $ node-swiftlint lint
  /bin/bash: node-swiftlint: command not found
  error: script "swiftlint" exited with code 127
  error: script "lint:check" exited with code 127
  ```

- The full core suite has identical branch/control failures because the operator-required no-install worktrees reuse the already-installed workspace links from a heavily modified shared checkout. Exact counts are recorded above; the only delta is the new passing test.
- The signed receipt trace could not finalize: `project run receipt failed: Slop identity poll returned HTTP 410`. This PR is therefore published unmeasured with no evidence bonus and no fabricated receipt.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: codex
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-eliza
Attribution status: self-reported
— [zero-first-embedding]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-eliza"} -->
