### PR TITLE
fix(cloud): add protected mobile auth registration repair

### DIFF
--- a/.github/workflows/mobile-app-auth-registration-admin.yml
+++ b/.github/workflows/mobile-app-auth-registration-admin.yml
@@ -1,0 +1,53 @@
+name: Mobile App Auth Registration Admin
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_environment:
+        description: Protected GitHub Environment to inspect or repair
+        required: true
+        type: choice
+        options:
+          - staging
+          - production
+      operation:
+        description: Diagnose is read-only; repair is idempotent and fail-closed
+        required: true
+        type: choice
+        options:
+          - diagnose
+          - repair
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mobile-app-auth-registration-${{ inputs.target_environment }}
+  cancel-in-progress: false
+
+jobs:
+  registration:
+    name: ${{ inputs.operation }} ${{ inputs.target_environment }} registration
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.target_environment }}
+    timeout-minutes: 10
+    steps:
+      - name: Checkout exact admin source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6.0.2
+      - name: Set up Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6.1.0
+        with:
+          node-version: "24"
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.1.2
+        with:
+          bun-version: "1.3.14"
+      - name: Install dependencies
+        run: bun install --frozen-lockfile --ignore-scripts
+      - name: Diagnose or repair protected registration
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          ELIZA_MOBILE_APP_AUTH_APP_ID: ${{ secrets.ELIZA_MOBILE_APP_AUTH_APP_ID }}
+          ELIZA_MOBILE_APP_AUTH_ORGANIZATION_ID: ${{ secrets.ELIZA_MOBILE_APP_AUTH_ORGANIZATION_ID }}
+          ELIZA_MOBILE_APP_AUTH_OWNER_USER_ID: ${{ secrets.ELIZA_MOBILE_APP_AUTH_OWNER_USER_ID }}
+        run: node packages/scripts/cloud/admin/repair-mobile-app-auth-registration.ts "${{ inputs.operation }}"

--- a/packages/scripts/cloud/admin/repair-mobile-app-auth-registration.test.ts
+++ b/packages/scripts/cloud/admin/repair-mobile-app-auth-registration.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import {
+  databaseFailureInvariant,
+  diagnose,
+  type RegistrationRepairClient,
+  repairRegistrationTransaction,
+} from "./repair-mobile-app-auth-registration.ts";
+
+const APP_ID = "11111111-1111-4111-8111-111111111111";
+const ORG_ID = "22222222-2222-4222-8222-222222222222";
+const OWNER_ID = "33333333-3333-4333-8333-333333333333";
+const KEY_ID = "44444444-4444-4444-8444-444444444444";
+
+interface FakeState {
+  app?: {
+    organization_id: string;
+    created_by_user_id: string;
+    api_key_id: string | null;
+  };
+  duplicateCount?: number;
+  key?: { organization_id: string; user_id: string; active: boolean };
+  failAfterMutation?: boolean;
+}
+
+class FakeClient implements RegistrationRepairClient {
+  readonly statements: string[] = [];
+  private snapshot?: FakeState;
+
+  constructor(readonly state: FakeState) {}
+
+  async query<T extends Record<string, unknown>>(
+    text: string,
+    values: unknown[] = [],
+  ): Promise<{ rows: T[] }> {
+    const sql = text.replace(/\s+/g, " ").trim();
+    this.statements.push(sql);
+    if (sql.startsWith("BEGIN")) {
+      this.snapshot = structuredClone(this.state);
+      return { rows: [] };
+    }
+    if (sql === "COMMIT") {
+      this.snapshot = undefined;
+      return { rows: [] };
+    }
+    if (sql === "ROLLBACK") {
+      if (this.snapshot) {
+        for (const key of Object.keys(this.state) as Array<keyof FakeState>) {
+          delete this.state[key];
+        }
+        Object.assign(this.state, structuredClone(this.snapshot));
+      }
+      this.snapshot = undefined;
+      return { rows: [] };
+    }
+    if (sql.includes("pg_advisory_xact_lock")) return { rows: [] };
+    if (sql.includes("FROM organizations AS org")) {
+      return {
+        rows: [
+          {
+            organization_active: true,
+            owner_active: true,
+            owner_matches_organization: true,
+            owner_role: "owner",
+          } as T,
+        ],
+      };
+    }
+    if (sql.startsWith("SELECT count(*)::integer AS count")) {
+      return { rows: [{ count: this.state.duplicateCount ?? 0 } as T] };
+    }
+    if (sql.includes("FROM apps WHERE id")) {
+      return { rows: this.state.app ? [this.state.app as T] : [] };
+    }
+    if (sql.includes("FROM api_keys WHERE id")) {
+      return {
+        rows: this.state.key
+          ? [
+              {
+                organization_id: this.state.key.organization_id,
+                user_id: this.state.key.user_id,
+              } as T,
+            ]
+          : [],
+      };
+    }
+    if (sql.startsWith("UPDATE api_keys")) {
+      if (this.state.key) this.state.key.active = false;
+      return { rows: [] };
+    }
+    if (sql.startsWith("UPDATE apps")) {
+      if (!this.state.app) throw new Error("missing fake app");
+      this.state.app.api_key_id = String(values[3]);
+      if (this.state.failAfterMutation)
+        throw new Error("injected post-update failure");
+      return { rows: [] };
+    }
+    if (sql.startsWith("INSERT INTO apps")) {
+      this.state.app = {
+        organization_id: String(values[2]),
+        created_by_user_id: String(values[3]),
+        api_key_id: String(values[6]),
+      };
+      if (this.state.failAfterMutation)
+        throw new Error("injected post-insert failure");
+      return { rows: [] };
+    }
+    throw new Error(`Unhandled fake SQL: ${sql}`);
+  }
+}
+
+describe("privacy-safe diagnosis", () => {
+  test("classifies allow-listed SQLSTATE values and redacts other failures", () => {
+    expect(databaseFailureInvariant({ code: "42703", detail: "secret" })).toBe(
+      "database.42703",
+    );
+    expect(databaseFailureInvariant({ code: "28P01", detail: "secret" })).toBe(
+      "database.connection_or_query",
+    );
+  });
+
+  test("unwraps the database cause without exposing its message", async () => {
+    const failure = new Error("wrapped", {
+      cause: Object.assign(new Error("contains private database detail"), {
+        code: "42P01",
+      }),
+    });
+    await expect(
+      diagnose("postgres://redacted", APP_ID, async () => {
+        throw failure;
+      }),
+    ).rejects.toThrow("database.42P01");
+  });
+});
+
+describe("registration repair transaction", () => {
+  test("creates an absent canonical app and commits", async () => {
+    const client = new FakeClient({});
+    await repairRegistrationTransaction(client, APP_ID, ORG_ID, OWNER_ID);
+    expect(client.state.app?.organization_id).toBe(ORG_ID);
+    expect(client.state.app?.created_by_user_id).toBe(OWNER_ID);
+    expect(client.state.app?.api_key_id).toMatch(/^[0-9a-f-]{36}$/);
+    expect(client.statements.at(-1)).toBe("COMMIT");
+  });
+
+  test("revokes a current generated key, updates, and is idempotent", async () => {
+    const client = new FakeClient({
+      app: {
+        organization_id: ORG_ID,
+        created_by_user_id: OWNER_ID,
+        api_key_id: KEY_ID,
+      },
+      key: { organization_id: ORG_ID, user_id: OWNER_ID, active: true },
+    });
+    await repairRegistrationTransaction(client, APP_ID, ORG_ID, OWNER_ID);
+    await repairRegistrationTransaction(client, APP_ID, ORG_ID, OWNER_ID);
+    expect(client.state.key?.active).toBe(false);
+    expect(client.state.app?.api_key_id).toBe(KEY_ID);
+    expect(client.statements.filter((sql) => sql === "COMMIT")).toHaveLength(2);
+  });
+
+  test("derives protected authority from an existing locked row", async () => {
+    const client = new FakeClient({
+      app: {
+        organization_id: ORG_ID,
+        created_by_user_id: OWNER_ID,
+        api_key_id: null,
+      },
+    });
+    await repairRegistrationTransaction(client, APP_ID);
+    expect(client.state.app?.organization_id).toBe(ORG_ID);
+    expect(client.state.app?.created_by_user_id).toBe(OWNER_ID);
+    expect(client.statements.at(-1)).toBe("COMMIT");
+  });
+
+  test("rejects ownership mismatch and rolls back", async () => {
+    const client = new FakeClient({
+      app: {
+        organization_id: ORG_ID,
+        created_by_user_id: APP_ID,
+        api_key_id: null,
+      },
+    });
+    await expect(
+      repairRegistrationTransaction(client, APP_ID, ORG_ID, OWNER_ID),
+    ).rejects.toThrow("registration.explicit_ownership_match");
+    expect(client.statements.at(-1)).toBe("ROLLBACK");
+  });
+
+  test("rejects a duplicate callback claimant and rolls back", async () => {
+    const client = new FakeClient({ duplicateCount: 1 });
+    await expect(
+      repairRegistrationTransaction(client, APP_ID, ORG_ID, OWNER_ID),
+    ).rejects.toThrow("registration.unique_callback_owner");
+    expect(client.state.app).toBeUndefined();
+    expect(client.statements.at(-1)).toBe("ROLLBACK");
+  });
+
+  test("requires protected ownership only when the app row is absent", async () => {
+    const client = new FakeClient({});
+    await expect(repairRegistrationTransaction(client, APP_ID)).rejects.toThrow(
+      "input.organization_id_for_creation",
+    );
+    expect(client.statements.at(-1)).toBe("ROLLBACK");
+  });
+
+  test("rolls back state after a post-insert mutation error", async () => {
+    const client = new FakeClient({ failAfterMutation: true });
+    await expect(
+      repairRegistrationTransaction(client, APP_ID, ORG_ID, OWNER_ID),
+    ).rejects.toThrow("database.connection_or_query");
+    expect(client.state.app).toBeUndefined();
+    expect(client.statements.at(-1)).toBe("ROLLBACK");
+  });
+
+  test("rolls back state after a post-update mutation error", async () => {
+    const client = new FakeClient({
+      app: {
+        organization_id: ORG_ID,
+        created_by_user_id: OWNER_ID,
+        api_key_id: KEY_ID,
+      },
+      key: { organization_id: ORG_ID, user_id: OWNER_ID, active: true },
+      failAfterMutation: true,
+    });
+    await expect(repairRegistrationTransaction(client, APP_ID)).rejects.toThrow(
+      "database.connection_or_query",
+    );
+    expect(client.state.key?.active).toBe(true);
+    expect(client.state.app?.api_key_id).toBe(KEY_ID);
+    expect(client.statements.at(-1)).toBe("ROLLBACK");
+  });
+});
+
+test("workflow binds protected ownership secrets, never dispatch inputs", () => {
+  const workflow = readFileSync(
+    new URL(
+      "../../../../.github/workflows/mobile-app-auth-registration-admin.yml",
+      import.meta.url,
+    ),
+    "utf8",
+  );
+  expect(workflow).toContain("secrets.ELIZA_MOBILE_APP_AUTH_ORGANIZATION_ID");
+  expect(workflow).toContain("secrets.ELIZA_MOBILE_APP_AUTH_OWNER_USER_ID");
+  expect(workflow).not.toContain("inputs.organization_id");
+  expect(workflow).not.toContain("inputs.owner_user_id");
+});

--- a/packages/scripts/cloud/admin/repair-mobile-app-auth-registration.ts
+++ b/packages/scripts/cloud/admin/repair-mobile-app-auth-registration.ts
@@ -1,0 +1,289 @@
+/**
+ * Protected, idempotent repair for the first-party mobile App Auth registration.
+ *
+ * The command intentionally reports invariant names only. Database URLs, row
+ * identifiers, and user-controlled values never cross the CLI boundary.
+ */
+import { randomUUID } from "node:crypto";
+import pg from "pg";
+import {
+  MOBILE_APP_AUTH_REDIRECT_ORIGIN,
+  MOBILE_APP_AUTH_REDIRECT_URI,
+  mobileAppAuthDatabaseConnection,
+  requireMobileAppAuthAppId,
+  verifyDatabaseMobileAppAuthRegistration,
+} from "./verify-mobile-app-auth-registration.ts";
+
+const { Client } = pg;
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+type Operation = "diagnose" | "repair";
+
+class RegistrationRepairError extends Error {
+  override readonly name = "RegistrationRepairError";
+}
+
+function fail(invariant: string): never {
+  throw new RegistrationRepairError(invariant);
+}
+
+function requireUuid(value: unknown, invariant: string): string {
+  if (typeof value !== "string" || !UUID_PATTERN.test(value)) fail(invariant);
+  return value;
+}
+
+function optionalUuid(value: unknown, invariant: string): string | undefined {
+  if (value === undefined || value === "") return undefined;
+  return requireUuid(value, invariant);
+}
+
+export function databaseFailureInvariant(error: unknown): string {
+  if (typeof error !== "object" || error === null) return "database.unknown";
+  const code = "code" in error ? String(error.code) : "unknown";
+  const safeCodes = new Set([
+    "23503", // foreign_key_violation
+    "23505", // unique_violation
+    "25P02", // failed transaction
+    "40001", // serialization_failure
+    "42703", // undefined_column
+    "42P01", // undefined_table
+    "42883", // undefined_function/operator
+  ]);
+  return `database.${safeCodes.has(code) ? code : "connection_or_query"}`;
+}
+
+export async function diagnose(
+  databaseUrl: string,
+  appId: string,
+  verify: typeof verifyDatabaseMobileAppAuthRegistration = verifyDatabaseMobileAppAuthRegistration,
+): Promise<void> {
+  try {
+    await verify(databaseUrl, appId);
+    console.log("[MobileAppAuthRegistration] valid");
+  } catch (error) {
+    const cause = error instanceof Error ? error.cause : undefined;
+    const invariant = cause
+      ? databaseFailureInvariant(cause)
+      : error instanceof Error
+        ? error.message
+        : "registration.unknown";
+    fail(invariant);
+  }
+}
+
+export interface RegistrationRepairClient {
+  query<T extends Record<string, unknown> = Record<string, unknown>>(
+    text: string,
+    values?: unknown[],
+  ): Promise<{ rows: T[] }>;
+}
+
+export async function repairRegistrationTransaction(
+  client: RegistrationRepairClient,
+  appId: string,
+  protectedOrganizationId?: string,
+  protectedOwnerUserId?: string,
+): Promise<void> {
+  try {
+    await client.query("BEGIN ISOLATION LEVEL SERIALIZABLE");
+    await client.query("SELECT pg_advisory_xact_lock(hashtext($1))", [
+      "eliza-mobile-app-auth-registration",
+    ]);
+
+    const existing = await client.query<{
+      organization_id: string;
+      created_by_user_id: string;
+      api_key_id: string | null;
+    }>(
+      `SELECT organization_id::text, created_by_user_id::text, api_key_id::text
+         FROM apps WHERE id = $1::uuid FOR UPDATE`,
+      [appId],
+    );
+    const current = existing.rows[0];
+    if (
+      current &&
+      ((protectedOrganizationId &&
+        current.organization_id !== protectedOrganizationId) ||
+        (protectedOwnerUserId &&
+          current.created_by_user_id !== protectedOwnerUserId))
+    ) {
+      fail("registration.explicit_ownership_match");
+    }
+    const organizationId = current?.organization_id ?? protectedOrganizationId;
+    const ownerUserId = current?.created_by_user_id ?? protectedOwnerUserId;
+    if (!organizationId) fail("input.organization_id_for_creation");
+    if (!ownerUserId) fail("input.owner_user_id_for_creation");
+
+    const authority = await client.query<{
+      organization_active: boolean;
+      owner_active: boolean;
+      owner_matches_organization: boolean;
+      owner_role: string | null;
+    }>(
+      `SELECT COALESCE(org.is_active, FALSE) AS organization_active,
+              COALESCE(owner.is_active AND owner.deleted_at IS NULL, FALSE) AS owner_active,
+              COALESCE(owner.organization_id = org.id, FALSE) AS owner_matches_organization,
+              owner.role AS owner_role
+         FROM organizations AS org
+         LEFT JOIN users AS owner ON owner.id = $2::uuid
+        WHERE org.id = $1::uuid
+        LIMIT 1`,
+      [organizationId, ownerUserId],
+    );
+    const authorityRow = authority.rows[0];
+    if (!authorityRow?.organization_active)
+      fail("authority.organization_active");
+    if (!authorityRow.owner_active) fail("authority.owner_active");
+    if (!authorityRow.owner_matches_organization)
+      fail("authority.same_organization");
+    if (
+      authorityRow.owner_role !== "owner" &&
+      authorityRow.owner_role !== "admin"
+    ) {
+      fail("authority.owner_or_admin");
+    }
+
+    const duplicate = await client.query<{ count: number }>(
+      `SELECT count(*)::integer AS count
+         FROM apps
+        WHERE id <> $1::uuid
+          AND is_active = TRUE
+          AND is_approved = TRUE
+          AND allowed_origins @> jsonb_build_array($2::text)`,
+      [appId, MOBILE_APP_AUTH_REDIRECT_URI],
+    );
+    if (duplicate.rows[0]?.count !== 0)
+      fail("registration.unique_callback_owner");
+
+    const apiKeyId = current?.api_key_id ?? randomUUID();
+    if (current?.api_key_id) {
+      const key = await client.query<{
+        organization_id: string;
+        user_id: string;
+      }>(
+        `SELECT organization_id::text, user_id::text
+           FROM api_keys WHERE id = $1::uuid FOR UPDATE`,
+        [current.api_key_id],
+      );
+      const keyRow = key.rows[0];
+      if (
+        keyRow &&
+        (keyRow.organization_id !== organizationId ||
+          keyRow.user_id !== ownerUserId)
+      ) {
+        fail("registration.generated_key_ownership");
+      }
+      if (keyRow) {
+        await client.query(
+          `UPDATE api_keys
+              SET is_active = FALSE, deleted_at = COALESCE(deleted_at, NOW())
+            WHERE id = $1::uuid`,
+          [current.api_key_id],
+        );
+      }
+    }
+
+    if (current) {
+      await client.query(
+        `UPDATE apps
+            SET app_url = $2,
+                allowed_origins = jsonb_build_array($3::text),
+                is_active = TRUE,
+                is_approved = TRUE,
+                api_key_id = $4::uuid,
+                updated_at = NOW()
+          WHERE id = $1::uuid`,
+        [
+          appId,
+          MOBILE_APP_AUTH_REDIRECT_ORIGIN,
+          MOBILE_APP_AUTH_REDIRECT_URI,
+          apiKeyId,
+        ],
+      );
+    } else {
+      await client.query(
+        `INSERT INTO apps
+           (id, name, description, slug, organization_id, created_by_user_id,
+            app_url, allowed_origins, api_key_id, is_active, is_approved)
+         VALUES
+           ($1::uuid, 'Eliza Mobile', 'First-party Eliza mobile authentication client',
+            $2, $3::uuid, $4::uuid, $5, jsonb_build_array($6::text),
+            $7::uuid, TRUE, TRUE)`,
+        [
+          appId,
+          `eliza-mobile-auth-${appId.slice(0, 8)}`,
+          organizationId,
+          ownerUserId,
+          MOBILE_APP_AUTH_REDIRECT_ORIGIN,
+          MOBILE_APP_AUTH_REDIRECT_URI,
+          apiKeyId,
+        ],
+      );
+    }
+    await client.query("COMMIT");
+  } catch (error) {
+    await client.query("ROLLBACK").catch(() => undefined);
+    if (error instanceof RegistrationRepairError) throw error;
+    fail(databaseFailureInvariant(error));
+  }
+}
+
+async function repair(
+  databaseUrl: string,
+  appId: string,
+  organizationId?: string,
+  ownerUserId?: string,
+): Promise<void> {
+  const { url, ssl } = mobileAppAuthDatabaseConnection(databaseUrl);
+  const client = new Client({ connectionString: url, ...(ssl ? { ssl } : {}) });
+  try {
+    await client.connect();
+    await repairRegistrationTransaction(
+      client,
+      appId,
+      organizationId,
+      ownerUserId,
+    );
+  } finally {
+    await client.end().catch(() => undefined);
+  }
+
+  await diagnose(databaseUrl, appId);
+  console.log("[MobileAppAuthRegistration] repaired_and_verified");
+}
+
+function parseOperation(value: string | undefined): Operation {
+  if (value === "diagnose" || value === "repair") return value;
+  return fail("input.operation");
+}
+
+async function main(): Promise<void> {
+  const operation = parseOperation(process.argv[2]);
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) fail("input.database_url");
+  const appId = requireMobileAppAuthAppId(
+    process.env.ELIZA_MOBILE_APP_AUTH_APP_ID,
+  );
+  if (operation === "diagnose") return await diagnose(databaseUrl, appId);
+  const organizationId = optionalUuid(
+    process.env.ELIZA_MOBILE_APP_AUTH_ORGANIZATION_ID,
+    "input.organization_id",
+  );
+  const ownerUserId = optionalUuid(
+    process.env.ELIZA_MOBILE_APP_AUTH_OWNER_USER_ID,
+    "input.owner_user_id",
+  );
+  await repair(databaseUrl, appId, organizationId, ownerUserId);
+}
+
+if (import.meta.main) {
+  main().catch((error: unknown) => {
+    const invariant =
+      error instanceof RegistrationRepairError
+        ? error.message
+        : "registration.unexpected";
+    console.error(`[MobileAppAuthRegistration] failed invariant=${invariant}`);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Summary
- add a protected, manual diagnose/repair workflow for mobile App Auth registration
- derive authority from an existing locked registration; protected owner/org secrets are required only for creation and act as optional exact-match pins otherwise
- make repair serializable, idempotent, ownership-pinned, callback-unique, and rollback-safe
- report invariant names only and preserve the existing release preflight

## Context
Production release 32991230895 failed closed at the protected mobile App Auth DB registration preflight. This adds the privacy-safe operator path required to identify and repair the registration without disabling or bypassing authentication.

## Verification
- focused admin tests: 11 pass / 31 assertions
- covers safe DB classification, existing-row authority derivation, absent/current rows, optional ownership mismatch, missing creation authority, duplicate callback, idempotence, post-insert and post-update rollback, and protected workflow secret wiring
- Biome: pass
- git diff --check: pass

## Safety
- diagnose is read-only
- repair runs only inside the selected protected GitHub Environment
- dispatch metadata contains no owner or organization identifiers
- existing rows derive and validate active owner/admin authority under lock; optional protected IDs must match exactly
- absent rows require both protected owner and organization secrets
- no secrets or row identifiers are printed
- no release gate is weakened