### PR TITLE
fix(ui): export radio group from browser barrel

### DIFF
--- a/packages/ui/src/browser.ts
+++ b/packages/ui/src/browser.ts
@@ -102,6 +102,7 @@ export { Input } from "./components/ui/input.tsx";
 export * from "./components/ui/label.tsx";
 export * from "./components/ui/popover.tsx";
 export * from "./components/ui/progress.tsx";
+export * from "./components/ui/radio-group.tsx";
 export * from "./components/ui/scroll-area.tsx";
 export { SegmentedControl } from "./components/ui/segmented-control.tsx";
 export * from "./components/ui/select.tsx";


### PR DESCRIPTION
## Summary
Export the existing RadioGroup primitives from the browser-safe @elizaos/ui barrel. This fixes the exact-9aa Android launcher Vite failure in LifeOpsConnectionsView, which imports RadioGroup and RadioGroupItem from @elizaos/ui.

## Verification
- packages/ui RadioGroup Vitest: 1/1
- exact failure reproduced before this export: Vite could not resolve RadioGroup/RadioGroupItem from packages/ui/src/browser.ts
- Biome and diff check pass