### PR TITLE
fix(ui): restore Android auth release gates

### DIFF
--- a/packages/ui/scripts/duplicate-molecular-components-report.md
+++ b/packages/ui/scripts/duplicate-molecular-components-report.md
@@ -1,6 +1,6 @@
 # Molecular component duplicate inventory
 
-Scanned 895 maintained React files. 100 exported compositions have a recognized molecular role and at least two atomic dependencies.
+Scanned 897 maintained React files. 100 exported compositions have a recognized molecular role and at least two atomic dependencies.
 
 Clusters share both a role and an atomic dependency signature. Detection creates a review queue; this committed report contains only final dispositions based on product behavior, state ownership, and responsive layout.
 

--- a/packages/ui/src/components/pages/PluginVisual.tsx
+++ b/packages/ui/src/components/pages/PluginVisual.tsx
@@ -42,6 +42,11 @@ const PROVIDER_LOGO_IDS = new Set([
   "zai",
 ]);
 
+const PLUGIN_VISUAL_LAYOUT_STYLES = {
+  md: { height: "2.75rem", width: "2.75rem" },
+  lg: { height: "3.5rem", width: "3.5rem" },
+} as const;
+
 /**
  * Resolve the strongest available visual for a plugin and render it as a square
  * tile. Resolution order: brand SVG logo (connectors) → AI-provider brand PNG →
@@ -56,7 +61,6 @@ export function PluginVisual({
   size?: "md" | "lg";
 }) {
   const [imgFailed, setImgFailed] = useState(false);
-  const dimension = size === "lg" ? "h-14 w-14" : "h-11 w-11";
   const glyph = size === "lg" ? "h-7 w-7" : "h-6 w-6";
   const monogramText = size === "lg" ? "text-lg" : "text-base";
 
@@ -66,7 +70,8 @@ export function PluginVisual({
       <Card
         variant="connectorAvatar"
         tone="text"
-        className={`flex ${dimension} shrink-0 items-center justify-center`}
+        layoutStyle={PLUGIN_VISUAL_LAYOUT_STYLES[size]}
+        className="flex shrink-0 items-center justify-center"
       >
         <BrandIcon className={glyph} />
       </Card>
@@ -79,7 +84,8 @@ export function PluginVisual({
       <Card
         variant="connectorAvatar"
         padding="compact"
-        className={`flex ${dimension} shrink-0 items-center justify-center`}
+        layoutStyle={PLUGIN_VISUAL_LAYOUT_STYLES[size]}
+        className="flex shrink-0 items-center justify-center"
       >
         <img
           src={logo}
@@ -99,7 +105,8 @@ export function PluginVisual({
         <Card
           variant="connectorAvatar"
           padding="compact"
-          className={`flex ${dimension} shrink-0 items-center justify-center`}
+          layoutStyle={PLUGIN_VISUAL_LAYOUT_STYLES[size]}
+          className="flex shrink-0 items-center justify-center"
         >
           <img
             src={imageSrc}
@@ -117,7 +124,8 @@ export function PluginVisual({
     return (
       <Card
         variant="connectorAvatar"
-        className={`flex ${dimension} shrink-0 items-center justify-center`}
+        layoutStyle={PLUGIN_VISUAL_LAYOUT_STYLES[size]}
+        className="flex shrink-0 items-center justify-center"
       >
         <Glyph className={glyph} />
       </Card>
@@ -128,14 +136,15 @@ export function PluginVisual({
   return (
     <Card
       variant="connectorAvatar"
-      className={`flex ${dimension} shrink-0 select-none items-center justify-center font-bold tracking-tight ${monogramText}`}
+      layoutStyle={PLUGIN_VISUAL_LAYOUT_STYLES[size]}
+      className="flex shrink-0 select-none items-center justify-center font-bold tracking-tight"
       visualStyle={{
         background: pluginTileGradient(plugin),
       }}
       wallpaperText
       aria-hidden="true"
     >
-      {pluginMonogram(plugin)}
+      <span className={monogramText}>{pluginMonogram(plugin)}</span>
     </Card>
   );
 }

--- a/packages/ui/src/components/shell/AssistantOverlay.tsx
+++ b/packages/ui/src/components/shell/AssistantOverlay.tsx
@@ -137,7 +137,7 @@ export function AssistantOverlay({
       // pseudo-elements. This overlay is itself the anchored surface, so keep
       // the fixed-position contract explicit at higher precedence.
       style={{ zIndex: Z_SHELL_OVERLAY + 1 }}
-      className="pointer-events-auto fixed inset-x-0 bottom-0 h-[80vh] sm:left-1/2 sm:right-auto sm:top-1/2 sm:bottom-auto sm:h-[min(640px,80vh)] sm:w-[min(560px,90vw)] sm:-translate-x-1/2 sm:-translate-y-1/2"
+      className="shell-assistant-overlay-positioner pointer-events-auto fixed inset-x-0 bottom-0 h-[80vh] sm:left-1/2 sm:right-auto sm:top-1/2 sm:bottom-auto sm:h-[min(640px,80vh)] sm:w-[min(560px,90vw)] sm:-translate-x-1/2 sm:-translate-y-1/2"
     >
       <Card
         surface="transparent"
@@ -169,7 +169,7 @@ export function AssistantOverlay({
         visualStyle={{
           borderColor: "var(--assistant-overlay-border)",
         }}
-        className="shell-assistant-overlay-panel h-full w-full overflow-hidden motion-safe:animate-[shell-overlay-in_220ms_ease-out]"
+        className="h-full w-full overflow-hidden motion-safe:animate-[shell-overlay-in_220ms_ease-out]"
       >
         <Button
           variant="ghostMuted"

--- a/packages/ui/src/i18n/locales/en.json
+++ b/packages/ui/src/i18n/locales/en.json
@@ -1948,6 +1948,8 @@
   "cloud.legal.terms.linkToPrivacy": "Privacy Policy",
   "cloud.legal.terms.meta.description": "Terms of Service for Eliza Cloud — read the terms and conditions for using our AI agent development platform.",
   "cloud.legal.terms.meta.title": "Terms of Service | Eliza Cloud",
+  "cloud.login.accountSwitch.retry": "Try again",
+  "cloud.login.accountSwitch.title": "Couldn't switch accounts",
   "cloud.login.backToLogin": "← Back to login",
   "cloud.login.button.discord": "Discord",
   "cloud.login.button.github": "GitHub",

--- a/packages/ui/src/styles/styles.css
+++ b/packages/ui/src/styles/styles.css
@@ -175,7 +175,7 @@ html.eliza-chat-overlay-shell #root {
   pointer-events: none;
 }
 
-html.eliza-chat-overlay-shell .shell-assistant-overlay-panel {
+html.eliza-chat-overlay-shell .shell-assistant-overlay-positioner {
   /* Card owns the fixed dark palette and glass paint; this shell selector
      keeps only native-popup placement and animation geometry. */
   top: auto;


### PR DESCRIPTION
Fixes #29233
Fixes #29245

## Summary
- catalog the Android Cloud account-switch failure copy
- keep PluginVisual runtime size geometry in Card.layoutStyle
- move AssistantOverlay shell placement CSS to its wrapper
- refresh canonical molecular report without widening baselines or exceptions

## Verification
- `bun run check:i18n`
- `bun run --cwd packages/ui typecheck`
- focused AssistantOverlay tests (13 passed)
- UI tight design-system inventory: all zero
- molecular inventory current
- `bun run --cwd packages/app audit:app` (215 passed; broken=0, needs-work=0; OCR broken=0)
- `bun run verify` (375/375 workspace tasks plus repository audits)