### PR TITLE
fix(app): stabilize noncanonical Android Cloud builds

### DIFF
--- a/packages/app-core/scripts/run-mobile-build-android-play-policy.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-android-play-policy.test.mjs
@@ -19,6 +19,8 @@ import {
   ANDROID_PLAY_ALLOWED_NATIVE_PLUGIN_PACKAGES,
   ANDROID_PLAY_ALLOWED_PERMISSIONS,
   ANDROID_PLAY_DATA_EXTRACTION_RULES,
+  ANDROID_SMS_GATEWAY_STRIPPED_JAVA_FILES,
+  ANDROID_SMS_GATEWAY_STRIPPED_NATIVE_PLUGINS,
   androidPlayManifestEvidenceFromAapt,
   applyAndroidCloudSplashTheme,
   applyAndroidGeneratedBuildTargetProperties,
@@ -175,10 +177,10 @@ describe("Android Play manifest policy", () => {
       /eliza\.app|localhost|127\.0\.0\.1|BackgroundRunner|bun-runtime|includePlugins/,
     );
     expect(sanitized).not.toHaveProperty("ios");
-    expect(sanitized).not.toHaveProperty("loggingBehavior");
+    expect(sanitized.loggingBehavior).toBe("none");
   });
 
-  it("preserves launcher-only logging suppression and opt-in WebView inspection", () => {
+  it("preserves Cloud logging suppression and launcher-only WebView inspection", () => {
     const sanitized = sanitizeAndroidCloudCapacitorConfig(
       {
         loggingBehavior: "debug",
@@ -189,6 +191,15 @@ describe("Android Play manifest policy", () => {
 
     expect(sanitized.loggingBehavior).toBe("none");
     expect(sanitized.android.webContentsDebuggingEnabled).toBe(true);
+  });
+
+  it("removes the SafePush source when SMS builds remove its native dependency", () => {
+    expect(ANDROID_SMS_GATEWAY_STRIPPED_JAVA_FILES).toContain(
+      "SafePushNotificationsPlugin.java",
+    );
+    expect(
+      ANDROID_SMS_GATEWAY_STRIPPED_NATIVE_PLUGINS.map(([pkg]) => pkg),
+    ).toContain("@capacitor/push-notifications");
   });
 
   it("allows only canonical hosted-auth navigation in launcher config", () => {

--- a/packages/app-core/scripts/run-mobile-build-cloud-main-activity.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-cloud-main-activity.test.mjs
@@ -26,11 +26,25 @@ describe("cloudSafeMainActivityJava", () => {
     expect(splashInstall).toBeLessThan(bridgeCreation);
   });
 
-  it("does not reference removed push or background-agent services", () => {
+  it("guards push registration without restoring background-agent services", () => {
     const source = cloudSafeMainActivityJava("ai.elizaos.app");
+    const bridgeCreation = source.indexOf(
+      "super.onCreate(savedInstanceState);",
+    );
+    const guardedPushRegistration = source.indexOf(
+      "getBridge().registerPlugin(SafePushNotificationsPlugin.class);",
+    );
+
+    expect(guardedPushRegistration).toBeGreaterThan(bridgeCreation);
+    expect(source).not.toContain("GatewayConnectionService");
+  });
+
+  it("omits the push guard when the target strips the push plugin", () => {
+    const source = cloudSafeMainActivityJava("ai.elizaos.app", {
+      safePushNotifications: false,
+    });
 
     expect(source).not.toContain("SafePushNotificationsPlugin");
-    expect(source).not.toContain("GatewayConnectionService");
   });
 
   it("uses public edge-to-edge APIs without hiding the system bars", () => {

--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -5963,7 +5963,7 @@ export function sanitizeAndroidCloudCapacitorConfig(
     appId: APP.appId,
     appName: APP.appName,
     webDir: "dist",
-    ...(launcherKiosk ? { loggingBehavior: "none" } : {}),
+    loggingBehavior: "none",
     server: {
       androidScheme: "https",
       ...(allowInAppAuthNavigation
@@ -6273,10 +6273,12 @@ export const ANDROID_SMS_GATEWAY_STRIPPED_PERMISSIONS =
     (permission) => !ANDROID_SMS_GATEWAY_PERMISSIONS.has(permission),
   );
 
-export const ANDROID_SMS_GATEWAY_STRIPPED_JAVA_FILES =
-  ANDROID_CLOUD_STRIPPED_JAVA_FILES.filter(
+export const ANDROID_SMS_GATEWAY_STRIPPED_JAVA_FILES = [
+  ...ANDROID_CLOUD_STRIPPED_JAVA_FILES.filter(
     (file) => !ANDROID_SMS_GATEWAY_COMPONENTS.has(file.replace(/\.java$/, "")),
-  );
+  ),
+  "SafePushNotificationsPlugin.java",
+];
 
 export const ANDROID_SMS_GATEWAY_STRIPPED_NATIVE_PLUGINS = [
   ...ANDROID_CLOUD_STRIPPED_NATIVE_PLUGINS,
@@ -6348,7 +6350,11 @@ export function findAndroidCloudPackagedRuntimeOffenders(entries) {
 
 export function cloudSafeMainActivityJava(
   androidPackage,
-  { launcherKiosk = false, immersiveNavigation = false } = {},
+  {
+    launcherKiosk = false,
+    immersiveNavigation = false,
+    safePushNotifications = true,
+  } = {},
 ) {
   const launcherImports = launcherKiosk
     ? `import android.app.admin.DevicePolicyManager;
@@ -6455,6 +6461,17 @@ import androidx.activity.OnBackPressedCallback;
     }
 `
     : "";
+  const safePushRegistration = safePushNotifications
+    ? `
+        // Capacitor discovers the community push plugin before Firebase is
+        // available in builds without google-services.json. Replace it after
+        // bridge creation so registration reports unavailable instead of
+        // terminating the process when the renderer requests notifications.
+        if (getBridge() != null) {
+            getBridge().registerPlugin(SafePushNotificationsPlugin.class);
+        }
+`
+    : "";
   return `package ${androidPackage};
 
 import android.os.Bundle;
@@ -6494,6 +6511,7 @@ ${launcherConstants}
         registerPlugin(ElizaPlaySettingsPlugin.class);
 
         super.onCreate(savedInstanceState);
+${safePushRegistration}
 
 ${launcherSetup}
 
@@ -7387,7 +7405,11 @@ public class ElizaTasksWorker extends Worker {
 function rewriteCloudJavaSources(
   javaRoots,
   androidPackage,
-  { launcherKiosk = false, immersiveNavigation = false } = {},
+  {
+    launcherKiosk = false,
+    immersiveNavigation = false,
+    safePushNotifications = true,
+  } = {},
 ) {
   let touched = 0;
   for (const root of javaRoots) {
@@ -7399,6 +7421,7 @@ function rewriteCloudJavaSources(
         cloudSafeMainActivityJava(androidPackage, {
           launcherKiosk,
           immersiveNavigation,
+          safePushNotifications,
         }),
         "utf8",
       );
@@ -8451,7 +8474,9 @@ function stripAndroidForSmsGateway() {
       `[mobile-build] Removed ${removedJavaRootCount} inactive Android Java source root(s).`,
     );
   }
-  rewriteCloudJavaSources(javaRoots, androidPackage);
+  rewriteCloudJavaSources(javaRoots, androidPackage, {
+    safePushNotifications: false,
+  });
 
   const resRoot = path.join(androidDir, "app", "src", "main", "res");
   for (const relPath of ANDROID_CLOUD_STRIPPED_RESOURCE_FILES) {

--- a/packages/app/capacitor.config.ts
+++ b/packages/app/capacitor.config.ts
@@ -136,16 +136,18 @@ function isFlagEnabled(value: string | undefined): boolean {
 }
 
 /**
- * The direct-install launcher is intentionally debuggable so adb can verify
- * the HOME-role handoff, but Capacitor's default debug logging serializes
- * native plugin results into logcat. That includes the Keystore-backed Cloud
- * credential returned by ElizaSecureCredentials.get(). Keep the launcher
- * debuggable without ever logging bridge payloads.
+ * Android Cloud clients retain Keystore-backed credentials across sessions,
+ * while Capacitor's default debug logging serializes native plugin results
+ * into logcat. Suppress bridge payload logging for every Cloud-derived target,
+ * including the launcher and SMS gateway, without disabling debug signing.
  */
 export function resolveCapacitorLoggingBehavior(
   env: NodeJS.ProcessEnv = process.env,
 ): "debug" | "none" {
-  return isFlagEnabled(env.ELIZA_ANDROID_LAUNCHER_BUILD) ? "none" : "debug";
+  return isFlagEnabled(env.ELIZA_ANDROID_CLOUD_BUILD) ||
+    isFlagEnabled(env.ELIZA_ANDROID_LAUNCHER_BUILD)
+    ? "none"
+    : "debug";
 }
 
 const webViewDebuggingEnabled =
@@ -160,8 +162,34 @@ export function resolveAndroidProjectPath(
     : "../app-core/platforms/android";
 }
 
-const androidProjectPath = resolveAndroidProjectPath(
-  process.env.ELIZA_ANDROID_USE_APP_DIR,
+export function resolveCapacitorAppId(
+  appIdOverride: string | undefined,
+  iosAppIdOverride: string | undefined,
+  configuredAppId: string,
+): string {
+  return appIdOverride?.trim() || iosAppIdOverride?.trim() || configuredAppId;
+}
+
+export function resolveCapacitorAndroidIdentity(
+  env: NodeJS.ProcessEnv,
+  configuredAppId: string,
+): { appId: string; projectPath: string } {
+  const appId = resolveCapacitorAppId(
+    env.ELIZA_APP_ID,
+    env.ELIZA_IOS_APP_ID,
+    configuredAppId,
+  );
+  return {
+    appId,
+    projectPath: resolveAndroidProjectPath(
+      env.ELIZA_ANDROID_USE_APP_DIR,
+      appId,
+    ),
+  };
+}
+
+const capacitorAndroidIdentity = resolveCapacitorAndroidIdentity(
+  process.env,
   appConfig.appId,
 );
 const capacitorHttpEnabled = resolveCapacitorHttpEnabled(
@@ -171,7 +199,7 @@ const capacitorHttpEnabled = resolveCapacitorHttpEnabled(
 );
 
 const config: CapacitorConfig = {
-  appId: appConfig.appId,
+  appId: capacitorAndroidIdentity.appId,
   appName: appConfig.appName,
   webDir: "dist",
   loggingBehavior: resolveCapacitorLoggingBehavior(),
@@ -244,7 +272,7 @@ const config: CapacitorConfig = {
     // Keep `cap sync` pointed at the same Android tree run-mobile-build will
     // package. Upstream elizaOS owns the shared app-core tree; white-label or
     // explicitly isolated builds use the app-local ignored android/ project.
-    path: androidProjectPath,
+    path: capacitorAndroidIdentity.projectPath,
     // Android owns the fused app runtime. Keep iOS's llama-cpp-capacitor
     // dependency out of raw Android sync while discovering every declared
     // Capacitor plugin, including the embedded Bun host, from package metadata.

--- a/packages/app/capacitor.config.ts
+++ b/packages/app/capacitor.config.ts
@@ -145,7 +145,8 @@ export function resolveCapacitorLoggingBehavior(
   env: NodeJS.ProcessEnv = process.env,
 ): "debug" | "none" {
   return isFlagEnabled(env.ELIZA_ANDROID_CLOUD_BUILD) ||
-    isFlagEnabled(env.ELIZA_ANDROID_LAUNCHER_BUILD)
+    isFlagEnabled(env.ELIZA_ANDROID_LAUNCHER_BUILD) ||
+    isFlagEnabled(env.ELIZA_ANDROID_CLOUD_HYBRID_BUILD)
     ? "none"
     : "debug";
 }

--- a/packages/app/test/capacitor-plugin-selection.test.ts
+++ b/packages/app/test/capacitor-plugin-selection.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, it } from "vitest";
 import {
   resolveAndroidCapacitorPlugins,
+  resolveCapacitorAndroidIdentity,
   resolveCapacitorHttpEnabled,
   resolveCapacitorLoggingBehavior,
 } from "../capacitor.config";
@@ -32,13 +33,50 @@ describe("Android Capacitor plugin selection", () => {
     expect(resolveCapacitorHttpEnabled("android", "local")).toBe(true);
     expect(resolveCapacitorHttpEnabled("ios", "cloud")).toBe(true);
   });
+
+  it("keeps the emitted identity and Android project selection aligned", () => {
+    const stagingIdentity = resolveCapacitorAndroidIdentity(
+      {
+        ELIZA_APP_ID: " ai.elizaos.app.staging ",
+        ELIZA_IOS_APP_ID: "ai.elizaos.app.ios",
+      },
+      "ai.elizaos.app",
+    );
+
+    expect(stagingIdentity).toEqual({
+      appId: "ai.elizaos.app.staging",
+      projectPath: "android",
+    });
+    expect(
+      resolveCapacitorAndroidIdentity({ ELIZA_APP_ID: " " }, "ai.elizaos.app"),
+    ).toEqual({
+      appId: "ai.elizaos.app",
+      projectPath: "../app-core/platforms/android",
+    });
+    expect(
+      resolveCapacitorAndroidIdentity(
+        { ELIZA_IOS_APP_ID: "ai.elizaos.app.ios" },
+        "ai.elizaos.app",
+      ),
+    ).toEqual({ appId: "ai.elizaos.app.ios", projectPath: "android" });
+  });
 });
 
 describe("Capacitor logging behavior", () => {
-  it("suppresses native bridge payloads in the debuggable launcher lane", () => {
+  it("suppresses native bridge payloads in every Android Cloud lane", () => {
     expect(
       resolveCapacitorLoggingBehavior({
         ELIZA_ANDROID_LAUNCHER_BUILD: "1",
+      }),
+    ).toBe("none");
+    expect(
+      resolveCapacitorLoggingBehavior({
+        ELIZA_ANDROID_CLOUD_BUILD: "1",
+      }),
+    ).toBe("none");
+    expect(
+      resolveCapacitorLoggingBehavior({
+        ELIZA_ANDROID_CLOUD_BUILD: "true",
       }),
     ).toBe("none");
   });

--- a/packages/app/test/capacitor-plugin-selection.test.ts
+++ b/packages/app/test/capacitor-plugin-selection.test.ts
@@ -79,6 +79,11 @@ describe("Capacitor logging behavior", () => {
         ELIZA_ANDROID_CLOUD_BUILD: "true",
       }),
     ).toBe("none");
+    expect(
+      resolveCapacitorLoggingBehavior({
+        ELIZA_ANDROID_CLOUD_HYBRID_BUILD: "1",
+      }),
+    ).toBe("none");
   });
 
   it("retains debug-only logging for other lanes", () => {


### PR DESCRIPTION
Closes #29111.

## What changed

- Align the emitted Capacitor app ID with the Android project selected by build overrides.
- Install the guarded push wrapper after the Capacitor bridge exists in Cloud activities.
- Omit and strip that wrapper when the SMS target removes the push dependency.
- Disable Capacitor native bridge payload logging for every Android Cloud-derived target.
- Add focused regressions for identity selection, generated activity ordering, SMS stripping, and logging policy.

## Exact source

- Base/current develop: a935a4c278f6de26c570c19cca7d4f9e1f77f65a
- Head: c0cfd20a87310e4f91d7dfdbba89f4e55646b7f8
- Tree: 2d1818edf6af4982525e18780115646af49e45e4
- Parent: d6fd85f296a2bfa8e80cbb62544f16738dd2ccaa
- Previous remote head: 148bf13a418793e4064c80efd958a9b006b4a27f
- Terminal rebase range-diff: 2/2 exact equals
- Stable patch IDs: e0f83f31478ca5f38dc8ad5a7833cc4f7bfe07f7 and c8699f913599a0d48080dff780096b352360a23d
- Independent source review carries through the exact mechanical rebase: P0-P3 none.

## Exact-current local gates

- 44/44 focused Android build/plugin tests: PASS
- Biome on all five touched files: PASS
- git diff --check: PASS
- bun install: PASS
- Full Cloud renderer rebuild: PASS
- Android pre-Gradle, post-Gradle, and artifact audits: PASS

## Android artifact proof

The exact-current noncanonical staging Cloud APK built successfully without Firebase configuration. It contains the staging app identity ai.elizaos.app.staging, Cloud runtime mode, direct renderer variant, loggingBehavior none, and no local server URL.

- APK SHA-256: 2473de54f05aa4223e62ec1580c3913643838a60f59474b46e17a0920840f2a9
- Renderer build ID: 3344871d90d90d6e65c233af239abc805a974f7713ca92640b545968da029062
- Renderer commit: c0cfd20a87310e4f91d7dfdbba89f4e55646b7f8
- Staged and source renderer manifests: byte-identical

The earlier pre-rebase proof installed and launched on Pixel 11 Pro without the prior push-registration crash. Exact-current reinstall and fresh hosted-auth evidence remain pending until the matching staging backend and Dedicated same-row adoption gate are ready.

## Evidence matrix

- Exact-current focused source tests: PASS
- Android build/audit logs: PASS
- Pixel screenshots/video: pending exact-current install
- Fresh hosted auth callback + relaunch: pending exact-current install
- Dedicated agent chat/history: pending exact-current staging adoption acceptance
- Production deployment: N/A - no production promotion from this PR before exact staging certification and real Pixel proof
