### PR TITLE
feat(shared): support whitespace and word unit aliases in parseDurationMs

### DIFF
--- a/packages/shared/src/cli/parse-duration.test.ts
+++ b/packages/shared/src/cli/parse-duration.test.ts
@@ -31,6 +31,7 @@ describe("parseDurationMs", () => {
     expect(parseDurationMs("250")).toBe(250); // default ms
     expect(parseDurationMs("5", { defaultUnit: "s" })).toBe(5000);
     expect(parseDurationMs("5s", { defaultUnit: "m" })).toBe(5000); // suffix wins
+    expect(parseDurationMs("5 s", { defaultUnit: "m" })).toBe(5000); // spaced suffix wins
   });
 
   it("throws on empty / malformed / negative input", () => {
@@ -41,6 +42,19 @@ describe("parseDurationMs", () => {
     expect(() => parseDurationMs("abc")).toThrow();
     expect(() => parseDurationMs("10x")).toThrow();
     expect(() => parseDurationMs("-5s")).toThrow();
+  });
+
+  it("rejects unsupported calendar and near-miss unit spellings", () => {
+    expect(() => parseDurationMs("1 month")).toThrow("invalid duration");
+    expect(() => parseDurationMs("1 months")).toThrow("invalid duration");
+    expect(() => parseDurationMs("3 mo")).toThrow("invalid duration");
+    expect(() => parseDurationMs("5 weeks")).toThrow("invalid duration");
+    expect(() => parseDurationMs("1w")).toThrow("invalid duration");
+    expect(() => parseDurationMs("1 year")).toThrow("invalid duration");
+    expect(() => parseDurationMs("2 y")).toThrow("invalid duration");
+    expect(() => parseDurationMs("1 secondz")).toThrow("invalid duration");
+    expect(() => parseDurationMs("5 hourss")).toThrow("invalid duration");
+    expect(() => parseDurationMs("5 m s")).toThrow("invalid duration");
   });
 
   it.each(["s", "m", "h", "d"] as const)(

--- a/packages/shared/src/cli/parse-duration.test.ts
+++ b/packages/shared/src/cli/parse-duration.test.ts
@@ -17,6 +17,16 @@ describe("parseDurationMs", () => {
     expect(parseDurationMs("1.5s")).toBe(1500);
   });
 
+  it("supports spaces and word aliases for duration units", () => {
+    expect(parseDurationMs("500 ms")).toBe(500);
+    expect(parseDurationMs("20 seconds")).toBe(20_000);
+    expect(parseDurationMs("15 secs")).toBe(15_000);
+    expect(parseDurationMs("5 minutes")).toBe(300_000);
+    expect(parseDurationMs("2 mins")).toBe(120_000);
+    expect(parseDurationMs("3 hours")).toBe(10_800_000);
+    expect(parseDurationMs("2 days")).toBe(172_800_000);
+  });
+
   it("uses the default unit only when no suffix is present", () => {
     expect(parseDurationMs("250")).toBe(250); // default ms
     expect(parseDurationMs("5", { defaultUnit: "s" })).toBe(5000);

--- a/packages/shared/src/cli/parse-duration.ts
+++ b/packages/shared/src/cli/parse-duration.ts
@@ -1,10 +1,35 @@
 /**
- * Parses a duration string (`500ms`, `30s`, `5m`, `2h`, `1d`) to milliseconds,
- * with a configurable default unit for bare numbers. Throws on empty or
+ * Parses a duration string (e.g. `500ms`, `500 ms`, `30s`, `20 seconds`, `5 mins`, `2h`, `1 day`)
+ * to milliseconds, with a configurable default unit for bare numbers. Throws on empty or
  * unparseable input. Used by config zod schemas and CLI flag parsing.
  */
 export type DurationMsParseOptions = {
   defaultUnit?: "ms" | "s" | "m" | "h" | "d";
+};
+
+const UNIT_ALIASES: Record<string, "ms" | "s" | "m" | "h" | "d"> = {
+  ms: "ms",
+  millis: "ms",
+  millisecond: "ms",
+  milliseconds: "ms",
+  s: "s",
+  sec: "s",
+  secs: "s",
+  second: "s",
+  seconds: "s",
+  m: "m",
+  min: "m",
+  mins: "m",
+  minute: "m",
+  minutes: "m",
+  h: "h",
+  hr: "h",
+  hrs: "h",
+  hour: "h",
+  hours: "h",
+  d: "d",
+  day: "d",
+  days: "d",
 };
 
 export function parseDurationMs(
@@ -36,26 +61,12 @@ export function parseDurationMs(
   let unit: "ms" | "s" | "m" | "h" | "d";
   if (!rawUnit) {
     unit = opts?.defaultUnit ?? "ms";
-  } else if (
-    rawUnit === "ms" ||
-    rawUnit === "millis" ||
-    rawUnit.startsWith("milli")
-  ) {
-    unit = "ms";
-  } else if (rawUnit === "s" || rawUnit.startsWith("sec")) {
-    unit = "s";
-  } else if (rawUnit === "m" || rawUnit.startsWith("min")) {
-    unit = "m";
-  } else if (
-    rawUnit === "h" ||
-    rawUnit.startsWith("hr") ||
-    rawUnit.startsWith("hour")
-  ) {
-    unit = "h";
-  } else if (rawUnit === "d" || rawUnit.startsWith("day")) {
-    unit = "d";
   } else {
-    unit = opts?.defaultUnit ?? "ms";
+    const mapped = UNIT_ALIASES[rawUnit];
+    if (!mapped) {
+      throw new Error(`invalid duration: ${raw}`);
+    }
+    unit = mapped;
   }
   const multiplier =
     unit === "ms"

--- a/packages/shared/src/cli/parse-duration.ts
+++ b/packages/shared/src/cli/parse-duration.ts
@@ -19,7 +19,10 @@ export function parseDurationMs(
     throw new Error("invalid duration (empty)");
   }
 
-  const m = /^(\d+(?:\.\d+)?)(ms|s|m|h|d)?$/.exec(trimmed);
+  const m =
+    /^(\d+(?:\.\d+)?)\s*(milliseconds?|millis|ms|seconds?|secs?|s|minutes?|mins?|m|hours?|hrs?|h|days?|d)?$/.exec(
+      trimmed,
+    );
   if (!m) {
     throw new Error(`invalid duration: ${raw}`);
   }
@@ -29,12 +32,31 @@ export function parseDurationMs(
     throw new Error(`invalid duration: ${raw}`);
   }
 
-  const unit = (m[2] ?? opts?.defaultUnit ?? "ms") as
-    | "ms"
-    | "s"
-    | "m"
-    | "h"
-    | "d";
+  const rawUnit = m[2];
+  let unit: "ms" | "s" | "m" | "h" | "d";
+  if (!rawUnit) {
+    unit = opts?.defaultUnit ?? "ms";
+  } else if (
+    rawUnit === "ms" ||
+    rawUnit === "millis" ||
+    rawUnit.startsWith("milli")
+  ) {
+    unit = "ms";
+  } else if (rawUnit === "s" || rawUnit.startsWith("sec")) {
+    unit = "s";
+  } else if (rawUnit === "m" || rawUnit.startsWith("min")) {
+    unit = "m";
+  } else if (
+    rawUnit === "h" ||
+    rawUnit.startsWith("hr") ||
+    rawUnit.startsWith("hour")
+  ) {
+    unit = "h";
+  } else if (rawUnit === "d" || rawUnit.startsWith("day")) {
+    unit = "d";
+  } else {
+    unit = opts?.defaultUnit ?? "ms";
+  }
   const multiplier =
     unit === "ms"
       ? 1


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Broadens accepted format patterns in `parseDurationMs` in `@elizaos/shared` to allow optional whitespace and human-readable unit words (e.g. `seconds`, `secs`, `minutes`, `mins`, `hours`, `hrs`, `days`).

# Background

## What does this PR do?

Enhances `parseDurationMs` in `packages/shared/src/cli/parse-duration.ts` to accept durations with spaces (e.g., `"500 ms"`) and unit aliases/words (e.g., `"20 seconds"`, `"5 minutes"`, `"3 hours"`, `"2 days"`).

## What kind of change is this?

Features (non-breaking change which adds functionality).

## Why are we doing this? Any context or related work?

CLI flags and configuration files commonly accept natural duration strings with spaces or long unit names. Supporting standard aliases prevents parse rejections on common configuration values.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Review `packages/shared/src/cli/parse-duration.ts` and `packages/shared/src/cli/parse-duration.test.ts`.

## Detailed testing steps

Run:
```bash
bun test packages/shared/src/cli/parse-duration.test.ts
bun run --cwd packages/shared typecheck
```

# Evidence Gate

<!-- evidence-head:a5c902e9b124ec2af61dd0d0cd56eb3f1fadc24a -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - Non-UI shared duration utility change`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - Non-UI shared duration utility change`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - Non-UI shared duration utility change`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - Shared duration unit function, verified via unit test execution`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - Non-UI shared duration utility change`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - Deterministic duration parsing without model calls`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - In-memory duration parsing`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - No rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

N/A - Deterministic duration parsing without model calls.

## Backend + frontend logs

N/A - Shared duration unit function, verified via unit test execution.

## Screenshots (before / after) + video walkthrough

N/A - Non-UI shared duration utility change.

## Audio / voice walkthrough

N/A - No audio or voice paths touched.

## Known gaps / failures

None.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
