### PR TITLE
fix(cloud): fail closed on database schema identity drift

### DIFF
--- a/.github/workflows/cloud-cf-release.yml
+++ b/.github/workflows/cloud-cf-release.yml
@@ -310,6 +310,33 @@ jobs:
             exit "$gate_status"
           fi
 
+      - name: Validate database identity gate configuration
+        if: ${{ steps.source_guard.outputs.superseded != 'true' }}
+        env:
+          TARGET_ENVIRONMENT: ${{ inputs.target_environment }}
+          DATABASE_IDENTITY_GATE_MODE: ${{ vars.DATABASE_IDENTITY_GATE_MODE || 'off' }}
+          DATABASE_IDENTITY_EXPECTED_CLUSTER_SHA256: ${{ vars.DATABASE_IDENTITY_EXPECTED_CLUSTER_SHA256 }}
+          DATABASE_IDENTITY_EXPECTED_AUTHORITY_SHA256: ${{ vars.DATABASE_IDENTITY_EXPECTED_AUTHORITY_SHA256 }}
+        run: |
+          set -euo pipefail
+          if [ "$TARGET_ENVIRONMENT" != "production" ]; then
+            exit 0
+          fi
+          if [ "$DATABASE_IDENTITY_GATE_MODE" != "enforce" ]; then
+            echo "::error::Production migrations require DATABASE_IDENTITY_GATE_MODE=enforce"
+            exit 1
+          fi
+          for name in \
+            DATABASE_IDENTITY_EXPECTED_CLUSTER_SHA256 \
+            DATABASE_IDENTITY_EXPECTED_AUTHORITY_SHA256; do
+            value="${!name:-}"
+            if [[ ! "$value" =~ ^[0-9a-f]{64}$ ]]; then
+              echo "::error::$name must be a protected lowercase SHA-256 identity receipt"
+              exit 1
+            fi
+          done
+          echo "Production database identity enforcement is configured; receipt values were not printed."
+
       - name: Run migrations
         if: ${{ steps.source_guard.outputs.superseded != 'true' }}
         env:

--- a/packages/cloud/scripts/admin/migrate-with-diagnostics-ledger.test.ts
+++ b/packages/cloud/scripts/admin/migrate-with-diagnostics-ledger.test.ts
@@ -8,7 +8,10 @@ import { describe, expect, test } from "bun:test";
 import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
-import { validateAppliedMigrationLedger } from "./migrate-with-diagnostics";
+import {
+  assertAppliedLedgerHasCanonicalRelations,
+  validateAppliedMigrationLedger,
+} from "./migrate-with-diagnostics";
 
 const CHECKPOINT_TAG = "0194_job_execution_interruptions_catalog_guard";
 const STAGING_RESTORE_OPERATION = {
@@ -61,6 +64,36 @@ function applied(...journalIndexes: number[]) {
 }
 
 describe("migration ledger checkpoint completeness", () => {
+  test("rejects a complete ledger when a canonical relation is missing", async () => {
+    await expect(
+      assertAppliedLedgerHasCanonicalRelations({
+        backend: "postgres",
+        end: async () => undefined,
+        query: async () => ({
+          rows: [
+            { apps: false, organizations: true, users: true, api_keys: true },
+          ],
+        }),
+      }),
+    ).rejects.toThrow(
+      "Migration ledger is non-empty but canonical application relations are missing",
+    );
+  });
+
+  test("accepts a complete ledger only when all canonical relations exist", async () => {
+    await expect(
+      assertAppliedLedgerHasCanonicalRelations({
+        backend: "postgres",
+        end: async () => undefined,
+        query: async () => ({
+          rows: [
+            { apps: true, organizations: true, users: true, api_keys: true },
+          ],
+        }),
+      }),
+    ).resolves.toBeUndefined();
+  });
+
   test("accepts an under-recorded historical prefix before the checkpoint", () => {
     expect(
       validateAppliedMigrationLedger(applied(0, 2, 3, 4), migrations),

--- a/packages/cloud/scripts/admin/migrate-with-diagnostics.ts
+++ b/packages/cloud/scripts/admin/migrate-with-diagnostics.ts
@@ -79,7 +79,7 @@ interface DatabaseError extends Error {
   position?: string;
 }
 
-interface MigrationClient {
+export interface MigrationClient {
   backend: "pglite" | "postgres";
   query<T = unknown>(text: string, params?: unknown[]): Promise<{ rows: T[] }>;
   end(): Promise<void>;
@@ -349,6 +349,48 @@ async function assertEmptyLedgerDatabaseIsFresh(
     );
     throw new Error(
       "Migration ledger is empty but the database contains application relations; refusing to replay historical migrations",
+    );
+  }
+}
+
+const CANONICAL_CLOUD_RELATIONS = [
+  "apps",
+  "organizations",
+  "users",
+  "api_keys",
+] as const;
+
+/**
+ * A complete/non-empty ledger cannot authorize a schema with missing baseline
+ * application relations. This catches a wrong DATABASE_URL and destructive
+ * schema drift before pending-count success can impersonate a healthy target.
+ */
+export async function assertAppliedLedgerHasCanonicalRelations(
+  client: MigrationClient,
+): Promise<void> {
+  const result = await client.query<Record<string, boolean>>(`
+    SELECT
+      to_regclass('public.apps') IS NOT NULL AS apps,
+      to_regclass('public.organizations') IS NOT NULL AS organizations,
+      to_regclass('public.users') IS NOT NULL AS users,
+      to_regclass('public.api_keys') IS NOT NULL AS api_keys
+  `);
+  const row = result.rows[0];
+  const presence = CANONICAL_CLOUD_RELATIONS.map((relation) => ({
+    present: row?.[relation] === true,
+    relation,
+  }));
+  console.log(
+    `[db:migrate] canonical relation presence: ${presence
+      .map(
+        ({ present, relation }) =>
+          `${relation}=${present ? "present" : "missing"}`,
+      )
+      .join(" ")}`,
+  );
+  if (presence.some(({ present }) => !present)) {
+    throw new Error(
+      "Migration ledger is non-empty but canonical application relations are missing",
     );
   }
 }
@@ -763,6 +805,9 @@ export async function runMigrations(
         applied,
         migrations,
       );
+      if (client.backend === "postgres" && applied.length > 0) {
+        await assertAppliedLedgerHasCanonicalRelations(client);
+      }
       const lastApplied = applied.at(-1);
       const lastAppliedCreatedAt = lastApplied
         ? createdAtValue(lastApplied)

--- a/packages/scripts/__tests__/cloud-database-identity-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-database-identity-workflow.test.ts
@@ -44,6 +44,34 @@ function expectSameSessionGate(
 }
 
 describe("Cloud database identity workflow", () => {
+  test("requires protected identity enforcement before production migrations", () => {
+    const guard = canonicalSource.indexOf(
+      "- name: Validate database identity gate configuration",
+    );
+    const migration = canonicalSource.indexOf("- name: Run migrations");
+    expect(guard).toBeGreaterThan(0);
+    expect(guard).toBeLessThan(migration);
+    const block = canonicalSource.slice(guard, migration);
+    expect(block).toContain('if [ "$TARGET_ENVIRONMENT" != "production" ]');
+    expect(block).toContain(
+      'if [ "$DATABASE_IDENTITY_GATE_MODE" != "enforce" ]',
+    );
+    expect(block).toContain(
+      "DATABASE_IDENTITY_EXPECTED_CLUSTER_SHA256: $" +
+        "{{ vars.DATABASE_IDENTITY_EXPECTED_CLUSTER_SHA256 }}",
+    );
+    expect(block).toContain(
+      "DATABASE_IDENTITY_EXPECTED_AUTHORITY_SHA256: $" +
+        "{{ vars.DATABASE_IDENTITY_EXPECTED_AUTHORITY_SHA256 }}",
+    );
+    expect(block).not.toContain(
+      'echo "$DATABASE_IDENTITY_EXPECTED_CLUSTER_SHA256"',
+    );
+    expect(block).not.toContain(
+      'echo "$DATABASE_IDENTITY_EXPECTED_AUTHORITY_SHA256"',
+    );
+  });
+
   test("delegates canonical release enforcement to its migration session", () => {
     expectSameSessionGate(
       canonicalSource,

--- a/packages/scripts/cloud/admin/repair-mobile-app-auth-registration.ts
+++ b/packages/scripts/cloud/admin/repair-mobile-app-auth-registration.ts
@@ -73,15 +73,27 @@ export async function diagnoseRequiredRegistrationSchema(
   const client = new Client({ connectionString: url, ...(ssl ? { ssl } : {}) });
   try {
     await client.connect();
+    const presence: Array<{
+      exists: boolean;
+      table: (typeof REQUIRED_REGISTRATION_TABLES)[number];
+    }> = [];
     for (const table of REQUIRED_REGISTRATION_TABLES) {
       const result = await client.query<{ exists: boolean }>(
         "SELECT to_regclass($1) IS NOT NULL AS exists",
         [`public.${table}`],
       );
-      if (result.rows[0]?.exists !== true) {
-        fail(missingRegistrationTableInvariant(table));
-      }
+      presence.push({ exists: result.rows[0]?.exists === true, table });
     }
+    console.log(
+      `[MobileAppAuthSchema] ${presence
+        .map(
+          ({ exists, table }) => `${table}=${exists ? "present" : "missing"}`,
+        )
+        .join(" ")}`,
+    );
+    const firstMissing = presence.find(({ exists }) => !exists);
+    if (firstMissing)
+      fail(missingRegistrationTableInvariant(firstMissing.table));
   } catch (error) {
     if (error instanceof RegistrationRepairError) throw error;
     fail(databaseFailureInvariant(error));


### PR DESCRIPTION
## Summary
- require production database identity enforcement and both protected SHA-256 receipts before migrations
- reject a non-empty canonical migration ledger when baseline application relations are missing
- enumerate only allowlisted registration schema presence for privacy-safe diagnosis

## Verification
- database identity workflow: 4/4
- migration ledger guard: 6/6
- registration admin: 12/12
- Biome and diff check pass

This does not repair or create production tables. It preserves the same-session migrator identity preflight as the blocking authority and stops before deployment when identity/schema drift is present.