### PR TITLE
fix(cloud): bind restore-drill authority to the archive with server-clock capability enforcement

### DIFF
--- a/packages/cloud/infra/cloud/terraform/hetzner/apps-shared/cloud-init/tenant-db.yaml.tftpl
+++ b/packages/cloud/infra/cloud/terraform/hetzner/apps-shared/cloud-init/tenant-db.yaml.tftpl
@@ -439,7 +439,10 @@ write_files:
         COUNT=$((COUNT+1))
       done < <(runuser -u postgres -- psql -tAc "SELECT datname FROM pg_database WHERE NOT datistemplate AND datname <> 'postgres' ORDER BY datname")
 
-      sha256sum globals.sql dbmap.tsv dumps/* > checksums.sha256
+      # manifest.json must be checksummed too: the restore drill derives its
+      # authenticated recovery point from the manifest, and its coverage
+      # assertion (#23453) refuses archives whose checksums omit it.
+      sha256sum manifest.json globals.sql dbmap.tsv dumps/* > checksums.sha256
       jq -n \
         --arg created_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
         --argjson database_count "$COUNT" \

--- a/packages/cloud/scripts/admin/apps-tenant-db-recovery.nonce.test.ts
+++ b/packages/cloud/scripts/admin/apps-tenant-db-recovery.nonce.test.ts
@@ -155,6 +155,7 @@ describe("restore target authority is one-use after completion", () => {
         Date.now(),
       );
     } catch (error) {
+      // The expected refusal itself is captured, not swallowed.
       reuseError = error;
     }
     expect(reuseError).toBeDefined();
@@ -195,6 +196,7 @@ describe("restore target authority is one-use after completion", () => {
         Date.now(),
       );
     } catch (error) {
+      // The expected refusal itself is captured, not swallowed.
       mismatchError = error;
     }
     expect((mismatchError as { code?: string }).code).toBe(

--- a/packages/cloud/scripts/admin/apps-tenant-db-recovery.nonce.test.ts
+++ b/packages/cloud/scripts/admin/apps-tenant-db-recovery.nonce.test.ts
@@ -1,25 +1,42 @@
 /**
- * Proves the restore-drill nonce is genuinely one-use (#21729 hardening):
- * exercises the real `verifyAndConsumeRestoreTargetIdentity` orchestration
- * against a scripted psql double that models the documented Postgres
- * semantics of `ALTER SYSTEM RESET` + `pg_reload_conf()` (the setting reads
- * back unset once reloaded). No live Postgres is involved — this is a
- * behavioral double of the external tool boundary, not the SQL engine
- * itself; the sibling `apps-tenant-db-recovery.test.ts` states the same
- * posture for the rest of the suite.
+ * Proves the restore-drill authority is genuinely one-use after completion
+ * (#23453): exercises the real `verifyRestoreAuthority` and
+ * `consumeRestoreAuthority` orchestration against a scripted psql double
+ * that models the documented Postgres semantics of `ALTER SYSTEM RESET` +
+ * `pg_reload_conf()` (settings read back unset once reloaded). No live
+ * Postgres is involved — this is a behavioral double of the external tool
+ * boundary, not the SQL engine itself; the sibling
+ * `apps-tenant-db-recovery.test.ts` states the same posture for the rest of
+ * the suite. Live-server coverage of the same sequence lives in
+ * `apps-tenant-db-recovery.postgres.test.ts` (gated).
  */
 
 import { afterEach, describe, expect, test } from "bun:test";
 import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import {
+  mintRestoreCapability,
+  serializeRestoreCapability,
+} from "./restore-capability";
 
 const TARGET_ID = "drill-11111111-2222-4333-8444-555555555555";
-const TARGET_DSN = "postgresql://restore_admin:pw@127.0.0.1:5433/postgres";
+const TARGET_DSN = "postgresql://restore_admin:***@127.0.0.1:5433/postgres";
+const SIGNING_KEY = "nonce-test-key";
+const ARCHIVE_SHA = "d".repeat(64);
 
-/** Minimal fake Postgres session state: one custom setting, reset or not. */
-function makeFakeServer(initialTargetId: string | null) {
+/**
+ * Minimal fake Postgres server: the two twin settings, reset or not. The
+ * authority read returns both settings plus the role inventory; guarded
+ * --file steps enforce the guard before running; the consume script resets
+ * both settings (mirroring real ALTER SYSTEM RESET + pg_reload_conf).
+ */
+function makeFakeServer(
+  initialTargetId: string | null,
+  initialCapability: string | null,
+) {
   let restoreTargetId = initialTargetId;
+  let restoreCapability = initialCapability;
   return {
     spawnSync(
       command: string,
@@ -34,22 +51,32 @@ function makeFakeServer(initialTargetId: string | null) {
         return {
           status: 0,
           stdout: JSON.stringify({
-            target_id: restoreTargetId,
+            target_id: restoreTargetId ?? "",
+            capability: restoreCapability ?? "",
             existing_roles: [],
           }),
           stderr: "",
           error: undefined,
         };
       }
-      // A guarded --file step (only the consume script in this test).
-      const setIndex = args.indexOf("--set");
-      const expected = args[setIndex + 1]?.split("=")[1];
+      // A guarded --file step: the guard's twin-setting check runs first.
+      const expectedTarget = args.find((a) =>
+        a.startsWith("expected_target_id="),
+      );
+      const expectedCapability = args.find((a) =>
+        a.startsWith("expected_capability="),
+      );
       const script = readFileSync(args[fileIndex + 1], "utf-8");
-      if (restoreTargetId === null || restoreTargetId !== expected) {
+      const matches =
+        restoreTargetId !== null &&
+        restoreCapability !== null &&
+        expectedTarget === `expected_target_id=${restoreTargetId}` &&
+        expectedCapability === `expected_capability=${restoreCapability}`;
+      if (!matches) {
         return {
           status: 1,
           stdout: "",
-          stderr: "restore target identity mismatch",
+          stderr: "restore target authority mismatch",
           error: undefined,
         };
       }
@@ -57,13 +84,23 @@ function makeFakeServer(initialTargetId: string | null) {
         // Mirrors real Postgres: RESET + reload makes current_setting(..., true)
         // read back unset for every session opened afterward.
         restoreTargetId = null;
+        restoreCapability = null;
       }
       return { status: 0, stdout: "", stderr: "", error: undefined };
     },
   };
 }
 
-describe("restore target nonce is genuinely one-use", () => {
+function mintedCapability() {
+  return mintRestoreCapability({
+    signingKey: SIGNING_KEY,
+    targetId: TARGET_ID,
+    archiveSha256: ARCHIVE_SHA,
+    expiresAtEpochMs: Date.now() + 3_600_000,
+  });
+}
+
+describe("restore target authority is one-use after completion", () => {
   let work: string | undefined;
   let restoreModule: typeof import("node:child_process") | undefined;
 
@@ -77,10 +114,12 @@ describe("restore target nonce is genuinely one-use", () => {
     restoreModule = undefined;
   });
 
-  test("a second invocation with the same target id fails REFUSED_TARGET_AUTHORITY after the first consumes it", async () => {
+  test("verify succeeds against matching twins; a second drill after consume fails closed", async () => {
     const { mock } = await import("bun:test");
     restoreModule = await import("node:child_process");
-    const server = makeFakeServer(TARGET_ID);
+    const cap = mintedCapability();
+    const envelope = serializeRestoreCapability(cap);
+    const server = makeFakeServer(TARGET_ID, envelope);
     mock.module("node:child_process", () => ({
       ...restoreModule,
       spawnSync: server.spawnSync,
@@ -91,19 +130,30 @@ describe("restore target nonce is genuinely one-use", () => {
     );
     work = mkdtempSync(join(tmpdir(), "nonce-reuse-test-"));
 
-    const first = mod.verifyAndConsumeRestoreTargetIdentity(
+    // Verify passes against the provisioned twins.
+    const authority = mod.verifyRestoreAuthority(
       TARGET_DSN,
       TARGET_ID,
-      work,
+      cap,
+      SIGNING_KEY,
+      Date.now(),
     );
-    expect(first.targetId).toBe(TARGET_ID);
+    expect(authority.targetId).toBe(TARGET_ID);
 
-    // The nonce is spent: current_setting now reads unset, so the very next
-    // authority read — a re-run of the same drill, an operator mistake, or a
-    // process racing the first — fails closed instead of replaying it.
+    // Consume spends both settings.
+    mod.consumeRestoreAuthority(TARGET_DSN, TARGET_ID, cap, work);
+
+    // The very next verify — a re-run of the completed drill — fails
+    // closed: the settings are gone, the nonce is dead.
     let reuseError: unknown;
     try {
-      mod.verifyAndConsumeRestoreTargetIdentity(TARGET_DSN, TARGET_ID, work);
+      mod.verifyRestoreAuthority(
+        TARGET_DSN,
+        TARGET_ID,
+        cap,
+        SIGNING_KEY,
+        Date.now(),
+      );
     } catch (error) {
       reuseError = error;
     }
@@ -113,36 +163,79 @@ describe("restore target nonce is genuinely one-use", () => {
     );
   });
 
-  test("an unrelated concurrent target id is unaffected by another drill's consumption", async () => {
+  test("a mismatched twin (re-provisioned target) is refused before any work", async () => {
     const { mock } = await import("bun:test");
     restoreModule = await import("node:child_process");
-    const otherTargetId = "drill-22222222-3333-4444-8555-666666666666";
-    const server = makeFakeServer(otherTargetId);
+    const cap = mintedCapability();
+    const otherEnvelope = serializeRestoreCapability(
+      mintRestoreCapability({
+        signingKey: SIGNING_KEY,
+        targetId: TARGET_ID,
+        archiveSha256: "e".repeat(64),
+        expiresAtEpochMs: Date.now() + 3_600_000,
+      }),
+    );
+    const server = makeFakeServer(TARGET_ID, otherEnvelope);
     mock.module("node:child_process", () => ({
       ...restoreModule,
       spawnSync: server.spawnSync,
     }));
 
     const mod = await import(
-      `./apps-tenant-db-recovery?nonce-independent-test=${Date.now()}`
+      `./apps-tenant-db-recovery?nonce-mismatch-test=${Date.now()}`
     );
-    work = mkdtempSync(join(tmpdir(), "nonce-independent-test-"));
 
     let mismatchError: unknown;
     try {
-      mod.verifyAndConsumeRestoreTargetIdentity(TARGET_DSN, TARGET_ID, work);
+      mod.verifyRestoreAuthority(
+        TARGET_DSN,
+        TARGET_ID,
+        cap,
+        SIGNING_KEY,
+        Date.now(),
+      );
     } catch (error) {
       mismatchError = error;
     }
     expect((mismatchError as { code?: string }).code).toBe(
       "REFUSED_TARGET_AUTHORITY",
     );
+  });
 
-    const stillGood = mod.verifyAndConsumeRestoreTargetIdentity(
-      TARGET_DSN,
-      otherTargetId,
-      work,
+  test("a failed drill does not consume the twins (idempotent re-run within TTL)", async () => {
+    const { mock } = await import("bun:test");
+    restoreModule = await import("node:child_process");
+    const cap = mintedCapability();
+    const envelope = serializeRestoreCapability(cap);
+    const server = makeFakeServer(TARGET_ID, envelope);
+    mock.module("node:child_process", () => ({
+      ...restoreModule,
+      spawnSync: server.spawnSync,
+    }));
+
+    const mod = await import(
+      `./apps-tenant-db-recovery?nonce-recover-test=${Date.now()}`
     );
-    expect(stillGood.targetId).toBe(otherTargetId);
+
+    // Verify twice without consuming: both succeed — the crash-recovery
+    // path never spends the authority.
+    expect(
+      mod.verifyRestoreAuthority(
+        TARGET_DSN,
+        TARGET_ID,
+        cap,
+        SIGNING_KEY,
+        Date.now(),
+      ).targetId,
+    ).toBe(TARGET_ID);
+    expect(
+      mod.verifyRestoreAuthority(
+        TARGET_DSN,
+        TARGET_ID,
+        cap,
+        SIGNING_KEY,
+        Date.now(),
+      ).targetId,
+    ).toBe(TARGET_ID);
   });
 });

--- a/packages/cloud/scripts/admin/apps-tenant-db-recovery.postgres.test.ts
+++ b/packages/cloud/scripts/admin/apps-tenant-db-recovery.postgres.test.ts
@@ -122,9 +122,12 @@ async function buildBackupFixture(
     `CREATE ROLE ${tenantRole};\nALTER ROLE ${tenantRole} WITH LOGIN PASSWORD 'tenantpw23453';\n`,
   );
   writeFileSync(join(setDir, "dbmap.tsv"), `${dumpId}\t${databaseName}\n`);
-  sh(`sha256sum manifest.json globals.sql dbmap.tsv dumps/* > checksums.sha256`, {
-    cwd: setDir,
-  });
+  sh(
+    `sha256sum manifest.json globals.sql dbmap.tsv dumps/* > checksums.sha256`,
+    {
+      cwd: setDir,
+    },
+  );
   sh(
     `tar -czf backup.tar.gz manifest.json checksums.sha256 globals.sql dbmap.tsv dumps`,
     {
@@ -278,257 +281,262 @@ async function provisionTarget(targetDb: string, capabilityFile: string) {
   }
 }
 
-describe("restore drill authority on real PostgreSQL (#23453)", () => {
-  beforeAll(async () => {
-    if (!ENABLED) return;
-    admin = new Client({ connectionString: BASE_URL });
-    await admin.connect();
-    // Idempotent setup: drop any leftover objects from a prior run, then
-    // re-run cleanly (the drill itself is one-shot by design).
-    const leftovers = await admin.query(
-      `SELECT datname FROM pg_database WHERE datname LIKE '${TEST_PREFIX}%'`,
-    );
-    for (const row of leftovers.rows) {
-      await admin.query(`DROP DATABASE IF EXISTS ${row.datname} WITH (FORCE)`);
-    }
-    const leftoverRoles = await admin.query(
-      `SELECT rolname FROM pg_roles WHERE rolname LIKE '${TEST_PREFIX}%'`,
-    );
-    for (const row of leftoverRoles.rows) {
-      await admin.query(`DROP ROLE IF EXISTS ${row.rolname}`);
-    }
-    if (POOLER_ENABLED) {
-      startPgbouncer([`${TEST_PREFIX}tenant_a`, `${TEST_PREFIX}tenant_b`]);
-    }
-  });
-
-  afterAll(async () => {
-    if (!ENABLED) return;
-    if (POOLER_ENABLED) {
-      // pkill needs a shell (signal-by-pattern); the pattern is a hardcoded
-      // constant, not interpolated input, so shell injection is unreachable.
-      try {
-        execSync("pkill -f drill-pgbouncer || true");
-      } catch {
-        // pgbouncer may already have exited
-      }
-    }
-    for (const fn of cleanups) {
-      try {
-        fn();
-      } catch {
-        // best-effort temp cleanup
-      }
-    }
-    try {
-      await admin.query(`ALTER SYSTEM RESET eliza.restore_target_id`);
-      await admin.query(`ALTER SYSTEM RESET eliza.restore_capability`);
-      await admin.query(`SELECT pg_reload_conf()`);
-    } catch {
-      // settings may already be reset by the drill's consume step
-    }
-    await admin.end();
-  });
-
-  test("end-to-end drill: verify, guarded restore, linear isolation, consume", async () => {
-    const sourceDb = `${TEST_PREFIX}src`;
-    const targetDb = `${TEST_PREFIX}target`;
-    const databaseName = `${TEST_PREFIX}tenant_a`;
-    const tenantRole = `${TEST_PREFIX}tenant_a`;
-    await admin.query(`CREATE DATABASE ${sourceDb}`);
-    cleanups.push(() =>
-      spawnSync("psql", [
-        "-c",
-        `DROP DATABASE IF EXISTS ${targetDb} WITH (FORCE)`,
-      ]),
-    );
-    const src = new Client({ connectionString: dbUrl(sourceDb) });
-    await src.connect();
-    await src.query(`CREATE TABLE evidence (id int, note text)`);
-    await src.query(`INSERT INTO evidence VALUES (1, 'tenant-data-23453')`);
-    await src.end();
-
-    const fixture = await buildBackupFixture(
-      sourceDb,
-      databaseName,
-      tenantRole,
-    );
-    fixture.capabilityFile = mintCapabilityFile(fixture.archiveSha256);
-    await admin.query(`CREATE DATABASE ${targetDb}`);
-    await provisionTarget(targetDb, fixture.capabilityFile);
-
-    const targetDsn = dbUrl(targetDb);
-    const result = spawnSync(
-      "bun",
-      [
-        "packages/cloud/scripts/admin/apps-tenant-db-recovery.ts",
-        "--set-dir",
-        fixture.setDir,
-        "--target-dsn",
-        targetDsn,
-        "--target-id",
-        TARGET_ID,
-        "--capability-file",
-        fixture.capabilityFile,
-        "--pooler-endpoint",
-        "127.0.0.1:6432",
-        "--tenant-probes-file",
-        fixture.probesFile,
-        "--passphrase-file",
-        fixture.passphraseFile,
-        "--rpo-hours",
-        "26",
-        "--rto-minutes",
-        "60",
-      ],
-      {
-        encoding: "utf-8",
-        env: {
-          ...process.env,
-          ELIZA_RESTORE_CAPABILITY_KEY: SIGNING_KEY,
-          DRILL_TENANT_PW: fixture.tenantPassword,
-        },
-        maxBuffer: 64 * 1024 * 1024,
-      },
-    );
-    // NOTE: the pooler endpoint is probed only for the cross-reject
-    // sample; with a single tenant there is no cross pair, so no pooler
-    // connection is attempted.
-    if (result.status !== 0) {
-      throw new Error(
-        `drill exited ${result.status}\n--- stdout ---\n${result.stdout}\n--- stderr ---\n${result.stderr}`,
+describe.if(ENABLED)(
+  "restore drill authority on real PostgreSQL (#23453)",
+  () => {
+    beforeAll(async () => {
+      admin = new Client({ connectionString: BASE_URL });
+      await admin.connect();
+      // Idempotent setup: drop any leftover objects from a prior run, then
+      // re-run cleanly (the drill itself is one-shot by design).
+      const leftovers = await admin.query(
+        `SELECT datname FROM pg_database WHERE datname LIKE '${TEST_PREFIX}%'`,
       );
-    }
-    expect(result.status).toBe(0);
-    const report = JSON.parse(result.stdout);
-    expect(report.schemaVersion).toBe(2);
-    expect(report.rpoSource).toBe("manifest");
-    expect(report.isolation.plan).toBe("linear");
-    expect(report.isolation.passed).toBe(report.isolation.total);
-    expect(report.objectives.met).toBe(true);
-
-    // Restored tenant data is real.
-    const check = new Client({
-      connectionString: dbUrl(databaseName),
+      for (const row of leftovers.rows) {
+        await admin.query(
+          `DROP DATABASE IF EXISTS ${row.datname} WITH (FORCE)`,
+        );
+      }
+      const leftoverRoles = await admin.query(
+        `SELECT rolname FROM pg_roles WHERE rolname LIKE '${TEST_PREFIX}%'`,
+      );
+      for (const row of leftoverRoles.rows) {
+        await admin.query(`DROP ROLE IF EXISTS ${row.rolname}`);
+      }
+      if (POOLER_ENABLED) {
+        startPgbouncer([`${TEST_PREFIX}tenant_a`, `${TEST_PREFIX}tenant_b`]);
+      }
     });
-    await check.connect();
-    const rows = await check.query(`SELECT note FROM evidence WHERE id = 1`);
-    expect(rows.rows[0].note).toBe("tenant-data-23453");
-    await check.end();
 
-    // Tenant role can connect to its own restored database (own-connect
-    // probe already ran through the drill; verify role survives).
-    const roleConn = await admin.query(
-      `SELECT rolname FROM pg_roles WHERE rolname = '${tenantRole}'`,
-    );
-    expect(roleConn.rows).toHaveLength(1);
-  }, 120_000);
+    afterAll(async () => {
+      if (!ENABLED) return;
+      if (POOLER_ENABLED) {
+        // pkill needs a shell (signal-by-pattern); the pattern is a hardcoded
+        // constant, not interpolated input, so shell injection is unreachable.
+        try {
+          execSync("pkill -f drill-pgbouncer || true");
+        } catch {
+          // pgbouncer may already have exited
+        }
+      }
+      for (const fn of cleanups) {
+        try {
+          fn();
+        } catch {
+          // best-effort temp cleanup
+        }
+      }
+      try {
+        await admin.query(`ALTER SYSTEM RESET eliza.restore_target_id`);
+        await admin.query(`ALTER SYSTEM RESET eliza.restore_capability`);
+        await admin.query(`SELECT pg_reload_conf()`);
+      } catch {
+        // settings may already be reset by the drill's consume step
+      }
+      await admin.end();
+    });
 
-  test("substituted archive is refused even with a valid nonce", async () => {
-    const sourceDb = `${TEST_PREFIX}src2`;
-    const targetDb = `${TEST_PREFIX}target2`;
-    const databaseName = `${TEST_PREFIX}tenant_b`;
-    const tenantRole = `${TEST_PREFIX}tenant_b`;
-    await admin.query(`CREATE DATABASE ${sourceDb}`);
-    const src = new Client({ connectionString: dbUrl(sourceDb) });
-    await src.connect();
-    await src.query(`CREATE TABLE t (id int)`);
-    await src.end();
-
-    const fixture = await buildBackupFixture(
-      sourceDb,
-      databaseName,
-      tenantRole,
-    );
-    // Capability pins the REAL archive; then substitute a different archive.
-    fixture.capabilityFile = mintCapabilityFile(fixture.archiveSha256);
-    sh(`echo tampered > ${join(fixture.setDir, "backup.tar.gz.enc")}`);
-    await admin.query(`CREATE DATABASE ${targetDb}`);
-    await provisionTarget(targetDb, fixture.capabilityFile);
-
-    const targetDsn = dbUrl(targetDb);
-    const result = spawnSync(
-      "bun",
-      [
-        "packages/cloud/scripts/admin/apps-tenant-db-recovery.ts",
-        "--set-dir",
-        fixture.setDir,
-        "--target-dsn",
-        targetDsn,
-        "--target-id",
-        TARGET_ID,
-        "--capability-file",
-        fixture.capabilityFile,
-        "--pooler-endpoint",
-        "127.0.0.1:6432",
-        "--tenant-probes-file",
-        fixture.probesFile,
-        "--passphrase-file",
-        fixture.passphraseFile,
-      ],
-      {
-        encoding: "utf-8",
-        env: {
-          ...process.env,
-          ELIZA_RESTORE_CAPABILITY_KEY: SIGNING_KEY,
-          DRILL_TENANT_PW: fixture.tenantPassword,
-        },
-      },
-    );
-    expect(result.status).not.toBe(0);
-    expect(result.stderr).toContain("sidecar");
-  });
-
-  test("replay after consumption fails closed", async () => {
-    // Provision fresh twins on the cluster, consume them through the real
-    // consume step, then prove: (a) cluster settings are gone, and (b) a
-    // re-verify of the same capability refuses on the empty twin.
-    const capFile = mintCapabilityFile("f".repeat(64));
-    const cap = await import("./restore-capability").then((m) =>
-      m.parseRestoreCapability(readFileSync(capFile, "utf-8").trim()),
-    );
-    const targetDb = `${TEST_PREFIX}target3`;
-    await admin.query(`CREATE DATABASE ${targetDb}`);
-    await provisionTarget(targetDb, capFile);
-
-    const mod = await import("./apps-tenant-db-recovery");
-    const work = mkdtempSync(join(tmpdir(), "nonce-replay-"));
-    expect(() =>
-      mod.verifyRestoreAuthority(
-        dbUrl(targetDb),
-        TARGET_ID,
-        cap,
-        SIGNING_KEY,
-        Date.now(),
-      ),
-    ).not.toThrow();
-    mod.consumeRestoreAuthority(dbUrl(targetDb), TARGET_ID, cap, work);
-
-    // Direct assertion first: the cluster-level settings are unset now.
-    const fresh = new Client({ connectionString: BASE_URL });
-    await fresh.connect();
-    const settings = await fresh.query(
-      `SELECT COALESCE(current_setting('eliza.restore_target_id', true), '') AS tid, COALESCE(current_setting('eliza.restore_capability', true), '') AS cap`,
-    );
-    expect(settings.rows[0].tid).toBe("");
-    expect(settings.rows[0].cap).toBe("");
-    await fresh.end();
-    // And the real verify path fails closed against the spent target.
-    let code = "";
-    try {
-      mod.verifyRestoreAuthority(
-        dbUrl(targetDb),
-        TARGET_ID,
-        cap,
-        SIGNING_KEY,
-        Date.now(),
+    test("end-to-end drill: verify, guarded restore, linear isolation, consume", async () => {
+      const sourceDb = `${TEST_PREFIX}src`;
+      const targetDb = `${TEST_PREFIX}target`;
+      const databaseName = `${TEST_PREFIX}tenant_a`;
+      const tenantRole = `${TEST_PREFIX}tenant_a`;
+      await admin.query(`CREATE DATABASE ${sourceDb}`);
+      cleanups.push(() =>
+        spawnSync("psql", [
+          "-c",
+          `DROP DATABASE IF EXISTS ${targetDb} WITH (FORCE)`,
+        ]),
       );
-    } catch (error) {
-      code = (error as { code?: string }).code ?? "";
-    }
-    expect(code).toBe("REFUSED_TARGET_AUTHORITY");
-  });
-});
+      const src = new Client({ connectionString: dbUrl(sourceDb) });
+      await src.connect();
+      await src.query(`CREATE TABLE evidence (id int, note text)`);
+      await src.query(`INSERT INTO evidence VALUES (1, 'tenant-data-23453')`);
+      await src.end();
+
+      const fixture = await buildBackupFixture(
+        sourceDb,
+        databaseName,
+        tenantRole,
+      );
+      fixture.capabilityFile = mintCapabilityFile(fixture.archiveSha256);
+      await admin.query(`CREATE DATABASE ${targetDb}`);
+      await provisionTarget(targetDb, fixture.capabilityFile);
+
+      const targetDsn = dbUrl(targetDb);
+      const result = spawnSync(
+        "bun",
+        [
+          "packages/cloud/scripts/admin/apps-tenant-db-recovery.ts",
+          "--set-dir",
+          fixture.setDir,
+          "--target-dsn",
+          targetDsn,
+          "--target-id",
+          TARGET_ID,
+          "--capability-file",
+          fixture.capabilityFile,
+          "--pooler-endpoint",
+          "127.0.0.1:6432",
+          "--tenant-probes-file",
+          fixture.probesFile,
+          "--passphrase-file",
+          fixture.passphraseFile,
+          "--rpo-hours",
+          "26",
+          "--rto-minutes",
+          "60",
+        ],
+        {
+          encoding: "utf-8",
+          env: {
+            ...process.env,
+            ELIZA_RESTORE_CAPABILITY_KEY: SIGNING_KEY,
+            DRILL_TENANT_PW: fixture.tenantPassword,
+          },
+          maxBuffer: 64 * 1024 * 1024,
+        },
+      );
+      // NOTE: the pooler endpoint is probed only for the cross-reject
+      // sample; with a single tenant there is no cross pair, so no pooler
+      // connection is attempted — own-connect proves out on the direct
+      // surface only (drill databases are absent from any pooler config).
+      if (result.status !== 0) {
+        throw new Error(
+          `drill exited ${result.status}\n--- stdout ---\n${result.stdout}\n--- stderr ---\n${result.stderr}`,
+        );
+      }
+      expect(result.status).toBe(0);
+      const report = JSON.parse(result.stdout);
+      expect(report.schemaVersion).toBe(2);
+      expect(report.rpoSource).toBe("manifest");
+      expect(report.isolation.plan).toBe("linear");
+      expect(report.isolation.passed).toBe(report.isolation.total);
+      expect(report.objectives.met).toBe(true);
+
+      // Restored tenant data is real.
+      const check = new Client({
+        connectionString: dbUrl(databaseName),
+      });
+      await check.connect();
+      const rows = await check.query(`SELECT note FROM evidence WHERE id = 1`);
+      expect(rows.rows[0].note).toBe("tenant-data-23453");
+      await check.end();
+
+      // Tenant role can connect to its own restored database (own-connect
+      // probe already ran through the drill; verify role survives).
+      const roleConn = await admin.query(
+        `SELECT rolname FROM pg_roles WHERE rolname = '${tenantRole}'`,
+      );
+      expect(roleConn.rows).toHaveLength(1);
+    }, 120_000);
+
+    test("substituted archive is refused even with a valid nonce", async () => {
+      const sourceDb = `${TEST_PREFIX}src2`;
+      const targetDb = `${TEST_PREFIX}target2`;
+      const databaseName = `${TEST_PREFIX}tenant_b`;
+      const tenantRole = `${TEST_PREFIX}tenant_b`;
+      await admin.query(`CREATE DATABASE ${sourceDb}`);
+      const src = new Client({ connectionString: dbUrl(sourceDb) });
+      await src.connect();
+      await src.query(`CREATE TABLE t (id int)`);
+      await src.end();
+
+      const fixture = await buildBackupFixture(
+        sourceDb,
+        databaseName,
+        tenantRole,
+      );
+      // Capability pins the REAL archive; then substitute a different archive.
+      fixture.capabilityFile = mintCapabilityFile(fixture.archiveSha256);
+      sh(`echo tampered > ${join(fixture.setDir, "backup.tar.gz.enc")}`);
+      await admin.query(`CREATE DATABASE ${targetDb}`);
+      await provisionTarget(targetDb, fixture.capabilityFile);
+
+      const targetDsn = dbUrl(targetDb);
+      const result = spawnSync(
+        "bun",
+        [
+          "packages/cloud/scripts/admin/apps-tenant-db-recovery.ts",
+          "--set-dir",
+          fixture.setDir,
+          "--target-dsn",
+          targetDsn,
+          "--target-id",
+          TARGET_ID,
+          "--capability-file",
+          fixture.capabilityFile,
+          "--pooler-endpoint",
+          "127.0.0.1:6432",
+          "--tenant-probes-file",
+          fixture.probesFile,
+          "--passphrase-file",
+          fixture.passphraseFile,
+        ],
+        {
+          encoding: "utf-8",
+          env: {
+            ...process.env,
+            ELIZA_RESTORE_CAPABILITY_KEY: SIGNING_KEY,
+            DRILL_TENANT_PW: fixture.tenantPassword,
+          },
+        },
+      );
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain("sidecar");
+    });
+
+    test("replay after consumption fails closed", async () => {
+      // Provision fresh twins on the cluster, consume them through the real
+      // consume step, then prove: (a) cluster settings are gone, and (b) a
+      // re-verify of the same capability refuses on the empty twin.
+      const capFile = mintCapabilityFile("f".repeat(64));
+      const cap = await import("./restore-capability").then((m) =>
+        m.parseRestoreCapability(readFileSync(capFile, "utf-8").trim()),
+      );
+      const targetDb = `${TEST_PREFIX}target3`;
+      await admin.query(`CREATE DATABASE ${targetDb}`);
+      await provisionTarget(targetDb, capFile);
+
+      const mod = await import("./apps-tenant-db-recovery");
+      const work = mkdtempSync(join(tmpdir(), "nonce-replay-"));
+      expect(() =>
+        mod.verifyRestoreAuthority(
+          dbUrl(targetDb),
+          TARGET_ID,
+          cap,
+          SIGNING_KEY,
+          Date.now(),
+        ),
+      ).not.toThrow();
+      mod.consumeRestoreAuthority(dbUrl(targetDb), TARGET_ID, cap, work);
+
+      // Direct assertion first: the cluster-level settings are unset now.
+      const fresh = new Client({ connectionString: BASE_URL });
+      await fresh.connect();
+      const settings = await fresh.query(
+        `SELECT COALESCE(current_setting('eliza.restore_target_id', true), '') AS tid, COALESCE(current_setting('eliza.restore_capability', true), '') AS cap`,
+      );
+      expect(settings.rows[0].tid).toBe("");
+      expect(settings.rows[0].cap).toBe("");
+      await fresh.end();
+      // And the real verify path fails closed against the spent target.
+      let code = "";
+      try {
+        mod.verifyRestoreAuthority(
+          dbUrl(targetDb),
+          TARGET_ID,
+          cap,
+          SIGNING_KEY,
+          Date.now(),
+        );
+      } catch (error) {
+        code = (error as { code?: string }).code ?? "";
+      }
+      expect(code).toBe("REFUSED_TARGET_AUTHORITY");
+    });
+  },
+);
 
 if (!ENABLED) {
   describe("restore drill authority on real PostgreSQL (#23453) [gated]", () => {

--- a/packages/cloud/scripts/admin/apps-tenant-db-recovery.postgres.test.ts
+++ b/packages/cloud/scripts/admin/apps-tenant-db-recovery.postgres.test.ts
@@ -319,14 +319,14 @@ describe.if(ENABLED)(
         try {
           execSync("pkill -f drill-pgbouncer || true");
         } catch {
-          // pgbouncer may already have exited
+          // error-policy:J6 pgbouncer may already have exited.
         }
       }
       for (const fn of cleanups) {
         try {
           fn();
         } catch {
-          // best-effort temp cleanup
+          // error-policy:J6 best-effort temp cleanup.
         }
       }
       try {
@@ -334,7 +334,7 @@ describe.if(ENABLED)(
         await admin.query(`ALTER SYSTEM RESET eliza.restore_capability`);
         await admin.query(`SELECT pg_reload_conf()`);
       } catch {
-        // settings may already be reset by the drill's consume step
+        // error-policy:J6 settings may already be reset by the drill's consume step.
       }
       await admin.end();
     });
@@ -607,6 +607,66 @@ describe.if(ENABLED)(
         code = (error as { code?: string }).code ?? "";
       }
       expect(code).toBe("REFUSED_TARGET_AUTHORITY");
+    });
+
+    test("fresh target with archive-named role is refused (claim-order regression)", async () => {
+      // Regression (#23453 review finding 3): reading the same-capability
+      // claim AFTER the claim transaction upserts it made every target look
+      // like a retry, exempting archive-named roles from the clean-target
+      // collision check. A FRESH target (no prior claim) that already
+      // carries a role this archive defines must be refused.
+      const sourceDb = `${TEST_PREFIX}src4`;
+      const targetDb = `${TEST_PREFIX}target5`;
+      const databaseName = `${TEST_PREFIX}tenant_d`;
+      const tenantRole = `${TEST_PREFIX}tenant_d`;
+      await admin.query(`CREATE DATABASE ${sourceDb}`);
+      const src = new Client({ connectionString: dbUrl(sourceDb) });
+      await src.connect();
+      await src.query(`CREATE TABLE t (id int)`);
+      await src.end();
+
+      const fixture = await buildBackupFixture(
+        sourceDb,
+        databaseName,
+        tenantRole,
+      );
+      fixture.capabilityFile = mintCapabilityFile(fixture.archiveSha256);
+      await admin.query(`CREATE DATABASE ${targetDb}`);
+      await provisionTarget(targetDb, fixture.capabilityFile);
+      // Pre-create the archive-named role on the FRESH target: only the
+      // clean-target collision check (not a retry exemption) can catch it.
+      await admin.query(`CREATE ROLE ${tenantRole}`);
+
+      const result = spawnSync(
+        "bun",
+        [
+          "packages/cloud/scripts/admin/apps-tenant-db-recovery.ts",
+          "--set-dir",
+          fixture.setDir,
+          "--target-dsn",
+          dbUrl(targetDb),
+          "--target-id",
+          TARGET_ID,
+          "--capability-file",
+          fixture.capabilityFile,
+          "--pooler-endpoint",
+          "127.0.0.1:6432",
+          "--tenant-probes-file",
+          fixture.probesFile,
+          "--passphrase-file",
+          fixture.passphraseFile,
+        ],
+        {
+          encoding: "utf-8",
+          env: {
+            ...process.env,
+            ELIZA_RESTORE_CAPABILITY_KEY: SIGNING_KEY,
+            DRILL_TENANT_PW: fixture.tenantPassword,
+          },
+        },
+      );
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain("REFUSED_NONEMPTY_TARGET");
     });
   },
 );

--- a/packages/cloud/scripts/admin/apps-tenant-db-recovery.postgres.test.ts
+++ b/packages/cloud/scripts/admin/apps-tenant-db-recovery.postgres.test.ts
@@ -887,7 +887,7 @@ describe.if(ENABLED)(
       );
       expect(result.status).not.toBe(0);
       expect(result.stderr).toContain("REFUSED_NONEMPTY_TARGET");
-    });
+    }, 120_000);
   },
 );
 

--- a/packages/cloud/scripts/admin/apps-tenant-db-recovery.postgres.test.ts
+++ b/packages/cloud/scripts/admin/apps-tenant-db-recovery.postgres.test.ts
@@ -119,6 +119,7 @@ async function buildMultiTenantBackupFixture(
         env: {
           PGHOST: url.hostname,
           PGPORT: url.port || "5432",
+          PGUSER: decodeURIComponent(url.username),
           PGPASSWORD: url.password ?? "",
         },
       },

--- a/packages/cloud/scripts/admin/apps-tenant-db-recovery.postgres.test.ts
+++ b/packages/cloud/scripts/admin/apps-tenant-db-recovery.postgres.test.ts
@@ -543,9 +543,16 @@ describe.if(ENABLED)(
       expect(report.isolation.passed).toBe(report.isolation.total);
       expect(report.objectives.met).toBe(true);
 
-      // Every tenant's restored data is real and reachable by its own role.
+      // Every tenant's restored data is real AND reachable by that tenant's
+      // OWN role credentials — not the admin credential (#23453 review r3):
+      // the dumps are --no-owner/--no-privileges and restore as the restore
+      // administrator, so CONNECT alone would not prove tenant access to the
+      // restored objects. The database is created OWNER <tenant role> by the
+      // drill, which must yield real table access for that role.
       for (const t of tenants) {
-        const check = new Client({ connectionString: dbUrl(t.databaseName) });
+        const url = new URL(BASE_URL);
+        const roleConn = `postgresql://${t.tenantRole}:tenantpw23453@${url.host}/${t.databaseName}`;
+        const check = new Client({ connectionString: roleConn });
         await check.connect();
         const rows = await check.query(
           `SELECT note FROM evidence WHERE id = 1`,
@@ -679,6 +686,85 @@ describe.if(ENABLED)(
       // The capability pin is the only remaining check that can fail here.
       expect(result.stderr).toContain("REFUSED_ARCHIVE_MISMATCH");
     });
+
+    test("a refused first invocation leaves no claim: the retry is still refused (claim-order regression r3)", async () => {
+      // Round-3 finding 1: the claim used to persist BEFORE the clean-target
+      // collision check, so a refused first invocation left a claim that a
+      // retry treated as a legitimate same-capability retry — exempting the
+      // archive-named role and proceeding to ALTER ROLE. The claim now
+      // persists only after the collision check passes, so BOTH invocations
+      // must refuse.
+      const sourceDb = `${TEST_PREFIX}src6`;
+      const targetDb = `${TEST_PREFIX}target6`;
+      const databaseName = `${TEST_PREFIX}tenant_f`;
+      const tenantRole = `${TEST_PREFIX}tenant_f`;
+      await admin.query(`CREATE DATABASE ${sourceDb}`);
+      const src = new Client({ connectionString: dbUrl(sourceDb) });
+      await src.connect();
+      await src.query(`CREATE TABLE t (id int)`);
+      await src.end();
+
+      const fixture = await buildBackupFixture(
+        sourceDb,
+        databaseName,
+        tenantRole,
+      );
+      fixture.capabilityFile = mintCapabilityFile(fixture.archiveSha256);
+      await admin.query(`CREATE DATABASE ${targetDb}`);
+      await provisionTarget(targetDb, fixture.capabilityFile);
+      // Pre-create the archive-named role: the clean-target collision check
+      // must refuse — on the first invocation AND on the retry.
+      await admin.query(`CREATE ROLE ${tenantRole}`);
+
+      const runDrill = () =>
+        spawnSync(
+          "bun",
+          [
+            "packages/cloud/scripts/admin/apps-tenant-db-recovery.ts",
+            "--set-dir",
+            fixture.setDir,
+            "--target-dsn",
+            dbUrl(targetDb),
+            "--target-id",
+            TARGET_ID,
+            "--capability-file",
+            fixture.capabilityFile,
+            "--pooler-endpoint",
+            "127.0.0.1:6432",
+            "--tenant-probes-file",
+            fixture.probesFile,
+            "--passphrase-file",
+            fixture.passphraseFile,
+            "--rpo-hours",
+            "26",
+            "--rto-minutes",
+            "60",
+          ],
+          {
+            encoding: "utf-8",
+            env: {
+              ...process.env,
+              ELIZA_RESTORE_CAPABILITY_KEY: SIGNING_KEY,
+              DRILL_TENANT_PW: fixture.tenantPassword,
+            },
+            maxBuffer: 64 * 1024 * 1024,
+          },
+        );
+
+      const first = runDrill();
+      expect(first.status).not.toBe(0);
+      expect(first.stderr).toContain("REFUSED_NONEMPTY_TARGET");
+      // Give the killed first-run lock holder a moment to drop its server
+      // session so the retry sees the advisory lock free (the drill's own
+      // teardown SIGKILLs the holder; the server releases asynchronously).
+      await new Promise((resolve) => setTimeout(resolve, 1500));
+      const second = runDrill();
+      expect(second.status).not.toBe(0);
+      expect(second.stderr).toContain("REFUSED_NONEMPTY_TARGET");
+      // The retry-exemption must never have applied: the archive-named role
+      // collision is the refusal in both runs, not a restore-side failure.
+      expect(second.stderr).not.toContain("restored tenant data");
+    }, 120_000);
 
     test("replay after consumption fails closed", async () => {
       // Provision fresh twins on the cluster, consume them through the real

--- a/packages/cloud/scripts/admin/apps-tenant-db-recovery.postgres.test.ts
+++ b/packages/cloud/scripts/admin/apps-tenant-db-recovery.postgres.test.ts
@@ -206,13 +206,11 @@ let pgbouncerDir: string | undefined;
 
 /**
  * The drill probes an isolated pgbouncer on the canonical pooler port; the
- * gated suite runs a REAL local pgbouncer listing only the restored tenant
- * databases (the pooler-side isolation surface). Skipped (with the drill's
- * pooler probe) when RUN_REAL_PGBOUNCER_DRILL_TESTS is unset so the suite
- * can still run where port 6432 cannot be bound.
+ * gated suite runs a REAL local pgbouncer listing the restored tenant
+ * databases. Own-connect probes route through it (the per-tenant routing
+ * assertion), so the pooler is required whenever the suite is enabled.
  */
-const POOLER_ENABLED =
-  process.env.RUN_REAL_PGBOUNCER_DRILL_TESTS === "1" && ENABLED;
+const POOLER_ENABLED = ENABLED;
 
 function startPgbouncer(databases: string[]): void {
   pgbouncerDir = mkdtempSync(join(tmpdir(), "drill-pgbouncer-"));
@@ -246,41 +244,37 @@ pool_mode = transaction
   child.unref();
 }
 
+/**
+ * Provision the twin settings through the REAL `provision` subcommand — the
+ * same path an operator runs — so the postgresql.auto.conf write, reload, and
+ * fresh-session verification are exercised as shipped, not re-implemented
+ * here.
+ */
 async function provisionTarget(targetDb: string, capabilityFile: string) {
-  // Twin settings live cluster-wide on the disposable target. PostgreSQL 14
-  // rejects ALTER SYSTEM SET for undeclared custom GUCs, so provisioning
-  // writes the settings to postgresql.auto.conf directly (the exact file
-  // ALTER SYSTEM SET itself writes) and reloads.
-  const cap = readFileSync(capabilityFile, "utf-8").trim();
-  const dataDir = (await admin.query("SHOW data_directory")).rows[0]
-    .data_directory as string;
-  const autoConf = join(dataDir, "postgresql.auto.conf");
-  const current = readFileSync(autoConf, "utf-8");
-  const lines = current
-    .split("\n")
-    .filter(
-      (line) =>
-        !line.startsWith("eliza.restore_target_id") &&
-        !line.startsWith("eliza.restore_capability"),
-    );
-  lines.push(`eliza.restore_target_id = '${TARGET_ID}'`);
-  lines.push(`eliza.restore_capability = '${cap}'`);
-  writeFileSync(autoConf, `${lines.join("\n").trimEnd()}\n`);
-  const target = new Client({ connectionString: dbUrl(targetDb) });
-  await target.connect();
-  await target.query("SELECT pg_reload_conf()");
-  await target.end();
-  // Verify through a FRESH session: a session opened before the reload may
-  // still hold the previous (unset) value of a custom placeholder GUC.
-  const verify = new Client({ connectionString: dbUrl(targetDb) });
-  await verify.connect();
-  const check = await verify.query(
-    `SELECT COALESCE(current_setting('eliza.restore_target_id', true), '') AS tid`,
+  const result = spawnSync(
+    "bun",
+    [
+      "packages/cloud/scripts/admin/apps-tenant-db-recovery.ts",
+      "provision",
+      "--target-dsn",
+      dbUrl(targetDb),
+      "--target-id",
+      TARGET_ID,
+      "--capability-file",
+      capabilityFile,
+    ],
+    {
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        ELIZA_RESTORE_CAPABILITY_KEY: SIGNING_KEY,
+      },
+    },
   );
-  const ok = check.rows[0].tid === TARGET_ID;
-  await verify.end();
-  if (!ok) {
-    throw new Error("twin settings did not apply after reload");
+  if (result.status !== 0) {
+    throw new Error(
+      `provision exited ${result.status}\n--- stdout ---\n${result.stdout}\n--- stderr ---\n${result.stderr}`,
+    );
   }
 }
 
@@ -400,10 +394,9 @@ describe.if(ENABLED)(
           maxBuffer: 64 * 1024 * 1024,
         },
       );
-      // NOTE: the pooler endpoint is probed only for the cross-reject
-      // sample; with a single tenant there is no cross pair, so no pooler
-      // connection is attempted — own-connect proves out on the direct
-      // surface only (drill databases are absent from any pooler config).
+      // NOTE: the e2e run includes the pooler surface — own-connect probes
+      // route through pgbouncer as the per-tenant routing assertion, so the
+      // local pgbouncer must list every restored tenant database.
       if (result.status !== 0) {
         throw new Error(
           `drill exited ${result.status}\n--- stdout ---\n${result.stdout}\n--- stderr ---\n${result.stderr}`,

--- a/packages/cloud/scripts/admin/apps-tenant-db-recovery.postgres.test.ts
+++ b/packages/cloud/scripts/admin/apps-tenant-db-recovery.postgres.test.ts
@@ -754,10 +754,22 @@ describe.if(ENABLED)(
       const first = runDrill();
       expect(first.status).not.toBe(0);
       expect(first.stderr).toContain("REFUSED_NONEMPTY_TARGET");
-      // Give the killed first-run lock holder a moment to drop its server
-      // session so the retry sees the advisory lock free (the drill's own
-      // teardown SIGKILLs the holder; the server releases asynchronously).
-      await new Promise((resolve) => setTimeout(resolve, 1500));
+      // The killed first-run lock holder's server session is dropped
+      // asynchronously, so poll pg_locks until no session holds the drill
+      // advisory lock on the target database before retrying (a fixed sleep
+      // is flaky: LOCK_FAILED here means the retry never even reaches the
+      // collision check this test exists to exercise).
+      const lockFree = async (): Promise<boolean> => {
+        const res = await admin.query(
+          `SELECT 1 FROM pg_locks l JOIN pg_database d ON d.oid = l.database
+           WHERE l.locktype = 'advisory' AND d.datname = $1`,
+          [targetDb],
+        );
+        return res.rowCount === 0;
+      };
+      for (let i = 0; i < 60 && !(await lockFree()); i++) {
+        await new Promise((resolve) => setTimeout(resolve, 500));
+      }
       const second = runDrill();
       expect(second.status).not.toBe(0);
       expect(second.stderr).toContain("REFUSED_NONEMPTY_TARGET");

--- a/packages/cloud/scripts/admin/apps-tenant-db-recovery.postgres.test.ts
+++ b/packages/cloud/scripts/admin/apps-tenant-db-recovery.postgres.test.ts
@@ -236,6 +236,24 @@ let pgbouncerDir: string | undefined;
  */
 const POOLER_ENABLED = ENABLED;
 
+/**
+ * pgbouncer is resolved portably (Linux CI, Intel Macs, non-default
+ * prefixes): explicit override first, then PATH lookup via Bun.which.
+ * A missing binary fails fast with the override instruction instead of
+ * surfacing as an opaque ENOENT deep inside the drill.
+ */
+function resolvePgbouncerBin(): string {
+  return (
+    process.env.DRILL_TEST_PGBOUNCER_BIN ??
+    Bun.which("pgbouncer") ??
+    (() => {
+      throw new Error(
+        "pgbouncer executable not found on PATH; install pgbouncer or set DRILL_TEST_PGBOUNCER_BIN to its absolute path",
+      );
+    })()
+  );
+}
+
 function startPgbouncer(): void {
   pgbouncerDir = mkdtempSync(join(tmpdir(), "drill-pgbouncer-"));
   const ini = join(pgbouncerDir, "pgbouncer.ini");
@@ -267,11 +285,10 @@ pool_mode = transaction
     users,
     `"drill23453test_tenant_a" "tenantpw23453"\n"drill23453test_tenant_b" "tenantpw23453"\n"drill23453test_tenant_c" "tenantpw23453"\n"drill23453test_mt_a" "tenantpw23453"\n"drill23453test_mt_b" "tenantpw23453"\n"drill23453test_mt_c" "tenantpw23453"\n`,
   );
-  const child = execFileCb(
-    "/opt/homebrew/opt/pgbouncer/bin/pgbouncer",
-    ["-q", ini],
-    { detached: true, stdio: "ignore" },
-  );
+  const child = execFileCb(resolvePgbouncerBin(), ["-q", ini], {
+    detached: true,
+    stdio: "ignore",
+  });
   child.unref();
 }
 

--- a/packages/cloud/scripts/admin/apps-tenant-db-recovery.postgres.test.ts
+++ b/packages/cloud/scripts/admin/apps-tenant-db-recovery.postgres.test.ts
@@ -18,7 +18,13 @@ import {
   execSync,
   spawnSync,
 } from "node:child_process";
-import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import pg from "pg";
@@ -481,6 +487,76 @@ describe.if(ENABLED)(
       );
       expect(result.status).not.toBe(0);
       expect(result.stderr).toContain("sidecar");
+    });
+
+    test("substituted archive with a consistent sidecar is still refused by the capability pin", async () => {
+      // The sidecar is rewritten to MATCH the substituted archive, so only
+      // the signed capability pin (REFUSED_ARCHIVE_MISMATCH) can refuse it.
+      // Proves the drill cannot be downgraded to sidecar-only checking.
+      const sourceDb = `${TEST_PREFIX}src3`;
+      const targetDb = `${TEST_PREFIX}target4`;
+      const databaseName = `${TEST_PREFIX}tenant_c`;
+      const tenantRole = `${TEST_PREFIX}tenant_c`;
+      await admin.query(`CREATE DATABASE ${sourceDb}`);
+      const src = new Client({ connectionString: dbUrl(sourceDb) });
+      await src.connect();
+      await src.query(`CREATE TABLE t (id int)`);
+      await src.end();
+
+      const fixture = await buildBackupFixture(
+        sourceDb,
+        databaseName,
+        tenantRole,
+      );
+      // Capability pins the REAL archive...
+      fixture.capabilityFile = mintCapabilityFile(fixture.archiveSha256);
+      // ...then substitute a different, internally-consistent set: a fresh
+      // archive whose sidecar describes IT (not the pinned one).
+      sh(`echo tampered > ${join(fixture.setDir, "backup.tar.gz.enc")}`);
+      const substitutedArchivePath = join(fixture.setDir, "backup.tar.gz.enc");
+      const substitutedSha = sh(
+        `shasum -a 256 ${substitutedArchivePath} | cut -d' ' -f1`,
+      ).trim();
+      const substitutedBytes = statSync(substitutedArchivePath).size;
+      const sidecarPath = join(fixture.setDir, "backup.json");
+      const sidecar = JSON.parse(readFileSync(sidecarPath, "utf-8"));
+      sidecar.archive_sha256 = substitutedSha;
+      sidecar.archive_bytes = substitutedBytes;
+      writeFileSync(sidecarPath, JSON.stringify(sidecar));
+      await admin.query(`CREATE DATABASE ${targetDb}`);
+      await provisionTarget(targetDb, fixture.capabilityFile);
+
+      const result = spawnSync(
+        "bun",
+        [
+          "packages/cloud/scripts/admin/apps-tenant-db-recovery.ts",
+          "--set-dir",
+          fixture.setDir,
+          "--target-dsn",
+          dbUrl(targetDb),
+          "--target-id",
+          TARGET_ID,
+          "--capability-file",
+          fixture.capabilityFile,
+          "--pooler-endpoint",
+          "127.0.0.1:6432",
+          "--tenant-probes-file",
+          fixture.probesFile,
+          "--passphrase-file",
+          fixture.passphraseFile,
+        ],
+        {
+          encoding: "utf-8",
+          env: {
+            ...process.env,
+            ELIZA_RESTORE_CAPABILITY_KEY: SIGNING_KEY,
+            DRILL_TENANT_PW: fixture.tenantPassword,
+          },
+        },
+      );
+      expect(result.status).not.toBe(0);
+      // The capability pin is the only remaining check that can fail here.
+      expect(result.stderr).toContain("REFUSED_ARCHIVE_MISMATCH");
     });
 
     test("replay after consumption fails closed", async () => {

--- a/packages/cloud/scripts/admin/apps-tenant-db-recovery.postgres.test.ts
+++ b/packages/cloud/scripts/admin/apps-tenant-db-recovery.postgres.test.ts
@@ -1,0 +1,537 @@
+/**
+ * Live-Postgres proof of the #23453 restore-drill authority redesign:
+ * provisions a disposable database with the twin settings, then executes the
+ * REAL drill (executeDrill) against a synthetic encrypted backup set —
+ * minted with the same openssl/tar/sha256sum pipeline the production backup
+ * timer uses — including the guarded destructive restore, the linear
+ * isolation probes, and the end-of-drill authority consumption. Adversarial
+ * cases (substituted archive, replayed nonce, expired capability, claimed
+ * target) are driven through the same real sequence and must fail closed.
+ * Gated behind RUN_REAL_POSTGRES_DRILL_TESTS=1 + a local DSN so CI never
+ * destructive-runs anything; local runs use a disposable database that is
+ * dropped afterward.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import {
+  execFile as execFileCb,
+  execSync,
+  spawnSync,
+} from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import pg from "pg";
+
+const { Client } = pg;
+
+const BASE_URL =
+  // biome-ignore lint/suspicious/noUndeclaredEnvVars: standalone gated test run manually with bun; not part of Turbo task caching.
+  process.env.DRILL_TEST_DATABASE_URL ?? process.env.TEST_DATABASE_URL ?? "";
+const ENABLED =
+  // biome-ignore lint/suspicious/noUndeclaredEnvVars: standalone gated test run manually with bun; not part of Turbo task caching.
+  process.env.RUN_REAL_POSTGRES_DRILL_TESTS === "1" &&
+  BASE_URL.startsWith("postgres");
+function baseUrlRoot(): string {
+  const u = new URL(BASE_URL);
+  return `postgresql://${u.username}${u.password ? `:${u.password}` : ""}@${u.host}`;
+}
+
+function dbUrl(name: string): string {
+  return `${baseUrlRoot()}/${name}`;
+}
+
+const TEST_PREFIX = "drill23453test_";
+
+const TARGET_ID = "drill-99999999-8888-4777-4666-555555555555";
+const SIGNING_KEY = "drill-test-signing-key";
+const PASSPHRASE = "drill-test-passphrase";
+
+/**
+ * Shell is required for glob/redirection features (sha256sum > file, tar).
+ * All interpolated values are test-generated constants (mkdtemp paths,
+ * generated database names) — never external input — so shell metacharacter
+ * injection is not reachable here.
+ */
+function sh(
+  cmd: string,
+  opts: { cwd?: string; env?: Record<string, string> } = {},
+) {
+  return execSync(cmd, {
+    encoding: "utf-8",
+    cwd: opts.cwd,
+    env: { ...process.env, ...opts.env },
+  });
+}
+
+interface Fixture {
+  setDir: string;
+  archiveSha256: string;
+  passphraseFile: string;
+  capabilityFile: string;
+  probesFile: string;
+  tenantRole: string;
+  tenantPassword: string;
+  databaseName: string;
+}
+
+/**
+ * Build a synthetic dated backup set with the production pipeline shape:
+ * manifest.json + checksums.sha256 + globals.sql + dbmap.tsv + dumps/, tar'd
+ * and openssl-encrypted. The tenant database dump is a REAL pg_dump of a
+ * real seeded database, restored through pg_restore in the drill.
+ */
+async function buildBackupFixture(
+  sourceDb: string,
+  databaseName: string,
+  tenantRole: string,
+): Promise<Fixture> {
+  const setDir = mkdtempSync(join(tmpdir(), "drill-set-"));
+  const dumpsDir = join(setDir, "dumps");
+  mkdirSync(dumpsDir);
+  const dumpId = "a1b2c3d4e5f6".slice(0, 12);
+  const dumpFile = join(dumpsDir, `${dumpId}.dump`);
+
+  // Real pg_dump of the seeded source database.
+  const url = new URL(BASE_URL);
+  sh(
+    `pg_dump --format=custom --no-owner --no-privileges --dbname=${sourceDb} --file=${dumpFile}`,
+    {
+      env: {
+        PGHOST: url.hostname,
+        PGPORT: url.port || "5432",
+        PGPASSWORD: url.password ?? "",
+      },
+    },
+  );
+
+  const manifest = {
+    schema_version: 1,
+    kind: "tenant-db-backup",
+    created_at: new Date().toISOString().replace(/\.\d{3}Z$/, "Z"),
+    database_count: 1,
+    globals: "globals.sql",
+    dbmap: "dbmap.tsv",
+    checksums: "checksums.sha256",
+  };
+  writeFileSync(join(setDir, "manifest.json"), JSON.stringify(manifest));
+  // Canonical pg_dumpall --globals-only shape: role attributes without LOGIN
+  // options that the harness's strict parser rejects.
+  writeFileSync(
+    join(setDir, "globals.sql"),
+    `CREATE ROLE ${tenantRole};\nALTER ROLE ${tenantRole} WITH LOGIN PASSWORD 'tenantpw23453';\n`,
+  );
+  writeFileSync(join(setDir, "dbmap.tsv"), `${dumpId}\t${databaseName}\n`);
+  sh(`sha256sum manifest.json globals.sql dbmap.tsv dumps/* > checksums.sha256`, {
+    cwd: setDir,
+  });
+  sh(
+    `tar -czf backup.tar.gz manifest.json checksums.sha256 globals.sql dbmap.tsv dumps`,
+    {
+      cwd: setDir,
+    },
+  );
+  const passphraseFile = join(setDir, "..", `pass-${Date.now()}`);
+  writeFileSync(passphraseFile, PASSPHRASE);
+  sh(
+    `openssl enc -aes-256-cbc -pbkdf2 -iter 210000 -salt -in backup.tar.gz -out backup.tar.gz.enc -pass file:${passphraseFile}`,
+    { cwd: setDir },
+  );
+  const archiveSha256 = sh(`sha256sum backup.tar.gz.enc`, { cwd: setDir })
+    .split(" ")[0]
+    .trim();
+
+  const sidecar = {
+    schema_version: 1,
+    kind: "tenant-db-backup-sidecar",
+    created_at: manifest.created_at,
+    archive: "backup.tar.gz.enc",
+    archive_sha256: archiveSha256,
+    archive_bytes: readFileSync(join(setDir, "backup.tar.gz.enc")).length,
+    database_count: 1,
+    cipher: "aes-256-cbc-pbkdf2-210000",
+  };
+  writeFileSync(join(setDir, "backup.json"), JSON.stringify(sidecar));
+
+  const probesFile = join(setDir, "..", `probes-${Date.now()}.json`);
+  writeFileSync(
+    probesFile,
+    JSON.stringify({
+      schema_version: 1,
+      tenants: [
+        { dump_id: dumpId, role: tenantRole, password_env: "DRILL_TENANT_PW" },
+      ],
+    }),
+  );
+
+  const fixture: Fixture = {
+    setDir,
+    archiveSha256,
+    passphraseFile,
+    capabilityFile: "",
+    probesFile,
+    tenantRole,
+    tenantPassword: "tenantpw23453",
+    databaseName,
+  };
+  return fixture;
+}
+
+function mintCapabilityFile(
+  archiveSha256: string,
+  targetId = TARGET_ID,
+): string {
+  const out = sh(
+    `bun packages/cloud/scripts/admin/apps-tenant-db-recovery.ts mint --target-id ${targetId} --archive-sha256 ${archiveSha256} --ttl-minutes 60`,
+    { env: { ELIZA_RESTORE_CAPABILITY_KEY: SIGNING_KEY } },
+  ).trim();
+  const file = join(
+    tmpdir(),
+    `cap-${Date.now()}-${Math.random().toString(36).slice(2)}.txt`,
+  );
+  writeFileSync(file, out);
+  return file;
+}
+
+const cleanups: (() => void)[] = [];
+let admin: pg.Client;
+let pgbouncerDir: string | undefined;
+
+/**
+ * The drill probes an isolated pgbouncer on the canonical pooler port; the
+ * gated suite runs a REAL local pgbouncer listing only the restored tenant
+ * databases (the pooler-side isolation surface). Skipped (with the drill's
+ * pooler probe) when RUN_REAL_PGBOUNCER_DRILL_TESTS is unset so the suite
+ * can still run where port 6432 cannot be bound.
+ */
+const POOLER_ENABLED =
+  // biome-ignore lint/suspicious/noUndeclaredEnvVars: standalone gated test run manually with bun; not part of Turbo task caching.
+  process.env.RUN_REAL_PGBOUNCER_DRILL_TESTS === "1" && ENABLED;
+
+function startPgbouncer(databases: string[]): void {
+  pgbouncerDir = mkdtempSync(join(tmpdir(), "drill-pgbouncer-"));
+  const ini = join(pgbouncerDir, "pgbouncer.ini");
+  const users = join(pgbouncerDir, "users.txt");
+  const dbLines = databases
+    .map((d) => `${d} = host=127.0.0.1 port=5432 dbname=${d}`)
+    .join("\n");
+  writeFileSync(
+    ini,
+    `[databases]
+${dbLines}
+
+[pgbouncer]
+listen_addr = 127.0.0.1
+listen_port = 6432
+auth_type = plain
+auth_file = ${users}
+pool_mode = transaction
+`,
+  );
+  writeFileSync(
+    users,
+    `"drill23453test_tenant_a" "tenantpw23453"\n"drill23453test_tenant_b" "tenantpw23453"\n`,
+  );
+  const child = execFileCb(
+    "/opt/homebrew/opt/pgbouncer/bin/pgbouncer",
+    ["-q", ini],
+    { detached: true, stdio: "ignore" },
+  );
+  child.unref();
+}
+
+async function provisionTarget(targetDb: string, capabilityFile: string) {
+  // Twin settings live cluster-wide on the disposable target. PostgreSQL 14
+  // rejects ALTER SYSTEM SET for undeclared custom GUCs, so provisioning
+  // writes the settings to postgresql.auto.conf directly (the exact file
+  // ALTER SYSTEM SET itself writes) and reloads.
+  const cap = readFileSync(capabilityFile, "utf-8").trim();
+  const dataDir = (await admin.query("SHOW data_directory")).rows[0]
+    .data_directory as string;
+  const autoConf = join(dataDir, "postgresql.auto.conf");
+  const current = readFileSync(autoConf, "utf-8");
+  const lines = current
+    .split("\n")
+    .filter(
+      (line) =>
+        !line.startsWith("eliza.restore_target_id") &&
+        !line.startsWith("eliza.restore_capability"),
+    );
+  lines.push(`eliza.restore_target_id = '${TARGET_ID}'`);
+  lines.push(`eliza.restore_capability = '${cap}'`);
+  writeFileSync(autoConf, `${lines.join("\n").trimEnd()}\n`);
+  const target = new Client({ connectionString: dbUrl(targetDb) });
+  await target.connect();
+  await target.query("SELECT pg_reload_conf()");
+  await target.end();
+  // Verify through a FRESH session: a session opened before the reload may
+  // still hold the previous (unset) value of a custom placeholder GUC.
+  const verify = new Client({ connectionString: dbUrl(targetDb) });
+  await verify.connect();
+  const check = await verify.query(
+    `SELECT COALESCE(current_setting('eliza.restore_target_id', true), '') AS tid`,
+  );
+  const ok = check.rows[0].tid === TARGET_ID;
+  await verify.end();
+  if (!ok) {
+    throw new Error("twin settings did not apply after reload");
+  }
+}
+
+describe("restore drill authority on real PostgreSQL (#23453)", () => {
+  beforeAll(async () => {
+    if (!ENABLED) return;
+    admin = new Client({ connectionString: BASE_URL });
+    await admin.connect();
+    // Idempotent setup: drop any leftover objects from a prior run, then
+    // re-run cleanly (the drill itself is one-shot by design).
+    const leftovers = await admin.query(
+      `SELECT datname FROM pg_database WHERE datname LIKE '${TEST_PREFIX}%'`,
+    );
+    for (const row of leftovers.rows) {
+      await admin.query(`DROP DATABASE IF EXISTS ${row.datname} WITH (FORCE)`);
+    }
+    const leftoverRoles = await admin.query(
+      `SELECT rolname FROM pg_roles WHERE rolname LIKE '${TEST_PREFIX}%'`,
+    );
+    for (const row of leftoverRoles.rows) {
+      await admin.query(`DROP ROLE IF EXISTS ${row.rolname}`);
+    }
+    if (POOLER_ENABLED) {
+      startPgbouncer([`${TEST_PREFIX}tenant_a`, `${TEST_PREFIX}tenant_b`]);
+    }
+  });
+
+  afterAll(async () => {
+    if (!ENABLED) return;
+    if (POOLER_ENABLED) {
+      // pkill needs a shell (signal-by-pattern); the pattern is a hardcoded
+      // constant, not interpolated input, so shell injection is unreachable.
+      try {
+        execSync("pkill -f drill-pgbouncer || true");
+      } catch {
+        // pgbouncer may already have exited
+      }
+    }
+    for (const fn of cleanups) {
+      try {
+        fn();
+      } catch {
+        // best-effort temp cleanup
+      }
+    }
+    try {
+      await admin.query(`ALTER SYSTEM RESET eliza.restore_target_id`);
+      await admin.query(`ALTER SYSTEM RESET eliza.restore_capability`);
+      await admin.query(`SELECT pg_reload_conf()`);
+    } catch {
+      // settings may already be reset by the drill's consume step
+    }
+    await admin.end();
+  });
+
+  test("end-to-end drill: verify, guarded restore, linear isolation, consume", async () => {
+    const sourceDb = `${TEST_PREFIX}src`;
+    const targetDb = `${TEST_PREFIX}target`;
+    const databaseName = `${TEST_PREFIX}tenant_a`;
+    const tenantRole = `${TEST_PREFIX}tenant_a`;
+    await admin.query(`CREATE DATABASE ${sourceDb}`);
+    cleanups.push(() =>
+      spawnSync("psql", [
+        "-c",
+        `DROP DATABASE IF EXISTS ${targetDb} WITH (FORCE)`,
+      ]),
+    );
+    const src = new Client({ connectionString: dbUrl(sourceDb) });
+    await src.connect();
+    await src.query(`CREATE TABLE evidence (id int, note text)`);
+    await src.query(`INSERT INTO evidence VALUES (1, 'tenant-data-23453')`);
+    await src.end();
+
+    const fixture = await buildBackupFixture(
+      sourceDb,
+      databaseName,
+      tenantRole,
+    );
+    fixture.capabilityFile = mintCapabilityFile(fixture.archiveSha256);
+    await admin.query(`CREATE DATABASE ${targetDb}`);
+    await provisionTarget(targetDb, fixture.capabilityFile);
+
+    const targetDsn = dbUrl(targetDb);
+    const result = spawnSync(
+      "bun",
+      [
+        "packages/cloud/scripts/admin/apps-tenant-db-recovery.ts",
+        "--set-dir",
+        fixture.setDir,
+        "--target-dsn",
+        targetDsn,
+        "--target-id",
+        TARGET_ID,
+        "--capability-file",
+        fixture.capabilityFile,
+        "--pooler-endpoint",
+        "127.0.0.1:6432",
+        "--tenant-probes-file",
+        fixture.probesFile,
+        "--passphrase-file",
+        fixture.passphraseFile,
+        "--rpo-hours",
+        "26",
+        "--rto-minutes",
+        "60",
+      ],
+      {
+        encoding: "utf-8",
+        env: {
+          ...process.env,
+          ELIZA_RESTORE_CAPABILITY_KEY: SIGNING_KEY,
+          DRILL_TENANT_PW: fixture.tenantPassword,
+        },
+        maxBuffer: 64 * 1024 * 1024,
+      },
+    );
+    // NOTE: the pooler endpoint is probed only for the cross-reject
+    // sample; with a single tenant there is no cross pair, so no pooler
+    // connection is attempted.
+    if (result.status !== 0) {
+      throw new Error(
+        `drill exited ${result.status}\n--- stdout ---\n${result.stdout}\n--- stderr ---\n${result.stderr}`,
+      );
+    }
+    expect(result.status).toBe(0);
+    const report = JSON.parse(result.stdout);
+    expect(report.schemaVersion).toBe(2);
+    expect(report.rpoSource).toBe("manifest");
+    expect(report.isolation.plan).toBe("linear");
+    expect(report.isolation.passed).toBe(report.isolation.total);
+    expect(report.objectives.met).toBe(true);
+
+    // Restored tenant data is real.
+    const check = new Client({
+      connectionString: dbUrl(databaseName),
+    });
+    await check.connect();
+    const rows = await check.query(`SELECT note FROM evidence WHERE id = 1`);
+    expect(rows.rows[0].note).toBe("tenant-data-23453");
+    await check.end();
+
+    // Tenant role can connect to its own restored database (own-connect
+    // probe already ran through the drill; verify role survives).
+    const roleConn = await admin.query(
+      `SELECT rolname FROM pg_roles WHERE rolname = '${tenantRole}'`,
+    );
+    expect(roleConn.rows).toHaveLength(1);
+  }, 120_000);
+
+  test("substituted archive is refused even with a valid nonce", async () => {
+    const sourceDb = `${TEST_PREFIX}src2`;
+    const targetDb = `${TEST_PREFIX}target2`;
+    const databaseName = `${TEST_PREFIX}tenant_b`;
+    const tenantRole = `${TEST_PREFIX}tenant_b`;
+    await admin.query(`CREATE DATABASE ${sourceDb}`);
+    const src = new Client({ connectionString: dbUrl(sourceDb) });
+    await src.connect();
+    await src.query(`CREATE TABLE t (id int)`);
+    await src.end();
+
+    const fixture = await buildBackupFixture(
+      sourceDb,
+      databaseName,
+      tenantRole,
+    );
+    // Capability pins the REAL archive; then substitute a different archive.
+    fixture.capabilityFile = mintCapabilityFile(fixture.archiveSha256);
+    sh(`echo tampered > ${join(fixture.setDir, "backup.tar.gz.enc")}`);
+    await admin.query(`CREATE DATABASE ${targetDb}`);
+    await provisionTarget(targetDb, fixture.capabilityFile);
+
+    const targetDsn = dbUrl(targetDb);
+    const result = spawnSync(
+      "bun",
+      [
+        "packages/cloud/scripts/admin/apps-tenant-db-recovery.ts",
+        "--set-dir",
+        fixture.setDir,
+        "--target-dsn",
+        targetDsn,
+        "--target-id",
+        TARGET_ID,
+        "--capability-file",
+        fixture.capabilityFile,
+        "--pooler-endpoint",
+        "127.0.0.1:6432",
+        "--tenant-probes-file",
+        fixture.probesFile,
+        "--passphrase-file",
+        fixture.passphraseFile,
+      ],
+      {
+        encoding: "utf-8",
+        env: {
+          ...process.env,
+          ELIZA_RESTORE_CAPABILITY_KEY: SIGNING_KEY,
+          DRILL_TENANT_PW: fixture.tenantPassword,
+        },
+      },
+    );
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("sidecar");
+  });
+
+  test("replay after consumption fails closed", async () => {
+    // Provision fresh twins on the cluster, consume them through the real
+    // consume step, then prove: (a) cluster settings are gone, and (b) a
+    // re-verify of the same capability refuses on the empty twin.
+    const capFile = mintCapabilityFile("f".repeat(64));
+    const cap = await import("./restore-capability").then((m) =>
+      m.parseRestoreCapability(readFileSync(capFile, "utf-8").trim()),
+    );
+    const targetDb = `${TEST_PREFIX}target3`;
+    await admin.query(`CREATE DATABASE ${targetDb}`);
+    await provisionTarget(targetDb, capFile);
+
+    const mod = await import("./apps-tenant-db-recovery");
+    const work = mkdtempSync(join(tmpdir(), "nonce-replay-"));
+    expect(() =>
+      mod.verifyRestoreAuthority(
+        dbUrl(targetDb),
+        TARGET_ID,
+        cap,
+        SIGNING_KEY,
+        Date.now(),
+      ),
+    ).not.toThrow();
+    mod.consumeRestoreAuthority(dbUrl(targetDb), TARGET_ID, cap, work);
+
+    // Direct assertion first: the cluster-level settings are unset now.
+    const fresh = new Client({ connectionString: BASE_URL });
+    await fresh.connect();
+    const settings = await fresh.query(
+      `SELECT COALESCE(current_setting('eliza.restore_target_id', true), '') AS tid, COALESCE(current_setting('eliza.restore_capability', true), '') AS cap`,
+    );
+    expect(settings.rows[0].tid).toBe("");
+    expect(settings.rows[0].cap).toBe("");
+    await fresh.end();
+    // And the real verify path fails closed against the spent target.
+    let code = "";
+    try {
+      mod.verifyRestoreAuthority(
+        dbUrl(targetDb),
+        TARGET_ID,
+        cap,
+        SIGNING_KEY,
+        Date.now(),
+      );
+    } catch (error) {
+      code = (error as { code?: string }).code ?? "";
+    }
+    expect(code).toBe("REFUSED_TARGET_AUTHORITY");
+  });
+});
+
+if (!ENABLED) {
+  describe("restore drill authority on real PostgreSQL (#23453) [gated]", () => {
+    test.skip("requires RUN_REAL_POSTGRES_DRILL_TESTS=1 and DRILL_TEST_DATABASE_URL", () => {});
+  });
+}

--- a/packages/cloud/scripts/admin/apps-tenant-db-recovery.postgres.test.ts
+++ b/packages/cloud/scripts/admin/apps-tenant-db-recovery.postgres.test.ts
@@ -90,30 +90,46 @@ async function buildBackupFixture(
   databaseName: string,
   tenantRole: string,
 ): Promise<Fixture> {
+  return buildMultiTenantBackupFixture([
+    { sourceDb, databaseName, tenantRole },
+  ]);
+}
+
+/**
+ * Multi-tenant variant: one real pg_dump per tenant database, one shared
+ * archive, one globals.sql with a distinct role per tenant. Drives the
+ * scaled (multi-database) drill path — linear own-connect per tenant plus
+ * the sampled cross-reject pair (#23453 review r2).
+ */
+async function buildMultiTenantBackupFixture(
+  tenants: { sourceDb: string; databaseName: string; tenantRole: string }[],
+): Promise<Fixture> {
+  const first = tenants[0];
   const setDir = mkdtempSync(join(tmpdir(), "drill-set-"));
   const dumpsDir = join(setDir, "dumps");
   mkdirSync(dumpsDir);
-  const dumpId = "a1b2c3d4e5f6".slice(0, 12);
-  const dumpFile = join(dumpsDir, `${dumpId}.dump`);
+  const dumpIds = tenants.map((_, i) => `${"a1b2c3d4e5f6".slice(0, 11)}${i}`);
 
-  // Real pg_dump of the seeded source database.
+  // Real pg_dump of every seeded source database.
   const url = new URL(BASE_URL);
-  sh(
-    `pg_dump --format=custom --no-owner --no-privileges --dbname=${sourceDb} --file=${dumpFile}`,
-    {
-      env: {
-        PGHOST: url.hostname,
-        PGPORT: url.port || "5432",
-        PGPASSWORD: url.password ?? "",
+  for (let i = 0; i < tenants.length; i++) {
+    sh(
+      `pg_dump --format=custom --no-owner --no-privileges --dbname=${tenants[i].sourceDb} --file=${join(dumpsDir, `${dumpIds[i]}.dump`)}`,
+      {
+        env: {
+          PGHOST: url.hostname,
+          PGPORT: url.port || "5432",
+          PGPASSWORD: url.password ?? "",
+        },
       },
-    },
-  );
+    );
+  }
 
   const manifest = {
     schema_version: 1,
     kind: "tenant-db-backup",
     created_at: new Date().toISOString().replace(/\.\d{3}Z$/, "Z"),
-    database_count: 1,
+    database_count: tenants.length,
     globals: "globals.sql",
     dbmap: "dbmap.tsv",
     checksums: "checksums.sha256",
@@ -123,9 +139,17 @@ async function buildBackupFixture(
   // options that the harness's strict parser rejects.
   writeFileSync(
     join(setDir, "globals.sql"),
-    `CREATE ROLE ${tenantRole};\nALTER ROLE ${tenantRole} WITH LOGIN PASSWORD 'tenantpw23453';\n`,
+    `${tenants
+      .map(
+        (t) =>
+          `CREATE ROLE ${t.tenantRole};\nALTER ROLE ${t.tenantRole} WITH LOGIN PASSWORD 'tenantpw23453';`,
+      )
+      .join("\n")}\n`,
   );
-  writeFileSync(join(setDir, "dbmap.tsv"), `${dumpId}\t${databaseName}\n`);
+  writeFileSync(
+    join(setDir, "dbmap.tsv"),
+    `${tenants.map((t, i) => `${dumpIds[i]}\t${t.databaseName}`).join("\n")}\n`,
+  );
   sh(
     `sha256sum manifest.json globals.sql dbmap.tsv dumps/* > checksums.sha256`,
     {
@@ -134,9 +158,7 @@ async function buildBackupFixture(
   );
   sh(
     `tar -czf backup.tar.gz manifest.json checksums.sha256 globals.sql dbmap.tsv dumps`,
-    {
-      cwd: setDir,
-    },
+    { cwd: setDir },
   );
   const passphraseFile = join(setDir, "..", `pass-${Date.now()}`);
   writeFileSync(passphraseFile, PASSPHRASE);
@@ -155,7 +177,7 @@ async function buildBackupFixture(
     archive: "backup.tar.gz.enc",
     archive_sha256: archiveSha256,
     archive_bytes: readFileSync(join(setDir, "backup.tar.gz.enc")).length,
-    database_count: 1,
+    database_count: tenants.length,
     cipher: "aes-256-cbc-pbkdf2-210000",
   };
   writeFileSync(join(setDir, "backup.json"), JSON.stringify(sidecar));
@@ -165,9 +187,11 @@ async function buildBackupFixture(
     probesFile,
     JSON.stringify({
       schema_version: 1,
-      tenants: [
-        { dump_id: dumpId, role: tenantRole, password_env: "DRILL_TENANT_PW" },
-      ],
+      tenants: tenants.map((t, i) => ({
+        dump_id: dumpIds[i],
+        role: t.tenantRole,
+        password_env: "DRILL_TENANT_PW",
+      })),
     }),
   );
 
@@ -177,9 +201,9 @@ async function buildBackupFixture(
     passphraseFile,
     capabilityFile: "",
     probesFile,
-    tenantRole,
+    tenantRole: first.tenantRole,
     tenantPassword: "tenantpw23453",
-    databaseName,
+    databaseName: first.databaseName,
   };
   return fixture;
 }
@@ -212,17 +236,24 @@ let pgbouncerDir: string | undefined;
  */
 const POOLER_ENABLED = ENABLED;
 
-function startPgbouncer(databases: string[]): void {
+function startPgbouncer(): void {
   pgbouncerDir = mkdtempSync(join(tmpdir(), "drill-pgbouncer-"));
   const ini = join(pgbouncerDir, "pgbouncer.ini");
   const users = join(pgbouncerDir, "users.txt");
-  const dbLines = databases
-    .map((d) => `${d} = host=127.0.0.1 port=5432 dbname=${d}`)
-    .join("\n");
+  // Production-representative routing (#23453 review r2): the tenant-db
+  // cloud-init configures pgbouncer with the WILDCARD database mapping
+  // `* = host=127.0.0.1 port=5432` + auth_file — any requested database
+  // routes to the local Postgres and the credential gates CONNECT. The
+  // harness mirrors that shape (wildcard, not per-database lines) so the
+  // drill's pooler-surface own-connect proves routing through the SAME
+  // configuration production uses. Plain auth stands in for production
+  // SCRAM-via-auth_query — the property under test is routing, not the
+  // auth backend; a mapping that pointed tenant A at tenant B's database
+  // fails the drill's identity check either way.
   writeFileSync(
     ini,
     `[databases]
-${dbLines}
+* = host=127.0.0.1 port=${new URL(BASE_URL).port || "5432"}
 
 [pgbouncer]
 listen_addr = 127.0.0.1
@@ -234,7 +265,7 @@ pool_mode = transaction
   );
   writeFileSync(
     users,
-    `"drill23453test_tenant_a" "tenantpw23453"\n"drill23453test_tenant_b" "tenantpw23453"\n`,
+    `"drill23453test_tenant_a" "tenantpw23453"\n"drill23453test_tenant_b" "tenantpw23453"\n"drill23453test_tenant_c" "tenantpw23453"\n"drill23453test_mt_a" "tenantpw23453"\n"drill23453test_mt_b" "tenantpw23453"\n"drill23453test_mt_c" "tenantpw23453"\n`,
   );
   const child = execFileCb(
     "/opt/homebrew/opt/pgbouncer/bin/pgbouncer",
@@ -301,7 +332,7 @@ describe.if(ENABLED)(
         await admin.query(`DROP ROLE IF EXISTS ${row.rolname}`);
       }
       if (POOLER_ENABLED) {
-        startPgbouncer([`${TEST_PREFIX}tenant_a`, `${TEST_PREFIX}tenant_b`]);
+        startPgbouncer();
       }
     });
 
@@ -426,6 +457,103 @@ describe.if(ENABLED)(
       );
       expect(roleConn.rows).toHaveLength(1);
     }, 120_000);
+
+    test("multi-tenant drill: three tenants, own-connect through pooler and direct, sampled cross-reject", async () => {
+      // Scaled isolation proof (#23453 review r2): three tenants exercise the
+      // linear own-connect per tenant on BOTH surfaces (direct + pooler with
+      // the production wildcard routing shape), the sampled cross-reject
+      // pair, and the per-database ACL assertion — the same guarantee the
+      // O(n^2) pairwise probe gave, at linear cost.
+      const tenants = ["a", "b", "c"].map((suffix) => ({
+        sourceDb: `${TEST_PREFIX}mt_src_${suffix}`,
+        databaseName: `${TEST_PREFIX}mt_${suffix}`,
+        tenantRole: `${TEST_PREFIX}mt_${suffix}`,
+      }));
+      const targetDb = `${TEST_PREFIX}mt_target`;
+      for (const t of tenants) {
+        await admin.query(`CREATE DATABASE ${t.sourceDb}`);
+        const src = new Client({ connectionString: dbUrl(t.sourceDb) });
+        await src.connect();
+        await src.query(`CREATE TABLE evidence (id int, note text)`);
+        await src.query(
+          `INSERT INTO evidence VALUES (1, 'mt-data-${t.tenantRole}')`,
+        );
+        await src.end();
+      }
+      cleanups.push(() =>
+        spawnSync("psql", [
+          "-c",
+          `DROP DATABASE IF EXISTS ${targetDb} WITH (FORCE)`,
+        ]),
+      );
+
+      const fixture = await buildMultiTenantBackupFixture(tenants);
+      // Every probe role must reach the pooler's auth_file: the roles are
+      // drill23453test_*-prefixed, but the production wildcard routing
+      // accepts ANY database name and defers to credentials — the same
+      // shape under test.
+      fixture.capabilityFile = mintCapabilityFile(fixture.archiveSha256);
+      await admin.query(`CREATE DATABASE ${targetDb}`);
+      await provisionTarget(targetDb, fixture.capabilityFile);
+
+      const result = spawnSync(
+        "bun",
+        [
+          "packages/cloud/scripts/admin/apps-tenant-db-recovery.ts",
+          "--set-dir",
+          fixture.setDir,
+          "--target-dsn",
+          dbUrl(targetDb),
+          "--target-id",
+          TARGET_ID,
+          "--capability-file",
+          fixture.capabilityFile,
+          "--pooler-endpoint",
+          "127.0.0.1:6432",
+          "--tenant-probes-file",
+          fixture.probesFile,
+          "--passphrase-file",
+          fixture.passphraseFile,
+          "--rpo-hours",
+          "26",
+          "--rto-minutes",
+          "60",
+        ],
+        {
+          encoding: "utf-8",
+          env: {
+            ...process.env,
+            ELIZA_RESTORE_CAPABILITY_KEY: SIGNING_KEY,
+            DRILL_TENANT_PW: fixture.tenantPassword,
+          },
+          maxBuffer: 64 * 1024 * 1024,
+        },
+      );
+      if (result.status !== 0) {
+        throw new Error(
+          `drill exited ${result.status}\n--- stdout ---\n${result.stdout}\n--- stderr ---\n${result.stderr}`,
+        );
+      }
+      const report = JSON.parse(result.stdout);
+      expect(report.databaseCount).toBe(3);
+      expect(report.isolation.plan).toBe("linear");
+      // 3 own-connects + 1 cross-reject sample, each on 2 surfaces, + 3 ACL
+      // assertions = 11 executed probes, all passing.
+      expect(report.isolation.total).toBe(11);
+      expect(report.isolation.passed).toBe(report.isolation.total);
+      expect(report.objectives.met).toBe(true);
+
+      // Every tenant's restored data is real and reachable by its own role.
+      for (const t of tenants) {
+        const check = new Client({ connectionString: dbUrl(t.databaseName) });
+        await check.connect();
+        const rows = await check.query(
+          `SELECT note FROM evidence WHERE id = 1`,
+        );
+        expect(rows.rows[0]?.note).toBe(`mt-data-${t.tenantRole}`);
+        await check.end();
+      }
+    }, 180_000);
 
     test("substituted archive is refused even with a valid nonce", async () => {
       const sourceDb = `${TEST_PREFIX}src2`;
@@ -597,6 +725,7 @@ describe.if(ENABLED)(
           Date.now(),
         );
       } catch (error) {
+        // The expected refusal's typed code is captured, not swallowed.
         code = (error as { code?: string }).code ?? "";
       }
       expect(code).toBe("REFUSED_TARGET_AUTHORITY");

--- a/packages/cloud/scripts/admin/apps-tenant-db-recovery.postgres.test.ts
+++ b/packages/cloud/scripts/admin/apps-tenant-db-recovery.postgres.test.ts
@@ -26,10 +26,8 @@ import pg from "pg";
 const { Client } = pg;
 
 const BASE_URL =
-  // biome-ignore lint/suspicious/noUndeclaredEnvVars: standalone gated test run manually with bun; not part of Turbo task caching.
   process.env.DRILL_TEST_DATABASE_URL ?? process.env.TEST_DATABASE_URL ?? "";
 const ENABLED =
-  // biome-ignore lint/suspicious/noUndeclaredEnvVars: standalone gated test run manually with bun; not part of Turbo task caching.
   process.env.RUN_REAL_POSTGRES_DRILL_TESTS === "1" &&
   BASE_URL.startsWith("postgres");
 function baseUrlRoot(): string {
@@ -208,7 +206,6 @@ let pgbouncerDir: string | undefined;
  * can still run where port 6432 cannot be bound.
  */
 const POOLER_ENABLED =
-  // biome-ignore lint/suspicious/noUndeclaredEnvVars: standalone gated test run manually with bun; not part of Turbo task caching.
   process.env.RUN_REAL_PGBOUNCER_DRILL_TESTS === "1" && ENABLED;
 
 function startPgbouncer(databases: string[]): void {

--- a/packages/cloud/scripts/admin/apps-tenant-db-recovery.postgres.test.ts
+++ b/packages/cloud/scripts/admin/apps-tenant-db-recovery.postgres.test.ts
@@ -52,6 +52,27 @@ const SIGNING_KEY = "drill-test-signing-key";
 const PASSPHRASE = "drill-test-passphrase";
 
 /**
+ * pg_dump/pg_dumpall connection environment for a parsed admin DSN. WHATWG
+ * `URL` returns `username` and `password` percent-encoded; postgres roles and
+ * passwords arrive in the DSN escaped, so both must be decoded before
+ * libpq sees them, or any credential the DSN grammar forced the author to
+ * escape (@ / : / %) reaches the tool as literal escaped bytes (#29135 r5).
+ */
+function pgEnvFromUrl(url: URL): {
+  PGHOST: string;
+  PGPORT: string;
+  PGUSER: string;
+  PGPASSWORD: string;
+} {
+  return {
+    PGHOST: url.hostname,
+    PGPORT: url.port || "5432",
+    PGUSER: decodeURIComponent(url.username),
+    PGPASSWORD: decodeURIComponent(url.password ?? ""),
+  };
+}
+
+/**
  * Shell is required for glob/redirection features (sha256sum > file, tar).
  * All interpolated values are test-generated constants (mkdtemp paths,
  * generated database names) — never external input — so shell metacharacter
@@ -116,12 +137,7 @@ async function buildMultiTenantBackupFixture(
     sh(
       `pg_dump --format=custom --no-owner --no-privileges --dbname=${tenants[i].sourceDb} --file=${join(dumpsDir, `${dumpIds[i]}.dump`)}`,
       {
-        env: {
-          PGHOST: url.hostname,
-          PGPORT: url.port || "5432",
-          PGUSER: decodeURIComponent(url.username),
-          PGPASSWORD: url.password ?? "",
-        },
+        env: pgEnvFromUrl(url),
       },
     );
   }
@@ -908,6 +924,27 @@ describe.if(ENABLED)(
     }, 120_000);
   },
 );
+
+describe("pg_dump DSN credential decoding (#29135 r5)", () => {
+  test("an escaped-password DSN reaches pg_dump decoded", () => {
+    // Every character class the DSN grammar forces the author to escape
+    // (@ / : %) plus non-ASCII, exercised together in one password.
+    const dsn =
+      "postgresql://drill_admin:p%40ss%2Fwo%3Ard%2520%E2%82%AC@db.example.com:5433/drill_src";
+    const env = pgEnvFromUrl(new URL(dsn));
+    expect(env.PGHOST).toBe("db.example.com");
+    expect(env.PGPORT).toBe("5433");
+    expect(env.PGUSER).toBe("drill_admin");
+    expect(env.PGPASSWORD).toBe("p@ss/wo:rd%20€");
+  });
+
+  test("a DSN without a password yields an empty PGPASSWORD, never 'null'/'undefined'", () => {
+    const env = pgEnvFromUrl(
+      new URL("postgresql://drill_admin@db.example.com:5433/drill_src"),
+    );
+    expect(env.PGPASSWORD).toBe("");
+  });
+});
 
 if (!ENABLED) {
   describe("restore drill authority on real PostgreSQL (#23453) [gated]", () => {

--- a/packages/cloud/scripts/admin/apps-tenant-db-recovery.test.ts
+++ b/packages/cloud/scripts/admin/apps-tenant-db-recovery.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { afterEach, describe, expect, test } from "bun:test";
-import { createHash } from "node:crypto";
+import { createHash, createHmac } from "node:crypto";
 import {
   mkdirSync,
   mkdtempSync,
@@ -30,6 +30,7 @@ import {
   guardedConsumeAuthoritySql,
   guardPsqlScript,
   isCrossTenantDenial,
+  makeGlobalsIdempotent,
   parseBackupManifest,
   parseBackupSidecar,
   parseChecksumFile,
@@ -206,6 +207,50 @@ describe("restore target authority", () => {
     expect(() =>
       assertNoGlobalRoleCollisions(globals, ["restore_admin"]),
     ).not.toThrow();
+  });
+
+  test("archive-owned roles do not collide on an idempotent retry", () => {
+    // Remnants of a failed run of the SAME drill (twin settings match the
+    // capability) must not block the retry. Roles the archive does NOT
+    // define are irrelevant — the drill never creates them, so their
+    // presence on the target cannot collide with the restore.
+    const globals = ["CREATE ROLE tenant_a;", ""].join("\n");
+    expect(() =>
+      assertNoGlobalRoleCollisions(globals, ["tenant_a"], ["tenant_a"]),
+    ).not.toThrow();
+    expect(() =>
+      assertNoGlobalRoleCollisions(
+        globals,
+        ["tenant_a", "tenant_b"],
+        ["tenant_a"],
+      ),
+    ).not.toThrow();
+    // A pre-existing role that the archive itself defines and that is NOT
+    // exempted as archive-owned still refuses (direct-call contract).
+    expect(() =>
+      assertNoGlobalRoleCollisions(
+        ["CREATE ROLE postgres;", ""].join("\n"),
+        ["postgres"],
+        ["tenant_a"],
+      ),
+    ).toThrow(expect.objectContaining({ code: "REFUSED_NONEMPTY_TARGET" }));
+  });
+
+  test("makeGlobalsIdempotent rewrites CREATE ROLE into conditional DO blocks", () => {
+    const globals = [
+      "CREATE ROLE tenant_a;",
+      "ALTER ROLE tenant_a WITH LOGIN;",
+      "CREATE ROLE tenant_b;",
+      "",
+    ].join("\n");
+    const idempotent = makeGlobalsIdempotent(globals);
+    expect(idempotent).toContain("IF NOT EXISTS");
+    expect(idempotent).not.toMatch(/(^|\n)CREATE ROLE tenant_a;/);
+    expect(idempotent).not.toMatch(/(^|\n)CREATE ROLE tenant_b;/);
+    // ALTER ROLE is already idempotent and must pass through untouched.
+    expect(idempotent).toContain("ALTER ROLE tenant_a WITH LOGIN;");
+    // Role names arrive as quoted literals inside the DO block.
+    expect(idempotent).toContain("rolname = 'tenant_a'");
   });
 
   test("parses the server role inventory and refuses malformed output", () => {
@@ -589,10 +634,11 @@ const CAP_ARCHIVE_SHA = "b".repeat(64);
 const CAP_KEY = "test-signing-key";
 
 function wellFormedCapabilityEnvelope(
+  issuedAtEpochMs: number,
   expiresAtEpochMs: number,
   signatureHex: string,
 ): string {
-  return `v1.eliza.restore|${CAP_TARGET_ID}|${CAP_ARCHIVE_SHA}|${expiresAtEpochMs}|${signatureHex}`;
+  return `v1.eliza.restore|${CAP_TARGET_ID}|${CAP_ARCHIVE_SHA}|${issuedAtEpochMs}|${expiresAtEpochMs}|${signatureHex}`;
 }
 
 describe("restore capability (#23453)", () => {
@@ -622,7 +668,11 @@ describe("restore capability (#23453)", () => {
       ("0" === minted.signature.slice(0, 1) ? "1" : "0") +
       minted.signature.slice(1);
     const tampered = parseRestoreCapability(
-      wellFormedCapabilityEnvelope(minted.expiresAtEpochMs, flipped),
+      wellFormedCapabilityEnvelope(
+        minted.issuedAtEpochMs,
+        minted.expiresAtEpochMs,
+        flipped,
+      ),
     );
     expect(() =>
       verifyRestoreCapability(tampered, CAP_KEY, Date.now()),
@@ -672,7 +722,46 @@ describe("restore capability (#23453)", () => {
     );
     expect(() =>
       parseRestoreCapability(
-        `v1.eliza.restore|not-a-target|aa|1|${"0".repeat(128)}`,
+        `v1.eliza.restore|not-a-target|aa|1|1|${"0".repeat(128)}`,
+      ),
+    ).toThrow(expect.objectContaining({ code: "INVALID_CAPABILITY" }));
+  });
+
+  test("refuses a signed capability whose lifetime exceeds the ceiling", () => {
+    // Even a correctly-signed grant cannot claim a span beyond the TTL
+    // ceiling: the ceiling is proven from the signed bytes.
+    const minted = mintRestoreCapability({
+      signingKey: CAP_KEY,
+      targetId: CAP_TARGET_ID,
+      archiveSha256: CAP_ARCHIVE_SHA,
+      expiresAtEpochMs: Date.now() + 60_000,
+    });
+    const stretched = {
+      ...minted,
+      expiresAtEpochMs: minted.issuedAtEpochMs + MAX_CAPABILITY_TTL_MS + 1,
+      payload: `v1.eliza.restore|${CAP_TARGET_ID}|${CAP_ARCHIVE_SHA}|${minted.issuedAtEpochMs}|${minted.issuedAtEpochMs + MAX_CAPABILITY_TTL_MS + 1}`,
+    };
+    // Re-sign so only the lifetime check can refuse it.
+    stretched.signature = createHmac("sha256", CAP_KEY)
+      .update(stretched.payload, "utf-8")
+      .digest("hex");
+    expect(() =>
+      verifyRestoreCapability(stretched, CAP_KEY, Date.now()),
+    ).toThrow(expect.objectContaining({ code: "INVALID_CAPABILITY" }));
+  });
+
+  test("refuses a capability whose issuedAt is in the future", () => {
+    const minted = mintRestoreCapability({
+      signingKey: CAP_KEY,
+      targetId: CAP_TARGET_ID,
+      archiveSha256: CAP_ARCHIVE_SHA,
+      expiresAtEpochMs: Date.now() + 60_000,
+    });
+    expect(() =>
+      verifyRestoreCapability(
+        minted,
+        CAP_KEY,
+        minted.issuedAtEpochMs - 120_000,
       ),
     ).toThrow(expect.objectContaining({ code: "INVALID_CAPABILITY" }));
   });
@@ -740,9 +829,7 @@ describe("authenticated archive coverage (#23453)", () => {
       { sha256: "c".repeat(64), file: "dbmap.tsv" },
       { sha256: "d".repeat(64), file: "dumps/aaaaaaaaaaaa.dump" },
     ];
-    expect(() =>
-      assertChecksumCoverage(good, ["aaaaaaaaaaaa"]),
-    ).not.toThrow();
+    expect(() => assertChecksumCoverage(good, ["aaaaaaaaaaaa"])).not.toThrow();
     for (const drop of [0, 1, 2, 3]) {
       const missing = good.filter((_, i) => i !== drop);
       expect(() => assertChecksumCoverage(missing, ["aaaaaaaaaaaa"])).toThrow(
@@ -759,9 +846,7 @@ describe("authenticated archive coverage (#23453)", () => {
       assertProbesCoverArchiveRoles(probes, ["tenant_a"]),
     ).not.toThrow();
     // A tampered probes file naming an attacker-chosen role is refused.
-    expect(() =>
-      assertProbesCoverArchiveRoles(probes, ["tenant_b"]),
-    ).toThrow(
+    expect(() => assertProbesCoverArchiveRoles(probes, ["tenant_b"])).toThrow(
       expect.objectContaining({ code: "INVALID_PROBE_METADATA" }),
     );
   });

--- a/packages/cloud/scripts/admin/apps-tenant-db-recovery.test.ts
+++ b/packages/cloud/scripts/admin/apps-tenant-db-recovery.test.ts
@@ -18,14 +18,16 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  assertChecksumCoverage,
   assertDirectTarget,
   assertNoGlobalRoleCollisions,
-  assertRestoreDrillExecutionEnabled,
+  assertProbesCoverArchiveRoles,
   assertRestoreTargetIdentity,
+  buildClaimExclusivitySql,
   buildIsolationChecks,
   evaluateObjectives,
   executeDrill,
-  guardedConsumeTargetIdentitySql,
+  guardedConsumeAuthoritySql,
   guardPsqlScript,
   isCrossTenantDenial,
   parseBackupManifest,
@@ -43,6 +45,14 @@ import {
   targetDatabaseDsn,
   verifyChecksums,
 } from "./apps-tenant-db-recovery";
+import {
+  assertRecoveryPointConsistency,
+  MAX_CAPABILITY_TTL_MS,
+  mintRestoreCapability,
+  parseRestoreCapability,
+  serializeRestoreCapability,
+  verifyRestoreCapability,
+} from "./restore-capability";
 
 const SIDECAR = {
   schema_version: 1,
@@ -55,13 +65,13 @@ const SIDECAR = {
   cipher: "aes-256-cbc-pbkdf2-210000",
 };
 
-describe("restore drill containment", () => {
-  test("refuses execution before any destructive collaborator can run", () => {
+describe("restore drill authority gating", () => {
+  test("execution requires a capability before any destructive collaborator runs", () => {
+    // No signing key in the environment: the drill refuses before touching
+    // psql or reading any file — the #23482 unconditional disable is gone;
+    // authority is now capability-gated instead of disabled outright.
     expect(() => executeDrill({} as never)).toThrow(
-      expect.objectContaining({ code: "RESTORE_DRILL_DISABLED" }),
-    );
-    expect(() => assertRestoreDrillExecutionEnabled()).toThrow(
-      RecoveryDrillError,
+      expect.objectContaining({ code: "MISSING_SIGNING_KEY" }),
     );
   });
 });
@@ -203,24 +213,38 @@ describe("restore target authority", () => {
       parseRestoreTargetAuthority(
         JSON.stringify({
           target_id: targetId,
+          capability: "v1.eliza.restore|...",
           existing_roles: ["restore_admin"],
         }),
       ),
-    ).toEqual({ targetId, existingRoles: ["restore_admin"] });
+    ).toEqual({
+      targetId,
+      capability: "v1.eliza.restore|...",
+      existingRoles: ["restore_admin"],
+    });
     expect(() => parseRestoreTargetAuthority("not-json")).toThrow(
       RecoveryDrillError,
     );
+    // Missing the capability twin is malformed: authority is incomplete.
+    expect(() =>
+      parseRestoreTargetAuthority(
+        JSON.stringify({ target_id: targetId, existing_roles: [] }),
+      ),
+    ).toThrow(RecoveryDrillError);
   });
 
   test("guards one exact session before any supplied SQL", () => {
     const guarded = guardPsqlScript("CREATE TABLE data(id int);\n");
     expect(guarded).not.toContain("\\quit");
     expect(guarded).toContain(
-      "RAISE EXCEPTION 'restore target identity mismatch'",
+      "RAISE EXCEPTION 'restore target authority mismatch'",
     );
     expect(guarded.indexOf("current_setting")).toBeLessThan(
       guarded.indexOf("CREATE TABLE"),
     );
+    // Both twin settings are checked: target id AND capability envelope.
+    expect(guarded).toContain("eliza.restore_target_id");
+    expect(guarded).toContain("eliza.restore_capability");
   });
 
   test("quotes tenant identifiers and targets the restored database", () => {
@@ -233,12 +257,13 @@ describe("restore target authority", () => {
     ).toBe("postgresql://restore:pw@127.0.0.1:5433/tenant%2Fa%20b");
   });
 
-  test("consuming the nonce re-verifies inside the same guard, then resets and reloads", () => {
-    const script = guardedConsumeTargetIdentitySql();
+  test("consuming the authority re-verifies inside the same guard, then resets and reloads", () => {
+    const script = guardedConsumeAuthoritySql();
     // Same guard as every other destructive statement — a mismatched setting
     // raises before ALTER SYSTEM is ever reached.
     expect(script.startsWith(guardPsqlScript(""))).toBe(true);
     expect(script).toContain("ALTER SYSTEM RESET eliza.restore_target_id;");
+    expect(script).toContain("ALTER SYSTEM RESET eliza.restore_capability;");
     expect(script).toContain("SELECT pg_reload_conf();");
     expect(script.indexOf("current_setting")).toBeLessThan(
       script.indexOf("ALTER SYSTEM RESET"),
@@ -446,16 +471,25 @@ describe("root-sourced backup environment", () => {
 });
 
 describe("buildIsolationChecks", () => {
-  test("plans one own-connect plus pairwise cross-reject probes", () => {
+  test("plans a linear proof: one own-connect per tenant plus one cross-reject sample", () => {
     const checks = buildIsolationChecks([
       { dumpId: "a".repeat(12), databaseName: "t1" },
       { dumpId: "b".repeat(12), databaseName: "t2" },
       { dumpId: "c".repeat(12), databaseName: "t3" },
     ]);
     expect(checks.filter((c) => c.kind === "own-connect")).toHaveLength(3);
-    expect(checks.filter((c) => c.kind === "cross-reject")).toHaveLength(6);
+    expect(checks.filter((c) => c.kind === "cross-reject")).toHaveLength(1);
+    expect(checks).toHaveLength(4); // linear, not n*(n-1)+n
     // Reports reference dump ids only — tenant names never appear in checks.
     expect(JSON.stringify(checks)).not.toContain("t1");
+  });
+
+  test("degrades to own-connect-only when a single tenant is restored", () => {
+    const checks = buildIsolationChecks([
+      { dumpId: "a".repeat(12), databaseName: "t1" },
+    ]);
+    expect(checks).toHaveLength(1);
+    expect(checks[0].kind).toBe("own-connect");
   });
 });
 
@@ -513,9 +547,11 @@ describe("parseCliArgs", () => {
       "--set-dir",
       "/tmp/set",
       "--target-dsn",
-      "postgresql://p:x@127.0.0.1:5433/postgres",
+      "postgresql://p:***@127.0.0.1:5433/postgres",
       "--target-id",
       "drill-11111111-2222-4333-8444-555555555555",
+      "--capability-file",
+      "/tmp/cap.txt",
       "--pooler-endpoint",
       "127.0.0.1:6432",
       "--tenant-probes-file",
@@ -526,6 +562,7 @@ describe("parseCliArgs", () => {
     expect(options.rpoHours).toBe(26);
     expect(options.rtoMinutes).toBe(60);
     expect(options.output).toBeUndefined();
+    expect(options.capabilityFile).toBe("/tmp/cap.txt");
   });
 
   test("rejects missing required flags and non-positive objectives", () => {
@@ -544,5 +581,188 @@ describe("parseCliArgs", () => {
         "0",
       ]),
     ).toThrow(expect.objectContaining({ code: "INVALID_ARGS" }));
+  });
+});
+
+const CAP_TARGET_ID = "drill-11111111-2222-4333-8444-555555555555";
+const CAP_ARCHIVE_SHA = "b".repeat(64);
+const CAP_KEY = "test-signing-key";
+
+function wellFormedCapabilityEnvelope(
+  expiresAtEpochMs: number,
+  signatureHex: string,
+): string {
+  return `v1.eliza.restore|${CAP_TARGET_ID}|${CAP_ARCHIVE_SHA}|${expiresAtEpochMs}|${signatureHex}`;
+}
+
+describe("restore capability (#23453)", () => {
+  test("round-trips mint -> serialize -> parse -> verify", () => {
+    const minted = mintRestoreCapability({
+      signingKey: CAP_KEY,
+      targetId: CAP_TARGET_ID,
+      archiveSha256: CAP_ARCHIVE_SHA,
+      expiresAtEpochMs: Date.now() + 3_600_000,
+    });
+    const parsed = parseRestoreCapability(serializeRestoreCapability(minted));
+    expect(parsed.targetId).toBe(CAP_TARGET_ID);
+    expect(parsed.archiveSha256).toBe(CAP_ARCHIVE_SHA);
+    expect(() =>
+      verifyRestoreCapability(parsed, CAP_KEY, Date.now()),
+    ).not.toThrow();
+  });
+
+  test("refuses a tampered signature (substitution)", () => {
+    const minted = mintRestoreCapability({
+      signingKey: CAP_KEY,
+      targetId: CAP_TARGET_ID,
+      archiveSha256: CAP_ARCHIVE_SHA,
+      expiresAtEpochMs: Date.now() + 3_600_000,
+    });
+    const flipped =
+      ("0" === minted.signature.slice(0, 1) ? "1" : "0") +
+      minted.signature.slice(1);
+    const tampered = parseRestoreCapability(
+      wellFormedCapabilityEnvelope(minted.expiresAtEpochMs, flipped),
+    );
+    expect(() =>
+      verifyRestoreCapability(tampered, CAP_KEY, Date.now()),
+    ).toThrow(
+      expect.objectContaining({ code: "REFUSED_CAPABILITY_SIGNATURE" }),
+    );
+  });
+
+  test("refuses an expired capability and one with a beyond-ceiling TTL", () => {
+    const minted = mintRestoreCapability({
+      signingKey: CAP_KEY,
+      targetId: CAP_TARGET_ID,
+      archiveSha256: CAP_ARCHIVE_SHA,
+      expiresAtEpochMs: Date.now() + 60_000,
+    });
+    expect(() =>
+      verifyRestoreCapability(minted, CAP_KEY, Date.now() + 120_000),
+    ).toThrow(expect.objectContaining({ code: "CAPABILITY_EXPIRED" }));
+    expect(() =>
+      mintRestoreCapability({
+        signingKey: CAP_KEY,
+        targetId: CAP_TARGET_ID,
+        archiveSha256: CAP_ARCHIVE_SHA,
+        expiresAtEpochMs: Date.now() + MAX_CAPABILITY_TTL_MS + 60_000,
+      }),
+    ).toThrow(expect.objectContaining({ code: "INVALID_CAPABILITY" }));
+  });
+
+  test("refuses a re-signed capability binding a different archive (cross-key substitution)", () => {
+    // Attacker with their own key pins a DIFFERENT archive to our target id.
+    const attacker = mintRestoreCapability({
+      signingKey: "attacker-key",
+      targetId: CAP_TARGET_ID,
+      archiveSha256: "c".repeat(64),
+      expiresAtEpochMs: Date.now() + 3_600_000,
+    });
+    expect(() =>
+      verifyRestoreCapability(attacker, CAP_KEY, Date.now()),
+    ).toThrow(
+      expect.objectContaining({ code: "REFUSED_CAPABILITY_SIGNATURE" }),
+    );
+  });
+
+  test("rejects malformed envelopes outright", () => {
+    expect(() => parseRestoreCapability("garbage")).toThrow(
+      expect.objectContaining({ code: "INVALID_CAPABILITY" }),
+    );
+    expect(() =>
+      parseRestoreCapability(
+        `v1.eliza.restore|not-a-target|aa|1|${"0".repeat(128)}`,
+      ),
+    ).toThrow(expect.objectContaining({ code: "INVALID_CAPABILITY" }));
+  });
+});
+
+describe("authenticated recovery point (#23453)", () => {
+  test("accepts a sidecar/manifest pair within the freshness window", () => {
+    const t0 = new Date("2026-08-25T00:00:00Z");
+    expect(() =>
+      assertRecoveryPointConsistency({
+        sidecarCreatedAt: t0,
+        manifestCreatedAt: new Date(t0.getTime() + 30_000),
+        nowEpochMs: t0.getTime() + 3_600_000,
+      }),
+    ).not.toThrow();
+  });
+
+  test("refuses a stale sidecar (cannot understate data loss)", () => {
+    const t0 = new Date("2026-08-25T00:00:00Z");
+    expect(() =>
+      assertRecoveryPointConsistency({
+        sidecarCreatedAt: t0,
+        manifestCreatedAt: new Date(t0.getTime() + 3_600_000),
+        nowEpochMs: t0.getTime() + 3_600_000,
+      }),
+    ).toThrow(expect.objectContaining({ code: "REFUSED_RECOVERY_POINT" }));
+  });
+
+  test("refuses a future-dated manifest beyond the window", () => {
+    const t0 = new Date("2026-08-25T00:00:00Z");
+    expect(() =>
+      assertRecoveryPointConsistency({
+        sidecarCreatedAt: t0,
+        manifestCreatedAt: new Date(t0.getTime() + 10 * 60_000),
+        nowEpochMs: t0.getTime(),
+      }),
+    ).toThrow(expect.objectContaining({ code: "REFUSED_RECOVERY_POINT" }));
+  });
+});
+
+describe("capability claim exclusivity (#23453)", () => {
+  test("claims under the advisory lock and refuses nothing for the same capability", () => {
+    const minted = mintRestoreCapability({
+      signingKey: CAP_KEY,
+      targetId: CAP_TARGET_ID,
+      archiveSha256: CAP_ARCHIVE_SHA,
+      expiresAtEpochMs: Date.now() + 3_600_000,
+    });
+    const sql = buildClaimExclusivitySql(minted);
+    expect(sql).toContain("pg_advisory_xact_lock");
+    expect(sql).toContain("eliza_restore_drill_claim");
+    expect(sql).toContain(
+      "RAISE EXCEPTION 'a different restore capability already claims this target'",
+    );
+    // Guarded: settings check precedes the transaction.
+    expect(sql.indexOf("current_setting")).toBeLessThan(sql.indexOf("BEGIN;"));
+  });
+});
+
+describe("authenticated archive coverage (#23453)", () => {
+  test("refuses checksums that omit any consumed artifact", () => {
+    const good = [
+      { sha256: "a".repeat(64), file: "manifest.json" },
+      { sha256: "b".repeat(64), file: "globals.sql" },
+      { sha256: "c".repeat(64), file: "dbmap.tsv" },
+      { sha256: "d".repeat(64), file: "dumps/aaaaaaaaaaaa.dump" },
+    ];
+    expect(() =>
+      assertChecksumCoverage(good, ["aaaaaaaaaaaa"]),
+    ).not.toThrow();
+    for (const drop of [0, 1, 2, 3]) {
+      const missing = good.filter((_, i) => i !== drop);
+      expect(() => assertChecksumCoverage(missing, ["aaaaaaaaaaaa"])).toThrow(
+        expect.objectContaining({ code: "INVALID_METADATA" }),
+      );
+    }
+  });
+
+  test("refuses probe roles absent from the archive globals", () => {
+    const probes = [
+      { dumpId: "aaaaaaaaaaaa", role: "tenant_a", passwordEnv: "PW_A" },
+    ];
+    expect(() =>
+      assertProbesCoverArchiveRoles(probes, ["tenant_a"]),
+    ).not.toThrow();
+    // A tampered probes file naming an attacker-chosen role is refused.
+    expect(() =>
+      assertProbesCoverArchiveRoles(probes, ["tenant_b"]),
+    ).toThrow(
+      expect.objectContaining({ code: "INVALID_PROBE_METADATA" }),
+    );
   });
 });

--- a/packages/cloud/scripts/admin/apps-tenant-db-recovery.test.ts
+++ b/packages/cloud/scripts/admin/apps-tenant-db-recovery.test.ts
@@ -279,7 +279,8 @@ describe("restore target authority", () => {
   });
 
   test("guards one exact session before any supplied SQL", () => {
-    const guarded = guardPsqlScript("CREATE TABLE data(id int);\n");
+    const expiresAt = Date.now() + 3_600_000;
+    const guarded = guardPsqlScript("CREATE TABLE data(id int);\n", expiresAt);
     expect(guarded).not.toContain("\\quit");
     expect(guarded).toContain(
       "RAISE EXCEPTION 'restore target authority mismatch'",
@@ -290,6 +291,58 @@ describe("restore target authority", () => {
     // Both twin settings are checked: target id AND capability envelope.
     expect(guarded).toContain("eliza.restore_target_id");
     expect(guarded).toContain("eliza.restore_capability");
+    // The server-clock expiry check is embedded in the same guard block,
+    // before any supplied SQL, and exactly once (#23453 review r8).
+    expect(guarded).toContain(
+      "restore capability has expired on the server clock",
+    );
+    expect(guarded.indexOf("eliza_capability_live")).toBeLessThan(
+      guarded.indexOf("CREATE TABLE"),
+    );
+    expect(guarded.split("eliza_capability_live").length - 1).toBe(2);
+  });
+
+  test("every guarded script class carries the expiry guard exactly once", () => {
+    // #23453 review r8: guard composition is construction-only — every
+    // destructive session's script embeds the twin-settings + expiry guards
+    // exactly once. A double-wrapped script (the old guardedPsqlFile
+    // re-wrap) or an unwrapped one is detectable by these counts.
+    const expiresAt = Date.now() + 3_600_000;
+    const minted = mintRestoreCapability({
+      signingKey: CAP_KEY,
+      targetId: CAP_TARGET_ID,
+      archiveSha256: CAP_ARCHIVE_SHA,
+      expiresAtEpochMs: expiresAt,
+    });
+    const scripts: Record<string, string> = {
+      claim: buildClaimExclusivitySql(minted),
+      globals: guardPsqlScript(
+        makeGlobalsIdempotent("CREATE ROLE tenant_a;\n"),
+        expiresAt,
+      ),
+      consume: guardedConsumeAuthoritySql(expiresAt),
+      drop: guardPsqlScript(
+        ['DROP DATABASE IF EXISTS "db";', 'CREATE DATABASE "db";', ""].join(
+          "\n",
+        ),
+        expiresAt,
+      ),
+    };
+    for (const [name, script] of Object.entries(scripts)) {
+      // Twin-settings guard once: one gset assignment + one \if read.
+      expect(script.split("eliza_restore_target_ok").length - 1, name).toBe(2);
+      // Expiry guard once: the variable is set and read inside one block.
+      expect(script.split("eliza_capability_live").length - 1, name).toBe(2);
+      // Guard precedes the first destructive statement.
+      expect(script.indexOf("current_setting"), name).toBeLessThan(
+        script.length,
+      );
+    }
+    // Double-wrapping is detectable: guardPsqlScript applied to an already
+    // guarded script doubles both markers.
+    const doubleWrapped = guardPsqlScript(scripts.globals, expiresAt);
+    expect(doubleWrapped.split("eliza_restore_target_ok").length - 1).toBe(4);
+    expect(doubleWrapped.split("eliza_capability_live").length - 1).toBe(4);
   });
 
   test("quotes tenant identifiers and targets the restored database", () => {
@@ -303,10 +356,11 @@ describe("restore target authority", () => {
   });
 
   test("consuming the authority re-verifies inside the same guard, then resets and reloads", () => {
-    const script = guardedConsumeAuthoritySql();
+    const expiresAt = Date.now() + 3_600_000;
+    const script = guardedConsumeAuthoritySql(expiresAt);
     // Same guard as every other destructive statement — a mismatched setting
     // raises before ALTER SYSTEM is ever reached.
-    expect(script.startsWith(guardPsqlScript(""))).toBe(true);
+    expect(script.startsWith(guardPsqlScript("", expiresAt))).toBe(true);
     expect(script).toContain("ALTER SYSTEM RESET eliza.restore_target_id;");
     expect(script).toContain("ALTER SYSTEM RESET eliza.restore_capability;");
     expect(script).toContain("SELECT pg_reload_conf();");
@@ -797,6 +851,26 @@ describe("authenticated recovery point (#23453)", () => {
         sidecarCreatedAt: t0,
         manifestCreatedAt: new Date(t0.getTime() + 10 * 60_000),
         nowEpochMs: t0.getTime(),
+      }),
+    ).toThrow(expect.objectContaining({ code: "REFUSED_RECOVERY_POINT" }));
+  });
+
+  test("refuses unparseable timestamps instead of passing by NaN comparison", () => {
+    // Math.abs(NaN) > WINDOW and NaN > now are both false, so an Invalid
+    // Date on either side must be rejected explicitly (#23453 review r8).
+    const t0 = new Date("2026-08-25T00:00:00Z");
+    expect(() =>
+      assertRecoveryPointConsistency({
+        sidecarCreatedAt: new Date("not-a-timestamp"),
+        manifestCreatedAt: t0,
+        nowEpochMs: t0.getTime() + 3_600_000,
+      }),
+    ).toThrow(expect.objectContaining({ code: "REFUSED_RECOVERY_POINT" }));
+    expect(() =>
+      assertRecoveryPointConsistency({
+        sidecarCreatedAt: t0,
+        manifestCreatedAt: new Date("not-a-timestamp"),
+        nowEpochMs: t0.getTime() + 3_600_000,
       }),
     ).toThrow(expect.objectContaining({ code: "REFUSED_RECOVERY_POINT" }));
   });

--- a/packages/cloud/scripts/admin/apps-tenant-db-recovery.test.ts
+++ b/packages/cloud/scripts/admin/apps-tenant-db-recovery.test.ts
@@ -327,16 +327,34 @@ describe("restore target authority", () => {
         ),
         expiresAt,
       ),
+      // The two remaining session classes are guarded inline in executeDrill;
+      // representative raw SQL pins their composition through the same
+      // guardPsqlScript path (pg_restore output / ownership handoff).
+      restore: guardPsqlScript("-- pg_restore extracted SQL\n", expiresAt),
+      handoff: guardPsqlScript(
+        'ALTER DATABASE "db" OWNER TO "tenant_a";\n',
+        expiresAt,
+      ),
+    };
+    const bodyMarkers: Record<string, string> = {
+      claim: "pg_advisory_xact_lock",
+      globals: "IF NOT EXISTS",
+      consume: "ALTER SYSTEM RESET",
+      drop: "DROP DATABASE",
+      restore: "pg_restore extracted",
+      handoff: "OWNER TO",
     };
     for (const [name, script] of Object.entries(scripts)) {
       // Twin-settings guard once: one gset assignment + one \if read.
       expect(script.split("eliza_restore_target_ok").length - 1, name).toBe(2);
       // Expiry guard once: the variable is set and read inside one block.
       expect(script.split("eliza_capability_live").length - 1, name).toBe(2);
-      // Guard precedes the first destructive statement.
-      expect(script.indexOf("current_setting"), name).toBeLessThan(
-        script.length,
-      );
+      // Guard block precedes the class's own first body statement.
+      const guardEnd = script.indexOf("restore capability has expired");
+      const bodyStart = script.indexOf(bodyMarkers[name]);
+      expect(guardEnd, name).toBeGreaterThanOrEqual(0);
+      expect(bodyStart, name).toBeGreaterThanOrEqual(0);
+      expect(guardEnd, name).toBeLessThan(bodyStart);
     }
     // Double-wrapping is detectable: guardPsqlScript applied to an already
     // guarded script doubles both markers.

--- a/packages/cloud/scripts/admin/apps-tenant-db-recovery.ts
+++ b/packages/cloud/scripts/admin/apps-tenant-db-recovery.ts
@@ -1289,6 +1289,8 @@ export const DRILL_LOCK_REFUSED = "drill-lock-refused";
 export interface DrillLock {
   child: ChildProcess;
   handshakePath: string;
+  targetDsn: string;
+  backendPid?: number;
 }
 
 /**
@@ -1328,7 +1330,7 @@ export function acquireDrillLock(
       "--dbname",
       targetDsn,
       "--command",
-      `SELECT CASE WHEN pg_try_advisory_lock(${DRILL_ADVISORY_LOCK_KEY}) THEN '${DRILL_LOCK_HANDSHAKE}' ELSE '${DRILL_LOCK_REFUSED}' END;`,
+      `SELECT CASE WHEN pg_try_advisory_lock(${DRILL_ADVISORY_LOCK_KEY}) THEN '${DRILL_LOCK_HANDSHAKE}:' || pg_backend_pid() ELSE '${DRILL_LOCK_REFUSED}' END;`,
       "--command",
       `SELECT pg_sleep(${DRILL_LOCK_MAX_SECONDS});`,
     ],
@@ -1343,6 +1345,7 @@ export function acquireDrillLock(
     stderrTail = `${stderrTail}${String(chunk)}`.slice(-500);
   });
   let acquired = false;
+  let backendPid: number | undefined;
   while (Date.now() < deadline) {
     Atomics.wait(
       new Int32Array(new SharedArrayBuffer(4)),
@@ -1359,6 +1362,17 @@ export function acquireDrillLock(
     }
     if (observed.includes(DRILL_LOCK_HANDSHAKE)) {
       acquired = true;
+      // The sentinel carries the holder's backend pid: pg_terminate_backend
+      // releases the session lock deterministically at release time. A
+      // client-side SIGKILL alone does NOT reach a backend blocked in
+      // pg_sleep — the backend notices the dropped client only at its next
+      // socket read/write, so the lock would stay pinned for the whole
+      // DRILL_LOCK_MAX_SECONDS sleep and refuse the documented idempotent
+      // re-run within the capability TTL.
+      const pidMatch = observed.match(
+        new RegExp(`${DRILL_LOCK_HANDSHAKE}:(\\d+)`),
+      );
+      backendPid = pidMatch?.[1] ? Number(pidMatch[1]) : undefined;
       break;
     }
     if (observed.includes(DRILL_LOCK_REFUSED)) {
@@ -1389,7 +1403,7 @@ export function acquireDrillLock(
       `drill lock acquisition was not confirmed within the settle window: ${stderrTail.trim().slice(0, 200)}`,
     );
   }
-  return { child, handshakePath };
+  return { child, handshakePath, targetDsn, backendPid };
 }
 
 /**
@@ -1421,7 +1435,37 @@ export function assertDrillLockHeld(lock: DrillLock): void {
 }
 
 export function releaseDrillLock(lock: DrillLock): void {
-  // SIGKILL drops the server session, which releases the session-level lock.
+  // Server-side release: terminate the holder's backend so the session lock
+  // drops immediately. SIGKILL on the client alone does not interrupt a
+  // backend blocked in pg_sleep — it only notices the closed socket at its
+  // next read/write, so the lock would stay held for the full
+  // DRILL_LOCK_MAX_SECONDS sleep and refuse every idempotent re-run within
+  // the capability TTL (proven by the claim-order regression test: a failed
+  // first invocation must leave the target retryable, not lock-pinned).
+  if (lock.backendPid !== undefined) {
+    const terminated = spawnSync(
+      "psql",
+      [
+        "--no-psqlrc",
+        "--quiet",
+        "--dbname",
+        lock.targetDsn,
+        "--command",
+        `SELECT pg_terminate_backend(${lock.backendPid}) WHERE pg_backend_pid() <> ${lock.backendPid};`,
+      ],
+      { encoding: "utf-8" },
+    );
+    if (terminated.status !== 0) {
+      // error-policy:J4 the SIGKILL fallback below still drops the client;
+      // termination is best-effort so a completed drill's report is never
+      // masked by a cleanup failure.
+      process.stderr.write(
+        `drill lock backend termination failed: ${terminated.stderr?.slice(-200) ?? "unknown"}\n`,
+      );
+    }
+  }
+  // Client-side kill: drops the local process and its socket even when the
+  // backend pid could not be parsed from the sentinel.
   lock.child.kill("SIGKILL");
   try {
     // error-policy:J6 best-effort cleanup of the handshake file.

--- a/packages/cloud/scripts/admin/apps-tenant-db-recovery.ts
+++ b/packages/cloud/scripts/admin/apps-tenant-db-recovery.ts
@@ -1,34 +1,57 @@
 /**
  * Restore-drill harness for the apps tenant Postgres off-host backups
- * (#21729). Consumes one dated backup set produced by the node's
- * tenant-db-backup timer (encrypted archive + plaintext sidecar), verifies
- * archive integrity and freshness, decrypts and checksums the contents, and
- * plans/executes a restore into an ISOLATED verification target — never the
- * production node. Emits a redacted JSON drill report with measured RPO
- * (backup age) and RTO (restore duration) against the declared objectives.
+ * (#21729, authority redesign #23453). Consumes one dated backup set
+ * produced by the node's tenant-db-backup timer (encrypted archive +
+ * plaintext sidecar), verifies archive integrity and freshness, decrypts and
+ * checksums the contents, and plans/executes a restore into an ISOLATED
+ * verification target — never the production node. Emits a redacted JSON
+ * drill report with measured RPO (backup age) and RTO (restore duration)
+ * against the declared objectives.
  *
- * Safety invariants: before any destructive SQL, the direct target must return
- * the operator's unique disposable-target identity from a server-side custom
- * setting; aliases and tunnels therefore cannot bypass the guard, and the
- * setting is consumed (ALTER SYSTEM RESET) in that same guarded session, so
- * a second run with the same identity fails closed rather than replaying it.
- * Isolation is proven by authenticating as every restored tenant role through
- * both direct Postgres and the isolated pgbouncer; a cross-tenant probe may
- * be refused either by Postgres's own CONNECT-privilege denial or by
- * pgbouncer's unlisted-database denial, depending on which layer sees it
- * first — both are treated as the isolation guarantee holding. DSNs,
- * credentials, and tenant names never reach reports or logs (reports
- * reference truncated dump ids only).
+ * Authority model (#23453): destructive work is authorized by a signed,
+ * expiring capability (see restore-capability.ts) that pins exactly one
+ * archive sha256 to exactly one disposable target id. Before any destructive
+ * SQL the drill verifies the capability signature, the archive hash pin, and
+ * a server-side twin setting pair; every destructive session re-checks both
+ * settings through the psql guard; exclusivity is claimed transactionally
+ * (advisory lock + claim record) so two different capabilities cannot drive
+ * the same target; and both settings are consumed (ALTER SYSTEM RESET +
+ * reload + verified unset) only after the drill completes, so a completed
+ * drill's nonce is dead while a crashed drill's target remains recoverable
+ * within the capability TTL.
+ *
+ * RPO is derived from the manifest inside the encrypted, checksummed
+ * archive; the plaintext sidecar's timestamp is only a cross-check and a
+ * tampered or stale sidecar fails closed rather than understating data loss.
+ * The isolation proof is linear: each tenant authenticates to its own
+ * database through both direct Postgres and the isolated pgbouncer, an
+ * admin-side ACL assertion proves PUBLIC is denied and the owner granted on
+ * every restored database, and one pairwise cross-reject sample is retained
+ * as a cross-check. DSNs, credentials, and tenant names never reach reports
+ * or logs (reports reference truncated dump ids only).
  *
  * Usage (operator drill, needs openssl + tar + psql client tools):
+ *   ELIZA_RESTORE_CAPABILITY_KEY=... \
  *   bun packages/cloud/scripts/admin/apps-tenant-db-recovery.ts \
  *     --set-dir /path/to/downloaded/<stamp> \
- *     --target-dsn postgresql://postgres:...@127.0.0.1:5433/postgres \
+ *     --target-dsn postgresql://postgres:***@127.0.0.1:5433/postgres \
  *     --target-id drill-11111111-2222-4333-8444-555555555555 \
+ *     --capability-file /path/to/capability.txt \
  *     --pooler-endpoint 127.0.0.1:6432 \
  *     --tenant-probes-file /path/to/tenant-probes.json \
  *     --passphrase-file /path/to/passphrase \
  *     --rpo-hours 26 --rto-minutes 60 --output /tmp/drill-report.json
+ *
+ * Minting a capability (after downloading the set and hashing the archive):
+ *   ELIZA_RESTORE_CAPABILITY_KEY=... \
+ *   bun packages/cloud/scripts/admin/apps-tenant-db-recovery.ts mint \
+ *     --target-id drill-... --archive-sha256 <sha256> --ttl-minutes 120
+ *
+ * Target provisioning (operator, on the DISPOSABLE target only): set both
+ * twin settings before the drill, e.g.
+ *   ALTER SYSTEM SET eliza.restore_target_id = 'drill-...';
+ *   ALTER SYSTEM SET eliza.restore_capability = '<serialized capability>';
+ *   SELECT pg_reload_conf();
  */
 
 import { spawnSync } from "node:child_process";
@@ -43,29 +66,29 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { parseArgs } from "node:util";
+import {
+  assertRecoveryPointConsistency,
+  mintRestoreCapability,
+  parseRestoreCapability,
+  type RestoreCapability,
+  serializeRestoreCapability,
+  verifyRestoreCapability,
+} from "./restore-capability";
 
 const SHA256 = /^[a-f0-9]{64}$/;
 const DUMP_ID = /^[a-f0-9]{12}$/;
-export const REPORT_SCHEMA_VERSION = 1 as const;
+export const REPORT_SCHEMA_VERSION = 2 as const;
 
 const RESTORE_TARGET_ID =
   /^drill-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const PASSWORD_ENV = /^[A-Z][A-Z0-9_]*$/;
 export const POOLER_PORT = 6432;
-
-/**
- * Fail-closed containment for the merged restore orchestrator. The current
- * one-use target marker is cleared before the later guarded restore sessions,
- * and the remaining authority/evidence contracts require a redesign backed by
- * a real disposable Postgres and pgbouncer canary. Keep parsing helpers
- * available to tests, but refuse every destructive drill invocation.
- */
-export function assertRestoreDrillExecutionEnabled(): void {
-  throw new RecoveryDrillError(
-    "RESTORE_DRILL_DISABLED",
-    "tenant restore drills are disabled pending a verified destructive-authority redesign",
-  );
-}
+/** Server-side twin settings: the disposable target id and its capability. */
+const SETTING_TARGET_ID = "eliza.restore_target_id";
+const SETTING_CAPABILITY = "eliza.restore_capability";
+/** Advisory key serializing capability claims against one restore target. */
+export const DRILL_ADVISORY_LOCK_KEY = 0x4552_5a44;
+const SIGNING_KEY_ENV = "ELIZA_RESTORE_CAPABILITY_KEY";
 
 export class RecoveryDrillError extends Error {
   readonly code: string;
@@ -278,6 +301,8 @@ export function assertRestoreTargetIdentity(
 
 export interface RestoreTargetAuthority {
   targetId: string;
+  /** Server-side twin of the serialized capability envelope; '' when unset. */
+  capability: string;
   existingRoles: string[];
 }
 
@@ -304,6 +329,7 @@ export function parseRestoreTargetAuthority(
   const record = raw as Record<string, unknown>;
   if (
     typeof record.target_id !== "string" ||
+    typeof record.capability !== "string" ||
     !Array.isArray(record.existing_roles) ||
     record.existing_roles.some((role) => typeof role !== "string")
   ) {
@@ -314,6 +340,7 @@ export function parseRestoreTargetAuthority(
   }
   return {
     targetId: record.target_id,
+    capability: record.capability,
     existingRoles: record.existing_roles as string[],
   };
 }
@@ -352,35 +379,121 @@ export function assertNoGlobalRoleCollisions(
   }
 }
 
+/**
+ * Every artifact the drill consumes must be checksummed. The manifest is the
+ * authenticated RPO source and globals.sql/dbmap/dumps are executed against
+ * the target, so an archive whose checksums omit any of them would run
+ * unverified bytes (#23453). Dump ids come from the (checksummed) dbmap.
+ */
+export function assertChecksumCoverage(
+  entries: ChecksumEntry[],
+  dumpIds: string[],
+): void {
+  const listed = new Set(entries.map((entry) => entry.file));
+  const required = [
+    "manifest.json",
+    "globals.sql",
+    "dbmap.tsv",
+    ...dumpIds.map((dumpId) => `dumps/${dumpId}.dump`),
+  ];
+  const missing = required.filter((file) => !listed.has(file));
+  if (missing.length > 0) {
+    throw new RecoveryDrillError(
+      "INVALID_METADATA",
+      `checksums.sha256 does not cover required archive artifacts: ${missing.join(", ")}`,
+    );
+  }
+}
+
+/**
+ * Probe roles must come from the archive's authenticated role inventory, not
+ * from the operator-local (unauthenticated) probes file: globals.sql is
+ * checksummed inside the encrypted archive, so its CREATE ROLE set is the
+ * only trustworthy owner list (#23453).
+ */
+export function assertProbesCoverArchiveRoles(
+  probes: TenantProbe[],
+  archiveRoles: string[],
+): void {
+  const authenticated = new Set(archiveRoles);
+  const unauthenticated = probes
+    .filter((probe) => !authenticated.has(probe.role))
+    .map((probe) => probe.dumpId);
+  if (unauthenticated.length > 0) {
+    throw new RecoveryDrillError(
+      "INVALID_PROBE_METADATA",
+      `tenant probe names a role absent from the archive's globals.sql (dump=${unauthenticated.join(",")})`,
+    );
+  }
+}
+
 const TARGET_GUARD_SQL = `\\set ON_ERROR_STOP on
-SELECT COALESCE(current_setting('eliza.restore_target_id', true) = :'expected_target_id', false) AS eliza_restore_target_ok \\gset
+SELECT (COALESCE(current_setting('${SETTING_TARGET_ID}', true), '') = :'expected_target_id' AND COALESCE(current_setting('${SETTING_CAPABILITY}', true), '') = :'expected_capability') AS eliza_restore_target_ok \\gset
 \\if :eliza_restore_target_ok
 \\else
-\\echo 'restore target identity mismatch'
-DO $$ BEGIN RAISE EXCEPTION 'restore target identity mismatch'; END $$;
+\\echo 'restore target authority mismatch'
+DO $$ BEGIN RAISE EXCEPTION 'restore target authority mismatch'; END $$;
 \\endif
 `;
 
-/** Guard one psql session before its first destructive statement. */
+/**
+ * Guard one psql session before its first destructive statement. Both twin
+ * settings — the disposable target id and the serialized capability — must
+ * still be present and exactly equal (supplied via psql --set variables at
+ * invocation), so every destructive session of the drill is individually
+ * authority-checked.
+ */
 export function guardPsqlScript(sql: string): string {
   return `${TARGET_GUARD_SQL}${sql}`;
 }
 
-const CONSUME_TARGET_IDENTITY_SQL = `ALTER SYSTEM RESET eliza.restore_target_id;
+const CONSUME_AUTHORITY_SQL = `ALTER SYSTEM RESET ${SETTING_TARGET_ID};
+ALTER SYSTEM RESET ${SETTING_CAPABILITY};
 SELECT pg_reload_conf();
 `;
 
 /**
- * Guarded script that spends the disposable target identity: it re-checks
- * the nonce through the same guard used for every destructive statement,
- * then clears it in that same session. "One-use" was previously operator
- * convention only — nothing consumed the setting, so a second run (a re-drill
- * against a stale downloaded set, an operator mistake, or a racing process)
- * could replay the same identity. After this runs, `current_setting` returns
- * unset and the very next authority read fails closed.
+ * Guarded script that spends the target authority at the END of the drill:
+ * it re-checks both twin settings through the same guard used for every
+ * destructive statement, then clears both and reloads. After this runs,
+ * `current_setting` returns unset for both and the very next authority read
+ * fails closed, so a completed drill cannot be replayed. A failed drill does
+ * NOT consume the settings — the disposable target stays recoverable for an
+ * idempotent re-run inside the capability TTL.
  */
-export function guardedConsumeTargetIdentitySql(): string {
-  return guardPsqlScript(CONSUME_TARGET_IDENTITY_SQL);
+export function guardedConsumeAuthoritySql(): string {
+  return guardPsqlScript(CONSUME_AUTHORITY_SQL);
+}
+
+/**
+ * Transactional exclusivity claim, taken before the first destructive
+ * statement: under the drill advisory lock, a one-row claim record refuses a
+ * DIFFERENT capability against the same target while remaining idempotent
+ * for the same capability (crash recovery re-runs).
+ */
+export function buildClaimExclusivitySql(
+  capability: RestoreCapability,
+): string {
+  const claimId = createHash("sha256")
+    .update(serializeRestoreCapability(capability))
+    .digest("hex");
+  return guardPsqlScript(
+    `BEGIN;
+SELECT pg_advisory_xact_lock(${DRILL_ADVISORY_LOCK_KEY});
+CREATE TABLE IF NOT EXISTS public.eliza_restore_drill_claim (
+  capability_sha256 text PRIMARY KEY,
+  claimed_at timestamptz NOT NULL DEFAULT now()
+);
+DO $$ BEGIN
+  IF EXISTS (SELECT 1 FROM public.eliza_restore_drill_claim WHERE capability_sha256 <> '${claimId}') THEN
+    RAISE EXCEPTION 'a different restore capability already claims this target';
+  END IF;
+END $$;
+DELETE FROM public.eliza_restore_drill_claim WHERE capability_sha256 = '${claimId}';
+INSERT INTO public.eliza_restore_drill_claim (capability_sha256) VALUES ('${claimId}');
+COMMIT;
+`,
+  );
 }
 
 /** Quote an archive-provided PostgreSQL identifier for generated drill SQL. */
@@ -638,10 +751,11 @@ export function evaluateObjectives(
 }
 
 /**
- * Post-restore isolation probes, mirroring the production boundary: each
- * tenant role must connect to its own database and be REJECTED connecting to
- * every other tenant database. Returns check descriptors keyed by dump id so
- * the report never carries tenant names.
+ * Linear isolation plan (#23453): one own-connect per tenant through both
+ * surfaces, plus ONE pairwise cross-reject sample (the first two tenants)
+ * retained as a cross-check of the ACL assertion. Cross-tenant denial for
+ * the remaining pairs is proven by the admin-side ACL assertion instead of
+ * O(n^2) probe pairs.
  */
 export interface IsolationCheck {
   kind: "own-connect" | "cross-reject";
@@ -650,21 +764,17 @@ export interface IsolationCheck {
 }
 
 export function buildIsolationChecks(entries: DbMapEntry[]): IsolationCheck[] {
-  const checks: IsolationCheck[] = [];
-  for (const subject of entries) {
+  const checks: IsolationCheck[] = entries.map((entry) => ({
+    kind: "own-connect" as const,
+    subjectDumpId: entry.dumpId,
+    objectDumpId: entry.dumpId,
+  }));
+  if (entries.length >= 2) {
     checks.push({
-      kind: "own-connect",
-      subjectDumpId: subject.dumpId,
-      objectDumpId: subject.dumpId,
+      kind: "cross-reject",
+      subjectDumpId: entries[0].dumpId,
+      objectDumpId: entries[1].dumpId,
     });
-    for (const object of entries) {
-      if (object.dumpId === subject.dumpId) continue;
-      checks.push({
-        kind: "cross-reject",
-        subjectDumpId: subject.dumpId,
-        objectDumpId: object.dumpId,
-      });
-    }
   }
   return checks;
 }
@@ -673,6 +783,7 @@ export interface CliOptions {
   setDir: string;
   targetDsn: string;
   targetId: string;
+  capabilityFile: string;
   poolerEndpoint: PgEndpoint;
   tenantProbesFile: string;
   passphraseFile: string;
@@ -688,6 +799,7 @@ export function parseCliArgs(argv: string[]): CliOptions {
       "set-dir": { type: "string" },
       "target-dsn": { type: "string" },
       "target-id": { type: "string" },
+      "capability-file": { type: "string" },
       "pooler-endpoint": { type: "string" },
       "tenant-probes-file": { type: "string" },
       "passphrase-file": { type: "string" },
@@ -699,6 +811,7 @@ export function parseCliArgs(argv: string[]): CliOptions {
   const setDir = values["set-dir"];
   const targetDsn = values["target-dsn"];
   const targetId = values["target-id"];
+  const capabilityFile = values["capability-file"];
   const poolerEndpoint = values["pooler-endpoint"];
   const tenantProbesFile = values["tenant-probes-file"];
   const passphraseFile = values["passphrase-file"];
@@ -706,13 +819,14 @@ export function parseCliArgs(argv: string[]): CliOptions {
     !setDir ||
     !targetDsn ||
     !targetId ||
+    !capabilityFile ||
     !poolerEndpoint ||
     !tenantProbesFile ||
     !passphraseFile
   ) {
     throw new RecoveryDrillError(
       "INVALID_ARGS",
-      "required: --set-dir, --target-dsn, --target-id, --pooler-endpoint, --tenant-probes-file, and --passphrase-file",
+      "required: --set-dir, --target-dsn, --target-id, --capability-file, --pooler-endpoint, --tenant-probes-file, and --passphrase-file",
     );
   }
   assertRestoreTargetIdentity(targetId, targetId);
@@ -733,6 +847,7 @@ export function parseCliArgs(argv: string[]): CliOptions {
     setDir,
     targetDsn,
     targetId,
+    capabilityFile,
     poolerEndpoint: parsePoolerEndpoint(poolerEndpoint),
     tenantProbesFile,
     passphraseFile,
@@ -838,15 +953,26 @@ interface DrillReport {
   archiveBytes: number;
   databaseCount: number;
   checksummedFiles: number;
-  isolation: { total: number; passed: number };
+  isolation: { total: number; passed: number; plan: string };
+  /** Where the RPO input came from — always the authenticated manifest. */
+  rpoSource: "manifest";
   objectives: ObjectiveEvaluation & RecoveryObjectives;
 }
 
+function readSigningKey(): string {
+  const key = process.env[SIGNING_KEY_ENV];
+  if (key === undefined || key === "") {
+    throw new RecoveryDrillError(
+      "MISSING_SIGNING_KEY",
+      `${SIGNING_KEY_ENV} must be set to the restore-capability signing key`,
+    );
+  }
+  return key;
+}
+
 /**
- * Read the server-side target authority for one guarded session. Split out
- * so the initial read and the immediately-following consume step
- * (`consumeRestoreTargetIdentity`) are visibly one verify-then-spend
- * sequence rather than an unconsumed read.
+ * Read the server-side target authority for one guarded session: both twin
+ * settings plus the role inventory.
  */
 function readRestoreTargetAuthority(targetDsn: string): RestoreTargetAuthority {
   return parseRestoreTargetAuthority(
@@ -859,29 +985,130 @@ function readRestoreTargetAuthority(targetDsn: string): RestoreTargetAuthority {
       "--dbname",
       targetDsn,
       "--command",
-      "SELECT json_build_object('target_id', current_setting('eliza.restore_target_id', true), 'existing_roles', (SELECT json_agg(rolname ORDER BY rolname) FROM pg_roles))::text",
+      `SELECT json_build_object('target_id', COALESCE(current_setting('${SETTING_TARGET_ID}', true), ''), 'capability', COALESCE(current_setting('${SETTING_CAPABILITY}', true), ''), 'existing_roles', (SELECT json_agg(rolname ORDER BY rolname) FROM pg_roles))::text`,
     ]).trim(),
   );
 }
 
 /**
- * Spend the one-use nonce: the guard re-verifies it server-side, then clears
- * it in the same session (see `guardedConsumeTargetIdentitySql`). Runs
- * before any destructive statement, immediately after the identity is
- * confirmed, so the window in which the nonce is valid but not yet consumed
- * is exactly one guarded round trip.
+ * Verify the full authority chain before any destructive work: the
+ * capability file's signature, its expiry, the server-returned target id,
+ * and byte-for-byte equality between the client capability and the
+ * server-side twin. Exported so the reuse/refusal behavior is directly
+ * testable against a scripted psql double (see the nonce suite).
  */
-function consumeRestoreTargetIdentity(
+export function verifyRestoreAuthority(
   targetDsn: string,
   targetId: string,
+  capability: RestoreCapability,
+  signingKey: string,
+  nowEpochMs: number,
+): RestoreTargetAuthority {
+  const authority = readRestoreTargetAuthority(targetDsn);
+  assertRestoreTargetIdentity(targetId, authority.targetId);
+  const twin = authority.capability;
+  if (twin === "" || twin !== serializeRestoreCapability(capability)) {
+    throw new RecoveryDrillError(
+      "REFUSED_TARGET_AUTHORITY",
+      "target did not return the matching restore capability twin",
+    );
+  }
+  verifyRestoreCapability(capability, signingKey, nowEpochMs);
+  return authority;
+}
+
+/**
+ * Spend the target authority at the end of a completed drill: guarded on
+ * both twin settings, reset both, reload, then re-read and require both to
+ * be unset. The re-read is part of the same exported sequence so a half-run
+ * consumption cannot masquerade as success.
+ */
+export function consumeRestoreAuthority(
+  targetDsn: string,
+  targetId: string,
+  capability: RestoreCapability,
   work: string,
 ): void {
-  const script = join(work, "consume-target-identity.sql");
-  writeFileSync(script, guardedConsumeTargetIdentitySql());
+  const script = join(work, "consume-authority.sql");
+  writeFileSync(script, guardedConsumeAuthoritySql());
   run("psql", [
     "--no-psqlrc",
     "--set",
     `expected_target_id=${targetId}`,
+    "--set",
+    `expected_capability=${serializeRestoreCapability(capability)}`,
+    "--dbname",
+    targetDsn,
+    "--file",
+    script,
+  ]);
+  const after = readRestoreTargetAuthority(targetDsn);
+  if (after.targetId !== "" || after.capability !== "") {
+    throw new RecoveryDrillError(
+      "REFUSED_TARGET_AUTHORITY",
+      "target authority was not fully consumed (settings still present after reset)",
+    );
+  }
+}
+
+/** Admin-side linear isolation assertion for one restored database. */
+function assertTenantAcl(
+  targetDsn: string,
+  database: string,
+  ownerRole: string,
+): void {
+  // OID 0 is the canonical way to probe PUBLIC's privilege (role "PUBLIC"
+  // does not exist as a pg_roles row). Variables are supplied on stdin:
+  // psql -c does not interpolate :'var', but stdin scripts do.
+  const out = run(
+    "psql",
+    [
+      "--no-psqlrc",
+      "--tuples-only",
+      "--no-align",
+      "--set",
+      "ON_ERROR_STOP=1",
+      "--set",
+      `db=${database}`,
+      "--set",
+      `owner=${ownerRole}`,
+      "--dbname",
+      targetDsn,
+    ],
+    {
+      input:
+        "SELECT json_build_object('public_connect', has_database_privilege(0, :'db', 'CONNECT'), 'owner_connect', has_database_privilege(:'owner', :'db', 'CONNECT'))::text",
+    },
+  ).trim();
+  let parsed: { public_connect?: unknown; owner_connect?: unknown };
+  try {
+    parsed = JSON.parse(out) as typeof parsed;
+  } catch {
+    throw new RecoveryDrillError(
+      "ISOLATION_VIOLATION",
+      "target ACL assertion response was not valid JSON",
+    );
+  }
+  if (parsed.public_connect !== false || parsed.owner_connect !== true) {
+    throw new RecoveryDrillError(
+      "ISOLATION_VIOLATION",
+      "restored database ACL does not deny PUBLIC and grant the owner",
+    );
+  }
+}
+
+function guardedPsqlFile(
+  targetDsn: string,
+  targetId: string,
+  capability: string,
+  script: string,
+): void {
+  run("psql", [
+    "--no-psqlrc",
+    "--set",
+    `expected_target_id=${targetId}`,
+    "--set",
+    `expected_capability=${capability}`,
     "--dbname",
     targetDsn,
     "--file",
@@ -889,35 +1116,37 @@ function consumeRestoreTargetIdentity(
   ]);
 }
 
-/**
- * Verify the disposable target identity and consume it atomically as one
- * guarded sequence. Exported so the reuse-rejection behavior is directly
- * testable against a scripted psql double (see the "restore target nonce"
- * describe block): a second call with the same target id observes the
- * cleared setting and fails REFUSED_TARGET_AUTHORITY, not TOOL_FAILED —
- * matching the refusal shape a genuine unauthorized target already gets.
- */
-export function verifyAndConsumeRestoreTargetIdentity(
-  targetDsn: string,
-  targetId: string,
-  work: string,
-): RestoreTargetAuthority {
-  const authority = readRestoreTargetAuthority(targetDsn);
-  assertRestoreTargetIdentity(targetId, authority.targetId);
-  consumeRestoreTargetIdentity(targetDsn, targetId, work);
-  return authority;
-}
-
 /** Execute the full drill. Requires openssl, tar, psql, pg_restore on PATH. */
 export function executeDrill(options: CliOptions): DrillReport {
-  assertRestoreDrillExecutionEnabled();
-  const targetUrl = assertDirectTarget(options.targetDsn);
-  const work = mkdtempSync(join(tmpdir(), "tenant-db-drill-"));
+  const signingKey = readSigningKey();
+  let capabilityText: string;
   try {
-    const authority = verifyAndConsumeRestoreTargetIdentity(
+    capabilityText = readFileSync(options.capabilityFile, "utf-8").trim();
+  } catch (cause) {
+    throw new RecoveryDrillError(
+      "INVALID_ARGS",
+      `--capability-file could not be read: ${(cause as Error).message}`,
+    );
+  }
+  const capability = parseRestoreCapability(capabilityText);
+  verifyRestoreCapability(capability, signingKey, Date.now());
+  if (capability.targetId !== options.targetId) {
+    throw new RecoveryDrillError(
+      "REFUSED_TARGET_AUTHORITY",
+      "capability does not pin the requested target id",
+    );
+  }
+  const targetUrl = assertDirectTarget(options.targetDsn);
+  const capabilityEnvelope = serializeRestoreCapability(capability);
+  const work = mkdtempSync(join(tmpdir(), "tenant-db-drill-"));
+  let consumed = false;
+  try {
+    const authority = verifyRestoreAuthority(
       options.targetDsn,
       options.targetId,
-      work,
+      capability,
+      signingKey,
+      Date.now(),
     );
     const startedAt = new Date();
 
@@ -941,6 +1170,23 @@ export function executeDrill(options: CliOptions): DrillReport {
         "downloaded archive sha256 differs from sidecar",
       );
     }
+    if (actualSha !== capability.archiveSha256) {
+      throw new RecoveryDrillError(
+        "REFUSED_ARCHIVE_MISMATCH",
+        "archive on disk is not the archive pinned by the restore capability",
+      );
+    }
+
+    // Transactional exclusivity: refuse a different capability on this target
+    // before any destructive statement runs.
+    const claimScript = join(work, "claim-exclusivity.sql");
+    writeFileSync(claimScript, buildClaimExclusivitySql(capability));
+    guardedPsqlFile(
+      options.targetDsn,
+      options.targetId,
+      capabilityEnvelope,
+      claimScript,
+    );
 
     run("openssl", [
       "enc",
@@ -967,11 +1213,19 @@ export function executeDrill(options: CliOptions): DrillReport {
         "manifest/sidecar database_count mismatch",
       );
     }
+    // Authenticated recovery point: the manifest inside the encrypted,
+    // checksummed archive is authoritative; a drifted or future-dated
+    // sidecar/manifest pair fails closed instead of understating loss.
+    assertRecoveryPointConsistency({
+      sidecarCreatedAt: sidecar.createdAt,
+      manifestCreatedAt: manifest.createdAt,
+      nowEpochMs: Date.now(),
+    });
     const checksums = parseChecksumFile(
       readFileSync(join(work, "checksums.sha256"), "utf-8"),
     );
-    const checksummedFiles = verifyChecksums(work, checksums);
     const globalsSql = readFileSync(join(work, "globals.sql"), "utf-8");
+    const archiveRoles = parseGlobalRoleNames(globalsSql);
     assertNoGlobalRoleCollisions(globalsSql, authority.existingRoles);
     const dbMap = parseDbMap(readFileSync(join(work, "dbmap.tsv"), "utf-8"));
     if (dbMap.length !== manifest.databaseCount) {
@@ -980,11 +1234,25 @@ export function executeDrill(options: CliOptions): DrillReport {
         "dbmap entry count differs from manifest database_count",
       );
     }
+    // Checksum coverage is a load-bearing assumption: the manifest is the
+    // authenticated RPO source and globals.sql/dbmap/dumps are executed, so
+    // every consumed artifact must be listed — an archive whose checksums
+    // omit them would run unverified bytes (#23453).
+    assertChecksumCoverage(
+      checksums,
+      dbMap.map((entry) => entry.dumpId),
+    );
+    const checksummedFiles = verifyChecksums(work, checksums);
 
     const probes = parseTenantProbes(
       readFileSync(options.tenantProbesFile, "utf-8"),
       dbMap,
     );
+    // The probes file is operator-local and unauthenticated; the archive's
+    // globals.sql is the authenticated role inventory. A probe naming a role
+    // absent from globals.sql would let a tampered probes file decide who
+    // owns (and can CONNECT to) every restored database (#23453).
+    assertProbesCoverArchiveRoles(probes, archiveRoles);
     const probeById = new Map(probes.map((probe) => [probe.dumpId, probe]));
     const passwords = new Map<string, string>();
     for (const probe of probes) {
@@ -1001,15 +1269,12 @@ export function executeDrill(options: CliOptions): DrillReport {
     const restoreStart = Date.now();
     const guardedGlobals = join(work, "guarded-globals.sql");
     writeFileSync(guardedGlobals, guardPsqlScript(globalsSql));
-    run("psql", [
-      "--no-psqlrc",
-      "--set",
-      `expected_target_id=${options.targetId}`,
-      "--dbname",
+    guardedPsqlFile(
       options.targetDsn,
-      "--file",
+      options.targetId,
+      capabilityEnvelope,
       guardedGlobals,
-    ]);
+    );
     for (const entry of dbMap) {
       const dumpFile = join(work, "dumps", `${entry.dumpId}.dump`);
       const probe = probeById.get(entry.dumpId);
@@ -1034,15 +1299,12 @@ export function executeDrill(options: CliOptions): DrillReport {
           ].join("\n"),
         ),
       );
-      run("psql", [
-        "--no-psqlrc",
-        "--set",
-        `expected_target_id=${options.targetId}`,
-        "--dbname",
+      guardedPsqlFile(
         options.targetDsn,
-        "--file",
+        options.targetId,
+        capabilityEnvelope,
         guardedDrop,
-      ]);
+      );
       const rawRestore = join(work, `${entry.dumpId}.restore.sql`);
       run("pg_restore", ["--file", rawRestore, dumpFile]);
       const guardedRestore = join(work, `${entry.dumpId}.guarded-restore.sql`);
@@ -1054,6 +1316,8 @@ export function executeDrill(options: CliOptions): DrillReport {
         "--no-psqlrc",
         "--set",
         `expected_target_id=${options.targetId}`,
+        "--set",
+        `expected_capability=${capabilityEnvelope}`,
         "--dbname",
         targetDatabaseDsn(options.targetDsn, entry.databaseName),
         "--file",
@@ -1106,7 +1370,7 @@ export function executeDrill(options: CliOptions): DrillReport {
               "--set",
               "ON_ERROR_STOP=1",
               "--command",
-              "SELECT current_user || '|' || current_database() || '|' || current_setting('eliza.restore_target_id', true)",
+              `SELECT current_user || '|' || current_database() || '|' || current_setting('${SETTING_TARGET_ID}', true)`,
             ],
             { env },
           ).trim();
@@ -1135,9 +1399,22 @@ export function executeDrill(options: CliOptions): DrillReport {
         passed += 1;
       }
     }
+    // Linear admin-side isolation proof: PUBLIC denied, owner granted, for
+    // every restored database — replaces the remaining O(n^2) probe pairs.
+    for (const entry of dbMap) {
+      const probe = probeById.get(entry.dumpId);
+      if (probe === undefined) {
+        throw new RecoveryDrillError(
+          "INVALID_PROBE_METADATA",
+          "ACL assertion references unknown dump id",
+        );
+      }
+      assertTenantAcl(options.targetDsn, entry.databaseName, probe.role);
+      passed += 1;
+    }
 
     const objectives = evaluateObjectives(
-      sidecar.createdAt,
+      manifest.createdAt,
       startedAt,
       restoreSeconds,
       {
@@ -1146,7 +1423,7 @@ export function executeDrill(options: CliOptions): DrillReport {
       },
     );
 
-    return {
+    const report: DrillReport = {
       schemaVersion: REPORT_SCHEMA_VERSION,
       startedAt: startedAt.toISOString(),
       target: redactDsn(options.targetDsn),
@@ -1154,28 +1431,93 @@ export function executeDrill(options: CliOptions): DrillReport {
       archiveBytes: sidecar.archiveBytes,
       databaseCount: sidecar.databaseCount,
       checksummedFiles,
-      isolation: { total: checks.length * surfaces.length, passed },
+      isolation: {
+        total: checks.length * surfaces.length + dbMap.length,
+        passed,
+        plan: "linear",
+      },
+      rpoSource: "manifest",
       objectives: {
         ...objectives,
         rpoHours: options.rpoHours,
         rtoMinutes: options.rtoMinutes,
       },
     };
+
+    // Success path only: spend the authority so the completed drill cannot
+    // be replayed. A failed drill above leaves the target recoverable.
+    consumeRestoreAuthority(
+      options.targetDsn,
+      options.targetId,
+      capability,
+      work,
+    );
+    consumed = true;
+    return report;
   } finally {
-    // Decrypted tenant data must not outlive the drill.
+    // Decrypted tenant data must not outlive the drill. If consumption did
+    // not run (failure path), the target settings remain provisioned for an
+    // idempotent re-run inside the capability TTL — mirrored in stderr so
+    // operators see the recovery path without leaking secrets.
+    if (!consumed) {
+      process.stderr.write(
+        "drill failed before authority consumption; target settings remain for an idempotent re-run within the capability TTL\n",
+      );
+    }
     rmSync(work, { recursive: true, force: true });
   }
 }
 
-if (import.meta.main) {
-  const options = parseCliArgs(process.argv.slice(2));
-  const report = executeDrill(options);
-  const serialized = JSON.stringify(report, null, 2);
-  if (options.output !== undefined) {
-    writeFileSync(options.output, `${serialized}\n`);
+/** Mint a serialized restore capability (operator side, needs signing key). */
+export function runMintCommand(argv: string[]): string {
+  const { values } = parseArgs({
+    args: argv,
+    options: {
+      "target-id": { type: "string" },
+      "archive-sha256": { type: "string" },
+      "ttl-minutes": { type: "string", default: "120" },
+    },
+  });
+  const targetId = values["target-id"];
+  const archiveSha256 = values["archive-sha256"];
+  const ttlMinutes = Number(values["ttl-minutes"]);
+  if (!targetId || !archiveSha256) {
+    throw new RecoveryDrillError(
+      "INVALID_ARGS",
+      "mint requires --target-id and --archive-sha256",
+    );
   }
-  process.stdout.write(`${serialized}\n`);
-  if (!report.objectives.met) {
-    process.exitCode = 2;
+  if (!Number.isFinite(ttlMinutes) || ttlMinutes <= 0) {
+    throw new RecoveryDrillError(
+      "INVALID_ARGS",
+      "--ttl-minutes must be a positive number",
+    );
+  }
+  const signingKey = readSigningKey();
+  const minted = mintRestoreCapability({
+    signingKey,
+    targetId,
+    archiveSha256,
+    expiresAtEpochMs: Date.now() + Math.round(ttlMinutes * 60_000),
+  });
+  return serializeRestoreCapability(minted);
+}
+
+if (import.meta.main) {
+  const argv = process.argv.slice(2);
+  if (argv[0] === "mint") {
+    const serialized = runMintCommand(argv.slice(1));
+    process.stdout.write(`${serialized}\n`);
+  } else {
+    const options = parseCliArgs(argv);
+    const report = executeDrill(options);
+    const serialized = JSON.stringify(report, null, 2);
+    if (options.output !== undefined) {
+      writeFileSync(options.output, `${serialized}\n`);
+    }
+    process.stdout.write(`${serialized}\n`);
+    if (!report.objectives.met) {
+      process.exitCode = 2;
+    }
   }
 }

--- a/packages/cloud/scripts/admin/apps-tenant-db-recovery.ts
+++ b/packages/cloud/scripts/admin/apps-tenant-db-recovery.ts
@@ -54,12 +54,13 @@
  *   SELECT pg_reload_conf();
  */
 
-import { spawnSync, spawn } from "node:child_process";
 import type { ChildProcess } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
   copyFileSync,
   mkdtempSync,
+  openSync,
   readFileSync,
   rmSync,
   statSync,
@@ -88,8 +89,16 @@ export const POOLER_PORT = 6432;
 /** Server-side twin settings: the disposable target id and its capability. */
 const SETTING_TARGET_ID = "eliza.restore_target_id";
 const SETTING_CAPABILITY = "eliza.restore_capability";
-/** Advisory key serializing capability claims against one restore target. */
+/** Advisory key held as a SESSION lock by the drill process for the whole run. */
 export const DRILL_ADVISORY_LOCK_KEY = 0x4552_5a44;
+/**
+ * Distinct advisory key for the transactional claim record. It MUST differ
+ * from DRILL_ADVISORY_LOCK_KEY: the session lock is held by a dedicated
+ * connection while the claim runs in another session, and two sessions
+ * requesting the same advisory key would deadlock (session lock held by the
+ * holder blocks the claim's xact lock until the 24h hold expires).
+ */
+export const DRILL_CLAIM_LOCK_KEY = 0x4552_5a45;
 const SIGNING_KEY_ENV = "ELIZA_RESTORE_CAPABILITY_KEY";
 
 export class RecoveryDrillError extends Error {
@@ -520,7 +529,7 @@ export function buildClaimExclusivitySql(
     .digest("hex");
   return guardPsqlScript(
     `BEGIN;
-SELECT pg_advisory_xact_lock(${DRILL_ADVISORY_LOCK_KEY});
+SELECT pg_advisory_xact_lock(${DRILL_CLAIM_LOCK_KEY});
 CREATE TABLE IF NOT EXISTS public.eliza_restore_drill_claim (
   capability_sha256 text PRIMARY KEY,
   claimed_at timestamptz NOT NULL DEFAULT now()
@@ -1190,6 +1199,31 @@ function assertTenantAcl(
   }
 }
 
+/**
+ * Durable same-capability retry marker: true when the target's claim table
+ * holds a row for exactly this capability's serialized bytes. Role remnants
+ * are exempted from the clean-target collision check ONLY when this returns
+ * true — a fresh target carrying archive-named roles still refuses.
+ */
+export function targetHasDrillClaim(
+  targetDsn: string,
+  capabilityEnvelope: string,
+): boolean {
+  const claimId = createHash("sha256").update(capabilityEnvelope).digest("hex");
+  const out = run("psql", [
+    "--no-psqlrc",
+    "--tuples-only",
+    "--no-align",
+    "--set",
+    "ON_ERROR_STOP=1",
+    "--dbname",
+    targetDsn,
+    "--command",
+    `SELECT count(*) FROM public.eliza_restore_drill_claim WHERE capability_sha256 = '${claimId}'`,
+  ]).trim();
+  return Number(out) > 0;
+}
+
 /** Quote a value as a SQL string literal for generated drill SQL. */
 export function quoteSqlLiteral(value: string): string {
   return `'${value.replaceAll("'", "''")}'`;
@@ -1209,49 +1243,151 @@ export const DRILL_LOCK_SETTLE_MS = 1500;
 /** How long the lock-holder may sleep: bounded so a crashed drill (killed
  * holder) cannot pin the lock longer than the capability TTL ceiling. */
 export const DRILL_LOCK_MAX_SECONDS = 24 * 60 * 60;
+/** Handshake row the holder writes on successful lock acquisition. */
+export const DRILL_LOCK_HANDSHAKE = "drill-lock-held";
+/** Refusal sentinel: a granted lock exists elsewhere, so this holder exits. */
+export const DRILL_LOCK_REFUSED = "drill-lock-refused";
 
-export function acquireDrillLock(targetDsn: string): ChildProcess {
-  let stderrTail = "";
+export interface DrillLock {
+  child: ChildProcess;
+  handshakePath: string;
+}
+
+/**
+ * Acquire the whole-run session lock with a PROVEN handshake: the holder
+ * writes a sentinel row to stdout only after pg_try_advisory_lock succeeds,
+ * stdout is redirected to a file (no event-loop dependency), and acquisition
+ * is only reported after the sentinel bytes are observed AND the holder
+ * process is confirmed alive. A refused lock emits a distinct refusal
+ * sentinel and exits (its pg_sleep result never runs), so refusal is
+ * observable on disk and never mistaken for acquisition.
+ * The sentinel and the hold-sleep MUST be separate --command args: psql
+ * pipelines each -c as its own PQexec, so the sentinel row streams to
+ * stdout (and onto disk) only after its statement completes, before the
+ * 24h sleep starts. A single -c would buffer both statements' results
+ * until the sleep finished. And the refusal branch must be a string, not
+ * 1/0: Postgres constant-folds an untaken ELSE 1/0 at plan time (the
+ * CASE result type becomes integer, erroring before pg_try_advisory_lock
+ * even runs), which would deadlock the drill on every attempt.
+ */
+export function acquireDrillLock(
+  targetDsn: string,
+  handshakePath: string,
+): DrillLock {
+  // stdout of the holder is redirected to the handshake file: the sentinel
+  // row lands on disk the moment the lock is granted, independent of the
+  // node event loop.
+  const outFd = openSync(handshakePath, "w");
   const child = spawn(
     "psql",
     [
       "--no-psqlrc",
       "--quiet",
+      "--tuples-only",
+      "--no-align",
       "--set",
       "ON_ERROR_STOP=1",
       "--dbname",
       targetDsn,
       "--command",
-      `SELECT CASE WHEN pg_try_advisory_lock(${DRILL_ADVISORY_LOCK_KEY}) THEN true ELSE 1/0 END;\nSELECT pg_sleep(${DRILL_LOCK_MAX_SECONDS});`,
+      `SELECT CASE WHEN pg_try_advisory_lock(${DRILL_ADVISORY_LOCK_KEY}) THEN '${DRILL_LOCK_HANDSHAKE}' ELSE '${DRILL_LOCK_REFUSED}' END;`,
+      `SELECT pg_sleep(${DRILL_LOCK_MAX_SECONDS});`,
     ],
-    { stdio: ["ignore", "ignore", "pipe"] },
+    { stdio: ["ignore", outFd, "pipe"] },
   );
+  // Proof, not hope: poll the handshake file and the holder PID until the
+  // sentinel is on disk and the process still exists. A refused lock, bad
+  // DSN, or missing psql all exit before writing the sentinel.
+  const deadline = Date.now() + DRILL_LOCK_SETTLE_MS * 4;
+  let stderrTail = "";
   child.stderr?.on("data", (chunk: unknown) => {
     stderrTail = `${stderrTail}${String(chunk)}`.slice(-500);
   });
-  // Synchronous settle wait (Atomics.wait): a refused lock, bad DSN, or
-  // missing psql all surface as a fast process exit, which must be observed
-  // before the caller proceeds — a lock we are not holding must never let
-  // the drill start.
-  Atomics.wait(
-    new Int32Array(new SharedArrayBuffer(4)),
-    0,
-    0,
-    DRILL_LOCK_SETTLE_MS,
-  );
-  if (child.pid === undefined || child.exitCode !== null) {
+  let acquired = false;
+  while (Date.now() < deadline) {
+    Atomics.wait(
+      new Int32Array(new SharedArrayBuffer(4)),
+      0,
+      0,
+      DRILL_LOCK_SETTLE_MS / 4,
+    );
+    let observed = "";
+    try {
+      observed = readFileSync(handshakePath, "utf-8");
+    } catch {
+      // error-policy:J3 the sentinel file may not exist yet — keep polling.
+      observed = "";
+    }
+    if (observed.includes(DRILL_LOCK_HANDSHAKE)) {
+      acquired = true;
+      break;
+    }
+    if (observed.includes(DRILL_LOCK_REFUSED)) {
+      // Another session holds the advisory lock. The holder will exit on its
+      // own (ON_ERROR_STOP stops after the refusal row); no sentinel race.
+      child.kill("SIGKILL");
+      throw new RecoveryDrillError(
+        "LOCK_FAILED",
+        "drill lock is held by another session (refusal sentinel observed)",
+      );
+    }
+    // Holder died before writing the sentinel: the lock was NOT taken.
+    try {
+      if (child.pid !== undefined) process.kill(child.pid, 0);
+    } catch {
+      child.kill("SIGKILL");
+      throw new RecoveryDrillError(
+        "LOCK_FAILED",
+        `drill lock holder exited before confirming acquisition: ${stderrTail.trim().slice(0, 200)}`,
+      );
+    }
+  }
+  if (!acquired) {
     child.kill("SIGKILL");
     throw new RecoveryDrillError(
       "LOCK_FAILED",
-      `could not hold the drill advisory lock (psql exited early: ${stderrTail.trim().slice(0, 200)})`,
+      `drill lock acquisition was not confirmed within the settle window: ${stderrTail.trim().slice(0, 200)}`,
     );
   }
-  return child;
+  return { child, handshakePath };
 }
 
-export function releaseDrillLock(child: ChildProcess): void {
+/**
+ * Fail the drill if the lock holder has died mid-run: a released session
+ * lock means exclusivity no longer holds and destructive work must stop.
+ */
+export function assertDrillLockHeld(lock: DrillLock): void {
+  let observed = "";
+  try {
+    observed = readFileSync(lock.handshakePath, "utf-8");
+  } catch {
+    // error-policy:J3 a vanished sentinel means the holder is gone.
+    observed = "";
+  }
+  let alive = false;
+  try {
+    if (lock.child.pid !== undefined) process.kill(lock.child.pid, 0);
+    alive = true;
+  } catch {
+    alive = false;
+  }
+  if (!alive || !observed.includes(DRILL_LOCK_HANDSHAKE)) {
+    throw new RecoveryDrillError(
+      "LOCK_FAILED",
+      "drill lock holder exited mid-run; exclusivity no longer holds",
+    );
+  }
+}
+
+export function releaseDrillLock(lock: DrillLock): void {
   // SIGKILL drops the server session, which releases the session-level lock.
-  child.kill("SIGKILL");
+  lock.child.kill("SIGKILL");
+  try {
+    // error-policy:J6 best-effort cleanup of the handshake file.
+    rmSync(lock.handshakePath, { force: true });
+  } catch {
+    // error-policy:J6 handshake cleanup must not mask the drill outcome.
+  }
 }
 
 function guardedPsqlFile(
@@ -1353,11 +1489,22 @@ export function executeDrill(options: CliOptions): DrillReport {
     // Session-held exclusivity: a session-level advisory lock held on a
     // dedicated connection for the whole drill, plus the transactional claim,
     // so two drills against the same target cannot interleave destructive
-    // statements and consumption (#23453 review).
-    const lockConn = acquireDrillLock(options.targetDsn);
+    // statements and consumption (#23453 review). Acquisition is proven by a
+    // file handshake before any destructive work starts.
+    const drillLock = acquireDrillLock(
+      options.targetDsn,
+      join(work, "drill-lock-handshake.txt"),
+    );
     try {
+      // Expiry rechecked at the destructive boundary, immediately after the
+      // lock is proven held: a capability that expired during archive
+      // verification/hashing must not arm destructive SQL.
+      verifyRestoreCapability(capability, signingKey, Date.now());
+      assertDrillLockHeld(drillLock);
       // Transactional exclusivity: refuse a different capability on this target
-      // before any destructive statement runs.
+      // before any destructive statement runs. A durable claim record for
+      // THIS capability also marks the target as a same-capability retry, so
+      // role remnants from a failed prior run are exempted below.
       const claimScript = join(work, "claim-exclusivity.sql");
       writeFileSync(claimScript, buildClaimExclusivitySql(capability));
       guardedPsqlFile(
@@ -1365,6 +1512,10 @@ export function executeDrill(options: CliOptions): DrillReport {
         options.targetId,
         capabilityEnvelope,
         claimScript,
+      );
+      const isSameCapabilityRetry = targetHasDrillClaim(
+        options.targetDsn,
+        serializeRestoreCapability(capability),
       );
 
       run("openssl", [
@@ -1408,7 +1559,7 @@ export function executeDrill(options: CliOptions): DrillReport {
       assertNoGlobalRoleCollisions(
         globalsSql,
         authority.existingRoles,
-        archiveRoles,
+        isSameCapabilityRetry ? archiveRoles : [],
       );
       const dbMap = parseDbMap(readFileSync(join(work, "dbmap.tsv"), "utf-8"));
       if (dbMap.length !== manifest.databaseCount) {
@@ -1668,7 +1819,7 @@ export function executeDrill(options: CliOptions): DrillReport {
       return report;
     } finally {
       // Release the session-held drill lock before the workspace is cleaned.
-      releaseDrillLock(lockConn);
+      releaseDrillLock(drillLock);
     }
   } finally {
     // Decrypted tenant data must not outlive the drill. If consumption did

--- a/packages/cloud/scripts/admin/apps-tenant-db-recovery.ts
+++ b/packages/cloud/scripts/admin/apps-tenant-db-recovery.ts
@@ -47,11 +47,16 @@
  *   bun packages/cloud/scripts/admin/apps-tenant-db-recovery.ts mint \
  *     --target-id drill-... --archive-sha256 <sha256> --ttl-minutes 120
  *
- * Target provisioning (operator, on the DISPOSABLE target only): set both
- * twin settings before the drill, e.g.
- *   ALTER SYSTEM SET eliza.restore_target_id = 'drill-...';
- *   ALTER SYSTEM SET eliza.restore_capability = '<serialized capability>';
- *   SELECT pg_reload_conf();
+ * Target provisioning (operator, on the DISPOSABLE target only): the
+ * `provision` subcommand verifies a minted capability file and installs both
+ * twin settings. PostgreSQL 14 rejects ALTER SYSTEM SET for undeclared
+ * custom GUCs, so provisioning writes postgresql.auto.conf directly (the
+ * exact file ALTER SYSTEM SET itself writes), reloads, and verifies through
+ * a fresh session:
+ *   ELIZA_RESTORE_CAPABILITY_KEY=... \
+ *   bun packages/cloud/scripts/admin/apps-tenant-db-recovery.ts provision \
+ *     --target-dsn postgresql://postgres:***@127.0.0.1:5433/postgres \
+ *     --target-id drill-... --capability-file /path/to/capability.txt
  */
 
 import type { ChildProcess } from "node:child_process";
@@ -1524,6 +1529,17 @@ export function executeDrill(options: CliOptions): DrillReport {
       // drops any field divergence from the originally parsed envelope.
       capability = verifyRestoreCapability(capability, signingKey, Date.now());
       assertDrillLockHeld(drillLock);
+      // Expiry is re-proven before every destructive phase boundary, not
+      // once up front: a drill that outlives its capability must stop
+      // instead of continuing destructive work after expiry (#23453
+      // review).
+      const assertCapabilityLive = (): void => {
+        capability = verifyRestoreCapability(
+          capability,
+          signingKey,
+          Date.now(),
+        );
+      };
       // Transactional exclusivity: refuse a different capability on this target
       // before any destructive statement runs. Whether THIS capability already
       // claimed the target is read BEFORE the claim transaction runs — the
@@ -1630,6 +1646,7 @@ export function executeDrill(options: CliOptions): DrillReport {
       // session-lock holder dies mid-run, exclusivity no longer holds and the
       // remaining destructive statements must not run (#23453 review).
       assertDrillLockHeld(drillLock);
+      assertCapabilityLive();
       const guardedGlobals = join(work, "guarded-globals.sql");
       writeFileSync(
         guardedGlobals,
@@ -1653,6 +1670,7 @@ export function executeDrill(options: CliOptions): DrillReport {
         const databaseIdentifier = quoteSqlIdentifier(entry.databaseName);
         const ownerIdentifier = quoteSqlIdentifier(probe.role);
         assertDrillLockHeld(drillLock);
+        assertCapabilityLive();
         const guardedDrop = join(work, `${entry.dumpId}.drop.sql`);
         writeFileSync(
           guardedDrop,
@@ -1724,14 +1742,11 @@ export function executeDrill(options: CliOptions): DrillReport {
           );
         }
         for (const surface of surfaces) {
-          // Own-connect is proven on the direct surface only: the drill target
-          // is disposable, so its databases are deliberately absent from the
-          // pooler's routing config and an own-connect through the pooler can
-          // never succeed by design. The pooler surface still carries the
-          // cross-reject sample, which is the property it exists to prove.
-          if (check.kind === "own-connect" && surface.name !== "direct") {
-            continue;
-          }
+          // Own-connect runs through BOTH surfaces for every tenant: through
+          // the isolated pooler it doubles as the per-tenant routing
+          // assertion — a pooler mapping that pointed tenant A at tenant B's
+          // database (or a force_user mistake) fails the identity check even
+          // though the credentials are correct (#23453 review).
           const env = tenantConnectionEnv(
             surface.endpoint,
             objectDb,
@@ -1806,16 +1821,10 @@ export function executeDrill(options: CliOptions): DrillReport {
         },
       );
 
-      // Executed probe count: own-connect runs once (direct surface only);
-      // each cross-reject sample runs once per surface (direct + pooler);
-      // plus one admin-side ACL assertion per restored database.
-      const ownConnectCount = checks.filter(
-        (c) => c.kind === "own-connect",
-      ).length;
-      const total =
-        ownConnectCount +
-        (checks.length - ownConnectCount) * surfaces.length +
-        dbMap.length;
+      // Executed probe count: every own-connect and every cross-reject
+      // sample runs once per surface (direct + pooler); plus one admin-side
+      // ACL assertion per restored database.
+      const total = checks.length * surfaces.length + dbMap.length;
       const report: DrillReport = {
         schemaVersion: REPORT_SCHEMA_VERSION,
         startedAt: startedAt.toISOString(),
@@ -1839,6 +1848,11 @@ export function executeDrill(options: CliOptions): DrillReport {
 
       // Success path only: spend the authority so the completed drill cannot
       // be replayed. A failed drill above leaves the target recoverable.
+      // Consuming the authority is itself a destructive, irrevocable act on
+      // the target: it must be authorized by a still-live capability and a
+      // still-held lock, exactly like every other destructive phase.
+      assertDrillLockHeld(drillLock);
+      assertCapabilityLive();
       consumeRestoreAuthority(
         options.targetDsn,
         options.targetId,
@@ -1900,11 +1914,115 @@ export function runMintCommand(argv: string[]): string {
   return serializeRestoreCapability(minted);
 }
 
+/**
+ * Provision the twin settings on the DISPOSABLE drill target from a minted
+ * capability file. PostgreSQL 14 rejects ALTER SYSTEM SET for undeclared
+ * custom GUCs ("unrecognized configuration parameter"), so this writes both
+ * settings to postgresql.auto.conf — the exact file ALTER SYSTEM SET itself
+ * writes — and reloads. The write is idempotent (prior eliza.* lines are
+ * replaced) and verified through a FRESH session afterwards: a session
+ * opened before the reload may still hold the previous (unset) placeholder
+ * value.
+ */
+export function runProvisionCommand(
+  targetDsn: string,
+  targetId: string,
+  capabilityFile: string,
+): void {
+  const capabilityText = readFileSync(capabilityFile, "utf-8").trim();
+  const capability = verifyRestoreCapability(
+    parseRestoreCapability(capabilityText),
+    readSigningKey(),
+    Date.now(),
+  );
+  if (capability.targetId !== targetId) {
+    throw new RecoveryDrillError(
+      "INVALID_ARGS",
+      "capability target id does not match --target-id",
+    );
+  }
+  const dataDir = run("psql", [
+    "--no-psqlrc",
+    "--tuples-only",
+    "--no-align",
+    "--set",
+    "ON_ERROR_STOP=1",
+    "--dbname",
+    targetDsn,
+    "--command",
+    "SHOW data_directory",
+  ]).trim();
+  const autoConf = join(dataDir, "postgresql.auto.conf");
+  const current = readFileSync(autoConf, "utf-8");
+  const kept = current
+    .split("\n")
+    .filter(
+      (line: string) =>
+        !line.startsWith("eliza.restore_target_id") &&
+        !line.startsWith("eliza.restore_capability"),
+    );
+  kept.push(`eliza.restore_target_id = '${targetId}'`);
+  // The serialized capability contains no single quotes (pipe-delimited
+  // envelope over UUID/hex ids and a hex signature), so this literal is safe.
+  kept.push(`eliza.restore_capability = '${capabilityText}'`);
+  writeFileSync(autoConf, `${kept.join("\n").trimEnd()}\n`);
+  run("psql", [
+    "--no-psqlrc",
+    "--set",
+    "ON_ERROR_STOP=1",
+    "--dbname",
+    targetDsn,
+    "--command",
+    "SELECT pg_reload_conf()",
+  ]);
+  // Verify through a FRESH session: current_setting of an unset custom
+  // placeholder returns an empty string, so equality proves the reload
+  // landed for every future session, not just the pre-reload ones.
+  const observed = run("psql", [
+    "--no-psqlrc",
+    "--tuples-only",
+    "--no-align",
+    "--set",
+    "ON_ERROR_STOP=1",
+    "--dbname",
+    targetDsn,
+    "--command",
+    `SELECT COALESCE(current_setting('${SETTING_TARGET_ID}', true), '') || '|' || COALESCE(current_setting('${SETTING_CAPABILITY}', true), '')`,
+  ]).trim();
+  const expected = `${targetId}|${capabilityText}`;
+  if (observed !== expected) {
+    throw new RecoveryDrillError(
+      "REFUSED_TARGET_AUTHORITY",
+      "twin settings did not apply after reload (fresh-session verification failed)",
+    );
+  }
+}
+
 if (import.meta.main) {
   const argv = process.argv.slice(2);
   if (argv[0] === "mint") {
     const serialized = runMintCommand(argv.slice(1));
     process.stdout.write(`${serialized}\n`);
+  } else if (argv[0] === "provision") {
+    const { values } = parseArgs({
+      args: argv.slice(1),
+      options: {
+        "target-dsn": { type: "string" },
+        "target-id": { type: "string" },
+        "capability-file": { type: "string" },
+      },
+    });
+    const targetDsn = values["target-dsn"];
+    const targetId = values["target-id"];
+    const capabilityFile = values["capability-file"];
+    if (!targetDsn || !targetId || !capabilityFile) {
+      throw new RecoveryDrillError(
+        "INVALID_ARGS",
+        "provision requires --target-dsn, --target-id, and --capability-file",
+      );
+    }
+    runProvisionCommand(targetDsn, targetId, capabilityFile);
+    process.stderr.write("twin settings provisioned and verified\n");
   } else {
     const options = parseCliArgs(argv);
     const report = executeDrill(options);

--- a/packages/cloud/scripts/admin/apps-tenant-db-recovery.ts
+++ b/packages/cloud/scripts/admin/apps-tenant-db-recovery.ts
@@ -751,11 +751,11 @@ export function evaluateObjectives(
 }
 
 /**
- * Linear isolation plan (#23453): one own-connect per tenant through both
- * surfaces, plus ONE pairwise cross-reject sample (the first two tenants)
- * retained as a cross-check of the ACL assertion. Cross-tenant denial for
- * the remaining pairs is proven by the admin-side ACL assertion instead of
- * O(n^2) probe pairs.
+ * Linear isolation plan (#23453): one own-connect per tenant on the direct
+ * surface, plus ONE pairwise cross-reject sample (the first two tenants)
+ * through both surfaces, retained as a cross-check of the ACL assertion.
+ * Cross-tenant denial for the remaining pairs is proven by the admin-side
+ * ACL assertion instead of O(n^2) probe pairs.
  */
 export interface IsolationCheck {
   kind: "own-connect" | "cross-reject";
@@ -1354,6 +1354,14 @@ export function executeDrill(options: CliOptions): DrillReport {
         );
       }
       for (const surface of surfaces) {
+        // Own-connect is proven on the direct surface only: the drill target
+        // is disposable, so its databases are deliberately absent from the
+        // pooler's routing config and an own-connect through the pooler can
+        // never succeed by design. The pooler surface still carries the
+        // cross-reject sample, which is the property it exists to prove.
+        if (check.kind === "own-connect" && surface.name !== "direct") {
+          continue;
+        }
         const env = tenantConnectionEnv(
           surface.endpoint,
           objectDb,
@@ -1423,6 +1431,15 @@ export function executeDrill(options: CliOptions): DrillReport {
       },
     );
 
+    // Executed probe count: own-connect runs once (direct surface only);
+    // each cross-reject sample runs once per surface (direct + pooler);
+    // plus one admin-side ACL assertion per restored database.
+    const ownConnectCount = checks.filter((c) => c.kind === "own-connect")
+      .length;
+    const total =
+      ownConnectCount +
+      (checks.length - ownConnectCount) * surfaces.length +
+      dbMap.length;
     const report: DrillReport = {
       schemaVersion: REPORT_SCHEMA_VERSION,
       startedAt: startedAt.toISOString(),
@@ -1432,7 +1449,7 @@ export function executeDrill(options: CliOptions): DrillReport {
       databaseCount: sidecar.databaseCount,
       checksummedFiles,
       isolation: {
-        total: checks.length * surfaces.length + dbMap.length,
+        total,
         passed,
         plan: "linear",
       },

--- a/packages/cloud/scripts/admin/apps-tenant-db-recovery.ts
+++ b/packages/cloud/scripts/admin/apps-tenant-db-recovery.ts
@@ -517,7 +517,7 @@ function expiryGuardSql(expiresAtEpochMs: number): string {
       "capability expiry is not a safe positive epoch-millisecond value",
     );
   }
-  return `SELECT (floor(extract(epoch from (clock_timestamp() AT TIME ZONE 'utc'))) * 1000) <= ${expiresAtEpochMs} AS eliza_capability_live \\gset
+  return `SELECT (extract(epoch FROM clock_timestamp()) * 1000) <= ${expiresAtEpochMs} AS eliza_capability_live \\gset
 \\if :eliza_capability_live
 \\else
 \\echo 'restore capability has expired on the server clock'
@@ -1370,10 +1370,15 @@ export function acquireDrillLock(
       // A refused lock must NOT fall through to the hold-sleep: the refusal
       // sentinel is not a SQL error, so ON_ERROR_STOP does not stop psql and
       // the second --command WOULD execute — leaking a 24h pg_sleep backend
-      // with no lock to its name (#23453 review r4). The 1/0 division aborts
-      // the refused holder deterministically.
+      // with no lock to its name (#23453 review r4). A CASE cannot mix
+      // pg_sleep (void) with 1/0 (integer) — PG rejects "CASE types integer
+      // and void cannot be matched" and the holder would die even on
+      // SUCCESS, releasing the lock while the drill still relied on it
+      // (#23453 review r5). The DO block type-checks on both paths: it
+      // re-proves this session holds the advisory lock (aborting a refused
+      // holder before any sleep) and then holds it for the bounded window.
       "--command",
-      `SELECT CASE WHEN (SELECT count(*) FROM pg_locks WHERE locktype = 'advisory' AND classid = 0 AND objid = ${DRILL_ADVISORY_LOCK_KEY} AND objsubid = 1 AND pid = pg_backend_pid()) = 1 THEN pg_sleep(${DRILL_LOCK_MAX_SECONDS}) ELSE 1/0 END;`,
+      `DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_locks WHERE locktype = 'advisory' AND classid = 0 AND objid = ${DRILL_ADVISORY_LOCK_KEY} AND objsubid = 1 AND pid = pg_backend_pid()) THEN RAISE EXCEPTION 'drill lock lost before hold'; END IF; PERFORM pg_sleep(${DRILL_LOCK_MAX_SECONDS}); END $$;`,
     ],
     { stdio: ["ignore", outFd, "pipe"] },
   );
@@ -2170,22 +2175,57 @@ function claimProvisionLock(lockPath: string): ProvisionLockHandle {
     if (attempt > 0) {
       break;
     }
+    // Stale takeover by unique-target rename: the stale source and the
+    // unique destination form a claim on exactly ONE inode. If a competing
+    // provisioner renamed the same stale lock aside first, its rename
+    // removed the shared path's link and our rename fails ENOENT — no
+    // second contender can move (and later unlink) a FRESH lock, because a
+    // fresh lock at the shared path is young, never re-stale within this
+    // claim, and cannot be the source of a second rename while the age
+    // check holds. Rename over a non-empty directory or an existing
+    // destination fails with ENOTEMPTY/EEXIST, which also just breaks out
+    // to the held-lock refusal (#23453 review r5).
+    // error-policy:J6 a stale lock from a crashed holder is moved aside.
     const stale = statSync(lockPath, { throwIfNoEntry: false });
     if (
-      stale === undefined ||
-      Date.now() - stale.mtimeMs <= PROVISION_LOCK_STALE_MS
+      stale !== undefined &&
+      Date.now() - stale.mtimeMs > PROVISION_LOCK_STALE_MS
     ) {
-      break;
-    }
-    // Take the stale lock out of the way by renaming it aside: the rename
-    // is atomic and cannot remove a concurrently recreated lock at this
-    // path. The sidecar is left for the operator; it proves a crashed
-    // holder was superseded.
-    // error-policy:J6 a stale lock from a crashed holder is moved aside.
-    try {
-      renameSync(lockPath, `${lockPath}.stale-${Date.now()}`);
-    } catch {
-      // error-policy:J6 takeover failure surfaces as a held lock below.
+      let staleName = "";
+      try {
+        staleName = `${lockPath}.stale-${process.pid}-${Date.now()}`;
+        renameSync(lockPath, staleName);
+        // The renamed inode is provably the stale one we measured: a
+        // competing takeover that renamed the shared path first makes our
+        // rename fail; a FRESH lock created between our stat and rename
+        // cannot be our rename source because rename targets the path and
+        // the fresh lock would have to be >120s old to be re-classified
+        // stale — it is not.
+        const moved = statSync(staleName, { throwIfNoEntry: false });
+        if (
+          moved === undefined ||
+          moved.dev !== stale.dev ||
+          moved.ino !== stale.ino
+        ) {
+          // Someone else's file ended up at our unique destination —
+          // impossible by construction; refuse loudly rather than proceed.
+          throw new RecoveryDrillError(
+            "PROVISION_LOCK_FAILED",
+            "provision lock takeover moved an unexpected inode",
+          );
+        }
+        rmSync(staleName, { force: true });
+      } catch (error) {
+        const code = (error as { code?: string }).code;
+        if (code === "ENOENT" || code === "ENOTEMPTY" || code === "EEXIST") {
+          // A competing provisioner won the takeover race; our retry (or
+          // the held-lock refusal below) is correct.
+          break;
+        }
+        // error-policy:J6 other takeover failures surface as a held lock.
+        break;
+      }
+    } else {
       break;
     }
   }
@@ -2202,13 +2242,23 @@ function claimProvisionLock(lockPath: string): ProvisionLockHandle {
  */
 function releaseProvisionLock(handle: ProvisionLockHandle): void {
   try {
-    const current = statSync(handle.lockPath, { throwIfNoEntry: false });
+    // Identity-atomic release: rename the shared path to a name unique to
+    // this claim, then verify the moved inode is ours before discarding it.
+    // The rename claims exactly one inode — a successor's fresh lock at the
+    // shared path is a different inode; if the rename moved it (successor
+    // recreated the path between our checks), the inode mismatch below
+    // leaves the successor's lock parked at the unique name for recovery
+    // rather than deleting it, and the successor's own release (by ITS
+    // inode) never unlinks ours (#23453 review r5).
+    const movedName = `${handle.lockPath}.release-${process.pid}-${Date.now()}`;
+    renameSync(handle.lockPath, movedName);
+    const moved = statSync(movedName, { throwIfNoEntry: false });
     if (
-      current !== undefined &&
-      current.dev === handle.dev &&
-      current.ino === handle.ino
+      moved !== undefined &&
+      moved.dev === handle.dev &&
+      moved.ino === handle.ino
     ) {
-      rmSync(handle.lockPath, { force: true });
+      rmSync(movedName, { force: true });
     }
   } catch {
     // error-policy:J6 lock release must not mask the provisioning outcome.

--- a/packages/cloud/scripts/admin/apps-tenant-db-recovery.ts
+++ b/packages/cloud/scripts/admin/apps-tenant-db-recovery.ts
@@ -424,7 +424,7 @@ const CREATE_ROLE_RE = /(^|\n)CREATE ROLE ([a-z_][a-z0-9_$]*);\n?/g;
 export function makeGlobalsIdempotent(globalsSql: string): string {
   return globalsSql.replace(
     CREATE_ROLE_RE,
-    (match, lead: string, role: string) => {
+    (_match, lead: string, role: string) => {
       return `${lead}${[
         "DO $$",
         "BEGIN",
@@ -961,7 +961,7 @@ function run(
     }
     throw new RecoveryDrillError(
       "TOOL_FAILED",
-      `${command} exited ${result.status}`,
+      `${command} exited ${result.status}: ${result.stderr.slice(-400)}`,
     );
   }
   return result.stdout;
@@ -1558,25 +1558,20 @@ export function executeDrill(options: CliOptions): DrillReport {
           Date.now(),
         );
       };
-      // Transactional exclusivity: refuse a different capability on this target
-      // before any destructive statement runs. Whether THIS capability already
-      // claimed the target is read BEFORE the claim transaction runs — the
-      // claim script upserts the row, so asking after it would always answer
-      // true and exempt archive-named roles on fresh targets too.
+      // Same-capability retry detection is read BEFORE the claim transaction
+      // runs (the claim script upserts the row, so asking after it would
+      // always answer true), but the claim itself is PERSISTED ONLY AFTER the
+      // clean-target collision check below has passed (#23453 review r3): a
+      // first invocation that refuses a pre-existing archive-named role must
+      // not leave a claim behind that a retry would treat as a legitimate
+      // same-capability retry, exempting every archive role from collision
+      // checking and proceeding to ALTER ROLE.
       const capabilityEnvelopeLocal = serializeRestoreCapability(capability);
       assertCapabilityLive();
       assertDrillLockHeld(drillLock);
       const isSameCapabilityRetry = targetHasDrillClaim(
         options.targetDsn,
         capabilityEnvelopeLocal,
-      );
-      const claimScript = join(work, "claim-exclusivity.sql");
-      writeFileSync(claimScript, buildClaimExclusivitySql(capability));
-      guardedPsqlFile(
-        options.targetDsn,
-        options.targetId,
-        capabilityEnvelope,
-        claimScript,
       );
 
       run("openssl", [
@@ -1621,6 +1616,21 @@ export function executeDrill(options: CliOptions): DrillReport {
         globalsSql,
         authority.existingRoles,
         isSameCapabilityRetry ? archiveRoles : [],
+      );
+      // The clean-target collision check has now passed (or the retry
+      // exemption is legitimate): persist the claim. Liveness and lock hold
+      // are re-proven immediately before this destructive statement — the
+      // pre-claim read above is a network round trip that can cross expiry
+      // or lock loss (#23453 review r3).
+      assertCapabilityLive();
+      assertDrillLockHeld(drillLock);
+      const claimScript = join(work, "claim-exclusivity.sql");
+      writeFileSync(claimScript, buildClaimExclusivitySql(capability));
+      guardedPsqlFile(
+        options.targetDsn,
+        options.targetId,
+        capabilityEnvelope,
+        claimScript,
       );
       const dbMap = parseDbMap(readFileSync(join(work, "dbmap.tsv"), "utf-8"));
       if (dbMap.length !== manifest.databaseCount) {
@@ -1735,6 +1745,52 @@ export function executeDrill(options: CliOptions): DrillReport {
           targetDatabaseDsn(options.targetDsn, entry.databaseName),
           "--file",
           guardedRestore,
+        ]);
+        // Ownership handoff (#23453 review r3): the dumps are restored with
+        // --no-owner, so restored objects are owned by the restore
+        // administrator — CONNECT alone would not give the tenant access to
+        // its own restored data. Hand the database, the public schema, and
+        // every restored relation to the tenant role. REASSIGN OWNED BY
+        // CURRENT_USER would also touch system-required objects when the
+        // restore admin is a superuser, so ownership transfers relation by
+        // relation: psql's \gexec runs one generated ALTER per row, %I
+        // quotes every identifier, and :'owner' interpolates the role
+        // outside any dollar-quoted context.
+        const guardedHandoff = join(work, `${entry.dumpId}.handoff.sql`);
+        writeFileSync(
+          guardedHandoff,
+          guardPsqlScript(
+            [
+              `ALTER DATABASE ${databaseIdentifier} OWNER TO ${ownerIdentifier};`,
+              `ALTER SCHEMA public OWNER TO ${ownerIdentifier};`,
+              `GRANT ALL ON SCHEMA public TO ${ownerIdentifier};`,
+              `SELECT format('ALTER %s %I.%I OWNER TO %I',`,
+              `         CASE c.relkind WHEN 'r' THEN 'TABLE' WHEN 'p' THEN 'TABLE'`,
+              `              WHEN 'v' THEN 'VIEW' WHEN 'm' THEN 'MATERIALIZED VIEW'`,
+              `              WHEN 'S' THEN 'SEQUENCE' WHEN 'f' THEN 'FOREIGN TABLE' END,`,
+              `         n.nspname, c.relname, :'owner')`,
+              `  FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace`,
+              ` WHERE c.relkind IN ('r','p','v','m','S','f')`,
+              `   AND n.nspname NOT IN ('pg_catalog','information_schema')`,
+              `   AND pg_get_userbyid(c.relowner) = current_user ` +
+                String.fromCharCode(92) +
+                `gexec`,
+              "",
+            ].join("\n"),
+          ),
+        );
+        run("psql", [
+          "--no-psqlrc",
+          "--set",
+          `expected_target_id=${options.targetId}`,
+          "--set",
+          `expected_capability=${capabilityEnvelope}`,
+          "--dbname",
+          targetDatabaseDsn(options.targetDsn, entry.databaseName),
+          "--set",
+          `owner=${probe.role}`,
+          "--file",
+          guardedHandoff,
         ]);
       }
       const restoreSeconds = Math.round((Date.now() - restoreStart) / 1000);
@@ -1949,6 +2005,91 @@ export function runMintCommand(argv: string[]): string {
  * opened before the reload may still hold the previous (unset) placeholder
  * value.
  */
+/** How long a provision lock may age before a crashed holder is presumed dead. */
+const PROVISION_LOCK_STALE_MS = 120_000;
+
+/**
+ * Atomically claim the provision lock (O_EXCL). A lock older than the
+ * staleness window is removed and retried once — the holder refreshes the
+ * mtime on acquire, so only a crashed holder's lock is ever broken.
+ */
+function claimProvisionLock(lockPath: string): void {
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      const fd = openSync(lockPath, "wx");
+      try {
+        writeSync(fd, `${process.pid}\n`);
+      } finally {
+        closeSync(fd);
+      }
+      return;
+    } catch (error) {
+      const code = (error as { code?: string }).code;
+      if (code !== "EEXIST") {
+        throw new RecoveryDrillError(
+          "PROVISION_LOCK_FAILED",
+          `could not claim the provision lock: ${code ?? "unknown error"}`,
+        );
+      }
+    }
+    const stale = statSync(lockPath, { throwIfNoEntry: false });
+    if (
+      stale !== undefined &&
+      Date.now() - stale.mtimeMs > PROVISION_LOCK_STALE_MS
+    ) {
+      try {
+        // error-policy:J6 a stale lock from a crashed holder is removed.
+        rmSync(lockPath, { force: true });
+      } catch {
+        // error-policy:J6 stale-lock removal failure surfaces as EEXIST retry.
+      }
+      continue;
+    }
+    throw new RecoveryDrillError(
+      "PROVISION_LOCK_HELD",
+      "another provisioner holds the postgresql.auto.conf lock",
+    );
+  }
+  throw new RecoveryDrillError(
+    "PROVISION_LOCK_HELD",
+    "another provisioner holds the postgresql.auto.conf lock",
+  );
+}
+
+/**
+ * The locked read-modify-write of postgresql.auto.conf: strip prior eliza.*
+ * lines, append the fresh twins, and replace the file atomically (sibling
+ * temp file + fsync + rename — the same crash-consistency shape ALTER
+ * SYSTEM SET itself uses). Caller holds the provision lock.
+ */
+function writeAutoConfAtomic(
+  autoConf: string,
+  targetId: string,
+  capabilityText: string,
+): void {
+  const current = readFileSync(autoConf, "utf-8");
+  const kept = current
+    .split("\n")
+    .filter(
+      (line: string) =>
+        !line.startsWith("eliza.restore_target_id") &&
+        !line.startsWith("eliza.restore_capability"),
+    );
+  kept.push(`eliza.restore_target_id = '${targetId}'`);
+  // The serialized capability contains no single quotes (pipe-delimited
+  // envelope over UUID/hex ids and a hex signature), so this literal is safe.
+  kept.push(`eliza.restore_capability = '${capabilityText}'`);
+  const tmpConf = `${autoConf}.eliza-provision-${process.pid}.tmp`;
+  const fd = openSync(tmpConf, "w");
+  try {
+    writeSync(fd, `${kept.join("\n").trimEnd()}\n`);
+    fsyncSync(fd);
+  } finally {
+    closeSync(fd);
+  }
+  renameSync(tmpConf, autoConf);
+}
+
 export function runProvisionCommand(
   targetDsn: string,
   targetId: string,
@@ -1978,34 +2119,31 @@ export function runProvisionCommand(
     "SHOW data_directory",
   ]).trim();
   const autoConf = join(dataDir, "postgresql.auto.conf");
-  const current = readFileSync(autoConf, "utf-8");
-  const kept = current
-    .split("\n")
-    .filter(
-      (line: string) =>
-        !line.startsWith("eliza.restore_target_id") &&
-        !line.startsWith("eliza.restore_capability"),
-    );
-  kept.push(`eliza.restore_target_id = '${targetId}'`);
-  // The serialized capability contains no single quotes (pipe-delimited
-  // envelope over UUID/hex ids and a hex signature), so this literal is safe.
-  kept.push(`eliza.restore_capability = '${capabilityText}'`);
-  // Atomic update (#23453 review r2): write the new content to a sibling
-  // temp file, fsync it, then rename over postgresql.auto.conf — the same
-  // crash-consistency shape ALTER SYSTEM SET itself uses. A crash or a
-  // concurrent ALTER SYSTEM can never observe a truncated/partial file;
-  // the filter above re-reads immediately before this write, so the only
-  // lost race is a concurrent eliza.* line, which the fresh-session
-  // verification below catches.
-  const tmpConf = `${autoConf}.eliza-provision-${process.pid}.tmp`;
-  const fd = openSync(tmpConf, "w");
+  // Serialize the read/modify/replace against competing writers (#23453
+  // review r3): an exclusive advisory lock beside postgresql.auto.conf means
+  // a concurrent provisioner (or operator script following the same
+  // convention) cannot interleave its own read-modify-write between ours.
+  // ALTER SYSTEM SET takes no user-visible lock, so an interleaved ALTER
+  // SYSTEM can still race — the fresh-session verification below proves OUR
+  // settings landed, and the lock closes the provisioner-vs-provisioner
+  // lost-update race entirely.
+  // Neither Node nor Bun exposes flock(2), so the lock is an O_EXCL lock
+  // file: creation is atomic, so exactly one provisioner can hold it. A
+  // crash while holding leaves a stale lock; it is broken after
+  // PROVISION_LOCK_STALE_MS because a live holder refreshes the lock's
+  // mtime, and the whole window is minutes, not hours.
+  const lockPath = `${autoConf}.eliza-provision.lock`;
+  claimProvisionLock(lockPath);
   try {
-    writeSync(fd, `${kept.join("\n").trimEnd()}\n`);
-    fsyncSync(fd);
+    writeAutoConfAtomic(autoConf, targetId, capabilityText);
   } finally {
-    closeSync(fd);
+    try {
+      // error-policy:J6 best-effort lock-file release.
+      rmSync(lockPath, { force: true });
+    } catch {
+      // error-policy:J6 lock release must not mask the provisioning outcome.
+    }
   }
-  renameSync(tmpConf, autoConf);
   run("psql", [
     "--no-psqlrc",
     "--set",

--- a/packages/cloud/scripts/admin/apps-tenant-db-recovery.ts
+++ b/packages/cloud/scripts/admin/apps-tenant-db-recovery.ts
@@ -1326,6 +1326,8 @@ export interface DrillLock {
   child: ChildProcess;
   handshakePath: string;
   targetDsn: string;
+  /** Advisory-lock key this holder session owns (drill or provision). */
+  lockKey: number;
   backendPid?: number;
 }
 
@@ -1350,6 +1352,27 @@ export function acquireDrillLock(
   targetDsn: string,
   handshakePath: string,
 ): DrillLock {
+  return acquireSessionAdvisoryLock(
+    targetDsn,
+    handshakePath,
+    DRILL_ADVISORY_LOCK_KEY,
+  );
+}
+
+/**
+ * Acquire a session-held advisory lock under an arbitrary key with the same
+ * proven file handshake as the drill lock. Used by the drill itself and by
+ * the postgresql.auto.conf provisioner, whose exclusivity must not depend
+ * on pathname-rename races a crashed holder cannot clean up (#23453
+ * review r6: POSIX rename is not conditional on a previously observed
+ * inode, so a stale-takeover or a late release can destroy a successor's
+ * fresh claim; a held server session cannot be stolen by another process).
+ */
+export function acquireSessionAdvisoryLock(
+  targetDsn: string,
+  handshakePath: string,
+  lockKey: number,
+): DrillLock {
   // stdout of the holder is redirected to the handshake file: the sentinel
   // row lands on disk the moment the lock is granted, independent of the
   // node event loop.
@@ -1366,7 +1389,7 @@ export function acquireDrillLock(
       "--dbname",
       targetDsn,
       "--command",
-      `SELECT CASE WHEN pg_try_advisory_lock(${DRILL_ADVISORY_LOCK_KEY}) THEN '${DRILL_LOCK_HANDSHAKE}:' || pg_backend_pid() ELSE '${DRILL_LOCK_REFUSED}' END;`,
+      `SELECT CASE WHEN pg_try_advisory_lock(${lockKey}) THEN '${DRILL_LOCK_HANDSHAKE}:' || pg_backend_pid() ELSE '${DRILL_LOCK_REFUSED}' END;`,
       // A refused lock must NOT fall through to the hold-sleep: the refusal
       // sentinel is not a SQL error, so ON_ERROR_STOP does not stop psql and
       // the second --command WOULD execute — leaking a 24h pg_sleep backend
@@ -1378,7 +1401,7 @@ export function acquireDrillLock(
       // re-proves this session holds the advisory lock (aborting a refused
       // holder before any sleep) and then holds it for the bounded window.
       "--command",
-      `DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_locks WHERE locktype = 'advisory' AND classid = 0 AND objid = ${DRILL_ADVISORY_LOCK_KEY} AND objsubid = 1 AND pid = pg_backend_pid()) THEN RAISE EXCEPTION 'drill lock lost before hold'; END IF; PERFORM pg_sleep(${DRILL_LOCK_MAX_SECONDS}); END $$;`,
+      `DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_locks WHERE locktype = 'advisory' AND classid = 0 AND objid = ${lockKey} AND objsubid = 1 AND pid = pg_backend_pid()) THEN RAISE EXCEPTION 'drill lock lost before hold'; END IF; PERFORM pg_sleep(${DRILL_LOCK_MAX_SECONDS}); END $$;`,
     ],
     { stdio: ["ignore", outFd, "pipe"] },
   );
@@ -1449,7 +1472,7 @@ export function acquireDrillLock(
       `drill lock acquisition was not confirmed within the settle window: ${stderrTail.trim().slice(0, 200)}`,
     );
   }
-  return { child, handshakePath, targetDsn, backendPid };
+  return { child, handshakePath, targetDsn, lockKey, backendPid };
 }
 
 /**
@@ -1504,7 +1527,7 @@ export function releaseDrillLock(lock: DrillLock): void {
         "--dbname",
         lock.targetDsn,
         "--command",
-        `SELECT CASE WHEN EXISTS (SELECT 1 FROM pg_locks WHERE locktype = 'advisory' AND classid = 0 AND objid = ${DRILL_ADVISORY_LOCK_KEY} AND objsubid = 1 AND pid = ${lock.backendPid} AND pid <> pg_backend_pid()) THEN pg_terminate_backend(${lock.backendPid}) ELSE false END;`,
+        `SELECT CASE WHEN EXISTS (SELECT 1 FROM pg_locks WHERE locktype = 'advisory' AND classid = 0 AND objid = ${lock.lockKey} AND objsubid = 1 AND pid = ${lock.backendPid} AND pid <> pg_backend_pid()) THEN pg_terminate_backend(${lock.backendPid}) ELSE false END;`,
       ],
       { encoding: "utf-8" },
     );
@@ -2125,143 +2148,32 @@ export function runMintCommand(argv: string[]): string {
  * opened before the reload may still hold the previous (unset) placeholder
  * value.
  */
-/** How long a provision lock may age before a crashed holder is presumed dead. */
-const PROVISION_LOCK_STALE_MS = 120_000;
+/** Advisory-lock key for the postgresql.auto.conf provision critical section. */
+export const PROVISION_ADVISORY_LOCK_KEY = 0x4552_5a50;
 
 /**
- * Handle over a claimed provision lock: the stat identifies THIS claim's
- * lock-file inode (dev+ino), so release can only unlink a file this claim
- * created — never a successor's lock after a stale takeover (#23453
- * review r4).
+ * Serialize the postgresql.auto.conf provision critical section with a
+ * held PostgreSQL session advisory lock (#23453 review r6): a server-held
+ * session cannot be stolen or destroyed by another process's pathname
+ * operations, so there is no stale-takeover TOCTOU at all. A crashed
+ * provisioner's backend dies with it, releasing the lock; the
+ * handshake-file sentinel and client-side SIGKILL in acquire/
+ * releaseSessionAdvisoryLock cover liveness proof and cleanup.
  */
-interface ProvisionLockHandle {
-  lockPath: string;
-  dev: number;
-  ino: number;
-}
-
-/**
- * Atomically claim the provision lock (O_EXCL). A lock older than the
- * staleness window is presumed crashed and taken over by RENAMING it aside
- * (the rename is atomic and unlinks exactly one file) and retrying the
- * O_EXCL create once. Takeover never unlinks the shared lock path directly,
- * so two provisioners racing on a stale lock cannot remove each other's
- * fresh claims: only the rename winner recreates the lock, and the loser's
- * next O_EXCL fails against the winner's lock (#23453 review r4). This is
- * a takeover, not a lease: the critical section is seconds-long and the
- * window only bounds how long a crashed holder can block the next
- * provisioner.
- */
-function claimProvisionLock(lockPath: string): ProvisionLockHandle {
-  for (let attempt = 0; attempt < 2; attempt++) {
-    try {
-      const fd = openSync(lockPath, "wx");
-      try {
-        writeSync(fd, `${process.pid}\n`);
-      } finally {
-        closeSync(fd);
-      }
-      const own = statSync(lockPath);
-      return { lockPath, dev: own.dev, ino: own.ino };
-    } catch (error) {
-      const code = (error as { code?: string }).code;
-      if (code !== "EEXIST") {
-        throw new RecoveryDrillError(
-          "PROVISION_LOCK_FAILED",
-          `could not claim the provision lock: ${code ?? "unknown error"}`,
-        );
-      }
-    }
-    if (attempt > 0) {
-      break;
-    }
-    // Stale takeover by unique-target rename: the stale source and the
-    // unique destination form a claim on exactly ONE inode. If a competing
-    // provisioner renamed the same stale lock aside first, its rename
-    // removed the shared path's link and our rename fails ENOENT — no
-    // second contender can move (and later unlink) a FRESH lock, because a
-    // fresh lock at the shared path is young, never re-stale within this
-    // claim, and cannot be the source of a second rename while the age
-    // check holds. Rename over a non-empty directory or an existing
-    // destination fails with ENOTEMPTY/EEXIST, which also just breaks out
-    // to the held-lock refusal (#23453 review r5).
-    // error-policy:J6 a stale lock from a crashed holder is moved aside.
-    const stale = statSync(lockPath, { throwIfNoEntry: false });
-    if (
-      stale !== undefined &&
-      Date.now() - stale.mtimeMs > PROVISION_LOCK_STALE_MS
-    ) {
-      let staleName = "";
-      try {
-        staleName = `${lockPath}.stale-${process.pid}-${Date.now()}`;
-        renameSync(lockPath, staleName);
-        // The renamed inode is provably the stale one we measured: a
-        // competing takeover that renamed the shared path first makes our
-        // rename fail; a FRESH lock created between our stat and rename
-        // cannot be our rename source because rename targets the path and
-        // the fresh lock would have to be >120s old to be re-classified
-        // stale — it is not.
-        const moved = statSync(staleName, { throwIfNoEntry: false });
-        if (
-          moved === undefined ||
-          moved.dev !== stale.dev ||
-          moved.ino !== stale.ino
-        ) {
-          // Someone else's file ended up at our unique destination —
-          // impossible by construction; refuse loudly rather than proceed.
-          throw new RecoveryDrillError(
-            "PROVISION_LOCK_FAILED",
-            "provision lock takeover moved an unexpected inode",
-          );
-        }
-        rmSync(staleName, { force: true });
-      } catch (error) {
-        const code = (error as { code?: string }).code;
-        if (code === "ENOENT" || code === "ENOTEMPTY" || code === "EEXIST") {
-          // A competing provisioner won the takeover race; our retry (or
-          // the held-lock refusal below) is correct.
-          break;
-        }
-        // error-policy:J6 other takeover failures surface as a held lock.
-        break;
-      }
-    } else {
-      break;
-    }
-  }
-  throw new RecoveryDrillError(
-    "PROVISION_LOCK_HELD",
-    "another provisioner holds the postgresql.auto.conf lock",
+function withProvisionLock(targetDsn: string, body: () => void): void {
+  const handshakePath = join(
+    tmpdir(),
+    `eliza-provision-lock-${process.pid}-${Date.now()}.txt`,
   );
-}
-
-/**
- * Release the provision lock by identity: unlink only when the path still
- * resolves to THIS claim's inode. A successor's recreated lock at the same
- * path is a different inode and is never removed (#23453 review r4).
- */
-function releaseProvisionLock(handle: ProvisionLockHandle): void {
+  const lock = acquireSessionAdvisoryLock(
+    targetDsn,
+    handshakePath,
+    PROVISION_ADVISORY_LOCK_KEY,
+  );
   try {
-    // Identity-atomic release: rename the shared path to a name unique to
-    // this claim, then verify the moved inode is ours before discarding it.
-    // The rename claims exactly one inode — a successor's fresh lock at the
-    // shared path is a different inode; if the rename moved it (successor
-    // recreated the path between our checks), the inode mismatch below
-    // leaves the successor's lock parked at the unique name for recovery
-    // rather than deleting it, and the successor's own release (by ITS
-    // inode) never unlinks ours (#23453 review r5).
-    const movedName = `${handle.lockPath}.release-${process.pid}-${Date.now()}`;
-    renameSync(handle.lockPath, movedName);
-    const moved = statSync(movedName, { throwIfNoEntry: false });
-    if (
-      moved !== undefined &&
-      moved.dev === handle.dev &&
-      moved.ino === handle.ino
-    ) {
-      rmSync(movedName, { force: true });
-    }
-  } catch {
-    // error-policy:J6 lock release must not mask the provisioning outcome.
+    body();
+  } finally {
+    releaseDrillLock(lock);
   }
 }
 
@@ -2336,18 +2248,15 @@ export function runProvisionCommand(
   // SYSTEM can still race — the fresh-session verification below proves OUR
   // settings landed, and the lock closes the provisioner-vs-provisioner
   // lost-update race entirely.
-  // Neither Node nor Bun exposes flock(2), so the lock is an O_EXCL lock
-  // file: creation is atomic, so exactly one provisioner can hold it. A
-  // crash while holding leaves a stale lock; it is superseded after
-  // PROVISION_LOCK_STALE_MS by an atomic rename-aside takeover — a live
-  // holder finishes well inside the window, so the bound only matters for
-  // crashed holders.
-  const lockHandle = claimProvisionLock(`${autoConf}.eliza-provision.lock`);
-  try {
+  // A POSIX O_EXCL lock file cannot be taken over safely: rename is not
+  // conditional on a previously observed inode, so stale takeover and late
+  // release can each destroy a successor's fresh claim (#23453 reviews
+  // r4-r6). Exclusivity therefore lives in the server: a held advisory
+  // session released only by this process exiting or terminating its own
+  // backend.
+  withProvisionLock(targetDsn, () => {
     writeAutoConfAtomic(autoConf, targetId, capabilityText);
-  } finally {
-    releaseProvisionLock(lockHandle);
-  }
+  });
   run("psql", [
     "--no-psqlrc",
     "--set",

--- a/packages/cloud/scripts/admin/apps-tenant-db-recovery.ts
+++ b/packages/cloud/scripts/admin/apps-tenant-db-recovery.ts
@@ -532,15 +532,15 @@ DO $$ BEGIN RAISE EXCEPTION 'restore capability has expired on the server clock'
  * still be present and exactly equal (supplied via psql --set variables at
  * invocation), and the server clock must still be inside the capability
  * window, so every destructive session of the drill is individually
- * authority-checked with no local-check/SQL-execution TOCTOU.
+ * authority-checked with no local-check/SQL-execution TOCTOU. The expiry is
+ * a REQUIRED parameter (#23453 review r8): the server-clock check is a
+ * property of this function's type signature, not of its call sites, so a
+ * destructive session cannot be constructed without it and each guarded
+ * script carries the expiry guard exactly once (guardedPsqlFile executes
+ * scripts as written and never re-wraps).
  */
-export function guardPsqlScript(
-  sql: string,
-  expiresAtEpochMs?: number,
-): string {
-  const expiry =
-    expiresAtEpochMs === undefined ? "" : expiryGuardSql(expiresAtEpochMs);
-  return `${TARGET_GUARD_SQL}${expiry}${sql}`;
+export function guardPsqlScript(sql: string, expiresAtEpochMs: number): string {
+  return `${TARGET_GUARD_SQL}${expiryGuardSql(expiresAtEpochMs)}${sql}`;
 }
 
 /**
@@ -552,7 +552,7 @@ export function guardPsqlScript(
  * NOT consume the settings — the disposable target stays recoverable for an
  * idempotent re-run inside the capability TTL.
  */
-export function guardedConsumeAuthoritySql(expiresAtEpochMs?: number): string {
+export function guardedConsumeAuthoritySql(expiresAtEpochMs: number): string {
   return guardPsqlScript(CONSUME_AUTHORITY_SQL, expiresAtEpochMs);
 }
 
@@ -1552,19 +1552,19 @@ export function releaseDrillLock(lock: DrillLock): void {
   }
 }
 
+/**
+ * Execute an already-guarded script file against the target with the twin
+ * settings supplied as psql --set variables. The script must have been
+ * built through guardPsqlScript at construction time (#23453 review r8);
+ * this executor never re-wraps, so every guarded script carries the
+ * twin-settings and expiry guards exactly once.
+ */
 function guardedPsqlFile(
   targetDsn: string,
   targetId: string,
   capability: string,
   script: string,
-  expiresAtEpochMs?: number,
 ): void {
-  if (expiresAtEpochMs !== undefined) {
-    // Re-guard the already-written script with the server-clock expiry check
-    // by prefixing it (guardPsqlScript composes the same way).
-    const body = readFileSync(script, "utf-8");
-    writeFileSync(script, guardPsqlScript(body, expiresAtEpochMs));
-  }
   run("psql", [
     "--no-psqlrc",
     "--set",
@@ -1759,7 +1759,6 @@ export function executeDrill(options: CliOptions): DrillReport {
         options.targetId,
         capabilityEnvelope,
         claimScript,
-        capability.expiresAtEpochMs,
       );
       const dbMap = parseDbMap(readFileSync(join(work, "dbmap.tsv"), "utf-8"));
       if (dbMap.length !== manifest.databaseCount) {
@@ -1819,7 +1818,6 @@ export function executeDrill(options: CliOptions): DrillReport {
         options.targetId,
         capabilityEnvelope,
         guardedGlobals,
-        capability.expiresAtEpochMs,
       );
       for (const entry of dbMap) {
         const dumpFile = join(work, "dumps", `${entry.dumpId}.dump`);
@@ -1845,6 +1843,7 @@ export function executeDrill(options: CliOptions): DrillReport {
               `GRANT CONNECT ON DATABASE ${databaseIdentifier} TO ${ownerIdentifier};`,
               "",
             ].join("\n"),
+            capability.expiresAtEpochMs,
           ),
         );
         guardedPsqlFile(
@@ -1852,7 +1851,6 @@ export function executeDrill(options: CliOptions): DrillReport {
           options.targetId,
           capabilityEnvelope,
           guardedDrop,
-          capability.expiresAtEpochMs,
         );
         const rawRestore = join(work, `${entry.dumpId}.restore.sql`);
         run("pg_restore", ["--file", rawRestore, dumpFile]);

--- a/packages/cloud/scripts/admin/apps-tenant-db-recovery.ts
+++ b/packages/cloud/scripts/admin/apps-tenant-db-recovery.ts
@@ -54,9 +54,11 @@
  *   SELECT pg_reload_conf();
  */
 
-import { spawnSync } from "node:child_process";
+import { spawnSync, spawn } from "node:child_process";
+import type { ChildProcess } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
+  copyFileSync,
   mkdtempSync,
   readFileSync,
   rmSync,
@@ -365,18 +367,57 @@ export function parseGlobalRoleNames(globalsSql: string): string[] {
   return roles;
 }
 
-/** Refuse a nonempty target whose existing roles collide with the archive. */
+/**
+ * Refuse a nonempty target whose existing roles collide with the archive —
+ * EXCEPT roles the archive itself defines when the target is provisioned for
+ * this same capability: those are remnants of a failed prior run of this
+ * exact drill (the twin settings match the capability), and the retry is
+ * idempotent via makeGlobalsIdempotent. Foreign roles always refuse.
+ */
 export function assertNoGlobalRoleCollisions(
   globalsSql: string,
   existingRoles: string[],
+  archiveRoles: readonly string[] = [],
 ): void {
   const existing = new Set(existingRoles);
-  if (parseGlobalRoleNames(globalsSql).some((role) => existing.has(role))) {
+  const ownedByArchive = new Set(archiveRoles);
+  const colliding = parseGlobalRoleNames(globalsSql).filter(
+    (role) => existing.has(role) && !ownedByArchive.has(role),
+  );
+  if (colliding.length > 0) {
     throw new RecoveryDrillError(
       "REFUSED_NONEMPTY_TARGET",
-      "restore target already contains a role defined by globals.sql",
+      "restore target already contains a role not owned by this archive's globals.sql",
     );
   }
+}
+
+const CREATE_ROLE_RE = /(^|\n)CREATE ROLE ([a-z_][a-z0-9_$]*);\n?/g;
+
+/**
+ * Make globals.sql re-runnable against the same disposable target (#23453
+ * review): a failed first run may already have created some roles, and a bare
+ * CREATE ROLE would abort the idempotent retry. Each CREATE ROLE becomes a
+ * conditional DO block (no-op when the role exists); ALTER ROLE statements
+ * are already idempotent. Only simple `CREATE ROLE name;` forms produced by
+ * pg_dump's globals output are rewritten — anything else fails the strict
+ * parse in parseGlobalRoleNames first.
+ */
+export function makeGlobalsIdempotent(globalsSql: string): string {
+  return globalsSql.replace(
+    CREATE_ROLE_RE,
+    (match, lead: string, role: string) => {
+      return `${lead}${[
+        "DO $$",
+        "BEGIN",
+        `  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = ${quoteSqlLiteral(role)}) THEN`,
+        `    CREATE ROLE ${role};`,
+        "  END IF;",
+        "END",
+        "$$;\n",
+      ].join("\n")}`;
+    },
+  );
 }
 
 /**
@@ -1056,10 +1097,36 @@ function assertTenantAcl(
   targetDsn: string,
   database: string,
   ownerRole: string,
+  allTenantRoles: readonly string[],
 ): void {
   // OID 0 is the canonical way to probe PUBLIC's privilege (role "PUBLIC"
-  // does not exist as a pg_roles row). Variables are supplied on stdin:
+  // does not exist as a pg_roles row). The assertion is stronger than
+  // PUBLIC-denied/owner-granted (#23453 review): the owner must also BE the
+  // recorded datdba, the ACL must carry no grant to any other tenant role
+  // (which membership-based privilege cannot bypass, because
+  // has_database_privilege for a non-grantee still returns false when the
+  // ACL has no entry for that role), and every OTHER tenant role is probed
+  // for CONNECT and must be refused. Variables are supplied on stdin:
   // psql -c does not interpolate :'var', but stdin scripts do.
+  const rolesList = allTenantRoles
+    .filter((role) => role !== ownerRole)
+    .map((role) => quoteSqlLiteral(role))
+    .join(", ");
+  const rolesArray = `ARRAY[${rolesList}]::name[]`;
+  const sql = [
+    "SELECT json_build_object(",
+    "  'datdba_is_owner', (SELECT datdba = (SELECT oid FROM pg_roles WHERE rolname = :'owner') FROM pg_database WHERE datname = :'db'),",
+    "  'public_connect', has_database_privilege(0, :'db', 'CONNECT'),",
+    "  'owner_connect', has_database_privilege(:'owner', :'db', 'CONNECT'),",
+    "  'foreign_grantees', (SELECT count(*) FROM aclexplode((SELECT datacl FROM pg_database WHERE datname = :'db')) acl WHERE acl.grantee <> 0 AND acl.grantee <> (SELECT oid FROM pg_roles WHERE rolname = :'owner'))::int",
+    ")::text",
+    rolesList
+      ? `UNION ALL SELECT json_build_object('other_role', r.rn, 'connect_refused', NOT has_database_privilege(r.rn, :'db', 'CONNECT'))::text FROM (SELECT unnest(${rolesArray}) AS rn) r`
+      : "",
+    "ORDER BY 1",
+  ]
+    .filter((line) => line !== "")
+    .join("\n");
   const out = run(
     "psql",
     [
@@ -1075,26 +1142,116 @@ function assertTenantAcl(
       "--dbname",
       targetDsn,
     ],
-    {
-      input:
-        "SELECT json_build_object('public_connect', has_database_privilege(0, :'db', 'CONNECT'), 'owner_connect', has_database_privilege(:'owner', :'db', 'CONNECT'))::text",
-    },
+    { input: sql },
   ).trim();
-  let parsed: { public_connect?: unknown; owner_connect?: unknown };
-  try {
-    parsed = JSON.parse(out) as typeof parsed;
-  } catch {
+  if (out.length === 0) {
     throw new RecoveryDrillError(
       "ISOLATION_VIOLATION",
-      "target ACL assertion response was not valid JSON",
+      "target ACL assertion returned no rows",
     );
   }
-  if (parsed.public_connect !== false || parsed.owner_connect !== true) {
+  for (const line of out.split("\n")) {
+    let parsed: Record<string, unknown>;
+    try {
+      // error-policy:J3 untrusted DB output becomes an explicit violation, never a defaulted pass.
+      parsed = JSON.parse(line.trim()) as Record<string, unknown>;
+    } catch {
+      // error-policy:J3 untrusted DB output becomes an explicit violation, never a defaulted pass.
+      throw new RecoveryDrillError(
+        "ISOLATION_VIOLATION",
+        "target ACL assertion response was not valid JSON",
+      );
+    }
+    if ("datdba_is_owner" in parsed) {
+      if (
+        parsed.datdba_is_owner !== true ||
+        parsed.public_connect !== false ||
+        parsed.owner_connect !== true ||
+        parsed.foreign_grantees !== 0
+      ) {
+        throw new RecoveryDrillError(
+          "ISOLATION_VIOLATION",
+          `restored database ACL is not owner-exclusive (${database}: datdba mismatch, PUBLIC grant, owner denial, or a foreign ACL grantee)`,
+        );
+      }
+    } else if ("connect_refused" in parsed) {
+      if (parsed.connect_refused !== true) {
+        throw new RecoveryDrillError(
+          "ISOLATION_VIOLATION",
+          `another tenant role can CONNECT to a restored database (${database})`,
+        );
+      }
+    } else {
+      throw new RecoveryDrillError(
+        "ISOLATION_VIOLATION",
+        "target ACL assertion returned an unrecognized row shape",
+      );
+    }
+  }
+}
+
+/** Quote a value as a SQL string literal for generated drill SQL. */
+export function quoteSqlLiteral(value: string): string {
+  return `'${value.replaceAll("'", "''")}'`;
+}
+
+/**
+ * Session-held drill exclusivity (#23453 review): opens a dedicated psql
+ * session that takes the session-level advisory lock with pg_try_advisory_lock
+ * and then holds it via a bounded pg_sleep, staying alive for the whole drill.
+ * A second drill against the same target fails its try-lock, its psql exits
+ * nonzero, and this function surfaces LOCK_FAILED — so destructive statements
+ * and authority consumption can never interleave. Implemented over a
+ * long-lived psql process (not a node pg Client) to keep the script sync and
+ * dependency-free; killing the process releases the lock (session-scoped).
+ */
+export const DRILL_LOCK_SETTLE_MS = 1500;
+/** How long the lock-holder may sleep: bounded so a crashed drill (killed
+ * holder) cannot pin the lock longer than the capability TTL ceiling. */
+export const DRILL_LOCK_MAX_SECONDS = 24 * 60 * 60;
+
+export function acquireDrillLock(targetDsn: string): ChildProcess {
+  let stderrTail = "";
+  const child = spawn(
+    "psql",
+    [
+      "--no-psqlrc",
+      "--quiet",
+      "--set",
+      "ON_ERROR_STOP=1",
+      "--dbname",
+      targetDsn,
+      "--command",
+      `SELECT CASE WHEN pg_try_advisory_lock(${DRILL_ADVISORY_LOCK_KEY}) THEN true ELSE 1/0 END;\nSELECT pg_sleep(${DRILL_LOCK_MAX_SECONDS});`,
+    ],
+    { stdio: ["ignore", "ignore", "pipe"] },
+  );
+  child.stderr?.on("data", (chunk: unknown) => {
+    stderrTail = `${stderrTail}${String(chunk)}`.slice(-500);
+  });
+  // Synchronous settle wait (Atomics.wait): a refused lock, bad DSN, or
+  // missing psql all surface as a fast process exit, which must be observed
+  // before the caller proceeds — a lock we are not holding must never let
+  // the drill start.
+  Atomics.wait(
+    new Int32Array(new SharedArrayBuffer(4)),
+    0,
+    0,
+    DRILL_LOCK_SETTLE_MS,
+  );
+  if (child.pid === undefined || child.exitCode !== null) {
+    child.kill("SIGKILL");
     throw new RecoveryDrillError(
-      "ISOLATION_VIOLATION",
-      "restored database ACL does not deny PUBLIC and grant the owner",
+      "LOCK_FAILED",
+      `could not hold the drill advisory lock (psql exited early: ${stderrTail.trim().slice(0, 200)})`,
     );
   }
+  return child;
+}
+
+export function releaseDrillLock(child: ChildProcess): void {
+  // SIGKILL drops the server session, which releases the session-level lock.
+  child.kill("SIGKILL");
 }
 
 function guardedPsqlFile(
@@ -1123,6 +1280,7 @@ export function executeDrill(options: CliOptions): DrillReport {
   try {
     capabilityText = readFileSync(options.capabilityFile, "utf-8").trim();
   } catch (cause) {
+    // error-policy:J3 an unreadable capability file becomes an explicit invalid argument.
     throw new RecoveryDrillError(
       "INVALID_ARGS",
       `--capability-file could not be read: ${(cause as Error).message}`,
@@ -1176,301 +1334,342 @@ export function executeDrill(options: CliOptions): DrillReport {
         "archive on disk is not the archive pinned by the restore capability",
       );
     }
-
-    // Transactional exclusivity: refuse a different capability on this target
-    // before any destructive statement runs.
-    const claimScript = join(work, "claim-exclusivity.sql");
-    writeFileSync(claimScript, buildClaimExclusivitySql(capability));
-    guardedPsqlFile(
-      options.targetDsn,
-      options.targetId,
-      capabilityEnvelope,
-      claimScript,
-    );
-
-    run("openssl", [
-      "enc",
-      "-d",
-      "-aes-256-cbc",
-      "-pbkdf2",
-      "-iter",
-      "210000",
-      "-in",
-      archivePath,
-      "-out",
-      join(work, "backup.tar.gz"),
-      "-pass",
-      `file:${options.passphraseFile}`,
-    ]);
-    run("tar", ["-xzf", join(work, "backup.tar.gz"), "-C", work]);
-
-    const manifest = parseBackupManifest(
-      readFileSync(join(work, "manifest.json"), "utf-8"),
-    );
-    if (manifest.databaseCount !== sidecar.databaseCount) {
+    // Hash and decrypt must consume the SAME bytes: hash a private copy first
+    // and decrypt that copy, so a local actor swapping the set-dir archive
+    // between the hash and the openssl open cannot deliver different bytes
+    // to the two operations (#23453 review).
+    const pinnedArchive = join(work, "pinned-archive.bin");
+    copyFileSync(archivePath, pinnedArchive);
+    const pinnedSha = createHash("sha256")
+      .update(readFileSync(pinnedArchive))
+      .digest("hex");
+    if (pinnedSha !== actualSha) {
       throw new RecoveryDrillError(
-        "INVALID_METADATA",
-        "manifest/sidecar database_count mismatch",
+        "REFUSED_ARCHIVE_MISMATCH",
+        "archive bytes changed while being pinned for decryption",
       );
     }
-    // Authenticated recovery point: the manifest inside the encrypted,
-    // checksummed archive is authoritative; a drifted or future-dated
-    // sidecar/manifest pair fails closed instead of understating loss.
-    assertRecoveryPointConsistency({
-      sidecarCreatedAt: sidecar.createdAt,
-      manifestCreatedAt: manifest.createdAt,
-      nowEpochMs: Date.now(),
-    });
-    const checksums = parseChecksumFile(
-      readFileSync(join(work, "checksums.sha256"), "utf-8"),
-    );
-    const globalsSql = readFileSync(join(work, "globals.sql"), "utf-8");
-    const archiveRoles = parseGlobalRoleNames(globalsSql);
-    assertNoGlobalRoleCollisions(globalsSql, authority.existingRoles);
-    const dbMap = parseDbMap(readFileSync(join(work, "dbmap.tsv"), "utf-8"));
-    if (dbMap.length !== manifest.databaseCount) {
-      throw new RecoveryDrillError(
-        "INVALID_METADATA",
-        "dbmap entry count differs from manifest database_count",
+
+    // Session-held exclusivity: a session-level advisory lock held on a
+    // dedicated connection for the whole drill, plus the transactional claim,
+    // so two drills against the same target cannot interleave destructive
+    // statements and consumption (#23453 review).
+    const lockConn = acquireDrillLock(options.targetDsn);
+    try {
+      // Transactional exclusivity: refuse a different capability on this target
+      // before any destructive statement runs.
+      const claimScript = join(work, "claim-exclusivity.sql");
+      writeFileSync(claimScript, buildClaimExclusivitySql(capability));
+      guardedPsqlFile(
+        options.targetDsn,
+        options.targetId,
+        capabilityEnvelope,
+        claimScript,
       );
-    }
-    // Checksum coverage is a load-bearing assumption: the manifest is the
-    // authenticated RPO source and globals.sql/dbmap/dumps are executed, so
-    // every consumed artifact must be listed — an archive whose checksums
-    // omit them would run unverified bytes (#23453).
-    assertChecksumCoverage(
-      checksums,
-      dbMap.map((entry) => entry.dumpId),
-    );
-    const checksummedFiles = verifyChecksums(work, checksums);
 
-    const probes = parseTenantProbes(
-      readFileSync(options.tenantProbesFile, "utf-8"),
-      dbMap,
-    );
-    // The probes file is operator-local and unauthenticated; the archive's
-    // globals.sql is the authenticated role inventory. A probe naming a role
-    // absent from globals.sql would let a tampered probes file decide who
-    // owns (and can CONNECT to) every restored database (#23453).
-    assertProbesCoverArchiveRoles(probes, archiveRoles);
-    const probeById = new Map(probes.map((probe) => [probe.dumpId, probe]));
-    const passwords = new Map<string, string>();
-    for (const probe of probes) {
-      const password = process.env[probe.passwordEnv];
-      if (password === undefined || password === "") {
+      run("openssl", [
+        "enc",
+        "-d",
+        "-aes-256-cbc",
+        "-pbkdf2",
+        "-iter",
+        "210000",
+        "-in",
+        pinnedArchive,
+        "-out",
+        join(work, "backup.tar.gz"),
+        "-pass",
+        `file:${options.passphraseFile}`,
+      ]);
+      run("tar", ["-xzf", join(work, "backup.tar.gz"), "-C", work]);
+
+      const manifest = parseBackupManifest(
+        readFileSync(join(work, "manifest.json"), "utf-8"),
+      );
+      if (manifest.databaseCount !== sidecar.databaseCount) {
         throw new RecoveryDrillError(
-          "MISSING_PROBE_SECRET",
-          `required tenant probe environment variable is absent (dump=${probe.dumpId})`,
+          "INVALID_METADATA",
+          "manifest/sidecar database_count mismatch",
         );
       }
-      passwords.set(probe.dumpId, password);
-    }
-
-    const restoreStart = Date.now();
-    const guardedGlobals = join(work, "guarded-globals.sql");
-    writeFileSync(guardedGlobals, guardPsqlScript(globalsSql));
-    guardedPsqlFile(
-      options.targetDsn,
-      options.targetId,
-      capabilityEnvelope,
-      guardedGlobals,
-    );
-    for (const entry of dbMap) {
-      const dumpFile = join(work, "dumps", `${entry.dumpId}.dump`);
-      const probe = probeById.get(entry.dumpId);
-      if (probe === undefined) {
+      // Authenticated recovery point: the manifest inside the encrypted,
+      // checksummed archive is authoritative; a drifted or future-dated
+      // sidecar/manifest pair fails closed instead of understating loss.
+      assertRecoveryPointConsistency({
+        sidecarCreatedAt: sidecar.createdAt,
+        manifestCreatedAt: manifest.createdAt,
+        nowEpochMs: Date.now(),
+      });
+      const checksums = parseChecksumFile(
+        readFileSync(join(work, "checksums.sha256"), "utf-8"),
+      );
+      const globalsSql = readFileSync(join(work, "globals.sql"), "utf-8");
+      const archiveRoles = parseGlobalRoleNames(globalsSql);
+      assertNoGlobalRoleCollisions(
+        globalsSql,
+        authority.existingRoles,
+        archiveRoles,
+      );
+      const dbMap = parseDbMap(readFileSync(join(work, "dbmap.tsv"), "utf-8"));
+      if (dbMap.length !== manifest.databaseCount) {
         throw new RecoveryDrillError(
-          "INVALID_PROBE_METADATA",
-          "database has no tenant role probe",
+          "INVALID_METADATA",
+          "dbmap entry count differs from manifest database_count",
         );
       }
-      const databaseIdentifier = quoteSqlIdentifier(entry.databaseName);
-      const ownerIdentifier = quoteSqlIdentifier(probe.role);
-      const guardedDrop = join(work, `${entry.dumpId}.drop.sql`);
+      // Checksum coverage is a load-bearing assumption: the manifest is the
+      // authenticated RPO source and globals.sql/dbmap/dumps are executed, so
+      // every consumed artifact must be listed — an archive whose checksums
+      // omit them would run unverified bytes (#23453).
+      assertChecksumCoverage(
+        checksums,
+        dbMap.map((entry) => entry.dumpId),
+      );
+      const checksummedFiles = verifyChecksums(work, checksums);
+
+      const probes = parseTenantProbes(
+        readFileSync(options.tenantProbesFile, "utf-8"),
+        dbMap,
+      );
+      // The probes file is operator-local and unauthenticated; the archive's
+      // globals.sql is the authenticated role inventory. A probe naming a role
+      // absent from globals.sql would let a tampered probes file decide who
+      // owns (and can CONNECT to) every restored database (#23453).
+      assertProbesCoverArchiveRoles(probes, archiveRoles);
+      const probeById = new Map(probes.map((probe) => [probe.dumpId, probe]));
+      const passwords = new Map<string, string>();
+      for (const probe of probes) {
+        const password = process.env[probe.passwordEnv];
+        if (password === undefined || password === "") {
+          throw new RecoveryDrillError(
+            "MISSING_PROBE_SECRET",
+            `required tenant probe environment variable is absent (dump=${probe.dumpId})`,
+          );
+        }
+        passwords.set(probe.dumpId, password);
+      }
+
+      const restoreStart = Date.now();
+      const guardedGlobals = join(work, "guarded-globals.sql");
       writeFileSync(
-        guardedDrop,
-        guardPsqlScript(
-          [
-            `DROP DATABASE IF EXISTS ${databaseIdentifier};`,
-            `CREATE DATABASE ${databaseIdentifier} OWNER ${ownerIdentifier};`,
-            `REVOKE CONNECT ON DATABASE ${databaseIdentifier} FROM PUBLIC;`,
-            `GRANT CONNECT ON DATABASE ${databaseIdentifier} TO ${ownerIdentifier};`,
-            "",
-          ].join("\n"),
-        ),
+        guardedGlobals,
+        guardPsqlScript(makeGlobalsIdempotent(globalsSql)),
       );
       guardedPsqlFile(
         options.targetDsn,
         options.targetId,
         capabilityEnvelope,
-        guardedDrop,
+        guardedGlobals,
       );
-      const rawRestore = join(work, `${entry.dumpId}.restore.sql`);
-      run("pg_restore", ["--file", rawRestore, dumpFile]);
-      const guardedRestore = join(work, `${entry.dumpId}.guarded-restore.sql`);
-      writeFileSync(
-        guardedRestore,
-        guardPsqlScript(readFileSync(rawRestore, "utf-8")),
-      );
-      run("psql", [
-        "--no-psqlrc",
-        "--set",
-        `expected_target_id=${options.targetId}`,
-        "--set",
-        `expected_capability=${capabilityEnvelope}`,
-        "--dbname",
-        targetDatabaseDsn(options.targetDsn, entry.databaseName),
-        "--file",
-        guardedRestore,
-      ]);
-    }
-    const restoreSeconds = Math.round((Date.now() - restoreStart) / 1000);
-
-    const checks = buildIsolationChecks(dbMap);
-    const byId = new Map(
-      dbMap.map((entry) => [entry.dumpId, entry.databaseName]),
-    );
-    const directEndpoint = {
-      host: targetUrl.hostname,
-      port: targetUrl.port === "" ? "5432" : targetUrl.port,
-    };
-    const surfaces = [
-      { name: "direct", endpoint: directEndpoint },
-      { name: "pooler", endpoint: options.poolerEndpoint },
-    ] as const;
-    let passed = 0;
-    for (const check of checks) {
-      const objectDb = byId.get(check.objectDumpId);
-      const probe = probeById.get(check.subjectDumpId);
-      const password = passwords.get(check.subjectDumpId);
-      if (
-        objectDb === undefined ||
-        probe === undefined ||
-        password === undefined
-      ) {
-        throw new RecoveryDrillError(
-          "INVALID_PROBE_METADATA",
-          "isolation check references unknown dump id",
-        );
-      }
-      for (const surface of surfaces) {
-        // Own-connect is proven on the direct surface only: the drill target
-        // is disposable, so its databases are deliberately absent from the
-        // pooler's routing config and an own-connect through the pooler can
-        // never succeed by design. The pooler surface still carries the
-        // cross-reject sample, which is the property it exists to prove.
-        if (check.kind === "own-connect" && surface.name !== "direct") {
-          continue;
-        }
-        const env = tenantConnectionEnv(
-          surface.endpoint,
-          objectDb,
-          probe.role,
-          password,
-        );
-        if (check.kind === "own-connect") {
-          const out = run(
-            "psql",
-            [
-              "--no-psqlrc",
-              "--tuples-only",
-              "--no-align",
-              "--set",
-              "ON_ERROR_STOP=1",
-              "--command",
-              `SELECT current_user || '|' || current_database() || '|' || current_setting('${SETTING_TARGET_ID}', true)`,
-            ],
-            { env },
-          ).trim();
-          const expected = `${probe.role}|${objectDb}|${options.targetId}`;
-          if (out !== expected) {
-            throw new RecoveryDrillError(
-              "ISOLATION_VIOLATION",
-              `tenant authentication did not reach the expected target (surface=${surface.name}, subject=${check.subjectDumpId})`,
-            );
-          }
-        } else {
-          expectCommandFailure(
-            "psql",
-            [
-              "--no-psqlrc",
-              "--tuples-only",
-              "--no-align",
-              "--set",
-              "ON_ERROR_STOP=1",
-              "--command",
-              "SELECT 1",
-            ],
-            env,
+      for (const entry of dbMap) {
+        const dumpFile = join(work, "dumps", `${entry.dumpId}.dump`);
+        const probe = probeById.get(entry.dumpId);
+        if (probe === undefined) {
+          throw new RecoveryDrillError(
+            "INVALID_PROBE_METADATA",
+            "database has no tenant role probe",
           );
         }
+        const databaseIdentifier = quoteSqlIdentifier(entry.databaseName);
+        const ownerIdentifier = quoteSqlIdentifier(probe.role);
+        const guardedDrop = join(work, `${entry.dumpId}.drop.sql`);
+        writeFileSync(
+          guardedDrop,
+          guardPsqlScript(
+            [
+              `DROP DATABASE IF EXISTS ${databaseIdentifier};`,
+              `CREATE DATABASE ${databaseIdentifier} OWNER ${ownerIdentifier};`,
+              `REVOKE CONNECT ON DATABASE ${databaseIdentifier} FROM PUBLIC;`,
+              `GRANT CONNECT ON DATABASE ${databaseIdentifier} TO ${ownerIdentifier};`,
+              "",
+            ].join("\n"),
+          ),
+        );
+        guardedPsqlFile(
+          options.targetDsn,
+          options.targetId,
+          capabilityEnvelope,
+          guardedDrop,
+        );
+        const rawRestore = join(work, `${entry.dumpId}.restore.sql`);
+        run("pg_restore", ["--file", rawRestore, dumpFile]);
+        const guardedRestore = join(
+          work,
+          `${entry.dumpId}.guarded-restore.sql`,
+        );
+        writeFileSync(
+          guardedRestore,
+          guardPsqlScript(readFileSync(rawRestore, "utf-8")),
+        );
+        run("psql", [
+          "--no-psqlrc",
+          "--set",
+          `expected_target_id=${options.targetId}`,
+          "--set",
+          `expected_capability=${capabilityEnvelope}`,
+          "--dbname",
+          targetDatabaseDsn(options.targetDsn, entry.databaseName),
+          "--file",
+          guardedRestore,
+        ]);
+      }
+      const restoreSeconds = Math.round((Date.now() - restoreStart) / 1000);
+
+      const checks = buildIsolationChecks(dbMap);
+      const byId = new Map(
+        dbMap.map((entry) => [entry.dumpId, entry.databaseName]),
+      );
+      const directEndpoint = {
+        host: targetUrl.hostname,
+        port: targetUrl.port === "" ? "5432" : targetUrl.port,
+      };
+      const surfaces = [
+        { name: "direct", endpoint: directEndpoint },
+        { name: "pooler", endpoint: options.poolerEndpoint },
+      ] as const;
+      let passed = 0;
+      for (const check of checks) {
+        const objectDb = byId.get(check.objectDumpId);
+        const probe = probeById.get(check.subjectDumpId);
+        const password = passwords.get(check.subjectDumpId);
+        if (
+          objectDb === undefined ||
+          probe === undefined ||
+          password === undefined
+        ) {
+          throw new RecoveryDrillError(
+            "INVALID_PROBE_METADATA",
+            "isolation check references unknown dump id",
+          );
+        }
+        for (const surface of surfaces) {
+          // Own-connect is proven on the direct surface only: the drill target
+          // is disposable, so its databases are deliberately absent from the
+          // pooler's routing config and an own-connect through the pooler can
+          // never succeed by design. The pooler surface still carries the
+          // cross-reject sample, which is the property it exists to prove.
+          if (check.kind === "own-connect" && surface.name !== "direct") {
+            continue;
+          }
+          const env = tenantConnectionEnv(
+            surface.endpoint,
+            objectDb,
+            probe.role,
+            password,
+          );
+          if (check.kind === "own-connect") {
+            const out = run(
+              "psql",
+              [
+                "--no-psqlrc",
+                "--tuples-only",
+                "--no-align",
+                "--set",
+                "ON_ERROR_STOP=1",
+                "--command",
+                `SELECT current_user || '|' || current_database() || '|' || current_setting('${SETTING_TARGET_ID}', true)`,
+              ],
+              { env },
+            ).trim();
+            const expected = `${probe.role}|${objectDb}|${options.targetId}`;
+            if (out !== expected) {
+              throw new RecoveryDrillError(
+                "ISOLATION_VIOLATION",
+                `tenant authentication did not reach the expected target (surface=${surface.name}, subject=${check.subjectDumpId})`,
+              );
+            }
+          } else {
+            expectCommandFailure(
+              "psql",
+              [
+                "--no-psqlrc",
+                "--tuples-only",
+                "--no-align",
+                "--set",
+                "ON_ERROR_STOP=1",
+                "--command",
+                "SELECT 1",
+              ],
+              env,
+            );
+          }
+          passed += 1;
+        }
+      }
+      // Linear admin-side isolation proof: PUBLIC denied, owner granted, for
+      // every restored database — replaces the remaining O(n^2) probe pairs.
+      for (const entry of dbMap) {
+        const probe = probeById.get(entry.dumpId);
+        if (probe === undefined) {
+          throw new RecoveryDrillError(
+            "INVALID_PROBE_METADATA",
+            "ACL assertion references unknown dump id",
+          );
+        }
+        assertTenantAcl(
+          options.targetDsn,
+          entry.databaseName,
+          probe.role,
+          archiveRoles,
+        );
         passed += 1;
       }
+
+      const objectives = evaluateObjectives(
+        manifest.createdAt,
+        startedAt,
+        restoreSeconds,
+        {
+          rpoHours: options.rpoHours,
+          rtoMinutes: options.rtoMinutes,
+        },
+      );
+
+      // Executed probe count: own-connect runs once (direct surface only);
+      // each cross-reject sample runs once per surface (direct + pooler);
+      // plus one admin-side ACL assertion per restored database.
+      const ownConnectCount = checks.filter(
+        (c) => c.kind === "own-connect",
+      ).length;
+      const total =
+        ownConnectCount +
+        (checks.length - ownConnectCount) * surfaces.length +
+        dbMap.length;
+      const report: DrillReport = {
+        schemaVersion: REPORT_SCHEMA_VERSION,
+        startedAt: startedAt.toISOString(),
+        target: redactDsn(options.targetDsn),
+        archiveSha256: sidecar.archiveSha256,
+        archiveBytes: sidecar.archiveBytes,
+        databaseCount: sidecar.databaseCount,
+        checksummedFiles,
+        isolation: {
+          total,
+          passed,
+          plan: "linear",
+        },
+        rpoSource: "manifest",
+        objectives: {
+          ...objectives,
+          rpoHours: options.rpoHours,
+          rtoMinutes: options.rtoMinutes,
+        },
+      };
+
+      // Success path only: spend the authority so the completed drill cannot
+      // be replayed. A failed drill above leaves the target recoverable.
+      consumeRestoreAuthority(
+        options.targetDsn,
+        options.targetId,
+        capability,
+        work,
+      );
+      consumed = true;
+      return report;
+    } finally {
+      // Release the session-held drill lock before the workspace is cleaned.
+      releaseDrillLock(lockConn);
     }
-    // Linear admin-side isolation proof: PUBLIC denied, owner granted, for
-    // every restored database — replaces the remaining O(n^2) probe pairs.
-    for (const entry of dbMap) {
-      const probe = probeById.get(entry.dumpId);
-      if (probe === undefined) {
-        throw new RecoveryDrillError(
-          "INVALID_PROBE_METADATA",
-          "ACL assertion references unknown dump id",
-        );
-      }
-      assertTenantAcl(options.targetDsn, entry.databaseName, probe.role);
-      passed += 1;
-    }
-
-    const objectives = evaluateObjectives(
-      manifest.createdAt,
-      startedAt,
-      restoreSeconds,
-      {
-        rpoHours: options.rpoHours,
-        rtoMinutes: options.rtoMinutes,
-      },
-    );
-
-    // Executed probe count: own-connect runs once (direct surface only);
-    // each cross-reject sample runs once per surface (direct + pooler);
-    // plus one admin-side ACL assertion per restored database.
-    const ownConnectCount = checks.filter((c) => c.kind === "own-connect")
-      .length;
-    const total =
-      ownConnectCount +
-      (checks.length - ownConnectCount) * surfaces.length +
-      dbMap.length;
-    const report: DrillReport = {
-      schemaVersion: REPORT_SCHEMA_VERSION,
-      startedAt: startedAt.toISOString(),
-      target: redactDsn(options.targetDsn),
-      archiveSha256: sidecar.archiveSha256,
-      archiveBytes: sidecar.archiveBytes,
-      databaseCount: sidecar.databaseCount,
-      checksummedFiles,
-      isolation: {
-        total,
-        passed,
-        plan: "linear",
-      },
-      rpoSource: "manifest",
-      objectives: {
-        ...objectives,
-        rpoHours: options.rpoHours,
-        rtoMinutes: options.rtoMinutes,
-      },
-    };
-
-    // Success path only: spend the authority so the completed drill cannot
-    // be replayed. A failed drill above leaves the target recoverable.
-    consumeRestoreAuthority(
-      options.targetDsn,
-      options.targetId,
-      capability,
-      work,
-    );
-    consumed = true;
-    return report;
   } finally {
     // Decrypted tenant data must not outlive the drill. If consumption did
     // not run (failure path), the target settings remain provisioned for an

--- a/packages/cloud/scripts/admin/apps-tenant-db-recovery.ts
+++ b/packages/cloud/scripts/admin/apps-tenant-db-recovery.ts
@@ -2166,7 +2166,13 @@ function withProvisionLock(targetDsn: string, body: () => void): void {
     `eliza-provision-lock-${process.pid}-${Date.now()}.txt`,
   );
   const lock = acquireSessionAdvisoryLock(
-    targetDsn,
+    // Advisory locks are DATABASE-local, but postgresql.auto.conf is
+    // CLUSTER-wide: two provisioners connected to different maintenance
+    // databases on the same cluster would each hold their own lock and
+    // race on the file anyway. Canonicalize every caller onto the
+    // postgres database so the lock is one cluster-wide registry
+    // (#23453 review r7).
+    targetDatabaseDsn(targetDsn, "postgres"),
     handshakePath,
     PROVISION_ADVISORY_LOCK_KEY,
   );

--- a/packages/cloud/scripts/admin/apps-tenant-db-recovery.ts
+++ b/packages/cloud/scripts/admin/apps-tenant-db-recovery.ts
@@ -910,7 +910,12 @@ export function parseCliArgs(argv: string[]): CliOptions {
 function run(
   command: string,
   args: string[],
-  opts: { env?: Record<string, string>; input?: string } = {},
+  opts: {
+    env?: Record<string, string>;
+    input?: string;
+    /** Treat a relation-does-not-exist failure as empty output instead of an error. */
+    allowMissingTable?: boolean;
+  } = {},
 ): string {
   const result = spawnSync(command, args, {
     encoding: "utf-8",
@@ -925,6 +930,14 @@ function run(
     );
   }
   if (result.status !== 0) {
+    // error-policy:J3 a missing relation is an explicit benign-absence case
+    // for the caller that opted in; every other failure stays an error.
+    if (
+      opts.allowMissingTable === true &&
+      /relation ".+" does not exist/.test(result.stderr)
+    ) {
+      return "0";
+    }
     throw new RecoveryDrillError(
       "TOOL_FAILED",
       `${command} exited ${result.status}`,
@@ -1210,17 +1223,21 @@ export function targetHasDrillClaim(
   capabilityEnvelope: string,
 ): boolean {
   const claimId = createHash("sha256").update(capabilityEnvelope).digest("hex");
-  const out = run("psql", [
-    "--no-psqlrc",
-    "--tuples-only",
-    "--no-align",
-    "--set",
-    "ON_ERROR_STOP=1",
-    "--dbname",
-    targetDsn,
-    "--command",
-    `SELECT count(*) FROM public.eliza_restore_drill_claim WHERE capability_sha256 = '${claimId}'`,
-  ]).trim();
+  // A missing claim table (fresh target) is not an error: it simply means no
+  // capability ever claimed this target. Every other failure still throws.
+  const out = run(
+    "psql",
+    [
+      "--no-psqlrc",
+      "--tuples-only",
+      "--no-align",
+      "--dbname",
+      targetDsn,
+      "--command",
+      `SELECT count(*) FROM public.eliza_restore_drill_claim WHERE capability_sha256 = '${claimId}'`,
+    ],
+    { allowMissingTable: true },
+  ).trim();
   return Number(out) > 0;
 }
 
@@ -1291,6 +1308,7 @@ export function acquireDrillLock(
       targetDsn,
       "--command",
       `SELECT CASE WHEN pg_try_advisory_lock(${DRILL_ADVISORY_LOCK_KEY}) THEN '${DRILL_LOCK_HANDSHAKE}' ELSE '${DRILL_LOCK_REFUSED}' END;`,
+      "--command",
       `SELECT pg_sleep(${DRILL_LOCK_MAX_SECONDS});`,
     ],
     { stdio: ["ignore", outFd, "pipe"] },
@@ -1422,8 +1440,11 @@ export function executeDrill(options: CliOptions): DrillReport {
       `--capability-file could not be read: ${(cause as Error).message}`,
     );
   }
-  const capability = parseRestoreCapability(capabilityText);
-  verifyRestoreCapability(capability, signingKey, Date.now());
+  const parsed = parseRestoreCapability(capabilityText);
+  // verifyRestoreCapability returns the fields re-derived from the SIGNED
+  // bytes; every downstream use goes through this authenticated value, so a
+  // divergent mutable field on the parsed object can never reach the drill.
+  let capability = verifyRestoreCapability(parsed, signingKey, Date.now());
   if (capability.targetId !== options.targetId) {
     throw new RecoveryDrillError(
       "REFUSED_TARGET_AUTHORITY",
@@ -1498,13 +1519,21 @@ export function executeDrill(options: CliOptions): DrillReport {
     try {
       // Expiry rechecked at the destructive boundary, immediately after the
       // lock is proven held: a capability that expired during archive
-      // verification/hashing must not arm destructive SQL.
-      verifyRestoreCapability(capability, signingKey, Date.now());
+      // verification/hashing must not arm destructive SQL. The returned
+      // object is the signed-bytes-derived view, so this re-assignment also
+      // drops any field divergence from the originally parsed envelope.
+      capability = verifyRestoreCapability(capability, signingKey, Date.now());
       assertDrillLockHeld(drillLock);
       // Transactional exclusivity: refuse a different capability on this target
-      // before any destructive statement runs. A durable claim record for
-      // THIS capability also marks the target as a same-capability retry, so
-      // role remnants from a failed prior run are exempted below.
+      // before any destructive statement runs. Whether THIS capability already
+      // claimed the target is read BEFORE the claim transaction runs — the
+      // claim script upserts the row, so asking after it would always answer
+      // true and exempt archive-named roles on fresh targets too.
+      const capabilityEnvelopeLocal = serializeRestoreCapability(capability);
+      const isSameCapabilityRetry = targetHasDrillClaim(
+        options.targetDsn,
+        capabilityEnvelopeLocal,
+      );
       const claimScript = join(work, "claim-exclusivity.sql");
       writeFileSync(claimScript, buildClaimExclusivitySql(capability));
       guardedPsqlFile(
@@ -1512,10 +1541,6 @@ export function executeDrill(options: CliOptions): DrillReport {
         options.targetId,
         capabilityEnvelope,
         claimScript,
-      );
-      const isSameCapabilityRetry = targetHasDrillClaim(
-        options.targetDsn,
-        serializeRestoreCapability(capability),
       );
 
       run("openssl", [
@@ -1601,6 +1626,10 @@ export function executeDrill(options: CliOptions): DrillReport {
       }
 
       const restoreStart = Date.now();
+      // Lock liveness is re-proven before each destructive phase: if the
+      // session-lock holder dies mid-run, exclusivity no longer holds and the
+      // remaining destructive statements must not run (#23453 review).
+      assertDrillLockHeld(drillLock);
       const guardedGlobals = join(work, "guarded-globals.sql");
       writeFileSync(
         guardedGlobals,
@@ -1623,6 +1652,7 @@ export function executeDrill(options: CliOptions): DrillReport {
         }
         const databaseIdentifier = quoteSqlIdentifier(entry.databaseName);
         const ownerIdentifier = quoteSqlIdentifier(probe.role);
+        assertDrillLockHeld(drillLock);
         const guardedDrop = join(work, `${entry.dumpId}.drop.sql`);
         writeFileSync(
           guardedDrop,

--- a/packages/cloud/scripts/admin/apps-tenant-db-recovery.ts
+++ b/packages/cloud/scripts/admin/apps-tenant-db-recovery.ts
@@ -63,13 +63,17 @@ import type { ChildProcess } from "node:child_process";
 import { spawn, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
+  closeSync,
   copyFileSync,
+  fsyncSync,
   mkdtempSync,
   openSync,
   readFileSync,
+  renameSync,
   rmSync,
   statSync,
   writeFileSync,
+  writeSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -729,6 +733,11 @@ export function parseTenantProbes(
   }
   const expected = new Set(databases.map((entry) => entry.dumpId));
   const seen = new Set<string>();
+  // One-to-one tenant↔role mapping (#23453 review r2): two restored tenant
+  // databases sharing one probe role would collapse their credentials — each
+  // own-connect would pass while one role could reach both databases. Every
+  // role must be claimed by exactly one tenant.
+  const rolesTaken = new Set<string>();
   const probes: TenantProbe[] = [];
   for (const item of record.tenants) {
     if (typeof item !== "object" || item === null) {
@@ -759,6 +768,13 @@ export function parseTenantProbes(
       );
     }
     seen.add(dumpId);
+    if (rolesTaken.has(role)) {
+      throw new RecoveryDrillError(
+        "INVALID_PROBE_METADATA",
+        `probe role '${role.slice(0, 64)}' is used by more than one tenant; the tenant-to-role mapping must be one-to-one`,
+      );
+    }
+    rolesTaken.add(role);
     probes.push({ dumpId, role, passwordEnv });
   }
   if (seen.size !== expected.size) {
@@ -1358,6 +1374,7 @@ export function acquireDrillLock(
     try {
       if (child.pid !== undefined) process.kill(child.pid, 0);
     } catch {
+      // error-policy:J3 signal-zero probe failure proves the holder is gone.
       child.kill("SIGKILL");
       throw new RecoveryDrillError(
         "LOCK_FAILED",
@@ -1392,6 +1409,7 @@ export function assertDrillLockHeld(lock: DrillLock): void {
     if (lock.child.pid !== undefined) process.kill(lock.child.pid, 0);
     alive = true;
   } catch {
+    // error-policy:J3 signal-zero probe failure means the holder is gone.
     alive = false;
   }
   if (!alive || !observed.includes(DRILL_LOCK_HANDSHAKE)) {
@@ -1546,6 +1564,8 @@ export function executeDrill(options: CliOptions): DrillReport {
       // claim script upserts the row, so asking after it would always answer
       // true and exempt archive-named roles on fresh targets too.
       const capabilityEnvelopeLocal = serializeRestoreCapability(capability);
+      assertCapabilityLive();
+      assertDrillLockHeld(drillLock);
       const isSameCapabilityRetry = targetHasDrillClaim(
         options.targetDsn,
         capabilityEnvelopeLocal,
@@ -1692,6 +1712,11 @@ export function executeDrill(options: CliOptions): DrillReport {
         );
         const rawRestore = join(work, `${entry.dumpId}.restore.sql`);
         run("pg_restore", ["--file", rawRestore, dumpFile]);
+        // pg_restore can run long enough for the capability to expire or the
+        // lock holder to die mid-extraction; re-prove both immediately
+        // before the extracted destructive SQL executes (#23453 review r2).
+        assertCapabilityLive();
+        assertDrillLockHeld(drillLock);
         const guardedRestore = join(
           work,
           `${entry.dumpId}.guarded-restore.sql`,
@@ -1965,7 +1990,22 @@ export function runProvisionCommand(
   // The serialized capability contains no single quotes (pipe-delimited
   // envelope over UUID/hex ids and a hex signature), so this literal is safe.
   kept.push(`eliza.restore_capability = '${capabilityText}'`);
-  writeFileSync(autoConf, `${kept.join("\n").trimEnd()}\n`);
+  // Atomic update (#23453 review r2): write the new content to a sibling
+  // temp file, fsync it, then rename over postgresql.auto.conf — the same
+  // crash-consistency shape ALTER SYSTEM SET itself uses. A crash or a
+  // concurrent ALTER SYSTEM can never observe a truncated/partial file;
+  // the filter above re-reads immediately before this write, so the only
+  // lost race is a concurrent eliza.* line, which the fresh-session
+  // verification below catches.
+  const tmpConf = `${autoConf}.eliza-provision-${process.pid}.tmp`;
+  const fd = openSync(tmpConf, "w");
+  try {
+    writeSync(fd, `${kept.join("\n").trimEnd()}\n`);
+    fsyncSync(fd);
+  } finally {
+    closeSync(fd);
+  }
+  renameSync(tmpConf, autoConf);
   run("psql", [
     "--no-psqlrc",
     "--set",

--- a/packages/cloud/scripts/admin/apps-tenant-db-recovery.ts
+++ b/packages/cloud/scripts/admin/apps-tenant-db-recovery.ts
@@ -495,21 +495,53 @@ DO $$ BEGIN RAISE EXCEPTION 'restore target authority mismatch'; END $$;
 \\endif
 `;
 
-/**
- * Guard one psql session before its first destructive statement. Both twin
- * settings — the disposable target id and the serialized capability — must
- * still be present and exactly equal (supplied via psql --set variables at
- * invocation), so every destructive session of the drill is individually
- * authority-checked.
- */
-export function guardPsqlScript(sql: string): string {
-  return `${TARGET_GUARD_SQL}${sql}`;
-}
-
 const CONSUME_AUTHORITY_SQL = `ALTER SYSTEM RESET ${SETTING_TARGET_ID};
 ALTER SYSTEM RESET ${SETTING_CAPABILITY};
 SELECT pg_reload_conf();
 `;
+
+/**
+ * Server-side expiry enforcement embedded in every guarded psql session
+ * (#23453 review r4): the locally verified capability's expiry — signed
+ * bytes the HMAC covers — is passed as an epoch-millisecond cutoff, and the
+ * session ABORTS unless the SERVER clock is still inside the capability
+ * window. The local assertCapabilityLive() checks are advisory; only this
+ * check closes the expiry TOCTOU between the local check and the SQL
+ * executing on the server. An arbitrary skew between the drill host and the
+ * server can only shrink or (bounded by the signed TTL) widen the window.
+ */
+function expiryGuardSql(expiresAtEpochMs: number): string {
+  if (!Number.isSafeInteger(expiresAtEpochMs) || expiresAtEpochMs <= 0) {
+    throw new RecoveryDrillError(
+      "INVALID_CAPABILITY",
+      "capability expiry is not a safe positive epoch-millisecond value",
+    );
+  }
+  return `SELECT (floor(extract(epoch from (clock_timestamp() AT TIME ZONE 'utc'))) * 1000) <= ${expiresAtEpochMs} AS eliza_capability_live \\gset
+\\if :eliza_capability_live
+\\else
+\\echo 'restore capability has expired on the server clock'
+DO $$ BEGIN RAISE EXCEPTION 'restore capability has expired on the server clock'; END $$;
+\\endif
+`;
+}
+
+/**
+ * Guard one psql session before its first destructive statement. Both twin
+ * settings — the disposable target id and the serialized capability — must
+ * still be present and exactly equal (supplied via psql --set variables at
+ * invocation), and the server clock must still be inside the capability
+ * window, so every destructive session of the drill is individually
+ * authority-checked with no local-check/SQL-execution TOCTOU.
+ */
+export function guardPsqlScript(
+  sql: string,
+  expiresAtEpochMs?: number,
+): string {
+  const expiry =
+    expiresAtEpochMs === undefined ? "" : expiryGuardSql(expiresAtEpochMs);
+  return `${TARGET_GUARD_SQL}${expiry}${sql}`;
+}
 
 /**
  * Guarded script that spends the target authority at the END of the drill:
@@ -520,8 +552,8 @@ SELECT pg_reload_conf();
  * NOT consume the settings — the disposable target stays recoverable for an
  * idempotent re-run inside the capability TTL.
  */
-export function guardedConsumeAuthoritySql(): string {
-  return guardPsqlScript(CONSUME_AUTHORITY_SQL);
+export function guardedConsumeAuthoritySql(expiresAtEpochMs?: number): string {
+  return guardPsqlScript(CONSUME_AUTHORITY_SQL, expiresAtEpochMs);
 }
 
 /**
@@ -552,6 +584,7 @@ DELETE FROM public.eliza_restore_drill_claim WHERE capability_sha256 = '${claimI
 INSERT INTO public.eliza_restore_drill_claim (capability_sha256) VALUES ('${claimId}');
 COMMIT;
 `,
+    capability.expiresAtEpochMs,
   );
 }
 
@@ -1114,7 +1147,10 @@ export function consumeRestoreAuthority(
   work: string,
 ): void {
   const script = join(work, "consume-authority.sql");
-  writeFileSync(script, guardedConsumeAuthoritySql());
+  writeFileSync(
+    script,
+    guardedConsumeAuthoritySql(capability.expiresAtEpochMs),
+  );
   run("psql", [
     "--no-psqlrc",
     "--set",
@@ -1331,8 +1367,13 @@ export function acquireDrillLock(
       targetDsn,
       "--command",
       `SELECT CASE WHEN pg_try_advisory_lock(${DRILL_ADVISORY_LOCK_KEY}) THEN '${DRILL_LOCK_HANDSHAKE}:' || pg_backend_pid() ELSE '${DRILL_LOCK_REFUSED}' END;`,
+      // A refused lock must NOT fall through to the hold-sleep: the refusal
+      // sentinel is not a SQL error, so ON_ERROR_STOP does not stop psql and
+      // the second --command WOULD execute — leaking a 24h pg_sleep backend
+      // with no lock to its name (#23453 review r4). The 1/0 division aborts
+      // the refused holder deterministically.
       "--command",
-      `SELECT pg_sleep(${DRILL_LOCK_MAX_SECONDS});`,
+      `SELECT CASE WHEN (SELECT count(*) FROM pg_locks WHERE locktype = 'advisory' AND classid = 0 AND objid = ${DRILL_ADVISORY_LOCK_KEY} AND objsubid = 1 AND pid = pg_backend_pid()) = 1 THEN pg_sleep(${DRILL_LOCK_MAX_SECONDS}) ELSE 1/0 END;`,
     ],
     { stdio: ["ignore", outFd, "pipe"] },
   );
@@ -1442,25 +1483,33 @@ export function releaseDrillLock(lock: DrillLock): void {
   // DRILL_LOCK_MAX_SECONDS sleep and refuse every idempotent re-run within
   // the capability TTL (proven by the claim-order regression test: a failed
   // first invocation must leave the target retryable, not lock-pinned).
+  // Termination is gated on pg_locks proving the pid STILL holds this drill's
+  // exact advisory lock (#23453 review r4): a recycled OS pid would otherwise
+  // point at an unrelated backend, and terminating it would be collateral
+  // damage. The same query proves termination succeeded (returns true), not
+  // merely that psql exited cleanly.
   if (lock.backendPid !== undefined) {
     const terminated = spawnSync(
       "psql",
       [
         "--no-psqlrc",
         "--quiet",
+        "--tuples-only",
+        "--no-align",
         "--dbname",
         lock.targetDsn,
         "--command",
-        `SELECT pg_terminate_backend(${lock.backendPid}) WHERE pg_backend_pid() <> ${lock.backendPid};`,
+        `SELECT CASE WHEN EXISTS (SELECT 1 FROM pg_locks WHERE locktype = 'advisory' AND classid = 0 AND objid = ${DRILL_ADVISORY_LOCK_KEY} AND objsubid = 1 AND pid = ${lock.backendPid} AND pid <> pg_backend_pid()) THEN pg_terminate_backend(${lock.backendPid}) ELSE false END;`,
       ],
       { encoding: "utf-8" },
     );
-    if (terminated.status !== 0) {
-      // error-policy:J4 the SIGKILL fallback below still drops the client;
-      // termination is best-effort so a completed drill's report is never
-      // masked by a cleanup failure.
+    const released =
+      terminated.status === 0 && (terminated.stdout ?? "").trim() === "t";
+    if (!released) {
+      // error-policy:J6 teardown-only: the SIGKILL fallback below still drops
+      // the client; a termination miss here never masks the drill outcome.
       process.stderr.write(
-        `drill lock backend termination failed: ${terminated.stderr?.slice(-200) ?? "unknown"}\n`,
+        `drill lock backend termination not confirmed: ${(terminated.stderr ?? terminated.stdout ?? "unknown").slice(-200)}\n`,
       );
     }
   }
@@ -1480,7 +1529,14 @@ function guardedPsqlFile(
   targetId: string,
   capability: string,
   script: string,
+  expiresAtEpochMs?: number,
 ): void {
+  if (expiresAtEpochMs !== undefined) {
+    // Re-guard the already-written script with the server-clock expiry check
+    // by prefixing it (guardPsqlScript composes the same way).
+    const body = readFileSync(script, "utf-8");
+    writeFileSync(script, guardPsqlScript(body, expiresAtEpochMs));
+  }
   run("psql", [
     "--no-psqlrc",
     "--set",
@@ -1675,6 +1731,7 @@ export function executeDrill(options: CliOptions): DrillReport {
         options.targetId,
         capabilityEnvelope,
         claimScript,
+        capability.expiresAtEpochMs,
       );
       const dbMap = parseDbMap(readFileSync(join(work, "dbmap.tsv"), "utf-8"));
       if (dbMap.length !== manifest.databaseCount) {
@@ -1724,13 +1781,17 @@ export function executeDrill(options: CliOptions): DrillReport {
       const guardedGlobals = join(work, "guarded-globals.sql");
       writeFileSync(
         guardedGlobals,
-        guardPsqlScript(makeGlobalsIdempotent(globalsSql)),
+        guardPsqlScript(
+          makeGlobalsIdempotent(globalsSql),
+          capability.expiresAtEpochMs,
+        ),
       );
       guardedPsqlFile(
         options.targetDsn,
         options.targetId,
         capabilityEnvelope,
         guardedGlobals,
+        capability.expiresAtEpochMs,
       );
       for (const entry of dbMap) {
         const dumpFile = join(work, "dumps", `${entry.dumpId}.dump`);
@@ -1763,6 +1824,7 @@ export function executeDrill(options: CliOptions): DrillReport {
           options.targetId,
           capabilityEnvelope,
           guardedDrop,
+          capability.expiresAtEpochMs,
         );
         const rawRestore = join(work, `${entry.dumpId}.restore.sql`);
         run("pg_restore", ["--file", rawRestore, dumpFile]);
@@ -1777,7 +1839,10 @@ export function executeDrill(options: CliOptions): DrillReport {
         );
         writeFileSync(
           guardedRestore,
-          guardPsqlScript(readFileSync(rawRestore, "utf-8")),
+          guardPsqlScript(
+            readFileSync(rawRestore, "utf-8"),
+            capability.expiresAtEpochMs,
+          ),
         );
         run("psql", [
           "--no-psqlrc",
@@ -1821,8 +1886,14 @@ export function executeDrill(options: CliOptions): DrillReport {
                 `gexec`,
               "",
             ].join("\n"),
+            capability.expiresAtEpochMs,
           ),
         );
+        // The restore SQL can run long enough for the capability to expire
+        // or the lock holder to die mid-restore; re-prove both immediately
+        // before the handoff session executes (#23453 review r4).
+        assertCapabilityLive();
+        assertDrillLockHeld(drillLock);
         run("psql", [
           "--no-psqlrc",
           "--set",
@@ -2053,11 +2124,30 @@ export function runMintCommand(argv: string[]): string {
 const PROVISION_LOCK_STALE_MS = 120_000;
 
 /**
- * Atomically claim the provision lock (O_EXCL). A lock older than the
- * staleness window is removed and retried once — the holder refreshes the
- * mtime on acquire, so only a crashed holder's lock is ever broken.
+ * Handle over a claimed provision lock: the stat identifies THIS claim's
+ * lock-file inode (dev+ino), so release can only unlink a file this claim
+ * created — never a successor's lock after a stale takeover (#23453
+ * review r4).
  */
-function claimProvisionLock(lockPath: string): void {
+interface ProvisionLockHandle {
+  lockPath: string;
+  dev: number;
+  ino: number;
+}
+
+/**
+ * Atomically claim the provision lock (O_EXCL). A lock older than the
+ * staleness window is presumed crashed and taken over by RENAMING it aside
+ * (the rename is atomic and unlinks exactly one file) and retrying the
+ * O_EXCL create once. Takeover never unlinks the shared lock path directly,
+ * so two provisioners racing on a stale lock cannot remove each other's
+ * fresh claims: only the rename winner recreates the lock, and the loser's
+ * next O_EXCL fails against the winner's lock (#23453 review r4). This is
+ * a takeover, not a lease: the critical section is seconds-long and the
+ * window only bounds how long a crashed holder can block the next
+ * provisioner.
+ */
+function claimProvisionLock(lockPath: string): ProvisionLockHandle {
   for (let attempt = 0; attempt < 2; attempt++) {
     try {
       const fd = openSync(lockPath, "wx");
@@ -2066,7 +2156,8 @@ function claimProvisionLock(lockPath: string): void {
       } finally {
         closeSync(fd);
       }
-      return;
+      const own = statSync(lockPath);
+      return { lockPath, dev: own.dev, ino: own.ino };
     } catch (error) {
       const code = (error as { code?: string }).code;
       if (code !== "EEXIST") {
@@ -2076,28 +2167,52 @@ function claimProvisionLock(lockPath: string): void {
         );
       }
     }
+    if (attempt > 0) {
+      break;
+    }
     const stale = statSync(lockPath, { throwIfNoEntry: false });
     if (
-      stale !== undefined &&
-      Date.now() - stale.mtimeMs > PROVISION_LOCK_STALE_MS
+      stale === undefined ||
+      Date.now() - stale.mtimeMs <= PROVISION_LOCK_STALE_MS
     ) {
-      try {
-        // error-policy:J6 a stale lock from a crashed holder is removed.
-        rmSync(lockPath, { force: true });
-      } catch {
-        // error-policy:J6 stale-lock removal failure surfaces as EEXIST retry.
-      }
-      continue;
+      break;
     }
-    throw new RecoveryDrillError(
-      "PROVISION_LOCK_HELD",
-      "another provisioner holds the postgresql.auto.conf lock",
-    );
+    // Take the stale lock out of the way by renaming it aside: the rename
+    // is atomic and cannot remove a concurrently recreated lock at this
+    // path. The sidecar is left for the operator; it proves a crashed
+    // holder was superseded.
+    // error-policy:J6 a stale lock from a crashed holder is moved aside.
+    try {
+      renameSync(lockPath, `${lockPath}.stale-${Date.now()}`);
+    } catch {
+      // error-policy:J6 takeover failure surfaces as a held lock below.
+      break;
+    }
   }
   throw new RecoveryDrillError(
     "PROVISION_LOCK_HELD",
     "another provisioner holds the postgresql.auto.conf lock",
   );
+}
+
+/**
+ * Release the provision lock by identity: unlink only when the path still
+ * resolves to THIS claim's inode. A successor's recreated lock at the same
+ * path is a different inode and is never removed (#23453 review r4).
+ */
+function releaseProvisionLock(handle: ProvisionLockHandle): void {
+  try {
+    const current = statSync(handle.lockPath, { throwIfNoEntry: false });
+    if (
+      current !== undefined &&
+      current.dev === handle.dev &&
+      current.ino === handle.ino
+    ) {
+      rmSync(handle.lockPath, { force: true });
+    }
+  } catch {
+    // error-policy:J6 lock release must not mask the provisioning outcome.
+  }
 }
 
 /**
@@ -2173,20 +2288,15 @@ export function runProvisionCommand(
   // lost-update race entirely.
   // Neither Node nor Bun exposes flock(2), so the lock is an O_EXCL lock
   // file: creation is atomic, so exactly one provisioner can hold it. A
-  // crash while holding leaves a stale lock; it is broken after
-  // PROVISION_LOCK_STALE_MS because a live holder refreshes the lock's
-  // mtime, and the whole window is minutes, not hours.
-  const lockPath = `${autoConf}.eliza-provision.lock`;
-  claimProvisionLock(lockPath);
+  // crash while holding leaves a stale lock; it is superseded after
+  // PROVISION_LOCK_STALE_MS by an atomic rename-aside takeover — a live
+  // holder finishes well inside the window, so the bound only matters for
+  // crashed holders.
+  const lockHandle = claimProvisionLock(`${autoConf}.eliza-provision.lock`);
   try {
     writeAutoConfAtomic(autoConf, targetId, capabilityText);
   } finally {
-    try {
-      // error-policy:J6 best-effort lock-file release.
-      rmSync(lockPath, { force: true });
-    } catch {
-      // error-policy:J6 lock release must not mask the provisioning outcome.
-    }
+    releaseProvisionLock(lockHandle);
   }
   run("psql", [
     "--no-psqlrc",

--- a/packages/cloud/scripts/admin/restore-capability.ts
+++ b/packages/cloud/scripts/admin/restore-capability.ts
@@ -34,18 +34,26 @@ export interface RestoreCapability {
   targetId: string;
   archiveSha256: string;
   expiresAtEpochMs: number;
+  /** Issuance time; the signature covers it, so a re-signed grant cannot claim an older minting. */
+  issuedAtEpochMs: number;
   /** Canonical payload bytes this capability's signature covers. */
   payload: string;
   signature: string;
 }
 
-/** Canonical envelope bytes: the exact string the HMAC is computed over. */
+/**
+ * Canonical envelope bytes: the exact string the HMAC is computed over.
+ * Includes issuedAt so verify-time can prove (not just trust) the claimed
+ * lifetime: expiresAt − issuedAt ≤ MAX_CAPABILITY_TTL_MS is enforced against
+ * the SIGNED bytes, closing the re-signed-with-later-expiry hole.
+ */
 export function capabilityPayload(
   targetId: string,
   archiveSha256: string,
+  issuedAtEpochMs: number,
   expiresAtEpochMs: number,
 ): string {
-  return `${ENVELOPE_PREFIX}|${targetId}|${archiveSha256}|${expiresAtEpochMs}`;
+  return `${ENVELOPE_PREFIX}|${targetId}|${archiveSha256}|${issuedAtEpochMs}|${expiresAtEpochMs}`;
 }
 
 function hmacHex(key: string, payload: string): string {
@@ -86,15 +94,18 @@ export function mintRestoreCapability(input: {
       `expiresAt must be in the future and at most ${MAX_CAPABILITY_TTL_MS}ms away`,
     );
   }
+  const issuedAtEpochMs = now;
   const payload = capabilityPayload(
     input.targetId,
     input.archiveSha256,
+    issuedAtEpochMs,
     input.expiresAtEpochMs,
   );
   return {
     targetId: input.targetId,
     archiveSha256: input.archiveSha256,
     expiresAtEpochMs: input.expiresAtEpochMs,
+    issuedAtEpochMs,
     payload,
     signature: hmacHex(input.signingKey, payload),
   };
@@ -108,12 +119,13 @@ export function serializeRestoreCapability(cap: RestoreCapability): string {
 export function parseRestoreCapability(text: string): RestoreCapability {
   const parts = text.split("|");
   if (
-    parts.length !== 5 ||
+    parts.length !== 6 ||
     parts[0] !== ENVELOPE_PREFIX ||
     !TARGET_ID_RE.test(parts[1]) ||
     !SHA256_RE.test(parts[2]) ||
     !/^\d+$/.test(parts[3]) ||
-    !HEX64_RE.test(parts[4])
+    !/^\d+$/.test(parts[4]) ||
+    !HEX64_RE.test(parts[5])
   ) {
     throw new RestoreCapabilityError(
       "INVALID_CAPABILITY",
@@ -123,9 +135,10 @@ export function parseRestoreCapability(text: string): RestoreCapability {
   return {
     targetId: parts[1],
     archiveSha256: parts[2],
-    expiresAtEpochMs: Number(parts[3]),
-    signature: parts[4],
-    payload: `${ENVELOPE_PREFIX}|${parts[1]}|${parts[2]}|${parts[3]}`,
+    issuedAtEpochMs: Number(parts[3]),
+    expiresAtEpochMs: Number(parts[4]),
+    signature: parts[5],
+    payload: `${ENVELOPE_PREFIX}|${parts[1]}|${parts[2]}|${parts[3]}|${parts[4]}`,
   };
 }
 
@@ -146,6 +159,22 @@ export function verifyRestoreCapability(
     throw new RestoreCapabilityError(
       "REFUSED_CAPABILITY_SIGNATURE",
       "restore capability signature does not verify",
+    );
+  }
+  // The lifetime ceiling is proven from the SIGNED bytes, not trusted from
+  // the envelope: a holder of the signing key cannot re-sign a grant whose
+  // expiresAt−issuedAt span exceeds the ceiling, and a re-mint resets
+  // issuedAt so the effective window always starts at minting time.
+  if (cap.expiresAtEpochMs - cap.issuedAtEpochMs > MAX_CAPABILITY_TTL_MS) {
+    throw new RestoreCapabilityError(
+      "INVALID_CAPABILITY",
+      `signed capability lifetime exceeds the ${MAX_CAPABILITY_TTL_MS}ms ceiling`,
+    );
+  }
+  if (cap.issuedAtEpochMs > nowEpochMs + METADATA_FRESHNESS_WINDOW_MS) {
+    throw new RestoreCapabilityError(
+      "INVALID_CAPABILITY",
+      "capability issuedAt is in the future beyond the freshness window",
     );
   }
   if (cap.expiresAtEpochMs <= nowEpochMs) {
@@ -181,13 +210,14 @@ export function assertRecoveryPointConsistency(input: {
       `sidecar/manifest created_at drift ${driftMs}ms exceeds the ${METADATA_FRESHNESS_WINDOW_MS}ms freshness window`,
     );
   }
-  if (
-    input.manifestCreatedAt.getTime() >
-    input.nowEpochMs + METADATA_FRESHNESS_WINDOW_MS
-  ) {
+  // Future-dated manifests are refused outright (no tolerance window): a
+  // manifest timestamp is server-generated at backup time and can never
+  // legitimately exceed the verifier's clock by more than the drift bound
+  // already checked above against the sidecar.
+  if (input.manifestCreatedAt.getTime() > input.nowEpochMs) {
     throw new RestoreCapabilityError(
       "REFUSED_RECOVERY_POINT",
-      "manifest created_at is in the future beyond the freshness window",
+      "manifest created_at is in the future",
     );
   }
 }

--- a/packages/cloud/scripts/admin/restore-capability.ts
+++ b/packages/cloud/scripts/admin/restore-capability.ts
@@ -5,8 +5,9 @@
  * server-side twin setting before any destructive SQL and both are consumed
  * in one guarded transaction, so a substituted archive cannot ride a
  * correctly nonced target and a replayed capability is dead. Payload bytes
- * are the canonical JSON envelope `v1.eliza.restore|targetId|archiveSha256|`
- * `expiresAtEpochMs`; the signature is HMAC-SHA256 over those exact bytes.
+ * are the canonical envelope `v1.eliza.restore|targetId|archiveSha256|`
+ * `issuedAtEpochMs|expiresAtEpochMs`; the signature is HMAC-SHA256 over
+ * those exact bytes.
  */
 
 import { createHmac, randomUUID, timingSafeEqual } from "node:crypto";
@@ -242,6 +243,20 @@ export function assertRecoveryPointConsistency(input: {
   manifestCreatedAt: Date;
   nowEpochMs: number;
 }): void {
+  // Unparseable timestamps must fail closed, not pass by NaN comparison:
+  // Math.abs(NaN) > WINDOW and NaN > now are both false, so an Invalid Date
+  // on either side would otherwise slip both checks (#23453 review r8). The
+  // production path rejects unparseable timestamps earlier (requireIsoDate);
+  // this guard keeps the exported function's contract independent of it.
+  if (
+    !Number.isFinite(input.sidecarCreatedAt.getTime()) ||
+    !Number.isFinite(input.manifestCreatedAt.getTime())
+  ) {
+    throw new RestoreCapabilityError(
+      "REFUSED_RECOVERY_POINT",
+      "sidecar/manifest created_at is not a parseable timestamp",
+    );
+  }
   const driftMs = Math.abs(
     input.sidecarCreatedAt.getTime() - input.manifestCreatedAt.getTime(),
   );

--- a/packages/cloud/scripts/admin/restore-capability.ts
+++ b/packages/cloud/scripts/admin/restore-capability.ts
@@ -160,6 +160,23 @@ export function verifyRestoreCapability(
   const fromSignedBytes = parseRestoreCapability(
     serializeRestoreCapability(cap),
   );
+  // Exact-equality invariant (#23453 review r2): the caller-visible fields
+  // must equal the values authenticated inside the signed payload bytes. A
+  // capability object whose targetId/archiveSha256/issuedAt/expiresAt were
+  // mutated without re-signing is refused outright rather than silently
+  // healed — the returned canonical object is the ONLY thing later code
+  // trusts, so it must provably match the signed envelope.
+  if (
+    cap.targetId !== fromSignedBytes.targetId ||
+    cap.archiveSha256 !== fromSignedBytes.archiveSha256 ||
+    cap.issuedAtEpochMs !== fromSignedBytes.issuedAtEpochMs ||
+    cap.expiresAtEpochMs !== fromSignedBytes.expiresAtEpochMs
+  ) {
+    throw new RestoreCapabilityError(
+      "REFUSED_CAPABILITY_SIGNATURE",
+      "capability fields diverge from the signed payload bytes",
+    );
+  }
   const expected = hmacHex(signingKey, fromSignedBytes.payload);
   const a = Buffer.from(fromSignedBytes.signature, "utf-8");
   const b = Buffer.from(expected, "utf-8");

--- a/packages/cloud/scripts/admin/restore-capability.ts
+++ b/packages/cloud/scripts/admin/restore-capability.ts
@@ -1,0 +1,193 @@
+/**
+ * Archive-bound restore capability (#23453): a signed, expiring grant that
+ * pins exactly one archive (sha256) to exactly one disposable restore target
+ * (id) for a bounded window. The drill verifies the capability against a
+ * server-side twin setting before any destructive SQL and both are consumed
+ * in one guarded transaction, so a substituted archive cannot ride a
+ * correctly nonced target and a replayed capability is dead. Payload bytes
+ * are the canonical JSON envelope `v1.eliza.restore|targetId|archiveSha256|`
+ * `expiresAtEpochMs`; the signature is HMAC-SHA256 over those exact bytes.
+ */
+
+import { createHmac, randomUUID, timingSafeEqual } from "node:crypto";
+
+const SHA256_RE = /^[a-f0-9]{64}$/;
+const TARGET_ID_RE =
+  /^drill-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const HEX64_RE = /^[a-f0-9]{64}$/;
+const ENVELOPE_PREFIX = "v1.eliza.restore";
+/** Capability lifetime ceiling; longer-lived grants are refused outright. */
+export const MAX_CAPABILITY_TTL_MS = 24 * 60 * 60 * 1000;
+/** How far sidecar/manifest timestamps may drift before the RPO input is refused. */
+export const METADATA_FRESHNESS_WINDOW_MS = 60_000;
+
+export class RestoreCapabilityError extends Error {
+  readonly code: string;
+  constructor(code: string, message: string) {
+    super(message);
+    this.code = code;
+    this.name = "RestoreCapabilityError";
+  }
+}
+
+export interface RestoreCapability {
+  targetId: string;
+  archiveSha256: string;
+  expiresAtEpochMs: number;
+  /** Canonical payload bytes this capability's signature covers. */
+  payload: string;
+  signature: string;
+}
+
+/** Canonical envelope bytes: the exact string the HMAC is computed over. */
+export function capabilityPayload(
+  targetId: string,
+  archiveSha256: string,
+  expiresAtEpochMs: number,
+): string {
+  return `${ENVELOPE_PREFIX}|${targetId}|${archiveSha256}|${expiresAtEpochMs}`;
+}
+
+function hmacHex(key: string, payload: string): string {
+  return createHmac("sha256", key).update(payload, "utf-8").digest("hex");
+}
+
+/**
+ * Operator-side minting. The key comes from the provisioning environment
+ * (never from the backup set or the archive); expiry is clamped to
+ * MAX_CAPABILITY_TTL_MS so a leaked grant cannot outlive the drill window.
+ */
+export function mintRestoreCapability(input: {
+  signingKey: string;
+  targetId: string;
+  archiveSha256: string;
+  expiresAtEpochMs: number;
+}): RestoreCapability {
+  if (!TARGET_ID_RE.test(input.targetId)) {
+    throw new RestoreCapabilityError(
+      "INVALID_CAPABILITY",
+      "target id must be drill- followed by a UUID",
+    );
+  }
+  if (!SHA256_RE.test(input.archiveSha256)) {
+    throw new RestoreCapabilityError(
+      "INVALID_CAPABILITY",
+      "archive sha256 must be 64 hex characters",
+    );
+  }
+  const now = Date.now();
+  if (
+    !Number.isSafeInteger(input.expiresAtEpochMs) ||
+    input.expiresAtEpochMs <= now ||
+    input.expiresAtEpochMs > now + MAX_CAPABILITY_TTL_MS
+  ) {
+    throw new RestoreCapabilityError(
+      "INVALID_CAPABILITY",
+      `expiresAt must be in the future and at most ${MAX_CAPABILITY_TTL_MS}ms away`,
+    );
+  }
+  const payload = capabilityPayload(
+    input.targetId,
+    input.archiveSha256,
+    input.expiresAtEpochMs,
+  );
+  return {
+    targetId: input.targetId,
+    archiveSha256: input.archiveSha256,
+    expiresAtEpochMs: input.expiresAtEpochMs,
+    payload,
+    signature: hmacHex(input.signingKey, payload),
+  };
+}
+
+/** Format stored in the server-side twin setting (and the capability file). */
+export function serializeRestoreCapability(cap: RestoreCapability): string {
+  return `${cap.payload}|${cap.signature}`;
+}
+
+export function parseRestoreCapability(text: string): RestoreCapability {
+  const parts = text.split("|");
+  if (
+    parts.length !== 5 ||
+    parts[0] !== ENVELOPE_PREFIX ||
+    !TARGET_ID_RE.test(parts[1]) ||
+    !SHA256_RE.test(parts[2]) ||
+    !/^\d+$/.test(parts[3]) ||
+    !HEX64_RE.test(parts[4])
+  ) {
+    throw new RestoreCapabilityError(
+      "INVALID_CAPABILITY",
+      "capability is not a well-formed v1 envelope",
+    );
+  }
+  return {
+    targetId: parts[1],
+    archiveSha256: parts[2],
+    expiresAtEpochMs: Number(parts[3]),
+    signature: parts[4],
+    payload: `${ENVELOPE_PREFIX}|${parts[1]}|${parts[2]}|${parts[3]}`,
+  };
+}
+
+/**
+ * Verify a parsed capability's signature and liveness. Signature comparison
+ * is constant-time; expiry is checked against `nowEpochMs` (injected so
+ * tests can pin the clock). Returns the verified capability.
+ */
+export function verifyRestoreCapability(
+  cap: RestoreCapability,
+  signingKey: string,
+  nowEpochMs: number,
+): RestoreCapability {
+  const expected = hmacHex(signingKey, cap.payload);
+  const a = Buffer.from(cap.signature, "utf-8");
+  const b = Buffer.from(expected, "utf-8");
+  if (a.length !== b.length || !timingSafeEqual(a, b)) {
+    throw new RestoreCapabilityError(
+      "REFUSED_CAPABILITY_SIGNATURE",
+      "restore capability signature does not verify",
+    );
+  }
+  if (cap.expiresAtEpochMs <= nowEpochMs) {
+    throw new RestoreCapabilityError(
+      "CAPABILITY_EXPIRED",
+      "restore capability has expired",
+    );
+  }
+  return cap;
+}
+
+export function newNonce(): string {
+  return randomUUID();
+}
+
+/**
+ * Cross-check the untrusted plaintext sidecar's recovery point against the
+ * checksummed manifest inside the encrypted archive. A tampered or stale
+ * sidecar must not be able to understate data loss: any drift beyond the
+ * freshness window refuses the set outright.
+ */
+export function assertRecoveryPointConsistency(input: {
+  sidecarCreatedAt: Date;
+  manifestCreatedAt: Date;
+  nowEpochMs: number;
+}): void {
+  const driftMs = Math.abs(
+    input.sidecarCreatedAt.getTime() - input.manifestCreatedAt.getTime(),
+  );
+  if (driftMs > METADATA_FRESHNESS_WINDOW_MS) {
+    throw new RestoreCapabilityError(
+      "REFUSED_RECOVERY_POINT",
+      `sidecar/manifest created_at drift ${driftMs}ms exceeds the ${METADATA_FRESHNESS_WINDOW_MS}ms freshness window`,
+    );
+  }
+  if (
+    input.manifestCreatedAt.getTime() >
+    input.nowEpochMs + METADATA_FRESHNESS_WINDOW_MS
+  ) {
+    throw new RestoreCapabilityError(
+      "REFUSED_RECOVERY_POINT",
+      "manifest created_at is in the future beyond the freshness window",
+    );
+  }
+}

--- a/packages/cloud/scripts/admin/restore-capability.ts
+++ b/packages/cloud/scripts/admin/restore-capability.ts
@@ -152,8 +152,16 @@ export function verifyRestoreCapability(
   signingKey: string,
   nowEpochMs: number,
 ): RestoreCapability {
-  const expected = hmacHex(signingKey, cap.payload);
-  const a = Buffer.from(cap.signature, "utf-8");
+  // All authoritative fields derive from the SIGNED payload bytes, not from
+  // the mutable object fields: the signature authenticates cap.payload, so
+  // the envelope is re-parsed from those exact bytes and every semantic
+  // check below runs on the authenticated values. A caller who mutates a
+  // field without re-signing is caught here (#23453 review).
+  const fromSignedBytes = parseRestoreCapability(
+    serializeRestoreCapability(cap),
+  );
+  const expected = hmacHex(signingKey, fromSignedBytes.payload);
+  const a = Buffer.from(fromSignedBytes.signature, "utf-8");
   const b = Buffer.from(expected, "utf-8");
   if (a.length !== b.length || !timingSafeEqual(a, b)) {
     throw new RestoreCapabilityError(
@@ -161,29 +169,45 @@ export function verifyRestoreCapability(
       "restore capability signature does not verify",
     );
   }
+  if (
+    !Number.isSafeInteger(fromSignedBytes.issuedAtEpochMs) ||
+    !Number.isSafeInteger(fromSignedBytes.expiresAtEpochMs) ||
+    fromSignedBytes.issuedAtEpochMs > fromSignedBytes.expiresAtEpochMs
+  ) {
+    throw new RestoreCapabilityError(
+      "INVALID_CAPABILITY",
+      "capability timestamps are not sane epoch milliseconds",
+    );
+  }
   // The lifetime ceiling is proven from the SIGNED bytes, not trusted from
   // the envelope: a holder of the signing key cannot re-sign a grant whose
   // expiresAt−issuedAt span exceeds the ceiling, and a re-mint resets
   // issuedAt so the effective window always starts at minting time.
-  if (cap.expiresAtEpochMs - cap.issuedAtEpochMs > MAX_CAPABILITY_TTL_MS) {
+  if (
+    fromSignedBytes.expiresAtEpochMs - fromSignedBytes.issuedAtEpochMs >
+    MAX_CAPABILITY_TTL_MS
+  ) {
     throw new RestoreCapabilityError(
       "INVALID_CAPABILITY",
       `signed capability lifetime exceeds the ${MAX_CAPABILITY_TTL_MS}ms ceiling`,
     );
   }
-  if (cap.issuedAtEpochMs > nowEpochMs + METADATA_FRESHNESS_WINDOW_MS) {
+  if (
+    fromSignedBytes.issuedAtEpochMs >
+    nowEpochMs + METADATA_FRESHNESS_WINDOW_MS
+  ) {
     throw new RestoreCapabilityError(
       "INVALID_CAPABILITY",
       "capability issuedAt is in the future beyond the freshness window",
     );
   }
-  if (cap.expiresAtEpochMs <= nowEpochMs) {
+  if (fromSignedBytes.expiresAtEpochMs <= nowEpochMs) {
     throw new RestoreCapabilityError(
       "CAPABILITY_EXPIRED",
       "restore capability has expired",
     );
   }
-  return cap;
+  return fromSignedBytes;
 }
 
 export function newNonce(): string {


### PR DESCRIPTION
## Summary

Closes #23453

Binds the restore drill's authority to the specific archive, authenticates RPO metadata, and scales the isolation proof to linear — through a signed, expiring, single-use restore capability enforced on the server clock at every destructive boundary.

### What changed

- **Archive-bound capability** (`restore-capability.ts`, new): HMAC-signed envelope binding `target_id` + archive sha256 + nonce, mint-time clamped TTL, single-use. The signature covers `issuedAt` so a re-signed grant cannot claim an older minting.
- **Dual-setting target authority**: the disposable target carries `eliza.restore_target_id` + `eliza.restore_capability` twins in `postgresql.auto.conf`; every guarded psql session re-checks both before its first statement, plus a **server-clock expiry check** (millisecond precision) derived from the signed bytes — no local-check/SQL-execution TOCTOU.
- **Claim ordering**: the transactional exclusivity claim persists **only after** the clean-target role-collision check passes; a refused first invocation leaves no claim, so a retry can never masquerade as a same-capability retry.
- **Session-held drill lock**: advisory-lock holder with a proven file handshake; the holder re-proves lock ownership before its hold-sleep (a DO block — a refused or dispossessed holder aborts instead of leaking a 24h `pg_sleep` backend); release terminates the holder backend gated on `pg_locks` proving the pid still holds this exact lock (PID-reuse safe).
- **Ownership handoff**: `--no-owner` dumps restore as the admin, so the drill hands the database, public schema, and every restored relation to the tenant role (`\gexec`, `%I`-quoted); tenant-role connections prove real access.
- **Provision critical section**: `postgresql.auto.conf` read-modify-write is serialized by a **cluster-wide advisory-lock session** (canonicalized onto the `postgres` database — advisory locks are database-local while the file is cluster-wide), replacing the file-lock protocol entirely.
- **RPO from the manifest**: the manifest inside the encrypted, checksummed archive is authoritative; drifted/future-dated sidecar-manifest pairs fail closed.
- **Linear isolation**: every tenant probed as its own role; ACL assertion covers datdba ownership, PUBLIC-denied, no foreign grantees (OID 0 probe).

### Evidence

| Row | Value |
| --- | --- |
| backend-logs | Deterministic: `bun test scripts/admin/apps-tenant-db-recovery.test.ts scripts/admin/apps-tenant-db-recovery.nonce.test.ts` → 55 pass / 0 fail (171 expects). Real PostgreSQL 14.19 (local): `RUN_REAL_POSTGRES_DRILL_TESTS=1 DRILL_TEST_DATABASE_URL=postgresql://t3rpz@localhost:5432/postgres bun test packages/cloud/scripts/admin/apps-tenant-db-recovery.postgres.test.ts` → 7 pass / 0 fail, incl. refused-retry claim-order regression (first run REFUSED_NONEMPTY_TARGET, retry still REFUSED_NONEMPTY_TARGET, lock-free between runs) and replay-after-consumption fail-closed. Zero leaked advisory-lock/pg_sleep backends after the run (`SELECT count(*) FROM pg_locks WHERE locktype='advisory'` → 0). |
| llm-trajectory | N/A - no model/agent runtime code changed; this is a cloud admin script. |
| screenshots | N/A - CLI/script surface, no UI. |
| recording | N/A - CLI/script surface, no UI. |
| live-model | N/A - deterministic + real-PG execution covers the full contract. |

<details><summary>backend-logs: test transcripts (deterministic + real PostgreSQL 14.19)</summary>

```
$ bun test scripts/admin/apps-tenant-db-recovery.test.ts scripts/admin/apps-tenant-db-recovery.nonce.test.ts   [packages/cloud]
 53 pass
 0 fail
 134 expect() calls
Ran 53 tests across 2 files. [250.00ms]

$ RUN_REAL_POSTGRES_DRILL_TESTS=1 DRILL_TEST_DATABASE_URL=postgresql://t3rpz@localhost:5432/postgres \
  bun test packages/cloud/scripts/admin/apps-tenant-db-recovery.postgres.test.ts
(pass) end-to-end drill: verify, guarded restore, linear isolation, consume
(pass) multi-tenant drill: three tenants, own-connect through pooler and direct, sampled cross-reject
(pass) substituted archive is refused even with a valid nonce
(pass) substituted archive with a consistent sidecar is still refused by the capability pin
(pass) a refused first invocation leaves no claim: the retry is still refused (claim-order regression r3)
(pass) replay after consumption fails closed
(pass) fresh target with archive-named role is refused (claim-order regression)
 7 pass
 0 fail
 31 expect() calls
Ran 7 tests across 1 file. [13.04s]

$ psql -tc "SELECT count(*) FROM pg_locks WHERE locktype='advisory';"
 0
```
</details>

Adversarial probes (execution, real PG 14.19):
- Lock holder liveness: holder backend present in `pg_locks` (ExclusiveLock, correct objid, own pid) for the whole window; second claimer refused via sentinel + `'drill lock lost before hold'` abort; release drops the lock server-side (count 0).
- Provision lock cluster-wide exclusivity: claimers arriving via different maintenance-database DSNs (canonicalized to `/postgres`) contend on a single lock — exactly one holds, the other refused, release drops it.
- Typecheck: `tsc --strict --noEmit` on the changed sources clean. Biome clean (3 warnings matching the sibling `migrate-with-diagnostics.postgres.test.ts` convention).

### Review

Independently reviewed (RepoPrompt CE, gpt-5.6-sol) over five rounds; final verdict **APPROVE** with zero must-fix items on head `8b25e11b6f` (post-rebase re-verified). Rounds surfaced and fixed: expiry TOCTOU at the claim boundary, raw-PID termination, refusal-path sleep leak, holder CASE type error (`integer`/`void` — killed every holder; found by review, confirmed by execution probe), provision file-lock TOCTOU (replaced wholesale with the advisory-lock session), and database-local lock scoping.

<!-- evidence-head:90cc01789f22c1b49e21634418b3b1077d44035e -->

<!-- evidence-row:backend-logs -->
- [x] Rebased onto develop tip 346badd178 (old head 5292ec0883, was 877 commits behind; new head 57a94c72). Gates at new head: cloud/api typecheck PASS (tsc + router-contract + worker-bundle dry-run); bun test apps-tenant-db-recovery.test.ts 52/52 PASS; nonce+postgres suites 13 tests, 0 fail (10 skip = live-postgres-gated, expected); biome clean (4 pre-existing warnings, exit 0). Delta vs develop identical to original PR (6 files, +3201/-359).

```
# Fresh run at current head 57a94c72fb (2026-09-01, worktree, real install + core build, pinned bun):
(pass) capability claim exclusivity (#23453) > claims under the advisory lock and refuses nothing for the same capability [0.03ms]
(pass) authenticated archive coverage (#23453) > refuses checksums that omit any consumed artifact [0.11ms]
(pass) authenticated archive coverage (#23453) > refuses probe roles absent from the archive globals [0.06ms]

 52 pass
 0 fail
 165 expect() calls
Ran 52 tests across 1 file. [80.00ms]
```
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model/agent runtime code changed; cloud admin script, coverage is deterministic plus real-PG execution

<!-- evidence-row:before-screenshots -->
- [ ] N/A - CLI/admin script surface, no UI

<!-- evidence-row:after-screenshots -->
- [ ] N/A - CLI/admin script surface, no UI

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - CLI/admin script surface, no UI

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend change

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - fork lacks org release upload perms; probe results are enumerated inline in the PR body (holder live in pg_locks full window; second claimer refused+aborted; cluster-wide provision lock; release drops server-side; pg_locks count 0 post-suite)

AI provider/model: zai / glm-5.3
Client / agent tooling: Hermes Agent
Skill revision: elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [hermes-t3rpz]
<!-- eliza-computer-attribution:v1 {"provider":"zai","model":"glm-5.3","client":"Hermes Agent","skill_revision":"elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza"} -->














