### PR TITLE
chore(registry): list @lurrielcode/plugin-qubic (third-party)

### DIFF
--- a/packages/registry/entries/third-party/lurrielcode__plugin-qubic.json
+++ b/packages/registry/entries/third-party/lurrielcode__plugin-qubic.json
@@ -1,0 +1,10 @@
+{
+  "package": "@lurrielcode/plugin-qubic",
+  "repository": "github:lurrielcode/plugin-qubic",
+  "kind": "plugin",
+  "description": "Qubic plugin for ElizaOS — wallet, balance, QU transfers, Qearn, QSWAP, OTC escrow, and contract query/invoke.",
+  "homepage": "https://github.com/lurrielcode/plugin-qubic",
+  "version": "0.1.19",
+  "directory": "plugin-qubic",
+  "tags": ["qubic", "blockchain", "wallet", "defi", "escrow"]
+}

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -369,6 +369,51 @@
       "registryKind": "plugin",
       "directory": null
     },
+    "@lurrielcode/plugin-qubic": {
+      "git": {
+        "repo": "lurrielcode/plugin-qubic",
+        "v0": {
+          "branch": null
+        },
+        "v1": {
+          "branch": null
+        },
+        "v2": {
+          "branch": "main"
+        }
+      },
+      "npm": {
+        "repo": "@lurrielcode/plugin-qubic",
+        "v0": null,
+        "v1": null,
+        "v2": "0.1.19"
+      },
+      "supports": {
+        "v0": false,
+        "v1": false,
+        "v2": true
+      },
+      "description": "Qubic plugin for ElizaOS — wallet, balance, QU transfers, Qearn, QSWAP, OTC escrow, and contract query/invoke.",
+      "homepage": "https://github.com/lurrielcode/plugin-qubic",
+      "topics": [
+        "qubic",
+        "blockchain",
+        "wallet",
+        "defi",
+        "escrow"
+      ],
+      "stargazers_count": 0,
+      "language": "TypeScript",
+      "origin": "third-party",
+      "source": "community",
+      "support": "community",
+      "builtIn": false,
+      "firstParty": false,
+      "thirdParty": true,
+      "kind": "plugin",
+      "registryKind": "plugin",
+      "directory": "plugin-qubic"
+    },
     "@ophis/plugin-elizaos": {
       "git": {
         "repo": "ophis-fi/ophis",


### PR DESCRIPTION
## Summary
- Register community plugin `@lurrielcode/plugin-qubic` in `packages/registry`.
- Source: `entries/third-party/lurrielcode__plugin-qubic.json` + regenerated `generated-registry.json`.

Follows [packages/registry/README.md](https://github.com/elizaOS/eliza/blob/develop/packages/registry/README.md).

## Plugin
| | |
|---|---|
| npm | https://www.npmjs.com/package/@lurrielcode/plugin-qubic (`0.1.19`) |
| GitHub | https://github.com/lurrielcode/plugin-qubic |
| Package dir | `plugin-qubic/` |
| Keywords | `elizaos`, `elizaos-plugin` |
| Scope | `@lurrielcode/*` (not `@elizaos/*`) |

Wallet/chain plugin: vault preferred (no seed in chat), QU transfers, Qearn, QSWAP (`minOut` required), OTC Escrow, contract query/invoke.

Setup: `npx plugin-qubic-setup` + `character.json`. Optional `QUBIC_MAX_TRANSFER_QU`. Peer: `@elizaos/core` `>= 2.0.3-beta.7`.

## Test plan
- [x] `bun run --cwd packages/registry validate`
- [x] `bun run --cwd packages/registry generate`
- [ ] After merge: `elizaos plugins list` / `elizaos plugins add @lurrielcode/plugin-qubic`