### PR TITLE
fix(cloud): decode Steward provider discovery responses

### DIFF
--- a/packages/cloud/api/src/steward/embedded.test.ts
+++ b/packages/cloud/api/src/steward/embedded.test.ts
@@ -384,6 +384,15 @@ describe("embeddedStewardHandler proxy", () => {
     expect(calls[0]?.headers.get("x-steward-tenant")).toBeNull();
   });
 
+  it("preserves accept-encoding on non-providers passthrough requests", async () => {
+    const calls = stubFetch(async () => Response.json({ ok: true }));
+    await makeApp(baseEnv()).request(
+      "https://api.elizacloud.ai/steward/auth/nonce",
+      { headers: { "accept-encoding": "gzip, br" } },
+    );
+    expect(calls[0]?.headers.get("accept-encoding")).toBe("gzip, br");
+  });
+
   it("signs PUT, PATCH, and DELETE when a signing secret is configured", async () => {
     const calls = stubFetch(async () => new Response("ok", { status: 200 }));
     const env = baseEnv({
@@ -451,6 +460,56 @@ describe("embeddedStewardHandler proxy", () => {
 });
 
 describe("patchProvidersResponse", () => {
+  it("removes inbound accept-encoding before reading uncompressed provider JSON", async () => {
+    const calls = stubFetch(async (_input, init) => {
+      expect(new Headers(init?.headers).get("accept-encoding")).toBeNull();
+      return Response.json(providersJson());
+    });
+    const response = await makeApp(baseEnv()).request(
+      "https://api.elizacloud.ai/steward/auth/providers",
+      { headers: { "accept-encoding": "gzip, br" } },
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-eliza-providers-cache")).toBe("miss");
+    expect(calls[0]?.headers.get("accept-encoding")).toBeNull();
+    await expect(response.json()).resolves.toMatchObject({ ok: true });
+  });
+
+  it("fails closed without caching when an upstream still returns compressed bytes", async () => {
+    let upstreamCalls = 0;
+    stubFetch(async () => {
+      upstreamCalls += 1;
+      const compressed = new Blob([JSON.stringify(providersJson())])
+        .stream()
+        .pipeThrough(new CompressionStream("gzip"));
+      return new Response(compressed, {
+        status: 200,
+        headers: {
+          "content-type": "application/json",
+          "content-encoding": "gzip",
+        },
+      });
+    });
+    const app = makeApp(baseEnv());
+    const first = await app.request(
+      "https://api.elizacloud.ai/steward/auth/providers",
+      { headers: { "accept-encoding": "gzip, br" } },
+    );
+    expect(first.status).toBe(502);
+    expect(first.headers.get("cache-control")).toBe("no-store");
+    await expect(first.json()).resolves.toMatchObject({
+      code: "steward_upstream_invalid_response",
+    });
+
+    const retry = await app.request(
+      "https://api.elizacloud.ai/steward/auth/providers",
+      { headers: { "accept-encoding": "gzip, br" } },
+    );
+    expect(retry.status).toBe(502);
+    expect(retry.headers.get("x-eliza-providers-cache")).toBeNull();
+    expect(upstreamCalls).toBe(2);
+  });
+
   it("patches discord and github from env credentials without duplicating oauth entries", async () => {
     stubFetch(async () =>
       Response.json(

--- a/packages/cloud/api/src/steward/embedded.ts
+++ b/packages/cloud/api/src/steward/embedded.ts
@@ -764,6 +764,12 @@ export const embeddedStewardHandler: MiddlewareHandler<AppEnv> = async (c) => {
   // upstream fetch sets its own.
   headers.delete("host");
   if (isProvidersRequest) {
+    // Provider discovery is not a passthrough response: the proxy reads and
+    // validates the upstream JSON before caching it. Forwarding the browser's
+    // Accept-Encoding opts Workers into compressed passthrough, which can
+    // leave readBoundedBody() inspecting gzip/brotli bytes instead of JSON.
+    // Let the Workers runtime negotiate and decode this subrequest itself.
+    headers.delete("accept-encoding");
     for (const name of [
       "authorization",
       "cookie",


### PR DESCRIPTION
## Summary

- stop forwarding the browser Accept-Encoding header only for Steward provider discovery
- let the Workers runtime negotiate and decode the upstream response before bounded JSON validation and caching
- preserve the existing passthrough header behavior on every other Steward route
- keep malformed or unexpectedly compressed provider responses fail-closed and uncached

## Why

Staging returned steward_upstream_invalid_response even though the Steward origin returned a valid provider contract with HTTP 200. Railway request evidence showed the embedded Worker request reached the origin successfully. Forwarding the browser Accept-Encoding header opted the subrequest into compressed passthrough while this route reads and validates the body, so the validator could receive gzip bytes instead of JSON.

## Verification

- 193 focused Steward, signing, thin-app, and Cloud entry tests passed
- Cloud API typecheck passed
- production Wrangler dry bundle passed
- exact Biome check passed for both touched files
- git diff check passed
- rebased onto exact develop 6a6fee4d42403a79920ae1958baca0592d91590d with stable patch-id dd252fac74c329c21832056f45b97454306246a8

No deployment, Pixel/device action, live agent mutation, billing action, or credential change was performed by this PR.

Run 32994036927 failed closed on canonical source drift and did not deploy its API Worker. The Pages failure in that run was an independent browser-barrel export issue already repaired on develop.
