### PR TITLE
fix(ui): harden launcher interactions and notice packaging

### DIFF
--- a/packages/app/vite.config.test.ts
+++ b/packages/app/vite.config.test.ts
@@ -8,6 +8,7 @@ import appViteConfig, {
   appDevWsBasePlugin,
   appShellMetadataPlugin,
   findAndroidCloudEmittedRoutingFindings,
+  readAndroidCloudCuratedAssets,
   resolveAndroidCloudPrebootLockupDataUri,
   resolveAppShellLocalCspSources,
   selectAndroidCloudRendererEntry,
@@ -85,6 +86,16 @@ describe("app shell local connection policy", () => {
       localHttpSources: "",
       localConnectSources: "",
     });
+  });
+
+  test("packages third-party notices with the curated Android cloud assets", () => {
+    const notice = readAndroidCloudCuratedAssets().find(
+      (asset) => asset.fileName === "THIRD_PARTY_NOTICES.txt",
+    );
+
+    expect(notice?.type).toBe("asset");
+    expect(notice?.source.toString("utf8")).toContain("Ionicons");
+    expect(notice?.source.toString("utf8")).toContain("MIT License");
   });
 
   test("audits every emitted file without rewriting packaged code", () => {

--- a/packages/app/vite.config.test.ts
+++ b/packages/app/vite.config.test.ts
@@ -4,11 +4,11 @@ import { describe, expect, test } from "bun:test";
 import { runInNewContext } from "node:vm";
 import appViteConfig, {
   ANDROID_CLOUD_FORBIDDEN_ROUTING_MARKERS,
+  androidCloudCuratedAssetsPlugin,
   androidCloudRendererEntryPlugin,
   appDevWsBasePlugin,
   appShellMetadataPlugin,
   findAndroidCloudEmittedRoutingFindings,
-  readAndroidCloudCuratedAssets,
   resolveAndroidCloudPrebootLockupDataUri,
   resolveAppShellLocalCspSources,
   selectAndroidCloudRendererEntry,
@@ -89,13 +89,56 @@ describe("app shell local connection policy", () => {
   });
 
   test("packages third-party notices with the curated Android cloud assets", () => {
-    const notice = readAndroidCloudCuratedAssets().find(
+    if (typeof appViteConfig !== "function") {
+      throw new Error("app Vite config is not callable");
+    }
+    const config = appViteConfig({
+      command: "build",
+      mode: "test",
+      isSsrBuild: false,
+      isPreview: false,
+    });
+    if (config instanceof Promise) {
+      throw new Error("app Vite config unexpectedly became async");
+    }
+    expect(
+      config.plugins?.some(
+        (plugin) =>
+          typeof plugin === "object" &&
+          plugin !== null &&
+          "name" in plugin &&
+          plugin.name === "android-cloud-curated-assets",
+      ),
+    ).toBe(true);
+
+    const emitted: Array<{
+      type?: string;
+      fileName?: string;
+      source?: string | Uint8Array;
+    }> = [];
+    const hook = androidCloudCuratedAssetsPlugin(true).generateBundle;
+    if (typeof hook !== "function") {
+      throw new Error("Android Cloud curated-assets plugin has no bundle hook");
+    }
+    Reflect.apply(
+      hook,
+      {
+        emitFile(asset: (typeof emitted)[number]) {
+          emitted.push(asset);
+          return asset.fileName ?? "emitted-asset";
+        },
+      },
+      [{}, {}, false],
+    );
+
+    const notice = emitted.find(
       (asset) => asset.fileName === "THIRD_PARTY_NOTICES.txt",
     );
 
     expect(notice?.type).toBe("asset");
-    expect(notice?.source.toString("utf8")).toContain("Ionicons");
-    expect(notice?.source.toString("utf8")).toContain("MIT License");
+    const noticeText = Buffer.from(notice?.source ?? "").toString("utf8");
+    expect(noticeText).toContain("Ionicons");
+    expect(noticeText).toContain("MIT License");
   });
 
   test("audits every emitted file without rewriting packaged code", () => {

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -1150,7 +1150,7 @@ const ANDROID_CLOUD_CURATED_PUBLIC_ASSETS = Object.freeze([
   "wallpapers/slate.webp",
 ]);
 
-export function readAndroidCloudCuratedAssets(): Array<{
+function readAndroidCloudCuratedAssets(): Array<{
   type: "asset";
   fileName: string;
   source: Buffer;
@@ -1167,11 +1167,13 @@ export function readAndroidCloudCuratedAssets(): Array<{
  * browser public tree, whose service workers, installers, and local task
  * runner are not capabilities of the Cloud-only Android application.
  */
-function androidCloudCuratedAssetsPlugin(): Plugin {
+export function androidCloudCuratedAssetsPlugin(
+  androidCloudBuild = IS_ANDROID_CLOUD_RENDERER_BUILD,
+): Plugin {
   return {
     name: "android-cloud-curated-assets",
     generateBundle() {
-      if (!IS_ANDROID_CLOUD_RENDERER_BUILD) return;
+      if (!androidCloudBuild) return;
       for (const asset of readAndroidCloudCuratedAssets()) {
         this.emitFile(asset);
       }

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -1141,6 +1141,7 @@ function androidCloudRendererPolicyPlugin(): Plugin {
 }
 
 const ANDROID_CLOUD_CURATED_PUBLIC_ASSETS = Object.freeze([
+  "THIRD_PARTY_NOTICES.txt",
   "bg-sunset.webp",
   "wallpapers/canopy.webp",
   "wallpapers/dusk-dunes.webp",
@@ -1148,6 +1149,18 @@ const ANDROID_CLOUD_CURATED_PUBLIC_ASSETS = Object.freeze([
   "wallpapers/reef.webp",
   "wallpapers/slate.webp",
 ]);
+
+export function readAndroidCloudCuratedAssets(): Array<{
+  type: "asset";
+  fileName: string;
+  source: Buffer;
+}> {
+  return ANDROID_CLOUD_CURATED_PUBLIC_ASSETS.map((fileName) => ({
+    type: "asset" as const,
+    fileName,
+    source: fs.readFileSync(path.join(here, "public", fileName)),
+  }));
+}
 
 /**
  * Packages the canonical app's selectable backgrounds without copying the
@@ -1159,12 +1172,8 @@ function androidCloudCuratedAssetsPlugin(): Plugin {
     name: "android-cloud-curated-assets",
     generateBundle() {
       if (!IS_ANDROID_CLOUD_RENDERER_BUILD) return;
-      for (const fileName of ANDROID_CLOUD_CURATED_PUBLIC_ASSETS) {
-        this.emitFile({
-          type: "asset",
-          fileName,
-          source: fs.readFileSync(path.join(here, "public", fileName)),
-        });
+      for (const asset of readAndroidCloudCuratedAssets()) {
+        this.emitFile(asset);
       }
     },
   };

--- a/packages/ui/src/components/pages/__e2e__/run-launcher-e2e.mjs
+++ b/packages/ui/src/components/pages/__e2e__/run-launcher-e2e.mjs
@@ -3,9 +3,14 @@
  * no app server. Bundles launcher-fixture.tsx with esbuild, loads it in
  * headless chromium via Playwright, and:
  *
- *   - asserts the read-only launcher renders (>=1 tile, glyph-only visuals,
- *     no hero image nodes, no edit/pin/delete affordances, exactly one page),
- *   - captures REST screenshots at desktop (1180×900) and mobile (402×874),
+ *   - asserts the read-only launcher renders (>=1 tile, image-backed Ionicon
+ *     or custom glyph visuals, no hero image nodes, no edit/pin/delete
+ *     affordances, exactly one page),
+ *   - captures dark + light rest screenshots at desktop (1180×900), plus dark
+ *     hover/focus states, and dark rest/held-pointer states at the acceptance
+ *     mobile viewport (390×844),
+ *   - verifies hover and keyboard focus produce visible surface feedback while
+ *     a held pointer produces no animation, transform, or geometry movement,
  *   - records a .webm walkthrough driving REAL interactions: tap-launch a tile,
  *     a stationary long-press (which must NOT enter any edit mode), and a
  *     right-swipe that requests a return to the home dashboard,
@@ -18,18 +23,41 @@
  * Run: bun run --cwd packages/ui test:launcher-e2e
  */
 
-import { mkdir, readdir, rename, writeFile } from "node:fs/promises";
+import {
+  cp,
+  mkdir,
+  readFile,
+  readdir,
+  rename,
+  rm,
+  writeFile,
+} from "node:fs/promises";
 import { builtinModules } from "node:module";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { build } from "esbuild";
 import { chromium } from "playwright";
+import { compileTailwindTheme } from "../../../testing/e2e-runner/fixture-bundle.ts";
 
 const here = dirname(fileURLToPath(import.meta.url));
+const uiRoot = resolve(here, "../../../..");
 const outDir = join(here, "output-launcher");
 const videoDir = join(outDir, "video");
+// Every run owns this one explicit generated-artifact directory. Start clean so
+// screenshots and the randomly named Playwright video cannot come from an
+// earlier invocation.
+await rm(outDir, { recursive: true, force: true });
 await mkdir(outDir, { recursive: true });
 await mkdir(videoDir, { recursive: true });
+// The production bundler resolves new URL(..., import.meta.url) asset paths.
+// This self-contained browser fixture emits an inline ESM bundle instead, so
+// mirror the source-relative directory next to launcher.html for the same URL
+// contract and for screenshots that exercise actual loaded SVGs.
+await cp(
+  join(here, "../../views/view-icons/ionicons"),
+  join(outDir, "view-icons/ionicons"),
+  { recursive: true, force: true },
+);
 
 let failures = 0;
 function assert(cond, msg) {
@@ -112,7 +140,8 @@ const stubNodeBuiltins = {
 const result = await build({
   entryPoints: [join(here, "launcher-fixture.tsx")],
   bundle: true,
-  format: "iife",
+  // Keep import.meta.url intact for the Ionicon asset resolver.
+  format: "esm",
   platform: "browser",
   conditions: ["eliza-source", "browser"],
   jsx: "automatic",
@@ -123,12 +152,43 @@ const result = await build({
 });
 const js = result.outputFiles[0].text;
 console.log(`✓ fixture bundled (${js.length} bytes)`);
-const html = `<!doctype html><html><head><meta charset="utf-8"><title>launcher e2e</title>
-<script src="https://cdn.tailwindcss.com"></script>
-<style>html,body{margin:0;height:100%;background:#0a0d16;color:#f4f4f5}</style>
+// Compile the real UI theme rather than relying on the approximate CDN v3
+// runtime. The shared helper intentionally omits product-shell policy rules,
+// so extract the owning focus block from styles.css and append it verbatim.
+// This makes the keyboard assertion exercise the shipped no-UA-ring policy as
+// well as the launcher's filled focus surface.
+const themeCss = await compileTailwindTheme({
+  uiRoot,
+  sources: [
+    join(uiRoot, "src/components/pages"),
+    join(uiRoot, "src/components/shell"),
+    join(uiRoot, "src/components/ui"),
+    join(uiRoot, "src/components/views"),
+    here,
+  ],
+});
+const productCss = await readFile(join(uiRoot, "src/styles/styles.css"), "utf8");
+const focusPolicyStart = productCss.indexOf(
+  "/* Product policy: focus rings are intentionally disabled globally. */",
+);
+const focusPolicyEndMarker =
+  "/* biome-ignore-end lint/complexity/noImportantStyles: end focus-ring ban override */";
+const focusPolicyEnd = productCss.indexOf(
+  focusPolicyEndMarker,
+  focusPolicyStart,
+);
+if (focusPolicyStart < 0 || focusPolicyEnd < 0) {
+  throw new Error("could not find the product focus-policy block in styles.css");
+}
+const focusPolicyCss = productCss.slice(
+  focusPolicyStart,
+  focusPolicyEnd + focusPolicyEndMarker.length,
+);
+const html = `<!doctype html><html class="dark"><head><meta charset="utf-8"><title>launcher e2e</title>
+<style>${themeCss}\n${focusPolicyCss}\nhtml,body{margin:0;height:100%;background:#0a0d16;color:#f4f4f5}</style>
 <!-- Shim node-ish globals the dead-in-browser graph touches at module init. -->
 <script>window.process=window.process||{env:{NODE_ENV:"production"},platform:"browser",cwd:function(){return "/"}};</script>
-</head><body><div id="root"></div><script>${js}</script></body></html>`;
+</head><body><div id="root"></div><script type="module">${js}</script></body></html>`;
 const htmlPath = join(outDir, "launcher.html");
 await writeFile(htmlPath, html);
 const url = `file://${htmlPath}`;
@@ -159,18 +219,107 @@ const readTelemetry = (p) =>
   p.evaluate(() => window.__ELIZA_VIEW_INTERACTION_TELEMETRY__ ?? []);
 const readCalls = (p) => p.evaluate(() => window.__launcherCalls ?? {});
 
+// Compare paint owned by the launcher state itself. Its inset depth must remain
+// stable under pointer focus even though the product-wide focus reset removes
+// ordinary descendant shadows.
+const SURFACE_PROPERTIES = ["backgroundColor", "borderColor", "boxShadow"];
+const GEOMETRY_PROPERTIES = ["x", "y", "width", "height"];
+
+function surfaceChanged(before, after) {
+  return SURFACE_PROPERTIES.some(
+    (property) => before[property] !== after[property],
+  );
+}
+
+function geometryStayedPut(before, after, tolerance = 0.5) {
+  return GEOMETRY_PROPERTIES.every(
+    (property) => Math.abs(before[property] - after[property]) <= tolerance,
+  );
+}
+
+function hasNeutralMotion(state) {
+  return Object.values(state.parts).every(
+    (part) => part.transform === "none" && part.animationName === "none",
+  );
+}
+
+async function readTileState(button) {
+  return button.evaluate((element) => {
+    const plate = element.querySelector("[data-launcher-icon]");
+    const glyph = element.querySelector("[data-launcher-glyph]");
+    if (!(plate instanceof HTMLElement) || !(glyph instanceof HTMLElement)) {
+      throw new Error("launcher tile is missing its icon plate or glyph");
+    }
+
+    const readPart = (part) => {
+      const style = getComputedStyle(part);
+      const rect = part.getBoundingClientRect();
+      return {
+        animationName: style.animationName,
+        transform: style.transform,
+        rect: {
+          x: rect.x,
+          y: rect.y,
+          width: rect.width,
+          height: rect.height,
+        },
+      };
+    };
+    const plateStyle = getComputedStyle(plate);
+
+    return {
+      focusVisible: element.matches(":focus-visible"),
+      surface: {
+        backgroundColor: plateStyle.backgroundColor,
+        borderColor: plateStyle.borderColor,
+        boxShadow: plateStyle.boxShadow,
+      },
+      parts: {
+        button: readPart(element),
+        plate: readPart(plate),
+        glyph: readPart(glyph),
+      },
+      activeAnimations: element
+        .getAnimations({ subtree: true })
+        .filter((animation) => animation.playState === "running").length,
+    };
+  });
+}
+
+function tileGeometryStayedPut(before, after) {
+  return Object.keys(before.parts).every((part) =>
+    geometryStayedPut(before.parts[part].rect, after.parts[part].rect),
+  );
+}
+
 const errors = [];
 const browser = await chromium.launch();
 
 // ── Screenshots: desktop + mobile ──────────────────────────────────────────
 // The launcher is a read-only single scrolling page of tiles (no edit mode, no
 // pagination), so there is one "rest" capture per viewport.
-async function captureViewport(name, viewport, deviceScaleFactor) {
+async function captureViewport(
+  name,
+  viewport,
+  deviceScaleFactor,
+  { theme = "dark", interactions = false } = {},
+) {
   const page = await browser.newPage({ viewport, deviceScaleFactor });
   page.on("pageerror", (e) => errors.push(String(e)));
   await page.goto(url);
+  await page.evaluate((mode) => {
+    document.documentElement.classList.toggle("dark", mode === "dark");
+  }, theme);
   await page.waitForSelector('[data-testid="launcher"]');
   await page.waitForTimeout(400);
+
+  const renderedColorScheme = await page.evaluate(
+    () => getComputedStyle(document.documentElement).colorScheme,
+  );
+  assert(
+    renderedColorScheme === theme,
+    `${name}: real theme CSS renders in ${theme} mode (color-scheme=${renderedColorScheme})`,
+  );
 
   const tiles = await page.locator('[data-testid^="launcher-tile-"]').count();
   assert(tiles >= 1, `${name}: >=1 tile renders (${tiles})`);
@@ -179,15 +328,67 @@ async function captureViewport(name, viewport, deviceScaleFactor) {
     visuals === tiles,
     `${name}: every launcher tile has a glyph visual (${visuals}/${tiles})`,
   );
-  const glyphs = await page.locator("[data-view-visual] svg").count();
-  assert(glyphs >= 1, `${name}: glyph-only launcher visuals render (${glyphs})`);
+  const glyphImages = await page
+    .locator("[data-view-visual] img[data-launcher-glyph]")
+    .count();
+  assert(
+    glyphImages === tiles,
+    `${name}: every launcher visual uses one glyph image (${glyphImages}/${tiles})`,
+  );
+  const ionicons = await page
+    .locator(
+      '[data-launcher-glyph-kind="ionicon"][data-ionicon]:not([data-ionicon=""])',
+    )
+    .count();
+  const ioniconsLoaded = await page
+    .locator('[data-launcher-glyph-kind="ionicon"]')
+    .evaluateAll((images) =>
+      images.every(
+        (image) =>
+          image instanceof HTMLImageElement &&
+          image.complete &&
+          image.naturalWidth > 0,
+      ),
+    );
+  const customImages = await page
+    .locator(
+      '[data-launcher-glyph-kind="image"]:not([data-ionicon]):not([data-testid^="launcher-image-"])',
+    )
+    .count();
+  assert(ionicons >= 1, `${name}: official Ionicon assets render (${ionicons})`);
+  assert(ioniconsLoaded, `${name}: every Ionicon SVG asset loads successfully`);
+  // A third-party icon URL is also an <img>, but its resolver kind is `image`
+  // and it deliberately has no data-ionicon attribute. Accept both outcomes
+  // while rejecting an unclassified image, so a third-party fixture remains
+  // compatible.
+  assert(
+    ionicons + customImages === glyphImages,
+    `${name}: glyph images are Ionicon or third-party custom assets (ionicon=${ionicons}, custom=${customImages})`,
+  );
   const heroImages = await page
-    .locator('[data-testid^="launcher-image-"], [data-view-visual] img')
+    .locator('[data-testid^="launcher-image-"]')
     .count();
   assert(
     heroImages === 0,
     `${name}: no launcher hero image nodes render (${heroImages})`,
   );
+  const uncontractedImages = await page
+    .locator("[data-view-visual] img:not([data-launcher-glyph])")
+    .count();
+  assert(
+    uncontractedImages === 0,
+    `${name}: no image bypasses the launcher glyph contract (${uncontractedImages})`,
+  );
+  for (const entryWithHero of ["wallet", "companion"]) {
+    const deterministicGlyph = await page
+      .getByTestId(`launcher-tile-${entryWithHero}`)
+      .locator("[data-launcher-glyph]")
+      .count();
+    assert(
+      deterministicGlyph === 1,
+      `${name}: ${entryWithHero} ignores its hero URL and keeps one deterministic glyph`,
+    );
+  }
   // Read-only: no per-tile edit/pin/delete affordances anywhere.
   const editAffordances = await page
     .locator(
@@ -206,12 +407,74 @@ async function captureViewport(name, viewport, deviceScaleFactor) {
     `${name}: single launcher page window (window=${pageWindow}, legacy-page-1=${legacyPage1})`,
   );
   await snap(page, `${name}-rest`);
+
+  if (interactions) {
+    const firstTile = page
+      .getByTestId("launcher-tile-chat")
+      .getByRole("button");
+    const restState = await readTileState(firstTile);
+
+    await firstTile.hover();
+    await page.waitForTimeout(250);
+    const hoverState = await readTileState(firstTile);
+    assert(
+      surfaceChanged(restState.surface, hoverState.surface),
+      `${name}: hover visibly changes the icon surface`,
+    );
+    assert(
+      tileGeometryStayedPut(restState, hoverState),
+      `${name}: hover feedback does not move or resize the tile`,
+    );
+    await snap(page, `${name}-hover`);
+
+    await page.mouse.move(1, 1);
+    await page.waitForTimeout(250);
+    const unfocusedState = await readTileState(firstTile);
+    await page.keyboard.press("Tab");
+    await page.waitForTimeout(100);
+    const focusState = await readTileState(firstTile);
+    const focusedTestId = await page.evaluate(
+      () =>
+        document.activeElement
+          ?.closest("[data-testid]")
+          ?.getAttribute("data-testid") ?? null,
+    );
+    assert(
+      focusedTestId === "launcher-tile-chat" && focusState.focusVisible,
+      `${name}: Tab puts visible keyboard focus on the first launcher tile`,
+    );
+    assert(
+      surfaceChanged(unfocusedState.surface, focusState.surface),
+      `${name}: keyboard focus visibly changes the icon surface`,
+    );
+    assert(
+      tileGeometryStayedPut(unfocusedState, focusState),
+      `${name}: keyboard focus feedback does not move or resize the tile`,
+    );
+    await snap(page, `${name}-keyboard-focus`);
+  }
   await page.close();
 }
 
 try {
-  await captureViewport("desktop", { width: 1180, height: 900 }, undefined);
-  await captureViewport("mobile", { width: 402, height: 874 }, 2);
+  await captureViewport(
+    "desktop-dark",
+    { width: 1180, height: 900 },
+    undefined,
+    { theme: "dark", interactions: true },
+  );
+  await captureViewport(
+    "desktop-light",
+    { width: 1180, height: 900 },
+    undefined,
+    { theme: "light" },
+  );
+  await captureViewport(
+    "mobile-dark",
+    { width: 390, height: 844 },
+    2,
+    { theme: "dark" },
+  );
 } catch (err) {
   // A harness exception (not a page console error) — surface it as its own
   // failed assertion rather than mislabelling it a "page error".
@@ -220,9 +483,9 @@ try {
 
 // ── Video walkthrough: real interactions on a recorded mobile context ──────
 const context = await browser.newContext({
-  viewport: { width: 402, height: 874 },
+  viewport: { width: 390, height: 844 },
   deviceScaleFactor: 2,
-  recordVideo: { dir: videoDir, size: { width: 402, height: 874 } },
+  recordVideo: { dir: videoDir, size: { width: 390, height: 844 } },
 });
 const page = await context.newPage();
 page.on("pageerror", (e) => errors.push(String(e)));
@@ -245,16 +508,42 @@ const launchInRing = (await readTelemetry(page)).some(
 );
 assert(launchInRing, "telemetry ring recorded the tap launch");
 
-// 2. A stationary long-press does NOT enter any edit mode (read-only launcher):
-//    the tile never animates and no edit/pin/delete affordance ever appears.
+// 2. A stationary long-press does NOT enter any edit mode (read-only launcher).
+//    Sample computed rendering before, shortly after pointer-down, and past the
+//    hold threshold: neither button, plate, nor glyph may animate, transform,
+//    or move. The held release must also be consumed rather than ghost-launch.
 {
   const tile = page.getByTestId("launcher-tile-wallet").getByRole("button");
   const box = await tile.boundingBox();
   await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+  await page.waitForTimeout(250);
+  const beforePress = await readTileState(tile);
   await page.mouse.down();
-  await page.waitForTimeout(600);
+  await page.waitForTimeout(80);
+  const afterPointerDown = await readTileState(tile);
+  await page.waitForTimeout(520);
+  const whileHeld = await readTileState(tile);
+  await snap(page, "mobile-long-press-held");
   await page.mouse.up();
   await page.waitForTimeout(150);
+  assert(
+    hasNeutralMotion(beforePress) &&
+      hasNeutralMotion(afterPointerDown) &&
+      hasNeutralMotion(whileHeld) &&
+      afterPointerDown.activeAnimations === 0 &&
+      whileHeld.activeAnimations === 0,
+    "pointer-down and long-press add no animation or transform to the tile",
+  );
+  assert(
+    tileGeometryStayedPut(beforePress, afterPointerDown) &&
+      tileGeometryStayedPut(beforePress, whileHeld),
+    "pointer-down and long-press do not move or resize the button, plate, or glyph",
+  );
+  assert(
+    !surfaceChanged(beforePress.surface, afterPointerDown.surface) &&
+      !surfaceChanged(beforePress.surface, whileHeld.surface),
+    "pointer-down and long-press keep launcher-owned paint and inset depth stable",
+  );
   const affordances = await page
     .locator(
       '[data-testid^="launcher-fav-"], [data-testid^="launcher-edit-"], [data-testid^="launcher-delete-"], button.animate-pulse',
@@ -263,6 +552,12 @@ assert(launchInRing, "telemetry ring recorded the tap launch");
   assert(
     affordances === 0,
     `a long-press never enters edit mode (read-only launcher; ${affordances} affordances)`,
+  );
+  const callsAfterHold = await readCalls(page);
+  assert(
+    !Array.isArray(callsAfterHold.launch) ||
+      !callsAfterHold.launch.includes("wallet"),
+    "a long-press release does not ghost-launch the held tile",
   );
 }
 
@@ -311,7 +606,11 @@ await browser.close();
 
 // Rename the recorded video to a stable name.
 const vids = (await readdir(videoDir)).filter((f) => f.endsWith(".webm"));
-if (vids[0]) {
+assert(
+  vids.length === 1,
+  `walkthrough emits exactly one video artifact (${vids.length})`,
+);
+if (vids.length === 1) {
   await rename(join(videoDir, vids[0]), join(outDir, "launcher-walkthrough.webm"));
   console.log("  🎬 launcher-walkthrough.webm");
 }

--- a/packages/ui/src/components/shell/wallpaper-idiom.ts
+++ b/packages/ui/src/components/shell/wallpaper-idiom.ts
@@ -38,7 +38,9 @@ export const WALLPAPER_GLASS = {
   // Launcher-native scale of the chat composer's smoked glass: enough of the
   // wallpaper survives to tint each squircle, while the neutral blur, quiet
   // rim, and inset light keep a repeated icon grid calmer than ten pale cards.
+  // Hover lifts only the graphite tone; keyboard focus uses the existing
+  // orange accent as a thin rim. Neither state moves or scales the icon.
   launcherIcon:
-    "relative border border-white/24 bg-[rgba(16,17,20,0.68)] text-white backdrop-blur-[18px] shadow-[inset_0_1px_0_rgba(255,255,255,0.30),inset_0_-1px_0_rgba(255,255,255,0.08),inset_0_-18px_34px_-28px_rgba(0,0,0,0.42)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:bg-[radial-gradient(120%_60%_at_30%_-10%,rgba(255,255,255,0.14)_0%,transparent_55%)] before:content-['']",
+    "relative border border-white/24 bg-[rgba(16,17,20,0.68)] text-white backdrop-blur-[18px] group-hover:bg-[rgba(28,29,32,0.74)] group-focus-visible:border-[var(--accent)] group-focus-visible:bg-[rgba(28,29,32,0.78)] !shadow-[inset_0_1px_0_rgba(255,255,255,0.30),inset_0_-1px_0_rgba(255,255,255,0.08),inset_0_-18px_34px_-28px_rgba(0,0,0,0.42)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:bg-[radial-gradient(120%_60%_at_30%_-10%,rgba(255,255,255,0.14)_0%,transparent_55%)] before:content-['']",
   floatingControl: "bg-black/55 text-white hover:bg-black/70",
 } as const;

--- a/packages/ui/src/components/views/LauncherAppIcon.test.tsx
+++ b/packages/ui/src/components/views/LauncherAppIcon.test.tsx
@@ -30,6 +30,18 @@ describe("LauncherAppIcon", () => {
     expect(glyph.draggable).toBe(false);
   });
 
+  it("keeps Chat on the approved filled message glyph", () => {
+    const { container } = render(
+      <LauncherAppIcon
+        entry={{ id: "chat", label: "Chat", icon: "MessageSquare" }}
+      />,
+    );
+
+    expect(renderedGlyph(container).dataset.ionicon).toBe(
+      "chatbubble-ellipses",
+    );
+  });
+
   it("preserves a third-party image URL without presenting it to assistive technology", () => {
     const src = "https://cdn.example.com/partner.png";
     const { container } = render(

--- a/packages/ui/src/components/views/LauncherAppIcon.test.tsx
+++ b/packages/ui/src/components/views/LauncherAppIcon.test.tsx
@@ -1,7 +1,5 @@
 // @vitest-environment jsdom
-/**
- * Verifies the shared launcher icon visual and interaction contract.
- */
+/** Verifies launcher icon resolution at the rendered consumer boundary. */
 
 import { cleanup, render } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
@@ -9,75 +7,70 @@ import { LauncherAppIcon, LauncherAppIconSkeleton } from "./LauncherAppIcon";
 
 afterEach(() => cleanup());
 
+function renderedGlyph(container: HTMLElement): HTMLImageElement {
+  const glyph = container.querySelector<HTMLImageElement>(
+    "img[data-launcher-glyph]",
+  );
+  expect(glyph).toBeTruthy();
+  return glyph as HTMLImageElement;
+}
+
 describe("LauncherAppIcon", () => {
-  it("renders first-party icons as decorative launcher glyphs", () => {
+  it("renders a semantic first-party glyph as decorative content", () => {
     const { container } = render(
       <LauncherAppIcon
         entry={{ id: "calendar", label: "Calendar", icon: "CalendarDays" }}
       />,
     );
 
-    const plate = container.querySelector<HTMLElement>("[data-launcher-icon]");
-    expect(plate).toBeTruthy();
-    expect(plate?.dataset.launcherIconVariant).toBe("ionicon");
-
-    const glyph = container.querySelector<HTMLImageElement>(
-      'img[data-ionicon="calendar"]',
-    );
-    expect(glyph?.src).toMatch(/^(?:data:image\/svg\+xml|https?:|file:)/);
-    expect(glyph?.getAttribute("alt")).toBe("");
-    expect(glyph?.getAttribute("aria-hidden")).toBe("true");
+    const glyph = renderedGlyph(container);
+    expect(glyph.dataset.ionicon).toBe("calendar");
+    expect(glyph.getAttribute("alt")).toBe("");
+    expect(glyph.getAttribute("aria-hidden")).toBe("true");
+    expect(glyph.draggable).toBe(false);
   });
 
-  it("uses the approved filled Ionicons family for Chat", () => {
+  it("preserves a third-party image URL without presenting it to assistive technology", () => {
+    const src = "https://cdn.example.com/partner.png";
     const { container } = render(
       <LauncherAppIcon
-        entry={{ id: "chat", label: "Chat", icon: "MessageSquare" }}
+        entry={{ id: "partner", label: "Partner", icon: src }}
       />,
     );
 
-    const plate = container.querySelector<HTMLElement>("[data-launcher-icon]");
-    expect(plate?.dataset.launcherIconVariant).toBe("ionicon");
-    expect(
-      plate?.querySelector('img[data-ionicon="chatbubble-ellipses"]'),
-    ).toBeTruthy();
+    const glyph = renderedGlyph(container);
+    expect(glyph.getAttribute("src")).toBe(src);
+    expect(glyph.dataset.launcherGlyphKind).toBe("image");
+    expect(glyph.hasAttribute("data-ionicon")).toBe(false);
+    expect(glyph.getAttribute("alt")).toBe("");
+    expect(glyph.getAttribute("aria-hidden")).toBe("true");
   });
 
-  it("preserves explicit third-party image icons and deterministic fallback", () => {
-    const image = render(
-      <LauncherAppIcon
-        entry={{
-          id: "partner",
-          label: "Partner",
-          icon: "https://cdn.example.com/partner.png",
-        }}
-      />,
-    );
-    expect(image.container.querySelector("img")?.getAttribute("src")).toBe(
-      "https://cdn.example.com/partner.png",
-    );
-    expect(
-      image.container
-        .querySelector("[data-launcher-icon]")
-        ?.getAttribute("data-launcher-icon-variant"),
-    ).toBe("image");
-    image.unmount();
-
-    const fallback = render(
+  it("renders the same deterministic fallback for unrelated unknown entries", () => {
+    const first = render(
       <LauncherAppIcon
         entry={{ id: "acme-tool", label: "Acme Tool", icon: "UnknownIcon" }}
       />,
     );
-    expect(
-      fallback.container.querySelector('img[data-ionicon="apps"]'),
-    ).toBeTruthy();
+    const second = render(
+      <LauncherAppIcon entry={{ id: "other-tool", label: "Other Tool" }} />,
+    );
+
+    const firstGlyph = renderedGlyph(first.container);
+    const secondGlyph = renderedGlyph(second.container);
+    expect(firstGlyph.dataset.launcherGlyphKind).toBe("ionicon");
+    expect(firstGlyph.dataset.ionicon).toBe(secondGlyph.dataset.ionicon);
+    expect(firstGlyph.getAttribute("src")).toBe(
+      secondGlyph.getAttribute("src"),
+    );
   });
 
-  it("marks loading placeholders as launcher icons", () => {
+  it("keeps loading placeholders decorative", () => {
     const { container } = render(<LauncherAppIconSkeleton />);
     const skeleton = container.querySelector<HTMLElement>(
       "[data-launcher-icon]",
     );
-    expect(skeleton).toBeTruthy();
+    expect(skeleton?.getAttribute("aria-hidden")).toBe("true");
+    expect(skeleton?.querySelector("img")).toBeNull();
   });
 });

--- a/packages/ui/src/components/views/ViewIcon.test.tsx
+++ b/packages/ui/src/components/views/ViewIcon.test.tsx
@@ -51,23 +51,17 @@ describe("ViewIcon lucide glyphs", () => {
     expect(svg?.classList.contains("size-7")).toBe(true);
   });
 
-  it("resolves every maintained registered-page glyph explicitly", () => {
-    const cases = [
-      ["CalendarDays", "lucide-calendar-days"],
-      ["Cloud", "lucide-cloud"],
-      ["Grid3x3", "lucide-grid-3x3"],
-      ["Map", "lucide-map"],
-      ["MonitorUp", "lucide-monitor-up"],
-      ["TerminalSquare", "lucide-square-terminal"],
-    ] as const;
+  it("honors a registered-page icon before conflicting label inference", () => {
+    const registered = render(
+      <ViewIcon icon="CalendarDays" label="Crypto Wallet" />,
+    );
+    const inferred = render(<ViewIcon label="Crypto Wallet" />);
+    const registeredGlyph = registered.container.querySelector("svg");
+    const inferredGlyph = inferred.container.querySelector("svg");
 
-    for (const [icon, expectedClass] of cases) {
-      const rendered = render(<ViewIcon icon={icon} label="Registered page" />);
-      expect(
-        rendered.container.querySelector(`svg.${expectedClass}`),
-        icon,
-      ).toBeTruthy();
-    }
+    expect(registeredGlyph).toBeTruthy();
+    expect(registeredGlyph?.getAttribute("aria-hidden")).toBe("true");
+    expect(registeredGlyph?.innerHTML).not.toBe(inferredGlyph?.innerHTML);
   });
 });
 

--- a/packages/ui/src/components/views/ViewIcon.test.tsx
+++ b/packages/ui/src/components/views/ViewIcon.test.tsx
@@ -51,6 +51,21 @@ describe("ViewIcon lucide glyphs", () => {
     expect(svg?.classList.contains("size-7")).toBe(true);
   });
 
+  it.each([
+    ["CalendarDays", "lucide-calendar-days"],
+    ["Cloud", "lucide-cloud"],
+    ["Grid3x3", "lucide-grid-3x3"],
+    ["Map", "lucide-map"],
+    ["MonitorUp", "lucide-monitor-up"],
+    ["TerminalSquare", "lucide-square-terminal"],
+  ])("resolves maintained registered-page glyph %s", (icon, expectedClass) => {
+    const { container } = render(
+      <ViewIcon icon={icon} label="Registered page" />,
+    );
+
+    expect(container.querySelector(`svg.${expectedClass}`)).toBeTruthy();
+  });
+
   it("honors a registered-page icon before conflicting label inference", () => {
     const registered = render(
       <ViewIcon icon="CalendarDays" label="Crypto Wallet" />,

--- a/packages/ui/src/components/views/ViewTileImage.test.tsx
+++ b/packages/ui/src/components/views/ViewTileImage.test.tsx
@@ -28,6 +28,23 @@ function entry(overrides: Partial<ViewEntry> = {}): ViewEntry {
 }
 
 describe("ViewTileImage catalog previews", () => {
+  it("delegates launcher tiles to the shared Ionicon plate without probing hero art", () => {
+    const { container } = render(
+      <ViewTileImage
+        entry={entry()}
+        source="launcher"
+        containerClassName="launcher-icon"
+        imageTestId="catalog-hero"
+      />,
+    );
+
+    expect(screen.queryByTestId("catalog-hero")).toBeNull();
+    expect(
+      container.querySelector('[data-launcher-icon-variant="ionicon"]'),
+    ).toBeTruthy();
+    expect(container.querySelector('[data-ionicon="calendar"]')).toBeTruthy();
+  });
+
   it("keeps catalog hero imagery independent from launcher glyph styling", () => {
     render(
       <ViewTileImage
@@ -60,5 +77,25 @@ describe("ViewTileImage catalog previews", () => {
     expect(screen.getByTestId("catalog-hero").getAttribute("src")).toBe(
       "https://cdn.example.com/calendar-fallback.png",
     );
+  });
+
+  it("falls back to the deterministic glyph after every catalog image fails", () => {
+    const { container } = render(
+      <ViewTileImage
+        entry={entry()}
+        source="view-catalog"
+        containerClassName="preview"
+        imageTestId="catalog-hero"
+      />,
+    );
+
+    fireEvent.error(screen.getByTestId("catalog-hero"));
+    fireEvent.error(screen.getByTestId("catalog-hero"));
+
+    expect(screen.queryByTestId("catalog-hero")).toBeNull();
+    expect(
+      container.querySelector('[data-view-visual="calendar"]'),
+    ).toBeTruthy();
+    expect(container.querySelector("svg.lucide-calendar-days")).toBeTruthy();
   });
 });

--- a/packages/ui/src/components/views/ViewTileImage.tsx
+++ b/packages/ui/src/components/views/ViewTileImage.tsx
@@ -49,10 +49,9 @@ function resolveTileImageUrl(url: string | undefined): string | undefined {
 /**
  * The shared visual core for view launch surfaces.
  *
- * Launcher tiles are app icons: paint the deterministic glyph tile
- * underneath the concrete hero or generated branded fallback so icons never
- * appear blank while image decoding catches up after a swipe. Catalog cards are
- * previews and use the same image/fallback order at their larger size.
+ * Launcher tiles are app icons and paint the deterministic shared glyph only.
+ * Catalog cards are previews and retain the concrete hero/generated fallback
+ * order at their larger size.
  *
  * A load failure emits a `hero-image-error` interaction event (best-effort,
  * client-only) from preview surfaces so broken hero endpoints are observable

--- a/packages/ui/src/components/views/launcher-ionicons.test.ts
+++ b/packages/ui/src/components/views/launcher-ionicons.test.ts
@@ -1,62 +1,106 @@
-/** Verifies canonical Ionicons coverage and launcher icon asset resolution. */
+/** Verifies launcher icon resolution precedence and fallback behavior. */
 import { describe, expect, it } from "vitest";
+import {
+  LAUNCHER_AOSP_ONLY_IDS,
+  LAUNCHER_APPS_ORDER,
+  LAUNCHER_DEVELOPER_ORDER,
+} from "../pages/launcher-curation";
 import { resolveLauncherIconAsset } from "./launcher-ionicons";
 
+const CURATED_FIRST_PARTY_IDS = [
+  ...LAUNCHER_APPS_ORDER,
+  ...LAUNCHER_DEVELOPER_ORDER,
+  ...LAUNCHER_AOSP_ONLY_IDS,
+];
+
 describe("launcher Ionicons resolver", () => {
-  it("preserves a supplied third-party image inside the shared plate", () => {
-    expect(
-      resolveLauncherIconAsset({
-        id: "partner",
-        label: "Partner",
-        icon: "https://cdn.example.com/partner.svg",
-      }),
-    ).toEqual({
-      kind: "image",
-      name: "custom-image",
-      src: "https://cdn.example.com/partner.svg",
+  it.each(CURATED_FIRST_PARTY_IDS)(
+    "resolves curated first-party destination %s to a real Ionicon asset",
+    (id) => {
+      const asset = resolveLauncherIconAsset({
+        id,
+        label: id,
+        icon: "UnknownLegacyIcon",
+      });
+
+      expect(asset.kind).toBe("ionicon");
+      expect(asset.name).not.toBe("apps");
+      expect(asset.src).toMatch(/\/view-icons\/ionicons\/[^/]+\.svg$/);
+    },
+  );
+
+  it("preserves a supplied third-party image URL", () => {
+    const src = "https://cdn.example.com/partner.svg";
+    const asset = resolveLauncherIconAsset({
+      id: "partner",
+      label: "Partner",
+      icon: src,
     });
+
+    expect(asset.kind).toBe("image");
+    expect(asset.src).toBe(src);
   });
 
-  it("keeps first-party apps in the chosen family even if catalog data supplies an image", () => {
-    expect(
-      resolveLauncherIconAsset({
-        id: "settings",
-        label: "Settings",
-        icon: "https://cdn.example.com/legacy-settings.png",
-      }).name,
-    ).toBe("settings");
+  it("gives first-party identity precedence over catalog image metadata", () => {
+    const canonical = resolveLauncherIconAsset({
+      id: "settings",
+      label: "Settings",
+    });
+    const withCatalogImage = resolveLauncherIconAsset({
+      id: "settings",
+      label: "Renamed in catalog",
+      icon: "https://cdn.example.com/legacy-settings.png",
+    });
+
+    expect(withCatalogImage.kind).toBe("ionicon");
+    expect(withCatalogImage).toEqual(canonical);
   });
 
-  it("uses explicit legacy names, keyword semantics, then one deterministic fallback", () => {
-    expect(
-      resolveLauncherIconAsset({
-        id: "legacy",
-        label: "Legacy",
-        icon: "TrendingUp",
-      }).name,
-    ).toBe("trending-up");
-    expect(
-      resolveLauncherIconAsset({
-        id: "marketplace-view",
-        label: "Trading Desk",
-      }).name,
-    ).toBe("trending-up");
-    expect(
-      resolveLauncherIconAsset({
-        id: "@elizaos/plugin-hyperliquid",
-        label: "Hyperliquid",
-        icon: "LayoutGrid",
-      }).name,
-    ).toBe("trending-up");
-    expect(
-      resolveLauncherIconAsset({
-        id: "release-calendar",
-        label: "Trading Calendar",
-        icon: "CalendarDays",
-      }).name,
-    ).toBe("calendar");
-    expect(resolveLauncherIconAsset({ id: "acme", label: "Acme" }).name).toBe(
-      "apps",
-    );
+  it("uses a semantic named icon before conflicting label keywords", () => {
+    const named = resolveLauncherIconAsset({
+      id: "marketplace-view",
+      label: "Calendar",
+      icon: "TrendingUp",
+    });
+    const matchingSemantics = resolveLauncherIconAsset({
+      id: "marketplace-view",
+      label: "Trading Desk",
+    });
+    const conflictingSemantics = resolveLauncherIconAsset({
+      id: "marketplace-view",
+      label: "Calendar",
+    });
+
+    expect(named).toEqual(matchingSemantics);
+    expect(named).not.toEqual(conflictingSemantics);
+  });
+
+  it("lets generic catalog placeholders defer to entry semantics", () => {
+    const genericCatalogIcon = resolveLauncherIconAsset({
+      id: "@elizaos/plugin-hyperliquid",
+      label: "Hyperliquid",
+      icon: "LayoutGrid",
+    });
+    const semanticResolution = resolveLauncherIconAsset({
+      id: "@elizaos/plugin-hyperliquid",
+      label: "Hyperliquid",
+    });
+
+    expect(genericCatalogIcon).toEqual(semanticResolution);
+  });
+
+  it("returns one stable family fallback for unrelated unknown entries", () => {
+    const first = resolveLauncherIconAsset({
+      id: "acme",
+      label: "Acme",
+      icon: "UnknownIcon",
+    });
+    const second = resolveLauncherIconAsset({
+      id: "other",
+      label: "Other",
+    });
+
+    expect(first.kind).toBe("ionicon");
+    expect(first).toEqual(second);
   });
 });

--- a/packages/ui/src/components/views/launcher-ionicons.test.ts
+++ b/packages/ui/src/components/views/launcher-ionicons.test.ts
@@ -89,6 +89,20 @@ describe("launcher Ionicons resolver", () => {
     expect(genericCatalogIcon).toEqual(semanticResolution);
   });
 
+  it.each([
+    ["chat", "Chat", "MessageSquare", "chatbubble-ellipses"],
+    ["settings", "Settings", "LayoutGrid", "settings"],
+    ["release-calendar", "Trading Calendar", "CalendarDays", "calendar"],
+    ["marketplace-view", "Trading Desk", undefined, "trending-up"],
+  ])(
+    "keeps representative destination %s on the approved %s asset",
+    (id, label, icon, expectedName) => {
+      expect(resolveLauncherIconAsset({ id, label, icon }).name).toBe(
+        expectedName,
+      );
+    },
+  );
+
   it("returns one stable family fallback for unrelated unknown entries", () => {
     const first = resolveLauncherIconAsset({
       id: "acme",
@@ -102,5 +116,6 @@ describe("launcher Ionicons resolver", () => {
 
     expect(first.kind).toBe("ionicon");
     expect(first).toEqual(second);
+    expect(first.name).toBe("apps");
   });
 });

--- a/plugins/plugin-calendar/src/register.test.ts
+++ b/plugins/plugin-calendar/src/register.test.ts
@@ -23,7 +23,7 @@ describe("Calendar app registration", () => {
       {
         id: "calendar",
         label: "Calendar",
-        icon: "CalendarDays",
+        icon: expect.any(String),
         path: "/calendar",
         viewKind: "release",
       },

--- a/plugins/plugin-calendar/src/register.test.ts
+++ b/plugins/plugin-calendar/src/register.test.ts
@@ -23,7 +23,7 @@ describe("Calendar app registration", () => {
       {
         id: "calendar",
         label: "Calendar",
-        icon: expect.any(String),
+        icon: "CalendarDays",
         path: "/calendar",
         viewKind: "release",
       },

--- a/scripts/generated/static-asset-manifest.json
+++ b/scripts/generated/static-asset-manifest.json
@@ -1,5 +1,6 @@
 {
   "app": [
+    "packages/app/public/THIRD_PARTY_NOTICES.txt",
     "packages/app/public/_headers",
     "packages/app/public/_redirects",
     "packages/app/public/bg-sunset.webp",


### PR DESCRIPTION
# Relates to

- Relates to #28858.
- Follow-up hardening for the launcher icon system merged in #29061.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] Focused exact-head verification was run after sync; the unrelated full-workspace
      verification blocker is recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Exact-head affected-path gates pass; the unrelated workspace-level blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. The runtime change is limited to launcher hover/focus paint and Android-cloud
third-party-notice packaging. The rest of the delta adds behavioral and real-browser
coverage around the already-merged Ionicons launcher.

# Background

## What does this PR do?

- Hardens the real-browser launcher contract around official Ionicon assets, dark/light
  rendering, visible hover and keyboard-focus feedback, and geometry-stable pointer and
  long-press behavior on desktop and mobile.
- Replaces brittle presentation-token assertions with behavioral component coverage for
  launcher/catalog separation, deterministic glyph resolution, and image-failure
  fallbacks.
- Registers `THIRD_PARTY_NOTICES.txt` in the static asset manifest and emits the exact
  Ionicons 8.1.0 MIT notice with Android-cloud curated assets.

The approved resting icon appearance is intentionally unchanged; the interaction
hardening makes hover and keyboard focus legible without reintroducing push/press motion.

## What kind of change is this?

Bug fix and test hardening (non-breaking).

# Documentation changes needed?

No user-facing documentation change is required. The required third-party notice is
included in packaged assets.

# Testing

## Where should a reviewer start?

1. Review the before/after contact sheets and MP4 in the Evidence Gate.
2. Inspect `packages/ui/src/components/pages/__e2e__/run-launcher-e2e.mjs` for the
   end-to-end interaction contract.
3. Inspect `packages/app/vite.config.test.ts` for the real `generateBundle` / `emitFile`
   notice boundary.

## Detailed testing steps

- `bun run --cwd packages/ui test -- src/components/views/LauncherAppIcon.test.tsx src/components/views/ViewIcon.test.tsx src/components/views/ViewTileImage.test.tsx src/components/views/launcher-ionicons.test.ts --coverage --coverage.include=src/components/views/LauncherAppIcon.tsx --coverage.include=src/components/views/ViewIcon.tsx --coverage.include=src/components/views/ViewTileImage.tsx --coverage.include=src/components/views/launcher-ionicons.ts`
  - 64/64 tests; 93.22% statements, 87.32% branches, 100% functions, 94.44% lines.
- `bun test --coverage-reporter=lcov --coverage-dir=/private/tmp/eliza-launcher-vite-coverage-41d88ad packages/app/vite.config.test.ts`
  - 14/14 tests, 49 assertions, including registered-plugin asset emission.
- `bun run --cwd packages/ui test:launcher-e2e`
  - 16/16 official Ionicon assets load in dark/light desktop and mobile; hover/focus
    feedback is visible and geometry-stable; pointer hold adds no transform, animation,
    paint, or inset-shadow change; no ghost launch; swipe-home and zero-page-error gates
    pass; exactly one video artifact is produced.
- `bun run --cwd packages/ui typecheck`
- `bun run --cwd packages/ui lint:check`
  - Zero errors/design-system violations; 12 pre-existing warnings.
- Storybook exact-head build plus six targeted LauncherAppIcon, ViewTileImage, and
  HomeLauncherSurface story gates: zero broken, console, or accessibility findings.
- Clean detached-worktree static asset contract: 3/3.
- Android-cloud renderer build: emitted notice is byte-identical to source,
  SHA-256 `eedda62806d3bf8a058580d9c24b43233a90eee94e0f6cba8170e49d00274327`, and
  includes Ionicons 8.1.0, MIT, and Ionic copyright.
- `bun run --cwd packages/app audit:app`: 227/227 capture cases, zero broken and zero
  needs-work DOM findings. OCR detail is attached below.
- Independent exact-head diff review: no blockers; all 61 vendored SVGs byte-match
  Ionicons 8.1.0 and the five rebased commits are patch-identical to the reviewed series.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:c1f8e5259b8bd5a57d7c427c32f7031d47ca4a79 -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29148-launcher-hardening-before-merged-29061-rest-states.jpg)
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29148-launcher-hardening-after-app-and-states-41d88ad.jpg)
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29148-launcher-hardening-walkthrough-41d88ad.mp4
<!-- evidence-row:backend-logs -->
- [ ] N/A - frontend interaction and static packaging only; no backend path changed
<!-- evidence-row:frontend-logs -->
- [x] [29148-launcher-hardening-frontend-audit-41d88ad.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29148-launcher-hardening-frontend-audit-41d88ad.json)
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, provider, agent, or action behavior changed
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database, wallet, schedule, memory, or generated domain output changed
<!-- evidence-row:ocr-review -->
- [x] [29148-launcher-hardening-ocr-review-c1f8e52.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29148-launcher-hardening-ocr-review-c1f8e52.json)

# Evidence Details

## Real LLM-call trajectory

N/A - no model, prompt, provider, agent, or action behavior changed.

## Backend + frontend logs

Backend: N/A - this PR changes frontend interaction coverage and static asset packaging;
no backend code path is involved.

Frontend: see the attached app aesthetic audit JSON in the evidence row above. It records
bundle provenance, console errors, render-state issues, and responsive findings for every
captured view.

## Screenshots (before / after) + video walkthrough

See the three inline artifacts in the Evidence Gate rows. The before sheet pairs the
approved orange-cloud resting state with true pre-hardening hover/focus captures; the
after sheet includes desktop/mobile app views plus dark/light hover, focus, and held-state
captures. The MP4 walks the complete launcher interaction contract.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or omnivoice behavior changed.

## Known gaps / failures

- Full `packages/app` typecheck / root `bun run verify` is blocked in this saved workspace
  by unrelated missing built exports and packages in auth, vault, wallet, and scheduling.
  The output contains no launcher-path diagnostics. UI typecheck and all affected-path
  gates pass.
- The app-wide audit recorded one unrelated Computer Use Sessions hover-probe timeout on
  mobile portrait. Its view rendered with real-dist provenance and no broken or needs-work
  DOM finding; it is outside this icon-only diff.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

