### PR TITLE
fix(android): restore launcher kiosk after auth

### DIFF
--- a/packages/app-core/scripts/run-mobile-build-cloud-main-activity.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-cloud-main-activity.test.mjs
@@ -68,6 +68,8 @@ describe("cloudSafeMainActivityJava", () => {
     expect(source).toContain("KeyEvent.KEYCODE_FORWARD");
     expect(source).toContain("KeyEvent.KEYCODE_NAVIGATE_NEXT");
     expect(source).toContain("startLockTask();");
+    expect(source).toContain("protected void onResume()");
+    expect(source).toContain("super.onResume();");
     expect(source).toContain(
       "IllegalArgumentException | IllegalStateException | SecurityException",
     );

--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -6233,15 +6233,22 @@ import androidx.activity.OnBackPressedCallback;
                 // Intentionally stay on the launcher root.
             }
         });
+`
+    : "";
+  const launcherMethods = launcherKiosk
+    ? `
+    @Override
+    protected void onResume() {
+        super.onResume();
+        // Browser-based identity providers temporarily cover the launcher.
+        // Re-enter containment whenever their deep-link callback returns.
         try {
             startLockTask();
         } catch (IllegalArgumentException | IllegalStateException | SecurityException e) {
             Log.w(TAG, "Unable to enter launcher lock-task mode", e);
         }
-`
-    : "";
-  const launcherMethods = launcherKiosk
-    ? `
+    }
+
     @Override
     public boolean dispatchKeyEvent(KeyEvent event) {
         // Keep hardware keyboards and accessibility navigation from moving the


### PR DESCRIPTION
## Summary
- enter launcher lock-task mode from `onResume` instead of only `onCreate`
- re-establish containment after hosted OAuth returns to the launcher
- keep Back and Forward suppression launcher-only

## Verification
- `bun test packages/app-core/scripts/run-mobile-build-cloud-main-activity.test.mjs packages/app-core/scripts/run-mobile-build-android-play-policy.test.mjs` (24 pass)
- `git diff --check`