### PR TITLE
fix(app): seed cloud boot config before async startup

### DIFF
--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -3478,6 +3478,11 @@ function initVisionBridgesIfEnabled(): void {
 
 async function main(): Promise<void> {
   markStartup("main-start");
+  markStartup("app-modules:start");
+  await initializeAppModules();
+  markStartup("app-modules:end");
+  measureStartup("app-modules", "app-modules:start", "app-modules:end");
+
   if (__ELIZA_SERVICE_WORKER__ === true) {
     const { registerViewServiceWorker } = await import("./sw-registration");
     registerViewServiceWorker();
@@ -3504,10 +3509,6 @@ async function main(): Promise<void> {
     return;
   }
 
-  markStartup("app-modules:start");
-  await initializeAppModules();
-  markStartup("app-modules:end");
-  measureStartup("app-modules", "app-modules:start", "app-modules:end");
   setupPlatformStyles();
   applyBuildTimeIosConnection();
 

--- a/packages/app/src/main.web-entrypoint.test.ts
+++ b/packages/app/src/main.web-entrypoint.test.ts
@@ -6,6 +6,7 @@
  */
 import { Capacitor } from "@capacitor/core";
 import { runIosFullBunSmokeIfRequested } from "@elizaos/app-core/desktop-shell";
+import { DEFAULT_BOOT_CONFIG, setBootConfig } from "@elizaos/ui/config";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const webBoot = vi.hoisted(() => ({
@@ -15,6 +16,7 @@ const webBoot = vi.hoisted(() => ({
   createRoot: vi.fn(),
   runEmbedHandshake: vi.fn(async () => undefined),
   registerServiceWorker: vi.fn(),
+  cloudApiBaseAtServiceWorkerModuleLoad: undefined as string | undefined,
 }));
 
 webBoot.createRoot.mockReturnValue({ render: webBoot.render });
@@ -43,9 +45,16 @@ vi.mock("./embed-bootstrap", async (importOriginal) => ({
   ...(await importOriginal<typeof import("./embed-bootstrap")>()),
   runEmbedHandshake: webBoot.runEmbedHandshake,
 }));
-vi.mock("./sw-registration", () => ({
-  registerViewServiceWorker: webBoot.registerServiceWorker,
-}));
+vi.mock("./sw-registration", () => {
+  const bootConfig = Reflect.get(globalThis, "__ELIZAOS_APP_BOOT_CONFIG__") as
+    | { cloudApiBase?: unknown }
+    | undefined;
+  webBoot.cloudApiBaseAtServiceWorkerModuleLoad =
+    typeof bootConfig?.cloudApiBase === "string"
+      ? bootConfig.cloudApiBase
+      : undefined;
+  return { registerViewServiceWorker: webBoot.registerServiceWorker };
+});
 
 beforeEach(() => {
   vi.mocked(Capacitor.getPlatform).mockReturnValue("web");
@@ -55,6 +64,9 @@ beforeEach(() => {
   vi.stubGlobal("__ELIZA_WEB_SHELL__", false);
   vi.stubGlobal("__ELIZA_SERVICE_WORKER__", true);
   vi.stubGlobal("__ELIZA_CHAT_UI_HARNESS__", false);
+  vi.stubEnv("VITE_ELIZA_CLOUD_BASE", "https://cloud-staging.eliza.app");
+  setBootConfig(DEFAULT_BOOT_CONFIG);
+  webBoot.cloudApiBaseAtServiceWorkerModuleLoad = undefined;
   animationFrames.length = 0;
   idleCallbacks.length = 0;
   vi.stubGlobal(
@@ -87,6 +99,9 @@ describe("renderer web composition", () => {
     expect(main.isNative).toBe(false);
     expect(webBoot.runEmbedHandshake).toHaveBeenCalledOnce();
     expect(webBoot.registerServiceWorker).toHaveBeenCalledOnce();
+    expect(webBoot.cloudApiBaseAtServiceWorkerModuleLoad).toBe(
+      "https://cloud-staging.eliza.app",
+    );
     expect(webBoot.initializeStorage).toHaveBeenCalledTimes(2);
     expect(webBoot.initializeCapacitor).toHaveBeenCalledOnce();
     expect(document.body.classList).toContain("platform-web");


### PR DESCRIPTION
Closes #29086

## Summary

- install the app build-time boot configuration before the first asynchronous service-worker import
- keep the existing native, headless, public-web, and marketing entrypoint boundaries
- assert the staging Cloud base is already authoritative when the service-worker module evaluates

## Exact identity

- Reviewed head: `b26b6bc236fad00e7b9f8d80adb83389a7f549e0`
- Tree: `c75db3c9d8759b29c89188e559357ebe8b4cd643`
- Parent/current develop at review: `4c68a1e93bbec5cc3133f8506817583eb6d65ed7`
- Stable patch-id: `e09aa6701e54a40a0b1181e5a80002ce414c5126`
- Scoped diff SHA-256: `04d3db5fb53536fb0da43710c5a479426d5cca36694064077f716380aa0a2155`

## Verification

- 36/36 focused Vitest checks across web, Android, iOS interactive, iOS full-Bun, network fallback, public boot config, and web-entry policy
- Biome clean on both changed files
- `git diff --check` clean
- Independent review: P0-P3 none; the regression assertion fails under the previous startup order

## Evidence matrix

- Before screenshot/video: N/A - no visual output changes; failure occurs before protected renderer auth checks
- After screenshot/video: N/A - exact staging deployment certificate will exercise the deployed renderer after merge
- Backend logs: N/A - renderer-only startup-order repair
- Frontend console/network: staging certificate is the authoritative follow-up evidence
- Real model trajectory: N/A - no model behavior changed