### PR TITLE
fix(android): audit launcher kiosk runtime config

### DIFF
--- a/packages/app-core/scripts/run-mobile-build-android-play-policy.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-android-play-policy.test.mjs
@@ -26,6 +26,7 @@ import {
   findAndroidCloudPackagedRuntimeOffenders,
   findAndroidPlayIndexHtmlFindings,
   findAndroidPlayTextAssetFindings,
+  resolveAndroidCloudAuditCapacitorConfig,
   sanitizeAndroidCloudCapacitorConfig,
 } from "./run-mobile-build.mjs";
 
@@ -187,6 +188,25 @@ describe("Android Play manifest policy", () => {
 
     expect(sanitized.loggingBehavior).toBe("none");
     expect(sanitized.android.webContentsDebuggingEnabled).toBe(true);
+  });
+
+  it("audits launcher configs against the launcher-only kiosk contract", () => {
+    const config = {
+      loggingBehavior: "none",
+      android: { webContentsDebuggingEnabled: true },
+    };
+
+    expect(
+      resolveAndroidCloudAuditCapacitorConfig(config, {
+        allowHomeRole: true,
+        env: { ELIZA_WEBVIEW_DEBUG: "1" },
+      }),
+    ).toMatchObject(config);
+    expect(
+      resolveAndroidCloudAuditCapacitorConfig(config, {
+        env: { ELIZA_WEBVIEW_DEBUG: "1" },
+      }),
+    ).not.toHaveProperty("loggingBehavior");
   });
 
   it("keeps the unused native Google identity stack out of Android source", () => {

--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -5962,6 +5962,17 @@ export function sanitizeAndroidCloudCapacitorConfig(
   };
 }
 
+export function resolveAndroidCloudAuditCapacitorConfig(
+  value,
+  { allowHomeRole = false, env = process.env } = {},
+) {
+  return sanitizeAndroidCloudCapacitorConfig(value, {
+    launcherKiosk: allowHomeRole,
+    webViewDebugging:
+      allowHomeRole && env.ELIZA_WEBVIEW_DEBUG === "1",
+  });
+}
+
 function sanitizeAndroidCloudPackagedConfig(env = process.env) {
   const configPath = path.join(
     androidDir,
@@ -7856,7 +7867,10 @@ function auditAndroidCloudSource(
   } else {
     try {
       const config = JSON.parse(fs.readFileSync(capacitorConfigPath, "utf8"));
-      const expected = sanitizeAndroidCloudCapacitorConfig(config);
+      const expected = resolveAndroidCloudAuditCapacitorConfig(config, {
+        allowHomeRole,
+        env,
+      });
       if (JSON.stringify(config) !== JSON.stringify(expected)) {
         failures.push(
           "capacitor.config.json differs from the restricted Play runtime contract",


### PR DESCRIPTION
## Summary
- audit generated launcher Capacitor config against the launcher-only kiosk contract
- preserve opt-in WebView debugging during launcher source audit
- cover launcher and ordinary Android cloud audit behavior

## Verification
- `run-mobile-build-android-play-policy.test.mjs`: 15 passed