### PR TITLE
fix(core): improve language tag validation and CRLF handling in unwrapWholeCodeFence

### DIFF
--- a/packages/core/src/utils/code-fence.test.ts
+++ b/packages/core/src/utils/code-fence.test.ts
@@ -8,7 +8,12 @@ describe("unwrapWholeCodeFence", () => {
 		expect(unwrapWholeCodeFence('```json\n{"ok":true}\n```', ["json"])).toBe(
 			'{"ok":true}',
 		);
+		expect(
+			unwrapWholeCodeFence('```json \r\n{"ok":true}\r\n```', ["json"]),
+		).toBe('{"ok":true}');
 		expect(unwrapWholeCodeFence("```ts\n{}\n```", ["json"])).toBeNull();
+		expect(unwrapWholeCodeFence("```json5\n{}\n```", ["json"])).toBeNull();
+		expect(unwrapWholeCodeFence("```json-schema\n{}\n```", ["json"])).toBeNull();
 	});
 
 	it("keeps compact unlabeled bodies distinct from language labels", () => {

--- a/packages/core/src/utils/code-fence.ts
+++ b/packages/core/src/utils/code-fence.ts
@@ -7,7 +7,27 @@ export function unwrapWholeCodeFence(
 	if (!value.startsWith("```") || !value.endsWith("```") || value.length < 6) {
 		return null;
 	}
+
 	const lowerValue = value.toLowerCase();
+	const newlineIndex = value.indexOf("\n", 3);
+	if (newlineIndex !== -1 && newlineIndex <= value.length - 3) {
+		const firstLine = value.slice(3, newlineIndex).trim();
+		if (firstLine.length > 0) {
+			const declaredLanguage = firstLine.split(/\s+/u)[0].toLowerCase();
+			const isAccepted = languages.some(
+				(lang) => lang.toLowerCase() === declaredLanguage,
+			);
+			if (!isAccepted) {
+				return null;
+			}
+		}
+		let cursor = newlineIndex + 1;
+		while (cursor < value.length - 3 && /\s/u.test(value[cursor])) cursor += 1;
+		let end = value.length - 3;
+		while (end > cursor && /\s/u.test(value[end - 1])) end -= 1;
+		return value.slice(cursor, end);
+	}
+
 	const acceptedLanguage = [...languages]
 		.sort((left, right) => right.length - left.length)
 		.find((language) => lowerValue.startsWith(language.toLowerCase(), 3));


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Improves whole-value markdown code fence parsing by accurately verifying the declared language tag on the first line and handling CRLF line endings.

# Background

## What does this PR do?

Improves `unwrapWholeCodeFence` in `@elizaos/core`:
1. Distinguishes prefix-sharing distinct language tags (e.g. `json5` or `json-schema` vs `json`) on multi-line code fences so they are properly rejected when not accepted.
2. Supports trailing spaces on the language tag line and CRLF line endings (`\r\n`).
3. Preserves compact single-line unlabeled code fence unwrapping behavior.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue).

## Why are we doing this? Any context or related work?

When model responses returned code fences with trailing whitespace or distinct languages starting with the same prefix (e.g. ```` ```json5 ```` when `languages` was `["json"]`), `startsWith` previously partially matched `"json"` and returned the remainder of the language tag as part of the unwrapped body (e.g. `"5\n..."`).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Review `packages/core/src/utils/code-fence.ts` and `packages/core/src/utils/code-fence.test.ts`.

## Detailed testing steps

Run:
```bash
bun test packages/core/src/utils/code-fence.test.ts
bun run --cwd packages/core typecheck
```

# Evidence Gate

<!-- evidence-head:ef1617474aade627ce70d05c25548fe97ca9b3e8 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - Non-UI runtime parser change`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - Non-UI runtime parser change`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - Non-UI runtime parser change`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - Core utility unit function, verified via unit test execution`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - Non-UI runtime parser change`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - Deterministic markdown fence parsing logic without model calls`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - In-memory text parser`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - No rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

N/A - Deterministic markdown fence parsing logic without model calls.

## Backend + frontend logs

N/A - Core utility unit function, verified via unit test execution.

## Screenshots (before / after) + video walkthrough

N/A - Non-UI runtime parser change.

## Audio / voice walkthrough

N/A - No audio or voice paths touched.

## Known gaps / failures

None.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
