### PR TITLE
fix(android): preserve rounded browser chat mask

### DIFF
--- a/packages/ui/src/surface/use-mobile-native-tab-surfaces.test.ts
+++ b/packages/ui/src/surface/use-mobile-native-tab-surfaces.test.ts
@@ -11,7 +11,7 @@
 
 import { act, renderHook } from "@testing-library/react";
 import { createElement, type ReactNode, StrictMode } from "react";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { APP_PAUSE_EVENT, APP_RESUME_EVENT } from "../events";
 import {
   CapacitorNativeSurfaceShell,
@@ -390,6 +390,40 @@ describe("useMobileNativeTabSurfaces", () => {
         cornerRadius: 32,
       },
     ]);
+  });
+
+  it("resolves a CSS-variable radius before sending a native occlusion", () => {
+    const sheet = elementAt({ left: 12, top: 22, width: 336, height: 180 });
+    sheet.className = "overlay";
+    sheet.style.borderRadius = "var(--chat-sheet-radius)";
+    document.body.append(sheet);
+    const realGetComputedStyle = window.getComputedStyle.bind(window);
+    const computedStyle = vi
+      .spyOn(window, "getComputedStyle")
+      .mockImplementation((element) =>
+        element === sheet
+          ? ({
+              display: "block",
+              visibility: "visible",
+              borderRadius: "32px",
+              borderTopLeftRadius: "32px",
+            } as CSSStyleDeclaration)
+          : realGetComputedStyle(element),
+      );
+
+    try {
+      expect(collectSurfaceOcclusionRects(".overlay", document)).toEqual([
+        {
+          x: 12,
+          y: 22,
+          width: 336,
+          height: 180,
+          cornerRadius: 32,
+        },
+      ]);
+    } finally {
+      computedStyle.mockRestore();
+    }
   });
 
   it("reads the nearest real rounded overflow host without duplicating its CSS radius", () => {

--- a/packages/ui/src/surface/use-mobile-native-tab-surfaces.ts
+++ b/packages/ui/src/surface/use-mobile-native-tab-surfaces.ts
@@ -267,6 +267,17 @@ function parseCornerRadius(value: string): number | null {
     : null;
 }
 
+function firstParsedCornerRadius(
+  ...values: ReadonlyArray<string | undefined>
+): number {
+  for (const value of values) {
+    if (value === undefined) continue;
+    const radius = parseCornerRadius(value);
+    if (radius !== null) return radius;
+  }
+  return 0;
+}
+
 const ZERO_CORNER_RADII: SurfaceCornerRadii = {
   topLeft: 0,
   topRight: 0,
@@ -386,14 +397,19 @@ export function collectSurfaceOcclusionRects(
       y: roundedCssPixel(rect.top),
       width: roundedCssPixel(rect.width),
       height: roundedCssPixel(rect.height),
-      cornerRadius:
-        parseCornerRadius(
-          element.style.borderTopLeftRadius ||
-            element.style.borderRadius ||
-            style?.borderTopLeftRadius ||
-            style?.borderRadius ||
-            "0",
-        ) ?? 0,
+      // Motion-driven chat chrome writes `border-radius` as a CSS variable
+      // (`var(--chat-sheet-radius)`). The inline token is intentionally not a
+      // number, while computed style contains the resolved pixel radius. Keep
+      // explicit numeric inline geometry authoritative, but continue through
+      // unparseable inline tokens to their computed values; otherwise Android
+      // receives radius 0 and cuts a square native-WebView hole behind the
+      // rounded chat sheet.
+      cornerRadius: firstParsedCornerRadius(
+        element.style.borderTopLeftRadius,
+        element.style.borderRadius,
+        style?.borderTopLeftRadius,
+        style?.borderRadius,
+      ),
     });
   }
   // A native mask represents the union of these regions. Nested portal/status


### PR DESCRIPTION
## Summary
- resolve motion-driven CSS variable radii before sending native Browser occlusion geometry
- prevent Android native WebView holes from falling back to square corners behind rounded chat
- add an exact regression for `var(--chat-sheet-radius)` resolving to 32px

## Verification
- `bun run --cwd packages/ui test -- src/surface/use-mobile-native-tab-surfaces.test.ts` (33 passed)
- `bunx @biomejs/biome check packages/ui/src/surface/use-mobile-native-tab-surfaces.ts packages/ui/src/surface/use-mobile-native-tab-surfaces.test.ts`
- `bun run --cwd packages/ui typecheck`
- Impeccable detector: no findings

Physical LP3 before/after evidence will be attached to the final handoff after installing the exact commit.