### PR TITLE
fix(cloud): gate crypto confirmation before shard load

### DIFF
--- a/packages/cloud/api/src/index.test.ts
+++ b/packages/cloud/api/src/index.test.ts
@@ -1,8 +1,10 @@
 /** Verifies Cloud Worker routing and thin-inference dispatch with deterministic fixtures. */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
+import type { Hono } from "hono";
 import type { AppEnv } from "@/types/cloud-worker-env";
 import cloudApiWorker, {
   decorateFullAppDispatchResponse,
+  dispatchFullApp,
   getFrontendAliasApiProxyTarget,
   getFrontendAliasProxyTarget,
   getGeneratedAgentId,
@@ -34,6 +36,189 @@ test("preserves Workerd WebSocket upgrade responses without rewrapping", () => {
       8,
     ),
   ).toBe(upgrade);
+});
+
+test("gates crypto payment confirmation before cold shard loading", async () => {
+  const env = { ENVIRONMENT: "staging" } as AppEnv["Bindings"];
+  const executionCtx = {
+    waitUntil: () => undefined,
+    passThroughOnException: () => undefined,
+  } as unknown as ExecutionContext;
+  const loadFullApp = mock(async () => {
+    throw new Error("payment shard must not load");
+  });
+
+  const missingCredentials = await dispatchFullApp(
+    new Request(
+      "https://api.eliza.app/api/crypto/payments/missing-id/confirm",
+      { method: "POST" },
+    ),
+    env,
+    executionCtx,
+    loadFullApp,
+  );
+  const apiKeyCredentials = await dispatchFullApp(
+    new Request(
+      "https://api.eliza.app/api/crypto/payments/missing-id/confirm",
+      {
+        method: "POST",
+        headers: { authorization: "Bearer eliza_test" },
+      },
+    ),
+    env,
+    executionCtx,
+    loadFullApp,
+  );
+  const unrelatedCookie = await dispatchFullApp(
+    new Request(
+      "https://api.eliza.app/api/crypto/payments/missing-id/confirm",
+      {
+        method: "POST",
+        headers: { cookie: "analytics-id=not-a-session" },
+      },
+    ),
+    env,
+    executionCtx,
+    loadFullApp,
+  );
+  const malformedBearer = await dispatchFullApp(
+    new Request(
+      "https://api.eliza.app/api/crypto/payments/missing-id/confirm",
+      {
+        method: "POST",
+        headers: { authorization: "Bearer not-a-jwt" },
+      },
+    ),
+    env,
+    executionCtx,
+    loadFullApp,
+  );
+  const disabledTestSession = await dispatchFullApp(
+    new Request(
+      "https://api.eliza.app/api/crypto/payments/missing-id/confirm",
+      {
+        method: "POST",
+        headers: { cookie: "eliza-test-session=payload.signature" },
+      },
+    ),
+    env,
+    executionCtx,
+    loadFullApp,
+  );
+  const productionTestSession = await dispatchFullApp(
+    new Request(
+      "https://api.eliza.app/api/crypto/payments/missing-id/confirm",
+      {
+        method: "POST",
+        headers: { cookie: "eliza-test-session=payload.signature" },
+      },
+    ),
+    {
+      ENVIRONMENT: "production",
+      PLAYWRIGHT_TEST_AUTH: "true",
+    } as AppEnv["Bindings"],
+    executionCtx,
+    loadFullApp,
+  );
+
+  expect(missingCredentials.status).toBe(401);
+  expect(await missingCredentials.json()).toMatchObject({
+    code: "authentication_required",
+  });
+  expect(apiKeyCredentials.status).toBe(401);
+  expect(await apiKeyCredentials.json()).toMatchObject({
+    code: "session_auth_required",
+  });
+  expect(unrelatedCookie.status).toBe(401);
+  expect(malformedBearer.status).toBe(401);
+  expect(disabledTestSession.status).toBe(401);
+  expect(productionTestSession.status).toBe(401);
+  expect(loadFullApp).not.toHaveBeenCalled();
+
+  const sessionFetch = mock(async () =>
+    Response.json({ error: "Payment not found" }, { status: 404 }),
+  );
+  const loadSessionApp = mock(
+    async () => ({ fetch: sessionFetch }) as unknown as Hono<AppEnv>,
+  );
+  const sessionCredentials = await dispatchFullApp(
+    new Request(
+      "https://api.eliza.app/api/crypto/payments/missing-id/confirm",
+      {
+        method: "POST",
+        headers: { cookie: "steward-token-staging=session" },
+      },
+    ),
+    env,
+    executionCtx,
+    loadSessionApp,
+  );
+
+  expect(sessionCredentials.status).toBe(404);
+  expect(loadSessionApp).toHaveBeenCalledTimes(1);
+  expect(sessionFetch).toHaveBeenCalledTimes(1);
+
+  const enabledTestSession = await dispatchFullApp(
+    new Request(
+      "https://api.eliza.app/api/crypto/payments/missing-id/confirm",
+      {
+        method: "POST",
+        headers: { cookie: "eliza-test-session=payload.signature" },
+      },
+    ),
+    {
+      ENVIRONMENT: "test",
+      NODE_ENV: "test",
+      PLAYWRIGHT_TEST_AUTH: "true",
+    } as AppEnv["Bindings"],
+    executionCtx,
+    loadSessionApp,
+  );
+
+  expect(enabledTestSession.status).toBe(404);
+  expect(loadSessionApp).toHaveBeenCalledTimes(2);
+  expect(sessionFetch).toHaveBeenCalledTimes(2);
+});
+
+test("answers crypto payment confirmation preflight before shard loading", async () => {
+  const env = { ENVIRONMENT: "staging" } as AppEnv["Bindings"];
+  const executionCtx = {
+    waitUntil: () => undefined,
+    passThroughOnException: () => undefined,
+  } as unknown as ExecutionContext;
+  const loadFullApp = mock(async () => {
+    throw new Error("payment shard must not load for preflight");
+  });
+
+  const response = await dispatchFullApp(
+    new Request(
+      "https://api.eliza.app/api/crypto/payments/missing-id/confirm",
+      {
+        method: "OPTIONS",
+        headers: {
+          origin: "https://develop.eliza-app.pages.dev",
+          "access-control-request-method": "POST",
+          "access-control-request-headers": "content-type, x-eliza-csrf",
+        },
+      },
+    ),
+    env,
+    executionCtx,
+    loadFullApp,
+  );
+
+  expect(response.status).toBe(204);
+  expect(response.headers.get("access-control-allow-origin")).toBe(
+    "https://develop.eliza-app.pages.dev",
+  );
+  expect(response.headers.get("access-control-allow-credentials")).toBe("true");
+  expect(response.headers.get("access-control-allow-methods")).toContain(
+    "POST",
+  );
+  expect(response.headers.get("access-control-allow-headers")).toContain(
+    "X-Eliza-CSRF",
+  );
+  expect(loadFullApp).not.toHaveBeenCalled();
 });
 
 test("dispatches provider webhooks without full-app bootstrap", async () => {

--- a/packages/cloud/api/src/index.ts
+++ b/packages/cloud/api/src/index.ts
@@ -14,12 +14,19 @@
 import "./worker-polyfills";
 
 import {
+  isPlaywrightTestAuthEnabled,
+  PLAYWRIGHT_TEST_SESSION_COOKIE_NAME,
+} from "@elizaos/cloud-shared/lib/auth/playwright-test-session";
+import { readStewardAccessCookieFromHeader } from "@elizaos/cloud-shared/lib/auth/steward-cookies";
+import { corsMiddleware } from "@elizaos/cloud-shared/lib/cors/cloud-api-hono-cors";
+import { getCookieValueFromHeader } from "@elizaos/cloud-shared/lib/http/cookie-header";
+import {
   canonicalCloudPathForLegacyDashboard,
   canonicalElizaServiceHostname,
   classifyElizaHostname,
   ELIZA_DOMAIN_CONTRACTS,
 } from "@elizaos/shared/elizacloud";
-import type { Hono, ExecutionContext as HonoExecutionContext } from "hono";
+import { Hono, type ExecutionContext as HonoExecutionContext } from "hono";
 import {
   cloneRequestWithScheduledCronMetadata,
   makeCronHandler,
@@ -78,6 +85,69 @@ let cliSessionThinAppPromise: Promise<Hono<AppEnv>> | undefined;
 let webhookAppPromise: Promise<Hono<AppEnv>> | undefined;
 /** Lazy authenticated Discord shell that avoids the generated application router. */
 let discordGatewayAppPromise: Promise<Hono<AppEnv>> | undefined;
+
+const CRYPTO_PAYMENT_CONFIRM_PATH_RE =
+  /^\/api\/crypto\/payments\/[^/]+\/confirm\/?$/;
+const STRUCTURAL_JWT_RE = /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/;
+
+// Preserve the full app's credentialed CORS policy without loading the route
+// shard for a browser preflight. The CORS middleware completes OPTIONS itself.
+const cryptoPaymentConfirmPreflightApp = new Hono<AppEnv>();
+cryptoPaymentConfirmPreflightApp.use("*", corsMiddleware);
+
+async function handleCryptoPaymentConfirmBeforeShard(
+  request: Request,
+  env: AppEnv["Bindings"],
+  ctx: ExecutionContext | HonoExecutionContext,
+): Promise<Response | null> {
+  const url = new URL(request.url);
+  if (!CRYPTO_PAYMENT_CONFIRM_PATH_RE.test(url.pathname)) {
+    return null;
+  }
+  if (request.method === "OPTIONS") {
+    return cryptoPaymentConfirmPreflightApp.fetch(request, env, ctx);
+  }
+  if (request.method !== "POST") return null;
+
+  const authorization = request.headers.get("authorization")?.trim() ?? "";
+  const bearer = authorization.match(/^Bearer\s+(.+)$/i)?.[1]?.trim() ?? "";
+  const hasApiKey =
+    Boolean(request.headers.get("x-api-key")?.trim()) ||
+    bearer.startsWith("eliza_");
+  if (hasApiKey) {
+    return Response.json(
+      {
+        success: false,
+        error: "A signed-in user session is required to confirm a payment.",
+        code: "session_auth_required",
+      },
+      { status: 401, headers: { "cache-control": "no-store" } },
+    );
+  }
+
+  const hasPossibleSession = Boolean(
+    readStewardAccessCookieFromHeader(
+      request.headers.get("cookie"),
+      env.ENVIRONMENT,
+    ) ||
+      STRUCTURAL_JWT_RE.test(bearer) ||
+      (isPlaywrightTestAuthEnabled(env) &&
+        getCookieValueFromHeader(
+          request.headers.get("cookie"),
+          PLAYWRIGHT_TEST_SESSION_COOKIE_NAME,
+        )),
+  );
+  if (hasPossibleSession) return null;
+
+  return Response.json(
+    {
+      success: false,
+      error: "Unauthorized",
+      code: "authentication_required",
+    },
+    { status: 401, headers: { "cache-control": "no-store" } },
+  );
+}
 
 const STAGING_SESSION_UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -268,6 +338,13 @@ export async function dispatchFullApp(
   ctx: ExecutionContext | HonoExecutionContext,
   loadFullApp?: () => Promise<Hono<AppEnv>>,
 ): Promise<Response> {
+  // Payment confirmation is session-only and money-moving. Reject an absent
+  // or explicitly API-key credential before constructing the route shard, so
+  // a cold module/init failure cannot turn the auth boundary into a 500.
+  const cryptoConfirmAuthRejection =
+    await handleCryptoPaymentConfirmBeforeShard(request, env, ctx);
+  if (cryptoConfirmAuthRejection) return cryptoConfirmAuthRejection;
+
   const startedAt = performance.now();
   const requestPathname = new URL(request.url).pathname;
   const moduleWasInitialized = loadFullApp

--- a/packages/cloud/api/test/e2e/group-h-misc.test.ts
+++ b/packages/cloud/api/test/e2e/group-h-misc.test.ts
@@ -425,6 +425,25 @@ describeE2E("Group H — POST /api/cron/agent-billing", () => {
 // /api/crypto/payments/:id/confirm — session/owner-required
 // ─────────────────────────────────────────────────────────────────────────
 describeE2E("Group H — POST /api/crypto/payments/:id/confirm", () => {
+  test("browser preflight returns credentialed CORS without route bootstrap", async () => {
+    const origin = "https://develop.eliza-app.pages.dev";
+    const res = await fetch(url("/api/crypto/payments/missing-id/confirm"), {
+      method: "OPTIONS",
+      headers: {
+        Origin: origin,
+        "Access-Control-Request-Method": "POST",
+        "Access-Control-Request-Headers": "content-type, x-eliza-csrf",
+      },
+    });
+    expect(res.status).toBe(204);
+    expect(res.headers.get("access-control-allow-origin")).toBe(origin);
+    expect(res.headers.get("access-control-allow-credentials")).toBe("true");
+    expect(res.headers.get("access-control-allow-methods")).toContain("POST");
+    expect(res.headers.get("access-control-allow-headers")).toContain(
+      "X-Eliza-CSRF",
+    );
+  });
+
   test("auth gate: missing credentials → 401", async () => {
     const res = await api.post(
       "/api/crypto/payments/00000000-0000-0000-0000-000000000000/confirm",


### PR DESCRIPTION
Closes #29274.

## What changed

- gate exact crypto payment-confirm POST requests before cold route-shard construction
- reject missing credentials and unrelated cookies/malformed bearer values with canonical 401 responses without invoking the loader
- reject Eliza API keys on this session-only endpoint with `session_auth_required`
- recognize only the environment-scoped Steward access cookie or a structurally plausible three-part JWT bearer as a possible user session
- preserve the existing non-production + `PLAYWRIGHT_TEST_AUTH`-gated test-session cookie contract; production or a missing flag cannot use it
- answer credentialed OPTIONS preflight through the canonical Cloud API CORS middleware before shard loading
- preserve valid session dispatch into existing organization, ownership, UUID, and payment checks from #29273

## Exact source

- base: `9109339b01d068d5e5f0d42f6b15bdd8aa4ed269` (`develop`)
- head: `7c9e103b5cbf3d94d58aa59dd15bb7798107ccf1`
- tree: `e56d211fecbbcd7315199acec7727bd7bc2818dc`
- exact three-dot diff: 3 files, `+282/-1`

## Verification

- full `packages/cloud/api/src/index.test.ts`: 55 pass / 0 fail / 321 assertions
- focused auth/preflight unit proof: 2 pass / 0 fail / 21 assertions
- real Worker + PGlite Group H: 5 pass / 0 fail
  - credentialed OPTIONS preflight: 204 without shard loading
  - missing credentials: 401
  - API key: 401
  - malformed UUID session request: 400, preserving #29273
  - valid unknown UUID session request: 404
- `bun run --cwd packages/cloud/api typecheck`: pass, including TypeScript and production Wrangler dry-run bundle
- pinned Biome on all 3 changed files: pass
- `git diff --check`: pass

The earlier root-configured coverage run completed its assertions but its very large text coverage output ended with a local `WriteFailed`. The exact focused rerun from `/tmp` exited 0, and the package/typecheck/Worker gates above are authoritative for this head.
