### PR TITLE
fix(ui): compact mobile browser toolbar

### DIFF
--- a/packages/ui/src/components/pages/BrowserWorkspaceView.chrome.test.tsx
+++ b/packages/ui/src/components/pages/BrowserWorkspaceView.chrome.test.tsx
@@ -310,30 +310,28 @@ describe("BrowserWorkspaceView fullscreen chrome (Notes/Calendar parity)", () =>
     expect(root.contains(surface)).toBe(true);
   });
 
-  it("uses a compact two-row mobile toolbar without shrinking any navigation target below 44px", async () => {
+  it("uses one compact mobile row with secondary actions in an accessible menu", async () => {
     render(<BrowserWorkspaceView />);
     expect(await screen.findByText("No page open")).not.toBeNull();
 
     const toolbar = screen.getByTestId("browser-workspace-toolbar");
     const nav = toolbar.firstElementChild as HTMLElement | null;
     expect(nav).not.toBeNull();
-    expect(nav?.className).toContain("grid-cols-");
+    expect(nav?.className).toContain("flex");
     expect(nav?.className).toContain("md:grid-cols-");
-    expect(nav?.className).not.toContain("sm:grid-cols-");
-    expect(nav?.className).toContain("gap-x-2");
-    expect(nav?.className).toContain("gap-y-1");
-    expect(nav?.className).toContain("px-2");
-    expect(nav?.className).toContain("py-0.5");
+    expect(nav?.className).toContain("gap-1");
+    expect(nav?.className).toContain("p-1");
 
     expect(
       screen.getByTestId("browser-workspace-address-input").className,
-    ).toContain("col-span-3");
+    ).toContain("flex-1");
     expect(
       screen.getByTestId("browser-workspace-address-input").className,
     ).toContain("md:col-span-1");
     expect(
       screen.getByTestId("browser-workspace-address-input").className,
-    ).not.toContain("sm:col-span-1");
+    ).toContain("min-w-0");
+    expect(screen.getByTestId("browser-workspace-mobile-more")).not.toBeNull();
     for (const control of toolbar.querySelectorAll("button, input")) {
       // size-11 is the merged h-11 w-11 form; all three satisfy the 44px floor.
       expect(control.className).toMatch(/(?:h-11|min-h-11|size-11)/);

--- a/packages/ui/src/components/pages/BrowserWorkspaceView.tsx
+++ b/packages/ui/src/components/pages/BrowserWorkspaceView.tsx
@@ -17,6 +17,7 @@
 import { Capacitor } from "@capacitor/core";
 import {
   ArrowRight,
+  EllipsisVertical,
   ExternalLink,
   Globe,
   Plus,
@@ -55,6 +56,12 @@ import { ViewBackButton } from "../shared/ViewHeader";
 import { Button } from "../ui/button";
 import { ConfirmDialog } from "../ui/confirm-dialog";
 import { useConfirm } from "../ui/confirm-dialog.hooks";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "../ui/dropdown-menu";
 import { Input } from "../ui/input";
 import { TooltipHint } from "../ui/tooltip";
 import { ShellViewAgentSurface } from "../views/ShellViewAgentSurface";
@@ -2574,7 +2581,7 @@ function BrowserWorkspaceForAuthority(): React.JSX.Element {
   }, []);
 
   const navNode = (
-    <div className="grid grid-cols-[2.75rem_minmax(0,1fr)_repeat(2,2.75rem)] items-center gap-x-2 gap-y-1 px-2 py-0.5 md:grid-cols-[2.75rem_minmax(10rem,4fr)_repeat(3,2.75rem)_minmax(10rem,5fr)_repeat(2,2.75rem)]">
+    <div className="flex items-center gap-1 p-1 md:grid md:grid-cols-[2.75rem_minmax(10rem,4fr)_repeat(3,2.75rem)_minmax(10rem,5fr)_repeat(2,2.75rem)] md:gap-x-2 md:gap-y-1 md:px-2 md:py-0.5">
       <TooltipHint
         content={t("common.backToLauncher", {
           defaultValue: "Back to launcher",
@@ -2612,7 +2619,7 @@ function BrowserWorkspaceForAuthority(): React.JSX.Element {
         }
         variant="ghost"
         size="icon"
-        className="size-11 shrink-0"
+        className="hidden size-11 shrink-0 md:inline-flex"
         aria-label={newTabLabel}
         disabled={busyAction !== null || browserWorkspaceUnavailable}
         onClick={() =>
@@ -2639,7 +2646,7 @@ function BrowserWorkspaceForAuthority(): React.JSX.Element {
         }
         variant="ghost"
         size="icon"
-        className="size-11"
+        className="hidden size-11 md:inline-flex"
         aria-label={t("common.refresh", { defaultValue: "Refresh" })}
         disabled={!selectedTab || busyAction !== null}
         onClick={() =>
@@ -2719,7 +2726,7 @@ function BrowserWorkspaceForAuthority(): React.JSX.Element {
           selectedTabIsInternal ||
           browserWorkspaceUnavailable
         }
-        className="col-span-3 h-11 min-w-[10rem] flex-1 rounded-full border-border/70 bg-bg/80 px-4 text-sm text-txt md:col-span-1"
+        className="h-11 min-w-0 flex-1 rounded-full border-border/70 bg-bg/80 px-3 text-sm text-txt md:col-span-1 md:min-w-[10rem] md:px-4"
       />
       <BrowserNavButton
         agentId="go"
@@ -2780,6 +2787,85 @@ function BrowserWorkspaceForAuthority(): React.JSX.Element {
           <ExternalLink className="size-4" />
         </BrowserNavButton>
       </span>
+      {/* Mobile overflow (#29261): the toolbar stays one 44px row, so the
+          secondary actions live behind one touch-sized menu instead of a
+          second row. */}
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="size-11 shrink-0 md:hidden"
+            aria-label={t("browserworkspace.MoreActions", {
+              defaultValue: "More browser actions",
+            })}
+            data-testid="browser-workspace-mobile-more"
+          >
+            <EllipsisVertical className="size-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="min-w-52 md:hidden">
+          <DropdownMenuItem
+            className="min-h-12 gap-3"
+            disabled={busyAction !== null || browserWorkspaceUnavailable}
+            onSelect={() =>
+              void runBrowserWorkspaceAction("open:new", async () => {
+                await openNewBrowserWorkspaceTab(
+                  newBrowserWorkspaceTabSeedUrl,
+                  "user",
+                );
+              })
+            }
+          >
+            <Plus className="size-4" />
+            {newTabLabel}
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            className="min-h-12 gap-3"
+            disabled={!selectedTab || busyAction !== null}
+            onSelect={() =>
+              void runBrowserWorkspaceAction("reload:selected", async () => {
+                await reloadSelectedBrowserWorkspaceTab();
+              })
+            }
+          >
+            <RefreshCw className="size-4" />
+            {t("common.refresh", { defaultValue: "Refresh" })}
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            className="min-h-12 gap-3"
+            disabled={
+              busyAction !== null ||
+              !workspace.tabs.some((tab) => !isInternalBrowserWorkspaceTab(tab))
+            }
+            onSelect={() =>
+              void runBrowserWorkspaceAction("close:all", async () => {
+                await closeAllBrowserWorkspaceTabs();
+              })
+            }
+          >
+            <X className="size-4" />
+            {t("browserworkspace.CloseAllTabs", {
+              defaultValue: "Close all tabs",
+            })}
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            className="min-h-12 gap-3"
+            disabled={!selectedTab || busyAction !== null}
+            onSelect={() =>
+              void runBrowserWorkspaceAction("open:external", async () => {
+                if (!selectedTab) return;
+                await openExternalUrl(selectedTab.url);
+              })
+            }
+          >
+            <ExternalLink className="size-4" />
+            {t("browserworkspace.OpenExternal", {
+              defaultValue: "Open external",
+            })}
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
     </div>
   );
 


### PR DESCRIPTION
Fixes #29261

## Summary

- keep the mobile in-app Browser navigation in one compact row
- preserve back, tab count, address entry, submit, and overflow as immediate controls
- move refresh, new-tab, external-open, and close-all into a touch-sized mobile overflow menu
- preserve the existing desktop and tablet toolbar layout

## Exact source identity

- Base: 9aa1af65ddd9c9971da8e82ff037cc33e2da7219
- Head: deefb7601ff3bb97843df8946fb1598f2af6ab62
- Tree: ba0e7d6846c8372ee989fcc01a164280f271ebb1
- Original reviewed local commit: a17948fd303fad28123fefe0053f1721cc2c953e
- Stable patch-id: 2c4e3489068c6aeaa57103153f0e0c9917c41560
- Range-diff: exact equals after replay onto current develop

## Verification

- Focused Vitest: 41/41 passed across BrowserWorkspaceView.chrome.test.tsx and browser-tab-switcher.test.tsx
- Biome: 3 touched files clean
- git diff --check: passed
- Impeccable detector: no findings

## Evidence status

The canonical Cloud build reached final Android packaging, where the existing Play AAB native-library allowlist rejected Capacitor datastore shared-counter libraries. That release-policy issue is separate from this three-file UI patch. Current Pixel APK installation and rendered-device proof are owned by the active Pixel lane and remain pending; this PR does not claim device acceptance yet.

N/A - backend logs: frontend-only layout change.
N/A - live-model trajectory: no agent, prompt, model, action, or provider behavior changed.