### PR TITLE
feat(shared): export hasConfigValueAtPath and guard parseConfigPath against non-string input

### DIFF
--- a/packages/shared/src/config/config-paths.test.ts
+++ b/packages/shared/src/config/config-paths.test.ts
@@ -3,17 +3,25 @@
 import { describe, expect, it } from "vitest";
 import {
   getConfigValueAtPath,
+  hasConfigValueAtPath,
   parseConfigPath,
   setConfigValueAtPath,
   unsetConfigValueAtPath,
 } from "./config-paths";
 
 describe("config path helpers", () => {
-  it("sets, reads, and removes an own nested value", () => {
+  it("sets, reads, checks presence, and removes an own nested value", () => {
     const root: Record<string, unknown> = {};
+
+    expect(
+      hasConfigValueAtPath(root, ["providers", "openai", "enabled"]),
+    ).toBe(false);
 
     setConfigValueAtPath(root, ["providers", "openai", "enabled"], true);
 
+    expect(
+      hasConfigValueAtPath(root, ["providers", "openai", "enabled"]),
+    ).toBe(true);
     expect(getConfigValueAtPath(root, ["providers", "openai", "enabled"])).toBe(
       true,
     );
@@ -104,6 +112,7 @@ describe("config path helpers", () => {
   it("bounds raw and direct paths before traversal", () => {
     expect(parseConfigPath(`${"a.".repeat(40)}z`).ok).toBe(false);
     expect(parseConfigPath("a".repeat(129)).ok).toBe(false);
+    expect(parseConfigPath(null as unknown as string).ok).toBe(false);
     expect(() =>
       setConfigValueAtPath(
         {},

--- a/packages/shared/src/config/config-paths.test.ts
+++ b/packages/shared/src/config/config-paths.test.ts
@@ -13,15 +13,15 @@ describe("config path helpers", () => {
   it("sets, reads, checks presence, and removes an own nested value", () => {
     const root: Record<string, unknown> = {};
 
-    expect(
-      hasConfigValueAtPath(root, ["providers", "openai", "enabled"]),
-    ).toBe(false);
+    expect(hasConfigValueAtPath(root, ["providers", "openai", "enabled"])).toBe(
+      false,
+    );
 
     setConfigValueAtPath(root, ["providers", "openai", "enabled"], true);
 
-    expect(
-      hasConfigValueAtPath(root, ["providers", "openai", "enabled"]),
-    ).toBe(true);
+    expect(hasConfigValueAtPath(root, ["providers", "openai", "enabled"])).toBe(
+      true,
+    );
     expect(getConfigValueAtPath(root, ["providers", "openai", "enabled"])).toBe(
       true,
     );
@@ -29,6 +29,17 @@ describe("config path helpers", () => {
       unsetConfigValueAtPath(root, ["providers", "openai", "enabled"]),
     ).toBe(true);
     expect(root).toEqual({});
+  });
+
+  it("identifies own property presence even when leaf value is undefined", () => {
+    const root: Record<string, unknown> = {};
+    setConfigValueAtPath(root, ["models", "primary"], undefined);
+
+    expect(getConfigValueAtPath(root, ["models", "primary"])).toBeUndefined();
+    expect(hasConfigValueAtPath(root, ["models", "primary"])).toBe(true);
+    expect(hasConfigValueAtPath(root, ["models", "nonexistent"])).toBe(false);
+    expect(unsetConfigValueAtPath(root, ["models", "primary"])).toBe(true);
+    expect(hasConfigValueAtPath(root, ["models", "primary"])).toBe(false);
   });
 
   it.each(["__proto__", "prototype", "constructor"])(
@@ -40,6 +51,9 @@ describe("config path helpers", () => {
         setConfigValueAtPath(root, [segment, "polluted"], true),
       ).toThrow("unsafe segment");
       expect(() => getConfigValueAtPath(root, [segment])).toThrow(
+        "unsafe segment",
+      );
+      expect(() => hasConfigValueAtPath(root, [segment])).toThrow(
         "unsafe segment",
       );
       expect(() => unsetConfigValueAtPath(root, [segment])).toThrow(
@@ -63,6 +77,9 @@ describe("config path helpers", () => {
     expect(() => getConfigValueAtPath(root, ["profile", "enabled"])).toThrow(
       "unsafe segment",
     );
+    expect(() => hasConfigValueAtPath(root, ["profile", "enabled"])).toThrow(
+      "unsafe segment",
+    );
     expect(() =>
       setConfigValueAtPath(root, ["profile", "enabled"], false),
     ).toThrow("unsafe segment");
@@ -84,12 +101,18 @@ describe("config path helpers", () => {
         getConfigValueAtPath(root, ["inheritedConfigProfile", "enabled"]),
       ).toBeUndefined();
       expect(
+        hasConfigValueAtPath(root, ["inheritedConfigProfile", "enabled"]),
+      ).toBe(false);
+      expect(
         unsetConfigValueAtPath(root, ["inheritedConfigProfile", "enabled"]),
       ).toBe(false);
       setConfigValueAtPath(root, ["inheritedConfigProfile", "enabled"], true);
 
       expect(
         getConfigValueAtPath(root, ["inheritedConfigProfile", "enabled"]),
+      ).toBe(true);
+      expect(
+        hasConfigValueAtPath(root, ["inheritedConfigProfile", "enabled"]),
       ).toBe(true);
       expect(inherited.enabled).toBe(false);
     } finally {
@@ -107,18 +130,27 @@ describe("config path helpers", () => {
     expect(() => getConfigValueAtPath(root, ["profile", "enabled"])).toThrow(
       "unsafe segment",
     );
+    expect(() => hasConfigValueAtPath(root, ["profile", "enabled"])).toThrow(
+      "unsafe segment",
+    );
   });
 
   it("bounds raw and direct paths before traversal", () => {
     expect(parseConfigPath(`${"a.".repeat(40)}z`).ok).toBe(false);
     expect(parseConfigPath("a".repeat(129)).ok).toBe(false);
-    expect(parseConfigPath(null as unknown as string).ok).toBe(false);
+    expect(parseConfigPath(null as unknown as string)).toEqual({
+      ok: false,
+      error: "Path must be a string.",
+    });
     expect(() =>
       setConfigValueAtPath(
         {},
         [...Array.from({ length: 33 }, () => "a")],
         true,
       ),
+    ).toThrow("unsafe segment");
+    expect(() =>
+      setConfigValueAtPath({}, ["a", "b".repeat(129)], true),
     ).toThrow("unsafe segment");
   });
 });

--- a/packages/shared/src/config/config-paths.ts
+++ b/packages/shared/src/config/config-paths.ts
@@ -95,6 +95,12 @@ export function parseConfigPath(raw: string): {
   path?: string[];
   error?: string;
 } {
+  if (typeof raw !== "string") {
+    return {
+      ok: false,
+      error: "Invalid path. Use dot notation (e.g. foo.bar).",
+    };
+  }
   const trimmed = raw.trim();
   if (!trimmed || trimmed.length > MAX_CONFIG_PATH_LENGTH) {
     return {
@@ -228,4 +234,8 @@ export function getConfigValueAtPath(root: PathNode, path: string[]): unknown {
     cursor = next.value;
   }
   return cursor;
+}
+
+export function hasConfigValueAtPath(root: PathNode, path: string[]): boolean {
+  return getConfigValueAtPath(root, path) !== undefined;
 }

--- a/packages/shared/src/config/config-paths.ts
+++ b/packages/shared/src/config/config-paths.ts
@@ -1,5 +1,5 @@
 /**
- * Dot-notation config path parsing and safe get/set/unset on nested config
+ * Dot-notation config path parsing and safe get/set/has/unset on nested config
  * objects. Prototype-pollution keys (`__proto__`, `prototype`, `constructor`)
  * are rejected so untrusted override paths cannot walk into the prototype chain.
  */
@@ -98,7 +98,7 @@ export function parseConfigPath(raw: string): {
   if (typeof raw !== "string") {
     return {
       ok: false,
-      error: "Invalid path. Use dot notation (e.g. foo.bar).",
+      error: "Path must be a string.",
     };
   }
   const trimmed = raw.trim();
@@ -236,6 +236,38 @@ export function getConfigValueAtPath(root: PathNode, path: string[]): unknown {
   return cursor;
 }
 
+/**
+ * Check whether an own data property exists at the given path on root.
+ * Returns true even when the leaf value is explicitly `undefined`.
+ * Throws ElizaError when encountering prototype pollution keys or unsafe nodes.
+ */
 export function hasConfigValueAtPath(root: PathNode, path: string[]): boolean {
-  return getConfigValueAtPath(root, path) !== undefined;
+  assertSafePath(path);
+  if (!isSafePathNode(root)) {
+    throw unsafeConfigPath({ reason: "root-prototype" });
+  }
+  let cursor: unknown = root;
+  for (let idx = 0; idx < path.length; idx += 1) {
+    const key = path[idx];
+    if (typeof cursor !== "object" || cursor === null) {
+      return false;
+    }
+    if (!isSafePathNode(cursor)) {
+      throw unsafeConfigPath({ key, reason: "nested-prototype" });
+    }
+    const next = ownDataValue(cursor, key);
+    if (!next.found) return false;
+    if (idx === path.length - 1) {
+      return true;
+    }
+    if (
+      typeof next.value === "object" &&
+      next.value !== null &&
+      !isSafePathNode(next.value)
+    ) {
+      throw unsafeConfigPath({ key, reason: "nested-prototype" });
+    }
+    cursor = next.value;
+  }
+  return false;
 }

--- a/packages/shared/src/config/runtime-overrides.test.ts
+++ b/packages/shared/src/config/runtime-overrides.test.ts
@@ -11,6 +11,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import {
   applyConfigOverrides,
   getConfigOverrides,
+  hasConfigOverride,
   resetConfigOverrides,
   setConfigOverride,
   unsetConfigOverride,
@@ -23,22 +24,38 @@ beforeEach(() => {
   resetConfigOverrides();
 });
 
-describe("setConfigOverride / unsetConfigOverride", () => {
+describe("setConfigOverride / unsetConfigOverride / hasConfigOverride", () => {
   it("stores a value at a dotted path", () => {
+    expect(hasConfigOverride("a.b.c")).toBe(false);
     expect(setConfigOverride("a.b.c", 1)).toEqual({ ok: true });
+    expect(hasConfigOverride("a.b.c")).toBe(true);
     expect(getConfigOverrides()).toMatchObject({ a: { b: { c: 1 } } });
+  });
+
+  it("identifies presence of overrides with undefined values", () => {
+    expect(hasConfigOverride("features.voice")).toBe(false);
+    setConfigOverride("features.voice", undefined);
+    expect(hasConfigOverride("features.voice")).toBe(true);
+    expect(hasConfigOverride("features.nonexistent")).toBe(false);
+    expect(unsetConfigOverride("features.voice")).toEqual({
+      ok: true,
+      removed: true,
+    });
+    expect(hasConfigOverride("features.voice")).toBe(false);
   });
 
   it("rejects an empty or malformed path without mutating state", () => {
     const result = setConfigOverride("   ", 1);
     expect(result.ok).toBe(false);
     expect(result.error).toBeTruthy();
+    expect(hasConfigOverride("   ")).toBe(false);
     expect(Object.keys(getConfigOverrides())).toHaveLength(0);
   });
 
   it("rejects a path segment that could reach Object.prototype", () => {
     const result = setConfigOverride("__proto__.polluted", true);
     expect(result.ok).toBe(false);
+    expect(hasConfigOverride("__proto__.polluted")).toBe(false);
     expect(({} as Record<string, unknown>).polluted).toBeUndefined();
     expect(Object.keys(getConfigOverrides())).toHaveLength(0);
   });
@@ -58,6 +75,7 @@ describe("setConfigOverride / unsetConfigOverride", () => {
   it("resetConfigOverrides clears every stored override", () => {
     setConfigOverride("a.b", 1);
     resetConfigOverrides();
+    expect(hasConfigOverride("a.b")).toBe(false);
     expect(Object.keys(getConfigOverrides())).toHaveLength(0);
   });
 });

--- a/packages/shared/src/config/runtime-overrides.ts
+++ b/packages/shared/src/config/runtime-overrides.ts
@@ -5,6 +5,7 @@
  */
 import { isPlainObject } from "../type-guards.js";
 import {
+  hasConfigValueAtPath,
   parseConfigPath,
   setConfigValueAtPath,
   unsetConfigValueAtPath,
@@ -35,6 +36,14 @@ export function getConfigOverrides(): OverrideTree {
 
 export function resetConfigOverrides(): void {
   overrides = {};
+}
+
+export function hasConfigOverride(pathRaw: string): boolean {
+  const parsed = parseConfigPath(pathRaw);
+  if (!parsed.ok || !parsed.path) {
+    return false;
+  }
+  return hasConfigValueAtPath(overrides, parsed.path);
 }
 
 export function setConfigOverride(


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Adds `hasConfigValueAtPath` helper and defensive non-string input guard in `packages/shared/src/config/config-paths.ts`.

# Background

## What does this PR do?

1. Adds and exports `hasConfigValueAtPath(root: PathNode, path: string[]): boolean` in `packages/shared/src/config/config-paths.ts`.
2. Guards `parseConfigPath(raw: string)` against non-string inputs (e.g. `null` or `undefined`) returning a descriptive error object instead of throwing `TypeError: raw.trim is not a function`.

## What kind of change is this?

Features (non-breaking change which adds functionality).

## Why are we doing this? Any context or related work?

Validating configuration overrides or checking whether nested keys exist in loaded config profiles requires a dedicated `hasConfigValueAtPath` check and robust error handling for unparsed/untyped inputs.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Review `packages/shared/src/config/config-paths.ts` and `packages/shared/src/config/config-paths.test.ts`.

## Detailed testing steps

Run:
```bash
npx vitest run packages/shared/src/config/config-paths.test.ts
bun run --cwd packages/shared typecheck
```

# Evidence Gate

<!-- evidence-head:22fe32c4b895f334ed733e15122d6d230b6d4a24 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - Non-UI shared config paths change`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - Non-UI shared config paths change`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - Non-UI shared config paths change`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - Shared config paths unit function, verified via unit test execution`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - Non-UI shared config paths change`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - Deterministic config paths inspection without model calls`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - In-memory config paths`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - No rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

N/A - Deterministic config paths inspection without model calls.

## Backend + frontend logs

N/A - Shared config paths unit function, verified via unit test execution.

## Screenshots (before / after) + video walkthrough

N/A - Non-UI shared config paths change.

## Audio / voice walkthrough

N/A - No audio or voice paths touched.

## Known gaps / failures

None.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
