### PR TITLE
fix(release): raise Worker build heap

### DIFF
--- a/.github/workflows/cloud-cf-release.yml
+++ b/.github/workflows/cloud-cf-release.yml
@@ -553,6 +553,11 @@ jobs:
 
       - name: Build
         working-directory: ${{ env.CHECKOUT_DIR }}
+        env:
+          # TypeScript's Worker graph now exceeds V8's 4 GiB default heap on
+          # hosted release runners. Keep the deploy gate fail-closed while
+          # matching the repository's canonical CI heap budget.
+          NODE_OPTIONS: "--max-old-space-size=8192"
         run: bun run --cwd packages/cloud/api build
 
       - name: Resolve deploy environment


### PR DESCRIPTION
The exact Android Cloud login staging candidate reached the real Worker deploy boundary but `tsc6 --noEmit` aborted at V8’s 4 GiB default heap. Give only the Worker build step the same 8 GiB heap budget used by canonical CI.

Evidence: staging run 32953633986, Deploy API Worker, `FATAL ERROR: Ineffective mark-compacts near heap limit` at ~4.1 GiB.

Verification: `git diff --check`.