### PR TITLE
fix(plugin-anthropic-proxy): strip thinking param without leaving dangling comma

### DIFF
--- a/plugins/plugin-anthropic-proxy/__tests__/process-body.edge.test.ts
+++ b/plugins/plugin-anthropic-proxy/__tests__/process-body.edge.test.ts
@@ -88,3 +88,66 @@ describe("processBody edge handling", () => {
     expect(JSON.stringify(parsed)).not.toContain("hidden");
   });
 });
+
+// Regression: the thinking-parameter strip must never leave a dangling comma,
+// regardless of the key's position. Production defaults keep the strip enabled,
+// and a request that already carries a `system` array (prompt caching) plus
+// `metadata` (user_id) leaves `thinking` as the first key, so neither the
+// billing nor metadata injector prepends ahead of it. Before the fix, the
+// first-key case produced `{,"system":...}` — malformed JSON rejected by
+// api.anthropic.com (400 invalid JSON), silently breaking extended-thinking
+// requests. See issue #29164.
+describe("processBody thinking-parameter strip position invariance", () => {
+  const prodDefaults: Partial<ProcessBodyConfig> = {
+    stripSystemConfig: true,
+    stripToolDescriptions: true,
+    injectCCSyntheticTools: true,
+    stripThinkingBlocks: true,
+  };
+  const thinking = { type: "enabled", budget_tokens: 2000 };
+
+  const positions: Array<[string, Record<string, unknown>]> = [
+    [
+      "first key (system array + metadata already present)",
+      {
+        thinking,
+        system: [{ type: "text", text: "sys" }],
+        metadata: { user_id: "u" },
+        model: "claude-opus-4-1",
+        messages: [{ role: "user", content: "hi" }],
+      },
+    ],
+    [
+      "middle key",
+      {
+        model: "claude-opus-4-1",
+        thinking,
+        messages: [{ role: "user", content: "hi" }],
+      },
+    ],
+    [
+      "last key",
+      {
+        model: "claude-opus-4-1",
+        messages: [{ role: "user", content: "hi" }],
+        thinking,
+      },
+    ],
+    ["sole key", { thinking }],
+  ];
+
+  for (const [label, body] of positions) {
+    it(`produces valid JSON with the thinking param removed when it is the ${label}`, () => {
+      const result = processBody(JSON.stringify(body), { ...baseConfig, ...prodDefaults });
+
+      // Must be parseable — the first-key case throws before the fix.
+      const parsed = JSON.parse(result.body) as Record<string, unknown>;
+      expect("thinking" in parsed).toBe(false);
+      expect(result.stats.thinkingParamsStripped).toBe(1);
+      // No dangling separator anywhere in the rewritten body.
+      expect(result.body).not.toContain("{,");
+      expect(result.body).not.toContain(",,");
+      expect(result.body).not.toContain(",}");
+    });
+  }
+});

--- a/plugins/plugin-anthropic-proxy/__tests__/process-body.edge.test.ts
+++ b/plugins/plugin-anthropic-proxy/__tests__/process-body.edge.test.ts
@@ -198,3 +198,88 @@ describe("processBody thinking-parameter strip raw-body shapes", () => {
     });
   }
 });
+
+// The strip targets Anthropic's own top-level `thinking` request parameter, not
+// every `"thinking"` key in the serialized body. A depth-blind marker scan
+// deletes nested object-valued `thinking` fields carried by replayed tool
+// arguments or tool-input schemas, silently corrupting the forwarded body while
+// it stays valid JSON. The removal must be restricted to the root object's own
+// property (depth 1) and leave every nested occurrence byte-for-byte intact.
+// See PR #29167 review by ss251.
+describe("processBody thinking-parameter strip is depth-restricted to the root object", () => {
+  // Only the thinking strip is under test; leave the tool-injection and
+  // prefill-strip layers off so the assertions read the parameter strip's own
+  // output rather than synthetic tools or a removed trailing assistant turn.
+  const stripOnly: Partial<ProcessBodyConfig> = { stripThinkingBlocks: true };
+
+  it("strips the top-level thinking parameter but keeps a nested thinking field in tool input", () => {
+    const toolInput = { thinking: { keep: true }, value: 1 };
+    const { parsed, stats } = parseProcessed(
+      {
+        model: "claude-opus-4-1",
+        thinking: { type: "enabled", budget_tokens: 2000 },
+        messages: [
+          {
+            role: "assistant",
+            content: [{ type: "tool_use", id: "t1", name: "do_thing", input: toolInput }],
+          },
+          { role: "user", content: "hi" },
+        ],
+      },
+      stripOnly
+    );
+
+    // Exactly one removal: the root parameter, not the nested field.
+    expect(stats.thinkingParamsStripped).toBe(1);
+    expect("thinking" in parsed).toBe(false);
+    const messages = parsed.messages as Array<Record<string, unknown>>;
+    const content = messages[0]?.content as Array<Record<string, unknown>>;
+    expect(content[0]?.input).toEqual(toolInput);
+  });
+
+  it("keeps a nested thinking property inside a tool-input JSON schema", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        thinking: { type: "object", properties: { keep: { type: "boolean" } } },
+        value: { type: "number" },
+      },
+    };
+    const { parsed, stats } = parseProcessed(
+      {
+        model: "claude-opus-4-1",
+        thinking: { type: "enabled", budget_tokens: 2000 },
+        tools: [{ name: "do_thing", input_schema: schema }],
+        messages: [{ role: "user", content: "hi" }],
+      },
+      stripOnly
+    );
+
+    expect(stats.thinkingParamsStripped).toBe(1);
+    expect("thinking" in parsed).toBe(false);
+    const tools = parsed.tools as Array<Record<string, unknown>>;
+    expect(tools[0]?.input_schema).toEqual(schema);
+  });
+
+  it("leaves nested thinking untouched when the request has no top-level thinking parameter", () => {
+    const toolInput = { thinking: { keep: true }, value: 1 };
+    const { parsed, stats } = parseProcessed(
+      {
+        model: "claude-opus-4-1",
+        messages: [
+          {
+            role: "assistant",
+            content: [{ type: "tool_use", id: "t1", name: "do_thing", input: toolInput }],
+          },
+          { role: "user", content: "hi" },
+        ],
+      },
+      stripOnly
+    );
+
+    expect(stats.thinkingParamsStripped).toBe(0);
+    const messages = parsed.messages as Array<Record<string, unknown>>;
+    const content = messages[0]?.content as Array<Record<string, unknown>>;
+    expect(content[0]?.input).toEqual(toolInput);
+  });
+});

--- a/plugins/plugin-anthropic-proxy/__tests__/process-body.edge.test.ts
+++ b/plugins/plugin-anthropic-proxy/__tests__/process-body.edge.test.ts
@@ -151,3 +151,50 @@ describe("processBody thinking-parameter strip position invariance", () => {
     });
   }
 });
+
+// The proxy forwards arbitrary client bodies, so the strip must survive raw
+// wire shapes that `JSON.stringify` never emits: pretty-printed whitespace
+// around the separator, a nested object inside the `thinking` value, and a `}`
+// that lives inside a string. Each row is a raw request string, not a
+// stringified object, and each must leave the whole pipeline output parseable
+// with `thinking` removed. See PR #29167 review.
+describe("processBody thinking-parameter strip raw-body shapes", () => {
+  const prodDefaults: Partial<ProcessBodyConfig> = {
+    stripSystemConfig: true,
+    stripToolDescriptions: true,
+    injectCCSyntheticTools: true,
+    stripThinkingBlocks: true,
+  };
+  const messages = '"messages":[{"role":"user","content":"hi"}]';
+
+  const rawBodies: Array<[string, string]> = [
+    [
+      "pretty-printed body with thinking as the last key",
+      `{\n  "model": "x",\n  ${messages},\n  "thinking": {"type": "enabled", "budget_tokens": 2000}\n}`,
+    ],
+    [
+      "a nested object inside the thinking value",
+      `{"model":"x","thinking":{"type":"enabled","budget":{"tokens":5}},${messages}}`,
+    ],
+    [
+      "a closing brace inside a string in the thinking value",
+      `{"model":"x","thinking":{"type":"enab}led"},${messages}}`,
+    ],
+  ];
+
+  for (const [label, raw] of rawBodies) {
+    it(`produces valid JSON with the thinking param removed for ${label}`, () => {
+      const result = processBody(raw, { ...baseConfig, ...prodDefaults });
+
+      // Before the fix each of these throws: the last-key case leaves a
+      // trailing comma, the nested and in-string cases stop removal early on
+      // the wrong `}` and leave orphaned syntax.
+      const parsed = JSON.parse(result.body) as Record<string, unknown>;
+      expect("thinking" in parsed).toBe(false);
+      expect(result.stats.thinkingParamsStripped).toBe(1);
+      expect(result.body).not.toContain("{,");
+      expect(result.body).not.toContain(",,");
+      expect(result.body).not.toContain(",}");
+    });
+  }
+});

--- a/plugins/plugin-anthropic-proxy/src/proxy/process-body.ts
+++ b/plugins/plugin-anthropic-proxy/src/proxy/process-body.ts
@@ -1,6 +1,10 @@
 /**
  * Forward request body pipeline. Mirrors processBody() in proxy.js v2.2.3
- * layer-by-layer, in the same order, with the same string operations.
+ * layer-by-layer, in the same order, with the same string operations, except
+ * that `stripThinkingParameters` brace-matches the parameter value and skips
+ * insignificant whitespace around the separator comma so removal never emits
+ * malformed JSON regardless of key position or pretty-printing. That is a
+ * deliberate correctness divergence, not drift to reconcile away.
  *
  * Layers (in processing order):
  *   2. String trigger sanitization       (sanitize.ts)
@@ -73,14 +77,23 @@ function stripThinkingParameters(value: string): {
       cursor = keyStart + 1;
       continue;
     }
-    const objectEnd = value.indexOf("}", objectStart + 1);
+    // Brace-match the value (tracking string/escape state) so a nested object
+    // or a `}` inside a string does not end the removal early and leave
+    // orphaned syntax on the wire. `findMatchingObjectEnd` returns the index
+    // just past the matching `}`.
+    const objectEnd = findMatchingObjectEnd(value, objectStart);
     if (objectEnd < 0) break;
     // Consume the leading comma when present; otherwise (first key of the
     // object) consume the trailing comma so removal never leaves a dangling
-    // separator such as `{,"system":...}` that api.anthropic.com rejects.
-    const hasLeadingComma = keyStart > cursor && value[keyStart - 1] === ",";
-    const removalStart = hasLeadingComma ? keyStart - 1 : keyStart;
-    let removalEnd = objectEnd + 1;
+    // separator such as `{,"system":...}` that api.anthropic.com rejects. Both
+    // scans skip insignificant whitespace so pretty-printed bodies (where the
+    // char adjacent to the key is a space or newline, not the comma) are
+    // handled the same as minified ones.
+    let leading = keyStart - 1;
+    while (leading > cursor && value[leading]?.trim() === "") leading -= 1;
+    const hasLeadingComma = leading >= cursor && value[leading] === ",";
+    const removalStart = hasLeadingComma ? leading : keyStart;
+    let removalEnd = objectEnd;
     if (!hasLeadingComma) {
       let trailing = removalEnd;
       while (trailing < value.length && value[trailing]?.trim() === "") {

--- a/plugins/plugin-anthropic-proxy/src/proxy/process-body.ts
+++ b/plugins/plugin-anthropic-proxy/src/proxy/process-body.ts
@@ -75,9 +75,21 @@ function stripThinkingParameters(value: string): {
     }
     const objectEnd = value.indexOf("}", objectStart + 1);
     if (objectEnd < 0) break;
-    const removalStart = keyStart > cursor && value[keyStart - 1] === "," ? keyStart - 1 : keyStart;
+    // Consume the leading comma when present; otherwise (first key of the
+    // object) consume the trailing comma so removal never leaves a dangling
+    // separator such as `{,"system":...}` that api.anthropic.com rejects.
+    const hasLeadingComma = keyStart > cursor && value[keyStart - 1] === ",";
+    const removalStart = hasLeadingComma ? keyStart - 1 : keyStart;
+    let removalEnd = objectEnd + 1;
+    if (!hasLeadingComma) {
+      let trailing = removalEnd;
+      while (trailing < value.length && value[trailing]?.trim() === "") {
+        trailing += 1;
+      }
+      if (value[trailing] === ",") removalEnd = trailing + 1;
+    }
     out.push(value.slice(cursor, removalStart));
-    cursor = objectEnd + 1;
+    cursor = removalEnd;
     count += 1;
   }
   out.push(value.slice(cursor));

--- a/plugins/plugin-anthropic-proxy/src/proxy/process-body.ts
+++ b/plugins/plugin-anthropic-proxy/src/proxy/process-body.ts
@@ -1,10 +1,12 @@
 /**
  * Forward request body pipeline. Mirrors processBody() in proxy.js v2.2.3
  * layer-by-layer, in the same order, with the same string operations, except
- * that `stripThinkingParameters` brace-matches the parameter value and skips
+ * that `stripThinkingParameters` removes only the root object's own `thinking`
+ * property (depth 1), brace-matches the parameter value, and skips
  * insignificant whitespace around the separator comma so removal never emits
- * malformed JSON regardless of key position or pretty-printing. That is a
- * deliberate correctness divergence, not drift to reconcile away.
+ * malformed JSON regardless of key position or pretty-printing and never
+ * corrupts a nested `thinking` field carried by tool inputs or tool schemas.
+ * That is a deliberate correctness divergence, not drift to reconcile away.
  *
  * Layers (in processing order):
  *   2. String trigger sanitization       (sanitize.ts)
@@ -61,49 +63,85 @@ function stripThinkingParameters(value: string): {
   value: string;
   count: number;
 } {
-  const marker = '"thinking":';
   const out: string[] = [];
-  let cursor = 0;
+  let cursor = 0; // start of the not-yet-emitted region
   let count = 0;
-  while (cursor < value.length) {
-    const keyStart = value.indexOf(marker, cursor);
-    if (keyStart < 0) break;
-    let objectStart = keyStart + marker.length;
-    while (objectStart < value.length && value[objectStart]?.trim() === "") {
-      objectStart += 1;
-    }
-    if (value[objectStart] !== "{") {
-      out.push(value.slice(cursor, keyStart + 1));
-      cursor = keyStart + 1;
+  // Structural nesting depth over `{`/`[`. The request body's root object is
+  // depth 1, so Anthropic's own top-level `thinking` request parameter is the
+  // only `"thinking"` key encountered at depth === 1. Keys nested inside
+  // messages, tool inputs, or tool schemas sit at depth >= 2 and MUST survive
+  // unchanged — stripping them silently corrupts replayed tool arguments that
+  // legitimately carry a `thinking` field. See PR #29167 review.
+  let depth = 0;
+  let i = 0;
+  while (i < value.length) {
+    const c = value[i];
+    if (c === '"') {
+      // Consume the whole string token so `{`/`}`/`,` inside it never move the
+      // depth counter or masquerade as a separator.
+      const stringStart = i;
+      i += 1;
+      while (i < value.length) {
+        const cc = value[i];
+        if (cc === "\\") {
+          i += 2;
+          continue;
+        }
+        if (cc === '"') {
+          i += 1;
+          break;
+        }
+        i += 1;
+      }
+      // A `"thinking"` string is the removable request parameter only when it
+      // is a key of the root object (depth === 1) whose value is an object.
+      if (depth === 1 && value.slice(stringStart, i) === '"thinking"') {
+        let j = i;
+        while (j < value.length && value[j]?.trim() === "") j += 1;
+        if (value[j] === ":") {
+          j += 1;
+          while (j < value.length && value[j]?.trim() === "") j += 1;
+          if (value[j] === "{") {
+            // Brace-match the value (tracking string/escape state) so a nested
+            // object or a `}` inside a string does not end the removal early
+            // and leave orphaned syntax on the wire. `findMatchingObjectEnd`
+            // returns the index just past the matching `}`.
+            const objectEnd = findMatchingObjectEnd(value, j);
+            if (objectEnd >= 0) {
+              // Consume the leading comma when present; otherwise (first key of
+              // the object) consume the trailing comma so removal never leaves
+              // a dangling separator such as `{,"system":...}` that
+              // api.anthropic.com rejects. Both scans skip insignificant
+              // whitespace so pretty-printed bodies (where the char adjacent to
+              // the key is a space or newline, not the comma) are handled the
+              // same as minified ones.
+              let leading = stringStart - 1;
+              while (leading > cursor && value[leading]?.trim() === "") leading -= 1;
+              const hasLeadingComma = leading >= cursor && value[leading] === ",";
+              const removalStart = hasLeadingComma ? leading : stringStart;
+              let removalEnd = objectEnd;
+              if (!hasLeadingComma) {
+                let trailing = removalEnd;
+                while (trailing < value.length && value[trailing]?.trim() === "") {
+                  trailing += 1;
+                }
+                if (value[trailing] === ",") removalEnd = trailing + 1;
+              }
+              out.push(value.slice(cursor, removalStart));
+              cursor = removalEnd;
+              count += 1;
+              // Skip the removed span; its braces are balanced so depth is
+              // unchanged.
+              i = removalEnd;
+            }
+          }
+        }
+      }
       continue;
     }
-    // Brace-match the value (tracking string/escape state) so a nested object
-    // or a `}` inside a string does not end the removal early and leave
-    // orphaned syntax on the wire. `findMatchingObjectEnd` returns the index
-    // just past the matching `}`.
-    const objectEnd = findMatchingObjectEnd(value, objectStart);
-    if (objectEnd < 0) break;
-    // Consume the leading comma when present; otherwise (first key of the
-    // object) consume the trailing comma so removal never leaves a dangling
-    // separator such as `{,"system":...}` that api.anthropic.com rejects. Both
-    // scans skip insignificant whitespace so pretty-printed bodies (where the
-    // char adjacent to the key is a space or newline, not the comma) are
-    // handled the same as minified ones.
-    let leading = keyStart - 1;
-    while (leading > cursor && value[leading]?.trim() === "") leading -= 1;
-    const hasLeadingComma = leading >= cursor && value[leading] === ",";
-    const removalStart = hasLeadingComma ? leading : keyStart;
-    let removalEnd = objectEnd;
-    if (!hasLeadingComma) {
-      let trailing = removalEnd;
-      while (trailing < value.length && value[trailing]?.trim() === "") {
-        trailing += 1;
-      }
-      if (value[trailing] === ",") removalEnd = trailing + 1;
-    }
-    out.push(value.slice(cursor, removalStart));
-    cursor = removalEnd;
-    count += 1;
+    if (c === "{" || c === "[") depth += 1;
+    else if (c === "}" || c === "]") depth -= 1;
+    i += 1;
   }
   out.push(value.slice(cursor));
   return { value: out.join(""), count };


### PR DESCRIPTION
# Relates to

Closes #29164

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (branch is at `origin/develop` head; `git rev-list --count HEAD..origin/develop` = 0).
- [x] `bun install` was run after sync. Repo-wide `bun run verify` is not run on
      this machine (see **Known gaps / failures**); the owning package's test,
      typecheck, and Biome lint gates all pass and are pasted below.
- [x] A reviewer can confirm the change works without reading the code, from the
      before/after reproduction and failing-then-passing test output below.

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync — not executed here; the focused package
      gates (test/typecheck/lint) pass. See **Known gaps / failures**.

# Risks

Low. The change is confined to one pure string-transform helper
(`stripThinkingParameters`) inside `plugins/plugin-anthropic-proxy`'s forward
request pipeline. It only widens comma consumption so removal of the top-level
`thinking` parameter never leaves a dangling separator. `thinkingParamsStripped`
stays exactly `1` per stripped parameter, so downstream stats are unchanged, and
the mid/last/sole-key behavior is byte-for-byte identical to before (proven by
the existing suite staying green and by the new position-invariance cases).

# Background

## What does this PR do?

Fixes a data-integrity bug on the Anthropic proxy's core body-rewrite path. The
forward pipeline strips the top-level `thinking` parameter before forwarding the
request to `api.anthropic.com`. `stripThinkingParameters` removed
`"thinking":{...}` but only consumed a **leading** comma. When `thinking` is the
**first** key of the top-level object there is no leading comma, so the trailing
comma was left behind, producing malformed JSON such as `{,"system":...}`.
Anthropic rejects that body with `400 invalid JSON`, silently breaking every
extended-thinking request whose serialization happens to place `thinking` first.

This occurs in production whenever the request already carries a `system` array
(array form, used for prompt caching) **and** `metadata` (user_id): neither the
billing nor the metadata injector prepends a key ahead of `thinking`, so it
stays the first key and the corruption reaches the wire.

The strip now consumes the leading comma when present, and otherwise (first key)
consumes the trailing comma, so removal never leaves a dangling separator
regardless of the parameter's position.

Following static review, the strip was hardened so it never emits malformed
JSON on any raw client body, not just minified ones: the leading-comma check
now skips insignificant whitespace (so a pretty-printed body with `thinking`
as the last key no longer leaves a trailing comma), and the value boundary is
brace-matched with string/escape tracking via `findMatchingObjectEnd` instead
of the first `}` (so a nested object under `thinking` or a `}` inside a string
value no longer ends removal early and orphans syntax). Three raw-wire
regression cases cover these shapes and fail against the prior source. This is
a deliberate, documented divergence from `proxy.js` v2.2.3's string operations,
noted in the module header so it is not reconciled away as drift.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation. Behavior is
restored to what the pipeline already intended (valid JSON with the `thinking`
param removed); no public surface, env var, or contract changed.

# Testing

## Where should a reviewer start?

`plugins/plugin-anthropic-proxy/src/proxy/process-body.ts` —
`stripThinkingParameters`, and the new
`processBody thinking-parameter strip position invariance` describe block in
`plugins/plugin-anthropic-proxy/__tests__/process-body.edge.test.ts`.

## Detailed testing steps

```bash
cd plugins/plugin-anthropic-proxy
bun run test        # 84 passed (11 files)
bun run typecheck   # tsc --noEmit, clean
```

Reproduction (real `processBody`, production defaults — thinking-strip enabled),
body with `thinking` first key + `system` array + `metadata`:

**Before fix**
```
thinkingParamsStripped: 1
out.body[0..40]: "{,\"system\":[{\"type\":\"text\",\"text\":\"x-ant"
JSON.parse: FAIL - JSON Parse error: Expected '}'
```

**After fix**
```
thinkingParamsStripped: 1
out.body[0..40]: "{\"system\":[{\"type\":\"text\",\"text\":\"x-anth"
JSON.parse: OK
```

Full position/shape sweep of the real `processBody` pipeline over the seven
request shapes this fix must survive, each output parsed with `JSON.parse`
(`FAIL(parse)` = a body `api.anthropic.com` rejects as 400 invalid JSON;
`OK` = valid forwarded body with `thinking` removed). Regenerated at head
`643c8b0`; `BEFORE` is the fully unpatched merge base `a935a4c`:

<details><summary>Before fix (merge base a935a4c) — 4 of 7 shapes reach the wire malformed</summary>

```
FAIL(parse) first key + system array + metadata    JSON Parse error: Expected '}'
            out.body[0..48]: "{,\"system\":[{\"type\":\"text\",\"text\":\"x-anthropic-b"
OK          middle key                             stripped=1
OK          last key                               stripped=1
OK          sole key                               stripped=1
FAIL(parse) pretty-printed, thinking last          JSON Parse error: Property name must be a string literal
FAIL(parse) nested object inside thinking          JSON Parse error: Unable to parse JSON string
FAIL(parse) closing brace inside a string          JSON Parse error: Expected '}'
```

</details>

<details><summary>After fix (head 643c8b0) — all 7 shapes emit valid JSON, thinking removed</summary>

```
OK          first key + system array + metadata    stripped=1
            out.body[0..48]: "{\"system\":[{\"type\":\"text\",\"text\":\"x-anthropic-bi"
OK          middle key                             stripped=1
OK          last key                               stripped=1
OK          sole key                               stripped=1
OK          pretty-printed, thinking last          stripped=1
OK          nested object inside thinking          stripped=1
OK          closing brace inside a string          stripped=1
```

</details>

### Depth-restriction fix (head 643c8b0, review by ss251)

The strip targets Anthropic's own top-level `thinking` request parameter, not
every `"thinking"` key in the serialized body. A depth-blind marker scan also
deleted nested object-valued `thinking` fields carried by replayed tool
arguments or tool-input schemas — valid-but-corrupted JSON that is harder to
observe than the parse failure this PR fixes. `stripThinkingParameters` now
tracks structural depth and removes only the root object's own property
(depth 1). Reproduction through the real `processBody` pipeline with a top-level
`thinking` parameter plus a tool-call input `{ thinking: { keep: true }, value: 1 }`:

```
Before fix: thinkingParamsStripped=2, nested tool input -> {"value":1}   (corrupted)
After fix:  thinkingParamsStripped=1, nested tool input -> {"thinking":{"keep":true},"value":1}  (intact)
```

Three new request-boundary regression tests (nested tool input, nested tool-input
schema, and no-top-level-parameter) fail against the pre-fix source and pass
after it.

New first-key regression test failing on the unpatched source (proving the
guard bites), then the whole edge file passing after the fix:

<details><summary>Before fix — new position-invariance test fails</summary>

```
 FAIL  __tests__/process-body.edge.test.ts > processBody thinking-parameter strip position invariance > produces valid JSON with the thinking param removed when it is the first key (system array + metadata already present)
SyntaxError: Expected property name or '}' in JSON at position 1 (line 1 column 2)
 ❯ __tests__/process-body.edge.test.ts:144:27
    143|       // Must be parseable — the first-key case throws before the fix.
    144|       const parsed = JSON.parse(result.body) as Record<string, unknown…

 Test Files  1 failed (1)
      Tests  1 failed | 3 passed | 3 skipped (7)
```

</details>

<details><summary>After fix — full package suite green</summary>

```
 Test Files  11 passed (11)
      Tests  84 passed (84)
```

</details>

# Evidence Gate

<!-- evidence-head:643c8b0038102e8a49c0a3951d95ab65f1401c15 -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - no UI surface; this is a server-side pure string transform in the Anthropic proxy request pipeline.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - no UI surface; server-side string transform only.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-facing UI flow; the change is a request-body rewrite verified by the reproduction script and vitest output above.`
<!-- evidence-row:backend-logs -->
- [ ] N/A - this contributor account has pull-only access to elizaOS/eliza, so a release-asset upload to the pr-evidence family returns HTTP 404, and the only other gate-accepted host (github.com/user-attachments/files) is minted solely by interactive web drag-and-drop, which a headless agent cannot reach; a fork-hosted release URL would not match the gate's elizaOS/eliza allowlist. The real backend-path proof is therefore pasted inline: the full 84-passing vitest lane and the focused 13-passing verbose edge suite (position invariance + the pretty-print/nested/brace-in-string raw-wire cases + the nested-`thinking` depth-restriction cases) in the Detailed testing steps above, regenerated at head 643c8b0.
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend involved.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - deterministic string transform; no model, prompt, provider, or action behavior changed. The stripped payload never reaches a live model in this test, and the fix restores the already-intended request shape.`
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - same pull-only hosting limitation as backend-logs (no gate-accepted host reachable headlessly). The domain artifact - the exact rewritten request-body bytes onto the wire - is pasted inline in the Detailed testing steps above as the seven-shape before/after sweep plus the depth-restriction reproduction: unpatched merge base a935a4c emits malformed bodies for 4 of 7 shapes ({,"system":... , trailing comma, orphaned brace), head 643c8b0 emits valid JSON with thinking removed for all seven, and the depth-restriction fix leaves a nested tool-input `thinking` field intact instead of corrupting it.
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - deterministic string-transform bug fix; no agent/action/provider/prompt/model change.`

## Backend + frontend logs

Backend: the forward pipeline's `stripThinkingParameters` path fires in the
reproduction and in the new tests; the before/after `out.body` seven-shape sweep,
the depth-restriction reproduction, and the failing-then-passing test output are
inline in the Detailed testing steps above, regenerated at head `643c8b0`.
GitHub-hosted artifact upload is
unavailable from this pull-only fork account (see the backend-logs /
domain-artifacts evidence rows for the exact host constraint), so the proof is
inline rather than a release-asset link. Frontend: `N/A - no frontend`.

## Screenshots (before / after) + video walkthrough

`N/A - no UI change.`

### Before

`N/A - no UI change.`

### After

`N/A - no UI change.`

### Walkthrough video

`N/A - no UI change.`

## Audio / voice walkthrough

`N/A - no voice/audio surface.`

## Known gaps / failures

- Repo-wide `bun run verify` was not executed on this machine. `bun install`
  requires `--minimum-release-age=0` to pass the host's global bun security
  policy for a freshly published transitive dependency (`@cloudflare/playwright`),
  which is unrelated to this change. The focused owning-package gates all pass:
  `bun run --cwd plugins/plugin-anthropic-proxy test` (84 passed), `typecheck`
  (clean), and Biome `check` on the two edited files (no fixes). The lockfile is
  intentionally unmodified.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@a935a4c278f6de26c570c19cca7d4f9e1f77f65a:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@a935a4c278f6de26c570c19cca7d4f9e1f77f65a:packages/skills/skills/contribute-to-eliza"} -->





