### PR TITLE
fix(cloud): keep rowless Personal Shared ids out of sandbox UUID lookups

### DIFF
--- a/packages/cloud/api/v1/eliza/agents/[agentId]/api/wallet/[...path]/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/api/wallet/[...path]/route.ts
@@ -11,6 +11,7 @@ import {
   requireUserOrApiKeyWithOrg,
 } from "@/lib/auth/workers-hono-auth";
 import { elizaSandboxService } from "@/lib/services/eliza-sandbox";
+import { isPersonalSharedAgentId } from "@/lib/services/shared-runtime/personal-shared-agent";
 import { applyCorsHeaders, handleCorsOptions } from "@/lib/services/proxy/cors";
 import { createStewardClient } from "@/lib/services/steward-client";
 import { parseClampedLimit, parseClampedOffset } from "@/lib/utils/clamp-limit";
@@ -176,6 +177,17 @@ async function resolveStewardAgentIdForProxy(
   sandboxAgentId: string,
   organizationId: string,
 ): Promise<string | null> {
+  // Personal Shared ids are rowless namespaced ids, not UUID-backed
+  // sandbox agents: skip the UUID-column sandbox mapping entirely and
+  // resolve straight through the Steward client (#28500).
+  if (isPersonalSharedAgentId(sandboxAgentId)) {
+    try {
+      await client.getAgent(sandboxAgentId);
+      return sandboxAgentId;
+    } catch {
+      return null;
+    }
+  }
   const stewardAgentId = await resolveStewardAgentId(
     sandboxAgentId,
     organizationId,
@@ -353,12 +365,20 @@ export async function handleDirectWalletRequest(
     );
   }
 
-  const agent = await elizaSandboxService.getAgent(
-    agentId,
-    user.organization_id,
-  );
-  if (!agent) {
-    return json({ success: false, error: "Agent not found" }, { status: 404 });
+  // Personal Shared identities are rowless (no agent_sandboxes row) with a
+  // namespaced `personal:` id. Passing that id into the UUID-backed sandbox
+  // lookup makes Postgres raise an invalid-UUID error (HTTP 500) before the
+  // intended behavior runs. Route Personal wallet requests straight to the
+  // account-scoped Steward resolution instead (#28500).
+  const isPersonal = isPersonalSharedAgentId(agentId);
+  if (!isPersonal) {
+    const agent = await elizaSandboxService.getAgent(
+      agentId,
+      user.organization_id,
+    );
+    if (!agent) {
+      return json({ success: false, error: "Agent not found" }, { status: 404 });
+    }
   }
 
   let client: StewardClient;

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/route.ts
@@ -20,6 +20,7 @@ import { containersEnv } from "@/lib/config/containers-env";
 import { getElizaAgentPublicWebUiUrl } from "@/lib/eliza-agent-web-ui";
 import { adminService } from "@/lib/services/admin";
 import { elizaSandboxService } from "@/lib/services/eliza-sandbox";
+import { isPersonalSharedAgentId } from "@/lib/services/shared-runtime/personal-shared-agent";
 import { provisioningJobService } from "@/lib/services/provisioning-jobs";
 import { getStewardAgent } from "@/lib/services/steward-client";
 import type {
@@ -133,6 +134,16 @@ app.get("/", async (c) => {
   try {
     const user = await requireUserOrApiKeyWithOrg(c);
     const agentId = c.req.param("agentId") ?? "";
+
+    // Personal Shared identities are rowless namespaced ids, not
+    // agent_sandboxes rows. Forwarding the namespaced id into the
+    // UUID-backed sandbox lookup raises an invalid-UUID error (HTTP 500)
+    // during Shared-to-Dedicated handoff polls; reject before repository
+    // I/O so the provisioning widget can fall back to the Dedicated
+    // target id (#28500).
+    if (isPersonalSharedAgentId(agentId)) {
+      return c.json({ success: false, error: "Agent not found" }, 404);
+    }
 
     const agent = await elizaSandboxService.getAgent(
       agentId,


### PR DESCRIPTION
## Summary
Personal Shared identities are rowless account identities with a namespaced `personal:` id; they are not `agent_sandboxes` rows. Two authenticated routes passed that id into UUID-backed sandbox lookups, making Postgres raise invalid-UUID errors (HTTP 500) before intended behavior ran:

1. wallet probes under `/api/v1/eliza/agents/:agentId/api/wallet/*`;
2. sandbox agent detail at `/api/v1/eliza/agents/:agentId`.

Staging observed **116 such errors in one window** (2026-08-24/25).

## Fix
- **wallet route**: skip `elizaSandboxService.getAgent` and the UUID-backed `sandbox_agent_id` mapping for Personal ids (`isPersonalSharedAgentId`); resolve straight through the account-scoped Steward client.
- **agent-detail route**: reject Personal ids before repository I/O (`404`), so the provisioning widget can fall back to the Dedicated target id.

Same invariant class as the Twilio fix in #20775.

## Verification
- `isPersonalSharedAgentId` regex verified against 5 cases: legal v5 personal id (match), ordinary sandbox UUID (no), malformed (no), non-v5 personal (no), uppercase v5 (match) — all pass.
- Acceptance: canonical Personal wallet requests never call the sandbox repository; sandbox-backed behavior unchanged.

Closes #28500.