### PR TITLE
fix(ui): preserve launcher icon URLs in home fixtures

### DIFF
--- a/packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs
@@ -121,16 +121,17 @@ const stubResolver = {
   },
 };
 
-// The production launcher resolves packaged PNGs relative to the generated
-// module with `new URL(..., import.meta.url)`. This fixture is intentionally an
-// inline IIFE, where esbuild otherwise replaces import.meta with an empty
-// object and every icon URL throws before React can mount. Preserve the real
-// icon module and assets by binding only that module's import.meta.url to its
-// source file URL during the fixture build.
+// The production launcher resolves packaged PNG and SVG assets relative to its
+// icon modules with `new URL(..., import.meta.url)`. This fixture is
+// intentionally an inline IIFE, where esbuild otherwise replaces import.meta
+// with an empty object and every icon URL throws before React can mount.
+// Preserve the real icon modules and assets by binding their import.meta.url to
+// their source file URLs during the fixture build.
+const fixtureIconModule = /(?:view-icons\.generated|launcher-ionicons)\.ts$/;
 const fixtureViewIconUrls = {
   name: "home-fixture-view-icon-urls",
   setup(b) {
-    b.onLoad({ filter: /view-icons\.generated\.ts$/ }, async (args) => {
+    b.onLoad({ filter: fixtureIconModule }, async (args) => {
       const source = await readFile(args.path, "utf8");
       return {
         contents: source.replaceAll(

--- a/packages/ui/src/components/shell/__e2e__/run-launcher-loop-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-launcher-loop-e2e.mjs
@@ -147,16 +147,17 @@ const stubResolver = {
   },
 };
 
-// The production launcher resolves packaged PNGs relative to the generated
-// module with `new URL(..., import.meta.url)`. This fixture is intentionally an
-// inline IIFE, where esbuild otherwise replaces import.meta with an empty
-// object and every icon URL throws before React can mount. Bind only that
-// module's import.meta.url to its source file URL, matching the sibling home
+// The production launcher resolves packaged PNG and SVG assets relative to its
+// icon modules with `new URL(..., import.meta.url)`. This fixture is
+// intentionally an inline IIFE, where esbuild otherwise replaces import.meta
+// with an empty object and every icon URL throws before React can mount. Bind
+// their import.meta.url to their source file URLs, matching the sibling home
 // fixture that exercises the same surface.
+const fixtureIconModule = /(?:view-icons\.generated|launcher-ionicons)\.ts$/;
 const fixtureViewIconUrls = {
   name: "launcher-loop-fixture-view-icon-urls",
   setup(b) {
-    b.onLoad({ filter: /view-icons\.generated\.ts$/ }, async (args) => {
+    b.onLoad({ filter: fixtureIconModule }, async (args) => {
       const source = await readFile(args.path, "utf8");
       return {
         contents: source.replaceAll(


### PR DESCRIPTION
## Summary

- preserve source-relative URL rewriting for both launcher icon modules in the home-screen fixtures
- keep the existing generated PNG icon coverage while including the new Ionicons SVG module
- prevent inline-IIFE builds from replacing `import.meta` before React can mount

Fixes #29238

## Validation

- `node --check packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs`
- `node --check packages/ui/src/components/shell/__e2e__/run-launcher-loop-e2e.mjs`
- Bun smoke check for `resolveLauncherIconAsset()` and its vendored SVG URL
- esbuild IIFE transform proof for both `launcher-ionicons.ts` and `view-icons.generated.ts`
- `git diff --check`

The exact home-screen browser runner reached its fixture build locally, but the intentionally sparse shared harness does not contain `@radix-ui/react-slot`; the repository CI environment with full workspace dependencies remains the end-to-end authority.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@5e309560fa5bf659d77b13cce2c30ba28af8c500:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [root]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@5e309560fa5bf659d77b13cce2c30ba28af8c500:packages/skills/skills/contribute-to-eliza"} -->
