### PR TITLE
fix(core): route explicit arithmetic consistently

### DIFF
--- a/packages/core/src/features/basic-capabilities/actions/calculate.ts
+++ b/packages/core/src/features/basic-capabilities/actions/calculate.ts
@@ -1,11 +1,7 @@
 /**
- * CALCULATE — deterministic arithmetic for the chat surface. Language models
- * reliably miscompute multi-digit arithmetic (live 2026-08-24: "3847 times
- * 292" drew three different wrong products across the simple and planner
- * paths), and the chat action surface carries no other compute tool: shell is
- * gate-rejected from chat and a coding sub-agent is a build, not a
- * calculator. The handler parses the expression itself — recursive descent,
- * no eval/Function — so the result is arithmetic, not model recall.
+ * Provides deterministic arithmetic for the general chat action surface.
+ * The handler parses expressions with recursive descent and never delegates
+ * calculation to model recall or dynamic code evaluation.
  *
  * Integer-only expressions (+ - * % and non-negative integer ^) evaluate in
  * BigInt and are exact within the explicit resource boundary below. Anything
@@ -248,9 +244,8 @@ export const calculateAction: Action = {
 	name: "CALCULATE",
 	contexts: ["general"],
 	description:
-		"Exact arithmetic: evaluates a numeric expression (+ - * / % ^ parentheses, decimals, unary minus) deterministically. Use for ANY multi-digit arithmetic instead of computing in your head — model mental math is unreliable and supported integer results are exact.",
-	descriptionCompressed:
-		"exact arithmetic eval; use for any multi-digit math instead of mental math",
+		"Exact arithmetic: evaluates a numeric expression (+ - * / % ^ parentheses, decimals, unary minus) deterministically. Use for arithmetic instead of computing in your head; supported integer results are exact.",
+	descriptionCompressed: "exact arithmetic eval; use instead of mental math",
 	similes: ["MATH", "COMPUTE", "ARITHMETIC", "MULTIPLY", "DIVIDE", "EVAL_MATH"],
 	parameters: [
 		{

--- a/packages/core/src/features/basic-capabilities/calculate.test.ts
+++ b/packages/core/src/features/basic-capabilities/calculate.test.ts
@@ -1,7 +1,6 @@
 /**
- * CALCULATE action: deterministic recursive-descent arithmetic (BigInt-exact
- * integer lane, disclosed float lane), typed rejection of unparseable input,
- * and general-context reachability. Deterministic unit harness; no model.
+ * Exercises deterministic arithmetic, typed invalid-input rejection, action
+ * registration, and direct-request routing without a model.
  */
 import { describe, expect, it } from "vitest";
 import { inferDirectCurrentRequestCandidateActions } from "../../services/message/direct-action-heuristics.ts";
@@ -10,8 +9,7 @@ import { calculateAction, evaluateArithmetic } from "./actions/calculate.ts";
 import { basicActions } from "./index.ts";
 
 describe("evaluateArithmetic", () => {
-	it("computes the live-incident product exactly", () => {
-		// 2026-08-24: the model produced 1,123,186 / 1,122,824 for this ask.
+	it("computes a representative product exactly", () => {
 		expect(evaluateArithmetic("3847 * 292")).toEqual({
 			text: "1123324",
 			exact: true,
@@ -106,7 +104,7 @@ describe("CALCULATE action", () => {
 describe("deterministic arithmetic routing", () => {
 	const actions = [{ name: "CALCULATE", similes: [], tags: [] }];
 
-	it("routes explicit multi-digit arithmetic to CALCULATE", () => {
+	it("routes explicit arithmetic to CALCULATE", () => {
 		for (const text of [
 			"whats 3847 times 292",
 			"3847 * 292?",
@@ -117,6 +115,10 @@ describe("deterministic arithmetic routing", () => {
 			"3847 x 292?",
 			"calculate 2024-2025",
 			"what is 2024-2025?",
+			"whats 17 times 23",
+			"17*23",
+			"what is 17 - 2?",
+			"5/2",
 		]) {
 			expect(inferDirectCurrentRequestCandidateActions(actions, text)).toEqual([
 				"CALCULATE",
@@ -124,9 +126,8 @@ describe("deterministic arithmetic routing", () => {
 		}
 	});
 
-	it("leaves two-digit mental math and ordinary prose on the simple path", () => {
+	it("leaves arithmetic-shaped ordinary prose on the simple path", () => {
 		for (const text of [
-			"whats 17 times 23",
 			"see you at 10 - 11 tomorrow",
 			"i walked 5 x this week",
 			"no math here at all",

--- a/packages/core/src/services/message/direct-action-heuristics.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.ts
@@ -1140,15 +1140,7 @@ export function inferDirectCurrentRequestCandidateActions(
 	).names;
 }
 
-/**
- * Explicit multi-digit arithmetic in the message ("whats 3847 times 292",
- * "1,234 * 56"). Deterministically detectable, and worth routing: models
- * reliably miscompute once any operand reaches three digits (live
- * 2026-08-24: three different wrong products for one ask), while the
- * CALCULATE action is exact. Two-digit mental math stays on the simple path
- * — it is fast and demonstrated reliable — so the detector requires at
- * least one operand of three or more digits (separators ignored).
- */
+/** Detects explicit arithmetic while excluding common range and count prose. */
 const ARITHMETIC_OPERAND = "\\d[\\d,_]*(?:\\.\\d+)?";
 const STRONG_ARITHMETIC_OPERATOR =
 	"(?:\\*\\*|[*×÷^%]|plus|minus|times|multiplied\\s+by|divided\\s+by|over|mod(?:ulo)?|to\\s+the\\s+power\\s+of)";
@@ -1172,25 +1164,12 @@ const BARE_AMBIGUOUS_ARITHMETIC_RE = new RegExp(
 	"iu",
 );
 
-function looksLikeMultiDigitArithmetic(text: string): boolean {
-	const digits = (operand: string) => operand.replace(/[^\d]/g, "").length;
-	const hasLargeOperand = (left: string, right: string) =>
-		digits(left) >= 3 || digits(right) >= 3;
+function looksLikeExplicitArithmetic(text: string): boolean {
 	const strongMatch = STRONG_ARITHMETIC_EXPRESSION_RE.exec(text);
-	if (
-		strongMatch &&
-		hasLargeOperand(strongMatch[1] ?? "", strongMatch[2] ?? "")
-	) {
-		return true;
-	}
+	if (strongMatch) return true;
 
 	const ambiguousMatch = AMBIGUOUS_ARITHMETIC_EXPRESSION_RE.exec(text);
-	if (
-		!ambiguousMatch ||
-		!hasLargeOperand(ambiguousMatch[1] ?? "", ambiguousMatch[5] ?? "")
-	) {
-		return false;
-	}
+	if (!ambiguousMatch) return false;
 	const operator = ambiguousMatch[3] ?? "";
 	const left = ambiguousMatch[1] ?? "";
 	const right = ambiguousMatch[5] ?? "";
@@ -1236,7 +1215,7 @@ export function inferDirectCurrentRequestCandidateInference(
 		const shellAction = findShellDirectActionName(actions);
 		if (shellAction) return { names: [shellAction], kind: "shell" };
 	}
-	if (looksLikeMultiDigitArithmetic(messageText)) {
+	if (looksLikeExplicitArithmetic(messageText)) {
 		const calculateAction = findCalculateActionName(actions);
 		if (calculateAction) {
 			return { names: [calculateAction], kind: "calculate" };


### PR DESCRIPTION
## Summary

- route explicit arithmetic through CALCULATE regardless of operand width
- preserve the existing fail-closed handling for dates, ranges, versions, dimensions, phone-like text, and other ambiguous prose
- replace dated incident/change-history narration in the new calculator files with present responsibility and invariant comments

Closes #28535.

## Verification

- focused calculator and action-retrieval Vitest: 76/76 passed on the exact rebased head
- core typecheck: passed
- exact-file Biome and git diff --check: passed
- full root verify passed on the immediately preceding reviewed base with 375/375 workspace tasks; after rebasing onto current develop at 5de87d5b2d32405c59d0de67c3e19a2ccc7d3dcb, the root gate reaches an unrelated pre-existing formatter failure in packages/cloud/shared/src/lib/voice-session/eliza-sse-bridge.ts, after which UI lint workers are interrupted
- no live-model/provider claim; a live trajectory remains required before readiness because this changes direct action routing

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@5de87d5b2d32405c59d0de67c3e19a2ccc7d3dcb:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [calculator-routing-followup]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@5de87d5b2d32405c59d0de67c3e19a2ccc7d3dcb:packages/skills/skills/contribute-to-eliza"} -->