### PR TITLE
feat(core): support thread, forum, guild, and group_dm chat type synonyms in normalizeChatType

### DIFF
--- a/packages/core/src/utils/channel-utils.test.ts
+++ b/packages/core/src/utils/channel-utils.test.ts
@@ -22,9 +22,18 @@ describe("normalizeChatType", () => {
 	it("folds platform synonyms into direct/group/channel", () => {
 		expect(normalizeChatType("dm")).toBe("direct");
 		expect(normalizeChatType("private")).toBe("direct");
+		expect(normalizeChatType("1on1")).toBe("direct");
+		expect(normalizeChatType("1:1")).toBe("direct");
+		expect(normalizeChatType("p2p")).toBe("direct");
 		expect(normalizeChatType("supergroup")).toBe("group");
+		expect(normalizeChatType("group_dm")).toBe("group");
+		expect(normalizeChatType("room")).toBe("group");
 		expect(normalizeChatType("broadcast")).toBe("channel");
+		expect(normalizeChatType("thread")).toBe("channel");
+		expect(normalizeChatType("forum")).toBe("channel");
+		expect(normalizeChatType("guild_text")).toBe("channel");
 		expect(normalizeChatType(undefined)).toBe("direct");
+		expect(normalizeChatType(null as unknown as string)).toBe("direct");
 		expect(normalizeChatType("weird")).toBe("direct");
 	});
 });

--- a/packages/core/src/utils/channel-utils.ts
+++ b/packages/core/src/utils/channel-utils.ts
@@ -17,17 +17,41 @@ export type NormalizedChatType = "direct" | "group" | "channel";
  * @returns Normalized chat type
  */
 export function normalizeChatType(raw?: string): NormalizedChatType {
-	const lower = raw?.toLowerCase().trim();
+	if (typeof raw !== "string") {
+		return "direct";
+	}
+	const lower = raw.toLowerCase().trim();
 	if (!lower) {
 		return "direct";
 	}
-	if (lower === "direct" || lower === "dm" || lower === "private") {
+	if (
+		lower === "direct" ||
+		lower === "dm" ||
+		lower === "private" ||
+		lower === "p2p" ||
+		lower === "1on1" ||
+		lower === "1:1"
+	) {
 		return "direct";
 	}
-	if (lower === "group" || lower === "supergroup" || lower === "room") {
+	if (
+		lower === "group" ||
+		lower === "supergroup" ||
+		lower === "room" ||
+		lower === "group_dm"
+	) {
 		return "group";
 	}
-	if (lower === "channel" || lower === "feed" || lower === "broadcast") {
+	if (
+		lower === "channel" ||
+		lower === "feed" ||
+		lower === "broadcast" ||
+		lower === "thread" ||
+		lower === "forum" ||
+		lower === "topic" ||
+		lower === "guild_text" ||
+		lower === "guild_announcement"
+	) {
 		return "channel";
 	}
 	return "direct";


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Expands recognized chat type strings in `normalizeChatType` in `@elizaos/core` to include common platform-specific terms (such as Discord/Slack/Matrix types).

# Background

## What does this PR do?

Expands `normalizeChatType` (`packages/core/src/utils/channel-utils.ts`) with platform synonyms:
- `"direct"`: adds `"1on1"`, `"1:1"`, `"p2p"`
- `"group"`: adds `"group_dm"`, `"room"`
- `"channel"`: adds `"thread"`, `"forum"`, `"topic"`, `"guild_text"`, `"guild_announcement"`
- Guards non-string inputs safely.

## What kind of change is this?

Features (non-breaking change which adds functionality).

## Why are we doing this? Any context or related work?

Incoming messages from Discord, Slack, and Matrix integrations often carry platform-specific channel types (such as `thread`, `forum`, `guild_text`, or `group_dm`). Normalizing these appropriately prevents them from defaulting incorrectly to direct messages.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Review `packages/core/src/utils/channel-utils.ts` and `packages/core/src/utils/channel-utils.test.ts`.

## Detailed testing steps

Run:
```bash
bun test packages/core/src/utils/channel-utils.test.ts
bun run --cwd packages/core typecheck
```

# Evidence Gate

<!-- evidence-head:6d32d2b3694c56f662c3d364db1f3096868a2535 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - Non-UI core channel utility change`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - Non-UI core channel utility change`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - Non-UI core channel utility change`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - Core channel unit function, verified via unit test execution`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - Non-UI core channel utility change`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - Deterministic channel type normalizer without model calls`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - In-memory channel utilities`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - No rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

N/A - Deterministic channel type normalizer without model calls.

## Backend + frontend logs

N/A - Core channel unit function, verified via unit test execution.

## Screenshots (before / after) + video walkthrough

N/A - Non-UI core channel utility change.

## Audio / voice walkthrough

N/A - No audio or voice paths touched.

## Known gaps / failures

None.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
