### PR TITLE
fix(cloud): simplify and guard launcher interactions

### DIFF
--- a/packages/app/test/audit/ocr-view-expectations.test.ts
+++ b/packages/app/test/audit/ocr-view-expectations.test.ts
@@ -93,12 +93,18 @@ describe("aesthetic audit semantic OCR policy coverage", () => {
     }
   });
 
-  it("expects the production Cloud plugin bundle's signed-out state", () => {
-    const policy = resolveViewOcrPolicy("plugin-cloud-gui");
-    expect(policy).toEqual({
+  it("keeps separate connected and signed-out Cloud semantic contracts", () => {
+    expect(resolveViewOcrPolicy("plugin-cloud-gui")).toEqual({
       kind: "expectation",
       expectation: {
         requireAll: ["Eliza Cloud"],
+        requireAny: ["Credits", "Hosted agents", "API keys", "Connected"],
+      },
+    });
+    expect(resolveViewOcrPolicy("plugin-cloud-signed-out-gui")).toEqual({
+      kind: "expectation",
+      expectation: {
+        requireAll: ["Eliza Cloud", "Connect in Settings"],
         requireAny: [
           "credits",
           "hosted agents",

--- a/packages/app/test/ui-smoke/aesthetic-audit-view-cases.ts
+++ b/packages/app/test/ui-smoke/aesthetic-audit-view-cases.ts
@@ -47,6 +47,7 @@ export interface AuditViewCase {
   path: string;
   viewType: "gui" | "tui";
   kind: "builtin" | "plugin";
+  fixtureState?: "cloud-signed-out";
 }
 
 export function buildAuditViewCases(): AuditViewCase[] {
@@ -67,14 +68,24 @@ export function buildAuditViewCases(): AuditViewCase[] {
       viewType: "gui",
       kind: "builtin",
     },
-    ...VIEW_CASES.map(
-      (view): AuditViewCase => ({
+    ...VIEW_CASES.flatMap((view): AuditViewCase[] => {
+      const base: AuditViewCase = {
         id: view.id,
         slug: `plugin-${view.id}-${view.viewType}`,
         path: view.path,
         viewType: view.viewType,
         kind: "plugin",
-      }),
-    ),
+      };
+      return view.id === "cloud"
+        ? [
+            base,
+            {
+              ...base,
+              slug: "plugin-cloud-signed-out-gui",
+              fixtureState: "cloud-signed-out",
+            },
+          ]
+        : [base];
+    }),
   ];
 }

--- a/packages/app/test/ui-smoke/all-views-aesthetic-audit.spec.ts
+++ b/packages/app/test/ui-smoke/all-views-aesthetic-audit.spec.ts
@@ -1344,6 +1344,76 @@ async function forceRemoteBundleAuditRoute(
   view: AuditViewCase,
 ): Promise<RemoteBundleAuditProof | null> {
   if (view.kind !== "plugin") return null;
+  if (view.id === "cloud" && view.fixtureState !== "cloud-signed-out") {
+    const connectedCloudResponses = new Map<string, unknown>([
+      [
+        "/api/cloud/status",
+        {
+          connected: true,
+          enabled: true,
+          hasApiKey: true,
+          userId: "audit-user",
+          organizationId: "audit-org",
+        },
+      ],
+      [
+        "/api/cloud/credits",
+        {
+          connected: true,
+          balance: 42.5,
+          low: false,
+          critical: false,
+          topUpUrl: "https://cloud.eliza.app/cloud/billing",
+        },
+      ],
+      [
+        "/api/cloud/compat/agents",
+        {
+          success: true,
+          data: [
+            {
+              agent_id: "audit-agent",
+              agent_name: "Research agent",
+              node_id: null,
+              container_id: null,
+              headscale_ip: null,
+              bridge_url: null,
+              web_ui_url: null,
+              status: "running",
+              agent_config: {},
+              created_at: "2026-08-01T00:00:00.000Z",
+              updated_at: "2026-08-01T00:00:00.000Z",
+              containerUrl: "",
+              webUiUrl: null,
+              database_status: "healthy",
+              error_message: null,
+              last_heartbeat_at: null,
+            },
+          ],
+        },
+      ],
+      [
+        "/api/cloud/billing/summary",
+        {
+          balance: 42.5,
+          currency: "USD",
+          hasPaymentMethod: true,
+        },
+      ],
+    ]);
+    await page.route("**/api/cloud/**", async (route) => {
+      const pathname = new URL(route.request().url()).pathname;
+      if (!connectedCloudResponses.has(pathname)) {
+        await route.fallback();
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(connectedCloudResponses.get(pathname)),
+      });
+    });
+  }
   if (view.id === "computer-use-sessions") {
     await page.route("**/api/computer-use/sessions", async (route) => {
       await route.fulfill({
@@ -1870,6 +1940,21 @@ test.describe("all-views aesthetic audit (#8796)", () => {
           readPaint,
           overlayRequired,
         );
+        if (view.id === "cloud" && view.fixtureState !== "cloud-signed-out") {
+          await expect(
+            viewRoot.getByTestId("cloud-ready"),
+            "the Cloud plugin audit must capture the connected account state",
+          ).toBeVisible();
+        }
+        if (view.fixtureState === "cloud-signed-out") {
+          await expect(
+            viewRoot.getByTestId("cloud-signed-out"),
+            "the Cloud plugin audit must preserve the disconnected recovery state",
+          ).toBeVisible();
+          await expect(
+            viewRoot.getByText("Connected", { exact: true }),
+          ).toHaveCount(0);
+        }
         await settleHomeEntrance(page);
         const { readableChars, semanticReady, overlayPresent } = paint;
         const renderStateIssues = [

--- a/packages/app/test/ui-smoke/ocr-view-expectations.ts
+++ b/packages/app/test/ui-smoke/ocr-view-expectations.ts
@@ -240,11 +240,14 @@ export const VIEW_OCR_POLICIES = {
     requireAll: ["Misty Forest", "Desert Dusk"],
     requireAny: ["Ocean Deep", "Alpine Dawn", "Ember Night"],
   }),
-  // The hermetic audit serves the production plugin bundle with a disconnected
-  // Cloud status, so the designed signed-out state is the stable semantic
-  // contract. The real /cloud management route is intentionally bypassed.
   "plugin-cloud-gui": expected({
     requireAll: ["Eliza Cloud"],
+    requireAny: ["Credits", "Hosted agents", "API keys", "Connected"],
+  }),
+  // Preserve the disconnected state as a separate production-bundle capture;
+  // connected account fixtures must not erase sign-in recovery coverage.
+  "plugin-cloud-signed-out-gui": expected({
+    requireAll: ["Eliza Cloud", "Connect in Settings"],
     requireAny: [
       "credits",
       "hosted agents",

--- a/plugins/plugin-elizacloud/src/components/cloud/CloudView.test.tsx
+++ b/plugins/plugin-elizacloud/src/components/cloud/CloudView.test.tsx
@@ -9,8 +9,8 @@
 
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import type { CloudViewFetchers } from "./CloudView.tsx";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CloudViewFetchers, CloudViewInteractions } from "./CloudView.tsx";
 import { CloudView } from "./CloudView.tsx";
 
 const CONNECTED_STATUS = {
@@ -48,7 +48,9 @@ const AGENT = {
   last_heartbeat_at: null,
 };
 
-function fetchers(overrides: Partial<CloudViewFetchers> = {}): CloudViewFetchers {
+function fetchers(
+  overrides: Partial<CloudViewFetchers> = {},
+): CloudViewFetchers {
   return {
     fetchStatus: async () => CONNECTED_STATUS,
     fetchCredits: async () => CREDITS,
@@ -69,10 +71,21 @@ function fetchers(overrides: Partial<CloudViewFetchers> = {}): CloudViewFetchers
   };
 }
 
+function interactions(
+  overrides: Partial<CloudViewInteractions> = {},
+): CloudViewInteractions {
+  return {
+    navigateInternal: vi.fn(),
+    openExternal: vi.fn(async () => true),
+    ...overrides,
+  };
+}
+
 let container: HTMLDivElement;
 let root: Root;
 
 beforeEach(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
   container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
@@ -85,9 +98,12 @@ afterEach(async () => {
   container.remove();
 });
 
-async function render(seam: CloudViewFetchers) {
+async function render(
+  seam: CloudViewFetchers,
+  interactionSeam: CloudViewInteractions = interactions(),
+) {
   await act(async () => {
-    root.render(<CloudView fetchers={seam} />);
+    root.render(<CloudView fetchers={seam} interactions={interactionSeam} />);
   });
   // Let the async account load settle.
   await act(async () => {
@@ -103,20 +119,50 @@ describe("CloudView", () => {
   it("shows the loading state while the account load is in flight", async () => {
     const never = new Promise<typeof CONNECTED_STATUS>(() => {});
     await act(async () => {
-      root.render(<CloudView fetchers={fetchers({ fetchStatus: () => never })} />);
+      root.render(
+        <CloudView fetchers={fetchers({ fetchStatus: () => never })} />,
+      );
     });
     expect(testId("cloud-loading")).not.toBeNull();
     expect(container.textContent).toContain("Loading your Eliza Cloud account");
   });
 
   it("renders the designed signed-out state with a connect CTA", async () => {
+    const interactionSeam = interactions();
     await render(
-      fetchers({ fetchStatus: async () => ({ connected: false, enabled: true }) }),
+      fetchers({
+        fetchStatus: async () => ({ connected: false, enabled: true }),
+      }),
+      interactionSeam,
     );
     expect(testId("cloud-signed-out")).not.toBeNull();
-    expect(container.textContent).toContain("Connect your Eliza Cloud account");
+    expect(container.textContent).toContain("Connect to view credits");
+    expect(container.textContent).not.toContain("Connected");
     expect(container.querySelector("button")?.textContent).toContain(
       "Connect in Settings",
+    );
+    await act(async () => {
+      container.querySelector("button")?.click();
+    });
+    expect(interactionSeam.navigateInternal).toHaveBeenCalledWith("/settings");
+  });
+
+  it("shows a visible failure when internal navigation is denied", async () => {
+    await render(
+      fetchers({
+        fetchStatus: async () => ({ connected: false, enabled: true }),
+      }),
+      interactions({
+        navigateInternal: () => {
+          throw new Error("scope denied");
+        },
+      }),
+    );
+    await act(async () => {
+      container.querySelector("button")?.click();
+    });
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain(
+      "Navigation is unavailable",
     );
   });
 
@@ -145,7 +191,7 @@ describe("CloudView", () => {
     await render(fetchers());
     expect(testId("cloud-ready")).not.toBeNull();
     expect(testId("cloud-credit-balance")?.textContent).toBe("$12.34");
-    expect(testId("cloud-org-id")?.textContent).toBe("org-1");
+    expect(container.textContent).toContain("Connected");
     expect(testId("cloud-agent-list")?.textContent).toContain("alpha");
     expect(testId("cloud-agent-list")?.textContent).toContain("running");
     expect(testId("cloud-api-key-count")?.textContent).toBe("2 API keys");
@@ -153,9 +199,52 @@ describe("CloudView", () => {
     expect(container.textContent).toContain("Top up");
   });
 
+  it("opens server-provided links only through the host interaction boundary", async () => {
+    const openExternal = vi.fn(async () => true);
+    await render(fetchers(), interactions({ openExternal }));
+    const topUp = [...container.querySelectorAll("button")].find(
+      (button) => button.textContent === "Top up",
+    );
+    const manage = [...container.querySelectorAll("button")].find(
+      (button) => button.textContent === "Manage",
+    );
+    await act(async () => {
+      topUp?.click();
+      manage?.click();
+      await Promise.resolve();
+    });
+    expect(openExternal).toHaveBeenCalledWith(CREDITS.topUpUrl);
+    expect(openExternal).toHaveBeenCalledWith(
+      "https://cloud.eliza.app/cloud/api-keys",
+    );
+    expect(container.querySelector('a[target="_blank"]')).toBeNull();
+  });
+
+  it.each([
+    ["rejected", async () => false],
+    ["failed", async () => Promise.reject(new Error("browser unavailable"))],
+  ])(
+    "shows a visible failure when an external URL is %s",
+    async (_name, open) => {
+      await render(fetchers(), interactions({ openExternal: open }));
+      const topUp = [...container.querySelectorAll("button")].find(
+        (button) => button.textContent === "Top up",
+      );
+      await act(async () => {
+        topUp?.click();
+        await Promise.resolve();
+      });
+      expect(container.querySelector('[role="alert"]')?.textContent).toContain(
+        "could not be opened safely",
+      );
+    },
+  );
+
   it("renders the designed empty state when there are no hosted agents", async () => {
-    await render(fetchers({ fetchAgents: async () => ({ success: true, data: [] }) }));
-    expect(container.textContent).toContain("No hosted agents yet");
+    await render(
+      fetchers({ fetchAgents: async () => ({ success: true, data: [] }) }),
+    );
+    expect(container.textContent).toContain("No hosted agents.");
   });
 
   it("degrades a failing section to its unavailable note without faking empty", async () => {
@@ -169,7 +258,9 @@ describe("CloudView", () => {
     // Still ready — credits render…
     expect(testId("cloud-credit-balance")?.textContent).toBe("$12.34");
     // …but the agents card is a designed unavailable note, not an empty list.
-    expect(container.textContent).toContain("Agents are unavailable right now.");
+    expect(container.textContent).toContain(
+      "Agents are unavailable right now.",
+    );
     expect(container.textContent).not.toContain("No hosted agents yet");
   });
 
@@ -184,6 +275,8 @@ describe("CloudView", () => {
       }),
     );
     expect(testId("cloud-api-key-count")).toBeNull();
-    expect(container.textContent).toContain("signed-in session");
+    expect(container.textContent).toContain(
+      "Open the console to view API keys",
+    );
   });
 });

--- a/plugins/plugin-elizacloud/src/components/cloud/CloudView.tsx
+++ b/plugins/plugin-elizacloud/src/components/cloud/CloudView.tsx
@@ -4,12 +4,9 @@
  * billing summary) rendered app-native in the dark launcher aesthetic.
  *
  * Served as this plugin's `cloud` view bundle (`vite.config.views.ts`) and
- * mounted by the shell's DynamicViewLoader at `/cloud`, so it may import ONLY
- * host-external specifiers (react, `@elizaos/ui/api`) — console surfaces under
- * `@elizaos/ui/cloud/*` are not in the host-external map and cannot be reused
- * here. Data comes from the host `client` singleton's cloud wrappers, which
- * already handle steward-token auth, direct-cloud base resolution, and native
- * transport.
+ * mounted by the shell's DynamicViewLoader at `/cloud`. Data comes from the
+ * host `client` singleton's cloud wrappers, while navigation uses the host's
+ * scope broker and safe external-URL boundary.
  *
  * State machine honors the repo three-state rule: loading / signed-out
  * (designed connect CTA) / error (with retry) / ready — and inside ready each
@@ -19,7 +16,16 @@
 
 // Host-provided UI atoms and the narrow API singleton are both externalized by
 // the dynamic-view loader, so this bundle does not ship a second UI runtime.
-import { Button } from "@elizaos/ui";
+import {
+  Badge,
+  Button,
+  Card,
+  CardAction,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@elizaos/ui";
+import { navigateBrowserPath } from "@elizaos/ui/app-navigate-view";
 import { client } from "@elizaos/ui/api";
 import type {
   CloudApiKeys,
@@ -28,6 +34,7 @@ import type {
   CloudCredits,
   CloudStatus,
 } from "@elizaos/ui/api";
+import { openExternalUrl } from "@elizaos/ui/utils";
 import type { ReactNode } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 
@@ -55,11 +62,15 @@ const defaultFetchers: CloudViewFetchers = {
   fetchBillingSummary: () => client.getCloudBillingSummary(),
 };
 
-/** In-shell navigation: pushState + popstate, the launcher tile convention. */
-function navigateTo(path: string): void {
-  window.history.pushState({}, "", path);
-  window.dispatchEvent(new PopStateEvent("popstate"));
+export interface CloudViewInteractions {
+  navigateInternal: (path: string) => void;
+  openExternal: (url: string) => Promise<boolean>;
 }
+
+const defaultInteractions: CloudViewInteractions = {
+  navigateInternal: navigateBrowserPath,
+  openExternal: openExternalUrl,
+};
 
 // ---------------------------------------------------------------------------
 // Load-state machine.
@@ -69,7 +80,6 @@ function navigateTo(path: string): void {
 type Section<T> = { data: T; error: null } | { data: null; error: string };
 
 interface ReadyData {
-  status: CloudStatus;
   credits: Section<CloudCredits>;
   agents: Section<CloudCompatAgent[]>;
   apiKeys: Section<CloudApiKeys>;
@@ -106,14 +116,16 @@ async function loadAccount(fetchers: CloudViewFetchers): Promise<LoadState> {
   const agentsSection: Section<CloudCompatAgent[]> =
     agents.status === "fulfilled"
       ? agents.value.success
-        ? { data: agents.value.data ?? [], error: null }
-        : { data: null, error: agents.value.error ?? "Agents are unavailable right now." }
+        ? { data: agents.value.data, error: null }
+        : {
+            data: null,
+            error: agents.value.error ?? "Agents are unavailable right now.",
+          }
       : { data: null, error: "Agents are unavailable right now." };
 
   return {
     kind: "ready",
     data: {
-      status,
       credits: section(credits, "Credits are unavailable right now."),
       agents: agentsSection,
       apiKeys: section(apiKeys, "API keys are unavailable right now."),
@@ -126,15 +138,21 @@ async function loadAccount(fetchers: CloudViewFetchers): Promise<LoadState> {
 // Presentational pieces (token classes only — the launcher theme owns colors).
 // ---------------------------------------------------------------------------
 
-function Card(props: { title: string; children: ReactNode; action?: ReactNode }) {
+function CloudCard(props: {
+  title: string;
+  children: ReactNode;
+  action?: ReactNode;
+}) {
   return (
-    <section className="rounded-lg border border-border bg-card p-4">
-      <div className="mb-3 flex items-center justify-between gap-2">
-        <h2 className="text-sm font-semibold text-txt">{props.title}</h2>
-        {props.action}
-      </div>
-      {props.children}
-    </section>
+    <Card asChild variant="panel">
+      <section>
+        <CardHeader className="grid grid-cols-[1fr_auto] items-start gap-2 space-y-0 p-4 pb-3">
+          <CardTitle className="text-sm text-txt">{props.title}</CardTitle>
+          {props.action ? <CardAction>{props.action}</CardAction> : null}
+        </CardHeader>
+        <CardContent className="px-4 pb-4 pt-0">{props.children}</CardContent>
+      </section>
+    </Card>
   );
 }
 
@@ -142,25 +160,31 @@ function SectionNote(props: { message: string }) {
   return <p className="text-sm text-muted">{props.message}</p>;
 }
 
-function ExternalLink(props: { href: string; children: ReactNode }) {
+function ExternalAction(props: {
+  href: string;
+  children: ReactNode;
+  onOpen: (href: string) => void;
+}) {
   return (
-    <a
-      className="text-sm font-medium text-accent hover:underline"
-      href={props.href}
-      target="_blank"
-      rel="noreferrer"
+    <Button
+      type="button"
+      variant="externalLink"
+      onClick={() => props.onOpen(props.href)}
     >
       {props.children}
-    </a>
+    </Button>
   );
 }
 
-function agentStatusClass(status: string): string {
+function agentStatusTone(
+  status: string,
+): "success" | "danger" | "warning" | "muted" {
   const normalized = status.toLowerCase();
-  if (normalized === "running") return "text-ok";
-  if (normalized === "error") return "text-danger";
-  if (normalized === "provisioning" || normalized === "pending") return "text-warn";
-  return "text-muted";
+  if (normalized === "running") return "success";
+  if (normalized === "error") return "danger";
+  if (normalized === "provisioning" || normalized === "pending")
+    return "warning";
+  return "muted";
 }
 
 function balanceClass(credits: CloudCredits): string {
@@ -177,54 +201,30 @@ function formatBalance(balance: number | null): string {
 // Cards.
 // ---------------------------------------------------------------------------
 
-function AccountCard(props: { status: CloudStatus }) {
-  const { status } = props;
-  return (
-    <Card
-      title="Account"
-      action={
-        <span className="rounded-md bg-accent/12 px-2 py-0.5 text-xs font-medium text-accent">
-          Connected
-        </span>
-      }
-    >
-      <dl className="space-y-1 text-sm">
-        {status.organizationId ? (
-          <div className="flex justify-between gap-2">
-            <dt className="text-muted">Organization</dt>
-            <dd className="truncate text-txt" data-testid="cloud-org-id">
-              {status.organizationId}
-            </dd>
-          </div>
-        ) : null}
-        {status.userId ? (
-          <div className="flex justify-between gap-2">
-            <dt className="text-muted">User</dt>
-            <dd className="truncate text-txt">{status.userId}</dd>
-          </div>
-        ) : null}
-      </dl>
-    </Card>
-  );
-}
-
 function CreditsCard(props: {
   credits: Section<CloudCredits>;
   billing: Section<CloudBillingSummary>;
+  onOpen: (href: string) => void;
 }) {
-  const { credits, billing } = props;
+  const { credits, billing, onOpen } = props;
   if (!credits.data) {
     return (
-      <Card title="Credits">
+      <CloudCard title="Credits">
         <SectionNote message={credits.error} />
-      </Card>
+      </CloudCard>
     );
   }
   const topUpUrl = credits.data.topUpUrl ?? billing.data?.topUpUrl;
   return (
-    <Card
+    <CloudCard
       title="Credits"
-      action={topUpUrl ? <ExternalLink href={topUpUrl}>Top up</ExternalLink> : undefined}
+      action={
+        topUpUrl ? (
+          <ExternalAction href={topUpUrl} onOpen={onOpen}>
+            Top up
+          </ExternalAction>
+        ) : undefined
+      }
     >
       <p
         className={`text-2xl font-semibold ${balanceClass(credits.data)}`}
@@ -246,18 +246,18 @@ function CreditsCard(props: {
       ) : (
         <p className="mt-2 text-sm text-muted">{billing.error}</p>
       )}
-    </Card>
+    </CloudCard>
   );
 }
 
 function AgentsCard(props: { agents: Section<CloudCompatAgent[]> }) {
   const { agents } = props;
   return (
-    <Card title="Hosted agents">
+    <CloudCard title="Hosted agents">
       {agents.data === null ? (
         <SectionNote message={agents.error} />
       ) : agents.data.length === 0 ? (
-        <SectionNote message="No hosted agents yet. Ask me to create one, or provision from the console." />
+        <SectionNote message="No hosted agents." />
       ) : (
         <ul className="space-y-2" data-testid="cloud-agent-list">
           {agents.data.map((agent) => (
@@ -265,39 +265,52 @@ function AgentsCard(props: { agents: Section<CloudCompatAgent[]> }) {
               key={agent.agent_id}
               className="flex items-center justify-between gap-2 rounded-md border border-border bg-surface px-3 py-2"
             >
-              <span className="truncate text-sm text-txt">{agent.agent_name}</span>
-              <span className={`text-xs font-medium ${agentStatusClass(agent.status)}`}>
-                {agent.status}
+              <span className="truncate text-sm text-txt">
+                {agent.agent_name}
               </span>
+              <Badge
+                variant="outline"
+                size="micro"
+                tone={agentStatusTone(agent.status)}
+              >
+                {agent.status}
+              </Badge>
             </li>
           ))}
         </ul>
       )}
-    </Card>
+    </CloudCard>
   );
 }
 
-function ApiKeysCard(props: { apiKeys: Section<CloudApiKeys> }) {
-  const { apiKeys } = props;
+function ApiKeysCard(props: {
+  apiKeys: Section<CloudApiKeys>;
+  onOpen: (href: string) => void;
+}) {
+  const { apiKeys, onOpen } = props;
   if (apiKeys.data === null) {
     return (
-      <Card title="API keys">
+      <CloudCard title="API keys">
         <SectionNote message={apiKeys.error} />
-      </Card>
+      </CloudCard>
     );
   }
   const { keys, manageUrl, reason } = apiKeys.data;
   return (
-    <Card
+    <CloudCard
       title="API keys"
-      action={<ExternalLink href={manageUrl}>Manage</ExternalLink>}
+      action={
+        <ExternalAction href={manageUrl} onOpen={onOpen}>
+          Manage
+        </ExternalAction>
+      }
     >
       {keys === null ? (
         <SectionNote
           message={
             reason === "session-required"
-              ? "API keys can only be listed from a signed-in session — manage them in the console."
-              : "Sign in to Eliza Cloud to see your API keys."
+              ? "Open the console to view API keys for this account."
+              : "Open the console to view API keys."
           }
         />
       ) : (
@@ -305,7 +318,7 @@ function ApiKeysCard(props: { apiKeys: Section<CloudApiKeys> }) {
           {keys.length === 1 ? "1 API key" : `${keys.length} API keys`}
         </p>
       )}
-    </Card>
+    </CloudCard>
   );
 }
 
@@ -316,14 +329,40 @@ function ApiKeysCard(props: { apiKeys: Section<CloudApiKeys> }) {
 export interface CloudViewProps {
   /** Test/host injection seam. Defaults to the host `client` cloud wrappers. */
   fetchers?: CloudViewFetchers;
+  /** Test seam for the host-brokered internal and external navigation paths. */
+  interactions?: CloudViewInteractions;
 }
 
 export function CloudView(props: CloudViewProps = {}): ReactNode {
   const fetchers = props.fetchers ?? defaultFetchers;
+  const interactions = props.interactions ?? defaultInteractions;
   const [state, setState] = useState<LoadState>({ kind: "loading" });
+  const [navigationError, setNavigationError] = useState<string | null>(null);
 
   const fetchersRef = useRef(fetchers);
   fetchersRef.current = fetchers;
+  const interactionsRef = useRef(interactions);
+  interactionsRef.current = interactions;
+
+  const navigateInternal = useCallback((path: string) => {
+    setNavigationError(null);
+    try {
+      interactionsRef.current.navigateInternal(path);
+    } catch {
+      setNavigationError("Navigation is unavailable right now.");
+    }
+  }, []);
+
+  const openExternal = useCallback((url: string) => {
+    setNavigationError(null);
+    void interactionsRef.current
+      .openExternal(url)
+      .then((opened) => {
+        if (!opened)
+          setNavigationError("This link could not be opened safely.");
+      })
+      .catch(() => setNavigationError("This link could not be opened safely."));
+  }, []);
 
   // `background` refreshes in place (the 30s agent-status poll); user-driven
   // loads (mount, retry) show the loading state. Background refreshes keep the
@@ -367,7 +406,10 @@ export function CloudView(props: CloudViewProps = {}): ReactNode {
 
   if (state.kind === "loading") {
     return (
-      <div className="flex h-full items-center justify-center bg-bg" data-testid="cloud-loading">
+      <div
+        className="flex h-full items-center justify-center bg-bg"
+        data-testid="cloud-loading"
+      >
         <p className="text-sm text-muted">Loading your Eliza Cloud account…</p>
       </div>
     );
@@ -381,13 +423,14 @@ export function CloudView(props: CloudViewProps = {}): ReactNode {
       >
         <h1 className="text-lg font-semibold text-txt">Eliza Cloud</h1>
         <p className="max-w-sm text-sm text-muted">
-          Connect your Eliza Cloud account to see credits, hosted agents, API
-          keys, and billing here.
+          Connect to view credits, agents, API keys, and billing.
         </p>
-        <Button
-          type="button"
-          onClick={() => navigateTo("/settings")}
-        >
+        {navigationError ? (
+          <p role="alert" className="text-sm text-danger">
+            {navigationError}
+          </p>
+        ) : null}
+        <Button type="button" onClick={() => navigateInternal("/settings")}>
           Connect in Settings
         </Button>
       </div>
@@ -401,11 +444,7 @@ export function CloudView(props: CloudViewProps = {}): ReactNode {
         data-testid="cloud-error"
       >
         <p className="text-sm text-danger">{state.message}</p>
-        <Button
-          type="button"
-          variant="outline"
-          onClick={() => load()}
-        >
+        <Button type="button" variant="outline" onClick={() => load()}>
           Retry
         </Button>
       </div>
@@ -416,11 +455,24 @@ export function CloudView(props: CloudViewProps = {}): ReactNode {
   return (
     <div className="h-full overflow-y-auto bg-bg" data-testid="cloud-ready">
       <div className="mx-auto flex max-w-2xl flex-col gap-4 px-4 py-6">
-        <h1 className="text-lg font-semibold text-txt">Eliza Cloud</h1>
-        <AccountCard status={data.status} />
-        <CreditsCard credits={data.credits} billing={data.billing} />
+        <div className="flex items-center justify-between gap-3">
+          <h1 className="text-lg font-semibold text-txt">Eliza Cloud</h1>
+          <Badge variant="outline" size="micro" tone="success">
+            Connected
+          </Badge>
+        </div>
+        {navigationError ? (
+          <p role="alert" className="text-sm text-danger">
+            {navigationError}
+          </p>
+        ) : null}
+        <CreditsCard
+          credits={data.credits}
+          billing={data.billing}
+          onOpen={openExternal}
+        />
         <AgentsCard agents={data.agents} />
-        <ApiKeysCard apiKeys={data.apiKeys} />
+        <ApiKeysCard apiKeys={data.apiKeys} onOpen={openExternal} />
       </div>
     </div>
   );


### PR DESCRIPTION
Closes #28957

## Summary

- replaces raw `history.pushState` and `_blank` links with the host-brokered internal-navigation and safe external-URL boundaries
- uses canonical UI cards, badges, and buttons; removes opaque account identifiers and verbose/contradictory copy
- keeps loading, disconnected, error, ready, empty, and per-section unavailable states visibly distinct
- adds explicit connected and signed-out production-bundle audit fixtures across mobile portrait/landscape, desktop, and iPad viewports
- adds interaction tests for allowed, denied, rejected, and failed navigation paths

## Evidence

Exact revision tested: `d889f9817d14184f13dd756cb8fac46b99539e5b`

| Gate | Result |
| --- | --- |
| `bunx vitest run plugins/plugin-elizacloud/src/components/cloud/CloudView.test.tsx packages/app/test/audit/ocr-view-expectations.test.ts` | PASS — 17 tests |
| `bun run --cwd plugins/plugin-elizacloud typecheck` | PASS |
| `bun run --cwd plugins/plugin-elizacloud build:views` | PASS — production bundle 8.86 kB, gzip 2.72 kB |
| `bun run audit:plugin-view-inventory` | PASS — 39 views from 21 sources |
| focused connected + signed-out audit after final rebase | PASS — 8/8 captures; broken=0, needs-work=0, minimalism/hover/density failures=0 |
| `bun run --cwd packages/app audit:app` before the final UI-icon-only base update | PASS — 231/231 browser cases; 228 captures; broken=0, needs-work=0; packaged OCR broken=0 |
| `git diff --check HEAD^ HEAD` | PASS |

The final rebase applied without conflicts. Focused tests, typecheck, bundle build, and all eight affected visual captures were rerun on the exact revision above.

## Visual review

Five connected-state inspection cycles were completed, followed by connected + signed-out coverage in cycles four and five and again after the final rebase. The final focused artifacts are under `/tmp/eliza-cloud-rebased-audit`; the complete audit artifacts are under `/tmp/eliza-cloud-full-audit` in the validating worktree environment.

- Connected: concise Credits, Hosted agents, and API keys cards with a visible Connected status.
- Signed out: concise recovery copy and a single Connect in Settings action; no false Connected status.
- Before captures: unavailable from the fresh issue worktree; none are claimed or fabricated.
- MP4 walkthrough: N/A for this draft evidence pass; the deterministic four-viewport captures exercise both state variants.
- Backend logs / live-model trajectory: N/A — no backend protocol, planner, or model behavior changed.
- Frontend console/network: covered by the strict Playwright audit; no affected-view failure was reported.

## Review notes

The PR intentionally stays focused on the connected Cloud launcher. Provider subscription/adoption and coding-agent routing are tracked separately by #24097/#24100 and their active PRs.

<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@63bce535e32738ad07e39552ed0cf16e36fa8dd9:packages/skills/skills/contribute-to-eliza"} -->

<!-- evidence-head:d889f9817d14184f13dd756cb8fac46b99539e5b -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - Fresh issue worktree had no pre-change capture; no before image is fabricated.

<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29055-plugin-cloud-gui.png)

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - Deterministic eight-case four-viewport capture covers both connected and signed-out states; no animation or multi-step workflow changed.

<!-- evidence-row:backend-logs -->
- [ ] N/A - No backend protocol or server behavior changed.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - Strict Playwright audit completed 231/231 cases and reported no affected-view console or network failure; the harness did not emit a standalone console transcript.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - No planner, prompt, model, or agent behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] [29055-ocr-triage.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29055-ocr-triage.json)

