### PR TITLE
fix(android): keep LP3 awake and compact browser chrome

### DIFF
--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/MainActivity.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/MainActivity.java
@@ -184,7 +184,7 @@ public class MainActivity extends BridgeActivity {
     }
 
     @Override
-    protected void onResume() {
+    public void onResume() {
         super.onResume();
         // Some vendor Android builds clear window flags while switching tasks
         // or returning from an out-of-process browser surface. Restore the

--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/MainActivity.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/MainActivity.java
@@ -122,7 +122,7 @@ public class MainActivity extends BridgeActivity {
         // is no longer visible (app moved to background or fully covered),
         // so background instances don't drain battery. Same flag set by
         // every video / voice-calling app (Snapchat, YouTube, Zoom, Meet).
-        getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+        keepScreenAwake();
 
         // Hide the bottom system navigation bar (the white gesture pill) for a
         // clean, full-bleed agent home — iOS-style. We hide ONLY the navigation
@@ -184,13 +184,28 @@ public class MainActivity extends BridgeActivity {
     }
 
     @Override
+    protected void onResume() {
+        super.onResume();
+        // Some vendor Android builds clear window flags while switching tasks
+        // or returning from an out-of-process browser surface. Restore the
+        // demo-mode wake contract every time Eliza becomes foreground again.
+        keepScreenAwake();
+        applyImmersiveNavigationBar();
+    }
+
+    @Override
     public void onWindowFocusChanged(boolean hasFocus) {
         super.onWindowFocusChanged(hasFocus);
         // The system restores the nav bar after dialogs / resume; re-hide it
         // whenever we regain focus so the full-bleed home stays clean.
         if (hasFocus) {
+            keepScreenAwake();
             applyImmersiveNavigationBar();
         }
+    }
+
+    private void keepScreenAwake() {
+        getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
     }
 
     /**

--- a/packages/app-core/scripts/run-mobile-build-cloud-main-activity.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-cloud-main-activity.test.mjs
@@ -63,7 +63,7 @@ describe("cloudSafeMainActivityJava", () => {
     const source = cloudSafeMainActivityJava("ai.elizaos.app");
 
     expect(source).toContain("import android.view.WindowManager;");
-    expect(source).toContain("protected void onResume()");
+    expect(source).toContain("public void onResume()");
     expect(source).toContain("onWindowFocusChanged(boolean hasFocus)");
     expect(source).toContain(
       "getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);",

--- a/packages/app-core/scripts/run-mobile-build-cloud-main-activity.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-cloud-main-activity.test.mjs
@@ -59,6 +59,20 @@ describe("cloudSafeMainActivityJava", () => {
     expect(source).not.toContain("SYSTEM_UI_FLAG_");
   });
 
+  it("restores the foreground keep-awake contract after lifecycle transitions", () => {
+    const source = cloudSafeMainActivityJava("ai.elizaos.app");
+
+    expect(source).toContain("import android.view.WindowManager;");
+    expect(source).toContain("protected void onResume()");
+    expect(source).toContain("onWindowFocusChanged(boolean hasFocus)");
+    expect(source).toContain(
+      "getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);",
+    );
+    expect(
+      source.match(/keepScreenAwake\(\);/g)?.length,
+    ).toBeGreaterThanOrEqual(3);
+  });
+
   it("keeps kiosk navigation suppression out of ordinary Cloud builds", () => {
     const source = cloudSafeMainActivityJava("ai.elizaos.app");
 

--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -6498,6 +6498,7 @@ import androidx.activity.OnBackPressedCallback;
     @Override
     public void onResume() {
         super.onResume();
+        keepScreenAwake();
         // Only a managed-device owner may contain the launcher task. Android's
         // unmanaged screen-pinning mode blocks the secure browser that Google
         // OAuth requires, preventing the callback from ever reaching the app.
@@ -6516,17 +6517,29 @@ import androidx.activity.OnBackPressedCallback;
     }
 `
     : "";
+  const resumeHandler = launcherKiosk
+    ? ""
+    : `
+    @Override
+    protected void onResume() {
+        super.onResume();
+        keepScreenAwake();
+    }
+`;
   const navigationBarPolicy = immersiveNavigation
     ? `            systemBars.hide(WindowInsetsCompat.Type.navigationBars());
             systemBars.setSystemBarsBehavior(
                 WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE);`
     : "            systemBars.setAppearanceLightNavigationBars(false);";
-  const focusHandler = immersiveNavigation
-    ? `
+  const focusHandler = `
     @Override
     public void onWindowFocusChanged(boolean hasFocus) {
         super.onWindowFocusChanged(hasFocus);
         if (!hasFocus) return;
+        keepScreenAwake();
+${
+  immersiveNavigation
+    ? `
         WindowInsetsControllerCompat controller =
             WindowCompat.getInsetsController(
                 getWindow(), getWindow().getDecorView());
@@ -6535,9 +6548,10 @@ import androidx.activity.OnBackPressedCallback;
             controller.setSystemBarsBehavior(
                 WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE);
         }
-    }
 `
-    : "";
+    : ""
+}    }
+`;
   const safePushRegistration = safePushNotifications
     ? `
         // Capacitor discovers the community push plugin before Firebase is
@@ -6555,6 +6569,7 @@ import android.os.Bundle;
 import android.content.Intent;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
+import android.view.WindowManager;
 
 import androidx.core.splashscreen.SplashScreen;
 import androidx.core.view.WindowCompat;
@@ -6588,6 +6603,7 @@ ${launcherConstants}
         registerPlugin(ElizaPlaySettingsPlugin.class);
 
         super.onCreate(savedInstanceState);
+        keepScreenAwake();
 ${safePushRegistration}
 
 ${launcherSetup}
@@ -6617,7 +6633,12 @@ ${navigationBarPolicy}
 ${launcherKiosk ? "        restoreBundledRendererAfterAuthCallback(intent);" : ""}
     }
 ${launcherMethods}
+${resumeHandler}
 ${focusHandler}
+
+    private void keepScreenAwake() {
+        getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+    }
 
 }
 `;

--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -6521,7 +6521,7 @@ import androidx.activity.OnBackPressedCallback;
     ? ""
     : `
     @Override
-    protected void onResume() {
+    public void onResume() {
         super.onResume();
         keepScreenAwake();
     }

--- a/packages/ui/src/browser.ts
+++ b/packages/ui/src/browser.ts
@@ -102,6 +102,7 @@ export { Input } from "./components/ui/input.tsx";
 export * from "./components/ui/label.tsx";
 export * from "./components/ui/popover.tsx";
 export * from "./components/ui/progress.tsx";
+export * from "./components/ui/radio-group.tsx";
 export * from "./components/ui/scroll-area.tsx";
 export { SegmentedControl } from "./components/ui/segmented-control.tsx";
 export * from "./components/ui/select.tsx";

--- a/packages/ui/src/components/pages/BrowserTabSwitcher.tsx
+++ b/packages/ui/src/components/pages/BrowserTabSwitcher.tsx
@@ -135,14 +135,14 @@ export function BrowserTabFoldControl({
       aria-label={openLabel}
       aria-haspopup="dialog"
       data-testid="browser-workspace-tab-fold-control"
-      className="min-w-0 shrink-0"
+      className="relative min-w-0 shrink-0 px-0 md:px-4"
     >
       <Globe className="size-4 shrink-0 text-muted" aria-hidden />
-      <span className="min-w-0 max-w-[9rem] truncate font-medium">
+      <span className="hidden min-w-0 max-w-[9rem] truncate font-medium md:inline">
         {activeLabel}
       </span>
       <span
-        className="inline-flex h-5 min-w-5 shrink-0 items-center justify-center rounded-full bg-bg-muted px-1.5 text-2xs font-semibold tabular-nums text-muted"
+        className="absolute right-1 top-1 inline-flex h-4 min-w-4 shrink-0 items-center justify-center rounded-full bg-bg-muted px-1 text-[9px] font-semibold tabular-nums text-muted md:static md:h-5 md:min-w-5 md:px-1.5 md:text-2xs"
         data-testid="browser-workspace-tab-count"
         aria-hidden
       >

--- a/packages/ui/src/components/pages/BrowserWorkspaceView.chrome.test.tsx
+++ b/packages/ui/src/components/pages/BrowserWorkspaceView.chrome.test.tsx
@@ -298,7 +298,7 @@ describe("BrowserWorkspaceView fullscreen chrome (Notes/Calendar parity)", () =>
     expect(root.contains(surface)).toBe(true);
   });
 
-  it("uses a compact two-row mobile toolbar without shrinking any navigation target below 44px", async () => {
+  it("uses one compact mobile toolbar row without shrinking any navigation target below 44px", async () => {
     render(<BrowserWorkspaceView />);
     expect(await screen.findByText("No page open")).not.toBeNull();
 
@@ -311,15 +311,18 @@ describe("BrowserWorkspaceView fullscreen chrome (Notes/Calendar parity)", () =>
     expect(nav?.className).toContain("gap-1");
     expect(nav?.className).toContain("py-1");
 
+    expect(nav?.className).toContain(
+      "grid-cols-[2.75rem_2.75rem_minmax(0,1fr)_repeat(3,2.75rem)]",
+    );
     expect(
       screen.getByTestId("browser-workspace-address-input").className,
-    ).toContain("col-span-2");
+    ).toContain("min-w-0");
     expect(
-      screen.getByTestId("browser-workspace-address-input").className,
-    ).toContain("md:col-span-1");
+      screen.getByTestId("browser-workspace-nav-new-tab").className,
+    ).toContain("hidden");
     expect(
-      screen.getByTestId("browser-workspace-address-input").className,
-    ).not.toContain("sm:col-span-1");
+      screen.getByTestId("browser-workspace-close-all-tabs").className,
+    ).toContain("hidden");
     for (const control of toolbar.querySelectorAll("button, input")) {
       // size-11 is the merged h-11 w-11 form; all three satisfy the 44px floor.
       expect(control.className).toMatch(/(?:h-11|min-h-11|size-11)/);

--- a/packages/ui/src/components/pages/BrowserWorkspaceView.tsx
+++ b/packages/ui/src/components/pages/BrowserWorkspaceView.tsx
@@ -2389,7 +2389,7 @@ export function BrowserWorkspaceView(): React.JSX.Element {
   });
 
   const navNode = (
-    <div className="grid grid-cols-[2.75rem_minmax(0,1fr)_repeat(3,2.75rem)] items-center gap-1 px-1.5 py-1 md:grid-cols-[2.75rem_minmax(10rem,4fr)_repeat(3,2.75rem)_minmax(10rem,5fr)_repeat(2,2.75rem)] md:gap-1.5 md:px-2 md:py-1.5 lg:gap-2 lg:px-3 lg:py-2">
+    <div className="grid grid-cols-[2.75rem_2.75rem_minmax(0,1fr)_repeat(3,2.75rem)] items-center gap-1 px-1.5 py-1 md:grid-cols-[2.75rem_minmax(10rem,4fr)_repeat(3,2.75rem)_minmax(10rem,5fr)_repeat(2,2.75rem)] md:gap-1.5 md:px-2 md:py-1.5 lg:gap-2 lg:px-3 lg:py-2">
       <TooltipHint
         content={t("common.backToLauncher", {
           defaultValue: "Back to launcher",
@@ -2426,7 +2426,7 @@ export function BrowserWorkspaceView(): React.JSX.Element {
         }
         variant="ghost"
         size="icon"
-        className="size-11 shrink-0"
+        className="hidden size-11 shrink-0 md:inline-flex"
         aria-label={newTabLabel}
         disabled={busyAction !== null}
         onClick={() =>
@@ -2453,7 +2453,7 @@ export function BrowserWorkspaceView(): React.JSX.Element {
         }
         variant="ghost"
         size="icon"
-        className="size-11"
+        className="order-5 size-11 md:order-none"
         aria-label={t("common.refresh", { defaultValue: "Refresh" })}
         disabled={!selectedTab || busyAction !== null}
         onClick={() =>
@@ -2478,7 +2478,7 @@ export function BrowserWorkspaceView(): React.JSX.Element {
         }
         variant="ghost"
         size="icon"
-        className="size-11"
+        className="hidden size-11 md:inline-flex"
         aria-label={t("browserworkspace.CloseAllTabs", {
           defaultValue: "Close all tabs",
         })}
@@ -2527,7 +2527,7 @@ export function BrowserWorkspaceView(): React.JSX.Element {
         })}
         data-testid="browser-workspace-address-input"
         disabled={busyAction !== null || selectedTabIsInternal}
-        className="col-span-2 h-11 min-w-[10rem] flex-1 rounded-full border-transparent bg-card/70 px-4 text-sm text-txt shadow-inset md:col-span-1"
+        className="order-3 h-11 min-w-0 flex-1 rounded-full border-transparent bg-card/70 px-3 text-sm text-txt shadow-inset md:order-none md:min-w-[10rem] md:px-4"
       />
       <BrowserNavButton
         agentId="go"
@@ -2541,7 +2541,7 @@ export function BrowserWorkspaceView(): React.JSX.Element {
         }
         variant="outline"
         size="sm"
-        className="h-11 shrink-0 px-3"
+        className="order-4 h-11 shrink-0 px-3 md:order-none"
         aria-label={goLabel}
         disabled={
           busyAction !== null ||
@@ -2571,7 +2571,7 @@ export function BrowserWorkspaceView(): React.JSX.Element {
         }
         variant="ghost"
         size="icon"
-        className="size-11"
+        className="order-6 size-11 md:order-none"
         aria-label={t("browserworkspace.OpenExternal", {
           defaultValue: "Open external",
         })}


### PR DESCRIPTION
## Summary
- collapse the phone Browser toolbar from two rows to one 52px row while preserving 44px touch targets
- keep new-tab and tab closing in the existing tab switcher on narrow screens
- reapply `FLAG_KEEP_SCREEN_ON` after Android resume and focus transitions
- retain the wake flag in the generated Cloud activity instead of losing it during the mobile build overlay
- export the existing RadioGroup primitives required by the current LifeOps renderer

## Physical LP3 acceptance
- exact APK from `1d2ad96b082bae6820eec3a79a2b094712eaa8dc` installed on `LP3LHMA632300459`
- running window reports `KEEP_SCREEN_ON`; power service reports `mStayOn=true` and Awake
- compact toolbar measured 348x52 CSS px on-device
- Apple.com rendered inside Eliza with no native-surface error

## Verification
- 102 focused UI/browser tests passed
- 15 generated Cloud activity tests passed
- UI typecheck passed
- Biome and Impeccable detector passed
- Android Cloud and LP3 direct artifact audits passed