### PR TITLE
fix(cloud): carry mobile auth app ID into live verification

### DIFF
--- a/.github/workflows/cloud-cf-release.yml
+++ b/.github/workflows/cloud-cf-release.yml
@@ -1560,6 +1560,7 @@ jobs:
         if: steps.cf.outputs.configured == 'true' && steps.freshness.outputs.should_deploy == 'true'
         working-directory: ${{ env.CHECKOUT_DIR }}
         env:
+          ELIZA_MOBILE_APP_AUTH_APP_ID: ${{ secrets.ELIZA_MOBILE_APP_AUTH_APP_ID }}
           ELIZA_MOBILE_APP_AUTH_ENABLED: ${{ contains(fromJSON('["1","true","TRUE","True","yes","YES","Yes","on","ON","On"]'), vars.ELIZA_MOBILE_APP_AUTH_ENABLED) && 'true' || 'false' }}
           ELIZA_MOBILE_APP_AUTH_ENVIRONMENT: ${{ steps.env.outputs.deploy_environment }}
         run: |

--- a/packages/scripts/__tests__/cloud-cf-atomic-worker-secrets-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-atomic-worker-secrets-workflow.test.ts
@@ -135,6 +135,9 @@ describe("Cloud CF atomic Worker secrets deploy", () => {
     expect(index("Verify deployed API commit")).toBeLessThan(
       index("Verify deployed mobile App Auth metadata"),
     );
+    expect(live.env?.ELIZA_MOBILE_APP_AUTH_APP_ID).toBe(
+      preflight.env?.ELIZA_MOBILE_APP_AUTH_APP_ID,
+    );
     expect(live.run).toContain("--skip-database --verify-live");
   });
 


### PR DESCRIPTION
Fixes #29001

## Summary

- pass the selected GitHub Environment's protected mobile App Auth registration UUID to the post-deploy metadata verifier, matching the already-valid pre-deploy registration step;
- extend the existing atomic Worker workflow regression to require both verification boundaries to consume the same protected expression.

No credential value is printed, copied into source, or inspected.

## Failure evidence

Staging run `32930763564` validated the registration, deployed and health-verified Worker commit `39680a727935177b16d57057debaeebbc584c914`, then the post-deploy verifier rejected its missing app-ID environment input. Pages deployment was consequently skipped. The workflow log masked the pre-deploy value.

## Verification

- `bun test --isolate packages/scripts/__tests__/cloud-cf-atomic-worker-secrets-workflow.test.ts packages/scripts/cloud/admin/verify-mobile-app-auth-registration.test.ts` - 26 pass, 0 fail, 136 assertions
- `bunx @biomejs/biome check packages/scripts/__tests__/cloud-cf-atomic-worker-secrets-workflow.test.ts` - pass
- `git diff --check origin/develop..HEAD` - pass
- exact base at verification: `0420df03fee3fcff3f8ff017a019bdce12096d18`

## Evidence applicability

- UI screenshots/video: N/A - release-workflow environment wiring only.
- Live model trajectory: N/A - no model, prompt, agent, or provider behavior changed.
- Device evidence: N/A - no native artifact or device behavior changed.
- Deployment evidence: N/A - no deployment was performed from this branch.
- Secret-value evidence: N/A - values must remain protected and were neither read nor printed.

No merge, deployment, environment mutation, database mutation, production action, or spend was performed.