### PR TITLE
fix(plugin-notes): lossless content round-trip (no injected newline, no dropped blank line)

### DIFF
--- a/plugins/plugin-notes/AGENTS.md
+++ b/plugins/plugin-notes/AGENTS.md
@@ -10,9 +10,18 @@ This package owns one intentionally focused Cloud surface:
 - `notes` — note CRUD with one user-authored content field and optional color.
 
 The persisted schema retains a derived first-line label plus body for stable
-lookup and compatibility with existing notes. That split is deterministic:
-planner capabilities accept one `content` value and never ask a model to invent
-a separate title or summary. The view renders the combined content as one field.
+lookup and compatibility with existing notes. That split is deterministic and
+lossless: `parseNoteContent` stores `title` as the first line bounded to 240
+characters (a lookup/agent-surface label) and `body` as the *verbatim*
+remainder, so `reconstructNoteContent` (`title + body`) returns exactly the
+content the user wrote. Planner capabilities accept one `content` value and
+never ask a model to invent a separate title or summary. A long first line is
+never split with an injected newline, and a blank line placed after the first
+line is never dropped. `reconstructNoteContent` in `src/types.ts` is the single
+reconstruction the view and validators share so the round-trip cannot drift.
+Documents are schema version 2; a version 1 document (whose `body` omitted the
+separator its retired view re-inserted) is migrated on load by restoring the
+leading newline, so an existing note reads back exactly as it rendered before.
 
 Managed dedicated agents load the runtime plugin through the `lean-chat`
 profile. The app build loads `src/register.ts` through the manifest-driven app

--- a/plugins/plugin-notes/CLAUDE.md
+++ b/plugins/plugin-notes/CLAUDE.md
@@ -10,9 +10,18 @@ This package owns one intentionally focused Cloud surface:
 - `notes` — note CRUD with one user-authored content field and optional color.
 
 The persisted schema retains a derived first-line label plus body for stable
-lookup and compatibility with existing notes. That split is deterministic:
-planner capabilities accept one `content` value and never ask a model to invent
-a separate title or summary. The view renders the combined content as one field.
+lookup and compatibility with existing notes. That split is deterministic and
+lossless: `parseNoteContent` stores `title` as the first line bounded to 240
+characters (a lookup/agent-surface label) and `body` as the *verbatim*
+remainder, so `reconstructNoteContent` (`title + body`) returns exactly the
+content the user wrote. Planner capabilities accept one `content` value and
+never ask a model to invent a separate title or summary. A long first line is
+never split with an injected newline, and a blank line placed after the first
+line is never dropped. `reconstructNoteContent` in `src/types.ts` is the single
+reconstruction the view and validators share so the round-trip cannot drift.
+Documents are schema version 2; a version 1 document (whose `body` omitted the
+separator its retired view re-inserted) is migrated on load by restoring the
+leading newline, so an existing note reads back exactly as it rendered before.
 
 Managed dedicated agents load the runtime plugin through the `lean-chat`
 profile. The app build loads `src/register.ts` through the manifest-driven app

--- a/plugins/plugin-notes/src/__tests__/backend.test.ts
+++ b/plugins/plugin-notes/src/__tests__/backend.test.ts
@@ -375,6 +375,64 @@ describe("NotesStore", () => {
     });
     expect(() => store.snapshot()).toThrow("not valid JSON");
   });
+
+  it("keeps a migrated v1 note at the body-length bound writable after reload (#29033)", async () => {
+    // A v1 body already at the 20,000-character limit gains one separator
+    // character during the v1→v2 upgrade. Before the persisted-body bound was
+    // widened, the next mutation reparsed the upgraded draft as v2 and rejected
+    // the 20,001-character body, leaving the store effectively read-only. This
+    // exercises the full load → mutate → stop → reload path so both the legacy
+    // bytes and the new write must survive exactly.
+    const filePath = await temporaryStateFile();
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    const legacyBody = "x".repeat(20_000);
+    await fs.writeFile(
+      filePath,
+      JSON.stringify({
+        schemaVersion: 1,
+        revision: 4,
+        persistedAt: "2026-07-16T12:00:00.000Z",
+        notes: [
+          {
+            id: "note-legacy",
+            title: "Legacy header",
+            body: legacyBody,
+            color: "yellow",
+            createdAt: "2026-07-16T12:00:00.000Z",
+            updatedAt: "2026-07-16T12:00:00.000Z",
+          },
+        ],
+      }),
+      "utf8",
+    );
+
+    const legacyReconstructed = `Legacy header\n${legacyBody}`;
+    const service = await serviceFor(filePath);
+    const migrated = service.getNote("note-legacy");
+    expect(migrated.body).toHaveLength(20_001);
+    expect(reconstructNoteContent(migrated)).toBe(legacyReconstructed);
+
+    // The mutation is the write that reparses the upgraded draft as v2; it must
+    // not fail because the migrated body is one character over the input bound.
+    const added = await service.createNote({
+      title: "New note",
+      body: "After upgrade",
+    });
+    await service.stop();
+
+    // On reload the document is already v2 on disk, so it is reparsed as v2
+    // without a second migration; the persisted body must still validate.
+    const reloaded = await serviceFor(filePath);
+    const reloadedLegacy = reloaded.getNote("note-legacy");
+    expect(reloadedLegacy.body).toHaveLength(20_001);
+    expect(reconstructNoteContent(reloadedLegacy)).toBe(legacyReconstructed);
+    const reloadedNew = reloaded.getNote(added.id);
+    expect(reloadedNew).toMatchObject({
+      title: "New note",
+      body: "After upgrade",
+    });
+    await reloaded.stop();
+  });
 });
 
 describe("Notes content round-trip (#29003)", () => {

--- a/plugins/plugin-notes/src/__tests__/backend.test.ts
+++ b/plugins/plugin-notes/src/__tests__/backend.test.ts
@@ -26,7 +26,8 @@ import {
 import { notesRoutes } from "../routes.js";
 import { NOTES_SERVICE_TYPE, NotesService } from "../service.js";
 import { NotesStore, notesStateFilePath } from "../store.js";
-import type { StickyNote } from "../types.js";
+import { reconstructNoteContent, type StickyNote } from "../types.js";
+import { parseNoteContent } from "../validation.js";
 
 const temporaryDirectories: string[] = [];
 const testRuntimes: AgentRuntime[] = [];
@@ -217,7 +218,7 @@ describe("NotesStore", () => {
 
     const persisted = JSON.parse(await fs.readFile(filePath, "utf8"));
     expect(persisted).toMatchObject({
-      schemaVersion: 1,
+      schemaVersion: 2,
       revision: 2,
     });
     expect(Object.keys(persisted).sort()).toEqual(
@@ -376,6 +377,90 @@ describe("NotesStore", () => {
   });
 });
 
+describe("Notes content round-trip (#29003)", () => {
+  // The create→render round-trip must commit exactly what the user wrote. These
+  // drive the real durable service (parse → createNote → snapshot → restart)
+  // and assert the reconstructed content equals the input, so a corrupt split
+  // can never reach the durable document or the planner-facing description.
+  const roundTripInputs: Array<[string, string]> = [
+    ["a long unwrapped single line", "a".repeat(300)],
+    [
+      "a long URL that must not gain a line break",
+      `https://example.com/${"x".repeat(280)}`,
+    ],
+    ["a blank line after the title", "Meeting\n\nDiscuss roadmap"],
+    ["trailing blank lines", "Shopping\nmilk\neggs\n\n"],
+    [
+      "a multi-paragraph body with internal blank lines",
+      "Roadmap\n\nQ1\n\nQ2\n\nQ3",
+    ],
+  ];
+
+  for (const [name, original] of roundTripInputs) {
+    it(`commits ${name} without corruption and reloads it intact`, async () => {
+      const filePath = await temporaryStateFile();
+      const service = await serviceFor(filePath);
+      const created = await service.createNote(parseNoteContent(original));
+      // The committed record reconstructs to the exact user input.
+      expect(reconstructNoteContent(created)).toBe(original);
+      // The bounded label never exceeds the schema's list-label ceiling.
+      expect(created.title.length).toBeGreaterThan(0);
+      expect(created.title.length).toBeLessThanOrEqual(240);
+
+      const snapshotNote = service.snapshot().notes[0];
+      if (!snapshotNote) throw new Error("snapshot note missing");
+      expect(reconstructNoteContent(snapshotNote)).toBe(original);
+      await service.stop();
+
+      // The durable bytes on disk survive a restart with the same content.
+      const restarted = await serviceFor(filePath);
+      const persistedNote = restarted.getNote(created.id);
+      expect(reconstructNoteContent(persistedNote)).toBe(original);
+      await restarted.stop();
+    });
+  }
+
+  it("upgrades a v1 durable document to the v2 body layout on load", async () => {
+    const filePath = await temporaryStateFile();
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    // A pre-existing v1 record: body stored without its leading separator, the
+    // way the retired view rebuilt content as `title + "\n" + body`.
+    await fs.writeFile(
+      filePath,
+      JSON.stringify({
+        schemaVersion: 1,
+        revision: 4,
+        persistedAt: "2026-07-16T12:00:00.000Z",
+        notes: [
+          {
+            id: "note-legacy-1",
+            title: "Header Line",
+            body: "First paragraph\nSecond paragraph",
+            color: "yellow",
+            createdAt: "2026-07-16T12:00:00.000Z",
+            updatedAt: "2026-07-16T12:00:00.000Z",
+          },
+        ],
+      }),
+      "utf8",
+    );
+
+    const service = await serviceFor(filePath);
+    const note = service.getNote("note-legacy-1");
+    // Migration restores the separator so v2 reconstruction reproduces exactly
+    // what the v1 view showed — no re-corruption of the historical note.
+    expect(note.body).toBe("\nFirst paragraph\nSecond paragraph");
+    expect(reconstructNoteContent(note)).toBe(
+      "Header Line\nFirst paragraph\nSecond paragraph",
+    );
+    // A subsequent write persists the upgraded v2 schema version.
+    await service.createNote(parseNoteContent("Fresh note"));
+    await service.stop();
+    const persisted = JSON.parse(await fs.readFile(filePath, "utf8"));
+    expect(persisted.schemaVersion).toBe(2);
+  });
+});
+
 describe("Notes capabilities", () => {
   it("dispatches server capabilities to the owning runtime service", async () => {
     const first = await serviceFor(await temporaryStateFile());
@@ -423,8 +508,11 @@ describe("Notes capabilities", () => {
       success: true,
       text: "Created note “Demo Checklist”.",
     });
+    // The body keeps the leading "\n" separator of the equivalent two-line note
+    // so the stored record round-trips through `reconstructNoteContent`; the
+    // view and action surfaces trim it, so the rendered details are unchanged.
     expect(service.listNotes()).toMatchObject([
-      { title: "Demo Checklist", body: "mic, charger, water" },
+      { title: "Demo Checklist", body: "\nmic, charger, water" },
     ]);
   });
 
@@ -466,7 +554,9 @@ describe("Notes capabilities", () => {
       id: noteId,
     });
     expect(service.getNote(noteId)).toMatchObject({
-      body: "Polished draft",
+      // `body` keeps the verbatim remainder (with its leading separator), so
+      // `reconstructNoteContent` returns the exact content the user wrote.
+      body: "\nPolished draft",
       color: "green",
     });
     await expect(
@@ -821,8 +911,8 @@ describe("Notes capabilities", () => {
       error: { code: "NOTES_NOT_FOUND" },
     });
     expect(service.listNotes().map((note) => note.body)).toEqual([
-      "Evening",
-      "Morning",
+      "\nEvening",
+      "\nMorning",
     ]);
   });
 
@@ -1032,15 +1122,15 @@ describe("Notes capabilities", () => {
     );
     expect(updated).toMatchObject({
       success: true,
-      data: { note: { title: "Shopping list", body: "Done shopping" } },
+      data: { note: { title: "Shopping list", body: "\nDone shopping" } },
     });
     // "Todo" remains unchanged; order may shift after update.
     expect(
       service.listNotes().map((n) => ({ title: n.title, body: n.body })),
     ).toEqual(
       expect.arrayContaining([
-        { title: "Shopping list", body: "Done shopping" },
-        { title: "Todo", body: "Fix the bug" },
+        { title: "Shopping list", body: "\nDone shopping" },
+        { title: "Todo", body: "\nFix the bug" },
       ]),
     );
   });
@@ -1084,7 +1174,7 @@ describe("Notes capabilities", () => {
 
     // Nothing was mutated.
     expect(service.listNotes().map((n) => n.body)).toEqual(
-      expect.arrayContaining(["Morning sync", "Afternoon review"]),
+      expect.arrayContaining(["\nMorning sync", "\nAfternoon review"]),
     );
   });
 

--- a/plugins/plugin-notes/src/__tests__/validation.test.ts
+++ b/plugins/plugin-notes/src/__tests__/validation.test.ts
@@ -3,7 +3,11 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { NOTES_SCHEMA_VERSION } from "../types.js";
+import {
+  NOTES_SCHEMA_VERSION,
+  NOTES_SCHEMA_VERSION_V1,
+  reconstructNoteContent,
+} from "../types.js";
 import {
   isRecord,
   parseCreateNoteInput,
@@ -36,34 +40,33 @@ describe("Notes boundary validation", () => {
       });
     });
 
-    it("splits multi-line content into first line title and remaining body", () => {
+    it("splits multi-line content into a label plus the verbatim remainder", () => {
       const result = parseNoteContent(
         "Header Line\nFirst paragraph\nSecond paragraph",
       );
       expect(result).toEqual({
         title: "Header Line",
-        body: "First paragraph\nSecond paragraph",
-      });
-    });
-
-    it("handles leading and trailing whitespace on lines cleanly", () => {
-      const result = parseNoteContent("   Padded Title   \n   Padded Body   ");
-      expect(result).toEqual({
-        title: "Padded Title",
-        body: "Padded Body",
+        body: "\nFirst paragraph\nSecond paragraph",
       });
     });
 
     it('splits a one-line "Label: details" note at the labelled colon', () => {
       // Planners flatten "create a note titled X saying Y" and users write
-      // "create a note called X: Y" into exactly this one-line shape.
-      expect(parseNoteContent("Demo Checklist: mic, charger, water")).toEqual({
+      // "create a note called X: Y" into exactly this one-line shape. The body
+      // carries the same leading "\n" separator a two-line note produces so the
+      // shared `reconstructNoteContent` yields coherent text rather than the
+      // label and details jammed together ("Demo Checklistmic, charger, water").
+      const demo = parseNoteContent("Demo Checklist: mic, charger, water");
+      expect(demo).toEqual({
         title: "Demo Checklist",
-        body: "mic, charger, water",
+        body: "\nmic, charger, water",
       });
+      expect(reconstructNoteContent(demo)).toBe(
+        "Demo Checklist\nmic, charger, water",
+      );
       expect(parseNoteContent("Groceries: eggs, bread")).toEqual({
         title: "Groceries",
-        body: "eggs, bread",
+        body: "\neggs, bread",
       });
     });
 
@@ -83,9 +86,12 @@ describe("Notes boundary validation", () => {
     });
 
     it("leaves multi-line content on the first-line label contract", () => {
+      // With a real newline present the note is already multi-line, so the
+      // labelled-colon one-liner rule does not apply and the verbatim remainder
+      // (its leading "\n") is preserved for a lossless round-trip.
       expect(parseNoteContent("Demo Checklist: mic\ncharger")).toEqual({
         title: "Demo Checklist: mic",
-        body: "charger",
+        body: "\ncharger",
       });
     });
 
@@ -94,12 +100,63 @@ describe("Notes boundary validation", () => {
       expect(() => parseNoteContent("   ")).toThrow();
     });
 
-    it("splits long single-line content with surrogate safety at max title length", () => {
+    it("derives a bounded label from a long first line without splitting it", () => {
       const longTitle = `${"a".repeat(239)}😀${"b".repeat(20)}`;
       const result = parseNoteContent(longTitle);
       expect(result.title.length).toBe(239);
       expect(result.title.endsWith("😀")).toBe(false);
       expect(result.body.startsWith("😀")).toBe(true);
+      // The label is only a lookup surface; the remainder still holds every
+      // character past it so the content is never split mid-word.
+      expect(result.title + result.body).toBe(longTitle);
+    });
+
+    // The create→render round-trip must be lossless: `parseNoteContent` and
+    // `reconstructNoteContent` are inverses, so no committed record silently
+    // gains an injected newline or loses a blank line the user typed (#29003).
+    describe("round-trips exactly through reconstructNoteContent", () => {
+      const cases: Array<[string, string]> = [
+        ["a single line longer than the 240-char label bound", "a".repeat(300)],
+        [
+          "a blank line placed right after the first line",
+          "Meeting\n\nDiscuss roadmap",
+        ],
+        ["trailing blank lines", "Shopping\nmilk\neggs\n\n"],
+        [
+          "a multi-paragraph body with internal blank lines",
+          "Roadmap\n\nQ1 goals\n\nQ2 goals\n\nQ3 goals",
+        ],
+        ["a first line of exactly 240 characters", `${"x".repeat(240)}\nbody`],
+        ["a first line of exactly 241 characters", `${"y".repeat(241)}\nbody`],
+        [
+          "a long unwrapped URL on one line",
+          `https://example.com/${"p".repeat(300)}`,
+        ],
+      ];
+      for (const [name, original] of cases) {
+        it(name, () => {
+          const parsed = parseNoteContent(original);
+          expect(reconstructNoteContent(parsed)).toBe(original);
+          // The stored label stays within the schema's list-label bound even
+          // when it is a truncated prefix of a long first line.
+          expect(parsed.title.length).toBeLessThanOrEqual(240);
+          expect(parsed.title.length).toBeGreaterThan(0);
+        });
+      }
+
+      it("normalizes CRLF newlines while preserving the split structure", () => {
+        const parsed = parseNoteContent("Title\r\n\r\nBody line");
+        // The first line's own \r moves into the verbatim remainder, so the
+        // label stays clean and concatenation reproduces the CRLF input.
+        expect(parsed.title).toBe("Title");
+        expect(reconstructNoteContent(parsed)).toBe("Title\r\n\r\nBody line");
+      });
+
+      it("reconstructs a short single line as the label alone", () => {
+        const parsed = parseNoteContent("Just a title");
+        expect(parsed).toEqual({ title: "Just a title", body: "" });
+        expect(reconstructNoteContent(parsed)).toBe("Just a title");
+      });
     });
   });
 
@@ -191,6 +248,68 @@ describe("Notes boundary validation", () => {
       };
       const parsed = parseNotesDocument(validDoc);
       expect(parsed).toEqual(validDoc);
+    });
+
+    it("migrates a v1 document so its body reconstructs the retired view output", () => {
+      const v1Note = {
+        id: "note-001",
+        title: "Header Line",
+        // v1 stored the remainder without its separator; the retired view
+        // rebuilt content as `title + "\n" + body`.
+        body: "First paragraph\nSecond paragraph",
+        color: "yellow" as const,
+        createdAt: "2026-08-12T12:00:00.000Z",
+        updatedAt: "2026-08-12T12:00:00.000Z",
+      };
+      const parsed = parseNotesDocument({
+        schemaVersion: NOTES_SCHEMA_VERSION_V1,
+        revision: 3,
+        persistedAt: "2026-08-12T12:00:00.000Z",
+        notes: [v1Note],
+      });
+      expect(parsed.schemaVersion).toBe(NOTES_SCHEMA_VERSION);
+      const migrated = parsed.notes[0];
+      if (!migrated) throw new Error("migrated note missing");
+      // The leading separator is restored so the v2 reconstruction matches
+      // exactly what the v1 view showed, with no re-corruption.
+      expect(migrated.body).toBe("\nFirst paragraph\nSecond paragraph");
+      expect(reconstructNoteContent(migrated)).toBe(
+        `${v1Note.title}\n${v1Note.body}`,
+      );
+    });
+
+    it("leaves an empty v1 body untouched during migration", () => {
+      const parsed = parseNotesDocument({
+        schemaVersion: NOTES_SCHEMA_VERSION_V1,
+        revision: 1,
+        persistedAt: "2026-08-12T12:00:00.000Z",
+        notes: [
+          {
+            id: "note-001",
+            title: "Standalone",
+            body: "",
+            color: "green" as const,
+            createdAt: "2026-08-12T12:00:00.000Z",
+            updatedAt: "2026-08-12T12:00:00.000Z",
+          },
+        ],
+      });
+      expect(parsed.schemaVersion).toBe(NOTES_SCHEMA_VERSION);
+      const migrated = parsed.notes[0];
+      if (!migrated) throw new Error("migrated note missing");
+      expect(migrated.body).toBe("");
+      expect(reconstructNoteContent(migrated)).toBe("Standalone");
+    });
+
+    it("rejects an unsupported schema version", () => {
+      expect(() =>
+        parseNotesDocument({
+          schemaVersion: 99,
+          revision: 0,
+          persistedAt: "2026-08-12T12:00:00.000Z",
+          notes: [],
+        }),
+      ).toThrow();
     });
 
     it("rejects duplicate note IDs in document", () => {

--- a/plugins/plugin-notes/src/types.ts
+++ b/plugins/plugin-notes/src/types.ts
@@ -5,7 +5,16 @@
  * browser/server models.
  */
 
-export const NOTES_SCHEMA_VERSION = 1 as const;
+export const NOTES_SCHEMA_VERSION = 2 as const;
+
+/**
+ * The pre-`reconstructNoteContent` on-disk layout. A v1 note stored `body` as
+ * the first line's newline-joined remainder with its leading separator trimmed,
+ * so the retired view rebuilt content as `title + "\n" + body`. Loading such a
+ * document migrates it to v2 (see `parseNotesDocument`), which stores `body` as
+ * the verbatim remainder so `reconstructNoteContent` is a faithful inverse.
+ */
+export const NOTES_SCHEMA_VERSION_V1 = 1 as const;
 
 export const STICKY_COLORS = ["yellow", "green", "rose", "slate"] as const;
 
@@ -57,4 +66,19 @@ export interface UpdateNoteInput {
   title?: string;
   body?: string;
   color?: StickyColor;
+}
+
+/**
+ * Rebuild the single user-authored content field from its stored parts. This is
+ * the exact inverse of `parseNoteContent`: the schema keeps `title` as the
+ * derived first-line label (bounded for list lookup and the agent surface) and
+ * `body` as the verbatim remainder, so plain concatenation returns exactly the
+ * content the user wrote — including a blank line after the first line or a
+ * first line longer than the label bound. Keep this the only reconstruction so
+ * the view and the validators can never drift into re-corrupting content.
+ */
+export function reconstructNoteContent(
+  parts: Pick<StickyNote, "title" | "body">,
+): string {
+  return `${parts.title}${parts.body}`;
 }

--- a/plugins/plugin-notes/src/validation.ts
+++ b/plugins/plugin-notes/src/validation.ts
@@ -13,6 +13,7 @@ import {
 import {
   type CreateNoteInput,
   NOTES_SCHEMA_VERSION,
+  NOTES_SCHEMA_VERSION_V1,
   type NotesDocument,
   type StickyColor,
   type StickyNote,
@@ -93,50 +94,93 @@ function parseRequiredTitle(value: unknown, field: string): string {
   });
 }
 
-function parseText(value: unknown, field: string): string {
-  return parseString(value, field, {
-    allowEmpty: true,
-    maxLength: MAX_BODY_LENGTH,
-  });
+/**
+ * Validate a note body without trimming. The body is verbatim user content that
+ * `reconstructNoteContent` concatenates onto the label, so a leading blank line
+ * or trailing whitespace is structure to preserve, not noise to normalize. It
+ * still fails fast on the wrong type, ill-formed Unicode, or the length bound.
+ */
+function parseBodyText(value: unknown, field: string): string {
+  if (typeof value !== "string") {
+    throw validationError(`${field} must be a string.`, field);
+  }
+  const text = toWellFormedUnicode(value);
+  if (text.length > MAX_BODY_LENGTH) {
+    throw validationError(
+      `${field} must be at most ${MAX_BODY_LENGTH} characters.`,
+      field,
+    );
+  }
+  return text;
 }
 
 /**
  * Split the one user-authored note field into the storage schema's stable list
- * label and remainder. The first line is the label; overflow and later lines
- * stay in the body, so the transformation never asks a model to invent text or
- * discards user content. A one-line note written as "Label: details" keeps the
- * label as the title and the details as the body — planners flatten "titled X
- * saying Y" into exactly that shape — and the colon must be followed by
- * whitespace so URLs ("https://…") and clock times ("5:30") never split.
+ * label and verbatim remainder. `title` is the first line bounded to
+ * `MAX_TITLE_LENGTH` for list lookup and the agent surface; `body` is the exact
+ * suffix so that `title + body` (see `reconstructNoteContent`) returns the
+ * original content unchanged. The transformation never asks a model to invent
+ * text, never injects a line break into a long first line, and never discards a
+ * blank line the user placed after the title. Only leading whitespace before
+ * the first character is normalized away, because the label must be non-empty.
+ *
+ * The one deliberate reshaping is a single-line note written as "Label: details"
+ * — the shape planners flatten "titled X saying Y" into. It splits at the
+ * labelled colon into `title` and a `"\n"`-separated `body`, the same layout a
+ * two-line note produces, so the retired multi-field intent survives and
+ * `reconstructNoteContent` still yields coherent text. The colon must be
+ * followed by whitespace, so URLs ("https://…") and clock times ("5:30") never
+ * split.
  */
 export function parseNoteContent(
   value: unknown,
   field = "content",
 ): Pick<CreateNoteInput, "title" | "body"> {
-  const content = parseString(value, field, {
-    allowEmpty: false,
-    maxLength: MAX_NOTE_CONTENT_LENGTH,
-  });
-  const [firstLine = "", ...remainingLines] = content.split(/\r?\n/);
-  let labelLine = toWellFormedUnicode(firstLine.trim());
-  let inlineDetails = "";
-  if (remainingLines.length === 0) {
-    const labeled = /^([^:]+):\s+(.+)$/.exec(labelLine);
-    if (labeled) {
-      labelLine = labeled[1].trim();
-      inlineDetails = labeled[2].trim();
+  if (typeof value !== "string") {
+    throw validationError(`${field} must be a string.`, field);
+  }
+  const content = toWellFormedUnicode(value).replace(/^\s+/u, "");
+  if (content.length === 0) {
+    throw validationError(`${field} must not be empty.`, field);
+  }
+  if (content.length > MAX_NOTE_CONTENT_LENGTH) {
+    throw validationError(
+      `${field} must be at most ${MAX_NOTE_CONTENT_LENGTH} characters.`,
+      field,
+    );
+  }
+  const newlineIndex = content.search(/\r?\n/u);
+  if (newlineIndex === -1) {
+    // A one-line "Label: details" note keeps the label as the title and the
+    // details as the body; the colon must be followed by whitespace so URLs and
+    // clock times never split. The body carries the same leading "\n" separator
+    // a two-line note would, so `reconstructNoteContent` stays coherent.
+    const labeled = /^([^:]+):\s+(.+)$/u.exec(content);
+    const labelText = labeled?.[1].trim() ?? "";
+    if (
+      labeled &&
+      labelText.length > 0 &&
+      labelText.length <= MAX_TITLE_LENGTH
+    ) {
+      const title = parseRequiredTitle(labelText, `${field}.firstLine`);
+      const body = parseBodyText(
+        `\n${labeled[2].trim()}`,
+        `${field}.remainder`,
+      );
+      return { title, body };
     }
   }
-  const title = truncateWellFormed(labelLine, MAX_TITLE_LENGTH).trim();
-  const overflow = labelLine.slice(title.length).trim();
-  const body = [overflow, inlineDetails, ...remainingLines]
-    .filter((part, index) => index >= 2 || part.length > 0)
-    .join("\n")
-    .trim();
-  return {
-    title: parseRequiredTitle(title, `${field}.firstLine`),
-    body: parseText(body, `${field}.remainder`),
-  };
+  const firstLine =
+    newlineIndex === -1 ? content : content.slice(0, newlineIndex);
+  // Trailing whitespace is dropped from the *label* only; the slice below keeps
+  // it in `body`, so `title + body` still reconstructs `content` exactly.
+  const label = truncateWellFormed(firstLine, MAX_TITLE_LENGTH).replace(
+    /[^\S\r\n]+$/u,
+    "",
+  );
+  const title = parseRequiredTitle(label, `${field}.firstLine`);
+  const body = parseBodyText(content.slice(title.length), `${field}.remainder`);
+  return { title, body };
 }
 
 export function parseEntityId(value: unknown, field = "id"): string {
@@ -193,7 +237,7 @@ export function parseCreateNoteInput(value: unknown): CreateNoteInput {
   assertOnlyKeys(record, ["title", "body", "color"], "note");
   return {
     title: parseRequiredTitle(record.title, "note.title"),
-    body: hasOwn(record, "body") ? parseText(record.body, "note.body") : "",
+    body: hasOwn(record, "body") ? parseBodyText(record.body, "note.body") : "",
     color: hasOwn(record, "color")
       ? parseStickyColor(record.color, "note.color")
       : "yellow",
@@ -208,7 +252,7 @@ export function parseUpdateNoteInput(value: unknown): UpdateNoteInput {
     patch.title = parseRequiredTitle(record.title, "note.title");
   }
   if (hasOwn(record, "body")) {
-    patch.body = parseText(record.body, "note.body");
+    patch.body = parseBodyText(record.body, "note.body");
   }
   if (hasOwn(record, "color")) {
     patch.color = parseStickyColor(record.color, "note.color");
@@ -233,11 +277,22 @@ function parseStickyNote(value: unknown, index: number): StickyNote {
   return {
     id: parseEntityId(record.id, `${field}.id`),
     title: parseRequiredTitle(record.title, `${field}.title`),
-    body: parseText(record.body, `${field}.body`),
+    body: parseBodyText(record.body, `${field}.body`),
     color: parseStickyColor(record.color, `${field}.color`),
     createdAt: parseTimestamp(record.createdAt, `${field}.createdAt`),
     updatedAt: parseTimestamp(record.updatedAt, `${field}.updatedAt`),
   };
+}
+
+/**
+ * Upgrade a v1 note to the v2 body layout. A v1 `body` dropped the separator
+ * that its retired view re-inserted as `title + "\n" + body`, so restoring that
+ * exact leading newline makes `reconstructNoteContent` reproduce what the old
+ * view showed without re-corrupting the record.
+ */
+function migrateNoteFromV1(note: StickyNote): StickyNote {
+  if (note.body.length === 0) return note;
+  return { ...note, body: `\n${note.body}` };
 }
 
 export function parseNotesDocument(value: unknown): NotesDocument {
@@ -247,7 +302,11 @@ export function parseNotesDocument(value: unknown): NotesDocument {
     ["schemaVersion", "revision", "persistedAt", "notes"],
     "notes state",
   );
-  if (record.schemaVersion !== NOTES_SCHEMA_VERSION) {
+  const schemaVersion = record.schemaVersion;
+  if (
+    schemaVersion !== NOTES_SCHEMA_VERSION &&
+    schemaVersion !== NOTES_SCHEMA_VERSION_V1
+  ) {
     throw validationError(
       `schemaVersion must be ${NOTES_SCHEMA_VERSION}.`,
       "schemaVersion",
@@ -256,7 +315,11 @@ export function parseNotesDocument(value: unknown): NotesDocument {
   if (!Array.isArray(record.notes)) {
     throw validationError("notes must be an array.", "notes");
   }
-  const notes = record.notes.map(parseStickyNote);
+  const parsedNotes = record.notes.map(parseStickyNote);
+  const notes =
+    schemaVersion === NOTES_SCHEMA_VERSION_V1
+      ? parsedNotes.map(migrateNoteFromV1)
+      : parsedNotes;
   const noteIds = new Set(notes.map((note) => note.id));
   if (noteIds.size !== notes.length) {
     throw validationError("notes contain duplicate ids.", "notes");

--- a/plugins/plugin-notes/src/validation.ts
+++ b/plugins/plugin-notes/src/validation.ts
@@ -24,6 +24,14 @@ const ENTITY_ID_PATTERN = /^[a-z][a-z0-9-]{2,127}$/;
 const MAX_TITLE_LENGTH = 240;
 const MAX_BODY_LENGTH = 20_000;
 const MAX_NOTE_CONTENT_LENGTH = 20_000;
+// The v1→v2 upgrade prepends a single separator newline to the retired view's
+// body (see `migrateNoteFromV1`), so a persisted v1 body already at
+// `MAX_BODY_LENGTH` becomes exactly one character longer once upgraded. Persisted
+// notes are therefore validated against this slightly wider bound; new create and
+// update input stays capped at `MAX_BODY_LENGTH`. The delta is exactly one
+// because a document is upgraded at most once (it is written back as v2 and never
+// re-migrated), so it cannot compound across reloads.
+const MAX_PERSISTED_BODY_LENGTH = MAX_BODY_LENGTH + 1;
 
 function validationError(message: string, field: string): ElizaError {
   return new ElizaError(message, {
@@ -99,15 +107,21 @@ function parseRequiredTitle(value: unknown, field: string): string {
  * `reconstructNoteContent` concatenates onto the label, so a leading blank line
  * or trailing whitespace is structure to preserve, not noise to normalize. It
  * still fails fast on the wrong type, ill-formed Unicode, or the length bound.
+ * `maxLength` defaults to the new-input bound; persisted parsing widens it by one
+ * to admit the migration separator (see `MAX_PERSISTED_BODY_LENGTH`).
  */
-function parseBodyText(value: unknown, field: string): string {
+function parseBodyText(
+  value: unknown,
+  field: string,
+  maxLength: number = MAX_BODY_LENGTH,
+): string {
   if (typeof value !== "string") {
     throw validationError(`${field} must be a string.`, field);
   }
   const text = toWellFormedUnicode(value);
-  if (text.length > MAX_BODY_LENGTH) {
+  if (text.length > maxLength) {
     throw validationError(
-      `${field} must be at most ${MAX_BODY_LENGTH} characters.`,
+      `${field} must be at most ${maxLength} characters.`,
       field,
     );
   }
@@ -277,7 +291,11 @@ function parseStickyNote(value: unknown, index: number): StickyNote {
   return {
     id: parseEntityId(record.id, `${field}.id`),
     title: parseRequiredTitle(record.title, `${field}.title`),
-    body: parseBodyText(record.body, `${field}.body`),
+    body: parseBodyText(
+      record.body,
+      `${field}.body`,
+      MAX_PERSISTED_BODY_LENGTH,
+    ),
     color: parseStickyColor(record.color, `${field}.color`),
     createdAt: parseTimestamp(record.createdAt, `${field}.createdAt`),
     updatedAt: parseTimestamp(record.updatedAt, `${field}.updatedAt`),

--- a/plugins/plugin-notes/src/views/NotesSurface.tsx
+++ b/plugins/plugin-notes/src/views/NotesSurface.tsx
@@ -11,7 +11,11 @@ import { PagePanel } from "@elizaos/ui/components/composites/page-panel";
 import { ViewHeader } from "@elizaos/ui/components/shared/ViewHeader";
 import { AlertTriangle, RefreshCw } from "lucide-react";
 import type { CSSProperties } from "react";
-import type { NotesSnapshot, StickyNote as StickyNoteModel } from "../types.js";
+import {
+  type NotesSnapshot,
+  reconstructNoteContent,
+  type StickyNote as StickyNoteModel,
+} from "../types.js";
 import {
   AgentAction,
   COLOR_MATERIALS,
@@ -52,13 +56,12 @@ function formatUpdatedAt(value: string): string {
   }).format(new Date(timestamp));
 }
 
-function noteContent(note: StickyNoteModel): string {
-  const body = note.body.trim();
-  return body ? `${note.title}\n${body}` : note.title;
-}
-
 function NoteRow({ note }: { note: StickyNoteModel }) {
-  const content = noteContent(note);
+  // v2 stores `body` as the verbatim remainder (including its leading
+  // separator), so `reconstructNoteContent` returns the exact authored text for
+  // the planner-visible agent description without re-injecting a newline or
+  // dropping a blank line the user placed after the first line (#29003).
+  const content = reconstructNoteContent(note);
   const card = useAgentElement<HTMLLIElement>({
     id: note.id,
     label: `Note ${note.title}`,

--- a/plugins/plugin-notes/src/views/NotesViews.test.tsx
+++ b/plugins/plugin-notes/src/views/NotesViews.test.tsx
@@ -9,14 +9,20 @@ import { ApiError } from "@elizaos/ui/api/client-types-core";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { NotesSnapshot, StickyNote } from "../types.js";
+import { parseNoteContent } from "../validation.js";
 import type { NotesState } from "./useNotesState.js";
 
 const stateHook = vi.hoisted(() => vi.fn());
 
 vi.mock("@elizaos/ui/agent-surface", () => ({
-  useAgentElement: (definition: { id: string }) => ({
+  useAgentElement: (definition: { id: string; description?: string }) => ({
     ref: { current: null },
-    agentProps: { "data-agent-id": definition.id },
+    // Surface the planner-visible description so a test can assert the exact
+    // model-facing content the row contributes (#29003).
+    agentProps: {
+      "data-agent-id": definition.id,
+      "data-agent-description": definition.description ?? "",
+    },
   }),
 }));
 
@@ -39,7 +45,9 @@ function stickyNote(overrides: Partial<StickyNote> = {}): StickyNote {
   return {
     id: "note-1",
     title: "Release checklist",
-    body: "Verify the signed build",
+    // v2 stores the verbatim remainder, including its leading separator, so the
+    // view's `title + body` reconstruction reproduces the exact content.
+    body: "\nVerify the signed build",
     color: "yellow",
     createdAt: "2026-07-22T12:00:00.000Z",
     updatedAt: "2026-07-22T12:00:00.000Z",
@@ -425,4 +433,32 @@ describe("chat-only presentation", () => {
     expect(firstHeading.style.overflowWrap).toBe("anywhere");
     expect(firstBody.style.overflowWrap).toBe("anywhere");
   });
+
+  // The row's agent description is the planner-visible create→render endpoint the
+  // user reads back. Rendering a note parsed by the real `parseNoteContent` must
+  // expose the exact authored text, so a long single line is not broken by an
+  // injected newline and a blank line after the first line is not dropped
+  // (#29003).
+  it.each([
+    ["a".repeat(300)],
+    ["Meeting\n\nDiscuss roadmap"],
+    [`https://example.com/${"x".repeat(280)}`],
+    ["Shopping\nmilk\neggs\n\n"],
+  ])(
+    "exposes parsed content %# to the planner without corrupting the round-trip",
+    (original) => {
+      const parsed = parseNoteContent(original);
+      const populated = snapshot(1);
+      populated.notes = [stickyNote({ ...parsed })];
+      stateHook.mockReturnValue(hookState({ snapshot: populated }));
+
+      const notes = render(<NotesView />);
+
+      expect(
+        notes.container
+          .querySelector('[data-agent-id="note-1"]')
+          ?.getAttribute("data-agent-description"),
+      ).toBe(original);
+    },
+  );
 });


### PR DESCRIPTION
# Relates to

Closes #29003

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` (head `c68430d9e6`). The rebase conflict was in `plugins/plugin-notes/src/validation.ts`, where develop (`60d00d76`) added a one-line `"Label: details"` colon-split to `parseNoteContent`; it was reconciled with this PR's lossless verbatim-remainder contract so both behaviors survive — see **Sync with develop**.
- [x] Owning-package gates were run after sync (`typecheck`, `lint`, `test`, and the repo `check:agents-claude` doc-parity gate). Full repo `bun run verify` was **not** run — see **Known gaps / failures**.
- [x] A reviewer can confirm the change works from the before/after round-trip evidence below without reading the code.

# Sync with develop

- [x] Rebased onto the latest `origin/develop` (head `c68430d9e6`). The only conflict was in `plugins/plugin-notes/src/validation.ts`: develop merged `60d00d76`, which splits a single-line `"Label: details"` note (the shape planners flatten `"titled X saying Y"` into) into a `title` + `body`, while this PR had rewritten the same function to be a lossless verbatim round-trip. Resolved by keeping **both**: the colon-split now emits a `body` carrying the same leading `"\n"` separator a two-line note produces, so develop's split semantics survive **and** the shared `reconstructNoteContent` stays coherent (it yields `"Demo Checklist\nmic, charger, water"`, never the jammed `"Demo Checklistmic, charger, water"`). Develop's colon tests were updated only to the verbatim body representation (`"\nmic, charger, water"`); the view and action surfaces `.trim()` the body, so their rendered output is byte-identical. A new assertion pins `reconstructNoteContent` coherence for the colon case. Owning-package `typecheck`, `lint:check`, and `test` (137 passing) were re-run at the new head.
- [ ] Full `bun run verify` not run post-sync — documented in **Known gaps / failures**. The owning package's `typecheck`, `lint:check`, `test` (137 passing), and `bun run check:agents-claude` all pass.

# Risks

Low. Scope is confined to `plugins/plugin-notes`. The persisted document moves to **schema version 2**; version 1 documents are migrated losslessly on load (verified by a real filesystem test), and no other package reads the notes schema version. The stored `body` field now preserves verbatim whitespace instead of being trimmed — display surfaces (chat provider/summary) already `.trim()` for their preview, so there is no rendering regression there.

# Background

## What does this PR do?

The Notes package documents an invariant: one user-authored `content` field is split **deterministically** into a derived first-line `title` label plus a `body`, and the view "renders the combined content as one field" while "never … discard[ing] user content." In practice `parseNoteContent` (`src/validation.ts`) was **not** the inverse of the view's reconstruction (`NotesView.tsx`: `body ? `${title}\n${body}` : title`), so real content was silently corrupted and committed to the durable per-agent document (and re-served to the planner via the agent-surface `description`):

1. **Long first line.** A single line longer than the 240-char label bound was split into `title` (first 240) + `body` (remainder), then the view rejoined them with an injected `\n`. A 300-char single line (e.g. a long URL or unwrapped paragraph) came back as two lines → copying it yields a broken URL. (300 chars → 301 chars, newline inserted at char 240.)
2. **Blank line after the first line.** `"Meeting\n\nDiscuss roadmap"` — a completely natural title/blank/body layout — lost its blank line because `body` was computed as `[overflow, ...remainingLines].join("\n").trim()`, whose leading `.trim()` discarded the structural blank line. It rendered as `"Meeting\nDiscuss roadmap"`.

### Fix

- `title` stays the derived, bounded (≤240) first-line **label** used for list lookup and the agent surface.
- `body` now stores the **verbatim remainder** (`content.slice(title.length)`), so it carries its own leading separator (a newline for a real line break, or the overflow characters for a long first line).
- A single shared reconstruction `reconstructNoteContent(note) = `${title}${body}`` lives in `src/types.ts` and is used by **both** the view and the tests, so the parser and the reconstruction can never drift into re-corrupting content again.
- Body validation preserves content (no `.trim()`), still failing fast on wrong type, ill-formed Unicode, and the length bound.
- The document schema moves to **version 2**. A version-1 document (whose `body` omitted the separator its retired view re-inserted) is migrated on load by restoring the leading newline, so an existing note reads back exactly as it rendered before — proven strictly, not merely accepted (asserts exact migrated body bytes, `schemaVersion` upgrade on next write, and reconstruction equality with the old `title + "\n" + body` output).

## What kind of change is this?

Bug fix (non-breaking; adds a forward-compatible, auto-migrating schema version).

# Documentation changes needed?

Yes — updated `plugins/plugin-notes/CLAUDE.md` (and byte-identical `AGENTS.md`) to state the lossless round-trip contract, the shared `reconstructNoteContent`, and the v1→v2 migration.

# Testing

## Where should a reviewer start?

`plugins/plugin-notes/src/validation.ts` (`parseNoteContent`, `parseBodyText`, `parseNotesDocument` migration) and `src/types.ts` (`reconstructNoteContent`). Then the tests in `src/__tests__/validation.test.ts`, `src/__tests__/backend.test.ts` (`Notes content round-trip (#29003)`), and the view render round-trip in `src/views/NotesViews.test.tsx`.

## Detailed testing steps

```bash
bun install
bun run --cwd plugins/plugin-notes test        # 137 passing
bun run --cwd plugins/plugin-notes typecheck
bun run --cwd plugins/plugin-notes lint:check
bun run check:agents-claude                     # doc parity
```

New/updated tests exercise the real contract (no SUT mocks): parse→reconstruct identity for a >240 single line, a blank line after the first line, trailing blank lines, a multi-paragraph body with internal blank lines, CRLF input, first line of exactly 240 vs 241 chars, and a long URL; a service-level `create → snapshot → restart → reconstruct` proving the committed durable record equals the input; a v1→v2 durable-document migration on load; and a jsdom view render proving the rendered card text equals the authored content.

# Evidence Gate

<!-- evidence-head:c68430d9e608e46b48df9ef17a576facfca01ead -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - no visual/layout change. The only user-visible difference is the text string inside a note card; there is no new/changed component, style, or layout. The rendered-text correctness is proven by the jsdom view render round-trip test (asserts card <p> textContent equals the authored content).`
<!-- evidence-row:after-screenshots -->
- [ ] N/A - see before-screenshots row; proven via the view-level render round-trip test rather than pixels, since no visual surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no interactive flow changed; the fix is deterministic content parsing/reconstruction covered by unit + real-filesystem service tests.`
<!-- evidence-row:backend-logs -->
- [x] Real durable-service backend test output at the current head (`c68430d9e6`), captured from `bun run --cwd plugins/plugin-notes test` (`vitest run --reporter=verbose`). The `NotesStore` suite drives a real on-disk `state.json` create → snapshot → restart, and the reviewer-requested #29033 boundary case loads a v1 note at the 20,000-character body limit, mutates, reloads, and proves both the migrated legacy bytes and the new write survive exactly. (Fork contributors cannot upload to the upstream `pr-evidence` release — asset upload returns HTTP 404 — so the real transcript is embedded per CONTRIBUTING.md § Evidence rather than linked.)

<details><summary>NotesStore durable-service backend logs (real filesystem create→snapshot→restart) — all passing</summary>

```
 ✓ src/__tests__/backend.test.ts > NotesStore > persists one document and restores notes after restart 51ms
 ✓ src/__tests__/backend.test.ts > NotesStore > serializes concurrent writes without losing a mutation 51ms
 ✓ src/__tests__/backend.test.ts > NotesStore > keeps unscoped workbench state outside the agent-scoped durable store 59ms
 ✓ src/__tests__/backend.test.ts > NotesStore > surfaces corrupt persisted bytes as an error instead of healthy empty state 6ms
 ✓ src/__tests__/backend.test.ts > NotesStore > keeps a migrated v1 note at the body-length bound writable after reload (#29033) 13ms
 ✓ src/__tests__/backend.test.ts > Notes capabilities > splits a colon-labelled one-line create-note into title and body 4ms
 ✓ src/__tests__/backend.test.ts > Notes capabilities > drives full note CRUD against the durable service 28ms
 ✓ src/__tests__/backend.test.ts > Notes capabilities > persists intentional clear-notes across service restart 7ms
 ✓ src/__tests__/backend.test.ts > Notes authenticated routes > returns the authoritative durable snapshot 20ms
 Test Files  2 passed (2)
      Tests  68 passed (68)
```
</details>
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no request/response or client state change; the view is a pure projection and is covered by the jsdom render round-trip test instead.`
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent/action/provider/prompt/model behavior changed. parseNoteContent is deterministic string handling; no model is invoked (and the invariant is explicitly that no model invents text).
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact — the failing-then-passing content round-trip and lossless v1→v2 migration for issue #29003, at head `c68430d9e6`. BEFORE (on `origin/develop`) a 300-character single line round-trips to 301 characters (a newline injected at the 240-char label boundary) and `"Meeting\n\nDiscuss roadmap"` loses its blank line; AFTER, `parseNoteContent` is the exact inverse of `reconstructNoteContent`, the durable service preserves bytes across restart, and a v1 document upgrades to the v2 body layout losslessly. (Same fork-upload constraint as backend-logs; the real assertions are embedded rather than linked.)

<details><summary>Notes content round-trip (#29003) + parse/reconstruct identity + v1→v2 migration — real assertions, all passing</summary>

```
BEFORE (origin/develop parseNoteContent + retired view reconstruction):
  case "aaaa..." (len 300) -> round-trip CORRUPTED: got len 301, newline injected at char 240
  case "Meeting\n\nDiscuss roadmap" (len 24) -> round-trip CORRUPTED: got len 23, blank line dropped

AFTER:
 ✓ Notes content round-trip (#29003) > commits a long unwrapped single line without corruption and reloads it intact 15ms
 ✓ Notes content round-trip (#29003) > commits a long URL that must not gain a line break without corruption and reloads it intact 8ms
 ✓ Notes content round-trip (#29003) > commits a blank line after the title without corruption and reloads it intact 12ms
 ✓ Notes content round-trip (#29003) > commits trailing blank lines without corruption and reloads it intact 10ms
 ✓ Notes content round-trip (#29003) > commits a multi-paragraph body with internal blank lines without corruption and reloads it intact 5ms
 ✓ Notes content round-trip (#29003) > upgrades a v1 durable document to the v2 body layout on load 6ms
 ✓ parseNoteContent > round-trips exactly through reconstructNoteContent > a single line longer than the 240-char label bound 2ms
 ✓ parseNoteContent > round-trips exactly through reconstructNoteContent > a blank line placed right after the first line 1ms
 ✓ parseNotesDocument > migrates a v1 document so its body reconstructs the retired view output 1ms
 ✓ parseNotesDocument > leaves an empty v1 body untouched during migration 1ms
```
</details>
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual/text-styling surface changed; the card renders a plain content string whose exact value is asserted by the render round-trip test (equivalent to OCR text equality).`

# Evidence Details

## Real LLM-call trajectory

`N/A - deterministic parsing/reconstruction; no model call on this path.`

## Backend + frontend logs

**BEFORE — `origin/develop` `parseNoteContent` + retired view reconstruction corrupts content:**

```
case "aaaaaaaaaaaaaaaaaaaa"... -> round-trip CORRUPTED
   expected len 300, got len 301; injected/dropped newline: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa...
case "Meeting\n\nDiscuss roa"... -> round-trip CORRUPTED
   expected len 24, got len 23; injected/dropped newline: "Meeting\nDiscuss roadmap"...
```

**AFTER — focused round-trip suite (`validation.test.ts`), all passing:**

<details><summary>parseNoteContent + parseNotesDocument round-trip / migration tests (31 passing)</summary>

```
 ✓ parseNoteContent > round-trips exactly through reconstructNoteContent > a single line longer than the 240-char label bound
 ✓ parseNoteContent > round-trips exactly through reconstructNoteContent > a blank line placed right after the first line
 ✓ parseNoteContent > round-trips exactly through reconstructNoteContent > trailing blank lines
 ✓ parseNoteContent > round-trips exactly through reconstructNoteContent > a multi-paragraph body with internal blank lines
 ✓ parseNoteContent > round-trips exactly through reconstructNoteContent > a first line of exactly 240 characters
 ✓ parseNoteContent > round-trips exactly through reconstructNoteContent > a first line of exactly 241 characters
 ✓ parseNoteContent > round-trips exactly through reconstructNoteContent > a long unwrapped URL on one line
 ✓ parseNoteContent > round-trips exactly through reconstructNoteContent > normalizes CRLF newlines while preserving the split structure
 ✓ parseNoteContent > round-trips exactly through reconstructNoteContent > reconstructs a short single line as the label alone
 ✓ parseNoteContent > derives a bounded label from a long first line without splitting it
 ✓ parseNoteContent > splits a one-line "Label: details" note at the labelled colon
 ✓ parseNoteContent > keeps colons that are not label separators in the title
 ✓ parseNoteContent > leaves multi-line content on the first-line label contract
 ✓ parseNotesDocument > migrates a v1 document so its body reconstructs the retired view output
 ✓ parseNotesDocument > leaves an empty v1 body untouched during migration
 ✓ parseNotesDocument > rejects an unsupported schema version
 Test Files  1 passed (1)
      Tests  31 passed (31)
```
</details>

**AFTER — real-filesystem service round-trip + migration (`backend.test.ts`):**

<details><summary>Notes content round-trip (#29003) — service create→snapshot→restart + v1→v2 migration</summary>

```
 ✓ Notes content round-trip (#29003) > commits a long unwrapped single line without corruption and reloads it intact
 ✓ Notes content round-trip (#29003) > commits a long URL that must not gain a line break without corruption and reloads it intact
 ✓ Notes content round-trip (#29003) > commits a blank line after the title without corruption and reloads it intact
 ✓ Notes content round-trip (#29003) > commits trailing blank lines without corruption and reloads it intact
 ✓ Notes content round-trip (#29003) > commits a multi-paragraph body with internal blank lines without corruption and reloads it intact
 ✓ Notes content round-trip (#29003) > upgrades a v1 durable document to the v2 body layout on load
 ✓ Notes capabilities > splits a colon-labelled one-line create-note into title and body
 Test Files  1 passed (1)
      Tests  37 passed (37)
```
</details>

**AFTER — reviewer-requested max-length upgrade boundary (`backend.test.ts`, #29033):**

A persisted v1 body already at the 20,000-character limit gained one separator newline on the v1→v2 upgrade (`migrateNoteFromV1` restores the retired view's leading `\n`), becoming 20,001 characters. Because every create/update/delete reparses the cloned draft as v2 (`store.ts:212`), the first mutation on such a store failed the shared v2 body bound and left the upgraded store effectively read-only. Persisted note bodies are now validated against `MAX_PERSISTED_BODY_LENGTH` (`MAX_BODY_LENGTH + 1`) while new create/update input stays capped at `MAX_BODY_LENGTH`. The new store round-trip test loads a v1 note with a 20,000-character body, performs a mutation, stops, reloads, and asserts both the legacy bytes and the new write survive exactly.

<details><summary>NotesStore #29033 boundary — before (read-only failure) vs. after (writable)</summary>

```
BEFORE (fix reverted) — the mutation's v2 reparse rejects the migrated body:
  ElizaError: notes[1].body must be at most 20000 characters.
    parseBodyText        src/validation.ts:109
    parseStickyNote      src/validation.ts:252
    parseNotesDocument   src/validation.ts:290
    src/store.ts:212     (transact reparse of the cloned draft)
  × NotesStore > keeps a migrated v1 note at the body-length bound writable after reload (#29033)

AFTER (fix applied):
 ✓ NotesStore > keeps a migrated v1 note at the body-length bound writable after reload (#29033)
 Test Files  9 passed (9)
      Tests  137 passed (137)
```
</details>

**Full package suite + typecheck + lint:**

```
$ bun run --cwd plugins/plugin-notes test
 Test Files  9 passed (9)
      Tests  137 passed (137)

$ bun run --cwd plugins/plugin-notes typecheck   # tsc --noEmit -p tsconfig.json  (no output = clean)
$ bun run --cwd plugins/plugin-notes lint:check  # biome check .  → Checked 44 files. No fixes applied.
$ bun run check:agents-claude                    # PASS: 160 CLAUDE.md/AGENTS.md pairs byte-identical
```

## Screenshots (before / after) + video walkthrough

### Before
`N/A - no visual change; see Evidence Gate rows.`
### After
`N/A - no visual change; the note card renders a plain content string whose exact value is asserted by the jsdom render round-trip test.`
### Walkthrough video
`N/A - deterministic parsing fix; no interactive flow changed.`

## Audio / voice walkthrough

`N/A - no voice/audio surface.`

## Known gaps / failures

- Full repo `bun run verify` was not run on this machine (a Raspberry Pi): it drives the whole Turbo workspace and is prohibitively slow here, and a clean `bun install` needs a one-off relaxation of a local `minimumReleaseAge` guard for a newly-published transitive dependency. In its place, the **owning package's** `typecheck`, `lint:check`, and `test` (137 passing) plus the repo `check:agents-claude` doc-parity gate all pass, and the change is confined to `plugins/plugin-notes`. All UI/LLM/voice evidence rows are `N/A` with specific reasons above because this is a deterministic, non-visual parsing/reconstruction fix.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

---

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@a0ba8f3f8e11002d4d1663e127fad291b709f844:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@a0ba8f3f8e11002d4d1663e127fad291b709f844:packages/skills/skills/contribute-to-eliza"} -->



