### PR TITLE
fix(macos): restore proof-bound packaged desktop bootstrap

### DIFF
--- a/packages/agent/src/api/server-auth-boundary.test.ts
+++ b/packages/agent/src/api/server-auth-boundary.test.ts
@@ -28,6 +28,11 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import WebSocket from "ws";
+import {
+  _resetAgentHostBridge,
+  defaultAgentHostBridge,
+  setAgentHostBridge,
+} from "../runtime/host-bridge.ts";
 import { startApiServer } from "./server.ts";
 import {
   __resetPendingWebSocketsForTests,
@@ -104,6 +109,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  _resetAgentHostBridge();
   if (api) {
     await api.close();
     api = null;
@@ -133,6 +139,34 @@ async function bootServer(
   process.env.ELIZA_API_PORT = String(api.port);
   return `http://127.0.0.1:${api.port}`;
 }
+
+describe("packaged desktop bootstrap host boundary", () => {
+  it("dispatches the host-owned bootstrap before generic API auth", async () => {
+    let calls = 0;
+    setAgentHostBridge({
+      ...defaultAgentHostBridge,
+      handleDesktopAuthBootstrapRoute: async (req, res) => {
+        if (req.url !== "/api/auth/desktop-bootstrap") return false;
+        calls += 1;
+        res.statusCode = 200;
+        res.setHeader("content-type", "application/json");
+        res.end(JSON.stringify({ desktopBootstrap: true }));
+        return true;
+      },
+    });
+    const baseUrl = await bootServer();
+
+    const response = await fetch(`${baseUrl}/api/auth/desktop-bootstrap`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ socketPath: "/unused-by-host-test" }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ desktopBootstrap: true });
+    expect(calls).toBe(1);
+  }, 120_000);
+});
 
 /** Headers that make a loopback test client look like a proxied remote peer. */
 const REMOTE_HEADERS = { "x-forwarded-for": "203.0.113.10" } as const;

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -1812,6 +1812,19 @@ async function handleRequest(
     return;
   }
 
+  // The packaged desktop runs the agent listener directly, but app-core owns
+  // its browser-session store. The host consumes the one-shot local socket
+  // proof here; its handler enforces loopback peer+Host, originlessness,
+  // socket ownership, and socket mode before minting anything.
+  const handleDesktopAuthBootstrapRoute =
+    getAgentHostBridge().handleDesktopAuthBootstrapRoute;
+  if (
+    typeof handleDesktopAuthBootstrapRoute === "function" &&
+    (await handleDesktopAuthBootstrapRoute(req, res, state.runtime))
+  ) {
+    return;
+  }
+
   // Serve dashboard static assets before the auth gates. serveStaticUi already
   // refuses /api/, /v1/, and /ws paths, so API endpoints remain protected
   // while steward-managed containers can still reach the built-in dashboard.

--- a/packages/agent/src/runtime/host-bridge.test.ts
+++ b/packages/agent/src/runtime/host-bridge.test.ts
@@ -33,6 +33,7 @@ describe("agent host bridge (downward injection seam)", () => {
     await expect(bridge.sharedVault().has("ANY")).resolves.toBe(false);
     await expect(bridge.sharedVault().get("ANY")).resolves.toBe("");
     expect(bridge.handleCloudPairRoute).toBeUndefined();
+    expect(bridge.handleDesktopAuthBootstrapRoute).toBeUndefined();
   });
 
   it("honors ELIZA_BUILD_VARIANT in the default build-variant flags", () => {
@@ -68,6 +69,7 @@ describe("agent host bridge (downward injection seam)", () => {
       getBuildVariant: () => "direct",
       isStoreBuild: () => false,
       handleCloudPairRoute: () => Promise.resolve(true),
+      handleDesktopAuthBootstrapRoute: () => Promise.resolve(true),
     };
 
     setAgentHostBridge(installed);
@@ -78,6 +80,7 @@ describe("agent host bridge (downward injection seam)", () => {
     bridge.startAccountPoolKeepAlive();
     expect(keepAliveStarted).toBe(true);
     expect(typeof bridge.handleCloudPairRoute).toBe("function");
+    expect(typeof bridge.handleDesktopAuthBootstrapRoute).toBe("function");
   });
 
   it("resets back to the default after _resetAgentHostBridge", () => {

--- a/packages/agent/src/runtime/host-bridge.test.ts
+++ b/packages/agent/src/runtime/host-bridge.test.ts
@@ -6,7 +6,7 @@
  * and get/set/reset of an installed bridge. Deterministic and in-process — the
  * real default bridge plus a hand-built stub, no actual host.
  */
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   _resetAgentHostBridge,
   type AgentHostBridge,
@@ -81,6 +81,24 @@ describe("agent host bridge (downward injection seam)", () => {
     expect(keepAliveStarted).toBe(true);
     expect(typeof bridge.handleCloudPairRoute).toBe("function");
     expect(typeof bridge.handleDesktopAuthBootstrapRoute).toBe("function");
+  });
+
+  it("shares the installed bridge across source and compiled module instances", async () => {
+    const installed: AgentHostBridge = {
+      ...defaultAgentHostBridge,
+      getDefaultAccountPool: () => ({ id: "process-shared-pool" }),
+    };
+    setAgentHostBridge(installed);
+
+    // Desktop app-core can load the Bun source export while the packaged agent
+    // server executes the compiled module. The injected capability is process
+    // state, so those module instances must observe the same bridge.
+    vi.resetModules();
+    const reloaded = await import("./host-bridge.ts");
+
+    expect(reloaded.getAgentHostBridge()).toBe(installed);
+    reloaded._resetAgentHostBridge();
+    expect(getAgentHostBridge()).toBe(defaultAgentHostBridge);
   });
 
   it("resets back to the default after _resetAgentHostBridge", () => {

--- a/packages/agent/src/runtime/host-bridge.ts
+++ b/packages/agent/src/runtime/host-bridge.ts
@@ -205,19 +205,37 @@ export const defaultAgentHostBridge: AgentHostBridge = {
   isStoreBuild: () => defaultBuildVariant() === "store",
 };
 
-let installedBridge: AgentHostBridge | null = null;
+interface AgentHostBridgeProcessState {
+  installedBridge: AgentHostBridge | null;
+}
+
+const HOST_BRIDGE_STATE_SYMBOL = Symbol.for(
+  "elizaos.agent.host-bridge.state.v1",
+);
+
+function getHostBridgeProcessState(): AgentHostBridgeProcessState {
+  const processGlobal = globalThis as typeof globalThis & {
+    [key: symbol]: AgentHostBridgeProcessState | undefined;
+  };
+  const existing = processGlobal[HOST_BRIDGE_STATE_SYMBOL];
+  if (existing) return existing;
+
+  const state: AgentHostBridgeProcessState = { installedBridge: null };
+  processGlobal[HOST_BRIDGE_STATE_SYMBOL] = state;
+  return state;
+}
 
 /**
  * Install the host bridge. Called by the app-core boot funnel before the
  * runtime starts. Idempotent — the last installer wins.
  */
 export function setAgentHostBridge(bridge: AgentHostBridge): void {
-  installedBridge = bridge;
+  getHostBridgeProcessState().installedBridge = bridge;
 }
 
 /** Read the installed host bridge, falling back to the no-op default. */
 export function getAgentHostBridge(): AgentHostBridge {
-  return installedBridge ?? defaultAgentHostBridge;
+  return getHostBridgeProcessState().installedBridge ?? defaultAgentHostBridge;
 }
 
 /**
@@ -232,5 +250,5 @@ export function hasDurableHostVault(): boolean {
 
 /** Test-only: drop any installed bridge so the default is used again. */
 export function _resetAgentHostBridge(): void {
-  installedBridge = null;
+  getHostBridgeProcessState().installedBridge = null;
 }

--- a/packages/agent/src/runtime/host-bridge.ts
+++ b/packages/agent/src/runtime/host-bridge.ts
@@ -157,6 +157,16 @@ export interface AgentHostBridge {
     req: HttpIncomingMessage,
     res: HttpServerResponse,
   ): Promise<boolean>;
+  /**
+   * One-shot desktop session bootstrap. The host owns browser-session
+   * persistence, while the agent owns the packaged HTTP listener, so this
+   * handler must cross the bridge before the generic API auth gate runs.
+   */
+  handleDesktopAuthBootstrapRoute?(
+    req: HttpIncomingMessage,
+    res: HttpServerResponse,
+    runtime: AgentRuntime | null,
+  ): Promise<boolean>;
 }
 
 const noopVault: Vault = {

--- a/packages/app-core/scripts/desktop-build.mjs
+++ b/packages/app-core/scripts/desktop-build.mjs
@@ -23,6 +23,7 @@ import {
   hasElectrobunViewExport,
   isSupportedBunVersion,
 } from "./lib/desktop-preflight.mjs";
+import { canReuseDesktopRuntimePackage } from "./lib/desktop-runtime-package-policy.mjs";
 import { hardenElectrobunRpcSockets } from "./lib/electrobun-loopback-hardening.mjs";
 import { hardenLinuxArtifactPermissions } from "./lib/linux-artifact-permissions.mjs";
 import { appIdentityEnv } from "./lib/read-app-identity.mjs";
@@ -920,8 +921,12 @@ function ensureWorkspaceRuntimePackageBuilt(packageName, packageDir) {
   }
 
   if (
-    process.env.ELIZA_DESKTOP_REBUILD_RUNTIME_PACKAGES !== "1" &&
-    workspaceRuntimePackageLooksBuilt(packageName, packageDir)
+    canReuseDesktopRuntimePackage({
+      packageName,
+      forceRebuild:
+        process.env.ELIZA_DESKTOP_REBUILD_RUNTIME_PACKAGES === "1",
+      looksBuilt: workspaceRuntimePackageLooksBuilt(packageName, packageDir),
+    })
   ) {
     console.log(
       `[desktop-build] Reusing existing ${packageName} runtime package`,

--- a/packages/app-core/scripts/lib/desktop-runtime-package-policy.mjs
+++ b/packages/app-core/scripts/lib/desktop-runtime-package-policy.mjs
@@ -1,0 +1,18 @@
+/** Desktop runtime package reuse policy for the native bundle. */
+
+/**
+ * app-core and agent are the embedded server authorities. Rebuilding both on
+ * every desktop package prevents a fresh-looking but incomplete dist from
+ * omitting source-visible routes or process bridge capabilities.
+ */
+export function canReuseDesktopRuntimePackage({
+  packageName,
+  forceRebuild,
+  looksBuilt,
+}) {
+  if (forceRebuild) return false;
+  if (packageName === "@elizaos/app-core" || packageName === "@elizaos/agent") {
+    return false;
+  }
+  return looksBuilt;
+}

--- a/packages/app-core/scripts/lib/desktop-runtime-package-policy.test.mjs
+++ b/packages/app-core/scripts/lib/desktop-runtime-package-policy.test.mjs
@@ -1,0 +1,39 @@
+/** Verifies the desktop packager always rebuilds both server authorities. */
+
+import { describe, expect, it } from "vitest";
+import { canReuseDesktopRuntimePackage } from "./desktop-runtime-package-policy.mjs";
+
+describe("desktop runtime package reuse", () => {
+  it.each(["@elizaos/app-core", "@elizaos/agent"])(
+    "rebuilds %s even when its dist looks fresh",
+    (packageName) => {
+      expect(
+        canReuseDesktopRuntimePackage({
+          packageName,
+          forceRebuild: false,
+          looksBuilt: true,
+        }),
+      ).toBe(false);
+    },
+  );
+
+  it("retains reuse for heavier unchanged runtime dependencies", () => {
+    expect(
+      canReuseDesktopRuntimePackage({
+        packageName: "@elizaos/ui",
+        forceRebuild: false,
+        looksBuilt: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("honors the explicit full-runtime rebuild switch", () => {
+    expect(
+      canReuseDesktopRuntimePackage({
+        packageName: "@elizaos/ui",
+        forceRebuild: true,
+        looksBuilt: true,
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/app-core/src/api/auth/auth-context.test.ts
+++ b/packages/app-core/src/api/auth/auth-context.test.ts
@@ -13,7 +13,10 @@ import type {
   AuthSessionRow,
   AuthStore,
 } from "../../services/auth-store";
-import { ensureSessionForRequest } from "./auth-context";
+import {
+  DESKTOP_LOOPBACK_SESSION_SCOPE,
+  ensureSessionForRequest,
+} from "./auth-context";
 import {
   BROWSER_SESSION_REMEMBER_CAP_MS,
   BROWSER_SESSION_TTL_MS,
@@ -603,5 +606,94 @@ describe("ensureSessionForRequest", () => {
     expect(ctx?.source).toBe("cookie");
     expect(ctx?.session?.id).toBe(SESSION_ID);
     expect(ctx?.identity?.id).toBe(OWNER_ID);
+  });
+});
+
+function makeDesktopRequest(options: {
+  remoteAddress: string;
+  host: string;
+  bearer?: boolean;
+}): http.IncomingMessage {
+  const req = makeReq(
+    options.bearer
+      ? { authorization: `Bearer ${SESSION_ID}`, host: options.host }
+      : { cookie: `${SESSION_COOKIE_NAME}=${SESSION_ID}`, host: options.host },
+  );
+  Object.defineProperty(req.socket, "remoteAddress", {
+    value: options.remoteAddress,
+    configurable: true,
+  });
+  return req;
+}
+
+async function resolveDesktopSession(
+  row: AuthSessionRow,
+  request: http.IncomingMessage,
+) {
+  const store = new FakeAuthStore().seed(row);
+  return ensureSessionForRequest(request, fakeRes(), {
+    store: asAuthStore(store),
+    now: NOW,
+    allowBootstrapBearer: false,
+  });
+}
+
+describe("desktop loopback browser sessions", () => {
+  it("accepts the marked session only from a loopback peer and Host", async () => {
+    const row = session({ scopes: [DESKTOP_LOOPBACK_SESSION_SCOPE] });
+
+    await expect(
+      resolveDesktopSession(
+        row,
+        makeDesktopRequest({
+          remoteAddress: "127.0.0.1",
+          host: "127.0.0.1:31337",
+        }),
+      ),
+    ).resolves.toMatchObject({ source: "cookie", identity: identity() });
+
+    await expect(
+      resolveDesktopSession(
+        row,
+        makeDesktopRequest({
+          remoteAddress: "203.0.113.5",
+          host: "127.0.0.1:31337",
+        }),
+      ),
+    ).resolves.toBeNull();
+    await expect(
+      resolveDesktopSession(
+        row,
+        makeDesktopRequest({
+          remoteAddress: "127.0.0.1",
+          host: "example.test",
+        }),
+      ),
+    ).resolves.toBeNull();
+  });
+
+  it("enforces the same restriction for bearer replay", async () => {
+    await expect(
+      resolveDesktopSession(
+        session({ scopes: [DESKTOP_LOOPBACK_SESSION_SCOPE] }),
+        makeDesktopRequest({
+          remoteAddress: "203.0.113.6",
+          host: "example.test",
+          bearer: true,
+        }),
+      ),
+    ).resolves.toBeNull();
+  });
+
+  it("does not change ordinary browser-session routing", async () => {
+    await expect(
+      resolveDesktopSession(
+        session({ scopes: [] }),
+        makeDesktopRequest({
+          remoteAddress: "203.0.113.7",
+          host: "example.test",
+        }),
+      ),
+    ).resolves.toMatchObject({ source: "cookie", identity: identity() });
   });
 });

--- a/packages/app-core/src/api/auth/auth-context.ts
+++ b/packages/app-core/src/api/auth/auth-context.ts
@@ -13,7 +13,11 @@
  */
 
 import type http from "node:http";
-import type { RuntimeEnvRecord } from "@elizaos/shared";
+import {
+  isLoopbackBindHost,
+  isLoopbackRemoteAddress,
+  type RuntimeEnvRecord,
+} from "@elizaos/shared";
 import type {
   AuthIdentityRow,
   AuthSessionRow,
@@ -45,6 +49,23 @@ export interface EnsureSessionOptions {
   allowBootstrapBearer?: boolean;
 }
 
+export const DESKTOP_LOOPBACK_SESSION_SCOPE = "desktop:loopback";
+
+function firstHeaderValue(value: string | string[] | undefined): string | null {
+  if (Array.isArray(value)) return value[0]?.trim() || null;
+  return value?.trim() || null;
+}
+
+function sessionAllowedForRequest(
+  session: AuthSessionRow,
+  req: Pick<http.IncomingMessage, "headers" | "socket">,
+): boolean {
+  if (!session.scopes.includes(DESKTOP_LOOPBACK_SESSION_SCOPE)) return true;
+  if (!isLoopbackRemoteAddress(req.socket.remoteAddress)) return false;
+  const host = firstHeaderValue(req.headers.host);
+  return host !== null && isLoopbackBindHost(host);
+}
+
 /**
  * Resolve the request to a session + identity if possible. Returns null on
  * any failure path; never throws on bad input. The caller is responsible
@@ -65,7 +86,7 @@ export async function ensureSessionForRequest(
     const session = await findActiveSession(store, cookieSessionId, now).catch(
       () => null,
     );
-    if (session) {
+    if (session && sessionAllowedForRequest(session, req)) {
       const identity = await store
         .findIdentity(session.identityId)
         .catch(() => null);
@@ -86,7 +107,7 @@ export async function ensureSessionForRequest(
     const session = await findActiveSession(store, bearer, now).catch(
       () => null,
     );
-    if (session) {
+    if (session && sessionAllowedForRequest(session, req)) {
       const identity = await store
         .findIdentity(session.identityId)
         .catch(() => null);

--- a/packages/app-core/src/api/auth/index.ts
+++ b/packages/app-core/src/api/auth/index.ts
@@ -35,6 +35,7 @@ export {
 } from "./audit.js";
 export {
   type AuthContextSource,
+  DESKTOP_LOOPBACK_SESSION_SCOPE,
   type EnsureSessionOptions,
   ensureSessionForRequest,
   type ResolvedAuthContext,

--- a/packages/app-core/src/api/auth/sessions.ts
+++ b/packages/app-core/src/api/auth/sessions.ts
@@ -52,6 +52,8 @@ export interface CreateBrowserSessionOptions {
   ip: string | null;
   userAgent: string | null;
   rememberDevice: boolean;
+  /** Capability restrictions enforced by the canonical request resolver. */
+  scopes?: string[];
   /** Override `Date.now()` for tests. */
   now?: number;
 }
@@ -119,7 +121,7 @@ export async function createBrowserSession(
     csrfSecret,
     ip: options.ip,
     userAgent: options.userAgent,
-    scopes: [],
+    scopes: [...(options.scopes ?? [])],
   });
   return { session, csrfToken: deriveCsrfToken(session) };
 }

--- a/packages/app-core/src/api/desktop-auth-bootstrap-routes.route.test.ts
+++ b/packages/app-core/src/api/desktop-auth-bootstrap-routes.route.test.ts
@@ -1,0 +1,188 @@
+/** Drives desktop bootstrap through a real migrated auth store and Unix socket. */
+
+import crypto from "node:crypto";
+import fs from "node:fs";
+import http from "node:http";
+import net, { Socket } from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { AuthStore, type DrizzleDatabase } from "../services/auth-store";
+import {
+  DESKTOP_LOOPBACK_SESSION_SCOPE,
+  ensureSessionForRequest,
+} from "./auth/index";
+import type { CompatRuntimeState } from "./compat-route-shared";
+import { handleDesktopAuthBootstrapRoute } from "./desktop-auth-bootstrap-routes";
+
+interface AdapterWithDb {
+  db?: unknown;
+  initialize?: () => Promise<void>;
+  init?: () => Promise<void>;
+  close?: () => Promise<void>;
+}
+
+interface SqlPluginModule {
+  createDatabaseAdapter: (
+    config: { dataDir: string },
+    id: `${string}-${string}-${string}-${string}-${string}`,
+  ) => unknown;
+  DatabaseMigrationService: new () => {
+    initializeWithDatabase: (db: unknown) => Promise<void>;
+    discoverAndRegisterPluginSchemas: (plugins: unknown[]) => void;
+    runAllPluginMigrations: () => Promise<void>;
+  };
+  plugin: unknown;
+}
+
+const cleanups: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+});
+
+async function openDatabase() {
+  const {
+    createDatabaseAdapter,
+    DatabaseMigrationService,
+    plugin: sqlPlugin,
+  } = (await import("@elizaos/plugin-sql")) as SqlPluginModule;
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "desktop-auth-db-"));
+  const adapter = createDatabaseAdapter(
+    { dataDir },
+    "00000000-0000-0000-0000-000000000017",
+  ) as AdapterWithDb;
+  if (adapter.initialize) await adapter.initialize();
+  else await adapter.init?.();
+  if (!adapter.db) throw new Error("test adapter has no database");
+  const db = adapter.db as DrizzleDatabase;
+  const migrations = new DatabaseMigrationService();
+  await migrations.initializeWithDatabase(db);
+  migrations.discoverAndRegisterPluginSchemas([sqlPlugin]);
+  await migrations.runAllPluginMigrations();
+  cleanups.push(async () => {
+    await adapter.close?.();
+    fs.rmSync(dataDir, { recursive: true, force: true });
+  });
+  return { db, store: new AuthStore(db) };
+}
+
+async function openProofSocket() {
+  const socketPath = path.join(
+    os.tmpdir(),
+    `mda-${crypto.randomBytes(4).toString("hex")}.sock`,
+  );
+  const server = net.createServer((connection) => {
+    connection.end(crypto.randomBytes(32));
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(socketPath, resolve);
+  });
+  fs.chmodSync(socketPath, 0o600);
+  cleanups.push(
+    () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          fs.rmSync(socketPath, { force: true });
+          if (error) reject(error);
+          else resolve();
+        });
+      }),
+  );
+  return socketPath;
+}
+
+function request(options: {
+  body?: unknown;
+  cookie?: string;
+  origin?: string;
+  remoteAddress?: string;
+  host?: string;
+}): http.IncomingMessage {
+  const req = new http.IncomingMessage(new Socket());
+  req.method = options.body === undefined ? "GET" : "POST";
+  req.url =
+    options.body === undefined ? "/api/auth/me" : "/api/auth/desktop-bootstrap";
+  req.headers = {
+    host: options.host ?? "127.0.0.1:31337",
+    ...(options.cookie ? { cookie: options.cookie } : {}),
+    ...(options.origin ? { origin: options.origin } : {}),
+  };
+  Object.defineProperty(req.socket, "remoteAddress", {
+    value: options.remoteAddress ?? "127.0.0.1",
+    configurable: true,
+  });
+  if (options.body !== undefined) req.push(JSON.stringify(options.body));
+  req.push(null);
+  return req;
+}
+
+function response(req: http.IncomingMessage) {
+  let body = "";
+  const res = new http.ServerResponse(req);
+  res.end = ((chunk?: string | Buffer) => {
+    if (chunk) body += chunk.toString();
+    return res;
+  }) as typeof res.end;
+  return { res, body: () => JSON.parse(body) as Record<string, unknown> };
+}
+
+describe("desktop auth bootstrap integration", () => {
+  it("mints a loopback-marked session that cannot be replayed remotely", async () => {
+    const { db, store } = await openDatabase();
+    const socketPath = await openProofSocket();
+    const req = request({ body: { socketPath } });
+    const reply = response(req);
+    const handled = await handleDesktopAuthBootstrapRoute(req, reply.res, {
+      current: { adapter: { db } } as CompatRuntimeState["current"],
+      pendingAgentName: null,
+      pendingRestartReasons: [],
+    });
+    expect(handled).toBe(true);
+    expect(reply.res.statusCode).toBe(200);
+    const sessionId = String(reply.body().sessionId);
+    const persisted = await store.findSession(sessionId, Date.now());
+    expect(persisted?.scopes).toEqual([DESKTOP_LOOPBACK_SESSION_SCOPE]);
+
+    const cookie = `eliza_session=${sessionId}`;
+    const localReq = request({ cookie });
+    await expect(
+      ensureSessionForRequest(localReq, response(localReq).res, {
+        store,
+        allowBootstrapBearer: false,
+      }),
+    ).resolves.toMatchObject({ source: "cookie" });
+
+    const remoteReq = request({
+      cookie,
+      remoteAddress: "203.0.113.18",
+      host: "example.test",
+    });
+    await expect(
+      ensureSessionForRequest(remoteReq, response(remoteReq).res, {
+        store,
+        allowBootstrapBearer: false,
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it("forbids origin-bearing bootstrap requests before consuming proof", async () => {
+    const { db } = await openDatabase();
+    const socketPath = await openProofSocket();
+    const req = request({
+      body: { socketPath },
+      origin: "http://127.0.0.1:5174",
+    });
+    const reply = response(req);
+    await handleDesktopAuthBootstrapRoute(req, reply.res, {
+      current: { adapter: { db } } as CompatRuntimeState["current"],
+      pendingAgentName: null,
+      pendingRestartReasons: [],
+    });
+    expect(reply.res.statusCode).toBe(403);
+    expect(reply.body()).toMatchObject({
+      error: "desktop_bootstrap_forbidden",
+    });
+  });
+});

--- a/packages/app-core/src/api/desktop-auth-bootstrap-routes.test.ts
+++ b/packages/app-core/src/api/desktop-auth-bootstrap-routes.test.ts
@@ -1,0 +1,72 @@
+/** Exercises the real Unix-socket proof used by desktop session bootstrap. */
+
+import crypto from "node:crypto";
+import fs from "node:fs";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { consumeDesktopSocketProof } from "./desktop-auth-bootstrap-routes";
+
+const createdPaths: string[] = [];
+
+afterEach(() => {
+  for (const socketPath of createdPaths.splice(0)) {
+    try {
+      fs.unlinkSync(socketPath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    }
+  }
+});
+
+async function openProofSocket(options?: {
+  bytes?: number;
+  mode?: number;
+  name?: string;
+}): Promise<{ path: string; close: () => Promise<void> }> {
+  const socketPath = path.join(
+    os.tmpdir(),
+    options?.name ?? `mda-${crypto.randomBytes(4).toString("hex")}.sock`,
+  );
+  createdPaths.push(socketPath);
+  const server = net.createServer((connection) => {
+    connection.end(crypto.randomBytes(options?.bytes ?? 32));
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(socketPath, resolve);
+  });
+  fs.chmodSync(socketPath, options?.mode ?? 0o600);
+  return {
+    path: socketPath,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      }),
+  };
+}
+
+describe("consumeDesktopSocketProof", () => {
+  it("accepts one owner-only socket yielding the exact proof length", async () => {
+    const socket = await openProofSocket();
+    expect(await consumeDesktopSocketProof(socket.path)).toBe(true);
+    await socket.close();
+  });
+
+  it("rejects a permissive socket before connecting", async () => {
+    const socket = await openProofSocket({ mode: 0o666 });
+    expect(await consumeDesktopSocketProof(socket.path)).toBe(false);
+    await socket.close();
+  });
+
+  it("rejects unexpected socket names and malformed proof lengths", async () => {
+    const wrongName = await openProofSocket({ name: "untrusted.sock" });
+    expect(await consumeDesktopSocketProof(wrongName.path)).toBe(false);
+    await wrongName.close();
+
+    const shortProof = await openProofSocket({ bytes: 16 });
+    expect(await consumeDesktopSocketProof(shortProof.path)).toBe(false);
+    await shortProof.close();
+  });
+});

--- a/packages/app-core/src/api/desktop-auth-bootstrap-routes.ts
+++ b/packages/app-core/src/api/desktop-auth-bootstrap-routes.ts
@@ -1,0 +1,204 @@
+/**
+ * Mints the trusted local desktop browser session after proving possession of
+ * a one-shot Unix socket created by the Electrobun main process. The route is
+ * loopback-only, originless, and restricted to owner-only socket paths so a
+ * web page cannot turn localhost reachability into a desktop session.
+ */
+
+import crypto from "node:crypto";
+import fs from "node:fs";
+import type http from "node:http";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { logger, resolveStateDir } from "@elizaos/core";
+import { AuthStore, type DrizzleDatabase } from "../services/auth-store";
+import {
+  appendAuditEvent,
+  createBrowserSession,
+  DESKTOP_LOOPBACK_SESSION_SCOPE,
+} from "./auth/index";
+import {
+  type CompatRuntimeState,
+  isTrustedLocalRequest,
+  readCompatJsonBody,
+} from "./compat-route-shared";
+import { sendJson, sendJsonError } from "./response";
+
+const DESKTOP_BOOTSTRAP_PATH = "/api/auth/desktop-bootstrap";
+const SOCKET_SECRET_BYTES = 32;
+const SOCKET_TIMEOUT_MS = 5_000;
+
+interface AdapterWithDb {
+  db?: unknown;
+}
+
+function getDrizzleDb(state: CompatRuntimeState): DrizzleDatabase | null {
+  const adapter = state.current?.adapter as AdapterWithDb | undefined;
+  return adapter?.db ? (adapter.db as DrizzleDatabase) : null;
+}
+
+function resolveAllowedSocketRoots(): string[] {
+  return [path.join(resolveStateDir(), "sockets"), os.tmpdir()].map((root) =>
+    path.resolve(root),
+  );
+}
+
+function isAllowedSocketPath(socketPath: string): boolean {
+  if (!path.isAbsolute(socketPath)) return false;
+  const resolved = path.resolve(socketPath);
+  const basename = path.basename(resolved);
+  const allowedName =
+    /^desktop-auth-[a-f0-9]{16}\.sock$/.test(basename) ||
+    /^mda-[a-f0-9]{8}\.sock$/.test(basename);
+  if (!allowedName) return false;
+  return resolveAllowedSocketRoots().some((root) =>
+    resolved.startsWith(`${root}${path.sep}`),
+  );
+}
+
+export async function consumeDesktopSocketProof(
+  socketPath: string,
+): Promise<boolean> {
+  if (!isAllowedSocketPath(socketPath)) return false;
+
+  let stat: fs.Stats;
+  try {
+    stat = fs.lstatSync(socketPath);
+  } catch {
+    // error-policy:J3 an absent/unreadable socket is invalid proof.
+    return false;
+  }
+  if (!stat.isSocket() || (stat.mode & 0o077) !== 0) return false;
+  if (typeof process.getuid === "function" && stat.uid !== process.getuid()) {
+    return false;
+  }
+
+  return new Promise<boolean>((resolve) => {
+    const socket = net.createConnection(socketPath);
+    const chunks: Buffer[] = [];
+    let settled = false;
+    const finish = (valid: boolean) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      socket.destroy();
+      resolve(valid);
+    };
+    const timeout = setTimeout(() => finish(false), SOCKET_TIMEOUT_MS);
+    socket.on("data", (chunk) => {
+      chunks.push(Buffer.from(chunk));
+      if (chunks.reduce((sum, value) => sum + value.length, 0) > 64) {
+        finish(false);
+      }
+    });
+    socket.once("end", () => {
+      finish(Buffer.concat(chunks).length === SOCKET_SECRET_BYTES);
+    });
+    socket.once("error", () => finish(false));
+  });
+}
+
+export async function handleDesktopAuthBootstrapRoute(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  state: CompatRuntimeState,
+): Promise<boolean> {
+  const method = (req.method ?? "GET").toUpperCase();
+  const url = new URL(req.url ?? "/", "http://localhost");
+  if (method !== "POST" || url.pathname !== DESKTOP_BOOTSTRAP_PATH) {
+    return false;
+  }
+
+  if (
+    !isTrustedLocalRequest(req) ||
+    req.headers.origin !== undefined ||
+    req.headers.referer !== undefined
+  ) {
+    sendJsonError(res, 403, "desktop_bootstrap_forbidden");
+    return true;
+  }
+
+  const db = getDrizzleDb(state);
+  if (!db) {
+    sendJsonError(res, 503, "db_unavailable");
+    return true;
+  }
+
+  const body = await readCompatJsonBody(req, res);
+  if (body == null) return true;
+  const socketPath =
+    typeof body.socketPath === "string" ? body.socketPath.trim() : "";
+  if (!socketPath || !(await consumeDesktopSocketProof(socketPath))) {
+    sendJsonError(res, 403, "desktop_bootstrap_proof_failed");
+    return true;
+  }
+
+  const store = new AuthStore(db);
+  let owner = (await store.listIdentitiesByKind("owner"))[0] ?? null;
+  const now = Date.now();
+  if (!owner) {
+    owner = await store.createIdentity({
+      id: crypto.randomUUID(),
+      kind: "owner",
+      displayName: "Local",
+      createdAt: now,
+      passwordHash: null,
+      cloudUserId: null,
+    });
+  }
+
+  const { session, csrfToken } = await createBrowserSession(store, {
+    identityId: owner.id,
+    ip: req.socket.remoteAddress ?? null,
+    userAgent: "Eliza desktop",
+    rememberDevice: true,
+    scopes: [DESKTOP_LOOPBACK_SESSION_SCOPE],
+    now,
+  });
+  try {
+    await appendAuditEvent(
+      {
+        actorIdentityId: owner.id,
+        ip: req.socket.remoteAddress ?? null,
+        userAgent: "Eliza desktop",
+        action: "auth.desktop.bootstrap",
+        outcome: "success",
+        metadata: { loopback: true },
+      },
+      { store },
+    );
+  } catch (error) {
+    // error-policy:J7 an audit sink failure must not orphan a valid desktop session.
+    logger.error(
+      {
+        error: error instanceof Error ? error.message : String(error),
+        loopback: true,
+      },
+      "[DesktopAuth] Bootstrap audit write failed",
+    );
+    try {
+      state.current?.reportError("appCore.desktopAuthAudit", error, {
+        loopback: true,
+      });
+    } catch (reportError) {
+      // error-policy:J7 the structured logger above remains the observed sink.
+      logger.error(
+        {
+          error:
+            reportError instanceof Error
+              ? reportError.message
+              : String(reportError),
+        },
+        "[DesktopAuth] Runtime error reporting failed",
+      );
+    }
+  }
+
+  sendJson(res, 200, {
+    sessionId: session.id,
+    csrfToken,
+    expiresAt: session.expiresAt,
+  });
+  return true;
+}

--- a/packages/app-core/src/api/route-auth-policy.dispatch.test.ts
+++ b/packages/app-core/src/api/route-auth-policy.dispatch.test.ts
@@ -285,6 +285,30 @@ describe("compat dispatcher default-deny (H5)", () => {
     });
   });
 
+  it("lets desktop bootstrap reach its one-shot proof handler before session auth", async () => {
+    const cap = captureRes();
+    const handled = await handleElizaCompatRoute(
+      trustedLoopbackReq("POST", "/api/auth/desktop-bootstrap"),
+      cap.res,
+      STATE,
+    );
+
+    expect(handled).toBe(true);
+    expect(cap.status()).toBe(503);
+    expect(cap.json()).toEqual({ error: "db_unavailable" });
+
+    const remote = captureRes();
+    const remoteHandled = await handleElizaCompatRoute(
+      unauthReq("POST", "/api/auth/desktop-bootstrap"),
+      remote.res,
+      STATE,
+    );
+
+    expect(remoteHandled).toBe(true);
+    expect(remote.status()).toBe(403);
+    expect(remote.json()).toEqual({ error: "desktop_bootstrap_forbidden" });
+  });
+
   it("denies remote-mode cloud mutations before the forwarder sees unauthenticated callers", async () => {
     const cap = captureRes();
     const handled = await handleElizaCompatRoute(

--- a/packages/app-core/src/api/route-auth-policy.ts
+++ b/packages/app-core/src/api/route-auth-policy.ts
@@ -127,6 +127,9 @@ export const COMPAT_ROUTE_AUTH_POLICIES: readonly CompatRouteAuthPolicy[] = [
     "POST",
     "/api/auth/bootstrap/exchange",
   ),
+  // Public at this outer gate only so the route can authenticate the native
+  // desktop through its stricter loopback + owned one-shot socket proof.
+  publicExact("auth.desktop-bootstrap", "POST", "/api/auth/desktop-bootstrap"),
   publicExact("auth.setup", "POST", "/api/auth/setup"),
   publicExact("auth.login.password", "POST", "/api/auth/login/password"),
   publicExact("auth.status", "GET", "/api/auth/status"),

--- a/packages/app-core/src/api/server.ts
+++ b/packages/app-core/src/api/server.ts
@@ -155,6 +155,7 @@ import { handleCatalogRoutes } from "./catalog-routes";
 import { handleCloudPairRoute } from "./cloud-pair-route";
 import { handleCredentialTunnelRoute } from "./credential-tunnel-routes";
 import { handleDatabaseRowsCompatRoute } from "./database-rows-compat-routes";
+import { handleDesktopAuthBootstrapRoute } from "./desktop-auth-bootstrap-routes";
 import { handleDevCompatRoutes } from "./dev-compat-routes";
 import { handleDropStatusCompatRoute } from "./drop-status-compat-route";
 import { handleEmbedAuthRoutes } from "./embed-auth-routes";
@@ -661,6 +662,12 @@ const COMPAT_ROUTE_CHAIN: readonly CompatRouteChainEntry[] = [
     // before any other auth handler so it owns the root `/pair` URL.
     id: "cloud-pair",
     handler: ({ req, res }) => handleCloudPairRoute(req, res),
+  },
+  {
+    // One-shot local desktop session proof must precede generic auth routes.
+    id: "desktop-auth-bootstrap",
+    handler: ({ req, res, state }) =>
+      handleDesktopAuthBootstrapRoute(req, res, state),
   },
   {
     // Must precede the auth-pairing handler so the rate-limited route owns

--- a/packages/app-core/src/runtime/eliza-host-bridge-order.test.ts
+++ b/packages/app-core/src/runtime/eliza-host-bridge-order.test.ts
@@ -1,0 +1,60 @@
+/** Proves app-core installs host-owned HTTP capabilities before either upstream boot entry executes. */
+
+import {
+  _resetAgentHostBridge,
+  getAgentHostBridge,
+} from "@elizaos/agent/runtime/host-bridge";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { upstreamBoot, upstreamStart } = vi.hoisted(() => ({
+  upstreamBoot: vi.fn(async () => null),
+  upstreamStart: vi.fn(async () => null),
+}));
+
+vi.mock("@elizaos/agent", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@elizaos/agent")>()),
+  bootElizaRuntime: upstreamBoot,
+  startEliza: upstreamStart,
+}));
+
+vi.mock("./startup/local-model-warmup.js", () => ({
+  ensureDefaultEmbeddingDimension: () => undefined,
+  prepareLocalEmbeddingWarmup: () => undefined,
+  startDeferredLocalEmbeddingWarmup: () => undefined,
+}));
+
+vi.mock("./bundled-fused-lib.js", () => ({
+  ensureBundledFusedLibDir: () => undefined,
+}));
+
+import { bootElizaRuntime, startEliza } from "./eliza";
+
+describe("app-core host bridge boot ordering", () => {
+  afterEach(() => {
+    _resetAgentHostBridge();
+    upstreamBoot.mockClear();
+    upstreamStart.mockClear();
+  });
+
+  it("installs desktop routes before the direct runtime boot", async () => {
+    upstreamBoot.mockImplementationOnce(async () => {
+      expect(typeof getAgentHostBridge().handleDesktopAuthBootstrapRoute).toBe(
+        "function",
+      );
+      return null;
+    });
+    await expect(bootElizaRuntime()).resolves.toBeNull();
+    expect(upstreamBoot).toHaveBeenCalledOnce();
+  });
+
+  it("installs desktop routes before the normal runtime boot", async () => {
+    upstreamStart.mockImplementationOnce(async () => {
+      expect(typeof getAgentHostBridge().handleDesktopAuthBootstrapRoute).toBe(
+        "function",
+      );
+      return null;
+    });
+    await expect(startEliza()).resolves.toBeNull();
+    expect(upstreamStart).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/app-core/src/runtime/eliza.ts
+++ b/packages/app-core/src/runtime/eliza.ts
@@ -93,6 +93,7 @@ export interface BootElizaRuntimeOptionsExt extends BootElizaRuntimeOptions {
 export async function bootElizaRuntime(
   opts: BootElizaRuntimeOptionsExt = {},
 ): Promise<Awaited<ReturnType<typeof upstreamBootElizaRuntime>>> {
+  installAgentHostBridge();
   const bootResources = createRuntimeBootResources();
   // Eagerly download the embedding model before the full runtime boot.
   // This way the TUI loading screen (or server logs) can show download
@@ -154,12 +155,6 @@ export interface StartElizaOptionsExt extends StartElizaOptions {
 async function upstreamStartElizaWithPgliteCompat(
   options?: StartElizaOptions,
 ): Promise<Awaited<ReturnType<typeof upstreamStartEliza>>> {
-  // Inject the app-core host capabilities (vault, account pool, wallet-key
-  // hydration, build variant, cloud-pair route) into the agent runtime before
-  // it boots. Every app-core agent boot funnels through here, and this is the
-  // sole caller of `upstreamStartEliza`, so the bridge is always installed
-  // before agent code that reads it runs. See install-agent-host-bridge.ts.
-  installAgentHostBridge();
   ensureBundledFusedLibDir();
   try {
     return await upstreamStartEliza(options);
@@ -175,6 +170,9 @@ export { attemptPgliteAutoReset, getPgliteRecoveryRetrySkipPlugins };
 export async function startEliza(
   options?: StartElizaOptionsExt,
 ): Promise<Awaited<ReturnType<typeof upstreamStartEliza>>> {
+  // The API binds before the deferred runtime boot, so host-owned HTTP routes
+  // must exist before server construction rather than arriving with the model.
+  installAgentHostBridge();
   const bootResources = createRuntimeBootResources();
   // Eliza app: load PTY / coding-swarm orchestration unless explicitly opted out.
   const orchRaw = readAliasedEnv("ELIZA_AGENT_ORCHESTRATOR")?.toLowerCase();

--- a/packages/app-core/src/runtime/install-agent-host-bridge.test.ts
+++ b/packages/app-core/src/runtime/install-agent-host-bridge.test.ts
@@ -33,6 +33,7 @@ describe("installAgentHostBridge", () => {
     expect(typeof bridge.sharedVault).toBe("function");
     expect(typeof bridge.getBuildVariant).toBe("function");
     expect(typeof bridge.handleCloudPairRoute).toBe("function");
+    expect(typeof bridge.handleDesktopAuthBootstrapRoute).toBe("function");
     expect(typeof bridge.resolveHttpRequestAuthorization).toBe("function");
 
     _resetAgentHostBridge();

--- a/packages/app-core/src/runtime/install-agent-host-bridge.ts
+++ b/packages/app-core/src/runtime/install-agent-host-bridge.ts
@@ -21,6 +21,7 @@ import { getBuildVariant, isStoreBuild } from "@elizaos/core";
 import { getAccountPoolBrokerSnapshot } from "../api/account-pool-broker-routes";
 import { resolveAuthorizedRouteRole } from "../api/auth";
 import { handleCloudPairRoute } from "../api/cloud-pair-route";
+import { handleDesktopAuthBootstrapRoute } from "../api/desktop-auth-bootstrap-routes";
 import {
   captureWalletEnvBootBaseline,
   hydrateWalletKeysFromNodePlatformSecureStore,
@@ -84,6 +85,12 @@ export function installAgentHostBridge(): void {
     getBuildVariant,
     isStoreBuild,
     handleCloudPairRoute,
+    handleDesktopAuthBootstrapRoute: (req, res, runtime) =>
+      handleDesktopAuthBootstrapRoute(req, res, {
+        current: runtime,
+        pendingAgentName: null,
+        pendingRestartReasons: [],
+      }),
     resolveHttpRequestAuthorization,
     isHttpRequestAuthorized: async (req, runtime) =>
       (


### PR DESCRIPTION
## Nonproduction demo bootstrap seam

DO NOT MERGE without review. This focused current-base PR restores the proof-bound packaged desktop bootstrap path that is absent from the current demo bundle and causes POST /api/auth/desktop-bootstrap to return 401.

### Exact composition

- Base: 39680a727935177b16d57057debaeebbc584c914
- App-core route/policy behavior semantically restacked from historical 7cc57ed2cbe7c85d44303a109dee9bee3d58870c only
- Agent host-dispatch behavior semantically restacked from historical 34e87c65ea80e8b01e84f1150ea72db1a64413cb only
- No ancient ancestry and no unrelated Computer PR payload

### Security contract

- Desktop bootstrap is loopback-only and socket/Host qualified.
- A scoped desktop session is issued only after native host proof succeeds.
- Bearer replay and remote callers remain rejected.
- Packaged agent dispatch is installed before generic authorization handles the request.

### Exact focused proof

- app-core auth/bootstrap/policy: 4 files, 44 tests passed
- agent server boundary + host bridge: 2 files, 19 tests passed
- app-core host installer: 1 file, 1 test passed
- packages/agent typecheck + build:dist passed
- packages/app-core typecheck + build:dist passed
- Biome: 16 changed files clean
- git diff --check clean
- scoped secret-pattern scan clean

### Runtime boundary

No native bundle was launched, stopped, or replaced. The orchestrator-owned QA process and ports were left untouched. A fresh exact package build/relaunch is still required to prove that the visible packaged first-run screen clears.