### PR TITLE
fix(core): execute POSIX npm wrappers directly

### DIFF
--- a/packages/core/scripts/npm-cli.test.ts
+++ b/packages/core/scripts/npm-cli.test.ts
@@ -11,7 +11,7 @@ function windowsInstallation(root: string): Set<string> {
 }
 
 describe("resolveNpmCliInvocation", () => {
-	it("runs a discovered POSIX npm script through Node", () => {
+	it("executes a discovered POSIX npm wrapper directly", () => {
 		const files = new Set(["/opt/node/bin/node", "/home/user/bin/npm"]);
 
 		expect(
@@ -21,8 +21,8 @@ describe("resolveNpmCliInvocation", () => {
 				fileExists: (filePath) => files.has(filePath),
 			}),
 		).toEqual({
-			command: "/opt/node/bin/node",
-			args: ["/home/user/bin/npm", "pack", "package path"],
+			command: "/home/user/bin/npm",
+			args: ["pack", "package path"],
 		});
 	});
 

--- a/packages/core/scripts/npm-cli.ts
+++ b/packages/core/scripts/npm-cli.ts
@@ -24,10 +24,11 @@ function normalizePathEntry(entry: string): string {
 /**
  * Resolve npm without asking a Windows shell to interpret `npm.cmd`.
  *
- * Core's build runs under Bun, so `process.execPath` is not Node. Instead,
- * inspect PATH for a complete Node distribution and execute npm's JavaScript
- * entrypoint through that distribution's `node.exe`. Non-Windows platforms
- * keep the existing direct `npm` invocation.
+ * Core's build runs under Bun, so `process.execPath` is not Node. Windows npm
+ * launchers are `.cmd` files, so inspect PATH for a complete Node distribution
+ * and execute npm's JavaScript entrypoint through that distribution's
+ * `node.exe`. POSIX npm entries may themselves be shell wrappers (for example
+ * mise's reshim wrapper), so invoke the discovered executable directly.
  */
 export function resolveNpmCliInvocation(
 	args: readonly string[],
@@ -37,21 +38,12 @@ export function resolveNpmCliInvocation(
 	const fileExists = options.fileExists ?? existsSync;
 	const pathValue = options.pathValue ?? process.env.PATH ?? "";
 	if (platform !== "win32") {
-		let nodeExecutable: string | undefined;
-		let npmScript: string | undefined;
 		for (const rawEntry of pathValue.split(":")) {
 			const entry = normalizePathEntry(rawEntry);
 			if (entry.length === 0) continue;
-			const nodeCandidate = path.posix.join(entry, "node");
 			const npmCandidate = path.posix.join(entry, "npm");
-			if (!nodeExecutable && fileExists(nodeCandidate)) {
-				nodeExecutable = nodeCandidate;
-			}
-			if (!npmScript && fileExists(npmCandidate)) {
-				npmScript = npmCandidate;
-			}
-			if (nodeExecutable && npmScript) {
-				return { command: nodeExecutable, args: [npmScript, ...args] };
+			if (fileExists(npmCandidate)) {
+				return { command: npmCandidate, args: [...args] };
 			}
 		}
 		return { command: "npm", args: [...args] };


### PR DESCRIPTION
## Summary
- execute POSIX `npm` entries directly instead of passing shell wrappers to Node
- preserve the Node + npm-cli.js strategy for Windows
- unblock Core package verification under mise and current Android builds

## Verification
- `bun test packages/core/scripts/npm-cli.test.ts` (5 pass)
- live resolver selects `/home/shaw/.local/share/mise/installs/node/24.15.0/bin/npm` as the executable
- `git diff --check`