### PR TITLE
fix(shared): safely serialize BigInt values in canonical JSON walk

### DIFF
--- a/packages/shared/src/canonical-json.test.ts
+++ b/packages/shared/src/canonical-json.test.ts
@@ -380,4 +380,12 @@ describe("canonical JSON fail-closed bounds", () => {
     expect(() => canonicalJsonString(cyclic, options)).toThrow(DomainError);
     expect(typeof failCanonicalJsonUnbounded).toBe("function");
   });
+
+  it("safely serializes BigInt values", () => {
+    expect(canonicalJsonString(123n, OPTIONS)).toBe('"123"');
+    expect(canonicalJsonString([1n, 2n], OPTIONS)).toBe('["1","2"]');
+    expect(canonicalJsonString({ id: 9007199254740993n }, OPTIONS)).toBe(
+      '{"id":"9007199254740993"}',
+    );
+  });
 });

--- a/packages/shared/src/canonical-json.ts
+++ b/packages/shared/src/canonical-json.ts
@@ -289,6 +289,8 @@ function canonicalWalk(
     // Object keys carrying these were already dropped by the snapshot; reaching
     // one here means an array slot, which `JSON.stringify` renders as `null`.
     if (isJsonInvisible(value)) return emit(ctx, "null");
+    if (typeof value === "bigint")
+      return emit(ctx, JSON.stringify(value.toString()));
     return emit(ctx, JSON.stringify(value));
   }
 


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Prevents native `TypeError: Do not know how to serialize a BigInt` by converting BigInt primitives to JSON-quoted strings in `canonicalWalk`.

# Background

## What does this PR do?

Adds support for `typeof value === "bigint"` in `canonicalWalk` (`packages/shared/src/canonical-json.ts`) by serializing the value to a string representation (`value.toString()`).

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue).

## Why are we doing this? Any context or related work?

`JSON.stringify` throws a runtime `TypeError` when encountering a `BigInt` value. When hashing agent backups, state objects, or database records containing bigints (such as transaction timestamps, token amounts, or large IDs), `canonicalJsonString` threw an unhandled exception.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Review `packages/shared/src/canonical-json.ts` and `packages/shared/src/canonical-json.test.ts`.

## Detailed testing steps

Run:
```bash
bun test packages/shared/src/canonical-json.test.ts
bun run --cwd packages/shared typecheck
```

# Evidence Gate

<!-- evidence-head:712fed505518fc9b6b7745f90a63c927dd8202d7 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - Non-UI shared canonical JSON utility change`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - Non-UI shared canonical JSON utility change`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - Non-UI shared canonical JSON utility change`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - Shared canonical JSON unit function, verified via unit test execution`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - Non-UI shared canonical JSON utility change`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - Deterministic canonical JSON serialization without model calls`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - In-memory canonical JSON`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - No rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

N/A - Deterministic canonical JSON serialization without model calls.

## Backend + frontend logs

N/A - Shared canonical JSON unit function, verified via unit test execution.

## Screenshots (before / after) + video walkthrough

N/A - Non-UI shared canonical JSON utility change.

## Audio / voice walkthrough

N/A - No audio or voice paths touched.

## Known gaps / failures

None.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
