### PR TITLE
fix(plugin-google-workspace): keep UTF-16 surrogate pairs intact in subject and clip truncation

### DIFF
--- a/plugins/plugin-google-workspace/src/gmail-message-connector.test.ts
+++ b/plugins/plugin-google-workspace/src/gmail-message-connector.test.ts
@@ -347,15 +347,13 @@ describe("gmail send handler", () => {
     });
     expect(sendGmailMessage).not.toHaveBeenCalled();
   });
-});
-
 
   it("preserves surrogate pairs when truncating long subject lines", async () => {
     const { runtime, sendGmailMessage } = runtimeStub({
       accounts: [CONNECTED_ACCOUNT],
     });
     const registration = createGmailMessageConnector(runtime);
-    const longText = "A".repeat(74) + "🎯" + " rest of the message";
+    const longText = `${"A".repeat(74)}🎯 rest of the message`;
 
     await invokeSend(
       registration,
@@ -366,10 +364,11 @@ describe("gmail send handler", () => {
 
     expect(sendGmailMessage).toHaveBeenCalledWith(
       expect.objectContaining({
-        subject: "A".repeat(74) + "...",
+        subject: `${"A".repeat(74)}...`,
       })
     );
   });
+});
 
 describe("isEmailAddress", () => {
   it("accepts literal addresses and rejects names/handles", () => {

--- a/plugins/plugin-google-workspace/src/gmail-message-connector.test.ts
+++ b/plugins/plugin-google-workspace/src/gmail-message-connector.test.ts
@@ -349,6 +349,28 @@ describe("gmail send handler", () => {
   });
 });
 
+
+  it("preserves surrogate pairs when truncating long subject lines", async () => {
+    const { runtime, sendGmailMessage } = runtimeStub({
+      accounts: [CONNECTED_ACCOUNT],
+    });
+    const registration = createGmailMessageConnector(runtime);
+    const longText = "A".repeat(74) + "🎯" + " rest of the message";
+
+    await invokeSend(
+      registration,
+      runtime,
+      { channelId: "shadow@example.com" },
+      { text: longText }
+    );
+
+    expect(sendGmailMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subject: "A".repeat(74) + "...",
+      })
+    );
+  });
+
 describe("isEmailAddress", () => {
   it("accepts literal addresses and rejects names/handles", () => {
     expect(isEmailAddress("shadow@example.com")).toBe(true);

--- a/plugins/plugin-google-workspace/src/gmail-message-connector.ts
+++ b/plugins/plugin-google-workspace/src/gmail-message-connector.ts
@@ -1,3 +1,15 @@
+function truncateUtf16Safe(text: string, maxLength: number): string {
+  if (text.length <= maxLength) {
+    return text;
+  }
+  let limit = maxLength;
+  const leadChar = text.charCodeAt(limit - 1);
+  if (leadChar >= 0xd800 && leadChar <= 0xdbff) {
+    limit -= 1;
+  }
+  return text.slice(0, limit);
+}
+
 /**
  * Gmail send-target MessageConnector: advertises Gmail as a cross-connector
  * send surface so `MESSAGE op=send source=gmail` (aliases "email"/"mail") and
@@ -170,7 +182,7 @@ function subjectFromContent(content: Content): string {
     .trim();
   return firstLine.length <= SUBJECT_MAX_LENGTH
     ? firstLine
-    : `${firstLine.slice(0, SUBJECT_MAX_LENGTH - 3)}...`;
+    : `${truncateUtf16Safe(firstLine, SUBJECT_MAX_LENGTH - 3)}...`;
 }
 
 async function sendGmailFromTarget(

--- a/plugins/plugin-google-workspace/src/lifeops-message-adapter.ts
+++ b/plugins/plugin-google-workspace/src/lifeops-message-adapter.ts
@@ -46,7 +46,17 @@ interface GmailDraftContext {
 }
 
 function clip(value: string, maxLength: number): string {
-  return value.length > maxLength ? `${value.slice(0, maxLength - 3)}...` : value;
+  if (value.length <= maxLength) {
+    return value;
+  }
+  let limit = maxLength - 3;
+  if (limit > 0) {
+    const leadChar = value.charCodeAt(limit - 1);
+    if (leadChar >= 0xd800 && leadChar <= 0xdbff) {
+      limit -= 1;
+    }
+  }
+  return `${value.slice(0, Math.max(0, limit))}...`;
 }
 
 function refId(messageId: string): string {


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:7ea68921edf200fe6cf16edb1959d92427f5be27 -->

## Summary
In `plugins/plugin-google-workspace`:
- In `gmail-message-connector.ts`, `subjectFromContent` truncated long first body lines using raw `.slice(0, SUBJECT_MAX_LENGTH - 3)` which could sever a high surrogate code point (`0xD800`..`0xDBFF`) from its low surrogate, leaving lone surrogate fragments in derived email subject lines.
- In `lifeops-message-adapter.ts`, `clip` truncated long strings using `.slice(0, maxLength - 3)` which also risked severing UTF-16 surrogate pairs.

## Proposed Changes
1. Added surrogate-safe boundary detection to `subjectFromContent` backing off the truncation boundary by 1 code unit when a high surrogate sits at the end of the slice.
2. Updated `clip` in `lifeops-message-adapter.ts` with UTF-16 surrogate pair boundary detection.
3. Added unit tests in `src/gmail-message-connector.test.ts` verifying that surrogate pairs (e.g. emoji) at the truncation boundary remain intact without orphaned high surrogates.

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-google-workspace test` (18 test files passed, 171/171 tests).

<!-- contribution-provenance:
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
-->
