### PR TITLE
fix(ui): expose live status above collapsed chat

### DIFF
--- a/packages/ui/src/components/shell/ChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ChatOverlay.test.tsx
@@ -3198,6 +3198,45 @@ describe("ChatOverlay", () => {
     expect(pill.getAttribute("tabindex")).toBeNull();
   });
 
+  it("shows the live turn phase while a response runs behind the collapsed pill", () => {
+    const { rerender } = render(<ChatOverlay controller={makeController()} />);
+    const sheet = screen.getByTestId("chat-sheet");
+    const grabber = screen.getByTestId("chat-sheet-grabber");
+    fireEvent.pointerDown(grabber, { clientY: 200, pointerId: 1 });
+    fireEvent.pointerMove(grabber, { clientY: 380, pointerId: 1 });
+    fireEvent.pointerUp(grabber, { clientY: 380, pointerId: 1 });
+    expect(sheet.getAttribute("data-detent")).toBe("pill");
+
+    rerender(
+      <ChatOverlay
+        controller={makeController({
+          phase: "responding",
+          responding: true,
+          turnStatus: {
+            kind: "running_action",
+            actionName: "VIEWS",
+          },
+        })}
+      />,
+    );
+
+    const status = screen.getByTestId("chat-pill-turn-status");
+    expect(status.className).toContain("pointer-events-none");
+    expect(screen.getByTestId("turn-status-label").textContent).toBe(
+      "Running Views",
+    );
+  });
+
+  it("keeps the collapsed pill quiet when no response is active", () => {
+    render(<ChatOverlay controller={makeController()} />);
+    const grabber = screen.getByTestId("chat-sheet-grabber");
+    fireEvent.pointerDown(grabber, { clientY: 200, pointerId: 1 });
+    fireEvent.pointerMove(grabber, { clientY: 380, pointerId: 1 });
+    fireEvent.pointerUp(grabber, { clientY: 380, pointerId: 1 });
+
+    expect(screen.queryByTestId("chat-pill-turn-status")).toBeNull();
+  });
+
   it("centers 64x12 resting material in a 64x44 detached desktop hit target", () => {
     render(<ChatOverlay controller={makeController()} fillHostAtHalf />);
     const grabber = screen.getByTestId("chat-sheet-grabber");

--- a/packages/ui/src/components/shell/ChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ChatOverlay.tsx
@@ -135,6 +135,7 @@ import type {
   ChatMessageData,
   ChatMessageRenderContext,
 } from "../composites/chat/chat-types";
+import { TurnStatus } from "../composites/chat/chat-typing-indicator";
 import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
 import { Card } from "../ui/card";
@@ -7029,6 +7030,18 @@ export function ChatOverlay({
                 pointerEvents: pilled ? "auto" : "none",
               }}
             >
+              {pilled && responding && turnStatus && !fillHostAtHalf ? (
+                <div
+                  className={cn(
+                    "pointer-events-none absolute bottom-7 max-w-[calc(100vw-2rem)] overflow-hidden whitespace-nowrap",
+                    "[&_[data-slot=marker-content]]:truncate",
+                    WALLPAPER_FLOAT_SHADOW,
+                  )}
+                  data-testid="chat-pill-turn-status"
+                >
+                  <TurnStatus status={turnStatus} showLabel={false} />
+                </div>
+              ) : null}
               <PillHandle
                 binding={pullBinding}
                 counterScale={pillCounterScale}


### PR DESCRIPTION
## Summary
- surface the existing live turn phase above the collapsed mobile chat pill
- reuse the canonical TurnStatus renderer without adding another glass box
- keep detached desktop pill behavior unchanged

## Verification
- `bun run --cwd packages/ui test -- src/components/shell/ChatOverlay.test.tsx --reporter=dot` (210/210)
- `bun run --cwd packages/ui typecheck`
- Biome check on both changed files
- Impeccable detector: no findings