### PR TITLE
fix(cloud): initialize Bun before database report guard

### DIFF
--- a/.github/workflows/database-identity-staging-report.yml
+++ b/.github/workflows/database-identity-staging-report.yml
@@ -32,6 +32,11 @@ jobs:
           submodules: false
           persist-credentials: false
 
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: 1.3.14
+
       - name: Require exact develop commit
         env:
           EXPECTED_COMMIT: ${{ inputs.expected_cloud_commit }}
@@ -45,11 +50,6 @@ jobs:
             if (!/^[0-9a-f]{40}$/.test(expected)) process.exit(1);
             if (expected !== checkedOut) process.exit(1);
           '
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-        with:
-          bun-version: 1.3.14
 
       - name: Install deterministic dependencies
         run: bun install --frozen-lockfile --ignore-scripts

--- a/packages/cloud/scripts/admin/database-identity-staging-report-workflow.test.ts
+++ b/packages/cloud/scripts/admin/database-identity-staging-report-workflow.test.ts
@@ -78,6 +78,9 @@ describe("database identity staging report workflow", () => {
 
   test("requires the exact develop commit", () => {
     const guard = step("Require exact develop commit");
+    expect(job.steps.indexOf(step("Setup Bun"))).toBeLessThan(
+      job.steps.indexOf(guard),
+    );
     expect(guard.env?.EXPECTED_COMMIT).toBe(
       expression("inputs.expected_cloud_commit"),
     );


### PR DESCRIPTION
Closes the concrete diagnostic blocker recorded in #29024.

The manual staging database identity report currently runs its exact-source guard with `bun -e` before `oven-sh/setup-bun`. Run 32932871069 therefore exited 127 on the hosted runner before it could perform any read-only database inspection.

This moves the pinned Bun setup ahead of the guard and adds a workflow contract assertion that preserves that executable-before-use ordering.

Exact checkpoint
- Base: `8b23b9b1fae0b7abd63bb9d1f49640bbf7904233`
- Head: `c85cc7e244262bc84f0ec7c07e62fa39eda22d73`
- Tree: `43ee30d3cec4c04f43c3694e4690b0f7d0e082cd`

Gates
- `bun test packages/cloud/scripts/admin/database-identity-staging-report-workflow.test.ts packages/cloud/scripts/admin/preflight-database-identity.test.ts` — 13 pass, 0 fail
- `bun run audit:workflow-triggers` — 61 workflows verified
- exact Biome check — pass
- `git diff --check` — pass

Evidence
- UI screenshots: N/A — workflow-only change
- Video: N/A — workflow-only change
- Frontend logs: N/A — no frontend path
- Backend/database receipt: pending exact-head manual workflow dispatch after review; the workflow is read-only and emits sanitized identity hashes only

@lalalune for visibility. This PR does not deploy, provision, spend, or expose protected values.
