### PR TITLE
feat(identity): resolve canonical delivery claims

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -2009,6 +2009,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.5.8",
+        "@elizaos/plugin-sql": "workspace:*",
         "@types/node": "^25.6.0",
         "@typescript/native": "npm:typescript@^7.0.2",
         "typescript": "^6.0.3",

--- a/packages/core/src/features/advanced-capabilities/actions/message.send-routing.test.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/message.send-routing.test.ts
@@ -14,12 +14,15 @@ import type {
 	IAgentRuntime,
 	Memory,
 } from "../../../types/index.ts";
+import { ServiceType } from "../../../types/index.ts";
 import { messageAction } from "./message.ts";
 
 const AGENT_ID = "00000000-0000-0000-0000-000000000001";
 const ROOM_ID = "00000000-0000-0000-0000-0000000000bb";
 const SENDER_ID = "00000000-0000-0000-0000-0000000000cc";
 const SHADOW_ID = "00000000-0000-0000-0000-0000000000e7";
+const DISCORD_ACCOUNT_ID = "00000000-0000-0000-0000-0000000000d1";
+const TELEGRAM_ACCOUNT_ID = "00000000-0000-0000-0000-0000000000d2";
 
 const baseMessage = {
 	id: "00000000-0000-0000-0000-0000000000aa",
@@ -150,9 +153,15 @@ describe("MESSAGE op=send exact-beats-prefix tier (ambiguity over-fire fix)", ()
 });
 
 describe("MESSAGE op=send unresolved recipient asks upfront (no doomed send)", () => {
-	function harness() {
+	function harness(matchingLiteralEntity = false) {
 		const sends: SentMessage[] = [];
 		const cache = new Map<string, unknown>();
+		const literalEntity = {
+			id: SHADOW_ID,
+			agentId: AGENT_ID,
+			names: ["shadow@example.com"],
+			components: [],
+		};
 		const runtime = createMockRuntime({
 			getCache: (async (key: string) =>
 				cache.get(key)) as IAgentRuntime["getCache"],
@@ -175,8 +184,12 @@ describe("MESSAGE op=send unresolved recipient asks upfront (no doomed send)", (
 				},
 			],
 			getRoom: async () => null,
-			getEntitiesForRoom: async () => [],
-			getEntityById: (async () => null) as IAgentRuntime["getEntityById"],
+			getEntitiesForRoom: async () =>
+				matchingLiteralEntity ? [literalEntity] : [],
+			getEntityById: (async (id: string) =>
+				matchingLiteralEntity && id === SHADOW_ID
+					? literalEntity
+					: null) as IAgentRuntime["getEntityById"],
 			getRelationships: (async () => []) as IAgentRuntime["getRelationships"],
 			sendMessageToTarget: async (target, content) => {
 				sends.push({
@@ -211,7 +224,7 @@ describe("MESSAGE op=send unresolved recipient asks upfront (no doomed send)", (
 	});
 
 	it("a literal email address is address-routed and delivers without a contact lookup", async () => {
-		const { runtime, sends } = harness();
+		const { runtime, sends } = harness(true);
 		const result = await send(runtime, {
 			target: "shadow@example.com",
 			message: "stop smoking",
@@ -251,20 +264,7 @@ describe("MESSAGE op=send last-delivered-channel preference", () => {
 			type: string;
 			sourceEntityId: string;
 			data: Record<string, unknown>;
-		}> = [
-			{
-				id: "00000000-0000-0000-0000-0000000000c1",
-				type: "discord",
-				sourceEntityId: AGENT_ID,
-				data: { channelId: "dm-discord" },
-			},
-			{
-				id: "00000000-0000-0000-0000-0000000000c2",
-				type: "telegram",
-				sourceEntityId: AGENT_ID,
-				data: { channelId: "dm-telegram" },
-			},
-		];
+		}> = [];
 		if (withPreference) {
 			components.push({
 				id: "00000000-0000-0000-0000-0000000000c3",
@@ -295,6 +295,27 @@ describe("MESSAGE op=send last-delivered-channel preference", () => {
 					capabilities: [],
 					supportedTargetKinds: ["user", "contact"],
 					contexts: [],
+					resolveTargets: async () => [
+						{
+							target: { source: "discord", channelId: "attacker-hook" },
+							label: "Shadow",
+							kind: "user" as const,
+							score: 1,
+							contexts: [],
+						},
+					],
+					resolveIdentityClaimTarget: async (claim: {
+						externalSubjectId: string;
+					}) => ({
+						identityDeliveryKey: claim.externalSubjectId,
+						target: {
+							source: "discord",
+							entityId: claim.externalSubjectId,
+						},
+						label: claim.externalSubjectId,
+						kind: "user" as const,
+						contexts: [],
+					}),
 				},
 				{
 					source: "telegram",
@@ -302,8 +323,53 @@ describe("MESSAGE op=send last-delivered-channel preference", () => {
 					capabilities: [],
 					supportedTargetKinds: ["user", "contact"],
 					contexts: [],
+					resolveIdentityClaimTarget: async (claim: {
+						externalSubjectId: string;
+					}) => ({
+						identityDeliveryKey: claim.externalSubjectId,
+						target: {
+							source: "telegram",
+							channelId: claim.externalSubjectId,
+						},
+						label: claim.externalSubjectId,
+						kind: "user" as const,
+						contexts: [],
+					}),
 				},
 			],
+			getService: ((serviceType: string) => {
+				if (serviceType !== ServiceType.PRINCIPAL) return null;
+				return {
+					resolveIdentityDeliveryClaim: async (request: {
+						principalId: string;
+						connectorId?: string;
+					}) => {
+						const discord = request.connectorId === "discord";
+						const accountId = discord
+							? DISCORD_ACCOUNT_ID
+							: TELEGRAM_ACCOUNT_ID;
+						const handle = discord ? "@shadow-discord" : "@shadow-telegram";
+						const externalSubjectId = discord
+							? "discord-user-123"
+							: "telegram-chat-456";
+						return {
+							decision: "resolved",
+							requestedPrincipalId: request.principalId,
+							canonicalPrincipalId: SHADOW_ID,
+							generation: 3,
+							claim: {
+								id: discord
+									? "00000000-0000-0000-0000-0000000000f1"
+									: "00000000-0000-0000-0000-0000000000f2",
+								connectorId: request.connectorId,
+								connectorAccountId: accountId,
+								handle,
+								externalSubjectId,
+							},
+						};
+					},
+				};
+			}) as IAgentRuntime["getService"],
 			// The room's source has no registered connector, so the room-first
 			// member path stays out of the way and the entity path is exercised.
 			getRoom: async () => ({ id: ROOM_ID, name: "app", source: "app" }),
@@ -331,7 +397,7 @@ describe("MESSAGE op=send last-delivered-channel preference", () => {
 		return { runtime, sends, upserts };
 	}
 
-	it("without a recorded preference, two stored handles stay ambiguous (baseline)", async () => {
+	it("without a recorded preference, two verified connector claims stay ambiguous", async () => {
 		const { runtime, sends } = harness({ withPreference: false });
 		const message = {
 			...baseMessage,
@@ -346,6 +412,24 @@ describe("MESSAGE op=send last-delivered-channel preference", () => {
 		expect(result.success).toBe(false);
 		expect((result.data as { error?: string })?.error).toBe("TARGET_AMBIGUOUS");
 		expect(sends).toHaveLength(0);
+	});
+
+	it("preserves a connector-owned provider entity target and excludes discovery hooks", async () => {
+		const { runtime, sends } = harness({ withPreference: false });
+		const result = await send(runtime, {
+			source: "discord",
+			target: "shadow",
+			targetKind: "user",
+			message: "stop smoking",
+		});
+
+		expect(result.success).toBe(true);
+		expect(sends).toHaveLength(1);
+		expect(sends[0].target).toMatchObject({
+			source: "discord",
+			entityId: "discord-user-123",
+		});
+		expect(sends[0].target).not.toHaveProperty("channelId");
 	});
 
 	it("prefers the channel the person was last reached on", async () => {
@@ -364,7 +448,7 @@ describe("MESSAGE op=send last-delivered-channel preference", () => {
 		expect(sends).toHaveLength(1);
 		expect(sends[0].target).toMatchObject({
 			source: "telegram",
-			channelId: "dm-telegram",
+			channelId: "telegram-chat-456",
 		});
 		expect(
 			(result.data as { resolutionReasons?: string[] })?.resolutionReasons,

--- a/packages/core/src/features/advanced-capabilities/actions/message.send-routing.test.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/message.send-routing.test.ts
@@ -77,6 +77,7 @@ describe("MESSAGE op=send exact-beats-prefix tier (ambiguity over-fire fix)", ()
 			getEntitiesForRoom: async () => [],
 			getEntityById: (async () => null) as IAgentRuntime["getEntityById"],
 			getRelationships: (async () => []) as IAgentRuntime["getRelationships"],
+			getSetting: (() => null) as IAgentRuntime["getSetting"],
 			sendMessageToTarget: async (target, content) => {
 				sends.push({
 					target: target as unknown as Record<string, unknown>,
@@ -191,6 +192,7 @@ describe("MESSAGE op=send unresolved recipient asks upfront (no doomed send)", (
 					? literalEntity
 					: null) as IAgentRuntime["getEntityById"],
 			getRelationships: (async () => []) as IAgentRuntime["getRelationships"],
+			getSetting: (() => null) as IAgentRuntime["getSetting"],
 			sendMessageToTarget: async (target, content) => {
 				sends.push({
 					target: target as unknown as Record<string, unknown>,
@@ -337,6 +339,10 @@ describe("MESSAGE op=send last-delivered-channel preference", () => {
 					}),
 				},
 			],
+			getSetting: ((key: string) =>
+				key === "IDENTITY_DELIVERY_CLAIMS_AUTHORITATIVE"
+					? "true"
+					: null) as IAgentRuntime["getSetting"],
 			getService: ((serviceType: string) => {
 				if (serviceType !== ServiceType.PRINCIPAL) return null;
 				return {
@@ -572,5 +578,199 @@ describe("MESSAGE op=send admin/owner target (app + connector transports)", () =
 		expect(sends[0].target).toMatchObject({ source: "discord" });
 		expect(sends[0].target.entityId).toBeDefined();
 		expect(resolveTargets).not.toHaveBeenCalled();
+	});
+});
+
+describe("MESSAGE op=send delivery-claim ambiguity is judged on distinct destinations", () => {
+	function harness(options: {
+		claimsAuthoritative: boolean;
+		claims: Array<{
+			id: string;
+			handle: string | null;
+			externalSubjectId: string;
+		}>;
+	}) {
+		const sends: SentMessage[] = [];
+		const entity = {
+			id: SHADOW_ID,
+			names: ["Shadow"],
+			agentId: AGENT_ID,
+			components: [
+				{
+					id: "00000000-0000-0000-0000-0000000000c4",
+					type: "discord",
+					sourceEntityId: AGENT_ID,
+					data: { channelId: "component-dm-shadow" },
+				},
+			],
+		};
+		const runtime = createMockRuntime({
+			agentId: AGENT_ID,
+			logger: { debug() {}, info() {}, warn() {}, error() {} },
+			getMessageConnectors: () => [
+				{
+					source: "discord",
+					label: "Discord",
+					capabilities: [],
+					supportedTargetKinds: ["user", "contact"],
+					contexts: [],
+					resolveIdentityClaimTarget: async (claim: {
+						handle: string | null;
+						externalSubjectId: string;
+					}) => ({
+						identityDeliveryKey: claim.handle ?? claim.externalSubjectId,
+						target: {
+							source: "discord",
+							channelId: claim.handle ?? claim.externalSubjectId,
+						},
+						label: claim.handle ?? claim.externalSubjectId,
+						kind: "user" as const,
+						contexts: [],
+					}),
+				},
+			],
+			getSetting: ((key: string) =>
+				key === "IDENTITY_DELIVERY_CLAIMS_AUTHORITATIVE" &&
+				options.claimsAuthoritative
+					? "true"
+					: null) as IAgentRuntime["getSetting"],
+			getService: ((serviceType: string) => {
+				if (serviceType !== ServiceType.PRINCIPAL) return null;
+				return {
+					resolveIdentityDeliveryClaim: async (request: {
+						principalId: string;
+					}) => {
+						const claims = options.claims.map((claim) => ({
+							...claim,
+							connectorId: "discord",
+							connectorAccountId: DISCORD_ACCOUNT_ID,
+						}));
+						if (claims.length === 1) {
+							return {
+								decision: "resolved",
+								requestedPrincipalId: request.principalId,
+								canonicalPrincipalId: SHADOW_ID,
+								generation: 3,
+								claim: claims[0],
+							};
+						}
+						return {
+							decision: "ambiguous",
+							requestedPrincipalId: request.principalId,
+							canonicalPrincipalId: SHADOW_ID,
+							generation: 3,
+							claims,
+							reason: "multiple_verified_claims",
+						};
+					},
+				};
+			}) as IAgentRuntime["getService"],
+			getRoom: async () => ({ id: ROOM_ID, name: "app", source: "app" }),
+			getEntitiesForRoom: async () => [entity],
+			getWorld: (async () => null) as IAgentRuntime["getWorld"],
+			getEntityById: (async (id: string) =>
+				id === SHADOW_ID ? entity : null) as IAgentRuntime["getEntityById"],
+			getRelationships: (async () => []) as IAgentRuntime["getRelationships"],
+			getMemories: (async () => []) as IAgentRuntime["getMemories"],
+			sendMessageToTarget: async (target, content) => {
+				sends.push({
+					target: target as unknown as Record<string, unknown>,
+					text: String(content.text ?? ""),
+				});
+				return { id: "00000000-0000-0000-0000-0000000000ff" } as Memory;
+			},
+			upsertComponent: (async () =>
+				undefined) as IAgentRuntime["upsertComponent"],
+			useModel: (async () => "not-json") as IAgentRuntime["useModel"],
+			reportError: () => undefined,
+		});
+		return { runtime, sends };
+	}
+
+	const appMessage = {
+		...baseMessage,
+		content: { text: "tell shadow to stop smoking", source: "app" },
+	} as Memory;
+
+	it("two verified claims mapping to one delivery key resolve instead of refusing", async () => {
+		const { runtime, sends } = harness({
+			claimsAuthoritative: true,
+			claims: [
+				{
+					id: "00000000-0000-0000-0000-0000000000f1",
+					handle: "@shadow",
+					externalSubjectId: "discord-user-123",
+				},
+				{
+					id: "00000000-0000-0000-0000-0000000000f2",
+					handle: "@shadow",
+					externalSubjectId: "discord-user-123-alt",
+				},
+			],
+		});
+		const result = await send(
+			runtime,
+			{ target: "shadow", message: "stop smoking" },
+			appMessage,
+		);
+
+		expect(result.success).toBe(true);
+		expect(sends).toHaveLength(1);
+		expect(sends[0].target).toMatchObject({ channelId: "@shadow" });
+	});
+
+	it("claims mapping to distinct delivery keys stay a choice with no duplicate entries", async () => {
+		const { runtime, sends } = harness({
+			claimsAuthoritative: true,
+			claims: [
+				{
+					id: "00000000-0000-0000-0000-0000000000f1",
+					handle: "@shadow-work",
+					externalSubjectId: "discord-user-123",
+				},
+				{
+					id: "00000000-0000-0000-0000-0000000000f2",
+					handle: "@shadow-work",
+					externalSubjectId: "discord-user-123",
+				},
+				{
+					id: "00000000-0000-0000-0000-0000000000f3",
+					handle: "@shadow-personal",
+					externalSubjectId: "discord-user-456",
+				},
+			],
+		});
+		const result = await send(
+			runtime,
+			{ target: "shadow", message: "stop smoking" },
+			appMessage,
+		);
+
+		expect(result.success).toBe(false);
+		expect((result.data as { error?: string })?.error).toBe("TARGET_AMBIGUOUS");
+		const candidates = (
+			result.data as { candidates?: Array<{ label?: string }> }
+		)?.candidates;
+		expect(candidates).toHaveLength(2);
+		expect(sends).toHaveLength(0);
+	});
+
+	it("with the rollout flag off, the legacy entity-component path routes the send", async () => {
+		const { runtime, sends } = harness({
+			claimsAuthoritative: false,
+			claims: [],
+		});
+		const result = await send(
+			runtime,
+			{ target: "shadow", message: "stop smoking" },
+			appMessage,
+		);
+
+		expect(result.success).toBe(true);
+		expect(sends).toHaveLength(1);
+		expect(sends[0].target).toMatchObject({
+			source: "discord",
+			channelId: "component-dm-shadow",
+		});
 	});
 });

--- a/packages/core/src/features/advanced-capabilities/actions/message.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/message.ts
@@ -42,6 +42,7 @@ import type {
 	Content,
 	HandlerOptions,
 	IAgentRuntime,
+	IdentityDeliveryClaimResolution,
 	Media,
 	Memory,
 	MessageConnector,
@@ -50,6 +51,7 @@ import type {
 	MessageConnectorQueryContext,
 	MessageConnectorTarget,
 	MessageTargetKind,
+	PrincipalService,
 	Room,
 	SearchCategoryRegistration,
 	State,
@@ -64,6 +66,7 @@ import {
 	ChannelType,
 	inspectSendHandlerResult,
 	ModelType,
+	ServiceType,
 } from "../../../types/index.ts";
 import { MESSAGE_SOURCE_CLIENT_CHAT } from "../../../types/message-source.ts";
 import { hasActionContext } from "../../../utils/action-validation.ts";
@@ -929,6 +932,14 @@ type SendCandidate = {
 	 * room participant (the room-first name resolution), the member to address
 	 * in the outgoing text. Absent for every other candidate shape. */
 	address?: { entityId: UUID; name: string };
+	/** Canonical evidence that authorized this person/account delivery target. */
+	identityClaim?: {
+		claimId: UUID;
+		canonicalPrincipalId: UUID;
+		connectorAccountId: UUID;
+		generation: number;
+		deliveryKey: string;
+	};
 };
 
 type TargetResolution =
@@ -1506,17 +1517,25 @@ function isUnresolvedPersonFallback(candidate: SendCandidate): boolean {
 	return aliases.has("user") || aliases.has("contact");
 }
 
-function componentString(
-	component: { data?: Record<string, unknown> },
-	keys: string[],
-): string | undefined {
-	for (const key of keys) {
-		const value = component.data?.[key];
-		if (typeof value === "string" && value.trim().length > 0)
-			return value.trim();
-		if (typeof value === "number") return String(value);
-	}
-	return undefined;
+type EntityCandidateCollection =
+	| { status: "not_found"; candidates: [] }
+	| {
+			status: "resolved";
+			candidates: SendCandidate[];
+			requiresChoice: boolean;
+	  }
+	| {
+			status: "no_claim" | "authority_unavailable";
+			candidates: [];
+			principalId: UUID;
+			detail: string;
+	  };
+
+function connectorIdentityAuthorityId(connector: ConnectorWithHooks): string {
+	const service = connector.metadata?.service;
+	return typeof service === "string" && service.trim().length > 0
+		? service.trim()
+		: connector.source;
 }
 
 async function collectEntityCandidates(
@@ -1528,16 +1547,17 @@ async function collectEntityCandidates(
 	targetKind: MessageTargetKind | undefined,
 	sourceWasExact: boolean,
 	accountId?: string,
-): Promise<SendCandidate[]> {
+): Promise<EntityCandidateCollection> {
 	if (
 		!query ||
+		EMAIL_LITERAL.test(query.trim()) ||
 		(targetKind &&
 			!kindAliases(targetKind).has("user") &&
 			!kindAliases(targetKind).has("contact") &&
 			!kindAliases(targetKind).has("email") &&
 			!kindAliases(targetKind).has("phone"))
 	) {
-		return [];
+		return { status: "not_found", candidates: [] };
 	}
 
 	// An entity UUID is already an unambiguous identifier. Resolving it through
@@ -1550,7 +1570,19 @@ async function collectEntityCandidates(
 				{ ...message, content: { ...message.content, text: query } },
 				state ?? ({ values: {}, data: {}, text: "" } as State),
 			);
-	if (!entity?.id) return [];
+	if (!entity?.id) return { status: "not_found", candidates: [] };
+
+	const principalService = runtime.getService<PrincipalService>(
+		ServiceType.PRINCIPAL,
+	);
+	if (!principalService) {
+		return {
+			status: "authority_unavailable",
+			candidates: [],
+			principalId: entity.id as UUID,
+			detail: "The canonical principal service is not registered.",
+		};
+	}
 
 	const label = entity.names[0] ?? query;
 	const preferredSource = preferredDeliverySource(entity);
@@ -1558,51 +1590,130 @@ async function collectEntityCandidates(
 		labelMatchesQuery(name, query),
 	);
 	const candidates: SendCandidate[] = [];
+	const noClaimReasons = new Set<string>();
+	let requiresChoice = false;
 	for (const connector of connectors) {
 		if (!connectorSupportsKind(connector, targetKind ?? "contact")) continue;
-		const matchingComponent = entity.components?.find(
-			(c) =>
-				normalizeComparable(c.type) === normalizeComparable(connector.source),
-		);
-		const target = {
-			source: connector.source,
-			accountId: connector.accountId ?? accountId,
-			entityId: entity.id as UUID,
-		} as TargetInfo;
-		if (matchingComponent) {
-			const channelId = componentString(matchingComponent, [
-				"channelId",
-				"chatId",
-				"conversationId",
-				"phone",
-				"phoneNumber",
-				"email",
-			]);
-			if (channelId) target.channelId = channelId;
-			const roomId = componentString(matchingComponent, ["roomId"]);
-			if (roomId) target.roomId = roomId as UUID;
-			const serverId = componentString(matchingComponent, ["serverId"]);
-			if (serverId) target.serverId = serverId;
+		const requestedAccountId = connector.accountId ?? accountId;
+		if (requestedAccountId && !isUuidLike(requestedAccountId)) {
+			noClaimReasons.add("connector account id is not a canonical UUID");
+			continue;
 		}
+		let resolution: IdentityDeliveryClaimResolution;
+		try {
+			resolution = await principalService.resolveIdentityDeliveryClaim({
+				agentId: runtime.agentId,
+				principalId: entity.id as UUID,
+				connectorId: connectorIdentityAuthorityId(connector),
+				connectorAccountId: requestedAccountId as UUID | undefined,
+			});
+		} catch (error) {
+			// error-policy:J4 canonical identity reads fail closed; connector hooks
+			// cannot replace unavailable delivery authority for a known principal.
+			runtime.reportError("MESSAGE.resolveIdentityDeliveryClaim", error, {
+				principalId: entity.id,
+				connector: connector.source,
+			});
+			return {
+				status: "authority_unavailable",
+				candidates: [],
+				principalId: entity.id as UUID,
+				detail: error instanceof Error ? error.message : String(error),
+			};
+		}
+		if (resolution.decision === "no_claim") {
+			noClaimReasons.add(resolution.reason);
+			continue;
+		}
+		const claims =
+			resolution.decision === "resolved"
+				? [resolution.claim]
+				: [...resolution.claims];
+		requiresChoice ||= resolution.decision === "ambiguous";
+		if (!connector.resolveIdentityClaimTarget) {
+			noClaimReasons.add(
+				`${connector.source} does not map identity claims to delivery targets`,
+			);
+			continue;
+		}
+		const context = buildQueryContext(
+			runtime,
+			message,
+			state,
+			connector.source,
+			undefined,
+			connector,
+			requestedAccountId,
+		);
 		const lastChannel =
 			preferredSource !== undefined &&
 			normalizeComparable(connector.source) ===
 				normalizeComparable(preferredSource);
-		const reasons = matchingComponent ? ["entity", "component"] : ["entity"];
-		if (lastChannel) reasons.push("lastChannel");
-		candidates.push({
-			connector,
-			target,
-			label,
-			kind: targetKind ?? "contact",
-			score:
-				(matchingComponent ? 0.78 : sourceWasExact ? 0.66 : 0.56) +
-				(lastChannel ? LAST_CHANNEL_BONUS : 0),
-			reasons,
-			exact,
-		});
+		for (const claim of claims) {
+			let mapped: MessageConnectorTarget | null;
+			try {
+				mapped = await connector.resolveIdentityClaimTarget(
+					claim,
+					context,
+					resolution.canonicalPrincipalId,
+				);
+			} catch (error) {
+				// error-policy:J4 claim-to-target mapping is connector-owned and must
+				// fail closed; shared routing cannot guess a platform identifier.
+				runtime.reportError("MESSAGE.resolveIdentityClaimTarget", error, {
+					principalId: entity.id,
+					connector: connector.source,
+					claimId: claim.id,
+				});
+				return {
+					status: "authority_unavailable",
+					candidates: [],
+					principalId: entity.id as UUID,
+					detail: error instanceof Error ? error.message : String(error),
+				};
+			}
+			const deliveryKey = mapped?.identityDeliveryKey?.trim();
+			if (!mapped || !deliveryKey) {
+				noClaimReasons.add(
+					`${connector.source} could not map verified claim ${claim.id}`,
+				);
+				continue;
+			}
+			const reasons = ["entity", "canonicalClaim"];
+			if (lastChannel) reasons.push("lastChannel");
+			candidates.push({
+				connector,
+				target: {
+					...mapped.target,
+					source: connector.source,
+					accountId: claim.connectorAccountId,
+				},
+				label: `${label} (${mapped.label || deliveryKey})`,
+				kind: mapped.kind ?? targetKind ?? "contact",
+				score:
+					(sourceWasExact ? 0.86 : 0.8) +
+					(lastChannel ? LAST_CHANNEL_BONUS : 0),
+				reasons,
+				exact,
+				identityClaim: {
+					claimId: claim.id,
+					canonicalPrincipalId: resolution.canonicalPrincipalId,
+					connectorAccountId: claim.connectorAccountId,
+					generation: resolution.generation,
+					deliveryKey,
+				},
+			});
+		}
 	}
-	return candidates;
+	if (candidates.length > 0)
+		return { status: "resolved", candidates, requiresChoice };
+	return {
+		status: "no_claim",
+		candidates: [],
+		principalId: entity.id as UUID,
+		detail:
+			[...noClaimReasons].sort().join(", ") || "no eligible connector claim",
+	};
 }
 
 /** The connector this entity was last successfully reached on, if recorded.
@@ -1994,7 +2105,7 @@ async function resolveSendTarget(
 	// the closest, least-surprising referent for a bare name — resolve to an
 	// in-room utterance addressing them before any connector-wide fuzzy lookup
 	// or contact search gets a chance to misroute the send.
-	if (params.target) {
+	if (params.target && !EMAIL_LITERAL.test(params.target.trim())) {
 		const roomMembers = await currentRoomMemberCandidates(
 			runtime,
 			message,
@@ -2023,43 +2134,72 @@ async function resolveSendTarget(
 	}
 
 	const candidates: SendCandidate[] = [];
-
-	for (const connector of considered) {
-		const context = buildQueryContext(
-			runtime,
-			message,
-			state,
-			connector.source,
-			undefined,
-			connector,
-			params.accountId,
-		);
-		candidates.push(
-			...(await collectHookTargets(
-				runtime,
-				connector,
-				params.target,
-				context,
-				params.targetKind,
-				sourceWasExact,
-				params.accountId,
-			)),
-		);
-	}
-	candidates.push(
-		...(await collectEntityCandidates(
-			runtime,
-			message,
-			state,
-			params.target,
-			considered,
-			params.targetKind,
-			sourceWasExact,
-			params.accountId,
-		)),
+	const entityCandidates = await collectEntityCandidates(
+		runtime,
+		message,
+		state,
+		params.target,
+		considered,
+		params.targetKind,
+		sourceWasExact,
+		params.accountId,
 	);
+	if (entityCandidates.status === "authority_unavailable") {
+		return {
+			status: "missing_target",
+			text: `MESSAGE op=send cannot resolve canonical delivery authority for principal ${entityCandidates.principalId}: ${entityCandidates.detail}`,
+			error: "TARGET_IDENTITY_AUTHORITY_UNAVAILABLE",
+			sourceResolution: params.sourceResolution,
+		};
+	}
+	if (entityCandidates.status === "no_claim") {
+		return {
+			status: "missing_target",
+			text:
+				`MESSAGE op=send found principal ${entityCandidates.principalId}, but no active verified delivery claim matches the selected connector/account (${entityCandidates.detail}). ` +
+				"Ask the user for a literal address or link and verify the connector identity before retrying.",
+			error: "TARGET_DELIVERY_CLAIM_MISSING",
+			sourceResolution: params.sourceResolution,
+		};
+	}
+	if (entityCandidates.status === "resolved") {
+		if (entityCandidates.requiresChoice) {
+			return {
+				status: "ambiguous",
+				text:
+					"MESSAGE op=send found multiple active verified delivery claims. Pick one:\n" +
+					formatCandidates(entityCandidates.candidates),
+				candidates: entityCandidates.candidates,
+				sourceResolution: params.source ? "exact" : "inferred",
+			};
+		}
+		candidates.push(...entityCandidates.candidates);
+	} else {
+		for (const connector of considered) {
+			const context = buildQueryContext(
+				runtime,
+				message,
+				state,
+				connector.source,
+				undefined,
+				connector,
+				params.accountId,
+			);
+			candidates.push(
+				...(await collectHookTargets(
+					runtime,
+					connector,
+					params.target,
+					context,
+					params.targetKind,
+					sourceWasExact,
+					params.accountId,
+				)),
+			);
+		}
+	}
 
-	if (params.target) {
+	if (params.target && entityCandidates.status === "not_found") {
 		for (const connector of considered) {
 			candidates.push(
 				explicitSendTarget(
@@ -2202,6 +2342,7 @@ async function recordDeliveryPreference(
 	const entityIdRaw = String(target.entityId ?? "").trim();
 	const entityId =
 		candidate.address?.entityId ??
+		candidate.identityClaim?.canonicalPrincipalId ??
 		(isUuidLike(entityIdRaw) ? (entityIdRaw as UUID) : undefined);
 	if (
 		!entityId ||
@@ -2605,7 +2746,7 @@ async function ensureSendAccountAllowed(
 const RECIPIENT_VETTED_REASONS = new Set([
 	"admin",
 	"entity",
-	"component",
+	"canonicalClaim",
 	"currentRoom",
 	"currentRoomMember",
 ]);
@@ -2798,14 +2939,18 @@ async function handleSend(
 			? `@${selected.address.name} ${normalized.message}`.trim()
 			: normalized.message;
 
-	const content = applyContentShaping(
-		selected.connector,
-		buildContent({
-			...normalized,
-			message: outboundMessage,
-			source: selected.connector.source,
-		}),
-	);
+	const builtContent = buildContent({
+		...normalized,
+		message: outboundMessage,
+		source: selected.connector.source,
+	});
+	if (selected.identityClaim) {
+		builtContent.metadata = {
+			...(isRecord(builtContent.metadata) ? builtContent.metadata : {}),
+			identityDeliveryClaim: selected.identityClaim,
+		};
+	}
+	const content = applyContentShaping(selected.connector, builtContent);
 
 	let persisted: Memory | undefined;
 	let providerMessageId: string | undefined;
@@ -3023,6 +3168,7 @@ async function handleSend(
 			targetKind: selected.kind,
 			sourceResolution: resolution.sourceResolution,
 			resolutionReasons: selected.reasons,
+			identityDeliveryClaim: selected.identityClaim,
 			thread: normalized.thread,
 			urgency: normalized.urgency,
 			memoryId: persisted?.id,

--- a/packages/core/src/features/advanced-capabilities/actions/message.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/message.ts
@@ -64,6 +64,8 @@ import {
 	buildReadSlice,
 	CANONICAL_MESSAGE_TARGET_KINDS,
 	ChannelType,
+	IDENTITY_DELIVERY_CLAIMS_AUTHORITATIVE_SETTING,
+	identityDeliveryClaimsAuthoritative,
 	inspectSendHandlerResult,
 	ModelType,
 	ServiceType,
@@ -1538,6 +1540,128 @@ function connectorIdentityAuthorityId(connector: ConnectorWithHooks): string {
 		: connector.source;
 }
 
+/**
+ * Rollout gate for claim-authoritative delivery. Until the identity-claim
+ * ingestion slice (issue #23099) ships, no runtime path writes claims, so the
+ * claim-mandatory branch would refuse every contact send; the legacy
+ * entity-component path stays authoritative unless an operator opts in via
+ * the IDENTITY_DELIVERY_CLAIMS_AUTHORITATIVE setting.
+ */
+function claimDeliveryAuthoritative(runtime: IAgentRuntime): boolean {
+	return identityDeliveryClaimsAuthoritative(
+		runtime.getSetting(IDENTITY_DELIVERY_CLAIMS_AUTHORITATIVE_SETTING),
+	);
+}
+
+function componentString(
+	component: { data?: Record<string, unknown> },
+	keys: string[],
+): string | undefined {
+	for (const key of keys) {
+		const value = component.data?.[key];
+		if (typeof value === "string" && value.trim().length > 0)
+			return value.trim();
+		if (typeof value === "number") return String(value);
+	}
+	return undefined;
+}
+
+/**
+ * Legacy (pre-claim-authority) entity candidate collection: the entity store
+ * plus stored connector components supply delivery coordinates. Active only
+ * while {@link claimDeliveryAuthoritative} is off; the claim-based collector
+ * replaces it once verified identity claims are ingested and opted in.
+ */
+async function collectLegacyEntityCandidates(
+	runtime: IAgentRuntime,
+	message: Memory,
+	state: State | undefined,
+	query: string | undefined,
+	connectors: ConnectorWithHooks[],
+	targetKind: MessageTargetKind | undefined,
+	sourceWasExact: boolean,
+	accountId?: string,
+): Promise<SendCandidate[]> {
+	// An email literal is a typed address, not a contact name: it routes on the
+	// explicit-address path in both delivery modes rather than through entity
+	// lookup heuristics.
+	if (
+		!query ||
+		EMAIL_LITERAL.test(query.trim()) ||
+		(targetKind &&
+			!kindAliases(targetKind).has("user") &&
+			!kindAliases(targetKind).has("contact") &&
+			!kindAliases(targetKind).has("email") &&
+			!kindAliases(targetKind).has("phone"))
+	) {
+		return [];
+	}
+
+	// An entity UUID is already an unambiguous identifier. Resolving it through
+	// the language model makes deterministic connector sends depend on provider
+	// availability and can reinterpret an exact target as a name.
+	const entity = isUuidLike(query)
+		? await runtime.getEntityById(query)
+		: await findEntityByName(
+				runtime,
+				{ ...message, content: { ...message.content, text: query } },
+				state ?? ({ values: {}, data: {}, text: "" } as State),
+			);
+	if (!entity?.id) return [];
+
+	const label = entity.names[0] ?? query;
+	const preferredSource = preferredDeliverySource(entity);
+	const exact = entityDisplayNames(entity).some((name) =>
+		labelMatchesQuery(name, query),
+	);
+	const candidates: SendCandidate[] = [];
+	for (const connector of connectors) {
+		if (!connectorSupportsKind(connector, targetKind ?? "contact")) continue;
+		const matchingComponent = entity.components?.find(
+			(c) =>
+				normalizeComparable(c.type) === normalizeComparable(connector.source),
+		);
+		const target = {
+			source: connector.source,
+			accountId: connector.accountId ?? accountId,
+			entityId: entity.id as UUID,
+		} as TargetInfo;
+		if (matchingComponent) {
+			const channelId = componentString(matchingComponent, [
+				"channelId",
+				"chatId",
+				"conversationId",
+				"phone",
+				"phoneNumber",
+				"email",
+			]);
+			if (channelId) target.channelId = channelId;
+			const roomId = componentString(matchingComponent, ["roomId"]);
+			if (roomId) target.roomId = roomId as UUID;
+			const serverId = componentString(matchingComponent, ["serverId"]);
+			if (serverId) target.serverId = serverId;
+		}
+		const lastChannel =
+			preferredSource !== undefined &&
+			normalizeComparable(connector.source) ===
+				normalizeComparable(preferredSource);
+		const reasons = matchingComponent ? ["entity", "component"] : ["entity"];
+		if (lastChannel) reasons.push("lastChannel");
+		candidates.push({
+			connector,
+			target,
+			label,
+			kind: targetKind ?? "contact",
+			score:
+				(matchingComponent ? 0.78 : sourceWasExact ? 0.66 : 0.56) +
+				(lastChannel ? LAST_CHANNEL_BONUS : 0),
+			reasons,
+			exact,
+		});
+	}
+	return candidates;
+}
+
 async function collectEntityCandidates(
 	runtime: IAgentRuntime,
 	message: Memory,
@@ -1629,7 +1753,6 @@ async function collectEntityCandidates(
 			resolution.decision === "resolved"
 				? [resolution.claim]
 				: [...resolution.claims];
-		requiresChoice ||= resolution.decision === "ambiguous";
 		if (!connector.resolveIdentityClaimTarget) {
 			noClaimReasons.add(
 				`${connector.source} does not map identity claims to delivery targets`,
@@ -1649,6 +1772,12 @@ async function collectEntityCandidates(
 			preferredSource !== undefined &&
 			normalizeComparable(connector.source) ===
 				normalizeComparable(preferredSource);
+		// Ambiguity is judged on distinct delivery destinations, not raw claim
+		// rows: several verified claims that map to the same connector-owned
+		// delivery key (for example one address observed as both handle and
+		// subject) are one destination, and the choice list must never show
+		// identical entries.
+		const candidatesByDeliveryKey = new Map<string, SendCandidate>();
 		for (const claim of claims) {
 			let mapped: MessageConnectorTarget | null;
 			try {
@@ -1679,9 +1808,10 @@ async function collectEntityCandidates(
 				);
 				continue;
 			}
+			if (candidatesByDeliveryKey.has(deliveryKey)) continue;
 			const reasons = ["entity", "canonicalClaim"];
 			if (lastChannel) reasons.push("lastChannel");
-			candidates.push({
+			candidatesByDeliveryKey.set(deliveryKey, {
 				connector,
 				target: {
 					...mapped.target,
@@ -1704,6 +1834,8 @@ async function collectEntityCandidates(
 				},
 			});
 		}
+		requiresChoice ||= candidatesByDeliveryKey.size > 1;
+		candidates.push(...candidatesByDeliveryKey.values());
 	}
 	if (candidates.length > 0)
 		return { status: "resolved", candidates, requiresChoice };
@@ -2101,10 +2233,14 @@ async function resolveSendTarget(
 		if (currentConnector) considered = [currentConnector];
 	}
 
+	const claimsAuthoritative = claimDeliveryAuthoritative(runtime);
+
 	// Check the room before the rolodex: someone present in the current room is
 	// the closest, least-surprising referent for a bare name — resolve to an
 	// in-room utterance addressing them before any connector-wide fuzzy lookup
-	// or contact search gets a chance to misroute the send.
+	// or contact search gets a chance to misroute the send. An email literal
+	// skips the room shortcut in both delivery modes so a typed address always
+	// reaches the literal-address path instead of a same-named room member.
 	if (params.target && !EMAIL_LITERAL.test(params.target.trim())) {
 		const roomMembers = await currentRoomMemberCandidates(
 			runtime,
@@ -2134,46 +2270,76 @@ async function resolveSendTarget(
 	}
 
 	const candidates: SendCandidate[] = [];
-	const entityCandidates = await collectEntityCandidates(
-		runtime,
-		message,
-		state,
-		params.target,
-		considered,
-		params.targetKind,
-		sourceWasExact,
-		params.accountId,
-	);
-	if (entityCandidates.status === "authority_unavailable") {
-		return {
-			status: "missing_target",
-			text: `MESSAGE op=send cannot resolve canonical delivery authority for principal ${entityCandidates.principalId}: ${entityCandidates.detail}`,
-			error: "TARGET_IDENTITY_AUTHORITY_UNAVAILABLE",
-			sourceResolution: params.sourceResolution,
-		};
-	}
-	if (entityCandidates.status === "no_claim") {
-		return {
-			status: "missing_target",
-			text:
-				`MESSAGE op=send found principal ${entityCandidates.principalId}, but no active verified delivery claim matches the selected connector/account (${entityCandidates.detail}). ` +
-				"Ask the user for a literal address or link and verify the connector identity before retrying.",
-			error: "TARGET_DELIVERY_CLAIM_MISSING",
-			sourceResolution: params.sourceResolution,
-		};
-	}
-	if (entityCandidates.status === "resolved") {
-		if (entityCandidates.requiresChoice) {
+	// Under claim authority a resolved principal short-circuits hook lookups
+	// and explicit fallbacks; the legacy path keeps the pre-claim behavior of
+	// merging hook, entity-component, and explicit candidates into one ranking.
+	let claimEntityFound = false;
+	if (claimsAuthoritative) {
+		const entityCandidates = await collectEntityCandidates(
+			runtime,
+			message,
+			state,
+			params.target,
+			considered,
+			params.targetKind,
+			sourceWasExact,
+			params.accountId,
+		);
+		if (entityCandidates.status === "authority_unavailable") {
 			return {
-				status: "ambiguous",
-				text:
-					"MESSAGE op=send found multiple active verified delivery claims. Pick one:\n" +
-					formatCandidates(entityCandidates.candidates),
-				candidates: entityCandidates.candidates,
-				sourceResolution: params.source ? "exact" : "inferred",
+				status: "missing_target",
+				text: `MESSAGE op=send cannot resolve canonical delivery authority for principal ${entityCandidates.principalId}: ${entityCandidates.detail}`,
+				error: "TARGET_IDENTITY_AUTHORITY_UNAVAILABLE",
+				sourceResolution: params.sourceResolution,
 			};
 		}
-		candidates.push(...entityCandidates.candidates);
+		if (entityCandidates.status === "no_claim") {
+			return {
+				status: "missing_target",
+				text:
+					`MESSAGE op=send found principal ${entityCandidates.principalId}, but no active verified delivery claim matches the selected connector/account (${entityCandidates.detail}). ` +
+					"Ask the user for a literal address or link and verify the connector identity before retrying.",
+				error: "TARGET_DELIVERY_CLAIM_MISSING",
+				sourceResolution: params.sourceResolution,
+			};
+		}
+		if (entityCandidates.status === "resolved") {
+			if (entityCandidates.requiresChoice) {
+				return {
+					status: "ambiguous",
+					text:
+						"MESSAGE op=send found multiple active verified delivery claims. Pick one:\n" +
+						formatCandidates(entityCandidates.candidates),
+					candidates: entityCandidates.candidates,
+					sourceResolution: params.source ? "exact" : "inferred",
+				};
+			}
+			claimEntityFound = true;
+			candidates.push(...entityCandidates.candidates);
+		} else {
+			for (const connector of considered) {
+				const context = buildQueryContext(
+					runtime,
+					message,
+					state,
+					connector.source,
+					undefined,
+					connector,
+					params.accountId,
+				);
+				candidates.push(
+					...(await collectHookTargets(
+						runtime,
+						connector,
+						params.target,
+						context,
+						params.targetKind,
+						sourceWasExact,
+						params.accountId,
+					)),
+				);
+			}
+		}
 	} else {
 		for (const connector of considered) {
 			const context = buildQueryContext(
@@ -2197,9 +2363,21 @@ async function resolveSendTarget(
 				)),
 			);
 		}
+		candidates.push(
+			...(await collectLegacyEntityCandidates(
+				runtime,
+				message,
+				state,
+				params.target,
+				considered,
+				params.targetKind,
+				sourceWasExact,
+				params.accountId,
+			)),
+		);
 	}
 
-	if (params.target && entityCandidates.status === "not_found") {
+	if (params.target && !claimEntityFound) {
 		for (const connector of considered) {
 			candidates.push(
 				explicitSendTarget(
@@ -2746,6 +2924,7 @@ async function ensureSendAccountAllowed(
 const RECIPIENT_VETTED_REASONS = new Set([
 	"admin",
 	"entity",
+	"component",
 	"canonicalClaim",
 	"currentRoom",
 	"currentRoomMember",

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -1114,6 +1114,8 @@ function normalizeMessageConnector(
 	if (metadata.metadata) connector.metadata = { ...metadata.metadata };
 	if (metadata.resolveTargets)
 		connector.resolveTargets = metadata.resolveTargets;
+	if (metadata.resolveIdentityClaimTarget)
+		connector.resolveIdentityClaimTarget = metadata.resolveIdentityClaimTarget;
 	if (metadata.listRecentTargets)
 		connector.listRecentTargets = metadata.listRecentTargets;
 	if (metadata.listRooms) connector.listRooms = metadata.listRooms;

--- a/packages/core/src/runtime/__tests__/message-post-connectors.test.ts
+++ b/packages/core/src/runtime/__tests__/message-post-connectors.test.ts
@@ -44,12 +44,14 @@ describe("message and post connector registries", () => {
 		} as Memory;
 		const sendHandler = vi.fn(async () => sentMemory);
 		const fetchMessages = vi.fn(async () => [] as Memory[]);
+		const resolveIdentityClaimTarget = vi.fn(async () => null);
 
 		runtime.registerMessageConnector({
 			source: "chat",
 			label: "Chat",
 			sendHandler,
 			fetchMessages,
+			resolveIdentityClaimTarget,
 			capabilities: ["send_message", "read_messages"],
 			supportedTargetKinds: ["room"],
 		});
@@ -69,6 +71,11 @@ describe("message and post connector registries", () => {
 			),
 		).toEqual(["archive", "chat"]);
 		expect(getMessageConnectorsWithHook(runtime, "resolveTargets")).toEqual([]);
+		expect(
+			getMessageConnectorsWithHook(runtime, "resolveIdentityClaimTarget").map(
+				(connector) => connector.source,
+			),
+		).toEqual(["chat"]);
 
 		const target = makeTarget("chat");
 		const content: Content = { text: "hello", source: "chat" };

--- a/packages/core/src/testing/mock-runtime.ts
+++ b/packages/core/src/testing/mock-runtime.ts
@@ -70,6 +70,10 @@ export function createMockRuntime(
 		services: new Map(),
 		stateCache: new Map(),
 		reportError: () => undefined,
+		// An unset setting reads as null on the real runtime; defaulting it here
+		// keeps setting-gated code paths on their default branch in unit tests
+		// unless a test overrides specific keys.
+		getSetting: () => null,
 		...overrides,
 	};
 

--- a/packages/core/src/types/identity-delivery-claim.test.ts
+++ b/packages/core/src/types/identity-delivery-claim.test.ts
@@ -1,0 +1,310 @@
+/**
+ * Exercises the shared PrincipalService delivery-claim resolution pipeline —
+ * the concrete logic in core that every backend inherits: refusal reasons for
+ * missing/filtered claims, the connector-account eligibility hook (including
+ * the base-owned `connector_account_ineligible` refusal), deterministic
+ * ambiguous ordering, and the fail-closed flag parser. Deterministic in-memory
+ * subclass; no runtime, DB, or model.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+	type IdentityClaim,
+	type IdentityCluster,
+	identityDeliveryClaimsAuthoritative,
+	orderIdentityDeliveryClaims,
+	PrincipalService,
+} from "./identity";
+import type { UUID } from "./primitives";
+
+const AGENT_ID = "00000000-0000-0000-0000-000000000001" as UUID;
+const PRINCIPAL_ID = "00000000-0000-0000-0000-0000000000aa" as UUID;
+const ACCOUNT_A = "00000000-0000-0000-0000-0000000000d1" as UUID;
+const ACCOUNT_B = "00000000-0000-0000-0000-0000000000d2" as UUID;
+
+function makeClaim(
+	overrides: Partial<IdentityClaim> & { id: UUID },
+): IdentityClaim {
+	return {
+		contractVersion: 1,
+		agentId: AGENT_ID,
+		principalEntityId: PRINCIPAL_ID,
+		namespace: "default",
+		connectorId: "google",
+		connectorAccountId: ACCOUNT_A,
+		externalSubjectId: "subject-1",
+		handle: "person@example.com",
+		displayName: null,
+		verification: "verified",
+		status: "active",
+		confidence: 1,
+		ownerBindingId: null,
+		provenance: {},
+		evidence: {},
+		firstSeenAt: "2026-01-01T00:00:00.000Z",
+		lastSeenAt: "2026-01-01T00:00:00.000Z",
+		verifiedAt: "2026-01-01T00:00:00.000Z",
+		revokedAt: null,
+		createdAt: "2026-01-01T00:00:00.000Z",
+		updatedAt: "2026-01-01T00:00:00.000Z",
+		...overrides,
+	};
+}
+
+function makeCluster(claims: IdentityClaim[]): IdentityCluster {
+	return {
+		contractVersion: 1,
+		agentId: AGENT_ID,
+		canonicalPrincipalId: PRINCIPAL_ID,
+		principalIds: [PRINCIPAL_ID],
+		claims,
+		generation: 7,
+		readAt: "2026-01-01T00:00:00.000Z",
+	};
+}
+
+/**
+ * Minimal in-memory PrincipalService: only the members the shared delivery
+ * pipeline touches are real (cluster read + eligibility hook); everything
+ * else throws so an unexpected call fails the test loudly.
+ */
+class FakePrincipalService extends PrincipalService {
+	constructor(
+		private readonly cluster: IdentityCluster | null,
+		private readonly eligibleAccountIds: readonly UUID[] | "all" = "all",
+	) {
+		super();
+	}
+	readonly eligibilityCalls: Array<readonly IdentityClaim[]> = [];
+
+	async getCluster(): Promise<IdentityCluster | null> {
+		return this.cluster;
+	}
+	protected async filterConnectorAccountEligibleClaims(
+		_agentId: UUID,
+		claims: readonly IdentityClaim[],
+	): Promise<readonly IdentityClaim[]> {
+		this.eligibilityCalls.push(claims);
+		if (this.eligibleAccountIds === "all") return claims;
+		return claims.filter((claim) =>
+			this.eligibleAccountIds.includes(claim.connectorAccountId),
+		);
+	}
+	async stop(): Promise<void> {}
+
+	private unexercised(): never {
+		throw new Error(
+			"FakePrincipalService: member not exercised by the delivery pipeline",
+		);
+	}
+	resolveCanonicalPrincipal(): never {
+		return this.unexercised();
+	}
+	resolveForDisplay(): never {
+		return this.unexercised();
+	}
+	resolveForDataAccess(): never {
+		return this.unexercised();
+	}
+	resolveClaim(): never {
+		return this.unexercised();
+	}
+	resolveVerifiedDeliveryClaims(): never {
+		return this.unexercised();
+	}
+	evaluateOwnerBinding(): never {
+		return this.unexercised();
+	}
+	attestPersonLink(): never {
+		return this.unexercised();
+	}
+	verifyPersonLink(): never {
+		return this.unexercised();
+	}
+	proposeMerge(): never {
+		return this.unexercised();
+	}
+	confirmMerge(): never {
+		return this.unexercised();
+	}
+	commitMerge(): never {
+		return this.unexercised();
+	}
+	split(): never {
+		return this.unexercised();
+	}
+	getJournal(): never {
+		return this.unexercised();
+	}
+	listRedirects(): never {
+		return this.unexercised();
+	}
+	listJournal(): never {
+		return this.unexercised();
+	}
+}
+
+const baseRequest = {
+	agentId: AGENT_ID,
+	principalId: PRINCIPAL_ID,
+	connectorId: "google",
+	connectorAccountId: ACCOUNT_A,
+};
+
+describe("PrincipalService.resolveIdentityDeliveryClaim (shared pipeline)", () => {
+	it("refuses an unknown principal before any claim filtering", async () => {
+		const service = new FakePrincipalService(null);
+		const resolution = await service.resolveIdentityDeliveryClaim(baseRequest);
+		expect(resolution).toMatchObject({
+			decision: "no_claim",
+			reason: "principal_not_found",
+			canonicalPrincipalId: null,
+		});
+		expect(service.eligibilityCalls).toHaveLength(0);
+	});
+
+	it("refuses when only unverified or inactive claims exist", async () => {
+		const service = new FakePrincipalService(
+			makeCluster([
+				makeClaim({
+					id: "00000000-0000-0000-0000-0000000000f1" as UUID,
+					verification: "observed",
+				}),
+				makeClaim({
+					id: "00000000-0000-0000-0000-0000000000f2" as UUID,
+					status: "revoked",
+				}),
+			]),
+		);
+		const resolution = await service.resolveIdentityDeliveryClaim(baseRequest);
+		expect(resolution).toMatchObject({
+			decision: "no_claim",
+			reason: "no_active_verified_claim",
+		});
+	});
+
+	it("scopes to the requested connector and account", async () => {
+		const service = new FakePrincipalService(
+			makeCluster([
+				makeClaim({
+					id: "00000000-0000-0000-0000-0000000000f1" as UUID,
+					connectorId: "discord",
+				}),
+			]),
+		);
+		expect(
+			await service.resolveIdentityDeliveryClaim(baseRequest),
+		).toMatchObject({ decision: "no_claim", reason: "no_connector_claim" });
+
+		const accountScoped = new FakePrincipalService(
+			makeCluster([
+				makeClaim({
+					id: "00000000-0000-0000-0000-0000000000f1" as UUID,
+					connectorAccountId: ACCOUNT_B,
+				}),
+			]),
+		);
+		expect(
+			await accountScoped.resolveIdentityDeliveryClaim(baseRequest),
+		).toMatchObject({ decision: "no_claim", reason: "no_account_claim" });
+	});
+
+	it("returns connector_account_ineligible when the eligibility hook rejects every claim", async () => {
+		const service = new FakePrincipalService(
+			makeCluster([
+				makeClaim({ id: "00000000-0000-0000-0000-0000000000f1" as UUID }),
+			]),
+			[],
+		);
+		const resolution = await service.resolveIdentityDeliveryClaim(baseRequest);
+		expect(resolution).toMatchObject({
+			decision: "no_claim",
+			reason: "connector_account_ineligible",
+			canonicalPrincipalId: PRINCIPAL_ID,
+			generation: 7,
+		});
+		expect(service.eligibilityCalls).toHaveLength(1);
+	});
+
+	it("resolves the sole eligible claim after the hook filters the rest", async () => {
+		const eligible = makeClaim({
+			id: "00000000-0000-0000-0000-0000000000f1" as UUID,
+		});
+		const ineligible = makeClaim({
+			id: "00000000-0000-0000-0000-0000000000f2" as UUID,
+			connectorAccountId: ACCOUNT_B,
+		});
+		const service = new FakePrincipalService(
+			makeCluster([ineligible, eligible]),
+			[ACCOUNT_A],
+		);
+		const resolution = await service.resolveIdentityDeliveryClaim({
+			...baseRequest,
+			connectorAccountId: undefined,
+		});
+		expect(resolution).toMatchObject({
+			decision: "resolved",
+			claim: { id: eligible.id },
+			generation: 7,
+		});
+	});
+
+	it("orders ambiguous claims by the canonical multi-key comparator, not raw id order", async () => {
+		// Ids are chosen so id-only ordering would reverse the expected result:
+		// the claim with the LOWER handle carries the HIGHER id.
+		const later = makeClaim({
+			id: "00000000-0000-0000-0000-00000000000a" as UUID,
+			handle: "zed@example.com",
+			externalSubjectId: "subject-z",
+		});
+		const earlier = makeClaim({
+			id: "00000000-0000-0000-0000-00000000000b" as UUID,
+			handle: "alice@example.com",
+			externalSubjectId: "subject-a",
+		});
+		const service = new FakePrincipalService(makeCluster([later, earlier]));
+		const resolution = await service.resolveIdentityDeliveryClaim(baseRequest);
+		if (resolution.decision !== "ambiguous") {
+			throw new Error(`expected ambiguous, got ${resolution.decision}`);
+		}
+		expect(resolution.claims.map((claim) => claim.id)).toEqual([
+			earlier.id,
+			later.id,
+		]);
+		expect(resolution.claims).toEqual(
+			orderIdentityDeliveryClaims([later, earlier]),
+		);
+	});
+
+	it("ignores namespace for eligibility: claims differing only by namespace both survive scoping", async () => {
+		const a = makeClaim({
+			id: "00000000-0000-0000-0000-0000000000f1" as UUID,
+			namespace: "workspace-a",
+		});
+		const b = makeClaim({
+			id: "00000000-0000-0000-0000-0000000000f2" as UUID,
+			namespace: "workspace-b",
+		});
+		const service = new FakePrincipalService(makeCluster([a, b]));
+		const resolution = await service.resolveIdentityDeliveryClaim(baseRequest);
+		expect(resolution.decision).toBe("ambiguous");
+		if (resolution.decision === "ambiguous") {
+			expect(resolution.claims).toHaveLength(2);
+		}
+	});
+});
+
+describe("identityDeliveryClaimsAuthoritative flag parsing", () => {
+	it("opts in only on explicit affirmative values and fails closed otherwise", () => {
+		expect(identityDeliveryClaimsAuthoritative(true)).toBe(true);
+		expect(identityDeliveryClaimsAuthoritative("true")).toBe(true);
+		expect(identityDeliveryClaimsAuthoritative(" ON ")).toBe(true);
+		expect(identityDeliveryClaimsAuthoritative("1")).toBe(true);
+		expect(identityDeliveryClaimsAuthoritative(undefined)).toBe(false);
+		expect(identityDeliveryClaimsAuthoritative(null)).toBe(false);
+		expect(identityDeliveryClaimsAuthoritative(false)).toBe(false);
+		expect(identityDeliveryClaimsAuthoritative("false")).toBe(false);
+		expect(identityDeliveryClaimsAuthoritative("enabled?")).toBe(false);
+		expect(identityDeliveryClaimsAuthoritative(1)).toBe(false);
+	});
+});

--- a/packages/core/src/types/identity.ts
+++ b/packages/core/src/types/identity.ts
@@ -105,6 +105,50 @@ export interface IdentityCluster {
 	readAt: string;
 }
 
+/** Deterministic query for one principal's provider/account-scoped delivery identity. */
+export interface ResolveIdentityDeliveryClaimRequest {
+	agentId: UUID;
+	principalId: UUID;
+	/** Connector authority namespace, such as `discord`, `telegram`, or `google`. */
+	connectorId?: string;
+	/** Connected account whose observations are permitted to route this send. */
+	connectorAccountId?: UUID;
+}
+
+/**
+ * Canonical delivery lookup never guesses between verified claims. Consumers
+ * may present `ambiguous` claims as choices, while `no_claim` is a hard stop
+ * before provider I/O rather than permission to inspect legacy entity fields.
+ */
+export type IdentityDeliveryClaimResolution =
+	| {
+			decision: "resolved";
+			requestedPrincipalId: UUID;
+			canonicalPrincipalId: UUID;
+			claim: IdentityClaim;
+			generation: number;
+	  }
+	| {
+			decision: "ambiguous";
+			requestedPrincipalId: UUID;
+			canonicalPrincipalId: UUID;
+			claims: readonly IdentityClaim[];
+			generation: number;
+			reason: "multiple_verified_claims";
+	  }
+	| {
+			decision: "no_claim";
+			requestedPrincipalId: UUID;
+			canonicalPrincipalId: UUID | null;
+			generation: number | null;
+			reason:
+				| "principal_not_found"
+				| "no_active_verified_claim"
+				| "no_connector_claim"
+				| "no_account_claim"
+				| "connector_account_ineligible";
+	  };
+
 export interface IdentityCanonicalResolution {
 	agentId: UUID;
 	requestedPrincipalId: UUID;
@@ -356,6 +400,85 @@ export abstract class PrincipalService extends Service {
 		principalId: UUID,
 		connectorAccountId?: UUID,
 	): Promise<readonly IdentityClaim[]>;
+	async resolveIdentityDeliveryClaim(
+		request: ResolveIdentityDeliveryClaimRequest,
+	): Promise<IdentityDeliveryClaimResolution> {
+		const cluster = await this.getCluster(request.agentId, request.principalId);
+		if (!cluster) {
+			return {
+				decision: "no_claim",
+				requestedPrincipalId: request.principalId,
+				canonicalPrincipalId: null,
+				generation: null,
+				reason: "principal_not_found",
+			};
+		}
+		const verified = cluster.claims.filter(
+			(claim) =>
+				claim.status === "active" &&
+				(claim.verification === "verified" ||
+					claim.verification === "owner_bound"),
+		);
+		if (verified.length === 0) {
+			return {
+				decision: "no_claim",
+				requestedPrincipalId: request.principalId,
+				canonicalPrincipalId: cluster.canonicalPrincipalId,
+				generation: cluster.generation,
+				reason: "no_active_verified_claim",
+			};
+		}
+		const connectorId = request.connectorId?.trim().toLowerCase();
+		const connectorClaims = connectorId
+			? verified.filter(
+					(claim) => claim.connectorId.trim().toLowerCase() === connectorId,
+				)
+			: verified;
+		if (connectorClaims.length === 0) {
+			return {
+				decision: "no_claim",
+				requestedPrincipalId: request.principalId,
+				canonicalPrincipalId: cluster.canonicalPrincipalId,
+				generation: cluster.generation,
+				reason: "no_connector_claim",
+			};
+		}
+		const claims = request.connectorAccountId
+			? connectorClaims.filter(
+					(claim) => claim.connectorAccountId === request.connectorAccountId,
+				)
+			: connectorClaims;
+		if (claims.length === 0) {
+			return {
+				decision: "no_claim",
+				requestedPrincipalId: request.principalId,
+				canonicalPrincipalId: cluster.canonicalPrincipalId,
+				generation: cluster.generation,
+				reason: "no_account_claim",
+			};
+		}
+		const ordered = [...claims].sort((left, right) =>
+			left.id.localeCompare(right.id),
+		);
+		const claim = ordered[0];
+		if (ordered.length === 1 && claim) {
+			return {
+				decision: "resolved",
+				requestedPrincipalId: request.principalId,
+				canonicalPrincipalId: cluster.canonicalPrincipalId,
+				claim,
+				generation: cluster.generation,
+			};
+		}
+		return {
+			decision: "ambiguous",
+			requestedPrincipalId: request.principalId,
+			canonicalPrincipalId: cluster.canonicalPrincipalId,
+			claims: ordered,
+			generation: cluster.generation,
+			reason: "multiple_verified_claims",
+		};
+	}
 	abstract evaluateOwnerBinding(
 		request: EvaluateOwnerBindingRequest,
 	): Promise<OwnerBindingEvaluation>;

--- a/packages/core/src/types/identity.ts
+++ b/packages/core/src/types/identity.ts
@@ -105,7 +105,47 @@ export interface IdentityCluster {
 	readAt: string;
 }
 
-/** Deterministic query for one principal's provider/account-scoped delivery identity. */
+/**
+ * Rollout switch for claim-authoritative named-recipient delivery. While the
+ * claim-ingestion slice deferred from issue #23099 is not shipped, nothing in
+ * the runtime writes `identity_claims` rows, so treating claims as the sole
+ * delivery authority would refuse every contact send. The flag therefore
+ * defaults OFF: MESSAGE op=send and connector recipient resolution keep the
+ * legacy entity-component path until an operator opts in. Turning it ON makes
+ * active verified identity claims mandatory for principal-UUID recipients and
+ * removes legacy entity components from delivery authority.
+ */
+export const IDENTITY_DELIVERY_CLAIMS_AUTHORITATIVE_SETTING =
+	"IDENTITY_DELIVERY_CLAIMS_AUTHORITATIVE" as const;
+
+/**
+ * Parse the {@link IDENTITY_DELIVERY_CLAIMS_AUTHORITATIVE_SETTING} runtime
+ * setting fail-closed: only an explicit boolean `true` or an affirmative
+ * string opts into claim-mandatory delivery; everything else keeps legacy
+ * resolution so an absent or malformed setting can never disable delivery.
+ */
+export function identityDeliveryClaimsAuthoritative(value: unknown): boolean {
+	if (value === true) return true;
+	if (typeof value !== "string") return false;
+	const normalized = value.trim().toLowerCase();
+	return (
+		normalized === "true" ||
+		normalized === "1" ||
+		normalized === "yes" ||
+		normalized === "on"
+	);
+}
+
+/**
+ * Deterministic query for one principal's provider/account-scoped delivery
+ * identity. `namespace` is intentionally absent: claims are unique per
+ * `(namespace, connectorId, connectorAccountId, externalSubjectId)`, but
+ * delivery eligibility ignores the namespace and scopes only by connector
+ * authority and connected account. Claims that differ solely in namespace all
+ * survive scoping; connectors then collapse them by delivery key, so the same
+ * provider subject observed under several namespaces is one destination, not
+ * a forced ambiguity.
+ */
 export interface ResolveIdentityDeliveryClaimRequest {
 	agentId: UUID;
 	principalId: UUID;
@@ -113,6 +153,26 @@ export interface ResolveIdentityDeliveryClaimRequest {
 	connectorId?: string;
 	/** Connected account whose observations are permitted to route this send. */
 	connectorAccountId?: UUID;
+}
+
+/**
+ * Canonical ordering for delivery-claim candidates. Every resolver must sort
+ * ambiguous claims with this comparator so a `resolved` single claim and the
+ * first entry of an `ambiguous` list are stable across implementations and
+ * across process restarts.
+ */
+export function orderIdentityDeliveryClaims(
+	claims: readonly IdentityClaim[],
+): IdentityClaim[] {
+	const key = (claim: IdentityClaim): string =>
+		[
+			claim.connectorId,
+			claim.connectorAccountId,
+			claim.handle ?? "",
+			claim.externalSubjectId,
+			claim.id,
+		].join("\u0000");
+	return [...claims].sort((left, right) => key(left).localeCompare(key(right)));
 }
 
 /**
@@ -400,6 +460,23 @@ export abstract class PrincipalService extends Service {
 		principalId: UUID,
 		connectorAccountId?: UUID,
 	): Promise<readonly IdentityClaim[]>;
+	/**
+	 * Filter delivery-claim candidates to those whose connector account is
+	 * currently eligible to route a send (for example: connected, not deleted,
+	 * and provider-matched to the claim's connector authority). Implementations
+	 * own the storage lookup; returning every input claim is only correct for
+	 * backends that cannot observe account state.
+	 */
+	protected abstract filterConnectorAccountEligibleClaims(
+		agentId: UUID,
+		claims: readonly IdentityClaim[],
+	): Promise<readonly IdentityClaim[]>;
+	/**
+	 * Shared delivery-claim resolution pipeline. Subclasses supply cluster
+	 * reads and account eligibility; the decision shape, refusal reasons, and
+	 * {@link orderIdentityDeliveryClaims} ordering are fixed here so every
+	 * implementation resolves and refuses identically.
+	 */
 	async resolveIdentityDeliveryClaim(
 		request: ResolveIdentityDeliveryClaimRequest,
 	): Promise<IdentityDeliveryClaimResolution> {
@@ -443,12 +520,12 @@ export abstract class PrincipalService extends Service {
 				reason: "no_connector_claim",
 			};
 		}
-		const claims = request.connectorAccountId
+		const accountClaims = request.connectorAccountId
 			? connectorClaims.filter(
 					(claim) => claim.connectorAccountId === request.connectorAccountId,
 				)
 			: connectorClaims;
-		if (claims.length === 0) {
+		if (accountClaims.length === 0) {
 			return {
 				decision: "no_claim",
 				requestedPrincipalId: request.principalId,
@@ -457,9 +534,20 @@ export abstract class PrincipalService extends Service {
 				reason: "no_account_claim",
 			};
 		}
-		const ordered = [...claims].sort((left, right) =>
-			left.id.localeCompare(right.id),
+		const eligibleClaims = await this.filterConnectorAccountEligibleClaims(
+			request.agentId,
+			accountClaims,
 		);
+		if (eligibleClaims.length === 0) {
+			return {
+				decision: "no_claim",
+				requestedPrincipalId: request.principalId,
+				canonicalPrincipalId: cluster.canonicalPrincipalId,
+				generation: cluster.generation,
+				reason: "connector_account_ineligible",
+			};
+		}
+		const ordered = orderIdentityDeliveryClaims(eligibleClaims);
 		const claim = ordered[0];
 		if (ordered.length === 1 && claim) {
 			return {

--- a/packages/core/src/types/runtime.ts
+++ b/packages/core/src/types/runtime.ts
@@ -41,6 +41,7 @@ import type {
 } from "./environment";
 import type { RegisteredEvaluator } from "./evaluator";
 import type { EventHandler, EventPayload, EventPayloadMap } from "./events";
+import type { IdentityClaim } from "./identity";
 import type { Memory, MemoryMetadata } from "./memory";
 import type { IMessageService } from "./message-service";
 import type {
@@ -255,6 +256,8 @@ export interface MessageConnectorQueryContext {
 
 export interface MessageConnectorTarget {
 	target: TargetInfo;
+	/** Connector-owned opaque key for auditing an identity-claim mapping. */
+	identityDeliveryKey?: string;
 	label?: string;
 	kind?: MessageTargetKind;
 	description?: string;
@@ -444,6 +447,16 @@ export interface MessageConnector {
 		query: string,
 		context: MessageConnectorQueryContext,
 	) => Promise<MessageConnectorTarget[]> | MessageConnectorTarget[];
+	/**
+	 * Convert a verified provider claim into this connector's concrete delivery
+	 * target. Handles are display data, so the shared runtime never guesses that
+	 * a handle or provider subject is a channel, chat, phone number, or address.
+	 */
+	resolveIdentityClaimTarget?: (
+		claim: IdentityClaim,
+		context: MessageConnectorQueryContext,
+		canonicalPrincipalId: UUID,
+	) => Promise<MessageConnectorTarget | null> | MessageConnectorTarget | null;
 	listRecentTargets?: (
 		context: MessageConnectorQueryContext,
 	) => Promise<MessageConnectorTarget[]> | MessageConnectorTarget[];

--- a/plugins/plugin-google-workspace/package.json
+++ b/plugins/plugin-google-workspace/package.json
@@ -55,6 +55,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.8",
+    "@elizaos/plugin-sql": "workspace:*",
     "@types/node": "^25.6.0",
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "^6.0.3",

--- a/plugins/plugin-google-workspace/src/gmail-canonical-delivery.real.test.ts
+++ b/plugins/plugin-google-workspace/src/gmail-canonical-delivery.real.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Exercises MESSAGE through a real AgentRuntime, migrated PGlite identity
+ * authority, production Gmail connector/client, and a stateful loopback Google
+ * API. Only the external provider is simulated; runtime and persistence code
+ * are the same implementations used in production.
+ */
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+import {
+  type Action,
+  type ActionResult,
+  getConnectorAccountManager,
+  type Memory,
+  ServiceType,
+  stringToUuid,
+  type UUID,
+} from "@elizaos/core";
+import { createTestRuntime } from "@elizaos/core/testing";
+import { identityClaimTable } from "@elizaos/plugin-sql";
+import { Auth } from "googleapis";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import googlePlugin from "./index.js";
+import { GoogleWorkspaceService } from "./service.js";
+import type { GoogleAuthClient, GoogleCredentialResolver } from "./types.js";
+
+const PRINCIPAL_ID = "00000000-0000-0000-0000-0000000000e7" as UUID;
+const SENDER_ID = "00000000-0000-0000-0000-0000000000e8" as UUID;
+const ACCOUNT_ID = "00000000-0000-4000-8000-0000000000a1" as UUID;
+const ROOM_ID = "00000000-0000-0000-0000-0000000000b1" as UUID;
+const WORLD_ID = "00000000-0000-0000-0000-0000000000c1" as UUID;
+
+interface RecordedGmailRequest {
+  authorization: string | undefined;
+  raw: string;
+}
+
+class LoopbackCredentialResolver implements GoogleCredentialResolver {
+  async getAuthClient(): Promise<GoogleAuthClient> {
+    const auth = new Auth.OAuth2Client();
+    auth.setCredentials({
+      access_token: "canonical-delivery-loopback-token",
+      expiry_date: Date.now() + 60 * 60 * 1000,
+    });
+    return auth;
+  }
+}
+
+async function readJson(request: IncomingMessage): Promise<Record<string, unknown>> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  const parsed: unknown = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("Gmail fixture request must be a JSON object");
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function writeJson(response: ServerResponse, status: number, body: unknown): void {
+  response.writeHead(status, { "content-type": "application/json" });
+  response.end(JSON.stringify(body));
+}
+
+describe("canonical principal to Gmail delivery", () => {
+  let server: Server;
+  let originalGoogleBase: string | undefined;
+  let cleanup: (() => Promise<void>) | undefined;
+  let runtime: Awaited<ReturnType<typeof createTestRuntime>>["runtime"];
+  let messageAction: Action;
+  const providerRequests: RecordedGmailRequest[] = [];
+
+  beforeAll(async () => {
+    originalGoogleBase = process.env.ELIZA_MOCK_GOOGLE_BASE;
+    server = createServer((request, response) => {
+      void (async () => {
+        const url = new URL(request.url ?? "/", "http://fixture.invalid");
+        if (request.method !== "POST" || url.pathname !== "/gmail/v1/users/me/messages/send") {
+          writeJson(response, 404, { error: { code: 404 } });
+          return;
+        }
+        const body = await readJson(request);
+        const raw = typeof body.raw === "string" ? body.raw : "";
+        providerRequests.push({
+          authorization: request.headers.authorization,
+          raw: Buffer.from(raw, "base64url").toString("utf8"),
+        });
+        writeJson(response, 200, {
+          id: `fixture-message-${providerRequests.length}`,
+          threadId: "fixture-thread-1",
+          labelIds: ["SENT"],
+        });
+      })().catch((error) => {
+        writeJson(response, 500, {
+          error: { code: 500, message: error instanceof Error ? error.message : String(error) },
+        });
+      });
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address() as AddressInfo;
+    process.env.ELIZA_MOCK_GOOGLE_BASE = `http://127.0.0.1:${address.port}/`;
+
+    const harness = await createTestRuntime({
+      characterName: "CanonicalDeliveryAgent",
+      plugins: [googlePlugin],
+    });
+    runtime = harness.runtime;
+    cleanup = harness.cleanup;
+    const google = runtime.getService<GoogleWorkspaceService>(GoogleWorkspaceService.serviceType);
+    if (!google) throw new Error("GoogleWorkspaceService did not start");
+    google.setCredentialResolver(new LoopbackCredentialResolver());
+
+    messageAction = runtime.actions.find((action) => action.name === "MESSAGE") as Action;
+    if (!messageAction) throw new Error("MESSAGE action is not registered");
+
+    await runtime.upsertEntities([
+      { id: PRINCIPAL_ID, agentId: runtime.agentId, names: ["Shadow"], metadata: {} },
+      { id: SENDER_ID, agentId: runtime.agentId, names: ["Owner"], metadata: {} },
+    ]);
+    await runtime.ensureWorldExists({
+      id: WORLD_ID,
+      agentId: runtime.agentId,
+      name: "Fixture world",
+      metadata: { type: "fixture" },
+    });
+    await runtime.ensureRoomExists({
+      id: ROOM_ID,
+      worldId: WORLD_ID,
+      source: "client_chat",
+      name: "Fixture room",
+      channelId: "fixture-room",
+      type: "DM",
+    });
+    await runtime.ensureParticipantInRoom(SENDER_ID, ROOM_ID);
+    await runtime.upsertComponent({
+      id: stringToUuid("canonical-delivery-malicious-legacy-email") as UUID,
+      entityId: PRINCIPAL_ID,
+      agentId: runtime.agentId,
+      roomId: ROOM_ID,
+      worldId: WORLD_ID,
+      sourceEntityId: runtime.agentId,
+      type: "contact_info",
+      createdAt: Date.now(),
+      data: { email: "attacker@example.com" },
+    });
+
+    await getConnectorAccountManager(runtime).upsertAccount("google", {
+      id: ACCOUNT_ID,
+      provider: "google",
+      role: "AGENT",
+      purpose: ["messaging"],
+      accessGate: "open",
+      status: "connected",
+      externalId: "fixture-owner",
+      displayHandle: "owner@example.com",
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      metadata: { grantedCapabilities: ["gmail.send"] },
+    });
+  }, 180_000);
+
+  afterAll(async () => {
+    await cleanup?.();
+    if (originalGoogleBase === undefined) delete process.env.ELIZA_MOCK_GOOGLE_BASE;
+    else process.env.ELIZA_MOCK_GOOGLE_BASE = originalGoogleBase;
+    if (server) {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+
+  async function sendToPrincipal(): Promise<ActionResult> {
+    const result = await messageAction.handler(
+      runtime,
+      {
+        id: stringToUuid(`canonical-delivery-input-${providerRequests.length}`) as UUID,
+        agentId: runtime.agentId,
+        entityId: SENDER_ID,
+        roomId: ROOM_ID,
+        worldId: WORLD_ID,
+        content: { text: "Send Shadow the fixture note", source: "client_chat" },
+        createdAt: Date.now(),
+      } as Memory,
+      undefined,
+      {
+        parameters: {
+          action: "send",
+          source: "gmail",
+          target: PRINCIPAL_ID,
+          targetKind: "contact",
+          message: "Canonical delivery fixture body",
+          subject: "Canonical delivery fixture",
+          persist: false,
+        },
+      },
+      undefined,
+      undefined
+    );
+    if (!result) throw new Error("MESSAGE returned no result");
+    return result;
+  }
+
+  it("refuses the legacy component, then sends through the exact verified account claim", async () => {
+    const withoutClaim = await sendToPrincipal();
+    expect(withoutClaim.success).toBe(false);
+    expect(withoutClaim.data).toMatchObject({ error: "TARGET_DELIVERY_CLAIM_MISSING" });
+    expect(providerRequests).toHaveLength(0);
+
+    await runtime.adapter.db.insert(identityClaimTable).values({
+      agentId: runtime.agentId,
+      principalEntityId: PRINCIPAL_ID,
+      namespace: "connector_subject",
+      connectorId: "google",
+      connectorAccountId: ACCOUNT_ID,
+      externalSubjectId: "shadow@example.com",
+      handle: "shadow@example.com",
+      displayName: "Shadow",
+      verification: "verified",
+      status: "active",
+      confidence: 1,
+      provenance: { fixture: "loopback-google" },
+      evidence: { verified: true },
+      verifiedAt: new Date(),
+    });
+
+    const delivered = await sendToPrincipal();
+    if (!delivered.success) {
+      throw new Error(`Expected canonical delivery success: ${JSON.stringify(delivered)}`);
+    }
+    expect(delivered.success).toBe(true);
+    expect(delivered.data).toMatchObject({
+      deliveryStatus: "delivered",
+      responseMessageId: "fixture-message-1",
+      identityDeliveryClaim: {
+        canonicalPrincipalId: PRINCIPAL_ID,
+        connectorAccountId: ACCOUNT_ID,
+      },
+    });
+    expect(providerRequests).toHaveLength(1);
+    expect(providerRequests[0]?.authorization).toBe("Bearer canonical-delivery-loopback-token");
+    expect(providerRequests[0]?.raw).toContain("To: shadow@example.com");
+    expect(providerRequests[0]?.raw).not.toContain("attacker@example.com");
+    expect(providerRequests[0]?.raw).toContain("Canonical delivery fixture body");
+    expect(runtime.getService(ServiceType.PRINCIPAL)).not.toBeNull();
+  });
+});

--- a/plugins/plugin-google-workspace/src/gmail-canonical-delivery.real.test.ts
+++ b/plugins/plugin-google-workspace/src/gmail-canonical-delivery.real.test.ts
@@ -106,6 +106,9 @@ describe("canonical principal to Gmail delivery", () => {
     });
     runtime = harness.runtime;
     cleanup = harness.cleanup;
+    // This suite proves the opt-in claim-authoritative contract; the rollout
+    // flag defaults off until claim ingestion (issue #23099) ships.
+    runtime.setSetting("IDENTITY_DELIVERY_CLAIMS_AUTHORITATIVE", "true");
     const google = runtime.getService<GoogleWorkspaceService>(GoogleWorkspaceService.serviceType);
     if (!google) throw new Error("GoogleWorkspaceService did not start");
     google.setCredentialResolver(new LoopbackCredentialResolver());

--- a/plugins/plugin-google-workspace/src/gmail-message-connector.test.ts
+++ b/plugins/plugin-google-workspace/src/gmail-message-connector.test.ts
@@ -2,7 +2,7 @@
  * Unit coverage for the Gmail send MessageConnector: provider wire-up
  * (registering the Google connector-account provider registers a `gmail` send
  * connector, closing the SOURCE_CONNECTOR_NOT_FOUND gap), literal-address and
- * entity-handle recipient resolution, account selection, subject derivation,
+ * canonical-claim recipient resolution, account selection, subject derivation,
  * and the structural delivery receipt. Mock runtime and Google service stubs —
  * no live Gmail API, nothing is actually sent.
  */
@@ -13,9 +13,11 @@ import {
   type Content,
   getConnectorAccountManager,
   type IAgentRuntime,
+  type IdentityClaim,
   InMemoryConnectorAccountStorage,
   type MessageConnectorRegistration,
   type SendHandlerOutcome,
+  ServiceType,
   type TargetInfo,
 } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
@@ -28,6 +30,7 @@ import {
 import { GOOGLE_SERVICE_NAME } from "./types.js";
 
 const SHADOW_ID = "00000000-0000-0000-0000-0000000000e7";
+const CONNECTED_ACCOUNT_ID = "00000000-0000-0000-0000-0000000000a1";
 
 type AccountStub = {
   id: string;
@@ -40,6 +43,8 @@ function runtimeStub(options: {
   accounts?: AccountStub[];
   sendGmailMessage?: ReturnType<typeof vi.fn>;
   entity?: { id: string; names: string[]; components?: Array<Record<string, unknown>> };
+  deliveryClaims?: string[];
+  principalError?: Error;
 }): {
   runtime: IAgentRuntime;
   sendGmailMessage: ReturnType<typeof vi.fn>;
@@ -72,11 +77,72 @@ function runtimeStub(options: {
     getService: vi.fn((serviceType: string) => {
       if (serviceType === "google") return { sendGmailMessage };
       if (serviceType === CONNECTOR_ACCOUNT_SERVICE_TYPE) return accountManager;
+      if (serviceType === ServiceType.PRINCIPAL) {
+        return {
+          resolveIdentityDeliveryClaim: vi.fn(async () => {
+            if (options.principalError) throw options.principalError;
+            const claims = (options.deliveryClaims ?? []).map(
+              (email, index) =>
+                ({
+                  contractVersion: 1,
+                  id: `00000000-0000-0000-0000-0000000001${String(index).padStart(2, "0")}`,
+                  agentId: "00000000-0000-0000-0000-000000000001",
+                  principalEntityId: SHADOW_ID,
+                  namespace: "connector_subject",
+                  connectorId: "google",
+                  connectorAccountId: CONNECTED_ACCOUNT_ID,
+                  externalSubjectId: email,
+                  handle: email,
+                  displayName: "Shadow",
+                  verification: "verified",
+                  status: "active",
+                  confidence: 1,
+                  ownerBindingId: null,
+                  provenance: {},
+                  evidence: {},
+                  firstSeenAt: "2026-08-23T00:00:00.000Z",
+                  lastSeenAt: "2026-08-23T00:00:00.000Z",
+                  verifiedAt: "2026-08-23T00:00:00.000Z",
+                  revokedAt: null,
+                  createdAt: "2026-08-23T00:00:00.000Z",
+                  updatedAt: "2026-08-23T00:00:00.000Z",
+                }) as IdentityClaim
+            );
+            if (claims.length === 0) {
+              return {
+                decision: "no_claim",
+                requestedPrincipalId: SHADOW_ID,
+                canonicalPrincipalId: SHADOW_ID,
+                generation: 1,
+                reason: "no_active_verified_claim",
+              };
+            }
+            if (claims.length > 1) {
+              return {
+                decision: "ambiguous",
+                requestedPrincipalId: SHADOW_ID,
+                canonicalPrincipalId: SHADOW_ID,
+                claims,
+                generation: 1,
+                reason: "multiple_verified_claims",
+              };
+            }
+            return {
+              decision: "resolved",
+              requestedPrincipalId: SHADOW_ID,
+              canonicalPrincipalId: SHADOW_ID,
+              claim: claims[0],
+              generation: 1,
+            };
+          }),
+        };
+      }
       return null;
     }),
     getEntityById: vi.fn(async (id: string) =>
       options.entity && id === options.entity.id ? options.entity : null
     ),
+    reportError: vi.fn(),
   } as unknown as IAgentRuntime;
   return { runtime, sendGmailMessage };
 }
@@ -149,7 +215,7 @@ async function invokeSend(
 }
 
 const CONNECTED_ACCOUNT: AccountStub = {
-  id: "acct_google_1",
+  id: CONNECTED_ACCOUNT_ID,
   status: "connected",
   displayHandle: "owner@example.com",
   metadata: { grantedCapabilities: ["gmail.read", "gmail.send"] },
@@ -219,7 +285,7 @@ describe("gmail send handler", () => {
     );
 
     expect(sendGmailMessage).toHaveBeenCalledWith({
-      accountId: "acct_google_1",
+      accountId: CONNECTED_ACCOUNT_ID,
       to: ["shadow@example.com"],
       subject: "A friendly reminder",
       bodyText: "Please stop smoking.",
@@ -249,6 +315,24 @@ describe("gmail send handler", () => {
     expect(sendGmailMessage).toHaveBeenCalledWith(
       expect.objectContaining({ subject: "Stop smoking" })
     );
+  });
+
+  it("returns unknown instead of fabricating delivery when Gmail supplies no message evidence", async () => {
+    const { runtime, sendGmailMessage } = runtimeStub({
+      accounts: [CONNECTED_ACCOUNT],
+      sendGmailMessage: vi.fn(async () => ({ messageId: null, threadId: null, labelIds: [] })),
+    });
+    const registration = createGmailMessageConnector(runtime);
+
+    if (!registration.sendHandler) throw new Error("sendHandler missing");
+    const outcome = await registration.sendHandler(
+      runtime,
+      { source: GMAIL_MESSAGE_SOURCE, channelId: "shadow@example.com" } as TargetInfo,
+      { text: "hello" }
+    );
+
+    expect(sendGmailMessage).toHaveBeenCalledTimes(1);
+    expect(outcome).toBeUndefined();
   });
 
   it("normalizes lone surrogates in explicit and short derived subjects", async () => {
@@ -352,7 +436,7 @@ describe("gmail send handler", () => {
     expect(subjects).toEqual(["m".repeat(78), "n".repeat(79)]);
   });
 
-  it("resolves an entity-store recipient through stored email handles", async () => {
+  it("resolves a principal recipient through its verified account-scoped claim", async () => {
     const { runtime, sendGmailMessage } = runtimeStub({
       accounts: [CONNECTED_ACCOUNT],
       entity: {
@@ -363,6 +447,7 @@ describe("gmail send handler", () => {
           { type: "contact_info", data: { email: "shadow@example.com" } },
         ],
       },
+      deliveryClaims: ["shadow@example.com"],
     });
     const registration = createGmailMessageConnector(runtime);
 
@@ -549,7 +634,7 @@ describe("gmail send handler", () => {
     expect(sendGmailMessage).not.toHaveBeenCalled();
   });
 
-  it("refuses structurally when the contact has multiple distinct stored emails", async () => {
+  it("refuses structurally when canonical authority has multiple verified email claims", async () => {
     const { runtime, sendGmailMessage } = runtimeStub({
       accounts: [CONNECTED_ACCOUNT],
       entity: {
@@ -560,6 +645,7 @@ describe("gmail send handler", () => {
           { type: "rolodex", data: { email: "shadow.personal@example.com" } },
         ],
       },
+      deliveryClaims: ["shadow.work@example.com", "shadow.personal@example.com"],
     });
     const registration = createGmailMessageConnector(runtime);
 
@@ -577,7 +663,28 @@ describe("gmail send handler", () => {
     expect(sendGmailMessage).not.toHaveBeenCalled();
   });
 
-  it("ignores email-shaped values in unrelated fields when a named email field exists", async () => {
+  it("does not surface an empty ambiguity choice when verified claims are not emails", async () => {
+    const { runtime, sendGmailMessage } = runtimeStub({
+      accounts: [CONNECTED_ACCOUNT],
+      deliveryClaims: ["discord-user-a", "discord-user-b"],
+    });
+    const registration = createGmailMessageConnector(runtime);
+
+    const outcome = await invokeSend(
+      registration,
+      runtime,
+      { entityId: SHADOW_ID as TargetInfo["entityId"] },
+      { text: "hello" }
+    );
+
+    expect(outcome).toMatchObject({
+      kind: "not_delivered",
+      code: "GMAIL_RECIPIENT_UNRESOLVED",
+    });
+    expect(sendGmailMessage).not.toHaveBeenCalled();
+  });
+
+  it("ignores every legacy component value and uses only the verified canonical claim", async () => {
     const { runtime, sendGmailMessage } = runtimeStub({
       accounts: [CONNECTED_ACCOUNT],
       entity: {
@@ -588,6 +695,7 @@ describe("gmail send handler", () => {
           { type: "contact_info", data: { email: "shadow@example.com" } },
         ],
       },
+      deliveryClaims: ["shadow@example.com"],
     });
     const registration = createGmailMessageConnector(runtime);
 
@@ -602,6 +710,90 @@ describe("gmail send handler", () => {
     expect(sendGmailMessage).toHaveBeenCalledWith(
       expect.objectContaining({ to: ["shadow@example.com"] })
     );
+  });
+
+  it("does not let a carried channel address bypass canonical revalidation for a principal", async () => {
+    const { runtime, sendGmailMessage } = runtimeStub({
+      accounts: [CONNECTED_ACCOUNT],
+      deliveryClaims: ["shadow@example.com"],
+    });
+    const registration = createGmailMessageConnector(runtime);
+
+    const outcome = await invokeSend(
+      registration,
+      runtime,
+      {
+        entityId: SHADOW_ID as TargetInfo["entityId"],
+        channelId: "attacker@example.com",
+      },
+      { text: "hello" }
+    );
+
+    expect(outcome.kind).toBe("delivered");
+    expect(sendGmailMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ to: ["shadow@example.com"] })
+    );
+  });
+
+  it("refuses when the canonical claim changes after MESSAGE selected its audited target", async () => {
+    const { runtime, sendGmailMessage } = runtimeStub({
+      accounts: [CONNECTED_ACCOUNT],
+      deliveryClaims: ["new-shadow@example.com"],
+    });
+    const registration = createGmailMessageConnector(runtime);
+
+    const outcome = await invokeSend(
+      registration,
+      runtime,
+      {
+        entityId: SHADOW_ID as TargetInfo["entityId"],
+        channelId: "old-shadow@example.com",
+      },
+      {
+        text: "hello",
+        metadata: {
+          identityDeliveryClaim: {
+            claimId: "00000000-0000-0000-0000-000000000199",
+            canonicalPrincipalId: SHADOW_ID,
+            connectorAccountId: CONNECTED_ACCOUNT_ID,
+            generation: 1,
+            deliveryKey: "old-shadow@example.com",
+          },
+        },
+      }
+    );
+
+    expect(outcome).toMatchObject({
+      kind: "not_delivered",
+      code: "GMAIL_IDENTITY_AUTHORITY_UNAVAILABLE",
+    });
+    expect(sendGmailMessage).not.toHaveBeenCalled();
+  });
+
+  it("refuses structurally when canonical authority throws", async () => {
+    const { runtime, sendGmailMessage } = runtimeStub({
+      accounts: [CONNECTED_ACCOUNT],
+      principalError: new Error("identity database unavailable"),
+    });
+    const registration = createGmailMessageConnector(runtime);
+
+    const outcome = await invokeSend(
+      registration,
+      runtime,
+      { entityId: SHADOW_ID as TargetInfo["entityId"] },
+      { text: "hello" }
+    );
+
+    expect(outcome).toMatchObject({
+      kind: "not_delivered",
+      code: "GMAIL_IDENTITY_AUTHORITY_UNAVAILABLE",
+    });
+    expect(runtime.reportError).toHaveBeenCalledWith(
+      "gmail.resolveIdentityDeliveryClaim",
+      expect.any(Error),
+      expect.objectContaining({ principalId: SHADOW_ID })
+    );
+    expect(sendGmailMessage).not.toHaveBeenCalled();
   });
 
   it("refuses structurally when no recipient email can be resolved", async () => {

--- a/plugins/plugin-google-workspace/src/gmail-message-connector.test.ts
+++ b/plugins/plugin-google-workspace/src/gmail-message-connector.test.ts
@@ -45,6 +45,8 @@ function runtimeStub(options: {
   entity?: { id: string; names: string[]; components?: Array<Record<string, unknown>> };
   deliveryClaims?: string[];
   principalError?: Error;
+  /** Defaults to claim-authoritative; pass false to exercise the legacy component path. */
+  claimsAuthoritative?: boolean;
 }): {
   runtime: IAgentRuntime;
   sendGmailMessage: ReturnType<typeof vi.fn>;
@@ -142,6 +144,11 @@ function runtimeStub(options: {
     getEntityById: vi.fn(async (id: string) =>
       options.entity && id === options.entity.id ? options.entity : null
     ),
+    getSetting: vi.fn((key: string) =>
+      key === "IDENTITY_DELIVERY_CLAIMS_AUTHORITATIVE" && options.claimsAuthoritative !== false
+        ? "true"
+        : null
+    ),
     reportError: vi.fn(),
   } as unknown as IAgentRuntime;
   return { runtime, sendGmailMessage };
@@ -192,6 +199,9 @@ async function runtimeWithRealAccountPolicy(options: {
       if (serviceType === CONNECTOR_ACCOUNT_SERVICE_TYPE) return manager;
       return null;
     }),
+    getSetting: vi.fn((key: string) =>
+      key === "IDENTITY_DELIVERY_CLAIMS_AUTHORITATIVE" ? "true" : null
+    ),
   } as unknown as IAgentRuntime;
   return { runtime, sendGmailMessage };
 }
@@ -663,6 +673,29 @@ describe("gmail send handler", () => {
     expect(sendGmailMessage).not.toHaveBeenCalled();
   });
 
+  it("resolves when multiple verified claims observe one distinct address", async () => {
+    // Two claim rows (e.g. the address seen as both handle and subject, or by
+    // two verification events) are one destination — refusing here would make
+    // re-verification of the same address break delivery.
+    const { runtime, sendGmailMessage } = runtimeStub({
+      accounts: [CONNECTED_ACCOUNT],
+      deliveryClaims: ["shadow@example.com", "Shadow@Example.com"],
+    });
+    const registration = createGmailMessageConnector(runtime);
+
+    const outcome = await invokeSend(
+      registration,
+      runtime,
+      { entityId: SHADOW_ID as TargetInfo["entityId"] },
+      { text: "hello" }
+    );
+
+    expect(outcome.kind).toBe("delivered");
+    expect(sendGmailMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ to: ["shadow@example.com"] })
+    );
+  });
+
   it("does not surface an empty ambiguity choice when verified claims are not emails", async () => {
     const { runtime, sendGmailMessage } = runtimeStub({
       accounts: [CONNECTED_ACCOUNT],
@@ -814,6 +847,112 @@ describe("gmail send handler", () => {
       code: "GMAIL_RECIPIENT_UNRESOLVED",
     });
     expect(sendGmailMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe("gmail send handler with claim authority disabled (legacy default)", () => {
+  it("routes a principal recipient through the stored entity email component", async () => {
+    const { runtime, sendGmailMessage } = runtimeStub({
+      accounts: [CONNECTED_ACCOUNT],
+      claimsAuthoritative: false,
+      entity: {
+        id: SHADOW_ID,
+        names: ["Shadow"],
+        components: [{ type: "contact_info", data: { email: "shadow@example.com" } }],
+      },
+    });
+    const registration = createGmailMessageConnector(runtime);
+
+    const outcome = await invokeSend(
+      registration,
+      runtime,
+      { entityId: SHADOW_ID as TargetInfo["entityId"] },
+      { text: "hello" }
+    );
+
+    expect(outcome.kind).toBe("delivered");
+    expect(sendGmailMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ to: ["shadow@example.com"] })
+    );
+  });
+
+  it("refuses when the entity stores multiple distinct email addresses", async () => {
+    const { runtime, sendGmailMessage } = runtimeStub({
+      accounts: [CONNECTED_ACCOUNT],
+      claimsAuthoritative: false,
+      entity: {
+        id: SHADOW_ID,
+        names: ["Shadow"],
+        components: [
+          { type: "contact_info", data: { email: "shadow.work@example.com" } },
+          { type: "rolodex", data: { email: "shadow.personal@example.com" } },
+        ],
+      },
+    });
+    const registration = createGmailMessageConnector(runtime);
+
+    const outcome = await invokeSend(
+      registration,
+      runtime,
+      { entityId: SHADOW_ID as TargetInfo["entityId"] },
+      { text: "hello" }
+    );
+
+    expect(outcome).toMatchObject({
+      kind: "not_delivered",
+      code: "GMAIL_RECIPIENT_AMBIGUOUS",
+    });
+    expect(sendGmailMessage).not.toHaveBeenCalled();
+  });
+
+  it("lets a literal carried address win over the entity lookup", async () => {
+    const { runtime, sendGmailMessage } = runtimeStub({
+      accounts: [CONNECTED_ACCOUNT],
+      claimsAuthoritative: false,
+      entity: {
+        id: SHADOW_ID,
+        names: ["Shadow"],
+        components: [{ type: "contact_info", data: { email: "stored@example.com" } }],
+      },
+    });
+    const registration = createGmailMessageConnector(runtime);
+
+    const outcome = await invokeSend(
+      registration,
+      runtime,
+      { entityId: SHADOW_ID as TargetInfo["entityId"], channelId: "typed@example.com" },
+      { text: "hello" }
+    );
+
+    expect(outcome.kind).toBe("delivered");
+    expect(sendGmailMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ to: ["typed@example.com"] })
+    );
+  });
+
+  it("refuses without consulting the principal service when nothing resolves", async () => {
+    const { runtime, sendGmailMessage } = runtimeStub({
+      accounts: [CONNECTED_ACCOUNT],
+      claimsAuthoritative: false,
+      // A principal error would surface if the claim path ran despite the
+      // flag being off; the legacy path must never read claim authority.
+      principalError: new Error("claim authority must not be consulted"),
+    });
+    const registration = createGmailMessageConnector(runtime);
+
+    const outcome = await invokeSend(
+      registration,
+      runtime,
+      { entityId: SHADOW_ID as TargetInfo["entityId"] },
+      { text: "hello" }
+    );
+
+    expect(outcome).toMatchObject({
+      kind: "not_delivered",
+      code: "GMAIL_RECIPIENT_UNRESOLVED",
+    });
+    expect(sendGmailMessage).not.toHaveBeenCalled();
+    expect(runtime.reportError).not.toHaveBeenCalled();
   });
 });
 

--- a/plugins/plugin-google-workspace/src/gmail-message-connector.ts
+++ b/plugins/plugin-google-workspace/src/gmail-message-connector.ts
@@ -5,9 +5,10 @@
  * SOURCE_CONNECTOR_NOT_FOUND, and routes delivery through
  * `GoogleWorkspaceService.sendGmailMessage`.
  *
- * Recipient resolution: a literal address on the target (channelId or
- * entityId) is used as-is — a typed address is unambiguous; an entity-store
- * UUID resolves through the entity's stored email handles (component data).
+ * Recipient resolution: a literal address is used as-is when no principal
+ * UUID is present. A principal UUID always resolves through the canonical
+ * identity service's active verified Google claim scoped to the selected
+ * connector account; a carried channelId cannot override that authority.
  * Account routing is `connector`-scoped: the handler honors an explicit
  * target accountId, else the sole policy-authorized, gmail-send-capable Google
  * account, and refuses with a structural not_delivered when the account choice
@@ -24,9 +25,12 @@ import {
   type Content,
   getConnectorAccountManager,
   type IAgentRuntime,
+  type IdentityDeliveryClaimResolution,
   type MessageConnectorRegistration,
   type MessageConnectorTarget,
+  type PrincipalService,
   type SendHandlerOutcome,
+  ServiceType,
   type TargetInfo,
   toWellFormedUnicode,
   type UUID,
@@ -37,7 +41,6 @@ export const GMAIL_MESSAGE_SOURCE = "gmail";
 
 const EMAIL_ADDRESS_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/;
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-const EMAIL_COMPONENT_KEYS = ["email", "emailAddress"] as const;
 const GMAIL_SEND_ACCOUNT_STATUSES: ConnectorAccountStatus[] = ["connected"];
 const GMAIL_SEND_ACCOUNT_PURPOSES: ConnectorAccountPurpose[] = ["messaging"];
 const GMAIL_SEND_ACCOUNT_ACCESS_GATES: ConnectorAccountAccessGate[] = ["open", "owner_binding"];
@@ -157,50 +160,160 @@ async function resolveGmailAccountId(
 }
 
 type RecipientResolution =
-  | { kind: "resolved"; email: string }
-  | { kind: "unresolved" }
+  | {
+      kind: "resolved";
+      email: string;
+      identityClaim?: {
+        claimId: UUID;
+        canonicalPrincipalId: UUID;
+        connectorAccountId: UUID;
+        generation: number;
+        deliveryKey: string;
+      };
+    }
+  | { kind: "unresolved"; reason: string }
+  | { kind: "unavailable"; reason: string }
   | { kind: "ambiguous"; candidates: string[] };
 
 /**
- * Resolve the recipient address fail-closed: a literal target address wins;
- * otherwise the entity graph must yield exactly one distinct stored email
- * (across explicitly email-named component fields, or — only when no named
- * field exists — email-shaped component values). Multiple distinct candidates
- * refuse rather than guess, so a contact with work + personal addresses never
- * gets mail routed by component iteration order.
+ * Resolve the recipient address fail-closed. A literal target is explicit only
+ * when the target does not also identify a principal UUID; principal delivery
+ * must yield exactly one active, verified Google claim observed through the
+ * selected sending account. Multiple claims refuse rather than guess, and
+ * legacy entity components are never consulted as recipient authority.
  */
 async function resolveRecipientEmail(
   runtime: IAgentRuntime,
-  target: TargetInfo
+  target: TargetInfo,
+  connectorAccountId: string,
+  expectedClaim?: {
+    claimId: string;
+    canonicalPrincipalId: string;
+    connectorAccountId: string;
+    generation: number;
+    deliveryKey: string;
+  }
 ): Promise<RecipientResolution> {
-  const literal = emailLiteral(target.channelId) ?? emailLiteral(target.entityId);
-  if (literal) return { kind: "resolved", email: literal };
-
   const entityId = String(target.entityId ?? "").trim();
-  if (!UUID_PATTERN.test(entityId) || typeof runtime.getEntityById !== "function") {
-    return { kind: "unresolved" };
+  if (!UUID_PATTERN.test(entityId)) {
+    const literal = emailLiteral(target.channelId) ?? emailLiteral(target.entityId);
+    if (literal) return { kind: "resolved", email: literal };
+    return { kind: "unresolved", reason: "target is not a canonical principal UUID" };
   }
-  const entity = await runtime.getEntityById(entityId as UUID);
-  if (!entity) return { kind: "unresolved" };
-
-  const named = new Set<string>();
-  const emailShaped = new Set<string>();
-  for (const component of entity.components ?? []) {
-    const data = component.data ?? {};
-    for (const key of EMAIL_COMPONENT_KEYS) {
-      const value = emailLiteral(data[key]);
-      if (value) named.add(value.toLowerCase());
-    }
-    for (const value of Object.values(data)) {
-      const email = emailLiteral(value);
-      if (email) emailShaped.add(email.toLowerCase());
-    }
+  if (!UUID_PATTERN.test(connectorAccountId)) {
+    return { kind: "unavailable", reason: "connector account id is not canonical" };
   }
+  const principalService = runtime.getService<PrincipalService>(ServiceType.PRINCIPAL);
+  if (!principalService) {
+    return { kind: "unavailable", reason: "canonical principal service is not registered" };
+  }
+  let resolution: IdentityDeliveryClaimResolution;
+  try {
+    resolution = await principalService.resolveIdentityDeliveryClaim({
+      agentId: runtime.agentId,
+      principalId: entityId as UUID,
+      connectorId: GOOGLE_SERVICE_NAME,
+      connectorAccountId: connectorAccountId as UUID,
+    });
+  } catch (error) {
+    // error-policy:J4 identity authority failures are structurally refused and
+    // reported; an address carried in target.channelId cannot bypass the read.
+    runtime.reportError("gmail.resolveIdentityDeliveryClaim", error, {
+      principalId: entityId,
+      connectorAccountId,
+    });
+    return {
+      kind: "unavailable",
+      reason: error instanceof Error ? error.message : String(error),
+    };
+  }
+  if (resolution.decision === "no_claim") {
+    return { kind: "unresolved", reason: resolution.reason };
+  }
+  if (resolution.decision === "ambiguous") {
+    const candidates = resolution.claims
+      .flatMap((claim) => [claim.handle, claim.externalSubjectId])
+      .filter(isEmailAddress)
+      .map((email) => email.toLowerCase());
+    const distinctCandidates = [...new Set(candidates)].sort();
+    if (distinctCandidates.length === 0) {
+      return {
+        kind: "unresolved",
+        reason: "verified claims contain no deliverable email address",
+      };
+    }
+    return { kind: "ambiguous", candidates: distinctCandidates };
+  }
+  const email =
+    emailLiteral(resolution.claim.handle) ?? emailLiteral(resolution.claim.externalSubjectId);
+  if (!email) {
+    return { kind: "unresolved", reason: "verified claim has no deliverable email address" };
+  }
+  const normalizedEmail = email.toLowerCase();
+  if (
+    expectedClaim &&
+    (expectedClaim.claimId !== resolution.claim.id ||
+      expectedClaim.canonicalPrincipalId !== resolution.canonicalPrincipalId ||
+      expectedClaim.connectorAccountId !== resolution.claim.connectorAccountId ||
+      expectedClaim.generation !== resolution.generation ||
+      expectedClaim.deliveryKey.toLowerCase() !== normalizedEmail)
+  ) {
+    return {
+      kind: "unavailable",
+      reason: "canonical delivery claim changed after target selection",
+    };
+  }
+  return {
+    kind: "resolved",
+    email: normalizedEmail,
+    identityClaim: {
+      claimId: resolution.claim.id,
+      canonicalPrincipalId: resolution.canonicalPrincipalId,
+      connectorAccountId: resolution.claim.connectorAccountId,
+      generation: resolution.generation,
+      deliveryKey: normalizedEmail,
+    },
+  };
+}
 
-  const candidates = named.size > 0 ? named : emailShaped;
-  if (candidates.size === 0) return { kind: "unresolved" };
-  if (candidates.size > 1) return { kind: "ambiguous", candidates: [...candidates].sort() };
-  return { kind: "resolved", email: [...candidates][0] };
+type ExpectedIdentityClaimRead =
+  | { kind: "absent" }
+  | { kind: "invalid" }
+  | {
+      kind: "present";
+      claimId: string;
+      canonicalPrincipalId: string;
+      connectorAccountId: string;
+      generation: number;
+      deliveryKey: string;
+    };
+
+function expectedIdentityClaim(content: Content): ExpectedIdentityClaimRead {
+  const metadata = content.metadata;
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+    return { kind: "absent" };
+  }
+  const value = (metadata as Record<string, unknown>).identityDeliveryClaim;
+  if (value === undefined) return { kind: "absent" };
+  if (!value || typeof value !== "object" || Array.isArray(value)) return { kind: "invalid" };
+  const evidence = value as Record<string, unknown>;
+  if (
+    typeof evidence.claimId !== "string" ||
+    typeof evidence.canonicalPrincipalId !== "string" ||
+    typeof evidence.connectorAccountId !== "string" ||
+    typeof evidence.generation !== "number" ||
+    typeof evidence.deliveryKey !== "string"
+  ) {
+    return { kind: "invalid" };
+  }
+  return {
+    kind: "present",
+    claimId: evidence.claimId,
+    canonicalPrincipalId: evidence.canonicalPrincipalId,
+    connectorAccountId: evidence.connectorAccountId,
+    generation: evidence.generation,
+    deliveryKey: evidence.deliveryKey,
+  };
 }
 
 function subjectFromContent(content: Content): string {
@@ -224,7 +337,7 @@ async function sendGmailFromTarget(
   runtime: IAgentRuntime,
   target: TargetInfo,
   content: Content
-): Promise<SendHandlerOutcome> {
+): Promise<SendHandlerOutcome | undefined> {
   const service = getGmailSendService(runtime);
   if (!service) {
     return {
@@ -234,13 +347,37 @@ async function sendGmailFromTarget(
     };
   }
 
-  const resolution = await resolveRecipientEmail(runtime, target);
+  const account = await resolveGmailAccountId(runtime, target.accountId);
+  if ("error" in account) {
+    return account.error;
+  }
+
+  const expectedClaim = expectedIdentityClaim(content);
+  if (expectedClaim.kind === "invalid") {
+    return {
+      kind: "not_delivered",
+      code: "GMAIL_IDENTITY_AUTHORITY_UNAVAILABLE",
+      message: "Canonical identity evidence is malformed; refusing to send.",
+    };
+  }
+  const resolution = await resolveRecipientEmail(
+    runtime,
+    target,
+    account.accountId,
+    expectedClaim.kind === "present" ? expectedClaim : undefined
+  );
   if (resolution.kind === "unresolved") {
     return {
       kind: "not_delivered",
       code: "GMAIL_RECIPIENT_UNRESOLVED",
-      message:
-        "Could not resolve an email address for the recipient. Provide a literal address (name@example.com) or a contact with a stored email.",
+      message: `Could not resolve an active verified email claim for the recipient (${resolution.reason}). Provide a literal address or verify the contact's Google identity.`,
+    };
+  }
+  if (resolution.kind === "unavailable") {
+    return {
+      kind: "not_delivered",
+      code: "GMAIL_IDENTITY_AUTHORITY_UNAVAILABLE",
+      message: `Canonical identity authority is unavailable (${resolution.reason}); refusing to send.`,
     };
   }
   if (resolution.kind === "ambiguous") {
@@ -254,11 +391,6 @@ async function sendGmailFromTarget(
   }
   const recipient = resolution.email;
 
-  const account = await resolveGmailAccountId(runtime, target.accountId);
-  if ("error" in account) {
-    return account.error;
-  }
-
   const bodyText = String(content.text ?? "");
   const sent = await service.sendGmailMessage({
     accountId: account.accountId,
@@ -267,14 +399,17 @@ async function sendGmailFromTarget(
     bodyText,
   });
 
+  const providerMessageId = sent.messageId ?? sent.threadId;
+  if (!providerMessageId) {
+    // The provider call may have been accepted, but without returned Gmail
+    // evidence the connector cannot truthfully classify it as delivered.
+    return undefined;
+  }
+
   return {
     kind: "delivered",
     receipt: {
-      // Gmail returns the created message id on acceptance; the thread id is
-      // the fallback evidence if the id field is ever absent on a 200.
-      providerMessageIds: [
-        sent.messageId ?? sent.threadId ?? `gmail:${account.accountId}:accepted`,
-      ],
+      providerMessageIds: [providerMessageId],
       acceptedAt: Date.now(),
       persistence: {
         status: "not_attempted",
@@ -316,6 +451,26 @@ export function createGmailMessageConnector(_runtime: IAgentRuntime): MessageCon
           contexts: ["email", "connectors"],
         },
       ];
+    },
+    resolveIdentityClaimTarget: (
+      claim,
+      _context,
+      canonicalPrincipalId
+    ): MessageConnectorTarget | null => {
+      const email = emailLiteral(claim.handle) ?? emailLiteral(claim.externalSubjectId);
+      if (!email) return null;
+      return {
+        target: {
+          source: GMAIL_MESSAGE_SOURCE,
+          entityId: canonicalPrincipalId,
+          channelId: email.toLowerCase(),
+        },
+        identityDeliveryKey: email.toLowerCase(),
+        label: email.toLowerCase(),
+        kind: "email",
+        score: 1,
+        contexts: ["email", "connectors"],
+      };
     },
     sendHandler: async (handlerRuntime, target, content) =>
       sendGmailFromTarget(handlerRuntime, target, content),

--- a/plugins/plugin-google-workspace/src/gmail-message-connector.ts
+++ b/plugins/plugin-google-workspace/src/gmail-message-connector.ts
@@ -5,11 +5,14 @@
  * SOURCE_CONNECTOR_NOT_FOUND, and routes delivery through
  * `GoogleWorkspaceService.sendGmailMessage`.
  *
- * Recipient resolution: a literal address is used as-is when no principal
- * UUID is present. A principal UUID always resolves through the canonical
- * identity service's active verified Google claim scoped to the selected
- * connector account; a carried channelId cannot override that authority.
- * Account routing is `connector`-scoped: the handler honors an explicit
+ * Recipient resolution is gated by the IDENTITY_DELIVERY_CLAIMS_AUTHORITATIVE
+ * runtime setting. Legacy mode (default, while claim ingestion from issue
+ * #23099 is unshipped): a literal address on the target is used as-is and an
+ * entity UUID resolves through the entity's stored email component data. Claim
+ * mode: a principal UUID always resolves through the canonical identity
+ * service's active verified Google claim scoped to the selected connector
+ * account; a carried channelId cannot override that authority. Account
+ * routing is `connector`-scoped: the handler honors an explicit
  * target accountId, else the sole policy-authorized, gmail-send-capable Google
  * account, and refuses with a structural not_delivered when the account choice
  * is unauthorized, ambiguous, or absent. Subject comes from `content.metadata.subject`
@@ -25,7 +28,10 @@ import {
   type Content,
   getConnectorAccountManager,
   type IAgentRuntime,
+  IDENTITY_DELIVERY_CLAIMS_AUTHORITATIVE_SETTING,
+  type IdentityClaim,
   type IdentityDeliveryClaimResolution,
+  identityDeliveryClaimsAuthoritative,
   type MessageConnectorRegistration,
   type MessageConnectorTarget,
   type PrincipalService,
@@ -41,6 +47,7 @@ export const GMAIL_MESSAGE_SOURCE = "gmail";
 
 const EMAIL_ADDRESS_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/;
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const EMAIL_COMPONENT_KEYS = ["email", "emailAddress"] as const;
 const GMAIL_SEND_ACCOUNT_STATUSES: ConnectorAccountStatus[] = ["connected"];
 const GMAIL_SEND_ACCOUNT_PURPOSES: ConnectorAccountPurpose[] = ["messaging"];
 const GMAIL_SEND_ACCOUNT_ACCESS_GATES: ConnectorAccountAccessGate[] = ["open", "owner_binding"];
@@ -176,10 +183,62 @@ type RecipientResolution =
   | { kind: "ambiguous"; candidates: string[] };
 
 /**
- * Resolve the recipient address fail-closed. A literal target is explicit only
- * when the target does not also identify a principal UUID; principal delivery
- * must yield exactly one active, verified Google claim observed through the
- * selected sending account. Multiple claims refuse rather than guess, and
+ * Legacy (pre-claim-authority) recipient resolution: a literal target address
+ * wins; otherwise the entity graph must yield exactly one distinct stored
+ * email (across explicitly email-named component fields, or — only when no
+ * named field exists — email-shaped component values). Multiple distinct
+ * candidates refuse rather than guess, so a contact with work + personal
+ * addresses never gets mail routed by component iteration order. Active only
+ * while IDENTITY_DELIVERY_CLAIMS_AUTHORITATIVE is off.
+ */
+async function resolveLegacyRecipientEmail(
+  runtime: IAgentRuntime,
+  target: TargetInfo
+): Promise<RecipientResolution> {
+  const literal = emailLiteral(target.channelId) ?? emailLiteral(target.entityId);
+  if (literal) return { kind: "resolved", email: literal };
+
+  const entityId = String(target.entityId ?? "").trim();
+  if (!UUID_PATTERN.test(entityId) || typeof runtime.getEntityById !== "function") {
+    return { kind: "unresolved", reason: "target carries no literal address or entity id" };
+  }
+  const entity = await runtime.getEntityById(entityId as UUID);
+  if (!entity) return { kind: "unresolved", reason: "entity not found" };
+
+  const named = new Set<string>();
+  const emailShaped = new Set<string>();
+  for (const component of entity.components ?? []) {
+    const data = component.data ?? {};
+    for (const key of EMAIL_COMPONENT_KEYS) {
+      const value = emailLiteral(data[key]);
+      if (value) named.add(value.toLowerCase());
+    }
+    for (const value of Object.values(data)) {
+      const email = emailLiteral(value);
+      if (email) emailShaped.add(email.toLowerCase());
+    }
+  }
+
+  const candidates = named.size > 0 ? named : emailShaped;
+  if (candidates.size === 0) {
+    return { kind: "unresolved", reason: "the contact has no stored email address" };
+  }
+  if (candidates.size > 1) return { kind: "ambiguous", candidates: [...candidates].sort() };
+  return { kind: "resolved", email: [...candidates][0] };
+}
+
+/** The lowercased deliverable address a verified Google claim carries, if any. */
+function claimEmail(claim: IdentityClaim): string | undefined {
+  const email = emailLiteral(claim.handle) ?? emailLiteral(claim.externalSubjectId);
+  return email?.toLowerCase();
+}
+
+/**
+ * Resolve the recipient address fail-closed under claim authority. A literal
+ * target is explicit only when the target does not also identify a principal
+ * UUID; principal delivery must yield exactly one distinct deliverable address
+ * across the active, verified Google claims observed through the selected
+ * sending account. Multiple distinct addresses refuse rather than guess, and
  * legacy entity components are never consulted as recipient authority.
  */
 async function resolveRecipientEmail(
@@ -231,31 +290,74 @@ async function resolveRecipientEmail(
     return { kind: "unresolved", reason: resolution.reason };
   }
   if (resolution.decision === "ambiguous") {
-    const candidates = resolution.claims
-      .flatMap((claim) => [claim.handle, claim.externalSubjectId])
-      .filter(isEmailAddress)
-      .map((email) => email.toLowerCase());
-    const distinctCandidates = [...new Set(candidates)].sort();
-    if (distinctCandidates.length === 0) {
+    // Ambiguity is judged on distinct deliverable addresses, not raw claim
+    // rows: one address observed by several claims (for example as both
+    // handle and subject id) is a single destination and must resolve.
+    const claimsByEmail = new Map<string, IdentityClaim>();
+    for (const claim of resolution.claims) {
+      const email = claimEmail(claim);
+      if (email && !claimsByEmail.has(email)) claimsByEmail.set(email, claim);
+    }
+    if (claimsByEmail.size === 0) {
       return {
         kind: "unresolved",
         reason: "verified claims contain no deliverable email address",
       };
     }
-    return { kind: "ambiguous", candidates: distinctCandidates };
+    if (claimsByEmail.size > 1) {
+      return { kind: "ambiguous", candidates: [...claimsByEmail.keys()].sort() };
+    }
+    const evidenceClaim = expectedClaim
+      ? resolution.claims.find((claim) => claim.id === expectedClaim.claimId)
+      : [...claimsByEmail.values()][0];
+    if (!evidenceClaim) {
+      return {
+        kind: "unavailable",
+        reason: "canonical delivery claim changed after target selection",
+      };
+    }
+    return claimRecipientResolution(
+      evidenceClaim,
+      resolution.canonicalPrincipalId,
+      resolution.generation,
+      expectedClaim
+    );
   }
-  const email =
-    emailLiteral(resolution.claim.handle) ?? emailLiteral(resolution.claim.externalSubjectId);
-  if (!email) {
+  return claimRecipientResolution(
+    resolution.claim,
+    resolution.canonicalPrincipalId,
+    resolution.generation,
+    expectedClaim
+  );
+}
+
+/**
+ * Finalize a single verified claim into a resolved recipient, revalidating
+ * the planner-carried claim evidence so an identity change between target
+ * selection and dispatch refuses instead of silently rerouting.
+ */
+function claimRecipientResolution(
+  claim: IdentityClaim,
+  canonicalPrincipalId: UUID,
+  generation: number,
+  expectedClaim?: {
+    claimId: string;
+    canonicalPrincipalId: string;
+    connectorAccountId: string;
+    generation: number;
+    deliveryKey: string;
+  }
+): RecipientResolution {
+  const normalizedEmail = claimEmail(claim);
+  if (!normalizedEmail) {
     return { kind: "unresolved", reason: "verified claim has no deliverable email address" };
   }
-  const normalizedEmail = email.toLowerCase();
   if (
     expectedClaim &&
-    (expectedClaim.claimId !== resolution.claim.id ||
-      expectedClaim.canonicalPrincipalId !== resolution.canonicalPrincipalId ||
-      expectedClaim.connectorAccountId !== resolution.claim.connectorAccountId ||
-      expectedClaim.generation !== resolution.generation ||
+    (expectedClaim.claimId !== claim.id ||
+      expectedClaim.canonicalPrincipalId !== canonicalPrincipalId ||
+      expectedClaim.connectorAccountId !== claim.connectorAccountId ||
+      expectedClaim.generation !== generation ||
       expectedClaim.deliveryKey.toLowerCase() !== normalizedEmail)
   ) {
     return {
@@ -267,10 +369,10 @@ async function resolveRecipientEmail(
     kind: "resolved",
     email: normalizedEmail,
     identityClaim: {
-      claimId: resolution.claim.id,
-      canonicalPrincipalId: resolution.canonicalPrincipalId,
-      connectorAccountId: resolution.claim.connectorAccountId,
-      generation: resolution.generation,
+      claimId: claim.id,
+      canonicalPrincipalId,
+      connectorAccountId: claim.connectorAccountId,
+      generation,
       deliveryKey: normalizedEmail,
     },
   };
@@ -352,25 +454,35 @@ async function sendGmailFromTarget(
     return account.error;
   }
 
-  const expectedClaim = expectedIdentityClaim(content);
-  if (expectedClaim.kind === "invalid") {
-    return {
-      kind: "not_delivered",
-      code: "GMAIL_IDENTITY_AUTHORITY_UNAVAILABLE",
-      message: "Canonical identity evidence is malformed; refusing to send.",
-    };
-  }
-  const resolution = await resolveRecipientEmail(
-    runtime,
-    target,
-    account.accountId,
-    expectedClaim.kind === "present" ? expectedClaim : undefined
+  const claimsAuthoritative = identityDeliveryClaimsAuthoritative(
+    runtime.getSetting(IDENTITY_DELIVERY_CLAIMS_AUTHORITATIVE_SETTING)
   );
+  let resolution: RecipientResolution;
+  if (claimsAuthoritative) {
+    const expectedClaim = expectedIdentityClaim(content);
+    if (expectedClaim.kind === "invalid") {
+      return {
+        kind: "not_delivered",
+        code: "GMAIL_IDENTITY_AUTHORITY_UNAVAILABLE",
+        message: "Canonical identity evidence is malformed; refusing to send.",
+      };
+    }
+    resolution = await resolveRecipientEmail(
+      runtime,
+      target,
+      account.accountId,
+      expectedClaim.kind === "present" ? expectedClaim : undefined
+    );
+  } else {
+    resolution = await resolveLegacyRecipientEmail(runtime, target);
+  }
   if (resolution.kind === "unresolved") {
     return {
       kind: "not_delivered",
       code: "GMAIL_RECIPIENT_UNRESOLVED",
-      message: `Could not resolve an active verified email claim for the recipient (${resolution.reason}). Provide a literal address or verify the contact's Google identity.`,
+      message: claimsAuthoritative
+        ? `Could not resolve an active verified email claim for the recipient (${resolution.reason}). Provide a literal address or verify the contact's Google identity.`
+        : `Could not resolve an email address for the recipient (${resolution.reason}). Provide a literal address (name@example.com) or a contact with a stored email.`,
     };
   }
   if (resolution.kind === "unavailable") {

--- a/plugins/plugin-sql/src/__tests__/integration/identity-authority.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/identity-authority.real.test.ts
@@ -36,6 +36,8 @@ describe("SQL identity authority", () => {
   const sourceF = crypto.randomUUID() as UUID;
   const ownerPrincipalId = crypto.randomUUID() as UUID;
   const configuredOwnerAliasId = crypto.randomUUID() as UUID;
+  const deliveryAccountA = crypto.randomUUID() as UUID;
+  const deliveryAccountB = crypto.randomUUID() as UUID;
 
   beforeAll(async () => {
     const setup = await createIsolatedTestDatabase("identity-authority-real");
@@ -156,6 +158,133 @@ describe("SQL identity authority", () => {
     expect(await db.select().from(identityMergeJournalTable)).toHaveLength(2);
     const [consumed] = await db.select().from(identityMergeConfirmationTable);
     expect(consumed?.status).toBe("consumed");
+  });
+
+  it("resolves delivery only through verified canonical-cluster claims and reports typed ambiguity", async () => {
+    await db
+      .insert(connectorAccountsTable)
+      .values([
+        {
+          id: deliveryAccountA,
+          agentId,
+          provider: "discord",
+          accountKey: "delivery-a",
+          status: "connected",
+        },
+        {
+          id: deliveryAccountB,
+          agentId,
+          provider: "discord",
+          accountKey: "delivery-b",
+          status: "connected",
+        },
+      ])
+      .onConflictDoNothing();
+    await db
+      .insert(identityClaimTable)
+      .values([
+        {
+          agentId,
+          principalEntityId: sourceB,
+          namespace: "connector_subject",
+          connectorId: "discord",
+          connectorAccountId: deliveryAccountA,
+          externalSubjectId: "discord-user-a",
+          handle: "shadow-a",
+          verification: "verified",
+          status: "active",
+          confidence: 1,
+          verifiedAt: new Date(),
+        },
+        {
+          agentId,
+          principalEntityId: sourceB,
+          namespace: "connector_subject",
+          connectorId: "discord",
+          connectorAccountId: deliveryAccountB,
+          externalSubjectId: "discord-user-b",
+          handle: "shadow-b",
+          verification: "verified",
+          status: "active",
+          confidence: 1,
+          verifiedAt: new Date(),
+        },
+      ])
+      .onConflictDoNothing();
+
+    const ambiguous = await service.resolveIdentityDeliveryClaim({
+      agentId,
+      principalId: canonicalId,
+      connectorId: "discord",
+    });
+    expect(ambiguous).toMatchObject({
+      decision: "ambiguous",
+      requestedPrincipalId: canonicalId,
+      canonicalPrincipalId: canonicalId,
+      reason: "multiple_verified_claims",
+    });
+    if (ambiguous.decision !== "ambiguous") throw new Error("expected ambiguity");
+    expect(ambiguous.claims.map((claim) => claim.connectorAccountId)).toEqual(
+      [deliveryAccountA, deliveryAccountB].sort()
+    );
+
+    for (const ineligibleAccount of [
+      { status: "disconnected", provider: "discord", deletedAt: null },
+      { status: "connected", provider: "google", deletedAt: null },
+      { status: "connected", provider: "discord", deletedAt: new Date() },
+    ]) {
+      await db
+        .update(connectorAccountsTable)
+        .set(ineligibleAccount)
+        .where(eq(connectorAccountsTable.id, deliveryAccountA));
+      await expect(
+        service.resolveIdentityDeliveryClaim({
+          agentId,
+          principalId: sourceB,
+          connectorId: "discord",
+          connectorAccountId: deliveryAccountA,
+        })
+      ).resolves.toMatchObject({
+        decision: "no_claim",
+        reason: "connector_account_ineligible",
+      });
+    }
+    await db
+      .update(connectorAccountsTable)
+      .set({ status: "connected", provider: "discord", deletedAt: null })
+      .where(eq(connectorAccountsTable.id, deliveryAccountA));
+
+    await expect(
+      service.resolveIdentityDeliveryClaim({
+        agentId,
+        principalId: sourceB,
+        connectorId: "discord",
+        connectorAccountId: deliveryAccountB,
+      })
+    ).resolves.toMatchObject({
+      decision: "resolved",
+      requestedPrincipalId: sourceB,
+      canonicalPrincipalId: canonicalId,
+      claim: {
+        connectorAccountId: deliveryAccountB,
+        externalSubjectId: "discord-user-b",
+      },
+    });
+    await expect(
+      service.resolveIdentityDeliveryClaim({
+        agentId,
+        principalId: sourceB,
+        connectorId: "gmail",
+      })
+    ).resolves.toMatchObject({ decision: "no_claim", reason: "no_connector_claim" });
+    await expect(
+      service.resolveIdentityDeliveryClaim({
+        agentId,
+        principalId: sourceB,
+        connectorId: "discord",
+        connectorAccountId: crypto.randomUUID() as UUID,
+      })
+    ).resolves.toMatchObject({ decision: "no_claim", reason: "no_account_claim" });
   });
 
   it("rejects foreign runtime tenants before reading", async () => {

--- a/plugins/plugin-sql/src/services/sql-principal.ts
+++ b/plugins/plugin-sql/src/services/sql-principal.ts
@@ -16,6 +16,7 @@ import {
   type IdentityClaimConflict,
   type IdentityClaimScope,
   type IdentityCluster,
+  type IdentityDeliveryClaimResolution,
   type IdentityJournalPage,
   type IdentityMergeConfirmation,
   type IdentityMergePlan,
@@ -26,13 +27,14 @@ import {
   type OwnerBindingEvaluation,
   PrincipalService,
   type ProposeIdentityMergeRequest,
+  type ResolveIdentityDeliveryClaimRequest,
   type Service,
   type SplitIdentityRequest,
   type UUID,
   type VerifyIdentityPersonLinkRequest,
 } from "@elizaos/core";
 import { sha256 } from "@noble/hashes/sha2.js";
-import { and, desc, eq, inArray, lt, or, sql } from "drizzle-orm";
+import { and, desc, eq, inArray, isNull, lt, or, sql } from "drizzle-orm";
 import { authOwnerBindingTable } from "../schema/authOwnerBinding";
 import { connectorAccountsTable } from "../schema/connectorAccounts";
 import { entityTable } from "../schema/entity";
@@ -431,6 +433,131 @@ export class SqlPrincipalService extends PrincipalService {
         (claim.verification === "verified" || claim.verification === "owner_bound") &&
         (connectorAccountId === undefined || claim.connectorAccountId === connectorAccountId)
     );
+  }
+
+  async resolveIdentityDeliveryClaim(
+    request: ResolveIdentityDeliveryClaimRequest
+  ): Promise<IdentityDeliveryClaimResolution> {
+    this.assertAgent(request.agentId);
+    const cluster = await this.getCluster(request.agentId, request.principalId);
+    if (!cluster) {
+      return {
+        decision: "no_claim",
+        requestedPrincipalId: request.principalId,
+        canonicalPrincipalId: null,
+        generation: null,
+        reason: "principal_not_found",
+      };
+    }
+
+    const verified = cluster.claims.filter(
+      (claim) =>
+        claim.status === "active" &&
+        (claim.verification === "verified" || claim.verification === "owner_bound")
+    );
+    if (verified.length === 0) {
+      return {
+        decision: "no_claim",
+        requestedPrincipalId: request.principalId,
+        canonicalPrincipalId: cluster.canonicalPrincipalId,
+        generation: cluster.generation,
+        reason: "no_active_verified_claim",
+      };
+    }
+
+    const requestedConnector = request.connectorId?.trim().toLowerCase();
+    const connectorClaims = requestedConnector
+      ? verified.filter((claim) => claim.connectorId.trim().toLowerCase() === requestedConnector)
+      : verified;
+    if (connectorClaims.length === 0) {
+      return {
+        decision: "no_claim",
+        requestedPrincipalId: request.principalId,
+        canonicalPrincipalId: cluster.canonicalPrincipalId,
+        generation: cluster.generation,
+        reason: "no_connector_claim",
+      };
+    }
+
+    const accountClaims = request.connectorAccountId
+      ? connectorClaims.filter((claim) => claim.connectorAccountId === request.connectorAccountId)
+      : connectorClaims;
+    if (accountClaims.length === 0) {
+      return {
+        decision: "no_claim",
+        requestedPrincipalId: request.principalId,
+        canonicalPrincipalId: cluster.canonicalPrincipalId,
+        generation: cluster.generation,
+        reason: "no_account_claim",
+      };
+    }
+
+    const accountIds = [...new Set(accountClaims.map((claim) => claim.connectorAccountId))];
+    const accountRows = await this.db
+      .select({ id: connectorAccountsTable.id, provider: connectorAccountsTable.provider })
+      .from(connectorAccountsTable)
+      .where(
+        and(
+          eq(connectorAccountsTable.agentId, request.agentId),
+          inArray(connectorAccountsTable.id, accountIds),
+          eq(connectorAccountsTable.status, "connected"),
+          isNull(connectorAccountsTable.deletedAt)
+        )
+      );
+    const eligibleProviders = new Map(
+      accountRows.map((account) => [account.id, account.provider.trim().toLowerCase()])
+    );
+    const eligibleClaims = accountClaims.filter(
+      (claim) =>
+        eligibleProviders.get(claim.connectorAccountId) === claim.connectorId.trim().toLowerCase()
+    );
+    if (eligibleClaims.length === 0) {
+      return {
+        decision: "no_claim",
+        requestedPrincipalId: request.principalId,
+        canonicalPrincipalId: cluster.canonicalPrincipalId,
+        generation: cluster.generation,
+        reason: "connector_account_ineligible",
+      };
+    }
+
+    const claims = [...eligibleClaims].sort((left, right) =>
+      [
+        left.connectorId,
+        left.connectorAccountId,
+        left.handle ?? "",
+        left.externalSubjectId,
+        left.id,
+      ]
+        .join("\u0000")
+        .localeCompare(
+          [
+            right.connectorId,
+            right.connectorAccountId,
+            right.handle ?? "",
+            right.externalSubjectId,
+            right.id,
+          ].join("\u0000")
+        )
+    );
+    const claim = claims[0];
+    if (claims.length === 1 && claim) {
+      return {
+        decision: "resolved",
+        requestedPrincipalId: request.principalId,
+        canonicalPrincipalId: cluster.canonicalPrincipalId,
+        claim,
+        generation: cluster.generation,
+      };
+    }
+    return {
+      decision: "ambiguous",
+      requestedPrincipalId: request.principalId,
+      canonicalPrincipalId: cluster.canonicalPrincipalId,
+      claims,
+      generation: cluster.generation,
+      reason: "multiple_verified_claims",
+    };
   }
 
   async evaluateOwnerBinding(

--- a/plugins/plugin-sql/src/services/sql-principal.ts
+++ b/plugins/plugin-sql/src/services/sql-principal.ts
@@ -435,70 +435,25 @@ export class SqlPrincipalService extends PrincipalService {
     );
   }
 
-  async resolveIdentityDeliveryClaim(
-    request: ResolveIdentityDeliveryClaimRequest
-  ): Promise<IdentityDeliveryClaimResolution> {
-    this.assertAgent(request.agentId);
-    const cluster = await this.getCluster(request.agentId, request.principalId);
-    if (!cluster) {
-      return {
-        decision: "no_claim",
-        requestedPrincipalId: request.principalId,
-        canonicalPrincipalId: null,
-        generation: null,
-        reason: "principal_not_found",
-      };
-    }
-
-    const verified = cluster.claims.filter(
-      (claim) =>
-        claim.status === "active" &&
-        (claim.verification === "verified" || claim.verification === "owner_bound")
-    );
-    if (verified.length === 0) {
-      return {
-        decision: "no_claim",
-        requestedPrincipalId: request.principalId,
-        canonicalPrincipalId: cluster.canonicalPrincipalId,
-        generation: cluster.generation,
-        reason: "no_active_verified_claim",
-      };
-    }
-
-    const requestedConnector = request.connectorId?.trim().toLowerCase();
-    const connectorClaims = requestedConnector
-      ? verified.filter((claim) => claim.connectorId.trim().toLowerCase() === requestedConnector)
-      : verified;
-    if (connectorClaims.length === 0) {
-      return {
-        decision: "no_claim",
-        requestedPrincipalId: request.principalId,
-        canonicalPrincipalId: cluster.canonicalPrincipalId,
-        generation: cluster.generation,
-        reason: "no_connector_claim",
-      };
-    }
-
-    const accountClaims = request.connectorAccountId
-      ? connectorClaims.filter((claim) => claim.connectorAccountId === request.connectorAccountId)
-      : connectorClaims;
-    if (accountClaims.length === 0) {
-      return {
-        decision: "no_claim",
-        requestedPrincipalId: request.principalId,
-        canonicalPrincipalId: cluster.canonicalPrincipalId,
-        generation: cluster.generation,
-        reason: "no_account_claim",
-      };
-    }
-
-    const accountIds = [...new Set(accountClaims.map((claim) => claim.connectorAccountId))];
+  /**
+   * Delivery-claim eligibility: a claim may route a send only through a
+   * connector account that is still connected, not soft-deleted, and whose
+   * provider matches the claim's connector authority. The decision pipeline
+   * and ordering live in the shared PrincipalService base.
+   */
+  protected async filterConnectorAccountEligibleClaims(
+    agentId: UUID,
+    claims: readonly IdentityClaim[]
+  ): Promise<readonly IdentityClaim[]> {
+    this.assertAgent(agentId);
+    if (claims.length === 0) return [];
+    const accountIds = [...new Set(claims.map((claim) => claim.connectorAccountId))];
     const accountRows = await this.db
       .select({ id: connectorAccountsTable.id, provider: connectorAccountsTable.provider })
       .from(connectorAccountsTable)
       .where(
         and(
-          eq(connectorAccountsTable.agentId, request.agentId),
+          eq(connectorAccountsTable.agentId, agentId),
           inArray(connectorAccountsTable.id, accountIds),
           eq(connectorAccountsTable.status, "connected"),
           isNull(connectorAccountsTable.deletedAt)
@@ -507,57 +462,17 @@ export class SqlPrincipalService extends PrincipalService {
     const eligibleProviders = new Map(
       accountRows.map((account) => [account.id, account.provider.trim().toLowerCase()])
     );
-    const eligibleClaims = accountClaims.filter(
+    return claims.filter(
       (claim) =>
         eligibleProviders.get(claim.connectorAccountId) === claim.connectorId.trim().toLowerCase()
     );
-    if (eligibleClaims.length === 0) {
-      return {
-        decision: "no_claim",
-        requestedPrincipalId: request.principalId,
-        canonicalPrincipalId: cluster.canonicalPrincipalId,
-        generation: cluster.generation,
-        reason: "connector_account_ineligible",
-      };
-    }
+  }
 
-    const claims = [...eligibleClaims].sort((left, right) =>
-      [
-        left.connectorId,
-        left.connectorAccountId,
-        left.handle ?? "",
-        left.externalSubjectId,
-        left.id,
-      ]
-        .join("\u0000")
-        .localeCompare(
-          [
-            right.connectorId,
-            right.connectorAccountId,
-            right.handle ?? "",
-            right.externalSubjectId,
-            right.id,
-          ].join("\u0000")
-        )
-    );
-    const claim = claims[0];
-    if (claims.length === 1 && claim) {
-      return {
-        decision: "resolved",
-        requestedPrincipalId: request.principalId,
-        canonicalPrincipalId: cluster.canonicalPrincipalId,
-        claim,
-        generation: cluster.generation,
-      };
-    }
-    return {
-      decision: "ambiguous",
-      requestedPrincipalId: request.principalId,
-      canonicalPrincipalId: cluster.canonicalPrincipalId,
-      claims,
-      generation: cluster.generation,
-      reason: "multiple_verified_claims",
-    };
+  override async resolveIdentityDeliveryClaim(
+    request: ResolveIdentityDeliveryClaimRequest
+  ): Promise<IdentityDeliveryClaimResolution> {
+    this.assertAgent(request.agentId);
+    return super.resolveIdentityDeliveryClaim(request);
   }
 
   async evaluateOwnerBinding(


### PR DESCRIPTION
## Summary

- make canonical principal clusters plus active, verified account-scoped identity claims the authority for named-recipient delivery
- add typed resolved, ambiguous, and no-claim outcomes and a connector-owned claim-to-target mapping hook
- migrate MESSAGE and Gmail without treating legacy entity components as delivery authority
- revalidate claim evidence at Gmail dispatch time to close identity-change races
- return structural unknown when Gmail supplies no message/thread identifier; do not fabricate a receipt or blind-retry

Closes #23099
Related to #23104

## Verification

- `bun install --frozen-lockfile`
- core typecheck; MESSAGE and connector-registration tests: 28/28
- Google Workspace typecheck; Gmail unit and real-runtime loopback tests: 31/31
- SQL typecheck; real migrated PGlite authority tests: 6/6
- app-core typecheck
- changed-file Biome checks and `git diff --check`
- independent adversarial review: no blocking findings after remediation

The real-runtime Gmail scenario uses production AgentRuntime, MESSAGE action, Google plugin/client, connector-account manager, SqlPrincipalService, and migrated PGlite. Only the external Gmail HTTP boundary is a deterministic loopback fixture.

A repository-wide `bun run verify` passed before the final develop rebase. The post-rebase run reported no failure but was stopped after prolonged host-wide contention from multiple concurrent monorepo TypeScript verification jobs; all changed-package gates above are green on the rebased commit.