### PR TITLE
fix(cloud): serialize exact backup operation lanes

### DIFF
--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-catalog-postgres.integration.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-catalog-postgres.integration.test.ts
@@ -50,11 +50,10 @@ interface TenantFixture {
   readonly organizationId: string;
   readonly userId: string;
   readonly agentId: string;
-  readonly nodeHistoryId: string;
+  readonly nodeHistoryId?: string;
   readonly nodeRecordId: string;
   readonly nodeId: string;
   readonly nodeIncarnation: string;
-  readonly nodeId: string;
   readonly providerHandle: string;
 }
 
@@ -64,7 +63,6 @@ const TENANT_A = {
   agentId: "30000000-0000-4000-8000-000000000201",
   nodeHistoryId: "41000000-0000-4000-8000-000000000201",
   nodeRecordId: "40000000-0000-4000-8000-000000000201",
-  nodeId: "backup-catalogue-tenant-a-node",
   nodeIncarnation: "50000000-0000-4000-8000-000000000201",
   nodeId: "backup-catalogue-tenant-a-node",
   providerHandle: "backup-catalogue-tenant-a-container",
@@ -84,7 +82,6 @@ const TENANT_B = {
   agentId: "30000000-0000-4000-8000-000000000202",
   nodeHistoryId: "41000000-0000-4000-8000-000000000202",
   nodeRecordId: "40000000-0000-4000-8000-000000000202",
-  nodeId: "backup-catalogue-tenant-b-node",
   nodeIncarnation: "50000000-0000-4000-8000-000000000202",
   nodeId: "backup-catalogue-tenant-b-node",
   providerHandle: "backup-catalogue-tenant-b-container",
@@ -380,6 +377,7 @@ async function expectDatabaseCause(
 
 async function seedSourceAuthority(tenant: TenantFixture): Promise<void> {
   if (!dbWrite) throw new Error("Real PostgreSQL harness was not initialized");
+  if (!tenant.nodeHistoryId) throw new Error("Source authority fixture requires a history ID");
   const hostKeyFingerprint = `sha256:${tenant.nodeId}`;
   await dbWrite.insert(agentNodeIncarnationHistories).values({
     id: tenant.nodeHistoryId,

--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-catalog-postgres.integration.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-catalog-postgres.integration.test.ts
@@ -15,6 +15,10 @@ import {
   type EphemeralPostgres,
 } from "../../../lib/services/tenant-db/__tests__/ephemeral-postgres";
 import { sqlRows } from "../../execute-helpers";
+import {
+  agentBackupNodeAdmissionCursors,
+  agentBackupOrganizationAdmissionCursors,
+} from "../../schemas/agent-backup-admission";
 import { agentNodeIncarnationHistories } from "../../schemas/agent-node-incarnation-histories";
 import {
   agentBackupCatalogAuthorities,
@@ -50,6 +54,8 @@ interface TenantFixture {
   readonly nodeRecordId: string;
   readonly nodeId: string;
   readonly nodeIncarnation: string;
+  readonly nodeId: string;
+  readonly providerHandle: string;
 }
 
 const TENANT_A = {
@@ -60,6 +66,17 @@ const TENANT_A = {
   nodeRecordId: "40000000-0000-4000-8000-000000000201",
   nodeId: "backup-catalogue-tenant-a-node",
   nodeIncarnation: "50000000-0000-4000-8000-000000000201",
+  nodeId: "backup-catalogue-tenant-a-node",
+  providerHandle: "backup-catalogue-tenant-a-container",
+} as const satisfies TenantFixture;
+const TENANT_A2 = {
+  organizationId: TENANT_A.organizationId,
+  userId: TENANT_A.userId,
+  agentId: "30000000-0000-4000-8000-000000000204",
+  nodeRecordId: "40000000-0000-4000-8000-000000000204",
+  nodeIncarnation: "50000000-0000-4000-8000-000000000204",
+  nodeId: "backup-catalogue-tenant-a-second-node",
+  providerHandle: "backup-catalogue-tenant-a-second-container",
 } as const satisfies TenantFixture;
 const TENANT_B = {
   organizationId: "10000000-0000-4000-8000-000000000202",
@@ -69,10 +86,23 @@ const TENANT_B = {
   nodeRecordId: "40000000-0000-4000-8000-000000000202",
   nodeId: "backup-catalogue-tenant-b-node",
   nodeIncarnation: "50000000-0000-4000-8000-000000000202",
+  nodeId: "backup-catalogue-tenant-b-node",
+  providerHandle: "backup-catalogue-tenant-b-container",
+} as const satisfies TenantFixture;
+const TENANT_C = {
+  organizationId: "10000000-0000-4000-8000-000000000203",
+  userId: "20000000-0000-4000-8000-000000000203",
+  agentId: "30000000-0000-4000-8000-000000000203",
+  nodeRecordId: TENANT_A.nodeRecordId,
+  nodeIncarnation: TENANT_A.nodeIncarnation,
+  nodeId: TENANT_A.nodeId,
+  providerHandle: "backup-catalogue-tenant-c-container",
 } as const satisfies TenantFixture;
 const OPERATION_A1 = "60000000-0000-4000-8000-000000000201";
 const OPERATION_A2 = "60000000-0000-4000-8000-000000000202";
 const OPERATION_B1 = "60000000-0000-4000-8000-000000000203";
+const OPERATION_C1 = "60000000-0000-4000-8000-000000000204";
+const ROTATED_NODE_INCARNATION = "50000000-0000-4000-8000-000000000299";
 const OWNER_A = "backup-catalogue-postgres-worker-a";
 const OWNER_B = "backup-catalogue-postgres-worker-b";
 const PAYLOAD_DIGEST = "a".repeat(64);
@@ -335,6 +365,19 @@ async function settleTeardown(
   }
 }
 
+async function expectDatabaseCause(
+  operation: PromiseLike<unknown>,
+  expectedFragment: string,
+): Promise<void> {
+  try {
+    await operation;
+    throw new Error("Expected database operation to fail");
+  } catch (error) {
+    const cause = error instanceof Error && "cause" in error ? error.cause : error;
+    expect(String(cause)).toContain(expectedFragment);
+  }
+}
+
 async function seedSourceAuthority(tenant: TenantFixture): Promise<void> {
   if (!dbWrite) throw new Error("Real PostgreSQL harness was not initialized");
   const hostKeyFingerprint = `sha256:${tenant.nodeId}`;
@@ -364,16 +407,45 @@ async function seedSourceAuthority(tenant: TenantFixture): Promise<void> {
 
 async function seedTenant(tenant: TenantFixture, suffix: string): Promise<void> {
   if (!dbWrite) throw new Error("Real PostgreSQL harness was not initialized");
-  await dbWrite.insert(organizations).values({
-    id: tenant.organizationId,
-    name: `Backup catalogue ${suffix}`,
-    slug: `backup-catalogue-${suffix}`,
-  });
-  await dbWrite.insert(users).values({
-    id: tenant.userId,
-    organization_id: tenant.organizationId,
-    steward_user_id: `backup-catalogue-${suffix}-user`,
-  });
+  await dbWrite
+    .insert(organizations)
+    .values({
+      id: tenant.organizationId,
+      name: `Backup catalogue ${suffix}`,
+      slug: `backup-catalogue-${suffix}`,
+    })
+    .onConflictDoNothing();
+  await dbWrite
+    .insert(users)
+    .values({
+      id: tenant.userId,
+      organization_id: tenant.organizationId,
+      steward_user_id: `backup-catalogue-${suffix}-user`,
+    })
+    .onConflictDoNothing();
+  await dbWrite
+    .insert(dockerNodes)
+    .values({
+      id: tenant.nodeRecordId,
+      node_id: tenant.nodeId,
+      hostname: `${tenant.nodeId}.example.test`,
+      host_key_fingerprint: `sha256:${tenant.nodeId}-host-key`,
+      fleet_kind: "robot",
+      infrastructure_provider: "hetzner",
+      node_incarnation: tenant.nodeIncarnation,
+      status: "healthy",
+      enabled: true,
+    })
+    .onConflictDoNothing();
+  const nodeHistoryId = await requireCurrentNodeHistoryId(tenant);
+  await dbWrite
+    .insert(agentBackupOrganizationAdmissionCursors)
+    .values({ organization_id: tenant.organizationId })
+    .onConflictDoNothing();
+  await dbWrite
+    .insert(agentBackupNodeAdmissionCursors)
+    .values({ node_history_id: nodeHistoryId })
+    .onConflictDoNothing();
   await dbWrite.insert(agentSandboxes).values({
     id: tenant.agentId,
     organization_id: tenant.organizationId,
@@ -381,12 +453,25 @@ async function seedTenant(tenant: TenantFixture, suffix: string): Promise<void> 
     agent_name: `Backup catalogue ${suffix} agent`,
     status: "running",
     execution_tier: "dedicated-always",
-    sandbox_id: `backup-catalogue-${suffix}-container`,
+    sandbox_id: tenant.providerHandle,
+    node_id: tenant.nodeId,
   });
   await dbWrite.insert(agentBackupCatalogAuthorities).values({
     organization_id: tenant.organizationId,
     agent_id: tenant.agentId,
   });
+}
+
+async function requireCurrentNodeHistoryId(tenant: TenantFixture): Promise<string> {
+  if (!dbWrite) throw new Error("Real PostgreSQL harness was not initialized");
+  const [node] = await dbWrite
+    .select({ historyId: dockerNodes.current_node_history_id })
+    .from(dockerNodes)
+    .where(eq(dockerNodes.id, tenant.nodeRecordId));
+  if (!node?.historyId) {
+    throw new Error(`Missing exact node occurrence fixture for ${tenant.nodeRecordId}`);
+  }
+  return node.historyId;
 }
 
 async function seedBackup(params: {
@@ -397,6 +482,7 @@ async function seedBackup(params: {
 }): Promise<string> {
   if (!dbWrite) throw new Error("Real PostgreSQL harness was not initialized");
   const id = randomUUID();
+  const nodeHistoryId = await requireCurrentNodeHistoryId(params.tenant);
   await dbWrite.insert(agentSandboxBackups).values({
     id,
     sandbox_record_id: params.tenant.agentId,
@@ -418,8 +504,9 @@ async function seedBackup(params: {
     source_node_record_id: params.tenant.nodeRecordId,
     source_node_id: params.tenant.nodeId,
     source_node_incarnation: params.tenant.nodeIncarnation,
+    source_node_history_id: nodeHistoryId,
     source_provider_server_id: null,
-    source_provider_handle: `backup-catalogue-${params.suffix}-container`,
+    source_provider_handle: params.tenant.providerHandle,
     source_container_id: CONTAINER_ID,
     retention_reason: "schedule",
     retention_until: new Date("2027-08-26T00:00:00.000Z"),
@@ -432,15 +519,16 @@ async function seedBackup(params: {
 async function installBackupMutationGuardForTests(): Promise<void> {
   if (!dbWrite) throw new Error("Real PostgreSQL harness was not initialized");
   await dbWrite.execute(sql`
-    CREATE OR REPLACE FUNCTION lock_backup_claim_sandbox_for_test()
+    CREATE OR REPLACE FUNCTION lock_backup_claim_gate_for_test()
     RETURNS trigger
     LANGUAGE plpgsql
     AS $guard$
     BEGIN
-      IF NEW.sandbox_record_id IS NOT NULL THEN
+      IF NEW.catalog_organization_id IS NOT NULL AND NEW.catalog_agent_id IS NOT NULL THEN
         PERFORM 1
-        FROM agent_sandboxes
-        WHERE id = NEW.sandbox_record_id
+        FROM agent_backup_catalog_authorities
+        WHERE organization_id = NEW.catalog_organization_id
+          AND agent_id = NEW.catalog_agent_id
         FOR KEY SHARE;
       END IF;
       RETURN NEW;
@@ -450,7 +538,7 @@ async function installBackupMutationGuardForTests(): Promise<void> {
   await dbWrite.execute(sql`
     CREATE TRIGGER agent_sandbox_backups_claim_guard_test
     BEFORE UPDATE ON agent_sandbox_backups
-    FOR EACH ROW EXECUTE FUNCTION lock_backup_claim_sandbox_for_test()
+    FOR EACH ROW EXECUTE FUNCTION lock_backup_claim_gate_for_test()
   `);
 }
 
@@ -498,13 +586,19 @@ realPostgres("canonical backup catalogue contention", () => {
   beforeEach(async () => {
     if (!dbWrite) throw new Error("Real PostgreSQL harness was not initialized");
     await dbWrite.delete(agentSandboxBackups);
+    await dbWrite.delete(agentBackupNodeAdmissionCursors);
+    await dbWrite.delete(agentBackupOrganizationAdmissionCursors);
     await dbWrite.delete(agentBackupCatalogAuthorities);
     await dbWrite.delete(agentSandboxes);
+    await dbWrite.delete(dockerNodes);
+    await dbWrite.delete(agentNodeIncarnationHistories);
     await dbWrite.delete(userCharacters);
     await dbWrite.delete(users);
     await dbWrite.delete(organizations);
     await seedTenant(TENANT_A, "tenant-a");
+    await seedTenant(TENANT_A2, "tenant-a-second-lane");
     await seedTenant(TENANT_B, "tenant-b");
+    await seedTenant(TENANT_C, "tenant-c");
   });
 
   test("retires only the protocol guard after the admission migration", async () => {
@@ -674,7 +768,7 @@ realPostgres("canonical backup catalogue contention", () => {
     });
   });
 
-  test("serves another tenant while preserving one-operation-per-tenant admission", async () => {
+  test("serves an independent lane without bypassing a blocked tenant or exact node", async () => {
     if (!isolatedDsn || !dbWrite || !catalogRepository) {
       throw new Error("Real PostgreSQL harness was not initialized");
     }
@@ -685,76 +779,77 @@ realPostgres("canonical backup catalogue contention", () => {
       dueAt: new Date("2020-01-01T00:00:00.000Z"),
     });
     const secondA = await seedBackup({
-      tenant: TENANT_A,
+      tenant: TENANT_A2,
       suffix: "tenant-a-second",
       operationId: OPERATION_A2,
       dueAt: new Date("2020-01-02T00:00:00.000Z"),
+    });
+    const firstC = await seedBackup({
+      tenant: TENANT_C,
+      suffix: "tenant-c-first",
+      operationId: OPERATION_C1,
+      dueAt: new Date("2020-01-03T00:00:00.000Z"),
     });
     const firstB = await seedBackup({
       tenant: TENANT_B,
       suffix: "tenant-b-first",
       operationId: OPERATION_B1,
-      dueAt: new Date("2020-01-03T00:00:00.000Z"),
+      dueAt: new Date("2020-01-04T00:00:00.000Z"),
     });
     const holder = new Client({
       connectionString: isolatedDsn,
       application_name: "backup-catalogue-contention-holder",
     });
-    const observer = new Client({
-      connectionString: isolatedDsn,
-      application_name: "backup-catalogue-contention-observer",
-    });
-    await Promise.all([holder.connect(), observer.connect()]);
+    await holder.connect();
     let holderOpen = false;
-    let firstClaimPromise: ReturnType<CatalogRepository["claimDueAgentBackupOperations"]> | null =
-      null;
-    let secondClaimPromise: ReturnType<CatalogRepository["claimDueAgentBackupOperations"]> | null =
-      null;
     let primaryFailure: { error: unknown } | null = null;
     try {
       await holder.query("BEGIN");
       holderOpen = true;
-      const holderPid = Number(
-        (await holder.query<{ pid: number }>("SELECT pg_backend_pid() AS pid")).rows[0]?.pid,
-      );
-      await holder.query("SELECT id FROM agent_sandboxes WHERE id = $1 FOR UPDATE", [
-        TENANT_A.agentId,
-      ]);
-      firstClaimPromise = catalogRepository.claimDueAgentBackupOperations({
-        ownerId: OWNER_A,
-        limit: 1,
-        leaseMs: 60_000,
-      });
-      await waitForRepositoryLockWaiters(observer, holderPid, 1);
+      await holder.query("SELECT id FROM agent_sandbox_backups WHERE id = $1 FOR UPDATE", [firstA]);
 
-      secondClaimPromise = catalogRepository.claimDueAgentBackupOperations({
-        ownerId: OWNER_B,
-        limit: 1,
-        leaseMs: 60_000,
-      });
-      const secondClaims = await resolveWithin(
-        secondClaimPromise,
+      const independentClaims = await resolveWithin(
+        catalogRepository.claimDueAgentBackupOperations({
+          ownerId: OWNER_B,
+          limit: 4,
+          leaseMs: 60_000,
+        }),
         5_000,
-        "Tenant B did not progress while tenant A remained trigger-blocked",
+        "Independent tenant B did not progress while the A1 head remained locked",
       );
-      expect(secondClaims).toHaveLength(1);
-      expect(secondClaims[0]?.backup.id).toBe(firstB);
-      await waitForRepositoryLockWaiters(observer, holderPid, 1);
+      expect(independentClaims).toHaveLength(1);
+      expect(independentClaims[0]?.backup.id).toBe(firstB);
+      expect(
+        await catalogRepository.claimDueAgentBackupOperations({
+          ownerId: "backup-catalogue-postgres-locked-head-observer",
+          limit: 4,
+          leaseMs: 60_000,
+        }),
+      ).toEqual([]);
 
       await holder.query("COMMIT");
       holderOpen = false;
 
-      const firstClaims = await firstClaimPromise;
-      firstClaimPromise = null;
-      secondClaimPromise = null;
-      expect(firstClaims).toHaveLength(1);
-      expect(firstClaims[0]?.backup.id).toBe(firstA);
-      const claimed = [...firstClaims, ...secondClaims];
+      const headClaims = await catalogRepository.claimDueAgentBackupOperations({
+        ownerId: OWNER_A,
+        limit: 1,
+        leaseMs: 60_000,
+      });
+      expect(headClaims).toHaveLength(1);
+      expect(headClaims[0]?.backup.id).toBe(firstA);
+      const claimed = [...headClaims, ...independentClaims];
       expect(claimed).toHaveLength(2);
       expect(new Set(claimed.map((claim) => claim.backup.id))).toEqual(new Set([firstA, firstB]));
       expect(new Set(claimed.map((claim) => claim.backup.catalog_organization_id))).toEqual(
         new Set([TENANT_A.organizationId, TENANT_B.organizationId]),
       );
+      expect(
+        await catalogRepository.claimDueAgentBackupOperations({
+          ownerId: "backup-catalogue-postgres-worker-c",
+          limit: 3,
+          leaseMs: 60_000,
+        }),
+      ).toEqual([]);
 
       const rows = await dbWrite
         .select({
@@ -766,8 +861,44 @@ realPostgres("canonical backup catalogue contention", () => {
       expect(rows).toEqual([
         { id: firstA, leaseOwner: expect.any(String) },
         { id: secondA, leaseOwner: null },
+        { id: firstC, leaseOwner: null },
         { id: firstB, leaseOwner: expect.any(String) },
       ]);
+      const organizationsWithCursors = await dbWrite
+        .select({
+          id: agentBackupOrganizationAdmissionCursors.organization_id,
+          cursorAt: agentBackupOrganizationAdmissionCursors.cursor_at,
+        })
+        .from(agentBackupOrganizationAdmissionCursors)
+        .orderBy(asc(agentBackupOrganizationAdmissionCursors.organization_id));
+      const organizationCursorById = new Map(
+        organizationsWithCursors.map((row) => [row.id, row.cursorAt]),
+      );
+      const tenantACursor = organizationCursorById.get(TENANT_A.organizationId);
+      const tenantBCursor = organizationCursorById.get(TENANT_B.organizationId);
+      expect(organizationsWithCursors).toHaveLength(3);
+      expect(tenantACursor).toBeInstanceOf(Date);
+      expect(tenantBCursor).toBeInstanceOf(Date);
+      expect(organizationCursorById.get(TENANT_C.organizationId)).toBeNull();
+      if (!tenantACursor || !tenantBCursor) throw new Error("Expected advanced tenant cursors");
+      expect(tenantACursor.getTime()).toBeGreaterThan(tenantBCursor.getTime());
+
+      const tenantAHistoryId = await requireCurrentNodeHistoryId(TENANT_A);
+      const tenantA2HistoryId = await requireCurrentNodeHistoryId(TENANT_A2);
+      const tenantBHistoryId = await requireCurrentNodeHistoryId(TENANT_B);
+      const nodesWithCursors = await dbWrite
+        .select({
+          historyId: agentBackupNodeAdmissionCursors.node_history_id,
+          cursorAt: agentBackupNodeAdmissionCursors.cursor_at,
+        })
+        .from(agentBackupNodeAdmissionCursors);
+      const nodeCursorByHistoryId = new Map(
+        nodesWithCursors.map((row) => [row.historyId, row.cursorAt]),
+      );
+      expect(nodesWithCursors).toHaveLength(3);
+      expect(nodeCursorByHistoryId.get(tenantAHistoryId)).toEqual(tenantACursor);
+      expect(nodeCursorByHistoryId.get(tenantA2HistoryId)).toBeNull();
+      expect(nodeCursorByHistoryId.get(tenantBHistoryId)).toEqual(tenantBCursor);
     } catch (error) {
       // error-policy:J2 context-adding rethrow — retain the primary assertion
       // so ordered teardown can aggregate cleanup failures without replacing it.
@@ -777,38 +908,13 @@ realPostgres("canonical backup catalogue contention", () => {
         holderOpen
           ? [{ label: "rollback claim contention holder", run: () => holder.query("ROLLBACK") }]
           : [],
-        [
-          ...(firstClaimPromise
-            ? [
-                {
-                  label: "settle tenant A claim",
-                  run: async () => {
-                    await firstClaimPromise;
-                  },
-                },
-              ]
-            : []),
-          ...(secondClaimPromise
-            ? [
-                {
-                  label: "settle tenant B claim",
-                  run: async () => {
-                    await secondClaimPromise;
-                  },
-                },
-              ]
-            : []),
-        ],
-        [
-          { label: "close claim contention holder", run: () => holder.end() },
-          { label: "close claim contention observer", run: () => observer.end() },
-        ],
+        [{ label: "close claim contention holder", run: () => holder.end() }],
       ]);
     }
   }, 60_000);
 
-  test("starts a claim lease from post-trigger database time", async () => {
-    if (!isolatedDsn || !catalogRepository) {
+  test("starts a claim lease and both cursors from post-trigger database time", async () => {
+    if (!isolatedDsn || !dbWrite || !catalogRepository) {
       throw new Error("Real PostgreSQL harness was not initialized");
     }
     await seedBackup({
@@ -817,6 +923,7 @@ realPostgres("canonical backup catalogue contention", () => {
       operationId: OPERATION_A1,
       dueAt: new Date("2020-01-01T00:00:00.000Z"),
     });
+    const nodeHistoryId = await requireCurrentNodeHistoryId(TENANT_A);
     const holder = new Client({
       connectionString: isolatedDsn,
       application_name: "backup-catalogue-clock-holder",
@@ -835,9 +942,13 @@ realPostgres("canonical backup catalogue contention", () => {
       const holderPid = Number(
         (await holder.query<{ pid: number }>("SELECT pg_backend_pid() AS pid")).rows[0]?.pid,
       );
-      await holder.query("SELECT id FROM agent_sandboxes WHERE id = $1 FOR UPDATE", [
-        TENANT_A.agentId,
-      ]);
+      await holder.query(
+        `SELECT organization_id
+         FROM agent_backup_catalog_authorities
+         WHERE organization_id = $1 AND agent_id = $2
+         FOR UPDATE`,
+        [TENANT_A.organizationId, TENANT_A.agentId],
+      );
       claimPromise = catalogRepository.claimDueAgentBackupOperations({
         ownerId: OWNER_A,
         limit: 1,
@@ -861,6 +972,24 @@ realPostgres("canonical backup catalogue contention", () => {
       expect(
         claim.backup.catalog_lease_expires_at.getTime() - claim.backup.catalog_updated_at.getTime(),
       ).toBe(60_000);
+      const [organization] = await dbWrite
+        .select({ cursorAt: agentBackupOrganizationAdmissionCursors.cursor_at })
+        .from(agentBackupOrganizationAdmissionCursors)
+        .where(
+          eq(agentBackupOrganizationAdmissionCursors.organization_id, TENANT_A.organizationId),
+        );
+      const [node] = await dbWrite
+        .select({ cursorAt: agentBackupNodeAdmissionCursors.cursor_at })
+        .from(agentBackupNodeAdmissionCursors)
+        .where(eq(agentBackupNodeAdmissionCursors.node_history_id, nodeHistoryId));
+      expect(organization?.cursorAt).toBeInstanceOf(Date);
+      expect(node?.cursorAt).toEqual(organization?.cursorAt);
+      expect(organization?.cursorAt?.getTime()).toBeGreaterThan(
+        staleTransactionThreshold.getTime(),
+      );
+      expect(organization?.cursorAt?.getTime()).toBeLessThanOrEqual(
+        claim.backup.catalog_updated_at.getTime(),
+      );
     } catch (error) {
       // error-policy:J2 context-adding rethrow — preserve the assertion while
       // ordered teardown records any independent cleanup failure.
@@ -887,6 +1016,174 @@ realPostgres("canonical backup catalogue contention", () => {
       ]);
     }
   }, 60_000);
+
+  test("keeps a waiting claim bound to its append-only occurrence when the node rotates", async () => {
+    if (!isolatedDsn || !dbWrite || !catalogRepository) {
+      throw new Error("Real PostgreSQL harness was not initialized");
+    }
+    const backupId = await seedBackup({
+      tenant: TENANT_A,
+      suffix: "node-rotation",
+      operationId: OPERATION_A1,
+      dueAt: new Date("2020-01-01T00:00:00.000Z"),
+    });
+    const originalNodeHistoryId = await requireCurrentNodeHistoryId(TENANT_A);
+    const holder = new Client({
+      connectionString: isolatedDsn,
+      application_name: "backup-catalogue-node-rotation-holder",
+    });
+    const observer = new Client({
+      connectionString: isolatedDsn,
+      application_name: "backup-catalogue-node-rotation-observer",
+    });
+    await Promise.all([holder.connect(), observer.connect()]);
+    let holderOpen = false;
+    let claimPromise: ReturnType<CatalogRepository["claimDueAgentBackupOperations"]> | null = null;
+    let primaryFailure: { error: unknown } | null = null;
+    try {
+      await holder.query("BEGIN");
+      holderOpen = true;
+      const holderPid = Number(
+        (await holder.query<{ pid: number }>("SELECT pg_backend_pid() AS pid")).rows[0]?.pid,
+      );
+      await holder.query(
+        `SELECT organization_id
+         FROM agent_backup_catalog_authorities
+         WHERE organization_id = $1 AND agent_id = $2
+         FOR UPDATE`,
+        [TENANT_A.organizationId, TENANT_A.agentId],
+      );
+      claimPromise = catalogRepository.claimDueAgentBackupOperations({
+        ownerId: "backup-catalogue-node-rotation-worker",
+        limit: 1,
+        leaseMs: 60_000,
+      });
+      await waitForRepositoryLockWaiters(observer, holderPid, 1);
+      const [rotated] = await dbWrite
+        .update(dockerNodes)
+        .set({ node_incarnation: ROTATED_NODE_INCARNATION })
+        .where(eq(dockerNodes.id, TENANT_A.nodeRecordId))
+        .returning({ incarnation: dockerNodes.node_incarnation });
+      expect(rotated?.incarnation).toBe(ROTATED_NODE_INCARNATION);
+      const rotatedNodeHistoryId = await requireCurrentNodeHistoryId(TENANT_A);
+      expect(rotatedNodeHistoryId).not.toBe(originalNodeHistoryId);
+      await holder.query("COMMIT");
+      holderOpen = false;
+
+      const [claim] = await claimPromise;
+      claimPromise = null;
+      expect(claim?.backup.id).toBe(backupId);
+      const [backup] = await dbWrite
+        .select({
+          owner: agentSandboxBackups.catalog_lease_owner,
+          generation: agentSandboxBackups.catalog_lease_generation,
+          expiresAt: agentSandboxBackups.catalog_lease_expires_at,
+          nodeHistoryId: agentSandboxBackups.source_node_history_id,
+        })
+        .from(agentSandboxBackups)
+        .where(eq(agentSandboxBackups.id, backupId));
+      const [organization] = await dbWrite
+        .select({ cursorAt: agentBackupOrganizationAdmissionCursors.cursor_at })
+        .from(agentBackupOrganizationAdmissionCursors)
+        .where(
+          eq(agentBackupOrganizationAdmissionCursors.organization_id, TENANT_A.organizationId),
+        );
+      const [originalNodeCursor] = await dbWrite
+        .select({ cursorAt: agentBackupNodeAdmissionCursors.cursor_at })
+        .from(agentBackupNodeAdmissionCursors)
+        .where(eq(agentBackupNodeAdmissionCursors.node_history_id, originalNodeHistoryId));
+      const [rotatedNodeCursor] = await dbWrite
+        .select({ cursorAt: agentBackupNodeAdmissionCursors.cursor_at })
+        .from(agentBackupNodeAdmissionCursors)
+        .where(eq(agentBackupNodeAdmissionCursors.node_history_id, rotatedNodeHistoryId));
+      const [node] = await dbWrite
+        .select({
+          incarnation: dockerNodes.node_incarnation,
+          historyId: dockerNodes.current_node_history_id,
+        })
+        .from(dockerNodes)
+        .where(eq(dockerNodes.id, TENANT_A.nodeRecordId));
+      expect(backup).toEqual({
+        owner: "backup-catalogue-node-rotation-worker",
+        generation: expect.any(String),
+        expiresAt: expect.any(Date),
+        nodeHistoryId: originalNodeHistoryId,
+      });
+      expect(organization?.cursorAt).toBeInstanceOf(Date);
+      expect(originalNodeCursor?.cursorAt).toEqual(organization?.cursorAt);
+      expect(rotatedNodeCursor).toBeUndefined();
+      expect(node).toEqual({
+        incarnation: ROTATED_NODE_INCARNATION,
+        historyId: rotatedNodeHistoryId,
+      });
+    } catch (error) {
+      // error-policy:J2 context-adding rethrow — preserve the assertion while
+      // ordered teardown records any independent cleanup failure.
+      primaryFailure = { error };
+    } finally {
+      await settleTeardown(primaryFailure, [
+        holderOpen
+          ? [{ label: "rollback node rotation holder", run: () => holder.query("ROLLBACK") }]
+          : [],
+        claimPromise
+          ? [
+              {
+                label: "settle node rotation claim",
+                run: async () => {
+                  await claimPromise;
+                },
+              },
+            ]
+          : [],
+        [
+          { label: "close node rotation holder", run: () => holder.end() },
+          { label: "close node rotation observer", run: () => observer.end() },
+        ],
+      ]);
+    }
+  }, 60_000);
+
+  test("rejects nulling or swapping a reserved source occurrence", async () => {
+    if (!dbWrite) throw new Error("Real PostgreSQL harness was not initialized");
+    const backupId = await seedBackup({
+      tenant: TENANT_A,
+      suffix: "immutable-occurrence",
+      operationId: OPERATION_A1,
+      dueAt: new Date("2020-01-01T00:00:00.000Z"),
+    });
+    const originalNodeHistoryId = await requireCurrentNodeHistoryId(TENANT_A);
+    await dbWrite
+      .update(dockerNodes)
+      .set({ node_incarnation: ROTATED_NODE_INCARNATION })
+      .where(eq(dockerNodes.id, TENANT_A.nodeRecordId));
+    await dbWrite
+      .update(dockerNodes)
+      .set({ node_incarnation: TENANT_A.nodeIncarnation })
+      .where(eq(dockerNodes.id, TENANT_A.nodeRecordId));
+    const replacementNodeHistoryId = await requireCurrentNodeHistoryId(TENANT_A);
+    expect(replacementNodeHistoryId).not.toBe(originalNodeHistoryId);
+
+    await expectDatabaseCause(
+      dbWrite
+        .update(agentSandboxBackups)
+        .set({ source_node_history_id: null })
+        .where(eq(agentSandboxBackups.id, backupId)),
+      "catalog v2 backup admission identity is immutable",
+    );
+    await expectDatabaseCause(
+      dbWrite
+        .update(agentSandboxBackups)
+        .set({ source_node_history_id: replacementNodeHistoryId })
+        .where(eq(agentSandboxBackups.id, backupId)),
+      "catalog v2 backup admission identity is immutable",
+    );
+
+    const [persisted] = await dbWrite
+      .select({ nodeHistoryId: agentSandboxBackups.source_node_history_id })
+      .from(agentSandboxBackups)
+      .where(eq(agentSandboxBackups.id, backupId));
+    expect(persisted?.nodeHistoryId).toBe(originalNodeHistoryId);
+  });
 
   test("renews a heartbeat lease from post-trigger database time", async () => {
     if (!isolatedDsn || !dbWrite || !catalogRepository) {
@@ -924,18 +1221,24 @@ realPostgres("canonical backup catalogue contention", () => {
       const holderPid = Number(
         (await holder.query<{ pid: number }>("SELECT pg_backend_pid() AS pid")).rows[0]?.pid,
       );
-      await holder.query("SELECT id FROM agent_sandboxes WHERE id = $1 FOR UPDATE", [
-        TENANT_A.agentId,
-      ]);
+      await holder.query(
+        `SELECT organization_id
+         FROM agent_backup_catalog_authorities
+         WHERE organization_id = $1 AND agent_id = $2
+         FOR UPDATE`,
+        [TENANT_A.organizationId, TENANT_A.agentId],
+      );
       heartbeatPromise = catalogRepository.heartbeatAgentBackupOperation({
         organizationId: TENANT_A.organizationId,
         backupId,
         execution: { ownerId: claim.ownerId, generation: claim.generation },
         leaseMs: 60_000,
       });
-      const [waiter] = await waitForRepositoryLockWaiters(observer, holderPid, 1);
-      if (!waiter) throw new Error("Expected one blocked backup catalogue heartbeat");
-      const staleTransactionThreshold = new Date(waiter.transactionStartedAt.getTime() + 200);
+      const [heartbeatWaiter] = await waitForRepositoryLockWaiters(observer, holderPid, 1);
+      if (!heartbeatWaiter) throw new Error("Expected one blocked backup catalogue heartbeat");
+      const staleTransactionThreshold = new Date(
+        heartbeatWaiter.transactionStartedAt.getTime() + 200,
+      );
       await waitForDatabaseTimeAfter(observer, staleTransactionThreshold);
       await holder.query("COMMIT");
       holderOpen = false;
@@ -996,7 +1299,7 @@ realPostgres("canonical backup catalogue contention", () => {
     }
   }, 60_000);
 
-  test("does not resurrect a heartbeat lease that expires during trigger contention", async () => {
+  test("prevents an expiring heartbeat from overlapping either capture lane", async () => {
     if (!isolatedDsn || !dbWrite || !catalogRepository) {
       throw new Error("Real PostgreSQL harness was not initialized");
     }
@@ -1005,6 +1308,18 @@ realPostgres("canonical backup catalogue contention", () => {
       suffix: "heartbeat-expiry",
       operationId: OPERATION_A1,
       dueAt: new Date("2020-01-01T00:00:00.000Z"),
+    });
+    const sameOrganizationBackupId = await seedBackup({
+      tenant: TENANT_A2,
+      suffix: "heartbeat-expiry-same-organization",
+      operationId: OPERATION_A2,
+      dueAt: new Date("2020-01-02T00:00:00.000Z"),
+    });
+    const sameNodeBackupId = await seedBackup({
+      tenant: TENANT_C,
+      suffix: "heartbeat-expiry-same-node",
+      operationId: OPERATION_C1,
+      dueAt: new Date("2020-01-03T00:00:00.000Z"),
     });
     const holder = new Client({
       connectionString: isolatedDsn,
@@ -1029,24 +1344,64 @@ realPostgres("canonical backup catalogue contention", () => {
     let heartbeatPromise: ReturnType<CatalogRepository["heartbeatAgentBackupOperation"]> | null =
       null;
     let primaryFailure: { error: unknown } | null = null;
+    let competingClaimPromise: ReturnType<
+      CatalogRepository["claimDueAgentBackupOperations"]
+    > | null = null;
     try {
       await holder.query("BEGIN");
       holderOpen = true;
       const holderPid = Number(
         (await holder.query<{ pid: number }>("SELECT pg_backend_pid() AS pid")).rows[0]?.pid,
       );
-      await holder.query("SELECT id FROM agent_sandboxes WHERE id = $1 FOR UPDATE", [
-        TENANT_A.agentId,
-      ]);
+      await holder.query(
+        `SELECT organization_id
+         FROM agent_backup_catalog_authorities
+         WHERE organization_id = $1 AND agent_id = $2
+         FOR UPDATE`,
+        [TENANT_A.organizationId, TENANT_A.agentId],
+      );
       heartbeatPromise = catalogRepository.heartbeatAgentBackupOperation({
         organizationId: TENANT_A.organizationId,
         backupId,
         execution: { ownerId: claim.ownerId, generation: claim.generation },
         leaseMs: 60_000,
       });
-      const [waiter] = await waitForRepositoryLockWaiters(observer, holderPid, 1);
-      if (!waiter) throw new Error("Expected one blocked backup catalogue heartbeat");
+      const [heartbeatWaiter] = await waitForRepositoryLockWaiters(observer, holderPid, 1);
+      if (!heartbeatWaiter) throw new Error("Expected one blocked backup catalogue heartbeat");
       await waitForDatabaseTimeAfter(observer, claim.backup.catalog_lease_expires_at);
+      const visibleExpiry = await observer.query<{ expired: boolean }>(
+        `SELECT catalog_lease_expires_at <= clock_timestamp() AS expired
+         FROM agent_sandbox_backups
+         WHERE id = $1`,
+        [backupId],
+      );
+      expect(visibleExpiry.rows[0]?.expired).toBe(true);
+
+      competingClaimPromise = catalogRepository.claimDueAgentBackupOperations({
+        ownerId: OWNER_B,
+        limit: 3,
+        leaseMs: 60_000,
+      });
+      const competingWaiters = await waitForRepositoryLockWaiters(observer, heartbeatWaiter.pid, 1);
+      expect(competingWaiters).toHaveLength(1);
+      const visibleRows = await dbWrite
+        .select({
+          id: agentSandboxBackups.id,
+          ownerId: agentSandboxBackups.catalog_lease_owner,
+          expiresAt: agentSandboxBackups.catalog_lease_expires_at,
+        })
+        .from(agentSandboxBackups)
+        .orderBy(asc(agentSandboxBackups.catalog_next_attempt_at));
+      expect(visibleRows).toEqual([
+        {
+          id: backupId,
+          ownerId: claim.ownerId,
+          expiresAt: claim.backup.catalog_lease_expires_at,
+        },
+        { id: sameOrganizationBackupId, ownerId: null, expiresAt: null },
+        { id: sameNodeBackupId, ownerId: null, expiresAt: null },
+      ]);
+
       await holder.query("COMMIT");
       holderOpen = false;
 
@@ -1054,18 +1409,122 @@ realPostgres("canonical backup catalogue contention", () => {
         "Backup operation lease expired while waiting for post-lock authority",
       );
       heartbeatPromise = null;
-      const [persisted] = await dbWrite
+      const recoveredClaims = await competingClaimPromise;
+      competingClaimPromise = null;
+      expect(new Set(recoveredClaims.map((recovered) => recovered.backup.id))).toEqual(
+        new Set([sameOrganizationBackupId, sameNodeBackupId]),
+      );
+      const recoveredGeneration = recoveredClaims[0]?.generation;
+      expect(recoveredGeneration).toEqual(expect.any(String));
+      expect(recoveredGeneration).not.toBe(claim.generation);
+      expect(new Set(recoveredClaims.map((recovered) => recovered.generation))).toEqual(
+        new Set([recoveredGeneration]),
+      );
+      const persisted = await dbWrite
         .select({
+          id: agentSandboxBackups.id,
           ownerId: agentSandboxBackups.catalog_lease_owner,
           generation: agentSandboxBackups.catalog_lease_generation,
           expiresAt: agentSandboxBackups.catalog_lease_expires_at,
         })
         .from(agentSandboxBackups)
-        .where(eq(agentSandboxBackups.id, backupId));
-      expect(persisted).toEqual({
-        ownerId: claim.ownerId,
-        generation: claim.generation,
-        expiresAt: claim.backup.catalog_lease_expires_at,
+        .orderBy(asc(agentSandboxBackups.catalog_next_attempt_at));
+      expect(persisted).toEqual([
+        {
+          id: backupId,
+          ownerId: claim.ownerId,
+          generation: claim.generation,
+          expiresAt: claim.backup.catalog_lease_expires_at,
+        },
+        {
+          id: sameOrganizationBackupId,
+          ownerId: OWNER_B,
+          generation: recoveredGeneration,
+          expiresAt: expect.any(Date),
+        },
+        {
+          id: sameNodeBackupId,
+          ownerId: OWNER_B,
+          generation: recoveredGeneration,
+          expiresAt: expect.any(Date),
+        },
+      ]);
+
+      const recoveredById = new Map(
+        recoveredClaims.map((recovered) => [recovered.backup.id, recovered]),
+      );
+      for (const [recoveredBackupId, operationId] of [
+        [sameOrganizationBackupId, OPERATION_A2],
+        [sameNodeBackupId, OPERATION_C1],
+      ] as const) {
+        const recovered = recoveredById.get(recoveredBackupId);
+        if (!recovered?.backup.catalog_organization_id || !recovered.backup.lifecycle_generation) {
+          throw new Error("Expected an exact recovered fairness claim");
+        }
+        const settled = await catalogRepository.failAgentBackupOperation({
+          organizationId: recovered.backup.catalog_organization_id,
+          backupId: recovered.backup.id,
+          operationId,
+          lifecycleGeneration: recovered.backup.lifecycle_generation,
+          expectedState: "scheduled",
+          terminal: true,
+          error: {
+            code: "FINITE_ROTATION_SETTLED",
+            message: "Finite fairness rotation fixture settled terminally",
+          },
+          execution: {
+            ownerId: recovered.ownerId,
+            generation: recovered.generation,
+          },
+        });
+        expect(settled).toMatchObject({
+          id: recoveredBackupId,
+          catalog_state: "failed_terminal",
+          catalog_lease_owner: null,
+          catalog_lease_generation: null,
+          catalog_lease_expires_at: null,
+        });
+      }
+
+      const finalClaims = await catalogRepository.claimDueAgentBackupOperations({
+        ownerId: "backup-catalogue-postgres-worker-final",
+        limit: 3,
+        leaseMs: 60_000,
+      });
+      expect(finalClaims).toHaveLength(1);
+      const [finalClaim] = finalClaims;
+      expect(finalClaim?.backup.id).toBe(backupId);
+      expect(finalClaim?.generation).not.toBe(claim.generation);
+      expect(finalClaim?.backup.catalog_lease_expires_at?.getTime()).toBeGreaterThan(
+        claim.backup.catalog_lease_expires_at.getTime(),
+      );
+
+      const finalRows = await dbWrite
+        .select({
+          id: agentSandboxBackups.id,
+          state: agentSandboxBackups.catalog_state,
+          ownerId: agentSandboxBackups.catalog_lease_owner,
+          generation: agentSandboxBackups.catalog_lease_generation,
+        })
+        .from(agentSandboxBackups);
+      const finalRowById = new Map(finalRows.map((row) => [row.id, row]));
+      expect(finalRowById.get(backupId)).toEqual({
+        id: backupId,
+        state: "scheduled",
+        ownerId: "backup-catalogue-postgres-worker-final",
+        generation: finalClaim?.generation,
+      });
+      expect(finalRowById.get(sameOrganizationBackupId)).toEqual({
+        id: sameOrganizationBackupId,
+        state: "failed_terminal",
+        ownerId: null,
+        generation: null,
+      });
+      expect(finalRowById.get(sameNodeBackupId)).toEqual({
+        id: sameNodeBackupId,
+        state: "failed_terminal",
+        ownerId: null,
+        generation: null,
       });
     } catch (error) {
       // error-policy:J2 context-adding rethrow — preserve the assertion while
@@ -1082,6 +1541,16 @@ realPostgres("canonical backup catalogue contention", () => {
                 label: "settle heartbeat expiry operation",
                 run: async () => {
                   await heartbeatPromise;
+                },
+              },
+            ]
+          : [],
+        competingClaimPromise
+          ? [
+              {
+                label: "settle competing heartbeat expiry claim",
+                run: async () => {
+                  await competingClaimPromise;
                 },
               },
             ]

--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-catalog.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-catalog.pglite.test.ts
@@ -61,6 +61,7 @@ import type {
   AgentBackupOperationExecution,
 } from "../agent-backup-catalog";
 import {
+  AgentBackupAdmissionContendedError,
   agentBackupObjectInventoryDigest,
   buildAgentBackupObjectKey,
   claimDueAgentBackupOperations,
@@ -1772,12 +1773,13 @@ describe("agent backup catalogue on primary PGlite", () => {
       FOR EACH ROW EXECUTE FUNCTION test_contend_backup_claim_cursor()
     `);
     try {
-      const claims = await claimDueAgentBackupOperations({
-        ownerId: "contended-cursor-claim-worker",
-        limit: 1,
-        leaseMs: 60_000,
-      });
-      expect(claims).toEqual([]);
+      await expect(
+        claimDueAgentBackupOperations({
+          ownerId: "contended-cursor-claim-worker",
+          limit: 1,
+          leaseMs: 60_000,
+        }),
+      ).rejects.toBeInstanceOf(AgentBackupAdmissionContendedError);
       const [persistedBackup] = await dbWrite
         .select({
           owner: agentSandboxBackups.catalog_lease_owner,

--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-catalog.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-catalog.pglite.test.ts
@@ -1586,7 +1586,8 @@ describe("agent backup catalogue on primary PGlite", () => {
       sandboxRecordId: AGENT_ID,
       operationId: "00000000-0000-4000-8000-00000000c03c",
     });
-    if (!first.source_node_history_id) throw new Error("Expected exact cursor node authority");
+    const sourceNodeHistoryId = first.source_node_history_id;
+    if (!sourceNodeHistoryId) throw new Error("Expected exact cursor node authority");
     await dbWrite.execute(sql`
       UPDATE ${agentBackupOrganizationAdmissionCursors}
       SET cursor_at = '2099-01-01T00:00:00.123455Z'::timestamptz
@@ -1595,7 +1596,7 @@ describe("agent backup catalogue on primary PGlite", () => {
     await dbWrite.execute(sql`
       UPDATE ${agentBackupNodeAdmissionCursors}
       SET cursor_at = '2099-01-01T00:00:00.123456Z'::timestamptz
-      WHERE node_history_id = ${first.source_node_history_id}
+      WHERE node_history_id = ${sourceNodeHistoryId}
     `);
     const readExactCursors = async () => {
       const [row] = await dbWrite
@@ -1612,7 +1613,7 @@ describe("agent backup catalogue on primary PGlite", () => {
         .from(agentBackupOrganizationAdmissionCursors)
         .innerJoin(
           agentBackupNodeAdmissionCursors,
-          eq(agentBackupNodeAdmissionCursors.node_history_id, first.source_node_history_id),
+          eq(agentBackupNodeAdmissionCursors.node_history_id, sourceNodeHistoryId),
         )
         .where(eq(agentBackupOrganizationAdmissionCursors.organization_id, ORG_ID));
       return row;
@@ -2030,7 +2031,8 @@ describe("agent backup catalogue on primary PGlite", () => {
       limit: 1,
       leaseMs: 60_000,
     });
-    if (!claim || !backup.source_node_history_id) {
+    const sourceNodeHistoryId = backup.source_node_history_id;
+    if (!claim || !sourceNodeHistoryId) {
       throw new Error("Expected heartbeat admission claim");
     }
     const readCursors = () =>
@@ -2048,9 +2050,7 @@ describe("agent backup catalogue on primary PGlite", () => {
             cursorAt: sql<string | null>`${agentBackupNodeAdmissionCursors.cursor_at}::text`,
           })
           .from(agentBackupNodeAdmissionCursors)
-          .where(
-            eq(agentBackupNodeAdmissionCursors.node_history_id, backup.source_node_history_id),
-          ),
+          .where(eq(agentBackupNodeAdmissionCursors.node_history_id, sourceNodeHistoryId)),
       ]);
     const cursorsBefore = await readCursors();
     expect(cursorsBefore[0]).toEqual([{ cursorAt: expect.any(String) }]);

--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-catalog.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-catalog.pglite.test.ts
@@ -28,6 +28,10 @@ process.env.MOCK_REDIS = "1";
 process.env.SKIP_AGENT_SANDBOX_ENSURE = "1";
 
 import { pushSchema } from "drizzle-kit/api";
+import {
+  createAgentBackupCaptureV3RuntimeContextResolver,
+  isResolvedAgentBackupCaptureV3RuntimeAuthorityStale,
+} from "../../../lib/services/agent-backup-capture-v3-runtime-context";
 import { executeAgentBackupGcClaims } from "../../../lib/services/agent-backup-catalog-worker";
 import { createAgentBackupObjectStoreRegistry } from "../../../lib/storage/agent-backup-object-store";
 import type {
@@ -36,6 +40,10 @@ import type {
 } from "../../../lib/storage/r2-runtime-binding";
 import { installAgentNodeOccurrenceTriggerForTests } from "../../agent-node-occurrence-test-support";
 import { closeDatabaseConnectionsForTests, dbWrite } from "../../client";
+import {
+  agentBackupNodeAdmissionCursors,
+  agentBackupOrganizationAdmissionCursors,
+} from "../../schemas/agent-backup-admission";
 import {
   agentBackupCatalogAuthorities,
   agentBackupGcOutbox,
@@ -48,13 +56,17 @@ import { dockerNodes } from "../../schemas/docker-nodes";
 import { organizations } from "../../schemas/organizations";
 import { userCharacters } from "../../schemas/user-characters";
 import { users } from "../../schemas/users";
-import type { AgentBackupOperationExecution } from "../agent-backup-catalog";
+import type {
+  AgentBackupOperationClaim,
+  AgentBackupOperationExecution,
+} from "../agent-backup-catalog";
 import {
   agentBackupObjectInventoryDigest,
   buildAgentBackupObjectKey,
   claimDueAgentBackupOperations,
   failAgentBackupOperation,
   handoffCapturedAgentBackupOperation,
+  heartbeatAgentBackupOperation,
   markAgentBackupObjectUploading,
   markAgentBackupObjectVerified,
   recordAgentBackupObjectPresent,
@@ -83,6 +95,16 @@ const PGLITE_TIMEOUT = 60_000;
 const ORG_ID = "00000000-0000-4000-8000-00000000c001";
 const FOREIGN_ORG_ID = "00000000-0000-4000-8000-00000000c00a";
 const FOREIGN_AGENT_ID = "00000000-0000-4000-8000-00000000c01a";
+const FOREIGN_USER_ID = "00000000-0000-4000-8000-00000000c016";
+const FOREIGN_NODE_RECORD_ID = "00000000-0000-4000-8000-00000000c017";
+const FOREIGN_NODE_INCARNATION = "00000000-0000-4000-8000-00000000c018";
+const THIRD_ORG_ID = "00000000-0000-4000-8000-00000000c019";
+const THIRD_USER_ID = "00000000-0000-4000-8000-00000000c01b";
+const THIRD_AGENT_ID = "00000000-0000-4000-8000-00000000c01c";
+const SAME_ORG_USER_ID = "00000000-0000-4000-8000-00000000c030";
+const SAME_ORG_AGENT_ID = "00000000-0000-4000-8000-00000000c031";
+const SAME_ORG_NODE_RECORD_ID = "00000000-0000-4000-8000-00000000c032";
+const SAME_ORG_NODE_INCARNATION = "00000000-0000-4000-8000-00000000c033";
 const USER_ID = "00000000-0000-4000-8000-00000000c002";
 const AGENT_ID = "00000000-0000-4000-8000-00000000c003";
 const OPERATION_ID = "00000000-0000-4000-8000-00000000c004";
@@ -188,13 +210,19 @@ function exactReservation(
 
 async function reserveTestBackup(overrides: Partial<TestBackupReservation> = {}) {
   const input = reservation(overrides);
-  const [sourceOccurrence] = await dbWrite
+  const [sourceNode] = await dbWrite
     .select({ historyId: dockerNodes.current_node_history_id })
     .from(dockerNodes)
     .where(eq(dockerNodes.id, input.sourceNodeRecordId));
-  if (!sourceOccurrence?.historyId) {
-    throw new Error("Expected exact source node occurrence fixture");
-  }
+  if (!sourceNode?.historyId) throw new Error("Expected exact source occurrence fixture");
+  await dbWrite
+    .insert(agentBackupOrganizationAdmissionCursors)
+    .values({ organization_id: input.organizationId })
+    .onConflictDoNothing();
+  await dbWrite
+    .insert(agentBackupNodeAdmissionCursors)
+    .values({ node_history_id: sourceNode.historyId })
+    .onConflictDoNothing();
   await dbWrite
     .insert(agentBackupCatalogAuthorities)
     .values({ organization_id: input.organizationId, agent_id: input.agentId })
@@ -229,7 +257,7 @@ async function reserveTestBackup(overrides: Partial<TestBackupReservation> = {})
       source_node_record_id: input.sourceNodeRecordId,
       source_node_id: input.sourceNodeId,
       source_node_incarnation: input.sourceNodeIncarnation,
-      source_node_history_id: sourceOccurrence.historyId,
+      source_node_history_id: sourceNode.historyId,
       source_provider_server_id: input.sourceProviderServerId,
       source_provider_handle: input.sourceProviderHandle,
       source_container_id: input.sourceContainerId,
@@ -241,6 +269,126 @@ async function reserveTestBackup(overrides: Partial<TestBackupReservation> = {})
     .returning();
   if (!backup) throw new Error("Expected catalogue backup fixture");
   return backup;
+}
+
+async function seedAdditionalFairnessLane(params: {
+  organizationId: string;
+  userId: string;
+  agentId: string;
+  nodeRecordId: string;
+  nodeIncarnation: string;
+  nodeId: string;
+  providerHandle: string;
+  providerServerId?: string;
+}): Promise<void> {
+  const suffix = params.agentId.slice(-4);
+  await dbWrite
+    .insert(organizations)
+    .values({
+      id: params.organizationId,
+      name: `Backup fairness ${suffix}`,
+      slug: `backup-fairness-${suffix}`,
+    })
+    .onConflictDoNothing();
+  await dbWrite
+    .insert(users)
+    .values({
+      id: params.userId,
+      steward_user_id: `backup-fairness-${suffix}`,
+      organization_id: params.organizationId,
+    })
+    .onConflictDoNothing();
+  await dbWrite
+    .insert(dockerNodes)
+    .values({
+      id: params.nodeRecordId,
+      node_id: params.nodeId,
+      hostname: `${params.nodeId}.example.test`,
+      host_key_fingerprint: `sha256:${params.nodeId}-host-key`,
+      fleet_kind: params.providerServerId ? "cloud" : "robot",
+      infrastructure_provider: "hetzner",
+      provider_server_id: params.providerServerId ?? null,
+      node_incarnation: params.nodeIncarnation,
+      status: "healthy",
+      enabled: true,
+    })
+    .onConflictDoNothing();
+  const [baselineSandbox] = await dbWrite
+    .select()
+    .from(agentSandboxes)
+    .where(eq(agentSandboxes.id, AGENT_ID));
+  if (!baselineSandbox?.activation_receipt) {
+    throw new Error("Expected baseline sandbox fairness fixture");
+  }
+  await dbWrite.insert(agentSandboxes).values({
+    ...baselineSandbox,
+    id: params.agentId,
+    organization_id: params.organizationId,
+    user_id: params.userId,
+    agent_name: `Backup fairness ${suffix}`,
+    sandbox_id: params.providerHandle,
+    node_id: params.nodeId,
+    container_name: `backup-fairness-${suffix}`,
+    activation_receipt: {
+      ...baselineSandbox.activation_receipt,
+      agentId: params.agentId,
+      organizationId: params.organizationId,
+      receiptId: params.nodeIncarnation,
+    },
+    activation_node_id: params.nodeId,
+    activation_boot_id: params.nodeIncarnation,
+  });
+}
+
+async function terminallyReleaseFairnessClaim(
+  claim: AgentBackupOperationClaim,
+  errorCode: string,
+): Promise<void> {
+  const backup = claim.backup;
+  if (
+    !backup.catalog_organization_id ||
+    !backup.backup_operation_id ||
+    !backup.lifecycle_generation
+  ) {
+    throw new Error("Expected exact fairness claim identity");
+  }
+  await failAgentBackupOperation({
+    organizationId: backup.catalog_organization_id,
+    backupId: backup.id,
+    operationId: backup.backup_operation_id,
+    lifecycleGeneration: backup.lifecycle_generation,
+    expectedState: "scheduled",
+    terminal: true,
+    error: { code: errorCode, message: "Fairness fixture completed" },
+    execution: { ownerId: claim.ownerId, generation: claim.generation },
+  });
+}
+
+async function expectClaimAdvancedBothAdmissionCursors(
+  claim: AgentBackupOperationClaim,
+): Promise<void> {
+  const backup = claim.backup;
+  if (
+    !backup.catalog_organization_id ||
+    !backup.source_node_history_id ||
+    !backup.catalog_updated_at
+  ) {
+    throw new Error("Expected timestamped fairness claim authority");
+  }
+  const [organization] = await dbWrite
+    .select({
+      cursorAt: sql<string | null>`${agentBackupOrganizationAdmissionCursors.cursor_at}::text`,
+    })
+    .from(agentBackupOrganizationAdmissionCursors)
+    .where(
+      eq(agentBackupOrganizationAdmissionCursors.organization_id, backup.catalog_organization_id),
+    );
+  const [node] = await dbWrite
+    .select({ cursorAt: sql<string | null>`${agentBackupNodeAdmissionCursors.cursor_at}::text` })
+    .from(agentBackupNodeAdmissionCursors)
+    .where(eq(agentBackupNodeAdmissionCursors.node_history_id, backup.source_node_history_id));
+  expect(organization?.cursorAt).not.toBeNull();
+  expect(node?.cursorAt).toBe(organization?.cursorAt);
 }
 
 function objectDescriptor(index = 0) {
@@ -988,6 +1136,8 @@ beforeAll(async () => {
         users,
         userCharacters,
         agentNodeIncarnationHistories,
+        agentBackupOrganizationAdmissionCursors,
+        agentBackupNodeAdmissionCursors,
         dockerNodes,
         agentSandboxes,
         agentSandboxBackups,
@@ -1011,6 +1161,8 @@ beforeEach(async () => {
   await dbWrite.delete(agentBackupGcOutbox);
   await dbWrite.delete(agentBackupObjects);
   await dbWrite.delete(agentSandboxBackups);
+  await dbWrite.delete(agentBackupNodeAdmissionCursors);
+  await dbWrite.delete(agentBackupOrganizationAdmissionCursors);
   await dbWrite.delete(agentBackupCatalogAuthorities);
   await dbWrite.delete(agentSandboxes);
   await dbWrite.delete(dockerNodes);
@@ -1102,39 +1254,47 @@ afterAll(async () => {
 });
 
 describe("agent backup catalogue on primary PGlite", () => {
-  test("proves repeated limit-one claims reset tenant fairness for A,A versus B", async () => {
-    const [baselineSandbox] = await dbWrite
-      .select()
-      .from(agentSandboxes)
-      .where(eq(agentSandboxes.id, AGENT_ID));
-    if (!baselineSandbox) throw new Error("Expected baseline sandbox fixture");
-    await dbWrite.insert(agentSandboxes).values({
-      ...baselineSandbox,
-      id: FOREIGN_AGENT_ID,
-      organization_id: FOREIGN_ORG_ID,
-      agent_name: "Foreign Backup Catalogue Agent",
-      sandbox_id: "foreign-container-generation-1",
-      container_name: "foreign-backup-catalogue-agent",
-      activation_receipt: baselineSandbox.activation_receipt
-        ? {
-            ...baselineSandbox.activation_receipt,
-            agentId: FOREIGN_AGENT_ID,
-            organizationId: FOREIGN_ORG_ID,
-          }
-        : null,
+  test("rotates durable organization fairness A,B,A across limit-one claims", async () => {
+    await seedAdditionalFairnessLane({
+      organizationId: ORG_ID,
+      userId: SAME_ORG_USER_ID,
+      agentId: SAME_ORG_AGENT_ID,
+      nodeRecordId: SAME_ORG_NODE_RECORD_ID,
+      nodeIncarnation: SAME_ORG_NODE_INCARNATION,
+      nodeId: "robot-node-2",
+      providerHandle: "same-org-container-generation-1",
+    });
+    await seedAdditionalFairnessLane({
+      organizationId: FOREIGN_ORG_ID,
+      userId: FOREIGN_USER_ID,
+      agentId: FOREIGN_AGENT_ID,
+      nodeRecordId: FOREIGN_NODE_RECORD_ID,
+      nodeIncarnation: FOREIGN_NODE_INCARNATION,
+      nodeId: "robot-node-3",
+      providerHandle: "foreign-container-generation-1",
     });
 
     const firstA = await reserveTestBackup({
       operationId: "00000000-0000-4000-8000-00000000c021",
     });
     const secondA = await reserveTestBackup({
+      organizationId: ORG_ID,
+      agentId: SAME_ORG_AGENT_ID,
+      sandboxRecordId: SAME_ORG_AGENT_ID,
       operationId: "00000000-0000-4000-8000-00000000c022",
+      sourceNodeRecordId: SAME_ORG_NODE_RECORD_ID,
+      sourceNodeId: "robot-node-2",
+      sourceNodeIncarnation: SAME_ORG_NODE_INCARNATION,
+      sourceProviderHandle: "same-org-container-generation-1",
     });
     const tenantB = await reserveTestBackup({
       organizationId: FOREIGN_ORG_ID,
       agentId: FOREIGN_AGENT_ID,
       sandboxRecordId: FOREIGN_AGENT_ID,
       operationId: "00000000-0000-4000-8000-00000000c023",
+      sourceNodeRecordId: FOREIGN_NODE_RECORD_ID,
+      sourceNodeId: "robot-node-3",
+      sourceNodeIncarnation: FOREIGN_NODE_INCARNATION,
       sourceProviderHandle: "foreign-container-generation-1",
     });
     await dbWrite
@@ -1151,22 +1311,760 @@ describe("agent backup catalogue on primary PGlite", () => {
       .where(eq(agentSandboxBackups.id, tenantB.id));
 
     const [firstClaim] = await claimDueAgentBackupOperations({
-      ownerId: "fairness-proof-1",
+      ownerId: "organization-fairness-proof-1",
       limit: 1,
       leaseMs: 60_000,
     });
+    if (!firstClaim) throw new Error("Expected the first organization fairness claim");
+    expect(firstClaim.backup.id).toBe(firstA.id);
+    await expectClaimAdvancedBothAdmissionCursors(firstClaim);
+    await terminallyReleaseFairnessClaim(firstClaim, "ORGANIZATION_FAIRNESS_A1_COMPLETE");
+
     const [secondClaim] = await claimDueAgentBackupOperations({
-      ownerId: "fairness-proof-2",
+      ownerId: "organization-fairness-proof-2",
       limit: 1,
       leaseMs: 60_000,
     });
-    expect(firstClaim?.backup.id).toBe(firstA.id);
-    expect(secondClaim?.backup.id).toBe(secondA.id);
-    const [unclaimedB] = await dbWrite
+    if (!secondClaim) throw new Error("Expected the second organization fairness claim");
+    expect(secondClaim.backup.id).toBe(tenantB.id);
+    await expectClaimAdvancedBothAdmissionCursors(secondClaim);
+    const [stillQueuedA] = await dbWrite
       .select({ owner: agentSandboxBackups.catalog_lease_owner })
       .from(agentSandboxBackups)
-      .where(eq(agentSandboxBackups.id, tenantB.id));
-    expect(unclaimedB?.owner).toBeNull();
+      .where(eq(agentSandboxBackups.id, secondA.id));
+    expect(stillQueuedA?.owner).toBeNull();
+    await terminallyReleaseFairnessClaim(secondClaim, "ORGANIZATION_FAIRNESS_B1_COMPLETE");
+
+    const [thirdClaim] = await claimDueAgentBackupOperations({
+      ownerId: "organization-fairness-proof-3",
+      limit: 1,
+      leaseMs: 60_000,
+    });
+    if (!thirdClaim) throw new Error("Expected the third organization fairness claim");
+    expect(thirdClaim.backup.id).toBe(secondA.id);
+    await expectClaimAdvancedBothAdmissionCursors(thirdClaim);
+  });
+
+  test("rotates durable exact-node fairness X,Y,X across limit-one claims", async () => {
+    await seedAdditionalFairnessLane({
+      organizationId: FOREIGN_ORG_ID,
+      userId: FOREIGN_USER_ID,
+      agentId: FOREIGN_AGENT_ID,
+      nodeRecordId: FOREIGN_NODE_RECORD_ID,
+      nodeIncarnation: FOREIGN_NODE_INCARNATION,
+      nodeId: "robot-node-3",
+      providerHandle: "foreign-container-generation-1",
+    });
+    await seedAdditionalFairnessLane({
+      organizationId: THIRD_ORG_ID,
+      userId: THIRD_USER_ID,
+      agentId: THIRD_AGENT_ID,
+      nodeRecordId: NODE_RECORD_ID,
+      nodeIncarnation: NODE_INCARNATION,
+      nodeId: "robot-node-1",
+      providerHandle: "third-container-generation-1",
+    });
+
+    const firstX = await reserveTestBackup({
+      operationId: "00000000-0000-4000-8000-00000000c024",
+    });
+    const secondX = await reserveTestBackup({
+      organizationId: THIRD_ORG_ID,
+      agentId: THIRD_AGENT_ID,
+      sandboxRecordId: THIRD_AGENT_ID,
+      operationId: "00000000-0000-4000-8000-00000000c025",
+      sourceProviderHandle: "third-container-generation-1",
+    });
+    const nodeY = await reserveTestBackup({
+      organizationId: FOREIGN_ORG_ID,
+      agentId: FOREIGN_AGENT_ID,
+      sandboxRecordId: FOREIGN_AGENT_ID,
+      operationId: "00000000-0000-4000-8000-00000000c026",
+      sourceNodeRecordId: FOREIGN_NODE_RECORD_ID,
+      sourceNodeId: "robot-node-3",
+      sourceNodeIncarnation: FOREIGN_NODE_INCARNATION,
+      sourceProviderHandle: "foreign-container-generation-1",
+    });
+    for (const [backup, dueAt] of [
+      [firstX, "2020-01-01T00:00:00.000Z"],
+      [secondX, "2020-01-02T00:00:00.000Z"],
+      [nodeY, "2020-01-03T00:00:00.000Z"],
+    ] as const) {
+      await dbWrite
+        .update(agentSandboxBackups)
+        .set({ catalog_next_attempt_at: new Date(dueAt) })
+        .where(eq(agentSandboxBackups.id, backup.id));
+    }
+
+    const [firstClaim] = await claimDueAgentBackupOperations({
+      ownerId: "node-fairness-proof-1",
+      limit: 1,
+      leaseMs: 60_000,
+    });
+    if (!firstClaim) throw new Error("Expected the first node fairness claim");
+    expect(firstClaim.backup.id).toBe(firstX.id);
+    await expectClaimAdvancedBothAdmissionCursors(firstClaim);
+    await terminallyReleaseFairnessClaim(firstClaim, "NODE_FAIRNESS_X1_COMPLETE");
+
+    const [secondClaim] = await claimDueAgentBackupOperations({
+      ownerId: "node-fairness-proof-2",
+      limit: 1,
+      leaseMs: 60_000,
+    });
+    if (!secondClaim) throw new Error("Expected the second node fairness claim");
+    expect(secondClaim.backup.id).toBe(nodeY.id);
+    await expectClaimAdvancedBothAdmissionCursors(secondClaim);
+    await terminallyReleaseFairnessClaim(secondClaim, "NODE_FAIRNESS_Y1_COMPLETE");
+
+    const [thirdClaim] = await claimDueAgentBackupOperations({
+      ownerId: "node-fairness-proof-3",
+      limit: 1,
+      leaseMs: 60_000,
+    });
+    if (!thirdClaim) throw new Error("Expected the third node fairness claim");
+    expect(thirdClaim.backup.id).toBe(secondX.id);
+    await expectClaimAdvancedBothAdmissionCursors(thirdClaim);
+  });
+
+  test("does not let older work from one tenant starve another tenant on a shared node", async () => {
+    await seedAdditionalFairnessLane({
+      organizationId: ORG_ID,
+      userId: SAME_ORG_USER_ID,
+      agentId: SAME_ORG_AGENT_ID,
+      nodeRecordId: NODE_RECORD_ID,
+      nodeIncarnation: NODE_INCARNATION,
+      nodeId: "robot-node-1",
+      providerHandle: "same-org-shared-node-generation-1",
+    });
+    await seedAdditionalFairnessLane({
+      organizationId: THIRD_ORG_ID,
+      userId: THIRD_USER_ID,
+      agentId: THIRD_AGENT_ID,
+      nodeRecordId: NODE_RECORD_ID,
+      nodeIncarnation: NODE_INCARNATION,
+      nodeId: "robot-node-1",
+      providerHandle: "third-shared-node-generation-1",
+    });
+    const firstA = await reserveTestBackup({
+      operationId: "00000000-0000-4000-8000-00000000c034",
+    });
+    const secondA = await reserveTestBackup({
+      organizationId: ORG_ID,
+      agentId: SAME_ORG_AGENT_ID,
+      sandboxRecordId: SAME_ORG_AGENT_ID,
+      operationId: "00000000-0000-4000-8000-00000000c035",
+      sourceProviderHandle: "same-org-shared-node-generation-1",
+    });
+    const tenantB = await reserveTestBackup({
+      organizationId: THIRD_ORG_ID,
+      agentId: THIRD_AGENT_ID,
+      sandboxRecordId: THIRD_AGENT_ID,
+      operationId: "00000000-0000-4000-8000-00000000c036",
+      sourceProviderHandle: "third-shared-node-generation-1",
+    });
+    for (const [backup, dueAt] of [
+      [firstA, "2020-01-01T00:00:00.000Z"],
+      [secondA, "2020-01-02T00:00:00.000Z"],
+      [tenantB, "2020-01-03T00:00:00.000Z"],
+    ] as const) {
+      await dbWrite
+        .update(agentSandboxBackups)
+        .set({ catalog_next_attempt_at: new Date(dueAt) })
+        .where(eq(agentSandboxBackups.id, backup.id));
+    }
+
+    const [firstClaim] = await claimDueAgentBackupOperations({
+      ownerId: "shared-node-fairness-proof-1",
+      limit: 1,
+      leaseMs: 60_000,
+    });
+    if (!firstClaim) throw new Error("Expected the first shared-node claim");
+    expect(firstClaim.backup.id).toBe(firstA.id);
+    await terminallyReleaseFairnessClaim(firstClaim, "SHARED_NODE_A1_COMPLETE");
+
+    const [secondClaim] = await claimDueAgentBackupOperations({
+      ownerId: "shared-node-fairness-proof-2",
+      limit: 1,
+      leaseMs: 60_000,
+    });
+    if (!secondClaim) throw new Error("Expected the second shared-node claim");
+    expect(secondClaim.backup.id).toBe(tenantB.id);
+    const [stillQueuedA] = await dbWrite
+      .select({ owner: agentSandboxBackups.catalog_lease_owner })
+      .from(agentSandboxBackups)
+      .where(eq(agentSandboxBackups.id, secondA.id));
+    expect(stillQueuedA?.owner).toBeNull();
+  });
+
+  test("fills a crossing two-row batch with independent tenant and node lanes", async () => {
+    await seedAdditionalFairnessLane({
+      organizationId: ORG_ID,
+      userId: SAME_ORG_USER_ID,
+      agentId: SAME_ORG_AGENT_ID,
+      nodeRecordId: SAME_ORG_NODE_RECORD_ID,
+      nodeIncarnation: SAME_ORG_NODE_INCARNATION,
+      nodeId: "robot-node-2",
+      providerHandle: "same-org-crossing-generation-1",
+    });
+    await seedAdditionalFairnessLane({
+      organizationId: FOREIGN_ORG_ID,
+      userId: FOREIGN_USER_ID,
+      agentId: FOREIGN_AGENT_ID,
+      nodeRecordId: FOREIGN_NODE_RECORD_ID,
+      nodeIncarnation: FOREIGN_NODE_INCARNATION,
+      nodeId: "robot-node-3",
+      providerHandle: "foreign-crossing-z-generation-1",
+    });
+    await seedAdditionalFairnessLane({
+      organizationId: FOREIGN_ORG_ID,
+      userId: THIRD_USER_ID,
+      agentId: THIRD_AGENT_ID,
+      nodeRecordId: NODE_RECORD_ID,
+      nodeIncarnation: NODE_INCARNATION,
+      nodeId: "robot-node-1",
+      providerHandle: "foreign-crossing-x-generation-1",
+    });
+
+    const aOnX = await reserveTestBackup({
+      operationId: "00000000-0000-4000-8000-00000000c037",
+    });
+    const aOnY = await reserveTestBackup({
+      organizationId: ORG_ID,
+      agentId: SAME_ORG_AGENT_ID,
+      sandboxRecordId: SAME_ORG_AGENT_ID,
+      operationId: "00000000-0000-4000-8000-00000000c038",
+      sourceNodeRecordId: SAME_ORG_NODE_RECORD_ID,
+      sourceNodeId: "robot-node-2",
+      sourceNodeIncarnation: SAME_ORG_NODE_INCARNATION,
+      sourceProviderHandle: "same-org-crossing-generation-1",
+    });
+    const bOnZ = await reserveTestBackup({
+      organizationId: FOREIGN_ORG_ID,
+      agentId: FOREIGN_AGENT_ID,
+      sandboxRecordId: FOREIGN_AGENT_ID,
+      operationId: "00000000-0000-4000-8000-00000000c039",
+      sourceNodeRecordId: FOREIGN_NODE_RECORD_ID,
+      sourceNodeId: "robot-node-3",
+      sourceNodeIncarnation: FOREIGN_NODE_INCARNATION,
+      sourceProviderHandle: "foreign-crossing-z-generation-1",
+    });
+    const bOnX = await reserveTestBackup({
+      organizationId: FOREIGN_ORG_ID,
+      agentId: THIRD_AGENT_ID,
+      sandboxRecordId: THIRD_AGENT_ID,
+      operationId: "00000000-0000-4000-8000-00000000c03a",
+      sourceProviderHandle: "foreign-crossing-x-generation-1",
+    });
+    for (const [backup, dueAt] of [
+      [bOnZ, "2020-01-01T00:00:00.000Z"],
+      [bOnX, "2020-01-02T00:00:00.000Z"],
+      [aOnX, "2020-01-03T00:00:00.000Z"],
+      [aOnY, "2020-01-04T00:00:00.000Z"],
+    ] as const) {
+      await dbWrite
+        .update(agentSandboxBackups)
+        .set({ catalog_next_attempt_at: new Date(dueAt) })
+        .where(eq(agentSandboxBackups.id, backup.id));
+    }
+
+    const claims = await claimDueAgentBackupOperations({
+      ownerId: "crossing-batch-proof",
+      limit: 2,
+      leaseMs: 60_000,
+    });
+    expect(claims.map((claim) => claim.backup.id)).toEqual([bOnZ.id, aOnX.id]);
+    await Promise.all(claims.map(expectClaimAdvancedBothAdmissionCursors));
+  });
+
+  test("advances exact lane cursors by one microsecond across a backward database clock", async () => {
+    const first = await reserveTestBackup({
+      operationId: "00000000-0000-4000-8000-00000000c03b",
+    });
+    const second = await reserveTestBackup({
+      organizationId: ORG_ID,
+      agentId: AGENT_ID,
+      sandboxRecordId: AGENT_ID,
+      operationId: "00000000-0000-4000-8000-00000000c03c",
+    });
+    if (!first.source_node_history_id) throw new Error("Expected exact cursor node authority");
+    await dbWrite.execute(sql`
+      UPDATE ${agentBackupOrganizationAdmissionCursors}
+      SET cursor_at = '2099-01-01T00:00:00.123455Z'::timestamptz
+      WHERE organization_id = ${ORG_ID}
+    `);
+    await dbWrite.execute(sql`
+      UPDATE ${agentBackupNodeAdmissionCursors}
+      SET cursor_at = '2099-01-01T00:00:00.123456Z'::timestamptz
+      WHERE node_history_id = ${first.source_node_history_id}
+    `);
+    const readExactCursors = async () => {
+      const [row] = await dbWrite
+        .select({
+          organization_cursor_at: sql<string>`to_char(
+            ${agentBackupOrganizationAdmissionCursors.cursor_at} AT TIME ZONE 'UTC',
+            'YYYY-MM-DD"T"HH24:MI:SS.US"Z"'
+          )`,
+          node_cursor_at: sql<string>`to_char(
+            ${agentBackupNodeAdmissionCursors.cursor_at} AT TIME ZONE 'UTC',
+            'YYYY-MM-DD"T"HH24:MI:SS.US"Z"'
+          )`,
+        })
+        .from(agentBackupOrganizationAdmissionCursors)
+        .innerJoin(
+          agentBackupNodeAdmissionCursors,
+          eq(agentBackupNodeAdmissionCursors.node_history_id, first.source_node_history_id),
+        )
+        .where(eq(agentBackupOrganizationAdmissionCursors.organization_id, ORG_ID));
+      return row;
+    };
+
+    const [firstClaim] = await claimDueAgentBackupOperations({
+      ownerId: "microsecond-cursor-proof-1",
+      limit: 1,
+      leaseMs: 60_000,
+    });
+    if (!firstClaim) throw new Error("Expected first microsecond cursor claim");
+    expect(firstClaim.backup.id).toBe(first.id);
+    expect(await readExactCursors()).toEqual({
+      node_cursor_at: "2099-01-01T00:00:00.123457Z",
+      organization_cursor_at: "2099-01-01T00:00:00.123457Z",
+    });
+    await terminallyReleaseFairnessClaim(firstClaim, "MICROSECOND_CURSOR_1_COMPLETE");
+
+    const [secondClaim] = await claimDueAgentBackupOperations({
+      ownerId: "microsecond-cursor-proof-2",
+      limit: 1,
+      leaseMs: 60_000,
+    });
+    if (!secondClaim) throw new Error("Expected second microsecond cursor claim");
+    expect(secondClaim.backup.id).toBe(second.id);
+    expect(await readExactCursors()).toEqual({
+      node_cursor_at: "2099-01-01T00:00:00.123458Z",
+      organization_cursor_at: "2099-01-01T00:00:00.123458Z",
+    });
+  });
+
+  test("blocks active organization and exact-node lanes while an independent lane progresses", async () => {
+    await seedAdditionalFairnessLane({
+      organizationId: ORG_ID,
+      userId: SAME_ORG_USER_ID,
+      agentId: SAME_ORG_AGENT_ID,
+      nodeRecordId: SAME_ORG_NODE_RECORD_ID,
+      nodeIncarnation: SAME_ORG_NODE_INCARNATION,
+      nodeId: "robot-node-2",
+      providerHandle: "same-org-container-generation-1",
+    });
+    await seedAdditionalFairnessLane({
+      organizationId: FOREIGN_ORG_ID,
+      userId: FOREIGN_USER_ID,
+      agentId: FOREIGN_AGENT_ID,
+      nodeRecordId: FOREIGN_NODE_RECORD_ID,
+      nodeIncarnation: FOREIGN_NODE_INCARNATION,
+      nodeId: "robot-node-3",
+      providerHandle: "foreign-container-generation-1",
+    });
+    await seedAdditionalFairnessLane({
+      organizationId: THIRD_ORG_ID,
+      userId: THIRD_USER_ID,
+      agentId: THIRD_AGENT_ID,
+      nodeRecordId: NODE_RECORD_ID,
+      nodeIncarnation: NODE_INCARNATION,
+      nodeId: "robot-node-1",
+      providerHandle: "third-container-generation-1",
+    });
+
+    const active = await reserveTestBackup({
+      operationId: "00000000-0000-4000-8000-00000000c027",
+    });
+    const sameOrganization = await reserveTestBackup({
+      organizationId: ORG_ID,
+      agentId: SAME_ORG_AGENT_ID,
+      sandboxRecordId: SAME_ORG_AGENT_ID,
+      operationId: "00000000-0000-4000-8000-00000000c028",
+      sourceNodeRecordId: SAME_ORG_NODE_RECORD_ID,
+      sourceNodeId: "robot-node-2",
+      sourceNodeIncarnation: SAME_ORG_NODE_INCARNATION,
+      sourceProviderHandle: "same-org-container-generation-1",
+    });
+    const sameNode = await reserveTestBackup({
+      organizationId: THIRD_ORG_ID,
+      agentId: THIRD_AGENT_ID,
+      sandboxRecordId: THIRD_AGENT_ID,
+      operationId: "00000000-0000-4000-8000-00000000c029",
+      sourceProviderHandle: "third-container-generation-1",
+    });
+    const independent = await reserveTestBackup({
+      organizationId: FOREIGN_ORG_ID,
+      agentId: FOREIGN_AGENT_ID,
+      sandboxRecordId: FOREIGN_AGENT_ID,
+      operationId: "00000000-0000-4000-8000-00000000c02a",
+      sourceNodeRecordId: FOREIGN_NODE_RECORD_ID,
+      sourceNodeId: "robot-node-3",
+      sourceNodeIncarnation: FOREIGN_NODE_INCARNATION,
+      sourceProviderHandle: "foreign-container-generation-1",
+    });
+    for (const [backup, dueAt] of [
+      [active, "2020-01-01T00:00:00.000Z"],
+      [sameOrganization, "2020-01-02T00:00:00.000Z"],
+      [sameNode, "2020-01-03T00:00:00.000Z"],
+      [independent, "2020-01-04T00:00:00.000Z"],
+    ] as const) {
+      await dbWrite
+        .update(agentSandboxBackups)
+        .set({ catalog_next_attempt_at: new Date(dueAt) })
+        .where(eq(agentSandboxBackups.id, backup.id));
+    }
+
+    const [activeClaim] = await claimDueAgentBackupOperations({
+      ownerId: "active-lane-proof-1",
+      limit: 1,
+      leaseMs: 60_000,
+    });
+    if (!activeClaim) throw new Error("Expected the active-lane fixture claim");
+    expect(activeClaim.backup.id).toBe(active.id);
+    const independentClaims = await claimDueAgentBackupOperations({
+      ownerId: "active-lane-proof-2",
+      limit: 3,
+      leaseMs: 60_000,
+    });
+    expect(independentClaims.map((claim) => claim.backup.id)).toEqual([independent.id]);
+    const blocked = await dbWrite
+      .select({ id: agentSandboxBackups.id, owner: agentSandboxBackups.catalog_lease_owner })
+      .from(agentSandboxBackups)
+      .where(sql`${agentSandboxBackups.id} IN (${sameOrganization.id}, ${sameNode.id})`);
+    expect(blocked).toHaveLength(2);
+    expect(blocked.every((row) => row.owner === null)).toBe(true);
+  });
+
+  test("rolls back a preliminary lease without erasing existing cursor history", async () => {
+    const backup = await reserveTestBackup({
+      operationId: "00000000-0000-4000-8000-00000000c02b",
+    });
+    if (!backup.source_node_history_id) throw new Error("Expected source occurrence fixture");
+    const organizationSentinel = new Date("2026-08-25T10:11:12.123Z");
+    const nodeSentinel = new Date("2026-08-25T10:11:13.456Z");
+    await dbWrite
+      .update(agentBackupOrganizationAdmissionCursors)
+      .set({ cursor_at: organizationSentinel })
+      .where(eq(agentBackupOrganizationAdmissionCursors.organization_id, ORG_ID));
+    await dbWrite
+      .update(agentBackupNodeAdmissionCursors)
+      .set({ cursor_at: nodeSentinel })
+      .where(eq(agentBackupNodeAdmissionCursors.node_history_id, backup.source_node_history_id));
+    await dbWrite.execute(sql`
+      CREATE OR REPLACE FUNCTION test_contend_backup_claim_cursor() RETURNS trigger
+      LANGUAGE plpgsql AS $$
+      BEGIN
+        IF NEW.catalog_lease_owner = 'contended-cursor-claim-worker'
+          AND OLD.catalog_lease_owner IS NULL THEN
+          UPDATE agent_backup_organization_admission_cursors
+          SET cursor_at = '2026-08-25T10:11:14.789Z'::timestamptz
+          WHERE organization_id = NEW.catalog_organization_id;
+        END IF;
+        RETURN NEW;
+      END;
+      $$
+    `);
+    await dbWrite.execute(sql`
+      CREATE TRIGGER test_contend_backup_claim_cursor
+      BEFORE UPDATE ON agent_sandbox_backups
+      FOR EACH ROW EXECUTE FUNCTION test_contend_backup_claim_cursor()
+    `);
+    try {
+      const claims = await claimDueAgentBackupOperations({
+        ownerId: "contended-cursor-claim-worker",
+        limit: 1,
+        leaseMs: 60_000,
+      });
+      expect(claims).toEqual([]);
+      const [persistedBackup] = await dbWrite
+        .select({
+          owner: agentSandboxBackups.catalog_lease_owner,
+          generation: agentSandboxBackups.catalog_lease_generation,
+          expiresAt: agentSandboxBackups.catalog_lease_expires_at,
+        })
+        .from(agentSandboxBackups)
+        .where(eq(agentSandboxBackups.id, backup.id));
+      const [organization] = await dbWrite
+        .select({ cursorAt: agentBackupOrganizationAdmissionCursors.cursor_at })
+        .from(agentBackupOrganizationAdmissionCursors)
+        .where(eq(agentBackupOrganizationAdmissionCursors.organization_id, ORG_ID));
+      const [node] = await dbWrite
+        .select({ cursorAt: agentBackupNodeAdmissionCursors.cursor_at })
+        .from(agentBackupNodeAdmissionCursors)
+        .where(eq(agentBackupNodeAdmissionCursors.node_history_id, backup.source_node_history_id));
+      expect(persistedBackup).toEqual({ owner: null, generation: null, expiresAt: null });
+      expect(organization?.cursorAt?.getTime()).toBe(organizationSentinel.getTime());
+      expect(node?.cursorAt?.getTime()).toBe(nodeSentinel.getTime());
+    } finally {
+      await dbWrite.execute(
+        sql`DROP TRIGGER IF EXISTS test_contend_backup_claim_cursor ON agent_sandbox_backups`,
+      );
+      await dbWrite.execute(sql`DROP FUNCTION IF EXISTS test_contend_backup_claim_cursor()`);
+    }
+  });
+
+  test("claims Cloud work only through the exact current provider authority", async () => {
+    await seedAdditionalFairnessLane({
+      organizationId: FOREIGN_ORG_ID,
+      userId: FOREIGN_USER_ID,
+      agentId: FOREIGN_AGENT_ID,
+      nodeRecordId: FOREIGN_NODE_RECORD_ID,
+      nodeIncarnation: FOREIGN_NODE_INCARNATION,
+      nodeId: "cloud-node-1",
+      providerHandle: "cloud-container-generation-1",
+      providerServerId: "12345",
+    });
+    const exact = await reserveTestBackup({
+      organizationId: FOREIGN_ORG_ID,
+      agentId: FOREIGN_AGENT_ID,
+      sandboxRecordId: FOREIGN_AGENT_ID,
+      operationId: "00000000-0000-4000-8000-00000000c02d",
+      sourceProvider: "hetzner-cloud",
+      sourceNodeRecordId: FOREIGN_NODE_RECORD_ID,
+      sourceNodeId: "cloud-node-1",
+      sourceNodeIncarnation: FOREIGN_NODE_INCARNATION,
+      sourceProviderServerId: "12345",
+      sourceProviderHandle: "cloud-container-generation-1",
+    });
+    await dbWrite
+      .update(agentSandboxBackups)
+      .set({ catalog_next_attempt_at: new Date("2020-01-02T00:00:00.000Z") })
+      .where(eq(agentSandboxBackups.id, exact.id));
+
+    const claims = await claimDueAgentBackupOperations({
+      ownerId: "cloud-authority-claim-worker",
+      limit: 2,
+      leaseMs: 60_000,
+    });
+    expect(claims.map((claim) => claim.backup.id)).toEqual([exact.id]);
+  });
+
+  test("rejects mismatched Cloud provider and fleet projections at claim time", async () => {
+    await seedAdditionalFairnessLane({
+      organizationId: FOREIGN_ORG_ID,
+      userId: FOREIGN_USER_ID,
+      agentId: FOREIGN_AGENT_ID,
+      nodeRecordId: FOREIGN_NODE_RECORD_ID,
+      nodeIncarnation: FOREIGN_NODE_INCARNATION,
+      nodeId: "cloud-node-negative",
+      providerHandle: "cloud-negative-generation-1",
+      providerServerId: "12345",
+    });
+    const exact = await reserveTestBackup({
+      organizationId: FOREIGN_ORG_ID,
+      agentId: FOREIGN_AGENT_ID,
+      sandboxRecordId: FOREIGN_AGENT_ID,
+      operationId: "00000000-0000-4000-8000-00000000c03d",
+      sourceProvider: "hetzner-cloud",
+      sourceNodeRecordId: FOREIGN_NODE_RECORD_ID,
+      sourceNodeId: "cloud-node-negative",
+      sourceNodeIncarnation: FOREIGN_NODE_INCARNATION,
+      sourceProviderServerId: "12345",
+      sourceProviderHandle: "cloud-negative-generation-1",
+    });
+    await dbWrite
+      .update(agentSandboxBackups)
+      .set({ source_provider_server_id: "12346" })
+      .where(eq(agentSandboxBackups.id, exact.id));
+    expect(
+      await claimDueAgentBackupOperations({
+        ownerId: "cloud-negative-server-worker",
+        limit: 1,
+        leaseMs: 60_000,
+      }),
+    ).toEqual([]);
+
+    await dbWrite
+      .update(agentSandboxBackups)
+      .set({ source_provider: "operator-onboarded", source_provider_server_id: null })
+      .where(eq(agentSandboxBackups.id, exact.id));
+    expect(
+      await claimDueAgentBackupOperations({
+        ownerId: "cloud-negative-fleet-worker",
+        limit: 1,
+        leaseMs: 60_000,
+      }),
+    ).toEqual([]);
+
+    await dbWrite
+      .update(agentSandboxBackups)
+      .set({ source_provider: "hetzner-cloud", source_provider_server_id: "12345" })
+      .where(eq(agentSandboxBackups.id, exact.id));
+    const [claim] = await claimDueAgentBackupOperations({
+      ownerId: "cloud-negative-repaired-worker",
+      limit: 1,
+      leaseMs: 60_000,
+    });
+    expect(claim?.backup.id).toBe(exact.id);
+  });
+
+  test("classifies failed-retryable capture resumption on both exact lanes", async () => {
+    const backup = await reserveTestBackup({
+      operationId: "00000000-0000-4000-8000-00000000c03e",
+    });
+    await dbWrite
+      .update(agentSandboxBackups)
+      .set({
+        catalog_state: "failed_retryable",
+        catalog_resume_state: "capturing",
+        catalog_next_attempt_at: new Date("2020-01-01T00:00:00.000Z"),
+      })
+      .where(eq(agentSandboxBackups.id, backup.id));
+    const [claim] = await claimDueAgentBackupOperations({
+      ownerId: "failed-retryable-capture-worker",
+      limit: 1,
+      leaseMs: 60_000,
+    });
+    expect(claim?.backup).toMatchObject({
+      id: backup.id,
+      catalog_state: "failed_retryable",
+      catalog_resume_state: "capturing",
+    });
+    if (!claim) throw new Error("Expected failed-retryable capture claim");
+    await expectClaimAdvancedBothAdmissionCursors(claim);
+  });
+
+  test("classifies failed-retryable publication on the tenant lane only", async () => {
+    const operationId = "00000000-0000-4000-8000-00000000c03f";
+    const backup = await reserveAgentBackupOperation(exactReservation({ operationId }));
+    const [captureClaim] = await claimDueAgentBackupOperations({
+      ownerId: "failed-retryable-publication-capture-worker",
+      limit: 1,
+      leaseMs: 60_000,
+    });
+    if (!backup.source_node_history_id || !captureClaim) {
+      throw new Error("Expected publication node cursor and capture claim");
+    }
+    const captureExecution = {
+      ownerId: captureClaim.ownerId,
+      generation: captureClaim.generation,
+    };
+    await transitionAgentBackupOperation({
+      organizationId: ORG_ID,
+      backupId: backup.id,
+      operationId,
+      lifecycleGeneration: LIFECYCLE_GENERATION,
+      expectedState: "scheduled",
+      to: "capturing",
+      execution: captureExecution,
+    });
+    await recordCapturedAgentBackupManifest({
+      organizationId: ORG_ID,
+      backupId: backup.id,
+      operationId,
+      expectedActivationGeneration: LIFECYCLE_GENERATION,
+      expectedLifecycleRevision: "0",
+      execution: captureExecution,
+      manifest: await capturedManifest([objectDescriptor()], {
+        operationId,
+        createdAt: backup.created_at.toISOString(),
+      }),
+    });
+    await failAgentBackupOperation({
+      organizationId: ORG_ID,
+      backupId: backup.id,
+      operationId,
+      lifecycleGeneration: LIFECYCLE_GENERATION,
+      expectedState: "captured",
+      terminal: false,
+      retryDelayMs: 1,
+      error: { code: "PUBLICATION_RETRY_PROOF", message: "retry publication" },
+      execution: captureExecution,
+    });
+    await dbWrite
+      .update(agentSandboxBackups)
+      .set({
+        catalog_next_attempt_at: new Date("2020-01-01T00:00:00.000Z"),
+      })
+      .where(eq(agentSandboxBackups.id, backup.id));
+    const [nodeBefore] = await dbWrite
+      .select({
+        cursorAt: sql<string | null>`${agentBackupNodeAdmissionCursors.cursor_at}::text`,
+      })
+      .from(agentBackupNodeAdmissionCursors)
+      .where(eq(agentBackupNodeAdmissionCursors.node_history_id, backup.source_node_history_id));
+    const [organizationBefore] = await dbWrite
+      .select({
+        cursorAt: sql<string | null>`${agentBackupOrganizationAdmissionCursors.cursor_at}::text`,
+      })
+      .from(agentBackupOrganizationAdmissionCursors)
+      .where(eq(agentBackupOrganizationAdmissionCursors.organization_id, ORG_ID));
+    if (!nodeBefore?.cursorAt || !organizationBefore?.cursorAt) {
+      throw new Error("Expected exact capture admission cursors before publication retry");
+    }
+    const [claim] = await claimDueAgentBackupOperations({
+      ownerId: "failed-retryable-publication-worker",
+      limit: 1,
+      leaseMs: 60_000,
+    });
+    expect(claim?.backup).toMatchObject({
+      id: backup.id,
+      catalog_state: "failed_retryable",
+      catalog_resume_state: "captured",
+    });
+    const [nodeAfter] = await dbWrite
+      .select({
+        cursorAt: sql<string | null>`${agentBackupNodeAdmissionCursors.cursor_at}::text`,
+      })
+      .from(agentBackupNodeAdmissionCursors)
+      .where(eq(agentBackupNodeAdmissionCursors.node_history_id, backup.source_node_history_id));
+    expect(nodeAfter?.cursorAt).toEqual(nodeBefore?.cursorAt);
+    const [organizationAfter] = await dbWrite
+      .select({
+        cursorAt: sql<string | null>`${agentBackupOrganizationAdmissionCursors.cursor_at}::text`,
+        advanced: sql<boolean>`${agentBackupOrganizationAdmissionCursors.cursor_at}
+          > ${organizationBefore.cursorAt}::timestamptz`,
+      })
+      .from(agentBackupOrganizationAdmissionCursors)
+      .where(eq(agentBackupOrganizationAdmissionCursors.organization_id, ORG_ID));
+    expect(organizationAfter).toEqual({ cursorAt: expect.any(String), advanced: true });
+  });
+
+  test("holds the exact admission lanes while heartbeating without advancing their turn", async () => {
+    const backup = await reserveTestBackup({
+      operationId: "00000000-0000-4000-8000-00000000c040",
+    });
+    const [claim] = await claimDueAgentBackupOperations({
+      ownerId: "heartbeat-lane-worker",
+      limit: 1,
+      leaseMs: 60_000,
+    });
+    if (!claim || !backup.source_node_history_id) {
+      throw new Error("Expected heartbeat admission claim");
+    }
+    const readCursors = () =>
+      Promise.all([
+        dbWrite
+          .select({
+            cursorAt: sql<
+              string | null
+            >`${agentBackupOrganizationAdmissionCursors.cursor_at}::text`,
+          })
+          .from(agentBackupOrganizationAdmissionCursors)
+          .where(eq(agentBackupOrganizationAdmissionCursors.organization_id, ORG_ID)),
+        dbWrite
+          .select({
+            cursorAt: sql<string | null>`${agentBackupNodeAdmissionCursors.cursor_at}::text`,
+          })
+          .from(agentBackupNodeAdmissionCursors)
+          .where(
+            eq(agentBackupNodeAdmissionCursors.node_history_id, backup.source_node_history_id),
+          ),
+      ]);
+    const cursorsBefore = await readCursors();
+    expect(cursorsBefore[0]).toEqual([{ cursorAt: expect.any(String) }]);
+    expect(cursorsBefore[1]).toEqual([{ cursorAt: cursorsBefore[0][0]?.cursorAt }]);
+    const heartbeat = await heartbeatAgentBackupOperation({
+      organizationId: ORG_ID,
+      backupId: backup.id,
+      execution: { ownerId: claim.ownerId, generation: claim.generation },
+      leaseMs: 120_000,
+    });
+    expect(heartbeat.catalog_lease_expires_at?.getTime()).toBeGreaterThan(
+      claim.backup.catalog_lease_expires_at?.getTime() ?? 0,
+    );
+    expect(await readCursors()).toEqual(cursorsBefore);
   });
 
   test("reserves and claims only one exact active source authority", async () => {
@@ -1192,6 +2090,143 @@ describe("agent backup catalogue on primary PGlite", () => {
     });
     expect(claims).toHaveLength(1);
     expect(claims[0]?.backup.id).toBe(first.id);
+  });
+
+  test("rejects an A1-B-A2 source before heartbeat, vault, decrypt, or routing", async () => {
+    const reserved = await reserveAgentBackupOperation(
+      exactReservation({ operationId: "00000000-0000-4000-8000-00000000c041" }),
+    );
+    const [claim] = await claimDueAgentBackupOperations({
+      ownerId: "runtime-occurrence-aba-worker",
+      limit: 1,
+      leaseMs: 60_000,
+    });
+    if (!claim || !reserved.source_node_history_id) {
+      throw new Error("Expected exact capture claim before runtime occurrence rotation");
+    }
+    await dbWrite
+      .update(dockerNodes)
+      .set({ node_incarnation: "00000000-0000-4000-8000-00000000c042" })
+      .where(eq(dockerNodes.id, NODE_RECORD_ID));
+    await dbWrite
+      .update(dockerNodes)
+      .set({ node_incarnation: NODE_INCARNATION })
+      .where(eq(dockerNodes.id, NODE_RECORD_ID));
+    const [rearmed] = await dbWrite
+      .select({ historyId: dockerNodes.current_node_history_id })
+      .from(dockerNodes)
+      .where(eq(dockerNodes.id, NODE_RECORD_ID));
+    expect(rearmed?.historyId).not.toBe(reserved.source_node_history_id);
+
+    let heartbeats = 0;
+    let vaultReads = 0;
+    let decryptions = 0;
+    let routeAuthorizations = 0;
+    const resolveRuntimeContext = createAgentBackupCaptureV3RuntimeContextResolver(
+      {
+        spool: {
+          stateDirectory: "/var/lib/eliza-backup-catalog/spool",
+          maxSpoolBytes: 1024 ** 3,
+          minFreeBytes: 1024,
+        },
+        keyBundle: { kind: "shared-key-bundle" } as never,
+        runtime: {
+          agentSchemaVersion: "2.0.0",
+          databaseSchemaVersion: "330",
+          plugins: [],
+        },
+      },
+      {
+        async loadVaultAuthority() {
+          vaultReads += 1;
+          throw new Error("vault must not be read for stale runtime occurrence");
+        },
+        async decryptEnvironmentVars() {
+          decryptions += 1;
+          throw new Error("environment must not be decrypted for stale runtime occurrence");
+        },
+        async authorizePublicUrl() {
+          routeAuthorizations += 1;
+          throw new Error("route must not be authorized for stale runtime occurrence");
+        },
+      },
+    );
+    let failure: unknown;
+    try {
+      await resolveRuntimeContext({
+        claim,
+        request: { agentId: AGENT_ID } as never,
+        expectedSource: {
+          kind: "robot",
+          provider: "hetzner",
+          nodeRecordId: NODE_RECORD_ID,
+          nodeId: "robot-node-1",
+          nodeIncarnation: NODE_INCARNATION,
+          containerId: SOURCE_CONTAINER_ID,
+        },
+        async heartbeat() {
+          heartbeats += 1;
+          return true;
+        },
+      });
+    } catch (error) {
+      failure = error;
+    }
+    expect(failure).toMatchObject({ code: "AGENT_BACKUP_V3_RUNTIME_AUTHORITY_STALE" });
+    expect(isResolvedAgentBackupCaptureV3RuntimeAuthorityStale(failure)).toBe(true);
+    expect({ heartbeats, vaultReads, decryptions, routeAuthorizations }).toEqual({
+      heartbeats: 0,
+      vaultReads: 0,
+      decryptions: 0,
+      routeAuthorizations: 0,
+    });
+  });
+
+  test("replays a legacy publication row without inferring its source occurrence", async () => {
+    const operationId = "00000000-0000-4000-8000-00000000c043";
+    const reservation = exactReservation({ operationId });
+    const reserved = await reserveAgentBackupOperation(reservation);
+    const [claim] = await claimDueAgentBackupOperations({
+      ownerId: "legacy-publication-replay-capture-worker",
+      limit: 1,
+      leaseMs: 60_000,
+    });
+    if (!claim || !reserved.source_node_history_id) {
+      throw new Error("Expected exact capture before legacy publication replay");
+    }
+    const execution = { ownerId: claim.ownerId, generation: claim.generation };
+    await transitionAgentBackupOperation({
+      organizationId: ORG_ID,
+      backupId: reserved.id,
+      operationId,
+      lifecycleGeneration: LIFECYCLE_GENERATION,
+      expectedState: "scheduled",
+      to: "capturing",
+      execution,
+    });
+    await recordCapturedAgentBackupManifest({
+      organizationId: ORG_ID,
+      backupId: reserved.id,
+      operationId,
+      expectedActivationGeneration: LIFECYCLE_GENERATION,
+      expectedLifecycleRevision: "0",
+      execution,
+      manifest: await capturedManifest([objectDescriptor()], {
+        operationId,
+        createdAt: reserved.created_at.toISOString(),
+      }),
+    });
+    await dbWrite
+      .update(agentSandboxBackups)
+      .set({ source_node_history_id: null })
+      .where(eq(agentSandboxBackups.id, reserved.id));
+
+    const replay = await reserveAgentBackupOperation(reservation);
+    expect(replay).toMatchObject({
+      id: reserved.id,
+      catalog_state: "captured",
+      source_node_history_id: null,
+    });
   });
 
   test("derives manifest projections and revalidates the active image before capture commit", async () => {
@@ -1250,7 +2285,7 @@ describe("agent backup catalogue on primary PGlite", () => {
     });
   });
 
-  test("hands an exact captured fence to publication without waiting for lease expiry", async () => {
+  test("hands captured work to publication across a source-node ABA", async () => {
     const reserved = await reserveAgentBackupOperation(exactReservation());
     const [claim] = await claimDueAgentBackupOperations({
       ownerId: "capture-worker-handoff",
@@ -1323,6 +2358,9 @@ describe("agent backup catalogue on primary PGlite", () => {
       catalog_lease_generation: null,
       catalog_lease_expires_at: null,
     });
+    if (!handedOff.source_node_history_id) {
+      throw new Error("Expected reservation-bound source occurrence");
+    }
 
     await expect(
       handoffCapturedAgentBackupOperation({
@@ -1334,6 +2372,43 @@ describe("agent backup catalogue on primary PGlite", () => {
       }),
     ).rejects.toThrow("exact execution fence");
 
+    const [nodeCursorBeforePublication] = await dbWrite
+      .select({
+        cursorAt: sql<string | null>`${agentBackupNodeAdmissionCursors.cursor_at}::text`,
+      })
+      .from(agentBackupNodeAdmissionCursors)
+      .where(eq(agentBackupNodeAdmissionCursors.node_history_id, handedOff.source_node_history_id));
+    const [organizationCursorBeforePublication] = await dbWrite
+      .select({
+        cursorAt: sql<string | null>`${agentBackupOrganizationAdmissionCursors.cursor_at}::text`,
+      })
+      .from(agentBackupOrganizationAdmissionCursors)
+      .where(eq(agentBackupOrganizationAdmissionCursors.organization_id, ORG_ID));
+    if (!nodeCursorBeforePublication?.cursorAt || !organizationCursorBeforePublication?.cursorAt) {
+      throw new Error("Expected exact capture admission cursors before ABA publication");
+    }
+    await dbWrite
+      .update(dockerNodes)
+      .set({ node_incarnation: "00000000-0000-4000-8000-00000000c01d" })
+      .where(eq(dockerNodes.id, NODE_RECORD_ID));
+    await dbWrite
+      .update(dockerNodes)
+      .set({ node_incarnation: NODE_INCARNATION })
+      .where(eq(dockerNodes.id, NODE_RECORD_ID));
+    const [rearmedNode] = await dbWrite
+      .select({ historyId: dockerNodes.current_node_history_id })
+      .from(dockerNodes)
+      .where(eq(dockerNodes.id, NODE_RECORD_ID));
+    expect(rearmedNode?.historyId).not.toBe(handedOff.source_node_history_id);
+    if (!rearmedNode?.historyId) throw new Error("Expected rearmed exact node occurrence");
+    const [rearmedNodeCursorBeforePublication] = await dbWrite
+      .select({
+        cursorAt: sql<string | null>`${agentBackupNodeAdmissionCursors.cursor_at}::text`,
+      })
+      .from(agentBackupNodeAdmissionCursors)
+      .where(eq(agentBackupNodeAdmissionCursors.node_history_id, rearmedNode.historyId));
+    expect(rearmedNodeCursorBeforePublication).toBeUndefined();
+
     const [publicationClaim] = await claimDueAgentBackupOperations({
       ownerId: "publication-worker-handoff",
       limit: 1,
@@ -1344,6 +2419,32 @@ describe("agent backup catalogue on primary PGlite", () => {
       backup: { id: reserved.id, catalog_state: "captured" },
     });
     expect(publicationClaim?.generation).not.toBe(execution.generation);
+    const [nodeCursorAfterPublication] = await dbWrite
+      .select({
+        cursorAt: sql<string | null>`${agentBackupNodeAdmissionCursors.cursor_at}::text`,
+      })
+      .from(agentBackupNodeAdmissionCursors)
+      .where(eq(agentBackupNodeAdmissionCursors.node_history_id, handedOff.source_node_history_id));
+    expect(nodeCursorAfterPublication?.cursorAt).toBe(nodeCursorBeforePublication?.cursorAt);
+    const [rearmedNodeCursorAfterPublication] = await dbWrite
+      .select({
+        cursorAt: sql<string | null>`${agentBackupNodeAdmissionCursors.cursor_at}::text`,
+      })
+      .from(agentBackupNodeAdmissionCursors)
+      .where(eq(agentBackupNodeAdmissionCursors.node_history_id, rearmedNode.historyId));
+    expect(rearmedNodeCursorAfterPublication).toBeUndefined();
+    if (!publicationClaim?.backup.catalog_updated_at) {
+      throw new Error("Expected publication claim timestamp");
+    }
+    const [organizationCursor] = await dbWrite
+      .select({
+        cursorAt: sql<string | null>`${agentBackupOrganizationAdmissionCursors.cursor_at}::text`,
+        advanced: sql<boolean>`${agentBackupOrganizationAdmissionCursors.cursor_at}
+          > ${organizationCursorBeforePublication.cursorAt}::timestamptz`,
+      })
+      .from(agentBackupOrganizationAdmissionCursors)
+      .where(eq(agentBackupOrganizationAdmissionCursors.organization_id, ORG_ID));
+    expect(organizationCursor).toEqual({ cursorAt: expect.any(String), advanced: true });
   });
 
   test("persists and exactly replays one manifest-v3 operation key bundle", async () => {

--- a/packages/cloud/shared/src/db/repositories/agent-backup-catalog.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-backup-catalog.ts
@@ -31,6 +31,10 @@ import type { DbTransaction } from "../client";
 import { sqlRows } from "../execute-helpers";
 import { dbWrite } from "../helpers";
 import {
+  agentBackupNodeAdmissionCursors,
+  agentBackupOrganizationAdmissionCursors,
+} from "../schemas/agent-backup-admission";
+import {
   type AgentBackupCopyRole,
   type AgentBackupObject,
   type AgentBackupObjectProvider,
@@ -39,6 +43,7 @@ import {
   agentBackupObjects,
   agentBackupRestoreLeases,
 } from "../schemas/agent-backup-catalog";
+import { agentNodeIncarnationHistories } from "../schemas/agent-node-incarnation-histories";
 import {
   type AgentBackupCatalogState,
   type AgentBackupKind,
@@ -50,12 +55,11 @@ import {
   agentSandboxes,
   type StoredAgentSandboxBackup,
 } from "../schemas/agent-sandboxes";
-import { dockerNodes } from "../schemas/docker-nodes";
 import {
   AgentBackupSourceAuthorityError,
   requireCanonicalNodeIncarnation,
   requireCanonicalProviderServerId,
-  resolveAgentBackupManifestSourceAuthorityInTransaction,
+  resolveAgentBackupManifestSourceOccurrenceAuthorityInTransaction,
 } from "./agent-backup-source-authority";
 import { readPostLockDatabaseNow } from "./primary-database-clock";
 
@@ -94,6 +98,14 @@ export class AgentBackupCatalogConflictError extends Error {
   constructor(message: string, options?: { cause?: unknown }) {
     super(message, { cause: options?.cause });
     this.name = "AgentBackupCatalogConflictError";
+  }
+}
+
+/** Expected contention that must roll back a preliminary lease and retry later. */
+class AgentBackupAdmissionContendedError extends Error {
+  constructor() {
+    super("Backup admission authority changed while the claim was waiting");
+    this.name = "AgentBackupAdmissionContendedError";
   }
 }
 
@@ -424,9 +436,21 @@ function validateReservationInput(input: ReserveAgentBackupOperationInput): void
 function assertReservationReplay(
   row: StoredAgentSandboxBackup,
   input: ReserveAgentBackupOperationInput,
-  sourceNodeHistoryId: string,
   payloadDigest: string,
+  sourceNodeHistoryId: string,
 ): void {
+  const replayRequiresSourceNode =
+    row.catalog_state === "scheduled" ||
+    row.catalog_state === "capturing" ||
+    (row.catalog_state === "failed_retryable" &&
+      (row.catalog_resume_state === "scheduled" || row.catalog_resume_state === "capturing"));
+  // The cutover intentionally leaves pre-existing publication rows unbound:
+  // their historical occurrence cannot be inferred, but publication no longer
+  // consumes the node lane. Exact payload replay may return that same immutable
+  // row; the DB CHECK prevents any NULL-occurrence row from re-entering capture.
+  const sourceOccurrenceMatches =
+    row.source_node_history_id === sourceNodeHistoryId ||
+    (row.source_node_history_id === null && !replayRequiresSourceNode);
   const matches =
     row.backup_operation_id === input.operationId.toLowerCase() &&
     row.catalog_organization_id === input.organizationId.toLowerCase() &&
@@ -443,7 +467,7 @@ function assertReservationReplay(
     row.source_node_record_id === input.sourceNodeRecordId.toLowerCase() &&
     row.source_node_id === input.sourceNodeId &&
     row.source_node_incarnation === input.sourceNodeIncarnation &&
-    row.source_node_history_id === sourceNodeHistoryId &&
+    sourceOccurrenceMatches &&
     row.source_provider_server_id === input.sourceProviderServerId &&
     row.source_provider_handle === input.sourceProviderHandle &&
     row.source_container_id === input.sourceContainerId &&
@@ -560,20 +584,22 @@ export async function reserveAgentBackupOperationInTransaction(
   ) {
     throw new AgentBackupCatalogConflictError("Backup source generation no longer matches");
   }
-  let sourceAuthority;
+  let sourceOccurrenceAuthority;
   try {
-    sourceAuthority = await resolveAgentBackupManifestSourceAuthorityInTransaction(tx, {
-      nodeRecordId: input.sourceNodeRecordId,
-      nodeId: input.sourceNodeId,
-      nodeIncarnation: input.sourceNodeIncarnation,
-      containerId: input.sourceContainerId,
-    });
+    sourceOccurrenceAuthority =
+      await resolveAgentBackupManifestSourceOccurrenceAuthorityInTransaction(tx, {
+        nodeRecordId: input.sourceNodeRecordId,
+        nodeId: input.sourceNodeId,
+        nodeIncarnation: input.sourceNodeIncarnation,
+        containerId: input.sourceContainerId,
+      });
   } catch (cause) {
     if (cause instanceof AgentBackupSourceAuthorityError) {
       throw new AgentBackupCatalogConflictError(cause.message);
     }
     throw cause;
   }
+  const sourceAuthority = sourceOccurrenceAuthority.source;
   const sourceKind = input.sourceProvider === "operator-onboarded" ? "robot" : "cloud";
   const resolvedProviderServerId =
     sourceAuthority.kind === "cloud" ? sourceAuthority.providerServerId : null;
@@ -585,23 +611,18 @@ export async function reserveAgentBackupOperationInTransaction(
       "Backup source node record or Robot/Cloud provider authority does not match",
     );
   }
-  const [sourceOccurrence] = await tx
-    .select({ historyId: dockerNodes.current_node_history_id })
-    .from(dockerNodes)
-    .where(
-      and(
-        eq(dockerNodes.id, input.sourceNodeRecordId),
-        eq(dockerNodes.node_incarnation, input.sourceNodeIncarnation),
-      ),
-    )
-    .limit(1);
-  if (!sourceOccurrence?.historyId) {
-    throw new AgentBackupCatalogConflictError(
-      "Backup source node lacks exact append-only occurrence authority",
-    );
-  }
-  const sourceNodeHistoryId = sourceOccurrence.historyId;
-  const payloadDigest = await sha256Hex(canonicalReservationPayload(input, sourceNodeHistoryId));
+  const payloadDigest = await sha256Hex(
+    canonicalReservationPayload(input, sourceOccurrenceAuthority.nodeHistoryId),
+  );
+
+  await tx
+    .insert(agentBackupOrganizationAdmissionCursors)
+    .values({ organization_id: input.organizationId.toLowerCase() })
+    .onConflictDoNothing();
+  await tx
+    .insert(agentBackupNodeAdmissionCursors)
+    .values({ node_history_id: sourceOccurrenceAuthority.nodeHistoryId })
+    .onConflictDoNothing();
 
   if (input.backupKind === "incremental") {
     const [directParent] = await tx
@@ -698,7 +719,7 @@ export async function reserveAgentBackupOperationInTransaction(
       source_node_record_id: input.sourceNodeRecordId.toLowerCase(),
       source_node_id: input.sourceNodeId,
       source_node_incarnation: input.sourceNodeIncarnation,
-      source_node_history_id: sourceNodeHistoryId,
+      source_node_history_id: sourceOccurrenceAuthority.nodeHistoryId,
       source_provider_server_id: input.sourceProviderServerId,
       source_provider_handle: input.sourceProviderHandle,
       source_container_id: input.sourceContainerId,
@@ -743,7 +764,7 @@ export async function reserveAgentBackupOperationInTransaction(
     .for("update")
     .limit(1);
   if (!row) throw new Error("Backup operation reservation disappeared");
-  assertReservationReplay(row, input, sourceNodeHistoryId, payloadDigest);
+  assertReservationReplay(row, input, payloadDigest, sourceOccurrenceAuthority.nodeHistoryId);
   const authority = await lockAgentBackupCatalogAuthority(tx, input.organizationId, input.agentId);
   if (row.catalog_revision > authority.catalog_revision) {
     throw new AgentBackupCatalogConflictError(
@@ -762,9 +783,10 @@ async function renewAgentBackupOperationLeasesAfterLocks(
     generation: string;
     leaseMs: number;
     leaseMustRemainValidUntil?: Date;
+    databaseNow?: Date;
   },
 ): Promise<StoredAgentSandboxBackup[]> {
-  const databaseNow = await readPostLockDatabaseNow(tx);
+  const databaseNow = params.databaseNow ?? (await readPostLockDatabaseNow(tx));
   if (
     params.leaseMustRemainValidUntil &&
     params.leaseMustRemainValidUntil.getTime() <= databaseNow.getTime()
@@ -795,9 +817,257 @@ async function renewAgentBackupOperationLeasesAfterLocks(
   return renewed;
 }
 
+interface DueAgentBackupOperationCandidate {
+  id: string;
+  organization_id: string;
+  requires_source_node: boolean;
+  source_node_record_id: string;
+  source_node_incarnation: string;
+  node_history_id: string | null;
+  organization_cursor_at: string | null;
+  node_cursor_at: string | null;
+}
+
+interface LockedAgentBackupAdmissionAuthorities {
+  organizationIds: string[];
+  nodeHistoryIds: string[];
+}
+
 /**
- * Fairly claim at most one due operation per tenant. Every capture/upload
- * mutation must carry the returned owner+generation fence.
+ * Lock admission-only rows after the candidate backup and sandbox are already
+ * locked. Lifecycle, billing, replacement, and node-registration writers never
+ * own these rows, so fairness cannot invert their canonical lock orders.
+ */
+async function lockAgentBackupAdmissionAuthorities(
+  tx: DbTransaction,
+  candidates: DueAgentBackupOperationCandidate[],
+): Promise<LockedAgentBackupAdmissionAuthorities> {
+  const organizationIds = [...new Set(candidates.map((row) => row.organization_id))].sort();
+  const sourceNodeCandidates = candidates.filter((candidate) => candidate.requires_source_node);
+  const candidateByNodeHistoryId = new Map<string, DueAgentBackupOperationCandidate>();
+  for (const candidate of sourceNodeCandidates) {
+    if (!candidate.node_history_id) {
+      throw new AgentBackupCatalogConflictError(
+        "Backup capture admission is missing exact source-node history",
+      );
+    }
+    candidateByNodeHistoryId.set(candidate.node_history_id, candidate);
+  }
+  const nodeHistoryIds = [...candidateByNodeHistoryId.keys()].sort();
+  if (
+    organizationIds.length !== candidates.length ||
+    nodeHistoryIds.length !== sourceNodeCandidates.length
+  ) {
+    throw new AgentBackupCatalogConflictError(
+      "Backup admission selected more than one operation from the same fairness lane",
+    );
+  }
+
+  const lockedOrganizations = await tx
+    .select({
+      id: agentBackupOrganizationAdmissionCursors.organization_id,
+      cursorAt: sql<string | null>`${agentBackupOrganizationAdmissionCursors.cursor_at}::text`,
+    })
+    .from(agentBackupOrganizationAdmissionCursors)
+    .where(inArray(agentBackupOrganizationAdmissionCursors.organization_id, organizationIds))
+    .orderBy(agentBackupOrganizationAdmissionCursors.organization_id)
+    .for("update");
+  if (lockedOrganizations.length !== organizationIds.length) {
+    throw new AgentBackupCatalogConflictError(
+      "Backup admission organization authority disappeared",
+    );
+  }
+  const expectedOrganizationCursorById = new Map(
+    candidates.map((candidate) => [candidate.organization_id, candidate.organization_cursor_at]),
+  );
+  for (const organization of lockedOrganizations) {
+    if (organization.cursorAt !== expectedOrganizationCursorById.get(organization.id)) {
+      throw new AgentBackupAdmissionContendedError();
+    }
+  }
+
+  if (nodeHistoryIds.length > 0) {
+    const lockedNodes = await tx
+      .select({
+        historyId: agentBackupNodeAdmissionCursors.node_history_id,
+        cursorAt: sql<string | null>`${agentBackupNodeAdmissionCursors.cursor_at}::text`,
+      })
+      .from(agentBackupNodeAdmissionCursors)
+      .where(inArray(agentBackupNodeAdmissionCursors.node_history_id, nodeHistoryIds))
+      .orderBy(agentBackupNodeAdmissionCursors.node_history_id)
+      .for("update");
+    if (lockedNodes.length !== nodeHistoryIds.length) {
+      throw new AgentBackupCatalogConflictError(
+        "Backup capture admission occurrence cursor disappeared",
+      );
+    }
+    for (const node of lockedNodes) {
+      const expected = candidateByNodeHistoryId.get(node.historyId);
+      if (!expected || node.cursorAt !== expected.node_cursor_at) {
+        throw new AgentBackupAdmissionContendedError();
+      }
+    }
+  }
+  return {
+    organizationIds,
+    nodeHistoryIds,
+  };
+}
+
+async function assertAgentBackupAdmissionLanesRemainFree(
+  tx: DbTransaction,
+  candidates: DueAgentBackupOperationCandidate[],
+  databaseNow: Date,
+): Promise<void> {
+  const candidateLanes = sql.join(
+    candidates.map(
+      (candidate) => sql`(
+        ${candidate.id}::uuid,
+        ${candidate.organization_id}::uuid,
+        ${candidate.requires_source_node}::boolean,
+        ${candidate.source_node_record_id}::uuid,
+        ${candidate.source_node_incarnation}::uuid,
+        ${candidate.node_history_id}::uuid
+      )`,
+    ),
+    sql`, `,
+  );
+  const [conflict] = await sqlRows<{ id: string }>(
+    tx,
+    sql`
+      WITH claimed_lanes (
+        id, organization_id, requires_source_node,
+        source_node_record_id, source_node_incarnation,
+        node_history_id
+      ) AS (VALUES ${candidateLanes})
+      SELECT active.id
+      FROM ${agentSandboxBackups} AS active
+      WHERE active.catalog_lease_expires_at > ${databaseNow}
+        AND NOT EXISTS (
+          SELECT 1 FROM claimed_lanes AS own_claim WHERE own_claim.id = active.id
+        )
+        AND EXISTS (
+          SELECT 1
+          FROM claimed_lanes AS claimed
+          WHERE active.catalog_organization_id = claimed.organization_id
+            OR (
+              claimed.requires_source_node
+              AND
+              (
+                active.source_node_history_id = claimed.node_history_id
+                OR (
+                  active.source_node_history_id IS NULL
+                  AND active.source_node_record_id = claimed.source_node_record_id
+                  AND active.source_node_incarnation = claimed.source_node_incarnation
+                )
+              )
+              AND (
+                active.catalog_state IN ('scheduled', 'capturing')
+                OR (
+                  active.catalog_state = 'failed_retryable'
+                  AND active.catalog_resume_state IN ('scheduled', 'capturing')
+                )
+              )
+            )
+        )
+      LIMIT 1
+    `,
+  );
+  if (conflict) throw new AgentBackupAdmissionContendedError();
+}
+
+async function advanceAgentBackupAdmissionCursors(
+  tx: DbTransaction,
+  authorities: LockedAgentBackupAdmissionAuthorities,
+  cursorAt: string,
+): Promise<void> {
+  const organizationsAdvanced = await tx
+    .update(agentBackupOrganizationAdmissionCursors)
+    .set({
+      cursor_at: sql`${cursorAt}::timestamptz`,
+      updated_at: sql`${cursorAt}::timestamptz`,
+    })
+    .where(
+      inArray(agentBackupOrganizationAdmissionCursors.organization_id, authorities.organizationIds),
+    )
+    .returning({ id: agentBackupOrganizationAdmissionCursors.organization_id });
+  if (organizationsAdvanced.length !== authorities.organizationIds.length) {
+    throw new AgentBackupCatalogConflictError(
+      "Backup admission did not advance every organization cursor",
+    );
+  }
+  if (authorities.nodeHistoryIds.length > 0) {
+    const nodesAdvanced = await tx
+      .update(agentBackupNodeAdmissionCursors)
+      .set({
+        cursor_at: sql`${cursorAt}::timestamptz`,
+        updated_at: sql`${cursorAt}::timestamptz`,
+      })
+      .where(inArray(agentBackupNodeAdmissionCursors.node_history_id, authorities.nodeHistoryIds))
+      .returning({
+        historyId: agentBackupNodeAdmissionCursors.node_history_id,
+      });
+    if (nodesAdvanced.length !== authorities.nodeHistoryIds.length) {
+      throw new AgentBackupCatalogConflictError(
+        "Backup admission did not advance every exact source-node cursor",
+      );
+    }
+  }
+}
+
+/** Produce one exact logical turn that is newer than every locked lane. */
+async function readNextAgentBackupAdmissionCursor(
+  tx: DbTransaction,
+  authorities: LockedAgentBackupAdmissionAuthorities,
+): Promise<string> {
+  const organizationIds = sql.join(
+    authorities.organizationIds.map((id) => sql`${id}::uuid`),
+    sql`, `,
+  );
+  const nodeCursorUnion =
+    authorities.nodeHistoryIds.length > 0
+      ? sql`
+        UNION ALL
+        SELECT node_cursor.cursor_at
+        FROM ${agentBackupNodeAdmissionCursors} AS node_cursor
+        WHERE node_cursor.node_history_id IN (${sql.join(
+          authorities.nodeHistoryIds.map((id) => sql`${id}::uuid`),
+          sql`, `,
+        )})
+      `
+      : sql``;
+  const [turn] = await sqlRows<{ cursor_at: string }>(
+    tx,
+    sql`
+      SELECT GREATEST(
+        clock_timestamp(),
+        COALESCE(MAX(lane.cursor_at), '-infinity'::timestamptz)
+          + INTERVAL '1 microsecond'
+      )::text AS cursor_at
+      FROM (
+        SELECT organization_cursor.cursor_at
+        FROM ${agentBackupOrganizationAdmissionCursors} AS organization_cursor
+        WHERE organization_cursor.organization_id IN (${organizationIds})
+        ${nodeCursorUnion}
+      ) AS lane
+    `,
+  );
+  if (!turn?.cursor_at) {
+    throw new AgentBackupCatalogConflictError(
+      "Backup admission could not allocate an exact monotonic cursor",
+    );
+  }
+  return turn.cursor_at;
+}
+
+/**
+ * Claim at most one due operation per tenant and, while capture still needs
+ * the source runtime, per exact source-node lane. The durable lane cursors are
+ * last-service hints; global starvation freedom belongs to the queued/deferred
+ * cohort authority and must not be inferred from this operation-level claim.
+ * Publication is driven from the durable capture spool/R2 inventory and
+ * advances only its tenant cursor. Every applicable cursor advances in the
+ * same commit as the returned owner+generation lease fence.
  */
 export async function claimDueAgentBackupOperations(params: {
   ownerId: string;
@@ -821,117 +1091,365 @@ export async function claimDueAgentBackupOperations(params: {
   }
   const generation = randomUUID();
 
-  return dbWrite.transaction(async (tx) => {
-    const candidates = await sqlRows<{ id: string }>(
-      tx,
-      sql`
-        WITH fair AS MATERIALIZED (
-          SELECT DISTINCT ON (backup.catalog_organization_id)
+  try {
+    return await dbWrite.transaction(async (tx) => {
+      const candidates = await sqlRows<DueAgentBackupOperationCandidate>(
+        tx,
+        sql`
+          WITH RECURSIVE operation_base AS MATERIALIZED (
+            SELECT
+              backup.id,
+              backup.catalog_organization_id AS organization_id,
+              backup.sandbox_record_id,
+              backup.catalog_state,
+              backup.catalog_resume_state,
+              backup.catalog_next_attempt_at,
+              (
+                backup.catalog_state IN ('scheduled', 'capturing')
+                OR (
+                  backup.catalog_state = 'failed_retryable'
+                  AND backup.catalog_resume_state IN ('scheduled', 'capturing')
+                )
+              ) AS requires_source_node,
+              backup.source_node_record_id,
+              backup.source_node_id,
+              backup.source_node_incarnation,
+              backup.source_node_history_id AS node_history_id,
+              backup.source_provider,
+              backup.source_provider_server_id,
+              backup.source_provider_handle,
+              backup.source_container_id,
+              organization_cursor.cursor_at AS organization_cursor_at,
+              COALESCE(backup.catalog_next_attempt_at, backup.created_at) AS due_at,
+              backup.created_at
+            FROM ${agentSandboxBackups} AS backup
+            JOIN ${agentBackupOrganizationAdmissionCursors} AS organization_cursor
+              ON organization_cursor.organization_id = backup.catalog_organization_id
+            WHERE backup.catalog_version = 2
+              AND backup.sandbox_record_id IS NOT NULL
+              AND backup.source_provider IN ('operator-onboarded', 'hetzner-cloud')
+              AND backup.source_node_record_id IS NOT NULL
+              AND backup.source_node_id IS NOT NULL
+              AND backup.source_node_id <> ''
+              AND backup.source_node_incarnation IS NOT NULL
+              AND backup.source_provider_handle IS NOT NULL
+              AND backup.source_provider_handle <> ''
+              AND backup.source_container_id ~ '^[0-9a-f]{64}$'
+              AND backup.source_provider_handle <> backup.source_container_id
+              AND (
+                (backup.source_provider = 'operator-onboarded'
+                  AND backup.source_provider_server_id IS NULL)
+                OR
+                (backup.source_provider = 'hetzner-cloud'
+                  AND CASE
+                    WHEN backup.source_provider_server_id ~ '^[1-9][0-9]{0,19}$'
+                      THEN backup.source_provider_server_id::numeric <= 18446744073709551615
+                    ELSE FALSE
+                  END)
+              )
+              AND backup.catalog_state IN (
+                'scheduled', 'capturing', 'captured', 'uploading',
+                'primary_uploaded', 'primary_verified', 'secondary_pending',
+                'failed_retryable'
+              )
+              AND (backup.catalog_next_attempt_at IS NULL
+                OR backup.catalog_next_attempt_at <= statement_timestamp())
+              AND (backup.catalog_lease_expires_at IS NULL
+                OR backup.catalog_lease_expires_at <= statement_timestamp())
+          ), eligible AS MATERIALIZED (
+            SELECT
+              operation_base.*,
+              node_cursor.cursor_at AS node_cursor_at,
+              CASE
+                WHEN operation_base.requires_source_node THEN node_cursor.cursor_at
+                ELSE operation_base.organization_cursor_at
+              END AS effective_node_cursor_at,
+              CASE
+                WHEN operation_base.requires_source_node THEN GREATEST(
+                  COALESCE(operation_base.organization_cursor_at, '-infinity'::timestamptz),
+                  COALESCE(node_cursor.cursor_at, '-infinity'::timestamptz)
+                )
+                ELSE COALESCE(
+                  operation_base.organization_cursor_at,
+                  '-infinity'::timestamptz
+                )
+              END AS admission_cursor_at
+            FROM operation_base
+            LEFT JOIN ${agentNodeIncarnationHistories} AS source_occurrence
+              ON operation_base.requires_source_node
+              AND source_occurrence.id = operation_base.node_history_id
+              AND source_occurrence.docker_node_record_id = operation_base.source_node_record_id
+              AND source_occurrence.node_incarnation = operation_base.source_node_incarnation
+            LEFT JOIN ${agentBackupNodeAdmissionCursors} AS node_cursor
+              ON operation_base.requires_source_node
+              AND node_cursor.node_history_id = operation_base.node_history_id
+            WHERE (
+                NOT operation_base.requires_source_node
+                OR (
+                  operation_base.node_history_id IS NOT NULL
+                  AND source_occurrence.id IS NOT NULL
+                  AND source_occurrence.node_id = operation_base.source_node_id
+                  AND source_occurrence.infrastructure_provider = 'hetzner'
+                  AND btrim(source_occurrence.host_key_fingerprint) <> ''
+                  AND node_cursor.node_history_id IS NOT NULL
+                  AND (
+                    (operation_base.source_provider = 'operator-onboarded'
+                      AND source_occurrence.fleet_kind = 'robot'
+                      AND source_occurrence.provider_server_id IS NULL)
+                    OR
+                    (operation_base.source_provider = 'hetzner-cloud'
+                      AND source_occurrence.fleet_kind = 'cloud'
+                      AND source_occurrence.provider_server_id =
+                        operation_base.source_provider_server_id)
+                  )
+                )
+              )
+              AND NOT EXISTS (
+                SELECT 1
+                FROM ${agentSandboxBackups} AS active
+                WHERE active.catalog_lease_expires_at > statement_timestamp()
+                  AND (
+                    active.catalog_organization_id = operation_base.organization_id
+                    OR (
+                      operation_base.requires_source_node
+                      AND (
+                        active.source_node_history_id = operation_base.node_history_id
+                        OR (
+                          active.source_node_history_id IS NULL
+                          AND active.source_node_record_id = operation_base.source_node_record_id
+                          AND active.source_node_incarnation = operation_base.source_node_incarnation
+                        )
+                      )
+                      AND (
+                        active.catalog_state IN ('scheduled', 'capturing')
+                        OR (
+                          active.catalog_state = 'failed_retryable'
+                          AND active.catalog_resume_state IN ('scheduled', 'capturing')
+                        )
+                      )
+                    )
+                  )
+              )
+          ), ordered AS MATERIALIZED (
+            SELECT
+              eligible.*,
+              ROW_NUMBER() OVER (
+                ORDER BY
+                  admission_cursor_at,
+                  COALESCE(organization_cursor_at, '-infinity'::timestamptz),
+                  COALESCE(effective_node_cursor_at, '-infinity'::timestamptz),
+                  due_at,
+                  created_at,
+                  organization_id,
+                  COALESCE(node_history_id, id),
+                  id
+              ) AS candidate_ordinal
+            FROM eligible
+          ), greedy AS (
+            SELECT
+              0::bigint AS candidate_ordinal,
+              ARRAY[]::uuid[] AS backup_ids,
+              ARRAY[]::uuid[] AS organization_ids,
+              ARRAY[]::uuid[] AS node_history_ids
+            UNION ALL
+            SELECT
+              candidate.candidate_ordinal,
+              CASE
+                WHEN decision.consider_candidate
+                  AND locked.id IS NOT NULL
+                  AND locked.is_fresh
+                THEN array_append(greedy.backup_ids, candidate.id)
+                ELSE greedy.backup_ids
+              END,
+              CASE WHEN decision.consider_candidate
+                THEN array_append(greedy.organization_ids, candidate.organization_id)
+                ELSE greedy.organization_ids
+              END,
+              CASE WHEN decision.consider_candidate AND candidate.requires_source_node
+                THEN array_append(greedy.node_history_ids, candidate.node_history_id)
+                ELSE greedy.node_history_ids
+              END
+            FROM greedy
+            JOIN ordered AS candidate
+              ON candidate.candidate_ordinal = greedy.candidate_ordinal + 1
+            CROSS JOIN LATERAL (
+              SELECT
+                NOT (candidate.organization_id = ANY(greedy.organization_ids))
+                AND (
+                  NOT candidate.requires_source_node
+                  OR NOT (candidate.node_history_id = ANY(greedy.node_history_ids))
+                ) AS consider_candidate
+            ) AS decision
+            LEFT JOIN LATERAL (
+              SELECT
+                backup.id,
+                ((
+                  backup.catalog_version = 2
+                  AND backup.catalog_organization_id = candidate.organization_id
+                  AND backup.sandbox_record_id = candidate.sandbox_record_id
+                  AND backup.catalog_state = candidate.catalog_state
+                  AND backup.catalog_resume_state
+                    IS NOT DISTINCT FROM candidate.catalog_resume_state
+                  AND backup.catalog_next_attempt_at
+                    IS NOT DISTINCT FROM candidate.catalog_next_attempt_at
+                  AND backup.source_node_record_id = candidate.source_node_record_id
+                  AND backup.source_node_id = candidate.source_node_id
+                  AND backup.source_node_incarnation = candidate.source_node_incarnation
+                  AND backup.source_node_history_id
+                    IS NOT DISTINCT FROM candidate.node_history_id
+                  AND backup.source_provider = candidate.source_provider
+                  AND backup.source_provider_server_id
+                    IS NOT DISTINCT FROM candidate.source_provider_server_id
+                  AND backup.source_provider_handle = candidate.source_provider_handle
+                  AND backup.source_container_id = candidate.source_container_id
+                  AND backup.created_at = candidate.created_at
+                  AND (
+                    backup.catalog_state IN ('scheduled', 'capturing')
+                    OR (
+                      backup.catalog_state = 'failed_retryable'
+                      AND backup.catalog_resume_state IN ('scheduled', 'capturing')
+                    )
+                  ) = candidate.requires_source_node
+                  AND backup.catalog_state IN (
+                    'scheduled', 'capturing', 'captured', 'uploading',
+                    'primary_uploaded', 'primary_verified', 'secondary_pending',
+                    'failed_retryable'
+                  )
+                  AND (backup.catalog_next_attempt_at IS NULL
+                    OR backup.catalog_next_attempt_at <= statement_timestamp())
+                  AND (backup.catalog_lease_expires_at IS NULL
+                    OR backup.catalog_lease_expires_at <= statement_timestamp())
+                ) IS TRUE) AS is_fresh
+              FROM ${agentSandboxBackups} AS backup
+              JOIN ${agentSandboxes} AS sandbox_row
+                ON sandbox_row.id = backup.sandbox_record_id
+                AND sandbox_row.organization_id = candidate.organization_id
+              WHERE decision.consider_candidate
+                AND backup.id = candidate.id
+              LIMIT 1
+              FOR UPDATE OF backup SKIP LOCKED
+              FOR KEY SHARE OF sandbox_row SKIP LOCKED
+            ) AS locked ON TRUE
+            WHERE cardinality(greedy.backup_ids) < ${params.limit}
+          ), selected AS MATERIALIZED (
+            SELECT backup_ids
+            FROM greedy
+            ORDER BY candidate_ordinal DESC
+            LIMIT 1
+          ), chosen AS MATERIALIZED (
+            SELECT chosen_backup.id, chosen_backup.ordinality
+            FROM selected
+            CROSS JOIN LATERAL unnest(selected.backup_ids)
+              WITH ORDINALITY AS chosen_backup(id, ordinality)
+          )
+          SELECT
             backup.id,
-            backup.catalog_organization_id,
-            COALESCE(backup.catalog_next_attempt_at, backup.created_at) AS due_at,
-            backup.created_at
+            candidate.organization_id,
+            candidate.requires_source_node,
+            candidate.source_node_record_id,
+            candidate.source_node_incarnation,
+            candidate.node_history_id,
+            candidate.organization_cursor_at::text AS organization_cursor_at,
+            candidate.node_cursor_at::text AS node_cursor_at
           FROM ${agentSandboxBackups} AS backup
-          WHERE backup.catalog_version = 2
-            AND backup.sandbox_record_id IS NOT NULL
-            AND backup.source_provider IN ('operator-onboarded', 'hetzner-cloud')
-            AND backup.source_node_record_id IS NOT NULL
-            AND backup.source_node_id IS NOT NULL
-            AND backup.source_node_id <> ''
-            AND backup.source_node_incarnation IS NOT NULL
-            AND backup.source_provider_handle IS NOT NULL
-            AND backup.source_provider_handle <> ''
-            AND backup.source_container_id ~ '^[0-9a-f]{64}$'
-            AND backup.source_provider_handle <> backup.source_container_id
-            AND (
-              (backup.source_provider = 'operator-onboarded'
-                AND backup.source_provider_server_id IS NULL)
+          JOIN chosen ON chosen.id = backup.id
+          JOIN ordered AS candidate ON candidate.id = backup.id
+          ORDER BY chosen.ordinality
+        `,
+      );
+      if (candidates.length === 0) return [];
+
+      const authorities = await lockAgentBackupAdmissionAuthorities(tx, candidates);
+      const preClaimDatabaseNow = await readPostLockDatabaseNow(tx);
+      await assertAgentBackupAdmissionLanesRemainFree(tx, candidates, preClaimDatabaseNow);
+      await tx.execute(sql`
+        SELECT set_config('eliza.agent_backup_admission_protocol', '2', TRUE)
+      `);
+      const claimed = await tx
+        .update(agentSandboxBackups)
+        .set({
+          catalog_lease_owner: params.ownerId,
+          catalog_lease_generation: generation,
+          // The backup, sandbox, and dedicated lane rows are already locked.
+          // This marker-bearing mutation is the atomic lease activation.
+          catalog_lease_expires_at: sql`clock_timestamp()
+            + (${params.leaseMs} * INTERVAL '1 millisecond')`,
+          catalog_updated_at: sql`clock_timestamp()`,
+        })
+        .where(
+          and(
+            eq(agentSandboxBackups.catalog_version, 2),
+            inArray(
+              agentSandboxBackups.id,
+              candidates.map((candidate) => candidate.id),
+            ),
+            sql`${agentSandboxBackups.sandbox_record_id} IS NOT NULL`,
+            sql`${agentSandboxBackups.source_provider} IN ('operator-onboarded', 'hetzner-cloud')`,
+            sql`${agentSandboxBackups.source_node_record_id} IS NOT NULL`,
+            sql`${agentSandboxBackups.source_node_id} IS NOT NULL
+              AND ${agentSandboxBackups.source_node_id} <> ''`,
+            sql`${agentSandboxBackups.source_node_incarnation} IS NOT NULL`,
+            sql`${agentSandboxBackups.source_provider_handle} IS NOT NULL
+              AND ${agentSandboxBackups.source_provider_handle} <> ''`,
+            sql`${agentSandboxBackups.source_container_id} ~ '^[0-9a-f]{64}$'`,
+            sql`${agentSandboxBackups.source_provider_handle}
+              <> ${agentSandboxBackups.source_container_id}`,
+            sql`(
+              (${agentSandboxBackups.source_provider} = 'operator-onboarded'
+                AND ${agentSandboxBackups.source_provider_server_id} IS NULL)
               OR
-              (backup.source_provider = 'hetzner-cloud'
+              (${agentSandboxBackups.source_provider} = 'hetzner-cloud'
                 AND CASE
-                  WHEN backup.source_provider_server_id ~ '^[1-9][0-9]{0,19}$'
-                    THEN backup.source_provider_server_id::numeric <= 18446744073709551615
+                  WHEN ${agentSandboxBackups.source_provider_server_id} ~ '^[1-9][0-9]{0,19}$'
+                    THEN ${agentSandboxBackups.source_provider_server_id}::numeric
+                      <= 18446744073709551615
                   ELSE FALSE
                 END)
-            )
-            AND backup.catalog_state IN (
-              'scheduled', 'capturing', 'captured', 'uploading',
-              'primary_uploaded', 'primary_verified', 'secondary_pending',
-              'failed_retryable'
-            )
-            AND (backup.catalog_next_attempt_at IS NULL OR backup.catalog_next_attempt_at <= NOW())
-            AND (backup.catalog_lease_expires_at IS NULL OR backup.catalog_lease_expires_at <= NOW())
-          ORDER BY backup.catalog_organization_id,
-            COALESCE(backup.catalog_next_attempt_at, backup.created_at), backup.created_at
-        )
-        SELECT backup.id
-        FROM ${agentSandboxBackups} AS backup
-        JOIN fair ON fair.id = backup.id
-        ORDER BY fair.due_at, fair.created_at, backup.id
-        LIMIT ${params.limit}
-        FOR UPDATE OF backup SKIP LOCKED
-      `,
-    );
-    if (candidates.length === 0) return [];
-    const claimed = await tx
-      .update(agentSandboxBackups)
-      .set({
-        catalog_lease_owner: params.ownerId,
-        catalog_lease_generation: generation,
-        // Preliminary fence. A backup-mutation trigger may still block after
-        // these expressions are evaluated, so this is renewed below from a
-        // post-trigger database clock before the transaction can commit.
-        catalog_lease_expires_at: sql`clock_timestamp()
-          + (${params.leaseMs} * INTERVAL '1 millisecond')`,
-        catalog_updated_at: sql`clock_timestamp()`,
-      })
-      .where(
-        and(
-          inArray(
-            agentSandboxBackups.id,
-            candidates.map((candidate) => candidate.id),
+            )`,
+            sql`(${agentSandboxBackups.catalog_lease_expires_at} IS NULL
+              OR ${agentSandboxBackups.catalog_lease_expires_at} <= clock_timestamp())`,
+            inArray(agentSandboxBackups.catalog_state, EXECUTION_OWNED_STATES),
+            or(
+              isNull(agentSandboxBackups.catalog_next_attempt_at),
+              lte(agentSandboxBackups.catalog_next_attempt_at, sql`clock_timestamp()`),
+            ),
           ),
-          sql`${agentSandboxBackups.sandbox_record_id} IS NOT NULL`,
-          sql`${agentSandboxBackups.source_provider} IN ('operator-onboarded', 'hetzner-cloud')`,
-          sql`${agentSandboxBackups.source_node_record_id} IS NOT NULL`,
-          sql`${agentSandboxBackups.source_node_id} IS NOT NULL
-            AND ${agentSandboxBackups.source_node_id} <> ''`,
-          sql`${agentSandboxBackups.source_node_incarnation} IS NOT NULL`,
-          sql`${agentSandboxBackups.source_provider_handle} IS NOT NULL
-            AND ${agentSandboxBackups.source_provider_handle} <> ''`,
-          sql`${agentSandboxBackups.source_container_id} ~ '^[0-9a-f]{64}$'`,
-          sql`${agentSandboxBackups.source_provider_handle}
-            <> ${agentSandboxBackups.source_container_id}`,
-          sql`(
-            (${agentSandboxBackups.source_provider} = 'operator-onboarded'
-              AND ${agentSandboxBackups.source_provider_server_id} IS NULL)
-            OR
-            (${agentSandboxBackups.source_provider} = 'hetzner-cloud'
-              AND CASE
-                WHEN ${agentSandboxBackups.source_provider_server_id} ~ '^[1-9][0-9]{0,19}$'
-                  THEN ${agentSandboxBackups.source_provider_server_id}::numeric
-                    <= 18446744073709551615
-                ELSE FALSE
-              END)
-          )`,
-          sql`(${agentSandboxBackups.catalog_lease_expires_at} IS NULL
-            OR ${agentSandboxBackups.catalog_lease_expires_at} <= NOW())`,
-        ),
-      )
-      .returning();
-    if (claimed.length === 0) return [];
-    const renewed = await renewAgentBackupOperationLeasesAfterLocks(tx, {
-      backupIds: claimed.map((backup) => backup.id),
-      ownerId: params.ownerId,
-      generation,
-      leaseMs: params.leaseMs,
+        )
+        .returning();
+      if (claimed.length !== candidates.length) {
+        throw new AgentBackupCatalogConflictError(
+          "Backup admission could not lease every selected operation",
+        );
+      }
+
+      // No external writer can mutate a locked lane. Rechecking here also
+      // fences database triggers or mixed-version code in this transaction.
+      await lockAgentBackupAdmissionAuthorities(tx, candidates);
+      const cursorAt = await readNextAgentBackupAdmissionCursor(tx, authorities);
+      const databaseNow = await readPostLockDatabaseNow(tx);
+      const renewed = await renewAgentBackupOperationLeasesAfterLocks(tx, {
+        backupIds: claimed.map((backup) => backup.id),
+        ownerId: params.ownerId,
+        generation,
+        leaseMs: params.leaseMs,
+        databaseNow,
+      });
+      await advanceAgentBackupAdmissionCursors(tx, authorities, cursorAt);
+      const renewedById = new Map(renewed.map((backup) => [backup.id, backup]));
+      return candidates.map((candidate) => {
+        const backup = renewedById.get(candidate.id);
+        if (!backup) {
+          throw new AgentBackupCatalogConflictError(
+            "Backup admission lost a renewed operation while preserving fair order",
+          );
+        }
+        return { backup, ownerId: params.ownerId, generation };
+      });
     });
-    return renewed.map((backup) => ({
-      backup,
-      ownerId: params.ownerId,
-      generation,
-    }));
-  });
+  } catch (error) {
+    if (error instanceof AgentBackupAdmissionContendedError) return [];
+    throw error;
+  }
 }
 
 export async function heartbeatAgentBackupOperation(params: {
@@ -951,32 +1469,91 @@ export async function heartbeatAgentBackupOperation(params: {
     throw new Error(`leaseMs must be between 1 and ${MAX_OPERATION_LEASE_MS}`);
   }
   return dbWrite.transaction(async (tx) => {
-    const [leased] = await tx
-      .select({
-        id: agentSandboxBackups.id,
-        leaseExpiresAt: agentSandboxBackups.catalog_lease_expires_at,
-      })
-      .from(agentSandboxBackups)
-      .where(
-        and(
-          eq(agentSandboxBackups.id, params.backupId),
-          eq(agentSandboxBackups.catalog_organization_id, params.organizationId),
-          eq(agentSandboxBackups.catalog_lease_owner, params.execution.ownerId),
-          eq(agentSandboxBackups.catalog_lease_generation, params.execution.generation),
-          sql`${agentSandboxBackups.sandbox_record_id} IS NOT NULL`,
-          sql`${agentSandboxBackups.catalog_state} IN (${sql.join(
-            EXECUTION_OWNED_STATES.map((state) => sql`${state}`),
-            sql`, `,
-          )})`,
-        ),
-      )
-      .limit(1)
-      .for("update");
-    if (!leased?.leaseExpiresAt) {
+    const [candidate] = await sqlRows<
+      DueAgentBackupOperationCandidate & { lease_expires_at: Date | string }
+    >(
+      tx,
+      sql`
+        SELECT
+          backup.id,
+          backup.catalog_organization_id AS organization_id,
+          (
+            backup.catalog_state IN ('scheduled', 'capturing')
+            OR (
+              backup.catalog_state = 'failed_retryable'
+              AND backup.catalog_resume_state IN ('scheduled', 'capturing')
+            )
+          ) AS requires_source_node,
+          backup.source_node_record_id,
+          backup.source_node_incarnation,
+          backup.source_node_history_id AS node_history_id,
+          organization_cursor.cursor_at::text AS organization_cursor_at,
+          node_cursor.cursor_at::text AS node_cursor_at,
+          backup.catalog_lease_expires_at AS lease_expires_at
+        FROM ${agentSandboxBackups} AS backup
+        JOIN ${agentSandboxes} AS sandbox_row
+          ON sandbox_row.id = backup.sandbox_record_id
+          AND sandbox_row.organization_id = backup.catalog_organization_id
+        JOIN ${agentBackupOrganizationAdmissionCursors} AS organization_cursor
+          ON organization_cursor.organization_id = backup.catalog_organization_id
+        LEFT JOIN ${agentBackupNodeAdmissionCursors} AS node_cursor
+          ON (
+            backup.catalog_state IN ('scheduled', 'capturing')
+            OR (
+              backup.catalog_state = 'failed_retryable'
+              AND backup.catalog_resume_state IN ('scheduled', 'capturing')
+            )
+          )
+          AND node_cursor.node_history_id = backup.source_node_history_id
+        WHERE backup.id = ${params.backupId}::uuid
+          AND backup.catalog_version = 2
+          AND backup.catalog_organization_id = ${params.organizationId}::uuid
+          AND backup.catalog_lease_owner = ${params.execution.ownerId}
+          AND backup.catalog_lease_generation = ${params.execution.generation}::uuid
+          AND backup.catalog_lease_expires_at > clock_timestamp()
+          AND backup.source_node_record_id IS NOT NULL
+          AND backup.source_node_incarnation IS NOT NULL
+          AND backup.catalog_state IN (
+            'scheduled', 'capturing', 'captured', 'uploading',
+            'primary_uploaded', 'primary_verified', 'secondary_pending',
+            'failed_retryable'
+          )
+          AND (
+            NOT (
+              backup.catalog_state IN ('scheduled', 'capturing')
+              OR (
+                backup.catalog_state = 'failed_retryable'
+                AND backup.catalog_resume_state IN ('scheduled', 'capturing')
+              )
+            )
+            OR (
+              backup.source_node_history_id IS NOT NULL
+              AND node_cursor.node_history_id IS NOT NULL
+            )
+          )
+        LIMIT 1
+        FOR UPDATE OF backup SKIP LOCKED
+        FOR KEY SHARE OF sandbox_row SKIP LOCKED
+      `,
+    );
+    if (!candidate?.lease_expires_at) {
       throw new AgentBackupCatalogConflictError(
         "Backup operation heartbeat lost its execution generation",
       );
     }
+    const leaseExpiresAt =
+      candidate.lease_expires_at instanceof Date
+        ? candidate.lease_expires_at
+        : new Date(candidate.lease_expires_at);
+    if (!Number.isFinite(leaseExpiresAt.getTime())) {
+      throw new AgentBackupCatalogConflictError(
+        "Backup operation heartbeat read an invalid lease expiry",
+      );
+    }
+    await lockAgentBackupAdmissionAuthorities(tx, [candidate]);
+    await tx.execute(sql`
+      SELECT set_config('eliza.agent_backup_admission_protocol', '2', TRUE)
+    `);
     const [updated] = await tx
       .update(agentSandboxBackups)
       .set({
@@ -1004,12 +1581,13 @@ export async function heartbeatAgentBackupOperation(params: {
         "Backup operation heartbeat lost its execution generation",
       );
     }
+    await lockAgentBackupAdmissionAuthorities(tx, [candidate]);
     const [renewed] = await renewAgentBackupOperationLeasesAfterLocks(tx, {
       backupIds: [updated.id],
       ownerId: params.execution.ownerId,
       generation: params.execution.generation,
       leaseMs: params.leaseMs,
-      leaseMustRemainValidUntil: leased.leaseExpiresAt,
+      leaseMustRemainValidUntil: leaseExpiresAt,
     });
     if (!renewed) {
       throw new AgentBackupCatalogConflictError(
@@ -1728,26 +2306,29 @@ export async function recordCapturedAgentBackupManifest(params: {
         "Backup source activation changed before the manifest was recorded",
       );
     }
-    let currentSourceAuthority;
+    let currentSourceOccurrenceAuthority;
     try {
-      currentSourceAuthority = await resolveAgentBackupManifestSourceAuthorityInTransaction(tx, {
-        nodeRecordId: row.source_node_record_id,
-        nodeId: row.source_node_id,
-        nodeIncarnation: row.source_node_incarnation,
-        containerId: row.source_container_id,
-      });
+      currentSourceOccurrenceAuthority =
+        await resolveAgentBackupManifestSourceOccurrenceAuthorityInTransaction(tx, {
+          nodeRecordId: row.source_node_record_id,
+          nodeId: row.source_node_id,
+          nodeIncarnation: row.source_node_incarnation,
+          containerId: row.source_container_id,
+        });
     } catch (cause) {
       if (cause instanceof AgentBackupSourceAuthorityError) {
         throw new AgentBackupCatalogConflictError(cause.message);
       }
       throw cause;
     }
+    const currentSourceAuthority = currentSourceOccurrenceAuthority.source;
     const currentProviderServerId =
       currentSourceAuthority.kind === "cloud" ? currentSourceAuthority.providerServerId : null;
     if (
       currentSourceAuthority.kind !==
         (row.source_provider === "operator-onboarded" ? "robot" : "cloud") ||
-      currentProviderServerId !== row.source_provider_server_id
+      currentProviderServerId !== row.source_provider_server_id ||
+      currentSourceOccurrenceAuthority.nodeHistoryId !== row.source_node_history_id
     ) {
       throw new AgentBackupCatalogConflictError(
         "Backup source node authority changed before the manifest was recorded",

--- a/packages/cloud/shared/src/db/repositories/agent-backup-catalog.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-backup-catalog.ts
@@ -2,6 +2,7 @@
 
 import { Buffer } from "node:buffer";
 import { randomUUID } from "node:crypto";
+import { ElizaError } from "@elizaos/core";
 import {
   AGENT_BACKUP_MANIFEST_V2_LIMITS,
   AGENT_BACKUP_OPERATION_KEY_BUNDLE_CONTEXT_DERIVATION,
@@ -102,10 +103,21 @@ export class AgentBackupCatalogConflictError extends Error {
 }
 
 /** Expected contention that must roll back a preliminary lease and retry later. */
-class AgentBackupAdmissionContendedError extends Error {
+export const AGENT_BACKUP_ADMISSION_CONTENDED_CODE =
+  "BACKUP_OPERATION_ADMISSION_CONTENDED" as const;
+
+export class AgentBackupAdmissionContendedError extends ElizaError {
+  override readonly name = "AgentBackupAdmissionContendedError";
+
   constructor() {
-    super("Backup admission authority changed while the claim was waiting");
-    this.name = "AgentBackupAdmissionContendedError";
+    super("Backup admission authority changed while the claim was waiting", {
+      code: AGENT_BACKUP_ADMISSION_CONTENDED_CODE,
+      context: {
+        operation: "claim",
+        retryAction: "retry-operation-claim",
+      },
+      severity: "ephemeral",
+    });
   }
 }
 
@@ -1091,11 +1103,10 @@ export async function claimDueAgentBackupOperations(params: {
   }
   const generation = randomUUID();
 
-  try {
-    return await dbWrite.transaction(async (tx) => {
-      const candidates = await sqlRows<DueAgentBackupOperationCandidate>(
-        tx,
-        sql`
+  return dbWrite.transaction(async (tx) => {
+    const candidates = await sqlRows<DueAgentBackupOperationCandidate>(
+      tx,
+      sql`
           WITH RECURSIVE operation_base AS MATERIALIZED (
             SELECT
               backup.id,
@@ -1356,45 +1367,45 @@ export async function claimDueAgentBackupOperations(params: {
           JOIN ordered AS candidate ON candidate.id = backup.id
           ORDER BY chosen.ordinality
         `,
-      );
-      if (candidates.length === 0) return [];
+    );
+    if (candidates.length === 0) return [];
 
-      const authorities = await lockAgentBackupAdmissionAuthorities(tx, candidates);
-      const preClaimDatabaseNow = await readPostLockDatabaseNow(tx);
-      await assertAgentBackupAdmissionLanesRemainFree(tx, candidates, preClaimDatabaseNow);
-      await tx.execute(sql`
+    const authorities = await lockAgentBackupAdmissionAuthorities(tx, candidates);
+    const preClaimDatabaseNow = await readPostLockDatabaseNow(tx);
+    await assertAgentBackupAdmissionLanesRemainFree(tx, candidates, preClaimDatabaseNow);
+    await tx.execute(sql`
         SELECT set_config('eliza.agent_backup_admission_protocol', '2', TRUE)
       `);
-      const claimed = await tx
-        .update(agentSandboxBackups)
-        .set({
-          catalog_lease_owner: params.ownerId,
-          catalog_lease_generation: generation,
-          // The backup, sandbox, and dedicated lane rows are already locked.
-          // This marker-bearing mutation is the atomic lease activation.
-          catalog_lease_expires_at: sql`clock_timestamp()
+    const claimed = await tx
+      .update(agentSandboxBackups)
+      .set({
+        catalog_lease_owner: params.ownerId,
+        catalog_lease_generation: generation,
+        // The backup, sandbox, and dedicated lane rows are already locked.
+        // This marker-bearing mutation is the atomic lease activation.
+        catalog_lease_expires_at: sql`clock_timestamp()
             + (${params.leaseMs} * INTERVAL '1 millisecond')`,
-          catalog_updated_at: sql`clock_timestamp()`,
-        })
-        .where(
-          and(
-            eq(agentSandboxBackups.catalog_version, 2),
-            inArray(
-              agentSandboxBackups.id,
-              candidates.map((candidate) => candidate.id),
-            ),
-            sql`${agentSandboxBackups.sandbox_record_id} IS NOT NULL`,
-            sql`${agentSandboxBackups.source_provider} IN ('operator-onboarded', 'hetzner-cloud')`,
-            sql`${agentSandboxBackups.source_node_record_id} IS NOT NULL`,
-            sql`${agentSandboxBackups.source_node_id} IS NOT NULL
+        catalog_updated_at: sql`clock_timestamp()`,
+      })
+      .where(
+        and(
+          eq(agentSandboxBackups.catalog_version, 2),
+          inArray(
+            agentSandboxBackups.id,
+            candidates.map((candidate) => candidate.id),
+          ),
+          sql`${agentSandboxBackups.sandbox_record_id} IS NOT NULL`,
+          sql`${agentSandboxBackups.source_provider} IN ('operator-onboarded', 'hetzner-cloud')`,
+          sql`${agentSandboxBackups.source_node_record_id} IS NOT NULL`,
+          sql`${agentSandboxBackups.source_node_id} IS NOT NULL
               AND ${agentSandboxBackups.source_node_id} <> ''`,
-            sql`${agentSandboxBackups.source_node_incarnation} IS NOT NULL`,
-            sql`${agentSandboxBackups.source_provider_handle} IS NOT NULL
+          sql`${agentSandboxBackups.source_node_incarnation} IS NOT NULL`,
+          sql`${agentSandboxBackups.source_provider_handle} IS NOT NULL
               AND ${agentSandboxBackups.source_provider_handle} <> ''`,
-            sql`${agentSandboxBackups.source_container_id} ~ '^[0-9a-f]{64}$'`,
-            sql`${agentSandboxBackups.source_provider_handle}
+          sql`${agentSandboxBackups.source_container_id} ~ '^[0-9a-f]{64}$'`,
+          sql`${agentSandboxBackups.source_provider_handle}
               <> ${agentSandboxBackups.source_container_id}`,
-            sql`(
+          sql`(
               (${agentSandboxBackups.source_provider} = 'operator-onboarded'
                 AND ${agentSandboxBackups.source_provider_server_id} IS NULL)
               OR
@@ -1406,50 +1417,46 @@ export async function claimDueAgentBackupOperations(params: {
                   ELSE FALSE
                 END)
             )`,
-            sql`(${agentSandboxBackups.catalog_lease_expires_at} IS NULL
+          sql`(${agentSandboxBackups.catalog_lease_expires_at} IS NULL
               OR ${agentSandboxBackups.catalog_lease_expires_at} <= clock_timestamp())`,
-            inArray(agentSandboxBackups.catalog_state, EXECUTION_OWNED_STATES),
-            or(
-              isNull(agentSandboxBackups.catalog_next_attempt_at),
-              lte(agentSandboxBackups.catalog_next_attempt_at, sql`clock_timestamp()`),
-            ),
+          inArray(agentSandboxBackups.catalog_state, EXECUTION_OWNED_STATES),
+          or(
+            isNull(agentSandboxBackups.catalog_next_attempt_at),
+            lte(agentSandboxBackups.catalog_next_attempt_at, sql`clock_timestamp()`),
           ),
-        )
-        .returning();
-      if (claimed.length !== candidates.length) {
+        ),
+      )
+      .returning();
+    if (claimed.length !== candidates.length) {
+      throw new AgentBackupCatalogConflictError(
+        "Backup admission could not lease every selected operation",
+      );
+    }
+
+    // No external writer can mutate a locked lane. Rechecking here also
+    // fences database triggers or mixed-version code in this transaction.
+    await lockAgentBackupAdmissionAuthorities(tx, candidates);
+    const cursorAt = await readNextAgentBackupAdmissionCursor(tx, authorities);
+    const databaseNow = await readPostLockDatabaseNow(tx);
+    const renewed = await renewAgentBackupOperationLeasesAfterLocks(tx, {
+      backupIds: claimed.map((backup) => backup.id),
+      ownerId: params.ownerId,
+      generation,
+      leaseMs: params.leaseMs,
+      databaseNow,
+    });
+    await advanceAgentBackupAdmissionCursors(tx, authorities, cursorAt);
+    const renewedById = new Map(renewed.map((backup) => [backup.id, backup]));
+    return candidates.map((candidate) => {
+      const backup = renewedById.get(candidate.id);
+      if (!backup) {
         throw new AgentBackupCatalogConflictError(
-          "Backup admission could not lease every selected operation",
+          "Backup admission lost a renewed operation while preserving fair order",
         );
       }
-
-      // No external writer can mutate a locked lane. Rechecking here also
-      // fences database triggers or mixed-version code in this transaction.
-      await lockAgentBackupAdmissionAuthorities(tx, candidates);
-      const cursorAt = await readNextAgentBackupAdmissionCursor(tx, authorities);
-      const databaseNow = await readPostLockDatabaseNow(tx);
-      const renewed = await renewAgentBackupOperationLeasesAfterLocks(tx, {
-        backupIds: claimed.map((backup) => backup.id),
-        ownerId: params.ownerId,
-        generation,
-        leaseMs: params.leaseMs,
-        databaseNow,
-      });
-      await advanceAgentBackupAdmissionCursors(tx, authorities, cursorAt);
-      const renewedById = new Map(renewed.map((backup) => [backup.id, backup]));
-      return candidates.map((candidate) => {
-        const backup = renewedById.get(candidate.id);
-        if (!backup) {
-          throw new AgentBackupCatalogConflictError(
-            "Backup admission lost a renewed operation while preserving fair order",
-          );
-        }
-        return { backup, ownerId: params.ownerId, generation };
-      });
+      return { backup, ownerId: params.ownerId, generation };
     });
-  } catch (error) {
-    if (error instanceof AgentBackupAdmissionContendedError) return [];
-    throw error;
-  }
+  });
 }
 
 export async function heartbeatAgentBackupOperation(params: {

--- a/packages/cloud/shared/src/db/repositories/agent-backup-source-authority.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-backup-source-authority.ts
@@ -70,6 +70,12 @@ export interface AgentBackupManifestSourceAuthorityLocator {
   containerId: string;
 }
 
+export interface AgentBackupManifestSourceOccurrenceAuthority {
+  source: AgentBackupManifestV2Source;
+  /** Append-only token; node incarnation UUIDs are reusable after ABA. */
+  nodeHistoryId: string;
+}
+
 function validateLocator(
   input: AgentBackupManifestSourceAuthorityLocator,
 ): AgentBackupManifestSourceAuthorityLocator {
@@ -83,13 +89,13 @@ function validateLocator(
 
 /**
  * Resolve exact source identity inside a caller-owned primary transaction.
- * The key-share lock prevents re-registration/reboot authority from changing
- * until the caller has durably snapshotted the returned vector.
+ * The no-key-update lock prevents re-registration/reboot authority from
+ * changing until the caller has durably snapshotted the returned vector.
  */
-export async function resolveAgentBackupManifestSourceAuthorityInTransaction(
+export async function resolveAgentBackupManifestSourceOccurrenceAuthorityInTransaction(
   tx: DbTransaction,
   input: AgentBackupManifestSourceAuthorityLocator,
-): Promise<AgentBackupManifestV2Source> {
+): Promise<AgentBackupManifestSourceOccurrenceAuthority> {
   const locator = validateLocator(input);
   const [node] = await tx
     .select({
@@ -99,6 +105,7 @@ export async function resolveAgentBackupManifestSourceAuthorityInTransaction(
       infrastructureProvider: dockerNodes.infrastructure_provider,
       providerServerId: dockerNodes.provider_server_id,
       nodeIncarnation: dockerNodes.node_incarnation,
+      nodeHistoryId: dockerNodes.current_node_history_id,
       hostKeyFingerprint: dockerNodes.host_key_fingerprint,
     })
     .from(dockerNodes)
@@ -116,6 +123,7 @@ export async function resolveAgentBackupManifestSourceAuthorityInTransaction(
     !node ||
     node.infrastructureProvider !== "hetzner" ||
     node.nodeIncarnation !== locator.nodeIncarnation ||
+    !node.nodeHistoryId ||
     !node.hostKeyFingerprint?.trim()
   ) {
     throw new AgentBackupSourceAuthorityError(
@@ -131,18 +139,31 @@ export async function resolveAgentBackupManifestSourceAuthorityInTransaction(
     containerId: locator.containerId,
   };
   if (node.fleetKind === "robot" && node.providerServerId === null) {
-    return Object.freeze({ kind: "robot" as const, ...base });
+    return Object.freeze({
+      source: Object.freeze({ kind: "robot" as const, ...base }),
+      nodeHistoryId: node.nodeHistoryId,
+    });
   }
   if (node.fleetKind === "cloud" && node.providerServerId !== null) {
     return Object.freeze({
-      kind: "cloud" as const,
-      ...base,
-      providerServerId: requireCanonicalProviderServerId(node.providerServerId),
+      source: Object.freeze({
+        kind: "cloud" as const,
+        ...base,
+        providerServerId: requireCanonicalProviderServerId(node.providerServerId),
+      }),
+      nodeHistoryId: node.nodeHistoryId,
     });
   }
   throw new AgentBackupSourceAuthorityError(
     "Backup source node has an incomplete or contradictory Robot/Cloud authority",
   );
+}
+
+export async function resolveAgentBackupManifestSourceAuthorityInTransaction(
+  tx: DbTransaction,
+  input: AgentBackupManifestSourceAuthorityLocator,
+): Promise<AgentBackupManifestV2Source> {
+  return (await resolveAgentBackupManifestSourceOccurrenceAuthorityInTransaction(tx, input)).source;
 }
 
 /** Resolve against the primary, never a replica or JSON metadata projection. */

--- a/packages/cloud/shared/src/lib/services/agent-backup-capture-v3-runtime-context.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-capture-v3-runtime-context.ts
@@ -143,10 +143,11 @@ async function loadRuntimeAuthority(input: {
   input.signal?.throwIfAborted();
   const identity = requireClaimIdentity(input.claim);
   const sourceRecordId = input.claim.backup.source_node_record_id;
-  if (!sourceRecordId) {
+  const sourceHistoryId = input.claim.backup.source_node_history_id;
+  if (!sourceRecordId || !sourceHistoryId) {
     contextError(
       "AGENT_BACKUP_V3_RUNTIME_AUTHORITY_INCOMPLETE",
-      "Capture claim is missing its exact node record authority",
+      "Capture claim is missing its exact node occurrence authority",
     );
   }
   const [row] = await dbWrite
@@ -176,6 +177,7 @@ async function loadRuntimeAuthority(input: {
       infrastructureProvider: dockerNodes.infrastructure_provider,
       providerServerId: dockerNodes.provider_server_id,
       nodeIncarnation: dockerNodes.node_incarnation,
+      nodeHistoryId: dockerNodes.current_node_history_id,
     })
     .from(agentSandboxes)
     .innerJoin(
@@ -203,6 +205,7 @@ async function loadRuntimeAuthority(input: {
     !row.activationImageDigest ||
     !row.providerHandle ||
     !row.nodeIncarnation ||
+    row.nodeHistoryId !== sourceHistoryId ||
     row.infrastructureProvider !== "hetzner" ||
     (row.fleetKind !== "robot" && row.fleetKind !== "cloud")
   ) {

--- a/packages/cloud/shared/src/lib/services/agent-backup-catalog-runtime.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-catalog-runtime.test.ts
@@ -2,7 +2,11 @@
 
 import { describe, expect, test } from "bun:test";
 import { ElizaError } from "@elizaos/core";
-import type { AgentBackupOperationClaim } from "../../db/repositories/agent-backup-catalog";
+import {
+  AGENT_BACKUP_ADMISSION_CONTENDED_CODE,
+  AgentBackupAdmissionContendedError,
+  type AgentBackupOperationClaim,
+} from "../../db/repositories/agent-backup-catalog";
 import type { AgentBackupGcClaim } from "../../db/repositories/agent-backup-gc";
 import type { AgentBackupObjectStoreRegistry } from "../storage/agent-backup-object-store";
 import {
@@ -548,6 +552,31 @@ describe("agent backup catalogue runtime scheduling", () => {
         "BACKUP_DELETION_FINALIZE_RECONCILE_REQUIRED",
       ]),
     );
+  });
+
+  test("reports operation admission contention instead of treating it as no work", async () => {
+    const contention = new AgentBackupAdmissionContendedError();
+    expect(contention).toMatchObject({
+      code: AGENT_BACKUP_ADMISSION_CONTENDED_CODE,
+      context: {
+        operation: "claim",
+        retryAction: "retry-operation-claim",
+      },
+      severity: "ephemeral",
+    });
+    const summary = await runAgentBackupCatalogRuntimeCycle({
+      config: ENABLED_CONFIG,
+      registry: UNUSED_REGISTRY,
+      dependencies: dependencies({
+        claimOperations: async () => {
+          throw contention;
+        },
+      }),
+    });
+
+    expect(summary.operationClaimed).toBe(0);
+    expect(summary.operationIndeterminate).toBe(1);
+    expect(summary.alertCodes).toContain(AGENT_BACKUP_ADMISSION_CONTENDED_CODE);
   });
 
   test("defers a failed admission without inventing success and fences response loss", async () => {

--- a/packages/cloud/shared/src/lib/services/agent-backup-catalog-runtime.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-catalog-runtime.test.ts
@@ -10,6 +10,10 @@ import {
   normalizeAgentBackupCaptureV2TerminalFailure,
 } from "./agent-backup-capture-v2-failure-disposition";
 import { AgentBackupCaptureV2PipelineError } from "./agent-backup-capture-v2-pipeline";
+import {
+  createAgentBackupCaptureV3RuntimeContextResolver,
+  isResolvedAgentBackupCaptureV3RuntimeAuthorityStale,
+} from "./agent-backup-capture-v3-runtime-context";
 import type { AgentBackupCaptureV3TerminalSpoolCleanupAuthority } from "./agent-backup-capture-v3-spool-cleanup";
 import {
   type AgentBackupCatalogRuntimeConfig,
@@ -27,6 +31,8 @@ const BACKUP_ID = "00000000-0000-4000-8000-000000000002";
 const OPERATION_ID = "00000000-0000-4000-8000-000000000003";
 const LIFECYCLE_GENERATION = "00000000-0000-4000-8000-000000000004";
 const CLAIM_GENERATION = "00000000-0000-4000-8000-000000000005";
+const RUNTIME_AGENT_ID = "00000000-0000-4000-8000-000000000006";
+const ROTATED_RUNTIME_AGENT_ID = "00000000-0000-4000-8000-000000000008";
 
 function trustedTerminalCaptureFailure(
   code: string,
@@ -159,6 +165,88 @@ function claimOperationsInOrder(
 }
 
 const UNUSED_REGISTRY = Object.freeze({}) as AgentBackupObjectStoreRegistry;
+
+async function resolvedRuntimeAuthorityStaleFailure(): Promise<unknown> {
+  const source = {
+    kind: "robot" as const,
+    provider: "hetzner" as const,
+    nodeRecordId: BACKUP_ID,
+    nodeId: "robot-01",
+    nodeIncarnation: CLAIM_GENERATION,
+    containerId: "a".repeat(64),
+  };
+  let authorityReads = 0;
+  const resolve = createAgentBackupCaptureV3RuntimeContextResolver(
+    {
+      spool: {
+        stateDirectory: "/var/lib/eliza-backup-catalog/spool",
+        maxSpoolBytes: 1024 ** 3,
+        minFreeBytes: 1024,
+      },
+      keyBundle: { kind: "shared-key-bundle" } as never,
+      runtime: {
+        agentSchemaVersion: "2.0.0",
+        databaseSchemaVersion: "238",
+        plugins: [{ id: "@elizaos/plugin-sql", version: "2.0.0" }],
+      },
+    },
+    {
+      async loadAuthority() {
+        authorityReads += 1;
+        return {
+          organizationId: ORG_ID,
+          catalogAgentId: AGENT_ID,
+          runtimeAgentId: authorityReads === 1 ? RUNTIME_AGENT_ID : ROTATED_RUNTIME_AGENT_ID,
+          activationGeneration: LIFECYCLE_GENERATION,
+          lifecycleRevision: "7",
+          status: "running",
+          activationPhase: "active",
+          source,
+          imageDigest: `sha256:${"b".repeat(64)}`,
+          providerHandle: "agent-runtime-name",
+          bridgeUrl: "https://exact-agent.invalid/",
+          bridgePort: null,
+          headscaleIp: null,
+          nodeHostname: "robot-01.example.test",
+          environmentVars: { ELIZA_API_TOKEN: "encrypted-token" },
+        };
+      },
+      async loadVaultAuthority() {
+        return {
+          kms: {
+            provider: "steward" as const,
+            keyId: `org:${ORG_ID}/dek/v1`,
+            keyVersion: 1,
+          },
+          vaultKeyAuthority: {
+            format: "kms-aead-vault-passphrase-v1" as const,
+            generationId: CLAIM_GENERATION,
+            receiptDerivation: "elizaos.agent-vault-key.authority-receipt.v1" as const,
+            receiptDigest: "c".repeat(64),
+          },
+        };
+      },
+      async decryptEnvironmentVars() {
+        return { ELIZA_API_TOKEN: "exact-agent-token" };
+      },
+      async authorizePublicUrl(rawUrl) {
+        return new URL(rawUrl);
+      },
+    },
+  );
+  const context = await resolve({
+    claim: operationClaim(),
+    request: { agentId: AGENT_ID } as never,
+    expectedSource: source,
+    heartbeat: async () => true,
+  });
+  try {
+    await context.revalidateAttestation();
+  } catch (error) {
+    return error;
+  }
+  throw new Error("Expected resolver revalidation to mint stale-authority evidence");
+}
 
 describe("agent backup catalogue runtime config", () => {
   test("gate off does not require or inspect storage configuration", async () => {
@@ -877,10 +965,11 @@ describe("agent backup catalogue runtime scheduling", () => {
 
   test("keeps an injected stale ElizaError retryable without exact spool cleanup", async () => {
     const claim = operationClaim();
-    let terminal: boolean | undefined;
+    let failure: { terminal: boolean; code: string; retryDelayMs: number | undefined } | undefined;
     const summary = await runAgentBackupCatalogRuntimeCycle({
       config: ENABLED_CONFIG,
       registry: UNUSED_REGISTRY,
+      random: () => 0.5,
       dependencies: dependencies({
         claimOperations: claimOperationsInOrder(claim),
         transitionOperation: async (params) => ({
@@ -888,7 +977,11 @@ describe("agent backup catalogue runtime scheduling", () => {
           catalog_state: params.to,
         }),
         failOperation: async (params) => {
-          terminal = params.terminal;
+          failure = {
+            terminal: params.terminal,
+            code: params.error.code,
+            retryDelayMs: params.retryDelayMs,
+          };
           return claim.backup;
         },
       }),
@@ -902,12 +995,90 @@ describe("agent backup catalogue runtime scheduling", () => {
       },
     });
 
-    expect(terminal).toBe(false);
+    expect(failure).toEqual({
+      terminal: false,
+      code: "BACKUP_CAPTURE_V2_RETRY_SCHEDULED",
+      retryDelayMs: 60_000,
+    });
     expect(summary).toMatchObject({
       operationCaptureTerminal: 0,
       operationCaptureRetryScheduled: 1,
       operationIndeterminate: 0,
     });
+    expect(summary.alertCodes).toContain("BACKUP_CAPTURE_V2_RETRY_SCHEDULED");
+    expect(summary.alertCodes).not.toContain("AGENT_BACKUP_V3_RUNTIME_AUTHORITY_STALE");
+  });
+
+  test("persists trusted resolver staleness as a dedicated retry without terminal cleanup", async () => {
+    const claim = operationClaim();
+    const trustedStale = await resolvedRuntimeAuthorityStaleFailure();
+    expect(isResolvedAgentBackupCaptureV3RuntimeAuthorityStale(trustedStale)).toBe(true);
+    let failure: { terminal: boolean; code: string; retryDelayMs: number | undefined } | undefined;
+    let terminalCleanupStages = 0;
+    const summary = await runAgentBackupCatalogRuntimeCycle({
+      config: ENABLED_CONFIG,
+      registry: UNUSED_REGISTRY,
+      random: () => 0.5,
+      dependencies: dependencies({
+        claimOperations: claimOperationsInOrder(claim),
+        transitionOperation: async (params) => ({
+          ...claim.backup,
+          catalog_state: params.to,
+        }),
+        failOperation: async (params) => {
+          failure = {
+            terminal: params.terminal,
+            code: params.error.code,
+            retryDelayMs: params.retryDelayMs,
+          };
+          return claim.backup;
+        },
+      }),
+      captureExecutor: {
+        async execute() {
+          throw trustedStale;
+        },
+      },
+      spoolCleanupJanitor: {
+        async enqueueProtectedBackup() {
+          throw new Error("Retryable stale authority must not enqueue protected cleanup");
+        },
+        async stageTerminalFailure() {
+          terminalCleanupStages += 1;
+          return "pending";
+        },
+        async runCycle() {
+          return {
+            discovered: 0,
+            authorized: 0,
+            completed: 0,
+            pending: 0,
+            skippedUnprotected: 0,
+            indeterminate: 0,
+          };
+        },
+      },
+    });
+
+    expect(failure).toEqual({
+      terminal: false,
+      code: "AGENT_BACKUP_V3_RUNTIME_AUTHORITY_STALE",
+      retryDelayMs: 60_000,
+    });
+    expect(terminalCleanupStages).toBe(0);
+    expect(summary).toMatchObject({
+      operationCaptureTerminal: 0,
+      operationCaptureRetryScheduled: 1,
+      operationIndeterminate: 0,
+      spoolCleanup: {
+        authorized: 0,
+        completed: 0,
+        pending: 0,
+        indeterminate: 0,
+      },
+    });
+    expect(summary.alertCodes).toContain("AGENT_BACKUP_V3_RUNTIME_AUTHORITY_STALE");
+    expect(summary.alertCodes).not.toContain("BACKUP_CAPTURE_V2_RETRY_SCHEDULED");
   });
 
   test("rejects forged and nested terminal dispositions from an injected executor", async () => {

--- a/packages/cloud/shared/src/lib/services/agent-backup-catalog-runtime.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-catalog-runtime.ts
@@ -44,6 +44,7 @@ import {
 } from "../storage/agent-backup-object-store";
 import type { RuntimeR2Bucket } from "../storage/r2-runtime-binding";
 import { isTrustedAgentBackupCaptureV2TerminalDisposition } from "./agent-backup-capture-v2-failure-disposition";
+import { isResolvedAgentBackupCaptureV3RuntimeAuthorityStale } from "./agent-backup-capture-v3-runtime-context";
 import type {
   AgentBackupCaptureV3SpoolCleanupJanitor,
   AgentBackupCaptureV3SpoolCleanupSummary,
@@ -77,6 +78,7 @@ const SCHEDULE_RETRY_CODE = "BACKUP_SCHEDULE_RESERVATION_RETRY";
 const SCHEDULE_RECONCILE_CODE = "BACKUP_SCHEDULE_RECONCILE_REQUIRED";
 const SCHEDULE_RPO_OVERDUE_CODE = "BACKUP_SCHEDULE_RPO_OVERDUE";
 const OPERATION_CAPTURE_RETRY_CODE = "BACKUP_CAPTURE_V2_RETRY_SCHEDULED";
+const OPERATION_CAPTURE_STALE_AUTHORITY_CODE = "AGENT_BACKUP_V3_RUNTIME_AUTHORITY_STALE";
 const OPERATION_CAPTURE_TERMINAL_CODE = "BACKUP_CAPTURE_V2_TERMINAL";
 const OPERATION_PUBLICATION_RETRY_CODE = "BACKUP_PUBLICATION_RETRY_SCHEDULED";
 const OPERATION_RECONCILE_CODE = "BACKUP_OPERATION_RECONCILE_REQUIRED";
@@ -559,12 +561,19 @@ function isCaptureOperationClaim(claim: Readonly<AgentBackupOperationClaim>): bo
 
 interface CaptureFailureDisposition {
   terminal: boolean;
+  retryErrorCode?: typeof OPERATION_CAPTURE_STALE_AUTHORITY_CODE;
   terminalSpoolCleanup?: Parameters<
     AgentBackupCaptureV3SpoolCleanupJanitor["stageTerminalFailure"]
   >[0]["authority"];
 }
 
 function classifyCaptureFailure(error: unknown): CaptureFailureDisposition {
+  if (isResolvedAgentBackupCaptureV3RuntimeAuthorityStale(error)) {
+    return {
+      terminal: false,
+      retryErrorCode: OPERATION_CAPTURE_STALE_AUTHORITY_CODE,
+    };
+  }
   if (!isTrustedAgentBackupCaptureV2TerminalDisposition(error)) return { terminal: false };
   // A stale runtime generation is irreversible only after the concrete
   // pipeline opened a spool and attached the exact cleanup authority. Stale
@@ -873,6 +882,9 @@ export async function runAgentBackupCatalogRuntimeCycle(params: {
         }
         const disposition = classifyCaptureFailure(error);
         const terminal = disposition.terminal;
+        const failureCode = terminal
+          ? OPERATION_CAPTURE_TERMINAL_CODE
+          : (disposition.retryErrorCode ?? OPERATION_CAPTURE_RETRY_CODE);
         if (terminal && disposition.terminalSpoolCleanup) {
           if (!params.spoolCleanupJanitor) {
             summary.operationIndeterminate += 1;
@@ -906,10 +918,12 @@ export async function runAgentBackupCatalogRuntimeCycle(params: {
             expectedState: "capturing",
             terminal,
             error: {
-              code: terminal ? OPERATION_CAPTURE_TERMINAL_CODE : OPERATION_CAPTURE_RETRY_CODE,
+              code: failureCode,
               message: terminal
                 ? "Capture-v2 returned deterministic authority, format, or replay-conflict evidence"
-                : "Capture-v2 did not reach a confirmed recordCaptured boundary; retry remains safe",
+                : disposition.retryErrorCode
+                  ? "Reserved capture runtime authority is stale; retry requires exact-source reconciliation"
+                  : "Capture-v2 did not reach a confirmed recordCaptured boundary; retry remains safe",
             },
             ...(terminal
               ? {}
@@ -931,7 +945,7 @@ export async function runAgentBackupCatalogRuntimeCycle(params: {
             alertCodes.add(OPERATION_CAPTURE_TERMINAL_CODE);
           } else {
             summary.operationCaptureRetryScheduled += 1;
-            alertCodes.add(OPERATION_CAPTURE_RETRY_CODE);
+            alertCodes.add(failureCode);
           }
         } catch {
           throwIfAborted();

--- a/packages/cloud/shared/src/lib/services/agent-backup-catalog-runtime.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-catalog-runtime.ts
@@ -10,6 +10,8 @@
  */
 
 import {
+  AGENT_BACKUP_ADMISSION_CONTENDED_CODE,
+  AgentBackupAdmissionContendedError,
   type AgentBackupOperationClaim,
   type AgentBackupOperationExecution,
   claimDueAgentBackupOperations,
@@ -812,6 +814,13 @@ export async function runAgentBackupCatalogRuntimeCycle(params: {
       }
     } catch (error) {
       throwIfAborted();
+      // error-policy:J1 Runtime-cycle boundary reports expected admission
+      // contention distinctly instead of fabricating an empty work queue.
+      if (error instanceof AgentBackupAdmissionContendedError) {
+        summary.operationIndeterminate += 1;
+        alertCodes.add(AGENT_BACKUP_ADMISSION_CONTENDED_CODE);
+        break;
+      }
       if (!params.config.scheduleEnabled) throw error;
       summary.operationIndeterminate += 1;
       alertCodes.add(OPERATION_RECONCILE_CODE);


### PR DESCRIPTION
## Summary

- serialize catalogue-v2 operation claims by organization and exact append-only source-node occurrence
- pin capture authority through claim and heartbeat, while publication remains organization-only
- renew leases from post-lock database time and reject source-node ABA before vault, decrypt, or routing
- preserve mixed-version cutover fences and legacy publication replay without inferring source authority

## Scope boundary

This Draft proves atomic operation-lane safety and durable last-service hints. It does not claim queued/deferred scheduler starvation freedom: priority, aging, resumable cohorts, and the deterministic 10,000-item proof remain required in the next #24407 slice before activation.

## Verification

- Bun 1.3.14: 172 focused PGlite/runtime tests passed
- real PostgreSQL: 14 lock/contention tests passed
- packages/cloud/shared TypeScript check passed
- Biome and git diff integrity passed

Stacked on #29194. No deployment or feature activation. Closes no issue.