### PR TITLE
fix(electrobun): skip superseded renderer reloads

### DIFF
--- a/packages/app-core/platforms/electrobun/src/lifecycle/desktop-session-renderer-ready.test.ts
+++ b/packages/app-core/platforms/electrobun/src/lifecycle/desktop-session-renderer-ready.test.ts
@@ -127,6 +127,40 @@ describe("desktop session renderer readiness", () => {
     expect(window.webview.loadURL).toHaveBeenCalledTimes(1);
   });
 
+  it("ignores a pending reload after a newer backend generation wins", async () => {
+    const window = createWindow();
+    const rendererUrl = "http://127.0.0.1:5174/chat";
+    let resolveOlderUrl!: (url: string) => void;
+    const olderUrl = new Promise<string>((resolve) => {
+      resolveOlderUrl = resolve;
+    });
+
+    const olderReload = reloadRendererAfterDesktopSessionPrime({
+      sessionPrimed: true,
+      backendGeneration: "31337:old",
+      window,
+      resolveRendererUrl: () => olderUrl,
+    });
+    const newerReload = reloadRendererAfterDesktopSessionPrime({
+      sessionPrimed: true,
+      backendGeneration: "31337:new",
+      window,
+      resolveRendererUrl: async () => rendererUrl,
+    });
+
+    await expect(newerReload).resolves.toBe(true);
+    expect(window.webview.loadURL).toHaveBeenCalledTimes(1);
+    expect(window.webview.loadURL).toHaveBeenLastCalledWith(rendererUrl);
+
+    resolveOlderUrl(rendererUrl);
+    await expect(olderReload).resolves.toBe(false);
+
+    expect(window.webview.loadURL).toHaveBeenCalledTimes(1);
+    expect(window.webview.loadURL).toHaveBeenLastCalledWith(rendererUrl);
+    expect(loggerState.info).toHaveBeenCalledTimes(1);
+    expect(loggerState.warn).not.toHaveBeenCalled();
+  });
+
   it("reloads the same window once for each backend generation", async () => {
     const window = createWindow();
     const resolveRendererUrl = vi.fn(async () => "http://127.0.0.1:5174/chat");

--- a/packages/app-core/platforms/electrobun/src/lifecycle/desktop-session-renderer-ready.ts
+++ b/packages/app-core/platforms/electrobun/src/lifecycle/desktop-session-renderer-ready.ts
@@ -43,6 +43,9 @@ export async function reloadRendererAfterDesktopSessionPrime({
 
   try {
     const rendererUrl = await resolveRendererUrl();
+    if (reloadedGenerationByWindow.get(window) !== backendGeneration) {
+      return false;
+    }
     window.webview.loadURL(rendererUrl);
     logger.info(
       "[Main] Reloaded desktop renderer after loopback session prime",


### PR DESCRIPTION
# Relates to

Fixes #29270.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest live `develop` with zero conflicts. Validated base: `d7ff04176ab1e0c878c598858ac601e552dac33d`.
- [ ] `bun install` and `bun run verify` were run after sync. This Windows host has no Bun executable and the lightweight disposable harness is not a full workspace install; the exact limitations are recorded below.
- [x] A reviewer can confirm the changed concurrency contract from the deterministic RED-to-GREEN evidence below without reading the implementation.

# Sync with develop

- [x] Rebased onto live `develop` at `d7ff04176ab1e0c878c598858ac601e552dac33d`; zero conflicts and zero intervening changes to either touched file.
- [ ] `bun run verify` passes post-sync. It was unavailable on this host; focused exact-head validation passes and the full-command blockers are documented below.

# Risks

Low. The change affects only the existing desktop-session renderer reload helper. A caller whose backend generation lost ownership while its renderer URL was resolving now returns `false` instead of issuing a second WebView navigation and success log. Same-generation coalescing, retry after the owning generation fails, and sequential reloads for distinct generations retain their existing behavior.

# Background

## What does this PR do?

It rechecks the window's reserved backend generation after the asynchronous renderer URL lookup. If a newer generation took ownership during that await, the older completion stops before `loadURL`.

The regression test overlaps two generations against the same production-faithful renderer URL: the older resolver is deferred, the newer generation completes, and then the older resolver is released. The newer call must be the only navigation and success log.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No. This restores the ownership invariant already described by the helper's reservation comment and does not change a public API or user workflow.

# Testing

## Where should a reviewer start?

`packages/app-core/platforms/electrobun/src/lifecycle/desktop-session-renderer-ready.test.ts`, in the test named `ignores a pending reload after a newer backend generation wins`.

## Detailed testing steps

1. RED on unchanged pre-fix source at base `1091a09064a0e6acfe943e52d3d7b92b22603a39` (the two target blobs remained unchanged through the final base):

   ```text
   node ../../../scripts/run-vitest.mjs run --config vitest.electrobun.config.ts src/lifecycle/desktop-session-renderer-ready.test.ts
   Test Files  1 failed (1)
   Tests       1 failed | 5 passed (6)
   AssertionError: expected true to be false
   ```

2. GREEN on exact head `38c7a897aeaffb90b1a93ba5c0c412b7b1b95ff7`, using Node `v22.19.0` and repository-pinned Vitest `4.1.10`:

   ```text
   node ../../../scripts/run-vitest.mjs run --config vitest.electrobun.config.ts src/lifecycle/desktop-session-renderer-ready.test.ts
   Test Files  1 passed (1)
   Tests       6 passed (6)
   ```

3. Changed-file TypeScript check with TypeScript `6.0.3` and pinned `bun-types` `1.3.14`:

   ```text
   node node_modules/typescript/bin/tsc --ignoreConfig --noEmit --target ESNext --module ESNext --moduleResolution bundler --strict --esModuleInterop --skipLibCheck --forceConsistentCasingInFileNames --resolveJsonModule --isolatedModules --allowImportingTsExtensions --types bun-types packages/app-core/platforms/electrobun/src/lifecycle/desktop-session-renderer-ready.ts packages/app-core/platforms/electrobun/src/lifecycle/desktop-session-renderer-ready.test.ts
   exit 0
   ```

4. Formatting/lint and diff hygiene:

   ```text
   @biomejs/biome 2.5.8 check <both changed files>
   Checked 2 files. No fixes applied.

   git diff --check d7ff04176ab1e0c878c598858ac601e552dac33d...HEAD
   exit 0
   ```

# Evidence Gate

<!-- evidence-head:38c7a897aeaffb90b1a93ba5c0c412b7b1b95ff7 -->

This is a two-file, non-visual main-process lifecycle correction. Its observable artifact is the ordered WebView call count and return values in the deterministic regression test.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI source or visual styling changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI source or visual styling changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - the timing contract is exercised deterministically without a user interaction flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend request or server boundary is changed.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, response, or state-management code is changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior is changed.
<!-- evidence-row:domain-artifacts -->
- [x] Deterministic lifecycle-test transcript:

  ```text
  PRE-FIX 1091a090: 1 failed | 5 passed; superseded call returned true (expected false).
  EXACT HEAD 38c7a897: 6 passed | 0 failed; winning generation performed the only loadURL call.
  Assertions: superseded call false; loadURL once; logger.info once; logger.warn zero.
  ```
<!-- evidence-row:ocr-review -->
- [x] N/A - the diff has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM-facing behavior.

## Backend + frontend logs

N/A - no backend or frontend transport boundary. The lifecycle logger is asserted directly: one info call and zero warnings in the supersession case.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI diff.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or audio behavior.

## Known gaps / failures

- `bun install` and `bun run verify`: not run because this Windows host has no Bun executable. The branch used a disposable npm-backed harness containing the exact Vitest, TypeScript, Bun type, and Biome versions needed by the changed files.
- Full Electrobun Vitest attempt: 105 test files and 1,047 tests passed; 44 files / 35 tests failed and 32 tests skipped. The failures are outside the changed lifecycle test and consist of absent optional workspace packages (`handlebars`, `electrobun/view`, and others) plus Unix/macOS path, executable-bit, UID, symlink, and permission assertions running on Windows. The changed lifecycle suite passes 6/6.
- Full Electrobun `typecheck`: attempted after adding `bun-types`, but the lightweight harness lacks the repository's workspace graph and reported missing modules across app-core, agent, core, and plugins. The two changed files pass the strict focused TypeScript command above.
- Hosted CI: run 32999057458 was fully green on the prior head. Because the new base changes the PR Static Smoke workflow and adds five Cloud Pages/CI contract suites, the rebased exact head dispatched run 33001466616; no CI exception is requested.
- Desktop build/install/manual evidence: not run. The patch does not alter native binaries or rendered UI, but the package guide requests an exact installed build and manual macOS, Windows, and Linux review; those platform lanes remain for maintainer/native validation before merge.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@5e309560fa5bf659d77b13cce2c30ba28af8c500:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
? [root]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@5e309560fa5bf659d77b13cce2c30ba28af8c500:packages/skills/skills/contribute-to-eliza"} -->
