### PR TITLE
fix(cloud): keep mobile auth preflight Node-runnable

### DIFF
--- a/packages/scripts/cloud/admin/verify-mobile-app-auth-registration.test.ts
+++ b/packages/scripts/cloud/admin/verify-mobile-app-auth-registration.test.ts
@@ -14,6 +14,7 @@ import { PGlite } from "@electric-sql/pglite";
 import {
   MOBILE_APP_AUTH_CONFIG_MAX_BYTES,
   type MobileAppAuthRegistrationRow,
+  mobileAppAuthDatabaseConnection,
   mobileAppAuthConfigUrl,
   queryMobileAppAuthRegistration,
   requireMobileAppAuthAppId,
@@ -33,6 +34,38 @@ const OTHER_ORGANIZATION_ID = "44444444-4444-4444-8444-444444444444";
 const CREATOR_ID = "55555555-5555-4555-8555-555555555555";
 const OTHER_CREATOR_ID = "66666666-6666-4666-8666-666666666666";
 const GENERATED_KEY_ID = "77777777-7777-4777-8777-777777777777";
+
+describe("mobile App Auth database connection boundary", () => {
+  test("allows local PostgreSQL without TLS", () => {
+    expect(
+      mobileAppAuthDatabaseConnection("postgresql://localhost:5432/eliza"),
+    ).toEqual({
+      url: "postgresql://localhost:5432/eliza",
+      ssl: undefined,
+    });
+  });
+
+  test("enforces verified TLS for remote PostgreSQL", () => {
+    const connection = mobileAppAuthDatabaseConnection(
+      "postgresql://user:pass@db.example/eliza",
+    );
+    expect(new URL(connection.url).searchParams.get("sslmode")).toBe(
+      "require",
+    );
+    expect(connection.ssl).toEqual({ rejectUnauthorized: true });
+  });
+
+  test("rejects remote plaintext modes", () => {
+    expect(() =>
+      mobileAppAuthDatabaseConnection(
+        "postgresql://db.example/eliza?sslmode=disable",
+      ),
+    ).toThrow(/must require TLS/);
+    expect(() =>
+      mobileAppAuthDatabaseConnection("https://db.example/eliza"),
+    ).toThrow(/postgres or postgresql/);
+  });
+});
 
 function liveResponse(
   environment: "staging" | "production",

--- a/packages/scripts/cloud/admin/verify-mobile-app-auth-registration.ts
+++ b/packages/scripts/cloud/admin/verify-mobile-app-auth-registration.ts
@@ -462,6 +462,46 @@ export async function verifyLiveMobileAppAuthConfig(
   }
 }
 
+/**
+ * Keep this release script runnable directly with Node. Importing the Cloud
+ * workspace's source-only db/client module here makes Node traverse its
+ * extensionless TypeScript imports and fails before PostgreSQL is contacted.
+ * This small copy preserves the same fail-closed TLS contract without pulling
+ * the Worker database runtime into the deployment preflight.
+ */
+export function mobileAppAuthDatabaseConnection(databaseUrl: string): {
+  url: string;
+  ssl: { rejectUnauthorized: boolean } | undefined;
+} {
+  let parsed: URL;
+  try {
+    parsed = new URL(databaseUrl);
+  } catch {
+    fail("DATABASE_URL must be a valid PostgreSQL URL");
+  }
+  if (parsed.protocol !== "postgres:" && parsed.protocol !== "postgresql:") {
+    fail("DATABASE_URL must use the postgres or postgresql scheme");
+  }
+  const isLocal =
+    parsed.hostname === "127.0.0.1" || parsed.hostname === "localhost";
+  if (isLocal) return { url: databaseUrl, ssl: undefined };
+
+  const sslmode = parsed.searchParams.get("sslmode");
+  if (sslmode === "disable" || sslmode === "allow") {
+    fail("Remote DATABASE_URL must require TLS");
+  }
+  const skipVerify =
+    process.env.DATABASE_SSL_NO_VERIFY === "true" ||
+    sslmode === "no-verify";
+  if (!sslmode) {
+    parsed.searchParams.set("sslmode", skipVerify ? "no-verify" : "require");
+  }
+  return {
+    url: parsed.toString(),
+    ssl: { rejectUnauthorized: !skipVerify },
+  };
+}
+
 async function closeDatabaseClient(client: pg.Client): Promise<void> {
   try {
     await client.end();
@@ -481,10 +521,7 @@ export async function verifyDatabaseMobileAppAuthRegistration(
   let row: MobileAppAuthRegistrationRow | undefined;
 
   try {
-    const { enforceTlsForRemote } = await import(
-      "@elizaos/cloud-shared/db/client"
-    );
-    const { url, ssl } = enforceTlsForRemote(databaseUrl);
+    const { url, ssl } = mobileAppAuthDatabaseConnection(databaseUrl);
     const connectedClient = new Client({
       connectionString: url,
       ...(ssl ? { ssl } : {}),


### PR DESCRIPTION
## Summary
- remove the release preflight's runtime import of an unresolvable source-only workspace subpath
- preserve fail-closed remote PostgreSQL TLS handling locally in the Node-executed script
- cover local, verified remote, and rejected plaintext database URLs

## Verification
- `bun test packages/scripts/cloud/admin/verify-mobile-app-auth-registration.test.ts packages/scripts/__tests__/cloud-cf-atomic-worker-secrets-workflow.test.ts` (26 pass)
- direct Node import of the release script succeeds
- staging deployment 32929604573 reproduced the pre-fix failure before PostgreSQL connect