### PR TITLE
test(app): wait for staging renderer API readiness

### DIFF
--- a/packages/app/test/cloud-live-renderer-api-readiness.test.ts
+++ b/packages/app/test/cloud-live-renderer-api-readiness.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Covers the renderer/API readiness boundary with a deterministic clock so
+ * transient defaults and persistent invalid builds remain distinguishable.
+ */
+
+import { describe, expect, it } from "vitest";
+import { waitForRendererCloudApiOrigin } from "./cloud-live-renderer-api-readiness";
+
+const STAGING_API_ORIGIN = "https://api-staging.eliza.app";
+
+function deterministicClock() {
+  let currentMs = 0;
+  return {
+    now: () => currentMs,
+    sleep: async (durationMs: number) => {
+      currentMs += durationMs;
+    },
+  };
+}
+
+describe("deployed renderer Cloud API readiness", () => {
+  it("waits through the production default until staging boot config arrives", async () => {
+    const values = ["https://eliza.app", "https://cloud-staging.eliza.app"];
+    let reads = 0;
+    const clock = deterministicClock();
+
+    const result = await waitForRendererCloudApiOrigin({
+      readCloudBase: async () => values[Math.min(reads++, values.length - 1)],
+      expectedApiOrigin: STAGING_API_ORIGIN,
+      timeoutMs: 10,
+      pollIntervalMs: 1,
+      ...clock,
+    });
+
+    expect(reads).toBe(2);
+    expect(result).toEqual({
+      cloudBase: "https://cloud-staging.eliza.app",
+      apiOrigin: STAGING_API_ORIGIN,
+    });
+  });
+
+  it("fails with the last base and origin when production persists", async () => {
+    const clock = deterministicClock();
+
+    await expect(
+      waitForRendererCloudApiOrigin({
+        readCloudBase: async () => "https://eliza.app",
+        expectedApiOrigin: STAGING_API_ORIGIN,
+        timeoutMs: 2,
+        pollIntervalMs: 1,
+        ...clock,
+      }),
+    ).rejects.toThrow(
+      "last base https://eliza.app resolved to https://api.eliza.app; expected https://api-staging.eliza.app",
+    );
+  });
+
+  it("fails with the malformed build value instead of defaulting", async () => {
+    const clock = deterministicClock();
+
+    await expect(
+      waitForRendererCloudApiOrigin({
+        readCloudBase: async () => "not a URL",
+        expectedApiOrigin: STAGING_API_ORIGIN,
+        timeoutMs: 1,
+        pollIntervalMs: 1,
+        ...clock,
+      }),
+    ).rejects.toThrow(
+      "last base not a URL resolved to <unparseable: not a URL>; expected https://api-staging.eliza.app",
+    );
+  });
+});

--- a/packages/app/test/cloud-live-renderer-api-readiness.ts
+++ b/packages/app/test/cloud-live-renderer-api-readiness.ts
@@ -1,0 +1,78 @@
+/**
+ * Waits for the deployed renderer's authoritative Cloud API boot value so the
+ * staging proof cannot mistake the synchronous production default for a build.
+ */
+
+import { resolveDirectCloudAuthApiBase } from "@elizaos/ui/api/direct-cloud-endpoints";
+
+export interface RendererCloudApiObservation {
+  cloudBase: string;
+  apiOrigin: string;
+}
+
+interface RendererCloudApiReadinessOptions {
+  readCloudBase: () => Promise<string>;
+  expectedApiOrigin: string;
+  timeoutMs?: number;
+  pollIntervalMs?: number;
+  now?: () => number;
+  sleep?: (durationMs: number) => Promise<void>;
+}
+
+function observeRendererCloudApi(
+  cloudBase: string,
+): RendererCloudApiObservation {
+  const normalizedCloudBase = cloudBase.trim();
+  if (!normalizedCloudBase) {
+    return { cloudBase: "", apiOrigin: "" };
+  }
+
+  try {
+    return {
+      cloudBase: normalizedCloudBase,
+      apiOrigin: new URL(resolveDirectCloudAuthApiBase(normalizedCloudBase))
+        .origin,
+    };
+  } catch {
+    // error-policy:J3 the exact malformed build value remains visible in the
+    // failed readiness receipt instead of becoming a plausible fallback.
+    return {
+      cloudBase: normalizedCloudBase,
+      apiOrigin: `<unparseable: ${normalizedCloudBase}>`,
+    };
+  }
+}
+
+function defaultSleep(durationMs: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, durationMs));
+}
+
+export async function waitForRendererCloudApiOrigin(
+  options: RendererCloudApiReadinessOptions,
+): Promise<RendererCloudApiObservation> {
+  const timeoutMs = options.timeoutMs ?? 30_000;
+  const pollIntervalMs = options.pollIntervalMs ?? 100;
+  const now = options.now ?? Date.now;
+  const sleep = options.sleep ?? defaultSleep;
+  const startedAt = now();
+  let lastObservation: RendererCloudApiObservation = {
+    cloudBase: "",
+    apiOrigin: "",
+  };
+
+  while (true) {
+    lastObservation = observeRendererCloudApi(await options.readCloudBase());
+    if (lastObservation.apiOrigin === options.expectedApiOrigin) {
+      return lastObservation;
+    }
+
+    const elapsedMs = now() - startedAt;
+    if (elapsedMs >= timeoutMs) {
+      throw new Error(
+        `Renderer Cloud API did not become ready within ${timeoutMs}ms: last base ${lastObservation.cloudBase || "<unset>"} resolved to ${lastObservation.apiOrigin || "<empty>"}; expected ${options.expectedApiOrigin}`,
+      );
+    }
+
+    await sleep(Math.min(pollIntervalMs, timeoutMs - elapsedMs));
+  }
+}

--- a/packages/app/test/ui-smoke/cloud-live.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-live.spec.ts
@@ -8,7 +8,6 @@
 import { randomBytes } from "node:crypto";
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
-import { resolveDirectCloudAuthApiBase } from "@elizaos/ui/api/direct-cloud-endpoints";
 import { isPersonalSharedElizaId } from "@elizaos/ui/utils/cloud-agent-base";
 import {
   type BrowserContext,
@@ -37,6 +36,7 @@ import {
   writeCloudLiveContinuityEvidence,
 } from "../cloud-live-continuity-contract";
 import { resolveCloudLiveOriginContract } from "../cloud-live-origin";
+import { waitForRendererCloudApiOrigin } from "../cloud-live-renderer-api-readiness";
 import {
   CLOUD_LIVE_TRAJECTORY_TIMEOUT_MS,
   type CloudLiveTrajectoryPhase,
@@ -267,28 +267,11 @@ async function requireRendererCloudApiOrigin(
       ).__ELIZAOS_APP_BOOT_CONFIG__;
       return config?.cloudApiBase?.trim() ?? "";
     });
-  await expect
-    .poll(readRendererCloudBase, {
-      message: "renderer boot config must expose its Cloud base",
-      timeout: 30_000,
-    })
-    .not.toBe("");
-  const rendererCloudBase = await readRendererCloudBase();
-  const rendererApiOrigin = (() => {
-    if (!rendererCloudBase) return "";
-    try {
-      return new URL(resolveDirectCloudAuthApiBase(rendererCloudBase)).origin;
-    } catch {
-      // error-policy:J3 a malformed boot value is reported as an explicit
-      // mismatch carrying the offending string, never as a raw TypeError.
-      return `<unparseable: ${rendererCloudBase}>`;
-    }
-  })();
-  expect(
-    rendererApiOrigin,
-    `renderer bundle resolves ${rendererCloudBase || "<unset>"} -> ${rendererApiOrigin || "<empty>"}; the lane pinned ${expectedApiOrigin}`,
-  ).toBe(expectedApiOrigin);
-  return rendererApiOrigin;
+  const observation = await waitForRendererCloudApiOrigin({
+    readCloudBase: readRendererCloudBase,
+    expectedApiOrigin,
+  });
+  return observation.apiOrigin;
 }
 
 async function openProtectedCloudBlankStart(


### PR DESCRIPTION
Closes #29131.

## What changed

- Wait for the renderer's resolved Cloud API origin to equal the workflow-pinned expected origin instead of accepting the first non-empty boot value.
- Keep empty, wrong-environment, and malformed states fail-closed with the last observed base/origin in the timeout error.
- Re-attest the renderer/API boundary before authenticated browser state is seeded.
- Add deterministic coverage for delayed staging initialization, persistent production mismatch, and malformed values.

## Exact identity

- Parent: `b67688577d929f9ecee5c8ad0c3ad9392c209728`
- Head: `19536bcea190f83a89c9a6eaf696bb5f8a54855a`
- Tree: `772c146e08f10342ea575254ad0a36a97afef736`
- Patch ID: `88686e73076c0f9c6dcaaae86a93b80e339d776b`

## Verification

- Focused readiness helper tests: 3/3 pass.
- Biome on the three changed files: pass.
- `git diff --check`: pass.
- Mechanical range-diff from the independently reviewed pre-sync commit: exact `=`.
- Independent review: P0-P3 none.

## Human-verifiable evidence

- Before/after screenshots: N/A - test-only certification harness change; no product pixels changed.
- Video walkthrough: N/A - test-only certification harness change; no user flow changed.
- Backend/frontend logs: N/A - no runtime/backend behavior changed. The deterministic failure tests preserve the observed base, resolved origin, expected origin, and timeout in the surfaced error.
- Real-model trajectory: N/A - no model, prompt, action, provider, or agent behavior changed.

The current unrelated staging deployment was not cancelled, restarted, or otherwise mutated by this work.
