### PR TITLE
fix(android): close lifecycle follow-up regressions

### DIFF
--- a/packages/ui/src/android-cloud/android-cloud-account-lifecycle.test.ts
+++ b/packages/ui/src/android-cloud/android-cloud-account-lifecycle.test.ts
@@ -134,6 +134,50 @@ describe("Android account lifecycle transport", () => {
     expect(secure.values.has("account_deletion_admission")).toBe(false);
   });
 
+  it("coalesces concurrent deletion submissions into one reservation", async () => {
+    const secure = secureStore();
+    let resolveRequest!: (value: {
+      status: number;
+      data: Record<string, unknown>;
+    }) => void;
+    const request = vi.fn(
+      async () =>
+        await new Promise<{
+          status: number;
+          data: Record<string, unknown>;
+        }>((resolve) => {
+          resolveRequest = resolve;
+        }),
+    );
+    const lifecycle = createAndroidCloudAccountLifecycle(
+      clientOptions({ secureCredentials: secure.plugin, request }),
+    );
+
+    const first = lifecycle.requestDeletion();
+    const second = lifecycle.requestDeletion();
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(1));
+    resolveRequest({
+      status: 202,
+      data: {
+        request: requestDto(),
+        statusCredential: STATUS_CREDENTIAL,
+        recoveryCredential: RECOVERY_CREDENTIAL,
+      },
+    });
+
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      requestDto(),
+      requestDto(),
+    ]);
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(secure.values.get("account_deletion_status")).toBe(
+      STATUS_CREDENTIAL,
+    );
+    expect(secure.values.get("account_deletion_recovery")).toBe(
+      RECOVERY_CREDENTIAL,
+    );
+  });
+
   it("CAS-invalidates only the rejected status capability", async () => {
     const secure = secureStore({
       account_deletion_status: STATUS_CREDENTIAL,

--- a/packages/ui/src/android-cloud/android-cloud-account-lifecycle.ts
+++ b/packages/ui/src/android-cloud/android-cloud-account-lifecycle.ts
@@ -163,6 +163,7 @@ export function createAndroidCloudAccountLifecycle(
   let volatileStatusCredential: string | null = null;
   let volatileRecoveryCredential: string | null = null;
   let mutationTail: Promise<void> = Promise.resolve();
+  let deletionRequestInFlight: Promise<AccountDeletionRequestDto> | null = null;
 
   const store = (slot: SecureCredentialSlot) => ({
     async read(): Promise<string | null> {
@@ -352,6 +353,58 @@ export function createAndroidCloudAccountLifecycle(
     return parseAccountDeletionRequest(body.request);
   }
 
+  async function requestDeletionOnce(): Promise<AccountDeletionRequestDto> {
+    const admission = await admissionCredential();
+    let body: Record<string, unknown>;
+    try {
+      body = await lifecycleRequest("/api/v1/me/account-deletion", {
+        method: "POST",
+        authenticated: true,
+        data: { confirmation: "DELETE", admissionCredential: admission },
+      });
+    } catch (error) {
+      const status =
+        error instanceof AndroidCloudLifecycleError ? error.status : null;
+      const ambiguous =
+        status === null ||
+        status === 408 ||
+        status === 425 ||
+        status === 429 ||
+        status >= 500;
+      if (!ambiguous) await Promise.allSettled([admissionStore.clear()]);
+      throw error;
+    }
+    const accepted = parseAccountDeletionAccepted(body);
+    try {
+      await persistCapabilities(accepted);
+    } catch (storageError) {
+      try {
+        const canceling = await cancelWith(accepted.recoveryCredential);
+        volatileRecoveryCredential = null;
+        await Promise.allSettled([admissionStore.clear()]);
+        return canceling;
+      } catch (rollbackError) {
+        throw new AndroidCloudLifecycleError(
+          `Deletion receipt ${accepted.request.requestId} was reserved, but this device could not preserve recovery access or verify automatic cancellation. Keep the app open and contact support.`,
+          "RECOVERY_STORAGE_AND_ROLLBACK_FAILED",
+          null,
+          { cause: new AggregateError([storageError, rollbackError]) },
+        );
+      }
+    }
+    try {
+      await admissionStore.clear();
+    } catch (cause) {
+      throw new AndroidCloudLifecycleError(
+        `Deletion receipt ${accepted.request.requestId} was reserved and recovery access was stored, but this device could not clear its pending admission credential. Retry to finish secure cleanup.`,
+        "ADMISSION_CLEANUP_UNAVAILABLE",
+        null,
+        { cause },
+      );
+    }
+    return accepted.request;
+  }
+
   return {
     async getAvailability() {
       return parseAccountDeletionAvailability(
@@ -383,55 +436,16 @@ export function createAndroidCloudAccountLifecycle(
     },
 
     async requestDeletion() {
-      const admission = await admissionCredential();
-      let body: Record<string, unknown>;
+      if (deletionRequestInFlight) return deletionRequestInFlight;
+      const attempt = requestDeletionOnce();
+      deletionRequestInFlight = attempt;
       try {
-        body = await lifecycleRequest("/api/v1/me/account-deletion", {
-          method: "POST",
-          authenticated: true,
-          data: { confirmation: "DELETE", admissionCredential: admission },
-        });
-      } catch (error) {
-        const status =
-          error instanceof AndroidCloudLifecycleError ? error.status : null;
-        const ambiguous =
-          status === null ||
-          status === 408 ||
-          status === 425 ||
-          status === 429 ||
-          status >= 500;
-        if (!ambiguous) await Promise.allSettled([admissionStore.clear()]);
-        throw error;
-      }
-      const accepted = parseAccountDeletionAccepted(body);
-      try {
-        await persistCapabilities(accepted);
-      } catch (storageError) {
-        try {
-          const canceling = await cancelWith(accepted.recoveryCredential);
-          volatileRecoveryCredential = null;
-          await Promise.allSettled([admissionStore.clear()]);
-          return canceling;
-        } catch (rollbackError) {
-          throw new AndroidCloudLifecycleError(
-            `Deletion receipt ${accepted.request.requestId} was reserved, but this device could not preserve recovery access or verify automatic cancellation. Keep the app open and contact support.`,
-            "RECOVERY_STORAGE_AND_ROLLBACK_FAILED",
-            null,
-            { cause: new AggregateError([storageError, rollbackError]) },
-          );
+        return await attempt;
+      } finally {
+        if (deletionRequestInFlight === attempt) {
+          deletionRequestInFlight = null;
         }
       }
-      try {
-        await admissionStore.clear();
-      } catch (cause) {
-        throw new AndroidCloudLifecycleError(
-          `Deletion receipt ${accepted.request.requestId} was reserved and recovery access was stored, but this device could not clear its pending admission credential. Retry to finish secure cleanup.`,
-          "ADMISSION_CLEANUP_UNAVAILABLE",
-          null,
-          { cause },
-        );
-      }
-      return accepted.request;
     },
 
     async cancelDeletion() {

--- a/plugins/plugin-app-control/src/actions/settings.ts
+++ b/plugins/plugin-app-control/src/actions/settings.ts
@@ -164,6 +164,12 @@ export const SETTINGS_NON_CATALOG_SECTION_AUDIT = {
 		coveredBy:
 			"AGENT_SWITCH for switching; cloud agent management needs its own product action if chat-write is required.",
 	},
+	"android-account-lifecycle": {
+		reason:
+			"Account export and deletion are security-sensitive Cloud workflows, not local setting values.",
+		coveredBy:
+			"The Account & Privacy settings surface owns authenticated export, deletion, status, and cancellation flows.",
+	},
 	"my-runtimes": {
 		reason:
 			"Runtime registry management spans local/cloud/VPS runtimes and is outside the pinned settings catalog.",


### PR DESCRIPTION
## Summary

Follow-up to #28991.

- coalesce concurrent account-deletion submissions so one reservation owns capability persistence
- add regression coverage for duplicate submissions
- classify the new Account & Privacy section in plugin-app-control’s exhaustive non-catalog audit

## Verification

- lifecycle adapter: 6/6 passed
- plugin-app-control settings: 116/116 passed
- plugin-app-control typecheck: passed
- Biome and diff check: passed
- `bun run verify`: 375/375 workspace tasks and all repository audits passed on the reviewed #28991 merge base
- `bun run --cwd packages/app audit:app`: 227/227 passed; broken=0, needs-work=0; OCR broken=0

After rebasing onto current `develop` at 4e540da04de, `bun run verify` stops before workspace checks because #27756 references two missing English i18n keys (`cloud.emailCallback.openingEliza`, `cloud.emailCallback.continueToEliza`). That baseline-only failure is outside this follow-up; the affected checks above remain green.