### PR TITLE
fix(app): bound Cloud live response diagnostics

### DIFF
--- a/packages/app/test/cloud-live-continuity-contract.test.ts
+++ b/packages/app/test/cloud-live-continuity-contract.test.ts
@@ -4,7 +4,7 @@ import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   assertCloudLiveNamedWarmingMode,
   assertCloudLiveNamedWarmingProof,
@@ -16,6 +16,7 @@ import {
   createCloudLiveNetworkAudit,
   installCloudLiveAnchoredRetryChipObserver,
   parseCloudLiveContinuityEvidence,
+  readCloudLiveBoundedResponseBody,
   readCloudLiveContinuityEvidence,
   writeCloudLiveContinuityEvidence,
 } from "./cloud-live-continuity-contract";
@@ -53,6 +54,7 @@ function boundedJsonBody(
 
 const temporaryDirectories: string[] = [];
 afterEach(async () => {
+  vi.useRealTimers();
   await Promise.all(
     temporaryDirectories
       .splice(0)
@@ -528,6 +530,92 @@ describe("forbidden Cloud agent mutations", () => {
     expect(wrongMedia.budgets).toEqual([]);
     expect(overBudget.budgets).toEqual([4096]);
     expect(lyingReader.budgets).toEqual([4096]);
+  });
+});
+
+describe("bounded Cloud response diagnostics", () => {
+  it("treats a zero-byte body as unavailable rather than inspected proof", async () => {
+    const read = vi.fn(async () => new Uint8Array());
+
+    await expect(
+      readCloudLiveBoundedResponseBody(
+        { contentType: "application/json", read },
+        1024,
+      ),
+    ).resolves.toBeNull();
+    expect(read).toHaveBeenCalledWith(1024);
+  });
+
+  it("settles an indefinitely pending body before the trajectory phase deadline", async () => {
+    vi.useFakeTimers();
+    const pending = readCloudLiveBoundedResponseBody(
+      {
+        contentType: "application/json",
+        read: () => new Promise<Uint8Array | null>(() => {}),
+      },
+      1024,
+      30_000,
+    );
+
+    let settled = false;
+    void pending.then(() => {
+      settled = true;
+    });
+    await vi.advanceTimersByTimeAsync(29_999);
+    expect(settled).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(pending).resolves.toBeNull();
+  });
+
+  it("drains stalled history and warming inspections without creating proof", async () => {
+    vi.useFakeTimers();
+    const audit = createCloudLiveNetworkAudit();
+    const history = "/api/conversations/private/messages";
+    const chat = `${history}/stream`;
+    const neverSettles = {
+      contentType: "application/json",
+      read: () => new Promise<Uint8Array | null>(() => {}),
+    };
+    audit.setHistoryAnchorToken("private-anchor");
+    audit.observeRequest("GET", history);
+    audit.observeResponse("GET", history, 200, neverSettles);
+    audit.observeRequest(
+      "POST",
+      chat,
+      JSON.stringify({ clientMessageId: "private-id" }),
+    );
+    audit.observeResponse("POST", chat, 503, neverSettles);
+
+    let settled = false;
+    const pending = audit.snapshot().then((snapshot) => {
+      settled = true;
+      return snapshot;
+    });
+    await vi.advanceTimersByTimeAsync(29_999);
+    expect(settled).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+
+    await expect(pending).resolves.toMatchObject({
+      successfulHistoryGetCount: 1,
+      inspectedHistoryResponseCount: 0,
+      uninspectableHistoryResponseCount: 1,
+      historyResponseWithAnchorUserCount: 0,
+      historyResponseWithAnchoredAssistantCount: 0,
+      namedWarmingResponseCount: 0,
+    });
+  });
+
+  it("rejects invalid byte and time budgets without reading the body", async () => {
+    const read = vi.fn(async () => textEncoder.encode("{}"));
+    const body = { contentType: "application/json", read };
+
+    await expect(readCloudLiveBoundedResponseBody(body, 0)).rejects.toThrow(
+      "byte budget must be a positive safe integer",
+    );
+    await expect(
+      readCloudLiveBoundedResponseBody(body, 1024, 0),
+    ).rejects.toThrow("timeout must be a positive safe integer");
+    expect(read).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/app/test/cloud-live-continuity-contract.ts
+++ b/packages/app/test/cloud-live-continuity-contract.ts
@@ -354,6 +354,7 @@ const NAMED_WARMING_CODES = new Set([
 ]);
 const MAX_WARMING_RESPONSE_BYTES = 4 * 1024;
 const MAX_HISTORY_RESPONSE_BYTES = 1024 * 1024;
+const RESPONSE_BODY_AUDIT_TIMEOUT_MS = 30_000;
 
 function isJsonContentType(contentType: string | null | undefined): boolean {
   return (
@@ -361,18 +362,50 @@ function isJsonContentType(contentType: string | null | undefined): boolean {
   );
 }
 
+/**
+ * Keeps diagnostic body inspection subordinate to the browser trajectory's
+ * phase deadline. Playwright can report response headers while its body promise
+ * remains pending forever; awaiting that promise directly would prevent the
+ * surrounding `expect.poll` timeout from ever adjudicating the real UI proof.
+ */
+export async function readCloudLiveBoundedResponseBody(
+  responseBody: CloudLiveBoundedResponseBody,
+  maxBytes: number,
+  timeoutMs = RESPONSE_BODY_AUDIT_TIMEOUT_MS,
+): Promise<Uint8Array | null> {
+  if (!Number.isSafeInteger(maxBytes) || maxBytes <= 0) {
+    fail("response body byte budget must be a positive safe integer");
+  }
+  if (!Number.isSafeInteger(timeoutMs) || timeoutMs <= 0) {
+    fail("response body timeout must be a positive safe integer");
+  }
+
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const bytes = await Promise.race([
+      responseBody.read(maxBytes).catch(() => null),
+      new Promise<null>((resolveTimeout) => {
+        timeoutId = setTimeout(resolveTimeout, timeoutMs, null);
+      }),
+    ]);
+    if (!bytes || bytes.byteLength === 0 || bytes.byteLength > maxBytes) {
+      return null;
+    }
+    return bytes;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
 async function isNamedWarmingResponse(
   responseBody: CloudLiveBoundedResponseBody,
 ): Promise<boolean> {
   if (!isJsonContentType(responseBody.contentType)) return false;
-  const bytes = await responseBody.read(MAX_WARMING_RESPONSE_BYTES);
-  if (
-    !bytes ||
-    bytes.byteLength === 0 ||
-    bytes.byteLength > MAX_WARMING_RESPONSE_BYTES
-  ) {
-    return false;
-  }
+  const bytes = await readCloudLiveBoundedResponseBody(
+    responseBody,
+    MAX_WARMING_RESPONSE_BYTES,
+  );
+  if (!bytes) return false;
   try {
     const parsed = JSON.parse(
       new TextDecoder("utf-8", { fatal: true }).decode(bytes),
@@ -405,14 +438,11 @@ async function inspectHistoryAnchor(
   };
   if (!isJsonContentType(responseBody.contentType)) return unavailable;
   try {
-    const bytes = await responseBody.read(MAX_HISTORY_RESPONSE_BYTES);
-    if (
-      !bytes ||
-      bytes.byteLength === 0 ||
-      bytes.byteLength > MAX_HISTORY_RESPONSE_BYTES
-    ) {
-      return unavailable;
-    }
+    const bytes = await readCloudLiveBoundedResponseBody(
+      responseBody,
+      MAX_HISTORY_RESPONSE_BYTES,
+    );
+    if (!bytes) return unavailable;
     const parsed = JSON.parse(
       new TextDecoder("utf-8", { fatal: true }).decode(bytes),
     ) as unknown;


### PR DESCRIPTION
Closes #29072

## Summary

- Bound privacy-safe Cloud-live diagnostic response-body inspection to 30 seconds, below the owning continuity phase deadline.
- Treat rejected, stalled, empty, or oversized diagnostic bodies as unavailable rather than evidence.
- Add integration coverage proving `createCloudLiveNetworkAudit().snapshot()` drains never-settling history and warming body readers without creating history-anchor or named-warming proof.

## Root cause

The deployed renderer trajectory entered `post-reload-history` approximately 41 seconds after starting, but its `expect.poll` callback called `audit.snapshot()`, which drained a Playwright response-body handler with no deadline. Playwright can expose response headers while the body promise remains pending indefinitely. An in-flight poll callback is not preempted by the poll's 120-second timeout, so the diagnostic helper held the test until the 35-minute aggregate timeout.

The observed privacy-safe artifact recorded aggregate counters only: one successful history response, one failed request, and an uninspectable body. It did not prove server history was missing.

## Acceptance remains unchanged

This change does not make the Cloud trajectory easier to pass. A diagnostic timeout records no proof. The real trajectory must still observe:

1. a successful server-history GET;
2. the exact challenge-anchored user row and following assistant row after reload;
3. the same anchored history in a fresh BrowserContext; and
4. unchanged Personal identity/runtime/API bindings with zero forbidden agent mutations.

## Exact identity

- Head: `324de7bdb1cd27acddbca5c263e0f5fe93e78b1d`
- Tree: `11e35709ecb9900cbe08b1c04b171aae16d05dcc`
- Parent / validated `origin/develop`: `a0065a415c8ccb6e9de72cb9b7291a18f3035ccf`
- Stable patch ID: `a38eaca0c29154ec649b68f950f2dc478a8f0c3b`
- Diff SHA-256: `2a4b81fd35d0165e378eb209e3f988ec11e8e0181ddb9ed98d8079f5ac1a168a`
- Mechanical carry from reviewed head `ee2846ef62f02654f0e293eaf670660f89af7b06`: range-diff exact `=`

## Validation

From `packages/app`:

```text
bunx vitest run --config vitest.config.ts test/cloud-live-continuity-contract.test.ts
Test Files  1 passed (1)
Tests       24 passed (24)

bunx @biomejs/biome check test/cloud-live-continuity-contract.ts test/cloud-live-continuity-contract.test.ts
Checked 2 files. No fixes applied.
```

From the repository root:

```text
git diff --check a0065a415c8ccb6e9de72cb9b7291a18f3035ccf 324de7bdb1cd27acddbca5c263e0f5fe93e78b1d
PASS
```

Independent exact-current source review: **P0-P3 none**.

## Evidence

- Privacy-safe observed failure artifact: [Cloud CF staging run 32931670374](https://github.com/elizaOS/eliza/actions/runs/32931670374), artifact `deployed-renderer-failure-diagnostics-32931670374-1`; manually inspected. It contains aggregate counters and trajectory phase timing only.
- Before/after desktop screenshots: **N/A — test-harness-only change; no rendered application pixels changed.**
- Before/after mobile screenshots: **N/A — test-harness-only change; no mobile code or pixels changed.**
- MP4 walkthrough: **N/A — there is no user-facing interaction or visual delta to record.**
- Frontend console/network logs: **N/A — no application runtime path changed; the credentialed Cloud lane intentionally retains only its closed privacy-safe diagnostics.**
- Backend logs: **N/A — no backend source or deployment changed.**
- Live-model trajectory: **N/A — no agent, model, provider, prompt, or action behavior changed.**
- Native/device evidence: **N/A — no native or device code changed.**
- `audit:app`: **N/A — the diff is confined to the Cloud-live test contract and its unit/integration regression; no UI source changed.**
