### PR TITLE
fix(core): fence plugin activation against a requested stop

### DIFF
--- a/packages/core/src/features/secrets/services/plugin-activator.stop-fence.test.ts
+++ b/packages/core/src/features/secrets/services/plugin-activator.stop-fence.test.ts
@@ -1,0 +1,276 @@
+/**
+ * Lifecycle fencing for secret-driven plugin activation across shutdown.
+ *
+ * `stop()` clears its maps only after awaiting in-flight work, so a secret
+ * lookup suspended when shutdown begins can resume, still satisfy the
+ * post-await identity guard, and start a brand-new activation after stop was
+ * requested. These cases pin every entrypoint that can resume across that
+ * boundary — the poll, the secret-change handler, and registration — while
+ * proving an already-started activation is still drained rather than orphaned.
+ *
+ * Real activator service; only the SecretsService collaborator is scripted so
+ * a lookup can be suspended at an exact point relative to `stop()`.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	createMockRuntime,
+	MOCK_AGENT_ID,
+} from "../../../testing/mock-runtime.ts";
+import type { IAgentRuntime } from "../../../types/index.ts";
+import type { SecretChangeCallback, SecretContext } from "../types.ts";
+import {
+	PluginActivatorService,
+	type PluginWithSecrets,
+} from "./plugin-activator.ts";
+import type { SecretsService } from "./secrets.ts";
+
+const PLUGIN: PluginWithSecrets = {
+	name: "stop-fence-plugin",
+	description: "Exercises activation fencing across stop().",
+	requiredSecrets: {
+		TOKEN: { description: "Test token", type: "token", required: true },
+	},
+};
+
+const SECRETLESS_PLUGIN: PluginWithSecrets = {
+	name: "stop-fence-secretless",
+	description: "Activates immediately when no secrets are required.",
+};
+
+const GLOBAL_CONTEXT: SecretContext = {
+	level: "global",
+	agentId: MOCK_AGENT_ID,
+	requesterId: MOCK_AGENT_ID,
+};
+
+interface Harness {
+	service: PluginActivatorService;
+	emitSecretChange: () => Promise<void>;
+	setRequirements: (ready: boolean) => void;
+	holdRequirements: () => { release: () => void; entered: Promise<void> };
+}
+
+async function createHarness(
+	getMissingSecrets: (keys: string[]) => Promise<string[]>,
+): Promise<Harness> {
+	let secretChangeCallback: SecretChangeCallback | undefined;
+	let requirementsReady = false;
+	let requirementsGate: Promise<void> | undefined;
+	let markEntered: (() => void) | undefined;
+
+	const secretsService = {
+		checkPluginRequirements: vi.fn(async () => {
+			if (requirementsGate) {
+				markEntered?.();
+				await requirementsGate;
+			}
+			return {
+				ready: requirementsReady,
+				missingRequired: requirementsReady ? [] : ["TOKEN"],
+				missingOptional: [],
+				invalid: [],
+			};
+		}),
+		getMissingSecrets: vi.fn(getMissingSecrets),
+		onAnySecretChanged: vi.fn((callback: SecretChangeCallback) => {
+			secretChangeCallback = callback;
+			return () => undefined;
+		}),
+	} satisfies Pick<
+		SecretsService,
+		"checkPluginRequirements" | "getMissingSecrets" | "onAnySecretChanged"
+	>;
+
+	const runtime = createMockRuntime({
+		getService: (() =>
+			secretsService as SecretsService) as IAgentRuntime["getService"],
+		reportError: vi.fn(),
+	});
+	const service = await PluginActivatorService.start(runtime, {
+		enableAutoActivation: true,
+		pollingIntervalMs: 1,
+	});
+
+	return {
+		service,
+		emitSecretChange: async () => {
+			if (!secretChangeCallback) {
+				throw new Error("Secret-change callback was not registered");
+			}
+			await secretChangeCallback("TOKEN", "ready", GLOBAL_CONTEXT);
+		},
+		setRequirements: (ready: boolean) => {
+			requirementsReady = ready;
+		},
+		holdRequirements: () => {
+			let release: (() => void) | undefined;
+			requirementsGate = new Promise<void>((resolve) => {
+				release = resolve;
+			});
+			const entered = new Promise<void>((resolve) => {
+				markEntered = resolve;
+			});
+			return {
+				entered,
+				release: () => {
+					requirementsGate = undefined;
+					release?.();
+				},
+			};
+		},
+	};
+}
+
+describe("PluginActivatorService stop fencing", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("refuses activation when a poll lookup resolves after stop was requested", async () => {
+		let releaseLookup: ((missing: string[]) => void) | undefined;
+		const suspended = new Promise<string[]>((resolve) => {
+			releaseLookup = resolve;
+		});
+		let markEntered: (() => void) | undefined;
+		const lookupEntered = new Promise<void>((resolve) => {
+			markEntered = resolve;
+		});
+		let firstLookup = true;
+		const harness = await createHarness(async () => {
+			if (firstLookup) {
+				firstLookup = false;
+				markEntered?.();
+				return suspended;
+			}
+			return [];
+		});
+		const activation = vi.fn(async () => undefined);
+
+		expect(await harness.service.registerPlugin(PLUGIN, activation)).toBe(
+			false,
+		);
+
+		await vi.advanceTimersByTimeAsync(2);
+		await lookupEntered;
+
+		const stopping = harness.service.stop();
+		releaseLookup?.([]);
+		await stopping;
+		await vi.advanceTimersByTimeAsync(5);
+
+		expect(activation).not.toHaveBeenCalled();
+	});
+
+	it("refuses activation when a secret-change lookup resolves after stop was requested", async () => {
+		let releaseLookup: ((missing: string[]) => void) | undefined;
+		const suspended = new Promise<string[]>((resolve) => {
+			releaseLookup = resolve;
+		});
+		let markEntered: (() => void) | undefined;
+		const lookupEntered = new Promise<void>((resolve) => {
+			markEntered = resolve;
+		});
+		let firstLookup = true;
+		const harness = await createHarness(async () => {
+			if (firstLookup) {
+				firstLookup = false;
+				markEntered?.();
+				return suspended;
+			}
+			return [];
+		});
+		const activation = vi.fn(async () => undefined);
+
+		expect(await harness.service.registerPlugin(PLUGIN, activation)).toBe(
+			false,
+		);
+
+		const change = harness.emitSecretChange();
+		await lookupEntered;
+
+		const stopping = harness.service.stop();
+		releaseLookup?.([]);
+		await change;
+		await stopping;
+		await vi.advanceTimersByTimeAsync(5);
+
+		expect(activation).not.toHaveBeenCalled();
+	});
+
+	it("refuses a secretless registration made after stop completed", async () => {
+		const harness = await createHarness(async () => []);
+		const activation = vi.fn(async () => undefined);
+
+		await harness.service.stop();
+
+		expect(
+			await harness.service.registerPlugin(SECRETLESS_PLUGIN, activation),
+		).toBe(false);
+		await vi.advanceTimersByTimeAsync(5);
+
+		expect(activation).not.toHaveBeenCalled();
+		expect(harness.service.isActivated(SECRETLESS_PLUGIN.name)).toBe(false);
+	});
+
+	it("refuses a registration suspended in checkPluginRequirements that resolves after stop", async () => {
+		const harness = await createHarness(async () => []);
+		const activation = vi.fn(async () => undefined);
+		harness.setRequirements(true);
+		const gate = harness.holdRequirements();
+
+		const registration = harness.service.registerPlugin(PLUGIN, activation);
+		await gate.entered;
+
+		const stopping = harness.service.stop();
+		gate.release();
+
+		expect(await registration).toBe(false);
+		await stopping;
+		await vi.advanceTimersByTimeAsync(5);
+
+		expect(activation).not.toHaveBeenCalled();
+		expect(harness.service.getPendingPlugins()).toEqual([]);
+		expect(harness.service.getRegisteredPluginIds()).toEqual([]);
+	});
+
+	it("still drains an activation that started before stop without re-entering it", async () => {
+		let releaseActivation: (() => void) | undefined;
+		const activationGate = new Promise<void>((resolve) => {
+			releaseActivation = resolve;
+		});
+		let markStarted: (() => void) | undefined;
+		const activationStarted = new Promise<void>((resolve) => {
+			markStarted = resolve;
+		});
+		const activation = vi.fn(async () => {
+			markStarted?.();
+			await activationGate;
+		});
+		const harness = await createHarness(async () => []);
+
+		expect(await harness.service.registerPlugin(PLUGIN, activation)).toBe(
+			false,
+		);
+		const change = harness.emitSecretChange();
+		await activationStarted;
+
+		let settled = false;
+		const stopping = harness.service.stop().then(() => {
+			settled = true;
+		});
+
+		await vi.advanceTimersByTimeAsync(5);
+		expect(settled).toBe(false);
+
+		releaseActivation?.();
+		await change;
+		await stopping;
+
+		expect(settled).toBe(true);
+		expect(activation).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/core/src/features/secrets/services/plugin-activator.ts
+++ b/packages/core/src/features/secrets/services/plugin-activator.ts
@@ -85,6 +85,10 @@ export class PluginActivatorService extends Service {
 	private pluginSecretMapping: Map<string, Set<string>> = new Map();
 	private pollingInterval: ReturnType<typeof setInterval> | null = null;
 	private activePoll: Promise<void> | null = null;
+	// Set before stop() awaits its drains. Work suspended when shutdown began
+	// resumes with its pending entry still identity-equal, so the identity
+	// guards alone cannot tell "still wanted" from "stopped while I slept".
+	private stopping = false;
 	private activationPromises: Map<string, Promise<boolean>> = new Map();
 	private unsubscribeSecretChanges: (() => void) | null = null;
 
@@ -134,6 +138,7 @@ export class PluginActivatorService extends Service {
 	 */
 	private async initialize(): Promise<void> {
 		logger.info("[PluginActivator] Initializing");
+		this.stopping = false;
 
 		// Try to get secrets service synchronously first
 		this.secretsService =
@@ -224,6 +229,9 @@ export class PluginActivatorService extends Service {
 	 * Stop the service
 	 */
 	async stop(): Promise<void> {
+		// First statement: invalidate suspended work before the awaits below give
+		// it a chance to resume and re-enter activation.
+		this.stopping = true;
 		logger.info("[PluginActivator] Stopping");
 
 		if (this.pollingInterval) {
@@ -264,6 +272,13 @@ export class PluginActivatorService extends Service {
 	): Promise<boolean> {
 		const pluginId = plugin.name;
 
+		if (this.stopping) {
+			logger.debug(
+				`[PluginActivator] Refusing registration of ${pluginId} after stop`,
+			);
+			return false;
+		}
+
 		if (this.activatedPlugins.has(pluginId)) {
 			logger.debug(`[PluginActivator] Plugin ${pluginId} already activated`);
 			return true;
@@ -294,6 +309,16 @@ export class PluginActivatorService extends Service {
 
 		// Check current secret status
 		const status = await this.checkPluginRequirements(plugin);
+
+		// This await can span stop(). Undo the registeredPlugins entry written
+		// above so an aborted registration cannot repopulate cleared state.
+		if (this.stopping) {
+			this.registeredPlugins.delete(pluginId);
+			logger.debug(
+				`[PluginActivator] Abandoning registration of ${pluginId}; stop was requested`,
+			);
+			return false;
+		}
 
 		if (status.ready) {
 			// All secrets available, activate now
@@ -370,11 +395,20 @@ export class PluginActivatorService extends Service {
 	): Promise<boolean> {
 		const existingActivation = this.activationPromises.get(pluginId);
 		if (existingActivation) {
+			// An attempt already in flight is joined and drained even during
+			// stop(); only brand-new attempts are refused below.
 			return existingActivation;
 		}
 
 		if (this.activatedPlugins.has(pluginId)) {
 			return Promise.resolve(true);
+		}
+
+		if (this.stopping) {
+			logger.debug(
+				`[PluginActivator] Refusing new activation of ${pluginId} after stop`,
+			);
+			return Promise.resolve(false);
 		}
 
 		// Defer the callback until after the promise is registered so concurrent
@@ -559,7 +593,7 @@ export class PluginActivatorService extends Service {
 
 				// Check if all required secrets are now available
 				const missing = await this.getMissingSecrets(pending.requiredSecrets);
-				if (this.pendingPlugins.get(pluginId) !== pending) {
+				if (this.stopping || this.pendingPlugins.get(pluginId) !== pending) {
 					continue;
 				}
 				if (missing.length === 0) {
@@ -752,7 +786,7 @@ export class PluginActivatorService extends Service {
 
 			// Check if secrets are now available
 			const missing = await this.getMissingSecrets(pending.requiredSecrets);
-			if (this.pendingPlugins.get(pluginId) !== pending) {
+			if (this.stopping || this.pendingPlugins.get(pluginId) !== pending) {
 				continue;
 			}
 			if (missing.length === 0) {


### PR DESCRIPTION
# Relates to

Closes #29025 — `PluginActivator` can activate plugins after `stop()` is requested (residual from #24428, whose merged post-await identity guards this completes).

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from current `origin/develop`; zero conflicts. Exact head `800041d9d0cee905a3590723cd9226a9f412accd`.

# Risks

Low, and deliberately narrow. One private boolean plus four guard sites in a single service. No public signature changes, no behavior change while the service is running — every new branch is reachable only once `stop()` has been requested. The one intentional semantic change is that `registerPlugin()` now returns `false` instead of activating when called after stop; that path previously activated a plugin into a service that had already torn its state down.

# Background

## What does this PR do?

`stop()` clears `pendingPlugins` **after** awaiting `activePoll` and the activation promises:

```ts
if (this.activePoll) { await this.activePoll; }
await Promise.allSettled(this.activationPromises.values());
this.pendingPlugins.clear();   // ← only now
```

A secret lookup suspended inside `getMissingSecrets` when shutdown begins therefore resumes with its pending entry **still identity-equal**, satisfies the post-await guard `#24428` added, and starts a brand-new activation after stop was requested. The identity guard is correct but cannot distinguish "still wanted" from "stopped while I slept", because the map it consults has not been cleared yet.

`registerPlugin()` had no lifecycle fence at all — a registration after `stop()` activates synchronously via the secretless path, and one suspended at `checkPluginRequirements()` resumes and repopulates state `stop()` had just cleared.

The fix records **intent** before any draining:

- `stopping` is set as the **first statement** of `stop()`, before the awaits that would let suspended work resume; `initialize()` clears it.
- Both post-await guards become `if (this.stopping || this.pendingPlugins.get(pluginId) !== pending)`.
- `registerPlugin()` refuses entry when stopping, and re-checks after its suspendable requirements lookup — deleting the `registeredPlugins` entry it wrote, so an aborted registration cannot repopulate cleared state.
- `activatePlugin()` refuses **brand-new** attempts after stop, while still returning any in-flight attempt, so an activation that already started is drained rather than orphaned.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`plugin-activator.stop-fence.test.ts`. Each case suspends a real lookup at an exact point relative to `stop()`; only the `SecretsService` collaborator is scripted, the activator itself is real.

## Detailed testing steps

1. Check out exact head `800041d9d0cee905a3590723cd9226a9f412accd`.
2. From `packages/core`: `bun x vitest run src/features/secrets/services/plugin-activator.stop-fence.test.ts` → **5/5**.
3. **RED control** — restore only `plugin-activator.ts` from `origin/develop`, keep the test, re-run → **3 failed | 2 passed**, the three being the poll path, the post-stop secretless registration, and the registration suspended in `checkPluginRequirements`.
4. Feature suite: `bun x vitest run src/features/secrets/` → **28 files, 154/154**. On pristine develop the same command is **1 file failed / 27 passed** (my new file).
5. Regression control across `packages/core/src/features/`: failing-test sets compared head-vs-develop — **15 failures on develop, 12 with this change, zero present here that are absent there**. The 3-item delta is exactly the new tests turning green.
6. Pinned Biome on both files: exit 0, captured directly. `tsc --noEmit` on `packages/core`: zero diagnostics naming `plugin-activator`.

<!-- evidence-head:800041d9d0cee905a3590723cd9226a9f412accd -->

## Evidence

<!-- evidence-row:before-screenshots -->
- Before screenshots: N/A — service lifecycle behavior with no UI surface.
<!-- evidence-row:after-screenshots -->
- After screenshots: N/A — service lifecycle behavior with no UI surface.
<!-- evidence-row:walkthrough-video -->
- Walkthrough video: N/A — the RED control below is the proof.
<!-- evidence-row:backend-logs -->
- Backend logs:

<details><summary>RED control vs fixed head, and the regression diff</summary>

```
# pristine develop plugin-activator.ts + this branch's test file
$ bun x vitest run src/features/secrets/services/plugin-activator.stop-fence.test.ts
 x refuses activation when a poll lookup resolves after stop was requested
 x refuses a secretless registration made after stop completed
 x refuses a registration suspended in checkPluginRequirements that resolves after stop
      Tests  3 failed | 2 passed (5)

# head 800041d9d0
      Tests  5 passed (5)

# feature suite at head
$ bun x vitest run src/features/secrets/
 Test Files  28 passed (28)
      Tests  154 passed (154)

# regression control over packages/core/src/features
develop  : 15 failing tests
head     : 12 failing tests
present-at-head-but-not-on-develop: (none)
resolved-by-this-change: the 3 stop-fence cases
```

</details>

<!-- evidence-row:frontend-logs -->
- Frontend console/network logs: N/A — no frontend surface changed.
<!-- evidence-row:llm-trajectory -->
- Live-model trajectory: N/A — deterministic service lifecycle, no agent path.
<!-- evidence-row:domain-artifacts -->
- Domain artifacts:

<details><summary>Static gates at exact head</summary>

```
$ node_modules/.bin/biome check \
    packages/core/src/features/secrets/services/plugin-activator.ts \
    packages/core/src/features/secrets/services/plugin-activator.stop-fence.test.ts
(exit 0, captured directly)

$ tsc --noEmit -p packages/core/tsconfig.json
0 diagnostics naming plugin-activator

$ git diff --stat origin/develop..HEAD
 .../services/plugin-activator.stop-fence.test.ts   | 276 +++++++++++++++++++++
 .../features/secrets/services/plugin-activator.ts  |  38 ++-
 2 files changed, 312 insertions(+), 2 deletions(-)
```

</details>

<!-- evidence-row:ocr-review -->
- OCR review: N/A — no captured imagery.

# Known gaps / failures

- `bun run verify` (repo-wide) was not run: hand-wired review worktree (packages linked from the main checkout) cannot support the full gate honestly; the focused suites, the head-vs-develop regression diff, Biome and typecheck above stand in.
- Two of the five cases (the secret-change path and the drain guarantee) pass on pristine develop as well, so they are guards against future regression rather than proof of a present defect. The issue reports four failing on its environment; I measured three, and I am reporting what I measured.
- The issue's own out-of-scope note still applies: `onSecretChanged()` continues to `notifySecretChanged()` after stop is requested. That is a notification-fencing concern, not an activation path, and is untouched here.

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: Claude Code
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Attribution status: self-reported
— [nxn-claude-code]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"Claude Code","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza"} -->
