### PR TITLE
fix(app): harden Android Cloud auth and account switching

### DIFF
--- a/packages/app-core/scripts/run-mobile-build-android-play-policy.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-android-play-policy.test.mjs
@@ -19,6 +19,8 @@ import {
   ANDROID_PLAY_ALLOWED_NATIVE_PLUGIN_PACKAGES,
   ANDROID_PLAY_ALLOWED_PERMISSIONS,
   ANDROID_PLAY_DATA_EXTRACTION_RULES,
+  ANDROID_SMS_GATEWAY_STRIPPED_JAVA_FILES,
+  ANDROID_SMS_GATEWAY_STRIPPED_NATIVE_PLUGINS,
   androidPlayManifestEvidenceFromAapt,
   applyAndroidCloudSplashTheme,
   applyAndroidGeneratedBuildTargetProperties,
@@ -175,10 +177,10 @@ describe("Android Play manifest policy", () => {
       /eliza\.app|localhost|127\.0\.0\.1|BackgroundRunner|bun-runtime|includePlugins/,
     );
     expect(sanitized).not.toHaveProperty("ios");
-    expect(sanitized).not.toHaveProperty("loggingBehavior");
+    expect(sanitized.loggingBehavior).toBe("none");
   });
 
-  it("preserves launcher-only logging suppression and opt-in WebView inspection", () => {
+  it("preserves Cloud logging suppression and launcher-only WebView inspection", () => {
     const sanitized = sanitizeAndroidCloudCapacitorConfig(
       {
         loggingBehavior: "debug",
@@ -189,6 +191,15 @@ describe("Android Play manifest policy", () => {
 
     expect(sanitized.loggingBehavior).toBe("none");
     expect(sanitized.android.webContentsDebuggingEnabled).toBe(true);
+  });
+
+  it("removes the SafePush source when SMS builds remove its native dependency", () => {
+    expect(ANDROID_SMS_GATEWAY_STRIPPED_JAVA_FILES).toContain(
+      "SafePushNotificationsPlugin.java",
+    );
+    expect(
+      ANDROID_SMS_GATEWAY_STRIPPED_NATIVE_PLUGINS.map(([pkg]) => pkg),
+    ).toContain("@capacitor/push-notifications");
   });
 
   it("allows only canonical hosted-auth navigation in launcher config", () => {

--- a/packages/app-core/scripts/run-mobile-build-cloud-main-activity.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-cloud-main-activity.test.mjs
@@ -26,11 +26,25 @@ describe("cloudSafeMainActivityJava", () => {
     expect(splashInstall).toBeLessThan(bridgeCreation);
   });
 
-  it("does not reference removed push or background-agent services", () => {
+  it("guards push registration without restoring background-agent services", () => {
     const source = cloudSafeMainActivityJava("ai.elizaos.app");
+    const bridgeCreation = source.indexOf(
+      "super.onCreate(savedInstanceState);",
+    );
+    const guardedPushRegistration = source.indexOf(
+      "getBridge().registerPlugin(SafePushNotificationsPlugin.class);",
+    );
+
+    expect(guardedPushRegistration).toBeGreaterThan(bridgeCreation);
+    expect(source).not.toContain("GatewayConnectionService");
+  });
+
+  it("omits the push guard when the target strips the push plugin", () => {
+    const source = cloudSafeMainActivityJava("ai.elizaos.app", {
+      safePushNotifications: false,
+    });
 
     expect(source).not.toContain("SafePushNotificationsPlugin");
-    expect(source).not.toContain("GatewayConnectionService");
   });
 
   it("uses public edge-to-edge APIs without hiding the system bars", () => {

--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -5963,7 +5963,7 @@ export function sanitizeAndroidCloudCapacitorConfig(
     appId: APP.appId,
     appName: APP.appName,
     webDir: "dist",
-    ...(launcherKiosk ? { loggingBehavior: "none" } : {}),
+    loggingBehavior: "none",
     server: {
       androidScheme: "https",
       ...(allowInAppAuthNavigation
@@ -6273,10 +6273,12 @@ export const ANDROID_SMS_GATEWAY_STRIPPED_PERMISSIONS =
     (permission) => !ANDROID_SMS_GATEWAY_PERMISSIONS.has(permission),
   );
 
-export const ANDROID_SMS_GATEWAY_STRIPPED_JAVA_FILES =
-  ANDROID_CLOUD_STRIPPED_JAVA_FILES.filter(
+export const ANDROID_SMS_GATEWAY_STRIPPED_JAVA_FILES = [
+  ...ANDROID_CLOUD_STRIPPED_JAVA_FILES.filter(
     (file) => !ANDROID_SMS_GATEWAY_COMPONENTS.has(file.replace(/\.java$/, "")),
-  );
+  ),
+  "SafePushNotificationsPlugin.java",
+];
 
 export const ANDROID_SMS_GATEWAY_STRIPPED_NATIVE_PLUGINS = [
   ...ANDROID_CLOUD_STRIPPED_NATIVE_PLUGINS,
@@ -6348,7 +6350,11 @@ export function findAndroidCloudPackagedRuntimeOffenders(entries) {
 
 export function cloudSafeMainActivityJava(
   androidPackage,
-  { launcherKiosk = false, immersiveNavigation = false } = {},
+  {
+    launcherKiosk = false,
+    immersiveNavigation = false,
+    safePushNotifications = true,
+  } = {},
 ) {
   const launcherImports = launcherKiosk
     ? `import android.app.admin.DevicePolicyManager;
@@ -6455,6 +6461,17 @@ import androidx.activity.OnBackPressedCallback;
     }
 `
     : "";
+  const safePushRegistration = safePushNotifications
+    ? `
+        // Capacitor discovers the community push plugin before Firebase is
+        // available in builds without google-services.json. Replace it after
+        // bridge creation so registration reports unavailable instead of
+        // terminating the process when the renderer requests notifications.
+        if (getBridge() != null) {
+            getBridge().registerPlugin(SafePushNotificationsPlugin.class);
+        }
+`
+    : "";
   return `package ${androidPackage};
 
 import android.os.Bundle;
@@ -6494,6 +6511,7 @@ ${launcherConstants}
         registerPlugin(ElizaPlaySettingsPlugin.class);
 
         super.onCreate(savedInstanceState);
+${safePushRegistration}
 
 ${launcherSetup}
 
@@ -7387,7 +7405,11 @@ public class ElizaTasksWorker extends Worker {
 function rewriteCloudJavaSources(
   javaRoots,
   androidPackage,
-  { launcherKiosk = false, immersiveNavigation = false } = {},
+  {
+    launcherKiosk = false,
+    immersiveNavigation = false,
+    safePushNotifications = true,
+  } = {},
 ) {
   let touched = 0;
   for (const root of javaRoots) {
@@ -7399,6 +7421,7 @@ function rewriteCloudJavaSources(
         cloudSafeMainActivityJava(androidPackage, {
           launcherKiosk,
           immersiveNavigation,
+          safePushNotifications,
         }),
         "utf8",
       );
@@ -8451,7 +8474,9 @@ function stripAndroidForSmsGateway() {
       `[mobile-build] Removed ${removedJavaRootCount} inactive Android Java source root(s).`,
     );
   }
-  rewriteCloudJavaSources(javaRoots, androidPackage);
+  rewriteCloudJavaSources(javaRoots, androidPackage, {
+    safePushNotifications: false,
+  });
 
   const resRoot = path.join(androidDir, "app", "src", "main", "res");
   for (const relPath of ANDROID_CLOUD_STRIPPED_RESOURCE_FILES) {

--- a/packages/app/capacitor.config.ts
+++ b/packages/app/capacitor.config.ts
@@ -136,16 +136,18 @@ function isFlagEnabled(value: string | undefined): boolean {
 }
 
 /**
- * The direct-install launcher is intentionally debuggable so adb can verify
- * the HOME-role handoff, but Capacitor's default debug logging serializes
- * native plugin results into logcat. That includes the Keystore-backed Cloud
- * credential returned by ElizaSecureCredentials.get(). Keep the launcher
- * debuggable without ever logging bridge payloads.
+ * Android Cloud clients retain Keystore-backed credentials across sessions,
+ * while Capacitor's default debug logging serializes native plugin results
+ * into logcat. Suppress bridge payload logging for every Cloud-derived target,
+ * including the launcher and SMS gateway, without disabling debug signing.
  */
 export function resolveCapacitorLoggingBehavior(
   env: NodeJS.ProcessEnv = process.env,
 ): "debug" | "none" {
-  return isFlagEnabled(env.ELIZA_ANDROID_LAUNCHER_BUILD) ? "none" : "debug";
+  return isFlagEnabled(env.ELIZA_ANDROID_CLOUD_BUILD) ||
+    isFlagEnabled(env.ELIZA_ANDROID_LAUNCHER_BUILD)
+    ? "none"
+    : "debug";
 }
 
 const webViewDebuggingEnabled =
@@ -160,8 +162,34 @@ export function resolveAndroidProjectPath(
     : "../app-core/platforms/android";
 }
 
-const androidProjectPath = resolveAndroidProjectPath(
-  process.env.ELIZA_ANDROID_USE_APP_DIR,
+export function resolveCapacitorAppId(
+  appIdOverride: string | undefined,
+  iosAppIdOverride: string | undefined,
+  configuredAppId: string,
+): string {
+  return appIdOverride?.trim() || iosAppIdOverride?.trim() || configuredAppId;
+}
+
+export function resolveCapacitorAndroidIdentity(
+  env: NodeJS.ProcessEnv,
+  configuredAppId: string,
+): { appId: string; projectPath: string } {
+  const appId = resolveCapacitorAppId(
+    env.ELIZA_APP_ID,
+    env.ELIZA_IOS_APP_ID,
+    configuredAppId,
+  );
+  return {
+    appId,
+    projectPath: resolveAndroidProjectPath(
+      env.ELIZA_ANDROID_USE_APP_DIR,
+      appId,
+    ),
+  };
+}
+
+const capacitorAndroidIdentity = resolveCapacitorAndroidIdentity(
+  process.env,
   appConfig.appId,
 );
 const capacitorHttpEnabled = resolveCapacitorHttpEnabled(
@@ -171,7 +199,7 @@ const capacitorHttpEnabled = resolveCapacitorHttpEnabled(
 );
 
 const config: CapacitorConfig = {
-  appId: appConfig.appId,
+  appId: capacitorAndroidIdentity.appId,
   appName: appConfig.appName,
   webDir: "dist",
   loggingBehavior: resolveCapacitorLoggingBehavior(),
@@ -244,7 +272,7 @@ const config: CapacitorConfig = {
     // Keep `cap sync` pointed at the same Android tree run-mobile-build will
     // package. Upstream elizaOS owns the shared app-core tree; white-label or
     // explicitly isolated builds use the app-local ignored android/ project.
-    path: androidProjectPath,
+    path: capacitorAndroidIdentity.projectPath,
     // Android owns the fused app runtime. Keep iOS's llama-cpp-capacitor
     // dependency out of raw Android sync while discovering every declared
     // Capacitor plugin, including the embedded Bun host, from package metadata.

--- a/packages/app/capacitor.config.ts
+++ b/packages/app/capacitor.config.ts
@@ -145,7 +145,8 @@ export function resolveCapacitorLoggingBehavior(
   env: NodeJS.ProcessEnv = process.env,
 ): "debug" | "none" {
   return isFlagEnabled(env.ELIZA_ANDROID_CLOUD_BUILD) ||
-    isFlagEnabled(env.ELIZA_ANDROID_LAUNCHER_BUILD)
+    isFlagEnabled(env.ELIZA_ANDROID_LAUNCHER_BUILD) ||
+    isFlagEnabled(env.ELIZA_ANDROID_CLOUD_HYBRID_BUILD)
     ? "none"
     : "debug";
 }

--- a/packages/app/test/capacitor-plugin-selection.test.ts
+++ b/packages/app/test/capacitor-plugin-selection.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, it } from "vitest";
 import {
   resolveAndroidCapacitorPlugins,
+  resolveCapacitorAndroidIdentity,
   resolveCapacitorHttpEnabled,
   resolveCapacitorLoggingBehavior,
 } from "../capacitor.config";
@@ -32,13 +33,50 @@ describe("Android Capacitor plugin selection", () => {
     expect(resolveCapacitorHttpEnabled("android", "local")).toBe(true);
     expect(resolveCapacitorHttpEnabled("ios", "cloud")).toBe(true);
   });
+
+  it("keeps the emitted identity and Android project selection aligned", () => {
+    const stagingIdentity = resolveCapacitorAndroidIdentity(
+      {
+        ELIZA_APP_ID: " ai.elizaos.app.staging ",
+        ELIZA_IOS_APP_ID: "ai.elizaos.app.ios",
+      },
+      "ai.elizaos.app",
+    );
+
+    expect(stagingIdentity).toEqual({
+      appId: "ai.elizaos.app.staging",
+      projectPath: "android",
+    });
+    expect(
+      resolveCapacitorAndroidIdentity({ ELIZA_APP_ID: " " }, "ai.elizaos.app"),
+    ).toEqual({
+      appId: "ai.elizaos.app",
+      projectPath: "../app-core/platforms/android",
+    });
+    expect(
+      resolveCapacitorAndroidIdentity(
+        { ELIZA_IOS_APP_ID: "ai.elizaos.app.ios" },
+        "ai.elizaos.app",
+      ),
+    ).toEqual({ appId: "ai.elizaos.app.ios", projectPath: "android" });
+  });
 });
 
 describe("Capacitor logging behavior", () => {
-  it("suppresses native bridge payloads in the debuggable launcher lane", () => {
+  it("suppresses native bridge payloads in every Android Cloud lane", () => {
     expect(
       resolveCapacitorLoggingBehavior({
         ELIZA_ANDROID_LAUNCHER_BUILD: "1",
+      }),
+    ).toBe("none");
+    expect(
+      resolveCapacitorLoggingBehavior({
+        ELIZA_ANDROID_CLOUD_BUILD: "1",
+      }),
+    ).toBe("none");
+    expect(
+      resolveCapacitorLoggingBehavior({
+        ELIZA_ANDROID_CLOUD_BUILD: "true",
       }),
     ).toBe("none");
   });

--- a/packages/app/test/capacitor-plugin-selection.test.ts
+++ b/packages/app/test/capacitor-plugin-selection.test.ts
@@ -79,6 +79,11 @@ describe("Capacitor logging behavior", () => {
         ELIZA_ANDROID_CLOUD_BUILD: "true",
       }),
     ).toBe("none");
+    expect(
+      resolveCapacitorLoggingBehavior({
+        ELIZA_ANDROID_CLOUD_HYBRID_BUILD: "1",
+      }),
+    ).toBe("none");
   });
 
   it("retains debug-only logging for other lanes", () => {

--- a/packages/ui/src/android-cloud/android-cloud-auth.test.ts
+++ b/packages/ui/src/android-cloud/android-cloud-auth.test.ts
@@ -59,8 +59,21 @@ describe("Android Cloud native auth handoff", () => {
   beforeEach(() => {
     harness.pending = null;
     harness.token = null;
+    localStorage.clear();
     vi.resetModules();
     vi.restoreAllMocks();
+  });
+
+  it("preserves account-switch intent across module recreation", async () => {
+    const first = await import("./android-cloud-auth");
+    first.markAndroidCloudAccountSwitchPending();
+    expect(first.isAndroidCloudAccountSwitchPending()).toBe(true);
+
+    vi.resetModules();
+    const recreated = await import("./android-cloud-auth");
+    expect(recreated.isAndroidCloudAccountSwitchPending()).toBe(true);
+    recreated.clearAndroidCloudAccountSwitchPending();
+    expect(recreated.isAndroidCloudAccountSwitchPending()).toBe(false);
   });
 
   it("keeps launcher login on the first-party HTTPS WebView surface", async () => {

--- a/packages/ui/src/android-cloud/android-cloud-auth.ts
+++ b/packages/ui/src/android-cloud/android-cloud-auth.ts
@@ -28,6 +28,8 @@ const ANDROID_CLOUD_LOGIN_HOSTS = new Set([
   "cloud.eliza.app",
   "cloud-staging.eliza.app",
 ]);
+const ANDROID_CLOUD_ACCOUNT_SWITCH_KEY =
+  "eliza:android-cloud:account-switch-pending:v1";
 
 export interface AndroidCloudAuthResult {
   apiBase?: string;
@@ -90,6 +92,24 @@ function publishResult(result: AndroidCloudAuthResult): void {
       detail: result,
     }),
   );
+}
+
+/** Persists explicit account-switch intent across renderer and app recreation. */
+export function markAndroidCloudAccountSwitchPending(): void {
+  window.localStorage.setItem(ANDROID_CLOUD_ACCOUNT_SWITCH_KEY, "1");
+  if (window.localStorage.getItem(ANDROID_CLOUD_ACCOUNT_SWITCH_KEY) !== "1") {
+    throw new Error("Eliza Cloud could not preserve the account switch.");
+  }
+}
+
+/** True until a replacement mobile session is verified end to end. */
+export function isAndroidCloudAccountSwitchPending(): boolean {
+  return window.localStorage.getItem(ANDROID_CLOUD_ACCOUNT_SWITCH_KEY) === "1";
+}
+
+/** Removes the durable switch marker after replacement-session verification. */
+export function clearAndroidCloudAccountSwitchPending(): void {
+  window.localStorage.removeItem(ANDROID_CLOUD_ACCOUNT_SWITCH_KEY);
 }
 
 /** Creates the hosted login URL while keeping the verifier in Android Keystore. */

--- a/packages/ui/src/android-cloud/android-cloud-auth.ts
+++ b/packages/ui/src/android-cloud/android-cloud-auth.ts
@@ -15,6 +15,7 @@ import {
   AndroidCloudClient,
   type AndroidCloudLoginAttempt,
   type AndroidCloudLoginCompletion,
+  type AndroidCloudLoginOptions,
   type AndroidCloudPendingLoginStore,
   parseAndroidCloudCallbackAttemptId,
 } from "./android-cloud-client";
@@ -94,8 +95,16 @@ function publishResult(result: AndroidCloudAuthResult): void {
 /** Creates the hosted login URL while keeping the verifier in Android Keystore. */
 export async function beginAndroidCloudSignIn(
   cloudApiBase?: string,
+  options: AndroidCloudLoginOptions = {},
 ): Promise<AndroidCloudLoginAttempt> {
-  return client(cloudApiBase).beginLogin();
+  return client(cloudApiBase).beginLogin(options);
+}
+
+/** Revokes the exact mobile credential before removing its local copy. */
+export async function signOutAndroidCloud(
+  cloudApiBase?: string,
+): Promise<void> {
+  await client(cloudApiBase).signOut();
 }
 
 /** Navigate the launcher WebView only to the canonical hosted login origins. */

--- a/packages/ui/src/android-cloud/android-cloud-auth.ts
+++ b/packages/ui/src/android-cloud/android-cloud-auth.ts
@@ -9,6 +9,7 @@
  */
 
 import { registerPlugin } from "@capacitor/core";
+import { shellLocalStorage } from "../surface-realm-channel";
 import { isSafeNavigationUrl } from "../utils/navigation-url";
 import {
   AndroidCloudAuthError,
@@ -96,7 +97,7 @@ function publishResult(result: AndroidCloudAuthResult): void {
 
 /** Persists explicit account-switch intent across renderer and app recreation. */
 export function markAndroidCloudAccountSwitchPending(): void {
-  window.localStorage.setItem(ANDROID_CLOUD_ACCOUNT_SWITCH_KEY, "1");
+  shellLocalStorage.setItem(ANDROID_CLOUD_ACCOUNT_SWITCH_KEY, "1");
   if (window.localStorage.getItem(ANDROID_CLOUD_ACCOUNT_SWITCH_KEY) !== "1") {
     throw new Error("Eliza Cloud could not preserve the account switch.");
   }
@@ -109,7 +110,7 @@ export function isAndroidCloudAccountSwitchPending(): boolean {
 
 /** Removes the durable switch marker after replacement-session verification. */
 export function clearAndroidCloudAccountSwitchPending(): void {
-  window.localStorage.removeItem(ANDROID_CLOUD_ACCOUNT_SWITCH_KEY);
+  shellLocalStorage.removeItem(ANDROID_CLOUD_ACCOUNT_SWITCH_KEY);
 }
 
 /** Creates the hosted login URL while keeping the verifier in Android Keystore. */

--- a/packages/ui/src/android-cloud/android-cloud-client.test.ts
+++ b/packages/ui/src/android-cloud/android-cloud-client.test.ts
@@ -124,13 +124,14 @@ describe("AndroidCloudClient", () => {
         }),
       );
     const client = new AndroidCloudClient({ credentialStore, fetchImpl });
-    const attempt = await client.beginLogin();
+    const attempt = await client.beginLogin({ switchAccount: true });
     const loginUrl = new URL(attempt.browserUrl);
     const returnTo = loginUrl.searchParams.get("returnTo");
     const authorizeUrl = new URL(returnTo ?? "", loginUrl.origin);
 
     expect(loginUrl.origin).toBe("https://cloud.eliza.app");
     expect(loginUrl.pathname).toBe("/login");
+    expect(loginUrl.searchParams.get("switchAccount")).toBe("1");
     expect(authorizeUrl.pathname).toBe("/app-auth/authorize");
     expect(authorizeUrl.searchParams.get("flow")).toBe("mobile_pkce");
     expect(authorizeUrl.searchParams.get("client_id")).toBe("ai.elizaos.app");
@@ -905,21 +906,32 @@ describe("AndroidCloudClient", () => {
     ).rejects.toThrow("invalid runtime binding");
   });
 
-  it("clears the local Steward token even when remote logout fails", async () => {
+  it("preserves the local credential when exact remote revocation fails", async () => {
     localStorage.setItem(STEWARD_TOKEN_KEY, "steward-token");
     const fetchImpl = vi
       .fn<typeof fetch>()
       .mockRejectedValueOnce(new Error("network unavailable"));
     const client = new AndroidCloudClient({ fetchImpl });
-    await expect(client.signOut()).resolves.toBeUndefined();
-    expect(localStorage.getItem(STEWARD_TOKEN_KEY)).toBeNull();
+    await expect(client.signOut()).rejects.toThrow("network unavailable");
+    expect(localStorage.getItem(STEWARD_TOKEN_KEY)).toBe("steward-token");
     expect(fetchImpl).toHaveBeenCalledWith(
-      "https://api.eliza.app/api/auth/logout",
+      "https://api.eliza.app/api/v1/api-keys/current",
       {
-        method: "POST",
+        method: "DELETE",
         headers: { Authorization: "Bearer steward-token" },
       },
     );
+  });
+
+  it("clears the local credential after exact remote revocation succeeds", async () => {
+    localStorage.setItem(STEWARD_TOKEN_KEY, "steward-token");
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(json(200, { success: true }));
+    const client = new AndroidCloudClient({ fetchImpl });
+
+    await expect(client.signOut()).resolves.toBeUndefined();
+    expect(localStorage.getItem(STEWARD_TOKEN_KEY)).toBeNull();
   });
 
   it("creates a server conversation and sends a text turn to that id", async () => {

--- a/packages/ui/src/android-cloud/android-cloud-client.ts
+++ b/packages/ui/src/android-cloud/android-cloud-client.ts
@@ -50,6 +50,10 @@ export interface AndroidCloudLoginAttempt {
   browserUrl: string;
 }
 
+export interface AndroidCloudLoginOptions {
+  switchAccount?: boolean;
+}
+
 export interface AndroidCloudLoginCompletion {
   apiBase: string;
   pendingCleanupRequired: boolean;
@@ -433,7 +437,9 @@ export class AndroidCloudClient {
     return { identity: { id, displayName }, token, chatApiBase };
   }
 
-  async beginLogin(): Promise<AndroidCloudLoginAttempt> {
+  async beginLogin(
+    options: AndroidCloudLoginOptions = {},
+  ): Promise<AndroidCloudLoginAttempt> {
     const clientId = MOBILE_APP_AUTH_CLIENT_ID;
     const redirectUri = MOBILE_APP_AUTH_REDIRECT_URI;
     const environment =
@@ -497,6 +503,7 @@ export class AndroidCloudClient {
       "returnTo",
       `${authorizePath.pathname}${authorizePath.search}`,
     );
+    if (options.switchAccount) loginUrl.searchParams.set("switchAccount", "1");
     return { state, browserUrl: loginUrl.toString() };
   }
 
@@ -761,19 +768,24 @@ export class AndroidCloudClient {
 
   async signOut(): Promise<void> {
     const token = await this.readToken();
-    try {
-      if (token) {
-        await this.fetchImpl(`${this.apiBase}/api/auth/logout`, {
-          method: "POST",
-          headers: { Authorization: `Bearer ${token}` },
-        });
-      }
-    } catch {
-      // error-policy:J6 remote logout is best-effort teardown; the authoritative
-      // local credential removal is awaited in the finally block below.
-    } finally {
-      await this.credentialStore.clear();
+    if (!token) return;
+    const response = await this.fetchImpl(
+      `${this.apiBase}/api/v1/api-keys/current`,
+      {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${token}` },
+      },
+    );
+    const body = await responseJson(response);
+    if (!response.ok || body.success !== true) {
+      throw new Error(
+        responseError(
+          body,
+          `Unable to revoke this device session (${response.status}).`,
+        ),
+      );
     }
+    await this.credentialStore.clear();
   }
 
   async getConversationMessages(

--- a/packages/ui/src/android-cloud/android-cloud-client.ts
+++ b/packages/ui/src/android-cloud/android-cloud-client.ts
@@ -19,6 +19,7 @@ import {
   resolveCanonicalDirectCloudApiBase,
   STAGING_DIRECT_CLOUD_API_BASE_URL,
 } from "../api/direct-cloud-endpoints";
+import { shellLocalStorage } from "../surface-realm-channel";
 
 const MANAGED_RUNTIME_HOST_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\.cloud(?:-staging)?\.eliza\.app$/i;
@@ -136,10 +137,10 @@ const browserPendingLoginStore: AndroidCloudPendingLoginStore = {
     return window.localStorage.getItem(ANDROID_CLOUD_PENDING_LOGIN_KEY);
   },
   async write(value) {
-    window.localStorage.setItem(ANDROID_CLOUD_PENDING_LOGIN_KEY, value);
+    shellLocalStorage.setItem(ANDROID_CLOUD_PENDING_LOGIN_KEY, value);
   },
   async clear() {
-    window.localStorage.removeItem(ANDROID_CLOUD_PENDING_LOGIN_KEY);
+    shellLocalStorage.removeItem(ANDROID_CLOUD_PENDING_LOGIN_KEY);
   },
 };
 

--- a/packages/ui/src/api/auth/csrf-cookie.ts
+++ b/packages/ui/src/api/auth/csrf-cookie.ts
@@ -1,5 +1,6 @@
 /** Reads the browser session's readable CSRF companion cookie. */
 
+import { shellLocalStorage } from "../../surface-realm-channel";
 import { CSRF_COOKIE_NAME } from "./sessions";
 
 const CSRF_TOKEN_BY_ORIGIN_STORAGE_KEY = "eliza_csrf_token_by_origin_v1";
@@ -50,7 +51,7 @@ export function rememberCsrfTokenForUrl(url: string, token: string): void {
   if (!origin || !normalizedToken || normalizedToken.length > 512) return;
   if (typeof localStorage === "undefined") return;
   try {
-    localStorage.setItem(
+    shellLocalStorage.setItem(
       CSRF_TOKEN_BY_ORIGIN_STORAGE_KEY,
       JSON.stringify({ ...readStoredCsrfTokens(), [origin]: normalizedToken }),
     );

--- a/packages/ui/src/bridge/storage-bridge-secure-contract.test.ts
+++ b/packages/ui/src/bridge/storage-bridge-secure-contract.test.ts
@@ -619,6 +619,10 @@ describe("native protected-storage bridge contract", () => {
   it("does not finish active-server teardown before native deletion commits", async () => {
     const bridge = await import("./storage-bridge");
     const persistence = await import("../state/persistence");
+    // Production installs the native storage proxy before any auth/runtime
+    // state is published. Model that boot boundary so synchronous persistence
+    // readers observe the verified secure-store cache rather than raw disk.
+    await bridge.initializeStorageBridge();
     await bridge.setStorageValue(
       "elizaos:active-server",
       JSON.stringify({

--- a/packages/ui/src/bridge/storage-bridge-secure-contract.test.ts
+++ b/packages/ui/src/bridge/storage-bridge-secure-contract.test.ts
@@ -59,6 +59,12 @@ vi.mock("@capacitor/preferences", () => ({
 }));
 
 vi.mock("@elizaos/logger", () => ({
+  createLogger: () => ({
+    debug: () => undefined,
+    error: () => undefined,
+    info: () => undefined,
+    warn: () => undefined,
+  }),
   logger: { error: () => undefined },
 }));
 
@@ -608,5 +614,42 @@ describe("native protected-storage bridge contract", () => {
     expect(await bridge.getStorageValue("elizaos:active-server")).toBe(
       "new-token",
     );
+  });
+
+  it("does not finish active-server teardown before native deletion commits", async () => {
+    const bridge = await import("./storage-bridge");
+    const persistence = await import("../state/persistence");
+    await bridge.setStorageValue(
+      "elizaos:active-server",
+      JSON.stringify({
+        id: "cloud:previous-account-agent",
+        kind: "cloud",
+        label: "Previous account agent",
+        apiBase: "https://previous-account-agent.cloud.eliza.app",
+      }),
+    );
+    expect(persistence.loadPersistedActiveServer()).not.toBeNull();
+
+    let releaseDelete: () => void = () => {};
+    nativeStores.secureDeleteWait = new Promise<void>((resolve) => {
+      releaseDelete = resolve;
+    });
+    let settled = false;
+    const removal = persistence.clearPersistedActiveServerDurably().then(() => {
+      settled = true;
+    });
+
+    await vi.waitFor(() => {
+      expect(nativeStores.operations).toContain(
+        "delete:start:runtime.active_server",
+      );
+    });
+    expect(settled).toBe(false);
+    expect(persistence.loadPersistedActiveServer()).not.toBeNull();
+
+    releaseDelete();
+    await removal;
+    expect(settled).toBe(true);
+    expect(persistence.loadPersistedActiveServer()).toBeNull();
   });
 });

--- a/packages/ui/src/cloud/public-pages/pages/login/login-page.same-origin.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/login-page.same-origin.test.tsx
@@ -9,7 +9,8 @@ import { cleanup, render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, expect, it, vi } from "vitest";
 
-const { redirectToSsoBridge } = vi.hoisted(() => ({
+const { prepareSsoAccountSwitch, redirectToSsoBridge } = vi.hoisted(() => ({
+  prepareSsoAccountSwitch: vi.fn(() => Promise.resolve()),
   redirectToSsoBridge: vi.fn(() => Promise.resolve(true)),
 }));
 
@@ -90,22 +91,43 @@ vi.mock("../../lib/use-page-title", () => ({ usePageTitle: () => {} }));
 // the same local page an app host renders, and every assertion below would
 // hold no matter which branch ran. Forcing it true makes the two outcomes
 // distinguishable, so these tests fail when an app host is misrouted.
-vi.mock("../../../sso-bridge/sso-bridge", async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import("../../../sso-bridge/sso-bridge")>();
-  return { ...actual, redirectToSsoBridge, shouldAutoBridgeToSso: () => true };
-});
+vi.mock("../../../sso-bridge/sso-bridge", () => ({
+  prepareSsoAccountSwitch,
+  redirectToSsoBridge,
+  shouldAutoBridgeToSso: () => true,
+}));
 
 import LoginPage from "./login-page";
-import "./steward-login-section";
+import StewardLoginSection from "./steward-login-section";
 
 afterEach(() => {
   cleanup();
+  prepareSsoAccountSwitch.mockReset();
+  prepareSsoAccountSwitch.mockResolvedValue(undefined);
   redirectToSsoBridge.mockClear();
   Object.defineProperty(window, "location", {
     configurable: true,
     value: realLocation,
   });
+});
+
+it("blocks every sign-in control when account-switch teardown fails", async () => {
+  prepareSsoAccountSwitch.mockRejectedValueOnce(
+    new Error("Previous session teardown unavailable"),
+  );
+
+  render(
+    <MemoryRouter initialEntries={["/login?switchAccount=1&returnTo=%2Fchat"]}>
+      <StewardLoginSection />
+    </MemoryRouter>,
+  );
+
+  expect(
+    await screen.findByText("Previous session teardown unavailable"),
+  ).toBeTruthy();
+  expect(screen.getByRole("button", { name: "Try again" })).toBeTruthy();
+  expect(screen.queryByRole("button", { name: /Magic Link/i })).toBeNull();
+  expect(screen.queryByRole("button", { name: /Google/i })).toBeNull();
 });
 
 it("keeps canonical app-host login on the current origin", async () => {

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
@@ -962,6 +962,43 @@ export default function StewardLoginSection() {
 
   useEffect(() => {
     if (PLAYWRIGHT_TEST_AUTH_ENABLED) return;
+    if (searchParams.get("switchAccount") !== "1") return;
+
+    setSessionRecoveryComplete(false);
+    let cancelled = false;
+    void import("../../../sso-bridge/sso-bridge")
+      .then(({ prepareSsoAccountSwitch }) => prepareSsoAccountSwitch())
+      .then(() => {
+        if (cancelled) return;
+        const next = new URLSearchParams(searchParams);
+        next.delete("switchAccount");
+        navigate(
+          {
+            pathname,
+            search: next.size > 0 ? `?${next.toString()}` : "",
+          },
+          { replace: true },
+        );
+      })
+      .catch((accountSwitchError) => {
+        if (cancelled) return;
+        setError(
+          getErrorMessage(
+            accountSwitchError,
+            "Could not end the previous Eliza Cloud session",
+          ),
+        );
+        setSessionRecoveryComplete(true);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [navigate, pathname, searchParams]);
+
+  useEffect(() => {
+    if (PLAYWRIGHT_TEST_AUTH_ENABLED) return;
+    if (searchParams.get("switchAccount") === "1") return;
     if (searchParams.get("code") || searchParams.get("error")) {
       setSessionRecoveryComplete(true);
       return;

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
@@ -650,6 +650,9 @@ export default function StewardLoginSection() {
   const [step, setStep] = useState<AuthStep>("idle");
   const [loading, setLoading] = useState<Provider | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [accountSwitchError, setAccountSwitchError] = useState<string | null>(
+    null,
+  );
   const [showPasskeyRecovery, setShowPasskeyRecovery] = useState(false);
   const [showPasskeyEnrollmentRecovery, setShowPasskeyEnrollmentRecovery] =
     useState(false);
@@ -965,6 +968,7 @@ export default function StewardLoginSection() {
     if (searchParams.get("switchAccount") !== "1") return;
 
     setSessionRecoveryComplete(false);
+    setAccountSwitchError(null);
     let cancelled = false;
     void import("../../../sso-bridge/sso-bridge")
       .then(({ prepareSsoAccountSwitch }) => prepareSsoAccountSwitch())
@@ -982,13 +986,12 @@ export default function StewardLoginSection() {
       })
       .catch((accountSwitchError) => {
         if (cancelled) return;
-        setError(
+        setAccountSwitchError(
           getErrorMessage(
             accountSwitchError,
             "Could not end the previous Eliza Cloud session",
           ),
         );
-        setSessionRecoveryComplete(true);
       });
 
     return () => {
@@ -2283,6 +2286,39 @@ export default function StewardLoginSection() {
           </Button>
         </div>
       </div>
+    );
+  }
+
+  if (accountSwitchError) {
+    return (
+      <ReservedLoginFrame>
+        <div
+          className="flex flex-col items-center gap-4 text-center"
+          role="alert"
+        >
+          <div className="flex size-12 items-center justify-center rounded-full bg-destructive/10 text-destructive">
+            <AlertCircle className="size-5" aria-hidden="true" />
+          </div>
+          <div className="space-y-1">
+            <p className="text-base font-semibold text-txt-strong">
+              {t("cloud.login.accountSwitch.title", {
+                defaultValue: "Couldn't switch accounts",
+              })}
+            </p>
+            <p className="text-sm text-muted">{accountSwitchError}</p>
+          </div>
+          <Button
+            variant="default"
+            type="button"
+            className="hosted-signin-focus-emphasis w-full"
+            onClick={() => window.location.reload()}
+          >
+            {t("cloud.login.accountSwitch.retry", {
+              defaultValue: "Try again",
+            })}
+          </Button>
+        </div>
+      </ReservedLoginFrame>
     );
   }
 

--- a/packages/ui/src/cloud/sso-bridge/sso-bridge.test.ts
+++ b/packages/ui/src/cloud/sso-bridge/sso-bridge.test.ts
@@ -31,6 +31,7 @@ import {
   mintSsoCode,
   pairedAppOrigin,
   performSsoExchange,
+  prepareSsoAccountSwitch,
   sanitizeBridgeReturnTo,
   shouldAttemptSsoBridge,
   shouldAutoBridgeToSso,
@@ -559,6 +560,26 @@ describe("signOutFromSsoBridgedHost", () => {
       expect(calls[0].url).toBe("https://cloud.eliza.app/api/auth/logout");
       expect(proofAtServerLogoutIssue).toBe(false);
       expect(localStorage.getItem(STEWARD_TOKEN_KEY)).toBeNull();
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+});
+
+describe("prepareSsoAccountSwitch", () => {
+  it("fails closed when the previous hosted session cannot be ended", async () => {
+    const token = liveToken();
+    localStorage.setItem(STEWARD_TOKEN_KEY, token);
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (() =>
+      Promise.resolve(json(200, { ok: true }))) as typeof fetch;
+    try {
+      const { fn } = fetchStub(() => json(503, { success: false }));
+      await expect(prepareSsoAccountSwitch("eliza.app", fn)).rejects.toThrow(
+        "could not end the previous browser session (503)",
+      );
+      expect(localStorage.getItem(STEWARD_TOKEN_KEY)).toBeNull();
+      expect(isSsoLoggedOut()).toBe(true);
     } finally {
       globalThis.fetch = realFetch;
     }

--- a/packages/ui/src/cloud/sso-bridge/sso-bridge.ts
+++ b/packages/ui/src/cloud/sso-bridge/sso-bridge.ts
@@ -634,3 +634,34 @@ export async function signOutFromSsoBridgedHost(
   await clearStaleStewardSession();
   await serverLogout;
 }
+
+/**
+ * Ends the ambient hosted session before a native account-switch login.
+ * Unlike ordinary sign-out, this boundary fails closed: rendering provider
+ * choices over a still-live HttpOnly session would silently select the prior
+ * account again.
+ */
+export async function prepareSsoAccountSwitch(
+  hostname: string = window.location.hostname,
+  fetchFn: typeof fetch = fetch,
+): Promise<void> {
+  invalidateStewardServerCookieSyncMarker();
+  markSsoLoggedOut();
+  const base = apiBaseForHostname(hostname);
+  if (!base) {
+    throw new Error(
+      "Eliza Cloud account switching is unavailable on this host.",
+    );
+  }
+  const serverLogout = fetchFn(`${base}/api/auth/logout`, {
+    method: "POST",
+    credentials: "include",
+  });
+  await clearStaleStewardSession();
+  const response = await serverLogout;
+  if (!response.ok) {
+    throw new Error(
+      `Eliza Cloud could not end the previous browser session (${response.status}).`,
+    );
+  }
+}

--- a/packages/ui/src/state/agent-profiles.ts
+++ b/packages/ui/src/state/agent-profiles.ts
@@ -6,6 +6,7 @@
  */
 
 import { logger } from "@elizaos/logger";
+import { setStorageValue } from "../bridge/storage-bridge";
 import { shellLocalStorage } from "../surface-realm-channel";
 import { isManagedCloudSharedAgentBase } from "../utils/cloud-agent-base";
 import type { AgentProfile, AgentProfileRegistry } from "./agent-profile-types";
@@ -303,6 +304,31 @@ export function removeManagedSharedCloudAgentProfiles(): void {
     activeProfileId: activeStillPresent ? registry.activeProfileId : null,
     profiles,
   });
+}
+
+/**
+ * Removes managed Cloud profiles only after the protected native rewrite has
+ * committed, so account sign-out cannot resolve over stale profile authority.
+ */
+export async function removeManagedCloudAgentProfilesDurably(): Promise<void> {
+  const registry = loadAgentProfileRegistry();
+  const profiles = registry.profiles.filter(
+    (profile) =>
+      profile.kind !== "cloud" &&
+      !isManagedCloudSharedAgentBase(profile.apiBase),
+  );
+  if (profiles.length === registry.profiles.length) return;
+  const activeStillPresent = profiles.some(
+    (profile) => profile.id === registry.activeProfileId,
+  );
+  await setStorageValue(
+    STORAGE_KEY,
+    JSON.stringify({
+      version: 1,
+      activeProfileId: activeStillPresent ? registry.activeProfileId : null,
+      profiles,
+    } satisfies AgentProfileRegistry),
+  );
 }
 
 export function removeAgentProfile(id: string): void {

--- a/packages/ui/src/state/cloud-auth-first-screen.ts
+++ b/packages/ui/src/state/cloud-auth-first-screen.ts
@@ -1,5 +1,7 @@
 /** Carries the one-shot greeting handoff across the Cloud login navigation. */
 
+import { shellLocalStorage } from "../surface-realm-channel";
+
 export const CLOUD_AUTH_FIRST_SCREEN_GREETING_KEY =
   "eliza:cloud-auth-first-screen-greeting";
 
@@ -7,7 +9,7 @@ export const CLOUD_AUTH_FIRST_SCREEN_GREETING_KEY =
 export function markCloudAuthFirstScreenGreeting(): void {
   if (typeof window === "undefined") return;
   try {
-    window.localStorage.setItem(CLOUD_AUTH_FIRST_SCREEN_GREETING_KEY, "1");
+    shellLocalStorage.setItem(CLOUD_AUTH_FIRST_SCREEN_GREETING_KEY, "1");
   } catch {
     // error-policy:J4 storage loss affects only the optional greeting handoff.
   }
@@ -17,7 +19,7 @@ export function markCloudAuthFirstScreenGreeting(): void {
 export function clearCloudAuthFirstScreenGreeting(): void {
   if (typeof window === "undefined") return;
   try {
-    window.localStorage.removeItem(CLOUD_AUTH_FIRST_SCREEN_GREETING_KEY);
+    shellLocalStorage.removeItem(CLOUD_AUTH_FIRST_SCREEN_GREETING_KEY);
   } catch {
     // error-policy:J4 blocked storage cannot retain a marker that was not writable.
   }
@@ -30,7 +32,7 @@ export function consumeCloudAuthFirstScreenGreeting(): boolean {
     const pending =
       window.localStorage.getItem(CLOUD_AUTH_FIRST_SCREEN_GREETING_KEY) === "1";
     if (pending) {
-      window.localStorage.removeItem(CLOUD_AUTH_FIRST_SCREEN_GREETING_KEY);
+      shellLocalStorage.removeItem(CLOUD_AUTH_FIRST_SCREEN_GREETING_KEY);
     }
     return pending;
   } catch {

--- a/packages/ui/src/state/persistence.ts
+++ b/packages/ui/src/state/persistence.ts
@@ -10,6 +10,7 @@ import { isTerminalIosNativeAgentBootErrorMessage } from "../api/ios-local-agent
 import { getShaderPreset } from "../backgrounds/shader-presets";
 import { normalizeUniforms } from "../backgrounds/shader-schema";
 import { isElectrobunRuntime } from "../bridge/electrobun-runtime";
+import { removeStorageValue } from "../bridge/storage-bridge";
 import { MAX_BACKGROUND_HISTORY } from "./background-history";
 
 // Re-exported so existing `import { MAX_BACKGROUND_HISTORY } from "./persistence"`
@@ -1431,6 +1432,11 @@ export function clearPersistedActiveServer(): void {
   tryLocalStorage(() => {
     shellLocalStorage.removeItem(ACTIVE_SERVER_STORAGE_KEY);
   }, undefined);
+}
+
+/** Delete the active runtime target from browser and protected native storage. */
+export async function clearPersistedActiveServerDurably(): Promise<void> {
+  await removeStorageValue(ACTIVE_SERVER_STORAGE_KEY);
 }
 
 /**

--- a/packages/ui/src/state/shared-cloud-account-binding.test.ts
+++ b/packages/ui/src/state/shared-cloud-account-binding.test.ts
@@ -11,7 +11,10 @@ import {
   loadPersistedActiveServer,
   savePersistedActiveServer,
 } from "./persistence";
-import { clearSharedCloudAccountBinding } from "./shared-cloud-account-binding";
+import {
+  clearManagedCloudAccountBinding,
+  clearSharedCloudAccountBinding,
+} from "./shared-cloud-account-binding";
 
 const SHARED_BASE =
   "https://api.eliza.app/api/v1/eliza/agents/previous-account-agent";
@@ -89,5 +92,53 @@ describe("clearSharedCloudAccountBinding", () => {
     expect(getBootConfig().apiToken).toBeUndefined();
     expect(localStorage.getItem("elizaos_api_base")).toBeNull();
     expect(sessionStorage.getItem("elizaos_api_base")).toBeNull();
+  });
+
+  it("clears dedicated Cloud selection while preserving self-hosted profiles", async () => {
+    const dedicatedBase =
+      "https://dedicated-agent.cloud.eliza.app/api/v1/eliza/agents/dedicated-agent";
+    savePersistedActiveServer({
+      id: "cloud:dedicated-agent",
+      kind: "cloud",
+      label: "Dedicated agent",
+      apiBase: dedicatedBase,
+      accessToken: "dedicated-pair-token",
+    });
+    saveAgentProfileRegistry({
+      version: 1,
+      activeProfileId: "dedicated-profile",
+      profiles: [
+        {
+          id: "dedicated-profile",
+          kind: "cloud",
+          label: "Dedicated agent",
+          apiBase: dedicatedBase,
+          accessToken: "dedicated-pair-token",
+          createdAt: new Date().toISOString(),
+        },
+        {
+          id: "self-hosted-profile",
+          kind: "remote",
+          label: "Self hosted",
+          apiBase: "https://box.example/api",
+          accessToken: "self-hosted-token",
+          createdAt: new Date().toISOString(),
+        },
+      ],
+    });
+
+    await clearManagedCloudAccountBinding();
+
+    expect(loadPersistedActiveServer()).toBeNull();
+    expect(loadAgentProfileRegistry()).toEqual({
+      version: 1,
+      activeProfileId: null,
+      profiles: [
+        expect.objectContaining({
+          id: "self-hosted-profile",
+          accessToken: "self-hosted-token",
+        }),
+      ],
+    });
   });
 });

--- a/packages/ui/src/state/shared-cloud-account-binding.ts
+++ b/packages/ui/src/state/shared-cloud-account-binding.ts
@@ -5,8 +5,13 @@
 
 import { client } from "../api";
 import { clearElizaApiBase } from "../utils/eliza-globals";
-import { removeManagedSharedCloudAgentProfiles } from "./agent-profiles";
 import {
+  removeManagedCloudAgentProfilesDurably,
+  removeManagedSharedCloudAgentProfiles,
+} from "./agent-profiles";
+import { isManagedCloudAgentServer } from "./agent-session-recovery";
+import {
+  clearPersistedActiveServerDurably,
   clearPersistedSharedCloudActiveServer,
   loadPersistedActiveServer,
 } from "./persistence";
@@ -37,4 +42,28 @@ export function clearSharedCloudAccountBinding(): boolean {
     }
   }
   return true;
+}
+
+/**
+ * Releases every browser mirror whose authority comes from the ending Eliza
+ * Cloud account while preserving unrelated local and self-hosted profiles.
+ */
+export async function clearManagedCloudAccountBinding(): Promise<void> {
+  const activeServer = loadPersistedActiveServer();
+  if (isManagedCloudAgentServer(activeServer)) {
+    await clearPersistedActiveServerDurably();
+    client.setToken(null);
+    client.setBaseUrl(null);
+    clearElizaApiBase();
+    if (typeof window !== "undefined") {
+      try {
+        window.localStorage.removeItem(STORED_API_BASE_KEY);
+        window.sessionStorage.removeItem(STORED_API_BASE_KEY);
+      } catch {
+        // error-policy:J6 account sign-out already cleared canonical managed
+        // selection state; inaccessible compatibility mirrors cannot be reused.
+      }
+    }
+  }
+  await removeManagedCloudAgentProfilesDurably();
 }

--- a/packages/ui/src/state/useCloudState.android-cloud-auth.test.tsx
+++ b/packages/ui/src/state/useCloudState.android-cloud-auth.test.tsx
@@ -14,6 +14,7 @@ const harness = vi.hoisted(() => ({
   cancel: vi.fn(async () => true),
   sequence: 0,
   stewardToken: null as string | null,
+  switchAccountPending: false,
   api: {
     getBaseUrl: vi.fn(() => ""),
     setBaseUrl: vi.fn(),
@@ -60,6 +61,13 @@ vi.mock("../android-cloud/android-cloud-auth", () => ({
   ANDROID_CLOUD_AUTH_STARTED_EVENT: "eliza:android-cloud-auth-started",
   beginAndroidCloudSignIn: harness.begin,
   cancelAndroidCloudSignIn: harness.cancel,
+  clearAndroidCloudAccountSwitchPending: vi.fn(() => {
+    harness.switchAccountPending = false;
+  }),
+  isAndroidCloudAccountSwitchPending: vi.fn(() => harness.switchAccountPending),
+  markAndroidCloudAccountSwitchPending: vi.fn(() => {
+    harness.switchAccountPending = true;
+  }),
   signOutAndroidCloud: vi.fn(async () => {}),
   hasPendingAndroidCloudSignIn: vi.fn(async () => {
     throw new Error("pending cleanup record unavailable");
@@ -107,6 +115,7 @@ describe("useCloudState Android hosted auth", () => {
     });
     harness.sequence = 0;
     harness.stewardToken = null;
+    harness.switchAccountPending = false;
     for (const method of Object.values(harness.api)) method.mockClear();
   });
 
@@ -148,6 +157,29 @@ describe("useCloudState Android hosted auth", () => {
     });
     expect(harness.cancel).toHaveBeenCalledWith("attempt-2");
     expect(result.current.elizaCloudLoginBusy).toBe(false);
+  });
+
+  it("preserves account-switch intent across hook recreation", async () => {
+    harness.switchAccountPending = true;
+    const first = renderHook(() => useCloudState(params()));
+    first.unmount();
+    const recreated = renderHook(() => useCloudState(params()));
+
+    let login: Promise<void> | undefined;
+    act(() => {
+      login = recreated.result.current.handleCloudLogin();
+    });
+    await act(async () => {
+      for (let index = 0; index < 5; index += 1) await Promise.resolve();
+    });
+    expect(harness.begin).toHaveBeenCalledWith("https://eliza.app", {
+      switchAccount: true,
+    });
+    act(() => harness.browserFinished?.());
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_500);
+      await login;
+    });
   });
 
   it("does not cancel a callback that starts before the browser-close grace expires", async () => {

--- a/packages/ui/src/state/useCloudState.android-cloud-auth.test.tsx
+++ b/packages/ui/src/state/useCloudState.android-cloud-auth.test.tsx
@@ -60,6 +60,7 @@ vi.mock("../android-cloud/android-cloud-auth", () => ({
   ANDROID_CLOUD_AUTH_STARTED_EVENT: "eliza:android-cloud-auth-started",
   beginAndroidCloudSignIn: harness.begin,
   cancelAndroidCloudSignIn: harness.cancel,
+  signOutAndroidCloud: vi.fn(async () => {}),
   hasPendingAndroidCloudSignIn: vi.fn(async () => {
     throw new Error("pending cleanup record unavailable");
   }),

--- a/packages/ui/src/state/useCloudState.cloud-sign-out.test.tsx
+++ b/packages/ui/src/state/useCloudState.cloud-sign-out.test.tsx
@@ -8,7 +8,10 @@
 
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { signOutAndroidCloud } from "../android-cloud/android-cloud-auth";
+import {
+  isAndroidCloudAccountSwitchPending,
+  signOutAndroidCloud,
+} from "../android-cloud/android-cloud-auth";
 import { client } from "../api";
 import { signOutFromSsoBridgedHost } from "../cloud/sso-bridge/sso-bridge";
 import {
@@ -144,6 +147,7 @@ describe("useCloudState — Cloud account sign-out", () => {
     });
 
     expect(signOutAndroidCloud).toHaveBeenCalledWith("https://eliza.app");
+    expect(isAndroidCloudAccountSwitchPending()).toBe(true);
     expect(signOutFromSsoBridgedHost).not.toHaveBeenCalled();
     expect(client.cloudDisconnect).not.toHaveBeenCalled();
     expect(result.current.elizaCloudConnected).toBe(false);

--- a/packages/ui/src/state/useCloudState.cloud-sign-out.test.tsx
+++ b/packages/ui/src/state/useCloudState.cloud-sign-out.test.tsx
@@ -8,9 +8,11 @@
 
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { signOutAndroidCloud } from "../android-cloud/android-cloud-auth";
 import { client } from "../api";
 import { signOutFromSsoBridgedHost } from "../cloud/sso-bridge/sso-bridge";
 import {
+  clearPersistedActiveServer,
   loadPersistedActiveServer,
   loadPersistedFirstRunComplete,
   savePersistedActiveServer,
@@ -22,8 +24,38 @@ const getCloudStatusMock = vi.hoisted(() => vi.fn());
 const getCloudCreditsMock = vi.hoisted(() => vi.fn());
 const cloudDisconnectMock = vi.hoisted(() => vi.fn());
 const signOutFromSsoBridgedHostMock = vi.hoisted(() => vi.fn());
+const signOutAndroidCloudMock = vi.hoisted(() => vi.fn());
+const nativePlatformState = vi.hoisted(() => ({ enabled: false }));
 const isElizaCloudRuntimeLockedMock = vi.hoisted(() => vi.fn());
 const isAppModeHostMock = vi.hoisted(() => vi.fn());
+const clearManagedCloudAccountBindingMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./shared-cloud-account-binding", () => ({
+  clearManagedCloudAccountBinding: clearManagedCloudAccountBindingMock,
+}));
+
+vi.mock("@capacitor/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@capacitor/core")>();
+  return {
+    ...actual,
+    Capacitor: {
+      ...actual.Capacitor,
+      isNativePlatform: () => nativePlatformState.enabled,
+    },
+  };
+});
+
+vi.mock("../platform/android-runtime", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../platform/android-runtime")>()),
+  isAndroidCloudBuild: () => true,
+}));
+
+vi.mock("../android-cloud/android-cloud-auth", async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import("../android-cloud/android-cloud-auth")
+  >()),
+  signOutAndroidCloud: signOutAndroidCloudMock,
+}));
 
 vi.mock("../api", () => ({
   client: {
@@ -75,6 +107,11 @@ describe("useCloudState — Cloud account sign-out", () => {
     });
     cloudDisconnectMock.mockResolvedValue(undefined);
     signOutFromSsoBridgedHostMock.mockResolvedValue(undefined);
+    signOutAndroidCloudMock.mockResolvedValue(undefined);
+    clearManagedCloudAccountBindingMock.mockImplementation(async () => {
+      clearPersistedActiveServer();
+    });
+    nativePlatformState.enabled = false;
     isElizaCloudRuntimeLockedMock.mockReturnValue(true);
     isAppModeHostMock.mockReturnValue(false);
   });
@@ -84,6 +121,7 @@ describe("useCloudState — Cloud account sign-out", () => {
   });
 
   it("clears the account session without calling the locked runtime disconnect path", async () => {
+    nativePlatformState.enabled = true;
     savePersistedActiveServer({
       id: "cloud:previous-account-agent",
       kind: "cloud",
@@ -105,7 +143,8 @@ describe("useCloudState — Cloud account sign-out", () => {
       await result.current.handleCloudSignOut();
     });
 
-    expect(signOutFromSsoBridgedHost).toHaveBeenCalledTimes(1);
+    expect(signOutAndroidCloud).toHaveBeenCalledWith("https://eliza.app");
+    expect(signOutFromSsoBridgedHost).not.toHaveBeenCalled();
     expect(client.cloudDisconnect).not.toHaveBeenCalled();
     expect(result.current.elizaCloudConnected).toBe(false);
     expect(result.current.elizaCloudEnabled).toBe(false);

--- a/packages/ui/src/state/useCloudState.cloud-sign-out.test.tsx
+++ b/packages/ui/src/state/useCloudState.cloud-sign-out.test.tsx
@@ -10,6 +10,12 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { client } from "../api";
 import { signOutFromSsoBridgedHost } from "../cloud/sso-bridge/sso-bridge";
+import {
+  loadPersistedActiveServer,
+  loadPersistedFirstRunComplete,
+  savePersistedActiveServer,
+  savePersistedFirstRunComplete,
+} from "./persistence";
 import { useCloudState } from "./useCloudState";
 
 const getCloudStatusMock = vi.hoisted(() => vi.fn());
@@ -22,6 +28,8 @@ const isAppModeHostMock = vi.hoisted(() => vi.fn());
 vi.mock("../api", () => ({
   client: {
     getBaseUrl: vi.fn(() => "https://api.eliza.app"),
+    setBaseUrl: vi.fn(),
+    setToken: vi.fn(),
     getCloudStatus: getCloudStatusMock,
     getCloudCredits: getCloudCreditsMock,
     cloudDisconnect: cloudDisconnectMock,
@@ -53,6 +61,8 @@ function makeParams() {
 
 describe("useCloudState — Cloud account sign-out", () => {
   beforeEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
     getCloudStatusMock.mockResolvedValue({
       connected: true,
       enabled: true,
@@ -74,6 +84,14 @@ describe("useCloudState — Cloud account sign-out", () => {
   });
 
   it("clears the account session without calling the locked runtime disconnect path", async () => {
+    savePersistedActiveServer({
+      id: "cloud:previous-account-agent",
+      kind: "cloud",
+      label: "Previous account agent",
+      apiBase: "https://previous-account-agent.cloud.eliza.app",
+      accessToken: "previous-account-pair-token",
+    });
+    savePersistedFirstRunComplete(true);
     const params = makeParams();
     const { result } = renderHook(() => useCloudState(params));
 
@@ -93,6 +111,8 @@ describe("useCloudState — Cloud account sign-out", () => {
     expect(result.current.elizaCloudEnabled).toBe(false);
     expect(result.current.elizaCloudUserId).toBeNull();
     expect(result.current.elizaCloudDisconnecting).toBe(false);
+    expect(loadPersistedActiveServer()).toBeNull();
+    expect(loadPersistedFirstRunComplete()).toBe(false);
     expect(params.setActionNotice).toHaveBeenCalledWith(
       "Signed out of Eliza Cloud.",
       "success",

--- a/packages/ui/src/state/useCloudState.ts
+++ b/packages/ui/src/state/useCloudState.ts
@@ -30,6 +30,9 @@ import {
   type AndroidCloudAuthResult,
   beginAndroidCloudSignIn,
   cancelAndroidCloudSignIn,
+  clearAndroidCloudAccountSwitchPending,
+  isAndroidCloudAccountSwitchPending,
+  markAndroidCloudAccountSwitchPending,
   navigateAndroidCloudSignInInApp,
   signOutAndroidCloud,
   takeLatestAndroidCloudCompletion,
@@ -538,8 +541,6 @@ export function useCloudState({
   const elizaCloudLoginCompletionRef = useRef<Promise<void> | null>(null);
   /** Synchronous lock to prevent duplicate login clicks in the same tick. */
   const elizaCloudLoginBusyRef = useRef(false);
-  /** Explicit native sign-out requires the next hosted handoff to change accounts. */
-  const androidCloudAccountSwitchPendingRef = useRef(false);
   /** Tracks whether the auth-rejected notice has already been sent for the current rejection. */
   const elizaCloudAuthNoticeSentRef = useRef(false);
 
@@ -855,7 +856,7 @@ export function useCloudState({
               );
           });
           const attempt = await beginAndroidCloudSignIn(cloudApiBase, {
-            switchAccount: androidCloudAccountSwitchPendingRef.current,
+            switchAccount: isAndroidCloudAccountSwitchPending(),
           });
           attemptId = attempt.state;
           if (isAndroidLauncherBuild()) {
@@ -923,7 +924,17 @@ export function useCloudState({
               "Could not verify your Eliza Cloud session. Please sign in again.",
             );
           }
-          androidCloudAccountSwitchPendingRef.current = false;
+          try {
+            clearAndroidCloudAccountSwitchPending();
+          } catch (error) {
+            // error-policy:J4 the replacement session is already verified;
+            // retaining this non-secret marker only forces another explicit
+            // account choice on a future login instead of weakening auth.
+            logger.warn(
+              { error },
+              "[useCloudState] Could not clear Android account-switch marker",
+            );
+          }
         } catch (error) {
           androidLoginError = error;
           setElizaCloudLoginError(
@@ -1790,7 +1801,7 @@ export function useCloudState({
         const cloudApiBase =
           getBootConfig().cloudApiBase ?? DEFAULT_DIRECT_CLOUD_BASE_URL;
         await signOutAndroidCloud(cloudApiBase);
-        androidCloudAccountSwitchPendingRef.current = true;
+        markAndroidCloudAccountSwitchPending();
       } else {
         await signOutFromSsoBridgedHost();
       }

--- a/packages/ui/src/state/useCloudState.ts
+++ b/packages/ui/src/state/useCloudState.ts
@@ -87,8 +87,12 @@ import {
   launchStewardLogin,
 } from "./cloud-steward-login";
 
-import { scrubPersistedActiveServerToken } from "./persistence";
+import {
+  savePersistedFirstRunComplete,
+  scrubPersistedActiveServerToken,
+} from "./persistence";
 import { isPrivateNetworkHost } from "./private-network-host";
+import { clearManagedCloudAccountBinding } from "./shared-cloud-account-binding";
 import type { CloudLoginOptions } from "./types";
 
 // ── Constants ──────────────────────────────────────────────────────────────
@@ -1775,6 +1779,12 @@ export function useCloudState({
       // cross-origin teardown here: synchronously suppress auto-bridging,
       // revoke the server session, then scrub the local Steward session.
       await signOutFromSsoBridgedHost();
+      // A managed agent selection is scoped to the account that proved
+      // ownership. Account switching must not restore that target under the
+      // next account or strand the cloud-only app in backend-unreachable.
+      await clearManagedCloudAccountBinding();
+      clearCloudPairApiToken();
+      savePersistedFirstRunComplete(false);
       setElizaCloudEnabled(false);
       setElizaCloudConnected(false);
       publishElizaCloudVoiceSnapshot(setElizaCloudHasPersistedKey, {

--- a/packages/ui/src/state/useCloudState.ts
+++ b/packages/ui/src/state/useCloudState.ts
@@ -31,6 +31,7 @@ import {
   beginAndroidCloudSignIn,
   cancelAndroidCloudSignIn,
   navigateAndroidCloudSignInInApp,
+  signOutAndroidCloud,
   takeLatestAndroidCloudCompletion,
 } from "../android-cloud/android-cloud-auth";
 import { client } from "../api";
@@ -537,6 +538,8 @@ export function useCloudState({
   const elizaCloudLoginCompletionRef = useRef<Promise<void> | null>(null);
   /** Synchronous lock to prevent duplicate login clicks in the same tick. */
   const elizaCloudLoginBusyRef = useRef(false);
+  /** Explicit native sign-out requires the next hosted handoff to change accounts. */
+  const androidCloudAccountSwitchPendingRef = useRef(false);
   /** Tracks whether the auth-rejected notice has already been sent for the current rejection. */
   const elizaCloudAuthNoticeSentRef = useRef(false);
 
@@ -851,7 +854,9 @@ export function useCloudState({
                 onResult,
               );
           });
-          const attempt = await beginAndroidCloudSignIn(cloudApiBase);
+          const attempt = await beginAndroidCloudSignIn(cloudApiBase, {
+            switchAccount: androidCloudAccountSwitchPendingRef.current,
+          });
           attemptId = attempt.state;
           if (isAndroidLauncherBuild()) {
             if (!navigateAndroidCloudSignInInApp(attempt.browserUrl)) {
@@ -918,6 +923,7 @@ export function useCloudState({
               "Could not verify your Eliza Cloud session. Please sign in again.",
             );
           }
+          androidCloudAccountSwitchPendingRef.current = false;
         } catch (error) {
           androidLoginError = error;
           setElizaCloudLoginError(
@@ -1778,7 +1784,16 @@ export function useCloudState({
       // inherits the retired console's sign-out menu. Preserve the hardened
       // cross-origin teardown here: synchronously suppress auto-bridging,
       // revoke the server session, then scrub the local Steward session.
-      await signOutFromSsoBridgedHost();
+      const nativeAndroidCloud =
+        isAndroidCloudBuild() && Capacitor.isNativePlatform();
+      if (nativeAndroidCloud) {
+        const cloudApiBase =
+          getBootConfig().cloudApiBase ?? DEFAULT_DIRECT_CLOUD_BASE_URL;
+        await signOutAndroidCloud(cloudApiBase);
+        androidCloudAccountSwitchPendingRef.current = true;
+      } else {
+        await signOutFromSsoBridgedHost();
+      }
       // A managed agent selection is scoped to the account that proved
       // ownership. Account switching must not restore that target under the
       // next account or strand the cloud-only app in backend-unreachable.


### PR DESCRIPTION
## Summary
- replay the six reviewed Android/Capacitor Cloud auth fixes onto current develop with exact patch identity
- preserve canonical hosted auth across cold/warm callbacks and noncanonical Android Cloud builds
- make sign-out and account switching clear stale account-scoped runtime state durably
- keep protected auth/runtime records in the native secure-store path and model production storage boot in the teardown regression

## Scope boundaries
- no Pixel or other physical device was touched
- no Dedicated adoption, provisioning, billing, or production path was changed
- preserved /private/tmp/eliza-pixel-dedicated-demo-current as read-only installed-build evidence

## Exact source
- base: e3b5643f9083e6fdd58e628be9ae1304cd89b455
- head: 497df3c1765b0b0618e4aa337f6c207f735f15c0
- tree: 689683792d8af7737880d38436fa61ce3235be64
- all seven commits remained exact equals across terminal rebase; the original six also match 239d2322189..a89c3c0f149 patch-for-patch

## Gates
- UI focused: 115/115
- Android Play policy and Cloud MainActivity: 30/30
- Capacitor plugin selection: 5/5
- app-core typecheck: pass
- app typecheck: pass
- UI typecheck: pass
- Biome: pass (one existing direct document.cookie warning in the touched SSO test)
- git diff --check: pass

## Hosted/device acceptance still pending
- deploy exact source to staging
- prove existing-user and fresh-account signup/sign-in/callback/relaunch/sign-out/account-switching against canonical Eliza Cloud
- device certification awaits an explicit device lease
- intended-agent provisioning/no-duplicate/wrong-tier acceptance remains a separate server-side gate and is not claimed by this PR