### PR TITLE
fix(mobile): preserve packaged registry asset access

### DIFF
--- a/packages/registry/src/generate.ts
+++ b/packages/registry/src/generate.ts
@@ -105,6 +105,17 @@ function main(): void {
 }
 
 function isDirectExecution(): boolean {
+  // Mobile builds bundle this module into the agent entry point. In that
+  // artifact import.meta.url and process.argv[1] both identify the bundle, so
+  // the ordinary direct-run check would regenerate a packaged read-only asset
+  // during every agent boot. The mobile bundler defines both markers.
+  if (
+    process.env.ELIZA_DISABLE_DIRECT_RUN === "1" ||
+    (globalThis as { __ELIZA_MOBILE_BUNDLE__?: unknown })
+      .__ELIZA_MOBILE_BUNDLE__ === true
+  ) {
+    return false;
+  }
   const entry = process.argv[1];
   return Boolean(entry) && import.meta.url === pathToFileURL(entry).href;
 }

--- a/packages/registry/src/registry.test.ts
+++ b/packages/registry/src/registry.test.ts
@@ -2,8 +2,10 @@
  * Tests for the third-party registry tooling: `validateRegistryEntry` accepts a
  * well-formed entry and rejects the reserved @elizaos scope, non-GitHub repos,
  * unknown kinds, and unknown fields; `generateRegistry` produces the wire
- * format. Runs against the real entries/third-party sources on disk.
+ * format, while bundled mobile imports cannot trigger on-disk regeneration.
+ * Runs against the real entries/third-party sources on disk.
  */
+import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -164,6 +166,31 @@ describe("toGeneratedEntry", () => {
 });
 
 describe("on-disk entries", () => {
+  it.each([
+    {
+      name: "environment marker",
+      setup: 'process.env.ELIZA_DISABLE_DIRECT_RUN = "1";',
+    },
+    {
+      name: "mobile bundle marker",
+      setup: "globalThis.__ELIZA_MOBILE_BUNDLE__ = true;",
+    },
+  ])("does not regenerate when the $name is set", ({ setup }) => {
+    const generatePath = path.join(packageRoot, "src", "generate.ts");
+    const script = [
+      `process.argv[1] = ${JSON.stringify(generatePath)};`,
+      setup,
+      `await import(${JSON.stringify(generatePath)});`,
+    ].join("\n");
+
+    expect(
+      execFileSync(process.execPath, ["-e", script], {
+        encoding: "utf8",
+        timeout: 30_000,
+      }),
+    ).toBe("");
+  });
+
   it("all entries are valid and generate a complete registry", () => {
     const entries = loadThirdPartyEntries();
     expect(entries.length).toBeGreaterThan(0);

--- a/plugins/plugin-capacitor-bridge/src/ios/bridge.ts
+++ b/plugins/plugin-capacitor-bridge/src/ios/bridge.ts
@@ -12,6 +12,7 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import path from "node:path";
 import process from "node:process";
 import { Readable } from "node:stream";
+import { fileURLToPath } from "node:url";
 import {
 	ChannelType,
 	compareMemoryIds,
@@ -577,7 +578,12 @@ async function startIosBridgeBackend(): Promise<IosBridgeBackend> {
 		(process.env.HOME
 			? `${process.env.HOME}/Library/Application Support/Eliza/workspace`
 			: "/tmp/eliza-workspace");
-	installMobileFsShim(mobileWorkspaceRoot);
+	const packagedPublicDir = argvEnv.bundlePath
+		? path.dirname(path.dirname(argvEnv.bundlePath))
+		: path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+	installMobileFsShim(mobileWorkspaceRoot, {
+		readOnlyRoots: [packagedPublicDir],
+	});
 
 	(
 		globalThis as { __ELIZA_DISABLE_DIRECT_RUN?: boolean }

--- a/plugins/plugin-capacitor-bridge/src/shared/fs-shim.alias.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/shared/fs-shim.alias.test.ts
@@ -9,6 +9,8 @@
  */
 
 import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import nodePath from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
@@ -67,7 +69,7 @@ describe("installMobileFsShim alias acceptance (real shim, Bun subprocess)", () 
 			`try { sandboxedPath("/data/data/other.pkg/files/x"); } catch { out.otherPkgBlocked = true; }`,
 			`console.log(JSON.stringify(out));`,
 		].join("\n");
-		const stdout = execFileSync("bun", ["-e", script], {
+		const stdout = execFileSync(process.execPath, ["-e", script], {
 			encoding: "utf8",
 			timeout: 30_000,
 		});
@@ -79,5 +81,42 @@ describe("installMobileFsShim alias acceptance (real shim, Bun subprocess)", () 
 			escapeBlocked: true,
 			otherPkgBlocked: true,
 		});
+	});
+
+	it("accepts an explicit packaged read-only root without allowing writes", () => {
+		const fixtureRoot = mkdtempSync(nodePath.join(tmpdir(), "eliza-fs-shim-"));
+		const workspaceRoot = nodePath.join(fixtureRoot, "workspace");
+		const publicRoot = nodePath.join(fixtureRoot, "App.app", "public");
+		const registryPath = nodePath.join(publicRoot, "generated-registry.json");
+		mkdirSync(workspaceRoot, { recursive: true });
+		mkdirSync(publicRoot, { recursive: true });
+		const expectedRegistry = '{"registry":{"fixture":{"version":"1.2.3"}}}\n';
+		writeFileSync(registryPath, expectedRegistry);
+
+		try {
+			const script = [
+				`(async () => {`,
+				`const { installMobileFsShim } = await import(${JSON.stringify(SHIM_PATH)});`,
+				`installMobileFsShim(${JSON.stringify(workspaceRoot)}, { readOnlyRoots: [${JSON.stringify(publicRoot)}] });`,
+				`const fs = require("node:fs");`,
+				`const out = { before: fs.readFileSync(${JSON.stringify(registryPath)}, "utf8"), writeBlocked: false, after: "" };`,
+				`try { fs.writeFileSync(${JSON.stringify(registryPath)}, "changed"); } catch (error) { out.writeBlocked = error?.code === "EACCES"; }`,
+				`out.after = fs.readFileSync(${JSON.stringify(registryPath)}, "utf8");`,
+				`console.log(JSON.stringify(out));`,
+				`})().catch((error) => { console.error(error); process.exitCode = 1; });`,
+			].join("\n");
+			const stdout = execFileSync(process.execPath, ["-e", script], {
+				encoding: "utf8",
+				timeout: 30_000,
+			});
+			const lastLine = stdout.trim().split("\n").at(-1) ?? "";
+			expect(JSON.parse(lastLine)).toEqual({
+				before: expectedRegistry,
+				writeBlocked: true,
+				after: expectedRegistry,
+			});
+		} finally {
+			rmSync(fixtureRoot, { recursive: true, force: true });
+		}
 	});
 });

--- a/plugins/plugin-capacitor-bridge/src/shared/fs-shim.ts
+++ b/plugins/plugin-capacitor-bridge/src/shared/fs-shim.ts
@@ -122,8 +122,14 @@ function isInsideRoot(pathname: string, root: string): boolean {
 	return pathname === root || pathname.startsWith(rootWithSep);
 }
 
-function envReadOnlyRoots(): string[] {
+export interface MobileFsShimOptions {
+	/** Trusted, packaged asset directories that may be read but never written. */
+	readOnlyRoots?: readonly string[];
+}
+
+function envReadOnlyRoots(options: MobileFsShimOptions): string[] {
 	const candidates = [
+		...(options.readOnlyRoots ?? []),
 		process.env.ELIZA_IOS_AGENT_PUBLIC_DIR,
 		process.env.ELIZA_IOS_AGENT_ASSET_DIR,
 		process.env.ELIZA_IOS_AGENT_BUNDLE
@@ -922,7 +928,10 @@ function patchFsModule(): void {
  * ignored.  A second call with a different root throws to prevent accidental
  * privilege escalation.
  */
-export function installMobileFsShim(workspaceRoot: string): void {
+export function installMobileFsShim(
+	workspaceRoot: string,
+	options: MobileFsShimOptions = {},
+): void {
 	if (!workspaceRoot || typeof workspaceRoot !== "string") {
 		throw new Error(
 			"mobile-fs-shim: installMobileFsShim() requires a non-empty workspaceRoot string",
@@ -947,7 +956,7 @@ export function installMobileFsShim(workspaceRoot: string): void {
 	_workspaceRoot = canonical;
 	_workspaceRootReal = realpathIfPossible(canonical);
 	_workspaceRootAlias = androidAliasSibling(canonical) ?? "";
-	_readOnlyRoots = envReadOnlyRoots().filter(
+	_readOnlyRoots = envReadOnlyRoots(options).filter(
 		(root) => !isInsideRoot(root, canonical),
 	);
 	_readOnlyRootReals = _readOnlyRoots.map((root) => realpathIfPossible(root));


### PR DESCRIPTION
Closes #28920.

The packaged iOS backend could not read `public/generated-registry.json` because the mobile filesystem bridge treated the bundled asset directory as an escape from its writable workspace. The bridge now accepts explicit read-only asset roots, and the iOS bootstrap supplies the actual bundle directory. Canonical-path checks continue to reject writes and symlink escapes. Registry generation is also safe to import without accidentally running its CLI.

Validated head: `f67b9bc98ba858e8179e6d96d7e73c8adff11e5a`; rebased and installed on develop `755a8213f0e165628a90ba0b573f6527f42037e5` with Bun 1.3.14 and Node 24.15.0.

Validation:

- Root `bun run verify`: all 376 workspace tasks and repository audits passed, including owning lint and typechecks.
- Registry suite: 55 passed. Mobile bridge suite previously passed 233 with 2 opt-in skips; the final full rerun passed 232 with 2 skips and one unchanged module-load timeout. That entire remaining file passed separately with a 180-second harness timeout. No assertion or production deadline was relaxed.
- Full embedded-Bun iOS simulator builds succeeded for both the base revision and final head. Strict initial-boot capture passed on both; onboarding alone does not expose this defect.
- The canonical native full-backend smoke reproduced the base failure at the bundled registry path. The final app started the real backend: runtime and database healthy, 18 plugins loaded, zero failed, and a conversation created. The test message returned an error reply, so this evidence does not claim successful model inference.
- The dedicated simulator's data ancestor defaulted to mode 0775. After the registry fix exposed the existing runtime identity guard, that test-only directory was changed to 0755. No application source bypass was added. This environment adjustment is recorded in the readback.

[Before/after native backend readback](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/28959-native-registry-readback-f67b9bc9.json).

<!-- evidence-head:f67b9bc98ba858e8179e6d96d7e73c8adff11e5a -->
<!-- evidence-row:before-screenshots -->
![Base iOS onboarding](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/28959-before-mobile-755a8213.jpg)
Desktop N/A: this change supplies the iOS packaged asset root.
<!-- evidence-row:after-screenshots -->
![Final iOS onboarding](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/28959-after-mobile-f67b9bc9.jpg)
<!-- evidence-row:walkthrough-video -->
![Final native startup](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/28959-final-native-startup.mp4)
<!-- evidence-row:backend-logs -->
[Native backend failure and successful health readback](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/28959-native-registry-readback-f67b9bc9.json).
<!-- evidence-row:frontend-logs -->
Strict native boot captures reached the onboarding surface on both revisions; final bridge status is ready. The native transport, health and send-message results are recorded in the linked JSON. No browser-network receipt is claimed for the native IPC path.
<!-- evidence-row:llm-trajectory -->
N/A - filesystem access and startup contract. The smoke message returned an error reply; model completion is not part of this acceptance claim.
<!-- evidence-row:domain-artifacts -->
Real filesystem tests prove bundle reads, write rejection and symlink-escape rejection; the final native app loads all 18 plugins with no failures. See the linked native readback.
<!-- evidence-row:ocr-review -->
Inspected both full-height iOS captures and accessibility output: the three onboarding choices remain readable and the final screen has no visible startup error. No rendered copy or layout changed.

Exact-head hosted checks must pass before merge.
