### PR TITLE
fix(plugin-sql): honor the documented metadata filter in getMemories

### DIFF
--- a/plugins/plugin-sql/src/__tests__/integration/memory-metadata-filter.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/memory-metadata-filter.real.test.ts
@@ -1,18 +1,24 @@
 /**
- * Focused correctness test for the documented `metadata` filter on the SQL
+ * Conformance test for the documented `metadata` filter on the SQL
  * `getMemories` and `countMemories` paths (issue #29069).
  *
  * The core `IDatabaseAdapter` contract documents `metadata?: Record<string,
  * unknown>` on both reads, and the reference `InMemoryDatabaseAdapter` honors
- * it via `memoryMatchesMetadata` (settled by issue #19089 / PR #19090). The
- * production SQL adapter (`BaseDrizzleAdapter`, used by Pg/PGlite/Neon)
- * previously accepted the key on `getMemories` and dropped it, returning a
- * superset of rows and — because a real consumer
+ * it via `memoryMatchesMetadata` (settled by issue #19089 / PR #19090): each
+ * requested top-level key must be present and its value must equal the stored
+ * value. The production SQL adapter (`BaseDrizzleAdapter`, used by
+ * Pg/PGlite/Neon) previously accepted the key on `getMemories` and dropped it,
+ * returning a superset of rows and \u2014 because a real consumer
  * (`personality-store.slotFromMemory`) throws on any non-slot row sharing the
- * table — breaking hydration. This pins that `getMemories` now applies JSONB
- * whole-object containment and that `getMemories`/`countMemories` totals cannot
- * drift for the same filter. Runs on PGlite by default; set `POSTGRES_URL` to
- * run against a real Postgres.
+ * table \u2014 breaking hydration.
+ *
+ * This runs one shared filter matrix against the real SQL adapter and pins the
+ * reference-aligned semantics: per-top-level JSON value equality, NOT `@>`
+ * whole-object containment. In particular nested-object and array supersets
+ * (`{tags:["a","b"]}` under filter `{tags:["a"]}`) must NOT match, which is
+ * exactly where recursive `@>` containment would diverge from the reference
+ * adapter. `getMemories`/`countMemories` totals must agree for every filter.
+ * Runs on PGlite by default; set `POSTGRES_URL` to run against a real Postgres.
  */
 import {
   type Entity,
@@ -30,6 +36,79 @@ import type { DrizzleDatabase } from "../../types";
 import { createIsolatedTestDatabase } from "../test-helpers";
 
 const TABLE = "probe_table";
+
+/**
+ * Fixtures carry a unique `label` (for identification) plus the metadata under
+ * test. Sources intentionally repeat so the matrix exercises multi-row filters.
+ */
+const FIXTURES: Array<{ label: string; metadata: Record<string, unknown> }> = [
+  { label: "L1", metadata: { source: "A" } },
+  { label: "L2", metadata: { source: "B" } },
+  { label: "L3", metadata: { source: "A", extra: 1 } },
+  { label: "L4", metadata: { profile: { tone: "warm", extra: 1 } } },
+  { label: "L5", metadata: { tags: ["a", "b"] } },
+  { label: "L6", metadata: { note: null } },
+];
+
+/**
+ * Each case names the requested filter and the labels that must be returned
+ * under reference top-level-equality semantics. `undefined` marks a no-op
+ * (absent/empty) filter that returns every row.
+ */
+const CASES: Array<{
+  name: string;
+  filter?: Record<string, unknown>;
+  expected: string[];
+}> = [
+  {
+    name: "absent filter is a no-op",
+    filter: undefined,
+    expected: ["L1", "L2", "L3", "L4", "L5", "L6"],
+  },
+  { name: "empty filter is a no-op", filter: {}, expected: ["L1", "L2", "L3", "L4", "L5", "L6"] },
+  { name: "scalar matches all containing rows", filter: { source: "A" }, expected: ["L1", "L3"] },
+  { name: "scalar single match", filter: { source: "B" }, expected: ["L2"] },
+  { name: "multi-key AND", filter: { source: "A", extra: 1 }, expected: ["L3"] },
+  {
+    name: "no-match scalar returns nothing (not a superset)",
+    filter: { source: "Z" },
+    expected: [],
+  },
+  // Reference alignment: nested-object and array supersets must NOT match.
+  {
+    name: "nested-object superset does NOT match (@> would)",
+    filter: { profile: { tone: "warm" } },
+    expected: [],
+  },
+  {
+    name: "nested-object exact match",
+    filter: { profile: { tone: "warm", extra: 1 } },
+    expected: ["L4"],
+  },
+  {
+    name: "nested-object reordered keys still match (canonical equality)",
+    filter: { profile: { extra: 1, tone: "warm" } },
+    expected: ["L4"],
+  },
+  { name: "array superset does NOT match (@> would)", filter: { tags: ["a"] }, expected: [] },
+  { name: "array exact match", filter: { tags: ["a", "b"] }, expected: ["L5"] },
+  { name: "array wrong order does NOT match", filter: { tags: ["b", "a"] }, expected: [] },
+  // Null vs missing: present-null matches only a present-null; a filter for a
+  // key absent on every row (or present as a non-null value) matches nothing.
+  { name: "present-null value matches", filter: { note: null }, expected: ["L6"] },
+  {
+    name: "null filter on a non-null/absent key matches nothing",
+    filter: { source: null },
+    expected: [],
+  },
+  // undefined is unsatisfiable (no match), never a backend-dependent no-op.
+  { name: "undefined value matches nothing", filter: { source: undefined }, expected: [] },
+  {
+    name: "undefined alongside a real key matches nothing",
+    filter: { source: "A", extra: undefined },
+    expected: [],
+  },
+];
 
 describe("getMemories/countMemories metadata filter (real SQL adapter)", () => {
   let adapter: PgliteDatabaseAdapter | PgDatabaseAdapter;
@@ -57,80 +136,48 @@ describe("getMemories/countMemories metadata filter (real SQL adapter)", () => {
     const db = adapter.getDatabase() as DrizzleDatabase;
     await db.delete(embeddingTable);
     await db.delete(memoryTable);
+    for (const fixture of FIXTURES) {
+      const memory: Memory & { metadata: MemoryMetadata } = {
+        id: v4() as UUID,
+        agentId: testAgentId,
+        roomId: undefined,
+        entityId,
+        content: { text: "probe" },
+        createdAt: Date.now(),
+        unique: false,
+        metadata: {
+          type: MemoryType.CUSTOM,
+          label: fixture.label,
+          ...fixture.metadata,
+        } as MemoryMetadata,
+      };
+      await adapter.createMemory(memory, TABLE);
+    }
   });
 
-  /** Seed one row in `probe_table` carrying the given (top-level) metadata. */
-  const seed = async (metadata: Record<string, unknown>): Promise<void> => {
-    const memory: Memory & { metadata: MemoryMetadata } = {
-      id: v4() as UUID,
-      agentId: testAgentId,
-      roomId: undefined,
-      entityId,
-      content: { text: "probe" },
-      createdAt: Date.now(),
-      unique: false,
-      metadata: { type: MemoryType.CUSTOM, ...metadata } as MemoryMetadata,
-    };
-    await adapter.createMemory(memory, TABLE);
-  };
-
-  const seedFixtures = async (): Promise<void> => {
-    await seed({ source: "A" });
-    await seed({ source: "B" });
-    await seed({ source: "A", extra: 1 });
-  };
-
-  const sourcesOf = async (metadata?: Record<string, unknown>): Promise<string[]> => {
+  const labelsOf = async (metadata?: Record<string, unknown>): Promise<string[]> => {
     const rows = await adapter.getMemories({
       tableName: TABLE,
       metadata,
       includeEmbedding: false,
     });
     return rows
-      .map((row) => (row.metadata as Record<string, unknown>).source)
-      .filter((s): s is string => typeof s === "string")
+      .map((row) => (row.metadata as Record<string, unknown>).label)
+      .filter((l): l is string => typeof l === "string")
       .sort();
   };
 
-  it("getMemories returns only rows whose metadata contains the filter (superset bug fixed)", async () => {
-    await seedFixtures();
+  for (const testCase of CASES) {
+    it(`getMemories: ${testCase.name}`, async () => {
+      expect(await labelsOf(testCase.filter)).toEqual([...testCase.expected].sort());
+    });
 
-    // {source:"A"} matches the plain A row AND {source:"A",extra:1} (containment,
-    // not exact-object equality) — exactly the two A rows, never all three.
-    expect(await sourcesOf({ source: "A" })).toEqual(["A", "A"]);
-    expect(await sourcesOf({ source: "B" })).toEqual(["B"]);
-  });
-
-  it("countMemories mirrors getMemories for the same filter (totals cannot drift)", async () => {
-    await seedFixtures();
-
-    expect(await adapter.countMemories({ tableName: TABLE, metadata: { source: "A" } })).toBe(2);
-    expect(await adapter.countMemories({ tableName: TABLE, metadata: { source: "B" } })).toBe(1);
-    // count === length(getMemories) for the identical filter, on both adapters.
-    expect(await adapter.countMemories({ tableName: TABLE, metadata: { source: "A" } })).toBe(
-      (await sourcesOf({ source: "A" })).length
-    );
-  });
-
-  it("AND-combines multiple metadata keys (all must be contained)", async () => {
-    await seedFixtures();
-
-    // Only the {source:"A",extra:1} row contains both keys.
-    expect(await sourcesOf({ source: "A", extra: 1 })).toEqual(["A"]);
-    expect(
-      await adapter.countMemories({ tableName: TABLE, metadata: { source: "A", extra: 1 } })
-    ).toBe(1);
-    // A key/value present on no row yields nothing, not a superset.
-    expect(await sourcesOf({ source: "Z" })).toEqual([]);
-    expect(await adapter.countMemories({ tableName: TABLE, metadata: { source: "Z" } })).toBe(0);
-  });
-
-  it("an absent or empty metadata filter is a no-op (no regression)", async () => {
-    await seedFixtures();
-
-    expect(await sourcesOf()).toEqual(["A", "A", "B"]);
-    expect(await sourcesOf({})).toEqual(["A", "A", "B"]);
-    expect(await adapter.countMemories({ tableName: TABLE })).toBe(3);
-    expect(await adapter.countMemories({ tableName: TABLE, metadata: {} })).toBe(3);
-  });
+    it(`countMemories mirrors getMemories: ${testCase.name}`, async () => {
+      const count = await adapter.countMemories({ tableName: TABLE, metadata: testCase.filter });
+      // count must equal both the expected total and the actual getMemories length,
+      // so the two SQL paths cannot drift for any filter shape.
+      expect(count).toBe(testCase.expected.length);
+      expect(count).toBe((await labelsOf(testCase.filter)).length);
+    });
+  }
 });

--- a/plugins/plugin-sql/src/__tests__/integration/memory-metadata-filter.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/memory-metadata-filter.real.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Focused correctness test for the documented `metadata` filter on the SQL
+ * `getMemories` and `countMemories` paths (issue #29069).
+ *
+ * The core `IDatabaseAdapter` contract documents `metadata?: Record<string,
+ * unknown>` on both reads, and the reference `InMemoryDatabaseAdapter` honors
+ * it via `memoryMatchesMetadata` (settled by issue #19089 / PR #19090). The
+ * production SQL adapter (`BaseDrizzleAdapter`, used by Pg/PGlite/Neon)
+ * previously accepted the key on `getMemories` and dropped it, returning a
+ * superset of rows and — because a real consumer
+ * (`personality-store.slotFromMemory`) throws on any non-slot row sharing the
+ * table — breaking hydration. This pins that `getMemories` now applies JSONB
+ * whole-object containment and that `getMemories`/`countMemories` totals cannot
+ * drift for the same filter. Runs on PGlite by default; set `POSTGRES_URL` to
+ * run against a real Postgres.
+ */
+import {
+  type Entity,
+  type Memory,
+  type MemoryMetadata,
+  MemoryType,
+  type UUID,
+} from "@elizaos/core";
+import { v4 } from "uuid";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import type { PgDatabaseAdapter } from "../../pg/adapter";
+import type { PgliteDatabaseAdapter } from "../../pglite/adapter";
+import { embeddingTable, memoryTable } from "../../schema";
+import type { DrizzleDatabase } from "../../types";
+import { createIsolatedTestDatabase } from "../test-helpers";
+
+const TABLE = "probe_table";
+
+describe("getMemories/countMemories metadata filter (real SQL adapter)", () => {
+  let adapter: PgliteDatabaseAdapter | PgDatabaseAdapter;
+  let cleanup: () => Promise<void>;
+  let testAgentId: UUID;
+  let entityId: UUID;
+
+  beforeAll(async () => {
+    const setup = await createIsolatedTestDatabase("memory_metadata_filter");
+    adapter = setup.adapter;
+    cleanup = setup.cleanup;
+    testAgentId = setup.testAgentId;
+
+    entityId = v4() as UUID;
+    await adapter.createEntities([
+      { id: entityId, agentId: testAgentId, names: ["Metadata Entity"] } as Entity,
+    ]);
+  });
+
+  afterAll(async () => {
+    if (cleanup) await cleanup();
+  });
+
+  beforeEach(async () => {
+    const db = adapter.getDatabase() as DrizzleDatabase;
+    await db.delete(embeddingTable);
+    await db.delete(memoryTable);
+  });
+
+  /** Seed one row in `probe_table` carrying the given (top-level) metadata. */
+  const seed = async (metadata: Record<string, unknown>): Promise<void> => {
+    const memory: Memory & { metadata: MemoryMetadata } = {
+      id: v4() as UUID,
+      agentId: testAgentId,
+      roomId: undefined,
+      entityId,
+      content: { text: "probe" },
+      createdAt: Date.now(),
+      unique: false,
+      metadata: { type: MemoryType.CUSTOM, ...metadata } as MemoryMetadata,
+    };
+    await adapter.createMemory(memory, TABLE);
+  };
+
+  const seedFixtures = async (): Promise<void> => {
+    await seed({ source: "A" });
+    await seed({ source: "B" });
+    await seed({ source: "A", extra: 1 });
+  };
+
+  const sourcesOf = async (metadata?: Record<string, unknown>): Promise<string[]> => {
+    const rows = await adapter.getMemories({
+      tableName: TABLE,
+      metadata,
+      includeEmbedding: false,
+    });
+    return rows
+      .map((row) => (row.metadata as Record<string, unknown>).source)
+      .filter((s): s is string => typeof s === "string")
+      .sort();
+  };
+
+  it("getMemories returns only rows whose metadata contains the filter (superset bug fixed)", async () => {
+    await seedFixtures();
+
+    // {source:"A"} matches the plain A row AND {source:"A",extra:1} (containment,
+    // not exact-object equality) — exactly the two A rows, never all three.
+    expect(await sourcesOf({ source: "A" })).toEqual(["A", "A"]);
+    expect(await sourcesOf({ source: "B" })).toEqual(["B"]);
+  });
+
+  it("countMemories mirrors getMemories for the same filter (totals cannot drift)", async () => {
+    await seedFixtures();
+
+    expect(await adapter.countMemories({ tableName: TABLE, metadata: { source: "A" } })).toBe(2);
+    expect(await adapter.countMemories({ tableName: TABLE, metadata: { source: "B" } })).toBe(1);
+    // count === length(getMemories) for the identical filter, on both adapters.
+    expect(await adapter.countMemories({ tableName: TABLE, metadata: { source: "A" } })).toBe(
+      (await sourcesOf({ source: "A" })).length
+    );
+  });
+
+  it("AND-combines multiple metadata keys (all must be contained)", async () => {
+    await seedFixtures();
+
+    // Only the {source:"A",extra:1} row contains both keys.
+    expect(await sourcesOf({ source: "A", extra: 1 })).toEqual(["A"]);
+    expect(
+      await adapter.countMemories({ tableName: TABLE, metadata: { source: "A", extra: 1 } })
+    ).toBe(1);
+    // A key/value present on no row yields nothing, not a superset.
+    expect(await sourcesOf({ source: "Z" })).toEqual([]);
+    expect(await adapter.countMemories({ tableName: TABLE, metadata: { source: "Z" } })).toBe(0);
+  });
+
+  it("an absent or empty metadata filter is a no-op (no regression)", async () => {
+    await seedFixtures();
+
+    expect(await sourcesOf()).toEqual(["A", "A", "B"]);
+    expect(await sourcesOf({})).toEqual(["A", "A", "B"]);
+    expect(await adapter.countMemories({ tableName: TABLE })).toBe(3);
+    expect(await adapter.countMemories({ tableName: TABLE, metadata: {} })).toBe(3);
+  });
+});

--- a/plugins/plugin-sql/src/base.ts
+++ b/plugins/plugin-sql/src/base.ts
@@ -452,6 +452,38 @@ function documentTimestampExpression(): SQL {
   )`;
 }
 
+/**
+ * Builds the WHERE predicates for the documented `metadata` filter on
+ * `getMemories`/`countMemories`. Mirrors the reference in-memory
+ * `memoryMatchesMetadata`: each requested top-level key must be present and its
+ * value must equal the stored value, AND-combined across keys. Equality is
+ * per-top-level JSON value equality via JSONB `=` (canonical), NOT `@>`
+ * whole-object containment — containment would recursively match nested-object
+ * and array supersets (e.g. stored `{tags:["a","b"]}` under filter
+ * `{tags:["a"]}`) and diverge from the reference adapter, so callers would see
+ * different results per backend (issue #29069).
+ *
+ * `undefined` is not representable in JSONB and cannot equal any stored value,
+ * so a filter value of `undefined` emits an unsatisfiable predicate and the
+ * filter matches nothing — the same result the reference matcher produces —
+ * rather than a backend-dependent serialization (`JSON.stringify` silently
+ * drops undefined keys).
+ */
+function metadataFilterConditions(
+  metadataColumn: SQLWrapper,
+  filter: Record<string, unknown>
+): SQL[] {
+  const conditions: SQL[] = [];
+  for (const [key, value] of Object.entries(filter)) {
+    if (value === undefined) {
+      conditions.push(sql`false`);
+      continue;
+    }
+    conditions.push(sql`(${metadataColumn} -> ${key}) = ${JSON.stringify(value)}::jsonb`);
+  }
+  return conditions;
+}
+
 function isMessageSearchObjectsMissing(error: unknown): boolean {
   const seen = new Set<unknown>();
   let current: unknown = error;
@@ -2792,12 +2824,13 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
     worldId?: UUID;
     textContains?: string;
     /**
-     * JSONB containment filter over `memory.metadata`. Documented on the core
+     * Top-level metadata filter over `memory.metadata`. Documented on the core
      * `IDatabaseAdapter.getMemories` contract and honored by the reference
      * `InMemoryDatabaseAdapter` (see `memoryMatchesMetadata`). Previously this
      * key was accepted but dropped here, so SQL callers received a superset of
-     * rows (issue #29069). Applied identically to `countMemories` so their
-     * totals cannot drift.
+     * rows (issue #29069). Each key is matched by per-top-level JSON value
+     * equality (see `metadataFilterConditions`) and applied identically to
+     * `countMemories` so their totals cannot drift.
      */
     metadata?: Record<string, unknown>;
     orderBy?: "createdAt";
@@ -2894,12 +2927,12 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
         conditions.push(eq(memoryTable.agentId, agentId));
       }
 
-      // Honor the documented `metadata` filter with JSONB whole-object
-      // containment, matching `countMemories` so get/count totals cannot drift
-      // and mirroring the in-memory reference adapter's top-level equality. An
+      // Honor the documented `metadata` filter with per-top-level JSON value
+      // equality, matching `countMemories` so get/count totals cannot drift and
+      // mirroring the in-memory reference adapter's `memoryMatchesMetadata`. An
       // empty object is a no-op (would otherwise match every row).
       if (params.metadata && Object.keys(params.metadata).length > 0) {
-        conditions.push(sql`${memoryTable.metadata} @> ${JSON.stringify(params.metadata)}::jsonb`);
+        conditions.push(...metadataFilterConditions(memoryTable.metadata, params.metadata));
       }
 
       if (textContains) {
@@ -4461,7 +4494,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
         conditions.push(eq(memoryTable.unique, true));
       }
       if (params.metadata && Object.keys(params.metadata).length > 0) {
-        conditions.push(sql`${memoryTable.metadata} @> ${JSON.stringify(params.metadata)}::jsonb`);
+        conditions.push(...metadataFilterConditions(memoryTable.metadata, params.metadata));
       }
 
       const result = await this.db

--- a/plugins/plugin-sql/src/base.ts
+++ b/plugins/plugin-sql/src/base.ts
@@ -2791,6 +2791,15 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
     roomId?: UUID;
     worldId?: UUID;
     textContains?: string;
+    /**
+     * JSONB containment filter over `memory.metadata`. Documented on the core
+     * `IDatabaseAdapter.getMemories` contract and honored by the reference
+     * `InMemoryDatabaseAdapter` (see `memoryMatchesMetadata`). Previously this
+     * key was accepted but dropped here, so SQL callers received a superset of
+     * rows (issue #29069). Applied identically to `countMemories` so their
+     * totals cannot drift.
+     */
+    metadata?: Record<string, unknown>;
     orderBy?: "createdAt";
     orderDirection?: "asc" | "desc";
     /**
@@ -2883,6 +2892,14 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
 
       if (agentId) {
         conditions.push(eq(memoryTable.agentId, agentId));
+      }
+
+      // Honor the documented `metadata` filter with JSONB whole-object
+      // containment, matching `countMemories` so get/count totals cannot drift
+      // and mirroring the in-memory reference adapter's top-level equality. An
+      // empty object is a no-op (would otherwise match every row).
+      if (params.metadata && Object.keys(params.metadata).length > 0) {
+        conditions.push(sql`${memoryTable.metadata} @> ${JSON.stringify(params.metadata)}::jsonb`);
       }
 
       if (textContains) {


### PR DESCRIPTION
# Relates to

Closes #29069

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run; focused package checks pass. Root `bun run verify` gap recorded under **Known gaps / failures**.
- [x] A reviewer can confirm the change works from the failing-before/passing-after evidence below.

# Sync with develop

- [x] Branch is based on the current `origin/develop` head (`5265b7740a`); zero conflicts.
- [ ] `bun run verify` — not run in full (see **Known gaps**); the owning package's test, typecheck, and lint pass.

# Risks

Low. The change adds guarded per-top-level-key WHERE predicates to `getMemories` and `countMemories`, and only narrows results when a caller passes a non-empty `metadata` filter. An empty or absent filter is a no-op, so every existing caller (the common case) is byte-for-byte unaffected — proven by the "no-op" cases and the untouched `memory.real.test.ts` / `memory-text-contains.real.test.ts` suites (57 tests green).

# Background

## What does this PR do?

`BaseDrizzleAdapter.getMemories` (the shared implementation behind the Pg, PGlite, and Neon adapters) accepted the `metadata` filter documented on the core `IDatabaseAdapter.getMemories` contract but **never applied it** to the SQL WHERE clause. It built conditions only from type/room/world/entity/agent/unique/textContains and dropped `metadata`, so a metadata-filtered read returned a **superset** of rows on the real database.

The reference `InMemoryDatabaseAdapter` already honors the filter via `memoryMatchesMetadata` (settled by issue #19089 / merged PR #19090): each requested top-level key must be present and its value must equal the stored value. `getMemories` on the SQL adapter dropped the filter entirely and returned a **superset**. This is not academic: `packages/core/.../personality/services/personality-store.ts` calls `getMemories({ tableName: PERSONALITY_SLOT_TABLE, metadata: { source: PERSONALITY_SLOT_MEMORY_SOURCE }, count: 10_000 })` and then throws a fatal `ElizaError` via `slotFromMemory` for any returned row that is not a valid slot. Any non-slot memory sharing that table therefore broke personality hydration.

Fix: honor the filter with **per-top-level JSON value equality** in both `getMemories` and `countMemories`, via a shared `metadataFilterConditions` helper:

```ts
for (const [key, value] of Object.entries(filter)) {
  if (value === undefined) { conditions.push(sql`false`); continue; }
  conditions.push(sql`(${metadataColumn} -> ${key}) = ${JSON.stringify(value)}::jsonb`);
}
```

**Why not `@>` whole-object containment** (per @startrack3r's review): PostgreSQL/PGlite `@>` applies *recursive* containment, so it would match nested-object and array **supersets** — stored `{profile:{tone:"warm",extra:1}}` under filter `{profile:{tone:"warm"}}`, or stored `{tags:["a","b"]}` under filter `{tags:["a"]}` — whereas the reference matcher requires top-level value equality. That divergence would let callers observe different `getMemories`/`countMemories` results purely from the selected adapter. Per-top-level `=` matches the settled reference for the cited cases and for scalars, arrays, and null. `undefined` is not representable in JSONB, so a filter value of `undefined` is unsatisfiable (matches nothing) — the same result the reference matcher produces — rather than a backend-dependent `JSON.stringify` no-op that silently drops the key.

Both SQL paths call the one helper, so get/count cannot drift. `metadata` is also documented on the `getMemories` params type (previously accepted structurally but undocumented locally).

Note on nested key order: JSONB `=` is canonical (order-insensitive), so a nested-object filter with reordered keys still matches; the reference's `JSON.stringify` comparison is order-sensitive. This is the one deliberate, documented refinement; it does not affect the superset cases above and is covered by the conformance matrix.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a documentation change. The behavior now matches the already-documented `IDatabaseAdapter.getMemories` contract and the reference in-memory adapter.

# Testing

## Where should a reviewer start?

`plugins/plugin-sql/src/__tests__/integration/memory-metadata-filter.real.test.ts` — a real PGlite integration test (`createIsolatedTestDatabase`, no credentials required) that fails on `develop` and passes with this change.

## Detailed testing steps

```bash
cd plugins/plugin-sql/src
npx vitest run --config vitest.real.config.ts __tests__/integration/memory-metadata-filter.real.test.ts
```

The test seeds six labelled `probe_table` rows (`{source:"A"}`, `{source:"B"}`, `{source:"A",extra:1}`, `{profile:{tone:"warm",extra:1}}`, `{tags:["a","b"]}`, `{note:null}`) and drives a shared filter matrix (16 filters × get + count = 32 cases) asserting the reference top-level-equality semantics:
- scalars match all containing rows; multi-key filters AND-combine; a no-match filter returns nothing (not a superset);
- **nested-object superset** `{profile:{tone:"warm"}}` and **array superset** `{tags:["a"]}` return nothing (where `@>` containment would wrongly match) — exact/reordered nested objects and exact arrays still match;
- present-null matches only present-null (distinct from a missing key); `undefined` values match nothing;
- `countMemories` mirrors `getMemories` for every filter (`count === length(getMemories)`), and absent/empty `{}` filters are no-ops returning all six rows.

# Evidence Gate

<!-- evidence-head:f2f1f7c45c085486763bd35c2beb098b8130c1ad -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface; server-side database adapter change only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface; server-side database adapter change only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no UI/user flow; the change is a SQL WHERE predicate exercised by the integration test below.
<!-- evidence-row:backend-logs -->
- [x] Real code path (PGlite migrations + `BaseDrizzleAdapter`) fires end to end — full hosted run: [pr29074-getMemories-countMemories-metadata-filter-AFTER-32pass.log](https://gist.githubusercontent.com/agent-cortex/ec6bc73bbaf2904813b69f7b0ef32a46/raw/493ad0e0675bec74648522f1a1b8d65c24066f4c/pr29074-getMemories-countMemories-metadata-filter-AFTER-32pass.log) (immutable, revision-pinned). Passing-after backend logs excerpt:

<details><summary>after — passing backend logs (32/32 green)</summary>

```
 Info       [PLUGIN:SQL] Migration completed successfully (pluginName=@elizaos/plugin-sql)
 Info       [PLUGIN:SQL] All migrations completed successfully (successCount=1)
 Info       [PLUGIN:SQL] [MessageSearch] full-text search objects applied (trigramAvailable=true)
 ✓ __tests__/integration/memory-metadata-filter.real.test.ts (32 tests) 7604ms
 Test Files  1 passed (1)
      Tests  32 passed (32)
   Duration  24.33s (transform 13.93s, setup 0ms, import 16.52s, tests 7.60s, environment 0ms)
```
</details>
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend; no request/response surface.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model change; pure persistence-layer filter fix.
<!-- evidence-row:domain-artifacts -->
- [x] Two failing-before runs (same conformance matrix) prove the fix changes real behavior in exactly the reviewer's cited cases — full hosted runs: [before A — getMemories drops filter, 28 failed/4 passed](https://gist.githubusercontent.com/agent-cortex/d6f726dbaf220209e7f1b048611f3a36/raw/a12e8d19cd36c6fdc563722566273d9b28835c3b/pr29074-BEFORE-A-getMemories-dropped-filter-28fail-4pass.log) · [before B — `@>` containment, 10 failed/22 passed](https://gist.githubusercontent.com/agent-cortex/b34004146900fc890d116d099a04ca74/raw/93f47bba6259eb6cc0bb6b58abfc3b0b2207a583/pr29074-BEFORE-B-jsonb-containment-10fail-22pass.log) (immutable, revision-pinned), plus the generated Drizzle SQL of the shipped per-key predicate:

<details><summary>before A — original bug (metadata filter dropped in getMemories → superset)</summary>

Reproduced on the PR head by removing only the `getMemories` filter call: `getMemories` returned all six seeded rows for `{source:"A"}` instead of the two containing rows, and `countMemories` (which still filtered) diverged from it — the every-filter `count === length(getMemories)` assertions therefore fail alongside the get assertions (**28 failed / 4 passed**; only the two no-op filters survive). This is the superset that broke personality hydration (issue #29069). Full run linked above.

</details>

<details><summary>before B — `@>` whole-object containment (10 failed / 22 passed): proves per-key equality is required, not containment</summary>

Replacing the shipped per-key predicate with the previously-proposed `@> ${JSON.stringify(filter)}::jsonb` fails exactly the nested/array/undefined conformance cases @startrack3r flagged:

```
     × getMemories: nested-object superset does NOT match (@> would) 86ms
     × countMemories mirrors getMemories: nested-object superset does NOT match (@> would) 53ms
     × getMemories: array superset does NOT match (@> would) 54ms
     × countMemories mirrors getMemories: array superset does NOT match (@> would) 43ms
     × getMemories: array wrong order does NOT match 50ms
     × countMemories mirrors getMemories: array wrong order does NOT match 61ms
     × getMemories: undefined value matches nothing 48ms
     × countMemories mirrors getMemories: undefined value matches nothing 54ms
     × getMemories: undefined alongside a real key matches nothing 50ms
     × countMemories mirrors getMemories: undefined alongside a real key matches nothing 42ms
 Test Files  1 failed (1)
      Tests  10 failed | 22 passed (32)
```
</details>

Generated Drizzle SQL of the shipped predicate (`db.select(...).where(and(...conditions)).toSQL()`) for `metadata:{source:"A"}`:

```
SQL: select "id" from "memories" where ("memories"."type" = $1 and ("memories"."metadata" -> $2) = $3::jsonb)
PARAMS: ["probe_table","source","\"A\""]
```
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Screenshots (before / after) + video walkthrough

N/A - server-side database adapter change; no rendered surface.

## Audio / voice walkthrough

N/A - no audio/voice surface.

## Settled-contract note

The in-memory reference adapter honors this filter via `memoryMatchesMetadata` (`packages/core/src/database/inMemoryAdapter.ts`, applied in both `getMemories` and `countMemories`), settled by issue #19089 / merged PR #19090 with **per-top-level JSON value equality**. This PR aligns both SQL paths (`getMemories` and `countMemories`) to that settled reference semantics rather than `@>` recursive containment, so the SQL adapter no longer diverges from the reference on nested-object/array supersets. Per @startrack3r's review, the canonical policy is the established reference behavior (top-level value equality), applied identically in get and count so they cannot drift.

## Known gaps / failures

- Root `bun run verify` was not run in full on this machine (it drives the whole Turbo workspace and is disproportionate for a one-package predicate fix). The owning package's focused test, `typecheck` (`tsc --noEmit`), and `lint` (Biome) all pass, and neighboring memory suites (`memory.real.test.ts`, `memory-text-contains.real.test.ts`, 57 tests) stay green.
- Full test-run artifacts are now attached as immutable, revision-pinned GitHub-hosted raw permalinks (the `after` 32/32 pass run and both failing-before runs, linked from the backend-logs and domain-artifacts rows above). The repository's `scripts/pr-evidence.mjs attach` release-upload path returns HTTP 404 for a fork contributor (it requires maintainer write access on the `elizaOS/eliza` releases), so these are hosted as revision-pinned gist raw URLs instead. Each is the real, current output of the single command above (PGlite embedded, no credentials) and is reproducible locally.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

---

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@f2f1f7c45c085486763bd35c2beb098b8130c1ad:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@f2f1f7c45c085486763bd35c2beb098b8130c1ad:packages/skills/skills/contribute-to-eliza"} -->
