### PR TITLE
fix(cloud): build prompts runtime before provisioning restart

### DIFF
--- a/.github/workflows/deploy-eliza-provisioning-worker.yml
+++ b/.github/workflows/deploy-eliza-provisioning-worker.yml
@@ -707,6 +707,23 @@ jobs:
             # `FATAL ERROR: ... JavaScript heap out of memory` (exit 134). Raise
             # the heap ceiling to match the repo's typecheck lane (8 GB).
             export NODE_OPTIONS="${NODE_OPTIONS:-} --max-old-space-size=8192"
+
+            # The systemd daemons execute through Node/tsx as well as Bun.
+            # `packages/core/src/prompts.ts` re-exports `@elizaos/prompts`, and
+            # default-condition resolution therefore requires the prompts
+            # package's dist entrypoint. The host deliberately preserves
+            # node_modules between deploys, so an old real directory can also
+            # mask the workspace link that `bun install` would normally create.
+            # Reconcile this one declared workspace dependency explicitly;
+            # `build:core` does not include the prompts package because its full
+            # build has a deliberate reverse action-doc dependency on core.
+            mkdir -p packages/core/node_modules/@elizaos
+            rm -rf packages/core/node_modules/@elizaos/prompts
+            ln -s ../../../prompts packages/core/node_modules/@elizaos/prompts
+            test "$(realpath packages/core/node_modules/@elizaos/prompts)" = \
+              /opt/eliza/packages/prompts
+            bun run --cwd packages/prompts build:package
+            test -f packages/core/node_modules/@elizaos/prompts/dist/index.js
             bun run build:core
             mkdir -p plugins/plugin-sql/node_modules/@elizaos
             rm -rf plugins/plugin-sql/node_modules/@elizaos/core

--- a/packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts
@@ -335,6 +335,41 @@ describe("provisioning worker deployment contract", () => {
     expect(backupService).not.toContain("ensure-generated-keywords.sh");
   });
 
+  it("builds the default-condition prompts runtime before core and restart", () => {
+    const script = deployStep("Deploy and restart worker").with?.script ?? "";
+    const install = script.indexOf(
+      "bun install --frozen-lockfile --no-save --ignore-scripts",
+    );
+    const promptsLinkRemoval = script.indexOf(
+      "rm -rf packages/core/node_modules/@elizaos/prompts",
+    );
+    const promptsLink = script.indexOf(
+      "ln -s ../../../prompts packages/core/node_modules/@elizaos/prompts",
+    );
+    const promptsLinkIdentity = script.indexOf(
+      'test "$(realpath packages/core/node_modules/@elizaos/prompts)" =',
+    );
+    const promptsBuild = script.indexOf(
+      "bun run --cwd packages/prompts build:package",
+    );
+    const promptsSentinel = script.indexOf(
+      "test -f packages/core/node_modules/@elizaos/prompts/dist/index.js",
+    );
+    const coreBuild = script.indexOf("bun run build:core");
+    const firstRestart = script.indexOf(
+      'sudo systemctl restart "$SYSTEMD_UNIT"',
+    );
+
+    expect(install).toBeGreaterThan(-1);
+    expect(promptsLinkRemoval).toBeGreaterThan(install);
+    expect(promptsLink).toBeGreaterThan(promptsLinkRemoval);
+    expect(promptsLinkIdentity).toBeGreaterThan(promptsLink);
+    expect(promptsBuild).toBeGreaterThan(promptsLinkIdentity);
+    expect(promptsSentinel).toBeGreaterThan(promptsBuild);
+    expect(coreBuild).toBeGreaterThan(promptsSentinel);
+    expect(firstRestart).toBeGreaterThan(coreBuild);
+  });
+
   it("installs the dormant backup worker with persistent spool and exact disabled health", () => {
     expect(workflow).toContain(
       "packages/cloud/scripts/admin/eliza-backup-catalog-worker.service",


### PR DESCRIPTION
Refs #29024

@lalalune — focused staging control-plane liveness repair.

## Live failure

- Staging control-plane checkout: `5d3e30b0515d3c5d1d14bb5b855d87c7dbbb1ecd`
- `eliza-provisioning-worker.service` was in an auto-restart loop (restart count >379).
- Sanitized fatal boundary: default-condition resolution could not find `packages/core/node_modules/@elizaos/prompts/dist/index.js`, imported from `packages/core/src/prompts.ts`.
- The public staging router remained live but unready: `/healthz` 200, `/readyz` 503 `router_dependencies_unavailable`.
- The host preserved a stale non-symlink nested prompts package and the expected dist entrypoint was absent.

## Repair

- Reconcile the declared Core -> Prompts workspace link after the preserved `node_modules` install.
- Build the prompts runtime-only package before `build:core`.
- Fail closed on exact resolved workspace identity and the nested default-condition entrypoint before any service restart.
- Add a workflow-order regression from install through restart.

## Immutable checkpoint

- Base: `4e540da04de96c5b3afb119e2b977500be1a9663`
- Head: `717060edcf70a64767583b60c3778345b917b2f5`
- Tree: `500ec285b4d07033ef3d4396aad192e9373b7559`

## Gates

- PASS: focused workflow regression (1/1)
- PASS: exact Biome on touched TypeScript
- PASS: `git diff --check`
- PASS: prompts `build:package` and nested default-condition Node import
- KNOWN BASELINE: the full provisioning workflow test file has 4 unrelated stale backup-catalog assertions already failing on this pinned `develop` base; this PR does not hide or modify them.
- PENDING: PR CI and real staging provisioning-worker deploy/health.

No paid agent action, balance change, production mutation, or provisioning occurred.