### PR TITLE
test(ui): compile shipped theme in chat-sheet fixture

### DIFF
--- a/packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs
@@ -36,11 +36,12 @@
  */
 
 import { mkdir } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { chromium, webkit } from "playwright";
 import { PNG } from "pngjs";
 import {
+  compileTailwindTheme,
   renameRecordedVideo,
   stubElizaCore,
   stubNodeBuiltins,
@@ -53,6 +54,7 @@ import {
 } from "../../../testing/real-touch-gestures.ts";
 
 const here = dirname(fileURLToPath(import.meta.url));
+const uiRoot = resolve(here, "../../../..");
 const browserName = process.argv.includes("--browser=webkit")
   ? "webkit"
   : "chromium";
@@ -80,6 +82,12 @@ function near(a, b, tol) {
 // at render in the browser; the only render-path core symbol,
 // findInteractionRegions, is test-only) are replaced with no-op proxies,
 // mirroring the sibling shell runners.
+// Compile every component-owned utility the fixture can reach (shell, ui,
+// chat, and composites) rather than relying on the approximate CDN scanner.
+const themeCss = await compileTailwindTheme({
+  uiRoot,
+  sources: [join(uiRoot, "src/components")],
+});
 const url = await writeFixturePage({
   entry: join(here, "chat-sheet-fixture.tsx"),
   outDir,
@@ -87,6 +95,7 @@ const url = await writeFixturePage({
   title: "chat sheet e2e",
   plugins: [stubElizaCore(), stubNodeBuiltins()],
   processShim: true,
+  tailwind: { css: themeCss },
   background: "#0a0d16",
   headHtml: "<style>.bg-bg{background-color:#0a0d16}</style>",
 });


### PR DESCRIPTION
## Summary

- compile the canonical UI Tailwind theme for the chat-sheet browser fixture
- inject the compiled CSS so the existing computed-style assertion exercises the shipped shell token and utility rule
- leave production components and theme declarations unchanged

## Root cause

The failed `develop` artifact contained `chat-handle-bar-surface` in the bundled JavaScript, but its generated page contained neither the matching CSS rule nor `--shell-overlay-grabber-background`. This runner omitted the shared theme compiler and fell back to the approximate CDN scanner, while the shipped app imports the canonical UI stylesheet.

## Validation

- `bun run --cwd packages/ui typecheck`
- `bun run --cwd packages/ui test -- src/testing/e2e-runner/fixture-bundle.test.ts src/components/shell/ChatOverlay.test.tsx` — 210 tests passed
- `node --check packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs`
- direct compiled-theme proof contains `--shell-overlay-grabber-background`, `.chat-handle-bar-surface`, and `.bg-transparent`
- `git diff --check`

The full browser runner bundled successfully, but this Windows host could not establish Playwright's Chromium CDP connection before either the runner's 180-second timeout or a standalone 300-second launch timeout. CI/Linux remains the browser-execution authority. The package lint script also cannot launch its `bunx` entrypoint from this pinned standalone Bun harness; the changed `__e2e__` runner is excluded by the package Biome configuration and was syntax-checked directly.

Fixes #29217

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@5e309560fa5bf659d77b13cce2c30ba28af8c500:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [root]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@5e309560fa5bf659d77b13cce2c30ba28af8c500:packages/skills/skills/contribute-to-eliza"} -->
