### PR TITLE
fix(app): greet after cookie-backed cloud auth

### DIFF
--- a/packages/app/test/ui-smoke/all-views-aesthetic-audit.spec.ts
+++ b/packages/app/test/ui-smoke/all-views-aesthetic-audit.spec.ts
@@ -36,6 +36,7 @@ import {
   type ScreenshotQuality,
   screenshotQualityIssues,
 } from "./helpers/screenshot-quality";
+import { seedStewardSession } from "./helpers/test-auth";
 import {
   normalize,
   type OcrExpectation,
@@ -1816,6 +1817,7 @@ test.describe("all-views aesthetic audit (#8796)", () => {
 
         await page.setViewportSize({ width: vp.width, height: vp.height });
         await seedAppStorage(page);
+        await seedStewardSession(page, { jwt: true });
         await installDefaultAppRoutes(page);
         const remoteBundleProof = await forceRemoteBundleAuditRoute(page, view);
         await openAppPath(page, remoteBundleProof?.auditPath ?? view.path);

--- a/packages/ui/src/first-run/use-first-run-conductor.test.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.test.ts
@@ -151,6 +151,7 @@ import {
   ConversationMessagesCtx,
   type ConversationMessagesValue,
 } from "../state/ConversationMessagesContext.hooks";
+import { markCloudAuthFirstScreenGreeting } from "../state/cloud-auth-first-screen";
 import {
   __resetPreparedDesktopCloudLoginSessionForTests,
   CLOUD_LOGIN_POPUP_NAME,
@@ -1799,6 +1800,33 @@ describe("cloud-only onboarding (runtime chooser off — the production default)
     expect(mocks.client.getPersonalSharedEliza.mock.calls[0][0]).toMatchObject({
       cloudApiBase: "https://eliza.app",
     });
+    unmount();
+  });
+
+  it("greets once after an auth-first login recovers through the hosted cookie session", async () => {
+    localStorage.removeItem("steward_session_token");
+    markCloudAuthFirstScreenGreeting();
+    writeTestCookie("steward-authed=1");
+    mocks.refreshCloudStewardSession.mockResolvedValue({
+      token: "cookie-token",
+    });
+    const spies = seedAppStore({ elizaCloudConnected: false });
+    const { transcript, turn, unmount } = renderConductor();
+
+    await waitFor(() => {
+      expect(spies.completeFirstRun).toHaveBeenCalledTimes(1);
+    });
+
+    const welcome = await waitForTurn(turn, "first-run:cloud-welcome");
+    expect(welcome.text).toContain("Hi, I'm Eliza.");
+    expect(
+      transcript.current.some((message) =>
+        message.text.includes("Sign in to Eliza Cloud"),
+      ),
+    ).toBe(false);
+    expect(localStorage.getItem("eliza:cloud-auth-first-screen-greeting")).toBe(
+      null,
+    );
     unmount();
   });
 

--- a/packages/ui/src/first-run/use-first-run-conductor.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.ts
@@ -1677,6 +1677,8 @@ export function useFirstRunConductor(): void {
               // error-policy:J6 best-effort nudge — consumers re-read the
               // stored token on their next tick regardless.
             }
+            greetAfterCloudAuthRef.current =
+              consumeCloudAuthFirstScreenGreeting();
             runCloudResumeRef.current("cloud");
             return;
           }


### PR DESCRIPTION
Closes #29095

Follow-up to #29100, which was already merged before review began.

## What changed
- consume the auth-first greeting marker after cookie-backed Steward recovery, so a fresh hosted login gets the one-time assistant welcome
- add a regression test proving the greeting appears and no “Sign in to Eliza Cloud” card remains in the transcript
- seed the canonical signed-in Steward session in the all-views visual audit, whose signed-in fixtures were intercepted by the new auth-first gate

## Verification
- `bun run --cwd packages/ui test -- src/first-run/use-first-run-conductor.test.ts` — 71 passed
- `bun run --cwd packages/ui typecheck` — passed
- Biome on all changed files — passed
- `bun run --cwd packages/app audit:app` — 227 passed; 0 broken, 0 needs-work; packaged OCR 0 broken
- `bun run verify` — blocked by the current develop baseline: `check:i18n` reports three missing English provider-discovery keys and pre-existing non-English gaps, all in untouched files