### PR TITLE
fix(core): preserve content refs beside falsy values

### DIFF
--- a/packages/core/src/runtime/content-access-manifest.test.ts
+++ b/packages/core/src/runtime/content-access-manifest.test.ts
@@ -101,6 +101,33 @@ describe("deriveCompactionContentManifest", () => {
 		]);
 	});
 
+	it.each([
+		["null field", { view: readView(0, 20), nextCursor: null }],
+		["empty-string field", { view: readView(0, 20), note: "" }],
+		["zero array element", { items: [readView(0, 20), 0] }],
+	])("keeps references next to a falsy %s", (_case, promptData) => {
+		const manifest = deriveCompactionContentManifest(
+			{
+				archivedSteps: [],
+				steps: [
+					{
+						iteration: 1,
+						toolCall: { name: "FILE" },
+						result: { success: true, promptData },
+					},
+				],
+			},
+			{ lastUsedAt: "2026-08-22T12:00:00.000Z" },
+		);
+
+		expect(manifest.contentRefs).toMatchObject([
+			{
+				reference: { ref: "opaque-file" },
+				rangesUsed: [{ unit: "byte", start: 0, end: 20 }],
+			},
+		]);
+	});
+
 	it("fails explicitly instead of silently truncating the manifest", () => {
 		expect(() =>
 			deriveCompactionContentManifest(

--- a/packages/core/src/runtime/content-access-manifest.ts
+++ b/packages/core/src/runtime/content-access-manifest.ts
@@ -161,7 +161,7 @@ export function deriveCompactionContentManifest(
 		const visited = new WeakSet<object>();
 		while (pending.length > 0) {
 			const current = pending.pop();
-			if (!current) break;
+			if (!current) continue;
 			if (isReadView(current)) {
 				addReference(current.reference, reason, {
 					unit: current.slice.range.unit,


### PR DESCRIPTION
## Defect

`deriveCompactionContentManifest` stops scanning a tool result whenever its stack pops a falsy sibling. On current `develop@4c26a6d84753b7a42a1c1bb72468b4306d6178ff`, a real `{ view: ReadView, nextCursor: null }` result returns `contentRefs: []`, making retained continuation content appear unreferenced at the archive/compaction seam.

This changes the walker from `break` to `continue`, so falsy values are skipped without terminating lossless traversal. The original contribution from #28862 is preserved with its author attribution.

## Verification

Exact head `1e7994d0beea500fc1d1858940412357cc4b4179`:

- current-develop reproduction: `contentRefs: []`
- focused manifest suite: 8/8 pass
- core typecheck: pass
- core Biome: pass (untouched warnings only)
- Node/browser/edge/testing bundles and declarations: pass
- package probe after build: blocked only by the local npm wrapper being a shell script invoked through Node
- `git diff --check`: pass

Awaiting hosted exact-head CI; no bypass requested.