### PR TITLE
fix(core): strip leading @ when building byName map in resolveAddressedTargets (#29168)

### DIFF
--- a/packages/core/src/runtime/addressed-to.test.ts
+++ b/packages/core/src/runtime/addressed-to.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { resolveAddressedTargets } from "./addressed-to";
+import type { Entity, IAgentRuntime, Memory, UUID } from "../../types/index";
+
+describe("resolveAddressedTargets", () => {
+	it("resolves entity names that include a leading @ (e.g. platform handles)", async () => {
+		const agentId = "00000000-0000-0000-0000-000000000001" as UUID;
+		const participantId = "00000000-0000-0000-0000-000000000002" as UUID;
+
+		const runtime = {
+			agentId,
+			character: { name: "Agent" },
+			getEntitiesForRoom: async () => [
+				{
+					id: participantId,
+					names: ["@sol_eth", "Sol"],
+				} as Entity,
+			],
+		} as unknown as IAgentRuntime;
+
+		const message = {
+			roomId: "00000000-0000-0000-0000-000000000003" as UUID,
+		} as Memory;
+
+		// 1. Lookup with '@'
+		const resolvedWithAt = await resolveAddressedTargets({
+			runtime,
+			message,
+			addressedTo: ["@sol_eth"],
+		});
+		expect(resolvedWithAt).toEqual([participantId]);
+
+		// 2. Lookup without '@'
+		const resolvedWithoutAt = await resolveAddressedTargets({
+			runtime,
+			message,
+			addressedTo: ["sol_eth"],
+		});
+		expect(resolvedWithoutAt).toEqual([participantId]);
+	});
+});

--- a/packages/core/src/runtime/addressed-to.ts
+++ b/packages/core/src/runtime/addressed-to.ts
@@ -249,13 +249,19 @@ export async function resolveAddressedTargets(
 		const byName = new Map<string, UUID>();
 		const agentName = runtime.character.name;
 		if (agentName) {
-			byName.set(normalize(agentName), runtime.agentId);
+			const normAgent = normalize(agentName.replace(/^@/, ""));
+			if (normAgent) {
+				byName.set(normAgent, runtime.agentId);
+			}
 		}
 		for (const entity of participants) {
 			const id = entity.id as UUID | undefined;
 			if (!id) continue;
 			for (const name of entityNames(entity)) {
-				byName.set(normalize(name), id);
+				const norm = normalize(name.replace(/^@/, ""));
+				if (norm) {
+					byName.set(norm, id);
+				}
 			}
 		}
 		for (const name of names) {

--- a/packages/core/src/runtime/addressed-to.ts
+++ b/packages/core/src/runtime/addressed-to.ts
@@ -259,9 +259,11 @@ export async function resolveAddressedTargets(
 			if (!id) continue;
 			for (const name of entityNames(entity)) {
 				const norm = normalize(name.replace(/^@/, ""));
-				if (norm) {
-					byName.set(norm, id);
-				}
+				if (!norm) continue;
+				// Stripping '@' collapses '@name' and 'name' into one key; never
+				// let a participant overwrite a key already bound to the agent.
+				if (byName.get(norm) === runtime.agentId) continue;
+				byName.set(norm, id);
 			}
 		}
 		for (const name of names) {


### PR DESCRIPTION
## Summary

Fixes #29168.

In `packages/core/src/runtime/addressed-to.ts`, `resolveAddressedTargets` strips a leading `@` from the lookup query (`name.replace(/^@/, "")`), but previously stored entity names in the `byName` map with the `@` intact.

As a result, entity names stored with platform handles (e.g. `"@sol_eth"` or `"@samantha_ai_bot"`) failed to resolve regardless of whether the lookup included or omitted `@`.

### Changes
- Strips leading `@` when populating `byName` for both `runtime.character.name` and `entity.names`.
- Adds unit tests covering `@handle` and plain `handle` lookups.