### PR TITLE
test(cloud): pin FAL_API_KEY canonical precedence over FAL_KEY

### DIFF
--- a/packages/cloud/shared/src/lib/providers/image/fal-image-generation.test.ts
+++ b/packages/cloud/shared/src/lib/providers/image/fal-image-generation.test.ts
@@ -1,0 +1,57 @@
+// Regression tests: FAL_API_KEY is canonical over the legacy FAL_KEY alias
+// (#28935). These pin the precedence so a future promotion cannot silently
+// prefer the legacy key again.
+import { describe, expect, test } from "bun:test";
+import { generateFalImageWithFetch } from "./fal-image-generation";
+import type { ImageGenRequest } from "./types";
+
+function makeRequest(apiKeys: Record<string, string | undefined>): ImageGenRequest {
+  return {
+    model: "fal-ai/flux/dev",
+    prompt: "a red cube",
+    apiKeys,
+    actor: { organizationId: "org", userId: "user", apiKeyId: null },
+  } as unknown as ImageGenRequest;
+}
+
+describe("FAL credential precedence", () => {
+  test("FAL_API_KEY wins when both keys are present", async () => {
+    let captured: string | null = null;
+    const fetchImpl = async (_url: string, init: RequestInit) => {
+      const headers = init.headers as Record<string, string>;
+      captured = headers["Authorization"] ?? null;
+      return new Response(JSON.stringify({ images: [{ url: "https://example/x.png" }] }));
+    };
+
+    await generateFalImageWithFetch(
+      makeRequest({ FAL_KEY: "stale-legacy-key", FAL_API_KEY: "canonical-key" }),
+      fetchImpl as typeof fetch,
+    );
+
+    expect(captured).toContain("canonical-key");
+    expect(captured).not.toContain("stale-legacy-key");
+  });
+
+  test("FAL_KEY is used only as a fallback when FAL_API_KEY is absent", async () => {
+    let captured: string | null = null;
+    const fetchImpl = async (_url: string, init: RequestInit) => {
+      const headers = init.headers as Record<string, string>;
+      captured = headers["Authorization"] ?? null;
+      return new Response(JSON.stringify({ images: [{ url: "https://example/x.png" }] }));
+    };
+
+    await generateFalImageWithFetch(
+      makeRequest({ FAL_KEY: "legacy-only" }),
+      fetchImpl as typeof fetch,
+    );
+
+    expect(captured).toContain("legacy-only");
+  });
+
+  test("missing keys throw the configuration error", async () => {
+    const fetchImpl = async () => new Response("{}");
+    await expect(
+      generateFalImageWithFetch(makeRequest({}), fetchImpl as typeof fetch),
+    ).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
Restore dual-key regression tests for the fal image path: `FAL_API_KEY` is the canonical deployment secret and must win over the legacy `FAL_KEY` alias. The production hotfix `f94dd392` made `FAL_API_KEY` authoritative across image/video/queue paths, but the two dual-key tests were dropped from `develop`, leaving the precedence unpinned — a future promotion could silently prefer the legacy key and regress the production credential repair (#28935).

## Tests
- `FAL_API_KEY` wins when both keys are present (Authorization header carries the canonical key, not the stale legacy one);
- `FAL_KEY` used only as a fallback when `FAL_API_KEY` is absent;
- missing keys throw the configuration error.

The video (`fal-video-generation`) and queue (`fal-queue`) paths already carry dual-key tests; this closes the image-path gap.

## Verification
- Key-resolution logic verified independently: dual-key → canonical wins; legacy-only → fallback; none → undefined. All pass.

Closes #28935.