### PR TITLE
fix(plugin-matrix): normalize MATRIX_ACCOUNTS object-form keys so listing and lookup agree

### DIFF
--- a/plugins/plugin-matrix/src/__tests__/accounts.test.ts
+++ b/plugins/plugin-matrix/src/__tests__/accounts.test.ts
@@ -67,6 +67,102 @@ describe("Matrix account settings", () => {
     });
   });
 
+  it("normalizes a padded MATRIX_ACCOUNTS object key so listing and lookup agree", () => {
+    const runtime = runtimeWithSettings({
+      MATRIX_ACCOUNTS: JSON.stringify({
+        " work ": {
+          homeserver: "https://hs.example",
+          userId: "@a:hs.example",
+          accessToken: "tok-123",
+        },
+      }),
+    });
+
+    expect(listMatrixAccountIds(runtime)).toEqual(["work"]);
+    // Before the fix this resolved to empty homeserver/userId/accessToken
+    // because accounts[" work "] was never rewritten to accounts["work"],
+    // which then reached MatrixService.initialize()'s validateSettings throw.
+    expect(resolveMatrixAccountSettings(runtime, "work")).toMatchObject({
+      accountId: "work",
+      homeserver: "https://hs.example",
+      userId: "@a:hs.example",
+      accessToken: "tok-123",
+    });
+  });
+
+  it("normalizes a padded character.settings.matrix.accounts key identically", () => {
+    const runtime = runtimeWithSettings(
+      {},
+      {
+        matrix: {
+          accounts: {
+            " work ": {
+              homeserver: "https://char.example",
+              userId: "@c:char.example",
+              accessToken: "char-tok",
+            },
+          },
+        },
+      }
+    );
+
+    expect(listMatrixAccountIds(runtime)).toEqual(["work"]);
+    expect(resolveMatrixAccountSettings(runtime, "work")).toMatchObject({
+      accountId: "work",
+      homeserver: "https://char.example",
+      userId: "@c:char.example",
+      accessToken: "char-tok",
+    });
+  });
+
+  it("rejects MATRIX_ACCOUNTS keys that collide after normalization", () => {
+    const runtime = runtimeWithSettings({
+      MATRIX_ACCOUNTS: JSON.stringify({
+        work: { homeserver: "https://a", userId: "@a:a", accessToken: "a" },
+        " work ": { homeserver: "https://b", userId: "@b:b", accessToken: "b" },
+      }),
+    });
+
+    try {
+      listMatrixAccountIds(runtime);
+      throw new Error("expected duplicate normalized account id to throw");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe("MATRIX_CONFIG_INVALID");
+      expect((error as ElizaError).context).toEqual({
+        setting: "MATRIX_ACCOUNTS",
+        accountId: "work",
+      });
+      expect((error as ElizaError).severity).toBe("fatal");
+    }
+  });
+
+  it("rejects character.settings.matrix.accounts keys that collide after normalization", () => {
+    const runtime = runtimeWithSettings(
+      {},
+      {
+        matrix: {
+          accounts: {
+            work: { homeserver: "https://a", userId: "@a:a", accessToken: "a" },
+            "work ": { homeserver: "https://b", userId: "@b:b", accessToken: "b" },
+          },
+        },
+      }
+    );
+
+    try {
+      listMatrixAccountIds(runtime);
+      throw new Error("expected duplicate normalized character account id to throw");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe("MATRIX_CONFIG_INVALID");
+      expect((error as ElizaError).context).toEqual({
+        setting: "character.settings.matrix.accounts",
+        accountId: "work",
+      });
+    }
+  });
+
   it("reads account IDs only from non-empty string fields across payload shapes", () => {
     expect(
       readMatrixAccountId(

--- a/plugins/plugin-matrix/src/__tests__/accounts.test.ts
+++ b/plugins/plugin-matrix/src/__tests__/accounts.test.ts
@@ -137,6 +137,34 @@ describe("Matrix account settings", () => {
     }
   });
 
+  it("names the offending entry index (not the synthesized default id) when array entries omit accountId/id", () => {
+    const runtime = runtimeWithSettings({
+      MATRIX_ACCOUNTS: JSON.stringify([
+        { homeserver: "https://a", userId: "@a:a", accessToken: "a" },
+        { homeserver: "https://b", userId: "@b:b", accessToken: "b" },
+      ]),
+    });
+
+    try {
+      listMatrixAccountIds(runtime);
+      throw new Error("expected id-less array entries to throw");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      const elizaError = error as ElizaError;
+      expect(elizaError.code).toBe("MATRIX_CONFIG_INVALID");
+      // The operator wrote no "default" id, so the message must not claim a
+      // duplicate of it; it names the second (index 1) entry instead.
+      expect(elizaError.message).not.toContain("duplicate account id");
+      expect(elizaError.message).toContain("index 1");
+      expect(elizaError.context).toEqual({
+        setting: "MATRIX_ACCOUNTS",
+        accountId: DEFAULT_MATRIX_ACCOUNT_ID,
+        index: 1,
+      });
+      expect(elizaError.severity).toBe("fatal");
+    }
+  });
+
   it("rejects character.settings.matrix.accounts keys that collide after normalization", () => {
     const runtime = runtimeWithSettings(
       {},

--- a/plugins/plugin-matrix/src/accounts.ts
+++ b/plugins/plugin-matrix/src/accounts.ts
@@ -42,23 +42,41 @@ function isAccountConfig(value: unknown): value is MatrixAccountConfig {
 // accountConfig() (which looks up the map key) agree: a padded " work " key
 // otherwise lists as `work` but resolves to an empty config. Reject a
 // post-normalization collision so two keys cannot silently clobber one config.
+// Two collision shapes get distinct diagnostics: a genuine duplicate of an
+// id the operator actually wrote names that id, while entries that supply no
+// id at all (e.g. array items missing both `accountId` and `id`) collapse to
+// the synthesized DEFAULT_MATRIX_ACCOUNT_ID sentinel — naming that sentinel
+// as a "duplicate" would send the operator searching for an id absent from
+// their config, so those name the offending entry index instead.
 function indexAccountConfigs(
   entries: Iterable<readonly [unknown, unknown]>,
   setting: string
 ): Record<string, MatrixAccountConfig> {
   const configs = new Map<string, MatrixAccountConfig>();
+  let index = -1;
   for (const [rawId, value] of entries) {
+    index += 1;
     if (!isAccountConfig(value)) continue;
+    const hasExplicitId = typeof rawId === "string" && rawId.trim().length > 0;
     const accountId = normalizeMatrixAccountId(rawId);
     if (configs.has(accountId)) {
-      throw new ElizaError(
-        `Matrix accounts config contains duplicate account id ${JSON.stringify(accountId)} after normalization.`,
-        {
-          code: "MATRIX_CONFIG_INVALID",
-          context: { setting, accountId },
-          severity: "fatal",
-        }
-      );
+      throw hasExplicitId
+        ? new ElizaError(
+            `Matrix accounts config contains duplicate account id ${JSON.stringify(accountId)} after normalization.`,
+            {
+              code: "MATRIX_CONFIG_INVALID",
+              context: { setting, accountId },
+              severity: "fatal",
+            }
+          )
+        : new ElizaError(
+            `Matrix accounts config entry at index ${index} supplies no accountId/id and collides with the ${JSON.stringify(accountId)} account; give each account an explicit accountId.`,
+            {
+              code: "MATRIX_CONFIG_INVALID",
+              context: { setting, accountId, index },
+              severity: "fatal",
+            }
+          );
     }
     configs.set(accountId, value);
   }

--- a/plugins/plugin-matrix/src/accounts.ts
+++ b/plugins/plugin-matrix/src/accounts.ts
@@ -33,23 +33,48 @@ function characterConfig(runtime: IAgentRuntime): MatrixMultiAccountConfig {
   return raw && typeof raw === "object" ? (raw as MatrixMultiAccountConfig) : {};
 }
 
+function isAccountConfig(value: unknown): value is MatrixAccountConfig {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+// Normalize each raw account key through normalizeMatrixAccountId at parse
+// time so listMatrixAccountIds() (which trims when building the id list) and
+// accountConfig() (which looks up the map key) agree: a padded " work " key
+// otherwise lists as `work` but resolves to an empty config. Reject a
+// post-normalization collision so two keys cannot silently clobber one config.
+function indexAccountConfigs(
+  entries: Iterable<readonly [unknown, unknown]>,
+  setting: string
+): Record<string, MatrixAccountConfig> {
+  const configs = new Map<string, MatrixAccountConfig>();
+  for (const [rawId, value] of entries) {
+    if (!isAccountConfig(value)) continue;
+    const accountId = normalizeMatrixAccountId(rawId);
+    if (configs.has(accountId)) {
+      throw new ElizaError(
+        `Matrix accounts config contains duplicate account id ${JSON.stringify(accountId)} after normalization.`,
+        {
+          code: "MATRIX_CONFIG_INVALID",
+          context: { setting, accountId },
+          severity: "fatal",
+        }
+      );
+    }
+    configs.set(accountId, value);
+  }
+  return Object.fromEntries(configs);
+}
+
 function parseAccountsJson(runtime: IAgentRuntime): Record<string, MatrixAccountConfig> {
   const raw = stringSetting(runtime, "MATRIX_ACCOUNTS");
   if (!raw) return {};
 
+  let parsed: unknown;
   try {
-    const parsed = JSON.parse(raw) as unknown;
-    if (Array.isArray(parsed)) {
-      return Object.fromEntries(
-        parsed
-          .filter((item): item is MatrixAccountConfig => Boolean(item) && typeof item === "object")
-          .map((item) => [normalizeMatrixAccountId(item.accountId ?? item.id), item])
-      );
-    }
-    return parsed && typeof parsed === "object"
-      ? (parsed as Record<string, MatrixAccountConfig>)
-      : {};
+    parsed = JSON.parse(raw) as unknown;
   } catch (error) {
+    // error-policy:J2 preserve the JSON parse cause and identify the setting
+    // whose invalid value must not degrade into an empty account collection.
     throw new ElizaError("Matrix accounts config is not valid JSON.", {
       code: "MATRIX_CONFIG_INVALID",
       cause: error,
@@ -57,11 +82,24 @@ function parseAccountsJson(runtime: IAgentRuntime): Record<string, MatrixAccount
       severity: "fatal",
     });
   }
+
+  if (Array.isArray(parsed)) {
+    return indexAccountConfigs(
+      parsed.map((item) => [isAccountConfig(item) ? (item.accountId ?? item.id) : undefined, item]),
+      "MATRIX_ACCOUNTS"
+    );
+  }
+  return isAccountConfig(parsed)
+    ? indexAccountConfigs(Object.entries(parsed), "MATRIX_ACCOUNTS")
+    : {};
 }
 
 function allAccountConfigs(runtime: IAgentRuntime): Record<string, MatrixAccountConfig> {
+  const characterAccounts = characterConfig(runtime).accounts;
   return {
-    ...(characterConfig(runtime).accounts ?? {}),
+    ...(isAccountConfig(characterAccounts)
+      ? indexAccountConfigs(Object.entries(characterAccounts), "character.settings.matrix.accounts")
+      : {}),
     ...parseAccountsJson(runtime),
   };
 }


### PR DESCRIPTION
# Relates to

Closes #29205

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; focused package gates (test, typecheck, lint:check) pass. Full `bun run verify` blocker noted under **Known gaps**.
- [x] A reviewer can confirm the change works from the before/after reproduction and red→green tests below.

# Sync with develop

- [x] Rebased onto the latest `origin/develop` (`aeb1055870`); zero conflicts.
- [ ] `bun run verify` not run to completion on this machine — see **Known gaps**. Owning-package `test`, `typecheck`, and `lint:check` all pass.

# Risks

Low. One file of connector config-resolution logic (`plugins/plugin-matrix/src/accounts.ts`), no public-surface change. The only behavior change beyond the fix is that two account keys that collide *after normalization* now throw a fatal `MATRIX_CONFIG_INVALID` instead of silently keeping the last-wins entry — this matches the sibling plugin-instagram contract and is strictly safer (a silently-dropped account is a worse failure than an explicit config error).

# Background

## What does this PR do?

plugin-matrix resolves multi-account config from a `MATRIX_ACCOUNTS` JSON map and `character.settings.matrix.accounts`. For the **object form**, `parseAccountsJson` returned the parsed object verbatim and `allAccountConfigs` spread the character map verbatim — neither normalized the keys. But the two consumers disagree about the key:

- `listMatrixAccountIds()` runs every key through `normalizeMatrixAccountId()` (which trims whitespace) when building the advertised id list.
- `accountConfig()` looks the config up by the normalized id.

So a whitespace-padded object key (e.g. `" work "`) is **advertised** as account `work`, but `accounts["work"]` misses the real `" work "` key and the config is lost. `resolveMatrixAccountSettings("work")` then returns empty `homeserver`/`userId`/`accessToken`. Because non-default accounts do not fall back to env (`allowOwnerBind` is false for named accounts), `MatrixService.initialize()` reaches `validateSettings()` on the empty settings and throws `MatrixConfigurationError("MATRIX_HOMESERVER is required")` — aborting the **entire** Matrix service start, including any valid `default` account processed earlier in the same loop. One malformed (padded) map key takes down the whole connector.

The fix mirrors the sibling plugin-instagram, which already fixed exactly this class of bug: add an `indexAccountConfigs(entries, setting)` helper that runs each raw key through `normalizeMatrixAccountId`, filters non-object values, and throws a fatal `MATRIX_CONFIG_INVALID` `ElizaError` on a post-normalization collision. Both the `MATRIX_ACCOUNTS` object/array branches and the `character.settings.matrix.accounts` map now route through it, so `listMatrixAccountIds()` and `accountConfig()` agree on the key.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation. Behavior for well-formed config is unchanged; only malformed/padded keys are now normalized consistently or explicitly rejected.

# Testing

## Where should a reviewer start?

`plugins/plugin-matrix/src/accounts.ts` (the new `indexAccountConfigs` helper and its two call sites) and the four new cases in `plugins/plugin-matrix/src/__tests__/accounts.test.ts`.

## Detailed testing steps

```bash
bun install --minimum-release-age=0   # workspace install (see Known gaps for the flag)
bun run --cwd plugins/plugin-matrix test
bun run --cwd plugins/plugin-matrix typecheck
bun run --cwd plugins/plugin-matrix lint:check
```

The four added tests fail on `origin/develop`'s `accounts.ts` and pass with this change (red→green capture below). A follow-up commit (`6dd8931b`) adds a fifth case covering the id-less array-collision diagnostic requested in review (see the update comment).

# Evidence Gate

<!-- evidence-head:6dd8931b9bee38d57d330ce38f6ba30276d150c2 -->

- [x] Before/after reproduction and red→green focused-test logs are attached inline below.
<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots — `N/A - backend-only config-resolution change; no rendered UI surface.`
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots — `N/A - backend-only config-resolution change; no rendered UI surface.`
<!-- evidence-row:walkthrough-video -->
- [ ] Video walkthrough — `N/A - no user-facing UI flow; the change is a pure config-parsing fix exercised by unit tests.`
<!-- evidence-row:backend-logs -->
- [ ] N/A - no server process in scope; the real listMatrixAccountIds + resolveMatrixAccountSettings code path is exercised by the deterministic probe whose empty->populated output is pasted inline under Evidence Details / Backend + frontend logs.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs — `N/A - no frontend surface touched.`
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory — `N/A - no agent/action/provider/prompt/model change; this is connector config parsing.`
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no DB/on-chain/file artifact; the domain output (before/after resolved MatrixSettings JSON for the padded-key input) is pasted inline under Evidence Details.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review — `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

Deterministic probe (plugin-matrix vitest, fake runtime): `getSetting` returns `MATRIX_ACCOUNTS = {" work ": {"homeserver":"https://hs.example","userId":"@a:hs.example","accessToken":"tok-123"}}`, `character.settings = {}`.

<details><summary>Before / after reproduction (empty → populated settings)</summary>

```
Deterministic probe (plugin-matrix vitest, fake runtime)
getSetting MATRIX_ACCOUNTS = {" work ": {"homeserver":"https://hs.example","userId":"@a:hs.example","accessToken":"tok-123"}}
character.settings = {}

BEFORE FIX (origin/develop plugins/plugin-matrix/src/accounts.ts):
  listMatrixAccountIds(runtime)            -> [ 'work' ]        (padded key normalized into advertised list)
  resolveMatrixAccountSettings(rt,"work")  -> { homeserver: '', userId: '', accessToken: '' }
  => MatrixService.initialize() reaches validateSettings() -> throws MatrixConfigurationError("MATRIX_HOMESERVER is required"), aborting the whole Matrix service start (including any valid `default` account in the same loop).

AFTER FIX:
  listMatrixAccountIds(runtime)            -> [ 'work' ]
  resolveMatrixAccountSettings(rt,"work")  -> { homeserver: 'https://hs.example', userId: '@a:hs.example', accessToken: 'tok-123' }
  => validateSettings() passes; the account starts. Listing and lookup now agree on the normalized key.
```

Machine-captured resolved objects for the same padded-key input:

BEFORE (origin/develop accounts.ts):
```json
{
  "listed": [
    "work"
  ],
  "resolved": {
    "accountId": "work",
    "homeserver": "",
    "userId": "",
    "accessToken": "",
    "rooms": [],
    "verifyAllowlist": [],
    "autoJoin": false,
    "encryption": false,
    "requireMention": false,
    "personal": false,
    "enabled": true
  }
}
```

AFTER (this PR):
```json
{
  "listed": [
    "work"
  ],
  "resolved": {
    "accountId": "work",
    "homeserver": "https://hs.example",
    "userId": "@a:hs.example",
    "accessToken": "tok-123",
    "rooms": [],
    "verifyAllowlist": [],
    "autoJoin": false,
    "encryption": false,
    "requireMention": false,
    "personal": false,
    "enabled": true
  }
}
```
</details>

<details><summary>Red BEFORE the fix — the four new tests fail on develop's accounts.ts</summary>

```
     × normalizes a padded MATRIX_ACCOUNTS object key so listing and lookup agree 13ms
     × normalizes a padded character.settings.matrix.accounts key identically 3ms
     × rejects MATRIX_ACCOUNTS keys that collide after normalization 2ms
     × rejects character.settings.matrix.accounts keys that collide after normalization 1ms
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 4 ⎯⎯⎯⎯⎯⎯⎯
 FAIL  src/__tests__/accounts.test.ts > Matrix account settings > normalizes a padded MATRIX_ACCOUNTS object key so listing and lookup agree
 FAIL  src/__tests__/accounts.test.ts > Matrix account settings > normalizes a padded character.settings.matrix.accounts key identically
 FAIL  src/__tests__/accounts.test.ts > Matrix account settings > rejects MATRIX_ACCOUNTS keys that collide after normalization
 FAIL  src/__tests__/accounts.test.ts > Matrix account settings > rejects character.settings.matrix.accounts keys that collide after normalization
 Test Files  1 failed (1)
      Tests  4 failed | 9 passed (13)
```
</details>

<details><summary>Green AFTER the fix — full plugin-matrix suite</summary>

```
 RUN  v4.1.10 /home/home/Developer/eliza-swarm/state/worktrees/pr-29211/plugins/plugin-matrix


 Test Files  5 passed (5)
      Tests  50 passed (50)
   Start at  22:24:35
   Duration  21.05s (transform 37.10s, setup 0ms, import 56.63s, tests 1.28s, environment 1ms)
```
</details>

<details><summary>Typecheck</summary>

```
typecheck exit: 0
```

lint:check: `Checked 20 files in 104ms. No fixes applied.` (exit 0)
</details>

## Screenshots (before / after) + video walkthrough

### Before
`N/A - backend-only config-resolution change; no rendered UI surface.`

### After
`N/A - backend-only config-resolution change; no rendered UI surface.`

### Walkthrough video
`N/A - no user-facing UI flow.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT change.`

## Known gaps / failures

- `bun install` requires `--minimum-release-age=0` on this machine because a very recently published transitive dependency (`@cloudflare/playwright@1.3.6`, pulled by `packages/cloud/shared`, unrelated to plugin-matrix) trips Bun's default minimum-release-age gate. This is an install-environment constraint, not a change in this PR.
- Full `bun run verify` was not run to completion here (it drives the whole workspace including cloud/app lanes unrelated to this one-file connector fix). The owning package's `test` (49 passed), `typecheck` (exit 0), and `lint:check` (clean) all pass and are captured above.
- Evidence artifacts are pasted inline as text (non-sensitive logs) rather than minted as GitHub attachment URLs because the attachment-upload session could not authenticate in this environment.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@a9eab309e06217c5f35e15e90eca88a4ee460e95:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@a9eab309e06217c5f35e15e90eca88a4ee460e95:packages/skills/skills/contribute-to-eliza"} -->


