### PR TITLE
fix(cloud): identify missing mobile auth schema

### DIFF
--- a/packages/scripts/cloud/admin/repair-mobile-app-auth-registration.test.ts
+++ b/packages/scripts/cloud/admin/repair-mobile-app-auth-registration.test.ts
@@ -3,6 +3,8 @@ import { readFileSync } from "node:fs";
 import {
   databaseFailureInvariant,
   diagnose,
+  missingRegistrationTableInvariant,
+  REQUIRED_REGISTRATION_TABLES,
   type RegistrationRepairClient,
   repairRegistrationTransaction,
 } from "./repair-mobile-app-auth-registration.ts";
@@ -110,6 +112,23 @@ class FakeClient implements RegistrationRepairClient {
 }
 
 describe("privacy-safe diagnosis", () => {
+  test("schema probes and reported invariants are a fixed allowlist", () => {
+    expect(REQUIRED_REGISTRATION_TABLES).toEqual([
+      "apps",
+      "organizations",
+      "users",
+      "api_keys",
+    ]);
+    expect(
+      REQUIRED_REGISTRATION_TABLES.map(missingRegistrationTableInvariant),
+    ).toEqual([
+      "schema.missing_apps",
+      "schema.missing_organizations",
+      "schema.missing_users",
+      "schema.missing_api_keys",
+    ]);
+  });
+
   test("classifies allow-listed SQLSTATE values and redacts other failures", () => {
     expect(databaseFailureInvariant({ code: "42703", detail: "secret" })).toBe(
       "database.42703",

--- a/packages/scripts/cloud/admin/repair-mobile-app-auth-registration.ts
+++ b/packages/scripts/cloud/admin/repair-mobile-app-auth-registration.ts
@@ -53,6 +53,43 @@ export function databaseFailureInvariant(error: unknown): string {
   return `database.${safeCodes.has(code) ? code : "connection_or_query"}`;
 }
 
+export const REQUIRED_REGISTRATION_TABLES = [
+  "apps",
+  "organizations",
+  "users",
+  "api_keys",
+] as const;
+
+export function missingRegistrationTableInvariant(
+  table: (typeof REQUIRED_REGISTRATION_TABLES)[number],
+): string {
+  return `schema.missing_${table}`;
+}
+
+export async function diagnoseRequiredRegistrationSchema(
+  databaseUrl: string,
+): Promise<void> {
+  const { url, ssl } = mobileAppAuthDatabaseConnection(databaseUrl);
+  const client = new Client({ connectionString: url, ...(ssl ? { ssl } : {}) });
+  try {
+    await client.connect();
+    for (const table of REQUIRED_REGISTRATION_TABLES) {
+      const result = await client.query<{ exists: boolean }>(
+        "SELECT to_regclass($1) IS NOT NULL AS exists",
+        [`public.${table}`],
+      );
+      if (result.rows[0]?.exists !== true) {
+        fail(missingRegistrationTableInvariant(table));
+      }
+    }
+  } catch (error) {
+    if (error instanceof RegistrationRepairError) throw error;
+    fail(databaseFailureInvariant(error));
+  } finally {
+    await client.end().catch(() => undefined);
+  }
+}
+
 export async function diagnose(
   databaseUrl: string,
   appId: string,
@@ -265,7 +302,10 @@ async function main(): Promise<void> {
   const appId = requireMobileAppAuthAppId(
     process.env.ELIZA_MOBILE_APP_AUTH_APP_ID,
   );
-  if (operation === "diagnose") return await diagnose(databaseUrl, appId);
+  if (operation === "diagnose") {
+    await diagnoseRequiredRegistrationSchema(databaseUrl);
+    return await diagnose(databaseUrl, appId);
+  }
   const organizationId = optionalUuid(
     process.env.ELIZA_MOBILE_APP_AUTH_ORGANIZATION_ID,
     "input.organization_id",


### PR DESCRIPTION
## Summary
- probe exactly the four allowlisted relations required by mobile App Auth registration
- report only fixed `schema.missing_*` invariants before the existing registration query
- retain generic SQLSTATE redaction for all other database failures

## Context
Production diagnostic run 32993181682 returned `database.42P01`. This narrows that schema failure without exposing database URLs, row IDs, SQL text, or arbitrary relation names. It does not create tables or alter migration history.

## Verification
- focused admin tests: 12 pass / 33 assertions
- Biome: pass
- git diff --check: pass