### PR TITLE
fix(app): generate one secure credential namespace resolver

### DIFF
--- a/packages/app-core/scripts/run-mobile-build-cloud-main-activity.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-cloud-main-activity.test.mjs
@@ -136,6 +136,10 @@ describe("cloudSafeMainActivityJava", () => {
     expect(source).toContain('"accountDeletionRecovery".equals(key)');
     expect(source).toContain('"pending_login".equals(slot)');
     expect(source).toContain('"mobile_login_ciphertext"');
+    expect(source.match(/private String preferenceKey\(PluginCall call\)/g)).toHaveLength(
+      1,
+    );
+    expect(source).not.toContain("CREDENTIAL_CIPHERTEXT");
     expect(source).toContain("putString(preferenceKey, encoded).commit()");
     expect(source).toContain("remove(preferenceKey).commit()");
     expect(source).toContain(

--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -6503,14 +6503,6 @@ public final class ElizaSecureCredentialsPlugin extends Plugin {
         return getContext().getSharedPreferences(PREFERENCES, Context.MODE_PRIVATE);
     }
 
-    private String preferenceKey(PluginCall call) {
-        String slot = call.getString("slot", "credential");
-        if ("credential".equals(slot)) return CREDENTIAL_CIPHERTEXT;
-        if ("pending_login".equals(slot)) return PENDING_LOGIN_CIPHERTEXT;
-        call.reject("The secure credential slot is invalid.", "SECURE_CREDENTIAL_INVALID");
-        return null;
-    }
-
     private SecretKey loadOrCreateKey() throws GeneralSecurityException {
         KeyStore keyStore = KeyStore.getInstance(ANDROID_KEYSTORE);
         try {


### PR DESCRIPTION
## Summary
- remove the stale duplicate `preferenceKey` method from the generated Android secure-credentials plugin
- retain the unified session, pending-login, and account-deletion namespaces
- assert that launcher generation emits one resolver and no removed ciphertext symbol

## Real-boundary reproduction
`VITE_ELIZA_CLOUD_BASE=https://api-staging.eliza.app ELIZA_WEBVIEW_DEBUG=1 bun run build:android:launcher` reached Gradle and failed in `:app:compileDebugJavaWithJavac` because the generated class had two methods and referenced `CREDENTIAL_CIPHERTEXT`.

## Verification
- focused Android generator/target suites: 27 pass