### PR TITLE
fix(app): retain launcher runtime safety config

### DIFF
--- a/packages/app-core/scripts/run-mobile-build-android-play-policy.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-android-play-policy.test.mjs
@@ -133,6 +133,20 @@ describe("Android Play manifest policy", () => {
       /eliza\.app|localhost|127\.0\.0\.1|BackgroundRunner|bun-runtime|includePlugins/,
     );
     expect(sanitized).not.toHaveProperty("ios");
+    expect(sanitized).not.toHaveProperty("loggingBehavior");
+  });
+
+  it("preserves launcher-only logging suppression and opt-in WebView inspection", () => {
+    const sanitized = sanitizeAndroidCloudCapacitorConfig(
+      {
+        loggingBehavior: "debug",
+        android: { webContentsDebuggingEnabled: false },
+      },
+      { launcherKiosk: true, webViewDebugging: true },
+    );
+
+    expect(sanitized.loggingBehavior).toBe("none");
+    expect(sanitized.android.webContentsDebuggingEnabled).toBe(true);
   });
 
   it("keeps the unused native Google identity stack out of Android source", () => {

--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -5846,7 +5846,10 @@ function isJsonRecord(value) {
 }
 
 /** Returns the minimal runtime config that is safe to package in a Play APK/AAB. */
-export function sanitizeAndroidCloudCapacitorConfig(value) {
+export function sanitizeAndroidCloudCapacitorConfig(
+  value,
+  { launcherKiosk = false, webViewDebugging = false } = {},
+) {
   if (!isJsonRecord(value)) {
     throw new Error(
       "android-cloud capacitor.config.json must contain an object",
@@ -5863,6 +5866,7 @@ export function sanitizeAndroidCloudCapacitorConfig(value) {
     appId: APP.appId,
     appName: APP.appName,
     webDir: "dist",
+    ...(launcherKiosk ? { loggingBehavior: "none" } : {}),
     server: {
       androidScheme: "https",
     },
@@ -5874,12 +5878,12 @@ export function sanitizeAndroidCloudCapacitorConfig(value) {
           : "#000000",
       allowMixedContent: false,
       captureInput: sourceAndroid.captureInput === true,
-      webContentsDebuggingEnabled: false,
+      webContentsDebuggingEnabled: launcherKiosk && webViewDebugging,
     },
   };
 }
 
-function sanitizeAndroidCloudPackagedConfig() {
+function sanitizeAndroidCloudPackagedConfig(env = process.env) {
   const configPath = path.join(
     androidDir,
     "app",
@@ -5903,7 +5907,10 @@ function sanitizeAndroidCloudPackagedConfig() {
       }`,
     );
   }
-  const sanitized = sanitizeAndroidCloudCapacitorConfig(parsed);
+  const sanitized = sanitizeAndroidCloudCapacitorConfig(parsed, {
+    launcherKiosk: env.ELIZA_ANDROID_LAUNCHER_BUILD === "1",
+    webViewDebugging: env.ELIZA_WEBVIEW_DEBUG === "1",
+  });
   fs.writeFileSync(configPath, `${JSON.stringify(sanitized, null, "\t")}\n`);
   console.log(
     "[mobile-build] Rewrote capacitor.config.json to the restricted Play runtime contract.",
@@ -8064,7 +8071,7 @@ function stripAndroidForCloud({ env = process.env } = {}) {
   //    libeliza_*.so jniLibs disguise.
   removeCloudNativeArtifacts();
   stripAndroidCloudNativePlugins();
-  sanitizeAndroidCloudPackagedConfig();
+  sanitizeAndroidCloudPackagedConfig(env);
 }
 
 function stripAndroidForSmsGateway() {


### PR DESCRIPTION
## Summary
- retain `loggingBehavior=none` when the Play-safe sanitizer packages the launcher lane
- permit WebView inspection only for launcher builds explicitly setting `ELIZA_WEBVIEW_DEBUG=1`
- keep ordinary Cloud APK/AAB configs stripped and non-debuggable

## Real-boundary reproduction
The corrected launcher compiled successfully, then its artifact audit rejected the APK because sanitization dropped `loggingBehavior=none`.

## Verification
- Android Play, launcher-generation, and target suites: 40 pass
- ordinary Cloud sanitizer still omits logging behavior and disables WebView debugging
- launcher sanitizer emits logging suppression and only opt-in debugging