### PR TITLE
fix(cloud): validate crypto confirmation payment ids

### DIFF
--- a/packages/cloud/api/crypto/payments/[id]/confirm/route.ts
+++ b/packages/cloud/api/crypto/payments/[id]/confirm/route.ts
@@ -46,6 +46,7 @@ function validateTransactionHashFormat(hash: string, network: string): boolean {
 const confirmSchema = z.object({
   transactionHash: z.string().min(1, "Transaction hash is required"),
 });
+const paymentIdSchema = z.string().uuid();
 
 const app = new Hono<AppEnv>();
 
@@ -58,6 +59,9 @@ app.post("/", moneyRateLimit(RateLimitPresets.STRICT), async (c) => {
   try {
     const user = await requireUserWithOrg(c);
     const id = c.req.param("id") ?? "";
+    if (!paymentIdSchema.safeParse(id).success) {
+      return c.json({ error: "Invalid payment ID" }, 400);
+    }
 
     const payment = await cryptoPaymentsRepository.findById(id);
     if (!payment) {

--- a/packages/cloud/api/test/e2e/group-h-misc.test.ts
+++ b/packages/cloud/api/test/e2e/group-h-misc.test.ts
@@ -426,9 +426,10 @@ describeE2E("Group H — POST /api/cron/agent-billing", () => {
 // ─────────────────────────────────────────────────────────────────────────
 describeE2E("Group H — POST /api/crypto/payments/:id/confirm", () => {
   test("auth gate: missing credentials → 401", async () => {
-    const res = await api.post("/api/crypto/payments/missing-id/confirm", {
-      transactionHash: VALID_ETH_TX_HASH,
-    });
+    const res = await api.post(
+      "/api/crypto/payments/00000000-0000-0000-0000-000000000000/confirm",
+      { transactionHash: VALID_ETH_TX_HASH },
+    );
     expect(res.status).toBe(401);
   });
 
@@ -441,6 +442,24 @@ describeE2E("Group H — POST /api/crypto/payments/:id/confirm", () => {
     // requireUserWithOrg is session-based; API keys never satisfy it.
     expect(res.status).toBe(401);
   });
+
+  testSession(
+    "validation: with a session, malformed payment id → 400",
+    async () => {
+      if (!sessionCookie) throw new Error("session cookie missing");
+      const res = await api.post(
+        "/api/crypto/payments/not-a-uuid/confirm",
+        { transactionHash: VALID_ETH_TX_HASH },
+        {
+          headers: sameOriginBrowserHeaders({
+            Cookie: sessionCookie,
+            "Content-Type": "application/json",
+          }),
+        },
+      );
+      expect(res.status).toBe(400);
+    },
+  );
 
   testSession(
     "happy path: with a session, unknown payment id → 404",


### PR DESCRIPTION
## Summary
- keep the crypto confirmation authentication gate isolated from resource validation by using a valid absent UUID in the missing-credentials regression
- reject an authenticated malformed payment ID with an explicit 400 before repository access
- preserve auth-before-resource-validation semantics and the session-only API-key rejection

## Exact source
- base: `a968c487f1118a611f76c17c6684d63b3632544e`
- head: `11f1c9951c55e45081de866e6ec5a5adc6a10858`
- tree: `9e3e9e63b3c3de258f03f844a1d887e6e1af0857`

## Verification
- Group H real PGlite + Wrangler e2e: 77 pass, 4 expected provider-key skips, 0 fail (81 tests)
- exact confirmation contracts: no credentials 401; API key 401; session + malformed ID 400; session + valid absent ID 404
- Cloud API TypeScript check passed (8 GB heap after the default 4 GB runner ceiling)
- production Wrangler dry bundle passed
- exact Biome and `git diff --check` passed

No payment, provider, deployment, production, inventory, billing, or device mutation occurred.