### PR TITLE
fix(evals): make stability artifacts tamper-evident

### DIFF
--- a/packages/cloud/e2e/AGENTS.md
+++ b/packages/cloud/e2e/AGENTS.md
@@ -80,6 +80,9 @@ and the asserted three-cycle seed/reset ledger. Failures still upload evidence.
 exact digest in both `stability.sha256` and `manifest.json`. Verify retained
 evidence before consuming it with
 `bun run stability:verify -- --output <artifact-directory>`.
+The verifier also checks the strict aggregate schema and a manifest self-hash
+that binds `reportSha256`; artifact publication is staged, fsynced, and refuses
+to overwrite a prior bundle.
 
 The lane composes #24081, #24136, #24209, and pending #24344. Until those stacks
 land together, source runs need their exact dependency heads; real-model proof

--- a/packages/cloud/e2e/AGENTS.md
+++ b/packages/cloud/e2e/AGENTS.md
@@ -76,6 +76,10 @@ Attempts retain trajectories, tool receipts, transitions, bounded logs,
 network and mock-service ledgers, and authority hashes. The aggregate retains
 first-attempt success, failure clusters, 3/3 status, a canonical report hash,
 and the asserted three-cycle seed/reset ledger. Failures still upload evidence.
+`stability.json` is stored as bounded canonical JSON; its raw SHA-256 is the
+exact digest in both `stability.sha256` and `manifest.json`. Verify retained
+evidence before consuming it with
+`bun run stability:verify -- --output <artifact-directory>`.
 
 The lane composes #24081, #24136, #24209, and pending #24344. Until those stacks
 land together, source runs need their exact dependency heads; real-model proof

--- a/packages/cloud/e2e/CLAUDE.md
+++ b/packages/cloud/e2e/CLAUDE.md
@@ -80,6 +80,9 @@ and the asserted three-cycle seed/reset ledger. Failures still upload evidence.
 exact digest in both `stability.sha256` and `manifest.json`. Verify retained
 evidence before consuming it with
 `bun run stability:verify -- --output <artifact-directory>`.
+The verifier also checks the strict aggregate schema and a manifest self-hash
+that binds `reportSha256`; artifact publication is staged, fsynced, and refuses
+to overwrite a prior bundle.
 
 The lane composes #24081, #24136, #24209, and pending #24344. Until those stacks
 land together, source runs need their exact dependency heads; real-model proof

--- a/packages/cloud/e2e/CLAUDE.md
+++ b/packages/cloud/e2e/CLAUDE.md
@@ -76,6 +76,10 @@ Attempts retain trajectories, tool receipts, transitions, bounded logs,
 network and mock-service ledgers, and authority hashes. The aggregate retains
 first-attempt success, failure clusters, 3/3 status, a canonical report hash,
 and the asserted three-cycle seed/reset ledger. Failures still upload evidence.
+`stability.json` is stored as bounded canonical JSON; its raw SHA-256 is the
+exact digest in both `stability.sha256` and `manifest.json`. Verify retained
+evidence before consuming it with
+`bun run stability:verify -- --output <artifact-directory>`.
 
 The lane composes #24081, #24136, #24209, and pending #24344. Until those stacks
 land together, source runs need their exact dependency heads; real-model proof

--- a/packages/cloud/e2e/README.md
+++ b/packages/cloud/e2e/README.md
@@ -100,6 +100,9 @@ and the asserted three-cycle seed/reset ledger. Failures still upload evidence.
 exact digest in both `stability.sha256` and `manifest.json`. Verify retained
 evidence before consuming it with
 `bun run stability:verify -- --output <artifact-directory>`.
+The verifier also checks the strict aggregate schema and a manifest self-hash
+that binds `reportSha256`; artifact publication is staged, fsynced, and refuses
+to overwrite a prior bundle.
 
 The lane composes #24081, #24136, #24209, and pending #24344. Until those stacks
 land together, source runs need their exact dependency heads; real-model proof

--- a/packages/cloud/e2e/README.md
+++ b/packages/cloud/e2e/README.md
@@ -96,6 +96,10 @@ Attempts retain trajectories, tool receipts, transitions, bounded logs,
 network and mock-service ledgers, and authority hashes. The aggregate retains
 first-attempt success, failure clusters, 3/3 status, a canonical report hash,
 and the asserted three-cycle seed/reset ledger. Failures still upload evidence.
+`stability.json` is stored as bounded canonical JSON; its raw SHA-256 is the
+exact digest in both `stability.sha256` and `manifest.json`. Verify retained
+evidence before consuming it with
+`bun run stability:verify -- --output <artifact-directory>`.
 
 The lane composes #24081, #24136, #24209, and pending #24344. Until those stacks
 land together, source runs need their exact dependency heads; real-model proof

--- a/packages/cloud/e2e/package.json
+++ b/packages/cloud/e2e/package.json
@@ -10,6 +10,7 @@
     "test:mock-llm": "bun test src/fixtures/mock-llm.test.ts",
     "stability:keyless": "bun --conditions=eliza-source scripts/run-stability-lane.ts --mode deterministic-mock",
     "stability:real": "bun --conditions=eliza-source scripts/run-stability-lane.ts --mode real-llm",
+    "stability:verify": "bun --conditions=eliza-source scripts/verify-stability-artifacts.ts",
     "test:stability": "bun --conditions=eliza-source test src/stability/cloud-stability-runner.test.ts src/stability/stability-network-guard.test.ts src/stability/stack-partial-cleanup.test.ts src/stability/stability-scenario-child.test.ts src/stability/authority-controller-cleanup.test.ts",
     "domains:ledger": "bun scripts/domain-purchase-ledger.ts",
     "format": "bunx @biomejs/biome format --write package.json",

--- a/packages/cloud/e2e/scenarios/cloud-stability-agent.scenario.ts
+++ b/packages/cloud/e2e/scenarios/cloud-stability-agent.scenario.ts
@@ -65,6 +65,7 @@ const syntheticRuntimePolicy = {
     "goals_migration",
     "identity_resolution",
     "lifeops_scheduled_task_runner",
+    "membership",
     "memoryStorage",
     "notification",
     "optimized_prompt",

--- a/packages/cloud/e2e/scripts/verify-stability-artifacts.ts
+++ b/packages/cloud/e2e/scripts/verify-stability-artifacts.ts
@@ -1,0 +1,22 @@
+/** Verifies a retained Cloud stability aggregate before it is consumed as evidence. */
+
+import path from "node:path";
+import { verifyCloudStabilityArtifacts } from "../src/stability/cloud-stability-runner.ts";
+
+const outputOption = process.argv.indexOf("--output");
+const suppliedOutput =
+  outputOption >= 0 ? process.argv[outputOption + 1] : undefined;
+if (!suppliedOutput) {
+  throw new Error("stability:verify requires --output <artifact-directory>");
+}
+
+const outputRoot = path.resolve(suppliedOutput);
+const verified = await verifyCloudStabilityArtifacts(outputRoot);
+process.stdout.write(
+  `${JSON.stringify({
+    outputRoot,
+    reportSha256: verified.reportSha256,
+    runId: verified.manifest.runId,
+    mode: verified.manifest.mode,
+  })}\n`,
+);

--- a/packages/cloud/e2e/src/stability/cloud-stability-runner.test.ts
+++ b/packages/cloud/e2e/src/stability/cloud-stability-runner.test.ts
@@ -152,7 +152,7 @@ describe("Cloud stability manifest", () => {
     expect((await verifyCloudStabilityArtifacts(outputRoot)).report).toEqual(
       report,
     );
-  });
+  }, 30_000);
 
   test("rejects modified, truncated, noncanonical, and duplicate-key reports", async () => {
     const outputRoot = await mkdtemp(
@@ -160,9 +160,10 @@ describe("Cloud stability manifest", () => {
     );
     directories.push(outputRoot);
     const adapter: ScenarioStabilityExecutionAdapter = {
-      async execute() {
+      async execute(input) {
+        const passed = input.attemptNumber !== 2;
         return {
-          passed: true,
+          passed,
           initialStateHash: "b".repeat(64),
           finalStateHash: "c".repeat(64),
           inputTokens: 1,
@@ -176,6 +177,7 @@ describe("Cloud stability manifest", () => {
             judgeVerdicts: [],
           },
           stateDiff: {},
+          ...(passed ? {} : { error: "synthetic scenario failure" }),
         };
       },
       async terminate() {},
@@ -189,9 +191,11 @@ describe("Cloud stability manifest", () => {
     const originalManifest = await readFile(manifestPath);
     const parsedReport = JSON.parse(originalReport.toString("utf8"));
 
+    const directlyModifiedReport = structuredClone(parsedReport);
+    directlyModifiedReport.cells[0].attempts[0].durationMs += 1;
     await writeFile(
       reportPath,
-      canonicalCloudStabilityJson({ ...parsedReport, status: "failed" }),
+      canonicalCloudStabilityJson(directlyModifiedReport),
     );
     await expect(verifyCloudStabilityArtifacts(outputRoot)).rejects.toThrow(
       /does not match retained report bytes/,
@@ -263,12 +267,105 @@ describe("Cloud stability manifest", () => {
     ).resolves.toMatchObject({ report: modifiedReport });
 
     const invalidReport = structuredClone(parsedReport);
-    invalidReport.cells[0].passedAttempts = 2;
+    invalidReport.cells[0].passedAttempts = 3;
     await bindAlteredReport(
       Buffer.from(canonicalCloudStabilityJson(invalidReport), "utf8"),
     );
     await expect(verifyCloudStabilityArtifacts(outputRoot)).rejects.toThrow(
       /summary does not match/,
+    );
+
+    const unclassifiedFailure = structuredClone(parsedReport);
+    unclassifiedFailure.cells[0].attempts[1].failureClassification = null;
+    await bindAlteredReport(
+      Buffer.from(canonicalCloudStabilityJson(unclassifiedFailure), "utf8"),
+    );
+    await expect(verifyCloudStabilityArtifacts(outputRoot)).rejects.toThrow(
+      /pass and failure classification disagree/,
+    );
+
+    const classifiedPass = structuredClone(parsedReport);
+    classifiedPass.cells[0].attempts[0].failureClassification =
+      "scenario-failure";
+    await bindAlteredReport(
+      Buffer.from(canonicalCloudStabilityJson(classifiedPass), "utf8"),
+    );
+    await expect(verifyCloudStabilityArtifacts(outputRoot)).rejects.toThrow(
+      /pass and failure classification disagree/,
+    );
+
+    const wrongPlan = structuredClone(parsedReport);
+    wrongPlan.planFingerprint = "0".repeat(64);
+    await bindAlteredReport(
+      Buffer.from(canonicalCloudStabilityJson(wrongPlan), "utf8"),
+    );
+    await expect(verifyCloudStabilityArtifacts(outputRoot)).rejects.toThrow(
+      /does not match its manifest/,
+    );
+
+    const wrongAttemptIdentity = structuredClone(parsedReport);
+    wrongAttemptIdentity.cells[0].attempts[0].attemptId += "-fabricated";
+    await bindAlteredReport(
+      Buffer.from(canonicalCloudStabilityJson(wrongAttemptIdentity), "utf8"),
+    );
+    await expect(verifyCloudStabilityArtifacts(outputRoot)).rejects.toThrow(
+      /does not match its manifest/,
+    );
+
+    const wrongAttemptDirectory = structuredClone(parsedReport);
+    wrongAttemptDirectory.cells[0].attempts[0].outputDir += "-fabricated";
+    await bindAlteredReport(
+      Buffer.from(canonicalCloudStabilityJson(wrongAttemptDirectory), "utf8"),
+    );
+    await expect(verifyCloudStabilityArtifacts(outputRoot)).rejects.toThrow(
+      /does not match its manifest/,
+    );
+
+    const wrongBaseline = structuredClone(parsedReport);
+    wrongBaseline.cells[0].baselineInitialStateHash = "f".repeat(64);
+    await bindAlteredReport(
+      Buffer.from(canonicalCloudStabilityJson(wrongBaseline), "utf8"),
+    );
+    await expect(verifyCloudStabilityArtifacts(outputRoot)).rejects.toThrow(
+      /baseline does not match its first attempt/,
+    );
+
+    const fabricatedSummaries = structuredClone(parsedReport);
+    fabricatedSummaries.focusList[0] = {
+      ...fabricatedSummaries.focusList[0],
+      scenarioId: "fabricated",
+      provider: "wrong",
+      model: "wrong",
+      failedAttemptIds: [],
+      failureClassifications: [],
+    };
+    fabricatedSummaries.failureClusters = [];
+    await bindAlteredReport(
+      Buffer.from(canonicalCloudStabilityJson(fabricatedSummaries), "utf8"),
+    );
+    await expect(verifyCloudStabilityArtifacts(outputRoot)).rejects.toThrow(
+      /summaries do not match derived execution evidence/,
+    );
+
+    const fabricatedCluster = structuredClone(parsedReport);
+    fabricatedCluster.failureClusters[0].sample = "fabricated sample";
+    fabricatedCluster.failureClusters[0].fingerprint = "0".repeat(64);
+    await bindAlteredReport(
+      Buffer.from(canonicalCloudStabilityJson(fabricatedCluster), "utf8"),
+    );
+    await expect(verifyCloudStabilityArtifacts(outputRoot)).rejects.toThrow(
+      /summaries do not match derived execution evidence/,
+    );
+
+    const duplicateCluster = structuredClone(parsedReport);
+    duplicateCluster.failureClusters.push(
+      structuredClone(duplicateCluster.failureClusters[0]),
+    );
+    await bindAlteredReport(
+      Buffer.from(canonicalCloudStabilityJson(duplicateCluster), "utf8"),
+    );
+    await expect(verifyCloudStabilityArtifacts(outputRoot)).rejects.toThrow(
+      /summaries do not match derived execution evidence/,
     );
 
     await Promise.all([
@@ -286,5 +383,5 @@ describe("Cloud stability manifest", () => {
     await rename(reportPath, reportTargetPath);
     await symlink(reportTargetPath, reportPath);
     await expect(verifyCloudStabilityArtifacts(outputRoot)).rejects.toThrow();
-  });
+  }, 30_000);
 });

--- a/packages/cloud/e2e/src/stability/cloud-stability-runner.test.ts
+++ b/packages/cloud/e2e/src/stability/cloud-stability-runner.test.ts
@@ -139,6 +139,16 @@ describe("Cloud stability manifest", () => {
       await readFile(path.join(outputRoot, "manifest.json"), "utf8"),
     );
     expect(artifactManifest.reportSha256).toBe(rawSha256);
+    const { manifestSha256, ...unsignedArtifactManifest } = artifactManifest;
+    expect(manifestSha256).toBe(
+      canonicalCloudStabilitySha256(unsignedArtifactManifest),
+    );
+    expect((await verifyCloudStabilityArtifacts(outputRoot)).report).toEqual(
+      report,
+    );
+    await expect(
+      runCloudStabilityLane({ manifest, outputRoot, adapter }),
+    ).rejects.toThrow();
     expect((await verifyCloudStabilityArtifacts(outputRoot)).report).toEqual(
       report,
     );
@@ -192,17 +202,28 @@ describe("Cloud stability manifest", () => {
       /not valid JSON/,
     );
 
-    const bindAlteredReport = async (bytes: Buffer): Promise<void> => {
+    const bindAlteredReport = async (
+      bytes: Buffer,
+      options: { rehashManifest?: boolean } = {},
+    ): Promise<void> => {
       const reportSha256 = createHash("sha256").update(bytes).digest("hex");
       const artifactManifest = JSON.parse(originalManifest.toString("utf8"));
+      const { manifestSha256, ...originalUnsignedManifest } = artifactManifest;
+      const unsignedArtifactManifest = {
+        ...originalUnsignedManifest,
+        reportSha256,
+      };
       await Promise.all([
         writeFile(reportPath, bytes),
         writeFile(checksumPath, `${reportSha256}  stability.json\n`),
         writeFile(
           manifestPath,
           canonicalCloudStabilityJson({
-            ...artifactManifest,
-            reportSha256,
+            ...unsignedArtifactManifest,
+            manifestSha256:
+              options.rehashManifest === false
+                ? manifestSha256
+                : canonicalCloudStabilitySha256(unsignedArtifactManifest),
           }),
         ),
       ]);
@@ -223,6 +244,31 @@ describe("Cloud stability manifest", () => {
     );
     await expect(verifyCloudStabilityArtifacts(outputRoot)).rejects.toThrow(
       /not canonical JSON/,
+    );
+
+    const modifiedReport = structuredClone(parsedReport);
+    modifiedReport.cells[0].attempts[0].durationMs += 1;
+    await bindAlteredReport(
+      Buffer.from(canonicalCloudStabilityJson(modifiedReport), "utf8"),
+      { rehashManifest: false },
+    );
+    await expect(verifyCloudStabilityArtifacts(outputRoot)).rejects.toThrow(
+      /manifest checksum does not match/,
+    );
+    await bindAlteredReport(
+      Buffer.from(canonicalCloudStabilityJson(modifiedReport), "utf8"),
+    );
+    await expect(
+      verifyCloudStabilityArtifacts(outputRoot),
+    ).resolves.toMatchObject({ report: modifiedReport });
+
+    const invalidReport = structuredClone(parsedReport);
+    invalidReport.cells[0].passedAttempts = 2;
+    await bindAlteredReport(
+      Buffer.from(canonicalCloudStabilityJson(invalidReport), "utf8"),
+    );
+    await expect(verifyCloudStabilityArtifacts(outputRoot)).rejects.toThrow(
+      /summary does not match/,
     );
 
     await Promise.all([

--- a/packages/cloud/e2e/src/stability/cloud-stability-runner.test.ts
+++ b/packages/cloud/e2e/src/stability/cloud-stability-runner.test.ts
@@ -1,15 +1,26 @@
 /** Exercises manifest validation and exact-three artifact semantics with a deterministic injected adapter. */
 
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import {
+  mkdtemp,
+  readFile,
+  rename,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import type { ScenarioStabilityExecutionAdapter } from "@elizaos/scenario-runner";
 import { authorityChildEnvironment } from "./cloud-stability-environment.ts";
 import {
   type CloudStabilityManifest,
+  canonicalCloudStabilityJson,
+  canonicalCloudStabilitySha256,
   parseCloudStabilityManifest,
   runCloudStabilityLane,
+  verifyCloudStabilityArtifacts,
 } from "./cloud-stability-runner.ts";
 
 const directories: string[] = [];
@@ -113,13 +124,121 @@ describe("Cloud stability manifest", () => {
     expect(attempts).toEqual([1, 2, 3]);
     expect(report.status).toBe("failed");
     expect(report.cells[0]?.passedAttempts).toBe(2);
-    expect(
-      JSON.parse(
-        await readFile(path.join(outputRoot, "stability.json"), "utf8"),
-      ),
-    ).toEqual(report);
+    const reportBytes = await readFile(path.join(outputRoot, "stability.json"));
+    const parsedReport = JSON.parse(reportBytes.toString("utf8"));
+    const rawSha256 = createHash("sha256").update(reportBytes).digest("hex");
+    expect(parsedReport).toEqual(report);
+    expect(reportBytes.toString("utf8")).toBe(
+      canonicalCloudStabilityJson(parsedReport),
+    );
+    expect(rawSha256).toBe(canonicalCloudStabilitySha256(parsedReport));
     expect(
       await readFile(path.join(outputRoot, "stability.sha256"), "utf8"),
-    ).toMatch(/^[a-f0-9]{64} {2}stability\.json\n$/);
+    ).toBe(`${rawSha256}  stability.json\n`);
+    const artifactManifest = JSON.parse(
+      await readFile(path.join(outputRoot, "manifest.json"), "utf8"),
+    );
+    expect(artifactManifest.reportSha256).toBe(rawSha256);
+    expect((await verifyCloudStabilityArtifacts(outputRoot)).report).toEqual(
+      report,
+    );
+  });
+
+  test("rejects modified, truncated, noncanonical, and duplicate-key reports", async () => {
+    const outputRoot = await mkdtemp(
+      path.join(tmpdir(), "cloud-stability-integrity-test-"),
+    );
+    directories.push(outputRoot);
+    const adapter: ScenarioStabilityExecutionAdapter = {
+      async execute() {
+        return {
+          passed: true,
+          initialStateHash: "b".repeat(64),
+          finalStateHash: "c".repeat(64),
+          inputTokens: 1,
+          outputTokens: 1,
+          toolCalls: 1,
+          evidence: {
+            trajectory: [],
+            toolReceipts: [],
+            stateTransitions: [],
+            providerReceipts: [],
+            judgeVerdicts: [],
+          },
+          stateDiff: {},
+        };
+      },
+      async terminate() {},
+    };
+    await runCloudStabilityLane({ manifest, outputRoot, adapter });
+    const reportPath = path.join(outputRoot, "stability.json");
+    const checksumPath = path.join(outputRoot, "stability.sha256");
+    const manifestPath = path.join(outputRoot, "manifest.json");
+    const originalReport = await readFile(reportPath);
+    const originalChecksum = await readFile(checksumPath);
+    const originalManifest = await readFile(manifestPath);
+    const parsedReport = JSON.parse(originalReport.toString("utf8"));
+
+    await writeFile(
+      reportPath,
+      canonicalCloudStabilityJson({ ...parsedReport, status: "failed" }),
+    );
+    await expect(verifyCloudStabilityArtifacts(outputRoot)).rejects.toThrow(
+      /does not match retained report bytes/,
+    );
+
+    await writeFile(reportPath, originalReport.subarray(0, -1));
+    await expect(verifyCloudStabilityArtifacts(outputRoot)).rejects.toThrow(
+      /not valid JSON/,
+    );
+
+    const bindAlteredReport = async (bytes: Buffer): Promise<void> => {
+      const reportSha256 = createHash("sha256").update(bytes).digest("hex");
+      const artifactManifest = JSON.parse(originalManifest.toString("utf8"));
+      await Promise.all([
+        writeFile(reportPath, bytes),
+        writeFile(checksumPath, `${reportSha256}  stability.json\n`),
+        writeFile(
+          manifestPath,
+          canonicalCloudStabilityJson({
+            ...artifactManifest,
+            reportSha256,
+          }),
+        ),
+      ]);
+    };
+
+    await bindAlteredReport(
+      Buffer.from(JSON.stringify(parsedReport, null, 2), "utf8"),
+    );
+    await expect(verifyCloudStabilityArtifacts(outputRoot)).rejects.toThrow(
+      /not canonical JSON/,
+    );
+
+    await bindAlteredReport(
+      Buffer.from(
+        `{"schemaVersion":1,${originalReport.toString("utf8").slice(1)}`,
+        "utf8",
+      ),
+    );
+    await expect(verifyCloudStabilityArtifacts(outputRoot)).rejects.toThrow(
+      /not canonical JSON/,
+    );
+
+    await Promise.all([
+      writeFile(reportPath, originalReport),
+      writeFile(checksumPath, originalChecksum),
+      writeFile(manifestPath, originalManifest),
+    ]);
+    await expect(
+      verifyCloudStabilityArtifacts(outputRoot),
+    ).resolves.toMatchObject({
+      reportSha256: canonicalCloudStabilitySha256(parsedReport),
+    });
+
+    const reportTargetPath = path.join(outputRoot, "stability-target.json");
+    await rename(reportPath, reportTargetPath);
+    await symlink(reportTargetPath, reportPath);
+    await expect(verifyCloudStabilityArtifacts(outputRoot)).rejects.toThrow();
   });
 });

--- a/packages/cloud/e2e/src/stability/cloud-stability-runner.test.ts
+++ b/packages/cloud/e2e/src/stability/cloud-stability-runner.test.ts
@@ -246,6 +246,17 @@ describe("Cloud stability manifest", () => {
       verifyCloudStabilityArtifacts(absentBaselineRoot),
     ).resolves.toMatchObject({ report: absentBaseline });
 
+    const unavailableSentinelAsBaseline = structuredClone(absentBaseline);
+    unavailableSentinelAsBaseline.cells[0].baselineInitialStateHash =
+      "unavailable";
+    await resealCloudStabilityReport(
+      absentBaselineRoot,
+      unavailableSentinelAsBaseline,
+    );
+    await expect(
+      verifyCloudStabilityArtifacts(absentBaselineRoot),
+    ).rejects.toThrow(/baseline does not match.*admitted passing attempts/);
+
     const ordinarySuccessRoot = await mkdtemp(
       path.join(tmpdir(), "cloud-stability-ordinary-baseline-test-"),
     );

--- a/packages/cloud/e2e/src/stability/cloud-stability-runner.test.ts
+++ b/packages/cloud/e2e/src/stability/cloud-stability-runner.test.ts
@@ -154,6 +154,70 @@ describe("Cloud stability manifest", () => {
     );
   }, 30_000);
 
+  test("accepts executor-owned baselines established after the first attempt or never", async () => {
+    const result = {
+      passed: true,
+      initialStateHash: "b".repeat(64),
+      finalStateHash: "c".repeat(64),
+      inputTokens: 1,
+      outputTokens: 1,
+      toolCalls: 1,
+      evidence: {
+        trajectory: [],
+        toolReceipts: [],
+        stateTransitions: [],
+        providerReceipts: [],
+        judgeVerdicts: [],
+      },
+      stateDiff: {},
+    };
+    const delayedBaselineRoot = await mkdtemp(
+      path.join(tmpdir(), "cloud-stability-delayed-baseline-test-"),
+    );
+    directories.push(delayedBaselineRoot);
+    const delayedBaseline = await runCloudStabilityLane({
+      manifest,
+      outputRoot: delayedBaselineRoot,
+      adapter: {
+        async execute(input) {
+          if (input.attemptNumber === 1) {
+            throw new Error("pre-admission harness failure");
+          }
+          return result;
+        },
+        async terminate() {},
+      },
+    });
+    expect(delayedBaseline.cells[0]?.baselineInitialStateHash).toBe(
+      result.initialStateHash,
+    );
+    expect(delayedBaseline.cells[0]?.attempts[0]?.initialStateHash).toBe(
+      "unavailable",
+    );
+    await expect(
+      verifyCloudStabilityArtifacts(delayedBaselineRoot),
+    ).resolves.toMatchObject({ report: delayedBaseline });
+
+    const absentBaselineRoot = await mkdtemp(
+      path.join(tmpdir(), "cloud-stability-absent-baseline-test-"),
+    );
+    directories.push(absentBaselineRoot);
+    const absentBaseline = await runCloudStabilityLane({
+      manifest,
+      outputRoot: absentBaselineRoot,
+      adapter: {
+        async execute() {
+          throw new Error("pre-admission harness failure");
+        },
+        async terminate() {},
+      },
+    });
+    expect(absentBaseline.cells[0]?.baselineInitialStateHash).toBeNull();
+    await expect(
+      verifyCloudStabilityArtifacts(absentBaselineRoot),
+    ).resolves.toMatchObject({ report: absentBaseline });
+  }, 30_000);
+
   test("rejects modified, truncated, noncanonical, and duplicate-key reports", async () => {
     const outputRoot = await mkdtemp(
       path.join(tmpdir(), "cloud-stability-integrity-test-"),
@@ -327,7 +391,7 @@ describe("Cloud stability manifest", () => {
       Buffer.from(canonicalCloudStabilityJson(wrongBaseline), "utf8"),
     );
     await expect(verifyCloudStabilityArtifacts(outputRoot)).rejects.toThrow(
-      /baseline does not match its first attempt/,
+      /baseline does not match its admitted passing attempts/,
     );
 
     const fabricatedSummaries = structuredClone(parsedReport);

--- a/packages/cloud/e2e/src/stability/cloud-stability-runner.test.ts
+++ b/packages/cloud/e2e/src/stability/cloud-stability-runner.test.ts
@@ -46,6 +46,35 @@ afterEach(async () => {
   }
 });
 
+async function resealCloudStabilityReport(
+  outputRoot: string,
+  report: unknown,
+): Promise<void> {
+  const reportBytes = Buffer.from(canonicalCloudStabilityJson(report), "utf8");
+  const reportSha256 = createHash("sha256").update(reportBytes).digest("hex");
+  const manifestPath = path.join(outputRoot, "manifest.json");
+  const artifactManifest = JSON.parse(await readFile(manifestPath, "utf8"));
+  const {
+    manifestSha256: _previousManifestSha256,
+    ...previousUnsignedManifest
+  } = artifactManifest;
+  const unsignedManifest = { ...previousUnsignedManifest, reportSha256 };
+  await Promise.all([
+    writeFile(path.join(outputRoot, "stability.json"), reportBytes),
+    writeFile(
+      path.join(outputRoot, "stability.sha256"),
+      `${reportSha256}  stability.json\n`,
+    ),
+    writeFile(
+      manifestPath,
+      canonicalCloudStabilityJson({
+        ...unsignedManifest,
+        manifestSha256: canonicalCloudStabilitySha256(unsignedManifest),
+      }),
+    ),
+  ]);
+}
+
 describe("Cloud stability manifest", () => {
   test("authority environment drops ambient credentials", () => {
     const environment = authorityChildEnvironment(
@@ -216,6 +245,42 @@ describe("Cloud stability manifest", () => {
     await expect(
       verifyCloudStabilityArtifacts(absentBaselineRoot),
     ).resolves.toMatchObject({ report: absentBaseline });
+
+    const ordinarySuccessRoot = await mkdtemp(
+      path.join(tmpdir(), "cloud-stability-ordinary-baseline-test-"),
+    );
+    directories.push(ordinarySuccessRoot);
+    const ordinarySuccess = await runCloudStabilityLane({
+      manifest,
+      outputRoot: ordinarySuccessRoot,
+      adapter: {
+        async execute() {
+          return result;
+        },
+        async terminate() {},
+      },
+    });
+    expect(ordinarySuccess.status).toBe("passed");
+
+    const ordinarySuccessWithoutBaseline = structuredClone(ordinarySuccess);
+    ordinarySuccessWithoutBaseline.cells[0].baselineInitialStateHash = null;
+    await resealCloudStabilityReport(
+      ordinarySuccessRoot,
+      ordinarySuccessWithoutBaseline,
+    );
+    await expect(
+      verifyCloudStabilityArtifacts(ordinarySuccessRoot),
+    ).rejects.toThrow(/without a baseline.*pre-admission harness failures/);
+
+    const delayedSuccessWithoutBaseline = structuredClone(delayedBaseline);
+    delayedSuccessWithoutBaseline.cells[0].baselineInitialStateHash = null;
+    await resealCloudStabilityReport(
+      delayedBaselineRoot,
+      delayedSuccessWithoutBaseline,
+    );
+    await expect(
+      verifyCloudStabilityArtifacts(delayedBaselineRoot),
+    ).rejects.toThrow(/without a baseline.*pre-admission harness failures/);
   }, 30_000);
 
   test("rejects modified, truncated, noncanonical, and duplicate-key reports", async () => {

--- a/packages/cloud/e2e/src/stability/cloud-stability-runner.ts
+++ b/packages/cloud/e2e/src/stability/cloud-stability-runner.ts
@@ -11,6 +11,9 @@ import path from "node:path";
 import {
   assertScenarioStabilityBoundedJson,
   createScenarioStabilityPlan,
+  deriveScenarioStabilityExecutionAttemptIdentities,
+  deriveScenarioStabilityFailureClusters,
+  deriveScenarioStabilityFocusList,
   executeScenarioStability,
   parseScenarioStabilityAttemptExecution,
   type ScenarioStabilityExecutionAdapter,
@@ -19,6 +22,7 @@ import {
   type ScenarioStabilityExecutionTarget,
   type ScenarioStabilityFailureClassification,
   type ScenarioStabilityTier,
+  scenarioStabilityExecutionPlanFingerprint,
 } from "@elizaos/scenario-runner";
 import { canonicalJsonString } from "@elizaos/shared/canonical-json";
 
@@ -505,6 +509,9 @@ function parseExecutedAttempt(value: unknown, index: number) {
           record.failureClassification,
           `${label} failureClassification`,
         );
+  if (execution.passed !== (classification === null)) {
+    throw new Error(`${label} pass and failure classification disagree`);
+  }
   return {
     ...execution,
     attemptNumber,
@@ -566,6 +573,9 @@ function parseExecutedCell(value: unknown, index: number) {
           record.baselineInitialStateHash,
           `${label} baselineInitialStateHash`,
         );
+  if (baselineInitialStateHash !== attempts[0]?.initialStateHash) {
+    throw new Error(`${label} baseline does not match its first attempt`);
+  }
   return {
     scenarioId: boundedString(record.scenarioId, `${label} scenarioId`),
     model: {
@@ -640,6 +650,7 @@ function parseFailureCluster(value: unknown, index: number) {
 function parseCloudStabilityExecutionReport(
   value: unknown,
   manifest: CloudStabilityManifest,
+  planOutputRoot: string,
 ): ScenarioStabilityExecutionReport {
   assertScenarioStabilityBoundedJson(
     value,
@@ -667,6 +678,10 @@ function parseCloudStabilityExecutionReport(
     throw new Error("Cloud stability aggregate report constants are invalid");
   }
   const runId = stabilityRunId(record.runId);
+  const planFingerprint = sha256String(
+    record.planFingerprint,
+    "stability report planFingerprint",
+  );
   const budgets = parseExecutionBudgets(record.budgets);
   const cells = strictArray(record.cells, "stability report cells").map(
     parseExecutedCell,
@@ -683,6 +698,16 @@ function parseCloudStabilityExecutionReport(
     throw new Error("Cloud stability aggregate must contain exactly one cell");
   }
   const cell = cells[0];
+  const target: ScenarioStabilityExecutionTarget = {
+    scenarioId: manifest.scenarioId,
+    model: { provider: manifest.provider, model: manifest.model },
+  };
+  const plan = createScenarioStabilityPlan({
+    runId: manifest.runId,
+    outputRoot: planOutputRoot,
+  });
+  const expectedAttemptIdentities =
+    deriveScenarioStabilityExecutionAttemptIdentities(plan, target);
   if (
     !cell ||
     runId !== manifest.runId ||
@@ -693,18 +718,36 @@ function parseCloudStabilityExecutionReport(
     budgets.maxInputTokens !== manifest.maxInputTokens ||
     budgets.maxOutputTokens !== manifest.maxOutputTokens ||
     budgets.maxToolCalls !== manifest.maxToolCalls ||
-    (record.status === "passed") !== cell.strictPassed ||
-    focusList.length !== (cell.strictPassed ? 0 : 1)
+    planFingerprint !== scenarioStabilityExecutionPlanFingerprint(plan) ||
+    cell.attempts.some((attempt, index) => {
+      const expected = expectedAttemptIdentities[index];
+      return (
+        !expected ||
+        attempt.attemptNumber !== expected.attemptNumber ||
+        attempt.attemptId !== expected.attemptId ||
+        attempt.outputDir !== expected.outputDir
+      );
+    })
   ) {
     throw new Error("Cloud stability aggregate does not match its manifest");
+  }
+  const expectedFocusList = deriveScenarioStabilityFocusList(cells);
+  const expectedFailureClusters = deriveScenarioStabilityFailureClusters(cells);
+  if (
+    canonicalCloudStabilityJson(focusList) !==
+      canonicalCloudStabilityJson(expectedFocusList) ||
+    canonicalCloudStabilityJson(failureClusters) !==
+      canonicalCloudStabilityJson(expectedFailureClusters) ||
+    record.status !== (expectedFocusList.length === 0 ? "passed" : "failed")
+  ) {
+    throw new Error(
+      "Cloud stability aggregate summaries do not match derived execution evidence",
+    );
   }
   return {
     schemaVersion: 1,
     runId,
-    planFingerprint: sha256String(
-      record.planFingerprint,
-      "stability report planFingerprint",
-    ),
+    planFingerprint,
     status: record.status,
     attemptCount: 3,
     requiredTier: "3/3",
@@ -740,9 +783,9 @@ function parseArtifactManifest(value: unknown): CloudStabilityArtifactManifest {
   return { ...manifest, manifestSha256, reportSha256 };
 }
 
-/** Verifies retained report bytes, sidecar, and manifest before returning data. */
-export async function verifyCloudStabilityArtifacts(
+async function verifyCloudStabilityArtifactsAt(
   outputRoot: string,
+  planOutputRoot: string,
 ): Promise<VerifiedCloudStabilityArtifacts> {
   const [reportBytes, checksumBytes, manifestBytes] = await Promise.all([
     readBoundedArtifact(
@@ -773,8 +816,19 @@ export async function verifyCloudStabilityArtifacts(
   ) {
     throw new Error("Cloud stability report checksums do not match");
   }
-  const report = parseCloudStabilityExecutionReport(reportValue, manifest);
+  const report = parseCloudStabilityExecutionReport(
+    reportValue,
+    manifest,
+    planOutputRoot,
+  );
   return { report, manifest, reportSha256 };
+}
+
+/** Verifies retained report bytes, sidecar, manifest, and output-path authority. */
+export async function verifyCloudStabilityArtifacts(
+  outputRoot: string,
+): Promise<VerifiedCloudStabilityArtifacts> {
+  return verifyCloudStabilityArtifactsAt(outputRoot, outputRoot);
 }
 
 async function removeStagedBundle(stagingRoot: string): Promise<void> {
@@ -839,7 +893,7 @@ async function persistCloudStabilityArtifacts(
       canonicalCloudStabilityJson(artifactManifest),
     );
     await syncDirectory(stagingRoot);
-    await verifyCloudStabilityArtifacts(stagingRoot);
+    await verifyCloudStabilityArtifactsAt(stagingRoot, outputRoot);
 
     // The manifest is the commit marker: it is linked last, and no link may
     // replace a prior artifact generation. Readers either verify all three or

--- a/packages/cloud/e2e/src/stability/cloud-stability-runner.ts
+++ b/packages/cloud/e2e/src/stability/cloud-stability-runner.ts
@@ -4,16 +4,21 @@
  * and artifact semantics without substituting for the production subprocess adapter.
  */
 
-import { createHash } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
 import { constants as fsConstants } from "node:fs";
-import { mkdir, open, rename, writeFile } from "node:fs/promises";
+import { link, mkdir, open, rmdir, unlink } from "node:fs/promises";
 import path from "node:path";
 import {
+  assertScenarioStabilityBoundedJson,
   createScenarioStabilityPlan,
   executeScenarioStability,
+  parseScenarioStabilityAttemptExecution,
   type ScenarioStabilityExecutionAdapter,
+  type ScenarioStabilityExecutionBudgets,
   type ScenarioStabilityExecutionReport,
   type ScenarioStabilityExecutionTarget,
+  type ScenarioStabilityFailureClassification,
+  type ScenarioStabilityTier,
 } from "@elizaos/scenario-runner";
 import { canonicalJsonString } from "@elizaos/shared/canonical-json";
 
@@ -91,10 +96,10 @@ export function canonicalCloudStabilitySha256(value: unknown): string {
 }
 
 function positiveInteger(value: unknown, field: string): number {
-  if (!Number.isSafeInteger(value) || (value as number) <= 0) {
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value <= 0) {
     throw new Error(`${field} must be a positive safe integer`);
   }
-  return value as number;
+  return value;
 }
 
 /** Validates the checked-in or workflow-supplied lane manifest. */
@@ -188,23 +193,69 @@ export function parseCloudStabilityManifest(
   return parsed;
 }
 
-async function writeJsonAtomic(
-  filePath: string,
-  value: unknown,
-): Promise<string> {
-  await mkdir(path.dirname(filePath), { recursive: true });
-  const bytes = canonicalCloudStabilityJson(value);
-  const temporary = `${filePath}.${process.pid}.tmp`;
-  await writeFile(temporary, bytes, { encoding: "utf8", mode: 0o600 });
-  await rename(temporary, filePath);
-  return bytes;
+async function syncDirectory(directoryPath: string): Promise<void> {
+  const handle = await open(directoryPath, fsConstants.O_RDONLY);
+  try {
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
 }
 
-async function writeTextAtomic(filePath: string, value: string): Promise<void> {
-  await mkdir(path.dirname(filePath), { recursive: true });
-  const temporary = `${filePath}.${process.pid}.tmp`;
-  await writeFile(temporary, value, { encoding: "utf8", mode: 0o600 });
-  await rename(temporary, filePath);
+async function writeExclusiveFile(
+  filePath: string,
+  bytes: string,
+): Promise<void> {
+  const handle = await open(
+    filePath,
+    fsConstants.O_WRONLY |
+      fsConstants.O_CREAT |
+      fsConstants.O_EXCL |
+      fsConstants.O_NOFOLLOW,
+    0o600,
+  );
+  let complete = false;
+  const failures: unknown[] = [];
+  try {
+    await handle.writeFile(bytes, "utf8");
+    await handle.sync();
+    complete = true;
+  } catch (error) {
+    // error-policy:J2 Artifact creation preserves the exact write failure.
+    failures.push(error);
+  }
+  try {
+    await handle.close();
+  } catch (error) {
+    // error-policy:J2 Artifact creation preserves close durability failures.
+    failures.push(error);
+  }
+  if (!complete) {
+    try {
+      await unlink(filePath);
+    } catch (error) {
+      // error-policy:J6 A missing failed artifact needs no cleanup.
+      if (
+        !error ||
+        typeof error !== "object" ||
+        !("code" in error) ||
+        error.code !== "ENOENT"
+      ) {
+        failures.push(error);
+      }
+    }
+  }
+  if (failures.length === 1) {
+    throw new Error("Cloud stability exclusive artifact write failed", {
+      cause: failures[0],
+    });
+  }
+  if (failures.length > 1) {
+    throw new AggregateError(
+      failures,
+      "Cloud stability exclusive artifact write failed",
+    );
+  }
 }
 
 export interface RunCloudStabilityLaneInput {
@@ -219,7 +270,7 @@ export interface CloudStabilityArtifactManifest extends CloudStabilityManifest {
 }
 
 export interface VerifiedCloudStabilityArtifacts {
-  report: unknown;
+  report: ScenarioStabilityExecutionReport;
   manifest: CloudStabilityArtifactManifest;
   reportSha256: string;
 }
@@ -233,20 +284,35 @@ async function readBoundedArtifact(
     fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW,
   );
   try {
-    const before = await handle.stat();
-    if (!before.isFile() || before.size > maximumBytes) {
+    const before = await handle.stat({ bigint: true });
+    if (!before.isFile() || before.size > BigInt(maximumBytes)) {
       throw new Error(`${path.basename(filePath)} exceeds its artifact limit`);
     }
-    const bytes = await handle.readFile();
-    const after = await handle.stat();
+    const expectedBytes = Number(before.size);
+    const bytes = Buffer.allocUnsafe(expectedBytes);
+    let offset = 0;
+    while (offset < expectedBytes) {
+      const result = await handle.read(
+        bytes,
+        offset,
+        expectedBytes - offset,
+        offset,
+      );
+      if (result.bytesRead === 0) {
+        throw new Error(`${path.basename(filePath)} changed while being read`);
+      }
+      offset += result.bytesRead;
+    }
+    const eofProbe = Buffer.allocUnsafe(1);
+    const probe = await handle.read(eofProbe, 0, 1, expectedBytes);
+    const after = await handle.stat({ bigint: true });
     if (
-      bytes.byteLength !== before.size ||
-      bytes.byteLength > maximumBytes ||
+      probe.bytesRead !== 0 ||
       before.dev !== after.dev ||
       before.ino !== after.ino ||
       before.size !== after.size ||
-      before.mtimeMs !== after.mtimeMs ||
-      before.ctimeMs !== after.ctimeMs
+      before.mtimeNs !== after.mtimeNs ||
+      before.ctimeNs !== after.ctimeNs
     ) {
       throw new Error(`${path.basename(filePath)} changed while being read`);
     }
@@ -271,12 +337,391 @@ function parseCanonicalArtifact(bytes: Buffer, artifactName: string): unknown {
   return parsed;
 }
 
+function strictRecord(
+  value: unknown,
+  label: string,
+  required: readonly string[],
+  optional: readonly string[] = [],
+): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} must be an ordinary object`);
+  }
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw new Error(`${label} must be an ordinary object`);
+  }
+  const record = Object.fromEntries(Object.entries(value));
+  const allowed = new Set([...required, ...optional]);
+  if (
+    !required.every((key) => Object.hasOwn(record, key)) ||
+    Object.keys(record).some((key) => !allowed.has(key))
+  ) {
+    throw new Error(`${label} contains missing or unknown fields`);
+  }
+  return record;
+}
+
+function strictArray(value: unknown, label: string): unknown[] {
+  if (!Array.isArray(value)) throw new Error(`${label} must be an array`);
+  return value;
+}
+
+function boundedString(
+  value: unknown,
+  label: string,
+  maximumLength = 512,
+): string {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.length > maximumLength
+  ) {
+    throw new Error(`${label} must be a non-empty bounded string`);
+  }
+  return value;
+}
+
+function sha256String(value: unknown, label: string): string {
+  if (typeof value !== "string" || !/^[a-f0-9]{64}$/.test(value)) {
+    throw new Error(`${label} must be a SHA-256 digest`);
+  }
+  return value;
+}
+
+function nonNegativeInteger(value: unknown, label: string): number {
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`${label} must be a non-negative safe integer`);
+  }
+  return value;
+}
+
+function booleanValue(value: unknown, label: string): boolean {
+  if (typeof value !== "boolean") throw new Error(`${label} must be boolean`);
+  return value;
+}
+
+function stabilityTier(value: unknown, label: string): ScenarioStabilityTier {
+  if (
+    value !== "0/3" &&
+    value !== "1/3" &&
+    value !== "2/3" &&
+    value !== "3/3"
+  ) {
+    throw new Error(`${label} is not a stability tier`);
+  }
+  return value;
+}
+
+function failureClassification(
+  value: unknown,
+  label: string,
+): ScenarioStabilityFailureClassification {
+  if (value !== "scenario-failure" && value !== "harness-failure") {
+    throw new Error(`${label} is not a failure classification`);
+  }
+  return value;
+}
+
+function parseExecutionBudgets(
+  value: unknown,
+): ScenarioStabilityExecutionBudgets {
+  const record = strictRecord(value, "stability report budgets", [
+    "timeoutMs",
+    "maxInputTokens",
+    "maxOutputTokens",
+    "maxToolCalls",
+  ]);
+  return {
+    timeoutMs: positiveInteger(record.timeoutMs, "report timeoutMs"),
+    maxInputTokens: positiveInteger(
+      record.maxInputTokens,
+      "report maxInputTokens",
+    ),
+    maxOutputTokens: positiveInteger(
+      record.maxOutputTokens,
+      "report maxOutputTokens",
+    ),
+    maxToolCalls: nonNegativeInteger(
+      record.maxToolCalls,
+      "report maxToolCalls",
+    ),
+  };
+}
+
+function canonicalAttemptNumber(index: number, value: unknown): 1 | 2 | 3 {
+  let expected: 1 | 2 | 3;
+  if (index === 0) expected = 1;
+  else if (index === 1) expected = 2;
+  else if (index === 2) expected = 3;
+  else throw new Error("stability report contains more than three attempts");
+  if (value !== expected) {
+    throw new Error(
+      `stability report attempt ${index + 1} has a noncanonical attempt number`,
+    );
+  }
+  return expected;
+}
+
+function parseExecutedAttempt(value: unknown, index: number) {
+  const label = `stability report attempt ${index + 1}`;
+  const record = strictRecord(
+    value,
+    label,
+    [
+      "passed",
+      "initialStateHash",
+      "finalStateHash",
+      "inputTokens",
+      "outputTokens",
+      "toolCalls",
+      "evidence",
+      "stateDiff",
+      "attemptNumber",
+      "attemptId",
+      "outputDir",
+      "durationMs",
+      "failureClassification",
+    ],
+    ["error"],
+  );
+  const base = {
+    passed: record.passed,
+    initialStateHash: record.initialStateHash,
+    finalStateHash: record.finalStateHash,
+    inputTokens: record.inputTokens,
+    outputTokens: record.outputTokens,
+    toolCalls: record.toolCalls,
+    evidence: record.evidence,
+    stateDiff: record.stateDiff,
+  };
+  const execution = parseScenarioStabilityAttemptExecution(
+    Object.hasOwn(record, "error") ? { ...base, error: record.error } : base,
+  );
+  const attemptNumber = canonicalAttemptNumber(index, record.attemptNumber);
+  const classification =
+    record.failureClassification === null
+      ? null
+      : failureClassification(
+          record.failureClassification,
+          `${label} failureClassification`,
+        );
+  return {
+    ...execution,
+    attemptNumber,
+    attemptId: boundedString(record.attemptId, `${label} attemptId`),
+    outputDir: boundedString(record.outputDir, `${label} outputDir`, 4_096),
+    durationMs: nonNegativeInteger(record.durationMs, `${label} durationMs`),
+    failureClassification: classification,
+  };
+}
+
+function parseExecutedCell(value: unknown, index: number) {
+  const label = `stability report cell ${index + 1}`;
+  const record = strictRecord(value, label, [
+    "scenarioId",
+    "model",
+    "baselineInitialStateHash",
+    "firstAttemptPassed",
+    "passedAttempts",
+    "tier",
+    "strictPassed",
+    "attempts",
+  ]);
+  const model = strictRecord(record.model, `${label} model`, [
+    "provider",
+    "model",
+  ]);
+  const attempts = strictArray(record.attempts, `${label} attempts`).map(
+    parseExecutedAttempt,
+  );
+  if (attempts.length !== 3) {
+    throw new Error(`${label} must contain exactly three attempts`);
+  }
+  const passedAttempts = nonNegativeInteger(
+    record.passedAttempts,
+    `${label} passedAttempts`,
+  );
+  const tier = stabilityTier(record.tier, `${label} tier`);
+  const strictPassed = booleanValue(
+    record.strictPassed,
+    `${label} strictPassed`,
+  );
+  const firstAttemptPassed = booleanValue(
+    record.firstAttemptPassed,
+    `${label} firstAttemptPassed`,
+  );
+  const actualPassed = attempts.filter((attempt) => attempt.passed).length;
+  if (
+    passedAttempts !== actualPassed ||
+    tier !== `${actualPassed}/3` ||
+    strictPassed !== (actualPassed === 3) ||
+    firstAttemptPassed !== attempts[0]?.passed
+  ) {
+    throw new Error(`${label} summary does not match its attempts`);
+  }
+  const baselineInitialStateHash =
+    record.baselineInitialStateHash === null
+      ? null
+      : boundedString(
+          record.baselineInitialStateHash,
+          `${label} baselineInitialStateHash`,
+        );
+  return {
+    scenarioId: boundedString(record.scenarioId, `${label} scenarioId`),
+    model: {
+      provider: boundedString(model.provider, `${label} provider`),
+      model: boundedString(model.model, `${label} model name`),
+    },
+    baselineInitialStateHash,
+    firstAttemptPassed,
+    passedAttempts,
+    tier,
+    strictPassed,
+    attempts,
+  };
+}
+
+function parseFocusItem(value: unknown, index: number) {
+  const label = `stability report focus item ${index + 1}`;
+  const record = strictRecord(value, label, [
+    "scenarioId",
+    "provider",
+    "model",
+    "tier",
+    "firstAttemptPassed",
+    "failedAttemptIds",
+    "failureClassifications",
+  ]);
+  return {
+    scenarioId: boundedString(record.scenarioId, `${label} scenarioId`),
+    provider: boundedString(record.provider, `${label} provider`),
+    model: boundedString(record.model, `${label} model`),
+    tier: stabilityTier(record.tier, `${label} tier`),
+    firstAttemptPassed: booleanValue(
+      record.firstAttemptPassed,
+      `${label} firstAttemptPassed`,
+    ),
+    failedAttemptIds: strictArray(
+      record.failedAttemptIds,
+      `${label} failedAttemptIds`,
+    ).map((attemptId) => boundedString(attemptId, `${label} attemptId`)),
+    failureClassifications: strictArray(
+      record.failureClassifications,
+      `${label} failureClassifications`,
+    ).map((classification) =>
+      failureClassification(classification, `${label} classification`),
+    ),
+  };
+}
+
+function parseFailureCluster(value: unknown, index: number) {
+  const label = `stability report failure cluster ${index + 1}`;
+  const record = strictRecord(value, label, [
+    "fingerprint",
+    "classification",
+    "occurrences",
+    "cells",
+    "sample",
+  ]);
+  return {
+    fingerprint: sha256String(record.fingerprint, `${label} fingerprint`),
+    classification: failureClassification(
+      record.classification,
+      `${label} classification`,
+    ),
+    occurrences: positiveInteger(record.occurrences, `${label} occurrences`),
+    cells: strictArray(record.cells, `${label} cells`).map((cell) =>
+      boundedString(cell, `${label} cell`, 1_536),
+    ),
+    sample: boundedString(record.sample, `${label} sample`, 4_000),
+  };
+}
+
+function parseCloudStabilityExecutionReport(
+  value: unknown,
+  manifest: CloudStabilityManifest,
+): ScenarioStabilityExecutionReport {
+  assertScenarioStabilityBoundedJson(
+    value,
+    "Cloud stability aggregate report",
+    CLOUD_STABILITY_MAX_CANONICAL_BYTES,
+  );
+  const record = strictRecord(value, "Cloud stability aggregate report", [
+    "schemaVersion",
+    "runId",
+    "planFingerprint",
+    "status",
+    "attemptCount",
+    "requiredTier",
+    "budgets",
+    "cells",
+    "focusList",
+    "failureClusters",
+  ]);
+  if (
+    record.schemaVersion !== 1 ||
+    record.attemptCount !== 3 ||
+    record.requiredTier !== "3/3" ||
+    (record.status !== "passed" && record.status !== "failed")
+  ) {
+    throw new Error("Cloud stability aggregate report constants are invalid");
+  }
+  const runId = stabilityRunId(record.runId);
+  const budgets = parseExecutionBudgets(record.budgets);
+  const cells = strictArray(record.cells, "stability report cells").map(
+    parseExecutedCell,
+  );
+  const focusList = strictArray(
+    record.focusList,
+    "stability report focusList",
+  ).map(parseFocusItem);
+  const failureClusters = strictArray(
+    record.failureClusters,
+    "stability report failureClusters",
+  ).map(parseFailureCluster);
+  if (cells.length !== 1) {
+    throw new Error("Cloud stability aggregate must contain exactly one cell");
+  }
+  const cell = cells[0];
+  if (
+    !cell ||
+    runId !== manifest.runId ||
+    cell.scenarioId !== manifest.scenarioId ||
+    cell.model.provider !== manifest.provider ||
+    cell.model.model !== manifest.model ||
+    budgets.timeoutMs !== manifest.timeoutMs ||
+    budgets.maxInputTokens !== manifest.maxInputTokens ||
+    budgets.maxOutputTokens !== manifest.maxOutputTokens ||
+    budgets.maxToolCalls !== manifest.maxToolCalls ||
+    (record.status === "passed") !== cell.strictPassed ||
+    focusList.length !== (cell.strictPassed ? 0 : 1)
+  ) {
+    throw new Error("Cloud stability aggregate does not match its manifest");
+  }
+  return {
+    schemaVersion: 1,
+    runId,
+    planFingerprint: sha256String(
+      record.planFingerprint,
+      "stability report planFingerprint",
+    ),
+    status: record.status,
+    attemptCount: 3,
+    requiredTier: "3/3",
+    budgets,
+    cells,
+    focusList,
+    failureClusters,
+  };
+}
+
 function parseArtifactManifest(value: unknown): CloudStabilityArtifactManifest {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     throw new Error("Cloud stability artifact manifest must be an object");
   }
   const record = Object.fromEntries(Object.entries(value));
-  const { manifestSha256, reportSha256, ...laneManifest } = record;
+  const { manifestSha256, ...unsignedArtifactManifest } = record;
+  const { reportSha256, ...laneManifest } = unsignedArtifactManifest;
   if (
     typeof manifestSha256 !== "string" ||
     !/^[a-f0-9]{64}$/.test(manifestSha256) ||
@@ -286,7 +731,10 @@ function parseArtifactManifest(value: unknown): CloudStabilityArtifactManifest {
     throw new Error("Cloud stability artifact manifest hashes are invalid");
   }
   const manifest = parseCloudStabilityManifest(laneManifest);
-  if (manifestSha256 !== canonicalCloudStabilitySha256(manifest)) {
+  if (
+    manifestSha256 !==
+    canonicalCloudStabilitySha256({ ...manifest, reportSha256 })
+  ) {
     throw new Error("Cloud stability manifest checksum does not match");
   }
   return { ...manifest, manifestSha256, reportSha256 };
@@ -310,10 +758,10 @@ export async function verifyCloudStabilityArtifacts(
       CLOUD_STABILITY_MAX_CANONICAL_BYTES,
     ),
   ]);
-  const report = parseCanonicalArtifact(reportBytes, "stability.json");
   const manifest = parseArtifactManifest(
     parseCanonicalArtifact(manifestBytes, "manifest.json"),
   );
+  const reportValue = parseCanonicalArtifact(reportBytes, "stability.json");
   const reportSha256 = createHash("sha256").update(reportBytes).digest("hex");
   const expectedSidecar = `${reportSha256}  stability.json\n`;
   if (!checksumBytes.equals(Buffer.from(expectedSidecar, "utf8"))) {
@@ -321,11 +769,123 @@ export async function verifyCloudStabilityArtifacts(
   }
   if (
     manifest.reportSha256 !== reportSha256 ||
-    canonicalCloudStabilitySha256(report) !== reportSha256
+    canonicalCloudStabilitySha256(reportValue) !== reportSha256
   ) {
     throw new Error("Cloud stability report checksums do not match");
   }
+  const report = parseCloudStabilityExecutionReport(reportValue, manifest);
   return { report, manifest, reportSha256 };
+}
+
+async function removeStagedBundle(stagingRoot: string): Promise<void> {
+  for (const name of ["stability.json", "stability.sha256", "manifest.json"]) {
+    try {
+      await unlink(path.join(stagingRoot, name));
+    } catch (error) {
+      // error-policy:J6 A missing staged file is expected after partial setup.
+      if (
+        !error ||
+        typeof error !== "object" ||
+        !("code" in error) ||
+        error.code !== "ENOENT"
+      ) {
+        throw error;
+      }
+    }
+  }
+  await rmdir(stagingRoot);
+}
+
+async function persistCloudStabilityArtifacts(
+  outputRoot: string,
+  report: ScenarioStabilityExecutionReport,
+  manifest: CloudStabilityManifest,
+): Promise<void> {
+  await mkdir(outputRoot, { recursive: true, mode: 0o700 });
+  const reportBytes = canonicalCloudStabilityJson(report);
+  const reportSha256 = createHash("sha256")
+    .update(reportBytes, "utf8")
+    .digest("hex");
+  if (reportSha256 !== canonicalCloudStabilitySha256(report)) {
+    throw new Error("Cloud stability report bytes are not canonical");
+  }
+  const unsignedArtifactManifest = {
+    ...manifest,
+    reportSha256,
+  };
+  const artifactManifest = {
+    ...unsignedArtifactManifest,
+    manifestSha256: canonicalCloudStabilitySha256(unsignedArtifactManifest),
+  };
+  const stagingRoot = path.join(
+    outputRoot,
+    `.stability-stage-${randomBytes(16).toString("hex")}`,
+  );
+  await mkdir(stagingRoot, { mode: 0o700 });
+  await syncDirectory(outputRoot);
+
+  const promoted: string[] = [];
+  try {
+    await writeExclusiveFile(
+      path.join(stagingRoot, "stability.json"),
+      reportBytes,
+    );
+    await writeExclusiveFile(
+      path.join(stagingRoot, "stability.sha256"),
+      `${reportSha256}  stability.json\n`,
+    );
+    await writeExclusiveFile(
+      path.join(stagingRoot, "manifest.json"),
+      canonicalCloudStabilityJson(artifactManifest),
+    );
+    await syncDirectory(stagingRoot);
+    await verifyCloudStabilityArtifacts(stagingRoot);
+
+    // The manifest is the commit marker: it is linked last, and no link may
+    // replace a prior artifact generation. Readers either verify all three or
+    // fail closed while promotion is in progress.
+    for (const name of [
+      "stability.json",
+      "stability.sha256",
+      "manifest.json",
+    ]) {
+      await link(path.join(stagingRoot, name), path.join(outputRoot, name));
+      promoted.push(name);
+    }
+    await syncDirectory(outputRoot);
+    await verifyCloudStabilityArtifacts(outputRoot);
+    await removeStagedBundle(stagingRoot);
+    await syncDirectory(outputRoot);
+  } catch (error) {
+    const cleanupFailures: unknown[] = [];
+    for (const name of promoted.reverse()) {
+      try {
+        await unlink(path.join(outputRoot, name));
+      } catch (cleanupError) {
+        // error-policy:J6 Promotion rollback is best-effort but never hidden.
+        cleanupFailures.push(cleanupError);
+      }
+    }
+    try {
+      await syncDirectory(outputRoot);
+    } catch (cleanupError) {
+      // error-policy:J6 Promotion rollback durability failure is reported.
+      cleanupFailures.push(cleanupError);
+    }
+    try {
+      await removeStagedBundle(stagingRoot);
+    } catch (cleanupError) {
+      // error-policy:J6 Staging cleanup failure is reported with the cause.
+      cleanupFailures.push(cleanupError);
+    }
+    if (cleanupFailures.length > 0) {
+      throw new AggregateError(
+        [error, ...cleanupFailures],
+        "Cloud stability artifact promotion and cleanup failed",
+      );
+    }
+    throw error;
+  }
 }
 
 /** Executes and persists the exact-three aggregate even when it blocks the lane. */
@@ -351,25 +911,6 @@ export async function runCloudStabilityLane(
     },
     adapter: input.adapter,
   });
-  const reportBytes = await writeJsonAtomic(
-    path.join(input.outputRoot, "stability.json"),
-    report,
-  );
-  const reportSha256 = createHash("sha256")
-    .update(reportBytes, "utf8")
-    .digest("hex");
-  if (reportSha256 !== canonicalCloudStabilitySha256(report)) {
-    throw new Error("Cloud stability report bytes are not canonical");
-  }
-  await writeTextAtomic(
-    path.join(input.outputRoot, "stability.sha256"),
-    `${reportSha256}  stability.json\n`,
-  );
-  await writeJsonAtomic(path.join(input.outputRoot, "manifest.json"), {
-    ...manifest,
-    manifestSha256: canonicalCloudStabilitySha256(manifest),
-    reportSha256,
-  });
-  await verifyCloudStabilityArtifacts(input.outputRoot);
+  await persistCloudStabilityArtifacts(input.outputRoot, report, manifest);
   return report;
 }

--- a/packages/cloud/e2e/src/stability/cloud-stability-runner.ts
+++ b/packages/cloud/e2e/src/stability/cloud-stability-runner.ts
@@ -5,7 +5,8 @@
  */
 
 import { createHash } from "node:crypto";
-import { mkdir, rename, writeFile } from "node:fs/promises";
+import { constants as fsConstants } from "node:fs";
+import { mkdir, open, rename, writeFile } from "node:fs/promises";
 import path from "node:path";
 import {
   createScenarioStabilityPlan,
@@ -34,6 +35,19 @@ export interface CloudStabilityManifest {
   maxToolCalls: number;
 }
 
+const CLOUD_STABILITY_MAX_CANONICAL_BYTES = 8 * 1024 * 1024;
+const CLOUD_STABILITY_CHECKSUM_BYTES = 81;
+
+const CLOUD_STABILITY_CANONICAL_OPTIONS = {
+  maxDepth: 32,
+  maxNodes: 100_000,
+  maxOutputChars: CLOUD_STABILITY_MAX_CANONICAL_BYTES,
+  sparseArrayHoles: "null" as const,
+  onUnbounded: () => {
+    throw new Error("Cloud stability artifact exceeds canonical limits");
+  },
+};
+
 function boundedIdentifier(value: unknown, field: string): string {
   if (
     typeof value !== "string" ||
@@ -56,19 +70,23 @@ function stabilityRunId(value: unknown): string {
   return value;
 }
 
+/** Returns the one bounded byte representation used for storage and hashing. */
+export function canonicalCloudStabilityJson(value: unknown): string {
+  const canonical = canonicalJsonString(
+    value,
+    CLOUD_STABILITY_CANONICAL_OPTIONS,
+  );
+  if (
+    Buffer.byteLength(canonical, "utf8") > CLOUD_STABILITY_MAX_CANONICAL_BYTES
+  ) {
+    throw new Error("Cloud stability artifact exceeds canonical byte limit");
+  }
+  return canonical;
+}
+
 export function canonicalCloudStabilitySha256(value: unknown): string {
   return createHash("sha256")
-    .update(
-      canonicalJsonString(value, {
-        maxDepth: 32,
-        maxNodes: 100_000,
-        maxOutputChars: 8 * 1024 * 1024,
-        sparseArrayHoles: "null",
-        onUnbounded: () => {
-          throw new Error("Cloud stability manifest exceeds canonical limits");
-        },
-      }),
-    )
+    .update(canonicalCloudStabilityJson(value), "utf8")
     .digest("hex");
 }
 
@@ -173,15 +191,13 @@ export function parseCloudStabilityManifest(
 async function writeJsonAtomic(
   filePath: string,
   value: unknown,
-): Promise<void> {
+): Promise<string> {
   await mkdir(path.dirname(filePath), { recursive: true });
-  const bytes = JSON.stringify(value, null, 2);
-  if (Buffer.byteLength(bytes) > 64 * 1024 * 1024) {
-    throw new Error("Cloud stability report exceeds 64 MiB");
-  }
+  const bytes = canonicalCloudStabilityJson(value);
   const temporary = `${filePath}.${process.pid}.tmp`;
   await writeFile(temporary, bytes, { encoding: "utf8", mode: 0o600 });
   await rename(temporary, filePath);
+  return bytes;
 }
 
 async function writeTextAtomic(filePath: string, value: string): Promise<void> {
@@ -195,6 +211,121 @@ export interface RunCloudStabilityLaneInput {
   manifest: CloudStabilityManifest;
   outputRoot: string;
   adapter: ScenarioStabilityExecutionAdapter;
+}
+
+export interface CloudStabilityArtifactManifest extends CloudStabilityManifest {
+  manifestSha256: string;
+  reportSha256: string;
+}
+
+export interface VerifiedCloudStabilityArtifacts {
+  report: unknown;
+  manifest: CloudStabilityArtifactManifest;
+  reportSha256: string;
+}
+
+async function readBoundedArtifact(
+  filePath: string,
+  maximumBytes: number,
+): Promise<Buffer> {
+  const handle = await open(
+    filePath,
+    fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW,
+  );
+  try {
+    const before = await handle.stat();
+    if (!before.isFile() || before.size > maximumBytes) {
+      throw new Error(`${path.basename(filePath)} exceeds its artifact limit`);
+    }
+    const bytes = await handle.readFile();
+    const after = await handle.stat();
+    if (
+      bytes.byteLength !== before.size ||
+      bytes.byteLength > maximumBytes ||
+      before.dev !== after.dev ||
+      before.ino !== after.ino ||
+      before.size !== after.size ||
+      before.mtimeMs !== after.mtimeMs ||
+      before.ctimeMs !== after.ctimeMs
+    ) {
+      throw new Error(`${path.basename(filePath)} changed while being read`);
+    }
+    return bytes;
+  } finally {
+    await handle.close();
+  }
+}
+
+function parseCanonicalArtifact(bytes: Buffer, artifactName: string): unknown {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(bytes.toString("utf8"));
+  } catch (cause) {
+    // error-policy:J2 Invalid retained JSON is an integrity failure with cause.
+    throw new Error(`${artifactName} is not valid JSON`, { cause });
+  }
+  const canonical = Buffer.from(canonicalCloudStabilityJson(parsed), "utf8");
+  if (!bytes.equals(canonical)) {
+    throw new Error(`${artifactName} is not canonical JSON`);
+  }
+  return parsed;
+}
+
+function parseArtifactManifest(value: unknown): CloudStabilityArtifactManifest {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("Cloud stability artifact manifest must be an object");
+  }
+  const record = Object.fromEntries(Object.entries(value));
+  const { manifestSha256, reportSha256, ...laneManifest } = record;
+  if (
+    typeof manifestSha256 !== "string" ||
+    !/^[a-f0-9]{64}$/.test(manifestSha256) ||
+    typeof reportSha256 !== "string" ||
+    !/^[a-f0-9]{64}$/.test(reportSha256)
+  ) {
+    throw new Error("Cloud stability artifact manifest hashes are invalid");
+  }
+  const manifest = parseCloudStabilityManifest(laneManifest);
+  if (manifestSha256 !== canonicalCloudStabilitySha256(manifest)) {
+    throw new Error("Cloud stability manifest checksum does not match");
+  }
+  return { ...manifest, manifestSha256, reportSha256 };
+}
+
+/** Verifies retained report bytes, sidecar, and manifest before returning data. */
+export async function verifyCloudStabilityArtifacts(
+  outputRoot: string,
+): Promise<VerifiedCloudStabilityArtifacts> {
+  const [reportBytes, checksumBytes, manifestBytes] = await Promise.all([
+    readBoundedArtifact(
+      path.join(outputRoot, "stability.json"),
+      CLOUD_STABILITY_MAX_CANONICAL_BYTES,
+    ),
+    readBoundedArtifact(
+      path.join(outputRoot, "stability.sha256"),
+      CLOUD_STABILITY_CHECKSUM_BYTES,
+    ),
+    readBoundedArtifact(
+      path.join(outputRoot, "manifest.json"),
+      CLOUD_STABILITY_MAX_CANONICAL_BYTES,
+    ),
+  ]);
+  const report = parseCanonicalArtifact(reportBytes, "stability.json");
+  const manifest = parseArtifactManifest(
+    parseCanonicalArtifact(manifestBytes, "manifest.json"),
+  );
+  const reportSha256 = createHash("sha256").update(reportBytes).digest("hex");
+  const expectedSidecar = `${reportSha256}  stability.json\n`;
+  if (!checksumBytes.equals(Buffer.from(expectedSidecar, "utf8"))) {
+    throw new Error("stability.sha256 does not match retained report bytes");
+  }
+  if (
+    manifest.reportSha256 !== reportSha256 ||
+    canonicalCloudStabilitySha256(report) !== reportSha256
+  ) {
+    throw new Error("Cloud stability report checksums do not match");
+  }
+  return { report, manifest, reportSha256 };
 }
 
 /** Executes and persists the exact-three aggregate even when it blocks the lane. */
@@ -220,8 +351,16 @@ export async function runCloudStabilityLane(
     },
     adapter: input.adapter,
   });
-  await writeJsonAtomic(path.join(input.outputRoot, "stability.json"), report);
-  const reportSha256 = canonicalCloudStabilitySha256(report);
+  const reportBytes = await writeJsonAtomic(
+    path.join(input.outputRoot, "stability.json"),
+    report,
+  );
+  const reportSha256 = createHash("sha256")
+    .update(reportBytes, "utf8")
+    .digest("hex");
+  if (reportSha256 !== canonicalCloudStabilitySha256(report)) {
+    throw new Error("Cloud stability report bytes are not canonical");
+  }
   await writeTextAtomic(
     path.join(input.outputRoot, "stability.sha256"),
     `${reportSha256}  stability.json\n`,
@@ -231,5 +370,6 @@ export async function runCloudStabilityLane(
     manifestSha256: canonicalCloudStabilitySha256(manifest),
     reportSha256,
   });
+  await verifyCloudStabilityArtifacts(input.outputRoot);
   return report;
 }

--- a/packages/cloud/e2e/src/stability/cloud-stability-runner.ts
+++ b/packages/cloud/e2e/src/stability/cloud-stability-runner.ts
@@ -10,6 +10,7 @@ import { link, mkdir, open, rmdir, unlink } from "node:fs/promises";
 import path from "node:path";
 import {
   assertScenarioStabilityBoundedJson,
+  assertScenarioStabilityExecutedCellCoherence,
   createScenarioStabilityPlan,
   deriveScenarioStabilityExecutionAttemptIdentities,
   deriveScenarioStabilityFailureClusters,
@@ -509,9 +510,6 @@ function parseExecutedAttempt(value: unknown, index: number) {
           record.failureClassification,
           `${label} failureClassification`,
         );
-  if (execution.passed !== (classification === null)) {
-    throw new Error(`${label} pass and failure classification disagree`);
-  }
   return {
     ...execution,
     attemptNumber,
@@ -557,15 +555,6 @@ function parseExecutedCell(value: unknown, index: number) {
     record.firstAttemptPassed,
     `${label} firstAttemptPassed`,
   );
-  const actualPassed = attempts.filter((attempt) => attempt.passed).length;
-  if (
-    passedAttempts !== actualPassed ||
-    tier !== `${actualPassed}/3` ||
-    strictPassed !== (actualPassed === 3) ||
-    firstAttemptPassed !== attempts[0]?.passed
-  ) {
-    throw new Error(`${label} summary does not match its attempts`);
-  }
   const baselineInitialStateHash =
     record.baselineInitialStateHash === null
       ? null
@@ -573,9 +562,6 @@ function parseExecutedCell(value: unknown, index: number) {
           record.baselineInitialStateHash,
           `${label} baselineInitialStateHash`,
         );
-  if (baselineInitialStateHash !== attempts[0]?.initialStateHash) {
-    throw new Error(`${label} baseline does not match its first attempt`);
-  }
   return {
     scenarioId: boundedString(record.scenarioId, `${label} scenarioId`),
     model: {
@@ -686,6 +672,9 @@ function parseCloudStabilityExecutionReport(
   const cells = strictArray(record.cells, "stability report cells").map(
     parseExecutedCell,
   );
+  for (const cell of cells) {
+    assertScenarioStabilityExecutedCellCoherence(cell);
+  }
   const focusList = strictArray(
     record.focusList,
     "stability report focusList",

--- a/packages/cloud/e2e/src/stability/stability-scenario-child.test.ts
+++ b/packages/cloud/e2e/src/stability/stability-scenario-child.test.ts
@@ -8,6 +8,7 @@ import { expect, test } from "bun:test";
 import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { ServiceType } from "@elizaos/core";
 import cloudScenario from "../../scenarios/cloud-stability-agent.scenario.ts";
 
 test("source scenario child exits naturally with zero runtime leaks", async () => {
@@ -16,6 +17,7 @@ test("source scenario child exits naturally with zero runtime leaks", async () =
   );
   try {
     const policy = cloudScenario.contract.syntheticRuntimePolicy;
+    expect(policy.allowedServiceTypes).toContain(ServiceType.MEMBERSHIP);
     const report = path.join(directory, "report.json");
     const quiescence = path.join(directory, "quiescence.json");
     const runtimeLedger = path.join(directory, "runtime.json");

--- a/packages/scenario-runner/AGENTS.md
+++ b/packages/scenario-runner/AGENTS.md
@@ -60,7 +60,9 @@ import {
 import {
   buildAggregate, writeReport, printStdoutSummary, writeScenarioRunViewer,
   createScenarioStabilityPlan, buildScenarioStabilityReport,
-  executeScenarioStability,
+  executeScenarioStability, deriveScenarioStabilityExecutionAttemptIdentities,
+  deriveScenarioStabilityFocusList, deriveScenarioStabilityFailureClusters,
+  scenarioStabilityExecutionPlanFingerprint,
 } from "@elizaos/scenario-runner";
 
 // Native (training corpus) export

--- a/packages/scenario-runner/CLAUDE.md
+++ b/packages/scenario-runner/CLAUDE.md
@@ -60,7 +60,9 @@ import {
 import {
   buildAggregate, writeReport, printStdoutSummary, writeScenarioRunViewer,
   createScenarioStabilityPlan, buildScenarioStabilityReport,
-  executeScenarioStability,
+  executeScenarioStability, deriveScenarioStabilityExecutionAttemptIdentities,
+  deriveScenarioStabilityFocusList, deriveScenarioStabilityFailureClusters,
+  scenarioStabilityExecutionPlanFingerprint,
 } from "@elizaos/scenario-runner";
 
 // Native (training corpus) export

--- a/packages/scenario-runner/README.md
+++ b/packages/scenario-runner/README.md
@@ -152,6 +152,9 @@ Programmatic stability execution is available through
 plan before any adapter call, bounds every retained evidence/state value as
 plain JSON, compares runtime-produced initial-state hashes, records
 first-attempt success, and blocks every cell below `3/3`.
+Its exported plan-fingerprint, attempt-identity, focus-list, and failure-cluster
+derivations let artifact verifiers enforce the exact production projections
+without maintaining a second implementation.
 
 Use `ScenarioStabilitySubprocessAdapter` for Cloud or qualification lanes. It
 opens the exact shared synthetic-control manifest for every attempt, launches a

--- a/packages/scenario-runner/src/stability-executor.ts
+++ b/packages/scenario-runner/src/stability-executor.ts
@@ -612,6 +612,54 @@ export function deriveScenarioStabilityFailureClusters(
     );
 }
 
+/** Validates the execution-owned relationships within one retained cell. */
+export function assertScenarioStabilityExecutedCellCoherence(
+  cell: ScenarioStabilityExecutedCell,
+): void {
+  if (
+    cell.attempts.length !== 3 ||
+    cell.attempts.some((attempt, index) => attempt.attemptNumber !== index + 1)
+  ) {
+    throw new Error(
+      "stability cell must retain canonical attempts 1, 2, and 3",
+    );
+  }
+  for (const attempt of cell.attempts) {
+    if (attempt.passed !== (attempt.failureClassification === null)) {
+      throw new Error(
+        "stability attempt pass and failure classification disagree",
+      );
+    }
+  }
+  const passedAttempts = cell.attempts.filter(
+    (attempt) => attempt.passed,
+  ).length;
+  if (
+    cell.passedAttempts !== passedAttempts ||
+    cell.tier !== tier(passedAttempts) ||
+    cell.strictPassed !== (passedAttempts === 3) ||
+    cell.firstAttemptPassed !== cell.attempts[0]?.passed
+  ) {
+    throw new Error("stability cell summary does not match its attempts");
+  }
+  if (cell.baselineInitialStateHash !== null) {
+    if (
+      !cell.attempts.some(
+        (attempt) => attempt.initialStateHash === cell.baselineInitialStateHash,
+      ) ||
+      cell.attempts.some(
+        (attempt) =>
+          attempt.passed &&
+          attempt.initialStateHash !== cell.baselineInitialStateHash,
+      )
+    ) {
+      throw new Error(
+        "stability cell baseline does not match its admitted passing attempts",
+      );
+    }
+  }
+}
+
 /** Runs every declared scenario/provider/model cell exactly three times. */
 export async function executeScenarioStability(input: {
   plan: ScenarioStabilityPlan;
@@ -729,7 +777,7 @@ export async function executeScenarioStability(input: {
       });
     }
     const passedAttempts = attempts.filter((attempt) => attempt.passed).length;
-    cells.push({
+    const cell: ScenarioStabilityExecutedCell = {
       scenarioId: target.scenarioId,
       model: target.model,
       baselineInitialStateHash,
@@ -738,7 +786,9 @@ export async function executeScenarioStability(input: {
       tier: tier(passedAttempts),
       strictPassed: passedAttempts === 3,
       attempts,
-    });
+    };
+    assertScenarioStabilityExecutedCellCoherence(cell);
+    cells.push(cell);
   }
   const focusList = deriveScenarioStabilityFocusList(cells);
   const report: ScenarioStabilityExecutionReport = {

--- a/packages/scenario-runner/src/stability-executor.ts
+++ b/packages/scenario-runner/src/stability-executor.ts
@@ -25,6 +25,12 @@ export interface ScenarioStabilityExecutionTarget {
   model: ScenarioStabilityModel;
 }
 
+export interface ScenarioStabilityExecutionAttemptIdentity {
+  attemptNumber: ScenarioStabilityAttemptNumber;
+  attemptId: string;
+  outputDir: string;
+}
+
 export interface ScenarioStabilityExecutionBudgets {
   timeoutMs: number;
   maxInputTokens: number;
@@ -301,6 +307,30 @@ function targetSlug(target: ScenarioStabilityExecutionTarget): string {
   return `${readable}-${digest}`;
 }
 
+/** Derives the exact target-qualified attempt identities used by execution. */
+export function deriveScenarioStabilityExecutionAttemptIdentities(
+  plan: ScenarioStabilityPlan,
+  target: ScenarioStabilityExecutionTarget,
+): readonly ScenarioStabilityExecutionAttemptIdentity[] {
+  const validatedPlan = validateScenarioStabilityPlan(plan);
+  validateTarget(target);
+  const slug = targetSlug(target);
+  return validatedPlan.attempts.map((attempt) => ({
+    attemptNumber: attempt.attemptNumber,
+    attemptId: `${attempt.attemptId}-${slug}`,
+    outputDir: path.join(attempt.outputDir, slug),
+  }));
+}
+
+/** Hashes the validated execution plan exactly as retained aggregate reports do. */
+export function scenarioStabilityExecutionPlanFingerprint(
+  plan: ScenarioStabilityPlan,
+): string {
+  return createHash("sha256")
+    .update(JSON.stringify(validateScenarioStabilityPlan(plan)))
+    .digest("hex");
+}
+
 function tier(passedAttempts: number): ScenarioStabilityTier {
   if (passedAttempts < 0 || passedAttempts > 3) {
     throw new Error(`invalid scenario stability pass count ${passedAttempts}`);
@@ -510,7 +540,35 @@ function normalizedFailureSample(
     .slice(0, 4_000);
 }
 
-function buildFailureClusters(
+/** Deterministically derives the exact failure focus projection from executed cells. */
+export function deriveScenarioStabilityFocusList(
+  cells: readonly ScenarioStabilityExecutedCell[],
+): ScenarioStabilityExecutionReport["focusList"] {
+  return cells
+    .filter((cell) => !cell.strictPassed)
+    .map((cell) => ({
+      scenarioId: cell.scenarioId,
+      provider: cell.model.provider,
+      model: cell.model.model,
+      tier: cell.tier,
+      firstAttemptPassed: cell.firstAttemptPassed,
+      failedAttemptIds: cell.attempts
+        .filter((attempt) => !attempt.passed)
+        .map((attempt) => attempt.attemptId),
+      failureClassifications: [
+        ...new Set(
+          cell.attempts.flatMap((attempt) =>
+            attempt.failureClassification
+              ? [attempt.failureClassification]
+              : [],
+          ),
+        ),
+      ].sort(),
+    }));
+}
+
+/** Deterministically clusters executed failures for reports and verification. */
+export function deriveScenarioStabilityFailureClusters(
   cells: readonly ScenarioStabilityExecutedCell[],
 ): ScenarioStabilityExecutionReport["failureClusters"] {
   const clusters = new Map<
@@ -579,9 +637,11 @@ export async function executeScenarioStability(input: {
     targetKeys.add(key);
     const attempts: ScenarioStabilityExecutedAttempt[] = [];
     let baselineInitialStateHash: string | null = null;
-    for (const attempt of plan.attempts) {
-      const attemptId = `${attempt.attemptId}-${targetSlug(target)}`;
-      const outputDir = path.join(attempt.outputDir, targetSlug(target));
+    for (const attempt of deriveScenarioStabilityExecutionAttemptIdentities(
+      plan,
+      target,
+    )) {
+      const { attemptId, outputDir } = attempt;
       const controller = new AbortController();
       const startedAt = Date.now();
       let execution: ScenarioStabilityAttemptExecution | undefined;
@@ -680,40 +740,18 @@ export async function executeScenarioStability(input: {
       attempts,
     });
   }
-  const focusList = cells
-    .filter((cell) => !cell.strictPassed)
-    .map((cell) => ({
-      scenarioId: cell.scenarioId,
-      provider: cell.model.provider,
-      model: cell.model.model,
-      tier: cell.tier,
-      firstAttemptPassed: cell.firstAttemptPassed,
-      failedAttemptIds: cell.attempts
-        .filter((attempt) => !attempt.passed)
-        .map((attempt) => attempt.attemptId),
-      failureClassifications: [
-        ...new Set(
-          cell.attempts.flatMap((attempt) =>
-            attempt.failureClassification
-              ? [attempt.failureClassification]
-              : [],
-          ),
-        ),
-      ].sort(),
-    }));
+  const focusList = deriveScenarioStabilityFocusList(cells);
   const report: ScenarioStabilityExecutionReport = {
     schemaVersion: 1,
     runId: plan.runId,
-    planFingerprint: createHash("sha256")
-      .update(JSON.stringify(plan))
-      .digest("hex"),
+    planFingerprint: scenarioStabilityExecutionPlanFingerprint(plan),
     status: focusList.length === 0 ? "passed" : "failed",
     attemptCount: 3,
     requiredTier: "3/3",
     budgets: input.budgets,
     cells,
     focusList,
-    failureClusters: buildFailureClusters(cells),
+    failureClusters: deriveScenarioStabilityFailureClusters(cells),
   };
   assertScenarioStabilityBoundedJson(
     report,

--- a/packages/scenario-runner/src/stability-executor.ts
+++ b/packages/scenario-runner/src/stability-executor.ts
@@ -642,7 +642,20 @@ export function assertScenarioStabilityExecutedCellCoherence(
   ) {
     throw new Error("stability cell summary does not match its attempts");
   }
-  if (cell.baselineInitialStateHash !== null) {
+  if (cell.baselineInitialStateHash === null) {
+    if (
+      cell.attempts.some(
+        (attempt) =>
+          attempt.initialStateHash !== "unavailable" ||
+          attempt.passed ||
+          attempt.failureClassification !== "harness-failure",
+      )
+    ) {
+      throw new Error(
+        "a stability cell without a baseline must contain only pre-admission harness failures",
+      );
+    }
+  } else {
     if (
       !cell.attempts.some(
         (attempt) => attempt.initialStateHash === cell.baselineInitialStateHash,

--- a/packages/scenario-runner/src/stability-executor.ts
+++ b/packages/scenario-runner/src/stability-executor.ts
@@ -657,8 +657,11 @@ export function assertScenarioStabilityExecutedCellCoherence(
     }
   } else {
     if (
+      cell.baselineInitialStateHash === "unavailable" ||
       !cell.attempts.some(
-        (attempt) => attempt.initialStateHash === cell.baselineInitialStateHash,
+        (attempt) =>
+          attempt.initialStateHash !== "unavailable" &&
+          attempt.initialStateHash === cell.baselineInitialStateHash,
       ) ||
       cell.attempts.some(
         (attempt) =>


### PR DESCRIPTION
## Summary

Stacks on #28936 and fixes #26809 for the Cloud stability lane.

- binds `stability.sha256`, the manifest report digest, and verifier input to the exact retained `stability.json` bytes
- adds a manifest self-seal and strict aggregate-schema verification
- recomputes plan fingerprints, attempt identities/directories, focus lists, failure clusters, summaries, and baseline semantics instead of trusting serialized claims
- rejects fabricated null/non-null baselines and excludes the `unavailable` sentinel from admitted baselines
- hardens reads and publication against symlinks, oversized/truncated files, TOCTOU mutation, partial bundles, and replacement of an existing valid bundle
- adds `stability:verify` plus adversarial resealed-tamper regressions

## Evidence

- Head: `1cef97240264d01f8f18662fe50aec075cb6eb09`
- Base: `cbd4c2f8a82f9a7ec68b168083d1dd55461c06cd` (#28936)
- Six commits replayed patch-identically with no conflicts
- Cloud checksum/verifier: 5/5 tests, 44 assertions
- Earlier isolated scenario adapter suite: 20/20 tests, 85 assertions
- Biome, AGENTS/CLAUDE parity, and `git diff --check`: pass
- Failed-run artifact still verifies fail-closed: raw report, sidecar, and manifest digest all equal `0b2257188ac0495cd6cd3b17404e74359b58ad5726ab243611c30b59eeef8947`

The final local exact behavioral rerun was invalidated by shared-host starvation: attempt 1 exceeded the 240s budget and teardown received OS `EPERM`; attempts 2–3 were correctly quarantined. The integrity bundle remained internally valid. Hosted Linux CI on this draft is the authoritative behavioral proof.

No live-model request was made.

Refs #25268 and #22896.