### PR TITLE
fix(ci): fail closed on Telegram release identity

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -333,6 +333,21 @@ Terraform domain workflow additionally requires zone-scoped DNS write and
 certificate packs. Prefer separate environment-scoped deploy and DNS/TLS
 tokens so staging automation cannot mutate production zones.
 
+The Cloud release resolves the public Telegram bot ID and username before
+database migration or API deployment. Staging consumes the complete
+repository-scoped `VITE_TELEGRAM_BOT_ID` / `VITE_TELEGRAM_BOT_USERNAME` pair
+and requires both components to differ from production. Production ignores
+that repository pair and derives its exact canonical identity from the checked
+out `packages/homepage/src/lib/contact.ts`. Missing, partial, malformed,
+out-of-range, or cross-environment staging values stop the release without
+printing either value. Do not expect same-named GitHub Environment variables
+to override the repository pair: GitHub makes Environment variables available
+after values in the `vars` context have already been resolved. Implicit Vite
+fallback use remains local/direct-only; protected production explicitly selects
+and validates the canonical source constants. Pull requests are validated by
+`pr-static-smoke.yml`; there is no credentialed or artifact-only Pages preview
+path in `cloud-cf-deploy.yml`.
+
 Cloudflare secret values are write-only and cannot be reconstructed into
 GitHub. Deploy workflows therefore publish shared Worker/control-plane secrets
 only when the selected protected environment explicitly supplies a value. When

--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -74,9 +74,10 @@ on:
         type: boolean
 
 concurrency:
-  # #18092: non-PR admission is unique per run so two dispatches/reruns of
-  # the same SHA both create jobs and can reach approval. Pull requests
-  # still supersede by number. Mutation is a single post-approval job lock
+  # #18092: admission is unique per run so two dispatches/reruns of the same
+  # SHA both create jobs and can reach approval. Keep the PR arm as defense in
+  # depth if the trigger policy ever changes: preview runs must supersede, not
+  # queue for canonical mutation. Mutation is a single post-approval job lock
   # on `release` (see cloud-cf-release.yml). v6 retires the v5 per-SHA groups.
   group: cloud-cf-deploy-v6-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('run-{0}', github.run_id) }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -89,9 +90,8 @@ permissions:
 jobs:
   validate-deploy-source:
     name: Validate Canonical Deploy Source
-    # Push and pull-request refs are constrained by the trigger itself. Only a
-    # manual dispatch can select an invalid ref, so automatic releases should
-    # not wait for a hosted runner merely to execute an unconditional exit 0.
+    # A manual dispatch can select an invalid ref, so reject it before any
+    # protected admission or release work begins.
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 2
@@ -130,7 +130,7 @@ jobs:
           fi
 
           if [ "$SOURCE_REF" != "$expected_ref" ]; then
-            echo "::error::Canonical $TARGET_ENVIRONMENT deploys must run from $expected_ref, not $SOURCE_REF. Use the pull-request Pages preview for feature refs."
+            echo "::error::Canonical $TARGET_ENVIRONMENT deploys must run from $expected_ref, not $SOURCE_REF. Feature refs are not deployable through this workflow."
             exit 1
           fi
 
@@ -462,163 +462,3 @@ jobs:
             exit 1
           }
           echo "Certified staging tree ${TREE_SHA} with artifact ${ARTIFACT_ID} (sha256:${ARTIFACT_DIGEST}) after all release and routing checks passed." >> "$GITHUB_STEP_SUMMARY"
-
-  resolve-pages-preview-config:
-    name: Resolve Pages preview configuration
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    outputs:
-      telegram_bot_id: ${{ steps.telegram.outputs.bot_id }}
-      telegram_bot_username: ${{ steps.telegram.outputs.bot_username }}
-      whatsapp_phone_number: ${{ steps.whatsapp.outputs.phone_number }}
-    steps:
-      - name: Resolve public preview defaults
-        id: telegram
-        env:
-          TELEGRAM_BOT_ID: ${{ vars.VITE_TELEGRAM_BOT_ID }}
-          TELEGRAM_BOT_USERNAME: ${{ vars.VITE_TELEGRAM_BOT_USERNAME }}
-        run: |
-          set -euo pipefail
-          if [[ -z "$TELEGRAM_BOT_ID" && -z "$TELEGRAM_BOT_USERNAME" ]]; then
-            TELEGRAM_BOT_ID=7684336618
-            TELEGRAM_BOT_USERNAME=Elizav2_Bot
-          elif [[ -z "$TELEGRAM_BOT_ID" || -z "$TELEGRAM_BOT_USERNAME" ]]; then
-            echo "::error::VITE_TELEGRAM_BOT_ID and VITE_TELEGRAM_BOT_USERNAME must be configured together"
-            exit 1
-          fi
-          [[ "$TELEGRAM_BOT_ID" =~ ^[0-9]+$ ]] || { echo "::error::VITE_TELEGRAM_BOT_ID must be numeric"; exit 1; }
-          [[ "$TELEGRAM_BOT_USERNAME" =~ ^[A-Za-z0-9_]+$ ]] || { echo "::error::VITE_TELEGRAM_BOT_USERNAME must be a Telegram username without @"; exit 1; }
-          echo "bot_id=$TELEGRAM_BOT_ID" >> "$GITHUB_OUTPUT"
-          echo "bot_username=$TELEGRAM_BOT_USERNAME" >> "$GITHUB_OUTPUT"
-
-      - name: Resolve public WhatsApp configuration
-        id: whatsapp
-        env:
-          WHATSAPP_PUBLIC_ENABLED: ${{ vars.WHATSAPP_PUBLIC_ENABLED }}
-          WHATSAPP_PHONE_NUMBER: ${{ vars.VITE_WHATSAPP_PHONE_NUMBER }}
-        run: |
-          set -euo pipefail
-          enabled="$(printf '%s' "$WHATSAPP_PUBLIC_ENABLED" | tr '[:upper:]' '[:lower:]')"
-          case "$enabled" in
-            ""|0|false|no|off)
-              echo "phone_number=" >> "$GITHUB_OUTPUT"
-              ;;
-            1|true|yes|on)
-              [[ "$WHATSAPP_PHONE_NUMBER" =~ ^\+[1-9][0-9]{7,14}$ ]] || { echo "::error::VITE_WHATSAPP_PHONE_NUMBER must be an E.164 number when WHATSAPP_PUBLIC_ENABLED is true"; exit 1; }
-              case "$WHATSAPP_PHONE_NUMBER" in
-                +14155238886|+15551649988|+14159611510)
-                  echo "::error::The public WhatsApp CTA cannot use a shared sandbox, developer test, or unverified sender"
-                  exit 1
-                  ;;
-              esac
-              echo "phone_number=$WHATSAPP_PHONE_NUMBER" >> "$GITHUB_OUTPUT"
-              ;;
-            *)
-              echo "::error::WHATSAPP_PUBLIC_ENABLED must be a boolean"
-              exit 1
-              ;;
-          esac
-
-  build-pages:
-    name: Build Pages artifacts
-    needs: [resolve-pages-preview-config]
-    if: ${{ github.event_name == 'pull_request' && needs.resolve-pages-preview-config.result == 'success' }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    # GitHub preserves outputs from successful jobs when only failed jobs are
-    # rerun. Consumers must therefore use the producer's attempt, not their own
-    # newer github.run_attempt. A full rerun executes this job again and emits
-    # the new attempt, so its deploy jobs consume the newly built artifacts.
-    outputs:
-      artifact_run_id: ${{ steps.pages-artifact.outputs.run_id }}
-      artifact_run_attempt: ${{ steps.pages-artifact.outputs.run_attempt }}
-      artifact_source_sha: ${{ steps.pages-artifact.outputs.source_sha }}
-      telegram_bot_id: ${{ needs.resolve-pages-preview-config.outputs.telegram_bot_id }}
-      telegram_bot_username: ${{ needs.resolve-pages-preview-config.outputs.telegram_bot_username }}
-    steps:
-      - name: Validate PR preview identity
-        if: github.event_name == 'pull_request'
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          set -euo pipefail
-          if ! [[ "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
-            echo "::error::Pull-request Pages branch requires a valid immutable PR number"
-            exit 1
-          fi
-          pages_branch="pr-${PR_NUMBER}"
-          case "$pages_branch" in
-            main|develop)
-              echo "::error::Pull-request Pages branch may not target canonical branch $pages_branch"
-              exit 1
-              ;;
-          esac
-          echo "Pages artifacts are bound to trusted preview branch ${pages_branch}." >> "$GITHUB_STEP_SUMMARY"
-
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
-
-      - name: Bind Pages artifacts to this producer attempt
-        id: pages-artifact
-        env:
-          PRODUCER_RUN_ID: ${{ github.run_id }}
-          PRODUCER_RUN_ATTEMPT: ${{ github.run_attempt }}
-          PRODUCER_SOURCE_SHA: ${{ github.sha }}
-        run: |
-          set -euo pipefail
-          echo "run_id=$PRODUCER_RUN_ID" >> "$GITHUB_OUTPUT"
-          echo "run_attempt=$PRODUCER_RUN_ATTEMPT" >> "$GITHUB_OUTPUT"
-          echo "source_sha=$PRODUCER_SOURCE_SHA" >> "$GITHUB_OUTPUT"
-
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
-        with:
-          node-version: "24.15.0"
-
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
-        with:
-          bun-version: "1.3.14"
-
-      - name: Install frontend dependencies
-        run: bun install --frozen-lockfile --ignore-scripts
-
-      - name: Build linked elizaOS core workspace once
-        run: bun run build:core
-
-      - name: Build consolidated frontend artifact
-        run: bun run --cwd packages/app build:web
-        env:
-          VITE_TELEGRAM_BOT_ID: ${{ needs.resolve-pages-preview-config.outputs.telegram_bot_id }}
-          VITE_TELEGRAM_BOT_USERNAME: ${{ needs.resolve-pages-preview-config.outputs.telegram_bot_username }}
-          VITE_WHATSAPP_PHONE_NUMBER: ${{ needs.resolve-pages-preview-config.outputs.whatsapp_phone_number }}
-          VITE_API_URL: https://api-staging.eliza.app
-          NEXT_PUBLIC_API_URL: https://api-staging.eliza.app
-          VITE_OIDC_ISSUER_URL: https://api-staging.eliza.app
-          VITE_ELIZA_CLOUD_BASE: https://cloud-staging.eliza.app
-          VITE_APP_URL: https://staging.eliza.app
-          NEXT_PUBLIC_APP_URL: https://cloud-staging.eliza.app
-          VITE_ELIZA_APP_URL: https://cloud-staging.eliza.app
-          VITE_STEWARD_TENANT_ID: elizacloud-staging
-          NEXT_PUBLIC_STEWARD_TENANT_ID: elizacloud-staging
-          VITE_ENVIRONMENT: staging
-          VITE_VOICE_REALTIME_WS: ${{ contains(fromJSON('["1","true","TRUE","True","yes","YES","Yes","on","ON","On"]'), vars.VOICE_REALTIME_WS_ENABLED) && '1' || '0' }}
-          VITE_VOICE_REALTIME_FORCE: "0"
-          NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID: ${{ vars.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID }}
-
-      - name: Verify frontend chunk safety
-        run: bun run --cwd packages/app verify:chunks
-
-      - name: Upload consolidated frontend artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
-        with:
-          name: pages-app-${{ steps.pages-artifact.outputs.run_id }}-${{ steps.pages-artifact.outputs.run_attempt }}
-          path: |
-            packages/app/dist
-            packages/app/functions
-            packages/app/wrangler.toml
-          if-no-files-found: error
-          retention-days: 1
-
-  # ---------------------------------------------------------------------------
-  # Consolidated frontend — packages/app at eliza.app and cloud.eliza.app.
-  # The same host-aware bundle serves marketing, auth, cloud management, and the
-  # managed Eliza agent app from the single `eliza-app` Pages project.
-  # ---------------------------------------------------------------------------

--- a/.github/workflows/cloud-cf-release.yml
+++ b/.github/workflows/cloud-cf-release.yml
@@ -34,8 +34,121 @@ permissions:
   actions: read
 
 jobs:
+  resolve-pages-environment-config:
+    name: Preflight Pages environment configuration
+    runs-on: ubuntu-latest
+    # Map an invalid callable input to the non-production environment only so
+    # GitHub cannot create or enter an arbitrary environment before the shell
+    # rejects it. The target value itself is never normalized.
+    environment: ${{ inputs.target_environment == 'production' && 'production' || 'staging' }}
+    outputs:
+      telegram_bot_id: ${{ steps.telegram.outputs.bot_id }}
+      telegram_bot_username: ${{ steps.telegram.outputs.bot_username }}
+      whatsapp_phone_number: ${{ steps.whatsapp.outputs.phone_number }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+
+      - name: Validate Telegram public identity preflight
+        id: telegram
+        env:
+          TARGET_ENVIRONMENT: ${{ inputs.target_environment }}
+          # GitHub Environment variables cannot overwrite values already
+          # resolved through the vars context. Treat this repository pair as
+          # staging-only input; production ignores it and uses source truth.
+          STAGING_TELEGRAM_BOT_ID: ${{ vars.VITE_TELEGRAM_BOT_ID }}
+          STAGING_TELEGRAM_BOT_USERNAME: ${{ vars.VITE_TELEGRAM_BOT_USERNAME }}
+        run: |
+          set -euo pipefail
+
+          fail() {
+            printf '%s\n' "::error::$1" >&2
+            exit 1
+          }
+
+          valid_bot_id() {
+            local candidate="$1"
+            [[ "$candidate" =~ ^[1-9][0-9]{0,15}$ ]] || return 1
+            (( 10#$candidate <= 4503599627370495 ))
+          }
+
+          case "$TARGET_ENVIRONMENT" in
+            staging|production) ;;
+            *) fail "target_environment must be exactly staging or production" ;;
+          esac
+
+          canonical_source="packages/homepage/src/lib/contact.ts"
+          canonical_bot_id="$(sed -nE 's/^export const ELIZA_TELEGRAM_BOT_ID = "([^"]+)";$/\1/p' "$canonical_source")"
+          canonical_bot_username="$(sed -nE 's/^export const ELIZA_TELEGRAM_BOT_USERNAME = "([^"]+)";$/\1/p' "$canonical_source")"
+          valid_bot_id "$canonical_bot_id" || \
+            fail "The homepage canonical Telegram bot ID is missing or invalid"
+          [[ "$canonical_bot_username" =~ ^[A-Za-z0-9_]{5,32}$ ]] || \
+            fail "The homepage canonical Telegram username is missing or invalid"
+          canonical_bot_username_key="$(printf '%s' "$canonical_bot_username" | tr '[:upper:]' '[:lower:]')"
+          [[ "$canonical_bot_username_key" == *bot ]] || \
+            fail "The homepage canonical Telegram username must use the managed bot suffix"
+
+          if [ "$TARGET_ENVIRONMENT" = "production" ]; then
+            resolved_bot_id="$canonical_bot_id"
+            resolved_bot_username="$canonical_bot_username"
+          else
+            if [ -z "$STAGING_TELEGRAM_BOT_ID" ] || \
+              [ -z "$STAGING_TELEGRAM_BOT_USERNAME" ]; then
+              fail "Repository VITE_TELEGRAM_BOT_ID and VITE_TELEGRAM_BOT_USERNAME must configure the complete staging pair"
+            fi
+            valid_bot_id "$STAGING_TELEGRAM_BOT_ID" || \
+              fail "Repository VITE_TELEGRAM_BOT_ID must match the Telegram bot ID contract"
+            [[ "$STAGING_TELEGRAM_BOT_USERNAME" =~ ^[A-Za-z0-9_]{5,32}$ ]] || \
+              fail "Repository VITE_TELEGRAM_BOT_USERNAME must match the Telegram username contract"
+            staging_bot_username_key="$(printf '%s' "$STAGING_TELEGRAM_BOT_USERNAME" | tr '[:upper:]' '[:lower:]')"
+            [[ "$staging_bot_username_key" == *bot ]] || \
+              fail "Repository VITE_TELEGRAM_BOT_USERNAME must use the managed bot suffix"
+            if [ "$STAGING_TELEGRAM_BOT_ID" = "$canonical_bot_id" ] || \
+              [ "$staging_bot_username_key" = "$canonical_bot_username_key" ]; then
+              fail "Staging Telegram configuration must use an identity fully distinct from production"
+            fi
+            resolved_bot_id="$STAGING_TELEGRAM_BOT_ID"
+            resolved_bot_username="$STAGING_TELEGRAM_BOT_USERNAME"
+          fi
+
+          printf 'bot_id=%s\n' "$resolved_bot_id" >> "$GITHUB_OUTPUT"
+          printf 'bot_username=%s\n' "$resolved_bot_username" >> "$GITHUB_OUTPUT"
+          printf 'Validated Telegram public identity policy for %s.\n' \
+            "$TARGET_ENVIRONMENT" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Resolve public WhatsApp configuration
+        id: whatsapp
+        env:
+          WHATSAPP_PUBLIC_ENABLED: ${{ vars.WHATSAPP_PUBLIC_ENABLED }}
+          WHATSAPP_PHONE_NUMBER: ${{ vars.VITE_WHATSAPP_PHONE_NUMBER }}
+        run: |
+          set -euo pipefail
+          enabled="$(printf '%s' "$WHATSAPP_PUBLIC_ENABLED" | tr '[:upper:]' '[:lower:]')"
+          case "$enabled" in
+            ""|0|false|no|off)
+              echo "phone_number=" >> "$GITHUB_OUTPUT"
+              ;;
+            1|true|yes|on)
+              [[ "$WHATSAPP_PHONE_NUMBER" =~ ^\+[1-9][0-9]{7,14}$ ]] || { echo "::error::VITE_WHATSAPP_PHONE_NUMBER must be an E.164 number when WHATSAPP_PUBLIC_ENABLED is true"; exit 1; }
+              case "$WHATSAPP_PHONE_NUMBER" in
+                +14155238886|+15551649988|+14159611510)
+                  echo "::error::The public WhatsApp CTA cannot use a shared sandbox, developer test, or unverified sender"
+                  exit 1
+                  ;;
+              esac
+              echo "phone_number=$WHATSAPP_PHONE_NUMBER" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "::error::WHATSAPP_PUBLIC_ENABLED must be a boolean"
+              exit 1
+              ;;
+          esac
+
   migrate-db:
     name: Run Database Migrations
+    needs: resolve-pages-environment-config
+    if: ${{ !cancelled() && needs.resolve-pages-environment-config.result == 'success' }}
     # Hosted unconditionally: CI must never contend with production
     # agent-placement nodes for disk or CPU (#17881).
     runs-on: ubuntu-latest
@@ -394,8 +507,8 @@ jobs:
     # Schema gate (#11208): the Worker talks to the database, so it only
     # deploys after migrate-db succeeded for this same commit. A failed or
     # cancelled migrate-db skips this job — fail-closed.
-    needs: migrate-db
-    if: ${{ !cancelled() && github.event_name != 'pull_request' && needs.migrate-db.result == 'success' && needs.migrate-db.outputs.superseded != 'true' }}
+    needs: [resolve-pages-environment-config, migrate-db]
+    if: ${{ !cancelled() && github.event_name != 'pull_request' && needs.resolve-pages-environment-config.result == 'success' && needs.migrate-db.result == 'success' && needs.migrate-db.outputs.superseded != 'true' }}
     env:
       CHECKOUT_DIR: /tmp/eliza-checkout-${{ github.run_id }}-${{ github.run_attempt }}-deploy-api
       CHECKOUT_MATERIALIZE_TIMEOUT_SECONDS: ${{ vars.CLOUD_CF_CHECKOUT_MATERIALIZE_TIMEOUT_SECONDS || '600' }}
@@ -411,9 +524,9 @@ jobs:
           # ones idle >90 min: a real deploy job runs <~50 min and self-cleans, so
           # a dir untouched for 90 min is a definitively-dead leak.
           # CONCURRENCY-SAFE: API, console, and app jobs within one release still
-          # materialize concurrently, and PR previews use independent groups. The
-          # age filter never deletes an actively-written checkout (its mtime stays
-          # fresh), and we also exclude this run's own dirs by name.
+          # materialize concurrently. The age filter never deletes an
+          # actively-written checkout (its mtime stays fresh), and we also
+          # exclude this run's own dirs by name.
           # UNFAILABLE BY CONSTRUCTION: sibling runs execute this same step at the
           # same moment, so one sibling's rm -rf can race another's find into
           # ENOENT (exit 1) — under the job's default `bash -e` (plus the pipefail
@@ -1796,64 +1909,6 @@ jobs:
   # ---------------------------------------------------------------------------
   # Pages build — one prepared workspace emits the host-aware frontend.
   # ---------------------------------------------------------------------------
-  resolve-pages-environment-config:
-    name: Resolve Pages environment configuration
-    needs: migrate-db
-    if: ${{ !cancelled() && needs.migrate-db.result == 'success' && needs.migrate-db.outputs.superseded != 'true' }}
-    runs-on: ubuntu-latest
-    environment: ${{ inputs.target_environment }}
-    outputs:
-      telegram_bot_id: ${{ steps.telegram.outputs.bot_id }}
-      telegram_bot_username: ${{ steps.telegram.outputs.bot_username }}
-      whatsapp_phone_number: ${{ steps.whatsapp.outputs.phone_number }}
-    steps:
-      - name: Validate Telegram configuration
-        id: telegram
-        env:
-          TELEGRAM_BOT_ID: ${{ vars.VITE_TELEGRAM_BOT_ID }}
-          TELEGRAM_BOT_USERNAME: ${{ vars.VITE_TELEGRAM_BOT_USERNAME }}
-        run: |
-          set -euo pipefail
-          if [[ -z "$TELEGRAM_BOT_ID" && -z "$TELEGRAM_BOT_USERNAME" ]]; then
-            TELEGRAM_BOT_ID=7684336618
-            TELEGRAM_BOT_USERNAME=Elizav2_Bot
-          elif [[ -z "$TELEGRAM_BOT_ID" || -z "$TELEGRAM_BOT_USERNAME" ]]; then
-            echo "::error::VITE_TELEGRAM_BOT_ID and VITE_TELEGRAM_BOT_USERNAME must be configured together"
-            exit 1
-          fi
-          [[ "$TELEGRAM_BOT_ID" =~ ^[0-9]+$ ]] || { echo "::error::VITE_TELEGRAM_BOT_ID must be numeric"; exit 1; }
-          [[ "$TELEGRAM_BOT_USERNAME" =~ ^[A-Za-z0-9_]+$ ]] || { echo "::error::VITE_TELEGRAM_BOT_USERNAME must be a Telegram username without @"; exit 1; }
-          echo "bot_id=$TELEGRAM_BOT_ID" >> "$GITHUB_OUTPUT"
-          echo "bot_username=$TELEGRAM_BOT_USERNAME" >> "$GITHUB_OUTPUT"
-
-      - name: Resolve public WhatsApp configuration
-        id: whatsapp
-        env:
-          WHATSAPP_PUBLIC_ENABLED: ${{ vars.WHATSAPP_PUBLIC_ENABLED }}
-          WHATSAPP_PHONE_NUMBER: ${{ vars.VITE_WHATSAPP_PHONE_NUMBER }}
-        run: |
-          set -euo pipefail
-          enabled="$(printf '%s' "$WHATSAPP_PUBLIC_ENABLED" | tr '[:upper:]' '[:lower:]')"
-          case "$enabled" in
-            ""|0|false|no|off)
-              echo "phone_number=" >> "$GITHUB_OUTPUT"
-              ;;
-            1|true|yes|on)
-              [[ "$WHATSAPP_PHONE_NUMBER" =~ ^\+[1-9][0-9]{7,14}$ ]] || { echo "::error::VITE_WHATSAPP_PHONE_NUMBER must be an E.164 number when WHATSAPP_PUBLIC_ENABLED is true"; exit 1; }
-              case "$WHATSAPP_PHONE_NUMBER" in
-                +14155238886|+15551649988|+14159611510)
-                  echo "::error::The public WhatsApp CTA cannot use a shared sandbox, developer test, or unverified sender"
-                  exit 1
-                  ;;
-              esac
-              echo "phone_number=$WHATSAPP_PHONE_NUMBER" >> "$GITHUB_OUTPUT"
-              ;;
-            *)
-              echo "::error::WHATSAPP_PUBLIC_ENABLED must be a boolean"
-              exit 1
-              ;;
-          esac
-
   build-pages:
     name: Build Pages artifacts
     needs: [migrate-db, resolve-pages-environment-config]
@@ -1872,25 +1927,6 @@ jobs:
       telegram_bot_username: ${{ needs.resolve-pages-environment-config.outputs.telegram_bot_username }}
       whatsapp_phone_number: ${{ needs.resolve-pages-environment-config.outputs.whatsapp_phone_number }}
     steps:
-      - name: Validate PR preview identity
-        if: github.event_name == 'pull_request'
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          set -euo pipefail
-          if ! [[ "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
-            echo "::error::Pull-request Pages branch requires a valid immutable PR number"
-            exit 1
-          fi
-          pages_branch="pr-${PR_NUMBER}"
-          case "$pages_branch" in
-            main|develop)
-              echo "::error::Pull-request Pages branch may not target canonical branch $pages_branch"
-              exit 1
-              ;;
-          esac
-          echo "Pages artifacts are bound to trusted preview branch ${pages_branch}." >> "$GITHUB_STEP_SUMMARY"
-
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       - name: Bind Pages artifacts to this producer attempt
@@ -1979,8 +2015,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 75
     # Release gate (#11208/#18088): canonical Pages aliases wait for the matching
-    # API deployment; pull-request artifacts
-    # are consumed only by the separate trusted preview workflow.
+    # API deployment and the artifact built by this protected release.
     needs: [deploy-api, build-pages]
     if: ${{ !cancelled() && github.event_name != 'pull_request' && needs.deploy-api.result == 'success' && needs.build-pages.result == 'success' }}
     env:
@@ -2005,9 +2040,9 @@ jobs:
           # ones idle >90 min: a real deploy job runs <~50 min and self-cleans, so
           # a dir untouched for 90 min is a definitively-dead leak.
           # CONCURRENCY-SAFE: API, console, and app jobs within one release still
-          # materialize concurrently, and PR previews use independent groups. The
-          # age filter never deletes an actively-written checkout (its mtime stays
-          # fresh), and we also exclude this run's own dirs by name.
+          # materialize concurrently. The age filter never deletes an
+          # actively-written checkout (its mtime stays fresh), and we also
+          # exclude this run's own dirs by name.
           # UNFAILABLE BY CONSTRUCTION: sibling runs execute this same step at the
           # same moment, so one sibling's rm -rf can race another's find into
           # ENOENT (exit 1) — under the job's default `bash -e` (plus the pipefail
@@ -2559,10 +2594,9 @@ jobs:
   verify-routing:
     name: Verify ${{ inputs.target_environment }} routing
     needs: [deploy-api, deploy-app]
-    # Custom domains only exist for the real environments -- PR previews deploy to
-    # a preview branch alias, so skip them. Require both deploys to have landed
-    # (the beacon is served by the API Worker; both frontend domains by
-    # one Pages project), else there is nothing trustworthy to probe.
+    # Require both canonical deploys to have landed (the beacon is served by the
+    # API Worker; both frontend domains by one Pages project), else there is
+    # nothing trustworthy to probe. Retain the non-PR guard as defense in depth.
     if: ${{ !cancelled() && github.event_name != 'pull_request' && needs.deploy-api.result == 'success' && needs.deploy-app.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/pr-static-smoke.yml
+++ b/.github/workflows/pr-static-smoke.yml
@@ -124,6 +124,15 @@ jobs:
       - name: Validate CI Bun version pin contract
         run: node packages/scripts/ci-bun-version-contract.mjs --inventory "$RUNNER_TEMP/bun-runtime-inventory.json"
 
+      - name: Test Cloud Pages workflow contracts
+        run: >-
+          bun test
+          packages/scripts/__tests__/homepage-deploy-workflow.test.ts
+          packages/scripts/__tests__/cloud-cf-canonical-source-guard-workflow.test.ts
+          packages/scripts/__tests__/cloud-cf-voice-deploy-workflow.test.ts
+          packages/scripts/__tests__/ci-bun-version-contract.test.ts
+          packages/scripts/__tests__/github-action-pinning.test.ts
+
       - name: Upload Bun runtime resolution inventory
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:

--- a/packages/app/.env.example
+++ b/packages/app/.env.example
@@ -28,10 +28,16 @@ VITE_ELIZA_IOS_API_TOKEN=
 VITE_ELIZA_DEVICE_BRIDGE_URL=
 VITE_ELIZA_DEVICE_BRIDGE_TOKEN=
 
-# Optional public marketing-channel overrides. The canonical Eliza bot/app
-# identifiers are source defaults, so ordinary builds remain functional when
-# these are unset.
+# Implicit Telegram source fallback use is local/direct-only. At repository
+# scope, this pair is the explicit staging release authority so the homepage
+# CTA and Steward Login Widget cannot resolve different identities. Protected
+# production releases ignore it and explicitly select the canonical constants
+# from contact.ts. A same-named GitHub Environment pair does not override the
+# repository pair.
 VITE_TELEGRAM_BOT_ID=
 VITE_TELEGRAM_BOT_USERNAME=
+
+# Optional public marketing-channel overrides. Canonical source defaults keep
+# ordinary local/direct builds functional when these are unset.
 VITE_DISCORD_CLIENT_ID=
 VITE_WHATSAPP_PHONE_NUMBER=

--- a/packages/homepage/.env.example
+++ b/packages/homepage/.env.example
@@ -12,12 +12,16 @@
 
 VITE_ELIZACLOUD_API_URL=https://api.eliza.app
 
+# Local/direct builds may use the source defaults. At repository scope, this ID
+# and the username below form the protected staging release pair and are
+# required before any release mutation starts. Protected production releases
+# ignore them and derive the canonical pair from contact.ts.
 # Bot numeric ID (first part of bot token before the colon)
 # Example: If token is 8202935775:AAGL9Dhf..., use 8202935775
 VITE_TELEGRAM_BOT_ID=
 
 # Bot username for Telegram Login Widget (without @ prefix)
-# This must match the bot configured in eliza-cloud-v2 ELIZA_APP_TELEGRAM_BOT_TOKEN
+# This must match the staging bot configured by the Cloud gateway.
 VITE_TELEGRAM_BOT_USERNAME=
 
 # Discord Application ID (from Discord Developer Portal > General Information)

--- a/packages/homepage/AGENTS.md
+++ b/packages/homepage/AGENTS.md
@@ -122,13 +122,21 @@ isolated visual harness.
 | Variable | Default | Purpose |
 |---|---|---|
 | `VITE_ELIZACLOUD_API_URL` | `https://api.eliza.app` | Eliza Cloud backend base URL |
-| `VITE_TELEGRAM_BOT_USERNAME` | `ElizaIsNotABot` | Optional Telegram bot username override |
-| `VITE_TELEGRAM_BOT_ID` | `8931353359` | Optional numeric Telegram bot ID override |
+| `VITE_TELEGRAM_BOT_USERNAME` | `ElizaIsNotABot` | Local/direct-build Telegram username fallback; with the ID, the repository-scoped staging release authority |
+| `VITE_TELEGRAM_BOT_ID` | `8931353359` | Local/direct-build numeric Telegram ID fallback; with the username, the repository-scoped staging release authority |
 | `VITE_DISCORD_CLIENT_ID` | `1468649258654630063` | Optional Discord Application ID override |
 | `WHATSAPP_PUBLIC_ENABLED` | disabled | Deployment-only switch that admits the public WhatsApp CTA |
 | `VITE_WHATSAPP_PHONE_NUMBER` | — | Admitted Blooio WhatsApp sender (E.164); production uses the shared `+18087881821` number only after its WhatsApp channel passes live proof |
 
 Auth token is stored in `localStorage` under key `eliza_app_session`. The test signer hook is `window.__siwsTestSigner` (used by Playwright e2e to skip wallet interaction).
+
+The Telegram defaults above do not authorize a protected staging Pages
+artifact. The Cloud release preflight requires the explicit, valid repository
+pair before staging migrations or API deployment, and neither component may
+match production. Production ignores the repository pair and derives its exact
+identity from `src/lib/contact.ts` at the checked-out release SHA. Do not treat
+same-named GitHub Environment variables as overrides: they arrive after the
+repository `vars` context has already been resolved.
 
 ## How to extend
 

--- a/packages/homepage/CLAUDE.md
+++ b/packages/homepage/CLAUDE.md
@@ -122,13 +122,21 @@ isolated visual harness.
 | Variable | Default | Purpose |
 |---|---|---|
 | `VITE_ELIZACLOUD_API_URL` | `https://api.eliza.app` | Eliza Cloud backend base URL |
-| `VITE_TELEGRAM_BOT_USERNAME` | `ElizaIsNotABot` | Optional Telegram bot username override |
-| `VITE_TELEGRAM_BOT_ID` | `8931353359` | Optional numeric Telegram bot ID override |
+| `VITE_TELEGRAM_BOT_USERNAME` | `ElizaIsNotABot` | Local/direct-build Telegram username fallback; with the ID, the repository-scoped staging release authority |
+| `VITE_TELEGRAM_BOT_ID` | `8931353359` | Local/direct-build numeric Telegram ID fallback; with the username, the repository-scoped staging release authority |
 | `VITE_DISCORD_CLIENT_ID` | `1468649258654630063` | Optional Discord Application ID override |
 | `WHATSAPP_PUBLIC_ENABLED` | disabled | Deployment-only switch that admits the public WhatsApp CTA |
 | `VITE_WHATSAPP_PHONE_NUMBER` | — | Admitted Blooio WhatsApp sender (E.164); production uses the shared `+18087881821` number only after its WhatsApp channel passes live proof |
 
 Auth token is stored in `localStorage` under key `eliza_app_session`. The test signer hook is `window.__siwsTestSigner` (used by Playwright e2e to skip wallet interaction).
+
+The Telegram defaults above do not authorize a protected staging Pages
+artifact. The Cloud release preflight requires the explicit, valid repository
+pair before staging migrations or API deployment, and neither component may
+match production. Production ignores the repository pair and derives its exact
+identity from `src/lib/contact.ts` at the checked-out release SHA. Do not treat
+same-named GitHub Environment variables as overrides: they arrive after the
+repository `vars` context has already been resolved.
 
 ## How to extend
 

--- a/packages/homepage/README.md
+++ b/packages/homepage/README.md
@@ -21,8 +21,8 @@ cp .env.example .env.local
 | Variable | Description |
 |---|---|
 | `VITE_ELIZACLOUD_API_URL` | Eliza Cloud backend URL (defaults to `https://api.eliza.app`) |
-| `VITE_TELEGRAM_BOT_USERNAME` | Optional Telegram bot username override (default `ElizaIsNotABot`) |
-| `VITE_TELEGRAM_BOT_ID` | Optional numeric Telegram bot ID override (default `8931353359`) |
+| `VITE_TELEGRAM_BOT_USERNAME` | Local/direct-build Telegram username fallback (default `ElizaIsNotABot`); with the ID, the repository-scoped staging release authority |
+| `VITE_TELEGRAM_BOT_ID` | Local/direct-build numeric Telegram ID fallback (default `8931353359`); with the username, the repository-scoped staging release authority |
 | `VITE_DISCORD_CLIENT_ID` | Optional Discord Application ID override (default `1468649258654630063`) |
 | `WHATSAPP_PUBLIC_ENABLED` | Deployment switch that must be true before the public WhatsApp CTA is built |
 | `VITE_WHATSAPP_PHONE_NUMBER` | Admitted Blooio WhatsApp sender in E.164 format; set to the shared `+18087881821` number |
@@ -30,6 +30,15 @@ cp .env.example .env.local
 OAuth provider callback configuration belongs to the unified Cloud auth routes
 and API deployment. Do not register a callback against this source package or
 its optional test-harness port.
+
+Protected staging releases require the complete repository-scoped pair before
+migrations or API deployment, and neither component may match the canonical
+production identity. Protected production releases ignore that pair and derive
+their exact identity from `src/lib/contact.ts` at the checked-out release SHA.
+Same-named GitHub Environment variables are not an override mechanism because
+GitHub resolves the repository `vars` context before Environment variables
+arrive on the runner. Pull requests have static build checks but no Pages
+preview release path.
 
 ### WhatsApp production activation
 

--- a/packages/scripts/__tests__/ci-bun-version-contract.test.ts
+++ b/packages/scripts/__tests__/ci-bun-version-contract.test.ts
@@ -60,7 +60,6 @@ const SHA = "0c5077e51419868618aeaa5fe8019c62421857d6";
 const GATE_WORKFLOWS = [
   "test.yml",
   "pr-static-smoke.yml",
-  "cloud-cf-deploy.yml",
   "cloud-cf-release.yml",
 ];
 
@@ -216,22 +215,22 @@ describe("ci-bun-version-contract", () => {
 
   test("fails when a gate workflow drops the canonical pin entirely", () => {
     expectViolation(
-      buildRepo({ overrides: { "cloud-cf-deploy.yml": GATE_NO_PIN } }),
+      buildRepo({ overrides: { "pr-static-smoke.yml": GATE_NO_PIN } }),
       /does not wire the canonical Bun pin/,
     );
   });
 
   test("fails loudly when a gate workflow is missing, instead of skipping", () => {
     expectViolation(
-      buildRepo({ overrides: { "cloud-cf-deploy.yml": null } }),
-      /cloud-cf-deploy\.yml/,
+      buildRepo({ overrides: { "pr-static-smoke.yml": null } }),
+      /pr-static-smoke\.yml/,
     );
   });
 
   test("fails loudly when the canonical release workflow is missing (#19183)", () => {
-    // After #18996 split the canary deploy from the canonical release, the
-    // release workflow publishes to production. A missing release gate must
-    // fail loudly the same way a missing canary gate does, not silently pass.
+    // The dispatch wrapper delegates every install and build to the canonical
+    // release workflow. A missing release gate must fail loudly, not silently
+    // pass because the wrapper itself needs no Bun runtime.
     expectViolation(
       buildRepo({ overrides: { "cloud-cf-release.yml": null } }),
       /cloud-cf-release\.yml/,

--- a/packages/scripts/__tests__/cloud-cf-canonical-source-guard-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-canonical-source-guard-workflow.test.ts
@@ -83,11 +83,11 @@ describe("Cloud CF canonical source mutation guards", () => {
     expect(workflow.on.workflow_call.outputs?.superseded?.value).toContain(
       "jobs.migrate-db.outputs.superseded",
     );
-    for (const dependent of [
-      "deploy-api",
-      "resolve-pages-environment-config",
-      "build-pages",
-    ]) {
+    // The read-only public-identity preflight now precedes migrate-db. Only
+    // downstream mutation/build jobs can consume migrate-db's supersession
+    // result; the preflight-to-migration edge is covered by the homepage
+    // workflow contract test.
+    for (const dependent of ["deploy-api", "build-pages"]) {
       expect(workflow.jobs[dependent].if).toContain(
         "needs.migrate-db.outputs.superseded != 'true'",
       );

--- a/packages/scripts/__tests__/cloud-cf-voice-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-voice-deploy-workflow.test.ts
@@ -25,14 +25,12 @@ interface Workflow {
   jobs?: Record<string, { if?: string; steps?: WorkflowStep[] }>;
 }
 
-// The Worker `deploy-api` job lives in the reusable release workflow that
-// `cloud-cf-deploy.yml` calls after admission; the pull-request entry workflow
-// still owns the credential-free preview frontend build. Both files are read so
-// no expression in either escapes the balance and realtime-flag contracts.
+// The Worker and frontend builds live in the reusable release workflow that
+// `cloud-cf-deploy.yml` calls after admission. The dispatch-only entry workflow
+// is still read so no expression in either file escapes the balance contract.
 const entrySource = read(".github/workflows/cloud-cf-deploy.yml");
 const workflowSource = read(".github/workflows/cloud-cf-release.yml");
 const workflow = Bun.YAML.parse(workflowSource) as Workflow;
-const entryWorkflow = Bun.YAML.parse(entrySource) as Workflow;
 const publishStep = workflow.jobs?.["deploy-api"]?.steps?.find(
   (step) => step.name === "Prepare Worker secrets for atomic deploy",
 );
@@ -281,8 +279,8 @@ describe("Cloud CF realtime voice deploy contract", () => {
       "&& 'true' || 'false'",
     );
 
-    // Canonical production builds pin the voice UI on. Staging and pull-request
-    // previews continue to use the repository variable.
+    // Canonical production builds pin the voice UI on. Staging releases use the
+    // repository variable through the same reusable build path.
     const flagPattern =
       /VITE_VOICE_REALTIME_WS: \$\{\{[^}]*vars\.VOICE_REALTIME_WS_ENABLED[^}]*&& '1' \|\| '0' \}\}/g;
     const releaseRealtimeFlags = workflowSource.match(flagPattern) ?? [];
@@ -293,24 +291,10 @@ describe("Cloud CF realtime voice deploy contract", () => {
       expect(flag).toContain("vars.VOICE_REALTIME_WS_ENABLED");
     }
 
-    const entryRealtimeFlags = entrySource.match(flagPattern) ?? [];
-    expect(entryRealtimeFlags.length).toBeGreaterThanOrEqual(1);
-    for (const flag of entryRealtimeFlags) {
-      expect(flag).toContain("vars.VOICE_REALTIME_WS_ENABLED");
-    }
-    const previewBuild = entryWorkflow.jobs?.["build-pages"]?.steps?.find(
-      (step) => step.name === "Build consolidated frontend artifact",
-    );
-    expect(previewBuild?.env?.VITE_VOICE_REALTIME_WS).toBe(
-      entryRealtimeFlags[0]?.replace("VITE_VOICE_REALTIME_WS: ", ""),
-    );
-    expect(previewBuild?.env?.VITE_ENVIRONMENT).toBe("staging");
-    expect(previewBuild?.env?.VITE_API_URL).toBe(
-      "https://api-staging.eliza.app",
-    );
-    expect(previewBuild?.env?.VITE_APP_URL).toBe("https://staging.eliza.app");
-    expect(entryWorkflow.jobs?.["build-pages"]?.if).toContain(
-      "github.event_name == 'pull_request'",
+    expect(entrySource).not.toContain("Build consolidated frontend artifact");
+    expect(entrySource).not.toContain("VITE_VOICE_REALTIME_WS:");
+    expect(entrySource).toContain(
+      "uses: ./.github/workflows/cloud-cf-release.yml",
     );
   });
 

--- a/packages/scripts/__tests__/github-action-pinning.test.ts
+++ b/packages/scripts/__tests__/github-action-pinning.test.ts
@@ -542,7 +542,8 @@ describe("GitHub action supply-chain references", () => {
     );
     expect(qualitySource).toContain("packages/homepage/");
     expect(qualitySource).toContain("Build the only deployable frontend");
-    expect(source).toContain("Build consolidated frontend artifact");
+    expect(source).toContain("uses: ./.github/workflows/cloud-cf-release.yml");
+    expect(source).not.toContain("Build consolidated frontend artifact");
     expect(releaseSource).toContain("Build consolidated frontend artifact");
     expect(releaseSource).toContain("PAGES_PROJECT: eliza-app");
     for (const workflowSource of [source, releaseSource]) {

--- a/packages/scripts/__tests__/homepage-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/homepage-deploy-workflow.test.ts
@@ -1,28 +1,167 @@
 /**
- * Guards the consolidated homepage deployment authority: homepage source is
- * embedded into packages/app and only the unified cloud workflow may deploy it.
+ * Guards the consolidated homepage deployment authority and the fail-closed
+ * public messaging identity preflight that must succeed before release
+ * mutations can begin.
  */
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 
 const repositoryRoot = path.resolve(import.meta.dirname, "../../..");
 const workflowsDirectory = path.join(repositoryRoot, ".github/workflows");
-// Homepage deployment authority spans the entry workflow (triggers and the
-// unprivileged pull-request preview build) and the reusable release workflow it
-// calls (canonical build and Pages deploy). Both are asserted explicitly so a
-// guarantee cannot silently satisfy itself from the wrong file.
 const workflowPath = path.join(workflowsDirectory, "cloud-cf-deploy.yml");
 const releaseWorkflowPath = path.join(
   workflowsDirectory,
   "cloud-cf-release.yml",
 );
 const qualityWorkflowPath = path.join(workflowsDirectory, "quality.yml");
+const contactPath = path.join(
+  repositoryRoot,
+  "packages/homepage/src/lib/contact.ts",
+);
+
+interface WorkflowStep {
+  env?: Record<string, string>;
+  id?: string;
+  if?: string;
+  name?: string;
+  run?: string;
+  uses?: string;
+}
+
+interface WorkflowJob {
+  environment?: string;
+  if?: string;
+  needs?: string | string[];
+  outputs?: Record<string, string>;
+  steps?: WorkflowStep[];
+  uses?: string;
+  with?: Record<string, string | boolean>;
+}
+
+interface WorkflowFile {
+  jobs?: Record<string, WorkflowJob>;
+  on?: Record<string, unknown>;
+}
+
+interface TelegramExecution {
+  exitCode: number;
+  githubOutput: string;
+  stderr: string;
+  stdout: string;
+  summary: string;
+}
+
+const workflow = readFileSync(workflowPath, "utf8");
+const releaseWorkflow = readFileSync(releaseWorkflowPath, "utf8");
+const qualityWorkflow = readFileSync(qualityWorkflowPath, "utf8");
+const contactSource = readFileSync(contactPath, "utf8");
+const parsedWorkflow = Bun.YAML.parse(workflow) as WorkflowFile;
+const parsedReleaseWorkflow = Bun.YAML.parse(releaseWorkflow) as WorkflowFile;
+
+const resolver =
+  parsedReleaseWorkflow.jobs?.["resolve-pages-environment-config"];
+const telegramValidation = resolver?.steps?.find(
+  (candidate) =>
+    candidate.name === "Validate Telegram public identity preflight",
+);
+
+function requiredTelegramConstant(
+  name: "ELIZA_TELEGRAM_BOT_ID" | "ELIZA_TELEGRAM_BOT_USERNAME",
+): string {
+  const match = contactSource.match(
+    new RegExp(`^export const ${name} = "([^"]+)";$`, "m"),
+  );
+  if (!match?.[1])
+    throw new Error(`Missing homepage Telegram constant: ${name}`);
+  return match[1];
+}
+
+const canonicalTelegram = {
+  botId: requiredTelegramConstant("ELIZA_TELEGRAM_BOT_ID"),
+  botUsername: requiredTelegramConstant("ELIZA_TELEGRAM_BOT_USERNAME"),
+};
+const stagingTelegram = {
+  botId: "1234567890123",
+  botUsername: "ElizaStage29206Bot",
+};
+
+function readOptionalFile(filePath: string): string {
+  return existsSync(filePath) ? readFileSync(filePath, "utf8") : "";
+}
+
+function runTelegramPreflight(
+  overrides: Partial<{
+    botId: string;
+    botUsername: string;
+    targetEnvironment: string;
+  }> = {},
+): TelegramExecution {
+  if (!telegramValidation?.run) {
+    throw new Error("Missing executable Telegram public identity preflight");
+  }
+
+  const fixtureRoot = mkdtempSync(
+    path.join(tmpdir(), "homepage-telegram-preflight-"),
+  );
+  const githubOutputPath = path.join(fixtureRoot, "github-output.txt");
+  const summaryPath = path.join(fixtureRoot, "step-summary.md");
+
+  try {
+    const result = Bun.spawnSync(["bash", "-c", telegramValidation.run], {
+      cwd: repositoryRoot,
+      env: {
+        ...process.env,
+        GITHUB_OUTPUT: githubOutputPath,
+        GITHUB_STEP_SUMMARY: summaryPath,
+        TARGET_ENVIRONMENT: overrides.targetEnvironment ?? "staging",
+        STAGING_TELEGRAM_BOT_ID: overrides.botId ?? stagingTelegram.botId,
+        STAGING_TELEGRAM_BOT_USERNAME:
+          overrides.botUsername ?? stagingTelegram.botUsername,
+      },
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    return {
+      exitCode: result.exitCode,
+      githubOutput: readOptionalFile(githubOutputPath),
+      stderr: result.stderr.toString(),
+      stdout: result.stdout.toString(),
+      summary: readOptionalFile(summaryPath),
+    };
+  } finally {
+    rmSync(fixtureRoot, { force: true, recursive: true });
+  }
+}
+
+function assertNoPublicSurfaceLeak(
+  execution: TelegramExecution,
+  values: string[],
+): void {
+  const publicSurfaces = `${execution.stdout}\n${execution.stderr}\n${execution.summary}`;
+  for (const value of values.filter((candidate) => candidate.length >= 4)) {
+    expect(publicSurfaces).not.toContain(value);
+  }
+}
+
+function jobNeeds(job: WorkflowJob | undefined): string[] {
+  if (!job?.needs) return [];
+  return Array.isArray(job.needs) ? job.needs : [job.needs];
+}
+
+function githubExpression(body: string): string {
+  return ["$", "{{ ", body, " }}"].join("");
+}
+
+function namedStep(job: WorkflowJob | undefined, name: string): WorkflowStep {
+  const found = job?.steps?.find((candidate) => candidate.name === name);
+  if (!found) throw new Error(`Missing workflow step: ${name}`);
+  return found;
+}
 
 describe("homepage deployment workflow", () => {
-  const workflow = readFileSync(workflowPath, "utf8");
-  const releaseWorkflow = readFileSync(releaseWorkflowPath, "utf8");
-  const qualityWorkflow = readFileSync(qualityWorkflowPath, "utf8");
   const homepagePackage = JSON.parse(
     readFileSync(
       path.join(repositoryRoot, "packages/homepage/package.json"),
@@ -63,81 +202,293 @@ describe("homepage deployment workflow", () => {
     expect(devAll).not.toContain("DEV_ALL_HOMEPAGE_PORT");
   });
 
-  it("builds homepage changes into the single eliza-app artifact", () => {
-    expect(appPackage.scripts?.["prebuild:web"]).toBe(
-      "bun run --cwd ../cloud/sdk build && bun run prebuild",
-    );
-    expect(qualityWorkflow).toContain("packages/homepage/");
-    expect(qualityWorkflow).toContain("Build the only deployable frontend");
-    expect(workflow).toContain("Build consolidated frontend artifact");
-    expect(workflow).toContain("Upload consolidated frontend artifact");
-    expect(releaseWorkflow).toContain("Build consolidated frontend artifact");
-    expect(releaseWorkflow).toContain("Upload consolidated frontend artifact");
-    expect(releaseWorkflow).toContain("PAGES_PROJECT: eliza-app");
-    expect(releaseWorkflow).toContain("https://eliza.app");
-    expect(releaseWorkflow).toContain("https://cloud.eliza.app");
-    expect(releaseWorkflow).toContain("https://staging.eliza.app");
-    expect(releaseWorkflow).toContain("https://cloud-staging.eliza.app");
+  it("keeps preview work out of the manual canonical entry workflow", () => {
+    expect(Object.keys(parsedWorkflow.on ?? {})).toEqual(["workflow_dispatch"]);
+    expect(
+      parsedWorkflow.jobs?.["resolve-pages-preview-config"],
+    ).toBeUndefined();
+    expect(parsedWorkflow.jobs?.["build-pages"]).toBeUndefined();
+    expect(workflow).not.toContain("pull-request Pages preview");
+
+    const release = parsedWorkflow.jobs?.release;
+    expect(release?.uses).toBe("./.github/workflows/cloud-cf-release.yml");
+    expect(release?.if).toContain("github.event_name != 'pull_request'");
+    expect(release?.with?.target_environment).toContain("staging");
+    expect(release?.with?.target_environment).toContain("production");
   });
 
-  it("resolves matched Telegram configuration for canonical and preview builds", () => {
-    expect(releaseWorkflow).toContain("resolve-pages-environment-config:");
-    expect(workflow).toContain("resolve-pages-preview-config:");
-    // Each workflow owns exactly one resolver, and each resolver still refuses a
-    // half-configured pair and supplies the matched public default.
-    for (const source of [workflow, releaseWorkflow]) {
-      expect(source).toContain("VITE_TELEGRAM_BOT_ID must be numeric");
-      expect(source.match(/TELEGRAM_BOT_ID=7684336618/g)).toHaveLength(1);
-      expect(source.match(/TELEGRAM_BOT_USERNAME=Elizav2_Bot/g)).toHaveLength(
-        1,
+  it("runs the Telegram resolver before every release mutation", () => {
+    const jobs = parsedReleaseWorkflow.jobs ?? {};
+    const jobNames = Object.keys(jobs);
+    const migration = jobs["migrate-db"];
+    const apiDeploy = jobs["deploy-api"];
+    const pagesBuild = jobs["build-pages"];
+
+    expect(jobNames.indexOf("resolve-pages-environment-config")).toBeLessThan(
+      jobNames.indexOf("migrate-db"),
+    );
+    expect(jobNeeds(resolver)).toEqual([]);
+    expect(resolver?.environment).toBe(
+      githubExpression(
+        "inputs.target_environment == 'production' && 'production' || 'staging'",
+      ),
+    );
+    expect(resolver?.steps?.[0]?.uses).toContain("actions/checkout@");
+    expect(telegramValidation?.env).toEqual({
+      TARGET_ENVIRONMENT: githubExpression("inputs.target_environment"),
+      STAGING_TELEGRAM_BOT_ID: githubExpression("vars.VITE_TELEGRAM_BOT_ID"),
+      STAGING_TELEGRAM_BOT_USERNAME: githubExpression(
+        "vars.VITE_TELEGRAM_BOT_USERNAME",
+      ),
+    });
+
+    expect(jobNeeds(migration)).toEqual(["resolve-pages-environment-config"]);
+    expect(migration?.if).toContain(
+      "needs.resolve-pages-environment-config.result == 'success'",
+    );
+    expect(jobNeeds(apiDeploy)).toEqual([
+      "resolve-pages-environment-config",
+      "migrate-db",
+    ]);
+    expect(apiDeploy?.if).toContain(
+      "needs.resolve-pages-environment-config.result == 'success'",
+    );
+    expect(jobNeeds(pagesBuild)).toEqual([
+      "migrate-db",
+      "resolve-pages-environment-config",
+    ]);
+    expect(pagesBuild?.if).toContain(
+      "needs.resolve-pages-environment-config.result == 'success'",
+    );
+  });
+
+  it("accepts valid repository-scoped staging Telegram identities", () => {
+    for (const valid of [
+      { target: "staging", ...stagingTelegram },
+      {
+        target: "staging",
+        botId: "4503599627370495",
+        botUsername: "MaxIdStageBot",
+      },
+    ]) {
+      const execution = runTelegramPreflight({
+        botId: valid.botId,
+        botUsername: valid.botUsername,
+        targetEnvironment: valid.target,
+      });
+      expect(execution.exitCode).toBe(0);
+      expect(execution.githubOutput).toBe(
+        `bot_id=${valid.botId}\nbot_username=${valid.botUsername}\n`,
       );
-      expect(
-        source.match(
-          /VITE_TELEGRAM_BOT_ID and VITE_TELEGRAM_BOT_USERNAME must be configured together/g,
-        ),
-      ).toHaveLength(1);
+      expect(execution.summary).toContain(
+        `Validated Telegram public identity policy for ${valid.target}.`,
+      );
+      assertNoPublicSurfaceLeak(execution, [valid.botId, valid.botUsername]);
     }
-    expect(releaseWorkflow).toContain(
-      "VITE_TELEGRAM_BOT_ID: $" +
-        "{{ needs.resolve-pages-environment-config.outputs.telegram_bot_id }}",
+  });
+
+  it("derives production Telegram identity from source and ignores repository staging input", () => {
+    for (const configuredStagingPair of [
+      { botId: "", botUsername: "" },
+      stagingTelegram,
+      { botId: "not-a-number", botUsername: "not-a-valid-name!" },
+    ]) {
+      const execution = runTelegramPreflight({
+        ...configuredStagingPair,
+        targetEnvironment: "production",
+      });
+      expect(execution.exitCode).toBe(0);
+      expect(execution.githubOutput).toBe(
+        `bot_id=${canonicalTelegram.botId}\nbot_username=${canonicalTelegram.botUsername}\n`,
+      );
+      expect(execution.summary).toContain(
+        "Validated Telegram public identity policy for production.",
+      );
+      assertNoPublicSurfaceLeak(execution, [
+        configuredStagingPair.botId,
+        configuredStagingPair.botUsername,
+        canonicalTelegram.botId,
+        canonicalTelegram.botUsername,
+      ]);
+    }
+  });
+
+  it("fails closed for incomplete, blank, malformed, crossed, or unknown Telegram configuration", () => {
+    const cases = [
+      { label: "both absent", target: "staging", botId: "", botUsername: "" },
+      {
+        label: "ID only",
+        target: "staging",
+        botId: stagingTelegram.botId,
+        botUsername: "",
+      },
+      {
+        label: "username only",
+        target: "staging",
+        botId: "",
+        botUsername: stagingTelegram.botUsername,
+      },
+      {
+        label: "blank ID",
+        target: "staging",
+        botId: " \t ",
+        botUsername: stagingTelegram.botUsername,
+      },
+      {
+        label: "blank username",
+        target: "staging",
+        botId: stagingTelegram.botId,
+        botUsername: " \t ",
+      },
+      {
+        label: "leading-zero ID",
+        target: "staging",
+        botId: "012345",
+        botUsername: stagingTelegram.botUsername,
+      },
+      {
+        label: "overlong ID",
+        target: "staging",
+        botId: "1".repeat(21),
+        botUsername: stagingTelegram.botUsername,
+      },
+      {
+        label: "ID above Telegram 52-bit maximum",
+        target: "staging",
+        botId: "4503599627370496",
+        botUsername: stagingTelegram.botUsername,
+      },
+      {
+        label: "nonnumeric ID",
+        target: "staging",
+        botId: "12345x",
+        botUsername: stagingTelegram.botUsername,
+      },
+      {
+        label: "short username",
+        target: "staging",
+        botId: stagingTelegram.botId,
+        botUsername: "Bot_",
+      },
+      {
+        label: "overlong username",
+        target: "staging",
+        botId: stagingTelegram.botId,
+        botUsername: "B".repeat(33),
+      },
+      {
+        label: "symbol in username",
+        target: "staging",
+        botId: stagingTelegram.botId,
+        botUsername: "Eliza-Stage",
+      },
+      {
+        label: "username is not a managed bot",
+        target: "staging",
+        botId: stagingTelegram.botId,
+        botUsername: "ordinary_user",
+      },
+      {
+        label: "unknown environment",
+        target: "preview",
+        botId: stagingTelegram.botId,
+        botUsername: stagingTelegram.botUsername,
+      },
+      {
+        label: "staging equals production",
+        target: "staging",
+        botId: canonicalTelegram.botId,
+        botUsername: canonicalTelegram.botUsername,
+      },
+      {
+        label: "staging reuses production ID",
+        target: "staging",
+        botId: canonicalTelegram.botId,
+        botUsername: stagingTelegram.botUsername,
+      },
+      {
+        label: "staging reuses production username",
+        target: "staging",
+        botId: stagingTelegram.botId,
+        botUsername: canonicalTelegram.botUsername,
+      },
+      {
+        label: "staging reuses production username with different casing",
+        target: "staging",
+        botId: stagingTelegram.botId,
+        botUsername: canonicalTelegram.botUsername.toLowerCase(),
+      },
+    ];
+
+    for (const invalid of cases) {
+      const execution = runTelegramPreflight({
+        botId: invalid.botId,
+        botUsername: invalid.botUsername,
+        targetEnvironment: invalid.target,
+      });
+      expect(execution.exitCode, invalid.label).toBe(1);
+      expect(execution.githubOutput, invalid.label).toBe("");
+      expect(execution.summary, invalid.label).toBe("");
+      assertNoPublicSurfaceLeak(execution, [
+        invalid.botId,
+        invalid.botUsername,
+      ]);
+    }
+  });
+
+  it("preserves resolver outputs through the primary and legacy Pages builds", () => {
+    const pagesBuild = parsedReleaseWorkflow.jobs?.["build-pages"];
+    const appDeploy = parsedReleaseWorkflow.jobs?.["deploy-app"];
+    const primaryBuild = namedStep(
+      pagesBuild,
+      "Build consolidated frontend artifact",
     );
-    expect(releaseWorkflow).toContain(
-      "VITE_TELEGRAM_BOT_USERNAME: $" +
-        "{{ needs.resolve-pages-environment-config.outputs.telegram_bot_username }}",
+    const legacyBuild = namedStep(
+      appDeploy,
+      "Legacy inline fallback - build app",
     );
-    expect(workflow).toContain(
-      "VITE_TELEGRAM_BOT_ID: $" +
-        "{{ needs.resolve-pages-preview-config.outputs.telegram_bot_id }}",
+
+    expect(pagesBuild?.outputs?.telegram_bot_id).toBe(
+      githubExpression(
+        "needs.resolve-pages-environment-config.outputs.telegram_bot_id",
+      ),
     );
-    expect(workflow).toContain(
-      "VITE_TELEGRAM_BOT_USERNAME: $" +
-        "{{ needs.resolve-pages-preview-config.outputs.telegram_bot_username }}",
+    expect(pagesBuild?.outputs?.telegram_bot_username).toBe(
+      githubExpression(
+        "needs.resolve-pages-environment-config.outputs.telegram_bot_username",
+      ),
     );
-    expect(releaseWorkflow).toContain(
-      "VITE_TELEGRAM_BOT_ID: $" +
-        "{{ needs.build-pages.outputs.telegram_bot_id }}",
+    expect(primaryBuild.env?.VITE_TELEGRAM_BOT_ID).toBe(
+      githubExpression(
+        "needs.resolve-pages-environment-config.outputs.telegram_bot_id",
+      ),
     );
-    expect(releaseWorkflow).toContain(
-      "VITE_TELEGRAM_BOT_USERNAME: $" +
-        "{{ needs.build-pages.outputs.telegram_bot_username }}",
+    expect(primaryBuild.env?.VITE_TELEGRAM_BOT_USERNAME).toBe(
+      githubExpression(
+        "needs.resolve-pages-environment-config.outputs.telegram_bot_username",
+      ),
     );
+    expect(legacyBuild.env?.VITE_TELEGRAM_BOT_ID).toBe(
+      githubExpression("needs.build-pages.outputs.telegram_bot_id"),
+    );
+    expect(legacyBuild.env?.VITE_TELEGRAM_BOT_USERNAME).toBe(
+      githubExpression("needs.build-pages.outputs.telegram_bot_username"),
+    );
+    expect(releaseWorkflow).not.toContain("7684336618");
+    expect(releaseWorkflow).not.toContain("Elizav2_Bot");
   });
 
   it("keeps WhatsApp disabled until a production sender is explicitly enabled", () => {
-    for (const source of [workflow, releaseWorkflow]) {
-      expect(source).toContain("WHATSAPP_PUBLIC_ENABLED");
-      expect(source).toContain(
-        "VITE_WHATSAPP_PHONE_NUMBER must be an E.164 number when WHATSAPP_PUBLIC_ENABLED is true",
-      );
-      expect(source).toContain(
-        "The public WhatsApp CTA cannot use a shared sandbox, developer test, or unverified sender",
-      );
-      expect(source).toContain("+14155238886|+15551649988|+14159611510");
-      expect(source).toContain('echo "phone_number=" >> "$GITHUB_OUTPUT"');
-    }
-    expect(workflow).toContain(
-      "VITE_WHATSAPP_PHONE_NUMBER: $" +
-        "{{ needs.resolve-pages-preview-config.outputs.whatsapp_phone_number }}",
+    expect(releaseWorkflow).toContain("WHATSAPP_PUBLIC_ENABLED");
+    expect(releaseWorkflow).toContain(
+      "VITE_WHATSAPP_PHONE_NUMBER must be an E.164 number when WHATSAPP_PUBLIC_ENABLED is true",
+    );
+    expect(releaseWorkflow).toContain(
+      "The public WhatsApp CTA cannot use a shared sandbox, developer test, or unverified sender",
+    );
+    expect(releaseWorkflow).toContain("+14155238886|+15551649988|+14159611510");
+    expect(releaseWorkflow).toContain(
+      'echo "phone_number=" >> "$GITHUB_OUTPUT"',
     );
     expect(releaseWorkflow).toContain(
       "VITE_WHATSAPP_PHONE_NUMBER: $" +
@@ -147,6 +498,23 @@ describe("homepage deployment workflow", () => {
       "VITE_WHATSAPP_PHONE_NUMBER: $" +
         "{{ needs.build-pages.outputs.whatsapp_phone_number }}",
     );
+  });
+
+  it("builds homepage changes into the single eliza-app artifact", () => {
+    expect(appPackage.scripts?.["prebuild:web"]).toBe(
+      "bun run --cwd ../cloud/sdk build && bun run prebuild",
+    );
+    expect(qualityWorkflow).toContain("packages/homepage/");
+    expect(qualityWorkflow).toContain("Build the only deployable frontend");
+    expect(workflow).not.toContain("Build consolidated frontend artifact");
+    expect(workflow).not.toContain("Upload consolidated frontend artifact");
+    expect(releaseWorkflow).toContain("Build consolidated frontend artifact");
+    expect(releaseWorkflow).toContain("Upload consolidated frontend artifact");
+    expect(releaseWorkflow).toContain("PAGES_PROJECT: eliza-app");
+    expect(releaseWorkflow).toContain("https://eliza.app");
+    expect(releaseWorkflow).toContain("https://cloud.eliza.app");
+    expect(releaseWorkflow).toContain("https://staging.eliza.app");
+    expect(releaseWorkflow).toContain("https://cloud-staging.eliza.app");
   });
 
   it("validates homepage source while building only packages/app in quality CI", () => {
@@ -171,7 +539,7 @@ describe("homepage deployment workflow", () => {
     // Homepage resolves UI's public dist subpaths and the frontend reaches
     // prompts through core. A clean --ignore-scripts install produces none of
     // those dist artifacts, so the consumer gates must follow their builds.
-    expect(workflow).toContain("run: bun run build:core");
+    expect(releaseWorkflow).toContain("run: bun run build:core");
     const promptsBuildIndex = qualityWorkflow.indexOf(
       "bun run --cwd packages/prompts build:package",
     );

--- a/packages/scripts/ci-bun-version-contract.mjs
+++ b/packages/scripts/ci-bun-version-contract.mjs
@@ -138,18 +138,16 @@ const EXCLUDED_SURFACES = [
 
 // Required, scheduled, and deploy-critical install lanes that must wire the
 // concrete pin directly (not merely resolve through indirection). The required
-// `ci-ok` aggregate (test.yml), the develop PR gate, the canary deploy, and
-// the canonical cloud release are the load-bearing paths. After #18996 split
-// the canary deploy (`cloud-cf-deploy.yml`) from the canonical release
-// (`cloud-cf-release.yml`), the release workflow is the one that actually
-// publishes to production. The general workflow scan already rejects floating
-// pins; gate membership additionally prevents the release file from
-// disappearing or replacing its direct canonical literal with indirection
-// (#19183).
+// `ci-ok` aggregate (test.yml), the develop PR gate, and the canonical Cloud
+// release are the load-bearing paths. `cloud-cf-deploy.yml` is now an
+// admission/dispatch wrapper with no Bun runtime; `cloud-cf-release.yml` owns
+// every install and build that publishes to staging or production. The general
+// workflow scan already rejects floating pins; gate membership additionally
+// prevents the release file from disappearing or replacing its direct
+// canonical literal with indirection (#19183).
 const GATE_WORKFLOWS = [
   "test.yml",
   "pr-static-smoke.yml",
-  "cloud-cf-deploy.yml",
   "cloud-cf-release.yml",
 ];
 


### PR DESCRIPTION
Refs #29206
Parent readiness epic: #25025

## Summary
- add a protected Pages Telegram preflight before database migration or API deployment
- make staging consume and validate the complete repository-scoped pair while rejecting the canonical production identity
- make production ignore GitHub Telegram inputs and derive its exact identity from the checked-out canonical source
- remove unreachable PR-only jobs from the dispatch-only deploy workflow and execute the resolver contract tests in PR static smoke
- document the authority model and fail-closed validation contract

The validator enforces a positive 52-bit Telegram ID and a 5–32 character bot username ending in bot, compares usernames case-insensitively for cross-environment collisions, preserves output casing, and does not log configured values.

## Validation
- exact reviewed head: `65657c56adb27166b6ea01bac28a61d56d55dcf7`, linearly rebased on `develop@56d8d56c30464fa56c97e6d181317cf0c1321b20`
- focused workflow matrix: 103 passed, 8 intentionally skipped, 0 failed (111 total; 23,511 assertions)
- homepage typecheck: passed
- homepage tests: 278 passed, 0 failed
- app web production build plus chunk and viewport guards: passed before the tree-preserving rebase
- core workspace build: 60/60 tasks passed before the tree-preserving rebase
- Biome, actionlint, AGENTS/CLAUDE parity, workflow trigger policy, and clean diff checks: passed
- independent exact-head security/workflow review: approved with no P0-P2 findings; the intervening UI/i18n and 45-minute CI-cap changes preserve the workflow patch without conflict

## Not proved by this PR
- no exact-SHA staging deployment or compiled-asset identity receipt has been produced
- no provider-backed Telegram /connect plus same-conversation reply has been sent
- GitHub-hosted checks remain pending due the current Actions outage

## Safety
No deployment, provider action, GitHub variable or secret write, database mutation, production query, or runtime mutation was performed. No configured Telegram value was printed.

<!-- evidence-head:65657c56adb27166b6ea01bac28a61d56d55dcf7 -->