### PR TITLE
fix(cloud): close remaining owner error path leaks

### DIFF
--- a/packages/cloud/api/v1/jobs/[jobId]/route.test.ts
+++ b/packages/cloud/api/v1/jobs/[jobId]/route.test.ts
@@ -146,8 +146,8 @@ describe("jobs route", () => {
 
   test("a stored stack never reaches the owner's response (#23117)", async () => {
     // The stored value is the operator diagnostic — full frames. The API must
-    // hand back the failure summary only: frames disclose absolute server
-    // paths and internal module layout to a non-admin org member.
+    // hand back the generic owner-safe failure: even the first line of an
+    // operator diagnostic is not a stable public contract.
     const storedDiagnostic = [
       "Error: agent_delete failed",
       "    at deleteAgent (/srv/eliza/packages/cloud/shared/src/lib/services/eliza-sandbox.ts:2703:11)",
@@ -180,7 +180,9 @@ describe("jobs route", () => {
 
     expect(response.status).toBe(200);
     const body = (await response.json()) as { data: { error: string | null } };
-    expect(body.data.error).toBe("Error: agent_delete failed");
+    expect(body.data.error).toBe(
+      "The operation failed. Retry from Eliza Cloud or contact support if it continues.",
+    );
     expect(body.data.error).not.toContain(" at ");
     expect(body.data.error).not.toContain("/srv/eliza");
     expect(body.data.error).not.toContain(".ts:");

--- a/packages/cloud/shared/src/lib/services/job-error-text.test.ts
+++ b/packages/cloud/shared/src/lib/services/job-error-text.test.ts
@@ -210,12 +210,16 @@ describe("publicJobErrorSummary — API boundary", () => {
   });
 
   test("still finds a formatted host path adjacent to a public URL", () => {
-    const stored = jobErrorText(
-      new Error("Provider https://api.eliza.app[/srv/eliza/agents/9c1/config.json]"),
-    );
-    expect(publicJobErrorSummary(stored)).toBe(
-      "The operation failed. Retry from Eliza Cloud or contact support if it continues.",
-    );
+    for (const stored of [
+      "Provider https://api.eliza.app/v1/chat(/srv/eliza/agents/9c1/config.json)",
+      "Provider https://api.eliza.app/callback[/workspace/eliza/agents/9c1/config.json]",
+      "Provider https://api.eliza.app/v1/chat,%2Fsrv%2Feliza%2Fagents%2F9c1%2Fconfig.json",
+      "Provider https://api.eliza.app/v1/chat;C:%5Celiza%5Cagents%5C9c1%5Cconfig.json",
+    ]) {
+      expect(publicJobErrorSummary(stored)).toBe(
+        "The operation failed. Retry from Eliza Cloud or contact support if it continues.",
+      );
+    }
   });
 
   test.each([

--- a/packages/cloud/shared/src/lib/services/job-error-text.ts
+++ b/packages/cloud/shared/src/lib/services/job-error-text.ts
@@ -34,6 +34,8 @@ const DRIVE_PATH_PATTERN = /[A-Za-z]:[\\/][^\s'"`<>]*/u;
 const UNC_PATH_PATTERN = /\\\\[^\\\s'"`<>]+\\[^\s'"`<>]*/u;
 const POSIX_PATH_PATTERN = /\/+[^\s'"`<>]+/u;
 const PUBLIC_URL_METADATA_PATH_PATTERN = /^\/(?:v1\/chat|callback)$/iu;
+const URL_PATH_ADJACENT_HOST_PATH_PATTERN =
+  /[()[\]{},;:=][\p{White_Space}\p{Cc}\p{Cf}]*(?:\/{1,2}|[A-Za-z]:[\\/]|\\\\)/u;
 const LEADING_URL_METADATA_PADDING_PATTERN = /^[\p{White_Space}\p{Cc}\p{Cf}]+/u;
 const STACK_FRAME_PATTERN = /\n\s+at\s+/u;
 const BEARER_CREDENTIAL_PATTERN = /\bBearer\s+\S+/iu;
@@ -148,8 +150,14 @@ function networkUrlContainsHostPath(urlToken: string): boolean {
     return true;
   }
 
-  // The URL pathname is public route data; only query and fragment metadata
-  // can carry an adjacent host path that must be withheld.
+  const canonicalPathname = canonicalizeUrlMetadata(url.pathname);
+  if (canonicalPathname === null || URL_PATH_ADJACENT_HOST_PATH_PATTERN.test(canonicalPathname)) {
+    return true;
+  }
+
+  // Ordinary pathname segments are public route data. Query and fragment
+  // metadata receive the stricter recursive host-path classifier because they
+  // are not endpoint labels.
   const queryMetadata = [...url.searchParams.entries()].flat();
   const candidates = [url.hash.slice(1), ...queryMetadata];
   return candidates.some(urlMetadataIsUnsafe);


### PR DESCRIPTION
## Summary

Follow-up to merged PR #27103. Merge commit `325784c56ba8bdfdb162273b64642076b4d8cd91` contains the earlier observability/privacy work but does not contain these two independently reproduced final repairs:

- withhold owner-visible filesystem paths appended to otherwise public URL pathnames, including parenthesized/bracketed/punctuation suffixes, while preserving ordinary public endpoint labels;
- align the jobs-route stack regression with the canonical generic owner-safe message instead of expecting a raw diagnostic first line.

## Exact scope

- Base: `325784c56ba8bdfdb162273b64642076b4d8cd91`
- One commit, exactly three paths
- Replay patch-id: `ee65403b57bd3ddd214bfc52174ec949fb0387f0`
- Range-diff is identical to the reviewed post-#27103 repair commit `70b81c02ec8`.

## Verification

- focused owner-error suites: 169 pass, 0 fail, 427 assertions
- Cloud Shared typecheck: pass
- Cloud API typecheck plus production Worker dry bundle: pass
- Biome on all three paths: pass
- `git diff --check`: pass
- pinned gitleaks: one commit scanned, no leaks
- merge-tree: clean and identical to the candidate tree

## Evidence applicability

- UI screenshots/video: N/A - server-side diagnostic projection and tests only.
- live model trajectory: N/A - no model or prompt behavior changes.
- deployment/device evidence: N/A - no deployment or device artifact was created.

No merge, deploy, provider mutation, browser/account action, or spend was performed. Independent terminal rereview requested.