### PR TITLE
fix(cloud): restore valid mobile auth deploy config

### DIFF
--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -566,7 +566,6 @@ APPS_DEPLOY_ENABLED = "1"
 NEXT_PUBLIC_APP_URL = "https://cloud-staging.eliza.app"
 NEXT_PUBLIC_API_URL = "https://api-staging.eliza.app"
 ELIZA_CLOUD_URL = "https://api-staging.eliza.app"
-ELIZA_MOBILE_APP_AUTH_ENABLED = "true"
 ELIZA_FRONTEND_HOST_SUFFIX = "sites-staging.eliza.app"
 # OpenID Connect provider (Eliza Cloud as the OP for Eliza Hub). Committed vars,
 # not secrets: the issuer string is byte-compared by every relying party, so it
@@ -620,9 +619,8 @@ ELIZA_ONBOARDING_APP_URL = "https://cloud-staging.eliza.app"
 # bindings immediately before deployment and restores their staging value if
 # that deployment fails. The committed var is the steady-state authority.
 ELIZA_ONBOARDING_LOGIN_APP_URL = "https://staging.eliza.app"
-# Mobile app auth is staged behind an explicit environment gate and a fixed
-# registered app identity. Production remains disabled until physical-device
-# hosted PKCE and session persistence are accepted against this environment.
+# Mobile app auth is gated explicitly and bound to a fixed registered app
+# identity. The protected deployment workflow verifies both before publishing.
 ELIZA_MOBILE_APP_AUTH_ENABLED = "true"
 ELIZA_MOBILE_APP_AUTH_APP_ID = "689a1597-85e7-43ca-b000-8c6392d79465"
 NEXT_PUBLIC_NETWORK = "base"


### PR DESCRIPTION
Removes the duplicate staging mobile-auth flag introduced by #29100, which made `wrangler.toml` invalid and blocked both staging and production Worker deployments. Also updates the stale activation comment.\n\nVerified with Wrangler 4.116.0 dry-run bundles for both staging and production.