### PR TITLE
fix(cloud): validate discovered Steward providers

### DIFF
--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.provider-discovery-error.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.provider-discovery-error.test.tsx
@@ -21,7 +21,8 @@ const harness = vi.hoisted(() => ({
   mode: "fail-twice-then-succeed" as
     | "fail-twice-then-succeed"
     | "always-fail"
-    | "hang",
+    | "hang"
+    | "malformed-then-succeed",
 }));
 
 const LIVE_PROVIDERS = {
@@ -60,7 +61,17 @@ vi.mock("@stwd/sdk", () => ({
       if (harness.mode === "hang") {
         return new Promise(() => {});
       }
-      if (harness.mode === "always-fail" || harness.getProvidersCalls <= 2) {
+      if (
+        harness.mode === "malformed-then-succeed" &&
+        harness.getProvidersCalls === 1
+      ) {
+        return Promise.resolve({});
+      }
+      if (
+        harness.mode === "always-fail" ||
+        (harness.mode === "fail-twice-then-succeed" &&
+          harness.getProvidersCalls <= 2)
+      ) {
         return Promise.reject(
           new Error("Provider service is temporarily unavailable"),
         );
@@ -182,6 +193,24 @@ describe("StewardLoginSection provider discovery truth", () => {
     await waitFor(() => expect(harness.getProvidersCalls).toBe(1));
     expect(screen.queryByText("Sign-in options couldn't load")).toBeNull();
     expect(screen.getByRole("button", { name: "Discord" })).toBeTruthy();
+  });
+
+  it("rejects a malformed successful response without fabricating providers", async () => {
+    harness.mode = "malformed-then-succeed";
+    renderSection();
+
+    expect(
+      await screen.findByText("Sign-in options couldn't load"),
+    ).toBeTruthy();
+    expect(
+      screen.getByText(
+        "Steward returned an invalid sign-in provider configuration.",
+      ),
+    ).toBeTruthy();
+    expect(screen.queryByLabelText("Email")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Passkey" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Google" })).toBeNull();
+    expect(harness.getProvidersCalls).toBe(1);
   });
 
   it("fails visibly without fabricated providers and survives repeated failure", async () => {

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
@@ -465,9 +465,7 @@ function providersSessionCacheKey(): string {
   return `${PROVIDERS_SESSION_CACHE_PREFIX}:${STEWARD_TENANT_ID}`;
 }
 
-function normalizeSessionCachedProviders(
-  value: unknown,
-): StewardProviders | null {
+function normalizeStewardProviders(value: unknown): StewardProviders | null {
   if (value === null || typeof value !== "object" || Array.isArray(value)) {
     return null;
   }
@@ -518,7 +516,7 @@ function readSessionCachedProviders(): StewardProviders | null {
   try {
     const raw = window.sessionStorage.getItem(providersSessionCacheKey());
     if (!raw) return null;
-    return normalizeSessionCachedProviders(JSON.parse(raw) as unknown);
+    return normalizeStewardProviders(JSON.parse(raw) as unknown);
   } catch (error) {
     // error-policy:J3 a corrupt or inaccessible snapshot is explicitly "no
     // cache" — the section falls back to the discovery skeleton, never to a
@@ -550,12 +548,21 @@ function loadStewardProviders(auth: {
   const requestGeneration = stewardProvidersRequestGeneration;
   stewardProvidersPromise ??= auth.getProviders().then(
     (loadedProviders) => {
-      if (requestGeneration === stewardProvidersRequestGeneration) {
-        cachedStewardProviders = loadedProviders;
-        stewardProvidersPromise = null;
-        writeSessionCachedProviders(loadedProviders);
+      // error-policy:J3 SDK response data is an untrusted transport boundary.
+      // Reject malformed 200 responses instead of caching or rendering a
+      // healthy-looking subset inferred from missing fields.
+      const normalizedProviders = normalizeStewardProviders(loadedProviders);
+      if (normalizedProviders === null) {
+        throw new Error(
+          "Steward returned an invalid sign-in provider configuration.",
+        );
       }
-      return loadedProviders;
+      if (requestGeneration === stewardProvidersRequestGeneration) {
+        cachedStewardProviders = normalizedProviders;
+        stewardProvidersPromise = null;
+        writeSessionCachedProviders(normalizedProviders);
+      }
+      return normalizedProviders;
     },
     (error: unknown) => {
       if (requestGeneration === stewardProvidersRequestGeneration) {
@@ -810,6 +817,8 @@ export default function StewardLoginSection() {
   }, []);
 
   useEffect(() => {
+    // The nonce is the explicit retry trigger for this discovery effect.
+    void providerDiscoveryAttempt;
     if (PLAYWRIGHT_TEST_AUTH_ENABLED) {
       setProvidersLoaded(true);
       return;


### PR DESCRIPTION
Follow-up to #29077 and the auth-consistency finding in #29024.

The Steward SDK throws on non-2xx responses but returns unvalidated response data on HTTP 200. The merged discovery boundary therefore still accepted and cached malformed provider objects. A partial object such as `{}` could infer email as enabled and recreate the fabricated sign-in surface that #29077 intended to remove.

This change:
- applies the existing structural provider normalizer to live discovery before cache or render;
- rejects malformed successful responses into the explicit retry boundary;
- adds a malformed-200 regression proving Email, Passkey, and Google are absent;
- makes the retry nonce an explicit effect input so the exact Biome gate remains clean.

Exact validation at `a139dcfa25094e5a31bd022402431beb56139e20` on base `4fc2881f0babdeb5386185e4c006e9b33ca9b122`:
- focused provider-discovery suite: 4/4 passed;
- exact Biome check: passed;
- `git diff --check`: passed.

No provider configuration, deployment, credential, or production state is changed.