### PR TITLE
fix(cloud-e2e): meter and constrain live stability models

### DIFF
--- a/packages/cloud/e2e/AGENTS.md
+++ b/packages/cloud/e2e/AGENTS.md
@@ -69,11 +69,13 @@ Strict deterministic fixtures are the only model in the PR lane.
 `stability:real -- --provider openai|anthropic` runs the identical scenario,
 world, plugins, services, and mock endpoints while replacing only the model.
 The selected provider is forced through a bounded loopback proxy; a pinned-Bun
-preload rejects direct child fetch and Node HTTP(S) egress. The attempt parent
-captures exactly one selected `OPENAI_API_KEY` or `ANTHROPIC_API_KEY`, removes
-it before starting the mock stack, and injects it only at the provider proxy;
-the scenario child receives a dummy SDK key. Real service credentials are never
-passed. Before dispatch, the proxy requires the exact target model, rejects
+preload rejects direct child fetch and Node HTTP(S) egress. The outer adapter
+conveys exactly one selected `OPENAI_API_KEY` or `ANTHROPIC_API_KEY` and its
+per-attempt receipt key over a bounded inherited pipe, never the harness
+environment. The trusted attempt harness consumes and closes that descriptor
+before starting the mock stack; the scenario child receives only a dummy SDK
+key. Real service credentials are injected only at the provider proxy. Before
+dispatch, the proxy requires the exact target model, rejects
 provider-hosted context/tools and non-text inputs, and injects or clamps the
 route-specific output cap to the remaining budget. Its conservative input
 envelope charges the larger canonical/original UTF-8 body size plus an 8,192
@@ -83,9 +85,13 @@ malformed, over-budget, oversized, or unmetered responses fail closed, and the
 manifest's 16-request ceiling remains binding.
 Accepted request evidence binds the exact canonical upstream byte length and
 SHA-256; rejected requests retain structural evidence without a forwarded hash.
-The trusted attempt harness signs the complete real-model receipt with a
-parent-owned, per-attempt HMAC key that is removed before any stack or scenario
-child starts; the outer adapter verifies that attestation before accepting it.
+The trusted attempt harness signs the complete real-model receipt with the
+parent-owned, per-attempt HMAC key; the outer adapter verifies that attestation
+before accepting it.
+This blocks direct secret inheritance into the harness and scenario child, but
+does not claim isolation from generic same-UID process inspection or raw network
+transports. The credentialed lane is not certifiable against a hostile child
+until #26821 supplies the OS/user/process sandbox for those boundaries.
 
 Attempts retain trajectories, tool receipts, transitions, bounded logs,
 network and mock-service ledgers, and authority hashes. The aggregate retains

--- a/packages/cloud/e2e/AGENTS.md
+++ b/packages/cloud/e2e/AGENTS.md
@@ -70,7 +70,10 @@ Strict deterministic fixtures are the only model in the PR lane.
 world, plugins, services, and mock endpoints while replacing only the model.
 The selected provider is forced through a bounded loopback proxy; a pinned-Bun
 preload rejects direct child fetch egress. Exactly one model credential is
-passed, and real service credentials are never passed.
+passed, and real service credentials are never passed. The proxy extracts
+authoritative OpenAI or Anthropic usage from JSON/SSE responses, aggregates it
+per attempt, rejects missing or malformed usage, and enforces the manifest's
+token budgets plus its 16-request ceiling before allowing further calls.
 
 Attempts retain trajectories, tool receipts, transitions, bounded logs,
 network and mock-service ledgers, and authority hashes. The aggregate retains

--- a/packages/cloud/e2e/AGENTS.md
+++ b/packages/cloud/e2e/AGENTS.md
@@ -69,8 +69,10 @@ Strict deterministic fixtures are the only model in the PR lane.
 `stability:real -- --provider openai|anthropic` runs the identical scenario,
 world, plugins, services, and mock endpoints while replacing only the model.
 The selected provider is forced through a bounded loopback proxy; a pinned-Bun
-preload rejects direct child fetch egress. Exactly one model credential is
-passed, and real service credentials are never passed. The proxy extracts
+preload rejects direct child fetch and Node HTTP(S) egress. The attempt parent
+captures exactly one selected `OPENAI_API_KEY` or `ANTHROPIC_API_KEY`, removes
+it before starting the mock stack, and injects it only at the provider proxy;
+the scenario child receives a dummy SDK key. Real service credentials are never passed. The proxy extracts
 authoritative OpenAI or Anthropic usage from JSON/SSE responses, aggregates it
 per attempt, rejects missing or malformed usage, and enforces the manifest's
 token budgets plus its 16-request ceiling before allowing further calls.

--- a/packages/cloud/e2e/AGENTS.md
+++ b/packages/cloud/e2e/AGENTS.md
@@ -83,6 +83,9 @@ malformed, over-budget, oversized, or unmetered responses fail closed, and the
 manifest's 16-request ceiling remains binding.
 Accepted request evidence binds the exact canonical upstream byte length and
 SHA-256; rejected requests retain structural evidence without a forwarded hash.
+The trusted attempt harness signs the complete real-model receipt with a
+parent-owned, per-attempt HMAC key that is removed before any stack or scenario
+child starts; the outer adapter verifies that attestation before accepting it.
 
 Attempts retain trajectories, tool receipts, transitions, bounded logs,
 network and mock-service ledgers, and authority hashes. The aggregate retains

--- a/packages/cloud/e2e/AGENTS.md
+++ b/packages/cloud/e2e/AGENTS.md
@@ -72,10 +72,15 @@ The selected provider is forced through a bounded loopback proxy; a pinned-Bun
 preload rejects direct child fetch and Node HTTP(S) egress. The attempt parent
 captures exactly one selected `OPENAI_API_KEY` or `ANTHROPIC_API_KEY`, removes
 it before starting the mock stack, and injects it only at the provider proxy;
-the scenario child receives a dummy SDK key. Real service credentials are never passed. The proxy extracts
-authoritative OpenAI or Anthropic usage from JSON/SSE responses, aggregates it
-per attempt, rejects missing or malformed usage, and enforces the manifest's
-token budgets plus its 16-request ceiling before allowing further calls.
+the scenario child receives a dummy SDK key. Real service credentials are never
+passed. Before dispatch, the proxy requires the exact target model, rejects
+provider-hosted context/tools and non-text inputs, and injects or clamps the
+route-specific output cap to the remaining budget. Its conservative input
+envelope charges the larger canonical/original UTF-8 body size plus an 8,192
+token hidden-overhead reserve; this is not provider tokenization, so returned
+OpenAI or Anthropic usage remains the authoritative postflight count. Missing,
+malformed, over-budget, oversized, or unmetered responses fail closed, and the
+manifest's 16-request ceiling remains binding.
 
 Attempts retain trajectories, tool receipts, transitions, bounded logs,
 network and mock-service ledgers, and authority hashes. The aggregate retains

--- a/packages/cloud/e2e/AGENTS.md
+++ b/packages/cloud/e2e/AGENTS.md
@@ -81,6 +81,8 @@ token hidden-overhead reserve; this is not provider tokenization, so returned
 OpenAI or Anthropic usage remains the authoritative postflight count. Missing,
 malformed, over-budget, oversized, or unmetered responses fail closed, and the
 manifest's 16-request ceiling remains binding.
+Accepted request evidence binds the exact canonical upstream byte length and
+SHA-256; rejected requests retain structural evidence without a forwarded hash.
 
 Attempts retain trajectories, tool receipts, transitions, bounded logs,
 network and mock-service ledgers, and authority hashes. The aggregate retains

--- a/packages/cloud/e2e/CLAUDE.md
+++ b/packages/cloud/e2e/CLAUDE.md
@@ -69,11 +69,13 @@ Strict deterministic fixtures are the only model in the PR lane.
 `stability:real -- --provider openai|anthropic` runs the identical scenario,
 world, plugins, services, and mock endpoints while replacing only the model.
 The selected provider is forced through a bounded loopback proxy; a pinned-Bun
-preload rejects direct child fetch and Node HTTP(S) egress. The attempt parent
-captures exactly one selected `OPENAI_API_KEY` or `ANTHROPIC_API_KEY`, removes
-it before starting the mock stack, and injects it only at the provider proxy;
-the scenario child receives a dummy SDK key. Real service credentials are never
-passed. Before dispatch, the proxy requires the exact target model, rejects
+preload rejects direct child fetch and Node HTTP(S) egress. The outer adapter
+conveys exactly one selected `OPENAI_API_KEY` or `ANTHROPIC_API_KEY` and its
+per-attempt receipt key over a bounded inherited pipe, never the harness
+environment. The trusted attempt harness consumes and closes that descriptor
+before starting the mock stack; the scenario child receives only a dummy SDK
+key. Real service credentials are injected only at the provider proxy. Before
+dispatch, the proxy requires the exact target model, rejects
 provider-hosted context/tools and non-text inputs, and injects or clamps the
 route-specific output cap to the remaining budget. Its conservative input
 envelope charges the larger canonical/original UTF-8 body size plus an 8,192
@@ -83,9 +85,13 @@ malformed, over-budget, oversized, or unmetered responses fail closed, and the
 manifest's 16-request ceiling remains binding.
 Accepted request evidence binds the exact canonical upstream byte length and
 SHA-256; rejected requests retain structural evidence without a forwarded hash.
-The trusted attempt harness signs the complete real-model receipt with a
-parent-owned, per-attempt HMAC key that is removed before any stack or scenario
-child starts; the outer adapter verifies that attestation before accepting it.
+The trusted attempt harness signs the complete real-model receipt with the
+parent-owned, per-attempt HMAC key; the outer adapter verifies that attestation
+before accepting it.
+This blocks direct secret inheritance into the harness and scenario child, but
+does not claim isolation from generic same-UID process inspection or raw network
+transports. The credentialed lane is not certifiable against a hostile child
+until #26821 supplies the OS/user/process sandbox for those boundaries.
 
 Attempts retain trajectories, tool receipts, transitions, bounded logs,
 network and mock-service ledgers, and authority hashes. The aggregate retains

--- a/packages/cloud/e2e/CLAUDE.md
+++ b/packages/cloud/e2e/CLAUDE.md
@@ -70,7 +70,10 @@ Strict deterministic fixtures are the only model in the PR lane.
 world, plugins, services, and mock endpoints while replacing only the model.
 The selected provider is forced through a bounded loopback proxy; a pinned-Bun
 preload rejects direct child fetch egress. Exactly one model credential is
-passed, and real service credentials are never passed.
+passed, and real service credentials are never passed. The proxy extracts
+authoritative OpenAI or Anthropic usage from JSON/SSE responses, aggregates it
+per attempt, rejects missing or malformed usage, and enforces the manifest's
+token budgets plus its 16-request ceiling before allowing further calls.
 
 Attempts retain trajectories, tool receipts, transitions, bounded logs,
 network and mock-service ledgers, and authority hashes. The aggregate retains

--- a/packages/cloud/e2e/CLAUDE.md
+++ b/packages/cloud/e2e/CLAUDE.md
@@ -69,8 +69,10 @@ Strict deterministic fixtures are the only model in the PR lane.
 `stability:real -- --provider openai|anthropic` runs the identical scenario,
 world, plugins, services, and mock endpoints while replacing only the model.
 The selected provider is forced through a bounded loopback proxy; a pinned-Bun
-preload rejects direct child fetch egress. Exactly one model credential is
-passed, and real service credentials are never passed. The proxy extracts
+preload rejects direct child fetch and Node HTTP(S) egress. The attempt parent
+captures exactly one selected `OPENAI_API_KEY` or `ANTHROPIC_API_KEY`, removes
+it before starting the mock stack, and injects it only at the provider proxy;
+the scenario child receives a dummy SDK key. Real service credentials are never passed. The proxy extracts
 authoritative OpenAI or Anthropic usage from JSON/SSE responses, aggregates it
 per attempt, rejects missing or malformed usage, and enforces the manifest's
 token budgets plus its 16-request ceiling before allowing further calls.

--- a/packages/cloud/e2e/CLAUDE.md
+++ b/packages/cloud/e2e/CLAUDE.md
@@ -83,6 +83,9 @@ malformed, over-budget, oversized, or unmetered responses fail closed, and the
 manifest's 16-request ceiling remains binding.
 Accepted request evidence binds the exact canonical upstream byte length and
 SHA-256; rejected requests retain structural evidence without a forwarded hash.
+The trusted attempt harness signs the complete real-model receipt with a
+parent-owned, per-attempt HMAC key that is removed before any stack or scenario
+child starts; the outer adapter verifies that attestation before accepting it.
 
 Attempts retain trajectories, tool receipts, transitions, bounded logs,
 network and mock-service ledgers, and authority hashes. The aggregate retains

--- a/packages/cloud/e2e/CLAUDE.md
+++ b/packages/cloud/e2e/CLAUDE.md
@@ -72,10 +72,15 @@ The selected provider is forced through a bounded loopback proxy; a pinned-Bun
 preload rejects direct child fetch and Node HTTP(S) egress. The attempt parent
 captures exactly one selected `OPENAI_API_KEY` or `ANTHROPIC_API_KEY`, removes
 it before starting the mock stack, and injects it only at the provider proxy;
-the scenario child receives a dummy SDK key. Real service credentials are never passed. The proxy extracts
-authoritative OpenAI or Anthropic usage from JSON/SSE responses, aggregates it
-per attempt, rejects missing or malformed usage, and enforces the manifest's
-token budgets plus its 16-request ceiling before allowing further calls.
+the scenario child receives a dummy SDK key. Real service credentials are never
+passed. Before dispatch, the proxy requires the exact target model, rejects
+provider-hosted context/tools and non-text inputs, and injects or clamps the
+route-specific output cap to the remaining budget. Its conservative input
+envelope charges the larger canonical/original UTF-8 body size plus an 8,192
+token hidden-overhead reserve; this is not provider tokenization, so returned
+OpenAI or Anthropic usage remains the authoritative postflight count. Missing,
+malformed, over-budget, oversized, or unmetered responses fail closed, and the
+manifest's 16-request ceiling remains binding.
 
 Attempts retain trajectories, tool receipts, transitions, bounded logs,
 network and mock-service ledgers, and authority hashes. The aggregate retains

--- a/packages/cloud/e2e/CLAUDE.md
+++ b/packages/cloud/e2e/CLAUDE.md
@@ -81,6 +81,8 @@ token hidden-overhead reserve; this is not provider tokenization, so returned
 OpenAI or Anthropic usage remains the authoritative postflight count. Missing,
 malformed, over-budget, oversized, or unmetered responses fail closed, and the
 manifest's 16-request ceiling remains binding.
+Accepted request evidence binds the exact canonical upstream byte length and
+SHA-256; rejected requests retain structural evidence without a forwarded hash.
 
 Attempts retain trajectories, tool receipts, transitions, bounded logs,
 network and mock-service ledgers, and authority hashes. The aggregate retains

--- a/packages/cloud/e2e/README.md
+++ b/packages/cloud/e2e/README.md
@@ -100,6 +100,8 @@ envelope charges the larger canonical/original UTF-8 body size plus an 8,192
 token hidden-overhead reserve; this is not provider tokenization, so returned
 OpenAI or Anthropic usage remains the authoritative postflight count. Missing,
 malformed, over-budget, oversized, or unmetered responses fail closed.
+Accepted request evidence binds the exact canonical upstream byte length and
+SHA-256; rejected requests retain structural evidence without a forwarded hash.
 
 Attempts retain trajectories, tool receipts, transitions, bounded logs,
 network and mock-service ledgers, and authority hashes. The aggregate retains

--- a/packages/cloud/e2e/README.md
+++ b/packages/cloud/e2e/README.md
@@ -102,6 +102,9 @@ OpenAI or Anthropic usage remains the authoritative postflight count. Missing,
 malformed, over-budget, oversized, or unmetered responses fail closed.
 Accepted request evidence binds the exact canonical upstream byte length and
 SHA-256; rejected requests retain structural evidence without a forwarded hash.
+The trusted attempt harness signs the complete real-model receipt with a
+parent-owned, per-attempt HMAC key that is removed before any stack or scenario
+child starts; the outer adapter verifies that attestation before accepting it.
 
 Attempts retain trajectories, tool receipts, transitions, bounded logs,
 network and mock-service ledgers, and authority hashes. The aggregate retains

--- a/packages/cloud/e2e/README.md
+++ b/packages/cloud/e2e/README.md
@@ -90,7 +90,9 @@ Strict deterministic fixtures are the only model in the PR lane.
 world, plugins, services, and mock endpoints while replacing only the model.
 The selected provider is forced through a bounded loopback proxy; a pinned-Bun
 preload rejects direct child fetch egress. Exactly one model credential is
-passed, and real service credentials are never passed.
+passed, and real service credentials are never passed. Successful responses
+must carry authoritative OpenAI or Anthropic usage; the proxy aggregates those
+counts and fails closed on missing, malformed, over-budget, or over-limit calls.
 
 Attempts retain trajectories, tool receipts, transitions, bounded logs,
 network and mock-service ledgers, and authority hashes. The aggregate retains

--- a/packages/cloud/e2e/README.md
+++ b/packages/cloud/e2e/README.md
@@ -92,9 +92,14 @@ The selected provider is forced through a bounded loopback proxy; a pinned-Bun
 preload rejects direct child fetch and Node HTTP(S) egress. The attempt parent
 captures exactly one selected `OPENAI_API_KEY` or `ANTHROPIC_API_KEY`, removes
 it before starting the mock stack, and injects it only at the provider proxy;
-the scenario child receives a dummy SDK key. Real service credentials are never passed. Successful responses
-must carry authoritative OpenAI or Anthropic usage; the proxy aggregates those
-counts and fails closed on missing, malformed, over-budget, or over-limit calls.
+the scenario child receives a dummy SDK key. Real service credentials are never
+passed. Before dispatch, the proxy requires the exact target model, rejects
+provider-hosted context/tools and non-text inputs, and injects or clamps the
+route-specific output cap to the remaining budget. Its conservative input
+envelope charges the larger canonical/original UTF-8 body size plus an 8,192
+token hidden-overhead reserve; this is not provider tokenization, so returned
+OpenAI or Anthropic usage remains the authoritative postflight count. Missing,
+malformed, over-budget, oversized, or unmetered responses fail closed.
 
 Attempts retain trajectories, tool receipts, transitions, bounded logs,
 network and mock-service ledgers, and authority hashes. The aggregate retains

--- a/packages/cloud/e2e/README.md
+++ b/packages/cloud/e2e/README.md
@@ -89,11 +89,13 @@ Strict deterministic fixtures are the only model in the PR lane.
 `stability:real -- --provider openai|anthropic` runs the identical scenario,
 world, plugins, services, and mock endpoints while replacing only the model.
 The selected provider is forced through a bounded loopback proxy; a pinned-Bun
-preload rejects direct child fetch and Node HTTP(S) egress. The attempt parent
-captures exactly one selected `OPENAI_API_KEY` or `ANTHROPIC_API_KEY`, removes
-it before starting the mock stack, and injects it only at the provider proxy;
-the scenario child receives a dummy SDK key. Real service credentials are never
-passed. Before dispatch, the proxy requires the exact target model, rejects
+preload rejects direct child fetch and Node HTTP(S) egress. The outer adapter
+conveys exactly one selected `OPENAI_API_KEY` or `ANTHROPIC_API_KEY` and its
+per-attempt receipt key over a bounded inherited pipe, never the harness
+environment. The trusted attempt harness consumes and closes that descriptor
+before starting the mock stack; the scenario child receives only a dummy SDK
+key. Real service credentials are injected only at the provider proxy. Before
+dispatch, the proxy requires the exact target model, rejects
 provider-hosted context/tools and non-text inputs, and injects or clamps the
 route-specific output cap to the remaining budget. Its conservative input
 envelope charges the larger canonical/original UTF-8 body size plus an 8,192
@@ -102,9 +104,13 @@ OpenAI or Anthropic usage remains the authoritative postflight count. Missing,
 malformed, over-budget, oversized, or unmetered responses fail closed.
 Accepted request evidence binds the exact canonical upstream byte length and
 SHA-256; rejected requests retain structural evidence without a forwarded hash.
-The trusted attempt harness signs the complete real-model receipt with a
-parent-owned, per-attempt HMAC key that is removed before any stack or scenario
-child starts; the outer adapter verifies that attestation before accepting it.
+The trusted attempt harness signs the complete real-model receipt with the
+parent-owned, per-attempt HMAC key; the outer adapter verifies that attestation
+before accepting it.
+This blocks direct secret inheritance into the harness and scenario child, but
+does not claim isolation from generic same-UID process inspection or raw network
+transports. The credentialed lane is not certifiable against a hostile child
+until #26821 supplies the OS/user/process sandbox for those boundaries.
 
 Attempts retain trajectories, tool receipts, transitions, bounded logs,
 network and mock-service ledgers, and authority hashes. The aggregate retains

--- a/packages/cloud/e2e/README.md
+++ b/packages/cloud/e2e/README.md
@@ -89,8 +89,10 @@ Strict deterministic fixtures are the only model in the PR lane.
 `stability:real -- --provider openai|anthropic` runs the identical scenario,
 world, plugins, services, and mock endpoints while replacing only the model.
 The selected provider is forced through a bounded loopback proxy; a pinned-Bun
-preload rejects direct child fetch egress. Exactly one model credential is
-passed, and real service credentials are never passed. Successful responses
+preload rejects direct child fetch and Node HTTP(S) egress. The attempt parent
+captures exactly one selected `OPENAI_API_KEY` or `ANTHROPIC_API_KEY`, removes
+it before starting the mock stack, and injects it only at the provider proxy;
+the scenario child receives a dummy SDK key. Real service credentials are never passed. Successful responses
 must carry authoritative OpenAI or Anthropic usage; the proxy aggregates those
 counts and fails closed on missing, malformed, over-budget, or over-limit calls.
 

--- a/packages/cloud/e2e/package.json
+++ b/packages/cloud/e2e/package.json
@@ -10,7 +10,7 @@
     "test:mock-llm": "bun test src/fixtures/mock-llm.test.ts",
     "stability:keyless": "bun --conditions=eliza-source scripts/run-stability-lane.ts --mode deterministic-mock",
     "stability:real": "bun --conditions=eliza-source scripts/run-stability-lane.ts --mode real-llm",
-    "test:stability": "bun --conditions=eliza-source test src/stability/cloud-stability-runner.test.ts src/stability/stability-network-guard.test.ts src/stability/stack-partial-cleanup.test.ts src/stability/stability-scenario-child.test.ts src/stability/authority-controller-cleanup.test.ts",
+    "test:stability": "bun --conditions=eliza-source test src/stability/cloud-stability-runner.test.ts src/stability/live-model-meter.test.ts src/stability/parent-network-guard.test.ts src/stability/stability-network-guard.test.ts src/stability/stack-partial-cleanup.test.ts src/stability/stability-scenario-child.test.ts src/stability/authority-controller-cleanup.test.ts",
     "domains:ledger": "bun scripts/domain-purchase-ledger.ts",
     "format": "bunx @biomejs/biome format --write package.json",
     "format:check": "bunx @biomejs/biome format package.json",

--- a/packages/cloud/e2e/scenarios/cloud-stability-agent.scenario.ts
+++ b/packages/cloud/e2e/scenarios/cloud-stability-agent.scenario.ts
@@ -65,6 +65,7 @@ const syntheticRuntimePolicy = {
     "goals_migration",
     "identity_resolution",
     "lifeops_scheduled_task_runner",
+    "membership",
     "memoryStorage",
     "notification",
     "optimized_prompt",

--- a/packages/cloud/e2e/scripts/run-stability-lane.ts
+++ b/packages/cloud/e2e/scripts/run-stability-lane.ts
@@ -312,6 +312,7 @@ try {
     timeoutMs: 240_000,
     maxInputTokens: 100_000,
     maxOutputTokens: 50_000,
+    maxModelRequests: 16,
     maxToolCalls: 50,
   });
   const adapter = new ScenarioStabilitySubprocessAdapter({
@@ -325,6 +326,9 @@ try {
     env: {
       ELIZA_STABILITY_SCENARIO_FINGERPRINT: manifest.scenarioFingerprint,
       ELIZA_STABILITY_WORLD_FINGERPRINT: manifest.worldFingerprint,
+      ELIZA_STABILITY_MAX_INPUT_TOKENS: String(manifest.maxInputTokens),
+      ELIZA_STABILITY_MAX_OUTPUT_TOKENS: String(manifest.maxOutputTokens),
+      ELIZA_STABILITY_MAX_MODEL_REQUESTS: String(manifest.maxModelRequests),
     },
     syntheticControl: {
       controlUrl: authority.url,

--- a/packages/cloud/e2e/scripts/stability-attempt.ts
+++ b/packages/cloud/e2e/scripts/stability-attempt.ts
@@ -283,6 +283,7 @@ const modelProxy =
   mode === "real-llm"
     ? await startLiveModelEgressProxy({
         provider: provider as StabilityModelProvider,
+        expectedModel: model,
         budgets: {
           maxInputTokens: requiredPositiveInteger(
             "ELIZA_STABILITY_MAX_INPUT_TOKENS",
@@ -532,6 +533,7 @@ const modelMeter = modelProxy?.snapshot() ?? {
   inputTokens: 0,
   outputTokens: 0,
   failures: [],
+  requestEnvelopes: [],
 };
 const providerReceipt =
   mode === "deterministic-mock"
@@ -584,6 +586,7 @@ const providerReceipt =
         inputTokens: modelMeter.inputTokens,
         outputTokens: modelMeter.outputTokens,
         meteringFailures: modelMeter.failures,
+        requestEnvelopes: modelMeter.requestEnvelopes,
         namespace,
         manifestId,
         generation,

--- a/packages/cloud/e2e/scripts/stability-attempt.ts
+++ b/packages/cloud/e2e/scripts/stability-attempt.ts
@@ -5,11 +5,12 @@
  */
 
 import { spawn } from "node:child_process";
-import { createHash } from "node:crypto";
+import { createHash, createHmac } from "node:crypto";
 import { readFile, writeFile } from "node:fs/promises";
 import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
 import path from "node:path";
+import { canonicalJsonString } from "@elizaos/shared/canonical-json";
 import cloudStabilityScenario from "../scenarios/cloud-stability-agent.scenario.ts";
 import { startCloudStack } from "../src/fixtures/stack.ts";
 import { canonicalCloudStabilitySha256 } from "../src/stability/cloud-stability-runner.ts";
@@ -123,8 +124,13 @@ const realModelCredential =
   mode === "real-llm" && providerRoute
     ? required(providerRoute.credentialEnvironment)
     : undefined;
+const meterAttestationKey =
+  mode === "real-llm"
+    ? required("ELIZA_STABILITY_METER_ATTESTATION_KEY")
+    : undefined;
 delete process.env.OPENAI_API_KEY;
 delete process.env.ANTHROPIC_API_KEY;
+delete process.env.ELIZA_STABILITY_METER_ATTESTATION_KEY;
 const guardedFetch = createLoopbackOnlyFetch(nativeFetch, networkLedger);
 globalThis.fetch = guardedFetch;
 
@@ -410,6 +416,7 @@ try {
 
 const explicitSecrets = [
   realModelCredential,
+  meterAttestationKey,
   process.env.ELIZA_SYNTHETIC_CONTROL_TOKEN,
 ].filter(
   (value): value is string => typeof value === "string" && value.length > 0,
@@ -535,7 +542,7 @@ const modelMeter = modelProxy?.snapshot() ?? {
   failures: [],
   requestEnvelopes: [],
 };
-const providerReceipt =
+const unsignedProviderReceipt =
   mode === "deterministic-mock"
     ? (() => {
         const diagnostics = scenarioResult.modelFixtureDiagnostics;
@@ -595,6 +602,27 @@ const providerReceipt =
         unexpectedRealServiceCalls: unexpectedEgress,
         unexpectedNetworkCalls: unexpectedEgress,
       };
+const providerReceipt =
+  mode === "real-llm" && meterAttestationKey
+    ? {
+        ...unsignedProviderReceipt,
+        attestation: createHmac("sha256", meterAttestationKey)
+          .update(
+            canonicalJsonString(unsignedProviderReceipt, {
+              maxDepth: 32,
+              maxNodes: 100_000,
+              maxOutputChars: 8 * 1024 * 1024,
+              sparseArrayHoles: "null",
+              onUnbounded: () => {
+                throw new Error(
+                  "real-model receipt attestation exceeds canonical JSON limits",
+                );
+              },
+            }),
+          )
+          .digest("hex"),
+      }
+    : unsignedProviderReceipt;
 const ledger = {
   network: { parentAndProxy: networkLedger, child: childNetworkLedger },
   mockServices: {

--- a/packages/cloud/e2e/scripts/stability-attempt.ts
+++ b/packages/cloud/e2e/scripts/stability-attempt.ts
@@ -13,10 +13,25 @@ import path from "node:path";
 import cloudStabilityScenario from "../scenarios/cloud-stability-agent.scenario.ts";
 import { startCloudStack } from "../src/fixtures/stack.ts";
 import { canonicalCloudStabilitySha256 } from "../src/stability/cloud-stability-runner.ts";
+import {
+  type StabilityModelProvider,
+  startLiveModelEgressProxy,
+} from "../src/stability/live-model-meter.ts";
+import {
+  createLoopbackOnlyFetch,
+  type StabilityParentNetworkEntry,
+} from "../src/stability/parent-network-guard.ts";
 
 const required = (name: string): string => {
   const value = process.env[name];
   if (!value) throw new Error(`Cloud stability attempt requires ${name}`);
+  return value;
+};
+const requiredPositiveInteger = (name: string): number => {
+  const value = Number(required(name));
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`${name} must be a positive safe integer`);
+  }
   return value;
 };
 const outputDir = required("ELIZA_STABILITY_OUTPUT_DIR");
@@ -80,11 +95,7 @@ const scenarioPath = path.join(
 );
 const scenarioReportPath = path.join(outputDir, "scenario-report.json");
 const nativePath = path.join(outputDir, "trajectory.native.jsonl");
-const networkLedger: Array<{
-  origin: string;
-  method: string;
-  allowed: boolean;
-}> = [];
+const networkLedger: StabilityParentNetworkEntry[] = [];
 
 const nativeFetch = globalThis.fetch;
 const providerRoutes: Record<
@@ -103,113 +114,8 @@ const providerRoutes: Record<
     baseUrlEnvironment: "ANTHROPIC_BASE_URL",
   },
 };
-const guardedFetch: typeof globalThis.fetch = Object.assign(
-  async (
-    input: Parameters<typeof nativeFetch>[0],
-    init?: Parameters<typeof nativeFetch>[1],
-  ) => {
-    const url = new URL(
-      typeof input === "string" || input instanceof URL ? input : input.url,
-    );
-    const loopback =
-      url.hostname === "localhost" ||
-      url.hostname === "::1" ||
-      url.hostname === "[::1]" ||
-      url.hostname.startsWith("127.");
-    const allowed =
-      loopback ||
-      (mode === "real-llm" && providerRoutes[provider]?.origin === url.origin);
-    networkLedger.push({
-      origin: url.origin,
-      method: init?.method ?? "GET",
-      allowed,
-    });
-    if (!allowed) throw new Error(`unexpected egress blocked: ${url.origin}`);
-    return nativeFetch(input, init);
-  },
-  { preconnect: nativeFetch.preconnect },
-);
+const guardedFetch = createLoopbackOnlyFetch(nativeFetch, networkLedger);
 globalThis.fetch = guardedFetch;
-
-async function startModelEgressProxy(): Promise<{
-  url: string;
-  requestCount: () => number;
-  stop: () => Promise<void>;
-}> {
-  const route = providerRoutes[provider];
-  if (!route) throw new Error(`unsupported real-model provider ${provider}`);
-  let requests = 0;
-  const server = createServer((request, response) => {
-    void (async () => {
-      const chunks: Buffer[] = [];
-      let requestBytes = 0;
-      for await (const chunk of request) {
-        const bytes = Buffer.from(chunk);
-        requestBytes += bytes.byteLength;
-        if (requestBytes > 8 * 1024 * 1024) {
-          throw new Error("provider proxy request exceeded 8 MiB");
-        }
-        chunks.push(bytes);
-      }
-      requests += 1;
-      const upstream = await nativeFetch(
-        `${route.origin}${request.url ?? "/"}`,
-        {
-          method: request.method,
-          headers: Object.fromEntries(
-            Object.entries(request.headers).flatMap(([key, value]) =>
-              value === undefined
-                ? []
-                : [[key, Array.isArray(value) ? value.join(",") : value]],
-            ),
-          ),
-          body: chunks.length > 0 ? Buffer.concat(chunks) : undefined,
-          signal: AbortSignal.timeout(120_000),
-        },
-      );
-      networkLedger.push({
-        origin: route.origin,
-        method: request.method ?? "GET",
-        allowed: true,
-      });
-      const responseBytes = Buffer.from(await upstream.arrayBuffer());
-      if (responseBytes.byteLength > 16 * 1024 * 1024) {
-        throw new Error("provider proxy response exceeded 16 MiB");
-      }
-      const headers = Object.fromEntries(upstream.headers);
-      delete headers["content-encoding"];
-      delete headers["content-length"];
-      delete headers.connection;
-      delete headers["transfer-encoding"];
-      response.writeHead(upstream.status, headers);
-      response.end(responseBytes);
-    })().catch((error: unknown) => {
-      // error-policy:J1 The loopback proxy translates selected-provider failures to the scenario client.
-      response.writeHead(502, { "content-type": "application/json" });
-      response.end(
-        JSON.stringify({
-          error: {
-            message:
-              error instanceof Error ? error.message : "provider proxy failure",
-          },
-        }),
-      );
-    });
-  });
-  await new Promise<void>((resolve, reject) => {
-    server.once("error", reject);
-    server.listen(0, "127.0.0.1", resolve);
-  });
-  const port = (server.address() as AddressInfo).port;
-  return {
-    url: `http://127.0.0.1:${port}/v1`,
-    requestCount: () => requests,
-    stop: () =>
-      new Promise<void>((resolve, reject) =>
-        server.close((error) => (error ? reject(error) : resolve())),
-      ),
-  };
-}
 
 type MockOperation = {
   service: "cloud-api" | "hetzner";
@@ -240,7 +146,7 @@ async function startMockAuditProxy(
         ? upstream.pathname.slice(0, -1)
         : upstream.pathname;
       const target = new URL(`${basePath}${incomingPath}`, upstream.origin);
-      const result = await nativeFetch(target, {
+      const result = await guardedFetch(target, {
         method: request.method,
         headers: Object.fromEntries(
           Object.entries(request.headers).flatMap(([key, value]) =>
@@ -358,8 +264,30 @@ const hetznerProxy = await startMockAuditProxy(
   stack.urls.hetzner,
   mockOperations,
 );
+const maxModelRequests =
+  mode === "real-llm"
+    ? requiredPositiveInteger("ELIZA_STABILITY_MAX_MODEL_REQUESTS")
+    : 0;
 const modelProxy =
-  mode === "real-llm" ? await startModelEgressProxy() : undefined;
+  mode === "real-llm"
+    ? await startLiveModelEgressProxy({
+        provider: provider as StabilityModelProvider,
+        budgets: {
+          maxInputTokens: requiredPositiveInteger(
+            "ELIZA_STABILITY_MAX_INPUT_TOKENS",
+          ),
+          maxOutputTokens: requiredPositiveInteger(
+            "ELIZA_STABILITY_MAX_OUTPUT_TOKENS",
+          ),
+          maxRequests: maxModelRequests,
+        },
+        fetchUpstream: (url, init) => nativeFetch(url, init),
+        upstreamOrigin: providerRoutes[provider]?.origin,
+        onUpstreamRequest: (origin, method) => {
+          networkLedger.push({ origin, method, allowed: true });
+        },
+      })
+    : undefined;
 const childNetworkLedgerPath = path.join(
   outputDir,
   "child-network-ledger.jsonl",
@@ -584,6 +512,12 @@ const runtimeErrors = childRuntimeLedger.reportedErrors ?? [];
 const unexpectedEgress = [...networkLedger, ...childNetworkLedger].filter(
   (entry) => !entry.allowed,
 ).length;
+const modelMeter = modelProxy?.snapshot() ?? {
+  requestCount: 0,
+  inputTokens: 0,
+  outputTokens: 0,
+  failures: [],
+};
 const providerReceipt =
   mode === "deterministic-mock"
     ? (() => {
@@ -630,7 +564,11 @@ const providerReceipt =
         receiptType: "eliza.stability.real-llm.v1",
         provider,
         model,
-        liveModelInvoked: (modelProxy?.requestCount() ?? 0) > 0,
+        liveModelInvoked: modelMeter.requestCount > 0,
+        requestCount: modelMeter.requestCount,
+        inputTokens: modelMeter.inputTokens,
+        outputTokens: modelMeter.outputTokens,
+        meteringFailures: modelMeter.failures,
         namespace,
         manifestId,
         generation,
@@ -644,7 +582,8 @@ const ledger = {
   mockServices: {
     hetznerServers: stack.mocks.hetzner.store.servers.size,
     controlPlaneUrl: stack.urls.controlPlane,
-    providerProxyRequests: modelProxy?.requestCount() ?? 0,
+    providerProxyRequests: modelMeter.requestCount,
+    providerUsage: modelMeter,
     operations: mockOperations,
   },
   actionCount: actions.length,
@@ -680,6 +619,11 @@ const passed =
   naturalExitLatencyMs >= 0 &&
   naturalExitLatencyMs <= 5_000 &&
   unexpectedEgress === 0 &&
+  modelMeter.failures.length === 0 &&
+  (mode !== "real-llm" ||
+    (modelMeter.requestCount > 0 &&
+      modelMeter.requestCount <= maxModelRequests &&
+      modelMeter.inputTokens > 0)) &&
   mockOperations.some(
     (operation) =>
       operation.service === "hetzner" &&
@@ -709,8 +653,8 @@ process.stdout.write(
     passed,
     initialStateHash,
     finalStateHash,
-    inputTokens: 0,
-    outputTokens: 0,
+    inputTokens: modelMeter.inputTokens,
+    outputTokens: modelMeter.outputTokens,
     toolCalls: actions.length,
     evidence: {
       trajectory: turns,
@@ -722,6 +666,10 @@ process.stdout.write(
     stateDiff: ledger,
     ...(passed
       ? {}
-      : { error: `scenario failed with code ${String(cliCode)}` }),
+      : {
+          error:
+            modelMeter.failures.at(-1)?.code ??
+            `scenario failed with code ${String(cliCode)}`,
+        }),
   }),
 );

--- a/packages/cloud/e2e/scripts/stability-attempt.ts
+++ b/packages/cloud/e2e/scripts/stability-attempt.ts
@@ -6,7 +6,6 @@
 
 import { spawn } from "node:child_process";
 import { createHash, createHmac } from "node:crypto";
-import { closeSync, readSync } from "node:fs";
 import { readFile, writeFile } from "node:fs/promises";
 import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
@@ -24,6 +23,7 @@ import {
   createLoopbackOnlyFetch,
   type StabilityParentNetworkEntry,
 } from "../src/stability/parent-network-guard.ts";
+import { readRealModelBootstrap } from "../src/stability/real-model-bootstrap.ts";
 
 const required = (name: string): string => {
   const value = process.env[name];
@@ -37,66 +37,6 @@ const requiredPositiveInteger = (name: string): number => {
   }
   return value;
 };
-const REAL_MODEL_BOOTSTRAP_FD = 3;
-const MAX_REAL_MODEL_BOOTSTRAP_BYTES = 128 * 1024;
-
-type RealModelBootstrap = {
-  credentialEnvironment: "OPENAI_API_KEY" | "ANTHROPIC_API_KEY";
-  credentialValue: string;
-  meterAttestationKey: string;
-};
-
-function readRealModelBootstrap(): RealModelBootstrap {
-  const chunks: Buffer[] = [];
-  let total = 0;
-  try {
-    while (true) {
-      const chunk = Buffer.allocUnsafe(
-        Math.min(16 * 1024, MAX_REAL_MODEL_BOOTSTRAP_BYTES + 1 - total),
-      );
-      const bytesRead = readSync(
-        REAL_MODEL_BOOTSTRAP_FD,
-        chunk,
-        0,
-        chunk.byteLength,
-        null,
-      );
-      if (bytesRead === 0) break;
-      total += bytesRead;
-      if (total > MAX_REAL_MODEL_BOOTSTRAP_BYTES) {
-        throw new Error("real-model bootstrap exceeds its byte limit");
-      }
-      chunks.push(chunk.subarray(0, bytesRead));
-    }
-  } finally {
-    closeSync(REAL_MODEL_BOOTSTRAP_FD);
-  }
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(Buffer.concat(chunks, total).toString("utf8"));
-  } catch (cause) {
-    // error-policy:J3 the trusted boundary rejects malformed bootstrap input.
-    throw new Error("real-model bootstrap must be valid JSON", { cause });
-  }
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    throw new Error("real-model bootstrap must be an object");
-  }
-  const bootstrap = parsed as Record<string, unknown>;
-  if (
-    Object.keys(bootstrap).length !== 4 ||
-    bootstrap.version !== 1 ||
-    (bootstrap.credentialEnvironment !== "OPENAI_API_KEY" &&
-      bootstrap.credentialEnvironment !== "ANTHROPIC_API_KEY") ||
-    typeof bootstrap.credentialValue !== "string" ||
-    bootstrap.credentialValue.trim().length === 0 ||
-    Buffer.byteLength(bootstrap.credentialValue) > 64 * 1024 ||
-    typeof bootstrap.meterAttestationKey !== "string" ||
-    !/^[a-f0-9]{64}$/u.test(bootstrap.meterAttestationKey)
-  ) {
-    throw new Error("real-model bootstrap has an invalid schema");
-  }
-  return bootstrap as RealModelBootstrap;
-}
 const outputDir = required("ELIZA_STABILITY_OUTPUT_DIR");
 const mode = required("ELIZA_STABILITY_MODEL_MODE");
 const provider = required("ELIZA_STABILITY_PROVIDER");
@@ -182,7 +122,7 @@ if (mode === "real-llm" && !providerRoute) {
   throw new Error(`unsupported real-model provider ${provider}`);
 }
 const realModelBootstrap =
-  mode === "real-llm" ? readRealModelBootstrap() : undefined;
+  mode === "real-llm" ? await readRealModelBootstrap() : undefined;
 if (
   realModelBootstrap &&
   providerRoute &&

--- a/packages/cloud/e2e/scripts/stability-attempt.ts
+++ b/packages/cloud/e2e/scripts/stability-attempt.ts
@@ -6,6 +6,7 @@
 
 import { spawn } from "node:child_process";
 import { createHash, createHmac } from "node:crypto";
+import { closeSync, readSync } from "node:fs";
 import { readFile, writeFile } from "node:fs/promises";
 import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
@@ -36,6 +37,66 @@ const requiredPositiveInteger = (name: string): number => {
   }
   return value;
 };
+const REAL_MODEL_BOOTSTRAP_FD = 3;
+const MAX_REAL_MODEL_BOOTSTRAP_BYTES = 128 * 1024;
+
+type RealModelBootstrap = {
+  credentialEnvironment: "OPENAI_API_KEY" | "ANTHROPIC_API_KEY";
+  credentialValue: string;
+  meterAttestationKey: string;
+};
+
+function readRealModelBootstrap(): RealModelBootstrap {
+  const chunks: Buffer[] = [];
+  let total = 0;
+  try {
+    while (true) {
+      const chunk = Buffer.allocUnsafe(
+        Math.min(16 * 1024, MAX_REAL_MODEL_BOOTSTRAP_BYTES + 1 - total),
+      );
+      const bytesRead = readSync(
+        REAL_MODEL_BOOTSTRAP_FD,
+        chunk,
+        0,
+        chunk.byteLength,
+        null,
+      );
+      if (bytesRead === 0) break;
+      total += bytesRead;
+      if (total > MAX_REAL_MODEL_BOOTSTRAP_BYTES) {
+        throw new Error("real-model bootstrap exceeds its byte limit");
+      }
+      chunks.push(chunk.subarray(0, bytesRead));
+    }
+  } finally {
+    closeSync(REAL_MODEL_BOOTSTRAP_FD);
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(Buffer.concat(chunks, total).toString("utf8"));
+  } catch (cause) {
+    // error-policy:J3 the trusted boundary rejects malformed bootstrap input.
+    throw new Error("real-model bootstrap must be valid JSON", { cause });
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("real-model bootstrap must be an object");
+  }
+  const bootstrap = parsed as Record<string, unknown>;
+  if (
+    Object.keys(bootstrap).length !== 4 ||
+    bootstrap.version !== 1 ||
+    (bootstrap.credentialEnvironment !== "OPENAI_API_KEY" &&
+      bootstrap.credentialEnvironment !== "ANTHROPIC_API_KEY") ||
+    typeof bootstrap.credentialValue !== "string" ||
+    bootstrap.credentialValue.trim().length === 0 ||
+    Buffer.byteLength(bootstrap.credentialValue) > 64 * 1024 ||
+    typeof bootstrap.meterAttestationKey !== "string" ||
+    !/^[a-f0-9]{64}$/u.test(bootstrap.meterAttestationKey)
+  ) {
+    throw new Error("real-model bootstrap has an invalid schema");
+  }
+  return bootstrap as RealModelBootstrap;
+}
 const outputDir = required("ELIZA_STABILITY_OUTPUT_DIR");
 const mode = required("ELIZA_STABILITY_MODEL_MODE");
 const provider = required("ELIZA_STABILITY_PROVIDER");
@@ -120,14 +181,19 @@ const providerRoute = providerRoutes[provider];
 if (mode === "real-llm" && !providerRoute) {
   throw new Error(`unsupported real-model provider ${provider}`);
 }
+const realModelBootstrap =
+  mode === "real-llm" ? readRealModelBootstrap() : undefined;
+if (
+  realModelBootstrap &&
+  providerRoute &&
+  realModelBootstrap.credentialEnvironment !==
+    providerRoute.credentialEnvironment
+) {
+  throw new Error("real-model bootstrap credential does not match provider");
+}
 const realModelCredential =
-  mode === "real-llm" && providerRoute
-    ? required(providerRoute.credentialEnvironment)
-    : undefined;
-const meterAttestationKey =
-  mode === "real-llm"
-    ? required("ELIZA_STABILITY_METER_ATTESTATION_KEY")
-    : undefined;
+  mode === "real-llm" ? realModelBootstrap?.credentialValue : undefined;
+const meterAttestationKey = realModelBootstrap?.meterAttestationKey;
 delete process.env.OPENAI_API_KEY;
 delete process.env.ANTHROPIC_API_KEY;
 delete process.env.ELIZA_STABILITY_METER_ATTESTATION_KEY;

--- a/packages/cloud/e2e/scripts/stability-attempt.ts
+++ b/packages/cloud/e2e/scripts/stability-attempt.ts
@@ -14,6 +14,7 @@ import cloudStabilityScenario from "../scenarios/cloud-stability-agent.scenario.
 import { startCloudStack } from "../src/fixtures/stack.ts";
 import { canonicalCloudStabilitySha256 } from "../src/stability/cloud-stability-runner.ts";
 import {
+  liveModelScenarioChildEnvironment,
   type StabilityModelProvider,
   startLiveModelEgressProxy,
 } from "../src/stability/live-model-meter.ts";
@@ -102,18 +103,28 @@ const providerRoutes: Record<
   string,
   {
     origin: string;
-    baseUrlEnvironment: "OPENAI_BASE_URL" | "ANTHROPIC_BASE_URL";
+    credentialEnvironment: "OPENAI_API_KEY" | "ANTHROPIC_API_KEY";
   }
 > = {
   openai: {
     origin: "https://api.openai.com",
-    baseUrlEnvironment: "OPENAI_BASE_URL",
+    credentialEnvironment: "OPENAI_API_KEY",
   },
   anthropic: {
     origin: "https://api.anthropic.com",
-    baseUrlEnvironment: "ANTHROPIC_BASE_URL",
+    credentialEnvironment: "ANTHROPIC_API_KEY",
   },
 };
+const providerRoute = providerRoutes[provider];
+if (mode === "real-llm" && !providerRoute) {
+  throw new Error(`unsupported real-model provider ${provider}`);
+}
+const realModelCredential =
+  mode === "real-llm" && providerRoute
+    ? required(providerRoute.credentialEnvironment)
+    : undefined;
+delete process.env.OPENAI_API_KEY;
+delete process.env.ANTHROPIC_API_KEY;
 const guardedFetch = createLoopbackOnlyFetch(nativeFetch, networkLedger);
 globalThis.fetch = guardedFetch;
 
@@ -281,8 +292,9 @@ const modelProxy =
           ),
           maxRequests: maxModelRequests,
         },
+        upstreamCredential: realModelCredential,
         fetchUpstream: (url, init) => nativeFetch(url, init),
-        upstreamOrigin: providerRoutes[provider]?.origin,
+        upstreamOrigin: providerRoute?.origin,
         onUpstreamRequest: (origin, method) => {
           networkLedger.push({ origin, method, allowed: true });
         },
@@ -300,6 +312,13 @@ const childQuiescenceLedgerPath = path.join(
   outputDir,
   "child-quiescence-ledger.json",
 );
+const childProcessEnvironment = modelProxy
+  ? liveModelScenarioChildEnvironment(
+      provider as StabilityModelProvider,
+      modelProxy.url,
+      process.env,
+    )
+  : process.env;
 let cliStdout = "";
 let cliStderr = "";
 let cliCode: number | null = null;
@@ -333,14 +352,11 @@ try {
     shell: false,
     stdio: ["ignore", "pipe", "pipe"],
     env: {
-      ...process.env,
+      ...childProcessEnvironment,
       CLOUD_E2E_API_URL: cloudApiProxy.url,
       CLOUD_E2E_CONTROL_PLANE_URL: stack.urls.controlPlane,
       CLOUD_E2E_HETZNER_URL: hetznerProxy.url,
       ELIZA_SCENARIO_MODEL: model,
-      ...(modelProxy
-        ? { [providerRoutes[provider].baseUrlEnvironment]: modelProxy.url }
-        : {}),
       ELIZA_STABILITY_CHILD_NETWORK_LEDGER: childNetworkLedgerPath,
       ELIZA_STABILITY_CHILD_QUIESCENCE_LEDGER: childQuiescenceLedgerPath,
       ELIZA_SYNTHETIC_RUNTIME_LEDGER: childRuntimeLedgerPath,
@@ -392,8 +408,7 @@ try {
 }
 
 const explicitSecrets = [
-  process.env.OPENAI_API_KEY,
-  process.env.ANTHROPIC_API_KEY,
+  realModelCredential,
   process.env.ELIZA_SYNTHETIC_CONTROL_TOKEN,
 ].filter(
   (value): value is string => typeof value === "string" && value.length > 0,

--- a/packages/cloud/e2e/scripts/stability-network-guard.mjs
+++ b/packages/cloud/e2e/scripts/stability-network-guard.mjs
@@ -5,12 +5,22 @@
  */
 
 import { appendFileSync } from "node:fs";
+import { isIP } from "node:net";
 
 const ledgerPath = process.env.ELIZA_STABILITY_CHILD_NETWORK_LEDGER;
 if (!ledgerPath) throw new Error("network guard requires its ledger path");
 const nativeFetch = globalThis.fetch;
-const loopback = (hostname) =>
-  hostname === "localhost" || hostname === "::1" || hostname.startsWith("127.");
+const loopback = (hostname) => {
+  if (hostname === "localhost") return true;
+  const address =
+    hostname.startsWith("[") && hostname.endsWith("]")
+      ? hostname.slice(1, -1)
+      : hostname;
+  return (
+    address === "::1" ||
+    (isIP(address) === 4 && address.split(".", 1)[0] === "127")
+  );
+};
 
 globalThis.fetch = async (input, init) => {
   const url = new URL(

--- a/packages/cloud/e2e/scripts/stability-network-guard.mjs
+++ b/packages/cloud/e2e/scripts/stability-network-guard.mjs
@@ -4,7 +4,11 @@
  * proxy; direct provider or service egress is rejected before bytes are sent.
  */
 
+import { mock } from "bun:test";
 import { appendFileSync } from "node:fs";
+import http from "node:http";
+import https from "node:https";
+import { syncBuiltinESMExports } from "node:module";
 import { isIP } from "node:net";
 
 const ledgerPath = process.env.ELIZA_STABILITY_CHILD_NETWORK_LEDGER;
@@ -22,22 +26,112 @@ const loopback = (hostname) => {
   );
 };
 
-globalThis.fetch = async (input, init) => {
-  const url = new URL(
-    typeof input === "string" || input instanceof URL ? input : input.url,
-  );
-  const allowed = loopback(url.hostname);
+const appendDecision = (url, method, allowed) => {
   appendFileSync(
     ledgerPath,
     `${JSON.stringify({
       at: new Date().toISOString(),
       origin: url.origin,
-      method: init?.method ?? "GET",
+      method,
       allowed,
     })}\n`,
     { encoding: "utf8", mode: 0o600 },
   );
+};
+
+const requestUrl = (defaultProtocol, args) => {
+  const first = args[0];
+  if (typeof first === "string" || first instanceof URL) return new URL(first);
+  if (!first || typeof first !== "object" || first.socketPath) {
+    throw new Error("stability network policy requires an explicit HTTP URL");
+  }
+  const protocol = first.protocol ?? defaultProtocol;
+  const rawHostname = first.hostname;
+  let authority;
+  if (typeof rawHostname === "string" && rawHostname.length > 0) {
+    const hostname = isIP(rawHostname) === 6 ? `[${rawHostname}]` : rawHostname;
+    authority = `${hostname}${first.port ? `:${String(first.port)}` : ""}`;
+  } else if (typeof first.host === "string" && first.host.length > 0) {
+    authority = first.host;
+  } else {
+    throw new Error("stability network policy requires an explicit HTTP host");
+  }
+  const rawPath = typeof first.path === "string" ? first.path : "/";
+  const pathname = rawPath.startsWith("/") ? rawPath : `/${rawPath}`;
+  return new URL(`${protocol}//${authority}${pathname}`);
+};
+
+const requestMethod = (args) => {
+  const first = args[0];
+  const second = args[1];
+  const options =
+    second && typeof second === "object"
+      ? second
+      : first && typeof first === "object" && !(first instanceof URL)
+        ? first
+        : undefined;
+  return options?.method ?? "GET";
+};
+
+const guardRequestModule = (module, defaultProtocol) => {
+  const nativeRequest = module.request;
+  module.request = function guardedRequest(...args) {
+    const url = requestUrl(defaultProtocol, args);
+    const method = requestMethod(args);
+    const allowed = loopback(url.hostname);
+    appendDecision(url, method, allowed);
+    if (!allowed)
+      throw new Error(`stability network policy blocked ${url.origin}`);
+    return Reflect.apply(nativeRequest, module, args);
+  };
+  module.get = function guardedGet(...args) {
+    const request = module.request(...args);
+    request.end();
+    return request;
+  };
+};
+
+guardRequestModule(http, "http:");
+guardRequestModule(https, "https:");
+syncBuiltinESMExports();
+mock.module("node:http", () => ({
+  ...http,
+  default: http,
+  request: http.request,
+  get: http.get,
+}));
+mock.module("node:https", () => ({
+  ...https,
+  default: https,
+  request: https.request,
+  get: https.get,
+}));
+
+globalThis.fetch = async (input, init) => {
+  const url = new URL(
+    typeof input === "string" || input instanceof URL ? input : input.url,
+  );
+  const allowed = loopback(url.hostname);
+  const method =
+    init?.method ?? (input instanceof Request ? input.method : "GET");
+  appendDecision(url, method, allowed);
   if (!allowed)
     throw new Error(`stability network policy blocked ${url.origin}`);
-  return nativeFetch(input, init);
+  const response = await nativeFetch(input, { ...init, redirect: "manual" });
+  if (response.status >= 300 && response.status < 400) {
+    const location = response.headers.get("location");
+    if (!location) throw new Error("loopback redirect omitted Location");
+    const target = new URL(location, url);
+    const targetAllowed = loopback(target.hostname);
+    appendDecision(target, method, targetAllowed);
+    if (!targetAllowed) {
+      throw new Error(
+        `stability network policy blocked redirect ${target.origin}`,
+      );
+    }
+    throw new Error(
+      `stability network policy blocked redirect ${target.origin}`,
+    );
+  }
+  return response;
 };

--- a/packages/cloud/e2e/src/stability/cloud-stability-runner.test.ts
+++ b/packages/cloud/e2e/src/stability/cloud-stability-runner.test.ts
@@ -26,6 +26,7 @@ const manifest: CloudStabilityManifest = {
   timeoutMs: 1_000,
   maxInputTokens: 100,
   maxOutputTokens: 100,
+  maxModelRequests: 16,
   maxToolCalls: 10,
 };
 
@@ -85,6 +86,7 @@ describe("Cloud stability manifest", () => {
     const adapter: ScenarioStabilityExecutionAdapter = {
       async execute(input) {
         attempts.push(input.attemptNumber);
+        expect(input.budgets.maxModelRequests).toBe(manifest.maxModelRequests);
         return {
           passed: input.attemptNumber !== 2,
           initialStateHash: "b".repeat(64),
@@ -121,5 +123,60 @@ describe("Cloud stability manifest", () => {
     expect(
       await readFile(path.join(outputRoot, "stability.sha256"), "utf8"),
     ).toMatch(/^[a-f0-9]{64} {2}stability\.json\n$/);
+  });
+
+  test("retains metering failures in the exact-three focus report", async () => {
+    const outputRoot = await mkdtemp(
+      path.join(tmpdir(), "cloud-stability-metering-test-"),
+    );
+    directories.push(outputRoot);
+    const { fixtureManifestFingerprint: _fixtureFingerprint, ...baseManifest } =
+      manifest;
+    const report = await runCloudStabilityLane({
+      manifest: {
+        ...baseManifest,
+        mode: "real-llm",
+        provider: "openai",
+        model: "gpt-test",
+      },
+      outputRoot,
+      adapter: {
+        async execute() {
+          return {
+            passed: false,
+            initialStateHash: "b".repeat(64),
+            finalStateHash: "c".repeat(64),
+            inputTokens: 0,
+            outputTokens: 0,
+            toolCalls: 0,
+            evidence: {
+              trajectory: [],
+              toolReceipts: [],
+              stateTransitions: [],
+              providerReceipts: [],
+              judgeVerdicts: [],
+            },
+            stateDiff: {
+              providerUsage: {
+                requestCount: 1,
+                inputTokens: 0,
+                outputTokens: 0,
+                failures: [
+                  { code: "STABILITY_MODEL_USAGE_MISSING", requestNumber: 1 },
+                ],
+              },
+            },
+            error: "STABILITY_MODEL_USAGE_MISSING",
+          };
+        },
+        async terminate() {},
+      },
+    });
+    expect(report.cells[0]).toMatchObject({ tier: "0/3", passedAttempts: 0 });
+    expect(report.focusList[0]?.failedAttemptIds).toHaveLength(3);
+    expect(report.failureClusters[0]?.sample).toContain(
+      "STABILITY_MODEL_USAGE_MISSING",
+    );
+    expect(report.cells[0]?.attempts).toHaveLength(3);
   });
 });

--- a/packages/cloud/e2e/src/stability/cloud-stability-runner.ts
+++ b/packages/cloud/e2e/src/stability/cloud-stability-runner.ts
@@ -31,6 +31,7 @@ export interface CloudStabilityManifest {
   timeoutMs: number;
   maxInputTokens: number;
   maxOutputTokens: number;
+  maxModelRequests: number;
   maxToolCalls: number;
 }
 
@@ -119,6 +120,7 @@ export function parseCloudStabilityManifest(
     "timeoutMs",
     "maxInputTokens",
     "maxOutputTokens",
+    "maxModelRequests",
     "maxToolCalls",
     ...(record.mode === "deterministic-mock"
       ? ["fixtureManifestFingerprint"]
@@ -154,6 +156,10 @@ export function parseCloudStabilityManifest(
     timeoutMs: positiveInteger(record.timeoutMs, "timeoutMs"),
     maxInputTokens: positiveInteger(record.maxInputTokens, "maxInputTokens"),
     maxOutputTokens: positiveInteger(record.maxOutputTokens, "maxOutputTokens"),
+    maxModelRequests: positiveInteger(
+      record.maxModelRequests,
+      "maxModelRequests",
+    ),
     maxToolCalls: positiveInteger(record.maxToolCalls, "maxToolCalls"),
   };
   if (record.mode === "deterministic-mock") {
@@ -216,6 +222,7 @@ export async function runCloudStabilityLane(
       timeoutMs: manifest.timeoutMs,
       maxInputTokens: manifest.maxInputTokens,
       maxOutputTokens: manifest.maxOutputTokens,
+      maxModelRequests: manifest.maxModelRequests,
       maxToolCalls: manifest.maxToolCalls,
     },
     adapter: input.adapter,

--- a/packages/cloud/e2e/src/stability/live-model-meter.test.ts
+++ b/packages/cloud/e2e/src/stability/live-model-meter.test.ts
@@ -12,6 +12,26 @@ import {
 } from "./live-model-meter.ts";
 
 const proxies: StabilityModelProxy[] = [];
+const EXPECTED_MODEL = "test-model";
+const OPENAI_RESPONSES_BODY = JSON.stringify({
+  model: EXPECTED_MODEL,
+  input: "test",
+  max_output_tokens: 1,
+});
+const OPENAI_CHAT_BODY = JSON.stringify({
+  model: EXPECTED_MODEL,
+  messages: [{ role: "user", content: "test" }],
+  max_completion_tokens: 1,
+});
+const ANTHROPIC_BODY = JSON.stringify({
+  model: EXPECTED_MODEL,
+  messages: [{ role: "user", content: "test" }],
+  max_tokens: 1,
+});
+
+function providerBody(provider: "openai" | "anthropic"): string {
+  return provider === "openai" ? OPENAI_RESPONSES_BODY : ANTHROPIC_BODY;
+}
 
 function reserve(meter: LiveModelUsageMeter) {
   const admission = meter.reserveRequest();
@@ -328,7 +348,12 @@ describe("live model usage meter", () => {
     ] as const) {
       const proxy = await startLiveModelEgressProxy({
         provider: "openai",
-        budgets: { maxInputTokens: 100, maxOutputTokens: 100, maxRequests: 2 },
+        expectedModel: EXPECTED_MODEL,
+        budgets: {
+          maxInputTokens: 10_000,
+          maxOutputTokens: 100,
+          maxRequests: 2,
+        },
         upstreamTimeoutMs: 5,
         fetchUpstream: fixture.response
           ? async () => fixture.response
@@ -342,7 +367,7 @@ describe("live model usage meter", () => {
       proxies.push(proxy);
       const response = await fetch(`${proxy.url}/chat/completions`, {
         method: "POST",
-        body: "{}",
+        body: OPENAI_CHAT_BODY,
       });
       expect(response.ok).toBe(false);
       expect(proxy.snapshot().failures.at(-1)?.code).toBe(fixture.code);
@@ -363,7 +388,7 @@ describe("live model usage meter", () => {
       code: "STABILITY_MODEL_USAGE_MALFORMED",
     },
     {
-      payload: { usage: { prompt_tokens: 101, completion_tokens: 1 } },
+      payload: { usage: { prompt_tokens: 10_001, completion_tokens: 1 } },
       code: "STABILITY_MODEL_TOKEN_BUDGET_EXCEEDED",
     },
   ] as const)(
@@ -371,14 +396,23 @@ describe("live model usage meter", () => {
     async ({ payload, code }) => {
       const proxy = await startLiveModelEgressProxy({
         provider: "openai",
-        budgets: { maxInputTokens: 100, maxOutputTokens: 100, maxRequests: 1 },
+        expectedModel: EXPECTED_MODEL,
+        budgets: {
+          maxInputTokens: 10_000,
+          maxOutputTokens: 100,
+          maxRequests: 1,
+        },
         fetchUpstream: async () => Response.json(payload),
       });
       proxies.push(proxy);
 
       expect(
-        (await fetch(`${proxy.url}/responses`, { method: "POST", body: "{}" }))
-          .status,
+        (
+          await fetch(`${proxy.url}/responses`, {
+            method: "POST",
+            body: OPENAI_RESPONSES_BODY,
+          })
+        ).status,
       ).toBe(502);
       expect(proxy.snapshot().failures.at(-1)?.code).toBe(code);
     },
@@ -399,7 +433,12 @@ describe("live model usage meter", () => {
     try {
       const proxy = await startLiveModelEgressProxy({
         provider: "openai",
-        budgets: { maxInputTokens: 100, maxOutputTokens: 100, maxRequests: 1 },
+        expectedModel: EXPECTED_MODEL,
+        budgets: {
+          maxInputTokens: 10_000,
+          maxOutputTokens: 100,
+          maxRequests: 1,
+        },
         upstreamCredential: "real-model-secret",
         upstreamOrigin: `http://127.0.0.1:${upstream.port}`,
         fetchUpstream: (url, init) => fetch(url, init),
@@ -417,7 +456,7 @@ describe("live model usage meter", () => {
               "proxy-connection": "child-hop-value",
               host: "child-loopback.invalid",
             },
-            body: "{}",
+            body: OPENAI_RESPONSES_BODY,
           })
         ).ok,
       ).toBe(true);
@@ -454,7 +493,12 @@ describe("live model usage meter", () => {
       let capturedHeaders: Record<string, string> = {};
       const proxy = await startLiveModelEgressProxy({
         provider,
-        budgets: { maxInputTokens: 100, maxOutputTokens: 100, maxRequests: 1 },
+        expectedModel: EXPECTED_MODEL,
+        budgets: {
+          maxInputTokens: 10_000,
+          maxOutputTokens: 100,
+          maxRequests: 1,
+        },
         upstreamCredential: "real-model-secret",
         fetchUpstream: async (_url, init) => {
           capturedHeaders = Object.fromEntries(new Headers(init.headers));
@@ -484,7 +528,7 @@ describe("live model usage meter", () => {
                 host: "child-loopback.invalid",
                 "anthropic-version": "2023-06-01",
               },
-              body: "{}",
+              body: providerBody(provider),
             },
           )
         ).ok,
@@ -523,7 +567,12 @@ describe("live model usage meter", () => {
       let upstreamCalls = 0;
       const proxy = await startLiveModelEgressProxy({
         provider: "openai",
-        budgets: { maxInputTokens: 100, maxOutputTokens: 100, maxRequests: 2 },
+        expectedModel: EXPECTED_MODEL,
+        budgets: {
+          maxInputTokens: 10_000,
+          maxOutputTokens: 100,
+          maxRequests: 2,
+        },
         upstreamCredential: "real-model-secret",
         fetchUpstream: async () => {
           upstreamCalls += 1;
@@ -538,7 +587,7 @@ describe("live model usage meter", () => {
         (
           await fetch(`${proxy.url}${path}`, {
             method,
-            body: method === "POST" ? "{}" : undefined,
+            body: method === "POST" ? OPENAI_RESPONSES_BODY : undefined,
           })
         ).status,
       ).toBe(404);
@@ -556,7 +605,8 @@ describe("live model usage meter", () => {
     let upstreamCalls = 0;
     const proxy = await startLiveModelEgressProxy({
       provider: "openai",
-      budgets: { maxInputTokens: 100, maxOutputTokens: 100, maxRequests: 1 },
+      expectedModel: EXPECTED_MODEL,
+      budgets: { maxInputTokens: 10_000, maxOutputTokens: 100, maxRequests: 1 },
       fetchUpstream: async () => {
         upstreamCalls += 1;
         return Response.json({
@@ -566,12 +616,20 @@ describe("live model usage meter", () => {
     });
     proxies.push(proxy);
     expect(
-      (await fetch(`${proxy.url}/responses`, { method: "POST", body: "{}" }))
-        .ok,
+      (
+        await fetch(`${proxy.url}/responses`, {
+          method: "POST",
+          body: OPENAI_RESPONSES_BODY,
+        })
+      ).ok,
     ).toBe(true);
     expect(
-      (await fetch(`${proxy.url}/responses`, { method: "POST", body: "{}" }))
-        .status,
+      (
+        await fetch(`${proxy.url}/responses`, {
+          method: "POST",
+          body: OPENAI_RESPONSES_BODY,
+        })
+      ).status,
     ).toBe(429);
     expect(upstreamCalls).toBe(1);
     expect(proxy.snapshot().failures.at(-1)?.code).toBe(
@@ -587,7 +645,8 @@ describe("live model usage meter", () => {
     });
     const proxy = await startLiveModelEgressProxy({
       provider: "openai",
-      budgets: { maxInputTokens: 100, maxOutputTokens: 100, maxRequests: 1 },
+      expectedModel: EXPECTED_MODEL,
+      budgets: { maxInputTokens: 10_000, maxOutputTokens: 100, maxRequests: 1 },
       fetchUpstream: async () => {
         upstreamCalls += 1;
         await upstreamBlocked;
@@ -599,9 +658,14 @@ describe("live model usage meter", () => {
     proxies.push(proxy);
 
     const requests = Array.from({ length: 8 }, () =>
-      fetch(`${proxy.url}/responses`, { method: "POST", body: "{}" }),
+      fetch(`${proxy.url}/responses`, {
+        method: "POST",
+        body: OPENAI_RESPONSES_BODY,
+      }),
     );
-    await Bun.sleep(10);
+    for (let attempt = 0; attempt < 200 && upstreamCalls === 0; attempt += 1) {
+      await Bun.sleep(10);
+    }
     expect(upstreamCalls).toBe(1);
     releaseUpstream?.();
     const responses = await Promise.all(requests);
@@ -630,12 +694,13 @@ describe("live model usage meter", () => {
     let upstreamCalls = 0;
     const proxy = await startLiveModelEgressProxy({
       provider: "openai",
-      budgets: { maxInputTokens: 2, maxOutputTokens: 1, maxRequests: 8 },
+      expectedModel: EXPECTED_MODEL,
+      budgets: { maxInputTokens: 10_000, maxOutputTokens: 1, maxRequests: 8 },
       fetchUpstream: async () => {
         upstreamCalls += 1;
         await Bun.sleep(5);
         return Response.json({
-          usage: { prompt_tokens: 2, completion_tokens: 1 },
+          usage: { prompt_tokens: 10_000, completion_tokens: 1 },
         });
       },
     });
@@ -643,23 +708,26 @@ describe("live model usage meter", () => {
 
     const responses = await Promise.all(
       Array.from({ length: 8 }, () =>
-        fetch(`${proxy.url}/responses`, { method: "POST", body: "{}" }),
+        fetch(`${proxy.url}/responses`, {
+          method: "POST",
+          body: OPENAI_RESPONSES_BODY,
+        }),
       ),
     );
 
     expect(responses.filter((response) => response.ok)).toHaveLength(1);
     expect(
-      responses.filter((response) => response.status === 429),
+      responses.filter((response) => response.status === 422),
     ).toHaveLength(7);
     expect(upstreamCalls).toBe(1);
     expect(proxy.snapshot()).toMatchObject({
       requestCount: 1,
-      inputTokens: 2,
+      inputTokens: 10_000,
       outputTokens: 1,
     });
     expect(proxy.snapshot().failures).toEqual([
       expect.objectContaining({
-        code: "STABILITY_MODEL_TOKEN_BUDGET_EXHAUSTED",
+        code: "STABILITY_MODEL_PRE_DISPATCH_REJECTED",
         requestNumber: 2,
       }),
     ]);
@@ -668,14 +736,19 @@ describe("live model usage meter", () => {
   test("proxy counts and retains an oversized upstream response", async () => {
     const proxy = await startLiveModelEgressProxy({
       provider: "openai",
-      budgets: { maxInputTokens: 100, maxOutputTokens: 100, maxRequests: 2 },
+      expectedModel: EXPECTED_MODEL,
+      budgets: { maxInputTokens: 10_000, maxOutputTokens: 100, maxRequests: 2 },
       fetchUpstream: async () =>
         new Response(new Uint8Array(16 * 1024 * 1024 + 1), { status: 200 }),
     });
     proxies.push(proxy);
     expect(
-      (await fetch(`${proxy.url}/responses`, { method: "POST", body: "{}" }))
-        .status,
+      (
+        await fetch(`${proxy.url}/responses`, {
+          method: "POST",
+          body: OPENAI_RESPONSES_BODY,
+        })
+      ).status,
     ).toBe(502);
     expect(proxy.snapshot()).toMatchObject({
       requestCount: 1,
@@ -686,6 +759,261 @@ describe("live model usage meter", () => {
       "STABILITY_MODEL_PROXY_ERROR",
     );
   });
+
+  test("proxy cancels a chunked provider response at the byte cap", async () => {
+    let cancelled = false;
+    let chunks = 0;
+    const proxy = await startLiveModelEgressProxy({
+      provider: "openai",
+      expectedModel: EXPECTED_MODEL,
+      budgets: { maxInputTokens: 10_000, maxOutputTokens: 100, maxRequests: 1 },
+      fetchUpstream: async () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            pull(controller) {
+              chunks += 1;
+              controller.enqueue(new Uint8Array(1024 * 1024));
+            },
+            cancel() {
+              cancelled = true;
+            },
+          }),
+        ),
+    });
+    proxies.push(proxy);
+
+    expect(
+      (
+        await fetch(`${proxy.url}/responses`, {
+          method: "POST",
+          body: OPENAI_RESPONSES_BODY,
+        })
+      ).status,
+    ).toBe(502);
+    expect(chunks).toBeLessThanOrEqual(18);
+    expect(cancelled).toBe(true);
+    expect(proxy.snapshot().failures.at(-1)?.code).toBe(
+      "STABILITY_MODEL_PROXY_ERROR",
+    );
+  });
+
+  test.each([
+    { name: "malformed JSON", body: "{" },
+    {
+      name: "missing model",
+      body: JSON.stringify({ input: "test", max_output_tokens: 1 }),
+    },
+    {
+      name: "wrong model",
+      body: JSON.stringify({
+        model: "wrong-model",
+        input: "test",
+        max_output_tokens: 1,
+      }),
+    },
+    {
+      name: "ambiguous output caps",
+      path: "/chat/completions",
+      body: JSON.stringify({
+        model: EXPECTED_MODEL,
+        messages: [{ role: "user", content: "test" }],
+        max_completion_tokens: 1,
+        max_tokens: 1,
+      }),
+    },
+    {
+      name: "multimodal input",
+      body: JSON.stringify({
+        model: EXPECTED_MODEL,
+        input: [
+          { type: "input_image", image_url: "https://example.invalid/x" },
+        ],
+        max_output_tokens: 1,
+      }),
+    },
+    {
+      name: "indirect previous response context",
+      body: JSON.stringify({
+        model: EXPECTED_MODEL,
+        input: "test",
+        previous_response_id: "resp_provider_hosted",
+        max_output_tokens: 1,
+      }),
+    },
+    {
+      name: "provider-hosted search tool",
+      body: JSON.stringify({
+        model: EXPECTED_MODEL,
+        input: "test",
+        tools: [{ type: "web_search_preview" }],
+        max_output_tokens: 1,
+      }),
+    },
+    {
+      name: "oversized textual input",
+      body: JSON.stringify({
+        model: EXPECTED_MODEL,
+        input: "x".repeat(1024 * 1024),
+        max_output_tokens: 1_000_000,
+      }),
+    },
+  ])(
+    "rejects $name before credential-bearing dispatch",
+    async ({ body, path }) => {
+      let upstreamCalls = 0;
+      const proxy = await startLiveModelEgressProxy({
+        provider: "openai",
+        expectedModel: EXPECTED_MODEL,
+        budgets: {
+          maxInputTokens: 10_000,
+          maxOutputTokens: 10,
+          maxRequests: 1,
+        },
+        upstreamCredential: "real-model-secret",
+        fetchUpstream: async () => {
+          upstreamCalls += 1;
+          return Response.json({
+            usage: { input_tokens: 1, output_tokens: 1 },
+          });
+        },
+      });
+      proxies.push(proxy);
+
+      expect(
+        (
+          await fetch(`${proxy.url}${path ?? "/responses"}`, {
+            method: "POST",
+            body,
+          })
+        ).status,
+      ).toBe(422);
+      expect(upstreamCalls).toBe(0);
+      expect(proxy.snapshot()).toMatchObject({
+        requestCount: 0,
+        failures: [
+          expect.objectContaining({
+            code: "STABILITY_MODEL_PRE_DISPATCH_REJECTED",
+          }),
+        ],
+        requestEnvelopes: [expect.objectContaining({ accepted: false })],
+      });
+      if (body.includes("wrong-model")) {
+        expect(proxy.snapshot().requestEnvelopes[0]?.observedModel).toBe(
+          "wrong-model",
+        );
+      }
+    },
+  );
+
+  test("canonicalizes output caps to the remaining attempt budget", async () => {
+    const forwardedCaps: number[] = [];
+    const proxy = await startLiveModelEgressProxy({
+      provider: "openai",
+      expectedModel: EXPECTED_MODEL,
+      budgets: { maxInputTokens: 20_000, maxOutputTokens: 5, maxRequests: 2 },
+      fetchUpstream: async (_url, init) => {
+        const body = JSON.parse(String(init.body)) as {
+          max_output_tokens: number;
+        };
+        forwardedCaps.push(body.max_output_tokens);
+        return Response.json({
+          usage: {
+            input_tokens: 1,
+            output_tokens: forwardedCaps.length === 1 ? 3 : 2,
+          },
+        });
+      },
+    });
+    proxies.push(proxy);
+    const requestBody = JSON.stringify({
+      model: EXPECTED_MODEL,
+      input: "test",
+      max_output_tokens: 1_000_000,
+    });
+
+    expect(
+      await Promise.all(
+        [1, 2].map(
+          async () =>
+            (
+              await fetch(`${proxy.url}/responses`, {
+                method: "POST",
+                body: requestBody,
+              })
+            ).status,
+        ),
+      ),
+    ).toEqual([200, 200]);
+    expect(forwardedCaps).toEqual([5, 2]);
+    expect(proxy.snapshot().requestEnvelopes).toMatchObject([
+      { requestedMaxOutputTokens: 1_000_000, effectiveMaxOutputTokens: 5 },
+      { requestedMaxOutputTokens: 1_000_000, effectiveMaxOutputTokens: 2 },
+    ]);
+  });
+
+  test.each([
+    {
+      provider: "openai" as const,
+      path: "/responses",
+      body: { model: EXPECTED_MODEL, input: "test" },
+      capField: "max_output_tokens",
+    },
+    {
+      provider: "openai" as const,
+      path: "/chat/completions",
+      body: {
+        model: EXPECTED_MODEL,
+        messages: [{ role: "user", content: "test" }],
+      },
+      capField: "max_completion_tokens",
+    },
+    {
+      provider: "anthropic" as const,
+      path: "/messages",
+      body: {
+        model: EXPECTED_MODEL,
+        messages: [{ role: "user", content: "test" }],
+        max_tokens: 64_000,
+      },
+      capField: "max_tokens",
+    },
+  ])(
+    "forwards a compatible canonical $provider$path request",
+    async ({ provider, path, body, capField }) => {
+      let forwarded: Record<string, unknown> | undefined;
+      const proxy = await startLiveModelEgressProxy({
+        provider,
+        expectedModel: EXPECTED_MODEL,
+        budgets: {
+          maxInputTokens: 10_000,
+          maxOutputTokens: 7,
+          maxRequests: 1,
+        },
+        fetchUpstream: async (_url, init) => {
+          forwarded = JSON.parse(String(init.body)) as Record<string, unknown>;
+          return Response.json({
+            usage:
+              provider === "openai"
+                ? { input_tokens: 1, output_tokens: 1 }
+                : { input_tokens: 1, output_tokens: 1 },
+          });
+        },
+      });
+      proxies.push(proxy);
+
+      expect(
+        (
+          await fetch(`${proxy.url}${path}`, {
+            method: "POST",
+            body: JSON.stringify(body),
+          })
+        ).status,
+      ).toBe(200);
+      expect(forwarded?.model).toBe(EXPECTED_MODEL);
+      expect(forwarded?.[capField]).toBe(7);
+      expect(JSON.stringify(forwarded)).not.toContain("real-model-secret");
+    },
+  );
 
   test("proxy never follows an upstream provider redirect", async () => {
     let targetCalls = 0;
@@ -707,7 +1035,12 @@ describe("live model usage meter", () => {
     try {
       const proxy = await startLiveModelEgressProxy({
         provider: "openai",
-        budgets: { maxInputTokens: 100, maxOutputTokens: 100, maxRequests: 2 },
+        expectedModel: EXPECTED_MODEL,
+        budgets: {
+          maxInputTokens: 10_000,
+          maxOutputTokens: 100,
+          maxRequests: 2,
+        },
         upstreamCredential: "real-model-secret",
         upstreamOrigin: `http://127.0.0.1:${redirect.port}`,
         fetchUpstream: (url, init) => fetch(url, init),
@@ -718,7 +1051,7 @@ describe("live model usage meter", () => {
         (
           await fetch(`${proxy.url}/responses`, {
             method: "POST",
-            body: "{}",
+            body: OPENAI_RESPONSES_BODY,
           })
         ).status,
       ).toBe(502);
@@ -737,7 +1070,8 @@ describe("live model usage meter", () => {
     let upstreamCalls = 0;
     const proxy = await startLiveModelEgressProxy({
       provider: "openai",
-      budgets: { maxInputTokens: 100, maxOutputTokens: 100, maxRequests: 2 },
+      expectedModel: EXPECTED_MODEL,
+      budgets: { maxInputTokens: 10_000, maxOutputTokens: 100, maxRequests: 2 },
       fetchUpstream: async () => {
         upstreamCalls += 1;
         return Response.json({
@@ -750,8 +1084,12 @@ describe("live model usage meter", () => {
     });
     proxies.push(proxy);
     expect(
-      (await fetch(`${proxy.url}/responses`, { method: "POST", body: "{}" }))
-        .status,
+      (
+        await fetch(`${proxy.url}/responses`, {
+          method: "POST",
+          body: OPENAI_RESPONSES_BODY,
+        })
+      ).status,
     ).toBe(502);
     expect(upstreamCalls).toBe(0);
     expect(proxy.snapshot().requestCount).toBe(1);
@@ -763,30 +1101,37 @@ describe("live model usage meter", () => {
   test("proxy retains a response-boundary failure after successful metering", async () => {
     const proxy = await startLiveModelEgressProxy({
       provider: "openai",
-      budgets: { maxInputTokens: 100, maxOutputTokens: 100, maxRequests: 2 },
+      expectedModel: EXPECTED_MODEL,
+      budgets: { maxInputTokens: 10_000, maxOutputTokens: 100, maxRequests: 2 },
       fetchUpstream: async () =>
         ({
           ok: true,
           status: 200,
           headers: {
-            get: () => "application/json",
+            get: (name: string) =>
+              name.toLowerCase() === "content-type" ? "application/json" : null,
             [Symbol.iterator](): IterableIterator<[string, string]> {
               throw new Error("injected response header boundary failure");
             },
           },
-          arrayBuffer: async () =>
+          body: new Response(
             new TextEncoder().encode(
               JSON.stringify({
                 usage: { prompt_tokens: 2, completion_tokens: 1 },
               }),
-            ).buffer,
+            ),
+          ).body,
         }) as unknown as Response,
     });
     proxies.push(proxy);
 
     expect(
-      (await fetch(`${proxy.url}/responses`, { method: "POST", body: "{}" }))
-        .status,
+      (
+        await fetch(`${proxy.url}/responses`, {
+          method: "POST",
+          body: OPENAI_RESPONSES_BODY,
+        })
+      ).status,
     ).toBe(502);
     expect(proxy.snapshot()).toMatchObject({
       requestCount: 1,

--- a/packages/cloud/e2e/src/stability/live-model-meter.test.ts
+++ b/packages/cloud/e2e/src/stability/live-model-meter.test.ts
@@ -5,6 +5,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import {
   LiveModelUsageMeter,
+  liveModelScenarioChildEnvironment,
   type StabilityModelFailureCode,
   type StabilityModelProxy,
   startLiveModelEgressProxy,
@@ -23,6 +24,34 @@ afterEach(async () => {
 });
 
 describe("live model usage meter", () => {
+  test.each(["openai", "anthropic"] as const)(
+    "scenario child receives only a dummy %s credential",
+    (provider) => {
+      const environment = liveModelScenarioChildEnvironment(
+        provider,
+        "http://127.0.0.1:43123/v1",
+        {
+          OPENAI_API_KEY: "real-openai-secret",
+          ANTHROPIC_API_KEY: "real-anthropic-secret",
+          RETAINED_VALUE: "retained",
+        },
+      );
+      expect(JSON.stringify(environment)).not.toContain("real-");
+      expect(environment.RETAINED_VALUE).toBe("retained");
+      if (provider === "openai") {
+        expect(environment.OPENAI_API_KEY).toContain("placeholder");
+        expect(environment.OPENAI_BASE_URL).toBe("http://127.0.0.1:43123/v1");
+        expect(environment.ANTHROPIC_API_KEY).toBeUndefined();
+      } else {
+        expect(environment.ANTHROPIC_API_KEY).toContain("placeholder");
+        expect(environment.ANTHROPIC_BASE_URL).toBe(
+          "http://127.0.0.1:43123/v1",
+        );
+        expect(environment.OPENAI_API_KEY).toBeUndefined();
+      }
+    },
+  );
+
   test("parses and cumulatively aggregates OpenAI and Anthropic usage", () => {
     const openai = new LiveModelUsageMeter("openai", {
       maxInputTokens: 100,
@@ -184,6 +213,30 @@ describe("live model usage meter", () => {
       outputTokens: 2,
     });
 
+    const mixed = new LiveModelUsageMeter("anthropic", {
+      maxInputTokens: 100,
+      maxOutputTokens: 100,
+      maxRequests: 1,
+    });
+    mixed.recordSuccessfulResponse(
+      reserve(mixed),
+      "application/json",
+      Buffer.from(
+        JSON.stringify({
+          usage: {
+            input_tokens: 3,
+            cache_creation_input_tokens: 5,
+            cache_read_input_tokens: 7,
+            output_tokens: 2,
+          },
+        }),
+      ),
+    );
+    expect(mixed.snapshot()).toMatchObject({
+      inputTokens: 15,
+      outputTokens: 2,
+    });
+
     const overflow = new LiveModelUsageMeter("anthropic", {
       maxInputTokens: Number.MAX_SAFE_INTEGER,
       maxOutputTokens: 100,
@@ -204,6 +257,65 @@ describe("live model usage meter", () => {
         ),
       ),
     ).toThrow("STABILITY_MODEL_USAGE_MALFORMED");
+  });
+
+  test("accepts cache-only Anthropic input in SSE", () => {
+    const meter = new LiveModelUsageMeter("anthropic", {
+      maxInputTokens: 100,
+      maxOutputTokens: 100,
+      maxRequests: 1,
+    });
+    meter.recordSuccessfulResponse(
+      reserve(meter),
+      "text/event-stream",
+      Buffer.from(
+        'data: {"type":"message_start","message":{"usage":{"input_tokens":0,"cache_read_input_tokens":19,"output_tokens":0}}}\n\ndata: {"type":"message_delta","usage":{"output_tokens":3}}\n\n',
+      ),
+    );
+    expect(meter.snapshot()).toMatchObject({
+      inputTokens: 19,
+      outputTokens: 3,
+    });
+  });
+
+  test("fails closed when individually safe responses overflow cumulative accounting", () => {
+    const meter = new LiveModelUsageMeter("openai", {
+      maxInputTokens: Number.MAX_SAFE_INTEGER,
+      maxOutputTokens: Number.MAX_SAFE_INTEGER,
+      maxRequests: 2,
+    });
+    meter.recordSuccessfulResponse(
+      reserve(meter),
+      "application/json",
+      Buffer.from(
+        JSON.stringify({
+          usage: {
+            prompt_tokens: Number.MAX_SAFE_INTEGER - 1,
+            completion_tokens: 1,
+          },
+        }),
+      ),
+    );
+    expect(() =>
+      meter.recordSuccessfulResponse(
+        reserve(meter),
+        "application/json",
+        Buffer.from(
+          JSON.stringify({ usage: { prompt_tokens: 2, completion_tokens: 1 } }),
+        ),
+      ),
+    ).toThrow("STABILITY_MODEL_USAGE_MALFORMED");
+    expect(meter.snapshot()).toMatchObject({
+      requestCount: 2,
+      inputTokens: Number.MAX_SAFE_INTEGER - 1,
+      outputTokens: 1,
+      failures: [
+        expect.objectContaining({
+          code: "STABILITY_MODEL_USAGE_MALFORMED",
+          requestNumber: 2,
+        }),
+      ],
+    });
   });
 
   test("proxy records provider errors and timeouts without fabricating usage", async () => {
@@ -240,6 +352,205 @@ describe("live model usage meter", () => {
       });
     }
   });
+
+  test.each([
+    {
+      payload: { id: "missing-usage" },
+      code: "STABILITY_MODEL_USAGE_MISSING",
+    },
+    {
+      payload: { usage: { prompt_tokens: "bad", completion_tokens: 1 } },
+      code: "STABILITY_MODEL_USAGE_MALFORMED",
+    },
+    {
+      payload: { usage: { prompt_tokens: 101, completion_tokens: 1 } },
+      code: "STABILITY_MODEL_TOKEN_BUDGET_EXCEEDED",
+    },
+  ] as const)(
+    "proxy retains $code from a successful provider response",
+    async ({ payload, code }) => {
+      const proxy = await startLiveModelEgressProxy({
+        provider: "openai",
+        budgets: { maxInputTokens: 100, maxOutputTokens: 100, maxRequests: 1 },
+        fetchUpstream: async () => Response.json(payload),
+      });
+      proxies.push(proxy);
+
+      expect(
+        (await fetch(`${proxy.url}/responses`, { method: "POST", body: "{}" }))
+          .status,
+      ).toBe(502);
+      expect(proxy.snapshot().failures.at(-1)?.code).toBe(code);
+    },
+  );
+
+  test("native upstream receives provider host/auth without child auth or proxy headers", async () => {
+    let capturedHeaders: Record<string, string> = {};
+    const upstream = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch(request) {
+        capturedHeaders = Object.fromEntries(request.headers);
+        return Response.json({
+          usage: { prompt_tokens: 2, completion_tokens: 1 },
+        });
+      },
+    });
+    try {
+      const proxy = await startLiveModelEgressProxy({
+        provider: "openai",
+        budgets: { maxInputTokens: 100, maxOutputTokens: 100, maxRequests: 1 },
+        upstreamCredential: "real-model-secret",
+        upstreamOrigin: `http://127.0.0.1:${upstream.port}`,
+        fetchUpstream: (url, init) => fetch(url, init),
+      });
+      proxies.push(proxy);
+
+      expect(
+        (
+          await fetch(`${proxy.url}/responses`, {
+            method: "POST",
+            headers: {
+              authorization: "Bearer child-placeholder",
+              "x-api-key": "child-placeholder",
+              "proxy-authorization": "Bearer child-placeholder",
+              "proxy-connection": "child-hop-value",
+              host: "child-loopback.invalid",
+            },
+            body: "{}",
+          })
+        ).ok,
+      ).toBe(true);
+      expect(capturedHeaders.host).toBe(`127.0.0.1:${upstream.port}`);
+      expect(capturedHeaders.authorization).toBe("Bearer real-model-secret");
+      expect(JSON.stringify(capturedHeaders)).not.toContain("child-");
+      for (const absent of [
+        "x-api-key",
+        "api-key",
+        "proxy-authorization",
+        "proxy-connection",
+      ]) {
+        expect(capturedHeaders[absent]).toBeUndefined();
+      }
+    } finally {
+      upstream.stop(true);
+    }
+  });
+
+  test.each([
+    {
+      provider: "openai" as const,
+      expectedHeader: "authorization",
+      expectedValue: "Bearer real-model-secret",
+    },
+    {
+      provider: "anthropic" as const,
+      expectedHeader: "x-api-key",
+      expectedValue: "real-model-secret",
+    },
+  ])(
+    "proxy replaces child authentication with the parent-held $provider credential",
+    async ({ provider, expectedHeader, expectedValue }) => {
+      let capturedHeaders: Record<string, string> = {};
+      const proxy = await startLiveModelEgressProxy({
+        provider,
+        budgets: { maxInputTokens: 100, maxOutputTokens: 100, maxRequests: 1 },
+        upstreamCredential: "real-model-secret",
+        fetchUpstream: async (_url, init) => {
+          capturedHeaders = Object.fromEntries(new Headers(init.headers));
+          return Response.json({
+            usage:
+              provider === "openai"
+                ? { prompt_tokens: 2, completion_tokens: 1 }
+                : { input_tokens: 2, output_tokens: 1 },
+          });
+        },
+      });
+      proxies.push(proxy);
+
+      expect(
+        (
+          await fetch(
+            `${proxy.url}/${provider === "anthropic" ? "messages" : "responses"}`,
+            {
+              method: "POST",
+              headers: {
+                authorization: "Bearer child-dummy-secret",
+                "x-api-key": "child-dummy-secret",
+                "api-key": "child-dummy-secret",
+                "proxy-authorization": "Bearer child-dummy-secret",
+                "proxy-connection": "keep-alive",
+                connection: "keep-alive",
+                host: "child-loopback.invalid",
+                "anthropic-version": "2023-06-01",
+              },
+              body: "{}",
+            },
+          )
+        ).ok,
+      ).toBe(true);
+      expect(capturedHeaders[expectedHeader]).toBe(expectedValue);
+      expect(JSON.stringify(capturedHeaders)).not.toContain(
+        "child-dummy-secret",
+      );
+      expect(
+        capturedHeaders[
+          expectedHeader === "authorization" ? "x-api-key" : "authorization"
+        ],
+      ).toBeUndefined();
+      for (const stripped of [
+        "host",
+        "connection",
+        "content-length",
+        "transfer-encoding",
+        "proxy-authorization",
+        "proxy-connection",
+        "api-key",
+      ]) {
+        expect(capturedHeaders[stripped]).toBeUndefined();
+      }
+      expect(capturedHeaders["anthropic-version"]).toBe("2023-06-01");
+    },
+  );
+
+  test.each([
+    { method: "GET", path: "/responses" },
+    { method: "POST", path: "/models" },
+    { method: "POST", path: "/responses?redirect=https://example.com" },
+  ])(
+    "proxy rejects non-model route $method $path",
+    async ({ method, path }) => {
+      let upstreamCalls = 0;
+      const proxy = await startLiveModelEgressProxy({
+        provider: "openai",
+        budgets: { maxInputTokens: 100, maxOutputTokens: 100, maxRequests: 2 },
+        upstreamCredential: "real-model-secret",
+        fetchUpstream: async () => {
+          upstreamCalls += 1;
+          return Response.json({
+            usage: { prompt_tokens: 2, completion_tokens: 1 },
+          });
+        },
+      });
+      proxies.push(proxy);
+
+      expect(
+        (
+          await fetch(`${proxy.url}${path}`, {
+            method,
+            body: method === "POST" ? "{}" : undefined,
+          })
+        ).status,
+      ).toBe(404);
+      expect(upstreamCalls).toBe(0);
+      expect(proxy.snapshot()).toMatchObject({
+        requestCount: 0,
+        failures: [
+          expect.objectContaining({ code: "STABILITY_MODEL_PROXY_ERROR" }),
+        ],
+      });
+    },
+  );
 
   test("proxy enforces request cap before a further upstream call", async () => {
     let upstreamCalls = 0;
@@ -374,6 +685,52 @@ describe("live model usage meter", () => {
     expect(proxy.snapshot().failures.at(-1)?.code).toBe(
       "STABILITY_MODEL_PROXY_ERROR",
     );
+  });
+
+  test("proxy never follows an upstream provider redirect", async () => {
+    let targetCalls = 0;
+    const target = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch() {
+        targetCalls += 1;
+        return Response.json({ reached: true });
+      },
+    });
+    const redirect = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch() {
+        return Response.redirect(`http://127.0.0.1:${target.port}/target`, 302);
+      },
+    });
+    try {
+      const proxy = await startLiveModelEgressProxy({
+        provider: "openai",
+        budgets: { maxInputTokens: 100, maxOutputTokens: 100, maxRequests: 2 },
+        upstreamCredential: "real-model-secret",
+        upstreamOrigin: `http://127.0.0.1:${redirect.port}`,
+        fetchUpstream: (url, init) => fetch(url, init),
+      });
+      proxies.push(proxy);
+
+      expect(
+        (
+          await fetch(`${proxy.url}/responses`, {
+            method: "POST",
+            body: "{}",
+          })
+        ).status,
+      ).toBe(502);
+      expect(targetCalls).toBe(0);
+      expect(proxy.snapshot().failures.at(-1)).toMatchObject({
+        code: "STABILITY_MODEL_PROXY_ERROR",
+        requestNumber: 1,
+      });
+    } finally {
+      redirect.stop(true);
+      target.stop(true);
+    }
   });
 
   test("proxy retains an observer failure before provider dispatch", async () => {

--- a/packages/cloud/e2e/src/stability/live-model-meter.test.ts
+++ b/packages/cloud/e2e/src/stability/live-model-meter.test.ts
@@ -53,10 +53,12 @@ describe("live model usage meter", () => {
         {
           OPENAI_API_KEY: "real-openai-secret",
           ANTHROPIC_API_KEY: "real-anthropic-secret",
+          ELIZA_STABILITY_METER_ATTESTATION_KEY: "parent-attestation-secret",
           RETAINED_VALUE: "retained",
         },
       );
       expect(JSON.stringify(environment)).not.toContain("real-");
+      expect(environment.ELIZA_STABILITY_METER_ATTESTATION_KEY).toBeUndefined();
       expect(environment.RETAINED_VALUE).toBe("retained");
       if (provider === "openai") {
         expect(environment.OPENAI_API_KEY).toContain("placeholder");

--- a/packages/cloud/e2e/src/stability/live-model-meter.test.ts
+++ b/packages/cloud/e2e/src/stability/live-model-meter.test.ts
@@ -635,6 +635,11 @@ describe("live model usage meter", () => {
     expect(proxy.snapshot().failures.at(-1)?.code).toBe(
       "STABILITY_MODEL_REQUEST_BUDGET_EXCEEDED",
     );
+    expect(proxy.snapshot().requestEnvelopes.at(-1)).toMatchObject({
+      accepted: false,
+      forwardedBodyBytes: null,
+      forwardedBodySha256: null,
+    });
   });
 
   test("proxy atomically reserves one admission under concurrent request pressure", async () => {
@@ -905,14 +910,176 @@ describe("live model usage meter", () => {
     },
   );
 
+  test.each([
+    {
+      name: "Anthropic remote URL document",
+      provider: "anthropic" as const,
+      path: "/messages",
+      body: {
+        model: EXPECTED_MODEL,
+        messages: [
+          {
+            role: "user",
+            content: [
+              {
+                type: "document",
+                source: { type: "url", url: "https://example.invalid/doc" },
+              },
+            ],
+          },
+        ],
+        max_tokens: 1,
+      },
+    },
+    {
+      name: "OpenAI provider item reference",
+      provider: "openai" as const,
+      path: "/responses",
+      body: {
+        model: EXPECTED_MODEL,
+        input: [{ type: "item_reference", id: "item_provider_hosted" }],
+        max_output_tokens: 1,
+      },
+    },
+    ...["shell", "local_shell", "apply_patch"].map((type) => ({
+      name: `OpenAI hosted ${type} tool`,
+      provider: "openai" as const,
+      path: "/responses",
+      body: {
+        model: EXPECTED_MODEL,
+        input: "test",
+        tools: [{ type }],
+        max_output_tokens: 1,
+      },
+    })),
+    ...["web_fetch_20250910", "code_execution_20250522"].map((type) => ({
+      name: `Anthropic hosted ${type} tool`,
+      provider: "anthropic" as const,
+      path: "/messages",
+      body: {
+        model: EXPECTED_MODEL,
+        messages: [{ role: "user", content: "test" }],
+        tools: [{ type, name: type, input_schema: {} }],
+        max_tokens: 1,
+      },
+    })),
+    ...[
+      ["fallback routing", { fallbacks: ["claude-expensive"] }],
+      ["default fallback routing", { fallbacks: "default" }],
+      ["container", { container: "container_provider" }],
+      ["context management", { context_management: { edits: [] } }],
+      [
+        "MCP servers",
+        { mcp_servers: [{ url: "https://example.invalid/mcp" }] },
+      ],
+      ["premium speed", { speed: "fast" }],
+      ["inference geography", { inference_geo: "us" }],
+    ].map(([name, extra]) => ({
+      name: `Anthropic ${name}`,
+      provider: "anthropic" as const,
+      path: "/messages",
+      body: {
+        model: EXPECTED_MODEL,
+        messages: [{ role: "user", content: "test" }],
+        max_tokens: 1,
+        ...(extra as object),
+      },
+    })),
+    ...[
+      ["multiple choices", { n: 2 }],
+      ["invalid n", { n: "1" }],
+      ["web search options", { web_search_options: {} }],
+      ["audio modality", { modalities: ["text", "audio"] }],
+      ["premium service tier", { service_tier: "priority" }],
+      [
+        "stream without usage",
+        { stream: true, stream_options: { include_usage: false } },
+      ],
+      [
+        "stream extra controls",
+        { stream: true, stream_options: { include_usage: true, extra: true } },
+      ],
+    ].map(([name, extra]) => ({
+      name: `OpenAI Chat ${name}`,
+      provider: "openai" as const,
+      path: "/chat/completions",
+      body: {
+        model: EXPECTED_MODEL,
+        messages: [{ role: "user", content: "test" }],
+        max_completion_tokens: 1,
+        ...(extra as object),
+      },
+    })),
+    ...[
+      ["background execution", { background: true }],
+      ["container", { container: "container_provider" }],
+      ["premium service tier", { service_tier: "priority" }],
+      ["generic remote URL", { url: "https://example.invalid/context" }],
+    ].map(([name, extra]) => ({
+      name: `OpenAI Responses ${name}`,
+      provider: "openai" as const,
+      path: "/responses",
+      body: {
+        model: EXPECTED_MODEL,
+        input: "test",
+        max_output_tokens: 1,
+        ...(extra as object),
+      },
+    })),
+  ])(
+    "rejects endpoint-schema bypass: $name",
+    async ({ provider, path, body }) => {
+      let upstreamCalls = 0;
+      const proxy = await startLiveModelEgressProxy({
+        provider,
+        expectedModel: EXPECTED_MODEL,
+        budgets: {
+          maxInputTokens: 10_000,
+          maxOutputTokens: 10,
+          maxRequests: 1,
+        },
+        upstreamCredential: "real-model-secret",
+        fetchUpstream: async () => {
+          upstreamCalls += 1;
+          return Response.json({
+            usage: { input_tokens: 1, output_tokens: 1 },
+          });
+        },
+      });
+      proxies.push(proxy);
+      expect(
+        (
+          await fetch(`${proxy.url}${path}`, {
+            method: "POST",
+            body: JSON.stringify(body),
+          })
+        ).status,
+      ).toBe(422);
+      expect(upstreamCalls).toBe(0);
+      expect(proxy.snapshot()).toMatchObject({
+        requestCount: 0,
+        requestEnvelopes: [
+          {
+            accepted: false,
+            forwardedBodyBytes: null,
+            forwardedBodySha256: null,
+          },
+        ],
+      });
+    },
+  );
+
   test("canonicalizes output caps to the remaining attempt budget", async () => {
     const forwardedCaps: number[] = [];
+    const forwardedBodies: string[] = [];
     const proxy = await startLiveModelEgressProxy({
       provider: "openai",
       expectedModel: EXPECTED_MODEL,
       budgets: { maxInputTokens: 20_000, maxOutputTokens: 5, maxRequests: 2 },
       fetchUpstream: async (_url, init) => {
-        const body = JSON.parse(String(init.body)) as {
+        const rawBody = String(init.body);
+        forwardedBodies.push(rawBody);
+        const body = JSON.parse(rawBody) as {
           max_output_tokens: number;
         };
         forwardedCaps.push(body.max_output_tokens);
@@ -949,13 +1116,38 @@ describe("live model usage meter", () => {
       { requestedMaxOutputTokens: 1_000_000, effectiveMaxOutputTokens: 5 },
       { requestedMaxOutputTokens: 1_000_000, effectiveMaxOutputTokens: 2 },
     ]);
+    for (const [index, envelope] of proxy
+      .snapshot()
+      .requestEnvelopes.entries()) {
+      const forwardedBody = forwardedBodies[index] ?? "";
+      expect(envelope.forwardedBodyBytes).toBe(
+        Buffer.byteLength(forwardedBody),
+      );
+      expect(envelope.forwardedBodySha256).toBe(
+        new Bun.CryptoHasher("sha256").update(forwardedBody).digest("hex"),
+      );
+      expect(envelope.inputBudgetCharge).toBe(
+        Math.max(envelope.bodyBytes, Buffer.byteLength(forwardedBody)) + 8_192,
+      );
+    }
   });
 
   test.each([
     {
       provider: "openai" as const,
       path: "/responses",
-      body: { model: EXPECTED_MODEL, input: "test" },
+      body: {
+        model: EXPECTED_MODEL,
+        input: "test",
+        tools: [
+          {
+            type: "function",
+            name: "local_tool",
+            parameters: { type: "object", properties: {} },
+          },
+        ],
+        tool_choice: { type: "function", name: "local_tool" },
+      },
       capField: "max_output_tokens",
     },
     {
@@ -964,6 +1156,17 @@ describe("live model usage meter", () => {
       body: {
         model: EXPECTED_MODEL,
         messages: [{ role: "user", content: "test" }],
+        stream: true,
+        tools: [
+          {
+            type: "function",
+            function: {
+              name: "local_tool",
+              parameters: { type: "object", properties: {} },
+            },
+          },
+        ],
+        tool_choice: { type: "function", function: { name: "local_tool" } },
       },
       capField: "max_completion_tokens",
     },
@@ -974,6 +1177,13 @@ describe("live model usage meter", () => {
         model: EXPECTED_MODEL,
         messages: [{ role: "user", content: "test" }],
         max_tokens: 64_000,
+        tools: [
+          {
+            name: "local_tool",
+            input_schema: { type: "object", properties: {} },
+          },
+        ],
+        tool_choice: { type: "tool", name: "local_tool" },
       },
       capField: "max_tokens",
     },
@@ -1011,6 +1221,9 @@ describe("live model usage meter", () => {
       ).toBe(200);
       expect(forwarded?.model).toBe(EXPECTED_MODEL);
       expect(forwarded?.[capField]).toBe(7);
+      if (path === "/chat/completions") {
+        expect(forwarded?.stream_options).toEqual({ include_usage: true });
+      }
       expect(JSON.stringify(forwarded)).not.toContain("real-model-secret");
     },
   );

--- a/packages/cloud/e2e/src/stability/live-model-meter.test.ts
+++ b/packages/cloud/e2e/src/stability/live-model-meter.test.ts
@@ -1,0 +1,447 @@
+/**
+ * Exercises real-provider token metering and proxy policy with keyless response fixtures.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  LiveModelUsageMeter,
+  type StabilityModelFailureCode,
+  type StabilityModelProxy,
+  startLiveModelEgressProxy,
+} from "./live-model-meter.ts";
+
+const proxies: StabilityModelProxy[] = [];
+
+function reserve(meter: LiveModelUsageMeter) {
+  const admission = meter.reserveRequest();
+  if (!admission.allowed) throw new Error(admission.failure.message);
+  return admission.reservation;
+}
+
+afterEach(async () => {
+  await Promise.all(proxies.splice(0).map((proxy) => proxy.stop()));
+});
+
+describe("live model usage meter", () => {
+  test("parses and cumulatively aggregates OpenAI and Anthropic usage", () => {
+    const openai = new LiveModelUsageMeter("openai", {
+      maxInputTokens: 100,
+      maxOutputTokens: 100,
+      maxRequests: 3,
+    });
+    openai.recordSuccessfulResponse(
+      reserve(openai),
+      "application/json",
+      Buffer.from(
+        JSON.stringify({ usage: { prompt_tokens: 7, completion_tokens: 3 } }),
+      ),
+    );
+    openai.recordSuccessfulResponse(
+      reserve(openai),
+      "application/json",
+      Buffer.from(
+        JSON.stringify({ usage: { input_tokens: 5, output_tokens: 2 } }),
+      ),
+    );
+    expect(openai.snapshot()).toMatchObject({
+      requestCount: 2,
+      inputTokens: 12,
+      outputTokens: 5,
+      failures: [],
+    });
+
+    const anthropic = new LiveModelUsageMeter("anthropic", {
+      maxInputTokens: 100,
+      maxOutputTokens: 100,
+      maxRequests: 2,
+    });
+    anthropic.recordSuccessfulResponse(
+      reserve(anthropic),
+      "application/json",
+      Buffer.from(
+        JSON.stringify({ usage: { input_tokens: 11, output_tokens: 4 } }),
+      ),
+    );
+    expect(anthropic.snapshot()).toMatchObject({
+      inputTokens: 11,
+      outputTokens: 4,
+    });
+  });
+
+  test("accepts the exact boundary and blocks any further provider request", () => {
+    const meter = new LiveModelUsageMeter("openai", {
+      maxInputTokens: 10,
+      maxOutputTokens: 5,
+      maxRequests: 2,
+    });
+    meter.recordSuccessfulResponse(
+      reserve(meter),
+      "application/json",
+      Buffer.from(
+        JSON.stringify({ usage: { prompt_tokens: 10, completion_tokens: 5 } }),
+      ),
+    );
+    expect(meter.reserveRequest()).toMatchObject({
+      allowed: false,
+      failure: { code: "STABILITY_MODEL_TOKEN_BUDGET_EXHAUSTED" },
+    });
+  });
+
+  test("fails closed on over-budget, missing, malformed, and zero usage", () => {
+    const cases: Array<[string, unknown, StabilityModelFailureCode]> = [
+      [
+        "over",
+        { usage: { prompt_tokens: 11, completion_tokens: 1 } },
+        "STABILITY_MODEL_TOKEN_BUDGET_EXCEEDED",
+      ],
+      ["missing", { id: "response" }, "STABILITY_MODEL_USAGE_MISSING"],
+      [
+        "malformed",
+        { usage: { prompt_tokens: "ten", completion_tokens: 1 } },
+        "STABILITY_MODEL_USAGE_MALFORMED",
+      ],
+      [
+        "zero",
+        { usage: { prompt_tokens: 0, completion_tokens: 0 } },
+        "STABILITY_MODEL_USAGE_MALFORMED",
+      ],
+    ];
+    for (const [, payload, code] of cases) {
+      const meter = new LiveModelUsageMeter("openai", {
+        maxInputTokens: 10,
+        maxOutputTokens: 10,
+        maxRequests: 2,
+      });
+      expect(() =>
+        meter.recordSuccessfulResponse(
+          reserve(meter),
+          "application/json",
+          Buffer.from(JSON.stringify(payload)),
+        ),
+      ).toThrow(new RegExp(code));
+      expect(meter.snapshot().failures.at(-1)?.code).toBe(code);
+    }
+  });
+
+  test("extracts authoritative usage from OpenAI and Anthropic SSE", () => {
+    const openai = new LiveModelUsageMeter("openai", {
+      maxInputTokens: 100,
+      maxOutputTokens: 100,
+      maxRequests: 1,
+    });
+    openai.recordSuccessfulResponse(
+      reserve(openai),
+      "text/event-stream",
+      Buffer.from(
+        'data: {"type":"response.completed","response":{"usage":{"input_tokens":13,"output_tokens":6}}}\n\ndata: [DONE]\n\n',
+      ),
+    );
+    expect(openai.snapshot()).toMatchObject({
+      inputTokens: 13,
+      outputTokens: 6,
+    });
+
+    const anthropic = new LiveModelUsageMeter("anthropic", {
+      maxInputTokens: 100,
+      maxOutputTokens: 100,
+      maxRequests: 1,
+    });
+    anthropic.recordSuccessfulResponse(
+      reserve(anthropic),
+      "text/event-stream",
+      Buffer.from(
+        'data: {"type":"message_start","message":{"usage":{"input_tokens":2,"cache_creation_input_tokens":3,"cache_read_input_tokens":4,"output_tokens":0}}}\n\ndata: {"type":"message_delta","usage":{"output_tokens":4}}\n\n',
+      ),
+    );
+    expect(anthropic.snapshot()).toMatchObject({
+      inputTokens: 9,
+      outputTokens: 4,
+    });
+  });
+
+  test("counts Anthropic cache-only input and rejects unsafe aggregate overflow", () => {
+    const cacheOnly = new LiveModelUsageMeter("anthropic", {
+      maxInputTokens: 100,
+      maxOutputTokens: 100,
+      maxRequests: 1,
+    });
+    cacheOnly.recordSuccessfulResponse(
+      reserve(cacheOnly),
+      "application/json",
+      Buffer.from(
+        JSON.stringify({
+          usage: {
+            input_tokens: 0,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 17,
+            output_tokens: 2,
+          },
+        }),
+      ),
+    );
+    expect(cacheOnly.snapshot()).toMatchObject({
+      inputTokens: 17,
+      outputTokens: 2,
+    });
+
+    const overflow = new LiveModelUsageMeter("anthropic", {
+      maxInputTokens: Number.MAX_SAFE_INTEGER,
+      maxOutputTokens: 100,
+      maxRequests: 1,
+    });
+    expect(() =>
+      overflow.recordSuccessfulResponse(
+        reserve(overflow),
+        "application/json",
+        Buffer.from(
+          JSON.stringify({
+            usage: {
+              input_tokens: Number.MAX_SAFE_INTEGER,
+              cache_read_input_tokens: 1,
+              output_tokens: 1,
+            },
+          }),
+        ),
+      ),
+    ).toThrow("STABILITY_MODEL_USAGE_MALFORMED");
+  });
+
+  test("proxy records provider errors and timeouts without fabricating usage", async () => {
+    for (const fixture of [
+      {
+        response: new Response("provider rejected", { status: 429 }),
+        code: "STABILITY_MODEL_PROVIDER_ERROR",
+      },
+      { response: null, code: "STABILITY_MODEL_PROVIDER_TIMEOUT" },
+    ] as const) {
+      const proxy = await startLiveModelEgressProxy({
+        provider: "openai",
+        budgets: { maxInputTokens: 100, maxOutputTokens: 100, maxRequests: 2 },
+        upstreamTimeoutMs: 5,
+        fetchUpstream: fixture.response
+          ? async () => fixture.response
+          : async (_url, init) =>
+              await new Promise<Response>((_resolve, reject) => {
+                init.signal?.addEventListener("abort", () =>
+                  reject(init.signal?.reason),
+                );
+              }),
+      });
+      proxies.push(proxy);
+      const response = await fetch(`${proxy.url}/chat/completions`, {
+        method: "POST",
+        body: "{}",
+      });
+      expect(response.ok).toBe(false);
+      expect(proxy.snapshot().failures.at(-1)?.code).toBe(fixture.code);
+      expect(proxy.snapshot()).toMatchObject({
+        inputTokens: 0,
+        outputTokens: 0,
+      });
+    }
+  });
+
+  test("proxy enforces request cap before a further upstream call", async () => {
+    let upstreamCalls = 0;
+    const proxy = await startLiveModelEgressProxy({
+      provider: "openai",
+      budgets: { maxInputTokens: 100, maxOutputTokens: 100, maxRequests: 1 },
+      fetchUpstream: async () => {
+        upstreamCalls += 1;
+        return Response.json({
+          usage: { prompt_tokens: 2, completion_tokens: 1 },
+        });
+      },
+    });
+    proxies.push(proxy);
+    expect(
+      (await fetch(`${proxy.url}/responses`, { method: "POST", body: "{}" }))
+        .ok,
+    ).toBe(true);
+    expect(
+      (await fetch(`${proxy.url}/responses`, { method: "POST", body: "{}" }))
+        .status,
+    ).toBe(429);
+    expect(upstreamCalls).toBe(1);
+    expect(proxy.snapshot().failures.at(-1)?.code).toBe(
+      "STABILITY_MODEL_REQUEST_BUDGET_EXCEEDED",
+    );
+  });
+
+  test("proxy atomically reserves one admission under concurrent request pressure", async () => {
+    let upstreamCalls = 0;
+    let releaseUpstream: (() => void) | undefined;
+    const upstreamBlocked = new Promise<void>((resolve) => {
+      releaseUpstream = resolve;
+    });
+    const proxy = await startLiveModelEgressProxy({
+      provider: "openai",
+      budgets: { maxInputTokens: 100, maxOutputTokens: 100, maxRequests: 1 },
+      fetchUpstream: async () => {
+        upstreamCalls += 1;
+        await upstreamBlocked;
+        return Response.json({
+          usage: { prompt_tokens: 2, completion_tokens: 1 },
+        });
+      },
+    });
+    proxies.push(proxy);
+
+    const requests = Array.from({ length: 8 }, () =>
+      fetch(`${proxy.url}/responses`, { method: "POST", body: "{}" }),
+    );
+    await Bun.sleep(10);
+    expect(upstreamCalls).toBe(1);
+    releaseUpstream?.();
+    const responses = await Promise.all(requests);
+
+    expect(responses.filter((response) => response.ok)).toHaveLength(1);
+    expect(
+      responses.filter((response) => response.status === 429),
+    ).toHaveLength(7);
+    expect(upstreamCalls).toBe(1);
+    expect(proxy.snapshot()).toMatchObject({
+      requestCount: 1,
+      inputTokens: 2,
+      outputTokens: 1,
+    });
+    expect(
+      proxy
+        .snapshot()
+        .failures.filter(
+          (failure) =>
+            failure.code === "STABILITY_MODEL_REQUEST_BUDGET_EXCEEDED",
+        ),
+    ).toHaveLength(1);
+  });
+
+  test("proxy serializes exchanges so concurrent calls cannot admit against stale token totals", async () => {
+    let upstreamCalls = 0;
+    const proxy = await startLiveModelEgressProxy({
+      provider: "openai",
+      budgets: { maxInputTokens: 2, maxOutputTokens: 1, maxRequests: 8 },
+      fetchUpstream: async () => {
+        upstreamCalls += 1;
+        await Bun.sleep(5);
+        return Response.json({
+          usage: { prompt_tokens: 2, completion_tokens: 1 },
+        });
+      },
+    });
+    proxies.push(proxy);
+
+    const responses = await Promise.all(
+      Array.from({ length: 8 }, () =>
+        fetch(`${proxy.url}/responses`, { method: "POST", body: "{}" }),
+      ),
+    );
+
+    expect(responses.filter((response) => response.ok)).toHaveLength(1);
+    expect(
+      responses.filter((response) => response.status === 429),
+    ).toHaveLength(7);
+    expect(upstreamCalls).toBe(1);
+    expect(proxy.snapshot()).toMatchObject({
+      requestCount: 1,
+      inputTokens: 2,
+      outputTokens: 1,
+    });
+    expect(proxy.snapshot().failures).toEqual([
+      expect.objectContaining({
+        code: "STABILITY_MODEL_TOKEN_BUDGET_EXHAUSTED",
+        requestNumber: 2,
+      }),
+    ]);
+  });
+
+  test("proxy counts and retains an oversized upstream response", async () => {
+    const proxy = await startLiveModelEgressProxy({
+      provider: "openai",
+      budgets: { maxInputTokens: 100, maxOutputTokens: 100, maxRequests: 2 },
+      fetchUpstream: async () =>
+        new Response(new Uint8Array(16 * 1024 * 1024 + 1), { status: 200 }),
+    });
+    proxies.push(proxy);
+    expect(
+      (await fetch(`${proxy.url}/responses`, { method: "POST", body: "{}" }))
+        .status,
+    ).toBe(502);
+    expect(proxy.snapshot()).toMatchObject({
+      requestCount: 1,
+      inputTokens: 0,
+      outputTokens: 0,
+    });
+    expect(proxy.snapshot().failures.at(-1)?.code).toBe(
+      "STABILITY_MODEL_PROXY_ERROR",
+    );
+  });
+
+  test("proxy retains an observer failure before provider dispatch", async () => {
+    let upstreamCalls = 0;
+    const proxy = await startLiveModelEgressProxy({
+      provider: "openai",
+      budgets: { maxInputTokens: 100, maxOutputTokens: 100, maxRequests: 2 },
+      fetchUpstream: async () => {
+        upstreamCalls += 1;
+        return Response.json({
+          usage: { prompt_tokens: 2, completion_tokens: 1 },
+        });
+      },
+      onUpstreamRequest: () => {
+        throw new Error("injected ledger boundary failure");
+      },
+    });
+    proxies.push(proxy);
+    expect(
+      (await fetch(`${proxy.url}/responses`, { method: "POST", body: "{}" }))
+        .status,
+    ).toBe(502);
+    expect(upstreamCalls).toBe(0);
+    expect(proxy.snapshot().requestCount).toBe(1);
+    expect(proxy.snapshot().failures.at(-1)?.code).toBe(
+      "STABILITY_MODEL_PROXY_ERROR",
+    );
+  });
+
+  test("proxy retains a response-boundary failure after successful metering", async () => {
+    const proxy = await startLiveModelEgressProxy({
+      provider: "openai",
+      budgets: { maxInputTokens: 100, maxOutputTokens: 100, maxRequests: 2 },
+      fetchUpstream: async () =>
+        ({
+          ok: true,
+          status: 200,
+          headers: {
+            get: () => "application/json",
+            [Symbol.iterator](): IterableIterator<[string, string]> {
+              throw new Error("injected response header boundary failure");
+            },
+          },
+          arrayBuffer: async () =>
+            new TextEncoder().encode(
+              JSON.stringify({
+                usage: { prompt_tokens: 2, completion_tokens: 1 },
+              }),
+            ).buffer,
+        }) as unknown as Response,
+    });
+    proxies.push(proxy);
+
+    expect(
+      (await fetch(`${proxy.url}/responses`, { method: "POST", body: "{}" }))
+        .status,
+    ).toBe(502);
+    expect(proxy.snapshot()).toMatchObject({
+      requestCount: 1,
+      inputTokens: 2,
+      outputTokens: 1,
+    });
+    expect(proxy.snapshot().failures).toEqual([
+      expect.objectContaining({
+        code: "STABILITY_MODEL_PROXY_ERROR",
+        requestNumber: 1,
+        message: "injected response header boundary failure",
+      }),
+    ]);
+  });
+});

--- a/packages/cloud/e2e/src/stability/live-model-meter.ts
+++ b/packages/cloud/e2e/src/stability/live-model-meter.ts
@@ -1,0 +1,586 @@
+/**
+ * Meters selected live-model responses at the loopback egress boundary and
+ * rejects unaccounted or over-budget provider traffic before it reaches the scenario.
+ */
+
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+
+export type StabilityModelProvider = "openai" | "anthropic";
+
+export interface StabilityModelBudgets {
+  maxInputTokens: number;
+  maxOutputTokens: number;
+  maxRequests: number;
+}
+
+export type StabilityModelFailureCode =
+  | "STABILITY_MODEL_USAGE_MISSING"
+  | "STABILITY_MODEL_USAGE_MALFORMED"
+  | "STABILITY_MODEL_TOKEN_BUDGET_EXCEEDED"
+  | "STABILITY_MODEL_TOKEN_BUDGET_EXHAUSTED"
+  | "STABILITY_MODEL_REQUEST_BUDGET_EXCEEDED"
+  | "STABILITY_MODEL_PROVIDER_ERROR"
+  | "STABILITY_MODEL_PROVIDER_TIMEOUT"
+  | "STABILITY_MODEL_PROXY_ERROR";
+
+export interface StabilityModelFailure {
+  code: StabilityModelFailureCode;
+  message: string;
+  requestNumber: number;
+}
+
+export interface StabilityModelMeterSnapshot {
+  requestCount: number;
+  inputTokens: number;
+  outputTokens: number;
+  failures: StabilityModelFailure[];
+}
+
+export interface StabilityModelRequestReservation {
+  requestNumber: number;
+}
+
+export type StabilityModelRequestAdmission =
+  | { allowed: true; reservation: StabilityModelRequestReservation }
+  | { allowed: false; failure: StabilityModelFailure };
+
+export class StabilityModelMeterError extends Error {
+  constructor(
+    readonly code: StabilityModelFailureCode,
+    message: string,
+  ) {
+    super(`${code}: ${message}`);
+    this.name = "StabilityModelMeterError";
+  }
+}
+
+interface ProviderUsage {
+  inputTokens: number;
+  outputTokens: number;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function parseCount(value: unknown, field: string, positive: boolean): number {
+  if (
+    !Number.isSafeInteger(value) ||
+    (positive ? (value as number) <= 0 : (value as number) < 0)
+  ) {
+    throw new StabilityModelMeterError(
+      "STABILITY_MODEL_USAGE_MALFORMED",
+      `${field} must be a ${positive ? "positive" : "non-negative"} safe integer`,
+    );
+  }
+  return value as number;
+}
+
+function anthropicInputTokens(usage: Record<string, unknown>): number {
+  const inputTokens = parseCount(
+    usage.input_tokens,
+    "input token usage",
+    false,
+  );
+  const cacheCreation =
+    usage.cache_creation_input_tokens === undefined
+      ? 0
+      : parseCount(
+          usage.cache_creation_input_tokens,
+          "cache creation input token usage",
+          false,
+        );
+  const cacheRead =
+    usage.cache_read_input_tokens === undefined
+      ? 0
+      : parseCount(
+          usage.cache_read_input_tokens,
+          "cache read input token usage",
+          false,
+        );
+  const total = inputTokens + cacheCreation + cacheRead;
+  if (!Number.isSafeInteger(total) || total <= 0) {
+    throw new StabilityModelMeterError(
+      "STABILITY_MODEL_USAGE_MALFORMED",
+      "Anthropic total input token usage must be a positive safe integer",
+    );
+  }
+  return total;
+}
+
+function usageFromRecord(
+  provider: StabilityModelProvider,
+  value: unknown,
+): ProviderUsage | null {
+  const root = asRecord(value);
+  if (!root) return null;
+  const response = asRecord(root.response);
+  const message = asRecord(root.message);
+  const usage =
+    asRecord(root.usage) ??
+    asRecord(response?.usage) ??
+    asRecord(message?.usage);
+  if (!usage) return null;
+  const input =
+    provider === "openai"
+      ? (usage.input_tokens ?? usage.prompt_tokens)
+      : usage.input_tokens;
+  const output =
+    provider === "openai"
+      ? (usage.output_tokens ?? usage.completion_tokens)
+      : usage.output_tokens;
+  return {
+    inputTokens:
+      provider === "anthropic"
+        ? anthropicInputTokens(usage)
+        : parseCount(input, "input token usage", true),
+    outputTokens: parseCount(output, "output token usage", false),
+  };
+}
+
+function parseJson(bytes: Buffer): unknown {
+  try {
+    return JSON.parse(bytes.toString("utf8"));
+  } catch (error) {
+    // error-policy:J2 Provider bytes are untrusted and the metering boundary must retain the parse cause.
+    throw new StabilityModelMeterError(
+      "STABILITY_MODEL_USAGE_MALFORMED",
+      `provider response is not valid JSON: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+function parseSseUsage(
+  provider: StabilityModelProvider,
+  bytes: Buffer,
+): ProviderUsage | null {
+  let inputTokens: number | undefined;
+  let outputTokens: number | undefined;
+  for (const line of bytes.toString("utf8").split(/\r?\n/)) {
+    if (!line.startsWith("data:")) continue;
+    const data = line.slice(5).trim();
+    if (!data || data === "[DONE]") continue;
+    const payload = parseJson(Buffer.from(data));
+    if (provider === "openai") {
+      const usage = usageFromRecord(provider, payload);
+      if (!usage) continue;
+      inputTokens = usage.inputTokens;
+      outputTokens = usage.outputTokens;
+      continue;
+    }
+    const root = asRecord(payload);
+    const message = asRecord(root?.message);
+    const usage = asRecord(root?.usage) ?? asRecord(message?.usage);
+    if (!usage) continue;
+    if (usage.input_tokens !== undefined) {
+      inputTokens = anthropicInputTokens(usage);
+    }
+    if (usage.output_tokens !== undefined) {
+      outputTokens = parseCount(
+        usage.output_tokens,
+        "output token usage",
+        false,
+      );
+    }
+  }
+  if (inputTokens === undefined || outputTokens === undefined) return null;
+  return { inputTokens, outputTokens };
+}
+
+function parseProviderUsage(
+  provider: StabilityModelProvider,
+  contentType: string,
+  bytes: Buffer,
+): ProviderUsage {
+  const usage = contentType.toLowerCase().includes("text/event-stream")
+    ? parseSseUsage(provider, bytes)
+    : usageFromRecord(provider, parseJson(bytes));
+  if (!usage) {
+    throw new StabilityModelMeterError(
+      "STABILITY_MODEL_USAGE_MISSING",
+      `${provider} successful response omitted authoritative token usage`,
+    );
+  }
+  return usage;
+}
+
+function assertBudget(value: number, field: string): void {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`${field} must be a positive safe integer`);
+  }
+}
+
+/** Aggregates authoritative usage and holds a failed meter closed for the attempt. */
+export class LiveModelUsageMeter {
+  #requestCount = 0;
+  #inputTokens = 0;
+  #outputTokens = 0;
+  readonly #failures: StabilityModelFailure[] = [];
+
+  constructor(
+    readonly provider: StabilityModelProvider,
+    readonly budgets: StabilityModelBudgets,
+  ) {
+    assertBudget(budgets.maxInputTokens, "maxInputTokens");
+    assertBudget(budgets.maxOutputTokens, "maxOutputTokens");
+    assertBudget(budgets.maxRequests, "maxRequests");
+  }
+
+  #failure(
+    code: StabilityModelFailureCode,
+    message: string,
+    requestNumber = this.#requestCount + 1,
+  ): StabilityModelMeterError {
+    this.#failures.push({
+      code,
+      message,
+      requestNumber,
+    });
+    return new StabilityModelMeterError(code, message);
+  }
+
+  reserveRequest(): StabilityModelRequestAdmission {
+    const retained = this.#failures.at(-1);
+    if (retained) return { allowed: false, failure: retained };
+    if (this.#requestCount >= this.budgets.maxRequests) {
+      const error = this.#failure(
+        "STABILITY_MODEL_REQUEST_BUDGET_EXCEEDED",
+        `model request budget ${this.budgets.maxRequests} is exhausted`,
+      );
+      return {
+        allowed: false,
+        failure: this.#failures.at(-1) ?? {
+          code: error.code,
+          message: error.message,
+          requestNumber: this.#requestCount + 1,
+        },
+      };
+    }
+    if (
+      this.#inputTokens >= this.budgets.maxInputTokens ||
+      this.#outputTokens >= this.budgets.maxOutputTokens
+    ) {
+      const error = this.#failure(
+        "STABILITY_MODEL_TOKEN_BUDGET_EXHAUSTED",
+        "token budget is exhausted; refusing another provider request",
+      );
+      return {
+        allowed: false,
+        failure: this.#failures.at(-1) ?? {
+          code: error.code,
+          message: error.message,
+          requestNumber: this.#requestCount + 1,
+        },
+      };
+    }
+    this.#requestCount += 1;
+    return {
+      allowed: true,
+      reservation: { requestNumber: this.#requestCount },
+    };
+  }
+
+  recordSuccessfulResponse(
+    reservation: StabilityModelRequestReservation,
+    contentType: string,
+    bytes: Buffer,
+  ): void {
+    let usage: ProviderUsage;
+    try {
+      usage = parseProviderUsage(this.provider, contentType, bytes);
+    } catch (error) {
+      // error-policy:J2 Meter failures become retained typed attempt evidence before rethrow.
+      const meterError =
+        error instanceof StabilityModelMeterError
+          ? error
+          : new StabilityModelMeterError(
+              "STABILITY_MODEL_USAGE_MALFORMED",
+              error instanceof Error ? error.message : String(error),
+            );
+      this.#failures.push({
+        code: meterError.code,
+        message: meterError.message,
+        requestNumber: reservation.requestNumber,
+      });
+      throw meterError;
+    }
+    this.#inputTokens += usage.inputTokens;
+    this.#outputTokens += usage.outputTokens;
+    if (
+      this.#inputTokens > this.budgets.maxInputTokens ||
+      this.#outputTokens > this.budgets.maxOutputTokens
+    ) {
+      const error = new StabilityModelMeterError(
+        "STABILITY_MODEL_TOKEN_BUDGET_EXCEEDED",
+        `cumulative usage ${this.#inputTokens}/${this.#outputTokens} exceeds ${this.budgets.maxInputTokens}/${this.budgets.maxOutputTokens}`,
+      );
+      this.#failures.push({
+        code: error.code,
+        message: error.message,
+        requestNumber: reservation.requestNumber,
+      });
+      throw error;
+    }
+  }
+
+  recordProviderFailure(
+    reservation: StabilityModelRequestReservation,
+    code: "STABILITY_MODEL_PROVIDER_ERROR" | "STABILITY_MODEL_PROVIDER_TIMEOUT",
+    message: string,
+  ): void {
+    this.#failures.push({
+      code,
+      message,
+      requestNumber: reservation.requestNumber,
+    });
+  }
+
+  recordProxyFailure(
+    message: string,
+    reservation?: StabilityModelRequestReservation,
+  ): void {
+    this.#failures.push({
+      code: "STABILITY_MODEL_PROXY_ERROR",
+      message,
+      requestNumber: reservation?.requestNumber ?? this.#requestCount + 1,
+    });
+  }
+
+  snapshot(): StabilityModelMeterSnapshot {
+    return {
+      requestCount: this.#requestCount,
+      inputTokens: this.#inputTokens,
+      outputTokens: this.#outputTokens,
+      failures: structuredClone(this.#failures),
+    };
+  }
+}
+
+export interface StabilityModelProxy {
+  url: string;
+  snapshot(): StabilityModelMeterSnapshot;
+  stop(): Promise<void>;
+}
+
+export async function startLiveModelEgressProxy(options: {
+  provider: StabilityModelProvider;
+  budgets: StabilityModelBudgets;
+  fetchUpstream?: (url: string, init: RequestInit) => Promise<Response>;
+  upstreamOrigin?: string;
+  upstreamTimeoutMs?: number;
+  onUpstreamRequest?: (origin: string, method: string) => void;
+}): Promise<StabilityModelProxy> {
+  const origin =
+    options.upstreamOrigin ??
+    (options.provider === "openai"
+      ? "https://api.openai.com"
+      : "https://api.anthropic.com");
+  const meter = new LiveModelUsageMeter(options.provider, options.budgets);
+  const fetchUpstream = options.fetchUpstream ?? globalThis.fetch;
+  const timeoutMs = options.upstreamTimeoutMs ?? 120_000;
+  let exchangeTail = Promise.resolve();
+  const acquireExchange = async (): Promise<() => void> => {
+    const previous = exchangeTail;
+    let release = (): void => {};
+    exchangeTail = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await previous;
+    return release;
+  };
+  const server = createServer((request, response) => {
+    let reservation: StabilityModelRequestReservation | undefined;
+    let failureRecorded = false;
+    void (async () => {
+      const chunks: Buffer[] = [];
+      let requestBytes = 0;
+      for await (const chunk of request) {
+        const bytes = Buffer.from(chunk);
+        requestBytes += bytes.byteLength;
+        if (requestBytes > 8 * 1024 * 1024) {
+          const message = "provider proxy request exceeded 8 MiB";
+          meter.recordProxyFailure(message);
+          failureRecorded = true;
+          response.writeHead(413, { "content-type": "application/json" });
+          response.end(
+            JSON.stringify({ error: meter.snapshot().failures.at(-1) }),
+          );
+          return;
+        }
+        chunks.push(bytes);
+      }
+      const releaseExchange = await acquireExchange();
+      try {
+        const admission = meter.reserveRequest();
+        if (!admission.allowed) {
+          failureRecorded = true;
+          response.writeHead(429, { "content-type": "application/json" });
+          response.end(JSON.stringify({ error: admission.failure }));
+          return;
+        }
+        reservation = admission.reservation;
+        options.onUpstreamRequest?.(origin, request.method ?? "GET");
+        let upstream: Response;
+        try {
+          upstream = await fetchUpstream(`${origin}${request.url ?? "/"}`, {
+            method: request.method,
+            headers: Object.fromEntries(
+              Object.entries(request.headers).flatMap(([key, value]) =>
+                value === undefined
+                  ? []
+                  : [[key, Array.isArray(value) ? value.join(",") : value]],
+              ),
+            ),
+            body: chunks.length > 0 ? Buffer.concat(chunks) : undefined,
+            signal: AbortSignal.timeout(timeoutMs),
+          });
+        } catch (error) {
+          // error-policy:J1 The proxy translates provider timeouts/transport failures into typed attempt evidence.
+          const timedOut =
+            error instanceof Error && error.name === "TimeoutError";
+          meter.recordProviderFailure(
+            reservation,
+            timedOut
+              ? "STABILITY_MODEL_PROVIDER_TIMEOUT"
+              : "STABILITY_MODEL_PROVIDER_ERROR",
+            error instanceof Error ? error.message : String(error),
+          );
+          failureRecorded = true;
+          response.writeHead(timedOut ? 504 : 502, {
+            "content-type": "application/json",
+          });
+          response.end(
+            JSON.stringify({ error: meter.snapshot().failures.at(-1) }),
+          );
+          return;
+        }
+        let responseBytes: Buffer;
+        try {
+          responseBytes = Buffer.from(await upstream.arrayBuffer());
+        } catch (error) {
+          // error-policy:J1 An unreadable upstream response is retained as a counted proxy failure.
+          meter.recordProxyFailure(
+            error instanceof Error ? error.message : String(error),
+            reservation,
+          );
+          failureRecorded = true;
+          response.writeHead(502, { "content-type": "application/json" });
+          response.end(
+            JSON.stringify({ error: meter.snapshot().failures.at(-1) }),
+          );
+          return;
+        }
+        if (responseBytes.byteLength > 16 * 1024 * 1024) {
+          meter.recordProxyFailure(
+            "provider proxy response exceeded 16 MiB",
+            reservation,
+          );
+          failureRecorded = true;
+          response.writeHead(502, { "content-type": "application/json" });
+          response.end(
+            JSON.stringify({ error: meter.snapshot().failures.at(-1) }),
+          );
+          return;
+        }
+        if (!upstream.ok) {
+          meter.recordProviderFailure(
+            reservation,
+            "STABILITY_MODEL_PROVIDER_ERROR",
+            `provider returned HTTP ${upstream.status}`,
+          );
+          failureRecorded = true;
+        } else {
+          try {
+            meter.recordSuccessfulResponse(
+              reservation,
+              upstream.headers.get("content-type") ?? "application/json",
+              responseBytes,
+            );
+          } catch (error) {
+            failureRecorded = true;
+            // error-policy:J1 Metering failures are returned to the model client and retained in the attempt ledger.
+            response.writeHead(502, { "content-type": "application/json" });
+            response.end(
+              JSON.stringify({
+                error: {
+                  code:
+                    error instanceof StabilityModelMeterError
+                      ? error.code
+                      : "STABILITY_MODEL_USAGE_MALFORMED",
+                  message:
+                    error instanceof Error ? error.message : String(error),
+                },
+              }),
+            );
+            return;
+          }
+        }
+        const headers = Object.fromEntries(upstream.headers);
+        delete headers["content-encoding"];
+        delete headers["content-length"];
+        delete headers.connection;
+        delete headers["transfer-encoding"];
+        response.writeHead(upstream.status, headers);
+        response.end(responseBytes);
+      } catch (error) {
+        // error-policy:J1 A post-admission proxy boundary failure is retained before the serialized exchange is released.
+        if (!failureRecorded) {
+          meter.recordProxyFailure(
+            error instanceof Error ? error.message : "provider proxy failure",
+            reservation,
+          );
+          failureRecorded = true;
+        }
+        if (!response.headersSent)
+          response.writeHead(502, { "content-type": "application/json" });
+        response.end(
+          JSON.stringify({
+            error: {
+              message:
+                error instanceof Error
+                  ? error.message
+                  : "provider proxy failure",
+            },
+          }),
+        );
+      } finally {
+        releaseExchange();
+      }
+    })().catch((error: unknown) => {
+      // error-policy:J1 The HTTP boundary emits a bounded failure rather than an unhandled rejection.
+      if (!failureRecorded) {
+        meter.recordProxyFailure(
+          error instanceof Error ? error.message : "provider proxy failure",
+          reservation,
+        );
+        failureRecorded = true;
+      }
+      if (!response.headersSent)
+        response.writeHead(502, { "content-type": "application/json" });
+      response.end(
+        JSON.stringify({
+          error: {
+            message:
+              error instanceof Error ? error.message : "provider proxy failure",
+          },
+        }),
+      );
+    });
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const port = (server.address() as AddressInfo).port;
+  return {
+    url: `http://127.0.0.1:${port}/v1`,
+    snapshot: () => meter.snapshot(),
+    stop: () =>
+      new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve())),
+      ),
+  };
+}

--- a/packages/cloud/e2e/src/stability/live-model-meter.ts
+++ b/packages/cloud/e2e/src/stability/live-model-meter.ts
@@ -15,6 +15,7 @@ export interface StabilityModelBudgets {
 }
 
 export type StabilityModelFailureCode =
+  | "STABILITY_MODEL_PRE_DISPATCH_REJECTED"
   | "STABILITY_MODEL_USAGE_MISSING"
   | "STABILITY_MODEL_USAGE_MALFORMED"
   | "STABILITY_MODEL_TOKEN_BUDGET_EXCEEDED"
@@ -35,6 +36,20 @@ export interface StabilityModelMeterSnapshot {
   inputTokens: number;
   outputTokens: number;
   failures: StabilityModelFailure[];
+  requestEnvelopes: StabilityModelRequestEnvelopeEvidence[];
+}
+
+export interface StabilityModelRequestEnvelopeEvidence {
+  requestNumber: number;
+  method: string;
+  route: string;
+  bodyBytes: number;
+  observedModel: string | null;
+  requestedMaxOutputTokens: number | null;
+  effectiveMaxOutputTokens: number | null;
+  inputBudgetCharge: number | null;
+  accepted: boolean;
+  failureCode?: StabilityModelFailureCode;
 }
 
 export interface StabilityModelRequestReservation {
@@ -59,6 +74,8 @@ interface ProviderUsage {
   inputTokens: number;
   outputTokens: number;
 }
+
+const INPUT_TOKEN_OVERHEAD_RESERVE = 8_192;
 
 function asRecord(value: unknown): Record<string, unknown> | null {
   return value !== null && typeof value === "object" && !Array.isArray(value)
@@ -229,12 +246,280 @@ function providerRouteAllowed(
     : target.pathname === "/v1/messages";
 }
 
+function preDispatchError(message: string): StabilityModelMeterError {
+  return new StabilityModelMeterError(
+    "STABILITY_MODEL_PRE_DISPATCH_REJECTED",
+    message,
+  );
+}
+
+function containsUnsupportedProviderInput(value: unknown): boolean {
+  if (Array.isArray(value)) return value.some(containsUnsupportedProviderInput);
+  const record = asRecord(value);
+  if (!record) return false;
+  for (const [key, child] of Object.entries(record)) {
+    const normalizedKey = key.toLowerCase();
+    if (
+      [
+        "image_url",
+        "file_id",
+        "file_url",
+        "input_audio",
+        "audio_url",
+        "video_url",
+      ].includes(normalizedKey)
+    ) {
+      return true;
+    }
+    if (
+      normalizedKey === "type" &&
+      typeof child === "string" &&
+      /(?:image|audio|video|file|web_search|computer|code_interpreter|mcp|connector)/iu.test(
+        child,
+      )
+    ) {
+      return true;
+    }
+    if (containsUnsupportedProviderInput(child)) return true;
+  }
+  return false;
+}
+
+function positiveOutputCap(value: unknown, field: string): number {
+  if (!Number.isSafeInteger(value) || (value as number) <= 0) {
+    throw preDispatchError(`${field} must be a positive safe integer`);
+  }
+  return value as number;
+}
+
+function parseRequestEnvelope(input: {
+  provider: StabilityModelProvider;
+  route: string;
+  bytes: Buffer;
+  expectedModel: string;
+  remainingInputTokens: number;
+  remainingOutputTokens: number;
+}): Omit<
+  StabilityModelRequestEnvelopeEvidence,
+  "requestNumber" | "method" | "route" | "accepted" | "failureCode"
+> & { forwardBody: Buffer } {
+  let value: unknown;
+  try {
+    value = JSON.parse(input.bytes.toString("utf8"));
+  } catch (error) {
+    // error-policy:J3 The provider request is untrusted and malformed JSON is rejected before dispatch.
+    throw preDispatchError(
+      `provider request body must be valid JSON: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  const body = asRecord(value);
+  if (!body) throw preDispatchError("provider request body must be an object");
+  const observedModel =
+    typeof body.model === "string" && body.model.length <= 512
+      ? body.model
+      : null;
+  if (observedModel !== input.expectedModel) {
+    throw preDispatchError(
+      "provider request model does not match the stability target",
+    );
+  }
+  for (const indirectContext of [
+    "conversation",
+    "previous_response_id",
+    "prompt",
+  ]) {
+    if (body[indirectContext] !== undefined) {
+      throw preDispatchError(
+        `${indirectContext} provider-hosted context is unsupported`,
+      );
+    }
+  }
+
+  let requestedMaxOutputTokens: number | null;
+  let outputCapField:
+    | "max_output_tokens"
+    | "max_completion_tokens"
+    | "max_tokens";
+  if (input.provider === "openai" && input.route === "/v1/responses") {
+    if (
+      body.max_tokens !== undefined ||
+      body.max_completion_tokens !== undefined
+    ) {
+      throw preDispatchError(
+        "OpenAI Responses output token limit is ambiguous",
+      );
+    }
+    outputCapField = "max_output_tokens";
+    requestedMaxOutputTokens =
+      body.max_output_tokens === undefined
+        ? null
+        : positiveOutputCap(body.max_output_tokens, "max_output_tokens");
+    if (body.input === undefined) {
+      throw preDispatchError("OpenAI Responses input is required");
+    }
+  } else if (
+    input.provider === "openai" &&
+    input.route === "/v1/chat/completions"
+  ) {
+    if (
+      body.max_completion_tokens !== undefined &&
+      body.max_tokens !== undefined
+    ) {
+      throw preDispatchError("OpenAI Chat output token limit is ambiguous");
+    }
+    outputCapField =
+      body.max_completion_tokens !== undefined || body.max_tokens === undefined
+        ? "max_completion_tokens"
+        : "max_tokens";
+    const requested = body.max_completion_tokens ?? body.max_tokens;
+    requestedMaxOutputTokens =
+      requested === undefined
+        ? null
+        : positiveOutputCap(requested, outputCapField);
+    if (!Array.isArray(body.messages) || body.messages.length === 0) {
+      throw preDispatchError("OpenAI Chat messages must be a non-empty array");
+    }
+  } else {
+    if (
+      body.max_output_tokens !== undefined ||
+      body.max_completion_tokens !== undefined
+    ) {
+      throw preDispatchError("Anthropic output token limit is ambiguous");
+    }
+    outputCapField = "max_tokens";
+    requestedMaxOutputTokens =
+      body.max_tokens === undefined
+        ? null
+        : positiveOutputCap(body.max_tokens, "max_tokens");
+    if (!Array.isArray(body.messages) || body.messages.length === 0) {
+      throw preDispatchError("Anthropic messages must be a non-empty array");
+    }
+  }
+  if (containsUnsupportedProviderInput(body)) {
+    throw preDispatchError(
+      "multimodal, file, audio, video, and provider-fetched URL inputs are unsupported",
+    );
+  }
+  const effectiveMaxOutputTokens = Math.min(
+    requestedMaxOutputTokens ?? input.remainingOutputTokens,
+    input.remainingOutputTokens,
+  );
+  if (
+    !Number.isSafeInteger(effectiveMaxOutputTokens) ||
+    effectiveMaxOutputTokens <= 0
+  ) {
+    throw preDispatchError("remaining output token budget is exhausted");
+  }
+  body[outputCapField] = effectiveMaxOutputTokens;
+  const forwardBody = Buffer.from(JSON.stringify(body));
+  const inputBudgetCharge =
+    Math.max(input.bytes.byteLength, forwardBody.byteLength) +
+    INPUT_TOKEN_OVERHEAD_RESERVE;
+  if (
+    !Number.isSafeInteger(inputBudgetCharge) ||
+    inputBudgetCharge > input.remainingInputTokens
+  ) {
+    throw preDispatchError(
+      `request byte charge plus ${INPUT_TOKEN_OVERHEAD_RESERVE}-token overhead reserve exceeds remaining input budget`,
+    );
+  }
+  return {
+    bodyBytes: input.bytes.byteLength,
+    observedModel,
+    requestedMaxOutputTokens,
+    effectiveMaxOutputTokens,
+    inputBudgetCharge,
+    forwardBody,
+  };
+}
+
+function inspectRejectedRequestEnvelope(
+  provider: StabilityModelProvider,
+  route: string,
+  bytes: Buffer,
+): Pick<
+  StabilityModelRequestEnvelopeEvidence,
+  | "bodyBytes"
+  | "observedModel"
+  | "requestedMaxOutputTokens"
+  | "effectiveMaxOutputTokens"
+  | "inputBudgetCharge"
+> {
+  let body: Record<string, unknown> | null = null;
+  try {
+    body = asRecord(JSON.parse(bytes.toString("utf8")));
+  } catch {
+    // error-policy:J3 Rejected JSON is represented only by bounded structural metadata.
+  }
+  const observedModel =
+    typeof body?.model === "string" && body.model.length <= 512
+      ? body.model
+      : null;
+  const candidate =
+    provider === "anthropic" || route === "/v1/chat/completions"
+      ? (body?.max_completion_tokens ?? body?.max_tokens)
+      : body?.max_output_tokens;
+  const requestedMaxOutputTokens =
+    Number.isSafeInteger(candidate) && (candidate as number) > 0
+      ? (candidate as number)
+      : null;
+  const inputBudgetCharge = bytes.byteLength + INPUT_TOKEN_OVERHEAD_RESERVE;
+  return {
+    bodyBytes: bytes.byteLength,
+    observedModel,
+    requestedMaxOutputTokens,
+    effectiveMaxOutputTokens: null,
+    inputBudgetCharge: Number.isSafeInteger(inputBudgetCharge)
+      ? inputBudgetCharge
+      : null,
+  };
+}
+
+const MAX_PROVIDER_RESPONSE_BYTES = 16 * 1024 * 1024;
+
+async function readBoundedProviderResponse(
+  upstream: Response,
+): Promise<Buffer> {
+  const declaredLength = upstream.headers.get("content-length");
+  if (declaredLength !== null) {
+    const length = Number(declaredLength);
+    if (!Number.isSafeInteger(length) || length < 0) {
+      throw new Error("provider response Content-Length is invalid");
+    }
+    if (length > MAX_PROVIDER_RESPONSE_BYTES) {
+      await upstream.body?.cancel();
+      throw new Error("provider proxy response exceeded 16 MiB");
+    }
+  }
+  if (!upstream.body) return Buffer.alloc(0);
+  const reader = upstream.body.getReader();
+  const chunks: Buffer[] = [];
+  let total = 0;
+  try {
+    while (true) {
+      const result = await reader.read();
+      if (result.done) break;
+      const chunk = Buffer.from(result.value);
+      total += chunk.byteLength;
+      if (!Number.isSafeInteger(total) || total > MAX_PROVIDER_RESPONSE_BYTES) {
+        await reader.cancel("provider response exceeded stability byte cap");
+        throw new Error("provider proxy response exceeded 16 MiB");
+      }
+      chunks.push(chunk);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  return Buffer.concat(chunks, total);
+}
+
 /** Aggregates authoritative usage and holds a failed meter closed for the attempt. */
 export class LiveModelUsageMeter {
   #requestCount = 0;
   #inputTokens = 0;
   #outputTokens = 0;
   readonly #failures: StabilityModelFailure[] = [];
+  readonly #requestEnvelopes: StabilityModelRequestEnvelopeEvidence[] = [];
 
   constructor(
     readonly provider: StabilityModelProvider,
@@ -382,12 +667,30 @@ export class LiveModelUsageMeter {
     });
   }
 
+  recordPreDispatchFailure(
+    message: string,
+    evidence: StabilityModelRequestEnvelopeEvidence,
+  ): void {
+    this.#requestEnvelopes.push(evidence);
+    if (this.#failures.length > 0) return;
+    this.#failures.push({
+      code: "STABILITY_MODEL_PRE_DISPATCH_REJECTED",
+      message,
+      requestNumber: evidence.requestNumber,
+    });
+  }
+
+  recordRequestEnvelope(evidence: StabilityModelRequestEnvelopeEvidence): void {
+    this.#requestEnvelopes.push(evidence);
+  }
+
   snapshot(): StabilityModelMeterSnapshot {
     return {
       requestCount: this.#requestCount,
       inputTokens: this.#inputTokens,
       outputTokens: this.#outputTokens,
       failures: structuredClone(this.#failures),
+      requestEnvelopes: structuredClone(this.#requestEnvelopes),
     };
   }
 }
@@ -421,6 +724,7 @@ export function liveModelScenarioChildEnvironment(
 export async function startLiveModelEgressProxy(options: {
   provider: StabilityModelProvider;
   budgets: StabilityModelBudgets;
+  expectedModel: string;
   upstreamCredential?: string;
   fetchUpstream?: (url: string, init: RequestInit) => Promise<Response>;
   upstreamOrigin?: string;
@@ -433,6 +737,13 @@ export async function startLiveModelEgressProxy(options: {
       ? "https://api.openai.com"
       : "https://api.anthropic.com");
   const meter = new LiveModelUsageMeter(options.provider, options.budgets);
+  if (
+    typeof options.expectedModel !== "string" ||
+    options.expectedModel.trim().length === 0 ||
+    options.expectedModel.length > 512
+  ) {
+    throw new Error("expectedModel must be a non-empty bounded identifier");
+  }
   const fetchUpstream = options.fetchUpstream ?? globalThis.fetch;
   const timeoutMs = options.upstreamTimeoutMs ?? 120_000;
   let exchangeTail = Promise.resolve();
@@ -466,6 +777,7 @@ export async function startLiveModelEgressProxy(options: {
         }
         chunks.push(bytes);
       }
+      const requestBody = Buffer.concat(chunks, requestBytes);
       const releaseExchange = await acquireExchange();
       try {
         if (
@@ -481,14 +793,74 @@ export async function startLiveModelEgressProxy(options: {
           );
           return;
         }
+        const route = new URL(
+          request.url ?? "/",
+          "http://stability-loopback.invalid",
+        ).pathname;
+        const requestNumber = meter.snapshot().requestCount + 1;
+        let envelope: ReturnType<typeof parseRequestEnvelope>;
+        try {
+          const snapshot = meter.snapshot();
+          envelope = parseRequestEnvelope({
+            provider: options.provider,
+            route,
+            bytes: requestBody,
+            expectedModel: options.expectedModel,
+            remainingInputTokens:
+              options.budgets.maxInputTokens - snapshot.inputTokens,
+            remainingOutputTokens:
+              options.budgets.maxOutputTokens - snapshot.outputTokens,
+          });
+        } catch (error) {
+          const meterError =
+            error instanceof StabilityModelMeterError
+              ? error
+              : preDispatchError(
+                  error instanceof Error ? error.message : String(error),
+                );
+          meter.recordPreDispatchFailure(meterError.message, {
+            requestNumber,
+            method: request.method ?? "UNKNOWN",
+            route,
+            ...inspectRejectedRequestEnvelope(
+              options.provider,
+              route,
+              requestBody,
+            ),
+            accepted: false,
+            failureCode: meterError.code,
+          });
+          failureRecorded = true;
+          response.writeHead(422, { "content-type": "application/json" });
+          response.end(
+            JSON.stringify({ error: meter.snapshot().failures.at(-1) }),
+          );
+          return;
+        }
+        const { forwardBody, ...envelopeEvidence } = envelope;
         const admission = meter.reserveRequest();
         if (!admission.allowed) {
+          meter.recordRequestEnvelope({
+            requestNumber,
+            method: request.method ?? "UNKNOWN",
+            route,
+            ...envelopeEvidence,
+            accepted: false,
+            failureCode: admission.failure.code,
+          });
           failureRecorded = true;
           response.writeHead(429, { "content-type": "application/json" });
           response.end(JSON.stringify({ error: admission.failure }));
           return;
         }
         reservation = admission.reservation;
+        meter.recordRequestEnvelope({
+          requestNumber: reservation.requestNumber,
+          method: request.method ?? "UNKNOWN",
+          route,
+          ...envelopeEvidence,
+          accepted: true,
+        });
         options.onUpstreamRequest?.(origin, request.method ?? "GET");
         const upstreamHeaders = Object.fromEntries(
           Object.entries(request.headers).flatMap(([key, value]) =>
@@ -518,7 +890,7 @@ export async function startLiveModelEgressProxy(options: {
           upstream = await fetchUpstream(`${origin}${request.url ?? "/"}`, {
             method: request.method,
             headers: upstreamHeaders,
-            body: chunks.length > 0 ? Buffer.concat(chunks) : undefined,
+            body: forwardBody,
             signal: AbortSignal.timeout(timeoutMs),
             redirect: "manual",
           });
@@ -558,23 +930,11 @@ export async function startLiveModelEgressProxy(options: {
         }
         let responseBytes: Buffer;
         try {
-          responseBytes = Buffer.from(await upstream.arrayBuffer());
+          responseBytes = await readBoundedProviderResponse(upstream);
         } catch (error) {
           // error-policy:J1 An unreadable upstream response is retained as a counted proxy failure.
           meter.recordProxyFailure(
             error instanceof Error ? error.message : String(error),
-            reservation,
-          );
-          failureRecorded = true;
-          response.writeHead(502, { "content-type": "application/json" });
-          response.end(
-            JSON.stringify({ error: meter.snapshot().failures.at(-1) }),
-          );
-          return;
-        }
-        if (responseBytes.byteLength > 16 * 1024 * 1024) {
-          meter.recordProxyFailure(
-            "provider proxy response exceeded 16 MiB",
             reservation,
           );
           failureRecorded = true;

--- a/packages/cloud/e2e/src/stability/live-model-meter.ts
+++ b/packages/cloud/e2e/src/stability/live-model-meter.ts
@@ -1087,6 +1087,7 @@ export function liveModelScenarioChildEnvironment(
   const environment = { ...parentEnvironment };
   delete environment.OPENAI_API_KEY;
   delete environment.ANTHROPIC_API_KEY;
+  delete environment.ELIZA_STABILITY_METER_ATTESTATION_KEY;
   if (provider === "openai") {
     environment.OPENAI_BASE_URL = proxyUrl;
     environment.OPENAI_API_KEY = "sk-stability-proxy-placeholder-000000000000";

--- a/packages/cloud/e2e/src/stability/live-model-meter.ts
+++ b/packages/cloud/e2e/src/stability/live-model-meter.ts
@@ -3,6 +3,7 @@
  * rejects unaccounted or over-budget provider traffic before it reaches the scenario.
  */
 
+import { createHash } from "node:crypto";
 import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
 
@@ -44,6 +45,8 @@ export interface StabilityModelRequestEnvelopeEvidence {
   method: string;
   route: string;
   bodyBytes: number;
+  forwardedBodyBytes: number | null;
+  forwardedBodySha256: string | null;
   observedModel: string | null;
   requestedMaxOutputTokens: number | null;
   effectiveMaxOutputTokens: number | null;
@@ -253,36 +256,408 @@ function preDispatchError(message: string): StabilityModelMeterError {
   );
 }
 
-function containsUnsupportedProviderInput(value: unknown): boolean {
-  if (Array.isArray(value)) return value.some(containsUnsupportedProviderInput);
+function exactKeys(
+  record: Record<string, unknown>,
+  allowed: readonly string[],
+): boolean {
+  const set = new Set(allowed);
+  return Object.keys(record).every((key) => set.has(key));
+}
+
+function cacheControl(value: unknown): boolean {
+  if (value === undefined) return true;
+  const record = asRecord(value);
+  return Boolean(
+    record &&
+      exactKeys(record, ["type", "ttl"]) &&
+      record.type === "ephemeral" &&
+      (record.ttl === undefined || record.ttl === "5m" || record.ttl === "1h"),
+  );
+}
+
+function openAiFunctionTool(value: unknown, responses: boolean): boolean {
   const record = asRecord(value);
   if (!record) return false;
-  for (const [key, child] of Object.entries(record)) {
-    const normalizedKey = key.toLowerCase();
-    if (
-      [
-        "image_url",
-        "file_id",
-        "file_url",
-        "input_audio",
-        "audio_url",
-        "video_url",
-      ].includes(normalizedKey)
-    ) {
-      return true;
-    }
-    if (
-      normalizedKey === "type" &&
-      typeof child === "string" &&
-      /(?:image|audio|video|file|web_search|computer|code_interpreter|mcp|connector)/iu.test(
-        child,
-      )
-    ) {
-      return true;
-    }
-    if (containsUnsupportedProviderInput(child)) return true;
+  if (responses) {
+    return (
+      record.type === "function" &&
+      exactKeys(record, [
+        "type",
+        "name",
+        "description",
+        "parameters",
+        "strict",
+      ]) &&
+      typeof record.name === "string" &&
+      asRecord(record.parameters) !== null
+    );
   }
-  return false;
+  const fn = asRecord(record.function);
+  return Boolean(
+    record.type === "function" &&
+      exactKeys(record, ["type", "function"]) &&
+      fn &&
+      exactKeys(fn, ["name", "description", "parameters", "strict"]) &&
+      typeof fn.name === "string" &&
+      asRecord(fn.parameters) !== null,
+  );
+}
+
+function openAiCustomTool(value: unknown): boolean {
+  const record = asRecord(value);
+  return Boolean(
+    record &&
+      record.type === "custom" &&
+      exactKeys(record, ["type", "name", "description", "format"]) &&
+      typeof record.name === "string",
+  );
+}
+
+function openAiToolChoice(value: unknown, responses: boolean): boolean {
+  if (
+    value === undefined ||
+    ["auto", "none", "required"].includes(String(value))
+  )
+    return true;
+  const record = asRecord(value);
+  if (!record) return false;
+  if (responses) {
+    return (
+      (record.type === "function" || record.type === "custom") &&
+      exactKeys(record, ["type", "name"]) &&
+      typeof record.name === "string"
+    );
+  }
+  const fn = asRecord(record.function);
+  return Boolean(
+    record.type === "function" &&
+      exactKeys(record, ["type", "function"]) &&
+      fn &&
+      exactKeys(fn, ["name"]) &&
+      typeof fn.name === "string",
+  );
+}
+
+function openAiChatContent(value: unknown): boolean {
+  if (typeof value === "string" || value === null) return true;
+  return (
+    Array.isArray(value) &&
+    value.every((part) => {
+      const record = asRecord(part);
+      return Boolean(
+        record &&
+          record.type === "text" &&
+          exactKeys(record, ["type", "text"]) &&
+          typeof record.text === "string",
+      );
+    })
+  );
+}
+
+function openAiChatMessage(value: unknown): boolean {
+  const record = asRecord(value);
+  if (
+    !record ||
+    !exactKeys(record, [
+      "role",
+      "content",
+      "name",
+      "tool_calls",
+      "tool_call_id",
+      "refusal",
+    ])
+  )
+    return false;
+  if (
+    !["system", "developer", "user", "assistant", "tool"].includes(
+      String(record.role),
+    )
+  )
+    return false;
+  if (!openAiChatContent(record.content)) return false;
+  if (record.tool_calls !== undefined) {
+    if (!Array.isArray(record.tool_calls)) return false;
+    for (const call of record.tool_calls) {
+      const item = asRecord(call);
+      const fn = asRecord(item?.function);
+      if (
+        !item ||
+        !fn ||
+        item.type !== "function" ||
+        !exactKeys(item, ["id", "type", "function"]) ||
+        !exactKeys(fn, ["name", "arguments"]) ||
+        typeof item.id !== "string" ||
+        typeof fn.name !== "string" ||
+        typeof fn.arguments !== "string"
+      )
+        return false;
+    }
+  }
+  return (
+    record.tool_call_id === undefined || typeof record.tool_call_id === "string"
+  );
+}
+
+function openAiResponsesInput(value: unknown): boolean {
+  if (typeof value === "string") return true;
+  if (!Array.isArray(value)) return false;
+  return value.every((item) => {
+    const record = asRecord(item);
+    if (!record) return false;
+    if (
+      record.type === "function_call_output" ||
+      record.type === "custom_tool_call_output"
+    ) {
+      return (
+        exactKeys(record, ["type", "call_id", "output"]) &&
+        typeof record.call_id === "string" &&
+        typeof record.output === "string"
+      );
+    }
+    if (
+      !exactKeys(record, ["role", "content", "type"]) ||
+      !["user", "assistant", "system", "developer"].includes(
+        String(record.role),
+      )
+    )
+      return false;
+    if (typeof record.content === "string") return true;
+    return (
+      Array.isArray(record.content) &&
+      record.content.every((part) => {
+        const content = asRecord(part);
+        return Boolean(
+          content &&
+            ["input_text", "output_text"].includes(String(content.type)) &&
+            exactKeys(content, ["type", "text"]) &&
+            typeof content.text === "string",
+        );
+      })
+    );
+  });
+}
+
+function anthropicContent(value: unknown): boolean {
+  if (typeof value === "string") return true;
+  if (!Array.isArray(value)) return false;
+  return value.every((part) => {
+    const record = asRecord(part);
+    if (!record) return false;
+    if (record.type === "text")
+      return (
+        exactKeys(record, ["type", "text", "cache_control"]) &&
+        typeof record.text === "string" &&
+        cacheControl(record.cache_control)
+      );
+    if (record.type === "tool_use")
+      return (
+        exactKeys(record, ["type", "id", "name", "input", "cache_control"]) &&
+        typeof record.id === "string" &&
+        typeof record.name === "string" &&
+        asRecord(record.input) !== null &&
+        cacheControl(record.cache_control)
+      );
+    if (record.type === "tool_result")
+      return (
+        exactKeys(record, [
+          "type",
+          "tool_use_id",
+          "content",
+          "is_error",
+          "cache_control",
+        ]) &&
+        typeof record.tool_use_id === "string" &&
+        (typeof record.content === "string" ||
+          anthropicContent(record.content)) &&
+        cacheControl(record.cache_control)
+      );
+    return false;
+  });
+}
+
+function validateProviderRequestShape(
+  provider: StabilityModelProvider,
+  route: string,
+  body: Record<string, unknown>,
+): void {
+  if (provider === "openai" && route === "/v1/chat/completions") {
+    const allowed = [
+      "model",
+      "messages",
+      "max_tokens",
+      "max_completion_tokens",
+      "temperature",
+      "top_p",
+      "frequency_penalty",
+      "presence_penalty",
+      "stop",
+      "stream",
+      "stream_options",
+      "tools",
+      "tool_choice",
+      "response_format",
+      "seed",
+      "user",
+      "parallel_tool_calls",
+      "logprobs",
+      "top_logprobs",
+      "reasoning_effort",
+      "n",
+    ];
+    if (
+      !exactKeys(body, allowed) ||
+      !Array.isArray(body.messages) ||
+      !body.messages.every(openAiChatMessage)
+    )
+      throw preDispatchError(
+        "OpenAI Chat request is outside the local text/function schema",
+      );
+    if (body.n !== undefined && body.n !== 1)
+      throw preDispatchError("OpenAI Chat n must be absent or exactly 1");
+    if (body.stream !== undefined && typeof body.stream !== "boolean")
+      throw preDispatchError("OpenAI Chat stream must be boolean");
+    if (body.stream === true) {
+      const streamOptions =
+        body.stream_options === undefined ? {} : asRecord(body.stream_options);
+      if (
+        !streamOptions ||
+        !exactKeys(streamOptions, ["include_usage"]) ||
+        (streamOptions.include_usage !== undefined &&
+          streamOptions.include_usage !== true)
+      ) {
+        throw preDispatchError(
+          "OpenAI Chat streaming requires exact include_usage support",
+        );
+      }
+      body.stream_options = { include_usage: true };
+    } else if (body.stream_options !== undefined) {
+      throw preDispatchError(
+        "OpenAI Chat stream_options requires streaming mode",
+      );
+    }
+    if (
+      body.tools !== undefined &&
+      (!Array.isArray(body.tools) ||
+        !body.tools.every((tool) => openAiFunctionTool(tool, false)))
+    )
+      throw preDispatchError("OpenAI Chat permits only client function tools");
+    if (!openAiToolChoice(body.tool_choice, false))
+      throw preDispatchError(
+        "OpenAI Chat tool choice must select a client function",
+      );
+    return;
+  }
+  if (provider === "openai") {
+    const allowed = [
+      "model",
+      "input",
+      "instructions",
+      "max_output_tokens",
+      "temperature",
+      "top_p",
+      "stream",
+      "tools",
+      "tool_choice",
+      "text",
+      "reasoning",
+      "parallel_tool_calls",
+      "store",
+      "metadata",
+    ];
+    if (
+      !exactKeys(body, allowed) ||
+      !openAiResponsesInput(body.input) ||
+      (body.instructions !== undefined && typeof body.instructions !== "string")
+    )
+      throw preDispatchError(
+        "OpenAI Responses request is outside the local text/function schema",
+      );
+    if (
+      body.tools !== undefined &&
+      (!Array.isArray(body.tools) ||
+        !body.tools.every(
+          (tool) => openAiFunctionTool(tool, true) || openAiCustomTool(tool),
+        ))
+    )
+      throw preDispatchError(
+        "OpenAI Responses permits only client function/custom tools",
+      );
+    if (
+      !openAiToolChoice(body.tool_choice, true) ||
+      (body.store !== undefined && body.store !== false)
+    )
+      throw preDispatchError(
+        "OpenAI Responses tool choice/storage is outside the local schema",
+      );
+    return;
+  }
+  const allowed = [
+    "model",
+    "messages",
+    "max_tokens",
+    "system",
+    "temperature",
+    "top_p",
+    "top_k",
+    "stop_sequences",
+    "stream",
+    "tools",
+    "tool_choice",
+    "metadata",
+    "thinking",
+    "output_config",
+  ];
+  if (
+    !exactKeys(body, allowed) ||
+    !Array.isArray(body.messages) ||
+    !body.messages.every((message) => {
+      const record = asRecord(message);
+      return Boolean(
+        record &&
+          exactKeys(record, ["role", "content"]) &&
+          ["user", "assistant"].includes(String(record.role)) &&
+          anthropicContent(record.content),
+      );
+    }) ||
+    (body.system !== undefined && !anthropicContent(body.system))
+  )
+    throw preDispatchError(
+      "Anthropic request is outside the local text/function schema",
+    );
+  if (
+    body.tools !== undefined &&
+    (!Array.isArray(body.tools) ||
+      !body.tools.every((tool) => {
+        const record = asRecord(tool);
+        return Boolean(
+          record &&
+            (record.type === undefined || record.type === "custom") &&
+            exactKeys(record, [
+              "type",
+              "name",
+              "description",
+              "input_schema",
+              "cache_control",
+            ]) &&
+            typeof record.name === "string" &&
+            asRecord(record.input_schema) !== null &&
+            cacheControl(record.cache_control),
+        );
+      }))
+  )
+    throw preDispatchError("Anthropic permits only client custom tools");
+  if (body.tool_choice !== undefined) {
+    const choice = asRecord(body.tool_choice);
+    if (
+      !choice ||
+      !exactKeys(choice, ["type", "name", "disable_parallel_tool_use"]) ||
+      !["auto", "any", "none", "tool"].includes(String(choice.type)) ||
+      (choice.type === "tool" && typeof choice.name !== "string")
+    )
+      throw preDispatchError(
+        "Anthropic tool choice must select a client custom tool",
+      );
+  }
 }
 
 function positiveOutputCap(value: unknown, field: string): number {
@@ -395,11 +770,7 @@ function parseRequestEnvelope(input: {
       throw preDispatchError("Anthropic messages must be a non-empty array");
     }
   }
-  if (containsUnsupportedProviderInput(body)) {
-    throw preDispatchError(
-      "multimodal, file, audio, video, and provider-fetched URL inputs are unsupported",
-    );
-  }
+  validateProviderRequestShape(input.provider, input.route, body);
   const effectiveMaxOutputTokens = Math.min(
     requestedMaxOutputTokens ?? input.remainingOutputTokens,
     input.remainingOutputTokens,
@@ -425,6 +796,8 @@ function parseRequestEnvelope(input: {
   }
   return {
     bodyBytes: input.bytes.byteLength,
+    forwardedBodyBytes: forwardBody.byteLength,
+    forwardedBodySha256: createHash("sha256").update(forwardBody).digest("hex"),
     observedModel,
     requestedMaxOutputTokens,
     effectiveMaxOutputTokens,
@@ -440,6 +813,8 @@ function inspectRejectedRequestEnvelope(
 ): Pick<
   StabilityModelRequestEnvelopeEvidence,
   | "bodyBytes"
+  | "forwardedBodyBytes"
+  | "forwardedBodySha256"
   | "observedModel"
   | "requestedMaxOutputTokens"
   | "effectiveMaxOutputTokens"
@@ -466,6 +841,8 @@ function inspectRejectedRequestEnvelope(
   const inputBudgetCharge = bytes.byteLength + INPUT_TOKEN_OVERHEAD_RESERVE;
   return {
     bodyBytes: bytes.byteLength,
+    forwardedBodyBytes: null,
+    forwardedBodySha256: null,
     observedModel,
     requestedMaxOutputTokens,
     effectiveMaxOutputTokens: null,
@@ -845,6 +1222,8 @@ export async function startLiveModelEgressProxy(options: {
             method: request.method ?? "UNKNOWN",
             route,
             ...envelopeEvidence,
+            forwardedBodyBytes: null,
+            forwardedBodySha256: null,
             accepted: false,
             failureCode: admission.failure.code,
           });

--- a/packages/cloud/e2e/src/stability/live-model-meter.ts
+++ b/packages/cloud/e2e/src/stability/live-model-meter.ts
@@ -213,6 +213,22 @@ function assertBudget(value: number, field: string): void {
   }
 }
 
+function providerRouteAllowed(
+  provider: StabilityModelProvider,
+  method: string | undefined,
+  rawTarget: string | undefined,
+): boolean {
+  if (method !== "POST" || !rawTarget?.startsWith("/")) return false;
+  const target = new URL(rawTarget, "http://stability-loopback.invalid");
+  if (target.origin !== "http://stability-loopback.invalid" || target.search) {
+    return false;
+  }
+  return provider === "openai"
+    ? target.pathname === "/v1/responses" ||
+        target.pathname === "/v1/chat/completions"
+    : target.pathname === "/v1/messages";
+}
+
 /** Aggregates authoritative usage and holds a failed meter closed for the attempt. */
 export class LiveModelUsageMeter {
   #requestCount = 0;
@@ -307,8 +323,25 @@ export class LiveModelUsageMeter {
       });
       throw meterError;
     }
-    this.#inputTokens += usage.inputTokens;
-    this.#outputTokens += usage.outputTokens;
+    const cumulativeInputTokens = this.#inputTokens + usage.inputTokens;
+    const cumulativeOutputTokens = this.#outputTokens + usage.outputTokens;
+    if (
+      !Number.isSafeInteger(cumulativeInputTokens) ||
+      !Number.isSafeInteger(cumulativeOutputTokens)
+    ) {
+      const error = new StabilityModelMeterError(
+        "STABILITY_MODEL_USAGE_MALFORMED",
+        "cumulative provider token usage exceeds safe-integer accounting",
+      );
+      this.#failures.push({
+        code: error.code,
+        message: error.message,
+        requestNumber: reservation.requestNumber,
+      });
+      throw error;
+    }
+    this.#inputTokens = cumulativeInputTokens;
+    this.#outputTokens = cumulativeOutputTokens;
     if (
       this.#inputTokens > this.budgets.maxInputTokens ||
       this.#outputTokens > this.budgets.maxOutputTokens
@@ -365,9 +398,30 @@ export interface StabilityModelProxy {
   stop(): Promise<void>;
 }
 
+/** Replaces parent-held provider credentials with SDK-only child placeholders. */
+export function liveModelScenarioChildEnvironment(
+  provider: StabilityModelProvider,
+  proxyUrl: string,
+  parentEnvironment: NodeJS.ProcessEnv,
+): NodeJS.ProcessEnv {
+  const environment = { ...parentEnvironment };
+  delete environment.OPENAI_API_KEY;
+  delete environment.ANTHROPIC_API_KEY;
+  if (provider === "openai") {
+    environment.OPENAI_BASE_URL = proxyUrl;
+    environment.OPENAI_API_KEY = "sk-stability-proxy-placeholder-000000000000";
+  } else {
+    environment.ANTHROPIC_BASE_URL = proxyUrl;
+    environment.ANTHROPIC_API_KEY =
+      "sk-ant-stability-proxy-placeholder-000000000000";
+  }
+  return environment;
+}
+
 export async function startLiveModelEgressProxy(options: {
   provider: StabilityModelProvider;
   budgets: StabilityModelBudgets;
+  upstreamCredential?: string;
   fetchUpstream?: (url: string, init: RequestInit) => Promise<Response>;
   upstreamOrigin?: string;
   upstreamTimeoutMs?: number;
@@ -414,6 +468,19 @@ export async function startLiveModelEgressProxy(options: {
       }
       const releaseExchange = await acquireExchange();
       try {
+        if (
+          !providerRouteAllowed(options.provider, request.method, request.url)
+        ) {
+          meter.recordProxyFailure(
+            `provider proxy route rejected: ${request.method ?? "UNKNOWN"} ${request.url ?? "missing"}`,
+          );
+          failureRecorded = true;
+          response.writeHead(404, { "content-type": "application/json" });
+          response.end(
+            JSON.stringify({ error: meter.snapshot().failures.at(-1) }),
+          );
+          return;
+        }
         const admission = meter.reserveRequest();
         if (!admission.allowed) {
           failureRecorded = true;
@@ -423,19 +490,37 @@ export async function startLiveModelEgressProxy(options: {
         }
         reservation = admission.reservation;
         options.onUpstreamRequest?.(origin, request.method ?? "GET");
+        const upstreamHeaders = Object.fromEntries(
+          Object.entries(request.headers).flatMap(([key, value]) =>
+            value === undefined
+              ? []
+              : [[key, Array.isArray(value) ? value.join(",") : value]],
+          ),
+        );
+        delete upstreamHeaders.authorization;
+        delete upstreamHeaders["x-api-key"];
+        delete upstreamHeaders["api-key"];
+        delete upstreamHeaders["proxy-authorization"];
+        delete upstreamHeaders.host;
+        delete upstreamHeaders.connection;
+        delete upstreamHeaders["content-length"];
+        delete upstreamHeaders["transfer-encoding"];
+        delete upstreamHeaders["proxy-connection"];
+        if (options.upstreamCredential) {
+          if (options.provider === "openai") {
+            upstreamHeaders.authorization = `Bearer ${options.upstreamCredential}`;
+          } else {
+            upstreamHeaders["x-api-key"] = options.upstreamCredential;
+          }
+        }
         let upstream: Response;
         try {
           upstream = await fetchUpstream(`${origin}${request.url ?? "/"}`, {
             method: request.method,
-            headers: Object.fromEntries(
-              Object.entries(request.headers).flatMap(([key, value]) =>
-                value === undefined
-                  ? []
-                  : [[key, Array.isArray(value) ? value.join(",") : value]],
-              ),
-            ),
+            headers: upstreamHeaders,
             body: chunks.length > 0 ? Buffer.concat(chunks) : undefined,
             signal: AbortSignal.timeout(timeoutMs),
+            redirect: "manual",
           });
         } catch (error) {
           // error-policy:J1 The proxy translates provider timeouts/transport failures into typed attempt evidence.
@@ -452,6 +537,20 @@ export async function startLiveModelEgressProxy(options: {
           response.writeHead(timedOut ? 504 : 502, {
             "content-type": "application/json",
           });
+          response.end(
+            JSON.stringify({ error: meter.snapshot().failures.at(-1) }),
+          );
+          return;
+        }
+        if (upstream.status >= 300 && upstream.status < 400) {
+          const location =
+            upstream.headers.get("location") ?? "missing Location";
+          meter.recordProxyFailure(
+            `provider redirect blocked: ${location}`,
+            reservation,
+          );
+          failureRecorded = true;
+          response.writeHead(502, { "content-type": "application/json" });
           response.end(
             JSON.stringify({ error: meter.snapshot().failures.at(-1) }),
           );

--- a/packages/cloud/e2e/src/stability/parent-network-guard.test.ts
+++ b/packages/cloud/e2e/src/stability/parent-network-guard.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Verifies the stability-attempt parent fetch boundary with keyless local
+ * transports and selected-provider rejection fixtures.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  createLoopbackOnlyFetch,
+  type StabilityParentNetworkEntry,
+} from "./parent-network-guard.ts";
+
+describe("stability parent network guard", () => {
+  test("admits loopback and retains the request decision", async () => {
+    const ledger: StabilityParentNetworkEntry[] = [];
+    const calls: string[] = [];
+    const nativeFetch = Object.assign(
+      async (input: Parameters<typeof fetch>[0]) => {
+        calls.push(String(input));
+        return Response.json({ ok: true });
+      },
+      { preconnect: fetch.preconnect },
+    ) as typeof fetch;
+    const guardedFetch = createLoopbackOnlyFetch(nativeFetch, ledger);
+
+    expect(
+      (await guardedFetch("http://127.0.0.1:43123/health", { method: "POST" }))
+        .ok,
+    ).toBe(true);
+    expect(calls).toEqual(["http://127.0.0.1:43123/health"]);
+    expect(ledger).toEqual([
+      {
+        origin: "http://127.0.0.1:43123",
+        method: "POST",
+        allowed: true,
+      },
+    ]);
+  });
+
+  test.each([
+    "https://api.openai.com/v1/responses",
+    "https://api.anthropic.com/v1/messages",
+  ])(
+    "rejects direct selected-provider origin and retains denial: %s",
+    async (url) => {
+      const ledger: StabilityParentNetworkEntry[] = [];
+      let nativeCalls = 0;
+      const nativeFetch = Object.assign(
+        async () => {
+          nativeCalls += 1;
+          return Response.json({});
+        },
+        { preconnect: fetch.preconnect },
+      ) as typeof fetch;
+      const guardedFetch = createLoopbackOnlyFetch(nativeFetch, ledger);
+
+      await expect(guardedFetch(url)).rejects.toThrow(
+        "unexpected egress blocked",
+      );
+      expect(nativeCalls).toBe(0);
+      expect(ledger).toEqual([
+        { origin: new URL(url).origin, method: "GET", allowed: false },
+      ]);
+    },
+  );
+
+  test("rejects a hostname that merely starts with the IPv4 loopback prefix", async () => {
+    const ledger: StabilityParentNetworkEntry[] = [];
+    let nativeCalls = 0;
+    const nativeFetch = Object.assign(
+      async () => {
+        nativeCalls += 1;
+        return Response.json({});
+      },
+      { preconnect: fetch.preconnect },
+    ) as typeof fetch;
+    const guardedFetch = createLoopbackOnlyFetch(nativeFetch, ledger);
+
+    await expect(
+      guardedFetch("http://127.attacker.invalid/provider"),
+    ).rejects.toThrow("unexpected egress blocked");
+    expect(nativeCalls).toBe(0);
+    expect(ledger).toEqual([
+      {
+        origin: "http://127.attacker.invalid",
+        method: "GET",
+        allowed: false,
+      },
+    ]);
+  });
+});

--- a/packages/cloud/e2e/src/stability/parent-network-guard.test.ts
+++ b/packages/cloud/e2e/src/stability/parent-network-guard.test.ts
@@ -87,4 +87,41 @@ describe("stability parent network guard", () => {
       },
     ]);
   });
+
+  test("rejects and retains a loopback redirect to a remote origin", async () => {
+    const ledger: StabilityParentNetworkEntry[] = [];
+    const nativeCalls: string[] = [];
+    const nativeFetch = Object.assign(
+      async (
+        input: Parameters<typeof fetch>[0],
+        init?: Parameters<typeof fetch>[1],
+      ) => {
+        nativeCalls.push(String(input));
+        expect(init?.redirect).toBe("manual");
+        return new Response(null, {
+          status: 302,
+          headers: { location: "https://api.openai.com/v1/responses" },
+        });
+      },
+      { preconnect: fetch.preconnect },
+    ) as typeof fetch;
+    const guardedFetch = createLoopbackOnlyFetch(nativeFetch, ledger);
+
+    await expect(
+      guardedFetch("http://127.0.0.1:43123/redirect"),
+    ).rejects.toThrow("unexpected redirect egress blocked");
+    expect(nativeCalls).toEqual(["http://127.0.0.1:43123/redirect"]);
+    expect(ledger).toEqual([
+      {
+        origin: "http://127.0.0.1:43123",
+        method: "GET",
+        allowed: true,
+      },
+      {
+        origin: "https://api.openai.com",
+        method: "GET",
+        allowed: false,
+      },
+    ]);
+  });
 });

--- a/packages/cloud/e2e/src/stability/parent-network-guard.ts
+++ b/packages/cloud/e2e/src/stability/parent-network-guard.ts
@@ -11,6 +11,13 @@ export interface StabilityParentNetworkEntry {
   allowed: boolean;
 }
 
+function requestMethod(
+  input: Parameters<typeof globalThis.fetch>[0],
+  init?: Parameters<typeof globalThis.fetch>[1],
+): string {
+  return init?.method ?? (input instanceof Request ? input.method : "GET");
+}
+
 function isLoopbackHostname(hostname: string): boolean {
   if (hostname === "localhost") return true;
   const address =
@@ -39,12 +46,32 @@ export function createLoopbackOnlyFetch(
       const allowed = isLoopbackHostname(url.hostname);
       ledger.push({
         origin: url.origin,
-        method:
-          init?.method ?? (input instanceof Request ? input.method : "GET"),
+        method: requestMethod(input, init),
         allowed,
       });
       if (!allowed) throw new Error(`unexpected egress blocked: ${url.origin}`);
-      return nativeFetch(input, init);
+      const response = await nativeFetch(input, {
+        ...init,
+        redirect: "manual",
+      });
+      if (response.status >= 300 && response.status < 400) {
+        const location = response.headers.get("location");
+        if (!location) throw new Error("loopback redirect omitted Location");
+        const target = new URL(location, url);
+        const targetAllowed = isLoopbackHostname(target.hostname);
+        ledger.push({
+          origin: target.origin,
+          method: requestMethod(input, init),
+          allowed: targetAllowed,
+        });
+        if (!targetAllowed) {
+          throw new Error(
+            `unexpected redirect egress blocked: ${target.origin}`,
+          );
+        }
+        throw new Error(`loopback redirect blocked: ${target.origin}`);
+      }
+      return response;
     },
     { preconnect: nativeFetch.preconnect },
   );

--- a/packages/cloud/e2e/src/stability/parent-network-guard.ts
+++ b/packages/cloud/e2e/src/stability/parent-network-guard.ts
@@ -1,0 +1,51 @@
+/**
+ * Constrains the stability-attempt parent process to loopback transports while
+ * retaining every admitted and rejected fetch decision for attempt evidence.
+ */
+
+import { isIP } from "node:net";
+
+export interface StabilityParentNetworkEntry {
+  origin: string;
+  method: string;
+  allowed: boolean;
+}
+
+function isLoopbackHostname(hostname: string): boolean {
+  if (hostname === "localhost") return true;
+  const address =
+    hostname.startsWith("[") && hostname.endsWith("]")
+      ? hostname.slice(1, -1)
+      : hostname;
+  return (
+    address === "::1" ||
+    (isIP(address) === 4 && address.split(".", 1)[0] === "127")
+  );
+}
+
+/** Creates a fetch wrapper that cannot directly reach any remote origin. */
+export function createLoopbackOnlyFetch(
+  nativeFetch: typeof globalThis.fetch,
+  ledger: StabilityParentNetworkEntry[],
+): typeof globalThis.fetch {
+  return Object.assign(
+    async (
+      input: Parameters<typeof nativeFetch>[0],
+      init?: Parameters<typeof nativeFetch>[1],
+    ) => {
+      const url = new URL(
+        typeof input === "string" || input instanceof URL ? input : input.url,
+      );
+      const allowed = isLoopbackHostname(url.hostname);
+      ledger.push({
+        origin: url.origin,
+        method:
+          init?.method ?? (input instanceof Request ? input.method : "GET"),
+        allowed,
+      });
+      if (!allowed) throw new Error(`unexpected egress blocked: ${url.origin}`);
+      return nativeFetch(input, init);
+    },
+    { preconnect: nativeFetch.preconnect },
+  );
+}

--- a/packages/cloud/e2e/src/stability/real-model-bootstrap.test.ts
+++ b/packages/cloud/e2e/src/stability/real-model-bootstrap.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Black-box tests the production inherited-pipe bootstrap parser in real Bun
+ * subprocesses; no Cloud stack, scenario child, or model provider is started.
+ */
+
+import { expect, test } from "bun:test";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { existsSync } from "node:fs";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { Writable } from "node:stream";
+import { pathToFileURL } from "node:url";
+import { MAX_REAL_MODEL_BOOTSTRAP_BYTES } from "./real-model-bootstrap.ts";
+
+const parserUrl = pathToFileURL(
+  path.resolve(import.meta.dirname, "real-model-bootstrap.ts"),
+).href;
+
+async function startParserProcess() {
+  const directory = await mkdtemp(path.join(tmpdir(), "stability-bootstrap-"));
+  const downstreamMarker = path.join(directory, "downstream-started");
+  const script = `
+    import { writeFileSync } from "node:fs";
+    import { readRealModelBootstrap } from ${JSON.stringify(parserUrl)};
+    await readRealModelBootstrap(3);
+    writeFileSync(process.env.ELIZA_TEST_DOWNSTREAM_MARKER, "started");
+    process.stdout.write("accepted");
+  `;
+  const child = spawn(
+    process.execPath,
+    ["--conditions=eliza-source", "-e", script],
+    {
+      cwd: directory,
+      env: {
+        PATH: process.env.PATH,
+        ELIZA_TEST_DOWNSTREAM_MARKER: downstreamMarker,
+      },
+      stdio: ["ignore", "pipe", "pipe", "pipe"],
+    },
+  );
+  const stdout = new Response(child.stdout).text();
+  const stderr = new Response(child.stderr).text();
+  const bootstrapPipe = child.stdio[3] as Writable;
+  bootstrapPipe.on("error", () => {
+    // error-policy:J5 child exit is observed below; EPIPE is expected on rejection.
+  });
+  const exited = once(child, "exit").then(([code, signal]) => ({
+    code: code as number | null,
+    signal: signal as NodeJS.Signals | null,
+  }));
+  return {
+    bootstrapPipe,
+    child,
+    directory,
+    downstreamMarker,
+    exited,
+    stderr,
+    stdout,
+  };
+}
+
+async function finish(
+  running: Awaited<ReturnType<typeof startParserProcess>>,
+  payload: string | Buffer,
+) {
+  running.bootstrapPipe.end(payload);
+  const [exit, stdout, stderr] = await Promise.all([
+    running.exited,
+    running.stdout,
+    running.stderr,
+  ]);
+  return { exit, stdout, stderr };
+}
+
+async function cleanup(
+  running: Awaited<ReturnType<typeof startParserProcess>>,
+) {
+  await rm(running.directory, { recursive: true, force: true });
+}
+
+test.each([
+  {
+    name: "malformed JSON",
+    payload: '{"credentialValue":"MALFORMED_BOOTSTRAP_SECRET"',
+    expected: "real-model bootstrap must be valid JSON",
+    secret: "MALFORMED_BOOTSTRAP_SECRET",
+  },
+  {
+    name: "invalid schema",
+    payload: JSON.stringify({
+      version: 1,
+      credentialEnvironment: "OPENAI_API_KEY",
+      credentialValue: "INVALID_SCHEMA_BOOTSTRAP_SECRET",
+      meterAttestationKey: "not-a-valid-attestation-key",
+    }),
+    expected: "real-model bootstrap has an invalid schema",
+    secret: "INVALID_SCHEMA_BOOTSTRAP_SECRET",
+  },
+  {
+    name: "oversized payload",
+    payload: Buffer.from(
+      `OVERSIZED_BOOTSTRAP_SECRET${"x".repeat(MAX_REAL_MODEL_BOOTSTRAP_BYTES + 1)}`,
+    ),
+    expected: "real-model bootstrap exceeds its byte limit",
+    secret: "OVERSIZED_BOOTSTRAP_SECRET",
+  },
+])("fails closed on $name without starting downstream", async (fixture) => {
+  const running = await startParserProcess();
+  try {
+    const result = await finish(running, fixture.payload);
+    expect(result.exit.code).not.toBe(0);
+    expect(result.stderr).toContain(fixture.expected);
+    expect(result.stderr).not.toContain(fixture.secret);
+    expect(result.stdout).not.toContain(fixture.secret);
+    expect(existsSync(running.downstreamMarker)).toBe(false);
+  } finally {
+    await cleanup(running);
+  }
+});
+
+test("waits for EOF and rejects a truncated bootstrap without downstream startup", async () => {
+  const running = await startParserProcess();
+  const secret = "TRUNCATED_BOOTSTRAP_SECRET";
+  try {
+    running.bootstrapPipe.write(`{"version":1,"credentialValue":"${secret}`);
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    expect(running.child.exitCode).toBeNull();
+    expect(existsSync(running.downstreamMarker)).toBe(false);
+    running.bootstrapPipe.end();
+    const [exit, stdout, stderr] = await Promise.all([
+      running.exited,
+      running.stdout,
+      running.stderr,
+    ]);
+    expect(exit.code).not.toBe(0);
+    expect(stderr).toContain("real-model bootstrap must be valid JSON");
+    expect(stderr).not.toContain(secret);
+    expect(stdout).not.toContain(secret);
+    expect(existsSync(running.downstreamMarker)).toBe(false);
+  } finally {
+    await cleanup(running);
+  }
+});
+
+test("accepts one valid bounded bootstrap and exposes no secret output", async () => {
+  const running = await startParserProcess();
+  const secret = "VALID_BOUNDED_BOOTSTRAP_SECRET";
+  try {
+    const result = await finish(
+      running,
+      JSON.stringify({
+        version: 1,
+        credentialEnvironment: "OPENAI_API_KEY",
+        credentialValue: secret,
+        meterAttestationKey: "a".repeat(64),
+      }),
+    );
+    expect(result.exit, result.stderr).toEqual({ code: 0, signal: null });
+    expect(result.stdout).toBe("accepted");
+    expect(result.stderr).toBe("");
+    expect(result.stdout).not.toContain(secret);
+    expect(await readFile(running.downstreamMarker, "utf8")).toBe("started");
+  } finally {
+    await cleanup(running);
+  }
+});

--- a/packages/cloud/e2e/src/stability/real-model-bootstrap.ts
+++ b/packages/cloud/e2e/src/stability/real-model-bootstrap.ts
@@ -1,0 +1,73 @@
+/**
+ * Consumes the trusted live-model credential and receipt-attestation key from
+ * a bounded inherited pipe before any Cloud stack or scenario child starts.
+ */
+
+import { once } from "node:events";
+import { createReadStream } from "node:fs";
+
+export const REAL_MODEL_BOOTSTRAP_FD = 3;
+export const MAX_REAL_MODEL_BOOTSTRAP_BYTES = 128 * 1024;
+
+export type RealModelBootstrap = {
+  credentialEnvironment: "OPENAI_API_KEY" | "ANTHROPIC_API_KEY";
+  credentialValue: string;
+  meterAttestationKey: string;
+};
+
+export async function readRealModelBootstrap(
+  descriptor = REAL_MODEL_BOOTSTRAP_FD,
+): Promise<RealModelBootstrap> {
+  const chunks: Buffer[] = [];
+  let total = 0;
+  const stream = createReadStream("", {
+    fd: descriptor,
+    autoClose: true,
+    highWaterMark: 16 * 1024,
+  });
+  const closed = once(stream, "close");
+  try {
+    await new Promise<void>((resolve, reject) => {
+      stream.on("data", (value: Buffer | string) => {
+        const chunk = Buffer.from(value);
+        total += chunk.byteLength;
+        if (total > MAX_REAL_MODEL_BOOTSTRAP_BYTES) {
+          stream.pause();
+          reject(new Error("real-model bootstrap exceeds its byte limit"));
+          return;
+        }
+        chunks.push(chunk);
+      });
+      stream.once("end", resolve);
+      stream.once("error", reject);
+    });
+  } finally {
+    if (!stream.closed) stream.destroy();
+    await closed;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(Buffer.concat(chunks, total).toString("utf8"));
+  } catch (cause) {
+    // error-policy:J3 the trusted boundary rejects malformed bootstrap input.
+    throw new Error("real-model bootstrap must be valid JSON", { cause });
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("real-model bootstrap must be an object");
+  }
+  const bootstrap = parsed as Record<string, unknown>;
+  if (
+    Object.keys(bootstrap).length !== 4 ||
+    bootstrap.version !== 1 ||
+    (bootstrap.credentialEnvironment !== "OPENAI_API_KEY" &&
+      bootstrap.credentialEnvironment !== "ANTHROPIC_API_KEY") ||
+    typeof bootstrap.credentialValue !== "string" ||
+    bootstrap.credentialValue.trim().length === 0 ||
+    Buffer.byteLength(bootstrap.credentialValue) > 64 * 1024 ||
+    typeof bootstrap.meterAttestationKey !== "string" ||
+    !/^[a-f0-9]{64}$/u.test(bootstrap.meterAttestationKey)
+  ) {
+    throw new Error("real-model bootstrap has an invalid schema");
+  }
+  return bootstrap as RealModelBootstrap;
+}

--- a/packages/cloud/e2e/src/stability/stability-network-guard.test.ts
+++ b/packages/cloud/e2e/src/stability/stability-network-guard.test.ts
@@ -52,3 +52,42 @@ test("production Bun preload blocks a child fetch before external egress", async
     await rm(directory, { recursive: true, force: true });
   }
 });
+
+test("production Bun preload rejects a DNS name with a loopback-looking prefix", async () => {
+  const directory = await mkdtemp(path.join(tmpdir(), "cloud-network-guard-"));
+  try {
+    const ledger = path.join(directory, "ledger.jsonl");
+    const guard = path.resolve(
+      import.meta.dirname,
+      "../../scripts/stability-network-guard.mjs",
+    );
+    const child = Bun.spawn(
+      [
+        process.execPath,
+        "--preload",
+        guard,
+        "-e",
+        'await fetch("http://127.attacker.invalid/forbidden")',
+      ],
+      {
+        cwd: directory,
+        env: {
+          PATH: process.env.PATH,
+          ELIZA_STABILITY_CHILD_NETWORK_LEDGER: ledger,
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      },
+    );
+    expect(await child.exited).not.toBe(0);
+    expect(await new Response(child.stderr).text()).toContain(
+      "stability network policy blocked http://127.attacker.invalid",
+    );
+    expect(JSON.parse((await readFile(ledger, "utf8")).trim())).toMatchObject({
+      origin: "http://127.attacker.invalid",
+      allowed: false,
+    });
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});

--- a/packages/cloud/e2e/src/stability/stability-network-guard.test.ts
+++ b/packages/cloud/e2e/src/stability/stability-network-guard.test.ts
@@ -91,3 +91,129 @@ test("production Bun preload rejects a DNS name with a loopback-looking prefix",
     await rm(directory, { recursive: true, force: true });
   }
 });
+
+test("production Bun preload rejects a loopback fetch redirect before the target", async () => {
+  const directory = await mkdtemp(path.join(tmpdir(), "cloud-network-guard-"));
+  let targetCalls = 0;
+  const target = Bun.serve({
+    hostname: "0.0.0.0",
+    port: 0,
+    fetch() {
+      targetCalls += 1;
+      return Response.json({ reached: true });
+    },
+  });
+  const redirect = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch() {
+      return Response.redirect(`http://0.0.0.0:${target.port}/target`, 302);
+    },
+  });
+  try {
+    const ledger = path.join(directory, "ledger.jsonl");
+    const guard = path.resolve(
+      import.meta.dirname,
+      "../../scripts/stability-network-guard.mjs",
+    );
+    const child = Bun.spawn(
+      [
+        process.execPath,
+        "--preload",
+        guard,
+        "-e",
+        `await fetch("http://127.0.0.1:${redirect.port}/redirect")`,
+      ],
+      {
+        cwd: directory,
+        env: {
+          PATH: process.env.PATH,
+          ELIZA_STABILITY_CHILD_NETWORK_LEDGER: ledger,
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      },
+    );
+    expect(await child.exited).not.toBe(0);
+    expect(targetCalls).toBe(0);
+    const entries = (await readFile(ledger, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    expect(entries).toEqual([
+      expect.objectContaining({
+        origin: `http://127.0.0.1:${redirect.port}`,
+        allowed: true,
+      }),
+      expect.objectContaining({
+        origin: `http://0.0.0.0:${target.port}`,
+        allowed: false,
+      }),
+    ]);
+  } finally {
+    redirect.stop(true);
+    target.stop(true);
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test.each([
+  {
+    name: "node:http.get",
+    script: (port: number) =>
+      `const http = await import("node:http"); http.get("http://0.0.0.0:${port}/target")`,
+    expectedOrigin: (port: number) => `http://0.0.0.0:${port}`,
+  },
+  {
+    name: "node:https.request",
+    script: () =>
+      'const https = await import("node:https"); https.request("https://example.com/target").end()',
+    expectedOrigin: () => "https://example.com",
+  },
+])(
+  "production Bun preload blocks $name alternate transport",
+  async ({ script, expectedOrigin }) => {
+    const directory = await mkdtemp(
+      path.join(tmpdir(), "cloud-network-guard-"),
+    );
+    let targetCalls = 0;
+    const target = Bun.serve({
+      hostname: "0.0.0.0",
+      port: 0,
+      fetch() {
+        targetCalls += 1;
+        return Response.json({ reached: true });
+      },
+    });
+    try {
+      const ledger = path.join(directory, "ledger.jsonl");
+      const guard = path.resolve(
+        import.meta.dirname,
+        "../../scripts/stability-network-guard.mjs",
+      );
+      const child = Bun.spawn(
+        [process.execPath, "--preload", guard, "-e", script(target.port)],
+        {
+          cwd: directory,
+          env: {
+            PATH: process.env.PATH,
+            ELIZA_STABILITY_CHILD_NETWORK_LEDGER: ledger,
+          },
+          stdout: "pipe",
+          stderr: "pipe",
+        },
+      );
+      expect(await child.exited).not.toBe(0);
+      expect(targetCalls).toBe(0);
+      expect(JSON.parse((await readFile(ledger, "utf8")).trim())).toMatchObject(
+        {
+          origin: expectedOrigin(target.port),
+          allowed: false,
+        },
+      );
+    } finally {
+      target.stop(true);
+      await rm(directory, { recursive: true, force: true });
+    }
+  },
+);

--- a/packages/cloud/e2e/src/stability/stability-scenario-child.test.ts
+++ b/packages/cloud/e2e/src/stability/stability-scenario-child.test.ts
@@ -8,6 +8,7 @@ import { expect, test } from "bun:test";
 import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { ServiceType } from "@elizaos/core";
 import cloudScenario from "../../scenarios/cloud-stability-agent.scenario.ts";
 
 test("source scenario child exits naturally with zero runtime leaks", async () => {
@@ -16,6 +17,7 @@ test("source scenario child exits naturally with zero runtime leaks", async () =
   );
   try {
     const policy = cloudScenario.contract.syntheticRuntimePolicy;
+    expect(policy.allowedServiceTypes).toContain(ServiceType.MEMBERSHIP);
     const report = path.join(directory, "report.json");
     const quiescence = path.join(directory, "quiescence.json");
     const runtimeLedger = path.join(directory, "runtime.json");

--- a/packages/scenario-runner/src/stability-executor.ts
+++ b/packages/scenario-runner/src/stability-executor.ts
@@ -29,6 +29,7 @@ export interface ScenarioStabilityExecutionBudgets {
   timeoutMs: number;
   maxInputTokens: number;
   maxOutputTokens: number;
+  maxModelRequests?: number;
   maxToolCalls: number;
 }
 
@@ -264,6 +265,9 @@ function validateBudgets(budgets: ScenarioStabilityExecutionBudgets): void {
   assertPositiveSafeInteger(budgets.timeoutMs, "timeoutMs");
   assertPositiveSafeInteger(budgets.maxInputTokens, "maxInputTokens");
   assertPositiveSafeInteger(budgets.maxOutputTokens, "maxOutputTokens");
+  if (budgets.maxModelRequests !== undefined) {
+    assertPositiveSafeInteger(budgets.maxModelRequests, "maxModelRequests");
+  }
   if (!Number.isSafeInteger(budgets.maxToolCalls) || budgets.maxToolCalls < 0) {
     throw new Error("maxToolCalls must be a non-negative safe integer");
   }

--- a/packages/scenario-runner/src/stability-executor.ts
+++ b/packages/scenario-runner/src/stability-executor.ts
@@ -613,11 +613,11 @@ export async function executeScenarioStability(input: {
             `initial state hash differs from the first attempt in this cell: ${execution.initialStateHash}`,
             execution,
           );
+        } else if (!execution.passed) {
+          failureClassification = "scenario-failure";
         } else if (violation) {
           failureClassification = "scenario-failure";
           execution = failedExecution(violation, execution);
-        } else if (!execution.passed) {
-          failureClassification = "scenario-failure";
         } else {
           failureClassification = null;
         }

--- a/packages/scenario-runner/src/stability-subprocess-adapter.test.ts
+++ b/packages/scenario-runner/src/stability-subprocess-adapter.test.ts
@@ -15,8 +15,34 @@ import { ScenarioStabilitySubprocessAdapter } from "./stability-subprocess-adapt
 
 const CHILD_SCRIPT = `
 const { createHmac } = require("node:crypto");
-const meterAttestationKey = process.env.ELIZA_STABILITY_METER_ATTESTATION_KEY;
-delete process.env.ELIZA_STABILITY_METER_ATTESTATION_KEY;
+const { closeSync, fstatSync, readFileSync, readSync } = require("node:fs");
+const { spawnSync } = require("node:child_process");
+let bootstrapIdentity;
+const readBootstrap = () => {
+  const bootstrapStat = fstatSync(3);
+  bootstrapIdentity = String(bootstrapStat.dev) + ":" + String(bootstrapStat.ino);
+  const chunks = [];
+  let total = 0;
+  try {
+    while (true) {
+      const chunk = Buffer.alloc(16384);
+      const count = readSync(3, chunk, 0, chunk.length, null);
+      if (count === 0) break;
+      total += count;
+      if (total > 131072) process.exit(96);
+      chunks.push(chunk.subarray(0, count));
+    }
+  } finally {
+    closeSync(3);
+  }
+  return JSON.parse(Buffer.concat(chunks).toString("utf8"));
+};
+const realBootstrap = process.env.ELIZA_STABILITY_MODEL_MODE === "real-llm" ? readBootstrap() : undefined;
+const meterAttestationKey = realBootstrap?.meterAttestationKey;
+if (process.platform === "linux" && realBootstrap) {
+  const initialEnvironment = readFileSync("/proc/self/environ");
+  if (initialEnvironment.includes(Buffer.from(realBootstrap.credentialValue)) || initialEnvironment.includes(Buffer.from(meterAttestationKey))) process.exit(97);
+}
 const canonical = (value) => {
   if (value === null || typeof value !== "object") return JSON.stringify(value);
   if (Array.isArray(value)) return "[" + value.map(canonical).join(",") + "]";
@@ -31,13 +57,17 @@ const attest = (receipt) => {
   if (process.env.ELIZA_TEST_FORGE_AFTER_ATTESTATION === "1") signed.requestEnvelopes[0].forwardedBodySha256 = "b".repeat(64);
   return signed;
 };
-if (process.env.ELIZA_STABILITY_METER_ATTESTATION_KEY) process.exit(93);
+if (process.env.ELIZA_STABILITY_METER_ATTESTATION_KEY || (process.env.ELIZA_STABILITY_MODEL_MODE === "real-llm" && process.env.OPENAI_API_KEY)) process.exit(93);
+if (process.env.ELIZA_TEST_INHERITANCE_PROBE === "1" && process.env.ELIZA_SYNTHETIC_GENERATION === "1") {
+  const inheritanceProbe = spawnSync(process.execPath, ["-e", "const fs=require('node:fs');if(process.env.OPENAI_API_KEY||process.env.ANTHROPIC_API_KEY||process.env.ELIZA_STABILITY_METER_ATTESTATION_KEY)process.exit(1);try{const stat=fs.fstatSync(3);if(String(stat.dev)+':'+String(stat.ino)===process.env.ELIZA_TEST_BOOTSTRAP_IDENTITY)process.exit(2)}catch{}process.exit(0)"], { env: { ...process.env, ELIZA_TEST_BOOTSTRAP_IDENTITY: bootstrapIdentity }, stdio: ["ignore", "pipe", "pipe"] });
+  if (inheritanceProbe.status !== 0) process.exit(94);
+}
 if (process.env.ELIZA_STABILITY_MODEL_MODE === "deterministic-mock" && process.env.OPENAI_API_KEY) {
   process.exit(91);
 }
 if (process.env.ELIZA_REQUIRE_MOCK_SERVICES !== "1") process.exit(92);
 if (process.env.ELIZA_TEST_PRINT_SECRETS === "1") {
-  process.stderr.write(String(process.env.ELIZA_SYNTHETIC_CONTROL_TOKEN) + " " + String(process.env.OPENAI_API_KEY || "") + " " + String(meterAttestationKey || ""));
+  process.stderr.write(String(process.env.ELIZA_SYNTHETIC_CONTROL_TOKEN) + " " + String(realBootstrap?.credentialValue || "") + " " + String(meterAttestationKey || ""));
 }
 const hash = process.env.ELIZA_STABILITY_AUTHORITY_INITIAL_STATE_HASH;
 const meterFailureCode = process.env.ELIZA_TEST_METER_FAILURE;
@@ -459,6 +489,7 @@ describe("scenario stability subprocess adapter", () => {
         },
         env: {
           ELIZA_TEST_PRINT_SECRETS: "1",
+          ...(failure === "none" ? { ELIZA_TEST_INHERITANCE_PROBE: "1" } : {}),
           ...(failure === "wrong-provider"
             ? { ELIZA_TEST_WRONG_REAL: "1" }
             : {}),
@@ -513,7 +544,7 @@ describe("scenario stability subprocess adapter", () => {
           },
         ],
         budgets: {
-          timeoutMs: 2_000,
+          timeoutMs: 10_000,
           maxInputTokens: 10_000,
           maxOutputTokens: 10,
           maxModelRequests: 2,
@@ -521,7 +552,12 @@ describe("scenario stability subprocess adapter", () => {
         },
         adapter,
       });
-      expect(report.cells[0]?.tier).toBe(failure === "none" ? "3/3" : "0/3");
+      expect(
+        report.cells[0]?.tier,
+        JSON.stringify(
+          report.cells[0]?.attempts.map((attempt) => attempt.error),
+        ),
+      ).toBe(failure === "none" ? "3/3" : "0/3");
       if (failure === "none") {
         for (const attempt of report.cells[0]?.attempts ?? []) {
           const stderr = readFileSync(

--- a/packages/scenario-runner/src/stability-subprocess-adapter.test.ts
+++ b/packages/scenario-runner/src/stability-subprocess-adapter.test.ts
@@ -22,14 +22,16 @@ if (process.env.ELIZA_TEST_PRINT_SECRETS === "1") {
   process.stderr.write(String(process.env.ELIZA_SYNTHETIC_CONTROL_TOKEN) + " " + String(process.env.OPENAI_API_KEY || ""));
 }
 const hash = process.env.ELIZA_STABILITY_AUTHORITY_INITIAL_STATE_HASH;
-const inputTokens = process.env.ELIZA_TEST_ZERO_REAL === "1" ? 0 : 4;
+const meterFailureCode = process.env.ELIZA_TEST_METER_FAILURE;
+const inputTokens = process.env.ELIZA_TEST_ZERO_REAL === "1" || meterFailureCode === "STABILITY_MODEL_USAGE_MISSING" || meterFailureCode === "STABILITY_MODEL_USAGE_MALFORMED" ? 0 : meterFailureCode === "STABILITY_MODEL_TOKEN_BUDGET_EXCEEDED" ? 12 : 4;
+const outputTokens = meterFailureCode === "STABILITY_MODEL_USAGE_MISSING" || meterFailureCode === "STABILITY_MODEL_USAGE_MALFORMED" ? 0 : 2;
 const requestCount = process.env.ELIZA_TEST_OVER_CAP_REAL === "1" ? 3 : 1;
 process.stdout.write(JSON.stringify({
-  passed: true,
+  passed: !meterFailureCode,
   initialStateHash: hash,
   finalStateHash: "b".repeat(64),
   inputTokens,
-  outputTokens: 2,
+  outputTokens,
   toolCalls: 1,
   evidence: {
     trajectory: [{ model: process.env.ELIZA_STABILITY_MODEL }],
@@ -56,8 +58,8 @@ process.stdout.write(JSON.stringify({
       liveModelInvoked: true,
       requestCount,
       inputTokens,
-      outputTokens: 2,
-      meteringFailures: [],
+      outputTokens,
+      meteringFailures: meterFailureCode ? [{ code: meterFailureCode, message: meterFailureCode + " retained", requestNumber: 1 }] : [],
       namespace: process.env.ELIZA_SYNTHETIC_NAMESPACE,
       manifestId: process.env.ELIZA_SYNTHETIC_MANIFEST_ID,
       generation: Number(process.env.ELIZA_SYNTHETIC_GENERATION),
@@ -66,7 +68,8 @@ process.stdout.write(JSON.stringify({
     }],
     judgeVerdicts: [{ passed: true }]
   },
-  stateDiff: { sent: true }
+  stateDiff: { sent: true },
+  ...(meterFailureCode ? { error: meterFailureCode } : {})
 }));
 `;
 
@@ -457,6 +460,103 @@ describe("scenario stability subprocess adapter", () => {
       }
     }
   });
+
+  it.each([
+    ["STABILITY_MODEL_USAGE_MISSING", 0, 0],
+    ["STABILITY_MODEL_USAGE_MALFORMED", 0, 0],
+    ["STABILITY_MODEL_TOKEN_BUDGET_EXCEEDED", 12, 2],
+  ] as const)(
+    "retains authentic failed real-model evidence for %s",
+    async (meterFailureCode, expectedInputTokens, expectedOutputTokens) => {
+      const outputRoot = root();
+      const manifest = {
+        version: 1 as const,
+        namespace: `real-failure-${meterFailureCode}`,
+        manifestId: `real-failure-${meterFailureCode}-v1`,
+        domains: {},
+      };
+      let generation = 0;
+      const adapter = new ScenarioStabilitySubprocessAdapter({
+        command: process.execPath,
+        args: () => ["-e", CHILD_SCRIPT],
+        cwd: outputRoot,
+        modelMode: {
+          kind: "real-llm",
+          credentialEnv: "OPENAI_API_KEY",
+          credentialValue: "dummy-model-key",
+        },
+        syntheticControl: {
+          controlUrl: "http://127.0.0.1:43191",
+          controlToken: "control-secret",
+          manifest,
+        },
+        mockServiceUrls: {
+          ELIZA_MOCK_MESSAGES_URL: "http://127.0.0.1:43192/messages",
+        },
+        env: { ELIZA_TEST_METER_FAILURE: meterFailureCode },
+        openSession: async () =>
+          ({
+            manifest,
+            generation: ++generation,
+            async execute() {
+              return { ready: true };
+            },
+            async close() {},
+          }) as unknown as SyntheticControlSession,
+      });
+      const report = await executeScenarioStability({
+        plan: createScenarioStabilityPlan({
+          runId: `real-failure-${meterFailureCode}`,
+          outputRoot,
+        }),
+        targets: [
+          {
+            scenarioId: "live-failure",
+            model: { provider: "openai", model: "gpt-test" },
+          },
+        ],
+        budgets: {
+          timeoutMs: 2_000,
+          maxInputTokens: 10,
+          maxOutputTokens: 10,
+          maxModelRequests: 2,
+          maxToolCalls: 2,
+        },
+        adapter,
+      });
+
+      expect(report.cells[0]?.tier).toBe("0/3");
+      expect(report.focusList[0]?.failedAttemptIds).toHaveLength(3);
+      expect(report.failureClusters).toEqual([
+        expect.objectContaining({
+          occurrences: 3,
+          sample: meterFailureCode,
+        }),
+      ]);
+      for (const attempt of report.cells[0]?.attempts ?? []) {
+        expect(attempt).toMatchObject({
+          passed: false,
+          error: meterFailureCode,
+          inputTokens: expectedInputTokens,
+          outputTokens: expectedOutputTokens,
+        });
+        expect(
+          attempt.evidence.providerReceipts.find(
+            (receipt) =>
+              (receipt as { receiptType?: unknown }).receiptType ===
+              "eliza.stability.real-llm.v1",
+          ),
+        ).toMatchObject({
+          requestCount: 1,
+          inputTokens: expectedInputTokens,
+          outputTokens: expectedOutputTokens,
+          meteringFailures: [
+            expect.objectContaining({ code: meterFailureCode }),
+          ],
+        });
+      }
+    },
+  );
 
   it("allows one explicit model credential only in real-llm mode", () => {
     const outputRoot = root();

--- a/packages/scenario-runner/src/stability-subprocess-adapter.test.ts
+++ b/packages/scenario-runner/src/stability-subprocess-adapter.test.ts
@@ -14,12 +14,30 @@ import { executeScenarioStability } from "./stability-executor.ts";
 import { ScenarioStabilitySubprocessAdapter } from "./stability-subprocess-adapter.ts";
 
 const CHILD_SCRIPT = `
+const { createHmac } = require("node:crypto");
+const meterAttestationKey = process.env.ELIZA_STABILITY_METER_ATTESTATION_KEY;
+delete process.env.ELIZA_STABILITY_METER_ATTESTATION_KEY;
+const canonical = (value) => {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return "[" + value.map(canonical).join(",") + "]";
+  return "{" + Object.keys(value).sort().map((key) => JSON.stringify(key) + ":" + canonical(value[key])).join(",") + "}";
+};
+const attest = (receipt) => {
+  if (process.env.ELIZA_TEST_ACCEPTED_AFTER_REJECT === "1") {
+    receipt.requestEnvelopes = [{ ...receipt.requestEnvelopes[0], requestNumber: 2, forwardedBodyBytes: null, forwardedBodySha256: null, accepted: false, failureCode: "STABILITY_MODEL_REQUEST_BUDGET_EXCEEDED" }, receipt.requestEnvelopes[0]];
+  }
+  const key = process.env.ELIZA_TEST_WRONG_ATTESTATION_KEY === "1" ? "wrong-attestation-key" : meterAttestationKey;
+  const signed = { ...receipt, attestation: createHmac("sha256", key).update(canonical(receipt)).digest("hex") };
+  if (process.env.ELIZA_TEST_FORGE_AFTER_ATTESTATION === "1") signed.requestEnvelopes[0].forwardedBodySha256 = "b".repeat(64);
+  return signed;
+};
+if (process.env.ELIZA_STABILITY_METER_ATTESTATION_KEY) process.exit(93);
 if (process.env.ELIZA_STABILITY_MODEL_MODE === "deterministic-mock" && process.env.OPENAI_API_KEY) {
   process.exit(91);
 }
 if (process.env.ELIZA_REQUIRE_MOCK_SERVICES !== "1") process.exit(92);
 if (process.env.ELIZA_TEST_PRINT_SECRETS === "1") {
-  process.stderr.write(String(process.env.ELIZA_SYNTHETIC_CONTROL_TOKEN) + " " + String(process.env.OPENAI_API_KEY || ""));
+  process.stderr.write(String(process.env.ELIZA_SYNTHETIC_CONTROL_TOKEN) + " " + String(process.env.OPENAI_API_KEY || "") + " " + String(meterAttestationKey || ""));
 }
 const hash = process.env.ELIZA_STABILITY_AUTHORITY_INITIAL_STATE_HASH;
 const meterFailureCode = process.env.ELIZA_TEST_METER_FAILURE;
@@ -52,7 +70,7 @@ process.stdout.write(JSON.stringify({
       ambiguousCalls: 0,
       unusedRequiredFixtures: 0,
       overconsumedFixtures: 1
-    }] : [])] : [{
+    }] : [])] : [attest({
       receiptType: "eliza.stability.real-llm.v1",
       provider: process.env.ELIZA_TEST_WRONG_REAL === "1" ? "wrong-provider" : process.env.ELIZA_STABILITY_PROVIDER,
       model: process.env.ELIZA_STABILITY_MODEL,
@@ -93,7 +111,7 @@ process.stdout.write(JSON.stringify({
       generation: Number(process.env.ELIZA_SYNTHETIC_GENERATION),
       unexpectedRealServiceCalls: 0,
       unexpectedNetworkCalls: 0
-    }],
+    })],
     judgeVerdicts: [{ passed: true }]
   },
   stateDiff: { sent: true },
@@ -408,6 +426,9 @@ describe("scenario stability subprocess adapter", () => {
       "bad-envelope-bytes",
       "bad-envelope-sequence",
       "extra-envelope-key",
+      "wrong-attestation-key",
+      "post-attestation-forgery",
+      "accepted-after-reject",
       "zero-metering",
       "over-request-cap",
     ] as const) {
@@ -456,6 +477,15 @@ describe("scenario stability subprocess adapter", () => {
           ...(failure === "extra-envelope-key"
             ? { ELIZA_TEST_EXTRA_ENVELOPE_KEY: "1" }
             : {}),
+          ...(failure === "wrong-attestation-key"
+            ? { ELIZA_TEST_WRONG_ATTESTATION_KEY: "1" }
+            : {}),
+          ...(failure === "post-attestation-forgery"
+            ? { ELIZA_TEST_FORGE_AFTER_ATTESTATION: "1" }
+            : {}),
+          ...(failure === "accepted-after-reject"
+            ? { ELIZA_TEST_ACCEPTED_AFTER_REJECT: "1" }
+            : {}),
           ...(failure === "zero-metering" ? { ELIZA_TEST_ZERO_REAL: "1" } : {}),
           ...(failure === "over-request-cap"
             ? { ELIZA_TEST_OVER_CAP_REAL: "1" }
@@ -500,6 +530,7 @@ describe("scenario stability subprocess adapter", () => {
           );
           expect(stderr).not.toContain("dummy-model-key");
           expect(stderr).not.toContain("control-secret");
+          expect(stderr).not.toMatch(/[a-f0-9]{64}/u);
         }
       } else {
         expect(report.cells[0]?.attempts[0]?.error).toContain(

--- a/packages/scenario-runner/src/stability-subprocess-adapter.test.ts
+++ b/packages/scenario-runner/src/stability-subprocess-adapter.test.ts
@@ -66,6 +66,8 @@ process.stdout.write(JSON.stringify({
         method: "POST",
         route: "/v1/responses",
         bodyBytes: 64,
+        forwardedBodyBytes: null,
+        forwardedBodySha256: null,
         observedModel: process.env.ELIZA_STABILITY_MODEL,
         requestedMaxOutputTokens: 1,
         effectiveMaxOutputTokens: null,
@@ -73,15 +75,18 @@ process.stdout.write(JSON.stringify({
         accepted: false,
         failureCode: meterFailureCode
       }] : Array.from({ length: requestCount }, (_, index) => ({
-        requestNumber: index + 1,
+        requestNumber: index + (process.env.ELIZA_TEST_BAD_ENVELOPE_SEQUENCE === "1" ? 2 : 1),
         method: "POST",
         route: "/v1/responses",
         bodyBytes: 64,
+        forwardedBodyBytes: process.env.ELIZA_TEST_BAD_ENVELOPE_BYTES === "1" ? 65 : 64,
+        forwardedBodySha256: process.env.ELIZA_TEST_BAD_ENVELOPE_HASH === "1" ? "not-a-hash" : "a".repeat(64),
         observedModel: process.env.ELIZA_TEST_WRONG_ENVELOPE_MODEL === "1" ? "wrong-model" : process.env.ELIZA_STABILITY_MODEL,
         requestedMaxOutputTokens: 2,
         effectiveMaxOutputTokens: 2,
         inputBudgetCharge: 8256,
-        accepted: true
+        accepted: true,
+        ...(process.env.ELIZA_TEST_EXTRA_ENVELOPE_KEY === "1" ? { extra: true } : {})
       })),
       namespace: process.env.ELIZA_SYNTHETIC_NAMESPACE,
       manifestId: process.env.ELIZA_SYNTHETIC_MANIFEST_ID,
@@ -399,6 +404,10 @@ describe("scenario stability subprocess adapter", () => {
       "none",
       "wrong-provider",
       "wrong-envelope-model",
+      "bad-envelope-hash",
+      "bad-envelope-bytes",
+      "bad-envelope-sequence",
+      "extra-envelope-key",
       "zero-metering",
       "over-request-cap",
     ] as const) {
@@ -434,6 +443,18 @@ describe("scenario stability subprocess adapter", () => {
             : {}),
           ...(failure === "wrong-envelope-model"
             ? { ELIZA_TEST_WRONG_ENVELOPE_MODEL: "1" }
+            : {}),
+          ...(failure === "bad-envelope-hash"
+            ? { ELIZA_TEST_BAD_ENVELOPE_HASH: "1" }
+            : {}),
+          ...(failure === "bad-envelope-bytes"
+            ? { ELIZA_TEST_BAD_ENVELOPE_BYTES: "1" }
+            : {}),
+          ...(failure === "bad-envelope-sequence"
+            ? { ELIZA_TEST_BAD_ENVELOPE_SEQUENCE: "1" }
+            : {}),
+          ...(failure === "extra-envelope-key"
+            ? { ELIZA_TEST_EXTRA_ENVELOPE_KEY: "1" }
             : {}),
           ...(failure === "zero-metering" ? { ELIZA_TEST_ZERO_REAL: "1" } : {}),
           ...(failure === "over-request-cap"

--- a/packages/scenario-runner/src/stability-subprocess-adapter.test.ts
+++ b/packages/scenario-runner/src/stability-subprocess-adapter.test.ts
@@ -22,11 +22,13 @@ if (process.env.ELIZA_TEST_PRINT_SECRETS === "1") {
   process.stderr.write(String(process.env.ELIZA_SYNTHETIC_CONTROL_TOKEN) + " " + String(process.env.OPENAI_API_KEY || ""));
 }
 const hash = process.env.ELIZA_STABILITY_AUTHORITY_INITIAL_STATE_HASH;
+const inputTokens = process.env.ELIZA_TEST_ZERO_REAL === "1" ? 0 : 4;
+const requestCount = process.env.ELIZA_TEST_OVER_CAP_REAL === "1" ? 3 : 1;
 process.stdout.write(JSON.stringify({
   passed: true,
   initialStateHash: hash,
   finalStateHash: "b".repeat(64),
-  inputTokens: 4,
+  inputTokens,
   outputTokens: 2,
   toolCalls: 1,
   evidence: {
@@ -52,6 +54,10 @@ process.stdout.write(JSON.stringify({
       provider: process.env.ELIZA_TEST_WRONG_REAL === "1" ? "wrong-provider" : process.env.ELIZA_STABILITY_PROVIDER,
       model: process.env.ELIZA_STABILITY_MODEL,
       liveModelInvoked: true,
+      requestCount,
+      inputTokens,
+      outputTokens: 2,
+      meteringFailures: [],
       namespace: process.env.ELIZA_SYNTHETIC_NAMESPACE,
       manifestId: process.env.ELIZA_SYNTHETIC_MANIFEST_ID,
       generation: Number(process.env.ELIZA_SYNTHETIC_GENERATION),
@@ -362,13 +368,18 @@ describe("scenario stability subprocess adapter", () => {
     ).toThrow("real credential seam");
   });
 
-  it("accepts one exact real-LLM receipt and rejects a wrong provider binding", async () => {
-    for (const wrong of [false, true]) {
+  it("accepts one metered real-LLM receipt and rejects wrong or zero metering", async () => {
+    for (const failure of [
+      "none",
+      "wrong-provider",
+      "zero-metering",
+      "over-request-cap",
+    ] as const) {
       const outputRoot = root();
       const manifest = {
         version: 1 as const,
-        namespace: `real-${wrong}`,
-        manifestId: `real-${wrong}-v1`,
+        namespace: `real-${failure}`,
+        manifestId: `real-${failure}-v1`,
         domains: {},
       };
       let generation = 0;
@@ -391,7 +402,13 @@ describe("scenario stability subprocess adapter", () => {
         },
         env: {
           ELIZA_TEST_PRINT_SECRETS: "1",
-          ...(wrong ? { ELIZA_TEST_WRONG_REAL: "1" } : {}),
+          ...(failure === "wrong-provider"
+            ? { ELIZA_TEST_WRONG_REAL: "1" }
+            : {}),
+          ...(failure === "zero-metering" ? { ELIZA_TEST_ZERO_REAL: "1" } : {}),
+          ...(failure === "over-request-cap"
+            ? { ELIZA_TEST_OVER_CAP_REAL: "1" }
+            : {}),
         },
         openSession: async () =>
           ({
@@ -405,7 +422,7 @@ describe("scenario stability subprocess adapter", () => {
       });
       const report = await executeScenarioStability({
         plan: createScenarioStabilityPlan({
-          runId: `real-${wrong}`,
+          runId: `real-${failure}`,
           outputRoot,
         }),
         targets: [
@@ -418,12 +435,13 @@ describe("scenario stability subprocess adapter", () => {
           timeoutMs: 2_000,
           maxInputTokens: 10,
           maxOutputTokens: 10,
+          maxModelRequests: 2,
           maxToolCalls: 2,
         },
         adapter,
       });
-      expect(report.cells[0]?.tier).toBe(wrong ? "0/3" : "3/3");
-      if (!wrong) {
+      expect(report.cells[0]?.tier).toBe(failure === "none" ? "3/3" : "0/3");
+      if (failure === "none") {
         for (const attempt of report.cells[0]?.attempts ?? []) {
           const stderr = readFileSync(
             path.join(attempt.outputDir, "subprocess.stderr.log"),
@@ -465,6 +483,35 @@ describe("scenario stability subprocess adapter", () => {
           },
           mockServiceUrls: {
             ELIZA_MOCK_MESSAGES_URL: "https://real-service.example/messages",
+          },
+        }),
+    ).toThrow("credential-free loopback HTTP URL");
+  });
+
+  it("rejects a mock service DNS name with a loopback-looking prefix", () => {
+    const outputRoot = root();
+    expect(
+      () =>
+        new ScenarioStabilitySubprocessAdapter({
+          command: process.execPath,
+          args: () => ["-e", CHILD_SCRIPT],
+          cwd: outputRoot,
+          modelMode: {
+            kind: "deterministic-mock",
+            fixtureManifestFingerprint: "f".repeat(64),
+          },
+          syntheticControl: {
+            controlUrl: "http://127.0.0.1:43191",
+            controlToken: "internal-control-token",
+            manifest: {
+              version: 1,
+              namespace: "loopback-prefix-test",
+              manifestId: "loopback-prefix-test-v1",
+              domains: {},
+            },
+          },
+          mockServiceUrls: {
+            ELIZA_MOCK_MESSAGES_URL: "http://127.attacker.invalid/messages",
           },
         }),
     ).toThrow("credential-free loopback HTTP URL");

--- a/packages/scenario-runner/src/stability-subprocess-adapter.test.ts
+++ b/packages/scenario-runner/src/stability-subprocess-adapter.test.ts
@@ -23,9 +23,10 @@ if (process.env.ELIZA_TEST_PRINT_SECRETS === "1") {
 }
 const hash = process.env.ELIZA_STABILITY_AUTHORITY_INITIAL_STATE_HASH;
 const meterFailureCode = process.env.ELIZA_TEST_METER_FAILURE;
-const inputTokens = process.env.ELIZA_TEST_ZERO_REAL === "1" || meterFailureCode === "STABILITY_MODEL_USAGE_MISSING" || meterFailureCode === "STABILITY_MODEL_USAGE_MALFORMED" ? 0 : meterFailureCode === "STABILITY_MODEL_TOKEN_BUDGET_EXCEEDED" ? 12 : 4;
-const outputTokens = meterFailureCode === "STABILITY_MODEL_USAGE_MISSING" || meterFailureCode === "STABILITY_MODEL_USAGE_MALFORMED" ? 0 : 2;
-const requestCount = process.env.ELIZA_TEST_OVER_CAP_REAL === "1" ? 3 : 1;
+const preDispatchFailure = meterFailureCode === "STABILITY_MODEL_PRE_DISPATCH_REJECTED";
+const inputTokens = process.env.ELIZA_TEST_ZERO_REAL === "1" || preDispatchFailure || meterFailureCode === "STABILITY_MODEL_USAGE_MISSING" || meterFailureCode === "STABILITY_MODEL_USAGE_MALFORMED" ? 0 : meterFailureCode === "STABILITY_MODEL_TOKEN_BUDGET_EXCEEDED" ? 12 : 4;
+const outputTokens = preDispatchFailure || meterFailureCode === "STABILITY_MODEL_USAGE_MISSING" || meterFailureCode === "STABILITY_MODEL_USAGE_MALFORMED" ? 0 : 2;
+const requestCount = process.env.ELIZA_TEST_OVER_CAP_REAL === "1" ? 3 : preDispatchFailure ? 0 : 1;
 process.stdout.write(JSON.stringify({
   passed: !meterFailureCode,
   initialStateHash: hash,
@@ -55,11 +56,33 @@ process.stdout.write(JSON.stringify({
       receiptType: "eliza.stability.real-llm.v1",
       provider: process.env.ELIZA_TEST_WRONG_REAL === "1" ? "wrong-provider" : process.env.ELIZA_STABILITY_PROVIDER,
       model: process.env.ELIZA_STABILITY_MODEL,
-      liveModelInvoked: true,
+      liveModelInvoked: requestCount > 0,
       requestCount,
       inputTokens,
       outputTokens,
       meteringFailures: meterFailureCode ? [{ code: meterFailureCode, message: meterFailureCode + " retained", requestNumber: 1 }] : [],
+      requestEnvelopes: preDispatchFailure ? [{
+        requestNumber: 1,
+        method: "POST",
+        route: "/v1/responses",
+        bodyBytes: 64,
+        observedModel: process.env.ELIZA_STABILITY_MODEL,
+        requestedMaxOutputTokens: 1,
+        effectiveMaxOutputTokens: null,
+        inputBudgetCharge: 8256,
+        accepted: false,
+        failureCode: meterFailureCode
+      }] : Array.from({ length: requestCount }, (_, index) => ({
+        requestNumber: index + 1,
+        method: "POST",
+        route: "/v1/responses",
+        bodyBytes: 64,
+        observedModel: process.env.ELIZA_TEST_WRONG_ENVELOPE_MODEL === "1" ? "wrong-model" : process.env.ELIZA_STABILITY_MODEL,
+        requestedMaxOutputTokens: 2,
+        effectiveMaxOutputTokens: 2,
+        inputBudgetCharge: 8256,
+        accepted: true
+      })),
       namespace: process.env.ELIZA_SYNTHETIC_NAMESPACE,
       manifestId: process.env.ELIZA_SYNTHETIC_MANIFEST_ID,
       generation: Number(process.env.ELIZA_SYNTHETIC_GENERATION),
@@ -375,6 +398,7 @@ describe("scenario stability subprocess adapter", () => {
     for (const failure of [
       "none",
       "wrong-provider",
+      "wrong-envelope-model",
       "zero-metering",
       "over-request-cap",
     ] as const) {
@@ -408,6 +432,9 @@ describe("scenario stability subprocess adapter", () => {
           ...(failure === "wrong-provider"
             ? { ELIZA_TEST_WRONG_REAL: "1" }
             : {}),
+          ...(failure === "wrong-envelope-model"
+            ? { ELIZA_TEST_WRONG_ENVELOPE_MODEL: "1" }
+            : {}),
           ...(failure === "zero-metering" ? { ELIZA_TEST_ZERO_REAL: "1" } : {}),
           ...(failure === "over-request-cap"
             ? { ELIZA_TEST_OVER_CAP_REAL: "1" }
@@ -436,7 +463,7 @@ describe("scenario stability subprocess adapter", () => {
         ],
         budgets: {
           timeoutMs: 2_000,
-          maxInputTokens: 10,
+          maxInputTokens: 10_000,
           maxOutputTokens: 10,
           maxModelRequests: 2,
           maxToolCalls: 2,
@@ -462,12 +489,13 @@ describe("scenario stability subprocess adapter", () => {
   });
 
   it.each([
-    ["STABILITY_MODEL_USAGE_MISSING", 0, 0],
-    ["STABILITY_MODEL_USAGE_MALFORMED", 0, 0],
-    ["STABILITY_MODEL_TOKEN_BUDGET_EXCEEDED", 12, 2],
+    ["STABILITY_MODEL_PRE_DISPATCH_REJECTED", 0, 0, 0],
+    ["STABILITY_MODEL_USAGE_MISSING", 0, 0, 1],
+    ["STABILITY_MODEL_USAGE_MALFORMED", 0, 0, 1],
+    ["STABILITY_MODEL_TOKEN_BUDGET_EXCEEDED", 12, 2, 1],
   ] as const)(
     "retains authentic failed real-model evidence for %s",
-    async (meterFailureCode, expectedInputTokens, expectedOutputTokens) => {
+    async (meterFailureCode, expectedInputTokens, expectedOutputTokens, expectedRequestCount) => {
       const outputRoot = root();
       const manifest = {
         version: 1 as const,
@@ -517,7 +545,7 @@ describe("scenario stability subprocess adapter", () => {
         ],
         budgets: {
           timeoutMs: 2_000,
-          maxInputTokens: 10,
+          maxInputTokens: 10_000,
           maxOutputTokens: 10,
           maxModelRequests: 2,
           maxToolCalls: 2,
@@ -547,7 +575,7 @@ describe("scenario stability subprocess adapter", () => {
               "eliza.stability.real-llm.v1",
           ),
         ).toMatchObject({
-          requestCount: 1,
+          requestCount: expectedRequestCount,
           inputTokens: expectedInputTokens,
           outputTokens: expectedOutputTokens,
           meteringFailures: [

--- a/packages/scenario-runner/src/stability-subprocess-adapter.ts
+++ b/packages/scenario-runner/src/stability-subprocess-adapter.ts
@@ -36,6 +36,16 @@ const INTERNAL_CONTROL_ENV = new Set([
   "ELIZA_SYNTHETIC_CONTROL_TOKEN",
   "ELIZA_SYNTHETIC_CONTROL_URL",
 ]);
+const REAL_MODEL_METER_FAILURE_CODES = new Set([
+  "STABILITY_MODEL_USAGE_MISSING",
+  "STABILITY_MODEL_USAGE_MALFORMED",
+  "STABILITY_MODEL_TOKEN_BUDGET_EXCEEDED",
+  "STABILITY_MODEL_TOKEN_BUDGET_EXHAUSTED",
+  "STABILITY_MODEL_REQUEST_BUDGET_EXCEEDED",
+  "STABILITY_MODEL_PROVIDER_ERROR",
+  "STABILITY_MODEL_PROVIDER_TIMEOUT",
+  "STABILITY_MODEL_PROXY_ERROR",
+]);
 
 export type ScenarioStabilityModelMode =
   | { kind: "deterministic-mock"; fixtureManifestFingerprint: string }
@@ -621,23 +631,64 @@ export class ScenarioStabilitySubprocessAdapter
         );
       });
       const receipt = receipts[0] as Record<string, unknown> | undefined;
+      const meteringFailures = Array.isArray(receipt?.meteringFailures)
+        ? receipt.meteringFailures
+        : null;
+      const meteringFailuresValid =
+        meteringFailures?.every((value) => {
+          if (!value || typeof value !== "object" || Array.isArray(value)) {
+            return false;
+          }
+          const failure = value as Record<string, unknown>;
+          return (
+            typeof failure.code === "string" &&
+            REAL_MODEL_METER_FAILURE_CODES.has(failure.code) &&
+            typeof failure.message === "string" &&
+            failure.message.trim().length > 0 &&
+            Number.isSafeInteger(failure.requestNumber) &&
+            (failure.requestNumber as number) > 0 &&
+            (failure.requestNumber as number) <=
+              (receipt && Number.isSafeInteger(receipt.requestCount)
+                ? (receipt.requestCount as number) + 1
+                : 0)
+          );
+        }) === true;
+      const lastMeteringFailure = meteringFailures?.at(-1) as
+        | Record<string, unknown>
+        | undefined;
+      const requestCount = receipt?.requestCount;
+      const successMeteringValid =
+        execution.passed === false ||
+        (receipt?.liveModelInvoked === true &&
+          Number.isSafeInteger(requestCount) &&
+          (requestCount as number) > 0 &&
+          execution.inputTokens > 0 &&
+          meteringFailures?.length === 0);
+      const failedMeteringBindingValid =
+        execution.passed === true ||
+        (((Number.isSafeInteger(requestCount) &&
+          (requestCount as number) > 0) ||
+          (meteringFailures?.length ?? 0) > 0) &&
+          ((meteringFailures?.length ?? 0) === 0 ||
+            execution.error === lastMeteringFailure?.code));
       if (
         receipts.length !== 1 ||
         !receipt ||
         receipt.provider !== input.target.model.provider ||
         receipt.model !== input.target.model.model ||
-        receipt.liveModelInvoked !== true ||
-        !Number.isSafeInteger(receipt.requestCount) ||
-        (receipt.requestCount as number) <= 0 ||
+        receipt.liveModelInvoked !==
+          (Number.isSafeInteger(requestCount) &&
+            (requestCount as number) > 0) ||
+        !Number.isSafeInteger(requestCount) ||
+        (requestCount as number) < 0 ||
         !Number.isSafeInteger(input.budgets.maxModelRequests) ||
         (input.budgets.maxModelRequests as number) <= 0 ||
-        (receipt.requestCount as number) >
-          (input.budgets.maxModelRequests as number) ||
+        (requestCount as number) > (input.budgets.maxModelRequests as number) ||
         receipt.inputTokens !== execution.inputTokens ||
         receipt.outputTokens !== execution.outputTokens ||
-        execution.inputTokens <= 0 ||
-        !Array.isArray(receipt.meteringFailures) ||
-        receipt.meteringFailures.length !== 0 ||
+        !meteringFailuresValid ||
+        !successMeteringValid ||
+        !failedMeteringBindingValid ||
         receipt.namespace !== session.manifest.namespace ||
         receipt.manifestId !== session.manifest.manifestId ||
         receipt.generation !== session.generation ||

--- a/packages/scenario-runner/src/stability-subprocess-adapter.ts
+++ b/packages/scenario-runner/src/stability-subprocess-adapter.ts
@@ -665,6 +665,23 @@ export class ScenarioStabilitySubprocessAdapter
         input.target.model.provider === "openai"
           ? new Set(["/v1/responses", "/v1/chat/completions"])
           : new Set(["/v1/messages"]);
+      const acceptedEnvelopeKeys = new Set([
+        "requestNumber",
+        "method",
+        "route",
+        "bodyBytes",
+        "forwardedBodyBytes",
+        "forwardedBodySha256",
+        "observedModel",
+        "requestedMaxOutputTokens",
+        "effectiveMaxOutputTokens",
+        "inputBudgetCharge",
+        "accepted",
+      ]);
+      const rejectedEnvelopeKeys = new Set([
+        ...acceptedEnvelopeKeys,
+        "failureCode",
+      ]);
       const requestEnvelopesValid =
         requestEnvelopes !== null &&
         requestEnvelopes.length <= 1_000 &&
@@ -677,7 +694,15 @@ export class ScenarioStabilitySubprocessAdapter
           const effective = envelope.effectiveMaxOutputTokens;
           const charge = envelope.inputBudgetCharge;
           const failureCode = envelope.failureCode;
+          const forwardedBytes = envelope.forwardedBodyBytes;
+          const forwardedHash = envelope.forwardedBodySha256;
+          const expectedKeys =
+            envelope.accepted === true
+              ? acceptedEnvelopeKeys
+              : rejectedEnvelopeKeys;
           return (
+            Object.keys(envelope).length === expectedKeys.size &&
+            Object.keys(envelope).every((key) => expectedKeys.has(key)) &&
             Number.isSafeInteger(envelope.requestNumber) &&
             (envelope.requestNumber as number) > 0 &&
             (envelope.requestNumber as number) <=
@@ -702,18 +727,49 @@ export class ScenarioStabilitySubprocessAdapter
             typeof envelope.accepted === "boolean" &&
             (envelope.accepted
               ? envelope.observedModel === input.target.model.model &&
+                Number.isSafeInteger(forwardedBytes) &&
+                (forwardedBytes as number) > 0 &&
+                typeof forwardedHash === "string" &&
+                /^[a-f0-9]{64}$/u.test(forwardedHash) &&
                 effective !== null &&
                 (effective as number) <= input.budgets.maxOutputTokens &&
+                (requested === null ||
+                  (effective as number) <= (requested as number)) &&
                 charge !== null &&
+                (charge as number) ===
+                  Math.max(
+                    envelope.bodyBytes as number,
+                    forwardedBytes as number,
+                  ) +
+                    8_192 &&
                 (charge as number) <= input.budgets.maxInputTokens &&
                 failureCode === undefined
-              : typeof failureCode === "string" &&
+              : forwardedBytes === null &&
+                forwardedHash === null &&
+                typeof failureCode === "string" &&
                 REAL_MODEL_METER_FAILURE_CODES.has(failureCode))
           );
         }) &&
         requestEnvelopes.filter(
           (value) => (value as Record<string, unknown>).accepted === true,
-        ).length === requestCount;
+        ).length === requestCount &&
+        requestEnvelopes
+          .filter(
+            (value) => (value as Record<string, unknown>).accepted === true,
+          )
+          .every(
+            (value, index) =>
+              (value as Record<string, unknown>).requestNumber === index + 1,
+          ) &&
+        requestEnvelopes
+          .filter(
+            (value) => (value as Record<string, unknown>).accepted === false,
+          )
+          .every(
+            (value) =>
+              (value as Record<string, unknown>).requestNumber ===
+              (requestCount as number) + 1,
+          );
       const successMeteringValid =
         execution.passed === false ||
         (receipt?.liveModelInvoked === true &&

--- a/packages/scenario-runner/src/stability-subprocess-adapter.ts
+++ b/packages/scenario-runner/src/stability-subprocess-adapter.ts
@@ -6,7 +6,12 @@
  */
 
 import { type ChildProcess, spawn } from "node:child_process";
-import { createHash } from "node:crypto";
+import {
+  createHash,
+  createHmac,
+  randomBytes,
+  timingSafeEqual,
+} from "node:crypto";
 import { constants } from "node:fs";
 import fs from "node:fs/promises";
 import { isIP } from "node:net";
@@ -36,6 +41,7 @@ const INTERNAL_CONTROL_ENV = new Set([
   "ELIZA_SYNTHETIC_CONTROL_TOKEN",
   "ELIZA_SYNTHETIC_CONTROL_URL",
 ]);
+const METER_ATTESTATION_ENV = "ELIZA_STABILITY_METER_ATTESTATION_KEY";
 const REAL_MODEL_METER_FAILURE_CODES = new Set([
   "STABILITY_MODEL_PRE_DISPATCH_REJECTED",
   "STABILITY_MODEL_USAGE_MISSING",
@@ -197,6 +203,41 @@ function canonicalSha256(value: unknown, source: string): string {
   return createHash("sha256").update(canonical).digest("hex");
 }
 
+function canonicalAttestationPayload(receipt: Record<string, unknown>): string {
+  const { attestation: _attestation, ...payload } = receipt;
+  assertScenarioStabilityBoundedJson(payload, "real-model receipt attestation");
+  return canonicalJsonString(payload, {
+    maxDepth: 32,
+    maxNodes: 100_000,
+    maxOutputChars: SCENARIO_STABILITY_MAX_ATTEMPT_JSON_BYTES,
+    sparseArrayHoles: "null",
+    onUnbounded: () => {
+      throw new Error(
+        "real-model receipt attestation exceeds canonical JSON limits",
+      );
+    },
+  });
+}
+
+function verifyReceiptAttestation(
+  receipt: Record<string, unknown>,
+  key: string,
+): boolean {
+  if (
+    typeof receipt.attestation !== "string" ||
+    !/^[a-f0-9]{64}$/u.test(receipt.attestation)
+  )
+    return false;
+  const expected = createHmac("sha256", key)
+    .update(canonicalAttestationPayload(receipt))
+    .digest();
+  const supplied = Buffer.from(receipt.attestation, "hex");
+  return (
+    supplied.byteLength === expected.byteLength &&
+    timingSafeEqual(supplied, expected)
+  );
+}
+
 function isLoopbackUrl(raw: string): boolean {
   const url = new URL(raw);
   const hostname =
@@ -220,6 +261,11 @@ function validateEnvironment(
   source: string,
 ): void {
   for (const [name, value] of Object.entries(values)) {
+    if (name === METER_ATTESTATION_ENV) {
+      throw new Error(
+        `${source} cannot override the internal meter attestation key`,
+      );
+    }
     if (!ENVIRONMENT_NAME.test(name)) {
       throw new Error(`${source} contains invalid environment name '${name}'`);
     }
@@ -305,6 +351,7 @@ function appendBounded(
 function sanitizedStderr(
   options: ScenarioStabilitySubprocessAdapterOptions,
   chunks: readonly Buffer[],
+  attestationKey?: string,
 ): Buffer {
   let text = new TextDecoder().decode(Buffer.concat(chunks));
   const secrets = [
@@ -312,6 +359,7 @@ function sanitizedStderr(
     ...(options.modelMode.kind === "real-llm"
       ? [options.modelMode.credentialValue]
       : []),
+    ...(attestationKey ? [attestationKey] : []),
   ];
   for (const secret of secrets) {
     if (secret.length > 0) text = text.replaceAll(secret, "[REDACTED_SECRET]");
@@ -415,8 +463,12 @@ function childEnvironment(
   input: Parameters<ScenarioStabilityExecutionAdapter["execute"]>[0],
   session: SyntheticControlSession,
   initialStateHash: string,
+  attestationKey?: string,
 ): NodeJS.ProcessEnv {
   const mode = options.modelMode;
+  if (mode.kind === "real-llm" && !attestationKey) {
+    throw new Error("real-llm attempt requires a parent-owned attestation key");
+  }
   return {
     PATH: process.env.PATH,
     TMPDIR: process.env.TMPDIR,
@@ -425,7 +477,10 @@ function childEnvironment(
     ...options.env,
     ...options.mockServiceUrls,
     ...(mode.kind === "real-llm"
-      ? { [mode.credentialEnv]: mode.credentialValue }
+      ? {
+          [mode.credentialEnv]: mode.credentialValue,
+          [METER_ATTESTATION_ENV]: attestationKey,
+        }
       : {}),
     ELIZA_STABILITY_MODEL_MODE: mode.kind,
     ...(mode.kind === "deterministic-mock"
@@ -494,6 +549,10 @@ export class ScenarioStabilitySubprocessAdapter
     };
     this.#boundaries.set(input.attemptId, boundary);
     const initialStateHash = await authorityInitialStateHash(session);
+    const attestationKey =
+      this.options.modelMode.kind === "real-llm"
+        ? randomBytes(32).toString("hex")
+        : undefined;
     const child = spawn(
       this.options.command,
       this.options.args({
@@ -506,7 +565,13 @@ export class ScenarioStabilitySubprocessAdapter
         detached: true,
         shell: false,
         stdio: ["ignore", "pipe", "pipe"],
-        env: childEnvironment(this.options, input, session, initialStateHash),
+        env: childEnvironment(
+          this.options,
+          input,
+          session,
+          initialStateHash,
+          attestationKey,
+        ),
       },
     );
     boundary.child = child;
@@ -572,7 +637,7 @@ export class ScenarioStabilitySubprocessAdapter
     const stderrArtifact = await persistStderrArtifact(
       input.outputDir,
       outputIdentities,
-      sanitizedStderr(this.options, stderr),
+      sanitizedStderr(this.options, stderr, attestationKey),
     );
     if (outputFailure) throw outputFailure;
     if (exitCode !== 0) {
@@ -632,6 +697,11 @@ export class ScenarioStabilitySubprocessAdapter
         );
       });
       const receipt = receipts[0] as Record<string, unknown> | undefined;
+      const receiptAttestationValid = Boolean(
+        receipt &&
+          attestationKey &&
+          verifyReceiptAttestation(receipt, attestationKey),
+      );
       const meteringFailures = Array.isArray(receipt?.meteringFailures)
         ? receipt.meteringFailures
         : null;
@@ -750,26 +820,13 @@ export class ScenarioStabilitySubprocessAdapter
                 REAL_MODEL_METER_FAILURE_CODES.has(failureCode))
           );
         }) &&
-        requestEnvelopes.filter(
-          (value) => (value as Record<string, unknown>).accepted === true,
-        ).length === requestCount &&
-        requestEnvelopes
-          .filter(
-            (value) => (value as Record<string, unknown>).accepted === true,
-          )
-          .every(
-            (value, index) =>
-              (value as Record<string, unknown>).requestNumber === index + 1,
-          ) &&
-        requestEnvelopes
-          .filter(
-            (value) => (value as Record<string, unknown>).accepted === false,
-          )
-          .every(
-            (value) =>
-              (value as Record<string, unknown>).requestNumber ===
-              (requestCount as number) + 1,
-          );
+        requestEnvelopes.every((value, index) => {
+          const envelope = value as Record<string, unknown>;
+          return index < (requestCount as number)
+            ? envelope.accepted === true && envelope.requestNumber === index + 1
+            : envelope.accepted === false &&
+                envelope.requestNumber === (requestCount as number) + 1;
+        });
       const successMeteringValid =
         execution.passed === false ||
         (receipt?.liveModelInvoked === true &&
@@ -796,6 +853,7 @@ export class ScenarioStabilitySubprocessAdapter
       if (
         receipts.length !== 1 ||
         !receipt ||
+        !receiptAttestationValid ||
         receipt.provider !== input.target.model.provider ||
         receipt.model !== input.target.model.model ||
         receipt.liveModelInvoked !==

--- a/packages/scenario-runner/src/stability-subprocess-adapter.ts
+++ b/packages/scenario-runner/src/stability-subprocess-adapter.ts
@@ -37,6 +37,7 @@ const INTERNAL_CONTROL_ENV = new Set([
   "ELIZA_SYNTHETIC_CONTROL_URL",
 ]);
 const REAL_MODEL_METER_FAILURE_CODES = new Set([
+  "STABILITY_MODEL_PRE_DISPATCH_REJECTED",
   "STABILITY_MODEL_USAGE_MISSING",
   "STABILITY_MODEL_USAGE_MALFORMED",
   "STABILITY_MODEL_TOKEN_BUDGET_EXCEEDED",
@@ -657,6 +658,62 @@ export class ScenarioStabilitySubprocessAdapter
         | Record<string, unknown>
         | undefined;
       const requestCount = receipt?.requestCount;
+      const requestEnvelopes = Array.isArray(receipt?.requestEnvelopes)
+        ? receipt.requestEnvelopes
+        : null;
+      const allowedRoutes =
+        input.target.model.provider === "openai"
+          ? new Set(["/v1/responses", "/v1/chat/completions"])
+          : new Set(["/v1/messages"]);
+      const requestEnvelopesValid =
+        requestEnvelopes !== null &&
+        requestEnvelopes.length <= 1_000 &&
+        requestEnvelopes.every((value) => {
+          if (!value || typeof value !== "object" || Array.isArray(value)) {
+            return false;
+          }
+          const envelope = value as Record<string, unknown>;
+          const requested = envelope.requestedMaxOutputTokens;
+          const effective = envelope.effectiveMaxOutputTokens;
+          const charge = envelope.inputBudgetCharge;
+          const failureCode = envelope.failureCode;
+          return (
+            Number.isSafeInteger(envelope.requestNumber) &&
+            (envelope.requestNumber as number) > 0 &&
+            (envelope.requestNumber as number) <=
+              (Number.isSafeInteger(requestCount)
+                ? (requestCount as number) + 1
+                : 0) &&
+            envelope.method === "POST" &&
+            typeof envelope.route === "string" &&
+            allowedRoutes.has(envelope.route) &&
+            Number.isSafeInteger(envelope.bodyBytes) &&
+            (envelope.bodyBytes as number) >= 0 &&
+            (envelope.observedModel === null ||
+              (typeof envelope.observedModel === "string" &&
+                envelope.observedModel.length > 0 &&
+                envelope.observedModel.length <= 512)) &&
+            (requested === null ||
+              (Number.isSafeInteger(requested) && (requested as number) > 0)) &&
+            (effective === null ||
+              (Number.isSafeInteger(effective) && (effective as number) > 0)) &&
+            (charge === null ||
+              (Number.isSafeInteger(charge) && (charge as number) > 0)) &&
+            typeof envelope.accepted === "boolean" &&
+            (envelope.accepted
+              ? envelope.observedModel === input.target.model.model &&
+                effective !== null &&
+                (effective as number) <= input.budgets.maxOutputTokens &&
+                charge !== null &&
+                (charge as number) <= input.budgets.maxInputTokens &&
+                failureCode === undefined
+              : typeof failureCode === "string" &&
+                REAL_MODEL_METER_FAILURE_CODES.has(failureCode))
+          );
+        }) &&
+        requestEnvelopes.filter(
+          (value) => (value as Record<string, unknown>).accepted === true,
+        ).length === requestCount;
       const successMeteringValid =
         execution.passed === false ||
         (receipt?.liveModelInvoked === true &&
@@ -664,6 +721,15 @@ export class ScenarioStabilitySubprocessAdapter
           (requestCount as number) > 0 &&
           execution.inputTokens > 0 &&
           meteringFailures?.length === 0);
+      const successEnvelopeBindingValid =
+        execution.passed === false ||
+        (requestEnvelopes?.length === requestCount &&
+          requestEnvelopes.every(
+            (value) =>
+              (value as Record<string, unknown>).accepted === true &&
+              (value as Record<string, unknown>).observedModel ===
+                input.target.model.model,
+          ));
       const failedMeteringBindingValid =
         execution.passed === true ||
         (((Number.isSafeInteger(requestCount) &&
@@ -687,7 +753,9 @@ export class ScenarioStabilitySubprocessAdapter
         receipt.inputTokens !== execution.inputTokens ||
         receipt.outputTokens !== execution.outputTokens ||
         !meteringFailuresValid ||
+        !requestEnvelopesValid ||
         !successMeteringValid ||
+        !successEnvelopeBindingValid ||
         !failedMeteringBindingValid ||
         receipt.namespace !== session.manifest.namespace ||
         receipt.manifestId !== session.manifest.manifestId ||

--- a/packages/scenario-runner/src/stability-subprocess-adapter.ts
+++ b/packages/scenario-runner/src/stability-subprocess-adapter.ts
@@ -9,6 +9,7 @@ import { type ChildProcess, spawn } from "node:child_process";
 import { createHash } from "node:crypto";
 import { constants } from "node:fs";
 import fs from "node:fs/promises";
+import { isIP } from "node:net";
 import path from "node:path";
 import { logger } from "@elizaos/core";
 import { canonicalJsonString } from "@elizaos/shared/canonical-json";
@@ -187,11 +188,15 @@ function canonicalSha256(value: unknown, source: string): string {
 
 function isLoopbackUrl(raw: string): boolean {
   const url = new URL(raw);
+  const hostname =
+    url.hostname.startsWith("[") && url.hostname.endsWith("]")
+      ? url.hostname.slice(1, -1)
+      : url.hostname;
   return (
     url.protocol === "http:" &&
-    (url.hostname === "localhost" ||
-      url.hostname === "[::1]" ||
-      url.hostname.startsWith("127.")) &&
+    (hostname === "localhost" ||
+      hostname === "::1" ||
+      (isIP(hostname) === 4 && hostname.split(".", 1)[0] === "127")) &&
     !url.username &&
     !url.password &&
     !url.search &&
@@ -622,6 +627,17 @@ export class ScenarioStabilitySubprocessAdapter
         receipt.provider !== input.target.model.provider ||
         receipt.model !== input.target.model.model ||
         receipt.liveModelInvoked !== true ||
+        !Number.isSafeInteger(receipt.requestCount) ||
+        (receipt.requestCount as number) <= 0 ||
+        !Number.isSafeInteger(input.budgets.maxModelRequests) ||
+        (input.budgets.maxModelRequests as number) <= 0 ||
+        (receipt.requestCount as number) >
+          (input.budgets.maxModelRequests as number) ||
+        receipt.inputTokens !== execution.inputTokens ||
+        receipt.outputTokens !== execution.outputTokens ||
+        execution.inputTokens <= 0 ||
+        !Array.isArray(receipt.meteringFailures) ||
+        receipt.meteringFailures.length !== 0 ||
         receipt.namespace !== session.manifest.namespace ||
         receipt.manifestId !== session.manifest.manifestId ||
         receipt.generation !== session.generation ||

--- a/packages/scenario-runner/src/stability-subprocess-adapter.ts
+++ b/packages/scenario-runner/src/stability-subprocess-adapter.ts
@@ -1,8 +1,9 @@
 /**
  * Executes stability attempts in independent OS process groups while one
  * leased synthetic-control session owns the exact mock manifest per attempt.
- * Child processes receive only explicit mock endpoints and, for live lanes,
- * one explicit model credential; ambient service credentials are never inherited.
+ * Child processes receive only explicit mock endpoints. For live lanes, the
+ * trusted attempt harness consumes secrets from a bounded bootstrap pipe that
+ * is closed before it starts any mock stack or scenario child.
  */
 
 import { type ChildProcess, spawn } from "node:child_process";
@@ -16,6 +17,7 @@ import { constants } from "node:fs";
 import fs from "node:fs/promises";
 import { isIP } from "node:net";
 import path from "node:path";
+import { Writable } from "node:stream";
 import { logger } from "@elizaos/core";
 import { canonicalJsonString } from "@elizaos/shared/canonical-json";
 import type {
@@ -33,6 +35,7 @@ import {
 import { openScenarioSyntheticWorld } from "./synthetic-control.ts";
 
 const MAX_STDERR_BYTES = 1024 * 1024;
+const MAX_REAL_MODEL_BOOTSTRAP_BYTES = 128 * 1024;
 const ENVIRONMENT_NAME = /^[A-Z_][A-Z0-9_]*$/;
 const CREDENTIAL_NAME =
   /(?:^|_)(?:API_KEY|TOKEN|SECRET|PASSWORD|CREDENTIALS?|ACCESS_KEY(?:_ID)?|PRIVATE_KEY|CLIENT_SECRET|CONNECTION_STRING)$/;
@@ -463,12 +466,8 @@ function childEnvironment(
   input: Parameters<ScenarioStabilityExecutionAdapter["execute"]>[0],
   session: SyntheticControlSession,
   initialStateHash: string,
-  attestationKey?: string,
 ): NodeJS.ProcessEnv {
   const mode = options.modelMode;
-  if (mode.kind === "real-llm" && !attestationKey) {
-    throw new Error("real-llm attempt requires a parent-owned attestation key");
-  }
   return {
     PATH: process.env.PATH,
     TMPDIR: process.env.TMPDIR,
@@ -476,12 +475,6 @@ function childEnvironment(
     TZ: process.env.TZ ?? "UTC",
     ...options.env,
     ...options.mockServiceUrls,
-    ...(mode.kind === "real-llm"
-      ? {
-          [mode.credentialEnv]: mode.credentialValue,
-          [METER_ATTESTATION_ENV]: attestationKey,
-        }
-      : {}),
     ELIZA_STABILITY_MODEL_MODE: mode.kind,
     ...(mode.kind === "deterministic-mock"
       ? {
@@ -553,6 +546,18 @@ export class ScenarioStabilitySubprocessAdapter
       this.options.modelMode.kind === "real-llm"
         ? randomBytes(32).toString("hex")
         : undefined;
+    const bootstrap =
+      this.options.modelMode.kind === "real-llm" && attestationKey
+        ? JSON.stringify({
+            version: 1,
+            credentialEnvironment: this.options.modelMode.credentialEnv,
+            credentialValue: this.options.modelMode.credentialValue,
+            meterAttestationKey: attestationKey,
+          })
+        : "";
+    if (Buffer.byteLength(bootstrap) > MAX_REAL_MODEL_BOOTSTRAP_BYTES) {
+      throw new Error("real-model bootstrap exceeds its byte limit");
+    }
     const child = spawn(
       this.options.command,
       this.options.args({
@@ -564,14 +569,8 @@ export class ScenarioStabilitySubprocessAdapter
         cwd: this.options.cwd,
         detached: true,
         shell: false,
-        stdio: ["ignore", "pipe", "pipe"],
-        env: childEnvironment(
-          this.options,
-          input,
-          session,
-          initialStateHash,
-          attestationKey,
-        ),
+        stdio: ["ignore", "pipe", "pipe", "pipe"],
+        env: childEnvironment(this.options, input, session, initialStateHash),
       },
     );
     boundary.child = child;
@@ -595,6 +594,15 @@ export class ScenarioStabilitySubprocessAdapter
         );
       }
     };
+    const bootstrapPipe = child.stdio[3];
+    if (!(bootstrapPipe instanceof Writable)) {
+      stopForOutputFailure(
+        new Error("stability subprocess omitted its bootstrap pipe"),
+      );
+    } else {
+      bootstrapPipe.on("error", stopForOutputFailure);
+      bootstrapPipe.end(bootstrap);
+    }
     child.stdout?.on("data", (chunk: Buffer) => {
       try {
         stdoutBytes = appendBounded(
@@ -820,13 +828,13 @@ export class ScenarioStabilitySubprocessAdapter
                 REAL_MODEL_METER_FAILURE_CODES.has(failureCode))
           );
         }) &&
-        requestEnvelopes.every((value, index) => {
+        requestEnvelopes?.every((value, index) => {
           const envelope = value as Record<string, unknown>;
           return index < (requestCount as number)
             ? envelope.accepted === true && envelope.requestNumber === index + 1
             : envelope.accepted === false &&
                 envelope.requestNumber === (requestCount as number) + 1;
-        });
+        }) === true;
       const successMeteringValid =
         execution.passed === false ||
         (receipt?.liveModelInvoked === true &&


### PR DESCRIPTION
## Summary

Stacks on #28936 and implements the safe metering/control-plane portion of #25518.

- removes real provider credentials from the scenario/harness environment and transports the selected credential plus per-attempt attestation key over a bounded FD3 bootstrap
- exposes only a loopback model proxy and dummy provider credential to the real runtime
- enforces request, conservative input-byte, authoritative output-token, tool-call, response-size, model, route, redirect, and attempt budgets before or during dispatch
- uses endpoint-specific request allowlists to reject hosted tools/contexts, remote URLs, MCP, containers, shell/code execution, search/audio, premium routing, background modes, and multi-choice bypasses
- requires authoritative OpenAI/Anthropic usage receipts and HMAC-attests canonical meter receipts
- verifies exact chronological accepted-envelope prefixes and rejected suffixes, request bytes/hashes, token arithmetic, model identity, and output caps
- records typed failed receipts across the exact three-attempt policy
- adds black-box production FD3 parser tests for malformed/schema-invalid, oversized, held-open/truncated, and valid payloads

## Evidence

- Head: `7f2dd5be968`
- Base: `cbd4c2f8a82` (#28936)
- Six implementation commits replayed patch-identically onto the base; parser coverage is a separate seventh commit
- Independent P0/P1 review: CLEAN
- Live-model meter: 64/64
- Parent + preload network guards: 10/10
- Production FD3 parser: 5/5, 27 assertions
- Parser review rerun: 5/5 in 4.31s
- Biome, guide parity, and diff checks pass
- Deterministic keyless exact lane passed first attempt and 3/3 before the final parser-only extraction

Shared-host subprocess reruns had only timeout/OS `EPERM` teardown failures; no credential, FD, receipt, HMAC, or request-policy assertion regressed. A loaded-host provider timeout case passed alone in 613ms.

## Security boundary

This PR removes direct environment and descriptor inheritance, but it does **not** claim hostile-code certification. Same-UID Linux `/proc/<pid>/environ` inspection and raw socket/network bypass remain possible unless the scenario process runs in the OS sandbox tracked by #26821. Therefore the credentialed GitHub lane must remain disabled until #26821 lands and proves distinct process identity/proc isolation plus network enforcement.

No live-model request was made.

Fixes #25518. Refs #25268, #26821, and #22896.