### PR TITLE
fix(cloud): preserve canonical FAL credential precedence

### DIFF
--- a/packages/cloud/shared/src/lib/providers/__tests__/fal-image-timeout.test.ts
+++ b/packages/cloud/shared/src/lib/providers/__tests__/fal-image-timeout.test.ts
@@ -46,4 +46,30 @@ describe("Fal image request deadlines", () => {
     expect(image.mimeType).toBe("image/png");
     expect(image.bytes).toEqual(new Uint8Array([1, 2, 3]));
   });
+
+  it("prefers the canonical FAL_API_KEY when both deployment keys exist", async () => {
+    const requests: Request[] = [];
+    const fetchImpl: typeof fetch = async (input, init) => {
+      requests.push(new Request(input, init));
+      if (requests.length === 1) {
+        return Response.json({ images: [{ url: "https://images.invalid/result.png" }] });
+      }
+      return new Response(new Uint8Array([1]), { headers: { "content-type": "image/png" } });
+    };
+
+    await generateFalImageWithFetch(
+      {
+        ...request,
+        apiKeys: {
+          FAL_KEY: "stale-legacy-key",
+          FAL_API_KEY: "canonical-key",
+          FAL_RUN_BASE_URL: "https://fal.invalid",
+        },
+      },
+      fetchImpl,
+      1_000,
+    );
+
+    expect(requests[0].headers.get("authorization")).toBe("Key canonical-key");
+  });
 });

--- a/packages/cloud/shared/src/lib/providers/fal-queue.ts
+++ b/packages/cloud/shared/src/lib/providers/fal-queue.ts
@@ -153,7 +153,9 @@ export async function runFalQueueJob(
 export function falQueueOptionsFromApiKeys(
   apiKeys: Record<string, string | undefined>,
 ): FalQueueOptions {
-  const apiKey = apiKeys.FAL_KEY ?? apiKeys.FAL_API_KEY;
+  // FAL_API_KEY is the canonical deployment secret; retain FAL_KEY only as a
+  // backwards-compatible fallback for older local environments.
+  const apiKey = apiKeys.FAL_API_KEY ?? apiKeys.FAL_KEY;
   if (!apiKey) {
     throw new Error("fal is not configured: missing FAL_KEY / FAL_API_KEY");
   }

--- a/packages/cloud/shared/src/lib/providers/image/fal-image-generation.ts
+++ b/packages/cloud/shared/src/lib/providers/image/fal-image-generation.ts
@@ -94,7 +94,9 @@ export async function generateFalImageWithFetch(
   fetchImpl: typeof fetch,
   generationTimeoutMs = FAL_IMAGE_GENERATION_TIMEOUT_MS,
 ): Promise<GeneratedImage> {
-  const apiKey = request.apiKeys.FAL_KEY ?? request.apiKeys.FAL_API_KEY;
+  // FAL_API_KEY is the canonical deployment secret; retain FAL_KEY only as a
+  // backwards-compatible fallback for older local environments.
+  const apiKey = request.apiKeys.FAL_API_KEY ?? request.apiKeys.FAL_KEY;
   if (!apiKey) {
     throw new Error(getAiProviderConfigurationError());
   }

--- a/packages/cloud/shared/src/lib/providers/video/fal-video-generation.test.ts
+++ b/packages/cloud/shared/src/lib/providers/video/fal-video-generation.test.ts
@@ -158,6 +158,25 @@ describe("FAL video provider", () => {
     });
   });
 
+  test("prefers the canonical FAL_API_KEY when both deployment keys exist", async () => {
+    createFalClient.mockClear();
+    subscribe.mockImplementationOnce(async () => ({
+      request_id: "canonical-key-result",
+      video: { url: "https://fal.media/canonical.mp4" },
+    }));
+
+    await generateFalVideo({
+      model: "fal-ai/veo3",
+      prompt: "a lighthouse",
+      apiKeys: { FAL_KEY: "stale-legacy-key", FAL_API_KEY: "canonical-key" },
+    });
+
+    expect(createFalClient).toHaveBeenCalledWith({
+      credentials: "canonical-key",
+      suppressLocalCredentialsWarning: true,
+    });
+  });
+
   test("rejects missing FAL credentials before calling upstream", async () => {
     createFalClient.mockClear();
 

--- a/packages/cloud/shared/src/lib/providers/video/fal-video-generation.ts
+++ b/packages/cloud/shared/src/lib/providers/video/fal-video-generation.ts
@@ -19,7 +19,9 @@ function isDefinitiveFalRejection(error: unknown): error is InstanceType<typeof 
 }
 
 function falKey(apiKeys: Record<string, string | undefined>): string | null {
-  const key = apiKeys.FAL_KEY ?? apiKeys.FAL_API_KEY;
+  // FAL_API_KEY is the canonical deployment secret; retain FAL_KEY only as a
+  // backwards-compatible fallback for older local environments.
+  const key = apiKeys.FAL_API_KEY ?? apiKeys.FAL_KEY;
   return typeof key === "string" && key.trim() ? key.trim() : null;
 }
 


### PR DESCRIPTION
Closes #28935

## Summary

- restore `FAL_API_KEY` as the canonical credential across FAL queue, image, and video adapters
- retain `FAL_KEY` only as a backwards-compatible fallback
- restore image and video regression tests proving the canonical key wins when both are present
- reconcile the production-only hotfix back into `develop` so the next staged promotion cannot overwrite it

## Validation

- `bun test ./packages/cloud/shared/src/lib/providers/__tests__/fal-image-timeout.test.ts` — 3 pass
- `bun test ./packages/cloud/shared/src/lib/providers/video/fal-video-generation.test.ts` — 22 pass
- `bun run --cwd packages/cloud/shared lint:check` — pass
- `git diff --check` — pass
- package typecheck was resource-starved by concurrent workspace typechecks; hosted exact-head checks remain required

## Evidence

- Before: current `develop` preferred stale `FAL_KEY` and lacked dual-key regression coverage.
- After: all three adapters prefer `FAL_API_KEY`; focused behavioral tests prove the selected credential.
- UI screenshots/video: N/A — server-side provider credential selection only.
- Live provider call: N/A — this deterministic contract selects credentials before the external request and must not expose secrets.
- Production deployment: intentionally not performed; the existing same-tree certification gate remains authoritative.

Failed production admission exposing the skew: https://github.com/elizaOS/eliza/actions/runs/32925185433