### PR TITLE
test(core): cover locale detection tie and diacritic edges

### DIFF
--- a/packages/core/src/runtime/locale-detection.test.ts
+++ b/packages/core/src/runtime/locale-detection.test.ts
@@ -89,3 +89,78 @@ describe("locale-detection", () => {
 		});
 	});
 });
+
+describe("locale-detection (edge cases)", () => {
+	describe("detectLocaleFromText", () => {
+		it("prefers Japanese kana even when Han characters are also present", () => {
+			// Mixed kanji + hiragana resolves to Japanese even though Han text is present.
+			expect(detectLocaleFromText("今日はいい天気ですね")).toBe("ja");
+		});
+
+		it("is case-insensitive for hint words", () => {
+			expect(detectLocaleFromText("HOLA GRACIAS")).toBe("es");
+			expect(detectLocaleFromText("Bonjour MERCI")).toBe("fr");
+		});
+
+		it("picks the language with more hint-word hits when both appear", () => {
+			expect(detectLocaleFromText("hola gracias mais")).toBe("es");
+			expect(detectLocaleFromText("hola merci oui")).toBe("fr");
+		});
+
+		it("abstains on a tied hint-word score", () => {
+			expect(detectLocaleFromText("hola merci")).toBeNull();
+		});
+
+		it("abstains when a diacritic is scored by both languages", () => {
+			// é signals both Spanish and French, so it cannot decide and the
+			// heuristic abstains rather than guess.
+			expect(detectLocaleFromText("café")).toBeNull();
+		});
+
+		it("decides via a diacritic unique to one language", () => {
+			// ñ uniquely signals Spanish; œ uniquely signals French.
+			expect(detectLocaleFromText("el niño")).toBe("es");
+			expect(detectLocaleFromText("cœur")).toBe("fr");
+		});
+
+		it("lets a unique diacritic break a one-hint-word tie", () => {
+			// Tied hint words: the Spanish-only ¿ breaks the tie.
+			expect(detectLocaleFromText("hola mais ¿")).toBe("es");
+		});
+	});
+
+	describe("resolveOwnerLocale", () => {
+		it("trims a whitespace-padded owner locale before accepting it", () => {
+			expect(
+				resolveOwnerLocale({ ownerLocale: "  ja  ", recentMessage: "hola" }),
+			).toBe("ja");
+		});
+
+		it("ignores a whitespace-only owner locale", () => {
+			expect(
+				resolveOwnerLocale({
+					ownerLocale: "   ",
+					recentMessage: "こんにちは",
+				}),
+			).toBe("ja");
+		});
+
+		it("defaults to en when the provided default is whitespace-only", () => {
+			expect(
+				resolveOwnerLocale({
+					recentMessage: "plain words",
+					defaultLocale: "  ",
+				}),
+			).toBe("en");
+		});
+
+		it("trims a padded valid default before returning it", () => {
+			expect(
+				resolveOwnerLocale({
+					recentMessage: "plain words",
+					defaultLocale: "  fr  ",
+				}),
+			).toBe("fr");
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Closes #29088

Extends `packages/core/src/runtime/locale-detection.test.ts` with 11 edge-case tests (+75 lines) pinning the locale-detection contract's abstention and whitespace-malformed branches, which the merged base suite (#26735) does not cover.

**What regression each test detects** (per the test-only PR policy):

- Tied hint-word scores (`"hola merci"`) and shared diacritics (`"café"` — é signals both es and fr) must **abstain** (`null`), not guess: catches a tie-break flipped to `>=` picking either language.
- Kana-over-Han precedence on mixed-script text: catches reordering the CJK checks so any Han-containing text resolves `zh-Hans`.
- Case-insensitive hint matching (`"HOLA GRACIAS"` → es): catches dropping the lowercase normalization.
- Hint-count dominance and unique-diacritic tie-breaks (`ñ`/`œ`/`¿`): catch Boolean-presence scoring replacing hit counting, or diacritic scoring removed entirely.
- `resolveOwnerLocale` whitespace handling: padded owner locale is trimmed and accepted, whitespace-only owner locale is ignored (falls through to detection), whitespace-only default falls back to `"en"`, padded default is trimmed: catches truthiness-based fallback (`defaultLocale || "en"`) and trim removal.

**Who observes the breakage:** `createOwnerLocaleExamplesProvider` in `plugins/plugin-personal-assistant/src/lifeops/i18n/localized-examples-provider.ts` keys the multilingual prompt-registry resolver off `resolveOwnerLocale`'s result; a tie-guessing or untrimmed-locale regression makes the provider resolve the wrong registry locale (or drop to the null/default branch), so the multilingual owner receives English-only or wrong-locale lifeops example prompts.

**Why no existing test owns this:** the base suite covers detection happy paths plus one no-signal abstention; the plugin-personal-assistant suites exercise example rendering with a fixed locale and never drive the heuristic's tie/abstention branches.

## Verification

- `vitest run src/runtime/locale-detection.test.ts`: 21/21 pass (10 base + 11 new), 3 consecutive green runs.
- `biome check` on the changed file: clean.
- Mutation matrix (behavior mutations, module restored byte-identical after each): 6/6 caught — tie-abstention flipped to `>=` → 2 tests fail; owner-locale trim removed → 2 fail; default-locale trim/fallback removed → 2 fail; kana/Han precedence inverted → 3 fail; lowercase normalization removed → 1 fail; diacritic scoring removed → 2 fail.
- Independent RP review (gpt-5.6-sol): APPROVE, zero must-fix; all 11 tests mapped to concrete mutations; consumer framing verified against the provider source. Two impl-oriented test comments reworded per review.

| Evidence row | Status |
| --- | --- |
| before/after screenshots | N/A - test-only change, no UI surface |
| walkthrough video | N/A - test-only change, no UI surface |
| backend logs | vitest 21/21 pass: Test Files 1 passed (1), Tests 21 passed (21), duration 125ms |
| frontend logs | N/A - no frontend change |
| llm trajectory | N/A - no model/trajectory code changed |
| domain artifacts | N/A - no runtime/domain behavior changed |

<!-- evidence-head:1fe251d39215fd1741fb0956f8b1cffdc000aa93 -->

<!-- evidence-row:backend-logs -->
- vitest run src/runtime/locale-detection.test.ts (packages/core, bun 1.3.14):

```text
 RUN  v4.1.10 /Users/t3rpz/projects/eliza-e-locale/packages/core
 Test Files  1 passed (1)
      Tests  21 passed (21)
   Duration  125ms (transform 30ms, setup 0ms, import 38ms, tests 4ms)

mutation rounds (vitest per round, module restored byte-identical after each):
tie-abstention flipped to >=:        2 failed | 19 passed
owner trim removed:                  2 failed | 19 passed
default trim/fallback removed:       2 failed | 19 passed
kana/Han precedence inverted:        3 failed | 18 passed
lowercase normalization removed:     1 failed | 20 passed
diacritic scoring removed:           2 failed | 19 passed
baseline + restored:                21 passed (21) x3 runs
```

- [x] <details><summary>Rebase wave 3 onto develop 870f4ec960 — head c9a61553 -> 7ad099b5 (2026-09-01)</summary>

```text
git rebase upstream/develop (tip 870f4ec960): 3/3 commits replayed, zero conflicts.
Diff preserved: 1 file (packages/core/src/runtime/locale-detection.test.ts).
Gates at new head 7ad099b5d1 (fresh worktree, real core build at same head):
  vitest pinned suite: Tests 21 passed (21)
  packages/core tsc --noEmit (typecheck script): clean
  biome check on the changed file: clean
Force-push with expected-lease on c9a61553; MERGEABLE verified post-push.
```
</details>

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only change, no UI surface

<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only change, no UI surface

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - test-only change, no UI surface

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend change

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model/trajectory code changed

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no runtime/domain behavior changed

AI provider/model: zai / glm-5.3
Client / agent tooling: Hermes Agent
Contribution skill revision: elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [hermes-t3rpz]
<!-- eliza-computer-attribution:v1 {"provider":"zai","model":"glm-5.3","client":"Hermes Agent","skill_revision":"elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza"} -->



