### PR TITLE
fix(plugin-agent-skills): parse SKILL.md YAML block sequences so otto.install stays an OttoInstallOption[]

### DIFF
--- a/plugins/plugin-agent-skills/src/parser.frontmatter.test.ts
+++ b/plugins/plugin-agent-skills/src/parser.frontmatter.test.ts
@@ -68,3 +68,116 @@ describe("parseFrontmatter", () => {
     expect(result.errors).toEqual([]);
   });
 });
+
+describe("parseFrontmatter YAML block sequences (issue #29157)", () => {
+  // The exact "Otto Compatibility" install list documented in the plugin
+  // README. Before the parser fix this collapsed into a single merged object
+  // (both `id` fields dropped, item 0 overwritten by item 1), which then made
+  // installSkillDependencies throw "installOptions is not iterable".
+  const ottoListSkill = [
+    "---",
+    "name: gh-skill",
+    "description: A skill that requires the GitHub CLI to operate correctly.",
+    "metadata:",
+    "  otto:",
+    '    emoji: "\ud83d\udc19"',
+    "    requires:",
+    "      bins:",
+    "        - gh",
+    "    install:",
+    "      - id: brew",
+    "        kind: brew",
+    "        formula: gh",
+    '        bins: ["gh"]',
+    '        label: "Install GitHub CLI (brew)"',
+    "      - id: apt",
+    "        kind: apt",
+    "        package: gh",
+    '        bins: ["gh"]',
+    '        label: "Install GitHub CLI (apt)"',
+    "---",
+    "",
+    "# GH Skill",
+  ].join("\n");
+
+  it("parses the README otto install list into a typed OttoInstallOption[]", () => {
+    const otto = parseFrontmatter(ottoListSkill).frontmatter?.metadata?.otto;
+    const install = otto?.install;
+
+    expect(Array.isArray(install)).toBe(true);
+    expect(install).toHaveLength(2);
+    // Each item's first key (`id`) must survive, not be dropped/merged.
+    expect(install?.[0]).toEqual({
+      id: "brew",
+      kind: "brew",
+      formula: "gh",
+      bins: ["gh"],
+      label: "Install GitHub CLI (brew)",
+    });
+    expect(install?.[1]).toEqual({
+      id: "apt",
+      kind: "apt",
+      package: "gh",
+      bins: ["gh"],
+      label: "Install GitHub CLI (apt)",
+    });
+  });
+
+  it("parses a block-style scalar sequence (requires.bins) into an array", () => {
+    const otto = parseFrontmatter(ottoListSkill).frontmatter?.metadata?.otto;
+    expect(otto?.requires?.bins).toEqual(["gh"]);
+    expect(otto?.emoji).toBe("\ud83d\udc19");
+  });
+
+  it("round-trips mixed block-list, nested-object, and scalar frontmatter", () => {
+    const mixed = [
+      "---",
+      "name: mixed-skill",
+      "description: Exercises lists alongside scalars and nested maps.",
+      "license: MIT",
+      "metadata:",
+      "  otto:",
+      "    requires:",
+      "      bins:",
+      "        - jq",
+      "        - yq",
+      "    install:",
+      "      - id: brew",
+      "        kind: brew",
+      "        formula: jq",
+      '        bins: ["jq"]',
+      "---",
+      "body",
+    ].join("\n");
+    const fm = parseFrontmatter(mixed).frontmatter;
+    expect(fm?.name).toBe("mixed-skill");
+    expect(fm?.license).toBe("MIT");
+    expect(fm?.metadata?.otto?.requires?.bins).toEqual(["jq", "yq"]);
+    expect(fm?.metadata?.otto?.install).toHaveLength(1);
+    expect(fm?.metadata?.otto?.install?.[0]).toEqual({
+      id: "brew",
+      kind: "brew",
+      formula: "jq",
+      bins: ["jq"],
+    });
+  });
+
+  it("regression: inline JSON array frontmatter still parses unchanged", () => {
+    const inlineJson = [
+      "---",
+      "name: inline-skill",
+      "description: Inline JSON install options must keep working after the fix.",
+      "metadata:",
+      "  otto:",
+      '    install: [{"id":"brew","kind":"brew","formula":"gh","bins":["gh"]}]',
+      "---",
+      "body",
+    ].join("\n");
+    const install =
+      parseFrontmatter(inlineJson).frontmatter?.metadata?.otto?.install;
+    expect(Array.isArray(install)).toBe(true);
+    expect(install).toEqual([
+      { id: "brew", kind: "brew", formula: "gh", bins: ["gh"] },
+    ]);
+  });
+});

--- a/plugins/plugin-agent-skills/src/parser.frontmatter.test.ts
+++ b/plugins/plugin-agent-skills/src/parser.frontmatter.test.ts
@@ -162,6 +162,52 @@ describe("parseFrontmatter YAML block sequences (issue #29157)", () => {
     });
   });
 
+  it("parses block sequences when a YAML comment precedes the first item", () => {
+    // A comment between an empty key and its first `- ` item must not misroute
+    // the sequence to the nested-object path (which collapsed `requires.bins`
+    // into `{}` and merged `install` into one object).
+    const commented = [
+      "---",
+      "name: commented-skill",
+      "description: Explains its install list with inline YAML comments.",
+      "metadata:",
+      "  otto:",
+      "    requires:",
+      "      bins:",
+      "        # gh drives the GitHub API calls",
+      "        - gh",
+      "    install:",
+      "      # prefer Homebrew on macOS",
+      "      - id: brew",
+      "        kind: brew",
+      "        formula: gh",
+      '        bins: ["gh"]',
+      "      # fall back to apt on Debian/Ubuntu",
+      "      - id: apt",
+      "        kind: apt",
+      "        package: gh",
+      '        bins: ["gh"]',
+      "---",
+      "body",
+    ].join("\n");
+    const otto = parseFrontmatter(commented).frontmatter?.metadata?.otto;
+    expect(otto?.requires?.bins).toEqual(["gh"]);
+    expect(Array.isArray(otto?.install)).toBe(true);
+    expect(otto?.install).toHaveLength(2);
+    expect(otto?.install?.[0]).toEqual({
+      id: "brew",
+      kind: "brew",
+      formula: "gh",
+      bins: ["gh"],
+    });
+    expect(otto?.install?.[1]).toEqual({
+      id: "apt",
+      kind: "apt",
+      package: "gh",
+      bins: ["gh"],
+    });
+  });
+
   it("regression: inline JSON array frontmatter still parses unchanged", () => {
     const inlineJson = [
       "---",

--- a/plugins/plugin-agent-skills/src/parser.ts
+++ b/plugins/plugin-agent-skills/src/parser.ts
@@ -202,9 +202,16 @@ function parseYamlSubset(yaml: string): Record<string, unknown> {
 
 			if (valueStr === "" || valueStr === "|" || valueStr === ">") {
 				// Could be object, multiline string, or multiline JSON
-				// Check if next non-empty line starts with { or [
+				// Check the first meaningful line. Blank lines and YAML comments
+				// carry no structure, so skip both: a comment between an empty key
+				// and its first `- ` item must not misroute a block sequence to the
+				// nested-object path (which merges the list into one mapping).
 				let nextLineIdx = i + 1;
-				while (nextLineIdx < lines.length && !lines[nextLineIdx].trim()) {
+				while (
+					nextLineIdx < lines.length &&
+					(!lines[nextLineIdx].trim() ||
+						lines[nextLineIdx].trim().startsWith("#"))
+				) {
 					nextLineIdx++;
 				}
 				const nextTrimmed =

--- a/plugins/plugin-agent-skills/src/parser.ts
+++ b/plugins/plugin-agent-skills/src/parser.ts
@@ -217,6 +217,21 @@ function parseYamlSubset(yaml: string): Record<string, unknown> {
 					jsonBuffer = "";
 					jsonDepth = 0;
 					collectingJson = true;
+				} else if (
+					nextTrimmed === "-" ||
+					nextTrimmed.startsWith("- ")
+				) {
+					// YAML block sequence (`- item` lines). Collect the list into an
+					// array so a documented `metadata.otto.install` list survives as
+					// OttoInstallOption[] instead of being merged into one object.
+					const listIndent = lines[nextLineIdx].search(/\S/);
+					const { items, nextIdx } = parseListBlock(
+						lines,
+						nextLineIdx,
+						listIndent,
+					);
+					parent[key] = items;
+					i = nextIdx - 1;
 				} else {
 					// Regular nested object
 					const childObj: Record<string, unknown> = {};
@@ -274,6 +289,99 @@ function parseYamlSubset(yaml: string): Record<string, unknown> {
 	}
 
 	return result;
+}
+
+/**
+ * Parse one YAML block sequence into an array of items.
+ *
+ * Called from {@link parseYamlSubset} when a key's value is empty and the next
+ * non-empty line at deeper indent is a `- ` item. Each item is one of:
+ * a mapping (the dash remainder is the first `key: value`, following
+ * deeper-indented lines are more entries), a nested block (bare `-` then
+ * deeper-indented lines), or a scalar/inline-JSON (`- gh`, `- ["gh"]`). Mapping
+ * and nested items recurse through `parseYamlSubset` so existing scalar,
+ * nested-object, and inline/multiline JSON handling applies unchanged inside a
+ * list item. Returns the parsed items and the index of the first line past the
+ * sequence so the caller can resume.
+ */
+function parseListBlock(
+	lines: string[],
+	startIdx: number,
+	listIndent: number,
+): { items: unknown[]; nextIdx: number } {
+	const items: unknown[] = [];
+	let i = startIdx;
+
+	while (i < lines.length) {
+		const line = lines[i];
+		const trimmed = line.trim();
+
+		if (!trimmed || trimmed.startsWith("#")) {
+			i++;
+			continue;
+		}
+
+		const indent = line.search(/\S/);
+		// A dedent below the list column, or a deeper/non-`-` line, ends the list.
+		if (indent < listIndent) break;
+		if (indent > listIndent || !(trimmed === "-" || trimmed.startsWith("- "))) {
+			break;
+		}
+
+		const remainder = trimmed.replace(/^-\s*/, "");
+
+		// Gather continuation lines that belong to this item (deeper indent).
+		const itemLines: string[] = [];
+		let j = i + 1;
+		while (j < lines.length) {
+			const l = lines[j];
+			const t = l.trim();
+			if (!t || t.startsWith("#")) {
+				itemLines.push(l);
+				j++;
+				continue;
+			}
+			if (l.search(/\S/) <= listIndent) break;
+			itemLines.push(l);
+			j++;
+		}
+
+		if (remainder === "") {
+			// Bare `-`: the item is defined entirely by its continuation lines.
+			items.push(
+				itemLines.length ? parseYamlSubset(itemLines.join("\n")) : null,
+			);
+		} else if (/^[A-Za-z0-9_-]+:(\s|$)/.test(remainder)) {
+			// Mapping item: the dash remainder is the first `key: value` pair.
+			const firstKeyPad = " ".repeat(listIndent + 2);
+			const block = [`${firstKeyPad}${remainder}`, ...itemLines].join("\n");
+			items.push(parseYamlSubset(block));
+		} else {
+			// Scalar (or inline JSON) list item, e.g. `- gh` or `- ["gh"]`.
+			items.push(parseListScalar(remainder));
+		}
+
+		i = j;
+	}
+
+	return { items, nextIdx: i };
+}
+
+/**
+ * Parse a single scalar list item, honoring inline JSON before YAML scalars.
+ */
+function parseListScalar(raw: string): unknown {
+	const trimmed = raw.trim();
+	if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+		try {
+			return JSON.parse(trimmed.replace(/,(\s*[}\]])/g, "$1"));
+		} catch {
+			// error-policy:J3 untrusted-input sanitizing — not valid JSON, keep the
+			// raw scalar text rather than fabricating a structured value.
+			return trimmed;
+		}
+	}
+	return parseYamlValue(trimmed);
 }
 
 /**

--- a/plugins/plugin-agent-skills/src/services/install.test.ts
+++ b/plugins/plugin-agent-skills/src/services/install.test.ts
@@ -128,6 +128,58 @@ describe("installSkillDependencies over list-frontmatter skills (issue #29157)",
 		expect(plan.recommendedOptions.length).toBeGreaterThan(0);
 	});
 
+	// A SKILL.md whose block sequences are documented with inline YAML comments
+	// before the first item. The comment previously misrouted both lists to the
+	// nested-object path, so `requires.bins` collapsed to `{}` and `install`
+	// merged into one object; the plan then reported no required binary and no
+	// install option, silently skipping dependency installation.
+	const commentedListSkillMd = [
+		"---",
+		"name: needs-missing-bin-commented",
+		"description: Requires a binary that is not installed, documented with comments.",
+		"metadata:",
+		"  otto:",
+		"    requires:",
+		"      bins:",
+		"        # the tool this skill shells out to",
+		"        - eliza-absent-tool",
+		"    install:",
+		"      # homebrew is the primary channel",
+		"      - id: brew",
+		"        kind: brew",
+		"        formula: eliza-absent-tool",
+		'        bins: ["eliza-absent-tool"]',
+		"      # fall back to apt on Debian/Ubuntu",
+		"      - id: apt",
+		"        kind: apt",
+		"        package: eliza-absent-tool",
+		'        bins: ["eliza-absent-tool"]',
+		"---",
+		"body",
+	].join("\n");
+
+	it("builds an install plan when comments precede both block lists", async () => {
+		const frontmatter = parseFrontmatter(commentedListSkillMd).frontmatter;
+		if (!frontmatter) throw new Error("expected parsed frontmatter");
+		expect(Array.isArray(frontmatter.metadata?.otto?.install)).toBe(true);
+
+		const plan = await getInstallPlan({
+			slug: "needs-missing-bin-commented",
+			frontmatter,
+		});
+
+		expect(plan.requiredBins).toEqual(["eliza-absent-tool"]);
+		expect(plan.missingBins).toEqual(["eliza-absent-tool"]);
+		expect(plan.recommendedOptions.length).toBeGreaterThan(0);
+
+		const results = await installSkillDependencies(
+			{ slug: "needs-missing-bin-commented", frontmatter },
+			{ dryRun: true },
+		);
+		expect(results).toHaveLength(1);
+		expect(results[0].option.bins).toContain("eliza-absent-tool");
+	});
+
 	it("returns [] for a skill without install options and does not throw", async () => {
 		const results = await installSkillDependencies(
 			{ slug: "bare", frontmatter: { name: "bare", description: "No otto." } },

--- a/plugins/plugin-agent-skills/src/services/install.test.ts
+++ b/plugins/plugin-agent-skills/src/services/install.test.ts
@@ -4,7 +4,12 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { installSkillDependency } from "./install";
+import { parseFrontmatter } from "../parser";
+import {
+	getInstallPlan,
+	installSkillDependencies,
+	installSkillDependency,
+} from "./install";
 
 describe("installSkillDependency command safety", () => {
 	it("rejects package names that would escape the install command", async () => {
@@ -60,5 +65,74 @@ describe("installSkillDependency command safety", () => {
 			error: "Manual installation required: Install from the vendor page",
 		});
 		expect(result.command).toBeUndefined();
+	});
+});
+
+describe("installSkillDependencies over list-frontmatter skills (issue #29157)", () => {
+	// A SKILL.md written with normal YAML block-sequence frontmatter (the format
+	// the README documents) previously parsed `otto.install` into a merged
+	// object. `installSkillDependencies` then did `installOptions.length === 0`
+	// (undefined === 0 -> false) and fell into `for (const option of ...)`,
+	// throwing `TypeError: installOptions is not iterable`. This proves the
+	// canonical parse-then-install path returns results and never throws.
+	const listSkillMd = [
+		"---",
+		"name: needs-missing-bin",
+		"description: Requires a binary that is not installed on this host.",
+		"metadata:",
+		"  otto:",
+		"    requires:",
+		"      bins:",
+		"        - eliza-absent-tool",
+		"    install:",
+		"      - id: brew",
+		"        kind: brew",
+		"        formula: eliza-absent-tool",
+		'        bins: ["eliza-absent-tool"]',
+		"      - id: apt",
+		"        kind: apt",
+		"        package: eliza-absent-tool",
+		'        bins: ["eliza-absent-tool"]',
+		"---",
+		"body",
+	].join("\n");
+
+	it("dry-runs a list-frontmatter skill without throwing", async () => {
+		const frontmatter = parseFrontmatter(listSkillMd).frontmatter;
+		if (!frontmatter) throw new Error("expected parsed frontmatter");
+		expect(Array.isArray(frontmatter.metadata?.otto?.install)).toBe(true);
+
+		const results = await installSkillDependencies(
+			{ slug: "needs-missing-bin", frontmatter },
+			{ dryRun: true },
+		);
+
+		expect(Array.isArray(results)).toBe(true);
+		// The missing bin has install options, so the iterate-and-plan path runs
+		// exactly once and the produced result references that binary's option —
+		// deterministically, regardless of which package managers this host has.
+		expect(results).toHaveLength(1);
+		expect(results[0].option.bins).toContain("eliza-absent-tool");
+	});
+
+	it("builds an install plan from a list-frontmatter skill", async () => {
+		const frontmatter = parseFrontmatter(listSkillMd).frontmatter;
+		if (!frontmatter) throw new Error("expected parsed frontmatter");
+		const plan = await getInstallPlan({
+			slug: "needs-missing-bin",
+			frontmatter,
+		});
+
+		expect(plan.requiredBins).toEqual(["eliza-absent-tool"]);
+		expect(plan.missingBins).toEqual(["eliza-absent-tool"]);
+		expect(plan.recommendedOptions.length).toBeGreaterThan(0);
+	});
+
+	it("returns [] for a skill without install options and does not throw", async () => {
+		const results = await installSkillDependencies(
+			{ slug: "bare", frontmatter: { name: "bare", description: "No otto." } },
+			{ dryRun: true },
+		);
+		expect(results).toEqual([]);
 	});
 });

--- a/plugins/plugin-agent-skills/src/services/install.ts
+++ b/plugins/plugin-agent-skills/src/services/install.ts
@@ -519,7 +519,12 @@ export async function installSkillDependencies(
 	} = {},
 ): Promise<InstallDependencyResult[]> {
 	const metadata = skill.frontmatter.metadata?.otto;
-	const installOptions = metadata?.install || [];
+	// Defensive: a malformed frontmatter could leave `install` non-array; treat
+	// anything but a real list as "no install options" so this never throws on
+	// the `for (const option of installOptions)` loop below.
+	const installOptions = Array.isArray(metadata?.install)
+		? metadata.install
+		: [];
 
 	if (installOptions.length === 0) {
 		return [];
@@ -599,8 +604,12 @@ export async function getInstallPlan(skill: {
 }> {
 	const metadata = skill.frontmatter.metadata?.otto;
 
-	const requiredBins = metadata?.requires?.bins || [];
-	const installOptions = metadata?.install || [];
+	const requiredBins = Array.isArray(metadata?.requires?.bins)
+		? metadata.requires.bins
+		: [];
+	const installOptions = Array.isArray(metadata?.install)
+		? metadata.install
+		: [];
 
 	// Check which bins are missing
 	const missingBins: string[] = [];


### PR DESCRIPTION
# Relates to

Closes #29157

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run; package `test`, `typecheck`, and `lint` pass. The repo-wide `bun run verify` blocker is recorded under **Known gaps**.
- [x] A reviewer can confirm the change works from the evidence below without reading the code.

# Sync with develop

- [x] Rebased onto the latest `origin/develop` (HEAD `e43b933906`); zero conflicts.
- [ ] `bun run verify` — see **Known gaps / failures** (unrelated install-time registry release-age gate on this machine; owning-package gates all pass).

# Risks

Low. The change is local to the SKILL.md frontmatter parser (`plugins/plugin-agent-skills/src/parser.ts`) plus a defensive guard in `services/install.ts`. It only adds handling for YAML block sequences that were previously dropped; existing scalar, nested-object, and inline/multiline-JSON paths are unchanged and still covered by existing (and new regression) tests. No public signature changes.

# Background

## What does this PR do?

`parseYamlSubset` — the plugin's sole SKILL.md frontmatter parser, used on the canonical skill-loading path by `storage.ts`, `services/skills.ts`, and validation — did not handle standard YAML **block sequences** (`- item` lines). A `- key: value` line failed the key/value regex and was dropped, and the item's remaining keys were merged into the parent mapping. So `metadata.otto.install` — documented in the plugin README as a YAML list and typed as `OttoInstallOption[]` — parsed into a **single merged object** with each list item's first key (`id`) lost and item 0 overwritten by item 1.

That corrupted otto metadata on load and then broke the public install API: `installSkillDependencies()` / `getInstallPlan()` do `installOptions.length === 0` (`undefined === 0` is `false`, bypassing the guard) and then `for (const option of installOptions)`, throwing `TypeError: installOptions is not iterable`. Any real SKILL.md written with the normal YAML list frontmatter the README itself documents loaded with corrupted otto metadata and crashed dependency installation.

This PR:

- Extends `parseYamlSubset` with a `parseListBlock` helper that collects a block sequence into an array. Mapping items (dash remainder is the first `key: value`, following deeper-indented lines are more entries) and bare-`-` nested items recurse through `parseYamlSubset`, so scalar, nested-object, and inline/multiline-JSON handling still applies **inside** a list item; scalar and inline-JSON items (`- gh`, `- ["gh"]`) are parsed directly.
- Adds a defensive `Array.isArray` guard in `installSkillDependencies`/`getInstallPlan` so a malformed frontmatter can never make the install loop throw (strictly stronger than the parser fix alone).

## What kind of change is this?

Bug fix (non-breaking change which fixes a data-integrity + crash defect).

# Documentation changes needed?

No. The README already documents `metadata.otto.install` as a YAML list; this PR makes the parser honor that documented contract, so no doc change is required.

# Testing

## Where should a reviewer start?

`plugins/plugin-agent-skills/src/parser.frontmatter.test.ts` (block-sequence parsing) and `plugins/plugin-agent-skills/src/services/install.test.ts` (install no-throw / plan) — both add `issue #29157` describe blocks.

## Detailed testing steps

```bash
bun run --cwd plugins/plugin-agent-skills test        # 34 files / 399 tests pass
bun run --cwd plugins/plugin-agent-skills typecheck   # clean
bun run --cwd plugins/plugin-agent-skills lint        # exit 0
```

# Evidence Gate

<!-- evidence-head:9fef723be567afcc8bc503db685241626a95fa39 -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - no UI surface; this is a YAML frontmatter parser and install-service fix.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - no UI surface; this is a YAML frontmatter parser and install-service fix.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no UI or user flow; backend parser and service change proven by the reproduction transcript below.`
<!-- evidence-row:backend-logs -->
- [x] Direct reproduction against the real source. Covers both the original block-sequence defect and the reviewer-found comment-lookahead defect. Also mirrored at [reproduction.log](https://github.com/agent-cortex/eliza/releases/download/pr-29159-evidence/reproduction.log) and [reproduction-comment.log](https://github.com/agent-cortex/eliza/releases/download/pr-29159-evidence/reproduction-comment.log).

<details><summary>reproduction.log — original block-sequence defect (before/after)</summary>

```
===== BEFORE (origin/develop parser) =====
otto.install = {"kind":"apt","formula":"gh","bins":["gh"],"label":"Install GitHub CLI (apt)","package":"gh"}
Array.isArray(install) = false

===== AFTER (this PR: parser + install) =====
otto.install length = 2 isArray = true
ids = ["brew","apt"]
installSkillDependencies(dryRun) did NOT throw; results = [{"success":true,"command":"sudo apt-get install -y eliza-absent-tool"}]
===== BEFORE: installSkillDependencies on list frontmatter (origin/develop) =====
THREW: TypeError - installOptions is not iterable
```

</details>

<details><summary>reproduction-comment.log — reviewer ss251's comment-lookahead defect (before/after at head 9fef723)</summary>

```
# SKILL.md with a valid YAML comment before the first `- ` item of both lists.

===== BEFORE (pre-fix parser at abba913ad4) =====
requires.bins = {}
install = {"kind":"brew","formula":"gh","bins":["gh"]}  isArray = false
# The comment misrouted each empty key to the nested-object path: requires.bins
# collapsed to {} and install merged into one object (id dropped). Those shapes
# then hit the Array.isArray fallbacks in install.ts and became empty arrays, so
# the skill reported NO required binary and NO install option — silent skip.

===== AFTER (this PR: comment-aware block-sequence lookahead) =====
requires.bins = ["gh"]
install isArray = true length = 2
install ids = ["brew","apt"]
plan.requiredBins = ["gh"]
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend request or response is involved in this parser and service fix.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent, action, provider, prompt, or model behavior changes; this is a pure parsing and data-integrity fix.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact is the parsed frontmatter shape (merged object to typed array) plus focused package test/typecheck/lint output. Also mirrored at [focused-tests.log](https://github.com/agent-cortex/eliza/releases/download/pr-29159-evidence/focused-tests.log).

<details><summary>focused-tests.log — package test / typecheck / lint</summary>

```
# Focused package checks for plugin-agent-skills at head 9fef723be5 (issue #29157 + reviewer follow-up)
# Command: bun run --cwd plugins/plugin-agent-skills test  => 34 files / 405 tests passed
# typecheck: tsc --noEmit => clean (@elizaos/skills built locally first for build-order dep)
# lint: biome => exit 0 (11 pre-existing warnings, 0 introduced); biome check on the 3 changed files => exit 0
#
# The reviewer-requested comment-lookahead regressions (both passing):
 ✓ src/parser.frontmatter.test.ts > parseFrontmatter YAML block sequences (issue #29157) > parses block sequences when a YAML comment precedes the first item 1ms
 ✓ src/services/install.test.ts > installSkillDependencies over list-frontmatter skills (issue #29157) > builds an install plan when comments precede both block lists 19ms


 RUN  v4.1.10 /home/home/Developer/eliza-swarm/state/worktrees/pr-29159/plugins/plugin-agent-skills


 Test Files  34 passed (34)
      Tests  405 passed (405)
   Duration  27.78s
```

</details>

<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface exists for OCR review.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent, action, provider, prompt, or model change.`

## Backend + frontend logs

See the **backend-logs** and **domain-artifacts** rows above for the full reproduction transcript and focused test/typecheck/lint output. Frontend: `N/A - no frontend involved.`

## Screenshots (before / after) + video walkthrough

### Before

`N/A - no UI surface.`

### After

`N/A - no UI surface.`

### Walkthrough video

`N/A - no UI or user flow.`

## Audio / voice walkthrough

`N/A - no voice or audio surface.`

## Known gaps / failures

- **Immutable evidence hosting:** the swarm attachment uploader could not reach an authenticated session, and fork contributors cannot push to the canonical `elizaOS/eliza` `pr-evidence` release, so the real logs are pasted inline in `<details>` blocks per CONTRIBUTING.md § Evidence and mirrored on my fork's release. Content is unmodified probe/test output.
- **`bun run verify` (repo-wide):** not completed on this machine. `bun install` now succeeds (the earlier `minimumReleaseAge` registry gate has cleared), but the full repo-wide gate was not run end-to-end here. All owning-package gates pass at head `9fef723be5`: `bun run --cwd plugins/plugin-agent-skills test` (34 files / 405 tests), `typecheck` (clean), `lint` (exit 0). `@elizaos/skills` was built locally so the plugin's typecheck could resolve it (pre-existing build-order dependency, not touched by this PR).

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@49cde6ad558f86624ee0b5a3e0f2330cb72d4021:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@49cde6ad558f86624ee0b5a3e0f2330cb72d4021:packages/skills/skills/contribute-to-eliza"} -->




