### PR TITLE
fix(cloud): keep Steward provider discovery authoritative

### DIFF
--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.provider-discovery-error.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.provider-discovery-error.test.tsx
@@ -1,0 +1,168 @@
+/**
+ * Verifies that a fresh Steward provider-discovery failure never fabricates an
+ * email/passkey-only login surface. The boundary must stay explicit and a retry
+ * must render the exact server-authorized provider set.
+ */
+// @vitest-environment jsdom
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const harness = vi.hoisted(() => ({
+  getProvidersCalls: 0,
+}));
+
+const LIVE_PROVIDERS = {
+  passkey: true,
+  email: true,
+  sms: true,
+  siwe: false,
+  siws: false,
+  google: true,
+  discord: true,
+  github: true,
+  twitter: true,
+  telegram: true,
+  oauth: ["google", "discord", "github", "twitter"],
+};
+
+vi.mock("../../lib/steward-session", () => ({
+  hasStewardOAuthCallbackInUrl: () => false,
+  consumeStewardCodeFromQuery: () => null,
+  consumeStewardOAuthStateFromCallback: () => null,
+  stripLegacyTokenHashFromAddressBar: () => false,
+  exchangeStewardCodeViaApi: () => new Promise(() => {}),
+  recoverStewardSessionViaCookie: () => Promise.resolve(null),
+  recoverStewardEmailSessionViaCookie: () => Promise.resolve(null),
+  refreshStewardSessionViaCookie: () => Promise.resolve({ ok: true as const }),
+  syncStewardSessionCookie: () => Promise.resolve(),
+}));
+
+vi.mock("@stwd/sdk", () => ({
+  StewardAuth: class {
+    getSession() {
+      return null;
+    }
+    getProviders() {
+      harness.getProvidersCalls += 1;
+      if (harness.getProvidersCalls === 1) {
+        return Promise.reject(
+          new Error("Provider service is temporarily unavailable"),
+        );
+      }
+      return Promise.resolve(LIVE_PROVIDERS);
+    }
+    refreshSession() {
+      return Promise.resolve(null);
+    }
+  },
+}));
+
+vi.mock("./passkey-capability", () => ({
+  resolveWebPasskeyCapability: () =>
+    Promise.resolve({ usable: true, reason: "available" }),
+}));
+
+vi.mock("./telegram-login-widget", () => ({
+  configuredTelegramBotUsername: () => "elizastagingfelibot",
+  TelegramLoginWidget: () => null,
+  TelegramLoginCancelledError: class TelegramLoginCancelledError extends Error {},
+  getConfiguredTelegramBotId: () => "7684336618",
+  requestTelegramLogin: () => new Promise(() => {}),
+}));
+
+vi.mock("../../../shell/steward-url", () => ({
+  resolveBrowserStewardApiUrl: () => "https://api.example.test",
+}));
+
+vi.mock("../../../shell/steward-config", () => ({
+  configuredStewardTenantId: () => "elizacloud",
+  DEFAULT_STEWARD_TENANT_ID: "elizacloud",
+}));
+
+vi.mock("../../../shell/CloudI18nProvider", () => ({
+  useCloudT: () => (_key: string, opts?: { defaultValue?: string }) =>
+    opts?.defaultValue ?? _key,
+}));
+
+vi.mock("@elizaos/shared/steward-session-client", async () => {
+  const actual = await vi.importActual<
+    typeof import("@elizaos/shared/steward-session-client")
+  >("@elizaos/shared/steward-session-client");
+  return {
+    ...actual,
+    peekStewardOAuthState: () => null,
+  };
+});
+
+vi.mock("../../lib/steward-oauth-url", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../lib/steward-oauth-url")
+  >("../../lib/steward-oauth-url");
+  return {
+    ...actual,
+    consumeStewardPkceVerifier: () => null,
+    buildStewardOAuthRedirectUri: () => "https://app.example.test/login",
+  };
+});
+
+vi.mock("../../lib/login-return-to", () => ({
+  resolveLoginReturnTo: () => "/cloud",
+  consumePendingOAuthReturnTo: () => null,
+  storePendingOAuthReturnTo: () => undefined,
+}));
+
+import StewardLoginSection from "./steward-login-section";
+
+function renderSection() {
+  return render(
+    <MemoryRouter initialEntries={["/login"]}>
+      <StewardLoginSection />
+    </MemoryRouter>,
+  );
+}
+
+describe("StewardLoginSection provider discovery truth", () => {
+  beforeEach(() => {
+    harness.getProvidersCalls = 0;
+    window.sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    window.sessionStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  it("fails visibly without a fabricated provider subset and retries live discovery", async () => {
+    renderSection();
+
+    expect(
+      await screen.findByText("Sign-in options couldn't load"),
+    ).toBeTruthy();
+    expect(screen.queryByLabelText("Email")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Passkey" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Magic Link" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Google" })).toBeNull();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Retry sign-in options" }),
+    );
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Google" })).toBeTruthy(),
+    );
+    expect(screen.getByRole("button", { name: "Discord" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "GitHub" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "X" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Telegram" })).toBeTruthy();
+    expect(harness.getProvidersCalls).toBe(2);
+  });
+});

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.provider-discovery-error.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.provider-discovery-error.test.tsx
@@ -6,6 +6,7 @@
 // @vitest-environment jsdom
 
 import {
+  act,
   cleanup,
   fireEvent,
   render,
@@ -17,6 +18,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const harness = vi.hoisted(() => ({
   getProvidersCalls: 0,
+  mode: "fail-twice-then-succeed" as
+    | "fail-twice-then-succeed"
+    | "always-fail"
+    | "hang",
 }));
 
 const LIVE_PROVIDERS = {
@@ -52,7 +57,10 @@ vi.mock("@stwd/sdk", () => ({
     }
     getProviders() {
       harness.getProvidersCalls += 1;
-      if (harness.getProvidersCalls === 1) {
+      if (harness.mode === "hang") {
+        return new Promise(() => {});
+      }
+      if (harness.mode === "always-fail" || harness.getProvidersCalls <= 2) {
         return Promise.reject(
           new Error("Provider service is temporarily unavailable"),
         );
@@ -132,16 +140,51 @@ function renderSection() {
 describe("StewardLoginSection provider discovery truth", () => {
   beforeEach(() => {
     harness.getProvidersCalls = 0;
+    harness.mode = "fail-twice-then-succeed";
     window.sessionStorage.clear();
   });
 
   afterEach(() => {
     cleanup();
+    vi.useRealTimers();
     window.sessionStorage.clear();
     vi.clearAllMocks();
   });
 
-  it("fails visibly without a fabricated provider subset and retries live discovery", async () => {
+  it("times out a provider request that never settles", async () => {
+    vi.useFakeTimers();
+    harness.mode = "hang";
+    renderSection();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(15_000);
+    });
+
+    expect(screen.getByText("Sign-in options couldn't load")).toBeTruthy();
+    expect(
+      screen.getByText(
+        "Steward provider discovery timed out. Check your connection and retry.",
+      ),
+    ).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Google" })).toBeNull();
+  });
+
+  it("keeps a valid session-cached provider set during reconcile failure", async () => {
+    harness.mode = "always-fail";
+    window.sessionStorage.setItem(
+      "eliza.steward.providers.v1:elizacloud",
+      JSON.stringify(LIVE_PROVIDERS),
+    );
+
+    renderSection();
+
+    expect(await screen.findByRole("button", { name: "Google" })).toBeTruthy();
+    await waitFor(() => expect(harness.getProvidersCalls).toBe(1));
+    expect(screen.queryByText("Sign-in options couldn't load")).toBeNull();
+    expect(screen.getByRole("button", { name: "Discord" })).toBeTruthy();
+  });
+
+  it("fails visibly without fabricated providers and survives repeated failure", async () => {
     renderSection();
 
     expect(
@@ -156,6 +199,15 @@ describe("StewardLoginSection provider discovery truth", () => {
       screen.getByRole("button", { name: "Retry sign-in options" }),
     );
 
+    expect(
+      await screen.findByText("Sign-in options couldn't load"),
+    ).toBeTruthy();
+    expect(harness.getProvidersCalls).toBe(2);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Retry sign-in options" }),
+    );
+
     await waitFor(() =>
       expect(screen.getByRole("button", { name: "Google" })).toBeTruthy(),
     );
@@ -163,6 +215,6 @@ describe("StewardLoginSection provider discovery truth", () => {
     expect(screen.getByRole("button", { name: "GitHub" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "X" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Telegram" })).toBeTruthy();
-    expect(harness.getProvidersCalls).toBe(2);
+    expect(harness.getProvidersCalls).toBe(3);
   });
 });

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
@@ -662,6 +662,10 @@ export default function StewardLoginSection() {
       cachedStewardProviders !== null ||
       readSessionCachedProviders() !== null,
   );
+  const [providerDiscoveryError, setProviderDiscoveryError] = useState<
+    string | null
+  >(null);
+  const [providerDiscoveryAttempt, setProviderDiscoveryAttempt] = useState(0);
   const [providers, setProviders] = useState<StewardProviders>(
     () =>
       cachedStewardProviders ??
@@ -771,10 +775,17 @@ export default function StewardLoginSection() {
     // (#18256). If the exchange fails, `completingCallback` clears and this
     // effect re-runs, so the retry surface still gets live discovery.
     if (completingCallback) return;
+    if (providerDiscoveryAttempt > 0) {
+      // A retry must not reuse the rejected process-wide request.
+      stewardProvidersPromise = null;
+    }
     let cancelled = false;
     loadStewardProviders(auth)
       .then((loadedProviders) => {
-        if (!cancelled) setProviders(loadedProviders);
+        if (!cancelled) {
+          setProviderDiscoveryError(null);
+          setProviders(loadedProviders);
+        }
       })
       .catch((providerError: unknown) => {
         stewardProvidersPromise = null;
@@ -784,7 +795,7 @@ export default function StewardLoginSection() {
         // of blasting an error over working sign-in options; a first-load
         // failure (nothing rendered yet) still surfaces the error.
         if (readSessionCachedProviders() === null) {
-          setError(
+          setProviderDiscoveryError(
             getErrorMessage(providerError, "Steward provider discovery failed"),
           );
         }
@@ -795,7 +806,15 @@ export default function StewardLoginSection() {
     return () => {
       cancelled = true;
     };
-  }, [auth, completingCallback]);
+  }, [auth, completingCallback, providerDiscoveryAttempt]);
+
+  const retryProviderDiscovery = useCallback(() => {
+    // Return to the reserved loading geometry and trigger a fresh server query;
+    // never render a fabricated subset of sign-in methods.
+    setProviderDiscoveryError(null);
+    setProvidersLoaded(false);
+    setProviderDiscoveryAttempt((attempt) => attempt + 1);
+  }, []);
 
   useEffect(() => {
     if (PLAYWRIGHT_TEST_AUTH_ENABLED) return;
@@ -2141,6 +2160,49 @@ export default function StewardLoginSection() {
           })}
         </span>
       </div>
+    );
+  }
+
+  // A fresh browser has no authoritative provider set to render when discovery
+  // fails. Showing DEFAULT_PROVIDERS here used to make the same Steward login
+  // look like a second email/passkey-only product and could hide enabled OAuth
+  // methods. Fail visibly and retry discovery instead. A valid session-cached
+  // set takes the separate background-reconcile path above and remains usable.
+  if (providerDiscoveryError) {
+    return (
+      <ReservedLoginFrame>
+        <div
+          className="flex flex-col items-center gap-4 text-center"
+          role="alert"
+        >
+          <div className="flex size-12 items-center justify-center rounded-full bg-destructive/10 text-destructive">
+            <AlertCircle className="size-5" aria-hidden="true" />
+          </div>
+          <div className="space-y-1">
+            <p className="text-base font-semibold text-txt-strong">
+              {t("cloud.login.providerDiscovery.title", {
+                defaultValue: "Sign-in options couldn't load",
+              })}
+            </p>
+            <p className="text-sm text-muted">{providerDiscoveryError}</p>
+            <p className="text-xs leading-relaxed text-muted">
+              {t("cloud.login.providerDiscovery.message", {
+                defaultValue:
+                  "Retry to load the sign-in methods enabled for this Eliza Cloud account.",
+              })}
+            </p>
+          </div>
+          <Button
+            type="button"
+            className="hosted-signin-focus-emphasis w-full"
+            onClick={retryProviderDiscovery}
+          >
+            {t("cloud.login.providerDiscovery.retry", {
+              defaultValue: "Retry sign-in options",
+            })}
+          </Button>
+        </div>
+      </ReservedLoginFrame>
     );
   }
 

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
@@ -300,6 +300,8 @@ const DEFAULT_PROVIDERS: StewardProviders = {
   oauth: [],
 };
 
+const STEWARD_PROVIDER_DISCOVERY_TIMEOUT_MS = 15_000;
+
 type LoginTranslator = ReturnType<typeof useCloudT>;
 
 function requireCompletedAuth(
@@ -443,6 +445,12 @@ function describeEmailLoginError(error: unknown, fallback: string): string {
 
 let cachedStewardProviders: StewardProviders | null = null;
 let stewardProvidersPromise: Promise<StewardProviders> | null = null;
+let stewardProvidersRequestGeneration = 0;
+
+function discardStewardProvidersRequest(): void {
+  stewardProvidersRequestGeneration += 1;
+  stewardProvidersPromise = null;
+}
 
 // The provider set is effectively static per deployment, but each SPA load —
 // notably the post-OAuth return leg, a second full cold load — used to block
@@ -539,13 +547,44 @@ function loadStewardProviders(auth: {
   getProviders: () => Promise<StewardProviders>;
 }): Promise<StewardProviders> {
   if (cachedStewardProviders) return Promise.resolve(cachedStewardProviders);
-  stewardProvidersPromise ??= auth.getProviders().then((loadedProviders) => {
-    cachedStewardProviders = loadedProviders;
-    stewardProvidersPromise = null;
-    writeSessionCachedProviders(loadedProviders);
-    return loadedProviders;
-  });
+  const requestGeneration = stewardProvidersRequestGeneration;
+  stewardProvidersPromise ??= auth.getProviders().then(
+    (loadedProviders) => {
+      if (requestGeneration === stewardProvidersRequestGeneration) {
+        cachedStewardProviders = loadedProviders;
+        stewardProvidersPromise = null;
+        writeSessionCachedProviders(loadedProviders);
+      }
+      return loadedProviders;
+    },
+    (error: unknown) => {
+      if (requestGeneration === stewardProvidersRequestGeneration) {
+        stewardProvidersPromise = null;
+      }
+      throw error;
+    },
+  );
   return stewardProvidersPromise;
+}
+
+function loadStewardProvidersWithTimeout(auth: {
+  getProviders: () => Promise<StewardProviders>;
+}): Promise<StewardProviders> {
+  return new Promise((resolve, reject) => {
+    const timeoutId = window.setTimeout(() => {
+      reject(
+        new Error(
+          "Steward provider discovery timed out. Check your connection and retry.",
+        ),
+      );
+    }, STEWARD_PROVIDER_DISCOVERY_TIMEOUT_MS);
+
+    void loadStewardProviders(auth)
+      .then(resolve, reject)
+      .finally(() => {
+        window.clearTimeout(timeoutId);
+      });
+  });
 }
 
 export default function StewardLoginSection() {
@@ -666,11 +705,11 @@ export default function StewardLoginSection() {
     string | null
   >(null);
   const [providerDiscoveryAttempt, setProviderDiscoveryAttempt] = useState(0);
-  const [providers, setProviders] = useState<StewardProviders>(
+  const [providers, setProviders] = useState<StewardProviders | null>(
     () =>
       cachedStewardProviders ??
       readSessionCachedProviders() ??
-      DEFAULT_PROVIDERS,
+      (PLAYWRIGHT_TEST_AUTH_ENABLED ? DEFAULT_PROVIDERS : null),
   );
   const [passkeyCapability, setPasskeyCapability] =
     useState<WebPasskeyCapability | null>(
@@ -679,14 +718,20 @@ export default function StewardLoginSection() {
         : null,
     );
 
-  const enabledOAuthProviders = STEWARD_OAUTH_PROVIDERS.filter((provider) =>
-    isStewardOAuthProviderEnabled(providers, provider),
-  );
+  const enabledOAuthProviders =
+    providers === null
+      ? []
+      : STEWARD_OAUTH_PROVIDERS.filter((provider) =>
+          isStewardOAuthProviderEnabled(providers, provider),
+        );
   const hasIdentityProviders =
-    enabledOAuthProviders.length > 0 || providers.telegram === true;
-  const showWallets = hasAnyWalletProvider(providers);
+    enabledOAuthProviders.length > 0 || providers?.telegram === true;
+  const emailEnabled = providers !== null && providers.email !== false;
+  const showWallets = providers !== null && hasAnyWalletProvider(providers);
   const showPasskey =
-    providers.passkey !== false && passkeyCapability?.usable === true;
+    providers !== null &&
+    providers.passkey !== false &&
+    passkeyCapability?.usable === true;
 
   const abortSharedEmailSessionRecovery = useCallback(() => {
     const pending = sharedSessionRecoveryRef.current;
@@ -775,12 +820,8 @@ export default function StewardLoginSection() {
     // (#18256). If the exchange fails, `completingCallback` clears and this
     // effect re-runs, so the retry surface still gets live discovery.
     if (completingCallback) return;
-    if (providerDiscoveryAttempt > 0) {
-      // A retry must not reuse the rejected process-wide request.
-      stewardProvidersPromise = null;
-    }
     let cancelled = false;
-    loadStewardProviders(auth)
+    loadStewardProvidersWithTimeout(auth)
       .then((loadedProviders) => {
         if (!cancelled) {
           setProviderDiscoveryError(null);
@@ -788,7 +829,7 @@ export default function StewardLoginSection() {
         }
       })
       .catch((providerError: unknown) => {
-        stewardProvidersPromise = null;
+        discardStewardProvidersRequest();
         if (cancelled) return;
         // error-policy:J4 with a session-cached provider set already rendered,
         // a failed background reconcile keeps the usable cached form instead
@@ -811,6 +852,7 @@ export default function StewardLoginSection() {
   const retryProviderDiscovery = useCallback(() => {
     // Return to the reserved loading geometry and trigger a fresh server query;
     // never render a fabricated subset of sign-in methods.
+    discardStewardProvidersRequest();
     setProviderDiscoveryError(null);
     setProvidersLoaded(false);
     setProviderDiscoveryAttempt((attempt) => attempt + 1);
@@ -1270,7 +1312,7 @@ export default function StewardLoginSection() {
 
   function validatePasskeyIntent(): boolean {
     if (!showPasskey) {
-      if (providers.email !== false) {
+      if (emailEnabled) {
         void handleEmail();
         return false;
       }
@@ -2094,7 +2136,7 @@ export default function StewardLoginSection() {
                   defaultValue: "Use existing passkey",
                 })}
               </Button>
-              {providers.email !== false && (
+              {emailEnabled && (
                 <Button
                   variant="outlineMuted"
                   type="button"
@@ -2168,7 +2210,7 @@ export default function StewardLoginSection() {
   // look like a second email/passkey-only product and could hide enabled OAuth
   // methods. Fail visibly and retry discovery instead. A valid session-cached
   // set takes the separate background-reconcile path above and remains usable.
-  if (providerDiscoveryError) {
+  if (providerDiscoveryError || providers === null) {
     return (
       <ReservedLoginFrame>
         <div
@@ -2184,7 +2226,10 @@ export default function StewardLoginSection() {
                 defaultValue: "Sign-in options couldn't load",
               })}
             </p>
-            <p className="text-sm text-muted">{providerDiscoveryError}</p>
+            <p className="text-sm text-muted">
+              {providerDiscoveryError ??
+                "Steward returned no authoritative sign-in options."}
+            </p>
             <p className="text-xs leading-relaxed text-muted">
               {t("cloud.login.providerDiscovery.message", {
                 defaultValue:


### PR DESCRIPTION
Closes the auth-consistency finding tracked in #29024.

Fresh provider-discovery failure previously rendered `DEFAULT_PROVIDERS` as a usable email/passkey-only surface, making the canonical Steward login look like a second product and hiding enabled OAuth methods. This change fails visibly when no authoritative provider set exists, keeps a valid session-cached set usable during background reconcile failure, and retries the live server contract without client-side provider fabrication.

@lalalune for visibility.

Exact source
- base: `3e0f196d9a6b51a9d677dfc44ef03d1661025156`
- head: `2018afa97e840582cfac5958ad1224a5aa9a3dd7`
- tree: `5ed646f3d49ea81c40d90c227e38ef1d731047c2`

Gates
- 14 Steward login component files, 88/88 tests
- UI typecheck
- UI production package build and runtime export verification
- exact Biome on touched files
- `git diff --check`

Hosted staging verification remains pending after review/merge/deploy. No production mutation, credential change, or paid resource action is part of this PR.