### PR TITLE
[P0][staging] Align WhatsApp readiness to complete runtime authorities

### DIFF
--- a/packages/cloud/shared/scripts/managed-accounts-doctor.test.mjs
+++ b/packages/cloud/shared/scripts/managed-accounts-doctor.test.mjs
@@ -21,6 +21,14 @@ const REQUIRED_ENV = {
   DISCORD_BOT_TOKEN: "contract-value",
 };
 
+const WHATSAPP_ENV = [
+  "ELIZA_APP_WHATSAPP_ACCESS_TOKEN",
+  "ELIZA_APP_WHATSAPP_PHONE_NUMBER_ID",
+  "ELIZA_APP_WHATSAPP_APP_SECRET",
+  "ELIZA_APP_WHATSAPP_VERIFY_TOKEN",
+];
+const WHATSAPP_CONTRACT_VALUE = "whatsapp-doctor-value-never-print";
+
 function run(cliArgs, env = {}) {
   return spawnSync(process.execPath, [SCRIPT, ...cliArgs], {
     encoding: "utf8",
@@ -76,4 +84,23 @@ test("placeholder credential values do not count as provisioned", () => {
   });
   assert.equal(result.status, 1, `${result.stdout}\n${result.stderr}`);
   assert.match(result.stderr, /telegram/);
+});
+
+test("WhatsApp doctor exposes missing, partial, and configured 4-of-4 states without values", () => {
+  for (const [count, expectedState] of [
+    [0, "missing"],
+    [3, "partial"],
+    [4, "configured"],
+  ]) {
+    const env = Object.fromEntries(
+      WHATSAPP_ENV.slice(0, count).map((name) => [name, WHATSAPP_CONTRACT_VALUE]),
+    );
+    const result = run(["--json", "--category=social_communications"], env);
+    assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+    const report = JSON.parse(result.stdout).reports.find(
+      (candidate) => candidate.id === "meta-whatsapp",
+    );
+    assert.equal(report?.state, expectedState);
+    assert.doesNotMatch(result.stdout, /whatsapp-doctor-value-never-print/);
+  }
 });

--- a/packages/cloud/shared/scripts/messaging-gateway-preflight-contract.mjs
+++ b/packages/cloud/shared/scripts/messaging-gateway-preflight-contract.mjs
@@ -1,0 +1,29 @@
+/**
+ * Defines the complete WhatsApp credential authorities used by the gateway
+ * preflight and resolves the smallest actionable missing-reference set.
+ */
+
+export const WHATSAPP_CREDENTIAL_SETS = [
+  [
+    "WHATSAPP_ACCESS_TOKEN",
+    "WHATSAPP_PHONE_NUMBER_ID",
+    "WHATSAPP_APP_SECRET",
+    "WHATSAPP_VERIFY_TOKEN",
+  ],
+  [
+    "ELIZA_APP_WHATSAPP_ACCESS_TOKEN",
+    "ELIZA_APP_WHATSAPP_PHONE_NUMBER_ID",
+    "ELIZA_APP_WHATSAPP_APP_SECRET",
+    "ELIZA_APP_WHATSAPP_VERIFY_TOKEN",
+  ],
+];
+
+export function missingWhatsAppCredentialRefs(env) {
+  const [nearest, ...candidates] = WHATSAPP_CREDENTIAL_SETS.map((set) =>
+    set.filter((name) => !env[name]?.trim()),
+  );
+  return candidates.reduce(
+    (current, candidate) => (candidate.length < current.length ? candidate : current),
+    nearest,
+  );
+}

--- a/packages/cloud/shared/scripts/messaging-gateway-preflight.mjs
+++ b/packages/cloud/shared/scripts/messaging-gateway-preflight.mjs
@@ -7,6 +7,8 @@
  * or deterministic contract sentinels.
  */
 
+import { missingWhatsAppCredentialRefs } from "./messaging-gateway-preflight-contract.mjs";
+
 const args = new Set(process.argv.slice(2));
 const strict = args.has("--strict");
 const channelsArg = process.argv.find((arg) => arg.startsWith("--channels="));
@@ -78,18 +80,13 @@ function checkDiscord() {
 }
 
 function checkWhatsApp() {
-  const missingWhatsapp = missing([
-    ["WHATSAPP_ACCESS_TOKEN", "ELIZA_APP_WHATSAPP_ACCESS_TOKEN"],
-    ["WHATSAPP_PHONE_NUMBER_ID", "ELIZA_APP_WHATSAPP_PHONE_NUMBER_ID"],
-    ["WHATSAPP_APP_SECRET", "ELIZA_APP_WHATSAPP_APP_SECRET"],
-    ["WHATSAPP_VERIFY_TOKEN", "ELIZA_APP_WHATSAPP_VERIFY_TOKEN"],
-  ]);
+  const missingWhatsapp = missingWhatsAppCredentialRefs(process.env);
   addCheck(
     "whatsapp",
     "Meta credentials",
     missingWhatsapp.length === 0,
     "WhatsApp Business Platform credentials are configured",
-    `Missing: ${missingWhatsapp.join(", ")}`,
+    `Missing from nearest complete set: ${missingWhatsapp.join(", ")}`,
   );
 }
 

--- a/packages/cloud/shared/scripts/messaging-gateway-preflight.test.mjs
+++ b/packages/cloud/shared/scripts/messaging-gateway-preflight.test.mjs
@@ -8,6 +8,10 @@ import { spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import test from "node:test";
+import {
+  missingWhatsAppCredentialRefs,
+  WHATSAPP_CREDENTIAL_SETS,
+} from "./messaging-gateway-preflight-contract.mjs";
 
 const REPOSITORY_ROOT = path.resolve(import.meta.dirname, "../../../..");
 const SCRIPT = path.join(
@@ -15,6 +19,7 @@ const SCRIPT = path.join(
   "packages/cloud/shared/scripts/messaging-gateway-preflight.mjs",
 );
 const WORKFLOW = path.join(REPOSITORY_ROOT, ".github/workflows/cloud-gateway-discord.yml");
+const DEVELOP_WORKFLOW = path.join(REPOSITORY_ROOT, ".github/workflows/develop-full.yml");
 
 const SHARED_ENV = {
   ELIZACLOUD_API_URL: "https://api.example.invalid",
@@ -23,6 +28,8 @@ const SHARED_ENV = {
   ELIZA_APP_WEBHOOK_GATEWAY_SECRET: "contract-value",
   GATEWAY_INTERNAL_SECRET: "contract-value",
 };
+
+const WHATSAPP_CONTRACT_VALUE = "whatsapp-contract-value-never-print";
 
 function runStrict(channels, env = {}) {
   return spawnSync(process.execPath, [SCRIPT, "--strict", `--channels=${channels}`], {
@@ -70,12 +77,58 @@ test("channel scoping does not require unrelated connector credentials", () => {
   assert.doesNotMatch(result.stdout, /telegram|whatsapp|imessage/i);
 });
 
-test("workflow keeps trusted configuration checks manual and source tests on develop", () => {
+test("WhatsApp readiness requires one complete authority across all 256 states", () => {
+  const allNames = WHATSAPP_CREDENTIAL_SETS.flat();
+  const combinations = 1 << allNames.length;
+
+  for (let mask = 0; mask < combinations; mask += 1) {
+    const env = Object.fromEntries(
+      allNames
+        .filter((_, index) => (mask & (1 << index)) !== 0)
+        .map((name) => [name, WHATSAPP_CONTRACT_VALUE]),
+    );
+    const hasCompleteAuthority = WHATSAPP_CREDENTIAL_SETS.some((credentialSet) =>
+      credentialSet.every((name) => Boolean(env[name])),
+    );
+    const missing = missingWhatsAppCredentialRefs(env);
+    assert.equal(missing.length === 0, hasCompleteAuthority);
+    assert.doesNotMatch(JSON.stringify(missing), /whatsapp-contract-value-never-print/);
+  }
+});
+
+test("WhatsApp strict preflight wires complete and split authorities without leaking values", () => {
+  for (const credentialSet of WHATSAPP_CREDENTIAL_SETS) {
+    const env = Object.fromEntries(credentialSet.map((name) => [name, WHATSAPP_CONTRACT_VALUE]));
+    const result = runStrict("whatsapp", env);
+    const output = `${result.stdout}\n${result.stderr}`;
+    assert.equal(result.status, 0, output);
+    assert.match(result.stdout, /All gateway preflight checks passed/);
+    assert.doesNotMatch(output, /whatsapp-contract-value-never-print/);
+  }
+
+  const splitEnv = Object.fromEntries(
+    WHATSAPP_CREDENTIAL_SETS.flatMap((credentialSet, setIndex) =>
+      credentialSet
+        .filter((_, index) => index % 2 === setIndex)
+        .map((name) => [name, WHATSAPP_CONTRACT_VALUE]),
+    ),
+  );
+  const split = runStrict("whatsapp", splitEnv);
+  const splitOutput = `${split.stdout}\n${split.stderr}`;
+  assert.equal(split.status, 1, splitOutput);
+  assert.match(split.stdout, /\[fail\] whatsapp: Meta credentials/);
+  assert.doesNotMatch(splitOutput, /whatsapp-contract-value-never-print/);
+});
+
+test("workflow keeps trusted checks manual and source tests reusable from develop", () => {
   const workflow = readFileSync(WORKFLOW, "utf8");
+  const developWorkflow = readFileSync(DEVELOP_WORKFLOW, "utf8");
 
   assert.match(workflow, /workflow_dispatch:/);
-  assert.match(workflow, /branches: \[develop\]/);
+  assert.match(workflow, /workflow_call:/);
   assert.doesNotMatch(workflow, /pull_request/);
+  assert.match(developWorkflow, /branches: \[develop\]/);
+  assert.match(developWorkflow, /uses: \.\/\.github\/workflows\/cloud-gateway-discord\.yml/);
   assert.match(workflow, /Enforce trusted messaging gateway configuration/);
   assert.match(workflow, /if: github\.event_name == 'workflow_dispatch'/);
   assert.match(

--- a/packages/cloud/shared/src/lib/config/managed-accounts.test.ts
+++ b/packages/cloud/shared/src/lib/config/managed-accounts.test.ts
@@ -131,6 +131,21 @@ describe("managed-account manifest invariants", () => {
 
 const CONFIGURED = "configured-contract-value";
 
+const WHATSAPP_CREDENTIAL_SETS = [
+  [
+    "WHATSAPP_ACCESS_TOKEN",
+    "WHATSAPP_PHONE_NUMBER_ID",
+    "WHATSAPP_APP_SECRET",
+    "WHATSAPP_VERIFY_TOKEN",
+  ],
+  [
+    "ELIZA_APP_WHATSAPP_ACCESS_TOKEN",
+    "ELIZA_APP_WHATSAPP_PHONE_NUMBER_ID",
+    "ELIZA_APP_WHATSAPP_APP_SECRET",
+    "ELIZA_APP_WHATSAPP_VERIFY_TOKEN",
+  ],
+] as const;
+
 const sample: ManagedAccountSpec = {
   id: "sample",
   name: "Sample",
@@ -232,5 +247,30 @@ describe("verifyManagedAccounts", () => {
   it("never places credential values in a report", () => {
     const { reports } = verifyManagedAccounts({ TELEGRAM_BOT_TOKEN: "secret-token-value" });
     expect(JSON.stringify(reports)).not.toContain("secret-token-value");
+  });
+});
+
+describe("managed WhatsApp 4-of-4 readiness contract", () => {
+  const whatsapp = MANAGED_ACCOUNTS.find((spec) => spec.id === "meta-whatsapp");
+  if (!whatsapp) throw new Error("meta-whatsapp managed account is missing");
+
+  it("classifies all 256 cross-namespace states without accepting split custody", () => {
+    const allNames = WHATSAPP_CREDENTIAL_SETS.flat();
+    const combinations = 1 << allNames.length;
+    for (let mask = 0; mask < combinations; mask += 1) {
+      const env: Record<string, string> = {};
+      for (const [index, name] of allNames.entries()) {
+        if ((mask & (1 << index)) !== 0) env[name] = CONFIGURED;
+      }
+
+      const report = evaluateManagedAccount(whatsapp, env);
+      const hasCompleteAuthority = WHATSAPP_CREDENTIAL_SETS.some((credentialSet) =>
+        credentialSet.every((name) => Boolean(env[name])),
+      );
+      expect(report.state).toBe(
+        hasCompleteAuthority ? "configured" : mask === 0 ? "missing" : "partial",
+      );
+      expect(JSON.stringify(report)).not.toContain(CONFIGURED);
+    }
   });
 });

--- a/packages/cloud/shared/src/lib/config/managed-accounts.ts
+++ b/packages/cloud/shared/src/lib/config/managed-accounts.ts
@@ -238,9 +238,15 @@ export const MANAGED_ACCOUNTS: readonly ManagedAccountSpec[] = [
     category: "social_communications",
     console: "https://developers.facebook.com",
     credentialSets: [
-      ["WHATSAPP_ACCESS_TOKEN", "WHATSAPP_APP_SECRET", "WHATSAPP_VERIFY_TOKEN"],
+      [
+        "WHATSAPP_ACCESS_TOKEN",
+        "WHATSAPP_PHONE_NUMBER_ID",
+        "WHATSAPP_APP_SECRET",
+        "WHATSAPP_VERIFY_TOKEN",
+      ],
       [
         "ELIZA_APP_WHATSAPP_ACCESS_TOKEN",
+        "ELIZA_APP_WHATSAPP_PHONE_NUMBER_ID",
         "ELIZA_APP_WHATSAPP_APP_SECRET",
         "ELIZA_APP_WHATSAPP_VERIFY_TOKEN",
       ],

--- a/packages/cloud/shared/src/lib/services/eliza-app/config.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/config.error-policy.test.ts
@@ -1,7 +1,8 @@
-// Pins the fail-closed error policy of the eliza-app config: the required JWT
-// secret and enabled-but-unconfigured channels must THROW (internal
-// misconfiguration surfaces), while a genuinely-optional, unconfigured channel
-// stays a distinguishable designed-empty value rather than a thrown failure.
+/**
+ * Pins the fail-closed error policy of the eliza-app config: the required JWT
+ * secret and enabled-but-unconfigured channels must throw, while a genuinely
+ * optional, unconfigured channel stays a distinguishable designed-empty value.
+ */
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 
 const TOUCHED_ENV = [
@@ -15,6 +16,19 @@ const TOUCHED_ENV = [
   "ELIZA_APP_DISCORD_CLIENT_SECRET",
   "ELIZA_APP_BLOOIO_ENABLED",
   "ELIZA_APP_BLOOIO_API_KEY",
+  "ELIZA_APP_WHATSAPP_ENABLED",
+  "ELIZA_APP_WHATSAPP_ACCESS_TOKEN",
+  "ELIZA_APP_WHATSAPP_PHONE_NUMBER_ID",
+  "ELIZA_APP_WHATSAPP_APP_SECRET",
+  "ELIZA_APP_WHATSAPP_VERIFY_TOKEN",
+  "ELIZA_APP_WHATSAPP_PHONE_NUMBER",
+] as const;
+
+const WHATSAPP_REQUIRED_ENV = [
+  "ELIZA_APP_WHATSAPP_ACCESS_TOKEN",
+  "ELIZA_APP_WHATSAPP_PHONE_NUMBER_ID",
+  "ELIZA_APP_WHATSAPP_APP_SECRET",
+  "ELIZA_APP_WHATSAPP_VERIFY_TOKEN",
 ] as const;
 
 let saved: Record<string, string | undefined>;
@@ -94,5 +108,36 @@ describe("eliza-app config fail-closed policy", () => {
     // required secret -> thrown error. A caller can tell them apart.
     expect(elizaAppConfig.telegram.botToken).toBe("");
     expect(() => elizaAppConfig.jwt.secret).toThrow();
+  });
+
+  it("requires the complete WhatsApp 4-of-4 runtime contract", async () => {
+    const { validateElizaAppConfig } = await loadConfig();
+    process.env.ELIZA_APP_JWT_SECRET = "s3cr3t-value";
+
+    const combinations = 1 << WHATSAPP_REQUIRED_ENV.length;
+    for (let mask = 0; mask < combinations; mask += 1) {
+      for (const name of WHATSAPP_REQUIRED_ENV) delete process.env[name];
+      delete process.env.ELIZA_APP_WHATSAPP_ENABLED;
+      for (const [index, name] of WHATSAPP_REQUIRED_ENV.entries()) {
+        if ((mask & (1 << index)) !== 0) process.env[name] = "configured-contract-value";
+      }
+
+      const supplied = WHATSAPP_REQUIRED_ENV.filter(
+        (_, index) => (mask & (1 << index)) !== 0,
+      ).length;
+      if (supplied === 0 || supplied === WHATSAPP_REQUIRED_ENV.length) {
+        expect(() => validateElizaAppConfig()).not.toThrow();
+      } else {
+        expect(() => validateElizaAppConfig()).toThrow(/WhatsApp is enabled/);
+      }
+    }
+
+    for (const name of WHATSAPP_REQUIRED_ENV) delete process.env[name];
+    process.env.ELIZA_APP_WHATSAPP_ENABLED = "true";
+    expect(() => validateElizaAppConfig()).toThrow(/WhatsApp is enabled/);
+
+    delete process.env.ELIZA_APP_WHATSAPP_ENABLED;
+    process.env.ELIZA_APP_WHATSAPP_PHONE_NUMBER = "+15551234567";
+    expect(() => validateElizaAppConfig()).not.toThrow();
   });
 });

--- a/packages/cloud/shared/src/lib/services/eliza-app/config.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/config.ts
@@ -152,8 +152,7 @@ export function validateElizaAppConfig() {
       process.env.ELIZA_APP_WHATSAPP_ACCESS_TOKEN ||
         process.env.ELIZA_APP_WHATSAPP_PHONE_NUMBER_ID ||
         process.env.ELIZA_APP_WHATSAPP_APP_SECRET ||
-        process.env.ELIZA_APP_WHATSAPP_VERIFY_TOKEN ||
-        process.env.ELIZA_APP_WHATSAPP_PHONE_NUMBER,
+        process.env.ELIZA_APP_WHATSAPP_VERIFY_TOKEN,
     );
 
   if (
@@ -161,8 +160,7 @@ export function validateElizaAppConfig() {
     (!process.env.ELIZA_APP_WHATSAPP_ACCESS_TOKEN ||
       !process.env.ELIZA_APP_WHATSAPP_PHONE_NUMBER_ID ||
       !process.env.ELIZA_APP_WHATSAPP_APP_SECRET ||
-      !process.env.ELIZA_APP_WHATSAPP_VERIFY_TOKEN ||
-      !process.env.ELIZA_APP_WHATSAPP_PHONE_NUMBER)
+      !process.env.ELIZA_APP_WHATSAPP_VERIFY_TOKEN)
   ) {
     throw new Error("WhatsApp is enabled but required WhatsApp env vars are not set in production");
   }


### PR DESCRIPTION
## Summary

- Requires one complete WhatsApp credential namespace, preventing split legacy/canonical custody from being reported ready.
- Aligns the managed-account doctor, strict gateway preflight, and Eliza App runtime on the four credentials actually required for webhook verification and delivery: access token, phone-number ID, app secret, and verify token.
- Keeps the display/business phone optional because Meta validation supplies a fallback and no maintained message path requires the env value.
- Keeps WhatsApp optional; this changes readiness classification only and does not create a protected-deploy launch gate.

## Review repairs

- Replaced the subprocess-per-state truth table with a pure 256-state contract test plus real CLI smoke for both complete namespaces, split custody, and value redaction. The original test timed out under the repository Bun lane.
- Removed a literal-only manifest assertion and fixed the touched test file header.

## Scope

Code and tests only. No provider account, credential value, environment/configuration, deployment, group, or live-message action was changed.

## Validation

Exact head: `d5ec68d51fb7a134298a799f257ef9aafa4b9ce1`
Validated base: `8cd98136ccc`

- Focused Bun lane: 39 passed, 0 failed; 771 assertions.
- Exhaustive 256-state cross-namespace truth tables plus all 16 canonical runtime masks.
- Real strict-preflight subprocess smoke for each complete namespace and a split namespace; diagnostics verified names-only with sentinel values absent.
- Cloud Shared typecheck passed.
- Biome passed on all eight changed files; full Cloud Shared lint passed across 2,498 files.
- `git diff --check` passed.
- Full Cloud Shared package lane reaches the pre-existing agent-backup restore API-boundary failure. The same `loadCurrentAgentVaultKeyAuthority must remain definition-only` failure was reproduced on clean `origin/develop`; the WhatsApp patch does not import or touch that boundary.

## Evidence

- UI screenshots/video: N/A — no rendered UI changed.
- Provider-backed smoke: N/A — this source-only classification repair does not authorize credential or message operations.
- Domain artifact: deterministic preflight and runtime validation outcomes are covered by the focused exact-head tests above.

Refs #29249
Parent context: #25025, #19910

<!-- evidence-head:d5ec68d51fb7a134298a799f257ef9aafa4b9ce1 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI changed

<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI changed

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-visible interaction changed

<!-- evidence-row:backend-logs -->
- [ ] N/A - no deployed backend or live request path changed

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, provider, or agent behavior changed

<!-- evidence-row:domain-artifacts -->
- [x] [29255-pr29255-domain-evidence.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29255-pr29255-domain-evidence.txt)
