### PR TITLE
fix(elizaresearch): SPF control must reject a permissive all before the terminal (first-match)

### DIFF
--- a/packages/elizaresearch/MAIL-SECURITY.md
+++ b/packages/elizaresearch/MAIL-SECURITY.md
@@ -22,7 +22,7 @@ verifies four things:
 | Check | Requirement |
 | --- | --- |
 | `mx` | every MX host is Google Workspace (`smtp.google.com`) |
-| `spf` | exactly one `v=spf1` record, includes `_spf.google.com`, ends in `~all` or `-all` |
+| `spf` | exactly one `v=spf1` record, includes `_spf.google.com`, and its first `all` mechanism is the terminal `~all` or `-all` (a permissive `+all`/`?all`/bare `all` before it matches first and opens the domain) |
 | `dkim` | exactly one 2048-bit key on the `google` selector, non-empty `p=` |
 | `dmarc` | exactly one `v=DMARC1` record with a valid `p=` and a `rua=mailto:` destination |
 

--- a/packages/elizaresearch/mail-security.mjs
+++ b/packages/elizaresearch/mail-security.mjs
@@ -86,12 +86,23 @@ function checkSpf(txt) {
       detail: "the SPF record does not authorize Google Workspace senders",
     };
   }
-  // Evaluation stops at the first matching mechanism, so only the LAST one
-  // decides the fate of an otherwise-unmatched sender. Matching "~all"
-  // anywhere would pass a record like "... ~all include:evil.com +all",
-  // whose real terminal mechanism authorizes the whole internet.
-  const terminal = mechanisms.at(-1)?.toLowerCase() ?? "";
-  if (terminal !== "~all" && terminal !== "-all") {
+  // Evaluation is first-match (RFC 7208 s4.6.2/s5.1): the FIRST `all`
+  // mechanism decides every otherwise-unmatched sender, and anything after
+  // it is dead weight. A permissive `+all` (or a bare `all`, which means
+  // `+all`) authorizes the whole internet at the point it appears, so
+  // inspecting only the terminal token would pass a wide-open record like
+  // "v=spf1 +all include:_spf.google.com ~all". Require that the first `all`
+  // exists, is `~all` or `-all`, and is the terminal mechanism.
+  const firstAllIndex = mechanisms.findIndex((mechanism) =>
+    /^[+\-~?]?all$/iu.test(mechanism),
+  );
+  const firstAll =
+    firstAllIndex === -1 ? "" : mechanisms[firstAllIndex].toLowerCase();
+  if (
+    firstAllIndex === -1 ||
+    firstAllIndex !== mechanisms.length - 1 ||
+    (firstAll !== "~all" && firstAll !== "-all")
+  ) {
     return {
       id: "spf",
       ok: false,

--- a/packages/elizaresearch/mail-security.test.mjs
+++ b/packages/elizaresearch/mail-security.test.mjs
@@ -119,10 +119,8 @@ describe("evaluateMailSecurity", () => {
   it("accepts a case-variant Workspace include", () => {
     // Mechanism names and domains are case-insensitive (RFC 7208 s4.6.1).
     expect(
-      check(
-        baseline({ txt: ["v=spf1 Include:_SPF.Google.com ~all"] }),
-        "spf",
-      ).ok,
+      check(baseline({ txt: ["v=spf1 Include:_SPF.Google.com ~all"] }), "spf")
+        .ok,
     ).toBe(true);
   });
 
@@ -132,11 +130,67 @@ describe("evaluateMailSecurity", () => {
     expect(
       check(
         baseline({
-          txt: ["v=spf1 include:_spf.google.com ~all include:evil.example +all"],
+          txt: [
+            "v=spf1 include:_spf.google.com ~all include:evil.example +all",
+          ],
         }),
         "spf",
       ).ok,
     ).toBe(false);
+  });
+
+  it("fails a leading +all even when a ~all trails it", () => {
+    // First-match semantics (RFC 7208 s4.6.2): the first `all` authorizes
+    // every sender, so a leading +all opens the domain and the trailing ~all
+    // is dead. Inspecting only the terminal mechanism would miss this.
+    const found = check(
+      baseline({ txt: ["v=spf1 +all include:_spf.google.com ~all"] }),
+      "spf",
+    );
+    expect(found.ok).toBe(false);
+    expect(found.detail).toContain("must end in ~all or -all");
+  });
+
+  it("fails a +all placed before the terminal ~all", () => {
+    // The +all matches first and authorizes the whole internet; the ~all
+    // after it never evaluates (RFC 7208 s5.1).
+    const found = check(
+      baseline({ txt: ["v=spf1 include:_spf.google.com +all ~all"] }),
+      "spf",
+    );
+    expect(found.ok).toBe(false);
+    expect(found.detail).toContain("not ?all or +all");
+  });
+
+  it("fails a leading ?all neutral qualifier before a terminal -all", () => {
+    // ?all is neutral, not a hard fail; as the first `all` it makes the
+    // record permissive regardless of the unreachable trailing -all.
+    expect(
+      check(
+        baseline({ txt: ["v=spf1 ?all include:_spf.google.com -all"] }),
+        "spf",
+      ).ok,
+    ).toBe(false);
+  });
+
+  it("fails a bare `all` mechanism, which defaults to +all", () => {
+    // An unqualified `all` means `+all` (RFC 7208 s4.6.2), so a leading bare
+    // all is as open as an explicit +all.
+    expect(
+      check(
+        baseline({ txt: ["v=spf1 all include:_spf.google.com -all"] }),
+        "spf",
+      ).ok,
+    ).toBe(false);
+  });
+
+  it("passes a record whose only `all` is a terminal ~all", () => {
+    // The legitimate posture: the first (and only) `all` is the terminal
+    // ~all softfail, so the control must stay green.
+    expect(
+      check(baseline({ txt: ["v=spf1 include:_spf.google.com ~all"] }), "spf")
+        .ok,
+    ).toBe(true);
   });
 
   it("treats a revoked DKIM key (empty p=) as a failure", () => {


### PR DESCRIPTION
# Relates to

Closes #29141

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] Focused package checks (test, biome) were run after sync; see **Known gaps** for the repo-wide `verify` note.
- [x] A reviewer can confirm the change works from the before/after evidence below without reading the code.

# Sync with develop

- [x] Rebased onto the latest `origin/develop` (`518cde18d1`); zero conflicts.
- [x] Focused package tests + biome pass post-sync. See **Known gaps** for the full `bun run verify` scope note.

# Risks

Low. The change is localized to `checkSpf` in a private, non-published diagnostic tool (`@elizaos/elizaresearch-site`). No public signature or output shape changes; the check strictly tightens from terminal-only to first-match SPF evaluation, so the only behavior change is that genuinely permissive SPF records now correctly FAIL.

# Background

## What does this PR do?

The mail-security baseline auditor's SPF control (`checkSpf` in `packages/elizaresearch/mail-security.mjs`, reached via the exported `evaluateMailSecurity`) validated only the **last** SPF mechanism (`mechanisms.at(-1)`). But SPF evaluation is **first-match** (RFC 7208 §4.6.2 / §5.1): the first `all` mechanism decides every otherwise-unmatched sender, and any mechanism after it is dead weight. A record such as:

- `v=spf1 +all include:_spf.google.com ~all` (leading `+all`), or
- `v=spf1 include:_spf.google.com +all ~all` (mid-record `+all`)

authorizes the **entire internet** to send as the domain via the earlier permissive `all`, yet the terminal-only check reported **PASS**. Since this tool exists precisely to catch regressions in the published DNS posture, a false PASS on a wide-open SPF record is a correctness defect in a security control.

The fix locates the **first** `all` mechanism (`/^[+\-~?]?all$/i`) and requires that it (a) exists, (b) is `~all` or `-all` (a bare `all` means `+all`), and (c) is the terminal mechanism. Otherwise it fails with the existing `"must end in ~all or -all, not ?all or +all"` detail. ~15 lines localized to `checkSpf`; no signature or public-shape change.

Each new test case maps to the first-match rule so a reviewer can verify without re-deriving the semantics:

| Record | Expected | Why (RFC 7208) |
| --- | --- | --- |
| `v=spf1 include:_spf.google.com ~all` | PASS | only `all` is the terminal softfail |
| `v=spf1 +all include:_spf.google.com ~all` | FAIL | leading `+all` matches first, authorizes all (§4.6.2) |
| `v=spf1 include:_spf.google.com +all ~all` | FAIL | `+all` matches before the trailing `~all` ever evaluates (§5.1) |
| `v=spf1 ?all include:_spf.google.com -all` | FAIL | neutral `?all` is the first `all`; trailing `-all` unreachable |
| `v=spf1 all include:_spf.google.com -all` | FAIL | bare `all` = `+all` (§4.6.2) |
| `v=spf1 include:_spf.google.com ~all include:evil.example +all` | FAIL (pre-existing) | terminal `+all` still caught |

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

Updated `packages/elizaresearch/MAIL-SECURITY.md` — the `spf` requirement row now states that the **first** `all` mechanism must be the terminal `~all`/`-all`, and that a permissive `+all`/`?all`/bare `all` before it opens the domain.

# Testing

## Where should a reviewer start?

`packages/elizaresearch/mail-security.mjs` (`checkSpf`) and the new cases in `packages/elizaresearch/mail-security.test.mjs`. Reproduce with the before/after probe below.

## Detailed testing steps

1. `bun run --cwd packages/elizaresearch test` — 32 pass (5 new SPF cases + the legitimate-record regression).
2. Run the before/after probe (attached) to see the two `+all` records flip from PASS to FAIL while the legitimate record stays PASS.

# Evidence Gate

<!-- evidence-head:2b5475d4068a5f2110078146c7d2a90859222802 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface; this is a Node diagnostic module (`mail-security.mjs`) and its deterministic test.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface; see before/after console output under **Backend + frontend logs**.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - non-interactive CLI/pure-function change; the before/after text log is the complete flow.
<!-- evidence-row:backend-logs -->
- [x] Before/after SPF probe output (same probe run against `origin/develop` then this PR's `mail-security.mjs`):

<details>
<summary>SPF probe output — before vs after</summary>

```
=== BEFORE (origin/develop terminal-only check) ===
PASS  <= v=spf1 include:_spf.google.com ~all
PASS  <= v=spf1 +all include:_spf.google.com ~all
PASS  <= v=spf1 include:_spf.google.com +all ~all
PASS  <= v=spf1 ?all include:_spf.google.com -all
PASS  <= v=spf1 all include:_spf.google.com -all

=== AFTER (this PR, first-match check) ===
PASS  <= v=spf1 include:_spf.google.com ~all
FAIL  <= v=spf1 +all include:_spf.google.com ~all
FAIL  <= v=spf1 include:_spf.google.com +all ~all
FAIL  <= v=spf1 ?all include:_spf.google.com -all
FAIL  <= v=spf1 all include:_spf.google.com -all
```

</details>
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend; `@elizaos/elizaresearch-site` mail-security is a Node script.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model path; pure DNS-posture evaluation.
<!-- evidence-row:domain-artifacts -->
- [x] The failing-then-passing reproduction is the domain artifact: the two `+all` records flip PASS→FAIL while the legitimate record stays PASS, and the focused package suite passes with the 5 new cases:

<details>
<summary>Focused package test output (bun test)</summary>

```
(pass) evaluateMailSecurity > fails a record whose terminal mechanism is permissive [0.14ms]
(pass) evaluateMailSecurity > fails a leading +all even when a ~all trails it [0.12ms]
(pass) evaluateMailSecurity > fails a +all placed before the terminal ~all [0.13ms]
(pass) evaluateMailSecurity > fails a leading ?all neutral qualifier before a terminal -all [0.12ms]
(pass) evaluateMailSecurity > fails a bare `all` mechanism, which defaults to +all [0.13ms]
(pass) evaluateMailSecurity > passes a record whose only `all` is a terminal ~all [0.12ms]
 32 pass
 0 fail
 135 expect() calls
Ran 32 tests across 2 files. [390.00ms]
```

</details>
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

Before/after SPF probe (same probe run against `origin/develop` `mail-security.mjs` then this PR's):

```
=== BEFORE (origin/develop terminal-only check) ===
PASS  <= v=spf1 include:_spf.google.com ~all
PASS  <= v=spf1 +all include:_spf.google.com ~all
PASS  <= v=spf1 include:_spf.google.com +all ~all
PASS  <= v=spf1 ?all include:_spf.google.com -all
PASS  <= v=spf1 all include:_spf.google.com -all

=== AFTER (this PR, first-match check) ===
PASS  <= v=spf1 include:_spf.google.com ~all
FAIL  <= v=spf1 +all include:_spf.google.com ~all
FAIL  <= v=spf1 include:_spf.google.com +all ~all
FAIL  <= v=spf1 ?all include:_spf.google.com -all
FAIL  <= v=spf1 all include:_spf.google.com -all
```

Focused package test (`bun run --cwd packages/elizaresearch test`):

<details>
<summary>32 pass, 0 fail (5 new SPF cases)</summary>

```
(pass) evaluateMailSecurity > fails a record whose terminal mechanism is permissive [0.14ms]
(pass) evaluateMailSecurity > fails a leading +all even when a ~all trails it [0.12ms]
(pass) evaluateMailSecurity > fails a +all placed before the terminal ~all [0.13ms]
(pass) evaluateMailSecurity > fails a leading ?all neutral qualifier before a terminal -all [0.12ms]
(pass) evaluateMailSecurity > fails a bare `all` mechanism, which defaults to +all [0.13ms]
(pass) evaluateMailSecurity > passes a record whose only `all` is a terminal ~all [0.12ms]
 32 pass
 0 fail
 135 expect() calls
Ran 32 tests across 2 files. [390.00ms]
```
</details>

## Screenshots (before / after) + video walkthrough

### Before
N/A - no UI change.
### After
N/A - no UI change.
### Walkthrough video
N/A - no UI change.

## Audio / voice walkthrough

N/A - no audio/voice path.

## Known gaps / failures

Repo-wide `bun run verify` was not run to completion on this constrained Raspberry Pi environment (it fans out Turbo typecheck/lint/audit across every workspace). The change is confined to one private package; I ran that package's full test suite (32 pass) and Biome check (clean, pinned `2.5.8`) on the final head. No production runtime consumes this module beyond the package's own CLI.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

---

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@2b5475d4068a5f2110078146c7d2a90859222802:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@2b5475d4068a5f2110078146c7d2a90859222802:packages/skills/skills/contribute-to-eliza"} -->

