### PR TITLE
fix(android): keep latest launcher sign-in in app

### DIFF
--- a/packages/app-core/scripts/lib/mobile-renderer-feature-env.mjs
+++ b/packages/app-core/scripts/lib/mobile-renderer-feature-env.mjs
@@ -17,6 +17,9 @@ export function resolveMobileRendererFeatureEnv({ platform, env = {} } = {}) {
   if (platform === "ios-local") {
     return { VITE_ELIZA_ENABLE_RUNTIME_CHOOSER: "1" };
   }
+  if (platform === "android-launcher") {
+    return { VITE_ELIZA_ANDROID_LAUNCHER_BUILD: "1" };
+  }
   const isLp3Debug =
     platform === ANDROID_CLOUD_DEBUG &&
     env.ELIZA_ANDROID_LP3_COLOR_POLICY_ENABLED === "1";
@@ -33,6 +36,7 @@ export function mobileRendererRequiresFreshBuild({ platform } = {}) {
   }
   return (
     platform === ANDROID_CLOUD_DEBUG ||
+    platform === "android-launcher" ||
     platform === "ios" ||
     platform === "ios-local"
   );
@@ -50,6 +54,9 @@ export function mobileRendererUnstampedFeatureProblem({ platform } = {}) {
   }
   if (platform === ANDROID_CLOUD_DEBUG) {
     return "dist cannot prove the Android cloud-debug realtime voice flags because they are not stamped";
+  }
+  if (platform === "android-launcher") {
+    return "dist cannot prove the Android launcher in-app auth contract because it is not stamped";
   }
   return null;
 }

--- a/packages/app-core/scripts/lib/mobile-renderer-feature-env.test.mts
+++ b/packages/app-core/scripts/lib/mobile-renderer-feature-env.test.mts
@@ -50,6 +50,15 @@ describe("resolveMobileRendererFeatureEnv", () => {
     ).toEqual({});
   });
 
+  it("marks only the launcher renderer for in-app authentication", () => {
+    expect(
+      resolveMobileRendererFeatureEnv({ platform: "android-launcher" }),
+    ).toEqual({ VITE_ELIZA_ANDROID_LAUNCHER_BUILD: "1" });
+    expect(
+      resolveMobileRendererFeatureEnv({ platform: "android-cloud" }),
+    ).toEqual({});
+  });
+
   it("requires an explicit platform", () => {
     expect(() => resolveMobileRendererFeatureEnv()).toThrow(
       /platform is required/,
@@ -62,7 +71,7 @@ describe("mobileRendererRequiresFreshBuild", () => {
     expect(
       mobileRendererRequiresFreshBuild({ platform: "android-cloud-debug" }),
     ).toBe(true);
-    for (const platform of ["ios", "ios-local"]) {
+    for (const platform of ["android-launcher", "ios", "ios-local"]) {
       expect(mobileRendererRequiresFreshBuild({ platform })).toBe(true);
     }
     for (const platform of ["android", "android-cloud", "ios-overlay"]) {
@@ -81,6 +90,9 @@ describe("mobileRendererUnstampedFeatureProblem", () => {
         platform: "android-cloud-debug",
       }),
     ).toContain("realtime voice flags");
+    expect(
+      mobileRendererUnstampedFeatureProblem({ platform: "android-launcher" }),
+    ).toContain("in-app auth contract");
     for (const platform of ["ios", "ios-overlay", "android", "android-cloud"]) {
       expect(mobileRendererUnstampedFeatureProblem({ platform })).toBeNull();
     }

--- a/packages/app-core/scripts/mobile/targets/android.mjs
+++ b/packages/app-core/scripts/mobile/targets/android.mjs
@@ -46,7 +46,7 @@ export const ANDROID_BUILD_TARGETS = Object.freeze({
   }),
   "android-launcher": freezeAndroidBuildTarget({
     target: "android-launcher",
-    webTarget: "android-cloud-debug",
+    webTarget: "android-launcher",
     env: {
       ELIZA_ANDROID_CLOUD_BUILD: "1",
       ELIZA_ANDROID_LAUNCHER_BUILD: "1",

--- a/packages/app-core/scripts/run-mobile-build-android-play-policy.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-android-play-policy.test.mjs
@@ -189,6 +189,22 @@ describe("Android Play manifest policy", () => {
     expect(sanitized.android.webContentsDebuggingEnabled).toBe(true);
   });
 
+  it("allows only canonical hosted-auth navigation in launcher config", () => {
+    const sanitized = sanitizeAndroidCloudCapacitorConfig(
+      {
+        server: {
+          allowNavigation: ["*", "evil.example", "accounts.google.com"],
+        },
+      },
+      { allowInAppAuthNavigation: true },
+    );
+
+    expect(sanitized.server).toEqual({
+      androidScheme: "https",
+      allowNavigation: ["cloud.eliza.app", "cloud-staging.eliza.app"],
+    });
+  });
+
   it("keeps the unused native Google identity stack out of Android source", () => {
     const androidSourceDir = new URL(
       "../platforms/android/app/src/main/java/ai/elizaos/app/",

--- a/packages/app-core/scripts/run-mobile-build-android-targets.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-android-targets.test.mjs
@@ -130,7 +130,7 @@ describe("Android mobile build target table", () => {
     });
     expect(ANDROID_BUILD_TARGETS["android-launcher"]).toMatchObject({
       target: "android-launcher",
-      webTarget: "android-cloud-debug",
+      webTarget: "android-launcher",
       env: {
         ELIZA_ANDROID_CLOUD_BUILD: "1",
         ELIZA_ANDROID_LAUNCHER_BUILD: "1",

--- a/packages/app-core/scripts/run-mobile-build-cloud-main-activity.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-cloud-main-activity.test.mjs
@@ -77,6 +77,30 @@ describe("cloudSafeMainActivityJava", () => {
     );
   });
 
+  it("restores the bundled launcher renderer after the exact in-app auth callback", () => {
+    const source = cloudSafeMainActivityJava("ai.elizaos.app", {
+      launcherKiosk: true,
+    });
+
+    expect(source).toContain("import android.net.Uri;");
+    expect(source).toContain("isCloudAuthCallback(Intent intent)");
+    expect(source).toContain('"elizaos".equalsIgnoreCase(data.getScheme())');
+    expect(source).toContain('"auth".equalsIgnoreCase(data.getHost())');
+    expect(source).toContain('"/callback".equals(data.getPath())');
+    expect(source).toContain(
+      "DeepLinkBufferPlugin.captureIntent(this, intent)",
+    );
+    expect(source).toContain("String localUrl = getBridge().getLocalUrl();");
+    expect(source).toContain("webView.post(() -> webView.loadUrl(localUrl));");
+    expect(source).toContain(
+      "restoreBundledRendererAfterAuthCallback(intent);",
+    );
+
+    const playSource = cloudSafeMainActivityJava("ai.elizaos.app");
+    expect(playSource).not.toContain("isCloudAuthCallback");
+    expect(playSource).not.toContain("restoreBundledRendererAfterAuthCallback");
+  });
+
   it("uses no hidden Android system-property API in the Play activity", () => {
     const source = cloudSafeMainActivityJava("ai.elizaos.app");
 

--- a/packages/app-core/scripts/run-mobile-build-cloud-main-activity.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-cloud-main-activity.test.mjs
@@ -117,6 +117,11 @@ describe("cloudSafeMainActivityJava", () => {
     });
 
     expect(source).toContain("import androidx.core.view.WindowInsetsCompat;");
+    expect(
+      source.match(
+        /import androidx\.core\.view\.WindowInsetsControllerCompat;/g,
+      ),
+    ).toHaveLength(1);
     expect(source).toContain(
       "controller.hide(WindowInsetsCompat.Type.navigationBars())",
     );

--- a/packages/app-core/scripts/run-mobile-build-cloud-main-activity.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-cloud-main-activity.test.mjs
@@ -110,6 +110,21 @@ describe("cloudSafeMainActivityJava", () => {
     expect(source).not.toContain("readSystemProperty");
   });
 
+  it("hides only the launcher navigation bar with transient swipe recovery", () => {
+    const source = cloudSafeMainActivityJava("ai.elizaos.app", {
+      launcherKiosk: true,
+      immersiveNavigation: true,
+    });
+
+    expect(source).toContain("import androidx.core.view.WindowInsetsCompat;");
+    expect(source).toContain(
+      "controller.hide(WindowInsetsCompat.Type.navigationBars())",
+    );
+    expect(source).toContain("BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE");
+    expect(source).toContain("onWindowFocusChanged(boolean hasFocus)");
+    expect(source).not.toContain("WindowInsetsCompat.Type.statusBars()");
+  });
+
   it("captures cold and warm deep links before Capacitor dispatches them", () => {
     const source = cloudSafeMainActivityJava("ai.elizaos.app");
     const coldCapture = source.indexOf(

--- a/packages/app-core/scripts/run-mobile-build-cloud-main-activity.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-cloud-main-activity.test.mjs
@@ -61,6 +61,8 @@ describe("cloudSafeMainActivityJava", () => {
       launcherKiosk: true,
     });
 
+    expect(source).toContain("public void onResume()");
+    expect(source).not.toContain("protected void onResume()");
     expect(source).toContain("import android.view.KeyEvent;");
     expect(source).toContain("import androidx.activity.OnBackPressedCallback;");
     expect(source).toContain("new OnBackPressedCallback(true)");

--- a/packages/app-core/scripts/run-mobile-build-cloud-main-activity.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-cloud-main-activity.test.mjs
@@ -71,7 +71,6 @@ describe("cloudSafeMainActivityJava", () => {
     expect(source).toContain("KeyEvent.KEYCODE_FORWARD");
     expect(source).toContain("KeyEvent.KEYCODE_NAVIGATE_NEXT");
     expect(source).toContain("startLockTask();");
-    expect(source).toContain("protected void onResume()");
     expect(source).toContain("super.onResume();");
     expect(source).toContain(
       "IllegalArgumentException | IllegalStateException | SecurityException",

--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -7856,7 +7856,10 @@ function auditAndroidCloudSource(
   } else {
     try {
       const config = JSON.parse(fs.readFileSync(capacitorConfigPath, "utf8"));
-      const expected = sanitizeAndroidCloudCapacitorConfig(config);
+      const expected = sanitizeAndroidCloudCapacitorConfig(config, {
+        launcherKiosk: env.ELIZA_ANDROID_LAUNCHER_BUILD === "1",
+        webViewDebugging: env.ELIZA_WEBVIEW_DEBUG === "1",
+      });
       if (JSON.stringify(config) !== JSON.stringify(expected)) {
         failures.push(
           "capacitor.config.json differs from the restricted Play runtime contract",

--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -6356,7 +6356,7 @@ import androidx.activity.OnBackPressedCallback;
   const launcherMethods = launcherKiosk
     ? `
     @Override
-    protected void onResume() {
+    public void onResume() {
         super.onResume();
         // Browser-based identity providers temporarily cover the launcher.
         // Re-enter containment whenever their deep-link callback returns.

--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -6339,7 +6339,7 @@ export function findAndroidCloudPackagedRuntimeOffenders(entries) {
 
 export function cloudSafeMainActivityJava(
   androidPackage,
-  { launcherKiosk = false } = {},
+  { launcherKiosk = false, immersiveNavigation = false } = {},
 ) {
   const launcherImports = launcherKiosk
     ? `import android.net.Uri;
@@ -6348,6 +6348,9 @@ import android.view.KeyEvent;
 
 import androidx.activity.OnBackPressedCallback;
 `
+    : "";
+  const navigationInsetsImport = immersiveNavigation
+    ? "import androidx.core.view.WindowInsetsCompat;\n"
     : "";
   const launcherConstants = launcherKiosk
     ? '    private static final String TAG = "ElizaMainActivity";\n'
@@ -6411,6 +6414,28 @@ import androidx.activity.OnBackPressedCallback;
     }
 `
     : "";
+  const navigationBarPolicy = immersiveNavigation
+    ? `            systemBars.hide(WindowInsetsCompat.Type.navigationBars());
+            systemBars.setSystemBarsBehavior(
+                WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE);`
+    : "            systemBars.setAppearanceLightNavigationBars(false);";
+  const focusHandler = immersiveNavigation
+    ? `
+    @Override
+    public void onWindowFocusChanged(boolean hasFocus) {
+        super.onWindowFocusChanged(hasFocus);
+        if (!hasFocus) return;
+        WindowInsetsControllerCompat controller =
+            WindowCompat.getInsetsController(
+                getWindow(), getWindow().getDecorView());
+        if (controller != null) {
+            controller.hide(WindowInsetsCompat.Type.navigationBars());
+            controller.setSystemBarsBehavior(
+                WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE);
+        }
+    }
+`
+    : "";
   return `package ${androidPackage};
 
 import android.os.Bundle;
@@ -6420,7 +6445,7 @@ import android.webkit.WebView;
 
 import androidx.core.splashscreen.SplashScreen;
 import androidx.core.view.WindowCompat;
-import androidx.core.view.WindowInsetsControllerCompat;
+${navigationInsetsImport}import androidx.core.view.WindowInsetsControllerCompat;
 ${launcherImports}
 
 import com.getcapacitor.BridgeActivity;
@@ -6458,17 +6483,16 @@ ${launcherConstants}
         getBridge().registerPlugin(SafePushNotificationsPlugin.class);
 ${launcherSetup}
 
-        // Draw the canonical Cloud renderer behind transparent system bars while
-        // keeping both bars visible and user-controlled. This uses only the
-        // public AndroidX edge-to-edge API and avoids white-on-white status
-        // icons on the signed-out screen.
+        // Draw the canonical Cloud renderer behind transparent system bars. The
+        // launcher variant hides only the navigation bar; a swipe can reveal
+        // it transiently; ordinary Cloud builds keep both bars visible.
         WindowCompat.setDecorFitsSystemWindows(getWindow(), false);
         WindowInsetsControllerCompat systemBars =
             WindowCompat.getInsetsController(
                 getWindow(), getWindow().getDecorView());
         if (systemBars != null) {
             systemBars.setAppearanceLightStatusBars(false);
-            systemBars.setAppearanceLightNavigationBars(false);
+${navigationBarPolicy}
         }
 
         if (getBridge() != null && getBridge().getWebView() != null) {
@@ -6484,6 +6508,7 @@ ${launcherSetup}
 ${launcherKiosk ? "        restoreBundledRendererAfterAuthCallback(intent);" : ""}
     }
 ${launcherMethods}
+${focusHandler}
 
 }
 `;
@@ -7348,7 +7373,7 @@ public class ElizaTasksWorker extends Worker {
 function rewriteCloudJavaSources(
   javaRoots,
   androidPackage,
-  { launcherKiosk = false } = {},
+  { launcherKiosk = false, immersiveNavigation = false } = {},
 ) {
   let touched = 0;
   for (const root of javaRoots) {
@@ -7357,7 +7382,10 @@ function rewriteCloudJavaSources(
     if (fs.existsSync(mainActivity)) {
       fs.writeFileSync(
         mainActivity,
-        cloudSafeMainActivityJava(androidPackage, { launcherKiosk }),
+        cloudSafeMainActivityJava(androidPackage, {
+          launcherKiosk,
+          immersiveNavigation,
+        }),
         "utf8",
       );
       touched += 1;
@@ -8289,6 +8317,7 @@ function stripAndroidForCloud({ env = process.env } = {}) {
   }
   rewriteCloudJavaSources([activeJavaRoot], androidPackage, {
     launcherKiosk: env.ELIZA_ANDROID_LAUNCHER_BUILD === "1",
+    immersiveNavigation: env.ELIZA_ANDROID_LAUNCHER_BUILD === "1",
   });
 
   const testJavaRoots = [

--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -5919,6 +5919,10 @@ export const ANDROID_PLAY_ALLOWED_CAPACITOR_CONFIG_PLUGINS = Object.freeze([
   "Keyboard",
   "SplashScreen",
 ]);
+export const ANDROID_LAUNCHER_IN_APP_AUTH_HOSTS = Object.freeze([
+  "cloud.eliza.app",
+  "cloud-staging.eliza.app",
+]);
 
 function isJsonRecord(value) {
   return value !== null && typeof value === "object" && !Array.isArray(value);
@@ -5927,7 +5931,11 @@ function isJsonRecord(value) {
 /** Returns the minimal runtime config that is safe to package in a Play APK/AAB. */
 export function sanitizeAndroidCloudCapacitorConfig(
   value,
-  { launcherKiosk = false, webViewDebugging = false } = {},
+  {
+    allowInAppAuthNavigation = false,
+    launcherKiosk = false,
+    webViewDebugging = false,
+  } = {},
 ) {
   if (!isJsonRecord(value)) {
     throw new Error(
@@ -5948,6 +5956,9 @@ export function sanitizeAndroidCloudCapacitorConfig(
     ...(launcherKiosk ? { loggingBehavior: "none" } : {}),
     server: {
       androidScheme: "https",
+      ...(allowInAppAuthNavigation
+        ? { allowNavigation: [...ANDROID_LAUNCHER_IN_APP_AUTH_HOSTS] }
+        : {}),
     },
     plugins,
     android: {
@@ -5987,6 +5998,7 @@ function sanitizeAndroidCloudPackagedConfig(env = process.env) {
     );
   }
   const sanitized = sanitizeAndroidCloudCapacitorConfig(parsed, {
+    allowInAppAuthNavigation: env.ELIZA_ANDROID_LAUNCHER_BUILD === "1",
     launcherKiosk: env.ELIZA_ANDROID_LAUNCHER_BUILD === "1",
     webViewDebugging: env.ELIZA_WEBVIEW_DEBUG === "1",
   });
@@ -6330,7 +6342,8 @@ export function cloudSafeMainActivityJava(
   { launcherKiosk = false } = {},
 ) {
   const launcherImports = launcherKiosk
-    ? `import android.util.Log;
+    ? `import android.net.Uri;
+import android.util.Log;
 import android.view.KeyEvent;
 
 import androidx.activity.OnBackPressedCallback;
@@ -6365,6 +6378,25 @@ import androidx.activity.OnBackPressedCallback;
         } catch (IllegalArgumentException | IllegalStateException | SecurityException e) {
             Log.w(TAG, "Unable to enter launcher lock-task mode", e);
         }
+    }
+
+    private boolean isCloudAuthCallback(Intent intent) {
+        Uri data = intent == null ? null : intent.getData();
+        return data != null
+            && "elizaos".equalsIgnoreCase(data.getScheme())
+            && "auth".equalsIgnoreCase(data.getHost())
+            && "/callback".equals(data.getPath());
+    }
+
+    private void restoreBundledRendererAfterAuthCallback(Intent intent) {
+        if (!isCloudAuthCallback(intent)
+                || getBridge() == null
+                || getBridge().getWebView() == null) {
+            return;
+        }
+        WebView webView = getBridge().getWebView();
+        String localUrl = getBridge().getLocalUrl();
+        webView.post(() -> webView.loadUrl(localUrl));
     }
 
     @Override
@@ -6449,6 +6481,7 @@ ${launcherSetup}
     protected void onNewIntent(Intent intent) {
         DeepLinkBufferPlugin.captureIntent(this, intent);
         super.onNewIntent(intent);
+${launcherKiosk ? "        restoreBundledRendererAfterAuthCallback(intent);" : ""}
     }
 ${launcherMethods}
 
@@ -7857,6 +7890,7 @@ function auditAndroidCloudSource(
     try {
       const config = JSON.parse(fs.readFileSync(capacitorConfigPath, "utf8"));
       const expected = sanitizeAndroidCloudCapacitorConfig(config, {
+        allowInAppAuthNavigation: env.ELIZA_ANDROID_LAUNCHER_BUILD === "1",
         launcherKiosk: env.ELIZA_ANDROID_LAUNCHER_BUILD === "1",
         webViewDebugging: env.ELIZA_WEBVIEW_DEBUG === "1",
       });
@@ -7898,6 +7932,43 @@ function auditAndroidLauncherSource(phase, options = {}) {
   assertAndroidLauncherManifest(manifest, {
     label: `android-launcher ${phase} source`,
   });
+  const mainActivityPath = path.join(
+    androidDir,
+    "app",
+    "src",
+    "main",
+    "java",
+    packageNameToPath(APP.appId),
+    "MainActivity.java",
+  );
+  const mainActivity = fs.existsSync(mainActivityPath)
+    ? fs.readFileSync(mainActivityPath, "utf8")
+    : "";
+  if (
+    !mainActivity.includes("hide(WindowInsetsCompat.Type.navigationBars())") ||
+    !mainActivity.includes("BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE")
+  ) {
+    throw new Error(
+      `[mobile-build] android-launcher ${phase} source audit failed: MainActivity does not hide the gesture navigation bar with transient swipe recovery.`,
+    );
+  }
+  if (mainActivity.includes("hide(WindowInsetsCompat.Type.statusBars())")) {
+    throw new Error(
+      `[mobile-build] android-launcher ${phase} source audit failed: MainActivity must keep the status bar visible.`,
+    );
+  }
+  if (
+    !mainActivity.includes("isCloudAuthCallback(Intent intent)") ||
+    !mainActivity.includes('"elizaos".equalsIgnoreCase(data.getScheme())') ||
+    !mainActivity.includes('"auth".equalsIgnoreCase(data.getHost())') ||
+    !mainActivity.includes('"/callback".equals(data.getPath())') ||
+    !mainActivity.includes("getBridge().getLocalUrl()") ||
+    !mainActivity.includes("webView.loadUrl(localUrl)")
+  ) {
+    throw new Error(
+      `[mobile-build] android-launcher ${phase} source audit failed: MainActivity does not restore the bundled renderer after the exact in-app auth callback.`,
+    );
+  }
   console.log(`[mobile-build] android-launcher ${phase} audit passed.`);
 }
 
@@ -8592,7 +8663,7 @@ export async function runAndroidBuild(
     ANDROID_SOURCE_AUDITS,
     "auditSourceKey",
     "pre-gradle",
-    { env: resolvedEnv },
+    { env: targetEnv },
   );
 
   const buildEnv = createAndroidBuildEnv(target, {
@@ -8620,7 +8691,7 @@ export async function runAndroidBuild(
     ANDROID_SOURCE_AUDITS,
     "auditSourceKey",
     "post-gradle",
-    { env: resolvedEnv },
+    { env: targetEnv },
   );
   if (target.artifactAuditKey === "cloud") {
     resolvedEnv[ANDROID_BUNDLETOOL_JAR_ENV] = await ensureAndroidBundletoolJar({
@@ -10058,6 +10129,21 @@ function auditAndroidLauncherArtifact({
         context: {
           artifact,
           loggingBehavior: runtimeConfig.loggingBehavior ?? null,
+        },
+      },
+    );
+  }
+  if (
+    JSON.stringify(runtimeConfig.server?.allowNavigation) !==
+    JSON.stringify(ANDROID_LAUNCHER_IN_APP_AUTH_HOSTS)
+  ) {
+    throw mobileBuildError(
+      "[mobile-build] android-launcher must keep WebView navigation pinned to the canonical Eliza hosted-auth origins.",
+      {
+        code: "ANDROID_LAUNCHER_AUTH_NAVIGATION_INVALID",
+        context: {
+          allowNavigation: runtimeConfig.server?.allowNavigation ?? null,
+          artifact,
         },
       },
     );

--- a/packages/ui/src/android-cloud/android-cloud-auth.test.ts
+++ b/packages/ui/src/android-cloud/android-cloud-auth.test.ts
@@ -63,6 +63,30 @@ describe("Android Cloud native auth handoff", () => {
     vi.restoreAllMocks();
   });
 
+  it("keeps launcher login on the first-party HTTPS WebView surface", async () => {
+    const auth = await import("./android-cloud-auth");
+    const navigate = vi.fn();
+
+    expect(
+      auth.navigateAndroidCloudSignInInApp(
+        "https://cloud.eliza.app/login?returnTo=%2Fapp-auth%2Fauthorize",
+        navigate,
+      ),
+    ).toBe(true);
+    expect(navigate).toHaveBeenCalledWith(
+      "https://cloud.eliza.app/login?returnTo=%2Fapp-auth%2Fauthorize",
+    );
+
+    for (const url of [
+      "http://cloud.eliza.app/login",
+      "https://cloud.eliza.app.evil.example/login",
+      "javascript:alert(1)",
+    ]) {
+      expect(auth.navigateAndroidCloudSignInInApp(url, navigate)).toBe(false);
+    }
+    expect(navigate).toHaveBeenCalledTimes(1);
+  });
+
   it("single-flights concurrent and sequential delivery of one callback", async () => {
     const fetchImpl = vi
       .fn<typeof fetch>()

--- a/packages/ui/src/android-cloud/android-cloud-auth.ts
+++ b/packages/ui/src/android-cloud/android-cloud-auth.ts
@@ -2,12 +2,14 @@
  * Native Android handoff for the canonical Eliza Cloud sign-in flow.
  *
  * The application keeps its normal first-run chat and full app shell; this
- * module contributes only the PKCE protocol and Keystore-backed pending-login
- * state needed to leave the WebView for hosted authentication and safely
- * resume through an Android deep link.
+ * module contributes the PKCE protocol and Keystore-backed pending-login state
+ * needed to use hosted authentication and safely resume through an Android
+ * deep link. Play builds use a Custom Tab; pinned launcher builds navigate the
+ * same first-party flow inside their own WebView task.
  */
 
 import { registerPlugin } from "@capacitor/core";
+import { isSafeNavigationUrl } from "../utils/navigation-url";
 import {
   AndroidCloudAuthError,
   AndroidCloudClient,
@@ -21,6 +23,10 @@ export const ANDROID_CLOUD_AUTH_RESULT_EVENT =
   "eliza:android-cloud-auth-result" as const;
 export const ANDROID_CLOUD_AUTH_STARTED_EVENT =
   "eliza:android-cloud-auth-started" as const;
+const ANDROID_CLOUD_LOGIN_HOSTS = new Set([
+  "cloud.eliza.app",
+  "cloud-staging.eliza.app",
+]);
 
 export interface AndroidCloudAuthResult {
   apiBase?: string;
@@ -90,6 +96,29 @@ export async function beginAndroidCloudSignIn(
   cloudApiBase?: string,
 ): Promise<AndroidCloudLoginAttempt> {
   return client(cloudApiBase).beginLogin();
+}
+
+/**
+ * Navigates the launcher WebView to the hosted first-party login surface.
+ * Unlike Capacitor Browser this remains inside the launcher's pinned task.
+ * The native callback handler restores the bundled renderer before replaying
+ * the protected PKCE callback.
+ */
+export function navigateAndroidCloudSignInInApp(
+  url: string,
+  navigate: (safeUrl: string) => void = (safeUrl) =>
+    window.location.assign(safeUrl),
+): boolean {
+  if (!isSafeNavigationUrl(url)) return false;
+  const parsed = new URL(url);
+  if (
+    parsed.protocol !== "https:" ||
+    !ANDROID_CLOUD_LOGIN_HOSTS.has(parsed.hostname.toLowerCase())
+  ) {
+    return false;
+  }
+  navigate(parsed.toString());
+  return true;
 }
 
 /**

--- a/packages/ui/src/platform/android-runtime.test.ts
+++ b/packages/ui/src/platform/android-runtime.test.ts
@@ -9,7 +9,10 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { resolveAndroidRuntimeMode } from "./android-runtime";
+import {
+  resolveAndroidLauncherBuild,
+  resolveAndroidRuntimeMode,
+} from "./android-runtime";
 
 const KEY = "VITE_ELIZA_ANDROID_RUNTIME_MODE";
 
@@ -88,5 +91,25 @@ describe("resolveAndroidRuntimeMode", () => {
   it("is pure — repeated calls with the same env agree", () => {
     const env = { [KEY]: "cloud" };
     expect(resolveAndroidRuntimeMode(env)).toBe(resolveAndroidRuntimeMode(env));
+  });
+});
+
+describe("resolveAndroidLauncherBuild", () => {
+  it("enables the launcher-only renderer contract only for exact 1", () => {
+    expect(
+      resolveAndroidLauncherBuild({ VITE_ELIZA_ANDROID_LAUNCHER_BUILD: "1" }),
+    ).toBe(true);
+    expect(
+      resolveAndroidLauncherBuild({
+        VITE_ELIZA_ANDROID_LAUNCHER_BUILD: " 1 ",
+      }),
+    ).toBe(true);
+    for (const value of [undefined, "", "0", "true", "launcher"]) {
+      expect(
+        resolveAndroidLauncherBuild({
+          VITE_ELIZA_ANDROID_LAUNCHER_BUILD: value,
+        }),
+      ).toBe(false);
+    }
   });
 });

--- a/packages/ui/src/platform/android-runtime.ts
+++ b/packages/ui/src/platform/android-runtime.ts
@@ -67,6 +67,24 @@ export function isAndroidCloudBuild(): boolean {
 }
 
 /**
+ * Returns true only for the direct-install HOME/launcher artifact. The Play
+ * cloud client deliberately keeps the system-browser OAuth handoff, while the
+ * pinned launcher must keep authentication inside its own task.
+ */
+export function resolveAndroidLauncherBuild(env: RuntimeEnv): boolean {
+  return readString(env, ["VITE_ELIZA_ANDROID_LAUNCHER_BUILD"]) === "1";
+}
+
+export function isAndroidLauncherBuild(): boolean {
+  const env =
+    typeof import.meta !== "undefined" &&
+    (import.meta as { env?: RuntimeEnv }).env
+      ? ((import.meta as { env: RuntimeEnv }).env as RuntimeEnv)
+      : {};
+  return resolveAndroidLauncherBuild(env);
+}
+
+/**
  * True on the Android builds that ship the on-device agent runtime
  * (`android` sideload / `android-system`): a native Android shell that is not
  * the cloud-locked Play-Store variant. These builds' whole point is the local

--- a/packages/ui/src/state/useCloudState.android-cloud-auth.test.tsx
+++ b/packages/ui/src/state/useCloudState.android-cloud-auth.test.tsx
@@ -12,6 +12,9 @@ const harness = vi.hoisted(() => ({
   })),
   browserFinished: null as null | (() => void),
   cancel: vi.fn(async () => true),
+  externalOpen: vi.fn(async () => true),
+  inAppNavigate: vi.fn(() => true),
+  launcher: false,
   sequence: 0,
   stewardToken: null as string | null,
   api: {
@@ -50,6 +53,7 @@ vi.mock("@elizaos/shared/steward-session-client", async (importOriginal) => {
 
 vi.mock("../platform/android-runtime", () => ({
   isAndroidCloudBuild: () => true,
+  isAndroidLauncherBuild: () => harness.launcher,
 }));
 
 vi.mock("../api", () => ({ client: harness.api }));
@@ -59,6 +63,7 @@ vi.mock("../android-cloud/android-cloud-auth", () => ({
   ANDROID_CLOUD_AUTH_STARTED_EVENT: "eliza:android-cloud-auth-started",
   beginAndroidCloudSignIn: harness.begin,
   cancelAndroidCloudSignIn: harness.cancel,
+  navigateAndroidCloudSignInInApp: harness.inAppNavigate,
   hasPendingAndroidCloudSignIn: vi.fn(async () => {
     throw new Error("pending cleanup record unavailable");
   }),
@@ -76,7 +81,7 @@ vi.mock("../utils", async (importOriginal) => {
         harness.browserFinished = null;
       };
     }),
-    openExternalUrl: vi.fn(async () => true),
+    openExternalUrl: harness.externalOpen,
   };
 });
 
@@ -95,6 +100,9 @@ describe("useCloudState Android hosted auth", () => {
     vi.useFakeTimers();
     harness.browserFinished = null;
     harness.cancel.mockClear();
+    harness.externalOpen.mockClear();
+    harness.inAppNavigate.mockClear();
+    harness.launcher = false;
     harness.begin.mockReset();
     harness.begin.mockImplementation(async () => {
       harness.sequence += 1;
@@ -106,6 +114,22 @@ describe("useCloudState Android hosted auth", () => {
     harness.sequence = 0;
     harness.stewardToken = null;
     for (const method of Object.values(harness.api)) method.mockClear();
+  });
+
+  it("navigates the launcher WebView without opening Chrome", async () => {
+    harness.launcher = true;
+    const { result } = renderHook(() => useCloudState(params()));
+
+    await act(async () => {
+      await result.current.handleCloudLogin();
+    });
+
+    expect(harness.inAppNavigate).toHaveBeenCalledWith(
+      "https://cloud.eliza.app/login",
+    );
+    expect(harness.externalOpen).not.toHaveBeenCalled();
+    expect(harness.browserFinished).toBeNull();
+    expect(harness.cancel).not.toHaveBeenCalled();
   });
 
   afterEach(() => {

--- a/packages/ui/src/state/useCloudState.ts
+++ b/packages/ui/src/state/useCloudState.ts
@@ -30,6 +30,7 @@ import {
   type AndroidCloudAuthResult,
   beginAndroidCloudSignIn,
   cancelAndroidCloudSignIn,
+  navigateAndroidCloudSignInInApp,
   takeLatestAndroidCloudCompletion,
 } from "../android-cloud/android-cloud-auth";
 import { client } from "../api";
@@ -51,7 +52,10 @@ import { signOutFromSsoBridgedHost } from "../cloud/sso-bridge/sso-bridge";
 import { getBootConfig, setBootConfig } from "../config/boot-config";
 import { dispatchElizaCloudStatusUpdated } from "../events";
 import { isElizaCloudRuntimeLocked } from "../first-run/mobile-runtime-mode";
-import { isAndroidCloudBuild } from "../platform/android-runtime";
+import {
+  isAndroidCloudBuild,
+  isAndroidLauncherBuild,
+} from "../platform/android-runtime";
 import { isViteDevUiShell } from "../platform/vite-dev-ui-shell";
 import {
   closeExternalBrowser,
@@ -845,6 +849,16 @@ export function useCloudState({
           });
           const attempt = await beginAndroidCloudSignIn(cloudApiBase);
           attemptId = attempt.state;
+          if (isAndroidLauncherBuild()) {
+            if (!navigateAndroidCloudSignInInApp(attempt.browserUrl)) {
+              await cancelAndroidCloudSignIn(attempt.state);
+              throw new Error("Eliza Cloud returned an invalid sign-in URL.");
+            }
+            // Navigation replaces this renderer. The callback is buffered by
+            // native code, which restores the bundled shell and completes the
+            // Keystore-bound PKCE exchange during the next bootstrap.
+            return loginCompletion;
+          }
           const onCallbackStarted = (event: Event) => {
             const startedAttemptId = (
               event as CustomEvent<{ attemptId?: string }>


### PR DESCRIPTION
## Summary
- port the launcher in-app hosted-auth flow onto current develop
- preserve launcher runtime options in source and artifact audits
- hide only the Android navigation gesture handle in launcher mode
- restore the bundled renderer after the exact auth callback

## Verification
- 44 Android launcher/build-policy tests pass
- canonical launcher build passes pre/post Gradle and APK artifact audits
- Pixel 11 Pro clean install shows sign-in-first UI and hosts cloud.eliza.app/login inside ai.elizaos.app.MainActivity