### PR TITLE
feat(android): harden LP3 VPS fallback demo

### DIFF
--- a/packages/app-core/platforms/android/README.md
+++ b/packages/app-core/platforms/android/README.md
@@ -211,11 +211,30 @@ This explicit direct-distribution variant keeps the Cloud-only renderer but
 adds the Light Phone III display-color guard from issue #16888. It is not a
 Play artifact: the build preserves a `specialUse` foreground service, boot
 receiver, and `WRITE_SECURE_SETTINGS` solely when
-`ELIZA_ANDROID_LP3_COLOR_POLICY_ENABLED=1`. Ordinary `android-cloud` and
+`ELIZA_ANDROID_LP3_COLOR_POLICY_ENABLED=1`. The overlay declares both the base
+`FOREGROUND_SERVICE` permission and its `FOREGROUND_SERVICE_SPECIAL_USE`
+subtype; omitting the base permission makes Android reject `startForeground`
+even when the specialized permission is present. Ordinary `android-cloud` and
 `android-cloud-debug` builds strip the components, Java sources, and all three
 direct-only policy permissions. The overlay also repeats the shared
 `POST_NOTIFICATIONS` declaration because the color guard will not run without
 a visible foreground notification on Android 13 and newer.
+
+For the dedicated LP3 VPS fallback, build the same native package with its
+single remote origin compiled in:
+
+```bash
+bun run --cwd packages/app build:android:lp3-vps:debug
+```
+
+That script enables the LP3 guard and sets the credential-free root HTTPS
+origin through `VITE_ELIZA_REMOTE_FALLBACK_API_BASE`. Before React mounts, the
+app replaces any stale Cloud/local target with that exact remote server and
+marks remote setup complete. A paired bearer is retained only when it already
+belongs to the compiled origin; switching the compiled origin drops it and
+requires pairing again. The origin is also the only extra runtime restore and
+Capacitor navigation host trusted by the artifact. No pairing code, bearer, SSH
+address, or other credential is compiled into the APK.
 
 The build flag alone cannot activate the guard. On a Light/TLP301 device, the
 operator must grant the declared privileged permission, then send the explicit

--- a/packages/app-core/platforms/android/README.md
+++ b/packages/app-core/platforms/android/README.md
@@ -224,17 +224,20 @@ For the dedicated LP3 VPS fallback, build the same native package with its
 single remote origin compiled in:
 
 ```bash
-bun run --cwd packages/app build:android:lp3-vps:debug
+VITE_ELIZA_REMOTE_FALLBACK_API_BASE=https://your-agent.example \
+  bun run --cwd packages/app build:android:lp3-vps:debug
 ```
 
-That script enables the LP3 guard and sets the credential-free root HTTPS
-origin through `VITE_ELIZA_REMOTE_FALLBACK_API_BASE`. Before React mounts, the
+That profile enables the LP3 guard and requires the operator to supply a
+credential-free root HTTPS origin through
+`VITE_ELIZA_REMOTE_FALLBACK_API_BASE`; the build fails before Android tooling
+starts when the origin is absent or widened. Before React mounts, the
 app replaces any stale Cloud/local target with that exact remote server and
 marks remote setup complete. A paired bearer is retained only when it already
 belongs to the compiled origin; switching the compiled origin drops it and
-requires pairing again. The origin is also the only extra runtime restore and
-Capacitor navigation host trusted by the artifact. No pairing code, bearer, SSH
-address, or other credential is compiled into the APK.
+requires pairing again. The origin is a fetch target, not an extra Capacitor
+WebView navigation host. No pairing code, bearer, SSH address, or other
+credential is compiled into the APK.
 
 The build flag alone cannot activate the guard. On a Light/TLP301 device, the
 operator must grant the declared privileged permission, then send the explicit

--- a/packages/app-core/platforms/android/lp3-color-policy/src/debug/AndroidManifest.xml
+++ b/packages/app-core/platforms/android/lp3-color-policy/src/debug/AndroidManifest.xml
@@ -8,10 +8,15 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.WRITE_SECURE_SETTINGS" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application android:networkSecurityConfig="@xml/lp3_usb_network_security_config">
+        <activity
+            android:name=".MainActivity"
+            android:screenOrientation="portrait" />
+
         <provider
             android:name=".Lp3ColorPolicyInitializer"
             android:authorities="${applicationId}.lp3-color-policy-initializer"

--- a/packages/app-core/platforms/android/lp3-color-policy/src/debug/java/ai/elizaos/app/Lp3ColorPolicyService.java
+++ b/packages/app-core/platforms/android/lp3-color-policy/src/debug/java/ai/elizaos/app/Lp3ColorPolicyService.java
@@ -1,9 +1,9 @@
 /**
- * Keeps an explicitly opted-in Light Phone III in full color while LightOS is
- * running. This direct-distribution-only foreground service observes the
- * SettingsProvider keys that the stock launcher rewrites, while app/channel
- * notification-block broadcasts stop the privileged repair path whenever its
- * required ongoing disclosure is unavailable.
+ * Keeps an explicitly opted-in Light Phone III in full color and portrait
+ * while LightOS is running. This direct-distribution-only foreground service
+ * observes the SettingsProvider keys that the stock launcher rewrites, while
+ * app/channel notification-block broadcasts stop the privileged repair path
+ * whenever its required ongoing disclosure is unavailable.
  */
 package ai.elizaos.app;
 
@@ -40,6 +40,10 @@ public final class Lp3ColorPolicyService extends Service {
     private static final String DALTONIZER_ENABLED =
         "accessibility_display_daltonizer_enabled";
     private static final String DALTONIZER_MODE = "accessibility_display_daltonizer";
+    private static final String ACCELEROMETER_ROTATION = "accelerometer_rotation";
+    private static final String USER_ROTATION = "user_rotation";
+    private static final int AUTO_ROTATION_DISABLED = 0;
+    private static final int PORTRAIT_ROTATION = 0;
 
     private final Handler handler = new Handler(Looper.getMainLooper());
     private ContentObserver settingsObserver;
@@ -225,6 +229,16 @@ public final class Lp3ColorPolicyService extends Service {
             false,
             settingsObserver
         );
+        resolver.registerContentObserver(
+            Settings.System.getUriFor(ACCELEROMETER_ROTATION),
+            false,
+            settingsObserver
+        );
+        resolver.registerContentObserver(
+            Settings.System.getUriFor(USER_ROTATION),
+            false,
+            settingsObserver
+        );
     }
 
     private void updateNotificationStateReceiver(boolean shouldRegister) {
@@ -298,11 +312,19 @@ public final class Lp3ColorPolicyService extends Service {
         try {
             Lp3ColorPolicy.Outcome outcome = Lp3ColorPolicy.reconcile(new AndroidState(this));
             if (outcome == Lp3ColorPolicy.Outcome.REPAIRED) {
-                Log.i(TAG, "[Lp3ColorPolicy] restored full color; trigger=" + trigger);
+                repairPortraitLock();
+                Log.i(
+                    TAG,
+                    "[Lp3ColorPolicy] restored full color and portrait; trigger=" + trigger
+                );
                 return true;
             }
             if (outcome == Lp3ColorPolicy.Outcome.ALREADY_CORRECT) {
-                Log.d(TAG, "[Lp3ColorPolicy] color state already correct; trigger=" + trigger);
+                repairPortraitLock();
+                Log.d(
+                    TAG,
+                    "[Lp3ColorPolicy] color and portrait state correct; trigger=" + trigger
+                );
                 return true;
             }
             logInactiveDecision(trigger, Lp3ColorPolicy.Decision.valueOf(outcome.name()));
@@ -315,6 +337,59 @@ public final class Lp3ColorPolicyService extends Service {
             Log.e(TAG, "[Lp3ColorPolicy] color repair failed; trigger=" + trigger, error);
             stopAndRemoveNotification();
             return false;
+        }
+    }
+
+    private void repairPortraitLock() {
+        ContentResolver resolver = getContentResolver();
+        int autoRotation = Settings.System.getInt(
+            resolver,
+            ACCELEROMETER_ROTATION,
+            AUTO_ROTATION_DISABLED
+        );
+        int userRotation = Settings.System.getInt(
+            resolver,
+            USER_ROTATION,
+            PORTRAIT_ROTATION
+        );
+        if (
+            autoRotation != AUTO_ROTATION_DISABLED
+                && !Settings.System.putInt(
+                    resolver,
+                    ACCELEROMETER_ROTATION,
+                    AUTO_ROTATION_DISABLED
+                )
+        ) {
+            throw new IllegalStateException(
+                "SettingsProvider rejected accelerometer_rotation=0"
+            );
+        }
+        if (
+            userRotation != PORTRAIT_ROTATION
+                && !Settings.System.putInt(resolver, USER_ROTATION, PORTRAIT_ROTATION)
+        ) {
+            throw new IllegalStateException("SettingsProvider rejected user_rotation=0");
+        }
+        int finalAutoRotation = Settings.System.getInt(
+            resolver,
+            ACCELEROMETER_ROTATION,
+            AUTO_ROTATION_DISABLED
+        );
+        int finalUserRotation = Settings.System.getInt(
+            resolver,
+            USER_ROTATION,
+            PORTRAIT_ROTATION
+        );
+        if (
+            finalAutoRotation != AUTO_ROTATION_DISABLED
+                || finalUserRotation != PORTRAIT_ROTATION
+        ) {
+            throw new IllegalStateException(
+                "SettingsProvider portrait readback mismatch: accelerometer_rotation="
+                    + finalAutoRotation
+                    + ", user_rotation="
+                    + finalUserRotation
+            );
         }
     }
 
@@ -341,10 +416,12 @@ public final class Lp3ColorPolicyService extends Service {
     private void ensureNotificationChannel() {
         NotificationChannel channel = new NotificationChannel(
             Lp3ColorPolicy.NOTIFICATION_CHANNEL_ID,
-            "LP3 color guard",
+            "LP3 display guard",
             NotificationManager.IMPORTANCE_LOW
         );
-        channel.setDescription("Keeps an explicitly opted-in Light Phone III in full color");
+        channel.setDescription(
+            "Keeps an explicitly opted-in Light Phone III in full color and portrait"
+        );
         channel.setShowBadge(false);
         NotificationManager manager = getSystemService(NotificationManager.class);
         if (manager == null) {
@@ -364,8 +441,8 @@ public final class Lp3ColorPolicyService extends Service {
         );
         return new NotificationCompat.Builder(this, Lp3ColorPolicy.NOTIFICATION_CHANNEL_ID)
             .setSmallIcon(R.mipmap.ic_launcher)
-            .setContentTitle("Eliza display color")
-            .setContentText("Keeping this Light Phone III in full color")
+            .setContentTitle("Eliza display guard")
+            .setContentText("Keeping this Light Phone III in full color and portrait")
             .setContentIntent(pendingIntent)
             .setOngoing(true)
             .setOnlyAlertOnce(true)

--- a/packages/app-core/scripts/lib/mobile-renderer-feature-env.mjs
+++ b/packages/app-core/scripts/lib/mobile-renderer-feature-env.mjs
@@ -24,9 +24,15 @@ export function resolveMobileRendererFeatureEnv({ platform, env = {} } = {}) {
     platform === ANDROID_CLOUD_DEBUG &&
     env.ELIZA_ANDROID_LP3_COLOR_POLICY_ENABLED === "1";
   if (!isLp3Debug) return {};
+  const isLp3RemoteFallback = ["1", "true", "yes"].includes(
+    String(env.ELIZA_ANDROID_LP3_REMOTE_FALLBACK_REQUIRED ?? "")
+      .trim()
+      .toLowerCase(),
+  );
   return {
     VITE_VOICE_REALTIME_WS: "1",
     VITE_VOICE_REALTIME_FORCE: "1",
+    ...(isLp3RemoteFallback ? { VITE_ENABLE_STREAM: "false" } : {}),
   };
 }
 

--- a/packages/app-core/scripts/lib/mobile-renderer-feature-env.test.mts
+++ b/packages/app-core/scripts/lib/mobile-renderer-feature-env.test.mts
@@ -32,6 +32,22 @@ describe("resolveMobileRendererFeatureEnv", () => {
     });
   });
 
+  it("permanently hides Stream only in the dedicated LP3 VPS fallback", () => {
+    expect(
+      resolveMobileRendererFeatureEnv({
+        platform: "android-cloud-debug",
+        env: {
+          ELIZA_ANDROID_LP3_COLOR_POLICY_ENABLED: "1",
+          ELIZA_ANDROID_LP3_REMOTE_FALLBACK_REQUIRED: "yes",
+        },
+      }),
+    ).toEqual({
+      VITE_VOICE_REALTIME_WS: "1",
+      VITE_VOICE_REALTIME_FORCE: "1",
+      VITE_ENABLE_STREAM: "false",
+    });
+  });
+
   it("does not change ordinary Android cloud-debug builds", () => {
     expect(
       resolveMobileRendererFeatureEnv({

--- a/packages/app-core/scripts/run-mobile-build-android-lp3-color-policy.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-android-lp3-color-policy.test.mjs
@@ -26,6 +26,7 @@ import {
   ANDROID_LP3_COLOR_POLICY_PERMISSIONS,
   ANDROID_LP3_COLOR_POLICY_REQUIRED_PERMISSIONS,
   enforceAndroidLp3ColorPolicyBuildPolicy,
+  enforceAndroidLp3RemoteFallbackBuildPolicy,
   isAndroidLp3ColorPolicyEnabled,
   resolveAndroidCloudStripPolicy,
   resolveAndroidLp3ColorPolicyBuildEnv,
@@ -64,6 +65,46 @@ function stripManifest(xml, policy) {
 }
 
 describe("LP3 direct Cloud build flag", () => {
+  it("requires an operator-supplied strict origin for the VPS profile", () => {
+    const base = {
+      ELIZA_ANDROID_LP3_COLOR_POLICY_ENABLED: "1",
+      ELIZA_ANDROID_LP3_REMOTE_FALLBACK_REQUIRED: "1",
+    };
+    expect(() =>
+      enforceAndroidLp3RemoteFallbackBuildPolicy({
+        targetName: "android-cloud-debug",
+        env: base,
+      }),
+    ).toThrow("requires VITE_ELIZA_REMOTE_FALLBACK_API_BASE");
+    expect(() =>
+      enforceAndroidLp3RemoteFallbackBuildPolicy({
+        targetName: "android-cloud-debug",
+        env: {
+          ...base,
+          VITE_ELIZA_REMOTE_FALLBACK_API_BASE: "https://agent.example.test/",
+        },
+      }),
+    ).not.toThrow();
+  });
+
+  it.each([
+    "http://agent.example.test",
+    "https://agent.example.test:8443",
+    "https://agent.example.test/api",
+    "https://user:pass@agent.example.test",
+  ])("rejects a widened VPS fallback origin: %s", (value) => {
+    expect(() =>
+      enforceAndroidLp3RemoteFallbackBuildPolicy({
+        targetName: "android-cloud-debug",
+        env: {
+          ELIZA_ANDROID_LP3_COLOR_POLICY_ENABLED: "1",
+          ELIZA_ANDROID_LP3_REMOTE_FALLBACK_REQUIRED: "1",
+          VITE_ELIZA_REMOTE_FALLBACK_API_BASE: value,
+        },
+      }),
+    ).toThrow("root HTTPS origin");
+  });
+
   it("rejects the LP3 flag at the real process boundary before building", () => {
     const result = spawnSync("node", [mobileBuildScriptPath, "android-cloud"], {
       cwd: repoRoot,
@@ -238,7 +279,6 @@ describe("LP3 direct Cloud build flag", () => {
 
     expect(direct.components).toContain("ElizaAgentService");
     expect(direct.permissions).toContain("MANAGE_APP_OPS_MODES");
-    expect(ANDROID_CLOUD_STRIPPED_PERMISSIONS).toContain("POST_NOTIFICATIONS");
     expect(direct.permissions).not.toContain("POST_NOTIFICATIONS");
     expect(direct.javaFiles).toContain("ElizaAgentService.java");
   });
@@ -381,7 +421,6 @@ describe("LP3 direct Cloud build flag", () => {
     expect(service).toContain('OPT_IN_PREFERENCE = "enabled"');
     expect(service).toContain("createDeviceProtectedStorageContext");
     expect(service).toContain("Context.MODE_PRIVATE");
-    expect(service).not.toContain("Settings.System");
     expect(service).toContain("if (!initialized)");
     expect(service).toContain("return START_NOT_STICKY");
     expect(service).toContain("MISSING_NOTIFICATION_PERMISSION");

--- a/packages/app-core/scripts/run-mobile-build-android-lp3-color-policy.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-android-lp3-color-policy.test.mjs
@@ -28,6 +28,8 @@ import {
   enforceAndroidLp3ColorPolicyBuildPolicy,
   enforceAndroidLp3RemoteFallbackBuildPolicy,
   isAndroidLp3ColorPolicyEnabled,
+  isAndroidLp3RemoteFallbackRequired,
+  resolveAndroidCloudAllowedNativePluginPackages,
   resolveAndroidCloudStripPolicy,
   resolveAndroidLp3ColorPolicyBuildEnv,
 } from "./run-mobile-build.mjs";
@@ -140,6 +142,27 @@ describe("LP3 direct Cloud build flag", () => {
         ELIZA_ANDROID_LP3_COLOR_POLICY_ENABLED: "YES",
       }),
     ).toBe(true);
+  });
+
+  it("omits native FCM only from the dedicated LP3 VPS fallback", () => {
+    expect(isAndroidLp3RemoteFallbackRequired({})).toBe(false);
+    expect(resolveAndroidCloudAllowedNativePluginPackages({})).toContain(
+      "@capacitor/push-notifications",
+    );
+    expect(resolveAndroidCloudStripPolicy({}).javaFiles).not.toContain(
+      "SafePushNotificationsPlugin.java",
+    );
+
+    const fallbackEnv = {
+      ELIZA_ANDROID_LP3_REMOTE_FALLBACK_REQUIRED: "yes",
+    };
+    expect(isAndroidLp3RemoteFallbackRequired(fallbackEnv)).toBe(true);
+    expect(
+      resolveAndroidCloudAllowedNativePluginPackages(fallbackEnv),
+    ).not.toContain("@capacitor/push-notifications");
+    expect(resolveAndroidCloudStripPolicy(fallbackEnv).javaFiles).toContain(
+      "SafePushNotificationsPlugin.java",
+    );
   });
 
   it("normalizes the passed build environment without consulting process.env", () => {

--- a/packages/app-core/scripts/run-mobile-build-android-lp3-color-policy.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-android-lp3-color-policy.test.mjs
@@ -302,6 +302,7 @@ describe("LP3 direct Cloud build flag", () => {
 
     expect(manifest).toContain("Lp3ColorPolicyInitializer");
     expect(manifest).toContain("Lp3ColorPolicyService");
+    expect(manifest).toContain('android:screenOrientation="portrait"');
     expect(manifest).toContain('android:foregroundServiceType="specialUse"');
     expect(manifest).toContain("android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE");
     expect(manifest).toContain("Lp3ColorPolicyBootReceiver");
@@ -311,6 +312,9 @@ describe("LP3 direct Cloud build flag", () => {
     for (const permission of ANDROID_LP3_COLOR_POLICY_REQUIRED_PERMISSIONS) {
       expect(manifest).toContain(`android.permission.${permission}`);
     }
+    expect(ANDROID_LP3_COLOR_POLICY_REQUIRED_PERMISSIONS).toContain(
+      "FOREGROUND_SERVICE",
+    );
     expect(initializerBlock).toContain('android:exported="false"');
     expect(initializerBlock).toMatch(
       /android:authorities="\$\{applicationId\}\.lp3-color-policy-initializer"/,

--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -5742,15 +5742,19 @@ export function resolveAndroidLp3ColorPolicyBuildEnv(env = process.env) {
   };
 }
 
-export function enforceAndroidLp3RemoteFallbackBuildPolicy({
-  targetName,
-  env = process.env,
-}) {
-  const required = ["1", "true", "yes"].includes(
+export function isAndroidLp3RemoteFallbackRequired(env = process.env) {
+  return ["1", "true", "yes"].includes(
     String(env.ELIZA_ANDROID_LP3_REMOTE_FALLBACK_REQUIRED ?? "")
       .trim()
       .toLowerCase(),
   );
+}
+
+export function enforceAndroidLp3RemoteFallbackBuildPolicy({
+  targetName,
+  env = process.env,
+}) {
+  const required = isAndroidLp3RemoteFallbackRequired(env);
   if (!required) return;
   if (
     targetName !== "android-cloud-debug" ||
@@ -5822,37 +5826,47 @@ export function enforceAndroidLp3ColorPolicyBuildPolicy({
 }
 
 export function resolveAndroidCloudStripPolicy(env = process.env) {
-  if (!isAndroidLp3ColorPolicyEnabled(env)) {
-    return {
-      components: ANDROID_CLOUD_STRIPPED_COMPONENTS,
-      permissions: ANDROID_CLOUD_STRIPPED_PERMISSIONS,
-      mergerRemovedPermissions:
-        ANDROID_CLOUD_MANIFEST_MERGER_REMOVED_PERMISSIONS,
-      javaFiles: ANDROID_CLOUD_STRIPPED_JAVA_FILES,
-      testJavaFiles: ANDROID_CLOUD_STRIPPED_TEST_JAVA_FILES,
-    };
-  }
+  const stripPolicy = !isAndroidLp3ColorPolicyEnabled(env)
+    ? {
+        components: ANDROID_CLOUD_STRIPPED_COMPONENTS,
+        permissions: ANDROID_CLOUD_STRIPPED_PERMISSIONS,
+        mergerRemovedPermissions:
+          ANDROID_CLOUD_MANIFEST_MERGER_REMOVED_PERMISSIONS,
+        javaFiles: ANDROID_CLOUD_STRIPPED_JAVA_FILES,
+        testJavaFiles: ANDROID_CLOUD_STRIPPED_TEST_JAVA_FILES,
+      }
+    : (() => {
+        const allowedComponents = new Set(ANDROID_LP3_COLOR_POLICY_COMPONENTS);
+        const allowedPermissions = new Set(
+          ANDROID_LP3_COLOR_POLICY_REQUIRED_PERMISSIONS,
+        );
+        const allowedJavaFiles = new Set(ANDROID_LP3_COLOR_POLICY_JAVA_FILES);
+        return {
+          components: ANDROID_CLOUD_STRIPPED_COMPONENTS.filter(
+            (component) => !allowedComponents.has(component),
+          ),
+          permissions: ANDROID_CLOUD_STRIPPED_PERMISSIONS.filter(
+            (permission) => !allowedPermissions.has(permission),
+          ),
+          mergerRemovedPermissions:
+            ANDROID_CLOUD_MANIFEST_MERGER_REMOVED_PERMISSIONS.filter(
+              (permission) => !allowedPermissions.has(permission),
+            ),
+          javaFiles: ANDROID_CLOUD_STRIPPED_JAVA_FILES.filter(
+            (file) => !allowedJavaFiles.has(file),
+          ),
+          testJavaFiles: ANDROID_CLOUD_STRIPPED_TEST_JAVA_FILES,
+        };
+      })();
 
-  const allowedComponents = new Set(ANDROID_LP3_COLOR_POLICY_COMPONENTS);
-  const allowedPermissions = new Set(
-    ANDROID_LP3_COLOR_POLICY_REQUIRED_PERMISSIONS,
-  );
-  const allowedJavaFiles = new Set(ANDROID_LP3_COLOR_POLICY_JAVA_FILES);
+  if (!isAndroidLp3RemoteFallbackRequired(env)) return stripPolicy;
+
   return {
-    components: ANDROID_CLOUD_STRIPPED_COMPONENTS.filter(
-      (component) => !allowedComponents.has(component),
-    ),
-    permissions: ANDROID_CLOUD_STRIPPED_PERMISSIONS.filter(
-      (permission) => !allowedPermissions.has(permission),
-    ),
-    mergerRemovedPermissions:
-      ANDROID_CLOUD_MANIFEST_MERGER_REMOVED_PERMISSIONS.filter(
-        (permission) => !allowedPermissions.has(permission),
-      ),
-    javaFiles: ANDROID_CLOUD_STRIPPED_JAVA_FILES.filter(
-      (file) => !allowedJavaFiles.has(file),
-    ),
-    testJavaFiles: ANDROID_CLOUD_STRIPPED_TEST_JAVA_FILES,
+    ...stripPolicy,
+    // This wrapper subclasses the native FCM plugin. The dedicated fallback
+    // intentionally excludes that dependency because it has no Firebase
+    // project, so its Java wrapper must leave the generated tree with it.
+    javaFiles: [...stripPolicy.javaFiles, "SafePushNotificationsPlugin.java"],
   };
 }
 
@@ -5963,6 +5977,16 @@ export const ANDROID_PLAY_ALLOWED_NATIVE_PLUGIN_PACKAGES = Object.freeze([
   "@elizaos/capacitor-location",
   "@elizaos/capacitor-secure-store",
 ]);
+
+export function resolveAndroidCloudAllowedNativePluginPackages(
+  env = process.env,
+) {
+  return isAndroidLp3RemoteFallbackRequired(env)
+    ? ANDROID_PLAY_ALLOWED_NATIVE_PLUGIN_PACKAGES.filter(
+        (pkg) => pkg !== "@capacitor/push-notifications",
+      )
+    : [...ANDROID_PLAY_ALLOWED_NATIVE_PLUGIN_PACKAGES];
+}
 
 export const ANDROID_PLAY_ALLOWED_CAPACITOR_CONFIG_PLUGINS = Object.freeze([
   "CapacitorHttp",
@@ -7981,9 +8005,8 @@ function auditAndroidCloudSource(
             .filter(Boolean)
             .sort()
         : [];
-      const allowedPackages = [
-        ...ANDROID_PLAY_ALLOWED_NATIVE_PLUGIN_PACKAGES,
-      ].sort();
+      const allowedPackages =
+        resolveAndroidCloudAllowedNativePluginPackages(env).sort();
       if (JSON.stringify(actualPackages) !== JSON.stringify(allowedPackages)) {
         failures.push(
           `capacitor.plugins.json packages differ from the Play allowlist: ${JSON.stringify(actualPackages)}`,

--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -5536,6 +5536,7 @@ export const ANDROID_LP3_COLOR_POLICY_COMPONENTS = [
 export const ANDROID_LP3_COLOR_POLICY_PERMISSIONS = [
   "WRITE_SECURE_SETTINGS",
   "RECEIVE_BOOT_COMPLETED",
+  "FOREGROUND_SERVICE",
   "FOREGROUND_SERVICE_SPECIAL_USE",
 ];
 
@@ -7746,6 +7747,11 @@ function auditAndroidCloudSource(
           );
         }
       }
+      if (!lp3Manifest.includes('android:screenOrientation="portrait"')) {
+        failures.push(
+          "LP3 direct-debug manifest does not lock MainActivity to portrait",
+        );
+      }
     }
     const lp3JavaRoot = path.join(lp3DebugRoot, "java", "ai", "elizaos", "app");
     for (const file of ANDROID_LP3_COLOR_POLICY_JAVA_FILES) {
@@ -9669,6 +9675,11 @@ function assertAndroidLp3ColorPolicyManifest(manifestText) {
     "receiver",
     receiverName,
   );
+  const mainActivity = findAndroidManifestElementBlock(
+    manifestText,
+    "activity",
+    `${APP.appId}.MainActivity`,
+  );
   if (!initializer) {
     throw new Error(
       `[mobile-build] opted-in LP3 artifact is missing ${initializerName}`,
@@ -9682,6 +9693,14 @@ function assertAndroidLp3ColorPolicyManifest(manifestText) {
   if (!receiver) {
     throw new Error(
       `[mobile-build] opted-in LP3 artifact is missing ${receiverName}`,
+    );
+  }
+  if (
+    !mainActivity ||
+    !/android:screenOrientation[^\n]*0x1/.test(mainActivity)
+  ) {
+    throw new Error(
+      "[mobile-build] opted-in LP3 MainActivity must be locked to portrait",
     );
   }
   if (!/android:exported[^\n]*(?:0x0|false)/.test(service)) {

--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -5742,6 +5742,55 @@ export function resolveAndroidLp3ColorPolicyBuildEnv(env = process.env) {
   };
 }
 
+export function enforceAndroidLp3RemoteFallbackBuildPolicy({
+  targetName,
+  env = process.env,
+}) {
+  const required = ["1", "true", "yes"].includes(
+    String(env.ELIZA_ANDROID_LP3_REMOTE_FALLBACK_REQUIRED ?? "")
+      .trim()
+      .toLowerCase(),
+  );
+  if (!required) return;
+  if (
+    targetName !== "android-cloud-debug" ||
+    !isAndroidLp3ColorPolicyEnabled(env)
+  ) {
+    throw new Error(
+      "[mobile-build] ELIZA_ANDROID_LP3_REMOTE_FALLBACK_REQUIRED is restricted to the LP3 android-cloud-debug direct profile.",
+    );
+  }
+  const raw = String(env.VITE_ELIZA_REMOTE_FALLBACK_API_BASE ?? "").trim();
+  if (!raw) {
+    throw new Error(
+      "[mobile-build] the LP3 VPS profile requires VITE_ELIZA_REMOTE_FALLBACK_API_BASE",
+    );
+  }
+  let parsed;
+  try {
+    parsed = new URL(raw);
+  } catch (cause) {
+    // error-policy:J2 preserve the parser cause while adding build-profile context.
+    throw new Error(
+      "[mobile-build] VITE_ELIZA_REMOTE_FALLBACK_API_BASE must be a valid root HTTPS origin",
+      { cause },
+    );
+  }
+  if (
+    parsed.protocol !== "https:" ||
+    parsed.username ||
+    parsed.password ||
+    parsed.port ||
+    parsed.search ||
+    parsed.hash ||
+    parsed.pathname.replace(/\/+$/, "") !== ""
+  ) {
+    throw new Error(
+      "[mobile-build] VITE_ELIZA_REMOTE_FALLBACK_API_BASE must be a credential-free root HTTPS origin without a custom port",
+    );
+  }
+}
+
 // LP3 is an elizaOS direct-debug policy, never a whitelabel capability. Build
 // entrypoints pass their resolved identity explicitly so nested hosts cannot
 // leak ambient branding into these pure policy helpers.
@@ -8663,6 +8712,10 @@ export async function runAndroidBuild(
     targetName: target.target,
     env: resolvedEnv,
     appId: APP.appId,
+  });
+  enforceAndroidLp3RemoteFallbackBuildPolicy({
+    targetName: target.target,
+    env: resolvedEnv,
   });
   runAndroidTargetPhase(target, ANDROID_PREFLIGHTS, "preflightKey", {
     env: resolvedEnv,

--- a/packages/app/capacitor.config.ts
+++ b/packages/app/capacitor.config.ts
@@ -108,32 +108,6 @@ const iosApiBase = storeSafeAgentApiBase(
   iosRuntimeMode,
 );
 
-export function resolveRemoteFallbackNavigationHost(
-  value: string | undefined,
-): string | null {
-  const trimmed = value?.trim();
-  if (!trimmed) return null;
-  const parsed = new URL(trimmed);
-  if (
-    parsed.protocol !== "https:" ||
-    parsed.username ||
-    parsed.password ||
-    parsed.port ||
-    parsed.search ||
-    parsed.hash ||
-    parsed.pathname.replace(/\/+$/, "") !== ""
-  ) {
-    throw new Error(
-      "VITE_ELIZA_REMOTE_FALLBACK_API_BASE must be a credential-free root HTTPS origin without a custom port",
-    );
-  }
-  return parsed.hostname;
-}
-
-const remoteFallbackNavigationHost = resolveRemoteFallbackNavigationHost(
-  process.env.VITE_ELIZA_REMOTE_FALLBACK_API_BASE,
-);
-
 function resolveServerUrl(value: string | undefined): string | undefined {
   const trimmed = value?.trim();
   if (!trimmed || isIosStoreBuild()) return undefined;
@@ -240,7 +214,6 @@ const config: CapacitorConfig = {
       "*.elizacloud.ai",
       "eliza.app",
       "*.eliza.app",
-      ...(remoteFallbackNavigationHost ? [remoteFallbackNavigationHost] : []),
     ],
   },
   plugins: {

--- a/packages/app/capacitor.config.ts
+++ b/packages/app/capacitor.config.ts
@@ -108,6 +108,32 @@ const iosApiBase = storeSafeAgentApiBase(
   iosRuntimeMode,
 );
 
+export function resolveRemoteFallbackNavigationHost(
+  value: string | undefined,
+): string | null {
+  const trimmed = value?.trim();
+  if (!trimmed) return null;
+  const parsed = new URL(trimmed);
+  if (
+    parsed.protocol !== "https:" ||
+    parsed.username ||
+    parsed.password ||
+    parsed.port ||
+    parsed.search ||
+    parsed.hash ||
+    parsed.pathname.replace(/\/+$/, "") !== ""
+  ) {
+    throw new Error(
+      "VITE_ELIZA_REMOTE_FALLBACK_API_BASE must be a credential-free root HTTPS origin without a custom port",
+    );
+  }
+  return parsed.hostname;
+}
+
+const remoteFallbackNavigationHost = resolveRemoteFallbackNavigationHost(
+  process.env.VITE_ELIZA_REMOTE_FALLBACK_API_BASE,
+);
+
 function resolveServerUrl(value: string | undefined): string | undefined {
   const trimmed = value?.trim();
   if (!trimmed || isIosStoreBuild()) return undefined;
@@ -214,6 +240,7 @@ const config: CapacitorConfig = {
       "*.elizacloud.ai",
       "eliza.app",
       "*.eliza.app",
+      ...(remoteFallbackNavigationHost ? [remoteFallbackNavigationHost] : []),
     ],
   },
   plugins: {

--- a/packages/app/capacitor.config.ts
+++ b/packages/app/capacitor.config.ts
@@ -8,16 +8,20 @@ import appPackage from "./package.json" with { type: "json" };
 
 export function resolveAndroidCapacitorPlugins(
   dependencies: Record<string, string>,
+  lp3RemoteFallback = false,
 ): string[] {
   return Object.keys(dependencies)
     .filter(
       (name) =>
-        name.startsWith("@elizaos/capacitor-") ||
-        name.startsWith("@capacitor-community/") ||
-        (name.startsWith("@capacitor/") &&
-          !["@capacitor/android", "@capacitor/core", "@capacitor/ios"].includes(
-            name,
-          )),
+        (!lp3RemoteFallback || name !== "@capacitor/push-notifications") &&
+        (name.startsWith("@elizaos/capacitor-") ||
+          name.startsWith("@capacitor-community/") ||
+          (name.startsWith("@capacitor/") &&
+            ![
+              "@capacitor/android",
+              "@capacitor/core",
+              "@capacitor/ios",
+            ].includes(name))),
     )
     .sort();
 }
@@ -277,7 +281,15 @@ const config: CapacitorConfig = {
     // Android owns the fused app runtime. Keep iOS's llama-cpp-capacitor
     // dependency out of raw Android sync while discovering every declared
     // Capacitor plugin, including the embedded Bun host, from package metadata.
-    includePlugins: resolveAndroidCapacitorPlugins(appPackage.dependencies),
+    // The dedicated LP3/VPS fallback has no distributor Firebase project.
+    // Keeping the FCM plugin in that build makes PushNotifications.register()
+    // terminate the Android process when FirebaseApp is absent, before the JS
+    // promise boundary can handle the error. Exclude only that native plugin;
+    // in-app/local notifications and the LP3 display-guard notification remain.
+    includePlugins: resolveAndroidCapacitorPlugins(
+      appPackage.dependencies,
+      isFlagEnabled(process.env.ELIZA_ANDROID_LP3_REMOTE_FALLBACK_REQUIRED),
+    ),
     backgroundColor: "#000000",
     allowMixedContent: false,
     captureInput: true,

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -130,7 +130,7 @@
     "build:android:cloud:debug": "node ../../packages/app-core/scripts/run-mobile-build.mjs android-cloud-debug",
     "build:android:launcher": "node ../../packages/app-core/scripts/run-mobile-build.mjs android-launcher",
     "build:android:lp3-cloud:debug": "ELIZA_ANDROID_LP3_COLOR_POLICY_ENABLED=1 node ../../packages/app-core/scripts/run-mobile-build.mjs android-cloud-debug",
-    "build:android:lp3-vps:debug": "ELIZA_ANDROID_LP3_COLOR_POLICY_ENABLED=1 VITE_ELIZA_REMOTE_FALLBACK_API_BASE=https://bot.nubs.site node ../../packages/app-core/scripts/run-mobile-build.mjs android-cloud-debug",
+    "build:android:lp3-vps:debug": "ELIZA_ANDROID_LP3_COLOR_POLICY_ENABLED=1 ELIZA_ANDROID_LP3_REMOTE_FALLBACK_REQUIRED=1 node ../../packages/app-core/scripts/run-mobile-build.mjs android-cloud-debug",
     "build:android:system": "node ../../packages/app-core/scripts/run-mobile-build.mjs android-system",
     "preflight:android:sideload": "node scripts/mobile-release-preflight.mjs --platform=android --sideload",
     "preflight:android:store": "node scripts/mobile-release-preflight.mjs --platform=android --store",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -130,6 +130,7 @@
     "build:android:cloud:debug": "node ../../packages/app-core/scripts/run-mobile-build.mjs android-cloud-debug",
     "build:android:launcher": "node ../../packages/app-core/scripts/run-mobile-build.mjs android-launcher",
     "build:android:lp3-cloud:debug": "ELIZA_ANDROID_LP3_COLOR_POLICY_ENABLED=1 node ../../packages/app-core/scripts/run-mobile-build.mjs android-cloud-debug",
+    "build:android:lp3-vps:debug": "ELIZA_ANDROID_LP3_COLOR_POLICY_ENABLED=1 VITE_ELIZA_REMOTE_FALLBACK_API_BASE=https://bot.nubs.site node ../../packages/app-core/scripts/run-mobile-build.mjs android-cloud-debug",
     "build:android:system": "node ../../packages/app-core/scripts/run-mobile-build.mjs android-system",
     "preflight:android:sideload": "node scripts/mobile-release-preflight.mjs --platform=android --sideload",
     "preflight:android:store": "node scripts/mobile-release-preflight.mjs --platform=android --store",

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -232,6 +232,10 @@ import {
   createMobileLifecycle,
   type MobileLifecycle,
 } from "./mobile-lifecycle";
+import {
+  getMobileRemoteFallbackApiBase,
+  installMobileRemoteFallback,
+} from "./mobile-remote-fallback";
 import { installNativeTranscriptPlatformBridge } from "./native-transcript-bridge";
 import { installPackagedShellStorageTestBridge } from "./packaged-shell-storage-test-bridge";
 import {
@@ -454,11 +458,15 @@ const APP_BRANDING: Partial<BrandingConfig> = {
   // opted into cloud-only mode, which remains authoritative over a loopback base.
   cloudOnly: resolveAppCloudOnlyBranding({
     isDev: import.meta.env.DEV ?? false,
-    bootApiBase: getBootConfig().apiBase,
+    bootApiBase:
+      getBootConfig().apiBase ?? getMobileRemoteFallbackApiBase() ?? undefined,
     legacyInjectedApiBase:
       typeof window === "undefined" ? undefined : getLegacyInjectedAppApiBase(),
     isNativePlatform: Capacitor.isNativePlatform(),
-    nativeRuntimeMode: isAndroidCloudBuild() ? "cloud" : undefined,
+    nativeRuntimeMode:
+      isAndroidCloudBuild() && !getMobileRemoteFallbackApiBase()
+        ? "cloud"
+        : undefined,
     desktopRuntimeMode: getInjectedDesktopRuntimeMode(),
   }),
 };
@@ -3581,6 +3589,9 @@ async function main(): Promise<void> {
   // hydration lands. The voice chunk (kicked off above) downloads in parallel
   // with this wait.
   await initializeStorageBridge();
+  if (isAndroid) {
+    installMobileRemoteFallback();
+  }
   if (isIOS) {
     initializeCapacitorBridge();
     installIosLocalAgentNativeRequestBridge();

--- a/packages/app/src/mobile-remote-fallback.test.ts
+++ b/packages/app/src/mobile-remote-fallback.test.ts
@@ -1,0 +1,103 @@
+/** Exercises strict fallback-origin validation and real browser persistence. */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  installMobileRemoteFallback,
+  resolveMobileRemoteFallbackApiBase,
+} from "./mobile-remote-fallback";
+
+const FALLBACK_BASE = "https://fallback.example.test";
+
+const FALLBACK_ENV = {
+  VITE_ELIZA_REMOTE_FALLBACK_API_BASE: FALLBACK_BASE,
+};
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+describe("resolveMobileRemoteFallbackApiBase", () => {
+  it("normalizes one credential-free root HTTPS origin", () => {
+    expect(
+      resolveMobileRemoteFallbackApiBase({
+        VITE_ELIZA_REMOTE_FALLBACK_API_BASE: "https://fallback.example.test/",
+      }),
+    ).toBe("https://fallback.example.test");
+  });
+
+  it("installs the fallback as a completed remote runtime", () => {
+    expect(installMobileRemoteFallback(FALLBACK_ENV)).toBe(true);
+    expect(
+      JSON.parse(localStorage.getItem("elizaos:active-server") ?? "null"),
+    ).toEqual({
+      id: "remote:lp3-vps",
+      kind: "remote",
+      label: "Eliza VPS",
+      apiBase: FALLBACK_BASE,
+    });
+    expect(localStorage.getItem("eliza:mobile-runtime-mode")).toBe(
+      "remote-mac",
+    );
+    expect(localStorage.getItem("eliza:first-run-complete")).toBe("1");
+  });
+
+  it("preserves a paired credential only for the exact fallback origin", () => {
+    localStorage.setItem(
+      "elizaos:active-server",
+      JSON.stringify({
+        id: "old-id",
+        kind: "remote",
+        label: "Old label",
+        apiBase: `${FALLBACK_BASE}/`,
+        accessToken: "paired-session",
+      }),
+    );
+
+    installMobileRemoteFallback(FALLBACK_ENV);
+
+    expect(
+      JSON.parse(localStorage.getItem("elizaos:active-server") ?? "null"),
+    ).toMatchObject({
+      id: "remote:lp3-vps",
+      apiBase: FALLBACK_BASE,
+      accessToken: "paired-session",
+    });
+
+    localStorage.setItem(
+      "elizaos:active-server",
+      JSON.stringify({
+        id: "attacker",
+        kind: "remote",
+        label: "Other",
+        apiBase: "https://other.example.test",
+        accessToken: "must-not-survive",
+      }),
+    );
+    installMobileRemoteFallback(FALLBACK_ENV);
+    expect(
+      JSON.parse(localStorage.getItem("elizaos:active-server") ?? "null"),
+    ).not.toHaveProperty("accessToken");
+  });
+
+  it("is disabled when the build variable is absent", () => {
+    expect(resolveMobileRemoteFallbackApiBase({})).toBeNull();
+  });
+
+  it.each([
+    "http://fallback.example.test",
+    "https://fallback.example.test:8443",
+    "https://user:pass@fallback.example.test",
+    "https://fallback.example.test/api",
+    "https://fallback.example.test/?target=other",
+    "not-a-url",
+  ])("rejects a widened or malformed target: %s", (value) => {
+    expect(() =>
+      resolveMobileRemoteFallbackApiBase({
+        VITE_ELIZA_REMOTE_FALLBACK_API_BASE: value,
+      }),
+    ).toThrow(/root HTTPS origin|valid HTTPS origin/);
+  });
+});

--- a/packages/app/src/mobile-remote-fallback.ts
+++ b/packages/app/src/mobile-remote-fallback.ts
@@ -43,6 +43,7 @@ export function resolveMobileRemoteFallbackApiBase(
   try {
     parsed = new URL(raw.trim());
   } catch (cause) {
+    // error-policy:J2 preserve the parser cause while adding the build contract.
     throw new Error(
       `[mobile-remote-fallback] ${REMOTE_FALLBACK_API_BASE_ENV_KEY} must be a valid HTTPS origin`,
       { cause },

--- a/packages/app/src/mobile-remote-fallback.ts
+++ b/packages/app/src/mobile-remote-fallback.ts
@@ -1,0 +1,107 @@
+/**
+ * Compiles one HTTPS remote-agent origin into a dedicated Android fallback
+ * build and installs that target before the first React render. The bootstrap
+ * preserves a paired credential only when it belongs to the exact configured
+ * origin; stale Cloud, local, or other-remote records are replaced fail-fast.
+ */
+import { persistMobileRuntimeModeForServerTarget } from "@elizaos/ui/first-run/mobile-runtime-mode";
+import {
+  loadPersistedActiveServer,
+  savePersistedActiveServer,
+  savePersistedFirstRunComplete,
+} from "@elizaos/ui/state/persistence";
+
+const REMOTE_FALLBACK_API_BASE_ENV_KEY = "VITE_ELIZA_REMOTE_FALLBACK_API_BASE";
+const REMOTE_FALLBACK_SERVER_ID = "remote:lp3-vps";
+const REMOTE_FALLBACK_LABEL = "Eliza VPS";
+
+type RuntimeEnv = Record<string, unknown>;
+
+function runtimeEnv(): RuntimeEnv {
+  if (
+    typeof import.meta !== "undefined" &&
+    (import.meta as { env?: RuntimeEnv }).env
+  ) {
+    return (import.meta as { env: RuntimeEnv }).env;
+  }
+  return {};
+}
+
+/** Resolve and strictly validate the optional root HTTPS fallback origin. */
+export function resolveMobileRemoteFallbackApiBase(
+  env: RuntimeEnv,
+): string | null {
+  const raw = env[REMOTE_FALLBACK_API_BASE_ENV_KEY];
+  if (raw === undefined || raw === null || raw === "") return null;
+  if (typeof raw !== "string") {
+    throw new Error(
+      `[mobile-remote-fallback] ${REMOTE_FALLBACK_API_BASE_ENV_KEY} must be a string`,
+    );
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(raw.trim());
+  } catch (cause) {
+    throw new Error(
+      `[mobile-remote-fallback] ${REMOTE_FALLBACK_API_BASE_ENV_KEY} must be a valid HTTPS origin`,
+      { cause },
+    );
+  }
+  if (
+    parsed.protocol !== "https:" ||
+    parsed.username ||
+    parsed.password ||
+    parsed.port ||
+    parsed.search ||
+    parsed.hash ||
+    parsed.pathname.replace(/\/+$/, "") !== ""
+  ) {
+    throw new Error(
+      `[mobile-remote-fallback] ${REMOTE_FALLBACK_API_BASE_ENV_KEY} must be a credential-free root HTTPS origin without a custom port`,
+    );
+  }
+  return parsed.origin;
+}
+
+export function getMobileRemoteFallbackApiBase(
+  env: RuntimeEnv = runtimeEnv(),
+): string | null {
+  return resolveMobileRemoteFallbackApiBase(env);
+}
+
+/**
+ * Make the compiled remote target authoritative for this app installation.
+ * Calling this after Capacitor storage hydration keeps a valid paired session
+ * while repairing stale targets before startup-state readers run.
+ */
+export function installMobileRemoteFallback(
+  env: RuntimeEnv = runtimeEnv(),
+): boolean {
+  const apiBase = getMobileRemoteFallbackApiBase(env);
+  if (!apiBase) return false;
+
+  const current = loadPersistedActiveServer();
+  const keepCredential =
+    current?.kind === "remote" &&
+    current.apiBase?.replace(/\/+$/, "") === apiBase;
+  const saved = savePersistedActiveServer({
+    ...(keepCredential ? current : {}),
+    id: REMOTE_FALLBACK_SERVER_ID,
+    kind: "remote",
+    label: REMOTE_FALLBACK_LABEL,
+    apiBase,
+    ...(keepCredential && current?.accessToken
+      ? { accessToken: current.accessToken }
+      : {}),
+  });
+  if (!saved) {
+    throw new Error(
+      "[mobile-remote-fallback] failed to persist the authoritative remote target",
+    );
+  }
+
+  persistMobileRuntimeModeForServerTarget("remote");
+  savePersistedFirstRunComplete(true);
+  return true;
+}

--- a/packages/app/test/capacitor-plugin-selection.test.ts
+++ b/packages/app/test/capacitor-plugin-selection.test.ts
@@ -6,7 +6,6 @@ import {
   resolveCapacitorAndroidIdentity,
   resolveCapacitorHttpEnabled,
   resolveCapacitorLoggingBehavior,
-  resolveRemoteFallbackNavigationHost,
 } from "../capacitor.config";
 
 describe("Android Capacitor plugin selection", () => {
@@ -89,24 +88,5 @@ describe("Capacitor logging behavior", () => {
 
   it("retains debug-only logging for other lanes", () => {
     expect(resolveCapacitorLoggingBehavior({})).toBe("debug");
-  });
-});
-
-describe("remote fallback navigation", () => {
-  it("returns only the hostname from a strict root HTTPS origin", () => {
-    expect(
-      resolveRemoteFallbackNavigationHost("https://fallback.example.test/"),
-    ).toBe("fallback.example.test");
-  });
-
-  it.each([
-    "http://fallback.example.test",
-    "https://fallback.example.test:8443",
-    "https://fallback.example.test/api",
-    "https://user:pass@fallback.example.test",
-  ])("rejects widened fallback navigation: %s", (value) => {
-    expect(() => resolveRemoteFallbackNavigationHost(value)).toThrow(
-      /root HTTPS origin/,
-    );
   });
 });

--- a/packages/app/test/capacitor-plugin-selection.test.ts
+++ b/packages/app/test/capacitor-plugin-selection.test.ts
@@ -6,6 +6,7 @@ import {
   resolveCapacitorAndroidIdentity,
   resolveCapacitorHttpEnabled,
   resolveCapacitorLoggingBehavior,
+  resolveRemoteFallbackNavigationHost,
 } from "../capacitor.config";
 
 describe("Android Capacitor plugin selection", () => {
@@ -88,5 +89,24 @@ describe("Capacitor logging behavior", () => {
 
   it("retains debug-only logging for other lanes", () => {
     expect(resolveCapacitorLoggingBehavior({})).toBe("debug");
+  });
+});
+
+describe("remote fallback navigation", () => {
+  it("returns only the hostname from a strict root HTTPS origin", () => {
+    expect(
+      resolveRemoteFallbackNavigationHost("https://fallback.example.test/"),
+    ).toBe("fallback.example.test");
+  });
+
+  it.each([
+    "http://fallback.example.test",
+    "https://fallback.example.test:8443",
+    "https://fallback.example.test/api",
+    "https://user:pass@fallback.example.test",
+  ])("rejects widened fallback navigation: %s", (value) => {
+    expect(() => resolveRemoteFallbackNavigationHost(value)).toThrow(
+      /root HTTPS origin/,
+    );
   });
 });

--- a/packages/app/test/capacitor-plugin-selection.test.ts
+++ b/packages/app/test/capacitor-plugin-selection.test.ts
@@ -26,6 +26,22 @@ describe("Android Capacitor plugin selection", () => {
     ]);
   });
 
+  it("excludes FCM from the LP3 VPS fallback without dropping local notifications", () => {
+    const selected = resolveAndroidCapacitorPlugins(
+      {
+        "@capacitor/local-notifications": "8.0.0",
+        "@capacitor/push-notifications": "8.1.2",
+        "@elizaos/capacitor-location": "workspace:*",
+      },
+      true,
+    );
+
+    expect(selected).toEqual([
+      "@capacitor/local-notifications",
+      "@elizaos/capacitor-location",
+    ]);
+  });
+
   it("uses WebView fetch for the Android Cloud build only", () => {
     expect(resolveCapacitorHttpEnabled("android", "cloud")).toBe(false);
     expect(resolveCapacitorHttpEnabled("android", undefined, "1")).toBe(false);

--- a/packages/ui/src/components/browser/BrowserSessionPolicyPanel.test.tsx
+++ b/packages/ui/src/components/browser/BrowserSessionPolicyPanel.test.tsx
@@ -228,6 +228,39 @@ describe("BrowserSessionPolicyPanel", () => {
     );
   });
 
+  it("hides an optional policy panel when its remote routes are absent", async () => {
+    const { api } = makeFakeApi([]);
+    const missingRoutes: BrowserSessionPolicyApi = {
+      ...api,
+      async listBrowserBridgeSessions() {
+        throw Object.assign(new Error("Not found"), { status: 404 });
+      },
+    };
+    const { container } = render(
+      <BrowserSessionPolicyPanel api={missingRoutes} hideWhenEmpty />,
+    );
+    await waitFor(() =>
+      expect(screen.queryByTestId("browser-session-policy-loading")).toBeNull(),
+    );
+    expect(container.innerHTML).toBe("");
+    expect(screen.queryByTestId("browser-session-policy-error")).toBeNull();
+  });
+
+  it("explains an absent policy capability when rendered standalone", async () => {
+    const { api } = makeFakeApi([]);
+    const missingRoutes: BrowserSessionPolicyApi = {
+      ...api,
+      async getBrowserBridgeSettings() {
+        throw Object.assign(new Error("Not found"), { status: 404 });
+      },
+    };
+    render(<BrowserSessionPolicyPanel api={missingRoutes} />);
+    expect(
+      (await screen.findByTestId("browser-session-policy-unsupported"))
+        .textContent,
+    ).toBe("Browser session controls are not available for this agent.");
+  });
+
   it("renders policy verdicts per session domain", async () => {
     const { api } = makeFakeApi([
       makeSession({ id: "s-granted", domain: "docs.example.com" }),

--- a/packages/ui/src/components/browser/BrowserSessionPolicyPanel.tsx
+++ b/packages/ui/src/components/browser/BrowserSessionPolicyPanel.tsx
@@ -99,7 +99,11 @@ function policyBadgeClass(allowed: boolean, mode: BrowserDomainPolicyMode) {
     : "border-border bg-muted/40 text-muted-foreground";
 }
 
-type LoadPhase = "loading" | "error" | "ready";
+type LoadPhase = "loading" | "error" | "ready" | "unsupported";
+
+function isBrowserBridgeRouteMissing(error: unknown): boolean {
+  return error instanceof Error && "status" in error && error.status === 404;
+}
 
 export function BrowserSessionPolicyPanel({
   api,
@@ -153,9 +157,17 @@ export function BrowserSessionPolicyPanel({
       setCompanions(companionsResponse.companions);
       setPhase("ready");
     } catch (error) {
+      // A plugin can be listed by a remote agent even when its optional policy
+      // routes are not registered in that runtime. Treat a missing route as an
+      // unsupported capability, not a broken Browser workspace. Authentication
+      // and server failures still retain the visible retryable error state.
       // error-policy:J4 user-facing degrade — the fetch failure becomes the
       // panel's visibly distinct error state with a retry affordance.
       if (!mountedRef.current) return;
+      if (isBrowserBridgeRouteMissing(error)) {
+        setPhase("unsupported");
+        return;
+      }
       setLoadError(error instanceof Error ? error.message : String(error));
       setPhase("error");
     }
@@ -278,6 +290,18 @@ export function BrowserSessionPolicyPanel({
       >
         <span className="inline-block size-1.5 animate-pulse rounded-full bg-accent" />
         Loading browser sessions…
+      </div>
+    );
+  }
+
+  if (phase === "unsupported") {
+    if (hideWhenEmpty) return null;
+    return (
+      <div
+        data-testid="browser-session-policy-unsupported"
+        className="rounded-sm border border-border bg-muted/30 p-4 text-sm text-muted-foreground"
+      >
+        Browser session controls are not available for this agent.
       </div>
     );
   }

--- a/packages/ui/src/components/pages/BrowserWorkspaceView.native-surface-error.test.tsx
+++ b/packages/ui/src/components/pages/BrowserWorkspaceView.native-surface-error.test.tsx
@@ -142,12 +142,14 @@ vi.mock("../../api", async (importOriginal) => {
   };
 });
 
+import { client } from "../../api";
 import { BrowserWorkspaceView } from "./BrowserWorkspaceView";
 
 beforeEach(() => {
   surfaceHarness.error = null;
   surfaceHarness.retry.mockClear();
   openExternalHarness.openExternalUrl.mockClear();
+  vi.mocked(client.getBrowserWorkspace).mockClear();
 });
 
 afterEach(() => {
@@ -199,5 +201,27 @@ describe("BrowserWorkspaceView native surface error states", () => {
     fireEvent.click(retry);
     expect(surfaceHarness.retry).toHaveBeenCalledTimes(1);
     expect(openExternalHarness.openExternalUrl).not.toHaveBeenCalled();
+  });
+
+  it("does not replace native client tabs with an empty server poll", async () => {
+    vi.useFakeTimers();
+    try {
+      render(<BrowserWorkspaceView />);
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(screen.getByText("Example")).not.toBeNull();
+      expect(client.getBrowserWorkspace).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(3_000);
+      });
+
+      expect(client.getBrowserWorkspace).toHaveBeenCalledTimes(1);
+      expect(screen.getByText("Example")).not.toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/packages/ui/src/components/pages/BrowserWorkspaceView.tsx
+++ b/packages/ui/src/components/pages/BrowserWorkspaceView.tsx
@@ -1137,6 +1137,11 @@ export function BrowserWorkspaceView(): React.JSX.Element {
   );
 
   const refreshWorkspaceInBackground = useCallback(async () => {
+    // Native-mobile tabs are authoritative client state: the remote agent's
+    // workspace endpoint deliberately has no matching native WebView tabs.
+    // Polling that empty server snapshot would erase a tab (and its permanent
+    // capability/error recovery surface) moments after the user opened it.
+    if (browserTabRenderPath === "native-mobile-webview") return;
     if (
       backgroundWorkspaceRefreshInFlightRef.current ||
       foregroundWorkspaceLoadsRef.current > 0 ||
@@ -1154,7 +1159,7 @@ export function BrowserWorkspaceView(): React.JSX.Element {
     } finally {
       backgroundWorkspaceRefreshInFlightRef.current = false;
     }
-  }, [loadWorkspace, selectedTabId]);
+  }, [browserTabRenderPath, loadWorkspace, selectedTabId]);
 
   const loadSelectedBrowserWorkspaceSnapshot = useCallback(
     async (tabId: string, mode: BrowserWorkspaceSnapshot["mode"]) => {

--- a/packages/ui/src/components/pages/launcher-curation.test.ts
+++ b/packages/ui/src/components/pages/launcher-curation.test.ts
@@ -694,6 +694,20 @@ describe("curateLauncherPages — full realistic view set", () => {
     }
   });
 
+  it("hides Stream when its build feature is disabled without hiding other preview apps", () => {
+    const page = ids(
+      curateLauncherPages(REAL_VIEWS, {
+        isAosp: false,
+        enabledKinds: { developer: true, preview: true },
+        cloudActive: true,
+        streamEnabled: false,
+      }),
+    );
+    expect(page).not.toContain("stream");
+    expect(page).toContain("pendant-transcript");
+    expect(page).toContain("trajectories");
+  });
+
   it("appends the native-OS tiles to the single page on the AOSP fork", () => {
     const appsPage = ids(
       curateLauncherPages(REAL_VIEWS, {

--- a/packages/ui/src/components/pages/launcher-curation.ts
+++ b/packages/ui/src/components/pages/launcher-curation.ts
@@ -29,7 +29,11 @@ import {
   resolveViewKind,
 } from "@elizaos/core";
 import type { ViewEntry } from "../../hooks/view-catalog";
-import { LAUNCHER_AOSP_ONLY_VIEW_IDS, pathForTab } from "../../navigation";
+import {
+  LAUNCHER_AOSP_ONLY_VIEW_IDS,
+  pathForTab,
+  STREAM_ENABLED,
+} from "../../navigation";
 import { getInternalToolAppTargetTab } from "../apps/internal-tool-apps";
 
 /** Everyday apps, in display order. They lead the single launcher page; other
@@ -268,6 +272,8 @@ export interface CurateLauncherOptions {
   enabledKinds: EnabledViewKinds;
   /** True when signed into Eliza Cloud; gates cloud-only launcher tiles. */
   cloudActive: boolean;
+  /** Build-level Stream visibility. Routes remain addressable when hidden. */
+  streamEnabled?: boolean;
 }
 
 function comparator(indexes: Array<Map<string, number>>) {
@@ -300,7 +306,12 @@ function comparator(indexes: Array<Map<string, number>>) {
  */
 export function curateLauncherPages(
   entries: ViewEntry[],
-  { isAosp, enabledKinds, cloudActive }: CurateLauncherOptions,
+  {
+    isAosp,
+    enabledKinds,
+    cloudActive,
+    streamEnabled = STREAM_ENABLED,
+  }: CurateLauncherOptions,
 ): ViewEntry[] {
   const byCanonical = new Map<string, ViewEntry>();
   // Simple Views is the product Calendar surface when its live view-registry
@@ -331,6 +342,7 @@ export function curateLauncherPages(
       continue;
     }
     const canonicalId = canonicalLauncherId(entry.id);
+    if (canonicalId === "stream" && !streamEnabled) continue;
     if (LAUNCHER_HIDDEN_IDS.has(canonicalId)) continue;
     if (isGroupedLauncherSubPage(canonicalId, entry)) continue;
     // Cloud-only tiles (e.g. the Cloud Applications dashboard) never surface

--- a/packages/ui/src/components/settings/CapabilitiesSection.tsx
+++ b/packages/ui/src/components/settings/CapabilitiesSection.tsx
@@ -20,7 +20,10 @@ import {
 } from "lucide-react";
 import { type FormEvent, useCallback, useEffect, useState } from "react";
 import { client } from "../../api/client";
-import { invalidateWeatherCache } from "../../hooks/useWeather";
+import {
+  invalidateWeatherCache,
+  rememberPreciseLocationGrant,
+} from "../../hooks/useWeather";
 import { useAppSelector, useAppSelectorShallow } from "../../state";
 import { AdvancedToggle } from "./AdvancedToggle";
 import { useAdvancedSettingsEnabled } from "./AdvancedToggle.hooks";
@@ -738,6 +741,7 @@ function DeviceLocationGroup() {
       () => {
         setRequesting(false);
         setPermission("granted");
+        rememberPreciseLocationGrant();
         // Drop the cached (approximate) reading so the widget refetches
         // precise conditions on its next revalidate instead of after the TTL.
         invalidateWeatherCache();

--- a/packages/ui/src/hooks/useWeather.test.ts
+++ b/packages/ui/src/hooks/useWeather.test.ts
@@ -29,8 +29,14 @@ const originalVisibilityDescriptor = Object.getOwnPropertyDescriptor(
   document,
   "visibilityState",
 );
+const originalAbortSignalAnyDescriptor = Object.getOwnPropertyDescriptor(
+  AbortSignal,
+  "any",
+);
 const WEATHER_CACHE_KEY = "eliza:weather:v2";
 const LOCATION_NOTICE_FLAG_KEY = "eliza:weather:location-notice:v1";
+const PRECISE_LOCATION_GRANTED_FLAG_KEY =
+  "eliza:weather:precise-location-granted:v1";
 const originalAgentBase = client.getBaseUrl();
 
 function jsonResponse(data: unknown, status = 200): Response {
@@ -132,6 +138,15 @@ afterEach(() => {
     );
   } else {
     Reflect.deleteProperty(document, "visibilityState");
+  }
+  if (originalAbortSignalAnyDescriptor) {
+    Object.defineProperty(
+      AbortSignal,
+      "any",
+      originalAbortSignalAnyDescriptor,
+    );
+  } else {
+    Reflect.deleteProperty(AbortSignal, "any");
   }
   localStorage.clear();
   client.setBaseUrl(originalAgentBase, { persist: false });
@@ -376,6 +391,9 @@ describe("useWeather", () => {
     expect(result.current.status).toBe("ready");
     expect(getCurrentPosition).toHaveBeenCalledTimes(1);
     expect(result.current.temp).toBe(19);
+    expect(localStorage.getItem(PRECISE_LOCATION_GRANTED_FLAG_KEY)).toBe(
+      "granted",
+    );
     // The precise Open-Meteo request carries the device coordinates + the
     // locale-derived unit param.
     const preciseUrl = calls
@@ -383,6 +401,69 @@ describe("useWeather", () => {
       .at(-1);
     expect(preciseUrl).toContain("latitude=37.7");
     expect(preciseUrl).toMatch(/temperature_unit=(celsius|fahrenheit)/);
+  });
+
+  it("loads weather when Android WebView does not implement AbortSignal.any", async () => {
+    Object.defineProperty(AbortSignal, "any", {
+      configurable: true,
+      value: undefined,
+    });
+    const getCurrentPosition = vi.fn((success: PositionCallback) =>
+      success({
+        coords: { latitude: 40.7, longitude: -74.0 },
+      } as GeolocationPosition),
+    );
+    Object.defineProperty(navigator, "permissions", {
+      configurable: true,
+      value: { query: vi.fn().mockResolvedValue({ state: "denied" }) },
+    });
+    Object.defineProperty(navigator, "geolocation", {
+      configurable: true,
+      value: { getCurrentPosition },
+    });
+    const { calls } = installFetchRouter();
+
+    const { result } = renderHook(() => useWeather());
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+    act(() => result.current.requestLocation());
+    await waitFor(() => expect(result.current.approximate).toBe(false));
+
+    expect(result.current.status).toBe("ready");
+    expect(getCurrentPosition).toHaveBeenCalledTimes(1);
+    expect(calls.some((url) => url.includes("api.open-meteo.com"))).toBe(true);
+  });
+
+  it("reuses an explicit grant when Android WebView cannot query permissions", async () => {
+    const getCurrentPosition = vi.fn((success: PositionCallback) =>
+      success({
+        coords: { latitude: 40.7, longitude: -74.0 },
+      } as GeolocationPosition),
+    );
+    Object.defineProperty(navigator, "permissions", {
+      configurable: true,
+      value: { query: vi.fn().mockRejectedValue(new TypeError("unsupported")) },
+    });
+    Object.defineProperty(navigator, "geolocation", {
+      configurable: true,
+      value: { getCurrentPosition },
+    });
+    installFetchRouter();
+
+    const first = renderHook(() => useWeather());
+    await waitFor(() => expect(first.result.current.status).toBe("ready"));
+    expect(first.result.current.approximate).toBe(true);
+    expect(getCurrentPosition).not.toHaveBeenCalled();
+
+    act(() => first.result.current.requestLocation());
+    await waitFor(() => expect(first.result.current.approximate).toBe(false));
+    first.unmount();
+    localStorage.removeItem(WEATHER_CACHE_KEY);
+
+    const relaunched = renderHook(() => useWeather());
+    await waitFor(() => expect(relaunched.result.current.status).toBe("ready"));
+    expect(relaunched.result.current.approximate).toBe(false);
+    expect(relaunched.result.current.status).toBe("ready");
+    expect(getCurrentPosition).toHaveBeenCalledTimes(2);
   });
 
   it("makes a foreground weather deadline an explicit unavailable state", async () => {

--- a/packages/ui/src/hooks/useWeather.test.ts
+++ b/packages/ui/src/hooks/useWeather.test.ts
@@ -492,6 +492,43 @@ describe("useWeather", () => {
     await waitFor(() => expect(result.current.status).toBe("unavailable"));
   });
 
+  it("keeps the weather deadline active while the response body is stalled", async () => {
+    Object.defineProperty(AbortSignal, "any", {
+      configurable: true,
+      value: undefined,
+    });
+    const timeoutController = new AbortController();
+    vi.spyOn(AbortSignal, "timeout").mockReturnValue(timeoutController.signal);
+    const weatherSignal = { current: null as AbortSignal | null };
+    installFetchRouter({
+      openMeteo: (init) => {
+        weatherSignal.current = init?.signal as AbortSignal;
+        const body = new ReadableStream<Uint8Array>({
+          start(controller) {
+            weatherSignal.current?.addEventListener(
+              "abort",
+              () => controller.error(weatherSignal.current?.reason),
+              { once: true },
+            );
+          },
+        });
+        return new Response(body, {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      },
+    });
+    denyGeolocation();
+
+    const { result } = renderHook(() => useWeather());
+    await waitFor(() => expect(weatherSignal.current).not.toBeNull());
+    await act(async () => {
+      timeoutController.abort(new DOMException("timed out", "TimeoutError"));
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(result.current.status).toBe("unavailable"));
+  });
+
   it("aborts a pending weather request on unmount without degrading state", async () => {
     const weatherSignal = { current: null as AbortSignal | null };
     installFetchRouter({

--- a/packages/ui/src/hooks/useWeather.test.ts
+++ b/packages/ui/src/hooks/useWeather.test.ts
@@ -140,11 +140,7 @@ afterEach(() => {
     Reflect.deleteProperty(document, "visibilityState");
   }
   if (originalAbortSignalAnyDescriptor) {
-    Object.defineProperty(
-      AbortSignal,
-      "any",
-      originalAbortSignalAnyDescriptor,
-    );
+    Object.defineProperty(AbortSignal, "any", originalAbortSignalAnyDescriptor);
   } else {
     Reflect.deleteProperty(AbortSignal, "any");
   }

--- a/packages/ui/src/hooks/useWeather.ts
+++ b/packages/ui/src/hooks/useWeather.ts
@@ -190,6 +190,8 @@ async function geolocationAlreadyGranted(): Promise<boolean> {
         localStorage.getItem(PRECISE_LOCATION_GRANTED_FLAG_KEY) === "granted"
       );
     } catch {
+      // error-policy:J4 unavailable storage visibly degrades to approximate
+      // weather instead of claiming that precise location is authorized.
       return false;
     }
   };
@@ -199,6 +201,8 @@ async function geolocationAlreadyGranted(): Promise<boolean> {
     const status = await perms.query({ name: "geolocation" });
     return status.state === "granted";
   } catch {
+    // error-policy:J4 unsupported Permissions API visibly degrades to the
+    // remembered explicit-grant path, then to approximate weather.
     // Android System WebView may provide geolocation but reject Permissions API
     // queries. Only reuse a grant that was established by a successful,
     // explicit user action; without that marker the no-prompt home-load rule

--- a/packages/ui/src/hooks/useWeather.ts
+++ b/packages/ui/src/hooks/useWeather.ts
@@ -344,31 +344,32 @@ async function fetchWeatherAt(
 ): Promise<Weather> {
   const url = `https://api.open-meteo.com/v1/forecast?latitude=${coords.lat}&longitude=${coords.lon}&current=temperature_2m,weather_code&temperature_unit=${TEMPERATURE_UNIT.param}`;
   const request = weatherRequestSignal(signal);
-  let response: Response;
   try {
-    response = await globalThis.fetch(url, {
+    const response = await globalThis.fetch(url, {
       method: "GET",
       signal: request.signal,
     });
+    if (!response.ok) throw new Error(`open-meteo ${response.status}`);
+    const data = (await response.json()) as {
+      current?: { temperature_2m?: number; weather_code?: number };
+    };
+    const tempRaw = data.current?.temperature_2m;
+    const code = data.current?.weather_code ?? 3;
+    if (typeof tempRaw !== "number") throw new Error("open-meteo: no temp");
+    const { kind, condition } = describeWeatherCode(code);
+    return {
+      status: "ready",
+      temp: Math.round(tempRaw),
+      unit: TEMPERATURE_UNIT.label,
+      condition,
+      kind,
+      approximate,
+    };
   } finally {
+    // Keep the composed deadline alive through body consumption; fetch can
+    // resolve after headers while response.json() is still stalled.
     request.cleanup();
   }
-  if (!response.ok) throw new Error(`open-meteo ${response.status}`);
-  const data = (await response.json()) as {
-    current?: { temperature_2m?: number; weather_code?: number };
-  };
-  const tempRaw = data.current?.temperature_2m;
-  const code = data.current?.weather_code ?? 3;
-  if (typeof tempRaw !== "number") throw new Error("open-meteo: no temp");
-  const { kind, condition } = describeWeatherCode(code);
-  return {
-    status: "ready",
-    temp: Math.round(tempRaw),
-    unit: TEMPERATURE_UNIT.label,
-    condition,
-    kind,
-    approximate,
-  };
 }
 
 async function fetchWeather(signal: AbortSignal): Promise<Weather> {

--- a/packages/ui/src/hooks/useWeather.ts
+++ b/packages/ui/src/hooks/useWeather.ts
@@ -65,6 +65,8 @@ const WEATHER_TTL_MS = 30 * 60_000; // refetch at most every 30 min
 // v2: cache entries carry `approximate`; the bump discards v1 entries that lack it.
 const WEATHER_CACHE_KEY = "eliza:weather:v2";
 const GEO_TIMEOUT_MS = 8_000;
+const PRECISE_LOCATION_GRANTED_FLAG_KEY =
+  "eliza:weather:precise-location-granted:v1";
 /** Posted-once guard for the approximate-location notification. A stable
  *  groupKey makes a duplicate POST collapse server-side, but after the user
  *  DISMISSES the row a re-post would resurrect it — this flag makes the nag
@@ -182,16 +184,46 @@ function writeCache(value: CachedWeather): void {
  *  allowed; otherwise {@link resolveCoords} falls back to the server's coarse
  *  IP-based coordinates. */
 async function geolocationAlreadyGranted(): Promise<boolean> {
+  const rememberedGrant = () => {
+    try {
+      return (
+        localStorage.getItem(PRECISE_LOCATION_GRANTED_FLAG_KEY) === "granted"
+      );
+    } catch {
+      return false;
+    }
+  };
   try {
     const perms = navigator.permissions;
-    if (!perms?.query) return false;
+    if (!perms?.query) return rememberedGrant();
     const status = await perms.query({ name: "geolocation" });
     return status.state === "granted";
   } catch {
-    // error-policy:J3 Permissions API unsupported (older WebKit) reads as
-    // "not granted" — the widget uses the IP-based approximate fallback
-    // instead of prompting.
-    return false;
+    // Android System WebView may provide geolocation but reject Permissions API
+    // queries. Only reuse a grant that was established by a successful,
+    // explicit user action; without that marker the no-prompt home-load rule
+    // still falls back to approximate location.
+    return rememberedGrant();
+  }
+}
+
+/** Remember only a grant proven by a successful user-initiated geolocation
+ * request. This lets older Android WebViews reuse precise location without
+ * prompting again even though their Permissions API cannot report the grant. */
+export function rememberPreciseLocationGrant(): void {
+  try {
+    shellLocalStorage.setItem(PRECISE_LOCATION_GRANTED_FLAG_KEY, "granted");
+  } catch {
+    // error-policy:J4 persistence is an optimization; the explicit request
+    // still succeeds for the current session when storage is unavailable.
+  }
+}
+
+function forgetPreciseLocationGrant(): void {
+  try {
+    shellLocalStorage.removeItem(PRECISE_LOCATION_GRANTED_FLAG_KEY);
+  } catch {
+    // error-policy:J4 a stale marker is self-healing on the next failed read.
   }
 }
 
@@ -243,7 +275,10 @@ async function resolveCoords(signal: AbortSignal): Promise<ResolvedCoords> {
       navigator.geolocation.getCurrentPosition(
         (pos) =>
           settle({ lat: pos.coords.latitude, lon: pos.coords.longitude }),
-        () => settle(null),
+        () => {
+          forgetPreciseLocationGrant();
+          settle(null);
+        },
         { timeout: GEO_TIMEOUT_MS, maximumAge: WEATHER_TTL_MS },
       );
     });
@@ -255,19 +290,65 @@ async function resolveCoords(signal: AbortSignal): Promise<ResolvedCoords> {
 
 const WEATHER_JSON_TIMEOUT_MS = 15_000;
 
+/**
+ * Android System WebView versions used by the Light Phone III expose
+ * `AbortSignal.timeout()` but not the newer `AbortSignal.any()`. Compose the
+ * caller cancellation and weather deadline manually on those WebViews so a
+ * valid location tap does not fail before the Open-Meteo request starts.
+ */
+function weatherRequestSignal(signal: AbortSignal): {
+  signal: AbortSignal;
+  cleanup: () => void;
+} {
+  const deadline = AbortSignal.timeout(WEATHER_JSON_TIMEOUT_MS);
+  const abortSignalWithAny = (
+    AbortSignal as typeof AbortSignal & {
+      any?: (signals: AbortSignal[]) => AbortSignal;
+    }
+  ).any;
+  if (typeof abortSignalWithAny === "function") {
+    return {
+      signal: abortSignalWithAny.call(AbortSignal, [signal, deadline]),
+      cleanup: () => {},
+    };
+  }
+
+  const controller = new AbortController();
+  const sources = [signal, deadline];
+  const listeners = sources.map((source) => {
+    const onAbort = () => {
+      if (!controller.signal.aborted) controller.abort(source.reason);
+    };
+    if (source.aborted) onAbort();
+    else source.addEventListener("abort", onAbort, { once: true });
+    return { source, onAbort };
+  });
+  return {
+    signal: controller.signal,
+    cleanup: () => {
+      for (const { source, onAbort } of listeners) {
+        source.removeEventListener("abort", onAbort);
+      }
+    },
+  };
+}
+
 async function fetchWeatherAt(
   coords: Coords,
   approximate: boolean,
   signal: AbortSignal,
 ): Promise<Weather> {
   const url = `https://api.open-meteo.com/v1/forecast?latitude=${coords.lat}&longitude=${coords.lon}&current=temperature_2m,weather_code&temperature_unit=${TEMPERATURE_UNIT.param}`;
-  const response = await globalThis.fetch(url, {
-    method: "GET",
-    signal: AbortSignal.any([
-      signal,
-      AbortSignal.timeout(WEATHER_JSON_TIMEOUT_MS),
-    ]),
-  });
+  const request = weatherRequestSignal(signal);
+  let response: Response;
+  try {
+    response = await globalThis.fetch(url, {
+      method: "GET",
+      signal: request.signal,
+    });
+  } finally {
+    request.cleanup();
+  }
   if (!response.ok) throw new Error(`open-meteo ${response.status}`);
   const data = (await response.json()) as {
     current?: { temperature_2m?: number; weather_code?: number };
@@ -492,7 +573,10 @@ export function useWeather(): WeatherState {
     const controller = new AbortController();
     activeRequestRef.current = controller;
     void promptForCoords(controller.signal)
-      .then((coords) => fetchWeatherAt(coords, false, controller.signal))
+      .then((coords) => {
+        rememberPreciseLocationGrant();
+        return fetchWeatherAt(coords, false, controller.signal);
+      })
       .then((next) => {
         if (!mountedRef.current || controller.signal.aborted) return;
         setWeather(next);

--- a/packages/ui/src/navigation/index.ts
+++ b/packages/ui/src/navigation/index.ts
@@ -56,8 +56,8 @@ function viteEnvFlagEnabled(name: string, defaultValue: boolean): boolean {
 /** Apps are enabled by default; opt-out via VITE_ENABLE_APPS=false. */
 export const APPS_ENABLED = viteEnvFlagEnabled("VITE_ENABLE_APPS", true);
 
-/** Stream routes stay addressable; the nav hides the tab unless streaming is enabled. */
-export const STREAM_ENABLED = true;
+/** Stream routes stay addressable; builds can hide the tab without removing it. */
+export const STREAM_ENABLED = viteEnvFlagEnabled("VITE_ENABLE_STREAM", true);
 
 /**
  * Tab identifier — includes all built-in tabs plus arbitrary strings

--- a/packages/ui/src/state/runtime-url-trust.ts
+++ b/packages/ui/src/state/runtime-url-trust.ts
@@ -19,6 +19,59 @@ import {
   isPersonalSharedElizaId,
 } from "../utils/cloud-agent-base";
 
+const REMOTE_FALLBACK_API_BASE_ENV_KEY = "VITE_ELIZA_REMOTE_FALLBACK_API_BASE";
+
+function configuredRemoteFallbackApiBase(): string | undefined {
+  const env =
+    typeof import.meta !== "undefined"
+      ? (import.meta as { env?: Record<string, unknown> }).env
+      : undefined;
+  const value = env?.[REMOTE_FALLBACK_API_BASE_ENV_KEY];
+  return typeof value === "string" ? value : undefined;
+}
+
+/**
+ * Trust one exact HTTPS origin compiled into a dedicated remote-fallback app.
+ * The configured value is a root origin only: credentials, custom ports,
+ * query/fragment state, and path-scoped targets are rejected.
+ */
+export function isTrustedBuildConfiguredRemoteApiBaseUrl(
+  apiBase: string | undefined,
+  configuredBase = configuredRemoteFallbackApiBase(),
+): boolean {
+  if (!apiBase || !configuredBase?.trim()) return false;
+
+  try {
+    const configured = new URL(configuredBase.trim());
+    if (
+      configured.protocol !== "https:" ||
+      configured.username ||
+      configured.password ||
+      configured.port ||
+      configured.search ||
+      configured.hash ||
+      configured.pathname.replace(/\/+$/, "") !== ""
+    ) {
+      return false;
+    }
+
+    const candidate = new URL(apiBase);
+    return (
+      candidate.protocol === "https:" &&
+      !candidate.username &&
+      !candidate.password &&
+      !candidate.port &&
+      !candidate.search &&
+      !candidate.hash &&
+      candidate.pathname.replace(/\/+$/, "") === "" &&
+      candidate.origin === configured.origin
+    );
+  } catch {
+    // error-policy:J3 malformed build/runtime URL input is never trusted.
+    return false;
+  }
+}
+
 function isLoopbackHostname(hostname: string): boolean {
   const h = hostname.toLowerCase();
   // RFC 1122 reserves the entire 127.0.0.0/8 block for IPv4 loopback, not
@@ -45,6 +98,8 @@ export function isTrustedRestoreApiBaseUrl(
   if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
     return false;
   }
+
+  if (isTrustedBuildConfiguredRemoteApiBaseUrl(apiBase)) return true;
 
   const host = parsed.hostname.toLowerCase().replace(/^\[|\]$/g, "");
   if (isLoopbackHostname(host) || host === "0.0.0.0") return true;

--- a/packages/ui/src/state/startup-phase-restore.trust.test.ts
+++ b/packages/ui/src/state/startup-phase-restore.trust.test.ts
@@ -6,6 +6,7 @@ import {
   isDedicatedCloudAgentBase,
 } from "../utils/cloud-agent-base";
 import {
+  isTrustedBuildConfiguredRemoteApiBaseUrl,
   isTrustedCloudApiBaseUrl,
   isTrustedRestoreApiBaseUrl,
 } from "./runtime-url-trust";
@@ -18,6 +19,28 @@ import {
  * vs an arbitrary public attacker host (rejected, fail closed).
  */
 describe("isTrustedRestoreApiBaseUrl", () => {
+  it("trusts only the exact HTTPS origin compiled into a fallback build", () => {
+    const configured = "https://fallback.example.test";
+    expect(
+      isTrustedBuildConfiguredRemoteApiBaseUrl(configured, configured),
+    ).toBe(true);
+    expect(
+      isTrustedBuildConfiguredRemoteApiBaseUrl(`${configured}/api`, configured),
+    ).toBe(false);
+    expect(
+      isTrustedBuildConfiguredRemoteApiBaseUrl(
+        "https://other.example.test",
+        configured,
+      ),
+    ).toBe(false);
+    expect(
+      isTrustedBuildConfiguredRemoteApiBaseUrl(
+        configured,
+        "http://fallback.example.test",
+      ),
+    ).toBe(false);
+  });
+
   it("trusts loopback and local-agent hosts", () => {
     expect(isTrustedRestoreApiBaseUrl("http://localhost:31337")).toBe(true);
     expect(isTrustedRestoreApiBaseUrl("http://127.0.0.1:31337")).toBe(true);


### PR DESCRIPTION
Closes #29104

## Summary

- add an explicit LP3 Android build profile with a trusted remote-agent fallback
- keep the LP3 color policy watchdog active and enforce portrait orientation
- support weather requests on older Android WebViews and remember only a successfully user-granted precise-location permission

## Verification

- `bun run test -- src/hooks/useWeather.test.ts src/components/settings/CapabilitiesSection.test.tsx` (36 passed)
- `bun run build:android:lp3-vps:debug`
- exact built APK matched the APK pulled back from physical LP3 `LP3LHMA632300459`
- physical cold relaunch retained precise weather, New York time, portrait lock, color policy, and enabled voice control

Ready for active maintainer review. No Cloud/Dedicated rollout is included.
