### PR TITLE
fix(cloud): fail closed on malformed base64 voice-catalog credentials

### DIFF
--- a/packages/cloud/api/v1/voice-models/catalog/route.test.ts
+++ b/packages/cloud/api/v1/voice-models/catalog/route.test.ts
@@ -1,0 +1,207 @@
+/**
+ * End-to-end behavioral test for the public voice-model catalog trust
+ * boundary: drives the REAL route handler (packages/cloud/api/v1/voice-models/
+ * catalog/route.ts) through Hono's app.request() with real generated Ed25519
+ * credentials, then feeds the raw response bytes and X-Eliza-Signature header
+ * to the REAL device-side verification path (`verifyManifestSignatureText`,
+ * the same function plugin-local-inference's cloudCatalogSource calls before
+ * parsing). Pins three contracts:
+ * 1. valid credentials produce a signed catalog the device verifier accepts,
+ *    and a tampered body fails exact-bytes verification;
+ * 2. malformed signing credentials (junk character, interior whitespace,
+ *    misplaced padding, non-zero slack bits) fail closed with NO signed or
+ *    cacheable success — never a silently re-decoded "working" credential;
+ * 3. malformed public-key env and a missing signing key behave the same.
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+import { generateKeyPairSync, type KeyObject } from "node:crypto";
+import { verifyManifestSignatureText } from "@elizaos/shared/local-inference/manifest-signature";
+import app from "./route";
+
+/** Ed25519 PKCS8 DER is 48 bytes: 16-byte RFC 8410 prefix + 32-byte seed. */
+function seedB64From(privateKey: KeyObject): string {
+  const der = privateKey.export({ format: "der", type: "pkcs8" }) as Buffer;
+  expect(der.byteLength).toBe(48);
+  return Buffer.from(der.subarray(16)).toString("base64");
+}
+
+/** SPKI DER for Ed25519 is 44 bytes: 12-byte prefix + 32-byte raw public key. */
+function rawPublicKey(publicKey: KeyObject): Uint8Array {
+  const spki = publicKey.export({ format: "der", type: "spki" }) as Buffer;
+  expect(spki.byteLength).toBe(44);
+  return new Uint8Array(spki.subarray(12));
+}
+
+describe("GET /api/v1/voice-models/catalog (route + device verifier, e2e)", () => {
+  let seedB64: string;
+  let pubRaw: Uint8Array;
+  let pubB64: string;
+
+  beforeEach(() => {
+    const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+    seedB64 = seedB64From(privateKey);
+    pubRaw = rawPublicKey(publicKey);
+    pubB64 = Buffer.from(pubRaw).toString("base64");
+  });
+
+  function baseEnv(): Record<string, string> {
+    return {
+      ELIZA_VOICE_CATALOG_SIGNING_KEY_BASE64: seedB64,
+      ELIZA_VOICE_CATALOG_PUBLIC_KEY_BASE64: pubB64,
+    };
+  }
+
+  async function fetchCatalog(env: Record<string, string | undefined>) {
+    return app.request("/", {}, env);
+  }
+
+  test("valid credentials: route signs, device verifier accepts the exact bytes", async () => {
+    const res = await fetchCatalog(baseEnv());
+    expect(res.status).toBe(200);
+    const signature = res.headers.get("X-Eliza-Signature");
+    expect(signature).toBeTruthy();
+    expect(res.headers.get("Content-Type")).toContain("application/json");
+    // Cacheable success must only exist alongside a signature.
+    expect(res.headers.get("Cache-Control")).toContain("s-maxage");
+
+    const bodyText = await res.text();
+    const parsed = JSON.parse(bodyText);
+    expect(parsed.schema).toBe("eliza-1-voice-models.v1");
+    expect(Array.isArray(parsed.versions)).toBe(true);
+    expect(parsed.versions.length).toBeGreaterThan(0);
+
+    // The device-side updater path: verify the signature over the EXACT
+    // response text before parsing (same call cloudCatalogSource makes).
+    const keyIndex = await verifyManifestSignatureText(bodyText, signature!, [
+      pubRaw,
+    ]);
+    expect(keyIndex).toBe(0);
+
+    // A single flipped byte in the body must fail exact-bytes verification.
+    const tampered = bodyText.replace("eliza-1", "eliza-9");
+    await expect(
+      verifyManifestSignatureText(tampered, signature!, [pubRaw]),
+    ).rejects.toThrow(/ELIZA_VOICE_SIG_REJECTED|no candidate public key/);
+  });
+
+  test("signature verifies against the rotation peer slot too (key list)", async () => {
+    const other = generateKeyPairSync("ed25519");
+    const res = await fetchCatalog(baseEnv());
+    expect(res.status).toBe(200);
+    const signature = res.headers.get("X-Eliza-Signature");
+    const bodyText = await res.text();
+    // Device configured with [rotationPeer, current]: index 1 must accept.
+    const idx = await verifyManifestSignatureText(bodyText, signature!, [
+      rawPublicKey(other.publicKey),
+      pubRaw,
+    ]);
+    expect(idx).toBe(1);
+  });
+
+  const malformedSigningKeys: Array<[string, (seed: string) => string]> = [
+    ["junk character appended", (s) => `${s}!`],
+    // Whitespace INSIDE an otherwise valid spelling: a lenient decoder
+    // silently discards it and the route would sign with "some" bytes —
+    // this is the case that distinguishes strict from lenient decoding.
+    [
+      "interior whitespace inside a valid key",
+      (s) => `${s.slice(0, 20)} ${s.slice(20)}`,
+    ],
+    ["misplaced leading padding", (s) => `=${s.slice(1)}`],
+    [
+      "non-zero slack bits in final quantum",
+      (s) => {
+        // Bump the last DATA character (before the trailing '=') so its two
+        // discarded low bits become non-zero. For the four canonical
+        // zero-slack chars (A/Q/g/w) the successor (B/R/h/x) is a guaranteed
+        // same-bytes alias — a lenient decoder silently accepts the SAME key
+        // bytes, and ONLY the canonical re-encode check rejects it. Any other
+        // spelling is still a hand-mangled non-canonical quantum the guard
+        // must reject. Decoded length stays 32 bytes and the alphabet test
+        // still passes, so the length check cannot catch this class.
+        const lastData = s[s.length - 2] ?? "";
+        const alias: Record<string, string> = {
+          A: "B",
+          Q: "R",
+          g: "h",
+          w: "x",
+        };
+        const bumped = alias[lastData] ?? "B";
+        return `${s.slice(0, -2)}${bumped}=`;
+      },
+    ],
+  ];
+
+  for (const [name, mangle] of malformedSigningKeys) {
+    test(`malformed signing key (${name}) fails closed: no signature, no cacheable success`, async () => {
+      const res = await fetchCatalog({
+        ...baseEnv(),
+        ELIZA_VOICE_CATALOG_SIGNING_KEY_BASE64: mangle(seedB64),
+      });
+      expect(res.status).toBeGreaterThanOrEqual(500);
+      expect(res.headers.get("X-Eliza-Signature")).toBeNull();
+      expect(res.headers.get("Cache-Control")).toBeNull();
+      const bodyText = await res.text();
+      // The failure body must not be a signable catalog payload.
+      expect(JSON.parse(bodyText).schema).toBeUndefined();
+    });
+  }
+
+  const malformedPublicKeys: Array<[string, (pub: string) => string]> = [
+    ["junk character appended", (p) => `${p}!`],
+    [
+      "interior whitespace inside a valid key",
+      (p) => `${p.slice(0, 20)} ${p.slice(20)}`,
+    ],
+    ["misplaced leading padding", (p) => `=${p.slice(1)}`],
+    [
+      "non-zero slack bits in final quantum",
+      (p) => {
+        const lastData = p[p.length - 2] ?? "";
+        const alias: Record<string, string> = {
+          A: "B",
+          Q: "R",
+          g: "h",
+          w: "x",
+        };
+        const bumped = alias[lastData] ?? "B";
+        return `${p.slice(0, -2)}${bumped}=`;
+      },
+    ],
+  ];
+
+  for (const [name, mangle] of malformedPublicKeys) {
+    test(`malformed public key (${name}) fails closed: no signature`, async () => {
+      const res = await fetchCatalog({
+        ...baseEnv(),
+        ELIZA_VOICE_CATALOG_PUBLIC_KEY_BASE64: mangle(pubB64),
+      });
+      expect(res.status).toBeGreaterThanOrEqual(500);
+      expect(res.headers.get("X-Eliza-Signature")).toBeNull();
+      expect(res.headers.get("Cache-Control")).toBeNull();
+    });
+  }
+
+  test("unconfigured signing key returns 503 service_unavailable, unsigned", async () => {
+    const res = await fetchCatalog({
+      ELIZA_VOICE_CATALOG_PUBLIC_KEY_BASE64: pubB64,
+    });
+    expect(res.status).toBe(503);
+    expect(res.headers.get("X-Eliza-Signature")).toBeNull();
+    const parsed = JSON.parse(await res.text());
+    expect(parsed.error.type).toBe("service_unavailable");
+  });
+
+  test("surrounding whitespace on the signing key is the documented operator convenience and still signs", async () => {
+    const res = await fetchCatalog({
+      ...baseEnv(),
+      ELIZA_VOICE_CATALOG_SIGNING_KEY_BASE64: `${seedB64}\n`,
+    });
+    expect(res.status).toBe(200);
+    const signature = res.headers.get("X-Eliza-Signature");
+    expect(signature).toBeTruthy();
+    const bodyText = await res.text();
+    await verifyManifestSignatureText(bodyText, signature!, [pubRaw]);
+  });
+});

--- a/packages/cloud/api/v1/voice-models/catalog/route.test.ts
+++ b/packages/cloud/api/v1/voice-models/catalog/route.test.ts
@@ -204,4 +204,44 @@ describe("GET /api/v1/voice-models/catalog (route + device verifier, e2e)", () =
     const bodyText = await res.text();
     await verifyManifestSignatureText(bodyText, signature!, [pubRaw]);
   });
+
+  test("base64url-spelled credentials (JWK/JOSE tooling output) keep signing and verifying", async () => {
+    // RFC 4648 §5 spellings decoded fine under Node's lenient decoder, so
+    // deployments configured from JWK `d` / `basenc --base64url` exist in
+    // the field and MUST NOT become 500s on a public endpoint. The key is
+    // drawn until its base64 spelling contains a mappable character, so
+    // the test always exercises the normalization path (never vacuous).
+    const toUrl = (b64: string) =>
+      b64.replaceAll("+", "-").replaceAll("/", "_");
+    // Redraw until BOTH credentials contain a mappable char, so the seed
+    // signing path AND the public-key fingerprint path are each exercised
+    // through the normalization (never vacuous). P(both per draw) is about
+    // 0.55, so 64 draws fail with probability ~1e-19; the assertions below
+    // are hard guards.
+    for (
+      let i = 0;
+      i < 64 && !(/[+/]/.test(seedB64) && /[+/]/.test(pubB64));
+      i++
+    ) {
+      const kp = generateKeyPairSync("ed25519");
+      seedB64 = seedB64From(kp.privateKey);
+      pubRaw = rawPublicKey(kp.publicKey);
+      pubB64 = Buffer.from(pubRaw).toString("base64");
+    }
+    expect(/[+/]/.test(seedB64)).toBe(true);
+    expect(/[+/]/.test(pubB64)).toBe(true);
+    const seedUrl = toUrl(seedB64);
+    const pubUrl = toUrl(pubB64);
+    const res = await fetchCatalog({
+      ELIZA_VOICE_CATALOG_SIGNING_KEY_BASE64: seedUrl,
+      ELIZA_VOICE_CATALOG_PUBLIC_KEY_BASE64: pubUrl,
+    });
+    expect(res.status).toBe(200);
+    const signature = res.headers.get("X-Eliza-Signature");
+    expect(signature).toBeTruthy();
+    const bodyText = await res.text();
+    await verifyManifestSignatureText(bodyText, signature!, [pubRaw]);
+    const parsed = JSON.parse(bodyText);
+    expect(parsed.publicKeyFingerprints).toContain(pubB64);
+  });
 });

--- a/packages/cloud/shared/src/lib/services/__tests__/voice-model-catalog.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/voice-model-catalog.test.ts
@@ -23,16 +23,22 @@ function seedFromPkcs8PrivateKey(
 ): string {
   const der = privateKey.export({ format: "der", type: "pkcs8" }) as Buffer;
   if (der.byteLength !== 48) {
-    throw new Error(`expected 48-byte Ed25519 PKCS8 DER, got ${der.byteLength}`);
+    throw new Error(
+      `expected 48-byte Ed25519 PKCS8 DER, got ${der.byteLength}`,
+    );
   }
   return Buffer.from(der.subarray(16)).toString("base64");
 }
 
 /** SPKI DER for Ed25519 is 44 bytes: 12-byte prefix + 32-byte raw public key. */
-function rawPublicKey(publicKey: ReturnType<typeof generateKeyPairSync>["publicKey"]): Uint8Array {
+function rawPublicKey(
+  publicKey: ReturnType<typeof generateKeyPairSync>["publicKey"],
+): Uint8Array {
   const spki = publicKey.export({ format: "der", type: "spki" }) as Buffer;
   if (spki.byteLength !== 44) {
-    throw new Error(`expected 44-byte Ed25519 SPKI DER, got ${spki.byteLength}`);
+    throw new Error(
+      `expected 44-byte Ed25519 SPKI DER, got ${spki.byteLength}`,
+    );
   }
   return new Uint8Array(spki.subarray(12));
 }
@@ -41,7 +47,9 @@ function b64ToBytes(b64: string): Uint8Array {
   return new Uint8Array(Buffer.from(b64, "base64"));
 }
 
-async function importVerifyKey(publicKey: ReturnType<typeof generateKeyPairSync>["publicKey"]) {
+async function importVerifyKey(
+  publicKey: ReturnType<typeof generateKeyPairSync>["publicKey"],
+) {
   return crypto.subtle.importKey(
     "raw",
     rawPublicKey(publicKey) as unknown as ArrayBuffer,
@@ -51,11 +59,35 @@ async function importVerifyKey(publicKey: ReturnType<typeof generateKeyPairSync>
   );
 }
 
+/**
+ * Generate a key pair whose base64 seed is GUARANTEED to contain a
+ * URL-mappable character (`+` or `/`), so base64url tests are never
+ * vacuous. A single draw misses with probability (31/32)^43 < 0.26, so
+ * 32 draws fail with probability ~1e-19 — the bound throw below is a
+ * hard guard, not a probabilistic pass.
+ */
+function generateKeyPairWithMappableSeed(): ReturnType<
+  typeof generateKeyPairSync
+> {
+  for (let i = 0; i < 32; i++) {
+    const kp = generateKeyPairSync("ed25519");
+    if (/[+\/]/.test(seedFromPkcs8PrivateKey(kp.privateKey))) {
+      return kp;
+    }
+  }
+  throw new Error(
+    "32 consecutive draws without a mappable seed character (p ~1e-19)",
+  );
+}
+
 describe("buildVoiceModelCatalogBody", () => {
   test("pins the body shape: schema literal, ISO generatedAt, full in-binary version list, fingerprint passthrough", () => {
     const now = new Date("2026-08-26T04:00:00.000Z");
     const fingerprints = ["AkZiDEp0bWx0", "TmV4dEtleUZw=="];
-    const body = buildVoiceModelCatalogBody({ now, publicKeyFingerprints: fingerprints });
+    const body = buildVoiceModelCatalogBody({
+      now,
+      publicKeyFingerprints: fingerprints,
+    });
 
     expect(body.schema).toBe("eliza-1-voice-models.v1");
     // The device updater treats generatedAt as an ISO timestamp; a raw
@@ -140,7 +172,10 @@ describe("signVoiceModelCatalog", () => {
   test("a single flipped body byte fails verification (exact-bytes contract)", async () => {
     const { publicKey, privateKey } = generateKeyPairSync("ed25519");
     const bodyText = JSON.stringify(
-      buildVoiceModelCatalogBody({ now: new Date(), publicKeyFingerprints: [] }),
+      buildVoiceModelCatalogBody({
+        now: new Date(),
+        publicKeyFingerprints: [],
+      }),
     );
     const signatureB64 = await signVoiceModelCatalog({
       bodyText,
@@ -163,7 +198,10 @@ describe("signVoiceModelCatalog", () => {
     const { publicKey } = generateKeyPairSync("ed25519");
     const other = generateKeyPairSync("ed25519");
     const bodyText = JSON.stringify(
-      buildVoiceModelCatalogBody({ now: new Date(), publicKeyFingerprints: [] }),
+      buildVoiceModelCatalogBody({
+        now: new Date(),
+        publicKeyFingerprints: [],
+      }),
     );
     const signatureB64 = await signVoiceModelCatalog({
       bodyText,
@@ -192,9 +230,9 @@ describe("signVoiceModelCatalog", () => {
     ).rejects.toThrow(/32 bytes/);
     // An unconfigured (empty) signing key must fail closed rather than
     // sign anything — the route's own missing-env guard mirrors this.
-    await expect(signVoiceModelCatalog({ bodyText: "{}", secretKeyBase64: "" })).rejects.toThrow(
-      /32 bytes/,
-    );
+    await expect(
+      signVoiceModelCatalog({ bodyText: "{}", secretKeyBase64: "" }),
+    ).rejects.toThrow(/32 bytes/);
   });
 
   test("fails closed on malformed signing keys: junk characters are rejected, not silently discarded", async () => {
@@ -221,6 +259,47 @@ describe("signVoiceModelCatalog", () => {
     });
     expect(b64ToBytes(signatureB64).byteLength).toBe(64);
   });
+
+  test("base64url spellings of the seed sign with the identical signature", async () => {
+    // RFC 4648 §5 URL-safe spellings (`-`/`_` for `+`/`/`) decode to the
+    // SAME bytes, and JWK `d`, `basenc --base64url`, and most JOSE
+    // tooling emit them — an operator configured from any of those has a
+    // correctly-signing deployment, so the strict decoder must normalize
+    // the alphabet rather than reject. The signatures must be identical
+    // (same seed ⇒ same signature), not merely both-valid.
+    // The key is drawn until its base64 spelling contains a mappable
+    // character (helper guarantees it), so the test always exercises the
+    // normalization path.
+    const { privateKey } = generateKeyPairWithMappableSeed();
+    const seedB64 = seedFromPkcs8PrivateKey(privateKey);
+    const seedUrl = seedB64
+      .replaceAll("+", "-")
+      .replaceAll("/", "_")
+      .replaceAll("=", "");
+    expect(/[+\/]/.test(seedB64)).toBe(true);
+    const bodyText = JSON.stringify({ schema: "eliza-1-voice-models.v1" });
+    const sigStd = await signVoiceModelCatalog({
+      bodyText,
+      secretKeyBase64: seedB64,
+    });
+    const sigUrl = await signVoiceModelCatalog({
+      bodyText,
+      secretKeyBase64: seedUrl,
+    });
+    expect(sigUrl).toBe(sigStd);
+    // Mixed alphabets (standard +// and URL-safe -/_ in ONE credential)
+    // are hand-mangled values no standard encoding emits: rejected even
+    // though per-character substitution alone would normalize them. The
+    // mixed spelling is built position-aware: keep the standard mappable
+    // char, replace an unrelated alphanumeric char with `-`.
+    const m = seedB64.search(/[+/]/);
+    let j = 0;
+    while (j === m || !/[A-Za-z0-9]/.test(seedB64[j] ?? "")) j += 1;
+    const mixedSeed = `${seedB64.slice(0, j)}-${seedB64.slice(j + 1)}`;
+    await expect(
+      signVoiceModelCatalog({ bodyText, secretKeyBase64: mixedSeed }),
+    ).rejects.toThrow(/mixed alphabets/);
+  });
 });
 
 describe("fingerprintPublicKey", () => {
@@ -233,12 +312,34 @@ describe("fingerprintPublicKey", () => {
     // check) would not: the passthrough returns the newline-terminated
     // spelling.
     const raw = crypto.getRandomValues(new Uint8Array(32));
-    const rawB64 = Buffer.from(raw).toString("base64");
+    let rawB64 = Buffer.from(raw).toString("base64");
     expect(fingerprintPublicKey(`${rawB64}\n`)).toBe(rawB64);
     expect(fingerprintPublicKey(` ${rawB64}`)).toBe(rawB64);
     // 43-char unpadded spelling of the same 32 bytes also canonicalizes
     // to the padded form.
     expect(fingerprintPublicKey(rawB64.replaceAll("=", ""))).toBe(rawB64);
+    // RFC 4648 §5 base64url spellings (`-`/`_`, padded or unpadded) are
+    // the same bytes in the alphabet JWK/JOSE tooling emits — they must
+    // canonicalize to the standard fingerprint, never throw. Redraw the
+    // random key until its base64 spelling contains a mappable char so the
+    // assertions always execute (p of 32 straight misses ~1e-19).
+    while (!/[+/]/.test(rawB64)) {
+      rawB64 = Buffer.from(crypto.getRandomValues(new Uint8Array(32))).toString(
+        "base64",
+      );
+    }
+    const rawUrl = rawB64.replaceAll("+", "-").replaceAll("/", "_");
+    expect(fingerprintPublicKey(rawUrl)).toBe(rawB64);
+    expect(fingerprintPublicKey(rawUrl.replaceAll("=", ""))).toBe(rawB64);
+    // Mixed alphabets in one credential are rejected, not normalized
+    // (position-aware: keep the standard mappable char, swap an
+    // unrelated alphanumeric char to `-`).
+    const m = rawB64.search(/[+/]/);
+    let j = 0;
+    while (j === m || !/[A-Za-z0-9]/.test(rawB64[j] ?? "")) j += 1;
+    expect(() =>
+      fingerprintPublicKey(`${rawB64.slice(0, j)}-${rawB64.slice(j + 1)}`),
+    ).toThrow(/mixed alphabets/);
     // Non-base64 junk is NOT a spelling of the same bytes: it throws
     // rather than canonicalizing (mirrors the signing-key fail-closed
     // contract above — a mistyped key must be rejected, not silently

--- a/packages/cloud/shared/src/lib/services/__tests__/voice-model-catalog.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/voice-model-catalog.test.ts
@@ -244,6 +244,14 @@ describe("fingerprintPublicKey", () => {
     // contract above — a mistyped key must be rejected, not silently
     // decoded).
     expect(() => fingerprintPublicKey(`${rawB64}!`)).toThrow(/Invalid base64/);
+    // A final quantum with non-zero discarded slack bits (here the last
+    // char bumped so the two unused bits are set — decodes to the same
+    // 32 bytes) is a hand-mangled spelling, not a legitimate one: it
+    // must throw rather than silently canonicalize.
+    const mangledTail = `${rawB64.slice(0, -2)}B=`;
+    if (mangledTail !== rawB64) {
+      expect(() => fingerprintPublicKey(mangledTail)).toThrow(/Invalid base64/);
+    }
   });
 
   test("rejects wrong-length public keys", () => {

--- a/packages/cloud/shared/src/lib/services/__tests__/voice-model-catalog.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/voice-model-catalog.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Pins the sign-side behavior of the voice-model catalog service (schema
+ * eliza-1-voice-models.v1): GET /api/v1/voice-models/catalog is public and
+ * unauthenticated, and the device-side updater verifies the Ed25519 signature
+ * in X-Eliza-Signature over the exact response text before parsing. These
+ * tests prove the service builds the documented body shape and produces
+ * signatures that verify (and stop verifying under tampering) with keys from
+ * an external generator, and that keys of the wrong decoded length are
+ * rejected. The HTTP route itself is out of scope here.
+ */
+import { describe, expect, test } from "bun:test";
+import { generateKeyPairSync } from "node:crypto";
+import { VOICE_MODEL_VERSIONS } from "@elizaos/shared/local-inference/voice-models";
+import {
+  buildVoiceModelCatalogBody,
+  fingerprintPublicKey,
+  signVoiceModelCatalog,
+} from "../voice-model-catalog";
+
+/** Ed25519 PKCS8 DER is 48 bytes: 16-byte RFC 8410 prefix + 32-byte seed. */
+function seedFromPkcs8PrivateKey(
+  privateKey: ReturnType<typeof generateKeyPairSync>["privateKey"],
+): string {
+  const der = privateKey.export({ format: "der", type: "pkcs8" }) as Buffer;
+  if (der.byteLength !== 48) {
+    throw new Error(`expected 48-byte Ed25519 PKCS8 DER, got ${der.byteLength}`);
+  }
+  return Buffer.from(der.subarray(16)).toString("base64");
+}
+
+/** SPKI DER for Ed25519 is 44 bytes: 12-byte prefix + 32-byte raw public key. */
+function rawPublicKey(publicKey: ReturnType<typeof generateKeyPairSync>["publicKey"]): Uint8Array {
+  const spki = publicKey.export({ format: "der", type: "spki" }) as Buffer;
+  if (spki.byteLength !== 44) {
+    throw new Error(`expected 44-byte Ed25519 SPKI DER, got ${spki.byteLength}`);
+  }
+  return new Uint8Array(spki.subarray(12));
+}
+
+function b64ToBytes(b64: string): Uint8Array {
+  return new Uint8Array(Buffer.from(b64, "base64"));
+}
+
+async function importVerifyKey(publicKey: ReturnType<typeof generateKeyPairSync>["publicKey"]) {
+  return crypto.subtle.importKey(
+    "raw",
+    rawPublicKey(publicKey) as unknown as ArrayBuffer,
+    { name: "Ed25519" },
+    false,
+    ["verify"],
+  );
+}
+
+describe("buildVoiceModelCatalogBody", () => {
+  test("pins the body shape: schema literal, ISO generatedAt, full in-binary version list, fingerprint passthrough", () => {
+    const now = new Date("2026-08-26T04:00:00.000Z");
+    const fingerprints = ["AkZiDEp0bWx0", "TmV4dEtleUZw=="];
+    const body = buildVoiceModelCatalogBody({ now, publicKeyFingerprints: fingerprints });
+
+    expect(body.schema).toBe("eliza-1-voice-models.v1");
+    // The device updater treats generatedAt as an ISO timestamp; a raw
+    // epoch-ms number here would change every response body's semantics.
+    expect(body.generatedAt).toBe("2026-08-26T04:00:00.000Z");
+    // The served version list must carry every in-binary version — a
+    // truncated or filtered list would hide models from devices.
+    expect(body.versions).toEqual(VOICE_MODEL_VERSIONS);
+    expect(Array.isArray(body.versions)).toBe(true);
+    expect(body.versions.length).toBeGreaterThan(0);
+    expect(body.publicKeyFingerprints).toEqual(fingerprints);
+  });
+
+  test("honors the injected clock: distinct dates produce distinct generatedAt values", () => {
+    const a = buildVoiceModelCatalogBody({
+      now: new Date("2026-01-01T00:00:00.000Z"),
+      publicKeyFingerprints: [],
+    });
+    const b = buildVoiceModelCatalogBody({
+      now: new Date("2026-01-01T00:00:01.000Z"),
+      publicKeyFingerprints: [],
+    });
+    expect(a.generatedAt).not.toBe(b.generatedAt);
+  });
+});
+
+describe("signVoiceModelCatalog", () => {
+  test("signature verifies against an externally generated Ed25519 key pair", async () => {
+    // The key pair comes from node:crypto and the seed is re-derived from
+    // its PKCS8 DER, so this proves the module's RFC 8410 seed wrapping
+    // matches Node's own key encoding, and that signing round-trips
+    // through WebCrypto import/verify.
+    const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+    const bodyText = JSON.stringify(
+      buildVoiceModelCatalogBody({
+        now: new Date("2026-08-26T04:00:00.000Z"),
+        publicKeyFingerprints: ["Zmlyc3Q=", "c2Vjb25k"],
+      }),
+    );
+
+    const signatureB64 = await signVoiceModelCatalog({
+      bodyText,
+      secretKeyBase64: seedFromPkcs8PrivateKey(privateKey),
+    });
+
+    // X-Eliza-Signature carries a base64 64-byte Ed25519 signature.
+    const sigBytes = b64ToBytes(signatureB64);
+    expect(sigBytes.byteLength).toBe(64);
+
+    const verifyKey = await importVerifyKey(publicKey);
+    const valid = await crypto.subtle.verify(
+      { name: "Ed25519" },
+      verifyKey,
+      sigBytes as unknown as ArrayBuffer,
+      new TextEncoder().encode(bodyText) as unknown as ArrayBuffer,
+    );
+    expect(valid).toBe(true);
+  });
+
+  test("signature verifies over a body containing multi-byte UTF-8 text", async () => {
+    const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+    const bodyText = JSON.stringify({
+      schema: "eliza-1-voice-models.v1",
+      note: "émoji ✓ 音声モデル",
+    });
+
+    const signatureB64 = await signVoiceModelCatalog({
+      bodyText,
+      secretKeyBase64: seedFromPkcs8PrivateKey(privateKey),
+    });
+
+    const verifyKey = await importVerifyKey(publicKey);
+    const valid = await crypto.subtle.verify(
+      { name: "Ed25519" },
+      verifyKey,
+      b64ToBytes(signatureB64) as unknown as ArrayBuffer,
+      new TextEncoder().encode(bodyText) as unknown as ArrayBuffer,
+    );
+    expect(valid).toBe(true);
+  });
+
+  test("a single flipped body byte fails verification (exact-bytes contract)", async () => {
+    const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+    const bodyText = JSON.stringify(
+      buildVoiceModelCatalogBody({ now: new Date(), publicKeyFingerprints: [] }),
+    );
+    const signatureB64 = await signVoiceModelCatalog({
+      bodyText,
+      secretKeyBase64: seedFromPkcs8PrivateKey(privateKey),
+    });
+
+    const tampered = bodyText.replace("eliza-1", "eliza-2");
+    expect(tampered).not.toBe(bodyText);
+    const verifyKey = await importVerifyKey(publicKey);
+    const valid = await crypto.subtle.verify(
+      { name: "Ed25519" },
+      verifyKey,
+      b64ToBytes(signatureB64) as unknown as ArrayBuffer,
+      new TextEncoder().encode(tampered) as unknown as ArrayBuffer,
+    );
+    expect(valid).toBe(false);
+  });
+
+  test("a signature made with a different seed does not verify", async () => {
+    const { publicKey } = generateKeyPairSync("ed25519");
+    const other = generateKeyPairSync("ed25519");
+    const bodyText = JSON.stringify(
+      buildVoiceModelCatalogBody({ now: new Date(), publicKeyFingerprints: [] }),
+    );
+    const signatureB64 = await signVoiceModelCatalog({
+      bodyText,
+      secretKeyBase64: seedFromPkcs8PrivateKey(other.privateKey),
+    });
+
+    const verifyKey = await importVerifyKey(publicKey);
+    const valid = await crypto.subtle.verify(
+      { name: "Ed25519" },
+      verifyKey,
+      b64ToBytes(signatureB64) as unknown as ArrayBuffer,
+      new TextEncoder().encode(bodyText) as unknown as ArrayBuffer,
+    );
+    expect(valid).toBe(false);
+  });
+
+  test("rejects keys whose decoded length is not exactly 32 bytes, before any signing", async () => {
+    const tooShort = Buffer.from(new Uint8Array(31)).toString("base64");
+    const tooLong = Buffer.from(new Uint8Array(33)).toString("base64");
+
+    await expect(
+      signVoiceModelCatalog({ bodyText: "{}", secretKeyBase64: tooShort }),
+    ).rejects.toThrow(/32 bytes/);
+    await expect(
+      signVoiceModelCatalog({ bodyText: "{}", secretKeyBase64: tooLong }),
+    ).rejects.toThrow(/32 bytes/);
+    // An unconfigured (empty) signing key must fail closed rather than
+    // sign anything — the route's own missing-env guard mirrors this.
+    await expect(signVoiceModelCatalog({ bodyText: "{}", secretKeyBase64: "" })).rejects.toThrow(
+      /32 bytes/,
+    );
+  });
+
+  test("documents the decode boundary: non-base64 characters are ignored by the decoder, so length is the fail-closed gate", async () => {
+    // Buffer-based base64 decoding is lenient: junk characters are
+    // dropped, so a padded 44-char base64 seed with one appended invalid
+    // character still decodes to the same 32 bytes and signs. Pinning that
+    // boundary makes any future move
+    // to strict decoding (which would reject such keys) a deliberate,
+    // visible change rather than a silent one.
+    const { privateKey } = generateKeyPairSync("ed25519");
+    const seedB64 = seedFromPkcs8PrivateKey(privateKey);
+    const signatureB64 = await signVoiceModelCatalog({
+      bodyText: "{}",
+      secretKeyBase64: `${seedB64}!`,
+    });
+    expect(b64ToBytes(signatureB64).byteLength).toBe(64);
+  });
+});
+
+describe("fingerprintPublicKey", () => {
+  test("base64-encodes a raw 32-byte public key unchanged", () => {
+    const raw = crypto.getRandomValues(new Uint8Array(32));
+    const rawB64 = Buffer.from(raw).toString("base64");
+    expect(fingerprintPublicKey(rawB64)).toBe(rawB64);
+  });
+
+  test("rejects wrong-length public keys", () => {
+    const shortB64 = Buffer.from(new Uint8Array(31)).toString("base64");
+    const longB64 = Buffer.from(new Uint8Array(64)).toString("base64");
+    expect(() => fingerprintPublicKey(shortB64)).toThrow(/32 bytes/);
+    expect(() => fingerprintPublicKey(longB64)).toThrow(/32 bytes/);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/__tests__/voice-model-catalog.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/voice-model-catalog.test.ts
@@ -201,9 +201,16 @@ describe("signVoiceModelCatalog", () => {
     // Buffer-based base64 decoding is lenient: junk characters are
     // dropped, so a padded 44-char base64 seed with one appended invalid
     // character still decodes to the same 32 bytes and signs. Pinning that
-    // boundary makes any future move
-    // to strict decoding (which would reject such keys) a deliberate,
+    // boundary makes any future move to strict decoding a deliberate,
     // visible change rather than a silent one.
+    //
+    // Note on the helper name: `decodeBase64Strict` in the module is
+    // aspirational — "strict" refers to the 32-byte length gate it
+    // enforces after decoding, NOT to character-level strictness. Node's
+    // Buffer base64 decoder ignores non-base64 characters (see the
+    // canonicalization tests in the fingerprintPublicKey block below for
+    // the observable leniency). The pinned behavior is the lenient
+    // decode; treat this comment, not the helper name, as the contract.
     const { privateKey } = generateKeyPairSync("ed25519");
     const seedB64 = seedFromPkcs8PrivateKey(privateKey);
     const signatureB64 = await signVoiceModelCatalog({
@@ -215,10 +222,22 @@ describe("signVoiceModelCatalog", () => {
 });
 
 describe("fingerprintPublicKey", () => {
-  test("base64-encodes a raw 32-byte public key unchanged", () => {
+  test("canonicalizes non-canonical base64 spellings to the same fingerprint", () => {
+    // Buffer-based base64 decoding is lenient: trailing whitespace or an
+    // appended invalid character decodes to the same 32 bytes, and
+    // re-encoding emits the canonical spelling. This is the realistic
+    // input class — a key pasted from a file routinely carries a
+    // trailing newline — and the case that proves the function does
+    // something a passthrough (return the input after the length check)
+    // would not: the passthrough returns the newline-terminated spelling.
     const raw = crypto.getRandomValues(new Uint8Array(32));
     const rawB64 = Buffer.from(raw).toString("base64");
-    expect(fingerprintPublicKey(rawB64)).toBe(rawB64);
+    expect(fingerprintPublicKey(`${rawB64}\n`)).toBe(rawB64);
+    expect(fingerprintPublicKey(` ${rawB64}`)).toBe(rawB64);
+    expect(fingerprintPublicKey(`${rawB64}!`)).toBe(rawB64);
+    // 43-char unpadded spelling of the same 32 bytes also canonicalizes
+    // to the padded form.
+    expect(fingerprintPublicKey(rawB64.replaceAll("=", ""))).toBe(rawB64);
   });
 
   test("rejects wrong-length public keys", () => {
@@ -226,5 +245,15 @@ describe("fingerprintPublicKey", () => {
     const longB64 = Buffer.from(new Uint8Array(64)).toString("base64");
     expect(() => fingerprintPublicKey(shortB64)).toThrow(/32 bytes/);
     expect(() => fingerprintPublicKey(longB64)).toThrow(/32 bytes/);
+  });
+
+  test("identity on canonical input: a canonical spelling round-trips unchanged", () => {
+    // Guards the other direction of the canonicalization contract: for a
+    // key already in canonical form the fingerprint equals the input, so
+    // storing/pinning fingerprints against operator-supplied canonical
+    // keys is stable.
+    const raw = crypto.getRandomValues(new Uint8Array(32));
+    const rawB64 = Buffer.from(raw).toString("base64");
+    expect(fingerprintPublicKey(rawB64)).toBe(rawB64);
   });
 });

--- a/packages/cloud/shared/src/lib/services/__tests__/voice-model-catalog.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/voice-model-catalog.test.ts
@@ -197,25 +197,27 @@ describe("signVoiceModelCatalog", () => {
     );
   });
 
-  test("documents the decode boundary: non-base64 characters are ignored by the decoder, so length is the fail-closed gate", async () => {
-    // Buffer-based base64 decoding is lenient: junk characters are
-    // dropped, so a padded 44-char base64 seed with one appended invalid
-    // character still decodes to the same 32 bytes and signs. Pinning that
-    // boundary makes any future move to strict decoding a deliberate,
-    // visible change rather than a silent one.
-    //
-    // Note on the helper name: `decodeBase64Strict` in the module is
-    // aspirational — "strict" refers to the 32-byte length gate it
-    // enforces after decoding, NOT to character-level strictness. Node's
-    // Buffer base64 decoder ignores non-base64 characters (see the
-    // canonicalization tests in the fingerprintPublicKey block below for
-    // the observable leniency). The pinned behavior is the lenient
-    // decode; treat this comment, not the helper name, as the contract.
+  test("fails closed on malformed signing keys: junk characters are rejected, not silently discarded", async () => {
+    // A corrupted or mistyped signing secret (e.g. a `!` pasted in, or an
+    // interior space) must throw before any signing, rather than being
+    // silently dropped by a lenient decoder and signing with "some" bytes:
+    // the operator would believe a broken credential is working. This pins
+    // the strict half of the decode contract — the flip side of the
+    // whitespace-trim convenience asserted in the canonicalization tests.
     const { privateKey } = generateKeyPairSync("ed25519");
     const seedB64 = seedFromPkcs8PrivateKey(privateKey);
+    await expect(
+      signVoiceModelCatalog({ bodyText: "{}", secretKeyBase64: `${seedB64}!` }),
+    ).rejects.toThrow(/Invalid base64/);
+    await expect(
+      signVoiceModelCatalog({ bodyText: "{}", secretKeyBase64: `ab cd` }),
+    ).rejects.toThrow(/Invalid base64/);
+    // The explicit operator convenience: surrounding whitespace (a key
+    // read from a file routinely carries a trailing newline) is trimmed,
+    // and the key still signs.
     const signatureB64 = await signVoiceModelCatalog({
       bodyText: "{}",
-      secretKeyBase64: `${seedB64}!`,
+      secretKeyBase64: `${seedB64}\n`,
     });
     expect(b64ToBytes(signatureB64).byteLength).toBe(64);
   });
@@ -223,21 +225,25 @@ describe("signVoiceModelCatalog", () => {
 
 describe("fingerprintPublicKey", () => {
   test("canonicalizes non-canonical base64 spellings to the same fingerprint", () => {
-    // Buffer-based base64 decoding is lenient: trailing whitespace or an
-    // appended invalid character decodes to the same 32 bytes, and
-    // re-encoding emits the canonical spelling. This is the realistic
-    // input class — a key pasted from a file routinely carries a
-    // trailing newline — and the case that proves the function does
-    // something a passthrough (return the input after the length check)
-    // would not: the passthrough returns the newline-terminated spelling.
+    // Surrounding whitespace is trimmed and unpadded spellings decode to
+    // the same 32 bytes, so re-encoding emits the canonical spelling. This
+    // is the realistic input class — a key pasted from a file routinely
+    // carries a trailing newline — and the case that proves the function
+    // does something a passthrough (return the input after the length
+    // check) would not: the passthrough returns the newline-terminated
+    // spelling.
     const raw = crypto.getRandomValues(new Uint8Array(32));
     const rawB64 = Buffer.from(raw).toString("base64");
     expect(fingerprintPublicKey(`${rawB64}\n`)).toBe(rawB64);
     expect(fingerprintPublicKey(` ${rawB64}`)).toBe(rawB64);
-    expect(fingerprintPublicKey(`${rawB64}!`)).toBe(rawB64);
     // 43-char unpadded spelling of the same 32 bytes also canonicalizes
     // to the padded form.
     expect(fingerprintPublicKey(rawB64.replaceAll("=", ""))).toBe(rawB64);
+    // Non-base64 junk is NOT a spelling of the same bytes: it throws
+    // rather than canonicalizing (mirrors the signing-key fail-closed
+    // contract above — a mistyped key must be rejected, not silently
+    // decoded).
+    expect(() => fingerprintPublicKey(`${rawB64}!`)).toThrow(/Invalid base64/);
   });
 
   test("rejects wrong-length public keys", () => {

--- a/packages/cloud/shared/src/lib/services/__tests__/voice-model-catalog.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/voice-model-catalog.test.ts
@@ -243,7 +243,9 @@ describe("fingerprintPublicKey", () => {
     // rather than canonicalizing (mirrors the signing-key fail-closed
     // contract above — a mistyped key must be rejected, not silently
     // decoded).
-    expect(() => fingerprintPublicKey(`${rawB64}!`)).toThrow(/Invalid base64/);
+    expect(() => fingerprintPublicKey(`${rawB64}!`)).toThrow(
+      /outside the canonical base64 alphabet/,
+    );
     // A final quantum with non-zero discarded slack bits (here the last
     // char bumped so the two unused bits are set — decodes to the same
     // 32 bytes) is a hand-mangled spelling, not a legitimate one: it

--- a/packages/cloud/shared/src/lib/services/__tests__/voice-model-catalog.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/voice-model-catalog.test.ts
@@ -23,22 +23,16 @@ function seedFromPkcs8PrivateKey(
 ): string {
   const der = privateKey.export({ format: "der", type: "pkcs8" }) as Buffer;
   if (der.byteLength !== 48) {
-    throw new Error(
-      `expected 48-byte Ed25519 PKCS8 DER, got ${der.byteLength}`,
-    );
+    throw new Error(`expected 48-byte Ed25519 PKCS8 DER, got ${der.byteLength}`);
   }
   return Buffer.from(der.subarray(16)).toString("base64");
 }
 
 /** SPKI DER for Ed25519 is 44 bytes: 12-byte prefix + 32-byte raw public key. */
-function rawPublicKey(
-  publicKey: ReturnType<typeof generateKeyPairSync>["publicKey"],
-): Uint8Array {
+function rawPublicKey(publicKey: ReturnType<typeof generateKeyPairSync>["publicKey"]): Uint8Array {
   const spki = publicKey.export({ format: "der", type: "spki" }) as Buffer;
   if (spki.byteLength !== 44) {
-    throw new Error(
-      `expected 44-byte Ed25519 SPKI DER, got ${spki.byteLength}`,
-    );
+    throw new Error(`expected 44-byte Ed25519 SPKI DER, got ${spki.byteLength}`);
   }
   return new Uint8Array(spki.subarray(12));
 }
@@ -47,9 +41,7 @@ function b64ToBytes(b64: string): Uint8Array {
   return new Uint8Array(Buffer.from(b64, "base64"));
 }
 
-async function importVerifyKey(
-  publicKey: ReturnType<typeof generateKeyPairSync>["publicKey"],
-) {
+async function importVerifyKey(publicKey: ReturnType<typeof generateKeyPairSync>["publicKey"]) {
   return crypto.subtle.importKey(
     "raw",
     rawPublicKey(publicKey) as unknown as ArrayBuffer,
@@ -66,18 +58,14 @@ async function importVerifyKey(
  * 32 draws fail with probability ~1e-19 — the bound throw below is a
  * hard guard, not a probabilistic pass.
  */
-function generateKeyPairWithMappableSeed(): ReturnType<
-  typeof generateKeyPairSync
-> {
+function generateKeyPairWithMappableSeed(): ReturnType<typeof generateKeyPairSync> {
   for (let i = 0; i < 32; i++) {
     const kp = generateKeyPairSync("ed25519");
-    if (/[+\/]/.test(seedFromPkcs8PrivateKey(kp.privateKey))) {
+    if (/[+/]/.test(seedFromPkcs8PrivateKey(kp.privateKey))) {
       return kp;
     }
   }
-  throw new Error(
-    "32 consecutive draws without a mappable seed character (p ~1e-19)",
-  );
+  throw new Error("32 consecutive draws without a mappable seed character (p ~1e-19)");
 }
 
 describe("buildVoiceModelCatalogBody", () => {
@@ -230,9 +218,9 @@ describe("signVoiceModelCatalog", () => {
     ).rejects.toThrow(/32 bytes/);
     // An unconfigured (empty) signing key must fail closed rather than
     // sign anything — the route's own missing-env guard mirrors this.
-    await expect(
-      signVoiceModelCatalog({ bodyText: "{}", secretKeyBase64: "" }),
-    ).rejects.toThrow(/32 bytes/);
+    await expect(signVoiceModelCatalog({ bodyText: "{}", secretKeyBase64: "" })).rejects.toThrow(
+      /32 bytes/,
+    );
   });
 
   test("fails closed on malformed signing keys: junk characters are rejected, not silently discarded", async () => {
@@ -272,11 +260,8 @@ describe("signVoiceModelCatalog", () => {
     // normalization path.
     const { privateKey } = generateKeyPairWithMappableSeed();
     const seedB64 = seedFromPkcs8PrivateKey(privateKey);
-    const seedUrl = seedB64
-      .replaceAll("+", "-")
-      .replaceAll("/", "_")
-      .replaceAll("=", "");
-    expect(/[+\/]/.test(seedB64)).toBe(true);
+    const seedUrl = seedB64.replaceAll("+", "-").replaceAll("/", "_").replaceAll("=", "");
+    expect(/[+/]/.test(seedB64)).toBe(true);
     const bodyText = JSON.stringify({ schema: "eliza-1-voice-models.v1" });
     const sigStd = await signVoiceModelCatalog({
       bodyText,
@@ -296,9 +281,9 @@ describe("signVoiceModelCatalog", () => {
     let j = 0;
     while (j === m || !/[A-Za-z0-9]/.test(seedB64[j] ?? "")) j += 1;
     const mixedSeed = `${seedB64.slice(0, j)}-${seedB64.slice(j + 1)}`;
-    await expect(
-      signVoiceModelCatalog({ bodyText, secretKeyBase64: mixedSeed }),
-    ).rejects.toThrow(/mixed alphabets/);
+    await expect(signVoiceModelCatalog({ bodyText, secretKeyBase64: mixedSeed })).rejects.toThrow(
+      /mixed alphabets/,
+    );
   });
 });
 
@@ -324,9 +309,7 @@ describe("fingerprintPublicKey", () => {
     // random key until its base64 spelling contains a mappable char so the
     // assertions always execute (p of 32 straight misses ~1e-19).
     while (!/[+/]/.test(rawB64)) {
-      rawB64 = Buffer.from(crypto.getRandomValues(new Uint8Array(32))).toString(
-        "base64",
-      );
+      rawB64 = Buffer.from(crypto.getRandomValues(new Uint8Array(32))).toString("base64");
     }
     const rawUrl = rawB64.replaceAll("+", "-").replaceAll("/", "_");
     expect(fingerprintPublicKey(rawUrl)).toBe(rawB64);
@@ -337,9 +320,9 @@ describe("fingerprintPublicKey", () => {
     const m = rawB64.search(/[+/]/);
     let j = 0;
     while (j === m || !/[A-Za-z0-9]/.test(rawB64[j] ?? "")) j += 1;
-    expect(() =>
-      fingerprintPublicKey(`${rawB64.slice(0, j)}-${rawB64.slice(j + 1)}`),
-    ).toThrow(/mixed alphabets/);
+    expect(() => fingerprintPublicKey(`${rawB64.slice(0, j)}-${rawB64.slice(j + 1)}`)).toThrow(
+      /mixed alphabets/,
+    );
     // Non-base64 junk is NOT a spelling of the same bytes: it throws
     // rather than canonicalizing (mirrors the signing-key fail-closed
     // contract above — a mistyped key must be rejected, not silently

--- a/packages/cloud/shared/src/lib/services/voice-model-catalog.ts
+++ b/packages/cloud/shared/src/lib/services/voice-model-catalog.ts
@@ -84,9 +84,7 @@ export async function signVoiceModelCatalog(args: {
 }): Promise<string> {
   const secretRaw = decodeBase64Strict(args.secretKeyBase64);
   if (secretRaw.byteLength !== 32) {
-    throw new Error(
-      `Ed25519 secret key must be 32 bytes, got ${secretRaw.byteLength}`,
-    );
+    throw new Error(`Ed25519 secret key must be 32 bytes, got ${secretRaw.byteLength}`);
   }
   // Web Crypto's importKey requires the "pkcs8" or "jwk" format for
   // Ed25519 private keys. Wrap the raw 32-byte seed in a minimal PKCS8
@@ -111,9 +109,7 @@ export async function signVoiceModelCatalog(args: {
 export function fingerprintPublicKey(rawPublicKeyBase64: string): string {
   const raw = decodeBase64Strict(rawPublicKeyBase64);
   if (raw.byteLength !== 32) {
-    throw new Error(
-      `Ed25519 public key must be 32 bytes, got ${raw.byteLength}`,
-    );
+    throw new Error(`Ed25519 public key must be 32 bytes, got ${raw.byteLength}`);
   }
   return encodeBase64(raw);
 }
@@ -211,8 +207,7 @@ function wrapEd25519SeedInPkcs8(seed: Uint8Array): Uint8Array {
     throw new Error(`Ed25519 seed must be 32 bytes`);
   }
   const prefix = new Uint8Array([
-    0x30, 0x2e, 0x02, 0x01, 0x00, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70,
-    0x04, 0x22, 0x04, 0x20,
+    0x30, 0x2e, 0x02, 0x01, 0x00, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x04, 0x22, 0x04, 0x20,
   ]);
   const out = new Uint8Array(prefix.length + seed.length);
   out.set(prefix, 0);

--- a/packages/cloud/shared/src/lib/services/voice-model-catalog.ts
+++ b/packages/cloud/shared/src/lib/services/voice-model-catalog.ts
@@ -84,7 +84,9 @@ export async function signVoiceModelCatalog(args: {
 }): Promise<string> {
   const secretRaw = decodeBase64Strict(args.secretKeyBase64);
   if (secretRaw.byteLength !== 32) {
-    throw new Error(`Ed25519 secret key must be 32 bytes, got ${secretRaw.byteLength}`);
+    throw new Error(
+      `Ed25519 secret key must be 32 bytes, got ${secretRaw.byteLength}`,
+    );
   }
   // Web Crypto's importKey requires the "pkcs8" or "jwk" format for
   // Ed25519 private keys. Wrap the raw 32-byte seed in a minimal PKCS8
@@ -109,7 +111,9 @@ export async function signVoiceModelCatalog(args: {
 export function fingerprintPublicKey(rawPublicKeyBase64: string): string {
   const raw = decodeBase64Strict(rawPublicKeyBase64);
   if (raw.byteLength !== 32) {
-    throw new Error(`Ed25519 public key must be 32 bytes, got ${raw.byteLength}`);
+    throw new Error(
+      `Ed25519 public key must be 32 bytes, got ${raw.byteLength}`,
+    );
   }
   return encodeBase64(raw);
 }
@@ -124,30 +128,45 @@ function toArrayBufferView(bytes: Uint8Array): Uint8Array<ArrayBuffer> {
  * Decode a base64 credential, failing closed on malformed input.
  *
  * Surrounding whitespace is trimmed first — keys pasted from files
- * routinely carry a trailing newline — but any remaining character
- * outside the canonical base64 alphabet (including interior whitespace)
- * throws instead of being silently discarded by the lenient Buffer
- * decoder: a corrupted or mistyped signing secret must never decode to
- * "some" bytes. Unpadded final quanta are accepted (a legitimate
- * spelling of the same bytes); a final quantum whose discarded slack
- * bits are non-zero (e.g. `AAB=` where the canonical spelling is `AAA=`)
- * and `=` padding anywhere but the tail also throw.
+ * routinely carry a trailing newline — and a pure RFC 4648 §5 URL-safe
+ * spelling (`-`/`_` throughout) is normalized to the standard alphabet
+ * before validation: base64url is the same bytes in a standard alternate
+ * encoding (JWK `d`, `basenc --base64url`, most JOSE tooling), not a
+ * mistyped secret, and must keep working. A MIXED alphabet (standard
+ * `+`/`/` and URL-safe `-`/`_` in the same credential) is rejected: no
+ * standard tool emits one, and it is the signature of a hand-mangled
+ * value. Any remaining character outside the canonical base64 alphabet
+ * (including interior whitespace) throws instead of being silently
+ * discarded by the lenient Buffer decoder: a corrupted or mistyped
+ * signing secret must never decode to "some" bytes. Unpadded final
+ * quanta are accepted (a legitimate spelling of the same bytes); a
+ * final quantum whose discarded slack bits are non-zero (e.g. `AAB=`
+ * where the canonical spelling is `AAA=`) and `=` padding anywhere but
+ * the tail also throw.
  */
 const CANONICAL_BASE64 =
   /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{2,3})?$/;
 
 function decodeBase64Strict(input: string): Uint8Array {
   const trimmed = input.trim();
-  if (!CANONICAL_BASE64.test(trimmed)) {
+  const hasStandardAlphabetChars = /[+/]/.test(trimmed);
+  const hasUrlSafeAlphabetChars = /[-_]/.test(trimmed);
+  if (hasStandardAlphabetChars && hasUrlSafeAlphabetChars) {
+    throw new Error(
+      `Invalid base64: mixed alphabets (standard +// and URL-safe -/_ in the same credential) — no standard encoding emits both`,
+    );
+  }
+  const normalized = trimmed.replace(/-/g, "+").replace(/_/g, "/");
+  if (!CANONICAL_BASE64.test(normalized)) {
     throw new Error(
       `Invalid base64: input contains characters outside the canonical base64 alphabet after trimming surrounding whitespace`,
     );
   }
   const bytes =
     typeof Buffer !== "undefined"
-      ? new Uint8Array(Buffer.from(trimmed, "base64"))
+      ? new Uint8Array(Buffer.from(normalized, "base64"))
       : (() => {
-          const bin = atob(trimmed);
+          const bin = atob(normalized);
           const out = new Uint8Array(bin.length);
           for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
           return out;
@@ -157,7 +176,7 @@ function decodeBase64Strict(input: string): Uint8Array {
   // discarded — a hand-mangled spelling, not an alternate encoding any
   // standard tool emits. Re-encoding the decoded bytes must reproduce
   // the input after restoring omitted padding.
-  const padded = trimmed.padEnd(Math.ceil(trimmed.length / 4) * 4, "=");
+  const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, "=");
   if (encodeBase64(bytes) !== padded) {
     throw new Error(
       `Invalid base64: non-canonical final quantum (discarded slack bits are non-zero)`,
@@ -192,7 +211,8 @@ function wrapEd25519SeedInPkcs8(seed: Uint8Array): Uint8Array {
     throw new Error(`Ed25519 seed must be 32 bytes`);
   }
   const prefix = new Uint8Array([
-    0x30, 0x2e, 0x02, 0x01, 0x00, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x04, 0x22, 0x04, 0x20,
+    0x30, 0x2e, 0x02, 0x01, 0x00, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70,
+    0x04, 0x22, 0x04, 0x20,
   ]);
   const out = new Uint8Array(prefix.length + seed.length);
   out.set(prefix, 0);

--- a/packages/cloud/shared/src/lib/services/voice-model-catalog.ts
+++ b/packages/cloud/shared/src/lib/services/voice-model-catalog.ts
@@ -38,9 +38,18 @@ export interface VoiceModelCatalogResponse {
   /** Stable copy of `VOICE_MODEL_VERSIONS`. */
   readonly versions: ReadonlyArray<VoiceModelVersion>;
   /**
-   * Public-key fingerprints the device-side updater can pin against.
-   * Base64 raw 32-byte keys. The runtime accepts ANY of these as a
-   * signing key — used to manage rotation windows.
+   * Fingerprints of the public keys corresponding to the signing keys in
+   * the rotation window, exposed for downstream auditors. Informational:
+   * the device-side updater does NOT read this field — it verifies
+   * against its own configured public keys (`args.publicKeys` on
+   * `verifyManifestSignatureText`), so rotation safety comes from the
+   * device key list accepting both keys during the window, not from this
+   * body-carried list. A key list carried inside a signed body can never
+   * act as a trust root: any signer could self-authorize by listing its
+   * own key. Base64 raw 32-byte keys. Values produced by
+   * `fingerprintPublicKey` are canonical base64 encodings of raw
+   * 32-byte keys; entries supplied through this field are passed
+   * through unchanged.
    */
   readonly publicKeyFingerprints: ReadonlyArray<string>;
 }

--- a/packages/cloud/shared/src/lib/services/voice-model-catalog.ts
+++ b/packages/cloud/shared/src/lib/services/voice-model-catalog.ts
@@ -123,13 +123,15 @@ function toArrayBufferView(bytes: Uint8Array): Uint8Array<ArrayBuffer> {
 /**
  * Decode a base64 credential, failing closed on malformed input.
  *
- * Surrounding ASCII whitespace is trimmed first — keys pasted from files
- * routinely carry a trailing newline — but any remaining character outside
- * the canonical base64 alphabet (including interior whitespace) throws
- * instead of being silently discarded by the lenient Buffer decoder: a
- * corrupted or mistyped signing secret must never decode to "some" bytes.
- * Unpadded final quanta are accepted (a legitimate spelling of the same
- * bytes); `=` padding anywhere but the tail still throws.
+ * Surrounding whitespace is trimmed first — keys pasted from files
+ * routinely carry a trailing newline — but any remaining character
+ * outside the canonical base64 alphabet (including interior whitespace)
+ * throws instead of being silently discarded by the lenient Buffer
+ * decoder: a corrupted or mistyped signing secret must never decode to
+ * "some" bytes. Unpadded final quanta are accepted (a legitimate
+ * spelling of the same bytes); a final quantum whose discarded slack
+ * bits are non-zero (e.g. `AAB=` where the canonical spelling is `AAA=`)
+ * and `=` padding anywhere but the tail also throw.
  */
 const CANONICAL_BASE64 =
   /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{2,3})?$/;
@@ -141,14 +143,27 @@ function decodeBase64Strict(input: string): Uint8Array {
       `Invalid base64: input contains characters outside the canonical base64 alphabet after trimming surrounding whitespace`,
     );
   }
-  if (typeof Buffer !== "undefined") {
-    const buf = Buffer.from(trimmed, "base64");
-    return new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
+  const bytes =
+    typeof Buffer !== "undefined"
+      ? new Uint8Array(Buffer.from(trimmed, "base64"))
+      : (() => {
+          const bin = atob(trimmed);
+          const out = new Uint8Array(bin.length);
+          for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+          return out;
+        })();
+  // Reject non-zero slack bits: a final quantum like `AAB=` (canonical
+  // `AAA=`) decodes to the same bytes only because its low bits are
+  // discarded — a hand-mangled spelling, not an alternate encoding any
+  // standard tool emits. Re-encoding the decoded bytes must reproduce
+  // the input after restoring omitted padding.
+  const padded = trimmed.padEnd(Math.ceil(trimmed.length / 4) * 4, "=");
+  if (encodeBase64(bytes) !== padded) {
+    throw new Error(
+      `Invalid base64: non-canonical final quantum (discarded slack bits are non-zero)`,
+    );
   }
-  const bin = atob(trimmed);
-  const out = new Uint8Array(bin.length);
-  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
-  return out;
+  return bytes;
 }
 
 function encodeBase64(bytes: Uint8Array): string {

--- a/packages/cloud/shared/src/lib/services/voice-model-catalog.ts
+++ b/packages/cloud/shared/src/lib/services/voice-model-catalog.ts
@@ -120,12 +120,32 @@ function toArrayBufferView(bytes: Uint8Array): Uint8Array<ArrayBuffer> {
   return copy;
 }
 
+/**
+ * Decode a base64 credential, failing closed on malformed input.
+ *
+ * Surrounding ASCII whitespace is trimmed first — keys pasted from files
+ * routinely carry a trailing newline — but any remaining character outside
+ * the canonical base64 alphabet (including interior whitespace) throws
+ * instead of being silently discarded by the lenient Buffer decoder: a
+ * corrupted or mistyped signing secret must never decode to "some" bytes.
+ * Unpadded final quanta are accepted (a legitimate spelling of the same
+ * bytes); `=` padding anywhere but the tail still throws.
+ */
+const CANONICAL_BASE64 =
+  /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{2,3})?$/;
+
 function decodeBase64Strict(input: string): Uint8Array {
+  const trimmed = input.trim();
+  if (!CANONICAL_BASE64.test(trimmed)) {
+    throw new Error(
+      `Invalid base64: input contains characters outside the canonical base64 alphabet after trimming surrounding whitespace`,
+    );
+  }
   if (typeof Buffer !== "undefined") {
-    const buf = Buffer.from(input, "base64");
+    const buf = Buffer.from(trimmed, "base64");
     return new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
   }
-  const bin = atob(input);
+  const bin = atob(trimmed);
   const out = new Uint8Array(bin.length);
   for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
   return out;


### PR DESCRIPTION
Closes #28995

## Summary

Adds a `bun:test` suite pinning the sign-side behavior of the voice-model catalog service (`packages/cloud/shared/src/lib/services/voice-model-catalog.ts`). `GET /api/v1/voice-models/catalog` is public and unauthenticated — the base64 Ed25519 signature in `X-Eliza-Signature` is the trust root, and the device-side updater verifies the exact response text before parsing. Until now, no test in the repository exercised this module: the catalog route has no tests, and the device-side updater (`plugin-local-inference`) is tested only against its fallback sources (GitHub releases / HuggingFace), never against signatures produced by this signer.

## What regression each test detects

- **Body shape pin** (`schema` literal, ISO `generatedAt` from the injected clock, full version list, fingerprint passthrough): the served body is what devices parse; a `generatedAt` epoch-ms regression, a truncated version list, or a schema rename would change what every paired device accepts.
- **Signature interop** (key pair generated by `node:crypto`, seed re-derived from its PKCS8 DER): proves the module's RFC 8410 seed wrapping matches Node's own key encoding and that `X-Eliza-Signature` round-trips through WebCrypto import/verify — a drift in the PKCS8 prefix or sign input breaks this.
- **Exact-bytes contract** (single flipped body byte fails verification; different-seed signature fails): the route signs `JSON.stringify(body)` and the updater verifies the raw response text — any change that signs different bytes than the response carries would brick devices silently.
- **Fail-closed key validation** (31/33-byte and empty seeds rejected before signing; wrong-length public keys rejected in `fingerprintPublicKey`): an unconfigured or malformed key must fail loudly (the route maps this to 503), never sign with a truncated key.
- **Decode-boundary documentation**: this PR *is* the move to strict decoding (first commit documented the lenient behavior so the shift would be a visible test change rather than silent — the later decoder-hardening commits then made it).

## Which consumer observes a breakage

`packages/cloud/api/v1/voice-models/catalog/route.ts` serves this catalog to paired devices; `plugins/plugin-local-inference/src/services/voice-model-updater.ts` (device side) verifies the signature before parsing. A signing regression surfaces as devices hard-rejecting the catalog (no voice-model updates), with no server-side error signal — which is exactly why it needs a CI-level pin.

## Why no existing higher-level test owns this

Before this PR, grep across the repository's test corpus returned zero hits for `signVoiceModelCatalog` / `buildVoiceModelCatalogBody` / `fingerprintPublicKey`. `X-Eliza-Signature` does appear in `plugin-local-inference/__tests__/services/voice-model-updater.test.ts`, but those tests build their own key pairs and fixtures rather than signatures produced by this module, so no existing test exercised this signer. The route is a Cloudflare Worker route with no route-level test.

## Verification

- `bun test src/lib/services/__tests__/voice-model-catalog.test.ts` — 11 pass / 0 fail at afca294bb3 (10 at the original head).
- Mutation controls (module edited, suite re-run, restored): seed-length gate off-by-one → 3 failures; sign-skewed-body (`bodyText + " "`) → 1; fingerprint length-gate drop → 1; schema literal drift → 1; `generatedAt` epoch-ms → 1; PKCS8 OID byte drift → 3. Two DER outer-length byte mutations are not caught (Bun's WebCrypto tolerates them — not observable behavior).
- Response-push RED control: replacing `fingerprintPublicKey` with a passthrough (`Buffer.byteLength` length check + `return` the input) fails exactly the canonicalization test (1 failure / 10 pass) — the new assertions distinguish the implementation from the passthrough refactor.
- Isolation control: `payment-request-settlement.pglite.test.ts` passes 13/13 with and without this file present (this suite uses no database).
- `biome check` clean; `bun run --cwd packages/cloud/shared typecheck` shows only the pre-existing `tsconfig.json` TS5103 (`--ignoreDeprecations`), identical with and without this diff.

## Review response (afca294bb3)

All findings from @sarah-pump-ai's review addressed — see the reply comment for the finding → fix → evidence table.

Production behavior note: commits 9c061fe2cd and 538c7db8f2 changed `decodeBase64Strict` so malformed `ELIZA_VOICE_CATALOG_*_KEY_BASE64` values that the old lenient decoder silently accepted (junk alphabet characters, interior whitespace, misplaced `=` padding, non-canonical final quanta) now throw. This changes `GET /api/v1/voice-models/catalog` availability behavior: the route fails closed to a canonical `{"success":false,...}` 500 with no `X-Eliza-Signature` and no cacheable success, while correctly-configured keys keep serving the signed catalog unchanged (end-to-end verified below).

| Evidence | Detail |
| --- | --- |
| backend-logs | E2E route-to-verifier at head b497cf6df1 — bun test isolated lane 13 pass / 0 fail / 74 expect() (packages/cloud/api/v1/voice-models/catalog/route.test.ts): valid generated Ed25519 creds → 200 + X-Eliza-Signature + Cache-Control s-maxage=900, device verifyManifestSignatureText accepts exact bytes (keyIndex 0), rejects one flipped byte, rotation-peer at index 1, trailing-newline convenience still signs; NEW base64url-spelled credentials (RFC 4648 §5, JWK/JOSE tooling output; keys redrawn until mappable so the test is never vacuous) → still 200, exact bytes verify, canonical fingerprints. Malformed matrix (junk char / interior whitespace / misplaced padding / non-zero slack bits) in both key positions → 500, no signature, no Cache-Control; MIXED alphabets (standard +// and URL-safe -/_ in one credential) → rejected with dedicated error; unconfigured key → 503 unsigned. Module suite 12/12 (33 expects) incl. identical-signature base64url test. RED controls: stash fix → exactly the base64url tests fail (10p/2f shared; route file FAILED); remove only mixed-guard → exactly mixed tests fail. tsc 0 errors; biome clean on all three files. RP independent review (GPT-5.6-sol, 3 rounds): round 1 caught mixed-alphabet acceptance + vacuous tests, round 2 caught an always-false redraw guard, round 3 APPROVE |
| screenshots | N/A - no UI change |
| mp4-walkthrough | N/A - no UI change |
| llm-trajectory | N/A - no model-behavior change |

<!-- evidence-head:12d326d3853b2af327abb75cf4d304c5205d0f0e -->

<!-- evidence-row:backend-logs -->
E2E route-to-verifier transcript at head 78dea70471 (bun test isolated lane `packages/cloud/api/test/run-unit-isolated.mjs voice-models/catalog`):

```text
Ran 12 tests across 1 file. [208.00ms]  — 12 pass / 0 fail / 71 expect() calls
(packages/cloud/api/v1/voice-models/catalog/route.test.ts)

[valid creds]     route: 200 + X-Eliza-Signature + Cache-Control s-maxage=900
                  device verifyManifestSignatureText(exact bytes): keyIndex 0
                  one flipped body byte: ELIZA_VOICE_SIG_REJECTED (throws)
                  rotation-peer slot: accepted at key index 1
                  trailing-newline convenience: still signs and verifies
[malformed matrix] junk char / interior whitespace in valid key / misplaced
                  leading padding / non-zero slack bits (same-bytes alias
                  A→B,Q→R,g→h,w→x) × BOTH signing and public-key positions:
                  route 500 failureResponse, no X-Eliza-Signature, no
                  Cache-Control, no catalog schema in body
[unconfigured]    missing signing key: 503 service_unavailable, unsigned
[consumer]        standalone real cloudCatalogSource harness (fetch-then-
                  verify-before-parse): 17/17 pass incl. tampered-body rejection
[gates]           tsc --noEmit (cloud/api + worker-bundle dry-run): exit 0
                  biome check: clean
```

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no UI change

<!-- evidence-row:after-screenshots -->
- [ ] N/A - no UI change

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no UI change

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no UI change

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model-behavior change

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - fork cannot attach release artifacts; catalog verification artifacts (raw signed body, full response headers incl. X-Eliza-Signature/Cache-Control, failure-matrix.json with per-cell fail-closed + log-redaction booleans, verification-summary.json) are reproduced inline in the review-response comment at head dfe1cde51e

<!-- evidence-row:ocr-review -->
- [ ] N/A - no UI change

AI provider/model: zai / glm-5.3
Client / agent tooling: Hermes Agent
Contribution skill revision: elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [hermes-t3rpz]
<!-- eliza-computer-attribution:v1 {"provider":"zai","model":"glm-5.3","client":"Hermes Agent","skill_revision":"elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza"} -->
