### PR TITLE
test(ui): pin Model Hub view-model helper contracts (hub-utils)

### DIFF
--- a/packages/ui/src/components/local-inference/__tests__/hub-consumers.test.tsx
+++ b/packages/ui/src/components/local-inference/__tests__/hub-consumers.test.tsx
@@ -1,0 +1,177 @@
+// @vitest-environment jsdom
+/**
+ * Consumer-boundary render tests for the Model Hub view-model helpers. The
+ * pure-function suite (hub-utils.test.ts) pins the helper math; this file
+ * proves the wiring: rendered DownloadProgress and ActiveModelBar output must
+ * derive from progressPercent / formatEta / formatBytes / displayModelName, so
+ * a wiring defect (wrong helper, dropped argument, hardcoded value) reddens
+ * these tests while the pure suite stays green. Real components over jsdom;
+ * useTranslation falls back to the real English test translator without a
+ * provider.
+ */
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import type {
+  ActiveModelState,
+  DownloadJob,
+  InstalledModel,
+} from "../../../api/client-local-inference";
+import { ActiveModelBar } from "../ActiveModelBar";
+import { DownloadProgress } from "../DownloadProgress";
+
+afterEach(cleanup);
+
+function job(overrides: Partial<DownloadJob> = {}): DownloadJob {
+  return {
+    jobId: "job-1",
+    modelId: "eliza-1-2b",
+    state: "downloading",
+    received: 410_000_000,
+    total: 820_000_000,
+    bytesPerSec: 12_500_000,
+    etaMs: 33_000,
+    startedAt: "2026-08-26T00:00:00Z",
+    updatedAt: "2026-08-26T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function installedModel(
+  overrides: Partial<InstalledModel> = {},
+): InstalledModel {
+  return {
+    id: "eliza-1-2b",
+    displayName: "Eliza 1 2B",
+    path: "/models/eliza-1-2b.gguf",
+    sizeBytes: 820_000_000,
+    installedAt: "2026-08-26T00:00:00Z",
+    lastUsedAt: null,
+    source: "eliza-download",
+    ...overrides,
+  };
+}
+
+function idleActive(): ActiveModelState {
+  return { modelId: null, loadedAt: null, status: "idle" };
+}
+
+/** The progress bar indicator; its translateX offset is -(100 - pct)% and so
+ * pins the percent into the rendered DOM without relying on copy text. */
+function indicatorTransform(): string {
+  const indicator = document.querySelector<HTMLElement>(
+    "[data-slot=progress-indicator]",
+  );
+  if (indicator === null) throw new Error("progress indicator not rendered");
+  return indicator.style.transform;
+}
+
+/** Radix's progressbar role surface; aria-valuenow mirrors the percent the
+ * bar received. */
+function barAriaValueNow(): string {
+  const bar = screen.getByRole("progressbar");
+  return bar.getAttribute("aria-valuenow") ?? "";
+}
+
+describe("DownloadProgress — rendered download telemetry", () => {
+  it("derives the bar offset, percent copy, speed, and ETA from the job", () => {
+    render(<DownloadProgress job={job()} />);
+    // 410_000_000 / 820_000_000 = 50%: the indicator sits at the half-way
+    // translateX(-50%) and the copy names the exact rounded percent.
+    expect(indicatorTransform()).toBe("translateX(-50%)");
+    // getByText throws unless the exact rendered copy is present.
+    screen.getByText("391.0 MB of 782.0 MB · 50%");
+    screen.getByText("11.9 MB/s · 33s left");
+  });
+
+  it("renders a fully-received job as a complete bar with 100% copy", () => {
+    render(
+      <DownloadProgress
+        job={job({
+          state: "completed",
+          received: 820_000_000,
+          bytesPerSec: 0,
+          etaMs: null,
+        })}
+      />,
+    );
+    // -(100 - 100) is -0; the bar sits fully open and the progressbar role
+    // reports 100.
+    expect(indicatorTransform()).toBe("translateX(-0%)");
+    expect(barAriaValueNow()).toBe("100");
+    screen.getByText("782.0 MB of 782.0 MB · 100%");
+  });
+
+  it("renders a zero-total job as an empty bar without NaN anywhere", () => {
+    render(
+      <DownloadProgress job={job({ received: 0, total: 0, etaMs: null })} />,
+    );
+    // progressPercent's non-positive-total guard must reach the DOM: 0%, not
+    // NaN% or a division-by-zero artifact.
+    expect(indicatorTransform()).toBe("translateX(-100%)");
+    expect(barAriaValueNow()).toBe("0");
+    expect(document.body.textContent).not.toContain("NaN");
+    expect(document.body.textContent).toContain("· 0%");
+  });
+});
+
+describe("ActiveModelBar — rendered active-model identity", () => {
+  it("labels the loaded model with the curated display name and status", () => {
+    const active: ActiveModelState = {
+      modelId: "eliza-1-9b-drafter",
+      loadedAt: "2026-08-26T00:00:00Z",
+      status: "ready",
+    };
+    render(
+      <ActiveModelBar
+        active={active}
+        installed={[
+          installedModel({
+            id: "eliza-1-9b-drafter",
+            displayName: "Eliza 1 9B Drafter",
+            path: "/models/eliza-1-9b-drafter.gguf",
+          }),
+        ]}
+        onUnload={() => {}}
+        busy={false}
+      />,
+    );
+    // The rendered label must be displayModelName's derivation ("base id +
+    // drafter"), which differs from BOTH the raw id ("eliza-1-9b-drafter")
+    // and the displayName ("Eliza 1 9B Drafter") — so dropping the helper
+    // for either fallback reddens this assertion.
+    screen.getByText("eliza-1-9b drafter");
+    screen.getByText("ready");
+    screen.getByRole("button", { name: "Unload" });
+  });
+
+  it("falls back to the raw model id when nothing is installed for it", () => {
+    const active: ActiveModelState = {
+      modelId: "external-hf-abc123",
+      loadedAt: null,
+      status: "loading",
+    };
+    render(
+      <ActiveModelBar
+        active={active}
+        installed={[installedModel()]}
+        onUnload={() => {}}
+        busy={false}
+      />,
+    );
+    screen.getByText("external-hf-abc123");
+    screen.getByText("loading");
+  });
+
+  it("renders nothing when no model is loaded", () => {
+    const { container } = render(
+      <ActiveModelBar
+        active={idleActive()}
+        installed={[]}
+        onUnload={() => {}}
+        busy={false}
+      />,
+    );
+    expect(container.innerHTML).toBe("");
+  });
+});

--- a/packages/ui/src/components/local-inference/__tests__/hub-consumers.test.tsx
+++ b/packages/ui/src/components/local-inference/__tests__/hub-consumers.test.tsx
@@ -11,14 +11,18 @@
  */
 
 import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it } from "vitest";
 import type {
   ActiveModelState,
+  CatalogModel,
   DownloadJob,
+  HardwareProbe,
   InstalledModel,
 } from "../../../api/client-local-inference";
 import { ActiveModelBar } from "../ActiveModelBar";
 import { DownloadProgress } from "../DownloadProgress";
+import { ModelCard } from "../ModelCard";
 
 afterEach(cleanup);
 
@@ -71,6 +75,51 @@ function indicatorTransform(): string {
 function barAriaValueNow(): string {
   const bar = screen.getByRole("progressbar");
   return bar.getAttribute("aria-valuenow") ?? "";
+}
+
+/** Complete CatalogModel fixture (mirrors the stories' shape; no casts). */
+function catalogModel(overrides: Partial<CatalogModel> = {}): CatalogModel {
+  return {
+    id: "eliza-1-2b",
+    displayName: "eliza-1-2b",
+    hfRepo: "elizaos/eliza-1",
+    ggufFile: "eliza-1-2b.gguf",
+    params: "2B",
+    parameterLabel: "2B",
+    quant: "Q4_K_M",
+    sizeGb: 2.4,
+    minRamGb: 6,
+    category: "chat",
+    bucket: "mid",
+    blurb: "fixture",
+    ...overrides,
+  };
+}
+
+function beefyHardware(): HardwareProbe {
+  return {
+    totalRamGb: 32,
+    freeRamGb: 24,
+    gpu: null,
+    cpuCores: 10,
+    platform: "darwin",
+    arch: "arm64",
+    appleSilicon: true,
+    recommendedBucket: "large",
+    source: "os-fallback",
+  };
+}
+
+/** ModelCard's full action-row props; noop handlers keep the fixture terse. */
+function cardActions() {
+  return {
+    onDownload: () => {},
+    onCancel: () => {},
+    onActivate: () => {},
+    onUninstall: () => {},
+    onVerify: () => {},
+    onRedownload: () => {},
+  };
 }
 
 describe("DownloadProgress — rendered download telemetry", () => {
@@ -173,5 +222,110 @@ describe("ActiveModelBar — rendered active-model identity", () => {
       />,
     );
     expect(container.innerHTML).toBe("");
+  });
+});
+
+describe("ModelCard — rendered install detection at its consumer", () => {
+  it("an exact-id installed entry suppresses Download and offers the installed action row", () => {
+    render(
+      <ModelCard
+        model={catalogModel()}
+        hardware={beefyHardware()}
+        installed={[installedModel()]}
+        downloads={[]}
+        active={idleActive()}
+        busy={false}
+        {...cardActions()}
+      />,
+    );
+    // Installed size line renders via findInstalled's exact-id match…
+    screen.getByText("Installed · 782.0 MB");
+    // …the Download button must NOT be offered for an installed model…
+    expect(screen.queryByRole("button", { name: "Download" })).toBeNull();
+    // …and the installed-only actions appear.
+    screen.getByRole("button", { name: "Make active" });
+    screen.getByRole("button", { name: "Verify" });
+    screen.getByRole("button", { name: "Uninstall" });
+  });
+
+  it("an external basename match installs the model and keeps Download off", async () => {
+    // Capture the id the Verify button actually receives — it must be the
+    // matched installed entry's own id (findInstalled's pick), not the
+    // catalog id.
+    let verifyId: string | undefined;
+    const actions = {
+      ...cardActions(),
+      onVerify: (id: string) => (verifyId = id),
+    };
+    render(
+      <ModelCard
+        model={catalogModel()}
+        hardware={beefyHardware()}
+        installed={[
+          installedModel({
+            // Different id — only the gguf basename matches, exercising
+            // findInstalled's external fallback path through the render.
+            id: "external-hf-xyz789",
+            path: "/external/models/eliza-1-2b.gguf",
+            source: "external-scan",
+            externalOrigin: "lm-studio",
+          }),
+        ]}
+        downloads={[]}
+        active={idleActive()}
+        busy={false}
+        {...actions}
+      />,
+    );
+    screen.getByText("Installed · 782.0 MB · via lm-studio");
+    expect(screen.queryByRole("button", { name: "Download" })).toBeNull();
+    // Verify uses the installed entry's own id (not the catalog id) —
+    // proven by firing the click, not by reading the component.
+    await userEvent.click(screen.getByRole("button", { name: "Verify" }));
+    expect(verifyId).toBe("external-hf-xyz789");
+    // External-scan installs offer no Uninstall/Redownload (source-gated).
+    expect(screen.queryByRole("button", { name: "Uninstall" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Redownload" })).toBeNull();
+  });
+
+  it("a not-installed model renders Download and no installed actions", () => {
+    render(
+      <ModelCard
+        model={catalogModel()}
+        hardware={beefyHardware()}
+        installed={[]}
+        downloads={[]}
+        active={idleActive()}
+        busy={false}
+        {...cardActions()}
+      />,
+    );
+    screen.getByRole("button", { name: "Download" });
+    expect(screen.queryByText(/Installed ·/)).toBeNull();
+    expect(screen.queryByRole("button", { name: "Make active" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Verify" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Uninstall" })).toBeNull();
+  });
+
+  it("an external entry whose basename does not match stays downloadable", () => {
+    render(
+      <ModelCard
+        model={catalogModel()}
+        hardware={beefyHardware()}
+        installed={[
+          installedModel({
+            id: "external-hf-xyz789",
+            path: "/external/models/other-model.gguf",
+            source: "external-scan",
+          }),
+        ]}
+        downloads={[]}
+        active={idleActive()}
+        busy={false}
+        {...cardActions()}
+      />,
+    );
+    screen.getByRole("button", { name: "Download" });
+    expect(screen.queryByText(/Installed ·/)).toBeNull();
   });
 });

--- a/packages/ui/src/components/local-inference/hub-utils.test.ts
+++ b/packages/ui/src/components/local-inference/hub-utils.test.ts
@@ -1,0 +1,330 @@
+/**
+ * Contract tests for the Model Hub view-model helpers (hub-utils). Harness is
+ * deterministic: pure functions exercised with real inputs at their owning
+ * boundary — no DOM, no mocks. computeFit is exercised through the REAL
+ * assessCatalogModelFit delegation (desktop branch: assessFit over sizeGb and
+ * minRamGb). Backlog for issue #29212.
+ */
+import { describe, expect, it } from "vitest";
+import type {
+  CatalogModel,
+  DownloadJob,
+  HardwareProbe,
+  InstalledModel,
+  ModelBucket,
+} from "../../api/client-local-inference";
+import {
+  bucketLabel,
+  computeFit,
+  displayModelName,
+  findCatalogModel,
+  findDownload,
+  findInstalled,
+  fitLabel,
+  formatBytes,
+  formatEta,
+  groupByBucket,
+  progressPercent,
+} from "./hub-utils";
+
+function job(overrides: Partial<DownloadJob> = {}): DownloadJob {
+  return {
+    jobId: "job-1",
+    modelId: "eliza-1-2b",
+    state: "downloading",
+    received: 0,
+    total: 1000,
+    bytesPerSec: 0,
+    etaMs: null,
+    startedAt: "2026-08-26T00:00:00Z",
+    updatedAt: "2026-08-26T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function installed(
+  id: string,
+  path: string,
+  overrides: Partial<InstalledModel> = {},
+): InstalledModel {
+  return {
+    id,
+    displayName: id,
+    path,
+    sizeBytes: 1024,
+    installedAt: "2026-08-26T00:00:00Z",
+    lastUsedAt: null,
+    source: "eliza-download",
+    ...overrides,
+  } satisfies InstalledModel;
+}
+
+/** Complete CatalogModel fixture — no `as` casts; satisfies keeps every
+ * required field checked so a type change on the contract breaks this suite
+ * at compile time instead of silently passing stale shapes. */
+function catalogModel(overrides: Partial<CatalogModel> = {}): CatalogModel {
+  return {
+    id: "eliza-1-9b",
+    displayName: "Eliza 1 9B",
+    hfRepo: "elizaos/eliza-1",
+    ggufFile: "eliza-1-9b-q4_k_m.gguf",
+    params: "9B",
+    quant: "q4_k_m",
+    sizeGb: 5,
+    minRamGb: 8,
+    category: "chat",
+    bucket: "mid",
+    blurb: "fixture",
+    ...overrides,
+  } satisfies CatalogModel;
+}
+
+function desktopProbe(overrides: Partial<HardwareProbe> = {}): HardwareProbe {
+  return {
+    totalRamGb: 32,
+    freeRamGb: 16,
+    gpu: null,
+    cpuCores: 10,
+    platform: "darwin",
+    arch: "arm64",
+    appleSilicon: false,
+    recommendedBucket: "mid",
+    source: "os-fallback",
+    ...overrides,
+  } satisfies HardwareProbe;
+}
+
+describe("formatEta — download ETA bucket math", () => {
+  it("returns empty string when eta is null, non-finite, or non-positive", () => {
+    expect(formatEta(null)).toBe("");
+    expect(formatEta(Number.NaN)).toBe("");
+    expect(formatEta(Number.POSITIVE_INFINITY)).toBe("");
+    expect(formatEta(0)).toBe("");
+    expect(formatEta(-5)).toBe("");
+  });
+
+  it("renders sub-minute ETAs in seconds using ceil rounding", () => {
+    expect(formatEta(1)).toBe("1s");
+    expect(formatEta(59_000)).toBe("59s");
+    // ceil(59_400/1000) = 60s crosses into the minutes bucket, not "60s".
+    expect(formatEta(59_400)).toBe("1m 0s");
+    expect(formatEta(0.1)).toBe("1s");
+  });
+
+  it("keeps an ETA under one hour in the minutes bucket", () => {
+    expect(formatEta(60_000)).toBe("1m 0s");
+    expect(formatEta(3_599_000)).toBe("59m 59s");
+    // ceil pushes 3_599_999ms to 3600s, which is already the hours bucket.
+    expect(formatEta(3_599_999)).toBe("1h 0m");
+  });
+
+  it("moves an hour-or-longer ETA into the hours bucket", () => {
+    expect(formatEta(3_600_000)).toBe("1h 0m");
+    expect(formatEta(7_322_000)).toBe("2h 2m");
+  });
+});
+
+describe("progressPercent — clamp and guard contract", () => {
+  it("returns 0 for a missing job or a non-positive total", () => {
+    expect(progressPercent(undefined)).toBe(0);
+    expect(progressPercent(job({ total: 0, received: 500 }))).toBe(0);
+    expect(progressPercent(job({ total: -10, received: 500 }))).toBe(0);
+  });
+
+  it("clamps over-reporting jobs at 100 instead of exceeding the bar", () => {
+    expect(progressPercent(job({ received: 1500, total: 1000 }))).toBe(100);
+  });
+
+  it("computes rounded percent from received/total", () => {
+    expect(progressPercent(job({ received: 250, total: 1000 }))).toBe(25);
+    expect(progressPercent(job({ received: 255, total: 1000 }))).toBe(26);
+    expect(progressPercent(job({ received: 1000, total: 1000 }))).toBe(100);
+  });
+});
+
+describe("findInstalled — install detection incl. external basename fallback", () => {
+  const model = catalogModel();
+
+  it("prefers an exact id match over the basename fallback", () => {
+    const exact = installed("eliza-1-9b", "/models/other.gguf");
+    const byBasename = installed(
+      "external-hf-abc",
+      "/models/eliza-1-9b-q4_k_m.gguf",
+    );
+    expect(findInstalled(model, [byBasename, exact])).toBe(exact);
+  });
+
+  it("matches external installs by POSIX path basename", () => {
+    const external = installed(
+      "external-hf-abc123",
+      "/Users/x/.eliza/models/eliza-1-9b-q4_k_m.gguf",
+    );
+    expect(findInstalled(model, [external])).toBe(external);
+  });
+
+  it("matches external installs by Windows path basename", () => {
+    const external = installed(
+      "external-hf-abc123",
+      "C:\\models\\eliza-1-9b-q4_k_m.gguf",
+    );
+    expect(findInstalled(model, [external])).toBe(external);
+  });
+
+  it("matches case-insensitively across ggufFile and installed path", () => {
+    const upperPath = installed(
+      "external-hf-upper",
+      "/models/ELIZA-1-9B-Q4_K_M.GGUF",
+    );
+    expect(findInstalled(model, [upperPath])).toBe(upperPath);
+  });
+
+  it("ignores files that merely contain the gguf name mid-path", () => {
+    const trick = installed(
+      "external-hf-xyz",
+      "/models/eliza-1-9b-q4_k_m.gguf.bak",
+    );
+    expect(findInstalled(model, [trick])).toBeUndefined();
+  });
+
+  it("returns undefined when nothing matches", () => {
+    expect(findInstalled(model, [])).toBeUndefined();
+    expect(
+      findInstalled(model, [installed("other-1", "/models/a.gguf")]),
+    ).toBeUndefined();
+  });
+});
+
+describe("groupByBucket — section grouping contract", () => {
+  it("always returns all four buckets in canonical order, empty ones included", () => {
+    const groups = groupByBucket([]);
+    expect([...groups.keys()]).toEqual(["small", "mid", "large", "xl"]);
+    for (const models of groups.values()) {
+      expect(models).toEqual([]);
+    }
+  });
+
+  it("groups models under their bucket, preserving input order", () => {
+    const small1 = catalogModel({ id: "a", bucket: "small" });
+    const mid1 = catalogModel({ id: "b", bucket: "mid" });
+    const small2 = catalogModel({ id: "c", bucket: "small" });
+    const groups = groupByBucket([small1, mid1, small2]);
+    expect(groups.get("small")?.map((m) => m.id)).toEqual(["a", "c"]);
+    expect(groups.get("mid")?.map((m) => m.id)).toEqual(["b"]);
+    expect(groups.get("large")).toEqual([]);
+    expect(groups.get("xl")).toEqual([]);
+  });
+});
+
+describe("displayModelName — curated table, drafter derivation, fallback chain", () => {
+  it("prefers the curated table label over a conflicting displayName", () => {
+    expect(
+      displayModelName({ id: "eliza-1-2b", displayName: "Wrong Label" }),
+    ).toBe("eliza-1-2b");
+  });
+
+  it("derives the drafter label from the base model id", () => {
+    expect(displayModelName({ id: "eliza-1-9b-drafter" })).toBe(
+      "eliza-1-9b drafter",
+    );
+    // A drafter suffix on a NON-curated base is not remapped; the displayName
+    // fallback then applies.
+    expect(
+      displayModelName({ id: "llama-3-drafter", displayName: "Llama Drafter" }),
+    ).toBe("Llama Drafter");
+    expect(displayModelName({ id: "llama-3-drafter" })).toBe("llama-3-drafter");
+  });
+
+  it("falls back to displayName, then the raw id", () => {
+    expect(displayModelName({ id: "hf-x", displayName: "Custom Label" })).toBe(
+      "Custom Label",
+    );
+    expect(displayModelName({ id: "hf-x" })).toBe("hf-x");
+  });
+});
+
+describe("bucketLabel / fitLabel — UI copy for tiers and fit states", () => {
+  it("labels every bucket distinctly", () => {
+    const labels = (
+      ["small", "mid", "large", "xl"] satisfies ModelBucket[]
+    ).map(bucketLabel);
+    expect(labels).toEqual(["Fast", "Balanced", "High quality", "Premium"]);
+    expect(new Set(labels).size).toBe(4);
+  });
+
+  it("labels every fit level distinctly", () => {
+    expect(fitLabel("fits")).toBe("Runs smoothly");
+    expect(fitLabel("tight")).toBe("Slow on your device");
+    expect(fitLabel("wontfit")).toBe("Not enough memory");
+  });
+});
+
+describe("computeFit — hardware fit delegation (desktop assessFit branch)", () => {
+  // CPU-only, non-Apple-Silicon desktop: effective memory = totalRamGb * 0.5.
+  const probe = desktopProbe({ totalRamGb: 20 }); // effective 10 GB
+
+  it("fits when size and minRam sit comfortably under thresholds", () => {
+    // sizeGb 5: 5 <= 10*0.7 → fits.
+    expect(computeFit(catalogModel({ sizeGb: 5, minRamGb: 8 }), probe)).toBe(
+      "fits",
+    );
+  });
+
+  it("is tight when size lands between 70% and 90% of effective memory", () => {
+    // sizeGb 8: 8 > 10*0.7 but <= 10*0.9 → tight.
+    expect(computeFit(catalogModel({ sizeGb: 8, minRamGb: 8 }), probe)).toBe(
+      "tight",
+    );
+  });
+
+  it("wont-fit when size exceeds 90% of effective memory", () => {
+    // sizeGb 9.5: 9.5 > 10*0.9 → wontfit.
+    expect(computeFit(catalogModel({ sizeGb: 9.5, minRamGb: 8 }), probe)).toBe(
+      "wontfit",
+    );
+  });
+
+  it("wont-fit when minRam alone exceeds effective memory", () => {
+    expect(computeFit(catalogModel({ sizeGb: 1, minRamGb: 16 }), probe)).toBe(
+      "wontfit",
+    );
+  });
+});
+
+describe("formatBytes — hub byte formatting (shared formatter + dash label)", () => {
+  it("renders plain bytes below 1 KiB", () => {
+    expect(formatBytes(512)).toBe("512 B");
+  });
+
+  it("renders KiB with one decimal", () => {
+    expect(formatBytes(1024)).toBe("1.0 KB");
+    expect(formatBytes(1536)).toBe("1.5 KB");
+  });
+
+  it("promotes magnitudes that would round across a unit boundary", () => {
+    // 1024**2 - 1 bytes would render as the impossible "1024.0 KB"; the
+    // shared formatter promotes it to MB instead.
+    expect(formatBytes(1024 ** 2 - 1)).toBe("1.0 MB");
+  });
+
+  it("renders the dash unknown label for null/negative input", () => {
+    expect(formatBytes(Number.NaN)).toBe("—");
+    expect(formatBytes(-1)).toBe("—");
+  });
+});
+
+describe("findDownload / findCatalogModel — id lookups", () => {
+  it("finds the download job for a model id", () => {
+    const target = job({ modelId: "eliza-1-4b", jobId: "job-4b" });
+    const other = job({ modelId: "eliza-1-2b", jobId: "job-2b" });
+    expect(findDownload("eliza-1-4b", [other, target])).toBe(target);
+    expect(findDownload("eliza-1-9b", [other, target])).toBeUndefined();
+  });
+
+  it("finds catalog entries by id in a caller-supplied catalog and misses cleanly", () => {
+    const a = catalogModel({ id: "m-a" });
+    const b = catalogModel({ id: "m-b" });
+    expect(findCatalogModel("m-b", [a, b])).toBe(b);
+    expect(findCatalogModel("m-missing", [a, b])).toBeUndefined();
+    expect(findCatalogModel("m-a", [])).toBeUndefined();
+  });
+});

--- a/packages/ui/src/components/local-inference/hub-utils.test.ts
+++ b/packages/ui/src/components/local-inference/hub-utils.test.ts
@@ -176,6 +176,15 @@ describe("findInstalled — install detection incl. external basename fallback",
       "/models/ELIZA-1-9B-Q4_K_M.GGUF",
     );
     expect(findInstalled(model, [upperPath])).toBe(upperPath);
+    // The other half of the same contract: an uppercase catalog ggufFile
+    // against a lowercase installed path. Pin both sides so a regression in
+    // either .toLowerCase() branch is caught independently.
+    const upperCatalog = { ...model, ggufFile: "ELIZA-1-9B-Q4_K_M.GGUF" };
+    const lowerPath = installed(
+      "external-hf-lower",
+      "/models/eliza-1-9b-q4_k_m.gguf",
+    );
+    expect(findInstalled(upperCatalog, [lowerPath])).toBe(lowerPath);
   });
 
   it("ignores files that merely contain the gguf name mid-path", () => {


### PR DESCRIPTION
# Relates to

Closes #29212

test(ui): pin Model Hub view-model helper contracts (hub-utils)

## What realistic regression does each test detect?

`packages/ui/src/components/local-inference/hub-utils.ts` is the pure view-model layer every Model Hub surface renders from (ModelHubView, ModelCard, DownloadProgress, DownloadQueue, ActiveModelBar, FirstRunOffer, HardwareBadge). Its header states it was "kept separate from components so they can be covered by unit tests without a DOM" — but no test file existed anywhere in the repo, and no higher-level suite imports these helpers. Each group pins an observable UI contract:

- **formatEta** — download-ETA rendering buckets. A boundary regression renders every download ETA in the wrong bucket (e.g. a "60s" that should be "1m 0s", or hour-long downloads labeled as minutes). Pins the `Math.ceil` bucket-crossing semantics (59_400ms → "1m 0s"; 3_599_999ms → already "1h 0m") and the empty-string sink for null/0/non-finite ETAs.
- **progressPercent** — the progress bar must never render negative or >100% when a server reports a bad Content-Length (`total <= 0`) or the job over-reports received bytes. Pins the clamp, the guard, and rounding.
- **findInstalled** — install detection. External installs surface as `external-<origin>-<hash>` ids, so the basename-of-path fallback against the catalog gguf filename is the ONLY thing keeping the hub from showing "Download" on a model the user already installed (the documented contract in the module header). Pins exact-id precedence, POSIX and Windows separators, case-insensitive matching, and that mid-path suffixes (`.gguf.bak`) do NOT match.
- **groupByBucket** — hub section rendering iterates all four buckets; a regression that drops empty-bucket keys or reorders them breaks the section layout. Pins key set + order + input-order preservation.
- **displayModelName** — curated-label precedence over a conflicting `displayName`, the `<base>-drafter` label derivation, and the displayName/id fallback chain.
- **bucketLabel / fitLabel** — the user-facing tier and fit copy for every variant (distinctness pinned).
- **computeFit** — delegates to the real `assessCatalogModelFit`; pins fits/tight/wontfit thresholds (70%/90% of effective memory) and the minRam-alone gate with a deterministic CPU-only desktop probe (effective = totalRamGb × 0.5).
- **formatBytes** — hub byte formatting: plain bytes, KiB decimals, the unit-promotion guard (1024²−1 must render "1.0 MB", not the impossible "1024.0 KB"), and the em-dash unknown label for null/negative.
- **findDownload / findCatalogModel** — id lookups incl. miss shapes.

## Which consumer observes the breakage?

The seven Model Hub components above render these values directly: DownloadProgress/DownloadQueue display `formatEta` and `progressPercent` for every active download; ModelCard and ModelHubView decide "installed vs downloadable" via `findInstalled` and group/label via `groupByBucket`/`bucketLabel`/`fitLabel`/`computeFit`; ActiveModelBar shows `displayModelName`.

## Why doesn't an existing higher-level test own this?

The `services/local-inference` suites cover the service layer (catalog, recommendation, readiness, downloader, token-tree) and never import `hub-utils`; the only tests under `components/local-inference` are two hooks (`useDeviceBridgeStatus`, `useHomeModelStatus`) and a stories smoke test. Verified by repo-wide import search at develop tip `a782460787`.

## Proof

- 30/30 new tests green; full local-inference tree 19 files / 207 tests green at the rebased head (develop drift in the interim commits touches none of these files — empty diff for both local-inference dirs).
- Mutation batteries (behavior flips, not literal edits): 18/18 caught — clamp removal, total-guard inversion, both ETA bucket boundaries (< → <=), basename-fallback drop, path-side case-folding drop, empty-bucket key drop, drafter branch disable, rounding drop, null-sink change, basename anchor loosening, bucket-label map emptied, fit-label branch drop, computeFit inversion, unknown-label change, catalog-lookup identity drop, curated-precedence flip.
- `tsc --noEmit -p tsconfig.json` exit 0 with the suite included (fixtures use `satisfies` with complete required fields — no `as` casts); `biome check` clean.
- Independent reviewer (RepoPrompt, gpt-5.6-sol): 3 rounds — r1 REQUEST_CHANGES (4 must-fix: uncovered exports, vacuous curated test, unpinned case-insensitivity, `as`-cast fixtures), r2 REQUEST_CHANGES (1 must-fix: residual `as ModelBucket[]`), r3 **APPROVE** at the cast-free head.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker. (Scoped: package typecheck + focused suites + biome green; test-only addition touching a single new file, no production surface.)
- [x] A reviewer can confirm the change works without reading the code, from the evidence below.

## Evidence

- before-screenshots: N/A - test-only PR with no UI change; the suite exercises pure helpers with no render surface.
- walkthrough-video: N/A - no interactive behavior changed.
- backend-logs: N/A - no backend code touched; test run transcript summary: 30/30 vitest green on `hub-utils.test.ts` at rebased head c9189f24cd (vitest v4.1.10, `npx vitest run`), full local-inference tree 207/207 green, `tsc --noEmit` exit 0.
- frontend-logs: N/A - no component or browser surface changed.
- llm-trajectory: N/A - no model, prompt, or trajectory-path change.
- domain-artifacts: N/A - no domain artifact surface touched.

<!-- evidence-head:2716865a296809d1d42cb0a1c715f546ea79dfee -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only PR with no UI change; the suite exercises pure helpers with no render surface.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive behavior changed.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only PR; no rendered surface changed, so no after state exists to capture.

<!-- evidence-row:backend-logs -->
- [ ] N/A - test-only PR; no runtime logs. Rebased onto develop 51626812ec at head ee9a5075bb; suites re-run green (hub-utils 10/10, hub-consumers 10/10 at /Users/t3rpz/projects/eliza-29219-rv).

```text
git rebase upstream/develop (tip 870f4ec960): 4/4 commits replayed, zero conflicts.
Diff preserved: 2 files (hub-utils.test.ts, hub-consumers.test.tsx).
Gates at new head 4bec7b5669 (fresh worktree, real core + cloud-routing build):
  vitest pinned suites: Test Files 2 passed (2) / Tests 40 passed (40)
  packages/ui tsc --noEmit (app + scripts tsconfig): clean
  biome check on both pinned test files: clean
Force-push with expected-lease on fe13d43a; MERGEABLE verified post-push.
```
</details>
- [x] Review-response push at head e61ade51a6 — RED control (reviewer's exact mutation, ModelCard.tsx:73 findInstalled -> undefined) fails 2/10 consumer tests; green run 10/10 (was 6); hub-utils 30/30; biome clean; packages/ui tsc --noEmit exit 0. Gates 2026-08-28T09:05Z.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no component or browser surface changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, or trajectory-path change.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no domain artifact surface touched.

AI provider/model: zai / glm-5.3
Client / agent tooling: Hermes Agent
Contribution skill revision: elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [hermes-t3rpz]
<!-- eliza-computer-attribution:v1 {"provider":"zai","model":"glm-5.3","client":"Hermes Agent","skill_revision":"elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza"} -->









