### PR TITLE
fix(plugin-native-screencapture): serialize startRecording to close concurrent-start display stream leak

### DIFF
--- a/plugins/plugin-native-screencapture/src/web.test.ts
+++ b/plugins/plugin-native-screencapture/src/web.test.ts
@@ -626,6 +626,97 @@ describe("ScreenCaptureWeb", () => {
     });
   });
 
+  it("serializes two concurrent startRecording calls, rejecting the second without leaking a display stream", async () => {
+    installDocument();
+    vi.stubGlobal("MediaRecorder", FakeMediaRecorder);
+
+    // Each getDisplayMedia call resolves to a *fresh* stream, mirroring the OS
+    // picker handing back a distinct capture. If the re-entrancy guard is racy,
+    // both concurrent calls acquire a stream and the first is orphaned.
+    const acquiredStreams: FakeStream[] = [];
+    const getDisplayMedia = vi.fn(async () => {
+      const stream = new FakeStream([new FakeTrack("video")]);
+      acquiredStreams.push(stream);
+      return stream as unknown as MediaStream;
+    });
+    setNavigator({
+      mediaDevices: { getDisplayMedia } as unknown as MediaDevices,
+    });
+
+    const plugin = new ScreenCaptureWeb();
+    const results = await Promise.allSettled([
+      plugin.startRecording(),
+      plugin.startRecording(),
+    ]);
+
+    const rejections = results.filter((r) => r.status === "rejected");
+    expect(rejections).toHaveLength(1);
+    expect((rejections[0] as PromiseRejectedResult).reason).toMatchObject({
+      message: expect.stringMatching(/already in progress/i),
+    });
+
+    // The guard's whole purpose: only one OS picker opens and only one display
+    // stream is ever acquired, so there is no orphaned, never-stopped track.
+    expect(getDisplayMedia).toHaveBeenCalledTimes(1);
+    expect(acquiredStreams).toHaveLength(1);
+    expect(FakeMediaRecorder.instances).toHaveLength(1);
+    const liveTrack = acquiredStreams[0].getVideoTracks()[0] as unknown as {
+      stopped: boolean;
+    };
+    expect(liveTrack.stopped).toBe(false);
+    await expect(plugin.getRecordingState()).resolves.toMatchObject({
+      isRecording: true,
+    });
+
+    // The single accepted recording still stops cleanly, releasing its track.
+    await plugin.stopRecording();
+    expect(liveTrack.stopped).toBe(true);
+  });
+
+  it("clears the in-flight guard after a failed start so a later start succeeds", async () => {
+    installDocument();
+    vi.stubGlobal("MediaRecorder", FakeMediaRecorder);
+
+    const firstVideoTrack = new FakeTrack("video");
+    const secondVideoTrack = new FakeTrack("video");
+    const getDisplayMedia = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new FakeStream([firstVideoTrack]) as unknown as MediaStream,
+      )
+      .mockResolvedValueOnce(
+        new FakeStream([secondVideoTrack]) as unknown as MediaStream,
+      );
+    const getUserMedia = vi.fn(async (): Promise<MediaStream> => {
+      throw new Error("Permission denied");
+    });
+    setNavigator({
+      mediaDevices: {
+        getDisplayMedia,
+        getUserMedia,
+      } as unknown as MediaDevices,
+    });
+
+    const plugin = new ScreenCaptureWeb();
+
+    // A mic-denied failure runs the J2 rollback; the finally must still release
+    // the in-flight latch or every subsequent start would falsely report
+    // "Recording already in progress".
+    await expect(
+      plugin.startRecording({ captureMicrophone: true }),
+    ).rejects.toThrow("Permission denied");
+    expect(firstVideoTrack.stopped).toBe(true);
+
+    await plugin.startRecording();
+    expect(getDisplayMedia).toHaveBeenCalledTimes(2);
+    await expect(plugin.getRecordingState()).resolves.toMatchObject({
+      isRecording: true,
+    });
+
+    await plugin.stopRecording();
+    expect(secondVideoTrack.stopped).toBe(true);
+  });
+
   it("surfaces an error event when auto-stop over the limit fails", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(1_000);

--- a/plugins/plugin-native-screencapture/src/web.ts
+++ b/plugins/plugin-native-screencapture/src/web.ts
@@ -72,6 +72,16 @@ export class ScreenCaptureWeb extends WebPlugin {
   private recordedChunks: Blob[] = [];
   private isRecording = false;
   private isPaused = false;
+  /**
+   * Synchronous re-entrancy latch covering the async setup window before
+   * `isRecording` flips true. `isRecording` is only set after the first
+   * `await getDisplayMedia(...)`, so without this latch two concurrent (or
+   * double-click) startRecording() calls both clear the `isRecording` guard,
+   * both open the OS picker, and the second overwrites `mediaStream` — leaking
+   * the first display stream and corrupting the shared chunk buffer. Set before
+   * any await and cleared in a finally that also covers the J2 rollback path.
+   */
+  private starting = false;
   private recordingStartTime = 0;
   private pausedDuration = 0;
   private pauseStartTime = 0;
@@ -185,143 +195,158 @@ export class ScreenCaptureWeb extends WebPlugin {
   }
 
   async startRecording(options?: ScreenRecordingOptions): Promise<void> {
-    if (this.isRecording) throw new Error("Recording already in progress");
-    if (options?.fps !== undefined) {
-      assertPositiveFiniteNumber(options.fps, "fps");
+    // Latch synchronously before the first await so a concurrent second call
+    // cannot slip past the guard while getDisplayMedia is still resolving.
+    if (this.isRecording || this.starting) {
+      throw new Error("Recording already in progress");
     }
-    if (options?.bitrate !== undefined) {
-      assertPositiveFiniteNumber(options.bitrate, "bitrate");
-    }
-    if (options?.maxDuration !== undefined) {
-      assertPositiveFiniteNumber(options.maxDuration, "maxDuration");
-    }
-    if (options?.maxFileSize !== undefined) {
-      assertPositiveFiniteNumber(options.maxFileSize, "maxFileSize");
-    }
-
-    const videoConstraints: MediaTrackConstraints = {
-      displaySurface: "monitor",
-    };
-    if (options?.fps) videoConstraints.frameRate = { ideal: options.fps };
-
-    this.mediaStream = await getDisplayMedia({
-      video: videoConstraints,
-      audio: options?.captureSystemAudio !== false,
-    });
-
-    // Once the display stream is live the OS "sharing your screen" indicator is
-    // on. Treat the remaining setup as one transaction: any failure must
-    // release every acquired track and restore the idle state before the error
-    // reaches the caller.
-    let microphoneStream: MediaStream | null = null;
+    this.starting = true;
     try {
-      if (options?.captureMicrophone) {
-        microphoneStream = await navigator.mediaDevices.getUserMedia({
-          audio: true,
-        });
-        microphoneStream.getAudioTracks().forEach((t) => {
-          this.mediaStream?.addTrack(t);
-        });
+      if (options?.fps !== undefined) {
+        assertPositiveFiniteNumber(options.fps, "fps");
+      }
+      if (options?.bitrate !== undefined) {
+        assertPositiveFiniteNumber(options.bitrate, "bitrate");
+      }
+      if (options?.maxDuration !== undefined) {
+        assertPositiveFiniteNumber(options.maxDuration, "maxDuration");
+      }
+      if (options?.maxFileSize !== undefined) {
+        assertPositiveFiniteNumber(options.maxFileSize, "maxFileSize");
       }
 
-      const mimeType = getSupportedMimeType();
-      if (!mimeType) {
-        throw new Error("No supported video mime type found");
-      }
+      const videoConstraints: MediaTrackConstraints = {
+        displaySurface: "monitor",
+      };
+      if (options?.fps) videoConstraints.frameRate = { ideal: options.fps };
 
-      const recorderOptions: MediaRecorderOptions = { mimeType };
-      if (options?.bitrate)
-        recorderOptions.videoBitsPerSecond = options.bitrate;
+      this.mediaStream = await getDisplayMedia({
+        video: videoConstraints,
+        audio: options?.captureSystemAudio !== false,
+      });
 
-      this.recordedChunks = [];
-      this.mediaRecorder = new MediaRecorder(this.mediaStream, recorderOptions);
-      this.mediaRecorder.ondataavailable = (event) => {
-        if (event.data.size > 0) {
-          this.recordedChunks.push(event.data);
+      // Once the display stream is live the OS "sharing your screen" indicator is
+      // on. Treat the remaining setup as one transaction: any failure must
+      // release every acquired track and restore the idle state before the error
+      // reaches the caller.
+      let microphoneStream: MediaStream | null = null;
+      try {
+        if (options?.captureMicrophone) {
+          microphoneStream = await navigator.mediaDevices.getUserMedia({
+            audio: true,
+          });
+          microphoneStream.getAudioTracks().forEach((t) => {
+            this.mediaStream?.addTrack(t);
+          });
         }
-      };
 
-      this.mediaRecorder.onerror = (event) => {
-        this.notifyListeners("error", {
-          code: "RECORDING_ERROR",
-          message: `Recording error: ${(event as ErrorEvent).message || "Unknown error"}`,
+        const mimeType = getSupportedMimeType();
+        if (!mimeType) {
+          throw new Error("No supported video mime type found");
+        }
+
+        const recorderOptions: MediaRecorderOptions = { mimeType };
+        if (options?.bitrate)
+          recorderOptions.videoBitsPerSecond = options.bitrate;
+
+        this.recordedChunks = [];
+        this.mediaRecorder = new MediaRecorder(
+          this.mediaStream,
+          recorderOptions,
+        );
+        this.mediaRecorder.ondataavailable = (event) => {
+          if (event.data.size > 0) {
+            this.recordedChunks.push(event.data);
+          }
+        };
+
+        this.mediaRecorder.onerror = (event) => {
+          this.notifyListeners("error", {
+            code: "RECORDING_ERROR",
+            message: `Recording error: ${(event as ErrorEvent).message || "Unknown error"}`,
+          });
+        };
+
+        const videoTrack = this.mediaStream.getVideoTracks()[0];
+        if (!videoTrack) {
+          throw new Error("Display capture produced no video track");
+        }
+        videoTrack.addEventListener("ended", () => {
+          if (this.isRecording) {
+            this.stopRecording().catch((err: unknown) => {
+              // error-policy:J1 surface the auto-stop failure to listeners as a structured error event
+              this.notifyListeners("error", {
+                code: "AUTO_STOP_FAILED",
+                message: `Auto-stop on track end failed: ${err instanceof Error ? err.message : String(err)}`,
+              });
+            });
+          }
         });
-      };
 
-      const videoTrack = this.mediaStream.getVideoTracks()[0];
-      if (!videoTrack) {
-        throw new Error("Display capture produced no video track");
+        this.recordingStartTime = Date.now();
+        this.pausedDuration = 0;
+        this.mediaRecorder.start(1000);
+        this.isRecording = true;
+        this.isPaused = false;
+      } catch (err) {
+        // error-policy:J2 release acquired media, restore idle state, and rethrow
+        // the original setup failure to the caller.
+        microphoneStream?.getTracks().forEach((track) => {
+          track.stop();
+        });
+        this.releaseMediaStream();
+        this.mediaRecorder = null;
+        this.recordedChunks = [];
+        this.isRecording = false;
+        this.isPaused = false;
+        this.recordingStartTime = 0;
+        this.pausedDuration = 0;
+        throw err;
       }
-      videoTrack.addEventListener("ended", () => {
-        if (this.isRecording) {
+
+      this.notifyListeners("recordingState", {
+        isRecording: true,
+        duration: 0,
+        fileSize: 0,
+      });
+
+      let autoStopping = false;
+      this.recordingStateInterval = setInterval(() => {
+        if (!this.isRecording || this.isPaused || autoStopping) return;
+
+        const duration = this.elapsedSeconds();
+        const fileSize = this.recordedChunks.reduce(
+          (acc, chunk) => acc + chunk.size,
+          0,
+        );
+
+        this.notifyListeners("recordingState", {
+          isRecording: true,
+          duration,
+          fileSize,
+        });
+
+        const overLimit =
+          (options?.maxDuration && duration >= options.maxDuration) ||
+          (options?.maxFileSize && fileSize >= options.maxFileSize);
+
+        if (overLimit) {
+          autoStopping = true;
           this.stopRecording().catch((err: unknown) => {
             // error-policy:J1 surface the auto-stop failure to listeners as a structured error event
             this.notifyListeners("error", {
               code: "AUTO_STOP_FAILED",
-              message: `Auto-stop on track end failed: ${err instanceof Error ? err.message : String(err)}`,
+              message: `Auto-stop recording failed: ${err instanceof Error ? err.message : String(err)}`,
             });
           });
         }
-      });
-
-      this.recordingStartTime = Date.now();
-      this.pausedDuration = 0;
-      this.mediaRecorder.start(1000);
-      this.isRecording = true;
-      this.isPaused = false;
-    } catch (err) {
-      // error-policy:J2 release acquired media, restore idle state, and rethrow
-      // the original setup failure to the caller.
-      microphoneStream?.getTracks().forEach((track) => {
-        track.stop();
-      });
-      this.releaseMediaStream();
-      this.mediaRecorder = null;
-      this.recordedChunks = [];
-      this.isRecording = false;
-      this.isPaused = false;
-      this.recordingStartTime = 0;
-      this.pausedDuration = 0;
-      throw err;
+      }, 500);
+    } finally {
+      // Release the in-flight latch on every exit: success (isRecording is now
+      // true and keeps guarding), option-validation throw, or the J2 rollback
+      // rethrow above (isRecording is back to false).
+      this.starting = false;
     }
-
-    this.notifyListeners("recordingState", {
-      isRecording: true,
-      duration: 0,
-      fileSize: 0,
-    });
-
-    let autoStopping = false;
-    this.recordingStateInterval = setInterval(() => {
-      if (!this.isRecording || this.isPaused || autoStopping) return;
-
-      const duration = this.elapsedSeconds();
-      const fileSize = this.recordedChunks.reduce(
-        (acc, chunk) => acc + chunk.size,
-        0,
-      );
-
-      this.notifyListeners("recordingState", {
-        isRecording: true,
-        duration,
-        fileSize,
-      });
-
-      const overLimit =
-        (options?.maxDuration && duration >= options.maxDuration) ||
-        (options?.maxFileSize && fileSize >= options.maxFileSize);
-
-      if (overLimit) {
-        autoStopping = true;
-        this.stopRecording().catch((err: unknown) => {
-          // error-policy:J1 surface the auto-stop failure to listeners as a structured error event
-          this.notifyListeners("error", {
-            code: "AUTO_STOP_FAILED",
-            message: `Auto-stop recording failed: ${err instanceof Error ? err.message : String(err)}`,
-          });
-        });
-      }
-    }, 500);
   }
 
   async stopRecording(): Promise<ScreenRecordingResult> {


### PR DESCRIPTION
# Recording starts now acquire only one display stream

Closes #28952.

Two concurrent `ScreenCaptureWeb.startRecording()` calls previously both passed the guard while the screen chooser was pending. Both acquired a display stream, and `stopRecording()` stopped only the last stream. A synchronous `starting` flag now rejects the second call before media acquisition and resets on every success or failure path.

Reviewed and rebased on `develop` commit `8508c73dc14ae546717c30d47e5fc948fa436ced`. Verified head: `b38584e8a25d1a3c8ec300230328dcb37803b00e`. The change is confined to the web capture implementation and its regression test.

## Validation

Fresh install with pinned Bun 1.3.14 / Node 24.15.0 on macOS arm64. Owning package tests: 24 passed; package typecheck and lint: passed. Root `bun run verify`: passed, 376/376 Turbo tasks (zero cached) plus all final repository audits.

Real Chromium `getDisplayMedia` and `MediaRecorder` captured a dedicated local test tab. The chooser selected that controlled tab by title; streams and recorders were real, with a forwarding wrapper counting acquisitions. Baseline source came from the base commit; after source came from the verified head.

| Observation | Before | After |
| --- | --- | --- |
| Concurrent starts | Both succeed | One succeeds; second rejects |
| Display streams acquired | 2 | 1 |
| Tracks after stop | One remains live | All ended |

Both runs produced real video. I inspected the before/after screenshots, recording frames, and decoded MP4. This validates the browser implementation on macOS; it does not claim an Electrobun OS picker or mobile native integration test. No product UI or native implementation changed.

## Evidence

<!-- evidence-head:b38584e8a25d1a3c8ec300230328dcb37803b00e -->
<!-- evidence-row:before-screenshots -->
- [x] [Before desktop browser reproduction](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/28962-before-desktop.jpg). Mobile: N/A — this is the desktop browser display-capture implementation, with no mobile UI change.
<!-- evidence-row:after-screenshots -->
- [x] [After desktop browser reproduction](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/28962-after-desktop.jpg).
<!-- evidence-row:walkthrough-video -->
- [x] [Real browser walkthrough](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/28962-walkthrough-faststart.mp4).
<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend participates in this client-side media method.
<!-- evidence-row:frontend-logs -->
- [x] [Before/after API results, stream state, and browser errors](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/28962-browser-media-proof.json). Both runs had no console/page errors.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, provider, or agent behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] [Actual recorded output](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/28962-recorded-output.mp4) and [reproduction harness](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/28962-browser-harness.mjs).
<!-- evidence-row:ocr-review -->
- [ ] N/A - no product visual changes. The controlled fixture screenshots and captured frames were manually inspected; no OCR result is claimed.

## Risk

Single-call behavior and existing rollback remain unchanged. The regression suite exercises overlapping starts and a successful retry following a failed start. The flag clears in `finally`, and `isRecording` continues ownership after successful acquisition.

## Original contributor attribution

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@a36f25aea7b6722cb5363d2b89dd892db21d36af:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@a36f25aea7b6722cb5363d2b89dd892db21d36af:packages/skills/skills/contribute-to-eliza"} -->
