### PR TITLE
fix(cloud): let live mobile auth probe omit private id

### DIFF
--- a/packages/scripts/cloud/admin/verify-mobile-app-auth-registration.ts
+++ b/packages/scripts/cloud/admin/verify-mobile-app-auth-registration.ts
@@ -573,7 +573,7 @@ async function main(): Promise<void> {
   const enabled = requireMobileAppAuthEnabled(
     readEnvironmentVariable("ELIZA_MOBILE_APP_AUTH_ENABLED"),
   );
-  const appId = enabled
+  const appId = enabled && !options.skipDatabase
     ? requireMobileAppAuthAppId(
         readEnvironmentVariable("ELIZA_MOBILE_APP_AUTH_APP_ID"),
       )


### PR DESCRIPTION
## Summary
- require the protected mobile app UUID only for the database preflight
- keep the post-deploy live probe independent of the private registration ID, matching its public metadata contract

## Verification
- release/preflight suites: 26 pass
- exact Node command from the failed workflow succeeds against live staging with `ELIZA_MOBILE_APP_AUTH_APP_ID` unset
- staging database preflight and Worker deploy already succeeded in run 32930763564