### PR TITLE
ci: extend PR static smoke source timeout

### DIFF
--- a/.github/workflows/pr-static-smoke.yml
+++ b/.github/workflows/pr-static-smoke.yml
@@ -30,7 +30,7 @@ jobs:
   source-smoke:
     name: Source static smoke
     runs-on: ubuntu-24.04
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - name: Checkout candidate source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1


### PR DESCRIPTION
# Relates to

Closes #29224

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync; the exact unrelated baseline i18n blocker is recorded below.
- [x] A reviewer can confirm the change works from the linked timing evidence and exact-head hosted checks.

# Sync with develop

- [x] Rebased onto `a7824607875cc9474b83cbec28a6ba3149dcfdb7`; zero conflicts.
- [x] `bun run verify` was run post-sync; its unrelated baseline failure is documented in **Known gaps / failures**.

# Risks

Low. The sole change raises one job's maximum wall-clock budget. It does not alter commands, affected filtering, concurrency, permissions, triggers, required jobs, or admission aggregation. A genuinely hung job may consume 15 additional runner minutes before cancellation.

# Background

## What does this PR do?

Raises only `jobs.source-smoke.timeout-minutes` in `.github/workflows/pr-static-smoke.yml` from 30 to 45 so legitimate full-workspace affected graphs can finish.

Run [32982876963](https://github.com/elizaOS/eliza/actions/runs/32982876963) passed lint and all 232 typecheck tasks but reached the 30-minute cap after only 4m43s of its 152-package build. Run [32971926030](https://github.com/elizaOS/eliza/actions/runs/32971926030) shows the same complete graph needs approximately 9m41s to typecheck and 10m44s to build, finishing in 29m02s under a faster checkout. Turbo identifies this conservative expansion as `RootInternalDepChanged`, not a bad merge base or lockfile change.

## What kind of change is this?

Bug fix to CI admission capacity; no product behavior changes.

# Documentation changes needed?

No. This adjusts an internal workflow budget and the issue/PR carry the operational evidence.

# Testing

## Where should a reviewer start?

Review the one-line workflow diff, then inspect the exact-head `PR Static Smoke` result to confirm all admission lanes and the source build complete without weakening the gate.

## Detailed testing steps

Exact head: `9ba55f0452091200d5dbff629e1e2356f5bdd43d`

- `bun install` with Bun 1.3.14: PASS
- pinned actionlint on `.github/workflows/pr-static-smoke.yml`: PASS
- `bun test --config=/dev/null --isolate packages/scripts/__tests__/pr-static-smoke-workflow.test.ts packages/scripts/__tests__/workflow-trigger-policy.test.ts packages/scripts/__tests__/github-action-pinning.test.ts packages/scripts/__tests__/repository-ruleset-contract.test.ts`: PASS, 43/43
- `bun run audit:workflow-triggers`: PASS, 61 workflows and one develop-push surface
- `bun run check:biome-version`: PASS; the YAML path is intentionally outside Biome's configured file set
- `git diff --check`: PASS
- `bun run verify`: reaches `check:i18n` and fails identically on untouched `origin/develop`; details below

No exact timeout-value test was added because it would only mirror an implementation literal. Existing behavioral workflow contracts cover trigger ownership, fail-closed aggregation, command presence, action pinning, and ruleset integration.

# Evidence Gate

<!-- evidence-head:9ba55f0452091200d5dbff629e1e2356f5bdd43d -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI surface changes
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI surface changes
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive user flow changes
<!-- evidence-row:backend-logs -->
- [ ] N/A - no product backend runtime path changes; hosted Actions logs are the applicable evidence
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend changes
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, provider, prompt, or model changes
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no domain-state changes
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual text or UI changes.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model changes.

## Backend + frontend logs

N/A - no product backend/frontend path changes. Applicable historical Actions timing evidence is linked above; exact-head hosted workflow results will appear in this PR.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI change.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, TTS, or STT changes.

## Known gaps / failures

`bun run verify` stops at `bun run check:i18n` on both this exact head and untouched detached `origin/develop` `a7824607875cc9474b83cbec28a6ba3149dcfdb7`. Both report the same existing missing English keys:

- `cloud.login.accountSwitch.title`
- `cloud.login.accountSwitch.retry`

The audit also reports the same pre-existing translation fallback gaps. A YAML timeout cannot affect locale extraction, and all workflow-owned checks listed above pass.

## Maintainer CI exception record

N/A - no exception requested. This PR will wait for required exact-head hosted checks.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`


