### PR TITLE
fix(x): remove generation-time length caps

### DIFF
--- a/plugins/plugin-x/package.json
+++ b/plugins/plugin-x/package.json
@@ -302,9 +302,9 @@
       },
       "TWITTER_MAX_TWEET_LENGTH": {
         "type": "number",
-        "description": "Maximum tweet length (supports long-form tweets up to 4000 characters).",
+        "description": "Legacy compatibility setting; complete text is delivered as an ordered thread of provider-sized posts.",
         "required": false,
-        "default": 4000,
+        "default": 280,
         "sensitive": false
       },
       "TWITTER_MAX_INTERACTIONS_PER_RUN": {

--- a/plugins/plugin-x/src/discovery.test.ts
+++ b/plugins/plugin-x/src/discovery.test.ts
@@ -9,6 +9,7 @@ import {
 import { describe, expect, it, vi } from "vitest";
 import type { ClientBase, TwitterAccountSession } from "./base";
 import { TwitterDiscoveryClient } from "./discovery";
+import { quoteTweetTemplate, replyTweetTemplate } from "./templates";
 import type { TwitterClientState } from "./types";
 
 type DiscoveryHarness = {
@@ -384,7 +385,7 @@ describe("TwitterDiscoveryClient engagement dedup (#22710)", () => {
         messages: [
           {
             role: "user",
-            content: expect.stringMatching(/under 280 characters/i),
+            content: expect.not.stringMatching(/(?:under|max) 280 characters/i),
           },
         ],
         omitMaxTokens: true,
@@ -392,6 +393,8 @@ describe("TwitterDiscoveryClient engagement dedup (#22710)", () => {
       expect(request).not.toHaveProperty("prompt");
       expect(request).not.toHaveProperty("maxTokens");
     }
+    expect(quoteTweetTemplate).not.toMatch(/(?:under|max) 280 characters/i);
+    expect(replyTweetTemplate).not.toMatch(/(?:under|max) 280 characters/i);
   });
 
   it.each([

--- a/plugins/plugin-x/src/discovery.ts
+++ b/plugins/plugin-x/src/discovery.ts
@@ -1082,7 +1082,7 @@ Character bio: ${characterBio}
 
 Keep the reply:
 - Relevant and adding value to the conversation
-- Under 280 characters
+- Complete; the connector will preserve longer output as an ordered thread
 - Natural and conversational
 - Related to your expertise and interests
 - Respectful and constructive
@@ -1120,7 +1120,7 @@ Character bio: ${characterBio}
 
 Create a quote tweet that:
 - Adds unique insight or perspective
-- Is under 280 characters
+- Is complete; the connector will preserve longer output as an ordered thread
 - Respectfully builds on the original idea
 - Showcases your expertise
 - Encourages further discussion

--- a/plugins/plugin-x/src/templates.ts
+++ b/plugins/plugin-x/src/templates.ts
@@ -37,7 +37,7 @@ export const quoteTweetTemplate = `# Task: Write a quote tweet in the voice, sty
 Respond with JSON only, with no prose or fences:
 {
   "thought": "Your thought here, explaining why the quote tweet is meaningful or how it connects to what {{agentName}} cares about",
-  "post": "The quote tweet content here, under 280 characters, without emojis, no questions"
+  "post": "The complete quote tweet content here, without emojis or questions"
 }
 
 Your quote tweet should be:
@@ -46,7 +46,7 @@ Your quote tweet should be:
 - 1 to 3 sentences long, chosen at random
 - No questions, no emojis, concise
 - Use "\\n\\n" (double spaces) between multiple sentences
-- Max 280 characters including line breaks
+- Complete; the connector will preserve longer output as an ordered thread
 
 Your output must only contain the JSON response.`;
 
@@ -58,7 +58,7 @@ export const replyTweetTemplate = `# Task: Write a reply tweet in the voice, sty
 Respond with JSON only, with no prose or fences:
 {
   "thought": "Your thought here, explaining why this reply is meaningful or how it connects to what {{agentName}} cares about",
-  "post": "The reply tweet content here, under 280 characters, without emojis, no questions"
+  "post": "The complete reply tweet content here, without emojis or questions"
 }
 
 Your reply should be:
@@ -67,6 +67,6 @@ Your reply should be:
 - 1 to 2 sentences long, chosen at random
 - No questions, no emojis, concise
 - Use "\\n\\n" (double spaces) between multiple sentences if needed
-- Max 280 characters including line breaks
+- Complete; the connector will preserve longer output as an ordered thread
 
 Your output must only contain the JSON response.`;


### PR DESCRIPTION
## Summary

Finishes #28884 after the post-merge review of #28895.

#28895 made X egress lossless, but four model-facing prompts still instructed the model to keep replies and quotes under/max 280 characters. That suppressed complete content before the new thread delivery path could preserve it. The plugin manifest also advertised an unsupported 4,000-character atomic post default while the runtime schema used 280.

- remove the four generation-time 280-character instructions
- explicitly tell each prompt that complete longer output is preserved as an ordered thread
- change the existing no-hidden-cap regression so capped prompts fail
- align the legacy manifest setting with the provider-sized atomic post boundary and document that complete text is threaded

## Verification

- five focused connector suites: 45/45 pass
- complete plugin-X suite: 362 pass, 13 skip; four unrelated stale baseline failures remain on current `develop` (three PostService tests mock a retired iterator path, one search-routing test expects page size 20 while production uses 100)
- plugin typecheck: pass
- plugin Biome check: pass
- plugin production + DTS build: pass
- CLAUDE/AGENTS parity: pass
- diff check: pass
- deterministic boundary audit: 150 mixed-Unicode URL/emoji/combining-mark inputs reassembled exactly with every post within 280 weighted units; a 10,001-scalar DM reassembled as provider-sized chunks

<!-- evidence-gate -->
<!-- evidence-head:3fe1d6b941eb1208c33db373d24b565b631775c7 -->
<!-- evidence-row:before-screenshots -->
- [x] N/A — model prompt and connector metadata change with no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A — model prompt and connector metadata change with no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A — no visual interaction changed.
<!-- evidence-row:backend-logs -->
- [x] Focused connector and package verification transcript follows.

<details><summary>Verification transcript</summary>

```text
focused connector suites: 5 files passed, 45 tests passed
package gates: TypeScript pass; Biome 100 files pass; production and DTS builds pass
full X suite: 362 passed, 13 skipped, four documented stale baseline assertions failed
```

</details>
<!-- evidence-row:frontend-logs -->
- [x] N/A — no frontend code changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no live-model credentials were available; deterministic prompt capture proves the exact reply and quote model requests contain no 280-character instruction.
<!-- evidence-row:domain-artifacts -->
- [x] Exact lossless-boundary transcript follows.

<details><summary>Lossless delivery audit</summary>

```text
150 deterministic mixed-Unicode strings included URLs, punctuation, astral emoji, ZWJ emoji, combining marks, CJK, mentions, and hashtags
for every case: chunks.join("") === input and twitter-text weightedLength(chunk) <= 280
10,001 astral Unicode scalars in a DM reassembled exactly from chunks of 10,000 and 1 scalars
```

</details>
<!-- evidence-row:ocr-review -->
- [x] N/A — no screenshots or rendered text changed.
<!-- evidence-row:visual-review -->
- [x] N/A — no UI surface changed.
<!-- evidence-row:live-e2e -->
- [x] N/A — this removes model-input constraints and corrects metadata; deterministic prompt capture is the exact changed boundary, and no live X credentials were available.
