### PR TITLE
fix(cloud): restore replacement lock fixture authority

### DIFF
--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-sandboxes-stuck-provisioning-lock.integration.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-sandboxes-stuck-provisioning-lock.integration.test.ts
@@ -342,6 +342,8 @@ async function createReplacementAttemptFixture(): Promise<ReplacementAttemptFixt
   const userId = randomUUID();
   const agentId = randomUUID();
   const nodeRecordId = randomUUID();
+  const nodeIncarnation = randomUUID();
+  const nodeHistoryId = randomUUID();
   const attemptId = randomUUID();
   const activationGeneration = randomUUID();
   const lifecycleJobId = randomUUID();
@@ -381,6 +383,16 @@ async function createReplacementAttemptFixture(): Promise<ReplacementAttemptFixt
     container_name: `old-container-${suffix}`,
     lifecycle_revision: 7,
   });
+  await dbWrite.insert(agentNodeIncarnationHistories).values({
+    id: nodeHistoryId,
+    docker_node_record_id: nodeRecordId,
+    node_id: nodeId,
+    node_incarnation: nodeIncarnation,
+    fleet_kind: "robot",
+    infrastructure_provider: "hetzner",
+    provider_server_id: null,
+    host_key_fingerprint: nodeHostKeyFingerprint,
+  });
   await dbWrite.insert(dockerNodes).values({
     id: nodeRecordId,
     node_id: nodeId,
@@ -391,6 +403,10 @@ async function createReplacementAttemptFixture(): Promise<ReplacementAttemptFixt
     status: "healthy",
     ssh_user: "root",
     host_key_fingerprint: nodeHostKeyFingerprint,
+    fleet_kind: "robot",
+    infrastructure_provider: "hetzner",
+    node_incarnation: nodeIncarnation,
+    current_node_history_id: nodeHistoryId,
   });
 
   return {
@@ -414,6 +430,8 @@ async function createReplacementAttemptFixture(): Promise<ReplacementAttemptFixt
       nodeId,
       containerName,
       nodeRecordId,
+      nodeIncarnation,
+      nodeHistoryId,
       nodeHostname,
       nodeSshPort: 22,
       nodeSshUser: "root",


### PR DESCRIPTION
## Summary

- restore the immutable node-incarnation history authority in the real PostgreSQL replacement-lock fixture
- bind the Docker node and replacement locator to the same exact occurrence
- unblock the Cloud Worker deploy typecheck without changing production behavior or weakening lock assertions

## Exact identity

- Base: 49cde6ad558f86624ee0b5a3e0f2330cb72d4021
- Head: a5fc97c141837540c24b2e64955c370844e76377
- Tree: 2a9049ab5f301668116173e7261b6a9a2ca1a7d8

## Verification

- PASS: bun run --cwd packages/cloud/shared typecheck
- PASS: Biome on the exact changed file
- PASS: git diff --check
- SOURCE APPROVE: independent review, P0-P3 none
- NOT EXECUTED LOCALLY: the focused real PostgreSQL suite loaded cleanly but reported 9 skips because Docker Desktop is not running; CI/deploy must execute the real database harness

## Deployment blocker reproduced

Cloud CF staging run 32962143863 reached migration 0329 successfully, then refused the Worker deploy at Verify Worker because this fixture omitted the required nodeIncarnation and nodeHistoryId fields. No Worker or Pages deployment occurred from that run.

## Evidence applicability

- UI screenshots/video: N/A - test-fixture-only repair with no product pixels
- live-model trajectory: N/A - no model, prompt, action, or provider behavior changed
- device evidence: N/A - no native/mobile behavior changed
