### PR TITLE
chore(cloud): add protected production database authority audit

### DIFF
--- a/.github/workflows/production-railway-database-authority-audit.yml
+++ b/.github/workflows/production-railway-database-authority-audit.yml
@@ -1,0 +1,176 @@
+name: Production Railway Database Authority Audit
+
+run-name: Production Railway database authority audit ${{ github.sha }}
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: production-railway-database-authority-audit
+  cancel-in-progress: false
+
+jobs:
+  audit:
+    name: Read-only production authority and schema audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: production
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+
+      - name: Require canonical develop source
+        env:
+          SOURCE_REF: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+          if [ "$SOURCE_REF" != "refs/heads/develop" ]; then
+            echo "::error::Production database authority audits must run from refs/heads/develop"
+            exit 1
+          fi
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: "24.15.0"
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+        with:
+          bun-version: "1.3.14"
+
+      - name: Install dependencies without lifecycle mutation
+        run: bun install --frozen-lockfile --no-save --ignore-scripts
+
+      - name: Validate protected audit configuration
+        env:
+          HAS_DATABASE_URL: ${{ secrets.DATABASE_URL != '' }}
+          HAS_RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN != '' }}
+          RAILWAY_PROJECT_ID: ${{ vars.RAILWAY_PROJECT_ID }}
+          RAILWAY_ENVIRONMENT_ID: ${{ vars.RAILWAY_ENVIRONMENT_ID }}
+          RAILWAY_POSTGRES_SERVICE_ID: ${{ vars.RAILWAY_POSTGRES_SERVICE_ID }}
+        run: |
+          set -euo pipefail
+          missing=()
+          [ "$HAS_DATABASE_URL" = "true" ] || missing+=(DATABASE_URL)
+          [ "$HAS_RAILWAY_TOKEN" = "true" ] || missing+=(RAILWAY_TOKEN)
+          for name in \
+            RAILWAY_PROJECT_ID \
+            RAILWAY_ENVIRONMENT_ID; do
+            value="${!name:-}"
+            if [[ ! "$value" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]; then
+              missing+=("$name")
+            fi
+          done
+          if [ -n "${RAILWAY_POSTGRES_SERVICE_ID:-}" ] && \
+            [[ ! "$RAILWAY_POSTGRES_SERVICE_ID" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]; then
+            missing+=(RAILWAY_POSTGRES_SERVICE_ID)
+          fi
+          if [ "${#missing[@]}" -gt 0 ]; then
+            echo "::error::Missing or invalid protected production audit setting name(s): ${missing[*]}"
+            exit 1
+          fi
+          echo "Protected production audit settings are configured; values were not printed."
+
+      - name: Install pinned Railway CLI
+        run: |
+          set -euo pipefail
+          cli_root="$RUNNER_TEMP/railway-cli-production-db-audit"
+          archive="$RUNNER_TEMP/railway-v5.38.0-production-db-audit.tar.gz"
+          mkdir -m 0700 "$cli_root"
+          curl --fail --silent --show-error --location --retry 3 \
+            --output "$archive" \
+            "https://github.com/railwayapp/cli/releases/download/v5.38.0/railway-v5.38.0-x86_64-unknown-linux-gnu.tar.gz"
+          printf '%s  %s\n' \
+            "72835c48a710c48c4542141bf12264823cf3a029b514f9e27994096c036c539e" \
+            "$archive" | sha256sum --check --status
+          tar -xzf "$archive" -C "$cli_root" railway
+          chmod 0755 "$cli_root/railway"
+          echo "$cli_root" >> "$GITHUB_PATH"
+          "$cli_root/railway" --version | grep -F "railway 5.38.0"
+
+      - name: Capture private read-only Railway authority evidence
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+          RAILWAY_PROJECT_ID: ${{ vars.RAILWAY_PROJECT_ID }}
+          RAILWAY_ENVIRONMENT_ID: ${{ vars.RAILWAY_ENVIRONMENT_ID }}
+          RAILWAY_POSTGRES_SERVICE_ID: ${{ vars.RAILWAY_POSTGRES_SERVICE_ID }}
+        run: |
+          set -euo pipefail
+          umask 077
+          evidence_dir="$RUNNER_TEMP/production-db-authority-audit"
+          mkdir -m 0700 "$evidence_dir"
+          capture() {
+            local label="$1"
+            local output="$2"
+            shift 2
+            if ! "$@" > "$output" 2>"$evidence_dir/${label}.stderr"; then
+              echo "::error::Railway $label read failed; raw output was not printed"
+              exit 1
+            fi
+            chmod 0600 "$output" "$evidence_dir/${label}.stderr"
+          }
+          common=(
+            --project "$RAILWAY_PROJECT_ID"
+            --environment "$RAILWAY_ENVIRONMENT_ID"
+          )
+          capture status "$evidence_dir/status.json" \
+            railway status "${common[@]}" --json
+          capture services "$evidence_dir/services.json" \
+            railway service list "${common[@]}" --json
+          bun packages/cloud/scripts/admin/resolve-production-railway-postgres-service.ts \
+            --status-json "$evidence_dir/status.json" \
+            --services-json "$evidence_dir/services.json" \
+            --service-id-output "$evidence_dir/resolved-service-id"
+          resolved_service_id="$(<"$evidence_dir/resolved-service-id")"
+          echo "::add-mask::$resolved_service_id"
+          capture variables "$evidence_dir/variables.json" \
+            railway variable list "${common[@]}" \
+              --service "$resolved_service_id" --json
+          resolved_service_id=""
+          echo "Captured private Railway target evidence without printing inventory or variables."
+
+      - name: Audit protected database authority, schema, and migration ledger
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          RAILWAY_PROJECT_ID: ${{ vars.RAILWAY_PROJECT_ID }}
+          RAILWAY_ENVIRONMENT_ID: ${{ vars.RAILWAY_ENVIRONMENT_ID }}
+          RAILWAY_POSTGRES_SERVICE_ID: ${{ vars.RAILWAY_POSTGRES_SERVICE_ID }}
+        run: |
+          set -euo pipefail
+          umask 077
+          evidence_dir="$RUNNER_TEMP/production-db-authority-audit"
+          report="$evidence_dir/report.json"
+          set +e
+          env -u GITHUB_STEP_SUMMARY \
+            bun packages/cloud/scripts/admin/audit-production-railway-database-authority.ts \
+            --status-json "$evidence_dir/status.json" \
+            --services-json "$evidence_dir/services.json" \
+            --variables-json "$evidence_dir/variables.json" \
+            --resolved-service-id-file "$evidence_dir/resolved-service-id" \
+            > "$report"
+          audit_status="$?"
+          set -e
+          chmod 0600 "$report"
+          if ! GITHUB_TOKEN='${{ github.token }}' \
+            node packages/cloud/scripts/canonical-deploy-source-guard.mjs \
+            --run-sha "$GITHUB_SHA" \
+            --canonical-ref refs/heads/develop \
+            > "$evidence_dir/freshness.stdout" \
+            2> "$evidence_dir/freshness.stderr"; then
+            echo "::error::Production database audit source is no longer canonical"
+            exit 1
+          fi
+          tee -a "$GITHUB_STEP_SUMMARY" < "$report"
+          exit "$audit_status"
+
+      - name: Destroy private audit evidence
+        if: ${{ always() }}
+        run: |
+          set +e
+          evidence_dir="$RUNNER_TEMP/production-db-authority-audit"
+          if [ -d "$evidence_dir" ]; then
+            find "$evidence_dir" -type f -exec shred -u -- {} +
+            find "$evidence_dir" -depth -type d -empty -delete
+          fi
+          exit 0

--- a/packages/cloud/scripts/admin/audit-production-railway-database-authority.test.ts
+++ b/packages/cloud/scripts/admin/audit-production-railway-database-authority.test.ts
@@ -1,0 +1,348 @@
+/** Exercises privacy-safe Railway resolution and dual-target read-only database audits. */
+import { describe, expect, test } from "bun:test";
+import {
+  type AuditQueryClient,
+  auditProductionDatabaseAuthority,
+  canonicalRailwayDatabaseUrl,
+  type ProductionDatabaseAuditReport,
+  type RailwayTargetEvidence,
+  REQUIRED_PRODUCTION_RELATIONS,
+  resolveCanonicalRailwayTarget,
+} from "./audit-production-railway-database-authority";
+import type { AppliedMigration, Migration } from "./canonical-migration-ledger";
+
+const PROJECT = "10000000-0000-4000-8000-000000000001";
+const ENVIRONMENT = "20000000-0000-4000-8000-000000000002";
+const SERVICE = "30000000-0000-4000-8000-000000000003";
+const PRIVATE_URL =
+  "postgresql://operator:private-password@canonical.example.test:5432/production";
+
+const canonicalMigrations: Migration[] = [
+  {
+    entry: {
+      idx: 0,
+      version: "7",
+      when: 1_700_000_000_000,
+      tag: "0194_job_execution_interruptions_catalog_guard",
+      breakpoints: true,
+    },
+    hash: "canonical-hash",
+    statements: [],
+  },
+];
+
+const applied: AppliedMigration[] = [
+  {
+    id: 1,
+    hash: "canonical-hash",
+    created_at: 1_700_000_000_000,
+  },
+];
+
+function railwayEvidence(): RailwayTargetEvidence {
+  return {
+    status: {
+      id: PROJECT,
+      environments: {
+        edges: [{ node: { id: ENVIRONMENT, name: "production" } }],
+      },
+      services: { edges: [{ node: { id: SERVICE, name: "Postgres" } }] },
+    },
+    services: [
+      {
+        id: SERVICE,
+        source: { image: "ghcr.io/railwayapp-templates/postgres-ssl:18" },
+      },
+    ],
+    variables: { DATABASE_PUBLIC_URL: PRIVATE_URL, ANOTHER_SECRET: "private" },
+  };
+}
+
+function allPresent(): Record<string, boolean> {
+  return Object.fromEntries(
+    REQUIRED_PRODUCTION_RELATIONS.map((relation) => [relation, true]),
+  );
+}
+
+class FakeClient implements AuditQueryClient {
+  readonly statements: string[] = [];
+
+  constructor(
+    private readonly identity: {
+      system_identifier: string;
+      database_name: string;
+      role_name: string;
+      server_version_num: string;
+    },
+    private readonly presence = allPresent(),
+    private readonly ledger = applied,
+  ) {}
+
+  async query<T = unknown>(text: string): Promise<{ rows: T[] }> {
+    const sql = text.replace(/\s+/g, " ").trim();
+    this.statements.push(sql);
+    if (sql.startsWith("BEGIN") || sql === "COMMIT" || sql === "ROLLBACK") {
+      return { rows: [] };
+    }
+    if (sql.includes("pg_catalog.pg_control_system()")) {
+      return { rows: [this.identity as T] };
+    }
+    if (sql.includes("to_regclass('public.apps')")) {
+      return { rows: [this.presence as T] };
+    }
+    if (sql.includes("FROM drizzle.__drizzle_migrations")) {
+      return { rows: this.ledger as T[] };
+    }
+    throw new Error("unhandled fake read-only query");
+  }
+}
+
+function identity(
+  overrides: Partial<{
+    system_identifier: string;
+    database_name: string;
+    role_name: string;
+    server_version_num: string;
+  }> = {},
+) {
+  return {
+    system_identifier: "1234567890123456789",
+    database_name: "production",
+    role_name: "operator",
+    server_version_num: "180001",
+    ...overrides,
+  };
+}
+
+async function audit(
+  protectedClient = new FakeClient(identity()),
+  canonicalClient = new FakeClient(identity()),
+): Promise<ProductionDatabaseAuditReport> {
+  return auditProductionDatabaseAuthority({
+    protectedClient,
+    canonicalClient,
+    canonicalMigrations,
+  });
+}
+
+describe("canonical Railway target", () => {
+  test("discovers exactly one Postgres 18 service when no protected ID is configured", () => {
+    const evidence = railwayEvidence();
+    expect(
+      resolveCanonicalRailwayTarget(evidence, {
+        projectId: PROJECT,
+        environmentId: ENVIRONMENT,
+      }),
+    ).toEqual({ verdict: "match", serviceId: SERVICE });
+    expect(
+      resolveCanonicalRailwayTarget(
+        {
+          ...evidence,
+          services: [{ id: SERVICE, source: { image: "postgres:17" } }],
+        },
+        {
+          projectId: PROJECT,
+          environmentId: ENVIRONMENT,
+        },
+      ),
+    ).toEqual({ verdict: "unavailable" });
+  });
+
+  test("fails safely on zero or multiple candidates", () => {
+    const evidence = railwayEvidence();
+    expect(
+      resolveCanonicalRailwayTarget(
+        { ...evidence, services: [] },
+        { projectId: PROJECT, environmentId: ENVIRONMENT },
+      ),
+    ).toEqual({ verdict: "unavailable" });
+    expect(
+      resolveCanonicalRailwayTarget(
+        {
+          ...evidence,
+          services: [
+            ...evidence.services,
+            {
+              id: "40000000-0000-4000-8000-000000000004",
+              source: { image: "postgres:18" },
+            },
+          ],
+        },
+        { projectId: PROJECT, environmentId: ENVIRONMENT },
+      ),
+    ).toEqual({ verdict: "unavailable" });
+  });
+
+  test("requires an optional protected service ID to match discovery", () => {
+    const evidence = railwayEvidence();
+    expect(
+      resolveCanonicalRailwayTarget(evidence, {
+        projectId: PROJECT,
+        environmentId: ENVIRONMENT,
+        serviceId: SERVICE,
+      }),
+    ).toEqual({ verdict: "match", serviceId: SERVICE });
+    expect(
+      resolveCanonicalRailwayTarget(evidence, {
+        projectId: PROJECT,
+        environmentId: ENVIRONMENT,
+        serviceId: "40000000-0000-4000-8000-000000000004",
+      }),
+    ).toEqual({ verdict: "mismatch" });
+  });
+
+  test("accepts only the selected service's public PostgreSQL URL", () => {
+    expect(canonicalRailwayDatabaseUrl(railwayEvidence().variables)).toBe(
+      PRIVATE_URL,
+    );
+    expect(() =>
+      canonicalRailwayDatabaseUrl({ DATABASE_URL: PRIVATE_URL }),
+    ).toThrow("canonical_database_url_unavailable");
+    expect(() =>
+      canonicalRailwayDatabaseUrl({ DATABASE_PUBLIC_URL: "https://private" }),
+    ).toThrow("canonical_database_url_invalid");
+  });
+});
+
+describe("read-only database audit", () => {
+  test("passes only when authority, every required table, and the full ledger match", async () => {
+    const protectedClient = new FakeClient(identity());
+    const canonicalClient = new FakeClient(identity());
+    const report = await audit(protectedClient, canonicalClient);
+    expect(report).toEqual({
+      schemaVersion: 1,
+      verdict: "pass",
+      checks: {
+        railwayTarget: "match",
+        protectedDatabaseAuthority: "match",
+      },
+      requiredTables: {
+        canonical: Object.fromEntries(
+          REQUIRED_PRODUCTION_RELATIONS.map((relation) => [
+            relation,
+            "present",
+          ]),
+        ),
+        protected: Object.fromEntries(
+          REQUIRED_PRODUCTION_RELATIONS.map((relation) => [
+            relation,
+            "present",
+          ]),
+        ),
+      },
+      migrationLedger: { canonical: "current", protected: "current" },
+    });
+    for (const statement of [
+      ...protectedClient.statements,
+      ...canonicalClient.statements,
+    ]) {
+      expect(statement).not.toMatch(
+        /\b(?:INSERT|UPDATE|DELETE|CREATE|ALTER|DROP|TRUNCATE)\b/i,
+      );
+    }
+    expect(protectedClient.statements[0]).toContain("READ ONLY");
+    expect(canonicalClient.statements[0]).toContain("READ ONLY");
+  });
+
+  test("distinguishes a wrong protected target from a healthy canonical target", async () => {
+    const protectedPresence = allPresent();
+    protectedPresence["public.mobile_app_auth_grants"] = false;
+    const report = await audit(
+      new FakeClient(
+        identity({ database_name: "wrong-private-name" }),
+        protectedPresence,
+        [],
+      ),
+      new FakeClient(identity()),
+    );
+    expect(report.verdict).toBe("fail");
+    expect(report.checks.protectedDatabaseAuthority).toBe("mismatch");
+    expect(
+      report.requiredTables.canonical["public.mobile_app_auth_grants"],
+    ).toBe("present");
+    expect(
+      report.requiredTables.protected["public.mobile_app_auth_grants"],
+    ).toBe("missing");
+    expect(report.migrationLedger).toEqual({
+      canonical: "current",
+      protected: "pending",
+    });
+    const output = JSON.stringify(report);
+    expect(output).not.toContain("wrong-private-name");
+    expect(output).not.toContain("operator");
+    expect(output).not.toContain(PROJECT);
+    expect(output).not.toContain(PRIVATE_URL);
+  });
+
+  test("reports fixed table presence and pending ledger status", async () => {
+    const presence = allPresent();
+    presence["public.mobile_app_auth_grants"] = false;
+    const report = await audit(
+      new FakeClient(identity(), presence, []),
+      new FakeClient(identity()),
+    );
+    expect(report.verdict).toBe("fail");
+    expect(
+      report.requiredTables.protected["public.mobile_app_auth_grants"],
+    ).toBe("missing");
+    expect(
+      report.requiredTables.canonical["public.mobile_app_auth_grants"],
+    ).toBe("present");
+    expect(report.migrationLedger).toEqual({
+      canonical: "current",
+      protected: "pending",
+    });
+  });
+
+  test("classifies a noncanonical ledger as diverged without returning row data", async () => {
+    const report = await audit(
+      new FakeClient(identity(), allPresent(), [
+        { ...applied[0], hash: "private-wrong-hash" },
+      ]),
+      new FakeClient(identity()),
+    );
+    expect(report.verdict).toBe("fail");
+    expect(report.migrationLedger).toEqual({
+      canonical: "current",
+      protected: "diverged",
+    });
+    expect(JSON.stringify(report)).not.toContain("private-wrong-hash");
+  });
+
+  test("reports canonical schema and ledger drift independently", async () => {
+    const canonicalPresence = allPresent();
+    canonicalPresence["public.apps"] = false;
+    const report = await audit(
+      new FakeClient(identity()),
+      new FakeClient(identity(), canonicalPresence, [
+        { ...applied[0], hash: "canonical-wrong-hash" },
+      ]),
+    );
+    expect(report.verdict).toBe("fail");
+    expect(report.checks.protectedDatabaseAuthority).toBe("match");
+    expect(report.requiredTables.canonical["public.apps"]).toBe("missing");
+    expect(report.requiredTables.protected["public.apps"]).toBe("present");
+    expect(report.migrationLedger).toEqual({
+      canonical: "diverged",
+      protected: "current",
+    });
+    expect(JSON.stringify(report)).not.toContain("canonical-wrong-hash");
+  });
+
+  test("reports matching authority with the same missing canonical relation", async () => {
+    const droppedPresence = allPresent();
+    droppedPresence["steward.sessions"] = false;
+    const report = await audit(
+      new FakeClient(identity(), droppedPresence),
+      new FakeClient(identity(), droppedPresence),
+    );
+    expect(report.verdict).toBe("fail");
+    expect(report.checks.protectedDatabaseAuthority).toBe("match");
+    expect(report.requiredTables.canonical["steward.sessions"]).toBe("missing");
+    expect(report.requiredTables.protected["steward.sessions"]).toBe("missing");
+    expect(report.migrationLedger).toEqual({
+      canonical: "current",
+      protected: "current",
+    });
+  });
+});

--- a/packages/cloud/scripts/admin/audit-production-railway-database-authority.ts
+++ b/packages/cloud/scripts/admin/audit-production-railway-database-authority.ts
@@ -1,0 +1,502 @@
+/**
+ * Read-only production database authority, schema, and migration-ledger audit.
+ *
+ * Raw Railway inventory and connection details stay in memory/private files.
+ * The CLI boundary emits only fixed verdicts and allowlisted relation names.
+ */
+import { appendFile, readFile, stat } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { parseArgs } from "node:util";
+import { enforceTlsForRemote } from "../../shared/src/db/postgres-tls";
+import {
+  type AppliedMigration,
+  loadCanonicalMigrations,
+  type Migration,
+  validateAppliedMigrationLedger,
+} from "./canonical-migration-ledger";
+import { readDatabaseIdentityReceipt } from "./database-identity-receipt";
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+const MAX_EVIDENCE_BYTES = 4 * 1024 * 1024;
+
+export const REQUIRED_PRODUCTION_RELATIONS = [
+  "public.apps",
+  "public.organizations",
+  "public.users",
+  "public.api_keys",
+  "public.mobile_app_auth_grants",
+  "steward.users",
+  "steward.accounts",
+  "steward.sessions",
+  "drizzle.__drizzle_migrations",
+] as const;
+
+type RequiredRelation = (typeof REQUIRED_PRODUCTION_RELATIONS)[number];
+type PresenceVerdict = "missing" | "present" | "unavailable";
+type MatchVerdict = "match" | "mismatch" | "unavailable";
+type LedgerVerdict =
+  | "current"
+  | "diverged"
+  | "missing"
+  | "pending"
+  | "unavailable";
+
+export interface ProductionDatabaseAuditReport {
+  schemaVersion: 1;
+  verdict: "fail" | "pass";
+  checks: {
+    railwayTarget: MatchVerdict;
+    protectedDatabaseAuthority: MatchVerdict;
+  };
+  requiredTables: {
+    canonical: Record<RequiredRelation, PresenceVerdict>;
+    protected: Record<RequiredRelation, PresenceVerdict>;
+  };
+  migrationLedger: {
+    canonical: LedgerVerdict;
+    protected: LedgerVerdict;
+  };
+}
+
+interface ResourceRef {
+  id?: unknown;
+  name?: unknown;
+}
+
+export interface RailwayTargetEvidence {
+  status: {
+    id?: unknown;
+    environments?: { edges?: Array<{ node?: ResourceRef }> };
+    services?: { edges?: Array<{ node?: ResourceRef }> };
+  };
+  services: Array<{
+    id?: unknown;
+    source?: { image?: unknown } | null;
+  }>;
+  variables: Record<string, unknown>;
+}
+
+export interface RailwayTargetExpectation {
+  projectId: string;
+  environmentId: string;
+  serviceId?: string;
+}
+
+export type RailwayTargetResolution =
+  | { verdict: "match"; serviceId: string }
+  | { verdict: "mismatch" | "unavailable" };
+
+export interface AuditQueryClient {
+  query<T = unknown>(text: string, values?: unknown[]): Promise<{ rows: T[] }>;
+}
+
+interface RuntimeAuditClient extends AuditQueryClient {
+  connect(): Promise<void>;
+  end(): Promise<void>;
+}
+
+interface RuntimeClientConfig {
+  application_name: string;
+  connectionString: string;
+  connectionTimeoutMillis: number;
+  options: string;
+  query_timeout: number;
+  ssl?: unknown;
+  statement_timeout: number;
+}
+
+const { Client } = createRequire(import.meta.url)("pg") as {
+  Client: new (config: RuntimeClientConfig) => RuntimeAuditClient;
+};
+
+function unavailablePresence(): Record<RequiredRelation, PresenceVerdict> {
+  return Object.fromEntries(
+    REQUIRED_PRODUCTION_RELATIONS.map((relation) => [relation, "unavailable"]),
+  ) as Record<RequiredRelation, PresenceVerdict>;
+}
+
+export function unavailableAuditReport(
+  railwayTarget: MatchVerdict = "unavailable",
+): ProductionDatabaseAuditReport {
+  return {
+    schemaVersion: 1,
+    verdict: "fail",
+    checks: {
+      railwayTarget,
+      protectedDatabaseAuthority: "unavailable",
+    },
+    requiredTables: {
+      canonical: unavailablePresence(),
+      protected: unavailablePresence(),
+    },
+    migrationLedger: {
+      canonical: "unavailable",
+      protected: "unavailable",
+    },
+  };
+}
+
+function resourceMatches(
+  edges: Array<{ node?: ResourceRef }> | undefined,
+  id: string,
+  name?: string,
+): boolean {
+  return (
+    (edges ?? []).filter(
+      ({ node }) =>
+        node?.id === id && (name === undefined || node.name === name),
+    ).length === 1
+  );
+}
+
+/** Resolves exactly one production Postgres 18 service, honoring an optional pin. */
+export function resolveCanonicalRailwayTarget(
+  evidence: RailwayTargetEvidence,
+  expected: RailwayTargetExpectation,
+): RailwayTargetResolution {
+  if (
+    evidence.status.id !== expected.projectId ||
+    !resourceMatches(
+      evidence.status.environments?.edges,
+      expected.environmentId,
+      "production",
+    )
+  ) {
+    return { verdict: "mismatch" };
+  }
+  const candidates = evidence.services.filter(
+    ({ id, source }) =>
+      typeof id === "string" &&
+      UUID.test(id) &&
+      typeof source?.image === "string" &&
+      /(?:^|\/)postgres[^:]*:18(?:$|[-.])/.test(source.image),
+  );
+  if (candidates.length !== 1) return { verdict: "unavailable" };
+  const serviceId = candidates[0]?.id;
+  if (typeof serviceId !== "string") return { verdict: "unavailable" };
+  if (expected.serviceId && expected.serviceId !== serviceId) {
+    return { verdict: "mismatch" };
+  }
+  if (!resourceMatches(evidence.status.services?.edges, serviceId)) {
+    return { verdict: "mismatch" };
+  }
+  return { verdict: "match", serviceId };
+}
+
+export function canonicalRailwayDatabaseUrl(
+  variables: Record<string, unknown>,
+): string {
+  const value = variables.DATABASE_PUBLIC_URL;
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error("canonical_database_url_unavailable");
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    // error-policy:J3 Railway variables are untrusted evidence.
+    throw new Error("canonical_database_url_invalid");
+  }
+  if (
+    (parsed.protocol !== "postgres:" && parsed.protocol !== "postgresql:") ||
+    !parsed.hostname ||
+    !parsed.username ||
+    !parsed.pathname.slice(1)
+  ) {
+    throw new Error("canonical_database_url_invalid");
+  }
+  return value;
+}
+
+async function relationPresence(
+  client: AuditQueryClient,
+): Promise<Record<RequiredRelation, PresenceVerdict>> {
+  const result = await client.query<Record<RequiredRelation, boolean>>(`
+    SELECT
+      to_regclass('public.apps') IS NOT NULL AS "public.apps",
+      to_regclass('public.organizations') IS NOT NULL AS "public.organizations",
+      to_regclass('public.users') IS NOT NULL AS "public.users",
+      to_regclass('public.api_keys') IS NOT NULL AS "public.api_keys",
+      to_regclass('public.mobile_app_auth_grants') IS NOT NULL AS "public.mobile_app_auth_grants",
+      to_regclass('steward.users') IS NOT NULL AS "steward.users",
+      to_regclass('steward.accounts') IS NOT NULL AS "steward.accounts",
+      to_regclass('steward.sessions') IS NOT NULL AS "steward.sessions",
+      to_regclass('drizzle.__drizzle_migrations') IS NOT NULL AS "drizzle.__drizzle_migrations"
+  `);
+  const row = result.rows[0];
+  return Object.fromEntries(
+    REQUIRED_PRODUCTION_RELATIONS.map((relation) => [
+      relation,
+      row?.[relation] === true ? "present" : "missing",
+    ]),
+  ) as Record<RequiredRelation, PresenceVerdict>;
+}
+
+async function migrationLedgerStatus(
+  client: AuditQueryClient,
+  canonicalMigrations: Migration[],
+  ledgerPresent: boolean,
+): Promise<LedgerVerdict> {
+  if (!ledgerPresent) return "missing";
+  const result = await client.query<AppliedMigration>(`
+    SELECT id, hash, created_at
+      FROM drizzle.__drizzle_migrations
+     ORDER BY id ASC
+  `);
+  try {
+    const validated = validateAppliedMigrationLedger(
+      result.rows,
+      canonicalMigrations,
+    );
+    if (validated.lastAppliedJournalIndex === canonicalMigrations.length - 1) {
+      return "current";
+    }
+    return "pending";
+  } catch {
+    // error-policy:J1 translate ledger validation failures to a fixed verdict.
+    return "diverged";
+  }
+}
+
+async function beginReadOnly(client: AuditQueryClient): Promise<void> {
+  await client.query(
+    "BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY",
+  );
+}
+
+async function finishReadOnly(client: AuditQueryClient): Promise<void> {
+  await client.query("COMMIT");
+}
+
+async function abortReadOnly(client: AuditQueryClient): Promise<void> {
+  try {
+    await client.query("ROLLBACK");
+  } catch {
+    // error-policy:J6 rollback is best-effort after the audit already failed.
+  }
+}
+
+/** Performs only SELECTs inside database-enforced read-only transactions. */
+export async function auditProductionDatabaseAuthority(input: {
+  canonicalClient: AuditQueryClient;
+  canonicalMigrations: Migration[];
+  protectedClient: AuditQueryClient;
+}): Promise<ProductionDatabaseAuditReport> {
+  try {
+    await beginReadOnly(input.canonicalClient);
+    await beginReadOnly(input.protectedClient);
+    const [canonicalIdentity, protectedIdentity] = await Promise.all([
+      readDatabaseIdentityReceipt(input.canonicalClient, "production"),
+      readDatabaseIdentityReceipt(input.protectedClient, "production"),
+    ]);
+    const authorityMatches =
+      canonicalIdentity.clusterSha256 === protectedIdentity.clusterSha256 &&
+      canonicalIdentity.authoritySha256 === protectedIdentity.authoritySha256;
+    const [canonicalRequiredTables, protectedRequiredTables] =
+      await Promise.all([
+        relationPresence(input.canonicalClient),
+        relationPresence(input.protectedClient),
+      ]);
+    const [canonicalMigrationLedger, protectedMigrationLedger] =
+      await Promise.all([
+        migrationLedgerStatus(
+          input.canonicalClient,
+          input.canonicalMigrations,
+          canonicalRequiredTables["drizzle.__drizzle_migrations"] === "present",
+        ),
+        migrationLedgerStatus(
+          input.protectedClient,
+          input.canonicalMigrations,
+          protectedRequiredTables["drizzle.__drizzle_migrations"] === "present",
+        ),
+      ]);
+    await finishReadOnly(input.protectedClient);
+    await finishReadOnly(input.canonicalClient);
+
+    const canonicalTablesPresent = Object.values(canonicalRequiredTables).every(
+      (value) => value === "present",
+    );
+    const protectedTablesPresent = Object.values(protectedRequiredTables).every(
+      (value) => value === "present",
+    );
+    const verdict =
+      authorityMatches &&
+      canonicalTablesPresent &&
+      protectedTablesPresent &&
+      canonicalMigrationLedger === "current" &&
+      protectedMigrationLedger === "current"
+        ? "pass"
+        : "fail";
+    return {
+      schemaVersion: 1,
+      verdict,
+      checks: {
+        railwayTarget: "match",
+        protectedDatabaseAuthority: authorityMatches ? "match" : "mismatch",
+      },
+      requiredTables: {
+        canonical: canonicalRequiredTables,
+        protected: protectedRequiredTables,
+      },
+      migrationLedger: {
+        canonical: canonicalMigrationLedger,
+        protected: protectedMigrationLedger,
+      },
+    };
+  } catch (error) {
+    // error-policy:J6 roll back both read-only sessions before preserving the failure.
+    await Promise.all([
+      abortReadOnly(input.protectedClient),
+      abortReadOnly(input.canonicalClient),
+    ]);
+    throw error;
+  }
+}
+
+async function readPrivateJson(path: string): Promise<unknown> {
+  const metadata = await stat(path);
+  if (!metadata.isFile() || metadata.size > MAX_EVIDENCE_BYTES) {
+    throw new Error("private_evidence_invalid");
+  }
+  if ((metadata.mode & 0o077) !== 0) {
+    throw new Error("private_evidence_permissions");
+  }
+  return JSON.parse(await readFile(path, "utf8")) as unknown;
+}
+
+async function readPrivateServiceId(path: string): Promise<string> {
+  const metadata = await stat(path);
+  if (
+    !metadata.isFile() ||
+    metadata.size > 128 ||
+    (metadata.mode & 0o077) !== 0
+  ) {
+    throw new Error("private_service_identity_invalid");
+  }
+  return requireUuid((await readFile(path, "utf8")).trim());
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function requireUuid(value: string | undefined): string {
+  if (!value || !UUID.test(value)) throw new Error("protected_target_invalid");
+  return value;
+}
+
+async function runtimeClient(databaseUrl: string): Promise<RuntimeAuditClient> {
+  const { url, ssl } = enforceTlsForRemote(databaseUrl);
+  const client = new Client({
+    connectionString: url,
+    application_name: "eliza-production-database-authority-audit",
+    connectionTimeoutMillis: 8_000,
+    statement_timeout: 8_000,
+    query_timeout: 8_000,
+    options: "-c default_transaction_read_only=on",
+    ...(ssl ? { ssl } : {}),
+  }) as RuntimeAuditClient;
+  await client.connect();
+  return client;
+}
+
+async function publishReport(
+  report: ProductionDatabaseAuditReport,
+): Promise<void> {
+  const output = `${JSON.stringify(report, null, 2)}\n`;
+  process.stdout.write(output);
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    await appendFile(process.env.GITHUB_STEP_SUMMARY, output, "utf8");
+  }
+}
+
+async function main(): Promise<void> {
+  const parsed = parseArgs({
+    args: process.argv.slice(2),
+    strict: true,
+    options: {
+      "status-json": { type: "string" },
+      "services-json": { type: "string" },
+      "variables-json": { type: "string" },
+      "resolved-service-id-file": { type: "string" },
+    },
+  });
+  const path = (name: keyof typeof parsed.values): string => {
+    const value = parsed.values[name];
+    if (typeof value !== "string" || !value)
+      throw new Error("input_path_invalid");
+    return value;
+  };
+  const protectedDatabaseUrl = process.env.DATABASE_URL;
+  if (!protectedDatabaseUrl) throw new Error("protected_database_url_missing");
+  const expectation: RailwayTargetExpectation = {
+    projectId: requireUuid(process.env.RAILWAY_PROJECT_ID),
+    environmentId: requireUuid(process.env.RAILWAY_ENVIRONMENT_ID),
+    serviceId: process.env.RAILWAY_POSTGRES_SERVICE_ID?.trim()
+      ? requireUuid(process.env.RAILWAY_POSTGRES_SERVICE_ID.trim())
+      : undefined,
+  };
+  const [statusDocument, servicesDocument, variablesDocument] =
+    await Promise.all([
+      readPrivateJson(path("status-json")),
+      readPrivateJson(path("services-json")),
+      readPrivateJson(path("variables-json")),
+    ]);
+  if (
+    !isRecord(statusDocument) ||
+    !Array.isArray(servicesDocument) ||
+    !isRecord(variablesDocument)
+  ) {
+    throw new Error("railway_evidence_invalid");
+  }
+  const evidence: RailwayTargetEvidence = {
+    status: statusDocument,
+    services: servicesDocument,
+    variables: variablesDocument,
+  };
+  const resolution = resolveCanonicalRailwayTarget(evidence, expectation);
+  if (resolution.verdict !== "match") {
+    await publishReport(unavailableAuditReport(resolution.verdict));
+    process.exitCode = 1;
+    return;
+  }
+  const privatelyResolvedServiceId = await readPrivateServiceId(
+    path("resolved-service-id-file"),
+  );
+  if (privatelyResolvedServiceId !== resolution.serviceId) {
+    await publishReport(unavailableAuditReport("mismatch"));
+    process.exitCode = 1;
+    return;
+  }
+
+  let protectedClient: RuntimeAuditClient | undefined;
+  let canonicalClient: RuntimeAuditClient | undefined;
+  try {
+    [protectedClient, canonicalClient] = await Promise.all([
+      runtimeClient(protectedDatabaseUrl),
+      runtimeClient(canonicalRailwayDatabaseUrl(variablesDocument)),
+    ]);
+    const report = await auditProductionDatabaseAuthority({
+      protectedClient,
+      canonicalClient,
+      canonicalMigrations: await loadCanonicalMigrations(),
+    });
+    await publishReport(report);
+    if (report.verdict !== "pass") process.exitCode = 1;
+  } finally {
+    // error-policy:J6 connection teardown must not replace the audit verdict.
+    await Promise.allSettled([protectedClient?.end(), canonicalClient?.end()]);
+  }
+}
+
+if (import.meta.main) {
+  // error-policy:J1 the CLI emits only a fixed unavailable report on failure.
+  main().catch(async () => {
+    try {
+      await publishReport(unavailableAuditReport());
+    } catch {
+      // error-policy:J1 a failed report write still terminates nonzero.
+    }
+    process.exitCode = 1;
+  });
+}

--- a/packages/cloud/scripts/admin/canonical-migration-ledger.ts
+++ b/packages/cloud/scripts/admin/canonical-migration-ledger.ts
@@ -1,0 +1,220 @@
+/** Dependency-light, read-only canonical Cloud migration ledger validation. */
+import { createHash } from "node:crypto";
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+const HASH_IDENTITY_ENFORCEMENT_TAG =
+  "0194_job_execution_interruptions_catalog_guard";
+const MIGRATIONS_DIR =
+  [
+    path.join(process.cwd(), "packages/cloud/shared/src/db/migrations"),
+    path.join(process.cwd(), "src/db/migrations"),
+  ].find((candidate) =>
+    existsSync(path.join(candidate, "meta/_journal.json")),
+  ) ?? path.join(process.cwd(), "packages/cloud/shared/src/db/migrations");
+const JOURNAL_PATH = path.join(MIGRATIONS_DIR, "meta/_journal.json");
+
+export interface JournalEntry {
+  idx: number;
+  version: string;
+  when: number;
+  tag: string;
+  breakpoints: boolean;
+}
+
+interface Journal {
+  version: string;
+  dialect: string;
+  entries: JournalEntry[];
+}
+
+export interface Migration {
+  entry: JournalEntry;
+  hash: string;
+  statements: string[];
+}
+
+export interface AppliedMigration {
+  id: number;
+  hash: string;
+  created_at: string | number | bigint | null;
+}
+
+export interface ValidatedMigrationLedger {
+  lastAppliedJournalIndex: number;
+}
+
+export interface CanonicalRelationQueryClient {
+  query<T = unknown>(text: string, params?: unknown[]): Promise<{ rows: T[] }>;
+}
+
+async function readJournal(): Promise<Journal> {
+  return JSON.parse(await readFile(JOURNAL_PATH, "utf8")) as Journal;
+}
+
+async function readMigration(entry: JournalEntry): Promise<Migration> {
+  const migrationPath = path.join(MIGRATIONS_DIR, `${entry.tag}.sql`);
+  const sql = await readFile(migrationPath, "utf8");
+  return {
+    entry,
+    hash: createHash("sha256").update(sql).digest("hex"),
+    statements: sql
+      .split("--> statement-breakpoint")
+      .map((statement) => statement.trim())
+      .filter(Boolean),
+  };
+}
+
+/** Loads the exact repository journal and migration SQL hashes without mutation. */
+export async function loadCanonicalMigrations(): Promise<Migration[]> {
+  const journal = await readJournal();
+  return Promise.all(journal.entries.map((entry) => readMigration(entry)));
+}
+
+export function createdAtValue(migration: AppliedMigration): number | null {
+  if (migration.created_at === null) return null;
+  const value = Number(migration.created_at);
+  return Number.isFinite(value) ? value : null;
+}
+
+export function validateAppliedMigrationLedger(
+  applied: AppliedMigration[],
+  migrations: Migration[],
+): ValidatedMigrationLedger {
+  if (applied.length > migrations.length) {
+    throw new Error(
+      `Migration ledger contains ${applied.length} rows but this checkout defines only ${migrations.length}`,
+    );
+  }
+
+  const migrationByCreatedAt = new Map<
+    number,
+    { journalIndex: number; migration: Migration }
+  >();
+  for (const [journalIndex, migration] of migrations.entries()) {
+    const createdAt = migration.entry.when;
+    if (migrationByCreatedAt.has(createdAt)) {
+      throw new Error(
+        `Migration journal contains duplicate created_at=${createdAt}`,
+      );
+    }
+    migrationByCreatedAt.set(createdAt, { journalIndex, migration });
+  }
+
+  const hashIdentityEnforcementIndex = migrations.findIndex(
+    (migration) => migration.entry.tag === HASH_IDENTITY_ENFORCEMENT_TAG,
+  );
+  if (hashIdentityEnforcementIndex === -1) {
+    throw new Error(
+      `Migration journal is missing hash enforcement checkpoint ${HASH_IDENTITY_ENFORCEMENT_TAG}`,
+    );
+  }
+
+  const seenCreatedAt = new Set<number>();
+  const appliedJournalIndexes = new Set<number>();
+  let lastAppliedJournalIndex = -1;
+  let lastEnforcedJournalIndex = hashIdentityEnforcementIndex - 1;
+  let hashEnforcementStarted = false;
+  for (const row of applied) {
+    const createdAt = createdAtValue(row);
+    if (createdAt === null) {
+      throw new Error(
+        `Migration ledger row id=${row.id} has an invalid created_at value`,
+      );
+    }
+    if (seenCreatedAt.has(createdAt)) {
+      throw new Error(
+        `Migration ledger contains duplicate created_at=${createdAt}`,
+      );
+    }
+    seenCreatedAt.add(createdAt);
+    const matched = migrationByCreatedAt.get(createdAt);
+    if (!matched) {
+      throw new Error(
+        `Migration ledger row id=${row.id} has no matching journal entry for created_at=${createdAt}`,
+      );
+    }
+    if (
+      matched.journalIndex >= hashIdentityEnforcementIndex &&
+      row.hash !== matched.migration.hash
+    ) {
+      throw new Error(
+        `Migration ledger hash mismatch for ${matched.migration.entry.tag}: expected ${matched.migration.hash}, found ${row.hash}`,
+      );
+    }
+    if (matched.journalIndex >= hashIdentityEnforcementIndex) {
+      if (matched.journalIndex <= lastEnforcedJournalIndex) {
+        throw new Error(
+          `Migration ledger is out of immutable journal order at row id=${row.id}: ${matched.migration.entry.tag} follows journal index ${lastEnforcedJournalIndex}`,
+        );
+      }
+      hashEnforcementStarted = true;
+      lastEnforcedJournalIndex = matched.journalIndex;
+    } else if (hashEnforcementStarted) {
+      throw new Error(
+        `Historical migration ${matched.migration.entry.tag} appears after hash enforcement checkpoint ${HASH_IDENTITY_ENFORCEMENT_TAG}`,
+      );
+    }
+    appliedJournalIndexes.add(matched.journalIndex);
+    lastAppliedJournalIndex = Math.max(
+      lastAppliedJournalIndex,
+      matched.journalIndex,
+    );
+  }
+
+  for (
+    let journalIndex = hashIdentityEnforcementIndex;
+    journalIndex <= lastAppliedJournalIndex;
+    journalIndex++
+  ) {
+    const migration = migrations[journalIndex];
+    if (!migration) {
+      throw new Error(`Migration journal is missing index ${journalIndex}`);
+    }
+    if (!appliedJournalIndexes.has(journalIndex)) {
+      throw new Error(
+        `Migration ledger is missing required journal entry ${migration.entry.tag}`,
+      );
+    }
+  }
+  return { lastAppliedJournalIndex };
+}
+
+export const CANONICAL_CLOUD_RELATIONS = [
+  "apps",
+  "organizations",
+  "users",
+  "api_keys",
+] as const;
+
+/** Rejects a non-empty ledger whose baseline application relations drifted. */
+export async function assertAppliedLedgerHasCanonicalRelations(
+  client: CanonicalRelationQueryClient,
+): Promise<void> {
+  const result = await client.query<Record<string, boolean>>(`
+    SELECT
+      to_regclass('public.apps') IS NOT NULL AS apps,
+      to_regclass('public.organizations') IS NOT NULL AS organizations,
+      to_regclass('public.users') IS NOT NULL AS users,
+      to_regclass('public.api_keys') IS NOT NULL AS api_keys
+  `);
+  const row = result.rows[0];
+  const presence = CANONICAL_CLOUD_RELATIONS.map((relation) => ({
+    present: row?.[relation] === true,
+    relation,
+  }));
+  process.stdout.write(
+    `[db:migrate] canonical relation presence: ${presence
+      .map(
+        ({ present, relation }) =>
+          `${relation}=${present ? "present" : "missing"}`,
+      )
+      .join(" ")}\n`,
+  );
+  if (presence.some(({ present }) => !present)) {
+    throw new Error(
+      "Migration ledger is non-empty but canonical application relations are missing",
+    );
+  }
+}

--- a/packages/cloud/scripts/admin/database-identity-receipt.ts
+++ b/packages/cloud/scripts/admin/database-identity-receipt.ts
@@ -1,0 +1,89 @@
+/** Dependency-light, read-only PostgreSQL identity receipt generation. */
+import { createHash } from "node:crypto";
+
+const IDENTITY_QUERY = `
+SELECT
+  control.system_identifier::text AS system_identifier,
+  pg_catalog.current_database()::text AS database_name,
+  current_user::text AS role_name,
+  pg_catalog.current_setting('server_version_num')::text AS server_version_num
+FROM pg_catalog.pg_control_system() AS control
+`;
+
+interface DatabaseIdentityRow {
+  database_name: string;
+  role_name: string;
+  server_version_num: string;
+  system_identifier: string;
+}
+
+export interface DatabaseIdentityReceipt {
+  authoritySha256: string;
+  clusterSha256: string;
+  environment: "staging" | "production";
+  postgresMajor: number;
+  version: 1;
+}
+
+export interface IdentityQueryClient {
+  query(text: string): Promise<{ rows: unknown[] }>;
+}
+
+function isIdentityRow(value: unknown): value is DatabaseIdentityRow {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    "system_identifier" in value &&
+    typeof value.system_identifier === "string" &&
+    /^\d+$/.test(value.system_identifier) &&
+    "database_name" in value &&
+    typeof value.database_name === "string" &&
+    value.database_name.length > 0 &&
+    "role_name" in value &&
+    typeof value.role_name === "string" &&
+    value.role_name.length > 0 &&
+    "server_version_num" in value &&
+    typeof value.server_version_num === "string" &&
+    /^\d+$/.test(value.server_version_num)
+  );
+}
+
+function digest(parts: readonly string[]): string {
+  const hash = createHash("sha256");
+  for (const part of parts) {
+    hash.update(part, "utf8");
+    hash.update("\0", "utf8");
+  }
+  return hash.digest("hex");
+}
+
+/** Queries only stable PostgreSQL identity fields and hashes every raw name. */
+export async function readDatabaseIdentityReceipt(
+  client: IdentityQueryClient,
+  environment: "staging" | "production",
+): Promise<DatabaseIdentityReceipt> {
+  const result = await client.query(IDENTITY_QUERY);
+  if (result.rows.length !== 1 || !isIdentityRow(result.rows[0])) {
+    throw new Error("database identity query returned an invalid row");
+  }
+  const row = result.rows[0];
+  const postgresMajor = Math.floor(Number(row.server_version_num) / 10_000);
+  if (!Number.isSafeInteger(postgresMajor) || postgresMajor < 10) {
+    throw new Error(
+      "database identity query returned an invalid PostgreSQL version",
+    );
+  }
+  return {
+    version: 1,
+    environment,
+    postgresMajor,
+    clusterSha256: digest(["eliza-postgres-cluster-v1", row.system_identifier]),
+    authoritySha256: digest([
+      "eliza-postgres-authority-v1",
+      environment,
+      row.system_identifier,
+      row.role_name,
+      row.database_name,
+    ]),
+  };
+}

--- a/packages/cloud/scripts/admin/migrate-with-diagnostics-ledger.test.ts
+++ b/packages/cloud/scripts/admin/migrate-with-diagnostics-ledger.test.ts
@@ -11,7 +11,7 @@ import path from "node:path";
 import {
   assertAppliedLedgerHasCanonicalRelations,
   validateAppliedMigrationLedger,
-} from "./migrate-with-diagnostics";
+} from "./canonical-migration-ledger";
 
 const CHECKPOINT_TAG = "0194_job_execution_interruptions_catalog_guard";
 const STAGING_RESTORE_OPERATION = {

--- a/packages/cloud/scripts/admin/migrate-with-diagnostics.ts
+++ b/packages/cloud/scripts/admin/migrate-with-diagnostics.ts
@@ -9,14 +9,18 @@
  * including the deploy pipeline's migrate-db gate; enforces TLS for remote
  * databases.
  */
-import { createHash } from "node:crypto";
-import { existsSync } from "node:fs";
-import { readFile } from "node:fs/promises";
-import path from "node:path";
 import { enforceTlsForRemote } from "@elizaos/cloud-shared/db/client";
 import { convergeAgentSandboxSchema } from "@elizaos/cloud-shared/db/ensure-agent-sandbox-schema";
 import { createMigrationClientSandboxExecutor } from "@elizaos/cloud-shared/db/migration-sandbox-schema-executor";
 import pg from "pg";
+import {
+  type AppliedMigration,
+  assertAppliedLedgerHasCanonicalRelations,
+  createdAtValue,
+  loadCanonicalMigrations,
+  type Migration,
+  validateAppliedMigrationLedger,
+} from "./canonical-migration-ledger";
 import {
   type CleanupFailure,
   runCleanupSteps,
@@ -30,6 +34,19 @@ import {
   runDatabaseIdentityPreflight,
 } from "./preflight-database-identity";
 
+export type {
+  AppliedMigration,
+  JournalEntry,
+  Migration,
+  ValidatedMigrationLedger,
+} from "./canonical-migration-ledger";
+export {
+  assertAppliedLedgerHasCanonicalRelations,
+  createdAtValue,
+  loadCanonicalMigrations,
+  validateAppliedMigrationLedger,
+} from "./canonical-migration-ledger";
+
 const { Client } = pg;
 
 const MIGRATIONS_SCHEMA = "drizzle";
@@ -39,41 +56,6 @@ const DEFAULT_LOCK_TIMEOUT_MS = 5_000;
 const DEFAULT_LOCK_MAX_ATTEMPTS = 5;
 const DEFAULT_LOCK_RETRY_BASE_MS = 250;
 const DEFAULT_LOCK_RETRY_MAX_MS = 2_000;
-const MIGRATIONS_DIR =
-  [
-    path.join(process.cwd(), "packages/cloud/shared/src/db/migrations"),
-    path.join(process.cwd(), "src/db/migrations"),
-  ].find((candidate) =>
-    existsSync(path.join(candidate, "meta/_journal.json")),
-  ) ?? path.join(process.cwd(), "packages/cloud/shared/src/db/migrations");
-const JOURNAL_PATH = path.join(MIGRATIONS_DIR, "meta/_journal.json");
-
-interface JournalEntry {
-  idx: number;
-  version: string;
-  when: number;
-  tag: string;
-  breakpoints: boolean;
-}
-
-interface Journal {
-  version: string;
-  dialect: string;
-  entries: JournalEntry[];
-}
-
-interface Migration {
-  entry: JournalEntry;
-  hash: string;
-  statements: string[];
-}
-
-interface AppliedMigration {
-  id: number;
-  hash: string;
-  created_at: string | number | bigint | null;
-}
-
 interface DatabaseError extends Error {
   code?: string;
   position?: string;
@@ -90,10 +72,6 @@ interface LockRetryOptions {
   maxAttempts: number;
   baseDelayMs: number;
   maxDelayMs: number;
-}
-
-interface ValidatedMigrationLedger {
-  lastAppliedJournalIndex: number;
 }
 
 type IdentityResultReporter = (
@@ -116,12 +94,6 @@ export async function convergeAgentSandboxSchemaOnMigrationClient(
   );
 }
 
-// Historical SQL files were edited after deployment, so their stored hashes
-// and some deployed schemas have no matching ledger row. The catalog-guard
-// migration is the first immutable checkpoint owned by this runner; hash,
-// order, and completeness identity are enforced from this entry forward.
-const HASH_IDENTITY_ENFORCEMENT_TAG =
-  "0194_job_execution_interruptions_catalog_guard";
 const USAGE_QUOTAS_RELEASE_BARRIER_TAGS = [
   "0282_drop_unused_usage_quotas_table",
   "0282_01_restore_usage_quotas_compatibility",
@@ -130,31 +102,6 @@ const USAGE_QUOTAS_RELEASE_BARRIER_TAGS = [
 type MigrationReleaseBarrierDecision =
   | { action: "continue"; atomicPairStartIndex?: number }
   | { action: "pause"; stopBeforeJournalIndex: number };
-
-async function readJournal(): Promise<Journal> {
-  return JSON.parse(await readFile(JOURNAL_PATH, "utf8")) as Journal;
-}
-
-async function readMigration(entry: JournalEntry): Promise<Migration> {
-  const migrationPath = path.join(MIGRATIONS_DIR, `${entry.tag}.sql`);
-  const sql = await readFile(migrationPath, "utf8");
-
-  return {
-    entry,
-    hash: createHash("sha256").update(sql).digest("hex"),
-    statements: sql
-      .split("--> statement-breakpoint")
-      .map((statement) => statement.trim())
-      .filter(Boolean),
-  };
-}
-
-function createdAtValue(migration: AppliedMigration): number | null {
-  if (migration.created_at === null) return null;
-
-  const value = Number(migration.created_at);
-  return Number.isFinite(value) ? value : null;
-}
 
 function readPositiveInteger(name: string, fallback: number): number {
   const raw = process.env[name];
@@ -351,155 +298,6 @@ async function assertEmptyLedgerDatabaseIsFresh(
       "Migration ledger is empty but the database contains application relations; refusing to replay historical migrations",
     );
   }
-}
-
-const CANONICAL_CLOUD_RELATIONS = [
-  "apps",
-  "organizations",
-  "users",
-  "api_keys",
-] as const;
-
-/**
- * A complete/non-empty ledger cannot authorize a schema with missing baseline
- * application relations. This catches a wrong DATABASE_URL and destructive
- * schema drift before pending-count success can impersonate a healthy target.
- */
-export async function assertAppliedLedgerHasCanonicalRelations(
-  client: MigrationClient,
-): Promise<void> {
-  const result = await client.query<Record<string, boolean>>(`
-    SELECT
-      to_regclass('public.apps') IS NOT NULL AS apps,
-      to_regclass('public.organizations') IS NOT NULL AS organizations,
-      to_regclass('public.users') IS NOT NULL AS users,
-      to_regclass('public.api_keys') IS NOT NULL AS api_keys
-  `);
-  const row = result.rows[0];
-  const presence = CANONICAL_CLOUD_RELATIONS.map((relation) => ({
-    present: row?.[relation] === true,
-    relation,
-  }));
-  console.log(
-    `[db:migrate] canonical relation presence: ${presence
-      .map(
-        ({ present, relation }) =>
-          `${relation}=${present ? "present" : "missing"}`,
-      )
-      .join(" ")}`,
-  );
-  if (presence.some(({ present }) => !present)) {
-    throw new Error(
-      "Migration ledger is non-empty but canonical application relations are missing",
-    );
-  }
-}
-
-export function validateAppliedMigrationLedger(
-  applied: AppliedMigration[],
-  migrations: Migration[],
-): ValidatedMigrationLedger {
-  if (applied.length > migrations.length) {
-    throw new Error(
-      `Migration ledger contains ${applied.length} rows but this checkout defines only ${migrations.length}`,
-    );
-  }
-
-  const migrationByCreatedAt = new Map<
-    number,
-    { journalIndex: number; migration: Migration }
-  >();
-  for (const [journalIndex, migration] of migrations.entries()) {
-    const createdAt = migration.entry.when;
-    if (migrationByCreatedAt.has(createdAt)) {
-      throw new Error(
-        `Migration journal contains duplicate created_at=${createdAt}`,
-      );
-    }
-    migrationByCreatedAt.set(createdAt, { journalIndex, migration });
-  }
-
-  const seenCreatedAt = new Set<number>();
-  const appliedJournalIndexes = new Set<number>();
-  const hashIdentityEnforcementIndex = migrations.findIndex(
-    (migration) => migration.entry.tag === HASH_IDENTITY_ENFORCEMENT_TAG,
-  );
-  if (hashIdentityEnforcementIndex === -1) {
-    throw new Error(
-      `Migration journal is missing hash enforcement checkpoint ${HASH_IDENTITY_ENFORCEMENT_TAG}`,
-    );
-  }
-  let lastAppliedJournalIndex = -1;
-  let lastEnforcedJournalIndex = hashIdentityEnforcementIndex - 1;
-  let hashEnforcementStarted = false;
-  for (const row of applied) {
-    const createdAt = createdAtValue(row);
-    if (createdAt === null) {
-      throw new Error(
-        `Migration ledger row id=${row.id} has an invalid created_at value`,
-      );
-    }
-    if (seenCreatedAt.has(createdAt)) {
-      throw new Error(
-        `Migration ledger contains duplicate created_at=${createdAt}`,
-      );
-    }
-    seenCreatedAt.add(createdAt);
-
-    const matched = migrationByCreatedAt.get(createdAt);
-    if (!matched) {
-      throw new Error(
-        `Migration ledger row id=${row.id} has no matching journal entry for created_at=${createdAt}`,
-      );
-    }
-    if (
-      matched.journalIndex >= hashIdentityEnforcementIndex &&
-      row.hash !== matched.migration.hash
-    ) {
-      throw new Error(
-        `Migration ledger hash mismatch for ${matched.migration.entry.tag}: expected ${matched.migration.hash}, found ${row.hash}`,
-      );
-    }
-    // Historical deployments used both journal-order and timestamp-order
-    // runners, so row id cannot authenticate ordering before the checkpoint.
-    // From the checkpoint forward this runner owns a single append-only order.
-    if (matched.journalIndex >= hashIdentityEnforcementIndex) {
-      if (matched.journalIndex <= lastEnforcedJournalIndex) {
-        throw new Error(
-          `Migration ledger is out of immutable journal order at row id=${row.id}: ${matched.migration.entry.tag} follows journal index ${lastEnforcedJournalIndex}`,
-        );
-      }
-      hashEnforcementStarted = true;
-      lastEnforcedJournalIndex = matched.journalIndex;
-    } else if (hashEnforcementStarted) {
-      throw new Error(
-        `Historical migration ${matched.migration.entry.tag} appears after hash enforcement checkpoint ${HASH_IDENTITY_ENFORCEMENT_TAG}`,
-      );
-    }
-    appliedJournalIndexes.add(matched.journalIndex);
-    lastAppliedJournalIndex = Math.max(
-      lastAppliedJournalIndex,
-      matched.journalIndex,
-    );
-  }
-
-  for (
-    let journalIndex = hashIdentityEnforcementIndex;
-    journalIndex <= lastAppliedJournalIndex;
-    journalIndex++
-  ) {
-    const migration = migrations[journalIndex];
-    if (!migration) {
-      throw new Error(`Migration journal is missing index ${journalIndex}`);
-    }
-    if (!appliedJournalIndexes.has(journalIndex)) {
-      throw new Error(
-        `Migration ledger is missing required journal entry ${migration.entry.tag}`,
-      );
-    }
-  }
-
-  return { lastAppliedJournalIndex };
 }
 
 /**
@@ -901,10 +699,7 @@ async function main(): Promise<void> {
     throw new Error("DATABASE_URL is required to run database migrations.");
   }
 
-  const journal = await readJournal();
-  const migrations = await Promise.all(
-    journal.entries.map((entry) => readMigration(entry)),
-  );
+  const migrations = await loadCanonicalMigrations();
   const retryOptions = lockRetryOptions();
   const configuredIdentityMode =
     environment.DATABASE_IDENTITY_GATE_MODE?.trim().toLowerCase();

--- a/packages/cloud/scripts/admin/preflight-database-identity.ts
+++ b/packages/cloud/scripts/admin/preflight-database-identity.ts
@@ -4,9 +4,19 @@
  * is read-only; authoritative release enforcement happens inside the migrator.
  */
 
-import { createHash } from "node:crypto";
 import { appendFile } from "node:fs/promises";
 import { createRequire } from "node:module";
+import {
+  type DatabaseIdentityReceipt,
+  type IdentityQueryClient,
+  readDatabaseIdentityReceipt,
+} from "./database-identity-receipt";
+
+export type {
+  DatabaseIdentityReceipt,
+  IdentityQueryClient,
+} from "./database-identity-receipt";
+export { readDatabaseIdentityReceipt } from "./database-identity-receipt";
 
 interface ClientConfig {
   application_name?: string;
@@ -26,14 +36,6 @@ const { Client } = createRequire(import.meta.url)("pg") as {
   Client: new (config: ClientConfig) => RuntimePgClient;
 };
 const SHA256_PATTERN = /^[0-9a-f]{64}$/;
-const IDENTITY_QUERY = `
-SELECT
-  control.system_identifier::text AS system_identifier,
-  pg_catalog.current_database()::text AS database_name,
-  current_user::text AS role_name,
-  pg_catalog.current_setting('server_version_num')::text AS server_version_num
-FROM pg_catalog.pg_control_system() AS control
-`;
 
 export type DatabaseIdentityGateMode = "off" | "report" | "enforce";
 
@@ -43,25 +45,6 @@ export interface DatabaseIdentityConfig {
   expectedClusterSha256?: string;
   ignoredExpectedDigests?: Array<"cluster" | "authority">;
   mode: DatabaseIdentityGateMode;
-}
-
-interface DatabaseIdentityRow {
-  database_name: string;
-  role_name: string;
-  server_version_num: string;
-  system_identifier: string;
-}
-
-export interface DatabaseIdentityReceipt {
-  authoritySha256: string;
-  clusterSha256: string;
-  environment: "staging" | "production";
-  postgresMajor: number;
-  version: 1;
-}
-
-export interface IdentityQueryClient {
-  query(text: string): Promise<{ rows: unknown[] }>;
 }
 
 export interface IdentityPreflightResult {
@@ -158,65 +141,6 @@ export function readDatabaseIdentityConfig(
     );
   }
   return config;
-}
-
-function isIdentityRow(value: unknown): value is DatabaseIdentityRow {
-  return (
-    value !== null &&
-    typeof value === "object" &&
-    "system_identifier" in value &&
-    typeof value.system_identifier === "string" &&
-    /^\d+$/.test(value.system_identifier) &&
-    "database_name" in value &&
-    typeof value.database_name === "string" &&
-    value.database_name.length > 0 &&
-    "role_name" in value &&
-    typeof value.role_name === "string" &&
-    value.role_name.length > 0 &&
-    "server_version_num" in value &&
-    typeof value.server_version_num === "string" &&
-    /^\d+$/.test(value.server_version_num)
-  );
-}
-
-function digest(parts: readonly string[]): string {
-  const hash = createHash("sha256");
-  for (const part of parts) {
-    hash.update(part, "utf8");
-    hash.update("\0", "utf8");
-  }
-  return hash.digest("hex");
-}
-
-/** Queries only stable, nonsecret PostgreSQL identity fields and hashes raw names. */
-export async function readDatabaseIdentityReceipt(
-  client: IdentityQueryClient,
-  environment: "staging" | "production",
-): Promise<DatabaseIdentityReceipt> {
-  const result = await client.query(IDENTITY_QUERY);
-  if (result.rows.length !== 1 || !isIdentityRow(result.rows[0])) {
-    throw new Error("database identity query returned an invalid row");
-  }
-  const row = result.rows[0];
-  const postgresMajor = Math.floor(Number(row.server_version_num) / 10_000);
-  if (!Number.isSafeInteger(postgresMajor) || postgresMajor < 10) {
-    throw new Error(
-      "database identity query returned an invalid PostgreSQL version",
-    );
-  }
-  return {
-    version: 1,
-    environment,
-    postgresMajor,
-    clusterSha256: digest(["eliza-postgres-cluster-v1", row.system_identifier]),
-    authoritySha256: digest([
-      "eliza-postgres-authority-v1",
-      environment,
-      row.system_identifier,
-      row.role_name,
-      row.database_name,
-    ]),
-  };
 }
 
 /** Evaluates the receipt without exposing the underlying server, role, or database names. */

--- a/packages/cloud/scripts/admin/resolve-production-railway-postgres-service.ts
+++ b/packages/cloud/scripts/admin/resolve-production-railway-postgres-service.ts
@@ -1,0 +1,94 @@
+/** Privacy-safe resolver for the protected production Railway Postgres service. */
+import { readFile, stat, writeFile } from "node:fs/promises";
+import { parseArgs } from "node:util";
+import {
+  type RailwayTargetEvidence,
+  type RailwayTargetExpectation,
+  resolveCanonicalRailwayTarget,
+} from "./audit-production-railway-database-authority";
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+const MAX_EVIDENCE_BYTES = 4 * 1024 * 1024;
+
+function requireUuid(value: string | undefined): string {
+  if (!value || !UUID.test(value)) throw new Error("protected_target_invalid");
+  return value;
+}
+
+async function readPrivateJson(path: string): Promise<unknown> {
+  const metadata = await stat(path);
+  if (
+    !metadata.isFile() ||
+    metadata.size > MAX_EVIDENCE_BYTES ||
+    (metadata.mode & 0o077) !== 0
+  ) {
+    throw new Error("private_evidence_invalid");
+  }
+  return JSON.parse(await readFile(path, "utf8")) as unknown;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function publish(verdict: "match" | "mismatch" | "unavailable"): void {
+  process.stdout.write(
+    `${JSON.stringify({ schemaVersion: 1, railwayTarget: verdict })}\n`,
+  );
+}
+
+async function main(): Promise<void> {
+  const parsed = parseArgs({
+    args: process.argv.slice(2),
+    strict: true,
+    options: {
+      "status-json": { type: "string" },
+      "services-json": { type: "string" },
+      "service-id-output": { type: "string" },
+    },
+  });
+  const requiredPath = (name: keyof typeof parsed.values): string => {
+    const value = parsed.values[name];
+    if (typeof value !== "string" || !value)
+      throw new Error("input_path_invalid");
+    return value;
+  };
+  const [status, services] = await Promise.all([
+    readPrivateJson(requiredPath("status-json")),
+    readPrivateJson(requiredPath("services-json")),
+  ]);
+  if (!isRecord(status) || !Array.isArray(services)) {
+    throw new Error("railway_evidence_invalid");
+  }
+  const expectation: RailwayTargetExpectation = {
+    projectId: requireUuid(process.env.RAILWAY_PROJECT_ID),
+    environmentId: requireUuid(process.env.RAILWAY_ENVIRONMENT_ID),
+    serviceId: process.env.RAILWAY_POSTGRES_SERVICE_ID?.trim()
+      ? requireUuid(process.env.RAILWAY_POSTGRES_SERVICE_ID.trim())
+      : undefined,
+  };
+  const evidence: RailwayTargetEvidence = {
+    status,
+    services,
+    variables: {},
+  };
+  const resolution = resolveCanonicalRailwayTarget(evidence, expectation);
+  publish(resolution.verdict);
+  if (resolution.verdict !== "match") {
+    process.exitCode = 1;
+    return;
+  }
+  await writeFile(
+    requiredPath("service-id-output"),
+    `${resolution.serviceId}\n`,
+    { encoding: "utf8", mode: 0o600, flag: "wx" },
+  );
+}
+
+if (import.meta.main) {
+  // error-policy:J1 the CLI translates all failures to one allowlisted verdict.
+  main().catch(() => {
+    publish("unavailable");
+    process.exitCode = 1;
+  });
+}

--- a/packages/cloud/shared/src/db/__tests__/postgres-tls-pure.test.ts
+++ b/packages/cloud/shared/src/db/__tests__/postgres-tls-pure.test.ts
@@ -27,8 +27,7 @@ describe("dependency-light PostgreSQL TLS policy", () => {
   });
 
   test("keeps encryption while allowing the explicit Railway CA opt-out", () => {
-    const url =
-      "postgresql://u:p@switchback.proxy.rlwy.net:49295/db?sslmode=no-verify";
+    const url = "postgresql://u:p@switchback.proxy.rlwy.net:49295/db?sslmode=no-verify";
     expect(shouldSkipTlsVerification(url)).toBe(true);
     expect(enforceTlsForRemote(url).ssl).toEqual({
       rejectUnauthorized: false,
@@ -37,17 +36,14 @@ describe("dependency-light PostgreSQL TLS policy", () => {
 
   test("rejects remote modes that permit plaintext", () => {
     for (const mode of ["disable", "allow"]) {
-      expect(() =>
-        enforceTlsForRemote(`postgresql://u:p@host.example/db?sslmode=${mode}`),
-      ).toThrow(/must use TLS/i);
+      expect(() => enforceTlsForRemote(`postgresql://u:p@host.example/db?sslmode=${mode}`)).toThrow(
+        /must use TLS/i,
+      );
     }
   });
 
   test("is re-exported by the full client without importing it", () => {
-    const clientSource = readFileSync(
-      new URL("../client.ts", import.meta.url),
-      "utf8",
-    );
+    const clientSource = readFileSync(new URL("../client.ts", import.meta.url), "utf8");
     expect(clientSource).toContain('from "./postgres-tls"');
     expect(clientSource).toContain("shouldSkipTlsVerification");
     expect(clientSource).toContain("enforceTlsForRemote");

--- a/packages/cloud/shared/src/db/__tests__/postgres-tls-pure.test.ts
+++ b/packages/cloud/shared/src/db/__tests__/postgres-tls-pure.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import {
+  enforceTlsForRemote,
+  isLocalTcpPostgresUrl,
+  shouldSkipTlsVerification,
+} from "../postgres-tls";
+
+const previous = process.env.DATABASE_SSL_NO_VERIFY;
+afterEach(() => {
+  if (previous === undefined) delete process.env.DATABASE_SSL_NO_VERIFY;
+  else process.env.DATABASE_SSL_NO_VERIFY = previous;
+});
+
+describe("dependency-light PostgreSQL TLS policy", () => {
+  test("preserves local plaintext development connections", () => {
+    const url = "postgresql://u:p@127.0.0.1:5432/db";
+    expect(isLocalTcpPostgresUrl(url)).toBe(true);
+    expect(enforceTlsForRemote(url)).toEqual({ url, ssl: undefined });
+  });
+
+  test("enforces strict TLS on remote connections by default", () => {
+    delete process.env.DATABASE_SSL_NO_VERIFY;
+    const result = enforceTlsForRemote("postgresql://u:p@host.example/db");
+    expect(result.url).toContain("sslmode=require");
+    expect(result.ssl).toEqual({ rejectUnauthorized: true });
+  });
+
+  test("keeps encryption while allowing the explicit Railway CA opt-out", () => {
+    const url =
+      "postgresql://u:p@switchback.proxy.rlwy.net:49295/db?sslmode=no-verify";
+    expect(shouldSkipTlsVerification(url)).toBe(true);
+    expect(enforceTlsForRemote(url).ssl).toEqual({
+      rejectUnauthorized: false,
+    });
+  });
+
+  test("rejects remote modes that permit plaintext", () => {
+    for (const mode of ["disable", "allow"]) {
+      expect(() =>
+        enforceTlsForRemote(`postgresql://u:p@host.example/db?sslmode=${mode}`),
+      ).toThrow(/must use TLS/i);
+    }
+  });
+
+  test("is re-exported by the full client without importing it", () => {
+    const clientSource = readFileSync(
+      new URL("../client.ts", import.meta.url),
+      "utf8",
+    );
+    expect(clientSource).toContain('from "./postgres-tls"');
+    expect(clientSource).toContain("shouldSkipTlsVerification");
+    expect(clientSource).toContain("enforceTlsForRemote");
+  });
+});

--- a/packages/cloud/shared/src/db/client.ts
+++ b/packages/cloud/shared/src/db/client.ts
@@ -9,16 +9,32 @@
  */
 
 import { AsyncLocalStorage } from "node:async_hooks";
-import type { NodePgDatabase, NodePgTransaction } from "drizzle-orm/node-postgres";
+import type {
+  NodePgDatabase,
+  NodePgTransaction,
+} from "drizzle-orm/node-postgres";
 import { drizzle as drizzleNode } from "drizzle-orm/node-postgres";
-import { drizzle as drizzlePGlite, type PgliteDatabase } from "drizzle-orm/pglite";
+import {
+  drizzle as drizzlePGlite,
+  type PgliteDatabase,
+} from "drizzle-orm/pglite";
 import type { ExtractTablesWithRelations } from "drizzle-orm/relations";
 import { Pool as PgPool, type PoolConfig } from "pg";
-import { getCloudAwareEnv, getCloudBinding } from "../lib/runtime/cloud-bindings";
+import {
+  getCloudAwareEnv,
+  getCloudBinding,
+} from "../lib/runtime/cloud-bindings";
 import { logger } from "../lib/utils/logger";
 import { applyDatabaseUrlFallback } from "./database-url";
 import { disableLocalPreparedStatements } from "./local-pg-query";
+import { enforceTlsForRemote, isLocalTcpPostgresUrl } from "./postgres-tls";
 import * as schema from "./schemas";
+
+export {
+  enforceTlsForRemote,
+  isLocalTcpPostgresUrl,
+  shouldSkipTlsVerification,
+} from "./postgres-tls";
 
 // ============================================================================
 // Types
@@ -36,7 +52,10 @@ type DatabaseCloser = () => Promise<void> | void;
 
 const databaseClosers = new WeakMap<Database, DatabaseCloser>();
 
-function registerDatabaseCloser(database: Database, closer: DatabaseCloser): Database {
+function registerDatabaseCloser(
+  database: Database,
+  closer: DatabaseCloser,
+): Database {
   databaseClosers.set(database, closer);
   return database;
 }
@@ -93,7 +112,8 @@ let pgliteClientForTests: import("@electric-sql/pglite").PGlite | null = null;
  * on the Workers runtime.
  */
 function createPGliteClient(dataDir: string): Database {
-  const { PGlite } = require("@electric-sql/pglite") as typeof import("@electric-sql/pglite");
+  const { PGlite } =
+    require("@electric-sql/pglite") as typeof import("@electric-sql/pglite");
   const { vector } =
     require("@electric-sql/pglite/vector") as typeof import("@electric-sql/pglite/vector");
   const client = new PGlite({
@@ -101,95 +121,24 @@ function createPGliteClient(dataDir: string): Database {
     extensions: { vector },
   });
   pgliteClientForTests = client;
-  const database: PgliteDatabase<typeof schema> = drizzlePGlite({ client, schema });
+  const database: PgliteDatabase<typeof schema> = drizzlePGlite({
+    client,
+    schema,
+  });
   return registerDatabaseCloser(database as Database, async () => {
     await client.close();
   });
 }
 
-function isLocalTcpPostgresUrl(url: string): boolean {
-  try {
-    const parsed = new URL(url);
-    return (
-      (parsed.protocol === "postgres:" || parsed.protocol === "postgresql:") &&
-      (parsed.hostname === "127.0.0.1" || parsed.hostname === "localhost")
-    );
-  } catch {
-    return false;
-  }
-}
-
-function parsePositiveInteger(value: string | undefined, fallback: number): number {
+function parsePositiveInteger(
+  value: string | undefined,
+  fallback: number,
+): number {
   if (!value) {
     return fallback;
   }
   const parsed = Number.parseInt(value, 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
-}
-
-/**
- * Whether to keep TLS but skip server-certificate verification.
- *
- * Managed providers like Railway terminate the public TCP proxy with a
- * self-signed certificate, so strict CA verification fails even though the
- * connection is fully encrypted. Opt in — per the provider's own guidance —
- * with `DATABASE_SSL_NO_VERIFY=true` or `?sslmode=no-verify` on the URL. The
- * default stays strict; this never disables encryption (only verification).
- */
-export function shouldSkipTlsVerification(url: string): boolean {
-  if (process.env.DATABASE_SSL_NO_VERIFY === "true") {
-    return true;
-  }
-  try {
-    return new URL(url).searchParams.get("sslmode") === "no-verify";
-  } catch {
-    return false;
-  }
-}
-
-/**
- * Enforce TLS on remote Postgres connections (D-2 / SOC2 CC6.7).
- *
- * Local (127.0.0.1 / localhost) connections may run without TLS for dev.
- * Anything else must use TLS — both via the URL `sslmode` parameter (so it
- * survives external connection-pool configs) AND via the `ssl` option on the
- * pg driver (so the handshake is enforced even if the parameter is dropped by
- * a proxy). We fail closed: `sslmode=disable`/`allow` is rejected outright, and
- * certificate verification stays on (`rejectUnauthorized: true`) unless the
- * operator explicitly opts into `no-verify` for a self-signed managed proxy
- * (the connection remains encrypted; only CA verification is relaxed).
- */
-export function enforceTlsForRemote(url: string): {
-  url: string;
-  ssl: PoolConfig["ssl"];
-} {
-  if (isLocalTcpPostgresUrl(url)) {
-    return { url, ssl: undefined };
-  }
-  const skipVerify = shouldSkipTlsVerification(url);
-  let normalized = url;
-  try {
-    const parsed = new URL(url);
-    const sslmode = parsed.searchParams.get("sslmode");
-    if (sslmode === "disable" || sslmode === "allow") {
-      throw new Error(
-        `Refusing to connect: remote DATABASE_URL has sslmode=${sslmode}. Remote Postgres connections must use TLS (SOC2 CC6.7).`,
-      );
-    }
-    if (!sslmode) {
-      parsed.searchParams.set("sslmode", skipVerify ? "no-verify" : "require");
-      normalized = parsed.toString();
-    }
-  } catch (err) {
-    if (err instanceof Error && err.message.startsWith("Refusing to connect")) {
-      throw err;
-    }
-    // URL parse failure — fall through with original string; pg will reject.
-  }
-  return {
-    url: normalized,
-    ssl: { rejectUnauthorized: !skipVerify },
-  };
 }
 
 /**
@@ -241,7 +190,9 @@ function createPgPool(url: string, hyperdriveUrl?: string): PgPool {
   const isLocalTcp = isLocalTcpPostgresUrl(url);
   // Hyperdrive proxies to the origin (pooling + TLS); the Worker connects to its
   // local plaintext endpoint, so bypass the remote-TLS enforcement.
-  const tls = hyperdriveUrl ? { url: hyperdriveUrl, ssl: undefined } : enforceTlsForRemote(url);
+  const tls = hyperdriveUrl
+    ? { url: hyperdriveUrl, ssl: undefined }
+    : enforceTlsForRemote(url);
   const options: PoolConfig = { connectionString: tls.url };
   // A remote Node daemon must fail a saturated pool checkout instead of
   // waiting forever behind a leaked transaction while outer job timers merely
@@ -317,7 +268,9 @@ function createPgPool(url: string, hyperdriveUrl?: string): PgPool {
 function createConnection(url: string): Database {
   if (url.startsWith("pglite://")) {
     if (isCloudflareWorkerRuntime()) {
-      throw new Error("pglite:// URLs are local-only and cannot run inside a Cloudflare Worker.");
+      throw new Error(
+        "pglite:// URLs are local-only and cannot run inside a Cloudflare Worker.",
+      );
     }
     return createPGliteClient(parsePGliteDataDir(url));
   }
@@ -332,14 +285,20 @@ function createConnection(url: string): Database {
   // terminates mid-query on workerd (#8629). If we're in a Worker reaching a
   // remote origin without a Hyperdrive binding, refuse loudly instead of
   // silently opening a doomed per-request connection.
-  if (isCloudflareWorkerRuntime() && !hyperdriveUrl && !isLocalTcpPostgresUrl(url)) {
+  if (
+    isCloudflareWorkerRuntime() &&
+    !hyperdriveUrl &&
+    !isLocalTcpPostgresUrl(url)
+  ) {
     throw new Error(
       "Refusing direct node-pg to external Postgres from a Worker: HYPERDRIVE binding missing. " +
         "Bind [[hyperdrive]] in wrangler.toml so the Worker proxies to the origin (see #8629).",
     );
   }
   const pool = createPgPool(url, hyperdriveUrl);
-  return registerDatabaseCloser(drizzleNode(pool, { schema }) as Database, () => pool.end());
+  return registerDatabaseCloser(drizzleNode(pool, { schema }) as Database, () =>
+    pool.end(),
+  );
 }
 
 // ============================================================================

--- a/packages/cloud/shared/src/db/client.ts
+++ b/packages/cloud/shared/src/db/client.ts
@@ -9,21 +9,12 @@
  */
 
 import { AsyncLocalStorage } from "node:async_hooks";
-import type {
-  NodePgDatabase,
-  NodePgTransaction,
-} from "drizzle-orm/node-postgres";
+import type { NodePgDatabase, NodePgTransaction } from "drizzle-orm/node-postgres";
 import { drizzle as drizzleNode } from "drizzle-orm/node-postgres";
-import {
-  drizzle as drizzlePGlite,
-  type PgliteDatabase,
-} from "drizzle-orm/pglite";
+import { drizzle as drizzlePGlite, type PgliteDatabase } from "drizzle-orm/pglite";
 import type { ExtractTablesWithRelations } from "drizzle-orm/relations";
 import { Pool as PgPool, type PoolConfig } from "pg";
-import {
-  getCloudAwareEnv,
-  getCloudBinding,
-} from "../lib/runtime/cloud-bindings";
+import { getCloudAwareEnv, getCloudBinding } from "../lib/runtime/cloud-bindings";
 import { logger } from "../lib/utils/logger";
 import { applyDatabaseUrlFallback } from "./database-url";
 import { disableLocalPreparedStatements } from "./local-pg-query";
@@ -52,10 +43,7 @@ type DatabaseCloser = () => Promise<void> | void;
 
 const databaseClosers = new WeakMap<Database, DatabaseCloser>();
 
-function registerDatabaseCloser(
-  database: Database,
-  closer: DatabaseCloser,
-): Database {
+function registerDatabaseCloser(database: Database, closer: DatabaseCloser): Database {
   databaseClosers.set(database, closer);
   return database;
 }
@@ -112,8 +100,7 @@ let pgliteClientForTests: import("@electric-sql/pglite").PGlite | null = null;
  * on the Workers runtime.
  */
 function createPGliteClient(dataDir: string): Database {
-  const { PGlite } =
-    require("@electric-sql/pglite") as typeof import("@electric-sql/pglite");
+  const { PGlite } = require("@electric-sql/pglite") as typeof import("@electric-sql/pglite");
   const { vector } =
     require("@electric-sql/pglite/vector") as typeof import("@electric-sql/pglite/vector");
   const client = new PGlite({
@@ -121,19 +108,13 @@ function createPGliteClient(dataDir: string): Database {
     extensions: { vector },
   });
   pgliteClientForTests = client;
-  const database: PgliteDatabase<typeof schema> = drizzlePGlite({
-    client,
-    schema,
-  });
+  const database: PgliteDatabase<typeof schema> = drizzlePGlite({ client, schema });
   return registerDatabaseCloser(database as Database, async () => {
     await client.close();
   });
 }
 
-function parsePositiveInteger(
-  value: string | undefined,
-  fallback: number,
-): number {
+function parsePositiveInteger(value: string | undefined, fallback: number): number {
   if (!value) {
     return fallback;
   }
@@ -190,9 +171,7 @@ function createPgPool(url: string, hyperdriveUrl?: string): PgPool {
   const isLocalTcp = isLocalTcpPostgresUrl(url);
   // Hyperdrive proxies to the origin (pooling + TLS); the Worker connects to its
   // local plaintext endpoint, so bypass the remote-TLS enforcement.
-  const tls = hyperdriveUrl
-    ? { url: hyperdriveUrl, ssl: undefined }
-    : enforceTlsForRemote(url);
+  const tls = hyperdriveUrl ? { url: hyperdriveUrl, ssl: undefined } : enforceTlsForRemote(url);
   const options: PoolConfig = { connectionString: tls.url };
   // A remote Node daemon must fail a saturated pool checkout instead of
   // waiting forever behind a leaked transaction while outer job timers merely
@@ -268,9 +247,7 @@ function createPgPool(url: string, hyperdriveUrl?: string): PgPool {
 function createConnection(url: string): Database {
   if (url.startsWith("pglite://")) {
     if (isCloudflareWorkerRuntime()) {
-      throw new Error(
-        "pglite:// URLs are local-only and cannot run inside a Cloudflare Worker.",
-      );
+      throw new Error("pglite:// URLs are local-only and cannot run inside a Cloudflare Worker.");
     }
     return createPGliteClient(parsePGliteDataDir(url));
   }
@@ -285,20 +262,14 @@ function createConnection(url: string): Database {
   // terminates mid-query on workerd (#8629). If we're in a Worker reaching a
   // remote origin without a Hyperdrive binding, refuse loudly instead of
   // silently opening a doomed per-request connection.
-  if (
-    isCloudflareWorkerRuntime() &&
-    !hyperdriveUrl &&
-    !isLocalTcpPostgresUrl(url)
-  ) {
+  if (isCloudflareWorkerRuntime() && !hyperdriveUrl && !isLocalTcpPostgresUrl(url)) {
     throw new Error(
       "Refusing direct node-pg to external Postgres from a Worker: HYPERDRIVE binding missing. " +
         "Bind [[hyperdrive]] in wrangler.toml so the Worker proxies to the origin (see #8629).",
     );
   }
   const pool = createPgPool(url, hyperdriveUrl);
-  return registerDatabaseCloser(drizzleNode(pool, { schema }) as Database, () =>
-    pool.end(),
-  );
+  return registerDatabaseCloser(drizzleNode(pool, { schema }) as Database, () => pool.end());
 }
 
 // ============================================================================

--- a/packages/cloud/shared/src/db/postgres-tls.ts
+++ b/packages/cloud/shared/src/db/postgres-tls.ts
@@ -14,7 +14,15 @@ export function isLocalTcpPostgresUrl(url: string): boolean {
   }
 }
 
-/** Keeps TLS while allowing an explicit self-signed managed-provider opt-out. */
+/**
+ * Whether to keep TLS but skip server-certificate verification.
+ *
+ * Managed providers like Railway terminate the public TCP proxy with a
+ * self-signed certificate, so strict CA verification fails even though the
+ * connection is fully encrypted. Opt in — per the provider's own guidance —
+ * with `DATABASE_SSL_NO_VERIFY=true` or `?sslmode=no-verify` on the URL. The
+ * default stays strict; this never disables encryption (only verification).
+ */
 export function shouldSkipTlsVerification(url: string): boolean {
   if (process.env.DATABASE_SSL_NO_VERIFY === "true") return true;
   try {
@@ -25,7 +33,18 @@ export function shouldSkipTlsVerification(url: string): boolean {
   }
 }
 
-/** Enforces encrypted remote PostgreSQL transport and rejects insecure modes. */
+/**
+ * Enforce TLS on remote Postgres connections (D-2 / SOC2 CC6.7).
+ *
+ * Local (127.0.0.1 / localhost) connections may run without TLS for dev.
+ * Anything else must use TLS — both via the URL `sslmode` parameter (so it
+ * survives external connection-pool configs) AND via the `ssl` option on the
+ * pg driver (so the handshake is enforced even if the parameter is dropped by
+ * a proxy). We fail closed: `sslmode=disable`/`allow` is rejected outright, and
+ * certificate verification stays on (`rejectUnauthorized: true`) unless the
+ * operator explicitly opts into `no-verify` for a self-signed managed proxy
+ * (the connection remains encrypted; only CA verification is relaxed).
+ */
 export function enforceTlsForRemote(url: string): {
   url: string;
   ssl: PoolConfig["ssl"];
@@ -47,10 +66,7 @@ export function enforceTlsForRemote(url: string): {
     }
   } catch (error) {
     // error-policy:J3 preserve malformed URLs for node-postgres to reject.
-    if (
-      error instanceof Error &&
-      error.message.startsWith("Refusing to connect")
-    ) {
+    if (error instanceof Error && error.message.startsWith("Refusing to connect")) {
       throw error;
     }
     // Preserve the original string so node-postgres owns the parse failure.

--- a/packages/cloud/shared/src/db/postgres-tls.ts
+++ b/packages/cloud/shared/src/db/postgres-tls.ts
@@ -1,0 +1,62 @@
+/** Dependency-light TLS policy shared by database clients and operator audits. */
+import type { PoolConfig } from "pg";
+
+export function isLocalTcpPostgresUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return (
+      (parsed.protocol === "postgres:" || parsed.protocol === "postgresql:") &&
+      (parsed.hostname === "127.0.0.1" || parsed.hostname === "localhost")
+    );
+  } catch {
+    // error-policy:J3 malformed URLs remain explicitly non-local.
+    return false;
+  }
+}
+
+/** Keeps TLS while allowing an explicit self-signed managed-provider opt-out. */
+export function shouldSkipTlsVerification(url: string): boolean {
+  if (process.env.DATABASE_SSL_NO_VERIFY === "true") return true;
+  try {
+    return new URL(url).searchParams.get("sslmode") === "no-verify";
+  } catch {
+    // error-policy:J3 malformed URLs cannot opt out of strict verification.
+    return false;
+  }
+}
+
+/** Enforces encrypted remote PostgreSQL transport and rejects insecure modes. */
+export function enforceTlsForRemote(url: string): {
+  url: string;
+  ssl: PoolConfig["ssl"];
+} {
+  if (isLocalTcpPostgresUrl(url)) return { url, ssl: undefined };
+  const skipVerify = shouldSkipTlsVerification(url);
+  let normalized = url;
+  try {
+    const parsed = new URL(url);
+    const sslmode = parsed.searchParams.get("sslmode");
+    if (sslmode === "disable" || sslmode === "allow") {
+      throw new Error(
+        `Refusing to connect: remote DATABASE_URL has sslmode=${sslmode}. Remote Postgres connections must use TLS (SOC2 CC6.7).`,
+      );
+    }
+    if (!sslmode) {
+      parsed.searchParams.set("sslmode", skipVerify ? "no-verify" : "require");
+      normalized = parsed.toString();
+    }
+  } catch (error) {
+    // error-policy:J3 preserve malformed URLs for node-postgres to reject.
+    if (
+      error instanceof Error &&
+      error.message.startsWith("Refusing to connect")
+    ) {
+      throw error;
+    }
+    // Preserve the original string so node-postgres owns the parse failure.
+  }
+  return {
+    url: normalized,
+    ssl: { rejectUnauthorized: !skipVerify },
+  };
+}

--- a/packages/scripts/__tests__/production-railway-database-authority-audit-workflow.test.ts
+++ b/packages/scripts/__tests__/production-railway-database-authority-audit-workflow.test.ts
@@ -1,0 +1,133 @@
+/** Guards the protected, read-only production Railway database authority audit. */
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const workflowSource = readFileSync(
+  new URL(
+    "../../../.github/workflows/production-railway-database-authority-audit.yml",
+    import.meta.url,
+  ),
+  "utf8",
+);
+const auditSource = readFileSync(
+  new URL(
+    "../../cloud/scripts/admin/audit-production-railway-database-authority.ts",
+    import.meta.url,
+  ),
+  "utf8",
+);
+
+interface WorkflowStep {
+  name?: string;
+  env?: Record<string, string>;
+  run?: string;
+}
+
+interface Workflow {
+  jobs?: Record<string, { environment?: string; steps?: WorkflowStep[] }>;
+}
+
+const workflow = Bun.YAML.parse(workflowSource) as Workflow;
+const job = workflow.jobs?.audit;
+const steps = job?.steps ?? [];
+
+function step(name: string): WorkflowStep {
+  const found = steps.find((candidate) => candidate.name === name);
+  if (!found) throw new Error(`Missing workflow step: ${name}`);
+  return found;
+}
+
+describe("production Railway database authority audit workflow", () => {
+  test("uses only the protected production environment and canonical develop source", () => {
+    expect(job?.environment).toBe("production");
+    expect(step("Require canonical develop source").run).toContain(
+      '"refs/heads/develop"',
+    );
+    const config = step("Validate protected audit configuration");
+    expect(config.env?.HAS_DATABASE_URL).toContain("secrets.DATABASE_URL");
+    expect(config.env?.HAS_RAILWAY_TOKEN).toContain("secrets.RAILWAY_TOKEN");
+    expect(config.env?.RAILWAY_PROJECT_ID).toContain("vars.RAILWAY_PROJECT_ID");
+    expect(config.env?.RAILWAY_ENVIRONMENT_ID).toContain(
+      "vars.RAILWAY_ENVIRONMENT_ID",
+    );
+    expect(config.run).toContain(
+      ['if [ -n "$', '{RAILWAY_POSTGRES_SERVICE_ID:-}" ]'].join(""),
+    );
+    expect(config.run).not.toContain(
+      "RAILWAY_ENVIRONMENT_ID \\\n            RAILWAY_POSTGRES_SERVICE_ID; do",
+    );
+  });
+
+  test("discovers one private Postgres target and never publishes its identity", () => {
+    const capture = step(
+      "Capture private read-only Railway authority evidence",
+    );
+    for (const command of [
+      "railway status",
+      "railway service list",
+      "railway variable list",
+      "resolve-production-railway-postgres-service.ts",
+    ]) {
+      expect(capture.run).toContain(command);
+    }
+    expect(capture.run).toContain('echo "::add-mask::$resolved_service_id"');
+    expect(capture.run).toContain('--service "$resolved_service_id"');
+    expect(capture.run).toContain("umask 077");
+    expect(capture.run).not.toContain('cat "$evidence_dir');
+    expect(workflowSource).not.toContain("actions/upload-artifact");
+    expect(workflowSource).not.toContain("GITHUB_ENV");
+  });
+
+  test("wires the protected URL only to the database-enforced read-only audit", () => {
+    const audit = step(
+      "Audit protected database authority, schema, and migration ledger",
+    );
+    expect(audit.env?.DATABASE_URL).toContain("secrets.DATABASE_URL");
+    expect(audit.env).not.toHaveProperty("GITHUB_TOKEN");
+    expect(audit.run).toContain(
+      "audit-production-railway-database-authority.ts",
+    );
+    expect(audit.run).toContain("--resolved-service-id-file");
+    expect(audit.run).toContain("canonical-deploy-source-guard.mjs");
+    expect(audit.run).toContain(
+      ["GITHUB_TOKEN='$", "{{ github.token }}'"].join(""),
+    );
+    expect(audit.run).toContain("--canonical-ref refs/heads/develop");
+    expect(audit.run).toContain("env -u GITHUB_STEP_SUMMARY");
+    expect(audit.run?.indexOf("audit-production-railway")).toBeLessThan(
+      audit.run?.indexOf("canonical-deploy-source-guard.mjs") ?? -1,
+    );
+    expect(
+      audit.run?.indexOf("canonical-deploy-source-guard.mjs"),
+    ).toBeLessThan(audit.run?.indexOf('tee -a "$GITHUB_STEP_SUMMARY"') ?? -1);
+    expect(auditSource).toContain(
+      "BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY",
+    );
+    expect(auditSource).toContain(
+      'options: "-c default_transaction_read_only=on"',
+    );
+    expect(auditSource).toContain(
+      'if (report.verdict !== "pass") process.exitCode = 1',
+    );
+  });
+
+  test("contains no database, Railway, or evidence-publishing mutation path", () => {
+    for (const mutation of [
+      "railway variable set",
+      "railway add",
+      "railway delete",
+      "railway postgres pitr enable",
+      "railway postgres pitr restore",
+      "bun run db:cloud:migrate",
+      "actions/upload-artifact",
+    ]) {
+      expect(workflowSource).not.toContain(mutation);
+    }
+    expect(auditSource).not.toMatch(
+      /\b(?:INSERT|UPDATE|DELETE|CREATE|ALTER|DROP|TRUNCATE)\b/,
+    );
+    const cleanup = step("Destroy private audit evidence");
+    expect(cleanup.run).toContain("shred -u");
+    expect(cleanup.run).toContain("find");
+  });
+});


### PR DESCRIPTION
## Summary

- add a protected, workflow-dispatch-only production Railway database authority audit
- resolve exactly one canonical Postgres 18 Railway service without publishing project, environment, service, URL, credential, database, role, or row values
- compare the protected `DATABASE_URL` authority to the canonical Railway target inside database-enforced read-only transactions
- report fixed allowlisted canonical and protected table-presence and migration-ledger verdicts independently, so wrong-secret drift is distinguishable from canonical schema drift
- extract dependency-light migration-ledger, database-identity, and PostgreSQL TLS helpers while preserving the existing migrator and client exports and diagnostic contracts
- publish the fixed audit report only after a final canonical `develop` freshness guard; scope `GITHUB_TOKEN` only to that guard

## Safety

- no DDL, migration, repair, Railway mutation, secret mutation, or artifact upload path
- both connections set `default_transaction_read_only=on` and use repeatable-read read-only transactions
- private Railway evidence is mode 0600, never logged, and shredded in an always-run cleanup step
- optional protected service ID acts only as an exact pin; absent pins require one unique Postgres 18 candidate, while zero or multiple candidates fail closed
- the audit exits nonzero on every fail or unavailable verdict

## Exact source

- validated `origin/develop`: `9109339b01d068d5e5f0d42f6b15bdd8aa4ed269`
- PR head: `20ecfa09d27cf7b235a01559b6628c61f5fd3e27`

## Validation

- `bun install --frozen-lockfile --no-save --ignore-scripts` — pass
- dependency-light standalone import probe for audit, resolver, canonical ledger, identity receipt, and TLS policy — pass
- focused audit, ledger, identity, TLS, and workflow suites — 38 pass / 0 fail / 169 expectations
- focused TypeScript check for dependency-light audit modules — pass
- `bun run --cwd packages/cloud/shared typecheck` — pass
- pinned touched-file Biome formatter and check — exit 0; only the two unchanged base warnings in `client.ts` remain (`initialized` unused and the existing connection-map non-null assertion)
- `git diff --check` — pass

`bun run verify:cloud` was also attempted. Its package-wide Cloud Shared lint lane fails on the existing canonical baseline with 2341 unrelated formatter errors and 983 warnings across pre-existing files. The affected-file Biome gate and Cloud Shared TypeScript gate above are green on this exact head.

## Evidence

- Production database result: N/A for this PR stage — this change creates the protected read-only operator workflow, and it has intentionally not been dispatched before review.
- UI screenshots/video: N/A — no rendered UI changes.
- Native/device evidence: N/A — no native or device changes.
- Database mutation evidence: N/A — the workflow is intentionally read-only and has not been run against production.

Do not merge or dispatch the production audit until the protected workflow and fixed-output contract are reviewed.