### PR TITLE
fix(cloud): distinguish staging session config from readiness

### DIFF
--- a/.github/workflows/cloud-cf-release.yml
+++ b/.github/workflows/cloud-cf-release.yml
@@ -1686,7 +1686,7 @@ jobs:
           echo "::error::Authenticated staging realtime canary did not prove the deployed route"
           exit 1
 
-      - name: Activate and verify staging session exchange after deploy proof
+      - name: Activate and verify staging session exchange configuration after deploy proof
         if: steps.cf.outputs.configured == 'true' && steps.freshness.outputs.should_deploy == 'true' && steps.env.outputs.deploy_environment == 'staging'
         working-directory: ${{ env.CHECKOUT_DIR }}/packages/cloud/api
         env:
@@ -1748,14 +1748,24 @@ jobs:
           const [path, expectedCommit, expectedEnabled] = process.argv.slice(2);
           const body = JSON.parse(fs.readFileSync(path, "utf8"));
           const status = body.stagingSessionExchange;
-          const enabled = status?.enabled === true;
           const expected = expectedEnabled === "true";
+          const statusIsObject =
+            status !== null && typeof status === "object" && !Array.isArray(status);
+          const versionIsSupported =
+            statusIsObject && (status.version === null || status.version === "v1");
           if (
             body.commit !== expectedCommit ||
             body.environment !== "staging" ||
-            enabled !== expected ||
-            (expected && (status?.ready !== true || status?.version !== "v1")) ||
-            (!expected && status?.ready !== false)
+            !statusIsObject ||
+            typeof status.enabled !== "boolean" ||
+            status.enabled !== expected ||
+            typeof status.configured !== "boolean" ||
+            status.ready !== false ||
+            !versionIsSupported ||
+            (expected &&
+              (status.configured !== true || status.version !== "v1")) ||
+            (!expected &&
+              (status.configured !== false || status.version !== null))
           ) {
             process.exit(1);
           }
@@ -1763,7 +1773,7 @@ jobs:
             then
               rm -f "$tmp"
               rollback_needed=false
-              echo "Staging session exchange cutover matches the exact deployed commit and desired state."
+              echo "Staging session exchange configuration matches the exact deployed commit and desired state."
               exit 0
             fi
             rm -f "$tmp"

--- a/packages/cloud/api/src/index.test.ts
+++ b/packages/cloud/api/src/index.test.ts
@@ -1174,7 +1174,7 @@ describe("cloud-api worker entrypoint", () => {
     expect(text).not.toContain("never-return-this-webhook-secret");
   });
 
-  test("reports only value-free staging session cutover readiness", async () => {
+  test("reports configuration separately without inferring operational readiness", async () => {
     const response = await cloudApiWorker.fetch(
       new Request("https://api-staging.eliza.app/api/health", {
         headers: { host: "api-staging.eliza.app" },
@@ -1206,8 +1206,9 @@ describe("cloud-api worker entrypoint", () => {
       commit: "cutover-commit",
       environment: "staging",
       stagingSessionExchange: {
+        configured: true,
         enabled: true,
-        ready: true,
+        ready: false,
         version: "v1",
       },
     });
@@ -1237,7 +1238,12 @@ describe("cloud-api worker entrypoint", () => {
       {} as never,
     );
     expect(await malformedResponse.json()).toMatchObject({
-      stagingSessionExchange: { enabled: true, ready: false, version: "v1" },
+      stagingSessionExchange: {
+        configured: false,
+        enabled: true,
+        ready: false,
+        version: "v1",
+      },
     });
 
     const serviceCollisionResponse = await cloudApiWorker.fetch(
@@ -1264,7 +1270,45 @@ describe("cloud-api worker entrypoint", () => {
       {} as never,
     );
     expect(await serviceCollisionResponse.json()).toMatchObject({
-      stagingSessionExchange: { enabled: true, ready: false, version: "v1" },
+      stagingSessionExchange: {
+        configured: false,
+        enabled: true,
+        ready: false,
+        version: "v1",
+      },
+    });
+
+    const disabledConfiguredResponse = await cloudApiWorker.fetch(
+      new Request("https://api-staging.eliza.app/api/health", {
+        headers: { host: "api-staging.eliza.app" },
+      }),
+      {
+        NODE_ENV: "production",
+        ENVIRONMENT: "staging",
+        STAGING_SESSION_EXCHANGE_ENABLED: "false",
+        STAGING_SESSION_EXCHANGE_VERSION: "v1",
+        STAGING_SESSION_EXCHANGE_SIGNING_SECRET:
+          "never-return-this-secret-0123456789abcdef",
+        ELIZA_SERVICE_JWT_SECRET:
+          "separate-service-bridge-secret-0123456789abcdef",
+        STAGING_SESSION_EXCHANGE_SIGNING_KEY_ID: "staging-qa-v1-test",
+        STEWARD_TENANT_ID: "staging-tenant",
+        STAGING_SESSION_EXCHANGE_ALLOWED_API_KEY_IDS:
+          "33333333-3333-4333-8333-333333333333",
+        STAGING_SESSION_EXCHANGE_ALLOWED_USER_IDS:
+          "11111111-1111-4111-8111-111111111111",
+        STAGING_SESSION_EXCHANGE_ALLOWED_ORGANIZATION_IDS:
+          "22222222-2222-4222-8222-222222222222",
+      } as never,
+      {} as never,
+    );
+    expect(await disabledConfiguredResponse.json()).toMatchObject({
+      stagingSessionExchange: {
+        configured: true,
+        enabled: false,
+        ready: false,
+        version: "v1",
+      },
     });
   });
 

--- a/packages/cloud/api/src/index.ts
+++ b/packages/cloud/api/src/index.ts
@@ -606,8 +606,10 @@ function healthResponse(env: AppEnv["Bindings"]): Response {
     env.ENVIRONMENT === "staging" &&
     env.STAGING_SESSION_EXCHANGE_ENABLED === "true" &&
     env.STAGING_SESSION_EXCHANGE_VERSION === "v1";
-  const stagingSessionReady =
-    stagingSessionEnabled &&
+  const stagingSessionConfigured =
+    env.NODE_ENV === "production" &&
+    env.ENVIRONMENT === "staging" &&
+    env.STAGING_SESSION_EXCHANGE_VERSION === "v1" &&
     stagingSessionSigningSecret.length >= 32 &&
     stagingSessionSigningSecret !== env.STEWARD_JWT_SECRET?.trim() &&
     stagingSessionSigningSecret !== env.STEWARD_SESSION_SECRET?.trim() &&
@@ -664,15 +666,18 @@ function healthResponse(env: AppEnv["Bindings"]): Response {
       schemaCompatibility: {
         usageQuotasTombstone: true,
       },
-      // Value-free cutover receipt for the default-off staging QA bridge. The
-      // deploy workflow proves exact code first, flips the secret last, then
-      // requires this beacon to report the expected version/readiness. No key,
-      // allowlist, kid, or subject value is exposed.
+      // Value-free configuration receipt for the default-off staging QA
+      // bridge. `configured` proves only that the binding shapes are valid;
+      // it deliberately cannot infer subject eligibility from primary data.
+      // Operational readiness remains false until a separate verified-subject
+      // receipt and provider-backed exchange exist. No key, allowlist, kid, or
+      // subject value is exposed.
       stagingSessionExchange:
         env.ENVIRONMENT === "staging"
           ? {
+              configured: stagingSessionConfigured,
               enabled: stagingSessionEnabled,
-              ready: stagingSessionReady,
+              ready: false,
               version: stagingSessionVersion,
             }
           : null,

--- a/packages/scripts/__tests__/cloud-cf-atomic-worker-secrets-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-atomic-worker-secrets-workflow.test.ts
@@ -141,7 +141,7 @@ describe("Cloud CF atomic Worker secrets deploy", () => {
   test("keeps post-deploy session activation separate from the atomic payload", () => {
     const prepare = step("Prepare Worker secrets for atomic deploy");
     const activation = step(
-      "Activate and verify staging session exchange after deploy proof",
+      "Activate and verify staging session exchange configuration after deploy proof",
     );
     expect(prepare.run).not.toContain(
       "wrangler secret put STAGING_SESSION_EXCHANGE_ENABLED",
@@ -150,7 +150,9 @@ describe("Cloud CF atomic Worker secrets deploy", () => {
       "wrangler secret put STAGING_SESSION_EXCHANGE_ENABLED --env staging",
     );
     expect(index("Verify deployed API commit")).toBeLessThan(
-      index("Activate and verify staging session exchange after deploy proof"),
+      index(
+        "Activate and verify staging session exchange configuration after deploy proof",
+      ),
     );
   });
 });

--- a/packages/scripts/__tests__/cloud-cf-staging-session-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-staging-session-deploy-workflow.test.ts
@@ -1,7 +1,10 @@
 /** Fail-closed ordering and input contracts for the staging QA auth cutover. */
 
 import { describe, expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { validateStagingSessionCutoverConfig } from "../../cloud/scripts/validate-staging-session-cutover.mjs";
 
 // The mutating `deploy-api` job lives in the reusable release workflow that
@@ -36,6 +39,40 @@ function index(name: string): number {
   return steps.findIndex((candidate) => candidate.name === name);
 }
 
+function runServedStateProof(
+  body: unknown,
+  expectedEnabled: boolean,
+): number | null {
+  const activation = step(
+    "Activate and verify staging session exchange configuration after deploy proof",
+  );
+  const proofScript = activation.run?.match(
+    /node - "\$tmp" "\$GITHUB_SHA" "\$expected_enabled" <<'NODE'\n([\s\S]*?)\n\s*NODE\b/,
+  )?.[1];
+  if (!proofScript) throw new Error("Missing served-state proof script");
+
+  const directory = mkdtempSync(join(tmpdir(), "staging-session-proof-"));
+  const responsePath = join(directory, "health.json");
+  try {
+    writeFileSync(responsePath, JSON.stringify(body));
+    return spawnSync(
+      "node",
+      [
+        "-",
+        responsePath,
+        "expected-commit",
+        expectedEnabled ? "true" : "false",
+      ],
+      {
+        input: proofScript,
+        encoding: "utf8",
+      },
+    ).status;
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+}
+
 const VALID = {
   DEPLOY_ENVIRONMENT: "staging",
   STAGING_SESSION_EXCHANGE_DESIRED_ENABLED: "true",
@@ -59,7 +96,7 @@ describe("Cloud CF staging session cutover", () => {
       "Prepare Worker secrets for atomic deploy",
       "Deploy to Cloudflare Workers",
       "Verify deployed API commit",
-      "Activate and verify staging session exchange after deploy proof",
+      "Activate and verify staging session exchange configuration after deploy proof",
     ].map(index);
     expect(ordered.every((value) => value >= 0)).toBe(true);
     expect(ordered).toEqual([...ordered].sort((a, b) => a - b));
@@ -87,14 +124,16 @@ describe("Cloud CF staging session cutover", () => {
     );
 
     const activation = step(
-      "Activate and verify staging session exchange after deploy proof",
+      "Activate and verify staging session exchange configuration after deploy proof",
     );
     expect(activation.if).toContain("steps.freshness.outputs.should_deploy");
     expect(activation.run).toContain(
       "wrangler secret put STAGING_SESSION_EXCHANGE_ENABLED --env staging",
     );
     expect(activation.run).toContain("trap rollback_on_unproven_exit EXIT");
-    expect(activation.run).toContain("status?.ready !== true");
+    expect(activation.run).toContain('typeof status.enabled !== "boolean"');
+    expect(activation.run).toContain('typeof status.configured !== "boolean"');
+    expect(activation.run).toContain("status.ready !== false");
     expect(activation.run).toContain("ensure-worker-secret-absent.mjs");
     expect(activation.run).not.toContain('grep -qi "not found"');
     expect(
@@ -104,6 +143,79 @@ describe("Cloud CF staging session cutover", () => {
     ).toBeLessThan(
       activation.run?.indexOf("body.stagingSessionExchange") ?? -1,
     );
+  });
+
+  test("executes a strict served-state matrix for enabled and disabled receipts", () => {
+    const receipt = (stagingSessionExchange: unknown) => ({
+      commit: "expected-commit",
+      environment: "staging",
+      stagingSessionExchange,
+    });
+
+    for (const [expectedEnabled, status] of [
+      [true, { configured: true, enabled: true, ready: false, version: "v1" }],
+      [
+        false,
+        { configured: false, enabled: false, ready: false, version: null },
+      ],
+    ] as const) {
+      expect(runServedStateProof(receipt(status), expectedEnabled)).toBe(0);
+    }
+
+    for (const [expectedEnabled, status] of [
+      [false, undefined],
+      [false, null],
+      [false, []],
+      [false, {}],
+      [false, { configured: false, enabled: "false", version: null }],
+      [false, { enabled: false, version: null }],
+      [false, { configured: "false", enabled: false, version: null }],
+      [false, { configured: false, enabled: false }],
+      [false, { configured: true, enabled: false, version: null }],
+      [false, { configured: true, enabled: false, version: "v1" }],
+      [false, { configured: false, enabled: false, version: "v1" }],
+      [false, { configured: false, enabled: false, version: "v2" }],
+      [false, { configured: false, enabled: false, version: null }],
+      [
+        false,
+        { configured: false, enabled: false, ready: true, version: null },
+      ],
+      [true, { configured: false, enabled: true, version: "v1" }],
+      [true, { configured: true, enabled: false, version: "v1" }],
+      [true, { configured: true, enabled: true, version: "v1" }],
+      [true, { configured: true, enabled: true, ready: true, version: "v1" }],
+    ] as const) {
+      expect(runServedStateProof(receipt(status), expectedEnabled)).toBe(1);
+    }
+
+    expect(
+      runServedStateProof(
+        {
+          commit: "wrong-commit",
+          environment: "staging",
+          stagingSessionExchange: {
+            configured: true,
+            enabled: true,
+            version: "v1",
+          },
+        },
+        true,
+      ),
+    ).toBe(1);
+    expect(
+      runServedStateProof(
+        {
+          commit: "expected-commit",
+          environment: "production",
+          stagingSessionExchange: {
+            configured: true,
+            enabled: true,
+            version: "v1",
+          },
+        },
+        true,
+      ),
+    ).toBe(1);
   });
 
   test("rejects malformed UUID allowlists without echoing their values", () => {
@@ -190,13 +302,15 @@ describe("Cloud CF staging session cutover", () => {
     // present. Activation follows both deploy and exact-commit proof and has no
     // override, so either failure leaves the off-first state served.
     const activation = step(
-      "Activate and verify staging session exchange after deploy proof",
+      "Activate and verify staging session exchange configuration after deploy proof",
     );
     expect(index("Deploy to Cloudflare Workers")).toBeLessThan(
       index("Verify deployed API commit"),
     );
     expect(index("Verify deployed API commit")).toBeLessThan(
-      index("Activate and verify staging session exchange after deploy proof"),
+      index(
+        "Activate and verify staging session exchange configuration after deploy proof",
+      ),
     );
     expect(activation.if).not.toContain("always()");
     expect(activation.if).not.toContain("failure()");


### PR DESCRIPTION
## Summary

- expose a value-free configured state for the staging QA session exchange without inferring subject eligibility
- keep operational ready false until a verified-subject receipt and provider-backed exchange exist
- make the release proof validate the exact health contract, reject malformed receipts, and prove complete cleanup when the desired state is off
- preserve the existing default-off gate and secret-value redaction

## Validation

- Mechanical terminal rebase onto exact `develop@6a6fee4d42403a79920ae1958baca0592d91590d`; range-diff is exact `=` and stable patch-id remains `c8d0f80a1438303d56e2ad116d45613d798cc2a8`
- Refreshed exact-head overlap gate: 109 pass, 0 fail across the owned tests plus current database-identity migration/workflow tests
- Cloud API entrypoint tests: 53 pass, 0 fail
- staging cutover and atomic-secret workflow tests: 11 pass, 0 fail
- workflow policy and release guard tests: 35 pass, 0 fail
- Cloud API Biome check and typecheck with Wrangler dry-run
- actionlint, AGENTS/CLAUDE parity, and git diff check
- two read-only adversarial reviews; no findings remain

The package-wide Cloud API lane was also run and is not fully green: 24 of 565 files failed. A read-only causality audit found none attributable to this five-file patch. The directly related staging-session security suite reproduces identically on the clean base SHA and this branch: 54 pass, 1 stale 403-versus-401 assertion failure. The other 23 failures are outside the only changed runtime import boundary and execute in isolated test processes; they were not individually rerun on the base.

## Not proved by this PR

- an eligible authoritative staging fixture or presented-key custody
- a live mint, authenticated route, logout, expiry, revocation, renewal, or reset
- deployment or the currently served staging health response
- production or provider state

No account, key, allowlist, Worker binding, database row, login session, deployment, or provider state was changed.

Refs #28511
Parent: #25025

<!-- evidence-head:75db79550a12ddcf59fb0ed6167617ca45ee27b7 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no UI surface changed; this patch changes a Worker health contract and release workflow only

<!-- evidence-row:after-screenshots -->
- [ ] N/A - no UI surface changed; this patch changes a Worker health contract and release workflow only

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive user flow changed

<!-- evidence-row:backend-logs -->
- [x] [29248-pr29248-health.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29248-pr29248-health.log)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code or runtime changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model or agent behavior changed

<!-- evidence-row:domain-artifacts -->
- [x] [29248-pr29248-workflows.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29248-pr29248-workflows.log)

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual artifact exists
