### PR TITLE
fix(android): expose Firebase compile API to system builds

### DIFF
--- a/packages/app-core/platforms/android/app/build.gradle
+++ b/packages/app-core/platforms/android/app/build.gradle
@@ -581,12 +581,11 @@ dependencies {
     implementation "com.google.code.gson:gson:2.14.0"
     if (project.findProperty('elizaCloudBuild') != 'true') {
         implementation "com.google.firebase:firebase-common-ktx:21.0.0"
-    } else {
-        // The push plugin supplies Firebase Messaging at runtime, but Gradle's
-        // implementation boundary does not expose it to the app module where
-        // SafePushNotificationsPlugin compiles its no-config crash guard.
-        compileOnly "com.google.firebase:firebase-messaging:25.0.1"
     }
+    // The push plugin supplies Firebase Messaging at runtime, but Gradle's
+    // implementation boundary does not expose it to the app module where
+    // SafePushNotificationsPlugin compiles its no-config crash guard.
+    compileOnly "com.google.firebase:firebase-messaging:25.0.1"
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"

--- a/packages/app-core/scripts/run-mobile-build-android-play-policy.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-android-play-policy.test.mjs
@@ -438,6 +438,12 @@ describe("Android Play manifest policy", () => {
     );
   });
 
+  it("exposes Firebase Messaging to the guarded push plugin in every lane", () => {
+    expect(APP_BUILD_GRADLE).toMatch(
+      /if \(project\.findProperty\('elizaCloudBuild'\) != 'true'\) \{\s*implementation "com\.google\.firebase:firebase-common-ktx:21\.0\.0"\s*\}\s*\/\/ The push plugin[\s\S]*compileOnly "com\.google\.firebase:firebase-messaging:25\.0\.1"/,
+    );
+  });
+
   it("rejects active development routing and credential material in packaged text assets", () => {
     expect(
       findAndroidPlayTextAssetFindings(


### PR DESCRIPTION
Closes #29128.

## What changed

- Keep `firebase-common-ktx` runtime implementation limited to non-cloud builds.
- Move the Firebase Messaging `compileOnly` declaration outside the cloud conditional so `SafePushNotificationsPlugin` compiles in system/AOSP, sideload, and cloud lanes.
- Add a source-contract test that locks the dependency outside the conditional.

This does not add Firebase configuration, initialize Firebase, or change the guarded no-config behavior.

## Verification

- `run-mobile-build-android-play-policy.test.mjs`: 16/16 passed.
- Biome changed-file check: passed.
- Real `build:android:system` passed the prior Java compile failure and is progressing through release shrink/lint with fused arm64-v8a and x86_64 libraries staged.