### PR TITLE
fix(agent-orchestrator): negotiate verifier ACP modes

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/__tests__/acp-native-transport.verifier.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/acp-native-transport.verifier.test.ts
@@ -1,15 +1,15 @@
 /**
- * AC4 (#8898): the independent verifier's read-only-but-executable capability is
- * enforced at the native transport, not by prompt text.
+ * AC4 (#8898): the independent verifier's read/search/execute capability and
+ * direct edit/write/delete denial are enforced at the native transport.
  *
- * `isOperationApproved` is the single gate every dangerous client method consults:
+ * `isOperationApproved` is the gate every ACP client method consults:
  * `writeTextFile` throws `PermissionDeniedError` when `!isOperationApproved("edit")`,
  * `createTerminal` when `!isOperationApproved("execute")`, and `readTextFile` when
  * `!isOperationApproved("read")`. The public `approvesPermissionRequest` mirrors
- * that exact decision (`isOperationApproved(inferToolKind(toolCall))`), so asserting
- * it proves the hard enforcement: under `verifier`, read/search/execute are approved
- * (the verifier can run `bun test`, `git diff`, and read files) while edit/write/delete
- * are denied (any write physically throws off the same gate).
+ * that exact decision (`isOperationApproved(inferToolKind(toolCall))`). Under
+ * `verifier`, read/search/execute are approved (the verifier can run `bun test`,
+ * `git diff`, and read files), while direct ACP edit/write/delete operations are
+ * denied. Execute is intentionally not a filesystem sandbox.
  */
 
 import { describe, expect, it } from "vitest";
@@ -20,8 +20,45 @@ function makeClient(approvalPreset: ApprovalPreset): NativeAcpClient {
   return new NativeAcpClient({
     command: "true",
     cwd: "/tmp",
+    mcpServers: [],
     approvalPreset,
   });
+}
+
+interface RequestCall {
+  method: string;
+  params: unknown;
+}
+
+interface StubSessionModes {
+  currentModeId: string;
+  availableModeIds: readonly string[];
+}
+
+function stubSessionHandshake(
+  client: NativeAcpClient,
+  modes?: StubSessionModes,
+): RequestCall[] {
+  const calls: RequestCall[] = [];
+  const request = async (method: string, params: unknown): Promise<unknown> => {
+    calls.push({ method, params });
+    if (method === "session/new") {
+      return {
+        sessionId: "session-1",
+        ...(modes
+          ? {
+              modes: {
+                currentModeId: modes.currentModeId,
+                availableModes: modes.availableModeIds.map((id) => ({ id })),
+              },
+            }
+          : {}),
+      };
+    }
+    return {};
+  };
+  (client as unknown as { request: typeof request }).request = request;
+  return calls;
 }
 
 const OPTIONS = [
@@ -44,7 +81,7 @@ describe("acp-native-transport approval preset 'verifier' (#8898 AC4)", () => {
     expect(approves(client, "execute")).toBe(true);
   });
 
-  it("denies edit, write, and delete (read-only enforced at the transport)", () => {
+  it("denies direct edit, write, and delete operations", () => {
     const client = makeClient("verifier");
     expect(approves(client, "edit")).toBe(false);
     expect(approves(client, "write")).toBe(false);
@@ -52,7 +89,7 @@ describe("acp-native-transport approval preset 'verifier' (#8898 AC4)", () => {
   });
 
   it("differs from 'standard' (which denies execute) and 'readonly' (which denies all)", () => {
-    // Contrast: only `verifier` grants execute while still denying writes.
+    // Contrast: only `verifier` grants execute while denying direct write kinds.
     const standard = makeClient("standard");
     expect(approves(standard, "execute")).toBe(false);
     expect(approves(standard, "read")).toBe(true);
@@ -62,4 +99,100 @@ describe("acp-native-transport approval preset 'verifier' (#8898 AC4)", () => {
     expect(approves(readonly, "read")).toBe(false);
     expect(approves(readonly, "execute")).toBe(false);
   });
+});
+
+describe("acp-native-transport session mode negotiation", () => {
+  const advertisedModes = ["bypassPermissions", "plan", "dontAsk", "default"];
+
+  it.each<{
+    approvalPreset: ApprovalPreset;
+    expectedModeId: string;
+  }>([
+    { approvalPreset: "autonomous", expectedModeId: "bypassPermissions" },
+    { approvalPreset: "permissive", expectedModeId: "bypassPermissions" },
+    { approvalPreset: "readonly", expectedModeId: "plan" },
+    { approvalPreset: "standard", expectedModeId: "dontAsk" },
+    { approvalPreset: "verifier", expectedModeId: "default" },
+  ])(
+    "selects $expectedModeId for $approvalPreset",
+    async ({ approvalPreset, expectedModeId }) => {
+      const client = makeClient(approvalPreset);
+      const calls = stubSessionHandshake(client, {
+        currentModeId: "dontAsk",
+        availableModeIds: advertisedModes,
+      });
+
+      await client.createSession();
+
+      expect(
+        calls.filter(({ method }) => method === "session/set_mode"),
+      ).toEqual([
+        {
+          method: "session/set_mode",
+          params: { sessionId: "session-1", modeId: expectedModeId },
+        },
+      ]);
+    },
+  );
+
+  it("keeps the agent fallback when modes are absent", async () => {
+    const client = makeClient("verifier");
+    const calls = stubSessionHandshake(client);
+
+    await client.createSession();
+
+    expect(calls.filter(({ method }) => method === "session/set_mode")).toEqual(
+      [],
+    );
+  });
+
+  it("selects read-only for Codex-shaped verifier modes", async () => {
+    const client = makeClient("verifier");
+    const calls = stubSessionHandshake(client, {
+      currentModeId: "agent",
+      availableModeIds: ["read-only", "agent", "agent-full-access"],
+    });
+
+    await client.createSession();
+
+    expect(calls.filter(({ method }) => method === "session/set_mode")).toEqual(
+      [
+        {
+          method: "session/set_mode",
+          params: { sessionId: "session-1", modeId: "read-only" },
+        },
+      ],
+    );
+  });
+
+  it.each([
+    {
+      currentModeId: "bypassPermissions",
+      availableModeIds: ["bypassPermissions", "dontAsk"],
+    },
+    {
+      currentModeId: "acceptEdits",
+      availableModeIds: ["acceptEdits", "dontAsk"],
+    },
+    {
+      currentModeId: "dontAsk",
+      availableModeIds: ["dontAsk"],
+    },
+  ])(
+    "rejects unsupported verifier mode state $currentModeId",
+    async ({ currentModeId, availableModeIds }) => {
+      const client = makeClient("verifier");
+      const calls = stubSessionHandshake(client, {
+        currentModeId,
+        availableModeIds,
+      });
+
+      await expect(client.createSession()).rejects.toThrow(
+        `ACP verifier requires an advertised permission-requesting mode ("read-only" or "default"); current mode is "${currentModeId}"`,
+      );
+      expect(
+        calls.filter(({ method }) => method === "session/set_mode"),
+      ).toEqual([]);
+    },
+  );
 });

--- a/plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts
@@ -307,12 +307,23 @@ export class NativeAcpClient {
         ? "bypassPermissions"
         : this.opts.approvalPreset === "readonly"
           ? "plan"
-          : "dontAsk";
+          : this.opts.approvalPreset === "verifier"
+            ? availableModes.includes("read-only")
+              ? "read-only"
+              : "default"
+            : "dontAsk";
     if (availableModes.includes(requestedMode)) {
       await this.request("session/set_mode", {
         sessionId,
         modeId: requestedMode,
       });
+    } else if (this.opts.approvalPreset === "verifier" && modes) {
+      const currentMode = stringValue(modes.currentModeId);
+      throw new Error(
+        `ACP verifier requires an advertised permission-requesting mode ("read-only" or "default")${
+          currentMode ? `; current mode is "${currentMode}"` : ""
+        }`,
+      );
     }
     return {
       sessionId,
@@ -797,9 +808,9 @@ export class NativeAcpClient {
       return kind === "read" || kind === "search";
     }
     // Independent verifier (#8898): may read, search, and EXECUTE (run tests /
-    // build / git diff) but is hard-blocked from edit/write/delete — writeTextFile
-    // throws PermissionDeniedError off this gate, so read-only is enforced at the
-    // transport, not by prompt text.
+    // build / git diff), while direct ACP edit/write/delete operations are
+    // denied. Execute is intentionally not a filesystem sandbox: validation
+    // commands can write, so the verifier prompt remains part of that boundary.
     if (this.opts.approvalPreset === "verifier") {
       return kind === "read" || kind === "search" || kind === "execute";
     }


### PR DESCRIPTION
# Relates to

Relates to #28400.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest upstream `develop` (`43c9c3795fbbe75518e1119b4a99c9697e6dd5a3`) with zero conflicts.
- [ ] `bun install` and `bun run verify` were not run in the intentionally sparse worktree; the exact dependency blocker and focused substitutes are recorded under **Known gaps / failures**.
- [x] A reviewer can confirm the mode-selection behavior from the handshake matrix and red/green test receipt below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@5e309560fa5bf659d77b13cce2c30ba28af8c500:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest upstream `develop`; zero conflicts.
- [ ] Full `bun run verify` was unavailable in the sparse checkout; focused Vitest, TypeScript, Biome, and diff validation are green, and the exact limitation is documented below.

# Risks

Medium. This changes the ACP mode selected for independent verifier sessions. Codex-shaped sessions select the sandboxed `read-only` mode; Claude-shaped sessions select `default` so Bash permission requests reach Eliza's existing verifier gate. Mode-aware agents advertising neither fail closed, while agents with no mode interface retain the prior fallback.

The existing #8898 verifier contract intentionally permits execute-class operations so it can run tests and builds. Direct ACP edit/write/delete operations remain denied, but Claude Bash/test execution is not filesystem containment; the corrected source comments now state that boundary instead of claiming hard read-only enforcement.

# Background

## What does this PR do?

- Selects advertised `read-only` for Codex verifier sessions, preferring its read-only sandbox and on-request approval policy.
- Otherwise selects advertised `default` for Claude verifier sessions so permission requests reach Eliza's read/search/execute gate.
- Rejects mode-aware verifier sessions that advertise neither permission-requesting mode instead of inheriting `bypassPermissions`, `acceptEdits`, or a non-executing `dontAsk` mode.
- Preserves the compatibility fallback when an ACP agent omits `modes` entirely.
- Adds protocol-valid handshake tests with `currentModeId` for every approval preset, both pinned adapter mode shapes, unsupported mode states, and the mode-less fallback.

## What kind of change is this?

Bug fix (non-breaking correction to verifier ACP session-mode negotiation).

# Documentation changes needed?

No external documentation change is needed. The transport and test comments were corrected to distinguish direct ACP write denial from filesystem sandboxing of execute-class commands.

# Testing

## Where should a reviewer start?

Start with `NativeAcpClient.createSession()` in `plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts`, then review the mode matrix in `src/__tests__/acp-native-transport.verifier.test.ts`.

## Detailed testing steps

In a fully installed checkout:

```bash
cd plugins/plugin-agent-orchestrator
bunx vitest run --config vitest.config.ts src/__tests__/acp-native-transport.verifier.test.ts
```

Local red phase against the original production mapping:

```text
Test Files  1 failed (1)
Tests       2 failed | 8 passed (10)
verifier received dontAsk instead of default
```

Final focused validation against exact head `129e71414b8b24c6c15ca0be6959dda2d3c6396a`:

```text
Test Files  1 passed (1)
Tests       13 passed (13)
Focused TypeScript: pass
Biome 2.5.8: Checked 2 files; no fixes applied
git diff --check: pass
Independent diff review: no P0-P3 findings
```

# Evidence Gate

<!-- evidence-head:129e71414b8b24c6c15ca0be6959dda2d3c6396a -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - transport-only Node.js change with no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - transport-only Node.js change with no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no user-facing visual flow changed.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - deterministic `session/new` / `session/set_mode` handshake assertions are the relevant boundary; no live child credentials were available.
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: N/A - no frontend request, response, or state changed.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - the isolated environment has no Claude or Codex subscription credentials; the exact pinned adapter mode contracts were inspected and the transport handshake is covered deterministically.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A - no DB, memory, scheduled-task, wallet, generated-media, or other domain output changed.
<!-- evidence-row:ocr-review -->
- [x] OCR review: N/A - no visual text or UI surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no Claude or Codex subscription credential was available in the isolated validation environment. The tests drive the real `NativeAcpClient.createSession()` negotiation boundary with Claude- and Codex-shaped `session/new.modes` responses.

## Backend + frontend logs

Backend: N/A - no live credentialed ACP child was available; the exact deterministic red/green receipt is included above.

Frontend: N/A - no frontend code path changed.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or audio behavior changed.

## Known gaps / failures

- The full package typecheck starts with repository TypeScript 6.0.3 and pinned `bun-types`, but the sparse harness lacks the complete workspace graph and generated data; it reports missing workspace/external modules such as `@elizaos/cloud-routing`, `@elizaos/logger`, `@elizaos/auth`, and `git-workspace-service`. A focused TypeScript project covering the changed transport, shared ACP types, and verifier test passes.
- `bun install` and monorepo-wide `bun run verify` were not run because this isolated sparse checkout intentionally lacks the full workspace dependency graph. Focused Vitest, TypeScript, Biome 2.5.8, `git diff --check`, and independent review all passed; exact-head hosted run 33002842563 is queued and remains authoritative for full repository closure.
- No live Claude/Codex trajectory was captured because the isolated environment had no subscription credentials. The test stubs only the JSON-RPC request boundary and executes the production mode-selection code.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@5e309560fa5bf659d77b13cce2c30ba28af8c500:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
? [root]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@5e309560fa5bf659d77b13cce2c30ba28af8c500:packages/skills/skills/contribute-to-eliza"} -->
