### PR TITLE
fix(cloud): prevent usage token aggregate overflow

### DIFF
--- a/packages/cloud/shared/src/db/repositories/usage-records-token-overflow.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/usage-records-token-overflow.pglite.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Guards usage-token aggregation against overflow through the real repository
+ * SQL against an in-memory PGlite database.
+ */
+import { afterAll, beforeAll, describe, expect, mock, test } from "bun:test";
+import { PGlite } from "@electric-sql/pglite";
+import { drizzle } from "drizzle-orm/pglite";
+import { usageRecords } from "../schemas/usage-records";
+
+const client = new PGlite();
+const database = drizzle({ client, schema: { usageRecords } });
+
+mock.module("../helpers", () => ({
+  dbRead: database,
+  dbWrite: database,
+}));
+
+const { UsageRecordsRepository } = await import("./usage-records");
+
+const ORGANIZATION_ID = "11111111-1111-4111-8111-111111111111";
+
+describe("UsageRecordsRepository token aggregation", () => {
+  beforeAll(async () => {
+    await client.exec(`
+      create table usage_records (
+        organization_id uuid not null,
+        provider text not null,
+        canonical_provider text not null,
+        input_tokens integer not null,
+        output_tokens integer not null,
+        input_cost numeric not null,
+        output_cost numeric not null,
+        is_successful boolean not null
+      );
+
+      insert into usage_records (
+        organization_id,
+        provider,
+        canonical_provider,
+        input_tokens,
+        output_tokens,
+        input_cost,
+        output_cost,
+        is_successful
+      ) values
+        ('${ORGANIZATION_ID}', 'openai', 'openai', 1000000000, 10, 1, 1, true),
+        ('${ORGANIZATION_ID}', 'openai', 'openai', 1000000000, 10, 1, 1, true),
+        ('${ORGANIZATION_ID}', 'openai', 'openai', 1000000000, 10, 1, 1, true);
+    `);
+  });
+
+  afterAll(async () => {
+    await client.close();
+  });
+
+  test("getStatsByOrganization sums 3e9 input tokens without overflow", async () => {
+    const stats = await new UsageRecordsRepository().getStatsByOrganization(ORGANIZATION_ID);
+
+    expect(stats.totalInputTokens).toBe(3_000_000_000);
+  });
+
+  test("getProviderBreakdown sums 3e9 tokens without overflow", async () => {
+    const breakdown = await new UsageRecordsRepository().getProviderBreakdown(ORGANIZATION_ID);
+
+    expect(breakdown[0]?.totalTokens).toBe(3_000_000_030);
+  });
+});

--- a/packages/cloud/shared/src/db/repositories/usage-records.ts
+++ b/packages/cloud/shared/src/db/repositories/usage-records.ts
@@ -182,8 +182,8 @@ export class UsageRecordsRepository {
     const [stats] = await dbRead
       .select({
         totalRequests: sql<number>`count(*)::int`,
-        totalInputTokens: sql<number>`coalesce(sum(${usageRecords.input_tokens}), 0)::int`,
-        totalOutputTokens: sql<number>`coalesce(sum(${usageRecords.output_tokens}), 0)::int`,
+        totalInputTokens: sql<number>`coalesce(sum(${usageRecords.input_tokens}), 0)::bigint`,
+        totalOutputTokens: sql<number>`coalesce(sum(${usageRecords.output_tokens}), 0)::bigint`,
         totalCost: sql<number>`coalesce(sum(${usageRecords.input_cost} + ${usageRecords.output_cost}), 0)::numeric`,
         successRate: sql<number>`coalesce(
           count(*) filter (where ${usageRecords.is_successful} = true)::float /
@@ -196,8 +196,8 @@ export class UsageRecordsRepository {
 
     return {
       totalRequests: stats?.totalRequests || 0,
-      totalInputTokens: stats?.totalInputTokens || 0,
-      totalOutputTokens: stats?.totalOutputTokens || 0,
+      totalInputTokens: Number(stats?.totalInputTokens || 0),
+      totalOutputTokens: Number(stats?.totalOutputTokens || 0),
       totalCost: Number(stats?.totalCost || 0), // Convert NUMERIC to number
       successRate: stats?.successRate ?? 1.0,
     };
@@ -274,8 +274,8 @@ export class UsageRecordsRepository {
         timestamp: truncateExpression.as("timestamp"),
         totalRequests: sql<number>`count(*)::int`,
         totalCost: sql<number>`coalesce(sum(${usageRecords.input_cost} + ${usageRecords.output_cost}), 0)::numeric`,
-        inputTokens: sql<number>`coalesce(sum(${usageRecords.input_tokens}), 0)::int`,
-        outputTokens: sql<number>`coalesce(sum(${usageRecords.output_tokens}), 0)::int`,
+        inputTokens: sql<number>`coalesce(sum(${usageRecords.input_tokens}), 0)::bigint`,
+        outputTokens: sql<number>`coalesce(sum(${usageRecords.output_tokens}), 0)::bigint`,
         successRate: sql<number>`coalesce(
           count(*) filter (where ${usageRecords.is_successful} = true)::float /
           nullif(count(*)::float, 0),
@@ -297,8 +297,8 @@ export class UsageRecordsRepository {
       timestamp: new Date(row.timestamp as string),
       totalRequests: row.totalRequests,
       totalCost: Number(row.totalCost || 0),
-      inputTokens: row.inputTokens,
-      outputTokens: row.outputTokens,
+      inputTokens: Number(row.inputTokens),
+      outputTokens: Number(row.outputTokens),
       successRate: row.successRate,
     }));
   }
@@ -332,8 +332,8 @@ export class UsageRecordsRepository {
         userEmail: users.email,
         totalRequests: sql<number>`count(*)::int`,
         totalCost: sql<number>`coalesce(sum(${usageRecords.input_cost} + ${usageRecords.output_cost}), 0)::numeric`,
-        inputTokens: sql<number>`coalesce(sum(${usageRecords.input_tokens}), 0)::int`,
-        outputTokens: sql<number>`coalesce(sum(${usageRecords.output_tokens}), 0)::int`,
+        inputTokens: sql<number>`coalesce(sum(${usageRecords.input_tokens}), 0)::bigint`,
+        outputTokens: sql<number>`coalesce(sum(${usageRecords.output_tokens}), 0)::bigint`,
         lastActive: sql<Date>`max(${usageRecords.created_at})`,
       })
       .from(usageRecords)
@@ -351,8 +351,8 @@ export class UsageRecordsRepository {
         userEmail: row.userEmail!,
         totalRequests: row.totalRequests,
         totalCost: Number(row.totalCost || 0),
-        inputTokens: row.inputTokens,
-        outputTokens: row.outputTokens,
+        inputTokens: Number(row.inputTokens),
+        outputTokens: Number(row.outputTokens),
         lastActive: row.lastActive,
       }));
   }
@@ -416,7 +416,7 @@ export class UsageRecordsRepository {
         provider: usageRecords.canonical_provider,
         totalRequests: sql<number>`count(*)::int`,
         totalCost: sql<number>`coalesce(sum(${usageRecords.input_cost} + ${usageRecords.output_cost}), 0)::numeric`,
-        totalTokens: sql<number>`coalesce(sum(${usageRecords.input_tokens} + ${usageRecords.output_tokens}), 0)::int`,
+        totalTokens: sql<number>`coalesce(sum(${usageRecords.input_tokens} + ${usageRecords.output_tokens}), 0)::bigint`,
         successRate: sql<number>`coalesce(
           count(*) filter (where ${usageRecords.is_successful} = true)::float /
           nullif(count(*)::float, 0),
@@ -432,7 +432,7 @@ export class UsageRecordsRepository {
       provider: row.provider ?? "unknown",
       totalRequests: row.totalRequests,
       totalCost: Number(row.totalCost || 0),
-      totalTokens: row.totalTokens,
+      totalTokens: Number(row.totalTokens),
       successRate: row.successRate,
     }));
     const totalCost = aggregated.reduce((sum, row) => sum + row.totalCost, 0);
@@ -471,7 +471,7 @@ export class UsageRecordsRepository {
         groupProvider: usageRecords.canonical_provider,
         totalRequests: sql<number>`count(*)::int`,
         totalCost: sql<number>`coalesce(sum(${usageRecords.input_cost} + ${usageRecords.output_cost}), 0)::numeric`,
-        totalTokens: sql<number>`coalesce(sum(${usageRecords.input_tokens} + ${usageRecords.output_tokens}), 0)::int`,
+        totalTokens: sql<number>`coalesce(sum(${usageRecords.input_tokens} + ${usageRecords.output_tokens}), 0)::bigint`,
         successRate: sql<number>`coalesce(
           count(*) filter (where ${usageRecords.is_successful} = true)::float /
           nullif(count(*)::float, 0),
@@ -488,7 +488,7 @@ export class UsageRecordsRepository {
       const groupModel = String(row.groupModel);
       const displayModel = groupModel === "__null__" ? "unknown" : groupModel;
       const totalCost = Number(row.totalCost || 0);
-      const totalTokens = row.totalTokens;
+      const totalTokens = Number(row.totalTokens);
       return {
         model: displayModel,
         provider: String(row.groupProvider),
@@ -594,7 +594,7 @@ export class UsageRecordsRepository {
       value: row.value || "unknown",
       cost: Number(row.cost || 0),
       requests: row.requests,
-      tokens: row.tokens,
+      tokens: Number(row.tokens),
       successCount: row.successCount,
       totalCount: row.totalCount,
     });
@@ -605,7 +605,7 @@ export class UsageRecordsRepository {
           value: usageRecords.canonical_model,
           cost: sql<number>`coalesce(sum(${usageRecords.input_cost} + ${usageRecords.output_cost}), 0)::numeric`,
           requests: sql<number>`count(*)::int`,
-          tokens: sql<number>`coalesce(sum(${usageRecords.input_tokens} + ${usageRecords.output_tokens}), 0)::int`,
+          tokens: sql<number>`coalesce(sum(${usageRecords.input_tokens} + ${usageRecords.output_tokens}), 0)::bigint`,
           successCount: sql<number>`count(*) filter (where ${usageRecords.is_successful} = true)::int`,
           totalCount: sql<number>`count(*)::int`,
         })
@@ -630,7 +630,7 @@ export class UsageRecordsRepository {
           value: usageRecords.canonical_provider,
           cost: sql<number>`coalesce(sum(${usageRecords.input_cost} + ${usageRecords.output_cost}), 0)::numeric`,
           requests: sql<number>`count(*)::int`,
-          tokens: sql<number>`coalesce(sum(${usageRecords.input_tokens} + ${usageRecords.output_tokens}), 0)::int`,
+          tokens: sql<number>`coalesce(sum(${usageRecords.input_tokens} + ${usageRecords.output_tokens}), 0)::bigint`,
           successCount: sql<number>`count(*) filter (where ${usageRecords.is_successful} = true)::int`,
           totalCount: sql<number>`count(*)::int`,
         })
@@ -651,7 +651,7 @@ export class UsageRecordsRepository {
         value: dimensionColumn,
         cost: sql<number>`coalesce(sum(${usageRecords.input_cost} + ${usageRecords.output_cost}), 0)::numeric`,
         requests: sql<number>`count(*)::int`,
-        tokens: sql<number>`coalesce(sum(${usageRecords.input_tokens} + ${usageRecords.output_tokens}), 0)::int`,
+        tokens: sql<number>`coalesce(sum(${usageRecords.input_tokens} + ${usageRecords.output_tokens}), 0)::bigint`,
         successCount: sql<number>`count(*) filter (where ${usageRecords.is_successful} = true)::int`,
         totalCount: sql<number>`count(*)::int`,
       })


### PR DESCRIPTION
# Relates to

No issue is filed for this defect. This pull request is the self-contained defect report and fix.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and was rebased onto `origin/develop` with zero conflicts. Validated base: `cbd1c9f93980409957f791140bea831f907e4f54`.
- [x] `bun install` was intentionally not run per the machine workflow; `bun run verify` was run after sync and its exact unrelated control-reproduced blocker is recorded below.
- [x] A reviewer can confirm the defect and fix from the real PGlite output below without reading the implementation.

# Defect and caller consequence

Usage analytics hard-fail for a high-volume organization once token usage in a queried window exceeds PostgreSQL's int4 maximum. `usage_records.input_tokens` and `output_tokens` are `integer`, so PostgreSQL correctly widens `sum(integer)` to int8. `UsageRecordsRepository` narrowed every token sum back to `::int`; at 2,147,483,648 tokens the SELECT aborts with SQLSTATE `22003` instead of returning analytics.

This breaks `getStatsByOrganization`, `getUsageTimeSeries`, `getUsageByUser`, `getProviderBreakdown`, `getModelBreakdown`, and `getCostBreakdown`. Their analytics and dashboard callers lose the entire response exactly when an organization's usage is largest, and lifetime aggregations remain broken as usage grows.

The fix preserves PostgreSQL's widened token totals with `::bigint` and converts them explicitly with `Number(...)` at the repository's JavaScript boundary. Cost aggregation, request counts, schemas, migrations, and unrelated repository behavior are unchanged.

# Sync with develop

- [x] Rebased onto `origin/develop`; zero conflicts.
- [x] `bun run verify` was run post-sync. Its unrelated missing-dependency failure is documented under **Known gaps / failures** and reproduced on untouched `origin/develop`.

# Risks

Low. The change only widens aggregate result casts from int4 to int8 and makes the existing numeric DTO boundary explicit. Individual token columns and public DTOs remain unchanged. JavaScript's safe-integer ceiling is still far above the reproduced 3,000,000,030-token total.

# Background

## What does this PR do?

- Changes every token `SUM` cast in `UsageRecordsRepository` from `::int` to `::bigint`.
- Converts each widened token result with `Number(...)` when constructing repository return values.
- Adds a real PGlite regression guard using three legal 1,000,000,000-token rows.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No. This corrects an internal query/result boundary without changing a documented API or operator workflow.

# Testing

## Where should a reviewer start?

Run:

```bash
bun test --parallel=2 --max-concurrency=2 packages/cloud/shared/src/db/repositories/usage-records-token-overflow.pglite.test.ts
```

The test invokes production repository SQL against an in-memory PGlite database. The handed-off scratch file was unavailable, so the reproduction was reconstructed from the reported repository boundary: three int4-valid rows contain 1,000,000,000 input tokens and 10 output tokens each.

## Before the production change: reproduced failure

Command:

```bash
cd packages/cloud/shared
bun test src/db/repositories/zz-token-overflow-repro.pglite.test.ts
```

Verbatim result lines:

```text
bun test v1.3.14 (0d9b296a)

src/db/repositories/zz-token-overflow-repro.pglite.test.ts:
error: Failed query: select count(*)::int, coalesce(sum("input_tokens"), 0)::int, coalesce(sum("output_tokens"), 0)::int, coalesce(sum("input_cost" + "output_cost"), 0)::numeric, coalesce(
          count(*) filter (where "is_successful" = true)::float /
          nullif(count(*)::float, 0),
          1.0
        ) from "usage_records" where "usage_records"."organization_id" = $1
error: integer out of range
       file: "int8.c",
    routine: "int84",
       code: "22003"
(fail) UsageRecordsRepository token aggregation > getStatsByOrganization sums 3e9 input tokens without overflow [5.32ms]
error: Failed query: select "canonical_provider", count(*)::int, coalesce(sum("input_cost" + "output_cost"), 0)::numeric, coalesce(sum("input_tokens" + "output_tokens"), 0)::int, coalesce(
          count(*) filter (where "is_successful" = true)::float /
          nullif(count(*)::float, 0),
          1.0
        ) from "usage_records" where "usage_records"."organization_id" = $1 group by "usage_records"."canonical_provider" order by sum("usage_records"."input_cost" + "usage_records"."output_cost") desc
error: integer out of range
       file: "int8.c",
    routine: "int84",
       code: "22003"
(fail) UsageRecordsRepository token aggregation > getProviderBreakdown sums 3e9 tokens without overflow [1.47ms]

 0 pass
 2 fail
Ran 2 tests across 1 file. [659.00ms]
```

## After the production change: fixed behavior

Command:

```bash
bun test --parallel=2 --max-concurrency=2 packages/cloud/shared/src/db/repositories/usage-records-token-overflow.pglite.test.ts
```

Verbatim result lines:

```text
bun test v1.3.14 (0d9b296a) 2x PARALLEL

packages/cloud/shared/src/db/repositories/usage-records-token-overflow.pglite.test.ts:
(pass) UsageRecordsRepository token aggregation > getStatsByOrganization sums 3e9 input tokens without overflow [3.50ms]
(pass) UsageRecordsRepository token aggregation > getProviderBreakdown sums 3e9 tokens without overflow [1.44ms]

 2 pass
 0 fail
 2 expect() calls
Ran 2 tests across 1 file. [643.00ms]
```

The assertions prove `getStatsByOrganization(...).totalInputTokens === 3_000_000_000` and `getProviderBreakdown(...)[0].totalTokens === 3_000_000_030`.

## Regression sensitivity: production fix reverted, test retained

Only `usage-records.ts` was restored to its original int4 casts; the regression test remained unchanged.

Verbatim result lines:

```text
bun test v1.3.14 (0d9b296a) 2x PARALLEL

packages/cloud/shared/src/db/repositories/usage-records-token-overflow.pglite.test.ts:
error: integer out of range
       file: "int8.c",
    routine: "int84",
       code: "22003"
(fail) UsageRecordsRepository token aggregation > getStatsByOrganization sums 3e9 input tokens without overflow [4.81ms]
error: integer out of range
       file: "int8.c",
    routine: "int84",
       code: "22003"
(fail) UsageRecordsRepository token aggregation > getProviderBreakdown sums 3e9 tokens without overflow [1.59ms]

 0 pass
 2 fail
Ran 2 tests across 1 file. [679.00ms]
```

Restoring the production fix returned the same test to `2 pass, 0 fail`.

## Additional verification

- `bunx biome check --write packages/cloud/shared/src/db/repositories/usage-records.ts packages/cloud/shared/src/db/repositories/usage-records-token-overflow.pglite.test.ts` — exit 0: `Checked 2 files in 65ms. No fixes applied.`
- `bunx tsc --noEmit --project packages/cloud/shared/tsconfig.json` — exit 0, no output. Untouched `origin/develop` control: exit 0, no output.
- Package-owned bounded runner on feature and detached control — identical: `106 pass`, `9 skip`, `4 fail`, `302 expect() calls`; the same four baseline failures stopped ordinary batch 1. Zero new failures relative to control.

# Evidence Gate

Evidence matches exact commit `103e2e0c9d83a077fd0e4af86b27eebfca7ca42b`.
<!-- evidence-head:103e2e0c9d83a077fd0e4af86b27eebfca7ca42b -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - database repository change with no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - database repository change with no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive or visual flow changed; the complete database path is exercised by PGlite above.
<!-- evidence-row:backend-logs -->
- [x] N/A - no running server boundary changed; verbatim production repository query failure/pass output is included above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code, request, or state changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, model, action, or tool behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact: inline PGlite SQLSTATE `22003` failure and successful 3,000,000,000 / 3,000,000,030 aggregate results are included under **Testing**.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model behavior changed.

## Backend + frontend logs

Backend: N/A - no server process changed; the repository SQL and PGlite result output are pasted inline above.

Frontend: N/A - no frontend code or network behavior changed.

## Screenshots (before / after) + video walkthrough

N/A - database-only repository fix with no rendered surface.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, TTS, or STT behavior changed.

## Known gaps / failures

- The package's supported bounded runner stopped after its first batch with `106 pass, 9 skip, 4 fail, 302 expect() calls`. A detached untouched control at `cbd1c9f93980409957f791140bea831f907e4f54` produced the identical four failures and counts: one messaging workflow assertion, two account-deletion FK inventory assertions, and one dormant restore API-boundary assertion.
- `bun run verify` stopped after `216 successful, 227 total` tasks because `plugin-contacts` typecheck could not resolve `@radix-ui/react-radio-group` from `packages/ui/src/components/ui/radio-group.tsx` (`TS2307`). Running `bun run --cwd plugins/plugin-contacts typecheck` on the untouched control reproduced the same error verbatim.
- A finalized private trace receipt is unavailable. The mandated factory receipt script path did not exist (`MODULE_NOT_FOUND`); the verified installed receipt tool then disclosed the reviewed snapshot but remained blocked on an interactive identity authorization URL and was terminated with exit 130. The PR is therefore published honestly without the evidence bonus.
- `bun install` was not run because the machine workflow explicitly prohibited it and stated dependencies were already installed.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: codex
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-eliza
Attribution status: self-reported
— [codex-usage-token-bigint-20260826]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-eliza"} -->
