### PR TITLE
fix(cloud): pass mobile app id to live metadata check

### DIFF
--- a/.github/workflows/cloud-cf-release.yml
+++ b/.github/workflows/cloud-cf-release.yml
@@ -1561,6 +1561,7 @@ jobs:
         working-directory: ${{ env.CHECKOUT_DIR }}
         env:
           ELIZA_MOBILE_APP_AUTH_ENABLED: ${{ contains(fromJSON('["1","true","TRUE","True","yes","YES","Yes","on","ON","On"]'), vars.ELIZA_MOBILE_APP_AUTH_ENABLED) && 'true' || 'false' }}
+          ELIZA_MOBILE_APP_AUTH_APP_ID: ${{ secrets.ELIZA_MOBILE_APP_AUTH_APP_ID }}
           ELIZA_MOBILE_APP_AUTH_ENVIRONMENT: ${{ steps.env.outputs.deploy_environment }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
The staging release metadata gate omitted ELIZA_MOBILE_APP_AUTH_APP_ID from its environment.

This caused a valid deployed registration to fail with the UUID validation error. Pass the protected app ID so the existing live contract check can validate the deployed endpoint.