### PR TITLE
fix(app): require Cloud auth before first chat

### DIFF
--- a/packages/app-core/scripts/lib/mobile-renderer-feature-env.mjs
+++ b/packages/app-core/scripts/lib/mobile-renderer-feature-env.mjs
@@ -17,6 +17,9 @@ export function resolveMobileRendererFeatureEnv({ platform, env = {} } = {}) {
   if (platform === "ios-local") {
     return { VITE_ELIZA_ENABLE_RUNTIME_CHOOSER: "1" };
   }
+  if (platform === "android-launcher") {
+    return { VITE_ELIZA_ANDROID_LAUNCHER_BUILD: "1" };
+  }
   const isLp3Debug =
     platform === ANDROID_CLOUD_DEBUG &&
     env.ELIZA_ANDROID_LP3_COLOR_POLICY_ENABLED === "1";
@@ -33,6 +36,7 @@ export function mobileRendererRequiresFreshBuild({ platform } = {}) {
   }
   return (
     platform === ANDROID_CLOUD_DEBUG ||
+    platform === "android-launcher" ||
     platform === "ios" ||
     platform === "ios-local"
   );
@@ -50,6 +54,9 @@ export function mobileRendererUnstampedFeatureProblem({ platform } = {}) {
   }
   if (platform === ANDROID_CLOUD_DEBUG) {
     return "dist cannot prove the Android cloud-debug realtime voice flags because they are not stamped";
+  }
+  if (platform === "android-launcher") {
+    return "dist cannot prove the Android launcher in-app auth contract because it is not stamped";
   }
   return null;
 }

--- a/packages/app-core/scripts/lib/mobile-renderer-feature-env.test.mts
+++ b/packages/app-core/scripts/lib/mobile-renderer-feature-env.test.mts
@@ -41,6 +41,12 @@ describe("resolveMobileRendererFeatureEnv", () => {
     ).toEqual({});
   });
 
+  it("stamps the launcher-only in-app auth renderer contract", () => {
+    expect(
+      resolveMobileRendererFeatureEnv({ platform: "android-launcher" }),
+    ).toEqual({ VITE_ELIZA_ANDROID_LAUNCHER_BUILD: "1" });
+  });
+
   it("does not leak LP3 renderer flags into another lane", () => {
     expect(
       resolveMobileRendererFeatureEnv({
@@ -62,7 +68,7 @@ describe("mobileRendererRequiresFreshBuild", () => {
     expect(
       mobileRendererRequiresFreshBuild({ platform: "android-cloud-debug" }),
     ).toBe(true);
-    for (const platform of ["ios", "ios-local"]) {
+    for (const platform of ["android-launcher", "ios", "ios-local"]) {
       expect(mobileRendererRequiresFreshBuild({ platform })).toBe(true);
     }
     for (const platform of ["android", "android-cloud", "ios-overlay"]) {
@@ -81,6 +87,9 @@ describe("mobileRendererUnstampedFeatureProblem", () => {
         platform: "android-cloud-debug",
       }),
     ).toContain("realtime voice flags");
+    expect(
+      mobileRendererUnstampedFeatureProblem({ platform: "android-launcher" }),
+    ).toContain("in-app auth contract");
     for (const platform of ["ios", "ios-overlay", "android", "android-cloud"]) {
       expect(mobileRendererUnstampedFeatureProblem({ platform })).toBeNull();
     }

--- a/packages/app-core/scripts/mobile/targets/android.mjs
+++ b/packages/app-core/scripts/mobile/targets/android.mjs
@@ -46,7 +46,7 @@ export const ANDROID_BUILD_TARGETS = Object.freeze({
   }),
   "android-launcher": freezeAndroidBuildTarget({
     target: "android-launcher",
-    webTarget: "android-cloud-debug",
+    webTarget: "android-launcher",
     env: {
       ELIZA_ANDROID_CLOUD_BUILD: "1",
       ELIZA_ANDROID_LAUNCHER_BUILD: "1",

--- a/packages/app-core/scripts/run-mobile-build-android-play-policy.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-android-play-policy.test.mjs
@@ -12,6 +12,7 @@ import {
   ANDROID_CLOUD_STRIPPED_PERMISSIONS,
   ANDROID_CLOUD_STRIPPED_RESOURCE_FILES,
   ANDROID_CLOUD_STRIPPED_RESOURCE_VALUES,
+  ANDROID_LAUNCHER_IN_APP_AUTH_HOSTS,
   ANDROID_PLAY_ALLOWED_CAPACITOR_CONFIG_PLUGINS,
   ANDROID_PLAY_ALLOWED_COMPONENTS,
   ANDROID_PLAY_ALLOWED_NATIVE_LIBRARIES,
@@ -26,7 +27,7 @@ import {
   findAndroidCloudPackagedRuntimeOffenders,
   findAndroidPlayIndexHtmlFindings,
   findAndroidPlayTextAssetFindings,
-  resolveAndroidCloudAuditCapacitorConfig,
+  resolveAndroidCloudCapacitorConfigPolicy,
   sanitizeAndroidCloudCapacitorConfig,
 } from "./run-mobile-build.mjs";
 
@@ -190,23 +191,35 @@ describe("Android Play manifest policy", () => {
     expect(sanitized.android.webContentsDebuggingEnabled).toBe(true);
   });
 
-  it("audits launcher configs against the launcher-only kiosk contract", () => {
-    const config = {
-      loggingBehavior: "none",
-      android: { webContentsDebuggingEnabled: true },
-    };
+  it("allows only canonical hosted-auth navigation in launcher config", () => {
+    expect(resolveAndroidCloudCapacitorConfigPolicy({})).toEqual({
+      allowInAppAuthNavigation: false,
+      launcherKiosk: false,
+      webViewDebugging: false,
+    });
+    expect(
+      resolveAndroidCloudCapacitorConfigPolicy({
+        ELIZA_ANDROID_LAUNCHER_BUILD: "1",
+        ELIZA_WEBVIEW_DEBUG: "1",
+      }),
+    ).toEqual({
+      allowInAppAuthNavigation: true,
+      launcherKiosk: true,
+      webViewDebugging: true,
+    });
+    const launcher = sanitizeAndroidCloudCapacitorConfig(
+      { plugins: {}, android: {} },
+      { allowInAppAuthNavigation: true, launcherKiosk: true },
+    );
+    const play = sanitizeAndroidCloudCapacitorConfig({
+      plugins: {},
+      android: {},
+    });
 
-    expect(
-      resolveAndroidCloudAuditCapacitorConfig(config, {
-        allowHomeRole: true,
-        env: { ELIZA_WEBVIEW_DEBUG: "1" },
-      }),
-    ).toMatchObject(config);
-    expect(
-      resolveAndroidCloudAuditCapacitorConfig(config, {
-        env: { ELIZA_WEBVIEW_DEBUG: "1" },
-      }),
-    ).not.toHaveProperty("loggingBehavior");
+    expect(launcher.server.allowNavigation).toEqual([
+      ...ANDROID_LAUNCHER_IN_APP_AUTH_HOSTS,
+    ]);
+    expect(play.server.allowNavigation).toBeUndefined();
   });
 
   it("keeps the unused native Google identity stack out of Android source", () => {

--- a/packages/app-core/scripts/run-mobile-build-android-targets.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-android-targets.test.mjs
@@ -130,7 +130,7 @@ describe("Android mobile build target table", () => {
     });
     expect(ANDROID_BUILD_TARGETS["android-launcher"]).toMatchObject({
       target: "android-launcher",
-      webTarget: "android-cloud-debug",
+      webTarget: "android-launcher",
       env: {
         ELIZA_ANDROID_CLOUD_BUILD: "1",
         ELIZA_ANDROID_LAUNCHER_BUILD: "1",
@@ -242,6 +242,12 @@ describe("Android mobile build target table", () => {
     expect(runMobileBuildSource).toContain('target !== "android-launcher"');
     expect(runMobileBuildSource).toContain(
       'await runAndroidBuild("android-launcher")',
+    );
+    expect(runMobileBuildSource).toMatch(
+      /ANDROID_SOURCE_AUDITS,[\s\S]*?"auditSourceKey",[\s\S]*?"pre-gradle",[\s\S]*?\{ env: targetEnv \}/,
+    );
+    expect(runMobileBuildSource).toMatch(
+      /ANDROID_SOURCE_AUDITS,[\s\S]*?"auditSourceKey",[\s\S]*?"post-gradle",[\s\S]*?\{ env: targetEnv \}/,
     );
   });
 

--- a/packages/app-core/scripts/run-mobile-build-cloud-main-activity.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-cloud-main-activity.test.mjs
@@ -101,6 +101,21 @@ describe("cloudSafeMainActivityJava", () => {
     expect(source).not.toContain("readSystemProperty");
   });
 
+  it("hides only the launcher navigation bar with transient swipe recovery", () => {
+    const source = cloudSafeMainActivityJava("ai.elizaos.app", {
+      launcherKiosk: true,
+      immersiveNavigation: true,
+    });
+
+    expect(source).toContain("import androidx.core.view.WindowInsetsCompat;");
+    expect(source).toContain(
+      "controller.hide(WindowInsetsCompat.Type.navigationBars())",
+    );
+    expect(source).toContain("BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE");
+    expect(source).toContain("onWindowFocusChanged(boolean hasFocus)");
+    expect(source).not.toContain("WindowInsetsCompat.Type.statusBars()");
+  });
+
   it("captures cold and warm deep links before Capacitor dispatches them", () => {
     const source = cloudSafeMainActivityJava("ai.elizaos.app");
     const coldCapture = source.indexOf(

--- a/packages/app-core/scripts/run-mobile-build-cloud-main-activity.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-cloud-main-activity.test.mjs
@@ -26,12 +26,10 @@ describe("cloudSafeMainActivityJava", () => {
     expect(splashInstall).toBeLessThan(bridgeCreation);
   });
 
-  it("registers crash-guarded push without any background agent service", () => {
+  it("does not reference removed push or background-agent services", () => {
     const source = cloudSafeMainActivityJava("ai.elizaos.app");
 
-    expect(source).toContain(
-      "getBridge().registerPlugin(SafePushNotificationsPlugin.class);",
-    );
+    expect(source).not.toContain("SafePushNotificationsPlugin");
     expect(source).not.toContain("GatewayConnectionService");
   });
 
@@ -62,6 +60,7 @@ describe("cloudSafeMainActivityJava", () => {
     });
 
     expect(source).toContain("import android.view.KeyEvent;");
+    expect(source).toContain("import android.app.admin.DevicePolicyManager;");
     expect(source).toContain("import androidx.activity.OnBackPressedCallback;");
     expect(source).toContain("new OnBackPressedCallback(true)");
     expect(source).toContain("public void handleOnBackPressed()");
@@ -69,10 +68,27 @@ describe("cloudSafeMainActivityJava", () => {
     expect(source).toContain("KeyEvent.KEYCODE_FORWARD");
     expect(source).toContain("KeyEvent.KEYCODE_NAVIGATE_NEXT");
     expect(source).toContain("startLockTask();");
-    expect(source).toContain("protected void onResume()");
+    expect(source).toContain("isLockTaskPermitted(getPackageName())");
+    expect(source).toContain("public void onResume()");
     expect(source).toContain("super.onResume();");
     expect(source).toContain(
       "IllegalArgumentException | IllegalStateException | SecurityException",
+    );
+  });
+
+  it("restores the bundled launcher renderer after the exact auth callback", () => {
+    const source = cloudSafeMainActivityJava("ai.elizaos.app", {
+      launcherKiosk: true,
+    });
+
+    expect(source).toContain("isCloudAuthCallback(Intent intent)");
+    expect(source).toContain('"elizaos".equalsIgnoreCase(data.getScheme())');
+    expect(source).toContain('"auth".equalsIgnoreCase(data.getHost())');
+    expect(source).toContain('"/callback".equals(data.getPath())');
+    expect(source).toContain("getBridge().getLocalUrl()");
+    expect(source).toContain("webView.loadUrl(localUrl)");
+    expect(source).toContain(
+      "restoreBundledRendererAfterAuthCallback(intent);",
     );
   });
 

--- a/packages/app-core/scripts/run-mobile-build-cloud-main-activity.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-cloud-main-activity.test.mjs
@@ -108,6 +108,11 @@ describe("cloudSafeMainActivityJava", () => {
     });
 
     expect(source).toContain("import androidx.core.view.WindowInsetsCompat;");
+    expect(
+      source.match(
+        /import androidx\.core\.view\.WindowInsetsControllerCompat;/g,
+      ),
+    ).toHaveLength(1);
     expect(source).toContain(
       "controller.hide(WindowInsetsCompat.Type.navigationBars())",
     );

--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -5919,6 +5919,20 @@ export const ANDROID_PLAY_ALLOWED_CAPACITOR_CONFIG_PLUGINS = Object.freeze([
   "Keyboard",
   "SplashScreen",
 ]);
+export const ANDROID_LAUNCHER_IN_APP_AUTH_HOSTS = Object.freeze([
+  "cloud.eliza.app",
+  "cloud-staging.eliza.app",
+]);
+
+/** Resolves the one sanitizer policy shared by write-time and source audits. */
+export function resolveAndroidCloudCapacitorConfigPolicy(env = process.env) {
+  const launcherKiosk = env.ELIZA_ANDROID_LAUNCHER_BUILD === "1";
+  return {
+    allowInAppAuthNavigation: launcherKiosk,
+    launcherKiosk,
+    webViewDebugging: launcherKiosk && env.ELIZA_WEBVIEW_DEBUG === "1",
+  };
+}
 
 function isJsonRecord(value) {
   return value !== null && typeof value === "object" && !Array.isArray(value);
@@ -5927,7 +5941,11 @@ function isJsonRecord(value) {
 /** Returns the minimal runtime config that is safe to package in a Play APK/AAB. */
 export function sanitizeAndroidCloudCapacitorConfig(
   value,
-  { launcherKiosk = false, webViewDebugging = false } = {},
+  {
+    allowInAppAuthNavigation = false,
+    launcherKiosk = false,
+    webViewDebugging = false,
+  } = {},
 ) {
   if (!isJsonRecord(value)) {
     throw new Error(
@@ -5948,6 +5966,9 @@ export function sanitizeAndroidCloudCapacitorConfig(
     ...(launcherKiosk ? { loggingBehavior: "none" } : {}),
     server: {
       androidScheme: "https",
+      ...(allowInAppAuthNavigation
+        ? { allowNavigation: [...ANDROID_LAUNCHER_IN_APP_AUTH_HOSTS] }
+        : {}),
     },
     plugins,
     android: {
@@ -5960,17 +5981,6 @@ export function sanitizeAndroidCloudCapacitorConfig(
       webContentsDebuggingEnabled: launcherKiosk && webViewDebugging,
     },
   };
-}
-
-export function resolveAndroidCloudAuditCapacitorConfig(
-  value,
-  { allowHomeRole = false, env = process.env } = {},
-) {
-  return sanitizeAndroidCloudCapacitorConfig(value, {
-    launcherKiosk: allowHomeRole,
-    webViewDebugging:
-      allowHomeRole && env.ELIZA_WEBVIEW_DEBUG === "1",
-  });
 }
 
 function sanitizeAndroidCloudPackagedConfig(env = process.env) {
@@ -5997,10 +6007,10 @@ function sanitizeAndroidCloudPackagedConfig(env = process.env) {
       }`,
     );
   }
-  const sanitized = sanitizeAndroidCloudCapacitorConfig(parsed, {
-    launcherKiosk: env.ELIZA_ANDROID_LAUNCHER_BUILD === "1",
-    webViewDebugging: env.ELIZA_WEBVIEW_DEBUG === "1",
-  });
+  const sanitized = sanitizeAndroidCloudCapacitorConfig(
+    parsed,
+    resolveAndroidCloudCapacitorConfigPolicy(env),
+  );
   fs.writeFileSync(configPath, `${JSON.stringify(sanitized, null, "\t")}\n`);
   console.log(
     "[mobile-build] Rewrote capacitor.config.json to the restricted Play runtime contract.",
@@ -6341,7 +6351,9 @@ export function cloudSafeMainActivityJava(
   { launcherKiosk = false } = {},
 ) {
   const launcherImports = launcherKiosk
-    ? `import android.util.Log;
+    ? `import android.app.admin.DevicePolicyManager;
+import android.net.Uri;
+import android.util.Log;
 import android.view.KeyEvent;
 
 import androidx.activity.OnBackPressedCallback;
@@ -6366,16 +6378,44 @@ import androidx.activity.OnBackPressedCallback;
     : "";
   const launcherMethods = launcherKiosk
     ? `
-    @Override
-    protected void onResume() {
-        super.onResume();
-        // Browser-based identity providers temporarily cover the launcher.
-        // Re-enter containment whenever their deep-link callback returns.
+    private void enterManagedLockTaskIfPermitted() {
+        DevicePolicyManager policy = getSystemService(DevicePolicyManager.class);
+        if (policy == null || !policy.isLockTaskPermitted(getPackageName())) {
+            return;
+        }
         try {
             startLockTask();
         } catch (IllegalArgumentException | IllegalStateException | SecurityException e) {
-            Log.w(TAG, "Unable to enter launcher lock-task mode", e);
+            Log.w(TAG, "Unable to enter managed launcher lock-task mode", e);
         }
+    }
+
+    private boolean isCloudAuthCallback(Intent intent) {
+        Uri data = intent == null ? null : intent.getData();
+        return data != null
+            && "elizaos".equalsIgnoreCase(data.getScheme())
+            && "auth".equalsIgnoreCase(data.getHost())
+            && "/callback".equals(data.getPath());
+    }
+
+    private void restoreBundledRendererAfterAuthCallback(Intent intent) {
+        if (!isCloudAuthCallback(intent)
+                || getBridge() == null
+                || getBridge().getWebView() == null) {
+            return;
+        }
+        WebView webView = getBridge().getWebView();
+        String localUrl = getBridge().getLocalUrl();
+        webView.post(() -> webView.loadUrl(localUrl));
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        // Only a managed-device owner may contain the launcher task. Android's
+        // unmanaged screen-pinning mode blocks the secure browser that Google
+        // OAuth requires, preventing the callback from ever reaching the app.
+        enterManagedLockTaskIfPermitted();
     }
 
     @Override
@@ -6430,11 +6470,6 @@ ${launcherConstants}
 
         super.onCreate(savedInstanceState);
 
-        // Push registration must be guarded when a distributor omits Firebase
-        // configuration. Permission checks and local notifications still work;
-        // register() then returns a typed configuration failure instead of
-        // crashing Android's activity startup.
-        getBridge().registerPlugin(SafePushNotificationsPlugin.class);
 ${launcherSetup}
 
         // Draw the canonical Cloud renderer behind transparent system bars while
@@ -6460,6 +6495,7 @@ ${launcherSetup}
     protected void onNewIntent(Intent intent) {
         DeepLinkBufferPlugin.captureIntent(this, intent);
         super.onNewIntent(intent);
+${launcherKiosk ? "        restoreBundledRendererAfterAuthCallback(intent);" : ""}
     }
 ${launcherMethods}
 
@@ -7867,10 +7903,10 @@ function auditAndroidCloudSource(
   } else {
     try {
       const config = JSON.parse(fs.readFileSync(capacitorConfigPath, "utf8"));
-      const expected = resolveAndroidCloudAuditCapacitorConfig(config, {
-        allowHomeRole,
-        env,
-      });
+      const expected = sanitizeAndroidCloudCapacitorConfig(
+        config,
+        resolveAndroidCloudCapacitorConfigPolicy(env),
+      );
       if (JSON.stringify(config) !== JSON.stringify(expected)) {
         failures.push(
           "capacitor.config.json differs from the restricted Play runtime contract",
@@ -7909,6 +7945,30 @@ function auditAndroidLauncherSource(phase, options = {}) {
   assertAndroidLauncherManifest(manifest, {
     label: `android-launcher ${phase} source`,
   });
+  const mainActivityPath = path.join(
+    androidDir,
+    "app",
+    "src",
+    "main",
+    "java",
+    packageNameToPath(APP.appId),
+    "MainActivity.java",
+  );
+  const mainActivity = fs.existsSync(mainActivityPath)
+    ? fs.readFileSync(mainActivityPath, "utf8")
+    : "";
+  if (
+    !mainActivity.includes("isCloudAuthCallback(Intent intent)") ||
+    !mainActivity.includes('"elizaos".equalsIgnoreCase(data.getScheme())') ||
+    !mainActivity.includes('"auth".equalsIgnoreCase(data.getHost())') ||
+    !mainActivity.includes('"/callback".equals(data.getPath())') ||
+    !mainActivity.includes("getBridge().getLocalUrl()") ||
+    !mainActivity.includes("webView.loadUrl(localUrl)")
+  ) {
+    throw new Error(
+      `[mobile-build] android-launcher ${phase} source audit failed: MainActivity does not restore the bundled renderer after the exact in-app auth callback.`,
+    );
+  }
   console.log(`[mobile-build] android-launcher ${phase} audit passed.`);
 }
 
@@ -8603,7 +8663,7 @@ export async function runAndroidBuild(
     ANDROID_SOURCE_AUDITS,
     "auditSourceKey",
     "pre-gradle",
-    { env: resolvedEnv },
+    { env: targetEnv },
   );
 
   const buildEnv = createAndroidBuildEnv(target, {
@@ -8631,7 +8691,7 @@ export async function runAndroidBuild(
     ANDROID_SOURCE_AUDITS,
     "auditSourceKey",
     "post-gradle",
-    { env: resolvedEnv },
+    { env: targetEnv },
   );
   if (target.artifactAuditKey === "cloud") {
     resolvedEnv[ANDROID_BUNDLETOOL_JAR_ENV] = await ensureAndroidBundletoolJar({
@@ -10069,6 +10129,21 @@ function auditAndroidLauncherArtifact({
         context: {
           artifact,
           loggingBehavior: runtimeConfig.loggingBehavior ?? null,
+        },
+      },
+    );
+  }
+  if (
+    JSON.stringify(runtimeConfig.server?.allowNavigation) !==
+    JSON.stringify(ANDROID_LAUNCHER_IN_APP_AUTH_HOSTS)
+  ) {
+    throw mobileBuildError(
+      "[mobile-build] android-launcher must keep WebView navigation pinned to the canonical Eliza hosted-auth origins.",
+      {
+        code: "ANDROID_LAUNCHER_AUTH_NAVIGATION_INVALID",
+        context: {
+          allowNavigation: runtimeConfig.server?.allowNavigation ?? null,
+          artifact,
         },
       },
     );

--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -6348,7 +6348,7 @@ export function findAndroidCloudPackagedRuntimeOffenders(entries) {
 
 export function cloudSafeMainActivityJava(
   androidPackage,
-  { launcherKiosk = false } = {},
+  { launcherKiosk = false, immersiveNavigation = false } = {},
 ) {
   const launcherImports = launcherKiosk
     ? `import android.app.admin.DevicePolicyManager;
@@ -6358,6 +6358,9 @@ import android.view.KeyEvent;
 
 import androidx.activity.OnBackPressedCallback;
 `
+    : "";
+  const navigationInsetsImport = immersiveNavigation
+    ? "import androidx.core.view.WindowInsetsCompat;\n"
     : "";
   const launcherConstants = launcherKiosk
     ? '    private static final String TAG = "ElizaMainActivity";\n'
@@ -6430,6 +6433,28 @@ import androidx.activity.OnBackPressedCallback;
     }
 `
     : "";
+  const navigationBarPolicy = immersiveNavigation
+    ? `            systemBars.hide(WindowInsetsCompat.Type.navigationBars());
+            systemBars.setSystemBarsBehavior(
+                WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE);`
+    : "            systemBars.setAppearanceLightNavigationBars(false);";
+  const focusHandler = immersiveNavigation
+    ? `
+    @Override
+    public void onWindowFocusChanged(boolean hasFocus) {
+        super.onWindowFocusChanged(hasFocus);
+        if (!hasFocus) return;
+        WindowInsetsControllerCompat controller =
+            WindowCompat.getInsetsController(
+                getWindow(), getWindow().getDecorView());
+        if (controller != null) {
+            controller.hide(WindowInsetsCompat.Type.navigationBars());
+            controller.setSystemBarsBehavior(
+                WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE);
+        }
+    }
+`
+    : "";
   return `package ${androidPackage};
 
 import android.os.Bundle;
@@ -6439,7 +6464,7 @@ import android.webkit.WebView;
 
 import androidx.core.splashscreen.SplashScreen;
 import androidx.core.view.WindowCompat;
-import androidx.core.view.WindowInsetsControllerCompat;
+${navigationInsetsImport}import androidx.core.view.WindowInsetsControllerCompat;
 ${launcherImports}
 
 import com.getcapacitor.BridgeActivity;
@@ -6472,17 +6497,16 @@ ${launcherConstants}
 
 ${launcherSetup}
 
-        // Draw the canonical Cloud renderer behind transparent system bars while
-        // keeping both bars visible and user-controlled. This uses only the
-        // public AndroidX edge-to-edge API and avoids white-on-white status
-        // icons on the signed-out screen.
+        // Draw the canonical Cloud renderer behind transparent system bars. The
+        // launcher variant hides only the navigation bar; a swipe can reveal
+        // it transiently; ordinary Cloud builds keep both bars visible.
         WindowCompat.setDecorFitsSystemWindows(getWindow(), false);
         WindowInsetsControllerCompat systemBars =
             WindowCompat.getInsetsController(
                 getWindow(), getWindow().getDecorView());
         if (systemBars != null) {
             systemBars.setAppearanceLightStatusBars(false);
-            systemBars.setAppearanceLightNavigationBars(false);
+${navigationBarPolicy}
         }
 
         if (getBridge() != null && getBridge().getWebView() != null) {
@@ -6498,6 +6522,7 @@ ${launcherSetup}
 ${launcherKiosk ? "        restoreBundledRendererAfterAuthCallback(intent);" : ""}
     }
 ${launcherMethods}
+${focusHandler}
 
 }
 `;
@@ -7362,7 +7387,7 @@ public class ElizaTasksWorker extends Worker {
 function rewriteCloudJavaSources(
   javaRoots,
   androidPackage,
-  { launcherKiosk = false } = {},
+  { launcherKiosk = false, immersiveNavigation = false } = {},
 ) {
   let touched = 0;
   for (const root of javaRoots) {
@@ -7371,7 +7396,10 @@ function rewriteCloudJavaSources(
     if (fs.existsSync(mainActivity)) {
       fs.writeFileSync(
         mainActivity,
-        cloudSafeMainActivityJava(androidPackage, { launcherKiosk }),
+        cloudSafeMainActivityJava(androidPackage, {
+          launcherKiosk,
+          immersiveNavigation,
+        }),
         "utf8",
       );
       touched += 1;
@@ -8289,6 +8317,7 @@ function stripAndroidForCloud({ env = process.env } = {}) {
   }
   rewriteCloudJavaSources([activeJavaRoot], androidPackage, {
     launcherKiosk: env.ELIZA_ANDROID_LAUNCHER_BUILD === "1",
+    immersiveNavigation: env.ELIZA_ANDROID_LAUNCHER_BUILD === "1",
   });
 
   const testJavaRoots = [

--- a/packages/cloud/api/__tests__/mobile-app-auth-wrangler.test.ts
+++ b/packages/cloud/api/__tests__/mobile-app-auth-wrangler.test.ts
@@ -1,0 +1,29 @@
+/** Verifies every deployable Cloud API environment enables native PKCE auth. */
+
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const wrangler = readFileSync(
+  new URL("../wrangler.toml", import.meta.url),
+  "utf8",
+);
+
+function varsBlock(environment?: "staging" | "production"): string {
+  const heading = environment ? `[env.${environment}.vars]` : "[vars]";
+  const start = wrangler.indexOf(heading);
+  expect(start).toBeGreaterThanOrEqual(0);
+  const rest = wrangler.slice(start + heading.length);
+  const end = rest.search(/^\[/m);
+  return end === -1 ? rest : rest.slice(0, end);
+}
+
+describe("mobile app auth Wrangler configuration", () => {
+  it.each([undefined, "staging", "production"] as const)(
+    "enables native PKCE in %s",
+    (environment) => {
+      expect(varsBlock(environment)).toMatch(
+        /^ELIZA_MOBILE_APP_AUTH_ENABLED = "true"$/m,
+      );
+    },
+  );
+});

--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -247,6 +247,9 @@ PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED = "false"
 NEXT_PUBLIC_APP_URL = "https://cloud.eliza.app"
 NEXT_PUBLIC_API_URL = "https://api.eliza.app"
 ELIZA_CLOUD_URL = "https://api.eliza.app"
+# Native Android PKCE is a committed product capability. The endpoint fails
+# closed unless this public environment flag is exactly "true" or "false".
+ELIZA_MOBILE_APP_AUTH_ENABLED = "true"
 ELIZA_CLOUD_AGENT_BASE_DOMAIN = "cloud.eliza.app"
 ELIZA_FRONTEND_HOST_SUFFIX = "sites.eliza.app"
 # Internal Worker-to-agent calls must target the control-plane origin directly;
@@ -563,6 +566,7 @@ APPS_DEPLOY_ENABLED = "1"
 NEXT_PUBLIC_APP_URL = "https://cloud-staging.eliza.app"
 NEXT_PUBLIC_API_URL = "https://api-staging.eliza.app"
 ELIZA_CLOUD_URL = "https://api-staging.eliza.app"
+ELIZA_MOBILE_APP_AUTH_ENABLED = "true"
 ELIZA_FRONTEND_HOST_SUFFIX = "sites-staging.eliza.app"
 # OpenID Connect provider (Eliza Cloud as the OP for Eliza Hub). Committed vars,
 # not secrets: the issuer string is byte-compared by every relying party, so it
@@ -872,6 +876,7 @@ APPS_DEPLOY_ALLOWED_ORG_IDS = "*"
 NEXT_PUBLIC_APP_URL = "https://cloud.eliza.app"
 NEXT_PUBLIC_API_URL = "https://api.eliza.app"
 ELIZA_CLOUD_URL = "https://api.eliza.app"
+ELIZA_MOBILE_APP_AUTH_ENABLED = "true"
 ELIZA_CLOUD_AGENT_BASE_DOMAIN = "cloud.eliza.app"
 ELIZA_FRONTEND_HOST_SUFFIX = "sites.eliza.app"
 # OpenID Connect provider — see the staging block for why these are vars, not

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -16,6 +16,7 @@ import {
   type SurfaceManifestBearer,
   type ViewKind,
 } from "@elizaos/core";
+import { hasStewardAuthedCookie } from "@elizaos/shared/steward-session-client";
 import { X } from "lucide-react";
 import "./components/chat/chat-source-registration";
 import {
@@ -121,6 +122,7 @@ import { useShellControllerContext } from "./components/shell/ShellControllerCon
 import { ShellOverlays } from "./components/shell/ShellOverlays";
 import { StartupFailureView } from "./components/shell/StartupFailureView";
 import { StartupScreen } from "./components/shell/StartupScreen";
+import { StartupShell } from "./components/shell/StartupShell";
 import { SystemWarningBanner } from "./components/shell/SystemWarningBanner";
 import { TrayLauncher } from "./components/shell/TrayLauncher";
 import { useBarSurfaceWindows } from "./components/shell/useBarSurfaceWindows";
@@ -132,6 +134,7 @@ import { ShellViewAgentSurface } from "./components/views/ShellViewAgentSurface"
 import { ViewErrorBoundary } from "./components/views/ViewErrorBoundary";
 import { AppWorkspaceChrome } from "./components/workspace/AppWorkspaceChrome";
 import { useBootConfig } from "./config/boot-config-react.hooks";
+import { useBranding } from "./config/branding";
 import {
   CHAT_OPEN_EVENT,
   dispatchNavigateViewEvent,
@@ -144,7 +147,10 @@ import {
   type PushToTalkHoldDetail,
 } from "./events";
 import { completeRemoteAgentFirstRun } from "./first-run/adopt-remote-first-run";
-import { persistMobileRuntimeModeForServerTarget } from "./first-run/mobile-runtime-mode";
+import {
+  isElizaCloudRuntimeLocked,
+  persistMobileRuntimeModeForServerTarget,
+} from "./first-run/mobile-runtime-mode";
 import { BootRecoveryConductorMount } from "./first-run/use-boot-recovery-conductor";
 import { FirstRunConductorMount } from "./first-run/use-first-run-conductor";
 import { ModelStatusConductorMount } from "./first-run/use-model-status-conductor";
@@ -172,6 +178,7 @@ import {
   titleForTab,
 } from "./navigation";
 import { applyLaunchConnection } from "./platform";
+import { isAndroidCloudBuild } from "./platform/android-runtime";
 import {
   type AppShellMode,
   resolveAppShellMode,
@@ -188,6 +195,11 @@ import {
   useChatComposer,
   useChatInputRef,
 } from "./state/ChatComposerContext.hooks";
+import {
+  clearCloudAuthFirstScreenGreeting,
+  markCloudAuthFirstScreenGreeting,
+} from "./state/cloud-auth-first-screen";
+import { hasUsableStoredStewardToken } from "./state/cloud-steward-login";
 import { isAuthoritativeFirstRunOpen } from "./state/first-run-chat-release";
 import {
   authProbeShouldHoldShell,
@@ -2322,6 +2334,7 @@ function HomeScreenMount({
 }
 
 function AppContent() {
+  const branding = useBranding();
   const {
     startupError,
     startupCoordinator,
@@ -2341,6 +2354,9 @@ function AppContent() {
     uiShellMode,
     uiLanguage,
     t,
+    elizaCloudConnected,
+    elizaCloudLoginBusy,
+    elizaCloudLoginError,
   } = useAppSelectorShallow((s) => ({
     startupError: s.startupError,
     startupCoordinator: s.startupCoordinator,
@@ -2360,6 +2376,9 @@ function AppContent() {
     uiShellMode: s.uiShellMode,
     uiLanguage: s.uiLanguage,
     t: s.t,
+    elizaCloudConnected: s.elizaCloudConnected,
+    elizaCloudLoginBusy: s.elizaCloudLoginBusy,
+    elizaCloudLoginError: s.elizaCloudLoginError,
   }));
   const isPopout = useIsPopout();
   const isAuxiliaryAppWindow = isAppWindowRoute();
@@ -3008,6 +3027,52 @@ function AppContent() {
   const bugReport = useBugReportState();
   // Loading is handled entirely by StartupScreen.
 
+  const cloudAuthFirstScreenOwnsSurface =
+    shellMode === "full" &&
+    !isPopout &&
+    !isAuxiliaryAppWindow &&
+    !cloudPairToken &&
+    (branding.cloudOnly === true ||
+      isAndroidCloudBuild() ||
+      isElizaCloudRuntimeLocked());
+  const hasUsableCloudSession =
+    elizaCloudConnected ||
+    hasUsableStoredStewardToken() ||
+    (typeof window !== "undefined" && hasStewardAuthedCookie());
+  const startCloudAuthFirstScreen = useCallback(async () => {
+    if (firstRunComplete !== true) {
+      markCloudAuthFirstScreenGreeting();
+    }
+    try {
+      await handleCloudLoginRecovery({ requireClientAuth: true });
+    } catch (error) {
+      clearCloudAuthFirstScreenGreeting();
+      throw error;
+    }
+  }, [firstRunComplete, handleCloudLoginRecovery]);
+  const cloudAuthAutoStartedRef = useRef(false);
+  useEffect(() => {
+    if (
+      !cloudAuthFirstScreenOwnsSurface ||
+      hasUsableCloudSession ||
+      elizaCloudLoginBusy ||
+      elizaCloudLoginError ||
+      cloudAuthAutoStartedRef.current
+    ) {
+      return;
+    }
+    cloudAuthAutoStartedRef.current = true;
+    void startCloudAuthFirstScreen().catch(() => {
+      // error-policy:J4 the full-screen retry surface renders the hook's error.
+    });
+  }, [
+    cloudAuthFirstScreenOwnsSurface,
+    elizaCloudLoginBusy,
+    elizaCloudLoginError,
+    hasUsableCloudSession,
+    startCloudAuthFirstScreen,
+  ]);
+
   useEffect(() => {
     // Safety-net watchdog: the coordinator has its own timeouts per phase, but
     // this catches any edge case where the coordinator gets stuck in a loading
@@ -3106,6 +3171,44 @@ function AppContent() {
   // Self-contained (its own ElizaClient + AudioContext); no app chrome / gate.
   if (shellMode === "voice-workbench") {
     return <VoiceWorkbenchShell />;
+  }
+
+  // Cloud account auth owns the primary viewport before chat exists. Hosted
+  // web redirects to Steward in this tab; the Android launcher keeps Eliza's
+  // hosted page in-app and uses the secure browser only for providers such as
+  // Google that reject embedded WebViews.
+  if (cloudAuthFirstScreenOwnsSurface && !hasUsableCloudSession) {
+    return (
+      <BugReportProvider value={bugReport}>
+        {elizaCloudLoginError ? (
+          <StartupFailureView
+            error={{
+              reason: "unknown",
+              phase: "starting-backend",
+              message: "Eliza Cloud sign-in could not be completed.",
+              detail: elizaCloudLoginError,
+            }}
+            onRetry={() => {
+              void startCloudAuthFirstScreen().catch(() => {
+                // error-policy:J4 the same retry surface receives the error.
+              });
+            }}
+          />
+        ) : (
+          <StartupShell
+            view={{
+              kind: "loading",
+              phase: "initializing-agent",
+              status: "Opening secure sign in…",
+            }}
+            onRetry={() => {
+              void startCloudAuthFirstScreen();
+            }}
+          />
+        )}
+        <BugReportModal />
+      </BugReportProvider>
+    );
   }
 
   // OS chat-overlay window — render JUST the floating assistant pill +

--- a/packages/ui/src/android-cloud/android-cloud-auth.test.ts
+++ b/packages/ui/src/android-cloud/android-cloud-auth.test.ts
@@ -63,6 +63,30 @@ describe("Android Cloud native auth handoff", () => {
     vi.restoreAllMocks();
   });
 
+  it("keeps launcher login on the first-party HTTPS WebView surface", async () => {
+    const auth = await import("./android-cloud-auth");
+    const navigate = vi.fn();
+
+    expect(
+      auth.navigateAndroidCloudSignInInApp(
+        "https://cloud.eliza.app/login?returnTo=%2Fapp-auth%2Fauthorize",
+        navigate,
+      ),
+    ).toBe(true);
+    expect(navigate).toHaveBeenCalledWith(
+      "https://cloud.eliza.app/login?returnTo=%2Fapp-auth%2Fauthorize",
+    );
+
+    for (const url of [
+      "http://cloud.eliza.app/login",
+      "https://cloud.eliza.app.evil.example/login",
+      "javascript:alert(1)",
+    ]) {
+      expect(auth.navigateAndroidCloudSignInInApp(url, navigate)).toBe(false);
+    }
+    expect(navigate).toHaveBeenCalledTimes(1);
+  });
+
   it("single-flights concurrent and sequential delivery of one callback", async () => {
     const fetchImpl = vi
       .fn<typeof fetch>()

--- a/packages/ui/src/android-cloud/android-cloud-auth.ts
+++ b/packages/ui/src/android-cloud/android-cloud-auth.ts
@@ -2,12 +2,14 @@
  * Native Android handoff for the canonical Eliza Cloud sign-in flow.
  *
  * The application keeps its normal first-run chat and full app shell; this
- * module contributes only the PKCE protocol and Keystore-backed pending-login
- * state needed to leave the WebView for hosted authentication and safely
- * resume through an Android deep link.
+ * module contributes the PKCE protocol and Keystore-backed pending-login state
+ * needed to use hosted authentication and safely resume through an Android
+ * deep link. Play builds use a Custom Tab; pinned launcher builds navigate the
+ * same first-party flow inside their own WebView task.
  */
 
 import { registerPlugin } from "@capacitor/core";
+import { isSafeNavigationUrl } from "../utils/navigation-url";
 import {
   AndroidCloudAuthError,
   AndroidCloudClient,
@@ -21,6 +23,10 @@ export const ANDROID_CLOUD_AUTH_RESULT_EVENT =
   "eliza:android-cloud-auth-result" as const;
 export const ANDROID_CLOUD_AUTH_STARTED_EVENT =
   "eliza:android-cloud-auth-started" as const;
+const ANDROID_CLOUD_LOGIN_HOSTS = new Set([
+  "cloud.eliza.app",
+  "cloud-staging.eliza.app",
+]);
 
 export interface AndroidCloudAuthResult {
   apiBase?: string;
@@ -90,6 +96,24 @@ export async function beginAndroidCloudSignIn(
   cloudApiBase?: string,
 ): Promise<AndroidCloudLoginAttempt> {
   return client(cloudApiBase).beginLogin();
+}
+
+/** Navigate the launcher WebView only to the canonical hosted login origins. */
+export function navigateAndroidCloudSignInInApp(
+  url: string,
+  navigate: (safeUrl: string) => void = (safeUrl) =>
+    window.location.assign(safeUrl),
+): boolean {
+  if (!isSafeNavigationUrl(url)) return false;
+  const parsed = new URL(url);
+  if (
+    parsed.protocol !== "https:" ||
+    !ANDROID_CLOUD_LOGIN_HOSTS.has(parsed.hostname.toLowerCase())
+  ) {
+    return false;
+  }
+  navigate(parsed.toString());
+  return true;
 }
 
 /**

--- a/packages/ui/src/first-run/use-first-run-conductor.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.ts
@@ -82,6 +82,7 @@ import {
   useAppSelectorShallow,
 } from "../state";
 import { useConversationMessages } from "../state/ConversationMessagesContext.hooks";
+import { consumeCloudAuthFirstScreenGreeting } from "../state/cloud-auth-first-screen";
 import {
   claimCloudLoginWindow,
   prepareDesktopCloudLoginSession,
@@ -523,6 +524,7 @@ export function useFirstRunConductor(): void {
   // genuinely interactive or genuinely slow must render: a REAL provisioning
   // status, the multi-agent selector, a sign-in retry ask, or an error turn.
   const silentCloudEntryRef = React.useRef(false);
+  const greetAfterCloudAuthRef = React.useRef(false);
   // Monotonic id source for typed-text turns: guarantees a unique user/reply id
   // per send even when two land in the same millisecond, so `seedTurn`'s id
   // dedup never silently swallows an acknowledged message.
@@ -620,7 +622,15 @@ export function useFirstRunConductor(): void {
     // already signed in and their agent already exists — land straight in chat
     // with no wrap-up turn. A create/wake path cleared the ref on its first
     // real provisioning status, so its wrap-up still renders.
-    if (!silentCloudEntryRef.current) {
+    if (greetAfterCloudAuthRef.current) {
+      greetAfterCloudAuthRef.current = false;
+      seedTurn(
+        makeTurn(
+          "first-run:cloud-welcome",
+          `${FIRST_RUN_GREETING} ${CLOUD_ONLY_DONE}`,
+        ),
+      );
+    } else if (!silentCloudEntryRef.current) {
       seedTurn(makeTurn("first-run:cloud-done", CLOUD_ONLY_DONE));
     }
     completeFirstRun("chat");
@@ -1614,6 +1624,7 @@ export function useFirstRunConductor(): void {
       document.addEventListener(APP_RESUME_EVENT, onNativeResume);
       document.addEventListener("visibilitychange", onVisibilityChange);
       if (elizaCloudConnectedRef.current || hasUsableStoredStewardToken()) {
+        greetAfterCloudAuthRef.current = consumeCloudAuthFirstScreenGreeting();
         silentCloudEntryRef.current = true;
         runCloudResumeRef.current("cloud");
       } else if (typeof window !== "undefined" && hasStewardAuthedCookie()) {

--- a/packages/ui/src/platform/android-runtime.test.ts
+++ b/packages/ui/src/platform/android-runtime.test.ts
@@ -9,7 +9,10 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { resolveAndroidRuntimeMode } from "./android-runtime";
+import {
+  resolveAndroidLauncherBuild,
+  resolveAndroidRuntimeMode,
+} from "./android-runtime";
 
 const KEY = "VITE_ELIZA_ANDROID_RUNTIME_MODE";
 
@@ -88,5 +91,25 @@ describe("resolveAndroidRuntimeMode", () => {
   it("is pure — repeated calls with the same env agree", () => {
     const env = { [KEY]: "cloud" };
     expect(resolveAndroidRuntimeMode(env)).toBe(resolveAndroidRuntimeMode(env));
+  });
+});
+
+describe("resolveAndroidLauncherBuild", () => {
+  it("enables the launcher-only renderer contract only for exact 1", () => {
+    expect(
+      resolveAndroidLauncherBuild({ VITE_ELIZA_ANDROID_LAUNCHER_BUILD: "1" }),
+    ).toBe(true);
+    expect(
+      resolveAndroidLauncherBuild({
+        VITE_ELIZA_ANDROID_LAUNCHER_BUILD: " 1 ",
+      }),
+    ).toBe(true);
+    for (const value of [undefined, "", "0", "true", "launcher"]) {
+      expect(
+        resolveAndroidLauncherBuild({
+          VITE_ELIZA_ANDROID_LAUNCHER_BUILD: value,
+        }),
+      ).toBe(false);
+    }
   });
 });

--- a/packages/ui/src/platform/android-runtime.ts
+++ b/packages/ui/src/platform/android-runtime.ts
@@ -66,6 +66,20 @@ export function isAndroidCloudBuild(): boolean {
   return resolveAndroidRuntimeMode(env) === "cloud";
 }
 
+/** True only for the direct-install HOME/launcher Cloud artifact. */
+export function resolveAndroidLauncherBuild(env: RuntimeEnv): boolean {
+  return readString(env, ["VITE_ELIZA_ANDROID_LAUNCHER_BUILD"]) === "1";
+}
+
+export function isAndroidLauncherBuild(): boolean {
+  const env =
+    typeof import.meta !== "undefined" &&
+    (import.meta as { env?: RuntimeEnv }).env
+      ? ((import.meta as { env: RuntimeEnv }).env as RuntimeEnv)
+      : {};
+  return resolveAndroidLauncherBuild(env);
+}
+
 /**
  * True on the Android builds that ship the on-device agent runtime
  * (`android` sideload / `android-system`): a native Android shell that is not

--- a/packages/ui/src/state/cloud-auth-first-screen.test.ts
+++ b/packages/ui/src/state/cloud-auth-first-screen.test.ts
@@ -1,0 +1,44 @@
+/** Verifies the durable, one-shot post-auth greeting handoff. */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  clearCloudAuthFirstScreenGreeting,
+  consumeCloudAuthFirstScreenGreeting,
+  markCloudAuthFirstScreenGreeting,
+} from "./cloud-auth-first-screen";
+
+describe("Cloud auth-first greeting handoff", () => {
+  const originalWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
+  beforeEach(() => {
+    const values = new Map<string, string>();
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: {
+        localStorage: {
+          getItem: (key: string) => values.get(key) ?? null,
+          removeItem: (key: string) => values.delete(key),
+          setItem: (key: string, value: string) => values.set(key, value),
+        },
+      },
+    });
+  });
+  afterEach(() => {
+    if (originalWindow) {
+      Object.defineProperty(globalThis, "window", originalWindow);
+    } else {
+      Reflect.deleteProperty(globalThis, "window");
+    }
+  });
+
+  it("survives navigation and is consumed exactly once", () => {
+    markCloudAuthFirstScreenGreeting();
+    expect(consumeCloudAuthFirstScreenGreeting()).toBe(true);
+    expect(consumeCloudAuthFirstScreenGreeting()).toBe(false);
+  });
+
+  it("does not greet after a failed login", () => {
+    markCloudAuthFirstScreenGreeting();
+    clearCloudAuthFirstScreenGreeting();
+    expect(consumeCloudAuthFirstScreenGreeting()).toBe(false);
+  });
+});

--- a/packages/ui/src/state/cloud-auth-first-screen.ts
+++ b/packages/ui/src/state/cloud-auth-first-screen.ts
@@ -1,0 +1,40 @@
+/** Carries the one-shot greeting handoff across the Cloud login navigation. */
+
+export const CLOUD_AUTH_FIRST_SCREEN_GREETING_KEY =
+  "eliza:cloud-auth-first-screen-greeting";
+
+/** Mark an interactive first-run login whose agent should greet after setup. */
+export function markCloudAuthFirstScreenGreeting(): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(CLOUD_AUTH_FIRST_SCREEN_GREETING_KEY, "1");
+  } catch {
+    // error-policy:J4 storage loss affects only the optional greeting handoff.
+  }
+}
+
+/** Clear the handoff when authentication fails before a session is installed. */
+export function clearCloudAuthFirstScreenGreeting(): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.removeItem(CLOUD_AUTH_FIRST_SCREEN_GREETING_KEY);
+  } catch {
+    // error-policy:J4 blocked storage cannot retain a marker that was not writable.
+  }
+}
+
+/** Consume the greeting handoff exactly once after Cloud auth succeeds. */
+export function consumeCloudAuthFirstScreenGreeting(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    const pending =
+      window.localStorage.getItem(CLOUD_AUTH_FIRST_SCREEN_GREETING_KEY) === "1";
+    if (pending) {
+      window.localStorage.removeItem(CLOUD_AUTH_FIRST_SCREEN_GREETING_KEY);
+    }
+    return pending;
+  } catch {
+    // error-policy:J3 blocked storage is an explicit absent marker.
+    return false;
+  }
+}

--- a/packages/ui/src/state/useCloudState.ts
+++ b/packages/ui/src/state/useCloudState.ts
@@ -30,6 +30,7 @@ import {
   type AndroidCloudAuthResult,
   beginAndroidCloudSignIn,
   cancelAndroidCloudSignIn,
+  navigateAndroidCloudSignInInApp,
   takeLatestAndroidCloudCompletion,
 } from "../android-cloud/android-cloud-auth";
 import { client } from "../api";
@@ -51,7 +52,10 @@ import { signOutFromSsoBridgedHost } from "../cloud/sso-bridge/sso-bridge";
 import { getBootConfig, setBootConfig } from "../config/boot-config";
 import { dispatchElizaCloudStatusUpdated } from "../events";
 import { isElizaCloudRuntimeLocked } from "../first-run/mobile-runtime-mode";
-import { isAndroidCloudBuild } from "../platform/android-runtime";
+import {
+  isAndroidCloudBuild,
+  isAndroidLauncherBuild,
+} from "../platform/android-runtime";
 import { isViteDevUiShell } from "../platform/vite-dev-ui-shell";
 import {
   closeExternalBrowser,
@@ -845,6 +849,15 @@ export function useCloudState({
           });
           const attempt = await beginAndroidCloudSignIn(cloudApiBase);
           attemptId = attempt.state;
+          if (isAndroidLauncherBuild()) {
+            if (!navigateAndroidCloudSignInInApp(attempt.browserUrl)) {
+              await cancelAndroidCloudSignIn(attempt.state);
+              throw new Error("Eliza Cloud returned an invalid sign-in URL.");
+            }
+            // Navigation replaces this renderer. Native code restores the
+            // bundled shell before replaying the protected callback.
+            return loginCompletion;
+          }
           const onCallbackStarted = (event: Event) => {
             const startedAttemptId = (
               event as CustomEvent<{ attemptId?: string }>


### PR DESCRIPTION
Closes #29095.

## What changed

- Cloud-only signed-out primary launches enter the canonical Steward login before chat mounts; there is no intermediate in-chat **Sign in to Eliza Cloud** card.
- A first interactive login carries a one-shot marker into first-run provisioning, so the agent initializes the normal chat and greets after the durable session is installed. Returning sessions remain silent and go directly to chat.
- The Android launcher keeps only canonical Eliza hosted-auth origins inside its WebView. Google and other providers that require a secure browser can leave that first-party page, and the exact `elizaos://auth/callback` deep link restores the bundled renderer before PKCE completion.
- Unmanaged Android screen pinning no longer blocks Google OAuth; managed device-owner lock-task containment remains supported.
- Play keeps its existing Custom Tab/deep-link path.
- Wrangler explicitly enables the existing mobile app-auth endpoint in default, staging, and production environment vars.

## Verification

- `bun run --cwd packages/ui typecheck`
- Biome check across all 18 changed files
- 69 focused tests passed across Cloud auth greeting, Android auth URL policy, launcher source/config/target policy, runtime feature stamping, and Wrangler configuration.
- `bun install` completed with pinned Bun 1.3.14. Its incidental lockfile rewrite was not committed.

## Device note

No `adb` command, install, uninstall, reboot, input event, or other mutation was sent to shared Pixel `66010DLKX00E5X`. Per coordination, physical Google OAuth acceptance remains to be run by the Pixel-owning task against this PR head.
