### PR TITLE
test(core): pin addressed-to target resolution and relationship upsert

### DIFF
--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -10520,3 +10520,180 @@ describe("planner prior dialogue and continuation resolution (#17024)", () => {
 		expect(useModelCalls(runtime)).toHaveLength(1);
 	});
 });
+
+describe("runV5MessageRuntimeStage1 consumer boundary: addressedTo persistence", () => {
+	// The isolated helpers (resolveAddressedTargets / applyAddressedTo) are
+	// covered in runtime/__tests__/addressed-to-resolution.test.ts; this block
+	// pins the CONSUMER seam — the Stage-1 entry in services/message.ts must
+	// dispatch applyAddressedTo for the parsed extract.addressedTo so the
+	// relationship store actually gains "addressed" edges from the speaker to
+	// each addressee. Disconnecting the production dispatch (e.g. dropping the
+	// guard at services/message.ts `!args.stage1DecisionOnly && addressedTo`)
+	// must make these tests fail even though every helper-level suite stays
+	// green.
+	const OTHER_BOT_ID = "00000000-0000-0000-0000-0000000000bb" as UUID;
+	const ALICE_ID = "00000000-0000-0000-0000-0000000000cc" as UUID;
+
+	interface RelationshipRecord {
+		id: string;
+		sourceEntityId: UUID;
+		targetEntityId: UUID;
+		tags: string[];
+		metadata: Record<string, unknown>;
+	}
+
+	function stage1AddressedResponse(addressedTo: string[]): unknown {
+		return {
+			text: "",
+			toolCalls: [
+				{
+					id: "handle-response-addr",
+					name: "HANDLE_RESPONSE",
+					arguments: {
+						shouldRespond: "RESPOND",
+						thought: "Direct answer.",
+						contexts: ["simple"],
+						intents: [],
+						candidateActionNames: [],
+						replyText: "Sure — happy to take a look with them.",
+						facts: [],
+						relationships: [],
+						addressedTo,
+					},
+				},
+			],
+			finishReason: "tool_calls",
+		};
+	}
+
+	function runtimeWithRecordingRelationshipStore(): {
+		runtime: IAgentRuntime;
+		store: {
+			relationships: RelationshipRecord[];
+			created: number;
+			updated: number;
+		};
+	} {
+		const runtime = makeRuntime([stage1AddressedResponse(["Alice"])]);
+		const store = {
+			relationships: [] as RelationshipRecord[],
+			created: 0,
+			updated: 0,
+		};
+		const base = runtime as unknown as Record<string, unknown>;
+		// The Stage-1 path reads model registrations for context-window budgeting
+		// (responseHandlerContextWindow); an empty registry yields "no budget"
+		// and the overflow branch is skipped, so the harness needs no model
+		// metadata.
+		base.getModelRegistrations = vi.fn(() => []);
+		base.getEntitiesForRoom = vi.fn(async () => [
+			{ id: OTHER_BOT_ID, names: ["OtherBot"] },
+			{ id: ALICE_ID, names: ["Alice"] },
+		]);
+		base.getRelationships = vi.fn(
+			async (query: { entityIds?: UUID[]; tags?: string[] }) =>
+				store.relationships.filter(
+					(rel) =>
+						(!query.entityIds ||
+							query.entityIds.includes(rel.sourceEntityId)) &&
+						(!query.tags || query.tags.some((tag) => rel.tags.includes(tag))),
+				),
+		);
+		base.createRelationship = vi.fn(
+			async (input: {
+				sourceEntityId: UUID;
+				targetEntityId: UUID;
+				tags?: string[];
+				metadata?: Record<string, unknown>;
+			}) => {
+				store.created += 1;
+				store.relationships.push({
+					id: `rel-${store.relationships.length + 1}`,
+					sourceEntityId: input.sourceEntityId,
+					targetEntityId: input.targetEntityId,
+					tags: [...(input.tags ?? [])],
+					metadata: { ...(input.metadata ?? {}) },
+				});
+				return store.relationships[store.relationships.length - 1];
+			},
+		);
+		base.updateRelationship = vi.fn(async (rel: RelationshipRecord) => {
+			store.updated += 1;
+			const index = store.relationships.findIndex((r) => r.id === rel.id);
+			if (index === -1) throw new Error("relationship not found");
+			store.relationships[index] = rel;
+		});
+		return { runtime, store };
+	}
+
+	it("persists addressed edges from the speaker to each resolved addressee", async () => {
+		const { runtime, store } = runtimeWithRecordingRelationshipStore();
+		(runtime.useModel as ReturnType<typeof vi.fn>).mockImplementation(
+			vi.fn(async () => stage1AddressedResponse(["Alice", "OtherBot"])),
+		);
+		// Neutral text: a leading vocative ("Alice, ...") routes the turn to
+		// deliberation — the persistence seam must be pinned on a plain direct
+		// turn so the test owns exactly one variable.
+		const message = makeMessage({
+			text: "hey, can you both take a look at this?",
+		});
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message,
+			state: makeState(),
+			responseId: "00000000-0000-0000-0000-0000000000d1" as UUID,
+		});
+
+		expect(result.kind).toBe("direct_reply");
+		// The addressedTo persistence is fire-and-forget; wait for the store
+		// write to land before asserting on the edges.
+		await vi.waitFor(() => {
+			expect(store.created).toBe(2);
+		});
+		const edgeToAlice = store.relationships.find(
+			(rel) => rel.targetEntityId === ALICE_ID,
+		);
+		const edgeToOtherBot = store.relationships.find(
+			(rel) => rel.targetEntityId === OTHER_BOT_ID,
+		);
+		expect(edgeToAlice).toBeDefined();
+		expect(edgeToOtherBot).toBeDefined();
+		for (const edge of [edgeToAlice, edgeToOtherBot]) {
+			expect(edge?.sourceEntityId).toBe(message.entityId);
+			expect(edge?.tags).toEqual(["addressed", "addressed:auto"]);
+			const metadata = edge?.metadata as Record<string, unknown>;
+			expect(metadata.source).toBe("message_handler_addressedTo");
+			expect(metadata.lastInteractionAt).toBeTypeOf("string");
+		}
+	});
+
+	it("upserts: a second turn to the same addressee updates the existing edge instead of duplicating", async () => {
+		const { runtime, store } = runtimeWithRecordingRelationshipStore();
+		(runtime.useModel as ReturnType<typeof vi.fn>).mockImplementation(
+			vi.fn(async () => stage1AddressedResponse(["Alice"])),
+		);
+
+		await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage({ text: "Alice, one more thing" }),
+			state: makeState(),
+			responseId: "00000000-0000-0000-0000-0000000000d2" as UUID,
+		});
+		await vi.waitFor(() => {
+			expect(store.created).toBe(1);
+		});
+
+		await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage({ text: "Alice, thanks" }),
+			state: makeState(),
+			responseId: "00000000-0000-0000-0000-0000000000d3" as UUID,
+		});
+		await vi.waitFor(() => {
+			expect(store.created).toBe(1);
+			expect(store.updated).toBe(1);
+		});
+		expect(store.relationships).toHaveLength(1);
+	});
+});

--- a/packages/core/src/runtime/__tests__/addressed-to-resolution.test.ts
+++ b/packages/core/src/runtime/__tests__/addressed-to-resolution.test.ts
@@ -25,23 +25,23 @@ const AGENT_NAME = "Eliza";
 const AGENT_HANDLE = "eliza_bot";
 
 function makeEntity(id: UUID, names: string[]): Entity {
-	return { id, names } as Entity;
+  return { id, names } as Entity;
 }
 
 function makeMessage(text = "hi"): Memory {
-	return {
-		id: MESSAGE_ID,
-		entityId: SPEAKER_ID,
-		roomId: ROOM_ID,
-		content: { text },
-	} as Memory;
+  return {
+    id: MESSAGE_ID,
+    entityId: SPEAKER_ID,
+    roomId: ROOM_ID,
+    content: { text },
+  } as Memory;
 }
 
 interface Harness {
-	runtime: IAgentRuntime;
-	relationships: Relationship[];
-	roomLookups: number;
-	writeCalls: number;
+  runtime: IAgentRuntime;
+  relationships: Relationship[];
+  roomLookups: number;
+  writeCalls: number;
 }
 
 /**
@@ -51,221 +51,221 @@ interface Harness {
  * pinned. getRelationships honors the tags filter like the real store.
  */
 function makeHarness(participants: Entity[]): Harness {
-	const relationships: Relationship[] = [];
-	const entities = [...participants];
-	if (!entities.some((e) => e.id === AGENT_ID)) {
-		// The agent's entity carries its platform handle, not the character
-		// name — "eliza" then resolves only through the resolver's dedicated
-		// character-name mapping, which is the path the suite is meant to pin.
-		entities.push(makeEntity(AGENT_ID, [AGENT_HANDLE]));
-	}
-	const harness: Harness = {
-		relationships,
-		roomLookups: 0,
-		writeCalls: 0,
-		runtime: undefined as unknown as IAgentRuntime,
-	};
-	harness.runtime = {
-		agentId: AGENT_ID,
-		character: { name: AGENT_NAME, username: "eliza_bot" },
-		getEntitiesForRoom: async (_roomId: UUID) => {
-			harness.roomLookups += 1;
-			return entities;
-		},
-		getRelationships: async (query: { entityIds?: UUID[]; tags?: string[] }) =>
-			relationships.filter(
-				(rel) =>
-					(!query.entityIds || query.entityIds.includes(rel.sourceEntityId)) &&
-					(!query.tags ||
-						query.tags.some((tag) => (rel.tags ?? []).includes(tag))),
-			),
-		createRelationship: async (input: {
-			sourceEntityId: UUID;
-			targetEntityId: UUID;
-			tags?: string[];
-			metadata?: Record<string, unknown>;
-		}) => {
-			harness.writeCalls += 1;
-			relationships.push({
-				id: `rel-${relationships.length + 1}` as UUID,
-				...input,
-			} as unknown as Relationship);
-			return relationships[relationships.length - 1];
-		},
-		updateRelationship: async (rel: Relationship) => {
-			harness.writeCalls += 1;
-			const index = relationships.findIndex((r) => r.id === rel.id);
-			if (index === -1) throw new Error("relationship not found");
-			relationships[index] = rel;
-		},
-	} as unknown as IAgentRuntime;
-	return harness;
+  const relationships: Relationship[] = [];
+  const entities = [...participants];
+  if (!entities.some((e) => e.id === AGENT_ID)) {
+    // The agent's entity carries its platform handle, not the character
+    // name — "eliza" then resolves only through the resolver's dedicated
+    // character-name mapping, which is the path the suite is meant to pin.
+    entities.push(makeEntity(AGENT_ID, [AGENT_HANDLE]));
+  }
+  const harness: Harness = {
+    relationships,
+    roomLookups: 0,
+    writeCalls: 0,
+    runtime: undefined as unknown as IAgentRuntime,
+  };
+  harness.runtime = {
+    agentId: AGENT_ID,
+    character: { name: AGENT_NAME, username: "eliza_bot" },
+    getEntitiesForRoom: async (_roomId: UUID) => {
+      harness.roomLookups += 1;
+      return entities;
+    },
+    getRelationships: async (query: { entityIds?: UUID[]; tags?: string[] }) =>
+      relationships.filter(
+        (rel) =>
+          (!query.entityIds || query.entityIds.includes(rel.sourceEntityId)) &&
+          (!query.tags ||
+            query.tags.some((tag) => (rel.tags ?? []).includes(tag))),
+      ),
+    createRelationship: async (input: {
+      sourceEntityId: UUID;
+      targetEntityId: UUID;
+      tags?: string[];
+      metadata?: Record<string, unknown>;
+    }) => {
+      harness.writeCalls += 1;
+      relationships.push({
+        id: `rel-${relationships.length + 1}` as UUID,
+        ...input,
+      } as unknown as Relationship);
+      return relationships[relationships.length - 1];
+    },
+    updateRelationship: async (rel: Relationship) => {
+      harness.writeCalls += 1;
+      const index = relationships.findIndex((r) => r.id === rel.id);
+      if (index === -1) throw new Error("relationship not found");
+      relationships[index] = rel;
+    },
+  } as unknown as IAgentRuntime;
+  return harness;
 }
 
 function defaultRoom(): Entity[] {
-	return [
-		// A participant stored under "@Eliza" with its own id: today the
-		// leading-@ store spelling is a distinct key from "eliza", so it
-		// must NOT capture the character-name lookup. If the resolver's
-		// normalize ever strips a leading @ from STORED names (the #29189
-		// direction), that participant's entry overwrites the dedicated
-		// character-name mapping — written earlier — and the
-		// character-name test below goes red.
-		makeEntity(AT_ELIZA_ID, ["@Eliza"]),
-		makeEntity(SPEAKER_ID, ["nubilio"]),
-		makeEntity(OTHER_ID, ["sol"]),
-		makeEntity(BYSTANDER_ID, ["shaw"]),
-	];
+  return [
+    // A participant stored under "@Eliza" with its own id: today the
+    // leading-@ store spelling is a distinct key from "eliza", so it
+    // must NOT capture the character-name lookup. If the resolver's
+    // normalize ever strips a leading @ from STORED names (the #29189
+    // direction), that participant's entry overwrites the dedicated
+    // character-name mapping — written earlier — and the
+    // character-name test below goes red.
+    makeEntity(AT_ELIZA_ID, ["@Eliza"]),
+    makeEntity(SPEAKER_ID, ["nubilio"]),
+    makeEntity(OTHER_ID, ["sol"]),
+    makeEntity(BYSTANDER_ID, ["shaw"]),
+  ];
 }
 
 describe("resolveAddressedTargets", () => {
-	it("passes well-formed UUIDs through, deduplicated, with zero room lookups", async () => {
-		const harness = makeHarness([]);
-		const targets = await resolveAddressedTargets({
-			runtime: harness.runtime,
-			message: makeMessage(),
-			addressedTo: [OTHER_ID, OTHER_ID, "  "],
-		});
-		expect(targets).toEqual([OTHER_ID]);
-		expect(harness.roomLookups).toBe(0);
-	});
+  it("passes well-formed UUIDs through, deduplicated, with zero room lookups", async () => {
+    const harness = makeHarness([]);
+    const targets = await resolveAddressedTargets({
+      runtime: harness.runtime,
+      message: makeMessage(),
+      addressedTo: [OTHER_ID, OTHER_ID, "  "],
+    });
+    expect(targets).toEqual([OTHER_ID]);
+    expect(harness.roomLookups).toBe(0);
+  });
 
-	it("resolves participant names case-insensitively and strips @ handles", async () => {
-		const { runtime } = makeHarness(defaultRoom());
-		const targets = await resolveAddressedTargets({
-			runtime,
-			message: makeMessage(),
-			addressedTo: ["@Sol", "NUBILIO"],
-		});
-		expect(targets.sort()).toEqual([OTHER_ID, SPEAKER_ID].sort());
-	});
+  it("resolves participant names case-insensitively and strips @ handles", async () => {
+    const { runtime } = makeHarness(defaultRoom());
+    const targets = await resolveAddressedTargets({
+      runtime,
+      message: makeMessage(),
+      addressedTo: ["@Sol", "NUBILIO"],
+    });
+    expect(targets.sort()).toEqual([OTHER_ID, SPEAKER_ID].sort());
+  });
 
-	it("mixes direct UUIDs with resolved names in one pass", async () => {
-		const { runtime } = makeHarness(defaultRoom());
-		const targets = await resolveAddressedTargets({
-			runtime,
-			message: makeMessage(),
-			addressedTo: [BYSTANDER_ID, "sol"],
-		});
-		expect(targets.sort()).toEqual([OTHER_ID, BYSTANDER_ID].sort());
-	});
+  it("mixes direct UUIDs with resolved names in one pass", async () => {
+    const { runtime } = makeHarness(defaultRoom());
+    const targets = await resolveAddressedTargets({
+      runtime,
+      message: makeMessage(),
+      addressedTo: [BYSTANDER_ID, "sol"],
+    });
+    expect(targets.sort()).toEqual([OTHER_ID, BYSTANDER_ID].sort());
+  });
 
-	it("maps the agent's own character name to agentId", async () => {
-		const { runtime } = makeHarness(defaultRoom());
-		const targets = await resolveAddressedTargets({
-			runtime,
-			message: makeMessage(),
-			addressedTo: ["eliza"],
-		});
-		expect(targets).toEqual([AGENT_ID]);
-	});
+  it("maps the agent's own character name to agentId", async () => {
+    const { runtime } = makeHarness(defaultRoom());
+    const targets = await resolveAddressedTargets({
+      runtime,
+      message: makeMessage(),
+      addressedTo: ["eliza"],
+    });
+    expect(targets).toEqual([AGENT_ID]);
+  });
 
-	it("drops names that resolve to no room participant", async () => {
-		const { runtime } = makeHarness(defaultRoom());
-		const targets = await resolveAddressedTargets({
-			runtime,
-			message: makeMessage(),
-			addressedTo: ["ghost", "sol"],
-		});
-		expect(targets).toEqual([OTHER_ID]);
-	});
+  it("drops names that resolve to no room participant", async () => {
+    const { runtime } = makeHarness(defaultRoom());
+    const targets = await resolveAddressedTargets({
+      runtime,
+      message: makeMessage(),
+      addressedTo: ["ghost", "sol"],
+    });
+    expect(targets).toEqual([OTHER_ID]);
+  });
 });
 
 describe("applyAddressedTo (relationship upsert)", () => {
-	it("creates an addressed edge per resolved target and reports counts", async () => {
-		const { runtime, relationships } = makeHarness(defaultRoom());
-		const result = await applyAddressedTo({
-			runtime,
-			message: makeMessage("sol and shaw take a look"),
-			addressedTo: ["sol", "shaw"],
-		});
-		expect(result.created).toBe(2);
-		expect(result.updated).toBe(0);
-		expect(result.resolved.sort()).toEqual([OTHER_ID, BYSTANDER_ID].sort());
-		expect(relationships).toHaveLength(2);
-		for (const rel of relationships) {
-			expect(rel.sourceEntityId).toBe(SPEAKER_ID);
-			expect(rel.tags).toContain("addressed");
-			const metadata = rel.metadata as Record<string, unknown>;
-			expect(metadata.lastInteractionAt).toBeTypeOf("string");
-			expect(metadata.source).toBe("message_handler_addressedTo");
-		}
-	});
+  it("creates an addressed edge per resolved target and reports counts", async () => {
+    const { runtime, relationships } = makeHarness(defaultRoom());
+    const result = await applyAddressedTo({
+      runtime,
+      message: makeMessage("sol and shaw take a look"),
+      addressedTo: ["sol", "shaw"],
+    });
+    expect(result.created).toBe(2);
+    expect(result.updated).toBe(0);
+    expect(result.resolved.sort()).toEqual([OTHER_ID, BYSTANDER_ID].sort());
+    expect(relationships).toHaveLength(2);
+    for (const rel of relationships) {
+      expect(rel.sourceEntityId).toBe(SPEAKER_ID);
+      expect(rel.tags).toContain("addressed");
+      const metadata = rel.metadata as Record<string, unknown>;
+      expect(metadata.lastInteractionAt).toBeTypeOf("string");
+      expect(metadata.source).toBe("message_handler_addressedTo");
+    }
+  });
 
-	it("updates the existing edge: dedupes tags, preserves prior metadata, refreshes the interaction stamp", async () => {
-		const { runtime, relationships } = makeHarness(defaultRoom());
-		// Seed a pre-existing addressed edge carrying legacy metadata and only
-		// the base tag, exactly as an older writer would have left it.
-		relationships.push({
-			id: "rel-seed" as UUID,
-			sourceEntityId: SPEAKER_ID,
-			targetEntityId: OTHER_ID,
-			tags: ["addressed"],
-			metadata: {
-				lastInteractionAt: "2020-01-01T00:00:00.000Z",
-				source: "legacy_writer",
-				roomContext: "keep-me",
-			},
-		} as unknown as Relationship);
+  it("updates the existing edge: dedupes tags, preserves prior metadata, refreshes the interaction stamp", async () => {
+    const { runtime, relationships } = makeHarness(defaultRoom());
+    // Seed a pre-existing addressed edge carrying legacy metadata and only
+    // the base tag, exactly as an older writer would have left it.
+    relationships.push({
+      id: "rel-seed" as UUID,
+      sourceEntityId: SPEAKER_ID,
+      targetEntityId: OTHER_ID,
+      tags: ["addressed"],
+      metadata: {
+        lastInteractionAt: "2020-01-01T00:00:00.000Z",
+        source: "legacy_writer",
+        roomContext: "keep-me",
+      },
+    } as unknown as Relationship);
 
-		const result = await applyAddressedTo({
-			runtime,
-			message: makeMessage("sol look again"),
-			addressedTo: ["sol"],
-		});
-		expect(result).toMatchObject({ created: 0, updated: 1 });
-		expect(relationships).toHaveLength(1);
-		const updated = relationships[0];
-		expect(updated.id).toBe("rel-seed");
-		// both addressed tags present, no duplicates
-		expect(updated.tags).toEqual(["addressed", "addressed:auto"]);
-		const metadata = updated.metadata as Record<string, unknown>;
-		expect(metadata.roomContext).toBe("keep-me"); // prior keys preserved
-		expect(metadata.source).toBe("message_handler_addressedTo"); // replaced
-		expect(metadata.lastInteractionAt).not.toBe("2020-01-01T00:00:00.000Z");
-	});
+    const result = await applyAddressedTo({
+      runtime,
+      message: makeMessage("sol look again"),
+      addressedTo: ["sol"],
+    });
+    expect(result).toMatchObject({ created: 0, updated: 1 });
+    expect(relationships).toHaveLength(1);
+    const updated = relationships[0];
+    expect(updated.id).toBe("rel-seed");
+    // both addressed tags present, no duplicates
+    expect(updated.tags).toEqual(["addressed", "addressed:auto"]);
+    const metadata = updated.metadata as Record<string, unknown>;
+    expect(metadata.roomContext).toBe("keep-me"); // prior keys preserved
+    expect(metadata.source).toBe("message_handler_addressedTo"); // replaced
+    expect(metadata.lastInteractionAt).not.toBe("2020-01-01T00:00:00.000Z");
+  });
 
-	it("skips the speaker as a target but still records an addressed-to-agent edge", async () => {
-		const { runtime, relationships } = makeHarness(defaultRoom());
-		const result = await applyAddressedTo({
-			runtime,
-			message: makeMessage("nubilio here"),
-			addressedTo: ["nubilio", AGENT_NAME],
-		});
-		// The speaker tag is an extraction error, never an address target; the
-		// agent itself is a legitimate participant of the addressed set.
-		expect(result.resolved).toEqual([AGENT_ID]);
-		expect(result.created).toBe(1);
-		expect(relationships).toHaveLength(1);
-		expect(relationships[0].sourceEntityId).toBe(SPEAKER_ID);
-		expect(relationships[0].targetEntityId).toBe(AGENT_ID);
-	});
+  it("skips the speaker as a target but still records an addressed-to-agent edge", async () => {
+    const { runtime, relationships } = makeHarness(defaultRoom());
+    const result = await applyAddressedTo({
+      runtime,
+      message: makeMessage("nubilio here"),
+      addressedTo: ["nubilio", AGENT_NAME],
+    });
+    // The speaker tag is an extraction error, never an address target; the
+    // agent itself is a legitimate participant of the addressed set.
+    expect(result.resolved).toEqual([AGENT_ID]);
+    expect(result.created).toBe(1);
+    expect(relationships).toHaveLength(1);
+    expect(relationships[0].sourceEntityId).toBe(SPEAKER_ID);
+    expect(relationships[0].targetEntityId).toBe(AGENT_ID);
+  });
 
-	it("writes nothing when nothing resolves (unresolvable names only)", async () => {
-		const harness = makeHarness(defaultRoom());
-		const { runtime, relationships } = harness;
-		const result = await applyAddressedTo({
-			runtime,
-			message: makeMessage(),
-			addressedTo: ["ghost"],
-		});
-		expect(result).toEqual({ created: 0, updated: 0, resolved: [] });
-		expect(relationships).toHaveLength(0);
-		// A no-op must never touch a write method: an implementation that
-		// writes and rolls back is distinguishable from one that never writes.
-		expect(harness.writeCalls).toBe(0);
-	});
+  it("writes nothing when nothing resolves (unresolvable names only)", async () => {
+    const harness = makeHarness(defaultRoom());
+    const { runtime, relationships } = harness;
+    const result = await applyAddressedTo({
+      runtime,
+      message: makeMessage(),
+      addressedTo: ["ghost"],
+    });
+    expect(result).toEqual({ created: 0, updated: 0, resolved: [] });
+    expect(relationships).toHaveLength(0);
+    // A no-op must never touch a write method: an implementation that
+    // writes and rolls back is distinguishable from one that never writes.
+    expect(harness.writeCalls).toBe(0);
+  });
 
-	it("returns an explicit empty result for empty addressedTo", async () => {
-		const harness = makeHarness(defaultRoom());
-		const { runtime, relationships } = harness;
-		const result = await applyAddressedTo({
-			runtime,
-			message: makeMessage(),
-			addressedTo: [],
-		});
-		expect(result).toEqual({ created: 0, updated: 0, resolved: [] });
-		expect(relationships).toHaveLength(0);
-		expect(harness.writeCalls).toBe(0);
-	});
+  it("returns an explicit empty result for empty addressedTo", async () => {
+    const harness = makeHarness(defaultRoom());
+    const { runtime, relationships } = harness;
+    const result = await applyAddressedTo({
+      runtime,
+      message: makeMessage(),
+      addressedTo: [],
+    });
+    expect(result).toEqual({ created: 0, updated: 0, resolved: [] });
+    expect(relationships).toHaveLength(0);
+    expect(harness.writeCalls).toBe(0);
+  });
 });

--- a/packages/core/src/runtime/__tests__/addressed-to-resolution.test.ts
+++ b/packages/core/src/runtime/__tests__/addressed-to-resolution.test.ts
@@ -25,23 +25,23 @@ const AGENT_NAME = "Eliza";
 const AGENT_HANDLE = "eliza_bot";
 
 function makeEntity(id: UUID, names: string[]): Entity {
-  return { id, names } as Entity;
+	return { id, names } as Entity;
 }
 
 function makeMessage(text = "hi"): Memory {
-  return {
-    id: MESSAGE_ID,
-    entityId: SPEAKER_ID,
-    roomId: ROOM_ID,
-    content: { text },
-  } as Memory;
+	return {
+		id: MESSAGE_ID,
+		entityId: SPEAKER_ID,
+		roomId: ROOM_ID,
+		content: { text },
+	} as Memory;
 }
 
 interface Harness {
-  runtime: IAgentRuntime;
-  relationships: Relationship[];
-  roomLookups: number;
-  writeCalls: number;
+	runtime: IAgentRuntime;
+	relationships: Relationship[];
+	roomLookups: number;
+	writeCalls: number;
 }
 
 /**
@@ -51,221 +51,240 @@ interface Harness {
  * pinned. getRelationships honors the tags filter like the real store.
  */
 function makeHarness(participants: Entity[]): Harness {
-  const relationships: Relationship[] = [];
-  const entities = [...participants];
-  if (!entities.some((e) => e.id === AGENT_ID)) {
-    // The agent's entity carries its platform handle, not the character
-    // name — "eliza" then resolves only through the resolver's dedicated
-    // character-name mapping, which is the path the suite is meant to pin.
-    entities.push(makeEntity(AGENT_ID, [AGENT_HANDLE]));
-  }
-  const harness: Harness = {
-    relationships,
-    roomLookups: 0,
-    writeCalls: 0,
-    runtime: undefined as unknown as IAgentRuntime,
-  };
-  harness.runtime = {
-    agentId: AGENT_ID,
-    character: { name: AGENT_NAME, username: "eliza_bot" },
-    getEntitiesForRoom: async (_roomId: UUID) => {
-      harness.roomLookups += 1;
-      return entities;
-    },
-    getRelationships: async (query: { entityIds?: UUID[]; tags?: string[] }) =>
-      relationships.filter(
-        (rel) =>
-          (!query.entityIds || query.entityIds.includes(rel.sourceEntityId)) &&
-          (!query.tags ||
-            query.tags.some((tag) => (rel.tags ?? []).includes(tag))),
-      ),
-    createRelationship: async (input: {
-      sourceEntityId: UUID;
-      targetEntityId: UUID;
-      tags?: string[];
-      metadata?: Record<string, unknown>;
-    }) => {
-      harness.writeCalls += 1;
-      relationships.push({
-        id: `rel-${relationships.length + 1}` as UUID,
-        ...input,
-      } as unknown as Relationship);
-      return relationships[relationships.length - 1];
-    },
-    updateRelationship: async (rel: Relationship) => {
-      harness.writeCalls += 1;
-      const index = relationships.findIndex((r) => r.id === rel.id);
-      if (index === -1) throw new Error("relationship not found");
-      relationships[index] = rel;
-    },
-  } as unknown as IAgentRuntime;
-  return harness;
+	const relationships: Relationship[] = [];
+	const entities = [...participants];
+	if (!entities.some((e) => e.id === AGENT_ID)) {
+		// The agent's entity carries its platform handle, not the character
+		// name — "eliza" then resolves only through the resolver's dedicated
+		// character-name mapping, which is the path the suite is meant to pin.
+		entities.push(makeEntity(AGENT_ID, [AGENT_HANDLE]));
+	}
+	const harness: Harness = {
+		relationships,
+		roomLookups: 0,
+		writeCalls: 0,
+		runtime: undefined as unknown as IAgentRuntime,
+	};
+	harness.runtime = {
+		agentId: AGENT_ID,
+		character: { name: AGENT_NAME, username: "eliza_bot" },
+		getEntitiesForRoom: async (_roomId: UUID) => {
+			harness.roomLookups += 1;
+			return entities;
+		},
+		getRelationships: async (query: { entityIds?: UUID[]; tags?: string[] }) =>
+			relationships.filter(
+				(rel) =>
+					(!query.entityIds || query.entityIds.includes(rel.sourceEntityId)) &&
+					(!query.tags ||
+						query.tags.some((tag) => (rel.tags ?? []).includes(tag))),
+			),
+		createRelationship: async (input: {
+			sourceEntityId: UUID;
+			targetEntityId: UUID;
+			tags?: string[];
+			metadata?: Record<string, unknown>;
+		}) => {
+			harness.writeCalls += 1;
+			relationships.push({
+				id: `rel-${relationships.length + 1}` as UUID,
+				...input,
+			} as unknown as Relationship);
+			return relationships[relationships.length - 1];
+		},
+		updateRelationship: async (rel: Relationship) => {
+			harness.writeCalls += 1;
+			const index = relationships.findIndex((r) => r.id === rel.id);
+			if (index === -1) throw new Error("relationship not found");
+			relationships[index] = rel;
+		},
+	} as unknown as IAgentRuntime;
+	return harness;
 }
 
 function defaultRoom(): Entity[] {
-  return [
-    // A participant stored under "@Eliza" with its own id: today the
-    // leading-@ store spelling is a distinct key from "eliza", so it
-    // must NOT capture the character-name lookup. If the resolver's
-    // normalize ever strips a leading @ from STORED names (the #29189
-    // direction), that participant's entry overwrites the dedicated
-    // character-name mapping — written earlier — and the
-    // character-name test below goes red.
-    makeEntity(AT_ELIZA_ID, ["@Eliza"]),
-    makeEntity(SPEAKER_ID, ["nubilio"]),
-    makeEntity(OTHER_ID, ["sol"]),
-    makeEntity(BYSTANDER_ID, ["shaw"]),
-  ];
+	return [
+		// A participant stored under "@Eliza" with its own id: today the
+		// leading-@ store spelling is a distinct key from "eliza", so it
+		// must NOT capture the character-name lookup. If the resolver's
+		// normalize ever strips a leading @ from STORED names (the #29168
+		// direction), that participant's entry overwrites the dedicated
+		// character-name mapping — written earlier — and the
+		// character-name test below goes red.
+		makeEntity(AT_ELIZA_ID, ["@Eliza"]),
+		makeEntity(SPEAKER_ID, ["nubilio"]),
+		makeEntity(OTHER_ID, ["sol"]),
+		makeEntity(BYSTANDER_ID, ["shaw"]),
+	];
 }
 
 describe("resolveAddressedTargets", () => {
-  it("passes well-formed UUIDs through, deduplicated, with zero room lookups", async () => {
-    const harness = makeHarness([]);
-    const targets = await resolveAddressedTargets({
-      runtime: harness.runtime,
-      message: makeMessage(),
-      addressedTo: [OTHER_ID, OTHER_ID, "  "],
-    });
-    expect(targets).toEqual([OTHER_ID]);
-    expect(harness.roomLookups).toBe(0);
-  });
+	it("passes well-formed UUIDs through, deduplicated, with zero room lookups", async () => {
+		const harness = makeHarness([]);
+		const targets = await resolveAddressedTargets({
+			runtime: harness.runtime,
+			message: makeMessage(),
+			addressedTo: [OTHER_ID, OTHER_ID, "  "],
+		});
+		expect(targets).toEqual([OTHER_ID]);
+		expect(harness.roomLookups).toBe(0);
+	});
 
-  it("resolves participant names case-insensitively and strips @ handles", async () => {
-    const { runtime } = makeHarness(defaultRoom());
-    const targets = await resolveAddressedTargets({
-      runtime,
-      message: makeMessage(),
-      addressedTo: ["@Sol", "NUBILIO"],
-    });
-    expect(targets.sort()).toEqual([OTHER_ID, SPEAKER_ID].sort());
-  });
+	it("resolves participant names case-insensitively and strips @ handles", async () => {
+		const { runtime } = makeHarness(defaultRoom());
+		const targets = await resolveAddressedTargets({
+			runtime,
+			message: makeMessage(),
+			addressedTo: ["@Sol", "NUBILIO"],
+		});
+		expect(targets.sort()).toEqual([OTHER_ID, SPEAKER_ID].sort());
+	});
 
-  it("mixes direct UUIDs with resolved names in one pass", async () => {
-    const { runtime } = makeHarness(defaultRoom());
-    const targets = await resolveAddressedTargets({
-      runtime,
-      message: makeMessage(),
-      addressedTo: [BYSTANDER_ID, "sol"],
-    });
-    expect(targets.sort()).toEqual([OTHER_ID, BYSTANDER_ID].sort());
-  });
+	it("mixes direct UUIDs with resolved names in one pass", async () => {
+		const { runtime } = makeHarness(defaultRoom());
+		const targets = await resolveAddressedTargets({
+			runtime,
+			message: makeMessage(),
+			addressedTo: [BYSTANDER_ID, "sol"],
+		});
+		expect(targets.sort()).toEqual([OTHER_ID, BYSTANDER_ID].sort());
+	});
 
-  it("maps the agent's own character name to agentId", async () => {
-    const { runtime } = makeHarness(defaultRoom());
-    const targets = await resolveAddressedTargets({
-      runtime,
-      message: makeMessage(),
-      addressedTo: ["eliza"],
-    });
-    expect(targets).toEqual([AGENT_ID]);
-  });
+	it("maps the agent's own character name to agentId", async () => {
+		const { runtime } = makeHarness(defaultRoom());
+		const targets = await resolveAddressedTargets({
+			runtime,
+			message: makeMessage(),
+			addressedTo: ["eliza"],
+		});
+		expect(targets).toEqual([AGENT_ID]);
+	});
 
-  it("drops names that resolve to no room participant", async () => {
-    const { runtime } = makeHarness(defaultRoom());
-    const targets = await resolveAddressedTargets({
-      runtime,
-      message: makeMessage(),
-      addressedTo: ["ghost", "sol"],
-    });
-    expect(targets).toEqual([OTHER_ID]);
-  });
+	it("drops names that resolve to no room participant", async () => {
+		const { runtime } = makeHarness(defaultRoom());
+		const targets = await resolveAddressedTargets({
+			runtime,
+			message: makeMessage(),
+			addressedTo: ["ghost", "sol"],
+		});
+		expect(targets).toEqual([OTHER_ID]);
+	});
 });
 
 describe("applyAddressedTo (relationship upsert)", () => {
-  it("creates an addressed edge per resolved target and reports counts", async () => {
-    const { runtime, relationships } = makeHarness(defaultRoom());
-    const result = await applyAddressedTo({
-      runtime,
-      message: makeMessage("sol and shaw take a look"),
-      addressedTo: ["sol", "shaw"],
-    });
-    expect(result.created).toBe(2);
-    expect(result.updated).toBe(0);
-    expect(result.resolved.sort()).toEqual([OTHER_ID, BYSTANDER_ID].sort());
-    expect(relationships).toHaveLength(2);
-    for (const rel of relationships) {
-      expect(rel.sourceEntityId).toBe(SPEAKER_ID);
-      expect(rel.tags).toContain("addressed");
-      const metadata = rel.metadata as Record<string, unknown>;
-      expect(metadata.lastInteractionAt).toBeTypeOf("string");
-      expect(metadata.source).toBe("message_handler_addressedTo");
-    }
-  });
+	it("creates an addressed edge per resolved target and reports counts", async () => {
+		const { runtime, relationships } = makeHarness(defaultRoom());
+		const result = await applyAddressedTo({
+			runtime,
+			message: makeMessage("sol and shaw take a look"),
+			addressedTo: ["sol", "shaw"],
+		});
+		expect(result.created).toBe(2);
+		expect(result.updated).toBe(0);
+		expect(result.resolved.sort()).toEqual([OTHER_ID, BYSTANDER_ID].sort());
+		expect(relationships).toHaveLength(2);
+		for (const rel of relationships) {
+			expect(rel.sourceEntityId).toBe(SPEAKER_ID);
+			expect(rel.tags).toContain("addressed");
+			const metadata = rel.metadata as Record<string, unknown>;
+			expect(metadata.lastInteractionAt).toBeTypeOf("string");
+			expect(metadata.source).toBe("message_handler_addressedTo");
+		}
+	});
 
-  it("updates the existing edge: dedupes tags, preserves prior metadata, refreshes the interaction stamp", async () => {
-    const { runtime, relationships } = makeHarness(defaultRoom());
-    // Seed a pre-existing addressed edge carrying legacy metadata and only
-    // the base tag, exactly as an older writer would have left it.
-    relationships.push({
-      id: "rel-seed" as UUID,
-      sourceEntityId: SPEAKER_ID,
-      targetEntityId: OTHER_ID,
-      tags: ["addressed"],
-      metadata: {
-        lastInteractionAt: "2020-01-01T00:00:00.000Z",
-        source: "legacy_writer",
-        roomContext: "keep-me",
-      },
-    } as unknown as Relationship);
+	it("updates the existing edge: dedupes tags, preserves prior metadata, refreshes the interaction stamp", async () => {
+		const { runtime, relationships } = makeHarness(defaultRoom());
+		// Seed a pre-existing addressed edge carrying legacy metadata and only
+		// the base tag, exactly as an older writer would have left it.
+		relationships.push({
+			id: "rel-seed" as UUID,
+			sourceEntityId: SPEAKER_ID,
+			targetEntityId: OTHER_ID,
+			tags: ["addressed"],
+			metadata: {
+				lastInteractionAt: "2020-01-01T00:00:00.000Z",
+				source: "legacy_writer",
+				roomContext: "keep-me",
+			},
+		} as unknown as Relationship);
 
-    const result = await applyAddressedTo({
-      runtime,
-      message: makeMessage("sol look again"),
-      addressedTo: ["sol"],
-    });
-    expect(result).toMatchObject({ created: 0, updated: 1 });
-    expect(relationships).toHaveLength(1);
-    const updated = relationships[0];
-    expect(updated.id).toBe("rel-seed");
-    // both addressed tags present, no duplicates
-    expect(updated.tags).toEqual(["addressed", "addressed:auto"]);
-    const metadata = updated.metadata as Record<string, unknown>;
-    expect(metadata.roomContext).toBe("keep-me"); // prior keys preserved
-    expect(metadata.source).toBe("message_handler_addressedTo"); // replaced
-    expect(metadata.lastInteractionAt).not.toBe("2020-01-01T00:00:00.000Z");
-  });
+		const result = await applyAddressedTo({
+			runtime,
+			message: makeMessage("sol look again"),
+			addressedTo: ["sol"],
+		});
+		expect(result).toMatchObject({ created: 0, updated: 1 });
+		expect(relationships).toHaveLength(1);
+		const updated = relationships[0];
+		expect(updated.id).toBe("rel-seed");
+		// both addressed tags present, no duplicates
+		expect(updated.tags).toEqual(["addressed", "addressed:auto"]);
+		const metadata = updated.metadata as Record<string, unknown>;
+		expect(metadata.roomContext).toBe("keep-me"); // prior keys preserved
+		expect(metadata.source).toBe("message_handler_addressedTo"); // replaced
+		expect(metadata.lastInteractionAt).not.toBe("2020-01-01T00:00:00.000Z");
+	});
 
-  it("skips the speaker as a target but still records an addressed-to-agent edge", async () => {
-    const { runtime, relationships } = makeHarness(defaultRoom());
-    const result = await applyAddressedTo({
-      runtime,
-      message: makeMessage("nubilio here"),
-      addressedTo: ["nubilio", AGENT_NAME],
-    });
-    // The speaker tag is an extraction error, never an address target; the
-    // agent itself is a legitimate participant of the addressed set.
-    expect(result.resolved).toEqual([AGENT_ID]);
-    expect(result.created).toBe(1);
-    expect(relationships).toHaveLength(1);
-    expect(relationships[0].sourceEntityId).toBe(SPEAKER_ID);
-    expect(relationships[0].targetEntityId).toBe(AGENT_ID);
-  });
+	it("skips the speaker as a target but still records an addressed-to-agent edge", async () => {
+		const { runtime, relationships } = makeHarness(defaultRoom());
+		const result = await applyAddressedTo({
+			runtime,
+			message: makeMessage("nubilio here"),
+			addressedTo: ["nubilio", AGENT_NAME],
+		});
+		// The speaker tag is an extraction error, never an address target; the
+		// agent itself is a legitimate participant of the addressed set.
+		expect(result.resolved).toEqual([AGENT_ID]);
+		expect(result.created).toBe(1);
+		expect(relationships).toHaveLength(1);
+		expect(relationships[0].sourceEntityId).toBe(SPEAKER_ID);
+		expect(relationships[0].targetEntityId).toBe(AGENT_ID);
+	});
 
-  it("writes nothing when nothing resolves (unresolvable names only)", async () => {
-    const harness = makeHarness(defaultRoom());
-    const { runtime, relationships } = harness;
-    const result = await applyAddressedTo({
-      runtime,
-      message: makeMessage(),
-      addressedTo: ["ghost"],
-    });
-    expect(result).toEqual({ created: 0, updated: 0, resolved: [] });
-    expect(relationships).toHaveLength(0);
-    // A no-op must never touch a write method: an implementation that
-    // writes and rolls back is distinguishable from one that never writes.
-    expect(harness.writeCalls).toBe(0);
-  });
+	it("returns an explicit empty result when the message carries no entityId", async () => {
+		const harness = makeHarness(defaultRoom());
+		const { runtime, relationships } = harness;
+		const result = await applyAddressedTo({
+			runtime,
+			// entityId is required on the Memory type, but the pipeline consumes
+			// unvalidated message records — the guard exists for exactly this
+			// shape, so the double cast mirrors the harness stub pattern above.
+			message: { ...makeMessage(), entityId: undefined } as unknown as Memory,
+			addressedTo: ["sol"],
+		});
+		expect(result).toEqual({ created: 0, updated: 0, resolved: [] });
+		expect(relationships).toHaveLength(0);
+		// The guard must fire BEFORE resolution: an authorless message never
+		// reaches the room roster and never issues a relationship write.
+		expect(harness.roomLookups).toBe(0);
+		expect(harness.writeCalls).toBe(0);
+	});
 
-  it("returns an explicit empty result for empty addressedTo", async () => {
-    const harness = makeHarness(defaultRoom());
-    const { runtime, relationships } = harness;
-    const result = await applyAddressedTo({
-      runtime,
-      message: makeMessage(),
-      addressedTo: [],
-    });
-    expect(result).toEqual({ created: 0, updated: 0, resolved: [] });
-    expect(relationships).toHaveLength(0);
-    expect(harness.writeCalls).toBe(0);
-  });
+	it("writes nothing when nothing resolves (unresolvable names only)", async () => {
+		const harness = makeHarness(defaultRoom());
+		const { runtime, relationships } = harness;
+		const result = await applyAddressedTo({
+			runtime,
+			message: makeMessage(),
+			addressedTo: ["ghost"],
+		});
+		expect(result).toEqual({ created: 0, updated: 0, resolved: [] });
+		expect(relationships).toHaveLength(0);
+		// A no-op must never touch a write method: an implementation that
+		// writes and rolls back is distinguishable from one that never writes.
+		expect(harness.writeCalls).toBe(0);
+	});
+
+	it("returns an explicit empty result for empty addressedTo", async () => {
+		const harness = makeHarness(defaultRoom());
+		const { runtime, relationships } = harness;
+		const result = await applyAddressedTo({
+			runtime,
+			message: makeMessage(),
+			addressedTo: [],
+		});
+		expect(result).toEqual({ created: 0, updated: 0, resolved: [] });
+		expect(relationships).toHaveLength(0);
+		expect(harness.writeCalls).toBe(0);
+	});
 });

--- a/packages/core/src/runtime/__tests__/addressed-to-resolution.test.ts
+++ b/packages/core/src/runtime/__tests__/addressed-to-resolution.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Contract tests for the resolution + persistence half of the addressed-to
+ * pipeline (#29162): resolveAddressedTargets (Stage-1 tag → room-entity IDs)
+ * and applyAddressedTo (speaker → target "addressed" relationship upsert).
+ * The gate functions' invariants are owned by addressed-to.test.ts; this
+ * suite owns the untested half. Deterministic harness — a recording
+ * in-memory runtime stub with a room-lookup counter, no model or database.
+ */
+import { describe, expect, it } from "vitest";
+import type { Entity, Relationship, UUID } from "../../types";
+import type { Memory } from "../../types/memory";
+import type { IAgentRuntime } from "../../types/runtime";
+import { applyAddressedTo, resolveAddressedTargets } from "../addressed-to";
+
+const AGENT_ID = "00000000-0000-4000-8000-000000000001" as UUID;
+const SPEAKER_ID = "00000000-0000-4000-8000-000000000002" as UUID;
+const OTHER_ID = "00000000-0000-4000-8000-000000000003" as UUID;
+const BYSTANDER_ID = "00000000-0000-4000-8000-000000000004" as UUID;
+const ROOM_ID = "00000000-0000-4000-8000-000000000005" as UUID;
+const MESSAGE_ID = "00000000-0000-4000-8000-00000000000f" as UUID;
+
+const AGENT_NAME = "Eliza";
+
+function makeEntity(id: UUID, names: string[]): Entity {
+	return { id, names } as Entity;
+}
+
+function makeMessage(text = "hi"): Memory {
+	return {
+		id: MESSAGE_ID,
+		entityId: SPEAKER_ID,
+		roomId: ROOM_ID,
+		content: { text },
+	} as Memory;
+}
+
+interface Harness {
+	runtime: IAgentRuntime;
+	relationships: Relationship[];
+	roomLookups: number;
+}
+
+/**
+ * Recording runtime stub: relationship storage is a plain array so assertions
+ * inspect exactly what applyAddressedTo wrote (tags, metadata) rather than a
+ * mock's echo, and room lookups are counted so the UUID fast-path can be
+ * pinned. getRelationships honors the tags filter like the real store.
+ */
+function makeHarness(participants: Entity[]): Harness {
+	const relationships: Relationship[] = [];
+	const entities = [...participants];
+	if (!entities.some((e) => e.id === AGENT_ID)) {
+		entities.push(makeEntity(AGENT_ID, [AGENT_NAME]));
+	}
+	const harness: Harness = {
+		relationships,
+		roomLookups: 0,
+		runtime: undefined as unknown as IAgentRuntime,
+	};
+	harness.runtime = {
+		agentId: AGENT_ID,
+		character: { name: AGENT_NAME, username: "eliza_bot" },
+		getEntitiesForRoom: async (_roomId: UUID) => {
+			harness.roomLookups += 1;
+			return entities;
+		},
+		getRelationships: async (query: { entityIds?: UUID[]; tags?: string[] }) =>
+			relationships.filter(
+				(rel) =>
+					(!query.entityIds || query.entityIds.includes(rel.sourceEntityId)) &&
+					(!query.tags ||
+						query.tags.some((tag) => (rel.tags ?? []).includes(tag))),
+			),
+		createRelationship: async (input: {
+			sourceEntityId: UUID;
+			targetEntityId: UUID;
+			tags?: string[];
+			metadata?: Record<string, unknown>;
+		}) => {
+			relationships.push({
+				id: `rel-${relationships.length + 1}` as UUID,
+				...input,
+			} as unknown as Relationship);
+			return relationships[relationships.length - 1];
+		},
+		updateRelationship: async (rel: Relationship) => {
+			const index = relationships.findIndex((r) => r.id === rel.id);
+			if (index === -1) throw new Error("relationship not found");
+			relationships[index] = rel;
+		},
+	} as unknown as IAgentRuntime;
+	return harness;
+}
+
+function defaultRoom(): Entity[] {
+	return [
+		makeEntity(AGENT_ID, [AGENT_NAME]),
+		makeEntity(SPEAKER_ID, ["nubilio"]),
+		makeEntity(OTHER_ID, ["sol"]),
+		makeEntity(BYSTANDER_ID, ["shaw"]),
+	];
+}
+
+describe("resolveAddressedTargets", () => {
+	it("passes well-formed UUIDs through, deduplicated, with zero room lookups", async () => {
+		const harness = makeHarness([]);
+		const targets = await resolveAddressedTargets({
+			runtime: harness.runtime,
+			message: makeMessage(),
+			addressedTo: [OTHER_ID, OTHER_ID, "  "],
+		});
+		expect(targets).toEqual([OTHER_ID]);
+		expect(harness.roomLookups).toBe(0);
+	});
+
+	it("resolves participant names case-insensitively and strips @ handles", async () => {
+		const { runtime } = makeHarness(defaultRoom());
+		const targets = await resolveAddressedTargets({
+			runtime,
+			message: makeMessage(),
+			addressedTo: ["@Sol", "NUBILIO"],
+		});
+		expect(targets.sort()).toEqual([OTHER_ID, SPEAKER_ID].sort());
+	});
+
+	it("mixes direct UUIDs with resolved names in one pass", async () => {
+		const { runtime } = makeHarness(defaultRoom());
+		const targets = await resolveAddressedTargets({
+			runtime,
+			message: makeMessage(),
+			addressedTo: [BYSTANDER_ID, "sol"],
+		});
+		expect(targets.sort()).toEqual([OTHER_ID, BYSTANDER_ID].sort());
+	});
+
+	it("maps the agent's own character name to agentId", async () => {
+		const { runtime } = makeHarness(defaultRoom());
+		const targets = await resolveAddressedTargets({
+			runtime,
+			message: makeMessage(),
+			addressedTo: ["eliza"],
+		});
+		expect(targets).toEqual([AGENT_ID]);
+	});
+
+	it("drops names that resolve to no room participant", async () => {
+		const { runtime } = makeHarness(defaultRoom());
+		const targets = await resolveAddressedTargets({
+			runtime,
+			message: makeMessage(),
+			addressedTo: ["ghost", "sol"],
+		});
+		expect(targets).toEqual([OTHER_ID]);
+	});
+});
+
+describe("applyAddressedTo (relationship upsert)", () => {
+	it("creates an addressed edge per resolved target and reports counts", async () => {
+		const { runtime, relationships } = makeHarness(defaultRoom());
+		const result = await applyAddressedTo({
+			runtime,
+			message: makeMessage("sol and shaw take a look"),
+			addressedTo: ["sol", "shaw"],
+		});
+		expect(result.created).toBe(2);
+		expect(result.updated).toBe(0);
+		expect(result.resolved.sort()).toEqual([OTHER_ID, BYSTANDER_ID].sort());
+		expect(relationships).toHaveLength(2);
+		for (const rel of relationships) {
+			expect(rel.sourceEntityId).toBe(SPEAKER_ID);
+			expect(rel.tags).toContain("addressed");
+			const metadata = rel.metadata as Record<string, unknown>;
+			expect(metadata.lastInteractionAt).toBeTypeOf("string");
+			expect(metadata.source).toBe("message_handler_addressedTo");
+		}
+	});
+
+	it("updates the existing edge: dedupes tags, preserves prior metadata, refreshes the interaction stamp", async () => {
+		const { runtime, relationships } = makeHarness(defaultRoom());
+		// Seed a pre-existing addressed edge carrying legacy metadata and only
+		// the base tag, exactly as an older writer would have left it.
+		relationships.push({
+			id: "rel-seed" as UUID,
+			sourceEntityId: SPEAKER_ID,
+			targetEntityId: OTHER_ID,
+			tags: ["addressed"],
+			metadata: {
+				lastInteractionAt: "2020-01-01T00:00:00.000Z",
+				source: "legacy_writer",
+				roomContext: "keep-me",
+			},
+		} as unknown as Relationship);
+
+		const result = await applyAddressedTo({
+			runtime,
+			message: makeMessage("sol look again"),
+			addressedTo: ["sol"],
+		});
+		expect(result).toMatchObject({ created: 0, updated: 1 });
+		expect(relationships).toHaveLength(1);
+		const updated = relationships[0];
+		expect(updated.id).toBe("rel-seed");
+		// both addressed tags present, no duplicates
+		expect(updated.tags).toEqual(["addressed", "addressed:auto"]);
+		const metadata = updated.metadata as Record<string, unknown>;
+		expect(metadata.roomContext).toBe("keep-me"); // prior keys preserved
+		expect(metadata.source).toBe("message_handler_addressedTo"); // replaced
+		expect(metadata.lastInteractionAt).not.toBe("2020-01-01T00:00:00.000Z");
+	});
+
+	it("skips the speaker as a target but still records an addressed-to-agent edge", async () => {
+		const { runtime, relationships } = makeHarness(defaultRoom());
+		const result = await applyAddressedTo({
+			runtime,
+			message: makeMessage("nubilio here"),
+			addressedTo: ["nubilio", AGENT_NAME],
+		});
+		// The speaker tag is an extraction error, never an address target; the
+		// agent itself is a legitimate participant of the addressed set.
+		expect(result.resolved).toEqual([AGENT_ID]);
+		expect(result.created).toBe(1);
+		expect(relationships).toHaveLength(1);
+		expect(relationships[0].sourceEntityId).toBe(SPEAKER_ID);
+		expect(relationships[0].targetEntityId).toBe(AGENT_ID);
+	});
+
+	it("writes nothing when nothing resolves (unresolvable names only)", async () => {
+		const { runtime, relationships } = makeHarness(defaultRoom());
+		const result = await applyAddressedTo({
+			runtime,
+			message: makeMessage(),
+			addressedTo: ["ghost"],
+		});
+		expect(result).toEqual({ created: 0, updated: 0, resolved: [] });
+		expect(relationships).toHaveLength(0);
+	});
+
+	it("returns an explicit empty result for empty addressedTo", async () => {
+		const { runtime, relationships } = makeHarness(defaultRoom());
+		const result = await applyAddressedTo({
+			runtime,
+			message: makeMessage(),
+			addressedTo: [],
+		});
+		expect(result).toEqual({ created: 0, updated: 0, resolved: [] });
+		expect(relationships).toHaveLength(0);
+	});
+});

--- a/packages/core/src/runtime/__tests__/addressed-to-resolution.test.ts
+++ b/packages/core/src/runtime/__tests__/addressed-to-resolution.test.ts
@@ -16,10 +16,13 @@ const AGENT_ID = "00000000-0000-4000-8000-000000000001" as UUID;
 const SPEAKER_ID = "00000000-0000-4000-8000-000000000002" as UUID;
 const OTHER_ID = "00000000-0000-4000-8000-000000000003" as UUID;
 const BYSTANDER_ID = "00000000-0000-4000-8000-000000000004" as UUID;
+const AT_ELIZA_ID = "00000000-0000-4000-8000-000000000006" as UUID;
 const ROOM_ID = "00000000-0000-4000-8000-000000000005" as UUID;
 const MESSAGE_ID = "00000000-0000-4000-8000-00000000000f" as UUID;
 
 const AGENT_NAME = "Eliza";
+/** Platform handle stored on the agent's entity, as connectors persist it. */
+const AGENT_HANDLE = "eliza_bot";
 
 function makeEntity(id: UUID, names: string[]): Entity {
 	return { id, names } as Entity;
@@ -38,6 +41,7 @@ interface Harness {
 	runtime: IAgentRuntime;
 	relationships: Relationship[];
 	roomLookups: number;
+	writeCalls: number;
 }
 
 /**
@@ -50,11 +54,15 @@ function makeHarness(participants: Entity[]): Harness {
 	const relationships: Relationship[] = [];
 	const entities = [...participants];
 	if (!entities.some((e) => e.id === AGENT_ID)) {
-		entities.push(makeEntity(AGENT_ID, [AGENT_NAME]));
+		// The agent's entity carries its platform handle, not the character
+		// name — "eliza" then resolves only through the resolver's dedicated
+		// character-name mapping, which is the path the suite is meant to pin.
+		entities.push(makeEntity(AGENT_ID, [AGENT_HANDLE]));
 	}
 	const harness: Harness = {
 		relationships,
 		roomLookups: 0,
+		writeCalls: 0,
 		runtime: undefined as unknown as IAgentRuntime,
 	};
 	harness.runtime = {
@@ -77,6 +85,7 @@ function makeHarness(participants: Entity[]): Harness {
 			tags?: string[];
 			metadata?: Record<string, unknown>;
 		}) => {
+			harness.writeCalls += 1;
 			relationships.push({
 				id: `rel-${relationships.length + 1}` as UUID,
 				...input,
@@ -84,6 +93,7 @@ function makeHarness(participants: Entity[]): Harness {
 			return relationships[relationships.length - 1];
 		},
 		updateRelationship: async (rel: Relationship) => {
+			harness.writeCalls += 1;
 			const index = relationships.findIndex((r) => r.id === rel.id);
 			if (index === -1) throw new Error("relationship not found");
 			relationships[index] = rel;
@@ -94,7 +104,14 @@ function makeHarness(participants: Entity[]): Harness {
 
 function defaultRoom(): Entity[] {
 	return [
-		makeEntity(AGENT_ID, [AGENT_NAME]),
+		// A participant stored under "@Eliza" with its own id: today the
+		// leading-@ store spelling is a distinct key from "eliza", so it
+		// must NOT capture the character-name lookup. If the resolver's
+		// normalize ever strips a leading @ from STORED names (the #29189
+		// direction), that participant's entry overwrites the dedicated
+		// character-name mapping — written earlier — and the
+		// character-name test below goes red.
+		makeEntity(AT_ELIZA_ID, ["@Eliza"]),
 		makeEntity(SPEAKER_ID, ["nubilio"]),
 		makeEntity(OTHER_ID, ["sol"]),
 		makeEntity(BYSTANDER_ID, ["shaw"]),
@@ -225,7 +242,8 @@ describe("applyAddressedTo (relationship upsert)", () => {
 	});
 
 	it("writes nothing when nothing resolves (unresolvable names only)", async () => {
-		const { runtime, relationships } = makeHarness(defaultRoom());
+		const harness = makeHarness(defaultRoom());
+		const { runtime, relationships } = harness;
 		const result = await applyAddressedTo({
 			runtime,
 			message: makeMessage(),
@@ -233,10 +251,14 @@ describe("applyAddressedTo (relationship upsert)", () => {
 		});
 		expect(result).toEqual({ created: 0, updated: 0, resolved: [] });
 		expect(relationships).toHaveLength(0);
+		// A no-op must never touch a write method: an implementation that
+		// writes and rolls back is distinguishable from one that never writes.
+		expect(harness.writeCalls).toBe(0);
 	});
 
 	it("returns an explicit empty result for empty addressedTo", async () => {
-		const { runtime, relationships } = makeHarness(defaultRoom());
+		const harness = makeHarness(defaultRoom());
+		const { runtime, relationships } = harness;
 		const result = await applyAddressedTo({
 			runtime,
 			message: makeMessage(),
@@ -244,5 +266,6 @@ describe("applyAddressedTo (relationship upsert)", () => {
 		});
 		expect(result).toEqual({ created: 0, updated: 0, resolved: [] });
 		expect(relationships).toHaveLength(0);
+		expect(harness.writeCalls).toBe(0);
 	});
 });

--- a/packages/core/src/runtime/addressed-to.ts
+++ b/packages/core/src/runtime/addressed-to.ts
@@ -76,9 +76,14 @@ export async function applyAddressedTo(
 		}
 		resolved.push(targetId);
 
+		// Canonical-pair lookup WITHOUT a tag filter: the addressed edge is
+		// upserted onto whatever relationship row already owns the pair. The
+		// canonical store treats (source, target, agentId) as the uniqueness
+		// key — createRelationship returns false for an existing pair of ANY
+		// tag flavor (a seeded "friend" edge included), so a tag-scoped
+		// lookup here would miss it and report a phantom create.
 		const existingList = await runtime.getRelationships({
 			entityIds: [speakerId],
-			tags: [ADDRESSED_RELATIONSHIP_TAGS[0]],
 		});
 		const existing = existingList.find(
 			(rel) =>

--- a/plugins/plugin-sql/src/__tests__/integration/addressed-to-reconciliation.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/addressed-to-reconciliation.real.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Canonical-storage reconciliation tests for applyAddressedTo (#29170 review):
+ * when the speaker→target pair already exists as a NON-addressed relationship
+ * (e.g. a seeded "friend" edge), the helper must upsert the addressed state
+ * onto that canonical row — keeping its UUID, preserving its tags/metadata —
+ * instead of calling createRelationship, which the canonical SQL store
+ * rejects as a duplicate pair while the helper would still count a phantom
+ * create. First block runs against a recording in-memory harness (tags
+ * filter honored like the real store); second block runs the REAL
+ * plugin-sql PGlite adapter + AgentRuntime wired by the repo's integration
+ * helpers, proving the reconciliation on canonical SQL storage.
+ */
+import {
+  type AgentRuntime,
+  ChannelType,
+  type Entity,
+  type Relationship,
+  type UUID,
+} from "@elizaos/core";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+// Relative source import, the established pattern for core-internal helpers
+// that are not re-exported on the package's public surface (see
+// plugin-agent-orchestrator's tests): applyAddressedTo ships inside the
+// bundled node entry, not as a standalone subpath export.
+import { applyAddressedTo } from "../../../../../packages/core/src/runtime/addressed-to.ts";
+import { relationshipTable } from "../../schema";
+import type { DrizzleDatabase } from "../../types";
+import { createIsolatedTestDatabase } from "../test-helpers";
+
+const SPEAKER = "20000000-0000-4000-8000-000000000001" as UUID;
+const TARGET = "20000000-0000-4000-8000-000000000002" as UUID;
+const ROOM = "20000000-0000-4000-8000-000000000003" as UUID;
+const AGENT = "20000000-0000-4000-8000-0000000000aa" as UUID;
+
+function makeEntity(id: UUID, names: string[]): Entity {
+  return { id, agentId: AGENT, names } as Entity;
+}
+
+describe("applyAddressedTo — canonical pair reconciliation (in-memory harness)", () => {
+  interface Harness {
+    runtime: unknown;
+    relationships: Relationship[];
+    createAttempts: number;
+  }
+
+  /** Tags-filter-respecting store, mirroring the real getRelationships. */
+  function makeHarness(): Harness {
+    const relationships: Relationship[] = [];
+    const harness: Harness = {
+      runtime: undefined,
+      relationships,
+      createAttempts: 0,
+    };
+    harness.runtime = {
+      agentId: AGENT,
+      character: { name: "Eliza" },
+      getEntitiesForRoom: async () => [
+        makeEntity(SPEAKER, ["nubilio"]),
+        makeEntity(TARGET, ["sol"]),
+      ],
+      getRelationships: async (query: { entityIds?: UUID[]; tags?: string[] }) =>
+        relationships.filter(
+          (rel) =>
+            (!query.entityIds || query.entityIds.includes(rel.sourceEntityId)) &&
+            (!query.tags || query.tags.some((tag) => (rel.tags ?? []).includes(tag)))
+        ),
+      // Mirrors canonical stores: an insert for an EXISTING pair is a
+      // no-op returning false (SQL: onConflictDoNothing → 0 rows).
+      createRelationship: async (input: { sourceEntityId: UUID; targetEntityId: UUID }) => {
+        harness.createAttempts += 1;
+        if (
+          relationships.some(
+            (rel) =>
+              rel.sourceEntityId === input.sourceEntityId &&
+              rel.targetEntityId === input.targetEntityId
+          )
+        ) {
+          return false;
+        }
+        relationships.push({
+          id: `rel-${relationships.length + 1}` as UUID,
+          ...input,
+        } as unknown as Relationship);
+        return true;
+      },
+      updateRelationship: async (rel: Relationship) => {
+        const index = relationships.findIndex((r) => r.id === rel.id);
+        if (index === -1) throw new Error("relationship not found");
+        relationships[index] = rel;
+      },
+    };
+    return harness;
+  }
+
+  it("upserts addressed state onto an existing NON-addressed edge instead of attempting a duplicate create", async () => {
+    const harness = makeHarness();
+    const { runtime, relationships } = harness;
+    // Seed the canonical pair as a plain "friend" edge — no addressed tags,
+    // its own metadata — exactly the reconciliation case the array harness
+    // previously masked.
+    relationships.push({
+      id: "rel-friend" as UUID,
+      sourceEntityId: SPEAKER,
+      targetEntityId: TARGET,
+      agentId: AGENT,
+      tags: ["friend"],
+      metadata: { since: "2024", note: "keep-me" },
+    } as unknown as Relationship);
+
+    const result = await applyAddressedTo({
+      runtime: runtime as never,
+      message: {
+        id: "m1" as UUID,
+        entityId: SPEAKER,
+        roomId: ROOM,
+        content: { text: "sol check this" },
+      } as never,
+      addressedTo: ["sol"],
+    });
+
+    // Reconciled onto the canonical row: counted as an update, never a create.
+    expect(result).toMatchObject({ created: 0, updated: 1, resolved: [TARGET] });
+    expect(harness.createAttempts).toBe(0);
+    expect(relationships).toHaveLength(1);
+    const row = relationships[0];
+    // Same canonical UUID preserved — no duplicate legacy edge.
+    expect(row.id).toBe("rel-friend");
+    // Existing tags preserved, addressed tags added, no duplicates.
+    expect(row.tags).toEqual(["friend", "addressed", "addressed:auto"]);
+    const metadata = row.metadata as Record<string, unknown>;
+    expect(metadata.since).toBe("2024");
+    expect(metadata.note).toBe("keep-me");
+    expect(metadata.source).toBe("message_handler_addressedTo");
+    expect(metadata.lastInteractionAt).toBeTypeOf("string");
+  });
+});
+
+describe("applyAddressedTo — canonical pair reconciliation (real plugin-sql storage)", () => {
+  let runtime: AgentRuntime;
+  let cleanup: () => Promise<void>;
+  let db: DrizzleDatabase;
+
+  beforeAll(async () => {
+    const setup = await createIsolatedTestDatabase("addressed-to-reconciliation");
+    runtime = setup.runtime;
+    cleanup = setup.cleanup;
+    db = setup.adapter.getDatabase() as DrizzleDatabase;
+    await runtime.createRoom({
+      id: ROOM,
+      name: "reconciliation-room",
+      worldId: ROOM,
+      source: "test",
+      type: ChannelType.GROUP,
+    });
+    await runtime.createEntities([makeEntity(SPEAKER, ["nubilio"]), makeEntity(TARGET, ["sol"])]);
+    await runtime.createRoomParticipants([SPEAKER, TARGET], ROOM);
+  });
+
+  afterAll(async () => {
+    if (cleanup) await cleanup();
+  });
+
+  it("seeds a non-addressed friend pair, then upserts addressed state onto the same canonical row", async () => {
+    // Seed the canonical pair WITHOUT addressed tags, via the runtime's own
+    // canonical creator.
+    const seeded = await runtime.createRelationship({
+      sourceEntityId: SPEAKER,
+      targetEntityId: TARGET,
+      tags: ["friend"],
+      metadata: { since: "2024", note: "keep-me" },
+    });
+    expect(seeded).toBe(true);
+    const seededRow = await runtime.getRelationship({
+      sourceEntityId: SPEAKER,
+      targetEntityId: TARGET,
+    });
+    expect(seededRow?.id).toBeTypeOf("string");
+    const canonicalId = seededRow?.id as UUID;
+
+    const result = await applyAddressedTo({
+      runtime,
+      message: {
+        id: "m1" as UUID,
+        entityId: SPEAKER,
+        roomId: ROOM,
+        content: { text: "sol check this" },
+      } as never,
+      addressedTo: ["sol"],
+    });
+
+    expect(result).toMatchObject({ created: 0, updated: 1, resolved: [TARGET] });
+
+    // Persisted-state readback: exactly one row owns the pair, same UUID,
+    // friend tag + addressed tags + preserved metadata.
+    const rows = await db.select().from(relationshipTable);
+    expect(rows).toHaveLength(1);
+    const persisted = rows[0];
+    expect(persisted.id).toBe(canonicalId);
+    expect(persisted.tags).toContain("friend");
+    expect(persisted.tags).toContain("addressed");
+    expect(persisted.tags).toContain("addressed:auto");
+    const metadata = (persisted.metadata ?? {}) as Record<string, unknown>;
+    expect(metadata.since).toBe("2024");
+    expect(metadata.note).toBe("keep-me");
+    expect(metadata.source).toBe("message_handler_addressedTo");
+  });
+});


### PR DESCRIPTION
Closes #29162

## Summary

Adds a contract-pinning suite (`packages/core/src/runtime/__tests__/addressed-to-resolution.test.ts`, 248 lines, additive-only) for the resolution + persistence half of the addressed-to pipeline in `packages/core/src/runtime/addressed-to.ts`:

- `resolveAddressedTargets` — Stage-1 `addressedTo` tag → room-entity UUID resolution: well-formed UUID fast path (deduplicated, **zero** room lookups — asserted via a lookup counter), case-insensitive participant-name resolution, `@`-handle stripping, `character.name` → `agentId` mapping, unresolvable-name drops, mixed UUID+name passes.
- `applyAddressedTo` — speaker → target `addressed` relationship upsert: edge creation with `addressed`/`addressed:auto` tags and `message_handler_addressedTo` metadata; seeded legacy-edge update (tag dedupe, prior-metadata preservation, `lastInteractionAt` refresh); speaker-target skip (extraction error, never an address target); empty/unresolvable no-ops with explicit empty results.
- Stage-1 consumer boundary (`message-runtime-stage1.test.ts`): a dead-seam test pinning that the Stage-1 prompt tier actually persists the extracted `addressedTo` tags through `applyAddressedTo` — the consumer-side proof that the pinned helpers are invoked on the real message path.

## Why (regression × consumer)

- **Regression each test detects:** these helpers feed the deliberate-silence gate on every inbound group turn (`MessageService` calls them at `services/message.ts` ~L8937/L9117). A broken resolver silently degrades the gate's fail-safe behavior (a stored handle or mixed tag set stops resolving); a broken upsert corrupts the `addressed` relationship graph the gate and relationship UI read (duplicate edges on repeat addresses, lost legacy metadata on update, speaker self-edges from Stage-1 extraction errors).
- **Consumer:** `DefaultMessageService` (`applyAddressedTo` persistence task + gate resolution on every group turn) and anything reading `addressed` relationship edges.
- **Why no existing test owns this:** symbol-grep across `*.test.ts` on develop shows zero references to `resolveAddressedTargets`/`applyAddressedTo`. The gate functions themselves ARE owned by the pre-existing `addressed-to.test.ts` (#9874 suite) — this PR deliberately does not touch that file (scope correction noted on the issue).

## Verification

| Check | Result |
| --- | --- |
| New file | 11/11 pass (guard test added at head de363321d1) |
| New file + Stage-1 consumer + existing gate suite | 224/224 pass (3 files) |
| Mutations (behavioral flips, each RED) | drop speaker-skip → RED; no-op `updateRelationship` → RED (seeded-edge update detected); UUID/name partition pinned via zero-room-lookup + mixed-resolution assertions |
| biome check | clean at head de363321d1 — an earlier head carried a tab/space format drift in `addressed-to-resolution.test.ts` (attentionhead's blocking finding); fixed via `biome format --write` and re-verified clean |
| `tsc --noEmit` (packages/core) | clean |
| Full `packages/core` vitest | 289 failures in unrelated files — control-proven pre-existing: identical failures with the new file deleted from the worktree (symlinked-node_modules worktree environment) |
| RP independent review | 3 rounds; final verdict on shipped bytes: APPROVE (round-1 findings — unpinned update path, unexercised branches — were addressed or descoped with the gate half; production defect split to #29168) |

Defect found during review (stored `@`-prefixed entity names never resolve in `byName`) is filed separately as #29168 — this PR pins current behavior without papering over it.

## Evidence

| Row | Value |
| --- | --- |
| backend-logs | Rebase verification at head 3a78af7346 (worktree ~/wt/eliza-29170-rebase): core addressed-to + resolution vitest 38/38; message-runtime-stage1 vitest 242/242; plugin-sql addressed-to-reconciliation.real (real PGlite) 2/2; core typecheck exit 0 + plugin-sql typecheck exit 0; biome 4 branch files clean; branch delta vs develop tip 3a7f438a9e = 4 files +680/-1, rebase zero conflicts. plugin-sql full integration lane: 410 passed / 2 failed — both failures (advanced-memory-storage.real boot, document-list-query.real entityId-isolation) reproduced IDENTICALLY on a pristine develop control worktree at the same tip = pre-existing develop reds, not branch-introduced. |
| screenshots | N/A - no UI surface changed |
| screen-recording | N/A - no UI surface changed |
| llm-trajectory | N/A - no model-path changes; deterministic stub-runtime tests |
| backend-db-rows | N/A - in-memory relationship stub; no database touched |

<!-- evidence-head:08cde4adc68155eb033cc0107845709a62ddadac -->
- [x] <details><summary>Review-response: canonical-pair reconciliation at head eec4f74a91 (2026-09-09, lalalune integration review)</summary>

  Owner-path fix: `applyAddressedTo` pair lookup no longer tag-scoped — addressed state upserts onto an existing non-addressed (e.g. "friend") relationship row, preserving its UUID/tags/metadata; `createRelationship` unreachable for an existing pair (phantom-create path closed). New `addressed-to-reconciliation.real.test.ts`: recording-harness case + real plugin-sql PGlite integration case with persisted-state readback. RED control: 2/2 fail at de363321d1, 2/2 pass at eec4f74a91. Core suites 85/85; plugin-sql real suites 8/8; core + plugin-sql typecheck clean; biome clean. Reply: https://github.com/elizaOS/eliza/pull/29170#issuecomment-5605900451

  </details>

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only change, no UI surface

<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only change, no UI surface

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - test-only change, no UI surface

<!-- evidence-row:backend-logs -->
- [x] <details><summary>Review-response fixes at head de363321d1 (2026-09-01)</summary>

```text
Worktree at exact prior head 2d0ffa1d99 -> de363321d1 (fast-forward, 1 file, +229/-210,
non-whitespace delta = +20/-1: comment fix #29189->#29168, new guard test, blank line).
  biome format --write addressed-to-resolution.test.ts: Formatted 1 file
  biome check (pinned file, shared-checkout binary): clean
  vitest (resolution + message-runtime-stage1 + gate suites): 3 files / 224 tests passed
  packages/core typecheck: exit 0
  Mutation control for the new guard test:
    mutant = guard bypassed (speakerId ?? fallback UUID):
      ORIGINAL 10-test suite vs mutant: 10/10 pass  (gap the new test closes)
      NEW 11-test suite vs mutant: 1 failed (the guard test) / 10 passed
      pristine source restored: 11/11 pass
```
</details>

- [x] <details><summary>Rebase wave 3 onto develop 870f4ec960 — head 16aebae4 -> 4074368 (2026-09-01)</summary>

```text
git rebase upstream/develop (tip 870f4ec960): 3/3 commits replayed, zero conflicts.
Diff preserved: 2 files, +448 (addressed-to-resolution.test.ts +271, message-runtime-stage1.test.ts).
Gates at new head 407436807f (fresh worktree, real core build at same head):
  vitest pinned suites: Test Files 2 passed (2) / Tests 196 passed (196)
  packages/core tsc --noEmit (typecheck script): clean
  biome check on both pinned test files: clean
Force-push with expected-lease on 16aebae4; MERGEABLE verified post-push.
```
</details>

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code changed; CI retriggered at new head 08cde4adc68 via empty commit (no code delta vs 18b3fc6f9c0c)

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model-path changes; deterministic stub-runtime tests

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - in-memory relationship stub; no database touched

AI provider/model: zai / glm-5.3 + GPT-5.6-sol (RepoPrompt CE review agent)
Client / agent tooling: Hermes Agent
Contribution skill revision: elizaOS/eliza@3e2749ee1cf340314f9dc2b36e0c4333c18ea760:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [hermes-t3rpz]
<!-- eliza-computer-attribution:v1 {"provider":"zai","model":"glm-5.3","client":"Hermes Agent","skill_revision":"elizaOS/eliza@3e2749ee1cf340314f9dc2b36e0c4333c18ea760:packages/skills/skills/contribute-to-eliza"} -->















