### PR TITLE
feat(app): make local views agent-aware

### DIFF
--- a/packages/agent/src/api/chat-routes.ts
+++ b/packages/agent/src/api/chat-routes.ts
@@ -103,6 +103,7 @@ import {
   isClientVisibleNoResponse,
   isNoResponsePlaceholder,
 } from "./chat-text-helpers.ts";
+import { enrichChatUiViewMetadata } from "./chat-view-metadata.ts";
 import { resolveClientChatAdminEntityId } from "./client-chat-admin.ts";
 import {
   extractAnthropicSystemAndLastUser,
@@ -3148,12 +3149,13 @@ export async function readChatRequestPayload(
     typeof body.source === "string" && body.source.trim().length > 0
       ? body.source.trim()
       : undefined;
-  const metadata =
+  const rawMetadata =
     body.metadata &&
     typeof body.metadata === "object" &&
     !Array.isArray(body.metadata)
       ? body.metadata
       : undefined;
+  const metadata = enrichChatUiViewMetadata(rawMetadata);
   const clientMessageId = normalizeClientMessageId(body.clientMessageId);
   if (body.clientMessageId !== undefined && clientMessageId === null) {
     helpers.error(

--- a/packages/agent/src/api/chat-view-metadata.test.ts
+++ b/packages/agent/src/api/chat-view-metadata.test.ts
@@ -1,0 +1,131 @@
+/** Exercises deterministic server authority over renderer-supplied view metadata without replacing the runtime action gates. */
+
+import type { ViewDeclaration } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import {
+  enrichChatUiViewMetadata,
+  resolveChatMetadataView,
+} from "./chat-view-metadata.ts";
+import type { ViewRegistryEntry } from "./view-registry-types.ts";
+
+function view(declaration: ViewDeclaration): ViewRegistryEntry {
+  return {
+    ...declaration,
+    viewType: "gui",
+    pluginName: `test:${declaration.id}`,
+    hasHeroImage: false,
+    available: true,
+    loadedAt: 1,
+    platform: "web",
+  };
+}
+
+const VIEWS = [
+  view({ id: "chat", label: "Chat", path: "/chat" }),
+  view({
+    id: "health",
+    label: "Health",
+    path: "/health",
+    relatedActions: ["OWNER_HEALTH", "OWNER_SCREENTIME"],
+    capabilities: [
+      { id: "read-summary", description: "Read the health summary" },
+      {
+        id: "human-only-control",
+        description: "A human-only control",
+        authority: "human",
+      },
+    ],
+    scopedActions: [
+      {
+        name: "HEALTH_OPEN_DETAIL",
+        description: "Open a health detail",
+        steps: [{ kind: "agent-click", target: "detail" }],
+      },
+    ],
+  }),
+  view({
+    id: "health-detail",
+    label: "Health Detail",
+    path: "/health/detail",
+    relatedActions: ["HEALTH_DETAIL"],
+  }),
+];
+
+describe("chat view metadata", () => {
+  it("resolves the most-specific registered route before a generic renderer id", () => {
+    expect(
+      resolveChatMetadataView(
+        { uiView: "apps", uiViewPath: "/health/detail/day" },
+        VIEWS,
+      )?.id,
+    ).toBe("health-detail");
+  });
+
+  it("publishes registry-owned view, capability, and action facts", () => {
+    expect(
+      enrichChatUiViewMetadata(
+        {
+          uiView: "apps",
+          uiViewPath: "/health/today?from=home",
+          uiViewCapabilities: ["generic-view-action"],
+          uiViewActionNames: ["EVM_TRANSFER"],
+          keep: "caller-data",
+        },
+        VIEWS,
+      ),
+    ).toEqual({
+      uiView: "health",
+      uiViewPath: "/health/today",
+      uiViewCapabilities: ["read-summary"],
+      uiViewActionNames: [
+        "OWNER_HEALTH",
+        "OWNER_SCREENTIME",
+        "HEALTH_OPEN_DETAIL",
+      ],
+      keep: "caller-data",
+    });
+  });
+
+  it("keeps renderer hints when a view has no declared capabilities", () => {
+    expect(
+      enrichChatUiViewMetadata(
+        {
+          uiView: "chat",
+          uiViewPath: "/chat",
+          uiViewCapabilities: ["general-chat"],
+        },
+        VIEWS,
+      ),
+    ).toMatchObject({
+      uiView: "chat",
+      uiViewCapabilities: ["general-chat"],
+      uiViewActionNames: [],
+    });
+  });
+
+  it("does not reinterpret non-renderer or unknown-view metadata", () => {
+    const apiMetadata = { requestId: "r1" };
+    const unknown = {
+      uiView: "unknown",
+      uiViewPath: "/unknown",
+      uiViewCapabilities: ["transfer-funds"],
+      uiViewActionNames: ["EVM_TRANSFER"],
+      requestId: "r2",
+    };
+    expect(enrichChatUiViewMetadata(apiMetadata, VIEWS)).toBe(apiMetadata);
+    expect(enrichChatUiViewMetadata(unknown, VIEWS)).toEqual({
+      uiView: "unknown",
+      uiViewPath: "/unknown",
+      requestId: "r2",
+    });
+  });
+
+  it("strips action names when no authoritative renderer view resolves", () => {
+    expect(
+      enrichChatUiViewMetadata(
+        { requestId: "r3", uiViewActionNames: ["EVM_TRANSFER"] },
+        VIEWS,
+      ),
+    ).toEqual({ requestId: "r3" });
+  });
+});

--- a/packages/agent/src/api/chat-view-metadata.ts
+++ b/packages/agent/src/api/chat-view-metadata.ts
@@ -1,0 +1,148 @@
+/**
+ * Resolve renderer chat metadata against the authoritative runtime view
+ * registry. The renderer supplies the visible path; the server supplies the
+ * exact view id, declared agent capabilities, and relevant runtime actions.
+ * This keeps typed chat and voice-transcription turns on the same contract
+ * without teaching either transport about individual plugins.
+ */
+
+import type { ViewRegistryEntry } from "./view-registry-types.ts";
+import { listViews } from "./views-registry.ts";
+
+function asString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function asStringList(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((entry) => {
+    const parsed = asString(entry);
+    return parsed ? [parsed] : [];
+  });
+}
+
+function uniqueStrings(values: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const value of values) {
+    const normalized = value.trim();
+    if (!normalized) continue;
+    const key = normalized.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(normalized);
+  }
+  return result;
+}
+
+function normalizeViewPath(value: unknown): string | null {
+  const path = asString(value);
+  if (!path) return null;
+  const withoutQuery = path.split(/[?#]/, 1)[0] ?? "";
+  if (!withoutQuery) return null;
+  const rooted = withoutQuery.startsWith("/")
+    ? withoutQuery
+    : `/${withoutQuery}`;
+  return rooted.length > 1 && rooted.endsWith("/")
+    ? rooted.slice(0, -1)
+    : rooted;
+}
+
+function viewPathMatches(
+  candidatePath: string,
+  registeredPath: string,
+): boolean {
+  return (
+    candidatePath === registeredPath ||
+    (registeredPath !== "/" && candidatePath.startsWith(`${registeredPath}/`))
+  );
+}
+
+/**
+ * Resolve the most-specific GUI view for renderer metadata. Path wins over the
+ * renderer's view id because older clients intentionally report broad ids such
+ * as "system" or "apps" for several distinct fullscreen views.
+ */
+export function resolveChatMetadataView(
+  metadata: Record<string, unknown>,
+  views: readonly ViewRegistryEntry[],
+): ViewRegistryEntry | null {
+  const candidatePath = normalizeViewPath(metadata.uiViewPath);
+  if (candidatePath) {
+    const byPath = views
+      .flatMap((view) => {
+        const registeredPath = normalizeViewPath(view.path);
+        return registeredPath && viewPathMatches(candidatePath, registeredPath)
+          ? [{ view, registeredPath }]
+          : [];
+      })
+      .sort((a, b) => b.registeredPath.length - a.registeredPath.length)[0];
+    if (byPath) return byPath.view;
+  }
+
+  const candidateId = asString(metadata.uiView);
+  if (!candidateId) return null;
+  return views.find((view) => view.id === candidateId) ?? null;
+}
+
+/**
+ * Add registry-owned view facts to renderer metadata. Unknown paths and
+ * non-renderer API turns are preserved unchanged. These fields affect planner
+ * relevance only; normal role, context, policy, validation, and execution
+ * gates remain authoritative.
+ */
+export function enrichChatUiViewMetadata(
+  metadata: Record<string, unknown> | undefined,
+  views: readonly ViewRegistryEntry[] = listViews({
+    developerMode: true,
+    includeAllKinds: true,
+    viewType: "gui",
+  }),
+): Record<string, unknown> | undefined {
+  if (!metadata) return undefined;
+  const {
+    uiViewActionNames: _callerActionNames,
+    ...metadataWithoutActionNames
+  } = metadata;
+  if (
+    !asString(metadata.uiView) &&
+    !asString(metadata.uiViewPath) &&
+    !Array.isArray(metadata.uiViewCapabilities)
+  ) {
+    return _callerActionNames === undefined
+      ? metadata
+      : metadataWithoutActionNames;
+  }
+
+  const view = resolveChatMetadataView(metadata, views);
+  if (!view) {
+    const { uiViewCapabilities: _callerCapabilities, ...unresolvedMetadata } =
+      metadataWithoutActionNames;
+    return unresolvedMetadata;
+  }
+
+  const declaredCapabilities = uniqueStrings(
+    (view.capabilities ?? [])
+      .filter((capability) => capability.authority !== "human")
+      .map((capability) => capability.id),
+  );
+  const rendererCapabilities = asStringList(metadata.uiViewCapabilities);
+  const viewActionNames = uniqueStrings([
+    ...(view.relatedActions ?? []),
+    ...(view.scopedActions ?? []).map((action) => action.name),
+  ]);
+
+  return {
+    ...metadataWithoutActionNames,
+    uiView: view.id,
+    uiViewPath:
+      normalizeViewPath(metadata.uiViewPath) ?? view.path ?? undefined,
+    uiViewCapabilities:
+      declaredCapabilities.length > 0
+        ? declaredCapabilities
+        : rendererCapabilities,
+    uiViewActionNames: viewActionNames,
+  };
+}

--- a/packages/core/src/__tests__/tiered-action-surface.test.ts
+++ b/packages/core/src/__tests__/tiered-action-surface.test.ts
@@ -90,6 +90,7 @@ function makeRuntime(opts: {
 		// Stage 1 reads the response-bypass channel/source settings before it can
 		// classify a turn as ambient; the fixture configures none of them.
 		getSetting: vi.fn(() => undefined),
+		getModelRegistrations: vi.fn(() => []),
 		reportError: vi.fn(),
 		responseHandlerFieldRegistry,
 		responseHandlerFieldEvaluators: [
@@ -348,6 +349,161 @@ describe("v5 tiered action surface", () => {
 		expect(prompt).toContain("PLAY_MUSIC");
 		expect(prompt).toContain("PAUSE_MUSIC");
 		expect(prompt).not.toContain("SEND_EMAIL");
+	});
+
+	it("starts app turns from the focused view and expands an explicitly requested action", async () => {
+		const notes = makeAction({
+			name: "NOTES",
+			description: "Read or update the notes shown in the open Notes view.",
+			contexts: ["notes" as AgentContext, "general"],
+		});
+		const views = makeAction({
+			name: "VIEWS",
+			description: "Navigate between app views.",
+			contexts: ["general"],
+		});
+		const email = makeAction({
+			name: "MESSAGE",
+			description: "Read or send email.",
+			contexts: ["general"],
+		});
+		const runtime = makeRuntime({
+			actions: [notes, views, email],
+			responses: [
+				stage1Response({
+					contexts: ["notes"],
+					candidateActionNames: ["MESSAGE"],
+				}),
+				plannerToolResponse("MESSAGE"),
+				finishEvaluatorResponse("Checked email."),
+			],
+		});
+
+		await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage("check my email from here", "test", {
+				uiView: "notes",
+				uiViewPath: "/notes",
+				uiViewCapabilities: ["get-notes", "get-note", "create-note"],
+				__responseContext: {
+					primaryContext: "notes",
+					secondaryContexts: ["notes"],
+				},
+			}),
+			state: makeState(),
+			responseId: RESPONSE_ID,
+		});
+
+		const tools = plannerToolNames(runtime);
+		expect(tools).toContain("NOTES");
+		expect(tools).not.toContain("VIEWS");
+		// Stage 1 may expand beyond the open view when the user explicitly asks.
+		expect(tools).toContain("MESSAGE");
+	});
+
+	it("retains unrelated context-authorized actions while promoting the focused view", async () => {
+		const notes = makeAction({
+			name: "NOTES",
+			description: "Read the notes shown in the open Notes view.",
+			contexts: ["notes" as AgentContext, "general"],
+		});
+		const views = makeAction({
+			name: "VIEWS",
+			description: "Navigate between app views.",
+			contexts: ["notes" as AgentContext, "general"],
+		});
+		const email = makeAction({
+			name: "MESSAGE",
+			description: "Read or send email.",
+			contexts: ["notes" as AgentContext, "general"],
+		});
+		const runtime = makeRuntime({
+			actions: [email, notes, views],
+			responses: [
+				stage1Response({
+					contexts: ["notes"],
+					candidateActionNames: ["NOTES"],
+				}),
+				plannerToolResponse("NOTES"),
+				finishEvaluatorResponse("I checked your notes."),
+			],
+		});
+
+		await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage("check my notes", "test", {
+				uiView: "notes",
+				uiViewPath: "/notes",
+				uiViewCapabilities: ["get-notes", "get-note"],
+				uiViewActionNames: ["NOTES"],
+				__responseContext: {
+					primaryContext: "notes",
+					secondaryContexts: ["notes"],
+				},
+			}),
+			state: makeState(),
+			responseId: RESPONSE_ID,
+		});
+
+		const tools = plannerToolNames(runtime);
+		expect(tools).toContain("NOTES");
+		expect(tools).toContain("VIEWS");
+		expect(tools).toContain("MESSAGE");
+		expect(tools.indexOf("NOTES")).toBeLessThan(tools.indexOf("MESSAGE"));
+		expect(tools.indexOf("NOTES")).toBeLessThan(tools.indexOf("VIEWS"));
+	});
+
+	it("does not let focused-view metadata widen action context admission", async () => {
+		const health = makeAction({
+			name: "OWNER_HEALTH",
+			description: "Read the health information shown in the Health view.",
+			contexts: ["health" as AgentContext],
+		});
+		const views = makeAction({
+			name: "VIEWS",
+			description: "Navigate between app views.",
+			contexts: ["navigation" as AgentContext],
+		});
+		const pageDelegate = makeAction({
+			name: "PAGE_DELEGATE",
+			description: "Delegate work to the active page.",
+			contexts: ["admin" as AgentContext],
+		});
+		const email = makeAction({
+			name: "MESSAGE",
+			description: "Read or send email.",
+			contexts: ["apps" as AgentContext, "general"],
+		});
+		const runtime = makeRuntime({
+			actions: [email, health, views, pageDelegate],
+			responses: [
+				stage1Response({ contexts: ["apps"], candidateActionNames: [] }),
+				plannerToolResponse("MESSAGE"),
+				finishEvaluatorResponse("I can help from this view."),
+			],
+		});
+
+		await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage("show me what is here", "test", {
+				uiView: "health",
+				uiViewPath: "/health",
+				uiViewCapabilities: ["read-summary"],
+				uiViewActionNames: ["OWNER_HEALTH", "VIEWS", "PAGE_DELEGATE"],
+				__responseContext: {
+					primaryContext: "apps",
+					secondaryContexts: ["apps"],
+				},
+			}),
+			state: makeState(),
+			responseId: RESPONSE_ID,
+		});
+
+		const tools = plannerToolNames(runtime);
+		expect(tools).not.toContain("OWNER_HEALTH");
+		expect(tools).not.toContain("VIEWS");
+		expect(tools).not.toContain("PAGE_DELEGATE");
+		expect(tools).toContain("MESSAGE");
 	});
 
 	it("admits an unambiguous reversed compound candidate through its own context gate", async () => {

--- a/packages/core/src/features/basic-capabilities/providers/uiContext.test.ts
+++ b/packages/core/src/features/basic-capabilities/providers/uiContext.test.ts
@@ -15,6 +15,7 @@ describe("UI_CONTEXT", () => {
 						uiTab: "views",
 						uiViewPath: "/notes",
 						uiViewCapabilities: ["view-actions", "inspect-view"],
+						uiViewActionNames: ["NOTES"],
 						__responseContext: {
 							primaryContext: "apps",
 							secondaryContexts: ["general"],
@@ -30,11 +31,19 @@ describe("UI_CONTEXT", () => {
 		expect(result.text).toContain(
 			"view_capabilities: view-actions, inspect-view",
 		);
-		expect(result.text).toContain("select the VIEWS action");
+		expect(result.text).toContain("view_actions: NOTES");
+		expect(result.text).toContain(
+			"Treat view_capabilities as available context, not as a request",
+		);
+		expect(result.text).toContain(
+			"answer directly from this UI Context without calling a tool",
+		);
+		expect(result.text).toContain("prefer the focused domain action");
 		expect(result.data).toMatchObject({
 			uiView: "notes",
 			uiViewPath: "/notes",
 			uiViewCapabilities: ["view-actions", "inspect-view"],
+			uiViewActionNames: ["NOTES"],
 		});
 	});
 

--- a/packages/core/src/features/basic-capabilities/providers/uiContext.ts
+++ b/packages/core/src/features/basic-capabilities/providers/uiContext.ts
@@ -46,6 +46,7 @@ export const uiContextProvider: Provider = {
 		const uiTab = asString(metadata?.uiTab);
 		const uiViewPath = asString(metadata?.uiViewPath);
 		const uiViewCapabilities = asStringList(metadata?.uiViewCapabilities);
+		const uiViewActionNames = asStringList(metadata?.uiViewActionNames);
 		const routing = parseContextRoutingMetadata(
 			metadata?.[CONTEXT_ROUTING_METADATA_KEY] ??
 				state.values[CONTEXT_ROUTING_STATE_KEY],
@@ -64,8 +65,13 @@ export const uiContextProvider: Provider = {
 			uiViewCapabilities.length > 0
 				? `view_capabilities: ${uiViewCapabilities.join(", ")}`
 				: null,
+			uiViewActionNames.length > 0
+				? `view_actions: ${uiViewActionNames.join(", ")}`
+				: null,
 			`active_contexts: ${activeContexts.join(", ") || "general"}`,
-			"Use actions and providers that match this UI context first. If the user refers to this focused view or asks to create, update, delete, or inspect something in it, select the VIEWS action instead of replying as though the operation already happened.",
+			"Treat view_capabilities as available context, not as a request to invoke them.",
+			"If the user asks which view is open or what can be done here, answer directly from this UI Context without calling a tool.",
+			"For an actual operation, prefer the focused domain action (for example NOTES for note records or CALENDAR for events). Use VIEWS for navigation, layout, or an explicit declared UI capability that has no dedicated domain action. Never claim an operation happened unless its action succeeded.",
 		].filter((line): line is string => line !== null);
 
 		return {
@@ -75,6 +81,7 @@ export const uiContextProvider: Provider = {
 				uiTab: uiTab ?? "",
 				uiViewPath: uiViewPath ?? "",
 				uiViewCapabilities: uiViewCapabilities.join(", "),
+				uiViewActionNames: uiViewActionNames.join(", "),
 				uiContexts: activeContexts.join(", "),
 			},
 			data: {
@@ -82,6 +89,7 @@ export const uiContextProvider: Provider = {
 				uiTab,
 				uiViewPath,
 				uiViewCapabilities,
+				uiViewActionNames,
 				activeContexts,
 			},
 		};

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -1246,6 +1246,70 @@ function hasPageScopedRoutingMetadata(message: Memory): boolean {
 }
 
 /**
+ * The first-party app attaches this renderer-owned metadata to chat and voice
+ * turns. It is a relevance signal, never an authority boundary: it can promote
+ * the focused action family, but it must not remove any otherwise authorized
+ * action from the model-facing catalog.
+ */
+function hasUiViewPlannerScope(message: Memory): boolean {
+	const metadataCandidates = [message.content?.metadata, message.metadata];
+	for (const rawMetadata of metadataCandidates) {
+		if (!rawMetadata || typeof rawMetadata !== "object") continue;
+		const metadata = rawMetadata as Record<string, unknown>;
+		if (
+			(typeof metadata.uiView === "string" && metadata.uiView.trim()) ||
+			(typeof metadata.uiViewPath === "string" && metadata.uiViewPath.trim()) ||
+			Array.isArray(metadata.uiViewCapabilities)
+		) {
+			return true;
+		}
+	}
+	return false;
+}
+
+function uiViewActionNames(message: Memory): Set<string> {
+	const actionNames = new Set<string>();
+	const metadataCandidates = [message.content?.metadata, message.metadata];
+	for (const rawMetadata of metadataCandidates) {
+		if (!rawMetadata || typeof rawMetadata !== "object") continue;
+		const rawNames = (rawMetadata as Record<string, unknown>).uiViewActionNames;
+		if (!Array.isArray(rawNames)) continue;
+		for (const rawName of rawNames) {
+			if (typeof rawName !== "string") continue;
+			const normalized = normalizeActionIdentifier(rawName);
+			if (normalized) actionNames.add(normalized);
+		}
+	}
+	return actionNames;
+}
+
+function uiViewActionPriority(
+	action: Action,
+	selectedContexts: readonly AgentContext[] | undefined,
+	viewActionNames: ReadonlySet<string>,
+): number {
+	const actionName = normalizeActionIdentifier(action.name);
+	if (viewActionNames.has(actionName)) return 0;
+
+	const focusedContexts = (selectedContexts ?? [])
+		.map((context) => String(context).trim().toLowerCase())
+		.filter(
+			(context) =>
+				context.length > 0 &&
+				context !== "general" &&
+				!isPageScopedRoutingContext(context),
+		);
+	if (focusedContexts.length === 0) return 2;
+
+	const focused = new Set(focusedContexts);
+	return (action.contexts ?? []).some((context) =>
+		focused.has(String(context).trim().toLowerCase()),
+	)
+		? 1
+		: 2;
+}
+
+/**
  * The provider include list for Stage-1 response-state composition: the core
  * response providers plus always-on plugin providers. Exported for tests.
  */
@@ -3380,8 +3444,32 @@ async function collectV5PlannerCandidateActions(args: {
 		}
 	};
 
-	for (const action of allRuntimeActions) {
-		await appendIfAllowed(action);
+	// View metadata changes ordering only. The complete runtime catalog still
+	// passes through the ordinary role/context/policy gates, so an ambiguous or
+	// cross-view request never loses an otherwise authorized action merely
+	// because Stage 1 did not guess its exact name.
+	const focusedViewActionNames = uiViewActionNames(args.message);
+	const baseRuntimeActions = hasUiViewPlannerScope(args.message)
+		? allRuntimeActions
+				.map((action, index) => ({ action, index }))
+				.sort((left, right) => {
+					const priorityDelta =
+						uiViewActionPriority(
+							left.action,
+							args.selectedContexts,
+							focusedViewActionNames,
+						) -
+						uiViewActionPriority(
+							right.action,
+							args.selectedContexts,
+							focusedViewActionNames,
+						);
+					return priorityDelta || left.index - right.index;
+				})
+				.map(({ action }) => action)
+		: allRuntimeActions;
+	for (const action of baseRuntimeActions) {
+		await appendIfAllowed(action, undefined, args.selectedContexts);
 	}
 
 	const explicitCandidateActions = Array.isArray(args.candidateActions)

--- a/packages/ui/src/App.navigate-view-wiring.test.tsx
+++ b/packages/ui/src/App.navigate-view-wiring.test.tsx
@@ -32,6 +32,7 @@ import { getActiveSurfaceRealmScope } from "./surface-realm-broker";
 import { shellHistory } from "./surface-realm-channel";
 
 const appState = vi.hoisted(() => ({
+  backendConnectionState: "connected",
   firstRunComplete: true,
   retryStartup: vi.fn(),
   setTab: vi.fn(),
@@ -392,7 +393,7 @@ vi.mock("./state", async () => {
     appRuns: [],
     appsSubTab: "browse",
     agentStatus: null,
-    backendConnection: { state: "connected" },
+    backendConnection: { state: appState.backendConnectionState },
     copyToClipboard: vi.fn(),
     databaseSubTab: "overview",
     dismissSystemWarning: vi.fn(),
@@ -573,6 +574,7 @@ describe("App navigate-view event wiring", () => {
     Reflect.deleteProperty(window, "__ELIZA_API_TOKEN__");
     Reflect.deleteProperty(window, "__ELIZAOS_API_TOKEN__");
     appState.firstRunComplete = true;
+    appState.backendConnectionState = "connected";
     appState.startupPhase = "ready";
     appState.tab = "chat";
     appState.plugins = [];
@@ -1213,6 +1215,94 @@ describe("App navigate-view event wiring", () => {
       );
     });
     expect(window.location.pathname).toBe("/apps/remote-ledger");
+  });
+
+  it("replays a failed cold-start view report once after reconnect and still clears Home", async () => {
+    appState.tab = "views";
+    appState.startupPhase = "polling-backend";
+    appState.backendConnectionState = "connecting";
+    window.history.replaceState(null, "", "/notes");
+    mockAvailableViews.push(notesFullscreenView);
+    setBootConfig({ ...DEFAULT_BOOT_CONFIG, apiBase: "http://agent.local" });
+
+    let viewNavigationAttempts = 0;
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/api/commands")) {
+        return new Response(JSON.stringify({ commands: [] }), {
+          headers: { "Content-Type": "application/json" },
+          status: 200,
+        });
+      }
+      if (url.includes("/api/custom-actions")) {
+        return new Response(JSON.stringify({ actions: [] }), {
+          headers: { "Content-Type": "application/json" },
+          status: 200,
+        });
+      }
+      if (url.includes("/api/views/")) {
+        viewNavigationAttempts += 1;
+        if (viewNavigationAttempts === 1) {
+          throw new Error("offline");
+        }
+      }
+      return new Response("{}", { status: 200 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const rendered = render(<App />);
+    const viewNavigationCalls = () =>
+      fetchMock.mock.calls.filter(([input]) =>
+        String(input).includes("/api/views/"),
+      );
+
+    expect(viewNavigationCalls()).toHaveLength(0);
+
+    appState.startupPhase = "ready";
+    appState.backendConnectionState = "connected";
+    rendered.rerender(<App />);
+
+    await waitFor(() => {
+      expect(viewNavigationCalls()).toHaveLength(1);
+    });
+
+    appState.backendConnectionState = "reconnecting";
+    rendered.rerender(<App />);
+    expect(viewNavigationCalls()).toHaveLength(1);
+
+    appState.backendConnectionState = "connected";
+    rendered.rerender(<App />);
+
+    await waitFor(() => {
+      expect(viewNavigationCalls()).toHaveLength(2);
+    });
+    expect(viewNavigationCalls()[1]).toEqual([
+      "http://agent.local/api/views/notes/navigate",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ source: "user", path: "/notes" }),
+      }),
+    ]);
+
+    rendered.rerender(<App />);
+    await act(async () => Promise.resolve());
+    expect(viewNavigationCalls()).toHaveLength(2);
+
+    act(() => {
+      shellHistory.replaceState(null, "", "/chat");
+      window.dispatchEvent(new PopStateEvent("popstate"));
+    });
+
+    await waitFor(() => {
+      expect(viewNavigationCalls()).toHaveLength(3);
+    });
+    expect(viewNavigationCalls()[2]).toEqual([
+      "http://agent.local/api/views/__all__/navigate",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ source: "user", action: "close-all" }),
+      }),
+    ]);
   });
 
   it("renders split-view events as a live dynamic view layout", async () => {

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -77,9 +77,13 @@ import { isElectrobunRuntime } from "./bridge/electrobun-runtime";
 import {
   NAVIGATE_SETTINGS_EVENT,
   type NavigateSettingsDetail,
-  reportUserViewSwitch,
   useSlashCommandController,
 } from "./chat/useSlashCommandController";
+import {
+  reportUserViewClosed,
+  reportUserViewSwitch,
+  shouldClearReportedView,
+} from "./chat/view-navigation-report";
 import { markCompletedActionNavigationHandled } from "./completed-action-navigation";
 import { OverlayAppSurface } from "./components/apps/AppWindowRenderer";
 import { GameViewOverlay } from "./components/apps/GameViewOverlay";
@@ -820,7 +824,7 @@ function resolveActiveScreenBackgroundPolicy({
   if (remoteView) return viewRegistrationBackgroundPolicy(remoteView);
 
   const appShellPageForTab = listAppShellPages().find(
-    (entry) => entry.id === tab,
+    (entry) => entry.id === tab || entry.tabAffinity === tab,
   );
   if (appShellPageForTab) {
     return viewRegistrationBackgroundPolicy(appShellPageForTab);
@@ -948,7 +952,7 @@ function resolveActiveViewSurface({
 
   const appShellPageForTab = listAppShellPages().find(
     (entry) =>
-      entry.id === tab &&
+      (entry.id === tab || entry.tabAffinity === tab) &&
       appShellPageIsAvailable(entry, {
         managedCloud: managedCloudRuntime,
       }) &&
@@ -2306,7 +2310,6 @@ function HomeScreenMount({
     firstRunComplete,
     startupPhase,
   );
-  const { views } = useAvailableViews();
   // Host apps can override the home screen via the `homeScreen` boot-config slot
   // (whitelabel seam); fall back to the built-in HomeScreen.
   const { homeScreen: HomeScreenOverride } = useBootConfig();
@@ -2314,19 +2317,11 @@ function HomeScreenMount({
     (target: HomeTileTarget) => {
       if (target.kind === "tab") {
         setTab(target.tab);
-        // Report the tab id as a surface so the proactive decider reacts to
-        // user-initiated tile navigation (#8792). Fire-and-forget.
-        reportUserViewSwitch(target.tab);
       } else {
         dispatchNavigateViewEvent({ viewPath: target.path });
-        // The tile only carries a path; resolve the registered view id so the
-        // decider keys off the same id the rest of the navigation bus uses
-        // (#8792). Skip the report when no view is registered at that path.
-        const viewId = views.find((v) => v.path === target.path)?.id;
-        if (viewId) reportUserViewSwitch(viewId, target.path);
       }
     },
-    [setTab, views],
+    [setTab],
   );
   const Home = HomeScreenOverride ?? HomeScreen;
   const home = useMemo(
@@ -2811,6 +2806,30 @@ function AppContent() {
     enabledKinds,
     managedCloudRuntime,
   });
+  // Browser history is the authoritative active-view lifecycle. Synchronizing
+  // here covers every route producer uniformly: launcher tiles, chat/voice
+  // navigation, command palette, deep links, Back/Forward, reload, and desktop
+  // tabs. Controls only navigate; the shell reports the surface that actually
+  // rendered, and Home/launcher routes clear all scoped tools.
+  useEffect(() => {
+    if (startupCoordinator.phase !== "ready") return;
+    if (backendConnection?.state !== "connected") return;
+    if (overlayAppSurfaceActive) return;
+    if (shouldClearReportedView(navigationPath)) {
+      reportUserViewClosed();
+      return;
+    }
+    reportUserViewSwitch(
+      resolveBuiltinTabId(activeViewSurface.viewId),
+      navigationPath,
+    );
+  }, [
+    activeViewSurface.viewId,
+    backendConnection?.state,
+    navigationPath,
+    overlayAppSurfaceActive,
+    startupCoordinator.phase,
+  ]);
   useEffect(() => {
     if (typeof window === "undefined") return;
     const scope = new SurfaceRealmScope(
@@ -3011,7 +3030,6 @@ function AppContent() {
       } catch {
         // sandboxed — ignore
       }
-      reportUserViewSwitch(viewId, dtab.path);
     },
     [desktopTabs],
   );

--- a/packages/ui/src/chat/report-shortcut-fired.test.ts
+++ b/packages/ui/src/chat/report-shortcut-fired.test.ts
@@ -14,10 +14,7 @@ vi.mock("../utils/eliza-globals", () => ({
   getElizaApiToken: () => "test-token",
 }));
 
-import {
-  reportShortcutFired,
-  reportUserViewSwitch,
-} from "./useSlashCommandController";
+import { reportShortcutFired } from "./useSlashCommandController";
 
 const fetchMock = vi.fn(() => Promise.resolve(new Response("{}")));
 
@@ -50,22 +47,6 @@ describe("reportShortcutFired (#8792)", () => {
     expect(init.signal).toBeInstanceOf(AbortSignal);
   });
 
-  it("POSTs a view switch to /api/views/:id/navigate with a deadline", () => {
-    reportUserViewSwitch("wallet", "/wallet");
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    const [url, init] = fetchMock.mock.calls[0] as unknown as [
-      string,
-      RequestInit,
-    ];
-    expect(url).toBe("http://localhost:31337/api/views/wallet/navigate");
-    expect(init.method).toBe("POST");
-    expect(JSON.parse(init.body as string)).toEqual({
-      source: "user",
-      path: "/wallet",
-    });
-    expect(init.signal).toBeInstanceOf(AbortSignal);
-  });
-
   it("omits context when not provided", () => {
     reportShortcutFired("show-keyboard-shortcuts");
     const [, init] = fetchMock.mock.calls[0] as unknown as [
@@ -83,11 +64,8 @@ describe("reportShortcutFired (#8792)", () => {
   });
 });
 
-describe("slash-command report request deadlines", () => {
-  it.each([
-    ["view switch", () => reportUserViewSwitch("wallet", "/wallet")],
-    ["shortcut", () => reportShortcutFired("open-command-palette")],
-  ])("bounds and consumes the %s response", async (_label, report) => {
+describe("shortcut report request deadlines", () => {
+  it("bounds and consumes the response", async () => {
     const nativeTimeout = AbortSignal.timeout.bind(AbortSignal);
     const budgets: number[] = [];
     vi.spyOn(AbortSignal, "timeout").mockImplementation((milliseconds) => {
@@ -122,7 +100,7 @@ describe("slash-command report request deadlines", () => {
       arrayBuffer,
     } as unknown as Response);
 
-    report();
+    reportShortcutFired("open-command-palette");
 
     await vi.waitFor(() => expect(arrayBuffer).toHaveBeenCalledTimes(1));
     await aborted;

--- a/packages/ui/src/chat/useSlashCommandController.ts
+++ b/packages/ui/src/chat/useSlashCommandController.ts
@@ -31,6 +31,9 @@ import { getElizaApiBase, getElizaApiToken } from "../utils/eliza-globals";
 import { reportRendererDiagnostic } from "../utils/renderer-diagnostics";
 import { loadSavedCustomCommands, normalizeSlashCommandName } from "./index";
 import { buildModelChoiceLabels, resolveModelChoices } from "./model-choices";
+
+export { reportUserViewSwitch } from "./view-navigation-report";
+
 import {
   filterCommandsForSurface,
   type SlashArgChoiceContext,
@@ -72,39 +75,8 @@ function isModelCatalogProviders(
   );
 }
 
-/** View-switch report POST — same 15s Fal #21205 family. */
-const SLASH_VIEW_SWITCH_FETCH_TIMEOUT_MS = 15_000;
 /** Shortcut report POST — independent hop, own 15s deadline. */
 const SLASH_SHORTCUT_FETCH_TIMEOUT_MS = 15_000;
-
-async function postViewSwitchReport(args: {
-  base: string;
-  token?: string | null;
-  viewId: string;
-  viewPath?: string;
-}): Promise<void> {
-  const res = await fetch(
-    `${args.base}/api/views/${encodeURIComponent(args.viewId)}/navigate`,
-    {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        ...(args.token ? { Authorization: `Bearer ${args.token}` } : {}),
-      },
-      body: JSON.stringify({
-        source: "user",
-        ...(args.viewPath ? { path: args.viewPath } : {}),
-      }),
-      signal: AbortSignal.timeout(SLASH_VIEW_SWITCH_FETCH_TIMEOUT_MS),
-    },
-  );
-  if (!res.ok) {
-    throw new Error(
-      `POST /api/views/${args.viewId}/navigate returned HTTP ${res.status}`,
-    );
-  }
-  await res.arrayBuffer();
-}
 
 async function postShortcutReport(args: {
   base: string;
@@ -130,33 +102,6 @@ async function postShortcutReport(args: {
     );
   }
   await res.arrayBuffer();
-}
-
-/**
- * Report a user-initiated view switch to the agent (#8792). Fire-and-forget,
- * fully guarded: a failure here must never break navigation. `source: "user"`
- * makes the server record state + emit VIEW_SWITCHED without echoing
- * shell:navigate:view back to the client. The surface id is any view/tab id
- * (e.g. a view id, a tab id, or "settings") the proactive decider keys off.
- */
-export function reportUserViewSwitch(viewId: string, viewPath?: string): void {
-  try {
-    const base = getElizaApiBase();
-    if (!base || typeof fetch === "undefined") return;
-    const token = getElizaApiToken();
-    void postViewSwitchReport({ base, token, viewId, viewPath }).catch(
-      (err) => {
-        // error-policy:J7 telemetry write must not break navigation; warn keeps
-        // a dead reporting endpoint observable in the console.
-        logger.warn(
-          `[useSlashCommandController] view-switch report failed: ${err instanceof Error ? err.message : String(err)}`,
-        );
-      },
-    );
-  } catch {
-    // error-policy:J7 same guard for synchronous setup failures — telemetry
-    // must never break navigation.
-  }
 }
 
 /**
@@ -532,9 +477,6 @@ export function useSlashCommandController(
   const navigateTab = React.useCallback(
     (tab: string) => {
       setTab(tab as Tab);
-      // Report the tab id as a surface so the proactive decider can react to
-      // user-initiated tab navigation (#8792). Fire-and-forget.
-      reportUserViewSwitch(tab);
     },
     [setTab],
   );
@@ -546,9 +488,6 @@ export function useSlashCommandController(
         detail: { section },
       }),
     );
-    // Surface key is "settings" with the section threaded through as the path
-    // so the decider can distinguish settings sub-screens (#8792).
-    reportUserViewSwitch("settings", section);
   }, []);
 
   const navigateView = React.useCallback(
@@ -558,14 +497,6 @@ export function useSlashCommandController(
         viewId: target.viewId,
         viewPath: target.viewPath,
       });
-      // Report this user-initiated switch to the agent (#8792) so the server's
-      // current-view state stays accurate and a VIEW_SWITCHED event fires for the
-      // proactive decider. `source: "user"` tells the server to record + emit
-      // WITHOUT re-broadcasting shell:navigate:view (the client already
-      // navigated above), avoiding an echo loop. Fire-and-forget.
-      if (target.viewId) {
-        reportUserViewSwitch(target.viewId, target.viewPath);
-      }
     },
     [],
   );

--- a/packages/ui/src/chat/view-navigation-report.test.ts
+++ b/packages/ui/src/chat/view-navigation-report.test.ts
@@ -1,0 +1,71 @@
+/** Verifies the centralized rendered-view lifecycle transport. */
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { rawRequestMock } = vi.hoisted(() => ({
+  rawRequestMock: vi.fn(),
+}));
+
+vi.mock("../api", () => ({
+  client: { rawRequest: rawRequestMock },
+}));
+
+import {
+  reportUserViewClosed,
+  reportUserViewSwitch,
+  shouldClearReportedView,
+} from "./view-navigation-report";
+
+beforeEach(() => {
+  rawRequestMock.mockReset();
+  rawRequestMock.mockResolvedValue(new Response("{}"));
+});
+
+describe("rendered view lifecycle reports", () => {
+  it("clears only Home/catalog roots, not views rendered inside the generic shell tab", () => {
+    expect(shouldClearReportedView("/")).toBe(true);
+    expect(shouldClearReportedView("/chat")).toBe(true);
+    expect(shouldClearReportedView("/views/")).toBe(true);
+    expect(shouldClearReportedView("/views/legacy-launcher")).toBe(true);
+
+    expect(shouldClearReportedView("/notes")).toBe(false);
+    expect(shouldClearReportedView("/calendar")).toBe(false);
+    expect(shouldClearReportedView("/apps")).toBe(false);
+    expect(shouldClearReportedView("/apps/tasks")).toBe(false);
+    expect(shouldClearReportedView("/apps/custom-plugin")).toBe(false);
+  });
+
+  it("publishes the rendered surface through the configured client transport", () => {
+    reportUserViewSwitch("wallet.inventory", "/wallet");
+
+    expect(rawRequestMock).toHaveBeenCalledWith(
+      "/api/views/wallet.inventory/navigate",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ source: "user", path: "/wallet" }),
+      },
+      { allowNonOk: true, timeoutMs: 15_000 },
+    );
+  });
+
+  it("clears all scoped capabilities on Home and launcher routes", () => {
+    reportUserViewClosed();
+
+    expect(rawRequestMock).toHaveBeenCalledWith(
+      "/api/views/__all__/navigate",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ source: "user", action: "close-all" }),
+      },
+      { allowNonOk: true, timeoutMs: 15_000 },
+    );
+  });
+
+  it("never throws when the runtime is unavailable", () => {
+    rawRequestMock.mockRejectedValueOnce(new Error("offline"));
+    expect(() => reportUserViewSwitch("notes", "/notes")).not.toThrow();
+  });
+});

--- a/packages/ui/src/chat/view-navigation-report.ts
+++ b/packages/ui/src/chat/view-navigation-report.ts
@@ -1,0 +1,87 @@
+/**
+ * Fire-and-forget renderer reports for the agent's active-view lifecycle.
+ *
+ * Navigation must remain usable when the runtime is offline, while a healthy
+ * runtime must receive the exact owning view id so it can scope prompt context
+ * and actions to the surface the user can actually see.
+ */
+
+import { logger } from "@elizaos/logger";
+import { client } from "../api";
+
+/** View lifecycle reports share the bounded 15s renderer-network budget. */
+const VIEW_NAVIGATION_FETCH_TIMEOUT_MS = 15_000;
+
+type ViewNavigationAction = "close" | "close-all";
+
+/**
+ * Only the actual Home/catalog roots have no focused capability owner.
+ * Dynamic plugin routes intentionally keep the generic `views` shell tab, so
+ * the tab id alone must never decide whether to clear the active view.
+ */
+export function shouldClearReportedView(navigationPath: string): boolean {
+  const path = navigationPath.split(/[?#]/, 1)[0]?.trim() || "/";
+  const normalized =
+    path.length > 1 && path.endsWith("/") ? path.slice(0, -1) : path;
+  return (
+    normalized === "/" ||
+    normalized === "/chat" ||
+    normalized === "/views" ||
+    normalized.startsWith("/views/")
+  );
+}
+
+async function postViewNavigationReport(args: {
+  viewId: string;
+  viewPath?: string;
+  action?: ViewNavigationAction;
+}): Promise<void> {
+  const res = await client.rawRequest(
+    `/api/views/${encodeURIComponent(args.viewId)}/navigate`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        source: "user",
+        ...(args.viewPath ? { path: args.viewPath } : {}),
+        ...(args.action ? { action: args.action } : {}),
+      }),
+    },
+    { allowNonOk: true, timeoutMs: VIEW_NAVIGATION_FETCH_TIMEOUT_MS },
+  );
+  if (!res.ok) {
+    throw new Error(
+      `POST /api/views/${args.viewId}/navigate returned HTTP ${res.status}`,
+    );
+  }
+  await res.arrayBuffer();
+}
+
+function reportViewNavigation(args: {
+  viewId: string;
+  viewPath?: string;
+  action?: ViewNavigationAction;
+}): void {
+  void postViewNavigationReport(args).catch((err) => {
+    // error-policy:J7 reporting must never break local navigation. Keep a
+    // failed runtime hop observable without presenting it as a page failure.
+    logger.warn(
+      `[view-navigation-report] report failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  });
+}
+
+/** Publish the exact agent-surface the user opened. */
+export function reportUserViewSwitch(viewId: string, viewPath?: string): void {
+  reportViewNavigation({ viewId, viewPath });
+}
+
+/**
+ * Clear every view-scoped capability when the user returns to Home/launcher.
+ * `__all__` is the server's synthetic lifecycle target for `close-all`.
+ */
+export function reportUserViewClosed(): void {
+  reportViewNavigation({ viewId: "__all__", action: "close-all" });
+}

--- a/packages/ui/src/components/chat/widgets/agent-orchestrator.test.tsx
+++ b/packages/ui/src/components/chat/widgets/agent-orchestrator.test.tsx
@@ -3,19 +3,9 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ActivityEvent } from "../../../hooks/useActivityEvents";
-import type { ChatSidebarWidgetProps } from "./types";
-
-// useWidgetNavigation → reportUserViewSwitch (slash-command controller). The
-// home card opens a builtin tab (no view-path event), so the click test asserts
-// the tab switch through this spy.
-const { reportUserViewSwitchSpy } = vi.hoisted(() => ({
-  reportUserViewSwitchSpy: vi.fn(),
-}));
-vi.mock("../../../chat/useSlashCommandController", () => ({
-  reportUserViewSwitch: reportUserViewSwitchSpy,
-}));
-
+import { seedAppValue } from "../../../state/app-store";
 import { AGENT_ORCHESTRATOR_PLUGIN_WIDGETS } from "./agent-orchestrator";
+import type { ChatSidebarWidgetProps } from "./types";
 
 const ActivityWidget = AGENT_ORCHESTRATOR_PLUGIN_WIDGETS.find(
   (w) => w.id === "agent-orchestrator.activity",
@@ -47,7 +37,6 @@ function props(
 
 afterEach(() => {
   cleanup();
-  reportUserViewSwitchSpy.mockReset();
 });
 
 // #9143 / consolidation — the orchestrator Activity widget renders icon-first on
@@ -85,6 +74,8 @@ describe("OrchestratorActivityWidget (home slot)", () => {
   });
 
   it("home slot: clicking the card opens the Tasks tab", () => {
+    const setTab = vi.fn();
+    seedAppValue({ setTab } as never);
     render(
       <ActivityWidget
         {...props({ slot: "home", events: [event({ summary: "Working" })] })}
@@ -93,8 +84,7 @@ describe("OrchestratorActivityWidget (home slot)", () => {
 
     fireEvent.click(screen.getByTestId("chat-widget-events"));
 
-    // openTab("tasks") reports the switch through the slash-command controller.
-    expect(reportUserViewSwitchSpy).toHaveBeenCalledWith("tasks");
+    expect(setTab).toHaveBeenCalledWith("tasks");
   });
 
   it("chat-sidebar slot: keeps the existing activity list (a row per event, not a single card button)", () => {

--- a/packages/ui/src/components/chat/widgets/home-widget-card.tsx
+++ b/packages/ui/src/components/chat/widgets/home-widget-card.tsx
@@ -16,7 +16,6 @@
  */
 
 import { type ReactNode, useMemo } from "react";
-import { reportUserViewSwitch } from "../../../chat/useSlashCommandController";
 import { dispatchNavigateViewEvent } from "../../../events";
 import { cn } from "../../../lib/utils";
 import { useAppSelectorShallow } from "../../../state";
@@ -26,9 +25,9 @@ import { StatusDot } from "../../ui/status-badge";
 
 /**
  * Navigation for home widgets: tapping a card opens the relevant full surface.
- * `openView` mirrors the home tile path (the `eliza:navigate:view` rail +
- * proactive-decider report), `openTab` switches a builtin tab. Stable across
- * renders so it never breaks a widget's memoization.
+ * `openView` mirrors the home tile path through the `eliza:navigate:view` rail;
+ * `openTab` switches a builtin tab. The shell reports whichever route actually
+ * renders, so this stays stable and transport-agnostic across widgets.
  */
 export function useWidgetNavigation(): {
   openView: (path: string, viewId?: string) => void;
@@ -38,12 +37,10 @@ export function useWidgetNavigation(): {
   return useMemo(
     () => ({
       openView(path, viewId) {
-        dispatchNavigateViewEvent({ viewPath: path });
-        reportUserViewSwitch(viewId ?? path, path);
+        dispatchNavigateViewEvent({ viewId, viewPath: path });
       },
       openTab(tab) {
         setTab?.(tab as never);
-        reportUserViewSwitch(tab);
       },
     }),
     [setTab],

--- a/packages/ui/src/components/pages/LauncherSurface.test.tsx
+++ b/packages/ui/src/components/pages/LauncherSurface.test.tsx
@@ -58,6 +58,7 @@ vi.mock("../../navigation", () => {
   return {
     isAospShellEnabled: () => aospEnabled,
     LAUNCHER_AOSP_ONLY_VIEW_IDS: ["phone"],
+    pathForTab: (id: string) => `/${id}`,
   };
 });
 

--- a/packages/ui/src/components/shell/ChatOverlay.slash.test.tsx
+++ b/packages/ui/src/components/shell/ChatOverlay.slash.test.tsx
@@ -84,7 +84,6 @@ const COMMANDS: SlashCommandCatalogItem[] = [
     requiresAuth: false,
     requiresElevated: false,
     surfaces: ["gui"],
-    // Single infinite thread (#13531): the overlay treats clear-chat as inert.
     target: { kind: "client", clientAction: "clear-chat" },
     source: "builtin",
   },
@@ -99,8 +98,7 @@ const COMMANDS: SlashCommandCatalogItem[] = [
     requiresAuth: false,
     requiresElevated: false,
     surfaces: ["gui"],
-    // A client command the overlay STILL forwards — exercises the generic
-    // client-action dispatch path now that clear-chat is inert (#13531).
+    // A second client command exercises the generic client-action dispatch path.
     target: { kind: "client", clientAction: "open-command-palette" },
     source: "builtin",
   },
@@ -209,9 +207,7 @@ describe("ChatOverlay slash commands", () => {
   it("Enter on a client command runs the client action", () => {
     const slash = makeSlash();
     const { input, controller } = renderOverlay(slash);
-    // `/commands` → open-command-palette, a client action the overlay still
-    // forwards (clear-chat is intentionally inert under one-infinite-thread,
-    // #13531).
+    // `/commands` → open-command-palette.
     fireEvent.change(input, { target: { value: "/commands" } });
     fireEvent.keyDown(input, { key: "Enter" });
     expect(slash.openCommandPalette).toHaveBeenCalled();
@@ -223,6 +219,7 @@ describe("ChatOverlay slash commands", () => {
     const { input, controller } = renderOverlay(slash);
     fireEvent.change(input, { target: { value: "/clear" } });
     fireEvent.keyDown(input, { key: "Enter" });
+    expect(controller.clearConversation).not.toHaveBeenCalled();
     expect(slash.clearChat).not.toHaveBeenCalled();
     expect(controller.send).not.toHaveBeenCalled();
     // The draft is still consumed (the command resolved), not left in the box.

--- a/packages/ui/src/components/shell/ChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ChatOverlay.tsx
@@ -4383,11 +4383,6 @@ export function ChatOverlay({
         navigateTab: slash.navigateTab,
         navigateSettings: slash.navigateSettings,
         navigateView: slash.navigateView,
-        // One infinite thread (#13531): the overlay no longer resets/switches
-        // conversations (clear-chat / new-conversation) or toggles full-screen
-        // via a command — maximize is a vertical pull now. These slash paths are
-        // inert in the overlay; the shared subsystem plumbing (first-run/wipe/
-        // switch, CommandPalette, TUI) is untouched and handled elsewhere.
         clearChat: () => {},
         newConversation: () => {},
         toggleFullscreen: () => {},

--- a/packages/ui/src/components/shell/CommandPalette.tsx
+++ b/packages/ui/src/components/shell/CommandPalette.tsx
@@ -8,8 +8,8 @@
  *
  * The palette opens on the COMMAND_PALETTE_EVENT (desktop shortcut) or a
  * Ctrl/Meta+K keydown in the browser; view switches route through the shared
- * `eliza:navigate:view` dispatcher and report VIEW_SWITCHED so the proactive
- * decider sees the same signal a manual nav produces. Visible-view gating
+ * `eliza:navigate:view` dispatcher. The app shell observes the rendered route
+ * and publishes VIEW_SWITCHED centrally. Visible-view gating
  * mirrors the view catalog, so hidden developer/preview views never leak.
  */
 
@@ -28,10 +28,7 @@ import {
   paletteViewEntries,
   type ViewNavEntry,
 } from "../../chat";
-import {
-  reportShortcutFired,
-  reportUserViewSwitch,
-} from "../../chat/useSlashCommandController";
+import { reportShortcutFired } from "../../chat/useSlashCommandController";
 import { COMMAND_PALETTE_EVENT, dispatchNavigateViewEvent } from "../../events";
 import { useBugReport } from "../../hooks";
 import { useAvailableViews } from "../../hooks/useAvailableViews";
@@ -119,12 +116,9 @@ export function CommandPalette() {
     () => paletteViewEntries(registeredViews, enabledKinds),
     [registeredViews, enabledKinds],
   );
-  // Navigation + agent reporting in one place: switching surfaces from the
-  // palette must reach the proactive decider as VIEW_SWITCHED (#8792).
   const navigateTab = useCallback(
     (tab: Tab) => {
       setTab(tab);
-      reportUserViewSwitch(String(tab));
     },
     [setTab],
   );
@@ -135,7 +129,6 @@ export function CommandPalette() {
   // consumer's `/apps/<viewId>` fallback.
   const navigateView = useCallback((viewId: string, path?: string) => {
     dispatchNavigateViewEvent({ viewId, viewPath: path });
-    reportUserViewSwitch(viewId, path);
   }, []);
 
   const allCommands = useMemo<CommandItem[]>(() => {

--- a/packages/ui/src/hooks/useAvailableViews.test.tsx
+++ b/packages/ui/src/hooks/useAvailableViews.test.tsx
@@ -12,6 +12,7 @@ import { emitViewEvent } from "../views/view-event-bus";
 import { VIEW_EVENTS } from "../views/view-event-types";
 import { __resetResourceCache } from "./resource-cache";
 import {
+  mergeViewRegistryEntries,
   useAvailableViews,
   useRoutableViews,
   type ViewRegistryEntry,
@@ -252,6 +253,38 @@ describe("useAvailableViews", () => {
         id: "calendar",
         bundleUrl: "/api/views/calendar/bundle.js",
         pluginName: "test-plugin",
+      }),
+    );
+  });
+
+  it("promotes an executable signed page over unavailable runtime metadata", () => {
+    const merged = mergeViewRegistryEntries(
+      [
+        view("calendar", {
+          available: false,
+          path: "/calendar",
+          bundleUrl: "/api/views/calendar/bundle.js",
+          description: "Runtime-owned calendar metadata",
+        }),
+      ],
+      [
+        [
+          view("calendar", {
+            available: true,
+            path: "/calendar",
+            pluginName: "@elizaos/plugin-calendar",
+          }),
+        ],
+      ],
+    );
+
+    expect(merged).toContainEqual(
+      expect.objectContaining({
+        id: "calendar",
+        available: true,
+        description: "Runtime-owned calendar metadata",
+        pluginName: "test-plugin",
+        bundleUrl: undefined,
       }),
     );
   });

--- a/packages/ui/src/hooks/useAvailableViews.ts
+++ b/packages/ui/src/hooks/useAvailableViews.ts
@@ -547,7 +547,7 @@ function getAppShellViewEntriesSnapshot(): ViewRegistryEntry[] {
  * — app-shell pages only fill ids the network didn't return, which on mobile is
  * every dynamically-bundled plugin view the route filtered out.
  */
-function mergeViewRegistryEntries(
+export function mergeViewRegistryEntries(
   primaryViews: ViewRegistryEntry[],
   fallbackGroups: ViewRegistryEntry[][],
 ): ViewRegistryEntry[] {
@@ -561,7 +561,31 @@ function mergeViewRegistryEntries(
   for (const group of fallbackGroups) {
     for (const entry of group) {
       const key = `${entry.viewType ?? "gui"}:${entry.id}`;
-      if (!byKey.has(key)) byKey.set(key, entry);
+      const existing = byKey.get(key);
+      if (!existing) {
+        byKey.set(key, entry);
+      } else if (existing.available === false && entry.available === true) {
+        // The runtime may advertise metadata for a plugin whose remote bundle
+        // is unavailable while this signed renderer has an in-process page for
+        // the same id. Use the executable page as the render identity (so the
+        // router does not try the missing remote bundle), while retaining the
+        // runtime's richer presentation metadata.
+        byKey.set(key, {
+          ...existing,
+          ...entry,
+          description: existing.description ?? entry.description,
+          icon: existing.icon ?? entry.icon,
+          heroImageUrl: existing.heroImageUrl ?? entry.heroImageUrl,
+          hasHeroImage: existing.hasHeroImage ?? entry.hasHeroImage,
+          capabilities: existing.capabilities ?? entry.capabilities,
+          tags: existing.tags ?? entry.tags,
+          pluginName: existing.pluginName,
+          bundleUrl: undefined,
+          frameUrl: undefined,
+          componentExport: undefined,
+          available: true,
+        });
+      }
     }
   }
   return [...byKey.values()];

--- a/packages/ui/src/state/chat-view-routing.test.ts
+++ b/packages/ui/src/state/chat-view-routing.test.ts
@@ -21,13 +21,48 @@ describe("resolveChatViewRouting", () => {
     });
   });
 
-  it("derives a dynamic view name from its normalized route", () => {
+  it("routes Calendar from a normalized fullscreen plugin route", () => {
     expect(
       resolveChatViewRouting("views", "calendar/?day=today"),
     ).toMatchObject({
       view: "calendar",
-      primaryContext: "apps",
-      capabilities: ["view-actions", "inspect-view", "navigate-view"],
+      primaryContext: "calendar",
+      capabilities: [],
+    });
+  });
+
+  it("routes fullscreen Notes chat and voice turns to the focused Notes domain", () => {
+    expect(resolveChatViewRouting("views", "/notes")).toEqual({
+      view: "notes",
+      primaryContext: "notes",
+      secondaryContexts: [],
+      capabilities: [],
+    });
+  });
+
+  it("does not invent capabilities for plugin routes without declarations", () => {
+    expect(resolveChatViewRouting("views", "/wallet")).toMatchObject({
+      view: "wallet",
+      capabilities: [],
+    });
+    expect(resolveChatViewRouting("inventory", "/")).toEqual({
+      view: "wallet",
+      primaryContext: "wallet",
+      secondaryContexts: ["documents"],
+      capabilities: ["wallet", "portfolio", "transactions"],
+    });
+  });
+
+  it("routes Projects and Memories by rendered route rather than generic tabs", () => {
+    expect(resolveChatViewRouting("apps", "/apps/tasks")).toMatchObject({
+      view: "projects",
+      primaryContext: "code",
+    });
+    expect(resolveChatViewRouting("views", "/apps/memories/item-1")).toEqual({
+      view: "memories",
+      primaryContext: "memory",
+      secondaryContexts: [],
+      capabilities: [],
     });
   });
 

--- a/packages/ui/src/state/chat-view-routing.ts
+++ b/packages/ui/src/state/chat-view-routing.ts
@@ -60,6 +60,43 @@ export function resolveChatViewRouting(
   navigationPath: string,
 ): ChatViewRouting {
   const viewPath = normalizeViewPath(navigationPath).toLowerCase();
+  // Fullscreen plugin pages keep the shell's generic `views` tab selected.
+  // Resolve their real domain from the rendered route before the tab switch so
+  // chat and voice turns carry the focused context instead of the broad Apps
+  // catalog. This is also the transport-independent path used by deep links,
+  // reloads, command navigation, and agent-driven navigation.
+  if (viewPath === "/notes" || viewPath.startsWith("/notes/")) {
+    return {
+      view: "notes",
+      primaryContext: "notes",
+      secondaryContexts: [],
+      capabilities: [],
+    };
+  }
+  if (viewPath === "/calendar" || viewPath.startsWith("/calendar/")) {
+    return {
+      view: "calendar",
+      primaryContext: "calendar",
+      secondaryContexts: [],
+      capabilities: [],
+    };
+  }
+  if (viewPath === "/apps/tasks" || viewPath.startsWith("/apps/tasks/")) {
+    return {
+      view: "projects",
+      primaryContext: "code",
+      secondaryContexts: ["automation"],
+      capabilities: [],
+    };
+  }
+  if (viewPath === "/apps/memories" || viewPath.startsWith("/apps/memories/")) {
+    return {
+      view: "memories",
+      primaryContext: "memory",
+      secondaryContexts: [],
+      capabilities: [],
+    };
+  }
   if (viewPath === "/orchestrator" || viewPath.startsWith("/orchestrator/")) {
     return {
       view: "orchestrator",
@@ -146,7 +183,7 @@ export function resolveChatViewRouting(
         view: dynamicViewNameFromPath(viewPath),
         primaryContext: "apps",
         secondaryContexts: ["admin", "documents"],
-        capabilities: ["view-actions", "inspect-view", "navigate-view"],
+        capabilities: [],
       };
     default:
       return {


### PR DESCRIPTION
## Status

**Ready for fresh independent review. Do not merge without explicit Nubs approval.**

## Summary

- publish the authoritative open-view context and only its scoped actions, including cold-start reconnect replay
- preserve direct replies for genuine read-only view inspection while routing actionable or ambiguous compounds to the planner
- keep one continuous Eliza conversation with no new-chat or clear-chat path
- repair context budgeting, provider truth, view states, Notes conversational finishing, and Settings bootstrap stability
- keep composer hover neutral, place message actions directly under their bubble, and restore the quiet rounded boundary around user turns while Eliza replies remain unboxed
- add the real 48-route side-by-side View Studio, Notes/VIEWS model-owned finishing, complete Experience routes, and an authoritative unfiltered Notes count contract

## Exact current source

- base: `origin/develop` at `5b6b94362e46f0939a65dfecda12001cd256bc05`
- head: `0a0a1f17c4f3c266d7a2790f0ca494d0a57df01a`
- tree: `7ae9a564edc7fc61b4019dd8c79425206bdd8a7d`
- parent: `9a99eff8dcef936a5d029d044e08440f613b7465`
- remote PR head equals local head; worktree and `git diff --check` are clean
- the prior 17-commit stack range-diffed exactly `=` while rebasing onto this base

## Exact-head gates

- direct-action/current-view heuristic matrix: **120/120 passed**
- focused Stage-1 overflow regressions: **2/2 passed**
- Notes action + backend suites, including strict-provider empty optional content: **42/42 passed**
- App Control focused suite: **82/82 passed**
- Experience focused suite: **4/4 passed**
- cold-start/offline-to-connected authoritative view replay regression: **1/1 passed**
- UI and plugin-notes typechecks: passed
- Biome and diff-check over all latest changed files: clean
- `node --check` for the View Studio: passed

**Stage-1 uses deterministic mock orchestration. It is regression coverage, not live-provider proof.**

## Live provider and browser proof

The isolated demo remains on the owned ports:

- API: `127.0.0.1:12342`, PID `54752`
- UI: `127.0.0.1:2342`, PID `38490`
- local voice gateway: `127.0.0.1:12343`, PID `38312`
- text provider: Cerebras at `api.cerebras.ai`
- text model: `gemma-4-31b`; no local chat fallback was used
- voice STT: Cartesia `ink-2`
- voice TTS: Cartesia `sonic-3.5`

Visible exact-head Notes prompt:

> In one short friendly sentence, tell me how many notes I have and include exact nonce COUNT-0A0A-20260826-1238-J4R. Do not create, update, or delete anything.

Observed model-owned response:

> You've got 13 notes, COUNT-0A0A-20260826-1238-J4R.

The trajectory shows Cerebras `gemma-4-31b` selected `NOTES action=list`; the strict-provider blank optional `content` was normalized to omission, the authoritative service returned 13, and the model produced the concise final response. Post-prompt logs contained zero new `PROVIDER_CONTEXT_OVERFLOW`, tool failure, or planner error entries. Browser reload plus reopening the collapsed composer preserved the exact prompt and reply.

The live approval surface is `http://127.0.0.1:2342/eliza-view-studio.html?view=%2Fnotes`; it renders the real current and Graphite proposal versions of the selected route side-by-side.

Credentials were loaded only through supported process configuration. No credential value is included in source, logs, browser state, or this PR.

## Honest residuals and unavailable integrations

- The full Stage-1 file still has the independently reproduced base-existing `maxReplyTokens` character-schema validation residual; this PR does not alter that schema.
- Six broad `App.navigate-view-wiring` assertions still target pre-refactor page-frame/data-attribute structure from the upstream molecule migration; the new reconnect regression passes independently.
- Native Camera, unavailable Cockpit remote bundle, optional account pools, and other unconfigured external services are reported as unavailable rather than working.
- Settings and Wallet visual polish remain intentionally last and are not represented as complete in this review checkpoint.

## Review boundary

This PR is non-draft for manual review. No merge, deployment, production mutation, Pixel, Dedicated Cloud, LP3, credential exposure, or paid-resource action is included.
