### PR TITLE
fix(cloud): fail closed on Dedicated adoption drift

### DIFF
--- a/packages/cloud/api/__tests__/admin-personal-dedicated-adoption-selection.pglite.test.ts
+++ b/packages/cloud/api/__tests__/admin-personal-dedicated-adoption-selection.pglite.test.ts
@@ -452,7 +452,7 @@ describe("admin personal Dedicated adoption selection", () => {
     ).toEqual({ state: "unavailable" });
   });
 
-  test("uses canonical catalogue restore states when legacy verification columns are null", async () => {
+  test("only canonical catalog-v2/manifest-v3 protected states are restorable", async () => {
     for (const manifestVersion of [2, 3] as const) {
       await dbWrite.delete(agentSandboxBackups);
       await dbWrite.delete(agentSandboxes);
@@ -489,8 +489,44 @@ describe("admin personal Dedicated adoption selection", () => {
       const protectedBackup = await post(requestBody(true));
       expect(protectedBackup.status).toBe(200);
       expect(await protectedBackup.json()).toMatchObject({
-        data: { stateDisposition: "verified_backup_present" },
+        data: {
+          stateDisposition:
+            manifestVersion === 3
+              ? "verified_backup_present"
+              : "fresh_boot_no_verified_backup",
+        },
       });
+    }
+
+    await dbWrite.delete(agentSandboxBackups);
+    for (const catalogState of [
+      "primary_verified",
+      "secondary_pending",
+    ] as const) {
+      const [backup] = await dbWrite
+        .insert(agentSandboxBackups)
+        .values({
+          sandbox_record_id: RETAINED,
+          snapshot_type: "auto",
+          state_data: { memories: [], config: {}, workspaceFiles: {} },
+          catalog_version: 2,
+          catalog_state: catalogState,
+          catalog_payload_digest: "c".repeat(64),
+          catalog_organization_id: ORG_A,
+          catalog_agent_id: RETAINED,
+          manifest_version: 3,
+          manifest_digest: "d".repeat(64),
+          object_inventory_digest: "e".repeat(64),
+        })
+        .returning();
+      const preview = await post(requestBody(true));
+      expect(preview.status).toBe(200);
+      expect(await preview.json()).toMatchObject({
+        data: { stateDisposition: "fresh_boot_no_verified_backup" },
+      });
+      await dbWrite
+        .delete(agentSandboxBackups)
+        .where(eq(agentSandboxBackups.id, backup!.id));
     }
   });
 
@@ -575,6 +611,52 @@ describe("admin personal Dedicated adoption selection", () => {
         alreadySelected: true,
       },
     });
+  });
+
+  test("idempotent execute replay succeeds only against the complete unchanged inventory", async () => {
+    await seedAmbiguousInventory();
+    const fingerprint = await previewFingerprint();
+    const execute = () =>
+      personalDedicatedAdoptionSelectionService.execute({
+        organizationId: ORG_A,
+        userId: USER_A,
+        sourceAgentId: SOURCE_A,
+        retainedAgentId: RETAINED,
+        selectedByUserId: ADMIN,
+        reason: "duplicate_owned_dedicated_inventory",
+        expectedInventoryFingerprint: fingerprint,
+        expectedStateDisposition: "fresh_boot_no_verified_backup",
+      });
+
+    expect(await execute()).toMatchObject({
+      alreadySelected: false,
+      candidateCount: 2,
+    });
+    expect(await execute()).toMatchObject({
+      alreadySelected: true,
+      candidateCount: 2,
+    });
+
+    await dbWrite.insert(jobs).values({
+      type: "agent_provision",
+      status: "pending",
+      organization_id: ORG_A,
+      agent_id: RETAINED,
+      data: { agentId: RETAINED, organizationId: ORG_A },
+    });
+    await expect(execute()).rejects.toMatchObject({
+      code: "PERSONAL_DEDICATED_SELECTION_ACTIVE_JOB",
+    });
+    await dbWrite.delete(jobs);
+
+    await seedCandidate({ id: "cccccccc-3333-4333-8333-333333333333" });
+    await expect(execute()).rejects.toMatchObject({
+      code: "PERSONAL_DEDICATED_SELECTION_INVENTORY_CHANGED",
+    });
+    expect(
+      await dbWrite.select().from(personalDedicatedAdoptionSelections),
+    ).toHaveLength(1);
+    expect((await post(requestBody(true))).status).toBe(409);
   });
 
   test("an invalidated selection fails closed instead of falling back to the stale row", async () => {

--- a/packages/cloud/api/__tests__/eliza-agents-upgrade-tier.test.ts
+++ b/packages/cloud/api/__tests__/eliza-agents-upgrade-tier.test.ts
@@ -280,7 +280,9 @@ beforeAll(async () => {
         organization_id: ORG_A,
         user_id: USER_A,
         agent_name: "Already Dedicated",
-        execution_tier: "dedicated-always",
+        // A separate custom Dedicated row is not an eligible personal
+        // same-row adoption candidate and must not block Shared upgrades.
+        execution_tier: "custom",
         status: "running",
         database_status: "none",
       },
@@ -492,7 +494,7 @@ describe("POST /api/v1/eliza/agents/:agentId/upgrade-tier", () => {
     );
   });
 
-  test("normal activation cannot bypass a durable same-row selection or mint a third target", async () => {
+  test("normal activation cannot bypass selected or unselected same-row inventory", async () => {
     expect(pgliteReady).toBe(true);
     const { dbWrite } = await import("@/db/client");
     const { agentSandboxes } = await import("@/db/schemas/agent-sandboxes");
@@ -572,6 +574,14 @@ describe("POST /api/v1/eliza/agents/:agentId/upgrade-tier", () => {
     ).toHaveLength(0);
 
     await dbWrite.delete(personalDedicatedAdoptionSelections);
+    const unselectedResponse = await upgrade(SHARED_SELECTED);
+    expect(unselectedResponse.status).toBe(409);
+    expect(await unselectedResponse.json()).toMatchObject({
+      success: false,
+      code: "dedicated_adoption_selection_required",
+    });
+    expect(await dbWrite.select().from(agentSandboxes)).toEqual(before);
+
     for (const id of [SHARED_SELECTED, SELECTED_EXISTING, SELECTED_STALE]) {
       await dbWrite.delete(agentSandboxes).where(eq(agentSandboxes.id, id));
     }
@@ -931,7 +941,9 @@ describe("POST /api/v1/eliza/agents/:agentId/upgrade-tier", () => {
         organization_id: ORG_FULL,
         user_id: USER_FULL,
         agent_name: `Filler ${index + 1}`,
-        execution_tier: "dedicated-always" as const,
+        // Custom Dedicated capacity counts toward quota but is not eligible
+        // for personal same-row adoption.
+        execution_tier: "custom" as const,
         status: "running" as const,
         database_status: "none" as const,
       })),

--- a/packages/cloud/shared/src/lib/services/agent-tier-upgrade-target-lock.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-tier-upgrade-target-lock.test.ts
@@ -69,6 +69,7 @@ function makeTx(txIndex: number) {
       const state = {
         table: undefined as unknown,
         hasAuthorityJoin: false,
+        hasAuthorityLeftJoin: false,
         hasOrderBy: false,
         selectsOnlyId: selection ? Object.keys(selection).length === 1 && "id" in selection : false,
       };
@@ -79,6 +80,10 @@ function makeTx(txIndex: number) {
         },
         innerJoin: () => {
           state.hasAuthorityJoin = true;
+          return chain;
+        },
+        leftJoin: () => {
+          state.hasAuthorityLeftJoin = true;
           return chain;
         },
         where: (_clause: SQL | undefined) => chain,
@@ -98,7 +103,12 @@ function makeTx(txIndex: number) {
             return liveTargetRowsForTx(txIndex).map((agent) => ({ agent }));
           }
           if (state.table === agentSandboxes && state.selectsOnlyId) {
-            events.push({ tx: txIndex, kind: "select-quarantined-marker" });
+            events.push({
+              tx: txIndex,
+              kind: state.hasAuthorityLeftJoin
+                ? "select-adoption-candidate"
+                : "select-quarantined-marker",
+            });
             return [];
           }
           if (state.table === agentSandboxes) {
@@ -242,6 +252,7 @@ describe("tier-upgrade single-flight span (#15943)", () => {
       "select-live-target",
       "select-quarantined-marker",
       "select-adoption-selection",
+      "select-adoption-candidate",
       "select-quota-count",
     ]);
     // Global lock order: the ORG-WIDE agent-create lock is acquired FIRST
@@ -264,6 +275,7 @@ describe("tier-upgrade single-flight span (#15943)", () => {
       "select-live-target",
       "select-quarantined-marker",
       "select-adoption-selection",
+      "select-adoption-candidate",
       "select-quota-count",
       "insert-target",
       "deadline",

--- a/packages/cloud/shared/src/lib/services/agent-tier-upgrade-target.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-tier-upgrade-target.test.ts
@@ -147,7 +147,9 @@ const SRC_RACE_1 = "cccccccc-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
 const SRC_RACE_2 = "cccccccc-dddd-4ddd-8ddd-dddddddddddd";
 const SRC_RACE_CREATE = "cccccccc-eeee-4eee-8eee-eeeeeeeeeeee";
 const SRC_SELECTED = "cccccccc-f111-4f11-8f11-111111111111";
+const SRC_UNSELECTED = "cccccccc-f222-4f22-8f22-222222222222";
 const SELECTED_TARGET = "dddddddd-f111-4f11-8f11-111111111111";
+const UNSELECTED_TARGET = "dddddddd-f222-4f22-8f22-222222222222";
 const QUOTA_EXISTING = "dddddddd-1111-4111-8111-111111111111";
 
 const PGLITE_TIMEOUT = 120_000;
@@ -237,6 +239,7 @@ beforeAll(async () => {
       execution_tier: "dedicated-always",
       status: "running",
       database_status: "none",
+      agent_config: { __agentUpgradedFrom: "quota-fixture-existing-source" },
     });
 
     svc = await import("./agent-tier-upgrade-target");
@@ -295,6 +298,36 @@ async function expectNoOrphanAgentKeys() {
 }
 
 describe("createTierUpgradeTargetWithProvision — durable single-flight boundary", () => {
+  test(
+    "an unselected same-owner Dedicated row blocks the normal mint path before credential preparation",
+    async () => {
+      expect(pgliteReady).toBe(true);
+      await dbWrite.insert(agentSandboxes).values({
+        id: UNSELECTED_TARGET,
+        organization_id: ORG_A,
+        user_id: USER_A,
+        agent_name: "Unselected existing target",
+        execution_tier: "dedicated-always",
+        status: "error",
+        database_status: "ready",
+      });
+
+      const callsBefore = prepCalls;
+      await expect(
+        svc.createTierUpgradeTargetWithProvision(upgradeParams(SRC_UNSELECTED)),
+      ).rejects.toMatchObject({
+        code: "PERSONAL_DEDICATED_SELECTION_REQUIRES_ADOPTION",
+      });
+      expect(prepCalls).toBe(callsBefore);
+      expect(await targetsForSource(SRC_UNSELECTED)).toHaveLength(0);
+      expect(await jobsForAgent(UNSELECTED_TARGET)).toHaveLength(0);
+      await expectNoOrphanAgentKeys();
+
+      await dbWrite.delete(agentSandboxes).where(eq(agentSandboxes.id, UNSELECTED_TARGET));
+    },
+    PGLITE_TIMEOUT,
+  );
+
   test(
     "a durable same-row selection blocks the normal mint path before credential preparation",
     async () => {

--- a/packages/cloud/shared/src/lib/services/agent-tier-upgrade-target.ts
+++ b/packages/cloud/shared/src/lib/services/agent-tier-upgrade-target.ts
@@ -149,7 +149,7 @@ function agentConfigKeyAbsent(key: string) {
   return sql`NOT (COALESCE(${agentSandboxes.agent_config}, '{}'::jsonb) ? ${key})`;
 }
 
-export function adoptableUnmarkedTargetWhere(organizationId: string, userId: string) {
+function adoptableUnmarkedTargetBaseWhere(organizationId: string, userId: string) {
   return and(
     eq(agentSandboxes.organization_id, organizationId),
     eq(agentSandboxes.user_id, userId),
@@ -163,6 +163,12 @@ export function adoptableUnmarkedTargetWhere(organizationId: string, userId: str
     // authority itself lives in the receipt table.
     agentConfigKeyAbsent(AGENT_UPGRADED_FROM_KEY),
     agentConfigKeyAbsent(AGENT_PERSONAL_CUTOVER_KEY),
+  );
+}
+
+export function adoptableUnmarkedTargetWhere(organizationId: string, userId: string) {
+  return and(
+    adoptableUnmarkedTargetBaseWhere(organizationId, userId),
     notExists(
       dbWrite
         .select({ id: personalDedicatedUpgradeAuthorities.id })
@@ -249,6 +255,7 @@ async function selectionReceiptMatchesInventory(params: {
     params.receipt.activation_backup_chain,
   );
   if (
+    params.receipt.candidate_count !== params.candidates.length ||
     params.receipt.state_disposition !==
       personalDedicatedStateDisposition(
         params.organizationId,
@@ -321,7 +328,7 @@ export class PersonalDedicatedSelectionRequiredError extends ElizaError {
   override readonly name = "PersonalDedicatedSelectionRequiredError";
 }
 
-async function assertNoPendingAdoptionSelectionInTx(
+async function assertNoExistingAdoptionCandidateInTx(
   tx: DbTransaction,
   params: Pick<CreateTierUpgradeTargetParams, "organizationId" | "userId" | "sourceAgentId">,
 ): Promise<void> {
@@ -337,9 +344,23 @@ async function assertNoPendingAdoptionSelectionInTx(
       ),
     )
     .limit(1);
-  if (selection) {
+  const [candidate] = await tx
+    .select({ id: agentSandboxes.id })
+    .from(agentSandboxes)
+    .leftJoin(
+      personalDedicatedUpgradeAuthorities,
+      eq(personalDedicatedUpgradeAuthorities.dedicated_agent_id, agentSandboxes.id),
+    )
+    .where(
+      and(
+        adoptableUnmarkedTargetBaseWhere(params.organizationId, params.userId),
+        isNull(personalDedicatedUpgradeAuthorities.id),
+      ),
+    )
+    .limit(1);
+  if (selection || candidate) {
     throw new PersonalDedicatedSelectionRequiredError(
-      "An existing Dedicated target is selected; use the same-row adoption contract",
+      "An existing Dedicated target must use the same-row adoption contract",
       {
         code: "PERSONAL_DEDICATED_SELECTION_REQUIRES_ADOPTION",
         context: {
@@ -1746,7 +1767,7 @@ export async function createTierUpgradeTargetWithProvision(
     );
     const existing = await findLiveTargetInTx(tx, params.organizationId, params.sourceAgentId);
     if (existing) return existing;
-    await assertNoPendingAdoptionSelectionInTx(tx, params);
+    await assertNoExistingAdoptionCandidateInTx(tx, params);
     // Refuse over-quota upgrades before any credential is minted. The locked
     // insert transaction below re-asserts this authoritatively.
     await assertOrgAgentQuota(tx, params.organizationId, params.maxNonTerminalAgents);
@@ -1797,7 +1818,7 @@ export async function createTierUpgradeTargetWithProvision(
 
       const existing = await findLiveTargetInTx(tx, params.organizationId, params.sourceAgentId);
       if (existing) return { created: false as const, agent: existing };
-      await assertNoPendingAdoptionSelectionInTx(tx, params);
+      await assertNoExistingAdoptionCandidateInTx(tx, params);
 
       await assertOrgAgentQuota(tx, params.organizationId, params.maxNonTerminalAgents);
 

--- a/packages/cloud/shared/src/lib/services/personal-dedicated-adoption-provenance.ts
+++ b/packages/cloud/shared/src/lib/services/personal-dedicated-adoption-provenance.ts
@@ -1,11 +1,11 @@
 /** Non-secret, deterministic state binding for duplicate Dedicated selection. */
 
+import { hasAgentBackupRestoreAuthority } from "../../db/repositories/agent-backup-restore-authority";
 import type { AgentSandbox } from "../../db/repositories/agent-sandboxes";
 import type {
   AgentBackupCatalogState,
   StoredAgentSandboxBackup,
 } from "../../db/schemas/agent-sandboxes";
-import { catalogStateAllowsRestore } from "./agent-backup-catalog-state";
 
 export type PersonalDedicatedStateDisposition =
   | "verified_backup_present"
@@ -42,7 +42,7 @@ export interface PersonalDedicatedBackupProvenance {
   verificationStatus: string | null;
   verifiedAt: Date | null;
   catalogVersion: number | null;
-  catalogState: string | null;
+  catalogState: AgentBackupCatalogState | null;
   catalogPayloadDigest: string | null;
   catalogRevision: bigint;
   catalogOrganizationId: string | null;
@@ -200,6 +200,10 @@ function backupCreatedAtDescending(
   return right.createdAt.getTime() - left.createdAt.getTime() || right.id.localeCompare(left.id);
 }
 
+function isSha256Digest(value: string | null): value is string {
+  return value !== null && /^[a-f0-9]{64}$/.test(value);
+}
+
 function reviewedLegacyBackupChain(
   selected: PersonalDedicatedBackupProvenance,
   retainedAgentId: string,
@@ -270,19 +274,18 @@ export function personalDedicatedActivationAuthority(
         );
       }
 
-      // Catalogue v2 intentionally leaves the legacy verification columns
-      // null. Bind its exact tenant, agent, payload, manifest, and inventory
-      // authority, but do not claim legacy provisioning can restore it.
+      // Canonical catalogue restore authority is catalog-v2 + manifest-v3
+      // protected by both providers. Earlier manifests and intermediate
+      // upload/verification states are not executable restore points.
       return (
         backup.catalogVersion === 2 &&
         backup.catalogOrganizationId === organizationId &&
         backup.catalogAgentId === retainedAgentId &&
-        (backup.manifestVersion === 2 || backup.manifestVersion === 3) &&
-        backup.catalogState !== null &&
-        catalogStateAllowsRestore(backup.catalogState as AgentBackupCatalogState) &&
-        Boolean(backup.catalogPayloadDigest) &&
-        Boolean(backup.manifestDigest) &&
-        Boolean(backup.objectInventoryDigest)
+        backup.manifestVersion === 3 &&
+        hasAgentBackupRestoreAuthority(backup.catalogState) &&
+        isSha256Digest(backup.catalogPayloadDigest) &&
+        isSha256Digest(backup.manifestDigest) &&
+        isSha256Digest(backup.objectInventoryDigest)
       );
     })
     .sort(backupCreatedAtDescending);

--- a/packages/cloud/shared/src/lib/services/personal-dedicated-adoption-selection.ts
+++ b/packages/cloud/shared/src/lib/services/personal-dedicated-adoption-selection.ts
@@ -336,6 +336,7 @@ export async function previewPersonalDedicatedSelection(
       existing.activation_backup_chain,
     );
     if (
+      candidates.length !== existing.candidate_count ||
       currentFingerprint !== existing.inventory_fingerprint ||
       personalDedicatedStateDisposition(params.organizationId, retained.id, backups) !==
         existing.state_disposition ||
@@ -345,6 +346,18 @@ export async function previewPersonalDedicatedSelection(
       throw selectionError(
         "PERSONAL_DEDICATED_SELECTION_INVENTORY_CHANGED",
         "The selected Dedicated state provenance changed after review",
+        params,
+      );
+    }
+    const activeJob = await findActiveCandidateLifecycleJob(
+      dbWrite,
+      params.organizationId,
+      candidates.map((candidate) => candidate.id),
+    );
+    if (activeJob) {
+      throw selectionError(
+        "PERSONAL_DEDICATED_SELECTION_ACTIVE_JOB",
+        "The reviewed Dedicated inventory has active lifecycle work",
         params,
       );
     }
@@ -638,14 +651,23 @@ export async function executePersonalDedicatedSelection(
     });
   } catch (error) {
     // error-policy:J1 a lost commit acknowledgement is classified by a fresh
-    // exact receipt read; no cleanup is needed because no external work ran.
+    // full-inventory replay, not by receipt presence alone. No cleanup is
+    // needed because no external work ran.
     if (committed) {
-      const durable = await findSelection(params);
-      if (
-        durable?.dedicated_agent_id === params.retainedAgentId &&
-        durable.inventory_fingerprint === params.expectedInventoryFingerprint
-      ) {
-        return { ...committed, alreadySelected: true };
+      try {
+        const durable = await previewPersonalDedicatedSelection(params);
+        if (
+          durable.alreadySelected &&
+          durable.retainedAgentId === params.retainedAgentId &&
+          durable.inventoryFingerprint === params.expectedInventoryFingerprint &&
+          durable.stateDisposition === params.expectedStateDisposition &&
+          durable.candidateCount === committed.candidateCount
+        ) {
+          return durable;
+        }
+      } catch {
+        // Preserve the original ambiguous boundary rejection when fresh
+        // inventory authority cannot prove the exact committed decision.
       }
     }
     throw error;


### PR DESCRIPTION
Closes the final fail-closed gaps for same-row Personal Dedicated adoption before the Pixel demo.

- block generic Upgrade when unselected same-owner Dedicated inventory exists
- require canonical catalog-v2/manifest-v3 protected restore authority
- revalidate the full candidate/backup/job/receipt inventory on replay
- preserve Shared authority until same-row adoption completes

Gates:
- 213/213 focused real-DB, route, restore, worker, migration, and account-deletion tests (1,402 assertions)
- Cloud shared typecheck
- Cloud API typecheck + production Wrangler dry bundle
- exact Biome on touched paths
- git diff --check

Tracking: #29024

@lalalune for visibility. No deploy, provisioning, row creation, or spend is performed by this PR.