### PR TITLE
fix(cloud): admit stability membership service

### DIFF
--- a/packages/cloud/e2e/scenarios/cloud-stability-agent.scenario.ts
+++ b/packages/cloud/e2e/scenarios/cloud-stability-agent.scenario.ts
@@ -65,6 +65,7 @@ const syntheticRuntimePolicy = {
     "goals_migration",
     "identity_resolution",
     "lifeops_scheduled_task_runner",
+    "membership",
     "memoryStorage",
     "notification",
     "optimized_prompt",

--- a/packages/cloud/e2e/src/stability/stability-scenario-child.test.ts
+++ b/packages/cloud/e2e/src/stability/stability-scenario-child.test.ts
@@ -8,6 +8,7 @@ import { expect, test } from "bun:test";
 import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { ServiceType } from "@elizaos/core";
 import cloudScenario from "../../scenarios/cloud-stability-agent.scenario.ts";
 
 test("source scenario child exits naturally with zero runtime leaks", async () => {
@@ -16,6 +17,7 @@ test("source scenario child exits naturally with zero runtime leaks", async () =
   );
   try {
     const policy = cloudScenario.contract.syntheticRuntimePolicy;
+    expect(policy.allowedServiceTypes).toContain(ServiceType.MEMBERSHIP);
     const report = path.join(directory, "report.json");
     const quiescence = path.join(directory, "quiescence.json");
     const runtimeLedger = path.join(directory, "runtime.json");


### PR DESCRIPTION
## Summary

Fixes the hosted deterministic Cloud stability failure on the rebased #25269 candidate.

The strict synthetic runtime inventory now declares the production SQL `membership` service. The hosted child previously rejected that registration before scenario execution; the later missing `scenario-report.json` and approximately 205-second attempt durations were secondary watchdog symptoms.

Refs #25268
Refs #22896

## Verification

- Hosted failing artifact: run https://github.com/elizaOS/eliza/actions/runs/32697900019
- Exact error in all three child ledgers: undeclared service `membership`
- Source scenario-child regression: 1/1 passed, 8 assertions, natural exit
- Exact deterministic lane on this commit: first-attempt pass and 3/3
- Attempt durations: 67.6s / 97.0s / 61.4s
- All three child runtime ledgers: zero denied admissions, zero reported errors
- Biome and git diff check: passed
- No real-model credentials or paid model calls

## Evidence

<!-- evidence-head:cbd4c2f8a82f9a7ec68b168083d1dd55461c06cd -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only synthetic runtime admission contract

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only synthetic runtime admission contract

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no rendered UI or user-facing flow changed

<!-- evidence-row:backend-logs -->
- [x] Hosted failure artifact and local exact-three proof summarized above

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - strict deterministic fixtures only; no live model invoked

<!-- evidence-row:domain-artifacts -->
- [x] Exact-three aggregate and child runtime ledgers retained locally; hosted rerun will upload the same artifact class
