### PR TITLE
fix(cloud): gate staging Steward provider discovery

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -310,6 +310,18 @@ through `cloud-release-dependency-trigger-workflow.test.ts`; otherwise a
 source-form package can change an artifact without creating a release
 candidate.
 
+The staging path of `cloud-cf-release.yml` uses the
+[anonymous Steward provider-discovery verifier](../../packages/cloud/scripts/verify-steward-provider-discovery.mjs)
+to fail closed at three boundaries: the canonical Steward upstream before
+session-exchange cutover, the deployed API after exact-source health verification
+and before Pages deployment, and both staging custom-domain Pages aliases during
+frontend-freshness verification. Proxy `GET` and `HEAD` must return HTTP 200,
+a JSON media type, and `x-eliza-steward-path: thin`; `GET` also validates the
+bounded provider document. These probes require no sign-in credentials and
+report only sanitized outcomes, never response bodies or header values.
+Production does not run these gates. They detect broken login discovery;
+restoring the upstream Railway service remains a separate authorized operation.
+
 Production Cloud admission is also tree-bound to staging. A staging release
 whose run SHA the `develop` head has fast-forwarded past ends neutrally before
 any mutation only when GitHub proves that an active Cloud CF Deploy push run

--- a/.github/workflows/cloud-cf-release.yml
+++ b/.github/workflows/cloud-cf-release.yml
@@ -718,6 +718,19 @@ jobs:
           set -euo pipefail
           node packages/scripts/cloud/admin/verify-mobile-app-auth-registration.ts
 
+      - name: Verify Steward provider discovery before cutover
+        if: steps.cf.outputs.configured == 'true' && steps.freshness.outputs.should_deploy == 'true' && steps.env.outputs.deploy_environment == 'staging'
+        working-directory: ${{ env.CHECKOUT_DIR }}
+        env:
+          DEPLOY_ENVIRONMENT: ${{ steps.env.outputs.deploy_environment }}
+          STEWARD_UPSTREAM_URL: https://steward-api-staging.up.railway.app
+        run: |
+          set -euo pipefail
+          node packages/cloud/scripts/verify-steward-provider-discovery.mjs \
+            --base-url "$STEWARD_UPSTREAM_URL" \
+            --environment "$DEPLOY_ENVIRONMENT" \
+            --surface upstream
+
       - name: Disable staging session exchange before cutover
         if: steps.cf.outputs.configured == 'true' && steps.freshness.outputs.should_deploy == 'true' && steps.env.outputs.deploy_environment == 'staging'
         working-directory: ${{ env.CHECKOUT_DIR }}/packages/cloud/api
@@ -1587,6 +1600,19 @@ jobs:
           done
           echo "::error::API health did not serve the deployed commit ${expected_commit} for ${expected_environment}."
           exit 1
+
+      - name: Verify deployed API provider discovery
+        if: steps.cf.outputs.configured == 'true' && steps.freshness.outputs.should_deploy == 'true' && steps.env.outputs.deploy_environment == 'staging'
+        working-directory: ${{ env.CHECKOUT_DIR }}
+        env:
+          API_URL: https://api-staging.eliza.app
+          DEPLOY_ENVIRONMENT: ${{ steps.env.outputs.deploy_environment }}
+        run: |
+          set -euo pipefail
+          node packages/cloud/scripts/verify-steward-provider-discovery.mjs \
+            --base-url "$API_URL" \
+            --environment "$DEPLOY_ENVIRONMENT" \
+            --surface proxy
 
       - name: Verify deployed mobile App Auth metadata
         if: steps.cf.outputs.configured == 'true' && steps.freshness.outputs.should_deploy == 'true'
@@ -2525,6 +2551,12 @@ jobs:
             verify_exact_api_route "$served_url/api"
             verify_json_endpoint "$served_url/.well-known/openid-configuration" discovery
             verify_json_endpoint "$served_url/.well-known/oidc/jwks.json" jwks
+            if [ "$DEPLOY_ENVIRONMENT" = "staging" ]; then
+              node packages/cloud/scripts/verify-steward-provider-discovery.mjs \
+                --base-url "$served_url" \
+                --environment "$DEPLOY_ENVIRONMENT" \
+                --surface proxy
+            fi
             tenant_id="elizacloud"
             if [ "$DEPLOY_ENVIRONMENT" = "staging" ]; then
               tenant_id="elizacloud-staging"

--- a/packages/cloud/api/src/steward/embedded.test.ts
+++ b/packages/cloud/api/src/steward/embedded.test.ts
@@ -2,11 +2,13 @@
  * Unit coverage for the embedded Steward proxy. Drives the real handler
  * through a Hono shell: fetch is only the upstream network boundary.
  * Assertions record observed cache, upstream-selection, and patching
- * behaviour — not the stub's return value.
+ * behaviour, plus parity with the release verifier on adversarial wire bodies.
  */
 import { Hono } from "hono";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
+import { verifyStewardProviderDiscovery } from "../../../scripts/verify-steward-provider-discovery.mjs";
 import {
   ageProvidersResponseCacheForTests,
   embeddedStewardHandler,
@@ -510,6 +512,77 @@ describe("patchProvidersResponse", () => {
     expect(upstreamCalls).toBe(2);
   });
 
+  it("classifies an upstream 404 without logging its body", async () => {
+    const sensitiveBody = "private-upstream-diagnostic-must-not-be-logged";
+    const warn = vi.spyOn(logger, "warn").mockImplementation(() => undefined);
+    stubFetch(
+      async () =>
+        new Response(sensitiveBody, {
+          status: 404,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+
+    const response = await makeApp(baseEnv()).request(
+      "https://api.elizacloud.ai/steward/auth/providers",
+    );
+
+    expect(response.status).toBe(502);
+    expect(warn).toHaveBeenCalledWith(
+      "[embedded-steward] invalid providers response",
+      { reason: "upstream_status", upstreamStatus: 404 },
+    );
+    expect(JSON.stringify(warn.mock.calls)).not.toContain(sensitiveBody);
+  });
+
+  it.each([
+    {
+      reason: "media_type",
+      response: () => new Response("not-json"),
+    },
+    {
+      reason: "body",
+      response: () =>
+        new Response(null, {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    },
+    {
+      reason: "json",
+      response: () =>
+        new Response("{not-json", {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    },
+    {
+      reason: "envelope",
+      response: () => Response.json({ ok: false, ...providersData() }),
+    },
+    {
+      reason: "provider_contract",
+      response: () =>
+        Response.json({
+          ok: true,
+          data: providersData({ passkey: "invalid" }),
+        }),
+    },
+  ])("logs only the bounded $reason reason", async ({ reason, response }) => {
+    const warn = vi.spyOn(logger, "warn").mockImplementation(() => undefined);
+    stubFetch(async () => response());
+
+    const result = await makeApp(baseEnv()).request(
+      "https://api.elizacloud.ai/steward/auth/providers",
+    );
+
+    expect(result.status).toBe(502);
+    expect(warn).toHaveBeenCalledWith(
+      "[embedded-steward] invalid providers response",
+      { reason },
+    );
+  });
+
   it("patches discord and github from env credentials without duplicating oauth entries", async () => {
     stubFetch(async () =>
       Response.json(
@@ -680,5 +753,241 @@ describe("patchProvidersResponse", () => {
     expect(head.status).toBe(200);
     expect(head.headers.get("x-eliza-providers-cache")).toBe("hit");
     expect(await head.text()).toBe("");
+  });
+});
+
+describe("provider contract parity with the release verifier", () => {
+  const upstreamOrigin = "https://steward-api-staging.up.railway.app";
+  const flatBody = JSON.stringify(providersJson());
+  const flatMembers = flatBody.slice(1, -1);
+  const encoder = new TextEncoder();
+  const withFuture = (rawJson: string): string =>
+    `{${flatMembers},"future":${rawJson}}`;
+
+  async function assertParity(
+    body: string | Uint8Array<ArrayBuffer>,
+    expectedAccepted: boolean,
+  ): Promise<void> {
+    vi.spyOn(logger, "warn").mockImplementation(() => undefined);
+    const calls = stubFetch(
+      async () =>
+        new Response(body, {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    const response = await makeApp(
+      baseEnv({ STEWARD_API_URL: upstreamOrigin }),
+    ).request("https://api-staging.eliza.app/steward/auth/providers");
+    const [verification] = await Promise.allSettled([
+      verifyStewardProviderDiscovery(
+        {
+          baseUrl: upstreamOrigin,
+          environment: "staging",
+          surface: "upstream",
+        },
+        { fetchImpl: globalThis.fetch },
+      ),
+    ]);
+
+    expect(response.status).toBe(expectedAccepted ? 200 : 502);
+    expect(verification.status).toBe(
+      expectedAccepted ? "fulfilled" : "rejected",
+    );
+    expect(verification.status === "fulfilled").toBe(response.status === 200);
+    await expect(response.json()).resolves.toMatchObject(
+      expectedAccepted
+        ? { ok: true }
+        : { code: "steward_upstream_invalid_response" },
+    );
+    if (!expectedAccepted) {
+      expect(response.headers.get("cache-control")).toBe("no-store");
+    }
+    expect(calls.map(({ url, method }) => ({ url, method }))).toEqual([
+      { url: `${upstreamOrigin}/auth/providers`, method: "GET" },
+      { url: `${upstreamOrigin}/auth/providers`, method: "GET" },
+    ]);
+  }
+
+  it.each([
+    { name: "flat contract", payload: providersJson() },
+    { name: "nested contract", payload: { ok: true, data: providersData() } },
+    {
+      name: "flat contract with a future data field",
+      payload: providersJson({ data: { futureEnvelopeField: true } }),
+    },
+    {
+      name: "nested contract with unvalidated contract-named siblings",
+      payload: { ok: true, passkey: "invalid", data: providersData() },
+    },
+    {
+      name: "optional providers and Turnstile captcha",
+      payload: providersJson({
+        sms: true,
+        whatsapp: false,
+        telegram: true,
+        oidc: ["partner"],
+        disabled: ["github"],
+        captcha: {
+          enabled: true,
+          provider: "turnstile",
+          siteKey: "public-test-site-key",
+          requiredFor: ["email_otp", "sms_otp"],
+        },
+      }),
+    },
+    {
+      name: "nested hCaptcha with forward-compatible Unicode metadata",
+      payload: {
+        ok: true,
+        data: providersData({
+          captcha: { provider: "hcaptcha", future: "雪" },
+        }),
+      },
+    },
+  ])("accepts $name on both boundaries", async ({ payload }) => {
+    await assertParity(JSON.stringify(payload), true);
+  });
+
+  it.each([
+    { name: "failed envelope", payload: { ...providersJson(), ok: false } },
+    { name: "error envelope", payload: providersJson({ error: null }) },
+    { name: "failed success flag", payload: providersJson({ success: false }) },
+    { name: "array provider data", payload: { ok: true, data: [] } },
+    {
+      name: "invalid required boolean",
+      payload: { ok: true, data: providersData({ passkey: "true" }) },
+    },
+    { name: "invalid oauth list", payload: providersJson({ oauth: [false] }) },
+    {
+      name: "invalid optional boolean",
+      payload: providersJson({ telegram: "yes" }),
+    },
+    { name: "invalid oidc list", payload: providersJson({ oidc: [12] }) },
+    {
+      name: "invalid disabled list",
+      payload: providersJson({ disabled: "github" }),
+    },
+    { name: "null captcha", payload: providersJson({ captcha: null }) },
+    {
+      name: "invalid captcha enabled flag",
+      payload: providersJson({ captcha: { enabled: "true" } }),
+    },
+    {
+      name: "unsupported captcha provider",
+      payload: providersJson({ captcha: { provider: "unknown" } }),
+    },
+    {
+      name: "invalid captcha site key",
+      payload: providersJson({ captcha: { siteKey: 12 } }),
+    },
+    {
+      name: "invalid captcha requirement list",
+      payload: providersJson({ captcha: { requiredFor: "email_otp" } }),
+    },
+    {
+      name: "unsupported captcha requirement",
+      payload: providersJson({ captcha: { requiredFor: ["unknown"] } }),
+    },
+  ])("rejects $name on both boundaries", async ({ payload }) => {
+    await assertParity(JSON.stringify(payload), false);
+  });
+
+  it.each([
+    {
+      name: "duplicate provider key",
+      body: `{${flatMembers},"passkey":false}`,
+    },
+    {
+      name: "escaped duplicate provider key",
+      body: `{${flatMembers},"pass\\u006bey":false}`,
+    },
+    {
+      name: "escaped duplicate nested unknown key",
+      body: withFuture('{"key":1,"\\u006bey":2}'),
+    },
+    ...["__proto__", "prototype", "constructor"].map((key) => ({
+      name: `nested dangerous ${key} key`,
+      body: withFuture(`[{"${key}":{}}]`),
+    })),
+    {
+      name: "escaped nested dangerous key",
+      body: withFuture('{"\\u0063onstructor":{}}'),
+    },
+    { name: "second JSON document", body: `${flatBody} {"extra":true}` },
+    {
+      name: "invalid UTF-8 inside otherwise valid provider JSON",
+      body: Uint8Array.from([
+        ...encoder.encode(`{${flatMembers},"future":"`),
+        0xff,
+        ...encoder.encode('"}'),
+      ]),
+    },
+  ])("rejects $name on both wire parsers", async ({ body }) => {
+    await assertParity(body, false);
+  });
+
+  it.each([
+    { name: "depth 16", depth: 15, accepted: true },
+    { name: "depth 17", depth: 16, accepted: false },
+  ])("enforces $name on both boundaries", async ({ depth, accepted }) => {
+    await assertParity(
+      withFuture(`${"[".repeat(depth)}0${"]".repeat(depth)}`),
+      accepted,
+    );
+  });
+
+  it.each([
+    { entries: 256, accepted: true },
+    { entries: 257, accepted: false },
+  ])(
+    "enforces $entries entries per container",
+    async ({ entries, accepted }) => {
+      await assertParity(
+        withFuture(JSON.stringify(Array.from({ length: entries }, () => null))),
+        accepted,
+      );
+      resetProvidersResponseCacheForTests();
+      vi.restoreAllMocks();
+      await assertParity(
+        withFuture(
+          JSON.stringify(
+            Object.fromEntries(
+              Array.from({ length: entries }, (_, index) => [
+                `field${index}`,
+                null,
+              ]),
+            ),
+          ),
+        ),
+        accepted,
+      );
+    },
+  );
+
+  it.each([
+    { nodes: 2_048, tailEntries: 236, accepted: true },
+    { nodes: 2_049, tailEntries: 237, accepted: false },
+  ])("enforces $nodes parsed values", async ({ tailEntries, accepted }) => {
+    // The flat contract has 11 values. The extension adds one outer array,
+    // eight inner arrays, and 7 * 256 + tailEntries primitive values.
+    const extension = [
+      ...Array.from({ length: 7 }, () =>
+        Array.from({ length: 256 }, () => null),
+      ),
+      Array.from({ length: tailEntries }, () => null),
+    ];
+    await assertParity(withFuture(JSON.stringify(extension)), accepted);
+  });
+
+  it.each([
+    { bytes: 65_536, accepted: true },
+    { bytes: 65_537, accepted: false },
+  ])("enforces $bytes response bytes", async ({ bytes, accepted }) => {
+    const emptyBodyBytes = encoder.encode(withFuture('""')).byteLength;
+    await assertParity(
+      withFuture(JSON.stringify("a".repeat(bytes - emptyBodyBytes))),
+      accepted,
+    );
   });
 });

--- a/packages/cloud/api/src/steward/embedded.ts
+++ b/packages/cloud/api/src/steward/embedded.ts
@@ -440,7 +440,22 @@ function isProvidersData(value: unknown): value is ProvidersData {
   return !Object.hasOwn(value, "captcha") || isValidCaptcha(value.captcha);
 }
 
-function invalidProvidersResponse(): Response {
+type InvalidProvidersReason =
+  | "upstream_status"
+  | "media_type"
+  | "body"
+  | "json"
+  | "envelope"
+  | "provider_contract";
+
+function invalidProvidersResponse(
+  reason: InvalidProvidersReason,
+  upstreamStatus?: number,
+): Response {
+  logger.warn("[embedded-steward] invalid providers response", {
+    reason,
+    ...(upstreamStatus === undefined ? {} : { upstreamStatus }),
+  });
   return Response.json(
     {
       success: false,
@@ -630,40 +645,53 @@ async function patchProvidersResponse(
   upstream: Response,
   env: AppEnv["Bindings"],
 ): Promise<Response> {
-  if (!upstream.ok) return invalidProvidersResponse();
-  if (upstream.status !== 200) return invalidProvidersResponse();
+  if (!upstream.ok || upstream.status !== 200) {
+    return invalidProvidersResponse("upstream_status", upstream.status);
+  }
   const contentType = upstream.headers
     .get("content-type")
     ?.split(";", 1)[0]
     ?.trim()
     .toLowerCase();
   if (contentType !== "application/json" && !contentType?.endsWith("+json")) {
-    return invalidProvidersResponse();
+    return invalidProvidersResponse("media_type");
   }
+
+  let text: string | null;
+  try {
+    text = await readBoundedBody(upstream);
+  } catch {
+    // error-policy:J3 the public discovery boundary maps a failed body read to
+    // a bounded reason without logging response bytes or transport metadata.
+    return invalidProvidersResponse("body");
+  }
+  if (text === null) return invalidProvidersResponse("body");
 
   let parsed: unknown;
   try {
-    const text = await readBoundedBody(upstream);
-    if (text === null) return invalidProvidersResponse();
     parsed = parseProvidersJson(text);
   } catch {
-    return invalidProvidersResponse();
+    // error-policy:J3 untrusted provider JSON becomes an explicit invalid
+    // response; parser details and upstream content never enter logs.
+    return invalidProvidersResponse("json");
   }
-  if (!isRecord(parsed)) return invalidProvidersResponse();
+  if (!isRecord(parsed)) return invalidProvidersResponse("envelope");
   if (
     parsed.ok !== true ||
     Object.hasOwn(parsed, "error") ||
     (Object.hasOwn(parsed, "success") && parsed.success !== true)
   ) {
-    return invalidProvidersResponse();
+    return invalidProvidersResponse("envelope");
   }
 
   const hasNestedData = !isProvidersData(parsed);
   if (hasNestedData && !Object.hasOwn(parsed, "data")) {
-    return invalidProvidersResponse();
+    return invalidProvidersResponse("envelope");
   }
   const providerData = hasNestedData ? parsed.data : parsed;
-  if (!isProvidersData(providerData)) return invalidProvidersResponse();
+  if (!isProvidersData(providerData)) {
+    return invalidProvidersResponse("provider_contract");
+  }
 
   const oauth = new Set<string>(providerData.oauth);
   const patched: ProvidersData = { ...providerData };

--- a/packages/cloud/scripts/__tests__/verify-steward-provider-discovery.test.ts
+++ b/packages/cloud/scripts/__tests__/verify-steward-provider-discovery.test.ts
@@ -1,0 +1,409 @@
+/**
+ * Provider-discovery release tests drive the verifier against deterministic
+ * HTTP boundaries and prove that failures cannot republish upstream content.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  isProviderDiscoveryPayload,
+  main,
+  parseProviderDiscoveryArgs,
+  parseProviderDiscoveryJson,
+  verifyStewardProviderDiscovery,
+  verifyStewardProviderDiscoveryWithRetry,
+} from "../verify-steward-provider-discovery.mjs";
+
+const PROVIDERS = {
+  passkey: true,
+  email: true,
+  sms: true,
+  siwe: true,
+  siws: true,
+  google: true,
+  discord: true,
+  github: true,
+  twitter: true,
+  telegram: true,
+  oauth: ["google", "discord", "github", "twitter"],
+};
+
+const UPSTREAM = {
+  baseUrl: "https://steward-api-staging.up.railway.app",
+  environment: "staging",
+  surface: "upstream",
+};
+
+const PROXY = {
+  baseUrl: "https://api-staging.eliza.app",
+  environment: "staging",
+  surface: "proxy",
+};
+
+function validResponse(
+  body: unknown = { ok: true, data: PROVIDERS },
+  headers: Record<string, string> = {},
+): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json", ...headers },
+  });
+}
+
+describe("provider discovery contract", () => {
+  test("accepts flat and nested valid provider contracts", () => {
+    expect(isProviderDiscoveryPayload({ ok: true, ...PROVIDERS })).toBe(true);
+    expect(isProviderDiscoveryPayload({ ok: true, data: PROVIDERS })).toBe(
+      true,
+    );
+    expect(
+      isProviderDiscoveryPayload({
+        ok: true,
+        ...PROVIDERS,
+        data: { futureEnvelopeField: true },
+      }),
+    ).toBe(true);
+  });
+
+  test.each([
+    '{"ok":true,"ok":true}',
+    '{"ok":true,"__proto__":{}}',
+    `${"[".repeat(18)}0${"]".repeat(18)}`,
+  ])("rejects duplicate, dangerous, or excessive JSON %#", (body) => {
+    expect(() => parseProviderDiscoveryJson(body)).toThrow();
+  });
+
+  test.each([
+    null,
+    { ok: false, data: PROVIDERS },
+    { ok: true, error: "failed", data: PROVIDERS },
+    { ok: true, data: { ...PROVIDERS, passkey: "yes" } },
+    { ok: true, data: { ...PROVIDERS, oauth: "google" } },
+    {
+      ok: true,
+      data: { ...PROVIDERS, captcha: { requiredFor: ["unknown"] } },
+    },
+  ])("rejects malformed provider state %#", (payload) => {
+    expect(isProviderDiscoveryPayload(payload)).toBe(false);
+  });
+});
+
+describe("provider discovery HTTP verifier", () => {
+  test("rejects non-staging targets before the exported verifier can send a request", async () => {
+    let calls = 0;
+    const fetchImpl = async () => {
+      calls += 1;
+      return validResponse();
+    };
+    await expect(
+      verifyStewardProviderDiscovery(
+        { ...UPSTREAM, baseUrl: "https://eliza.steward.fi" },
+        { fetchImpl },
+      ),
+    ).rejects.toThrow("not a canonical staging upstream origin");
+    await expect(
+      verifyStewardProviderDiscoveryWithRetry(
+        {
+          ...PROXY,
+          environment: "production",
+          baseUrl: "https://api.eliza.app",
+        },
+        { fetchImpl },
+      ),
+    ).rejects.toThrow("--environment must be staging");
+    expect(calls).toBe(0);
+  });
+
+  test("probes the direct upstream with the canonical staging tenant", async () => {
+    let requestedUrl = "";
+    let requestedHeaders = new Headers();
+    const result = await verifyStewardProviderDiscovery(UPSTREAM, {
+      fetchImpl: async (input: string | URL | Request, init?: RequestInit) => {
+        requestedUrl = String(input);
+        requestedHeaders = new Headers(init?.headers);
+        return validResponse();
+      },
+    });
+
+    expect(result).toEqual({ environment: "staging", surface: "upstream" });
+    expect(requestedUrl).toBe(
+      "https://steward-api-staging.up.railway.app/auth/providers",
+    );
+    expect(requestedHeaders.get("x-steward-tenant")).toBe("elizacloud-staging");
+  });
+
+  test("requires the deployed proxy to prove the thin path", async () => {
+    const methods: string[] = [];
+    const result = await verifyStewardProviderDiscovery(PROXY, {
+      fetchImpl: async (_input: string | URL | Request, init?: RequestInit) => {
+        methods.push(init?.method ?? "GET");
+        const headers = {
+          "content-type": "application/json",
+          "x-eliza-steward-path": "thin",
+        };
+        return init?.method === "HEAD"
+          ? new Response(null, { status: 200, headers })
+          : validResponse({ ok: true, ...PROVIDERS }, headers);
+      },
+    });
+    expect(result).toEqual({ environment: "staging", surface: "proxy" });
+    expect(methods).toEqual(["GET", "HEAD"]);
+
+    await expect(
+      verifyStewardProviderDiscovery(PROXY, {
+        fetchImpl: async () => validResponse({ ok: true, ...PROVIDERS }),
+      }),
+    ).rejects.toThrow("did not traverse the thin Steward path");
+  });
+
+  test("fails closed when proxy HEAD is unhealthy or leaves the thin path", async () => {
+    const privateBody = "private-head-detail-must-not-escape";
+    let failure: Error | undefined;
+    try {
+      await verifyStewardProviderDiscovery(PROXY, {
+        fetchImpl: async (
+          _input: string | URL | Request,
+          init?: RequestInit,
+        ) =>
+          init?.method === "HEAD"
+            ? new Response(privateBody, { status: 405 })
+            : validResponse(undefined, { "x-eliza-steward-path": "thin" }),
+      });
+    } catch (error) {
+      failure = error as Error;
+    }
+    expect(failure?.message).toBe(
+      "provider discovery proxy HEAD returned HTTP 405",
+    );
+    expect(failure?.message).not.toContain(privateBody);
+
+    await expect(
+      verifyStewardProviderDiscovery(PROXY, {
+        fetchImpl: async (
+          _input: string | URL | Request,
+          init?: RequestInit,
+        ) =>
+          init?.method === "HEAD"
+            ? new Response(null, {
+                status: 200,
+                headers: { "content-type": "application/json" },
+              })
+            : validResponse(undefined, { "x-eliza-steward-path": "thin" }),
+      }),
+    ).rejects.toThrow("proxy HEAD did not traverse the thin Steward path");
+  });
+
+  test("reports only status when an upstream failure body contains private data", async () => {
+    const privateBody = "private-tenant-detail-must-not-escape";
+    let failure: Error | undefined;
+    try {
+      await verifyStewardProviderDiscovery(UPSTREAM, {
+        fetchImpl: async () => new Response(privateBody, { status: 404 }),
+      });
+    } catch (error) {
+      failure = error as Error;
+    }
+    expect(failure?.message).toBe(
+      "provider discovery upstream returned HTTP 404",
+    );
+    expect(failure?.message).not.toContain(privateBody);
+  });
+
+  test.each([
+    [
+      "non-JSON media type",
+      () => new Response("text", { headers: { "content-type": "text/plain" } }),
+    ],
+    [
+      "invalid JSON",
+      () =>
+        new Response("{bad", {
+          headers: { "content-type": "application/json" },
+        }),
+    ],
+    ["invalid provider contract", () => validResponse({ ok: true })],
+  ])("rejects %s without body output", async (reason, response) => {
+    await expect(
+      verifyStewardProviderDiscovery(UPSTREAM, {
+        fetchImpl: async () => response(),
+      }),
+    ).rejects.toThrow(reason);
+  });
+
+  test("rejects a body beyond the bounded release-proof limit", async () => {
+    const oversized = `{"ok":true,"padding":"${"x".repeat(70_000)}"}`;
+    await expect(
+      verifyStewardProviderDiscovery(UPSTREAM, {
+        fetchImpl: async () =>
+          new Response(oversized, {
+            headers: { "content-type": "application/json" },
+          }),
+      }),
+    ).rejects.toThrow("exceeds the safe limit");
+  });
+
+  test("does not reflect network or stream exception messages", async () => {
+    const privateDetail = "safe limit private-upstream-detail-must-not-escape";
+    await expect(
+      verifyStewardProviderDiscovery(UPSTREAM, {
+        fetchImpl: async () => {
+          throw new Error(privateDetail);
+        },
+      }),
+    ).rejects.toThrow(/^provider discovery upstream request failed$/);
+
+    await expect(
+      verifyStewardProviderDiscovery(UPSTREAM, {
+        fetchImpl: async () =>
+          new Response(
+            new ReadableStream<Uint8Array>({
+              start(controller) {
+                controller.error(new Error(privateDetail));
+              },
+            }),
+            { headers: { "content-type": "application/json" } },
+          ),
+      }),
+    ).rejects.toThrow(/^provider discovery body could not be read$/);
+  });
+
+  test("keeps the size failure private when cancelling an oversized stream also fails", async () => {
+    await expect(
+      verifyStewardProviderDiscovery(UPSTREAM, {
+        fetchImpl: async () =>
+          new Response(
+            new ReadableStream<Uint8Array>({
+              start(controller) {
+                controller.enqueue(new Uint8Array(70_000));
+              },
+              cancel() {
+                throw new Error("private-cancel-detail-must-not-escape");
+              },
+            }),
+            { headers: { "content-type": "application/json" } },
+          ),
+      }),
+    ).rejects.toThrow(/^provider discovery body exceeds the safe limit$/);
+  });
+
+  test("retries bounded transient failure and then proves the contract", async () => {
+    let calls = 0;
+    let sleeps = 0;
+    const result = await verifyStewardProviderDiscoveryWithRetry(UPSTREAM, {
+      attempts: 2,
+      retryDelayMs: 1,
+      sleepImpl: async () => {
+        sleeps += 1;
+      },
+      fetchImpl: async () => {
+        calls += 1;
+        return calls === 1
+          ? new Response("down", { status: 503 })
+          : validResponse();
+      },
+    });
+    expect(result.surface).toBe("upstream");
+    expect(calls).toBe(2);
+    expect(sleeps).toBe(1);
+  });
+});
+
+describe("provider discovery CLI", () => {
+  test("rejects cross-environment, credentialed, duplicate, and unknown inputs", () => {
+    expect(() =>
+      parseProviderDiscoveryArgs([
+        "--base-url",
+        "https://api.eliza.app",
+        "--environment",
+        "production",
+        "--surface",
+        "proxy",
+      ]),
+    ).toThrow("--environment must be staging");
+    expect(() =>
+      parseProviderDiscoveryArgs([
+        "--base-url",
+        "https://eliza.steward.fi",
+        "--environment",
+        "staging",
+        "--surface",
+        "upstream",
+      ]),
+    ).toThrow("not a canonical staging upstream origin");
+    expect(() =>
+      parseProviderDiscoveryArgs([
+        "--base-url",
+        "https://user@api-staging.eliza.app",
+        "--environment",
+        "staging",
+        "--surface",
+        "proxy",
+      ]),
+    ).toThrow("must be an HTTPS origin");
+    expect(() =>
+      parseProviderDiscoveryArgs([
+        "--surface",
+        "proxy",
+        "--surface",
+        "proxy",
+        "--environment",
+        "staging",
+        "--base-url",
+        PROXY.baseUrl,
+      ]),
+    ).toThrow("Duplicate argument");
+    expect(() =>
+      parseProviderDiscoveryArgs([
+        "--base-url",
+        PROXY.baseUrl,
+        "--environment",
+        "staging",
+        "--target",
+        "proxy",
+      ]),
+    ).toThrow("Unsupported argument");
+  });
+
+  test("never republishes malformed argument content", () => {
+    const privateArgument = "private-cli-material-must-not-escape";
+    for (const argv of [
+      [privateArgument],
+      [privateArgument, "value"],
+      ["--base-url", `https://${privateArgument}`],
+    ]) {
+      let failure: Error | undefined;
+      try {
+        parseProviderDiscoveryArgs(argv);
+      } catch (error) {
+        failure = error as Error;
+      }
+      expect(failure).toBeDefined();
+      expect(failure?.message).not.toContain(privateArgument);
+    }
+  });
+
+  test("prints only the verified surface and environment", async () => {
+    const logs: string[] = [];
+    await main(
+      [
+        "--base-url",
+        PROXY.baseUrl,
+        "--environment",
+        "staging",
+        "--surface",
+        "proxy",
+      ],
+      {
+        fetchImpl: async () =>
+          validResponse(
+            { ok: true, data: PROVIDERS },
+            { "x-eliza-steward-path": "thin" },
+          ),
+        log: (message: string) => logs.push(message),
+        sleepImpl: async () => undefined,
+      },
+    );
+    expect(logs).toEqual([
+      "Verified anonymous Steward provider discovery through the proxy boundary for staging.",
+    ]);
+  });
+});

--- a/packages/cloud/scripts/verify-steward-provider-discovery.d.mts
+++ b/packages/cloud/scripts/verify-steward-provider-discovery.d.mts
@@ -1,0 +1,68 @@
+/**
+ * Types the anonymous Steward discovery release boundary for TypeScript callers.
+ * Raw configuration strings are validated before HTTP; successful results name
+ * the verified staging surface, without carrying provider response content.
+ */
+
+export type ProviderDiscoverySurface = "upstream" | "proxy";
+
+export interface ProviderDiscoveryConfigInput {
+  baseUrl: string;
+  environment: string;
+  surface: string;
+}
+
+export interface ProviderDiscoveryConfig extends ProviderDiscoveryConfigInput {
+  environment: "staging";
+  surface: ProviderDiscoverySurface;
+}
+
+export interface ProviderDiscoveryResult {
+  environment: "staging";
+  surface: ProviderDiscoverySurface;
+}
+
+export type ProviderDiscoveryFetch = (
+  input: RequestInfo | URL,
+  init?: RequestInit,
+) => Promise<Response>;
+
+export interface ProviderDiscoveryDependencies {
+  fetchImpl?: ProviderDiscoveryFetch;
+}
+
+export interface ProviderDiscoveryRetryDependencies
+  extends ProviderDiscoveryDependencies {
+  attempts?: number;
+  retryDelayMs?: number;
+  sleepImpl?: (delayMs: number) => Promise<void>;
+}
+
+export interface ProviderDiscoveryCliDependencies
+  extends ProviderDiscoveryDependencies {
+  log?: (message: string) => void;
+  sleepImpl?: (delayMs: number) => Promise<void>;
+}
+
+export function isProviderDiscoveryPayload(value: unknown): boolean;
+
+export function parseProviderDiscoveryJson(text: string): unknown;
+
+export function parseProviderDiscoveryArgs(
+  argv: readonly string[],
+): ProviderDiscoveryConfig;
+
+export function verifyStewardProviderDiscovery(
+  config: ProviderDiscoveryConfigInput,
+  dependencies?: ProviderDiscoveryDependencies,
+): Promise<ProviderDiscoveryResult>;
+
+export function verifyStewardProviderDiscoveryWithRetry(
+  config: ProviderDiscoveryConfigInput,
+  dependencies?: ProviderDiscoveryRetryDependencies,
+): Promise<ProviderDiscoveryResult>;
+
+export function main(
+  argv?: readonly string[],
+  dependencies?: ProviderDiscoveryCliDependencies,
+): Promise<void>;

--- a/packages/cloud/scripts/verify-steward-provider-discovery.mjs
+++ b/packages/cloud/scripts/verify-steward-provider-discovery.mjs
@@ -1,0 +1,521 @@
+#!/usr/bin/env node
+/**
+ * Verifies anonymous Steward provider discovery at release boundaries without
+ * printing response bodies, tenant data, headers, or credential material.
+ */
+
+import { pathToFileURL } from "node:url";
+
+const MAX_RESPONSE_BYTES = 64 * 1024;
+const MAX_JSON_DEPTH = 16;
+const MAX_CONTAINER_ENTRIES = 256;
+const MAX_JSON_NODES = 2_048;
+const REQUEST_TIMEOUT_MS = 20_000;
+const DEFAULT_ATTEMPTS = 6;
+const DEFAULT_RETRY_DELAY_MS = 5_000;
+const DANGEROUS_JSON_KEYS = new Set(["__proto__", "prototype", "constructor"]);
+
+const ENVIRONMENT_CONTRACTS = Object.freeze({
+  staging: Object.freeze({
+    tenantId: "elizacloud-staging",
+    upstreamOrigin: "https://steward-api-staging.up.railway.app",
+    proxyOrigins: Object.freeze([
+      "https://api-staging.eliza.app",
+      "https://cloud-staging.eliza.app",
+      "https://staging.eliza.app",
+      "https://develop.eliza-app.pages.dev",
+    ]),
+  }),
+});
+
+const SURFACES = new Set(["upstream", "proxy"]);
+const REQUIRED_BOOLEAN_FIELDS = [
+  "passkey",
+  "email",
+  "siwe",
+  "siws",
+  "google",
+  "discord",
+  "github",
+  "twitter",
+];
+const OPTIONAL_BOOLEAN_FIELDS = [
+  "sms",
+  "whatsapp",
+  "totp",
+  "telegram",
+  "farcaster",
+  "linkedin",
+  "spotify",
+  "twitch",
+  "instagram",
+  "line",
+  "jwt",
+];
+const OPTIONAL_STRING_ARRAY_FIELDS = ["oidc", "disabled"];
+const CAPTCHA_PROVIDERS = new Set(["turnstile", "hcaptcha"]);
+const CAPTCHA_REQUIREMENTS = new Set(["email_otp", "sms_otp"]);
+
+function isRecord(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isStringArray(value) {
+  return (
+    Array.isArray(value) && value.every((entry) => typeof entry === "string")
+  );
+}
+
+function isCaptcha(value) {
+  if (!isRecord(value)) return false;
+  if (Object.hasOwn(value, "enabled") && typeof value.enabled !== "boolean") {
+    return false;
+  }
+  if (
+    Object.hasOwn(value, "provider") &&
+    (typeof value.provider !== "string" ||
+      !CAPTCHA_PROVIDERS.has(value.provider))
+  ) {
+    return false;
+  }
+  if (Object.hasOwn(value, "siteKey") && typeof value.siteKey !== "string") {
+    return false;
+  }
+  if (Object.hasOwn(value, "requiredFor")) {
+    if (!isStringArray(value.requiredFor)) return false;
+    if (!value.requiredFor.every((entry) => CAPTCHA_REQUIREMENTS.has(entry))) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function isProviderDiscoveryData(value) {
+  if (!isRecord(value)) return false;
+  if (
+    !REQUIRED_BOOLEAN_FIELDS.every(
+      (field) =>
+        Object.hasOwn(value, field) && typeof value[field] === "boolean",
+    )
+  ) {
+    return false;
+  }
+  if (!Object.hasOwn(value, "oauth") || !isStringArray(value.oauth)) {
+    return false;
+  }
+  if (
+    !OPTIONAL_BOOLEAN_FIELDS.every(
+      (field) =>
+        !Object.hasOwn(value, field) || typeof value[field] === "boolean",
+    )
+  ) {
+    return false;
+  }
+  if (
+    !OPTIONAL_STRING_ARRAY_FIELDS.every(
+      (field) => !Object.hasOwn(value, field) || isStringArray(value[field]),
+    )
+  ) {
+    return false;
+  }
+  return !Object.hasOwn(value, "captcha") || isCaptcha(value.captcha);
+}
+
+export function isProviderDiscoveryPayload(value) {
+  if (!isRecord(value) || value.ok !== true || Object.hasOwn(value, "error")) {
+    return false;
+  }
+  if (Object.hasOwn(value, "success") && value.success !== true) return false;
+
+  const hasNestedData = !isProviderDiscoveryData(value);
+  if (hasNestedData && !Object.hasOwn(value, "data")) return false;
+  return isProviderDiscoveryData(hasNestedData ? value.data : value);
+}
+
+/**
+ * Keep this release-boundary parser in lockstep with parseProvidersJson in
+ * packages/cloud/api/src/steward/embedded.ts. The real-handler parity tests
+ * protect duplicate-key, dangerous-key, depth, and flat-vs-nested semantics.
+ */
+export function parseProviderDiscoveryJson(text) {
+  let position = 0;
+  let nodes = 0;
+  const skipWhitespace = () => {
+    while (/\s/.test(text[position] ?? "")) position += 1;
+  };
+  const parseString = () => {
+    if (text[position] !== '"') throw new Error("expected JSON string");
+    const start = position++;
+    while (position < text.length) {
+      if (text[position] === "\\") {
+        position += 2;
+        continue;
+      }
+      if (text[position++] === '"') {
+        return JSON.parse(text.slice(start, position));
+      }
+    }
+    throw new Error("unterminated JSON string");
+  };
+  const parseValue = (depth) => {
+    nodes += 1;
+    if (nodes > MAX_JSON_NODES || depth > MAX_JSON_DEPTH) {
+      throw new Error("provider JSON complexity exceeded");
+    }
+    skipWhitespace();
+    if (text[position] === "{") {
+      position += 1;
+      skipWhitespace();
+      const keys = new Set();
+      let entries = 0;
+      if (text[position] === "}") {
+        position += 1;
+        return;
+      }
+      while (true) {
+        const key = parseString();
+        if (keys.has(key) || DANGEROUS_JSON_KEYS.has(key)) {
+          throw new Error("unsafe or duplicate provider JSON key");
+        }
+        keys.add(key);
+        entries += 1;
+        if (entries > MAX_CONTAINER_ENTRIES) {
+          throw new Error("provider object too large");
+        }
+        skipWhitespace();
+        if (text[position++] !== ":") throw new Error("expected colon");
+        parseValue(depth + 1);
+        skipWhitespace();
+        const separator = text[position++];
+        if (separator === "}") return;
+        if (separator !== ",") throw new Error("expected object separator");
+        skipWhitespace();
+      }
+    }
+    if (text[position] === "[") {
+      position += 1;
+      skipWhitespace();
+      let entries = 0;
+      if (text[position] === "]") {
+        position += 1;
+        return;
+      }
+      while (true) {
+        entries += 1;
+        if (entries > MAX_CONTAINER_ENTRIES) {
+          throw new Error("provider array too large");
+        }
+        parseValue(depth + 1);
+        skipWhitespace();
+        const separator = text[position++];
+        if (separator === "]") return;
+        if (separator !== ",") throw new Error("expected array separator");
+      }
+    }
+    if (text[position] === '"') {
+      parseString();
+      return;
+    }
+    const start = position;
+    while (position < text.length && !/[\s,\]}]/.test(text[position])) {
+      position += 1;
+    }
+    JSON.parse(text.slice(start, position));
+  };
+  parseValue(0);
+  skipWhitespace();
+  if (position !== text.length) throw new Error("trailing JSON data");
+  return JSON.parse(text);
+}
+
+function requiredEnvironment(value) {
+  const normalized =
+    typeof value === "string" ? value.trim().toLowerCase() : "";
+  if (!Object.hasOwn(ENVIRONMENT_CONTRACTS, normalized ?? "")) {
+    throw new Error("--environment must be staging");
+  }
+  return normalized;
+}
+
+function requiredSurface(value) {
+  const normalized =
+    typeof value === "string" ? value.trim().toLowerCase() : "";
+  if (!normalized || !SURFACES.has(normalized)) {
+    throw new Error("--surface must be upstream or proxy");
+  }
+  return normalized;
+}
+
+function requiredOrigin(value) {
+  if (typeof value !== "string" || !value) {
+    throw new Error("--base-url is required");
+  }
+  let url;
+  try {
+    url = new URL(value);
+  } catch {
+    // error-policy:J3 CLI URL parsing fails closed without reflecting input.
+    throw new Error("--base-url must be an HTTPS origin");
+  }
+  if (
+    url.protocol !== "https:" ||
+    url.username ||
+    url.password ||
+    url.pathname !== "/" ||
+    url.search ||
+    url.hash
+  ) {
+    throw new Error("--base-url must be an HTTPS origin");
+  }
+  return url.origin;
+}
+
+function validateProviderDiscoveryConfig(config) {
+  const environment = requiredEnvironment(config.environment);
+  const surface = requiredSurface(config.surface);
+  const baseUrl = requiredOrigin(config.baseUrl);
+  const contract = ENVIRONMENT_CONTRACTS[environment];
+  const allowedOrigins =
+    surface === "upstream" ? [contract.upstreamOrigin] : contract.proxyOrigins;
+  if (!allowedOrigins.includes(baseUrl)) {
+    throw new Error(
+      `--base-url is not a canonical ${environment} ${surface} origin`,
+    );
+  }
+  return { baseUrl, environment, surface };
+}
+
+export function parseProviderDiscoveryArgs(argv) {
+  if (argv.length % 2 !== 0) {
+    throw new Error("Arguments must be flag-value pairs");
+  }
+  const values = new Map();
+  for (let index = 0; index < argv.length; index += 2) {
+    const flag = argv[index];
+    const value = argv[index + 1];
+    if (!flag?.startsWith("--") || !value) {
+      throw new Error("Arguments must use supported flag-value pairs");
+    }
+    if (!["--base-url", "--environment", "--surface"].includes(flag)) {
+      throw new Error("Unsupported argument");
+    }
+    if (values.has(flag)) throw new Error(`Duplicate argument: ${flag}`);
+    values.set(flag, value);
+  }
+
+  return validateProviderDiscoveryConfig({
+    baseUrl: values.get("--base-url"),
+    environment: values.get("--environment"),
+    surface: values.get("--surface"),
+  });
+}
+
+async function readBoundedBody(response) {
+  if (!response.body) throw new Error("provider discovery body is missing");
+  const reader = response.body.getReader();
+  const chunks = [];
+  let total = 0;
+  let tooLarge = false;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > MAX_RESPONSE_BYTES) {
+        tooLarge = true;
+        await reader.cancel();
+        break;
+      }
+      chunks.push(value);
+    }
+  } catch {
+    // error-policy:J1 the verifier boundary translates body-read failures to a
+    // privacy-safe error and never republishes upstream bytes or metadata.
+    throw new Error(
+      tooLarge
+        ? "provider discovery body exceeds the safe limit"
+        : "provider discovery body could not be read",
+    );
+  } finally {
+    reader.releaseLock();
+  }
+  if (tooLarge) {
+    throw new Error("provider discovery body exceeds the safe limit");
+  }
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    // error-policy:J3 invalid UTF-8 is rejected without logging bytes.
+    throw new Error("provider discovery body is not valid UTF-8");
+  }
+}
+
+async function fetchProviderDiscoveryBoundary({
+  baseUrl,
+  path,
+  headers,
+  surface,
+  method,
+  fetchImpl,
+}) {
+  const boundary = method === "HEAD" ? `${surface} HEAD` : surface;
+  let response;
+  try {
+    response = await fetchImpl(`${baseUrl}${path}`, {
+      method,
+      headers,
+      redirect: "manual",
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+  } catch {
+    // error-policy:J1 network and timeout failures become a stable deploy-gate
+    // error without exposing a URL, tenant, request header, or provider detail.
+    throw new Error(`provider discovery ${boundary} request failed`);
+  }
+  if (response.status !== 200) {
+    throw new Error(
+      `provider discovery ${boundary} returned HTTP ${response.status}`,
+    );
+  }
+  const contentType = response.headers
+    .get("content-type")
+    ?.split(";", 1)[0]
+    ?.trim()
+    .toLowerCase();
+  if (contentType !== "application/json" && !contentType?.endsWith("+json")) {
+    throw new Error(
+      `provider discovery ${boundary} returned a non-JSON media type`,
+    );
+  }
+  if (
+    surface === "proxy" &&
+    response.headers.get("x-eliza-steward-path") !== "thin"
+  ) {
+    throw new Error(
+      `provider discovery ${boundary} did not traverse the thin Steward path`,
+    );
+  }
+  return response;
+}
+
+export async function verifyStewardProviderDiscovery(
+  config,
+  { fetchImpl = fetch } = {},
+) {
+  const {
+    baseUrl,
+    environment: deployEnvironment,
+    surface: checkedSurface,
+  } = validateProviderDiscoveryConfig(config);
+  const contract = ENVIRONMENT_CONTRACTS[deployEnvironment];
+  const path =
+    checkedSurface === "upstream"
+      ? "/auth/providers"
+      : "/steward/auth/providers";
+  const headers = new Headers({ Accept: "application/json" });
+  if (checkedSurface === "upstream") {
+    headers.set("x-steward-tenant", contract.tenantId);
+  }
+
+  const response = await fetchProviderDiscoveryBoundary({
+    baseUrl,
+    path,
+    headers,
+    surface: checkedSurface,
+    method: "GET",
+    fetchImpl,
+  });
+
+  const body = await readBoundedBody(response);
+  let payload;
+  try {
+    payload = parseProviderDiscoveryJson(body);
+  } catch {
+    // error-policy:J3 invalid JSON becomes a stable result without body output.
+    throw new Error(
+      `provider discovery ${checkedSurface} returned invalid JSON`,
+    );
+  }
+  if (!isProviderDiscoveryPayload(payload)) {
+    throw new Error(
+      `provider discovery ${checkedSurface} returned an invalid provider contract`,
+    );
+  }
+  if (checkedSurface === "proxy") {
+    await fetchProviderDiscoveryBoundary({
+      baseUrl,
+      path,
+      headers,
+      surface: checkedSurface,
+      method: "HEAD",
+      fetchImpl,
+    });
+  }
+  return { environment: deployEnvironment, surface: checkedSurface };
+}
+
+export async function verifyStewardProviderDiscoveryWithRetry(
+  config,
+  {
+    fetchImpl = fetch,
+    attempts = DEFAULT_ATTEMPTS,
+    retryDelayMs = DEFAULT_RETRY_DELAY_MS,
+    sleepImpl = (delayMs) =>
+      new Promise((resolve) => setTimeout(resolve, delayMs)),
+  } = {},
+) {
+  if (!Number.isSafeInteger(attempts) || attempts < 1 || attempts > 10) {
+    throw new Error("attempts must be an integer from 1 through 10");
+  }
+  const checkedConfig = validateProviderDiscoveryConfig(config);
+  let lastError;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      return await verifyStewardProviderDiscovery(checkedConfig, { fetchImpl });
+    } catch (error) {
+      // error-policy:J1 retain only the already-sanitized boundary error for a
+      // bounded retry; no response object or body crosses this boundary.
+      lastError = error;
+      if (attempt < attempts) await sleepImpl(retryDelayMs);
+    }
+  }
+  const detail =
+    lastError instanceof Error ? lastError.message : "unknown safe failure";
+  throw new Error(
+    `provider discovery failed after ${attempts} attempts: ${detail}`,
+  );
+}
+
+export async function main(
+  argv = process.argv.slice(2),
+  { fetchImpl = fetch, log = console.log, sleepImpl } = {},
+) {
+  const config = parseProviderDiscoveryArgs(argv);
+  const result = await verifyStewardProviderDiscoveryWithRetry(config, {
+    fetchImpl,
+    ...(sleepImpl ? { sleepImpl } : {}),
+  });
+  log(
+    `Verified anonymous Steward provider discovery through the ${result.surface} boundary for ${result.environment}.`,
+  );
+}
+
+const invokedPath = process.argv[1]
+  ? pathToFileURL(process.argv[1]).href
+  : undefined;
+if (invokedPath === import.meta.url) {
+  main().catch((error) => {
+    // error-policy:J1 the process boundary emits only errors already reduced
+    // to stable, privacy-safe verifier messages.
+    console.error(
+      `verify-steward-provider-discovery: ${error instanceof Error ? error.message : "unknown safe failure"}`,
+    );
+    process.exitCode = 1;
+  });
+}

--- a/packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts
+++ b/packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts
@@ -772,6 +772,45 @@ describe("canonical cloud deployment environment contract", () => {
     expect(inventory?.run).toContain("values were not read");
   });
 
+  test("gates anonymous provider discovery before cutover and after the exact Worker deploy", () => {
+    const steps = cloud.jobs?.["deploy-api"]?.steps ?? [];
+    const upstreamIndex = steps.findIndex(
+      (candidate) =>
+        candidate.name === "Verify Steward provider discovery before cutover",
+    );
+    const cutoverIndex = steps.findIndex(
+      (candidate) =>
+        candidate.name === "Disable staging session exchange before cutover",
+    );
+    const healthIndex = steps.findIndex(
+      (candidate) => candidate.name === "Verify deployed API commit",
+    );
+    const deployedIndex = steps.findIndex(
+      (candidate) =>
+        candidate.name === "Verify deployed API provider discovery",
+    );
+    expect(upstreamIndex).toBeGreaterThan(0);
+    expect(upstreamIndex).toBeLessThan(cutoverIndex);
+    expect(deployedIndex).toBeGreaterThan(healthIndex);
+
+    const upstream = steps[upstreamIndex];
+    expect(upstream?.env?.STEWARD_UPSTREAM_URL).toContain(
+      "https://steward-api-staging.up.railway.app",
+    );
+    expect(upstream?.env?.STEWARD_UPSTREAM_URL).not.toContain(
+      "https://eliza.steward.fi",
+    );
+    expect(upstream?.if).toContain("deploy_environment == 'staging'");
+    expect(upstream?.run).toContain("verify-steward-provider-discovery.mjs");
+    expect(upstream?.run).toContain("--surface upstream");
+
+    const deployed = steps[deployedIndex];
+    expect(deployed?.env?.API_URL).toContain("https://api-staging.eliza.app");
+    expect(deployed?.env?.API_URL).not.toContain("https://api.eliza.app");
+    expect(deployed?.if).toContain("deploy_environment == 'staging'");
+    expect(deployed?.run).toContain("--surface proxy");
+  });
+
   test("handles only the Pages project already-exists outcome", () => {
     const bootstrap = step(
       cloud,
@@ -809,6 +848,14 @@ describe("canonical cloud deployment environment contract", () => {
     expect(verify.run).toContain(
       "node packages/cloud/scripts/verify-steward-oauth-callbacks.mjs",
     );
+    expect(verify.run).toContain(
+      "node packages/cloud/scripts/verify-steward-provider-discovery.mjs",
+    );
+    expect(verify.run).toContain(
+      'if [ "$DEPLOY_ENVIRONMENT" = "staging" ]; then',
+    );
+    expect(verify.run).toContain('--base-url "$served_url"');
+    expect(verify.run).toContain("--surface proxy");
     expect(verify.run).toContain('--callback-url "$served_url/login"');
     expect(verify.run).toContain('tenant_id="elizacloud-staging"');
     expect(verify.run).toContain("OIDC issuer mismatch");


### PR DESCRIPTION
# Relates to

Relates to #29259 and the staging-account readiness epic #25025. This PR adds diagnostics and release checks; it does **not** close the live-auth or account-readiness acceptance criteria.

Definition of Done: the standard in `CONTRIBUTING.md` applies.

- [x] Targets `develop`; rebased without remaining conflicts onto `594c0703bfec16c6f8235971f149d152bbcd761f` before validation.
- [x] Frozen dependency installation and root verification were run after sync. The exact unrelated audit failure is recorded below.
- [x] Exact-head behavior, automated checks, independent review and read-only live observations are recorded below.

# Sync with develop

- [x] Rebased onto the fetched `origin/develop` before validation; preserves the #29267 provider-decoding fix and its regression tests, and includes the #29271 UI-inventory correction.
- [x] Post-sync verification completed all 375 typecheck/lint/build tasks. The subsequent `audit:scripts` blocker is reproduced on the clean parent; the five remaining repository audits pass when run separately.

Validated head: `50e19c1c6a50e6f0a5a076bedba35ec289a494cd`.
Validated base: `594c0703bfec16c6f8235971f149d152bbcd761f`.
`develop` advanced to `9109339b01d068d5e5f0d42f6b15bdd8aa4ed269` while validation ran; the incoming crypto-payment change is not claimed as reviewed by this PR's exact-head review.

# Risks

Medium: staging release admission now fails closed on anonymous provider discovery. A broken Steward upstream can stop the release before session cutover; a broken deployed API stops the Pages dependency chain; a broken Pages proxy fails frontend verification. Probes are staging-only, bounded and read-only. Production gate conditions are unchanged. No credentials, provider response bodies or request headers are printed by the verifier or new diagnostics.

# Background

## What does this PR do?

- Adds bounded reason-only diagnostics to the existing invalid-provider-response 502 path, preserving its public response and fail-closed caching behavior.
- Adds a staging-only verifier for the canonical Steward upstream and API/Pages proxies. GET validates bounded UTF-8 JSON and the real provider contract; proxy GET and HEAD must return HTTP 200, a JSON media type and the thin-path marker.
- Runs the upstream check before staging session-exchange cutover, API discovery after exact-source health verification, and discovery on both staging custom-domain Pages aliases during frontend freshness checks.
- Protects parser/handler parity, duplicate and dangerous keys, UTF-8/body/depth/container/node limits, flat/nested envelopes, safe error reporting and non-staging rejection with regression tests.

## What kind of change is this?

Non-breaking diagnostics and staging release-safety improvement. No new login method, bot installation, account-creation policy, group ownership or Shared/Dedicated routing behavior.

# Documentation changes needed?

Updated `.github/workflows/README.md` with the three staging verification boundaries, GET/HEAD contract and limitations. The verifier accepts the canonical staging Pages preview origin, but this workflow checks the two custom-domain Pages aliases; it does not claim preview-origin release coverage.

# Testing

## Where should a reviewer start?

Inspect the three workflow boundaries, the verifier's strict staging target validation, and the real-handler parity tests. Keep the live recovery observations separate from proof that this PR has deployed.

## Detailed testing steps

Node 24.15.0 and Bun 1.3.14 at the head above:

```text
bun install --frozen-lockfile
PASS

bun test packages/cloud/api/src/steward/embedded.test.ts packages/cloud/scripts/__tests__/verify-steward-provider-discovery.test.ts packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts
134 pass, 0 fail, 755 assertions

bun run --cwd packages/cloud/api lint:check
1441 files checked; PASS

bun run verify
375 successful / 375 typecheck, lint and build tasks
post-build audits pass through workflow-trigger-policy
audit:scripts: FAIL on the pre-existing portable-linux-fused-inference coupling

audit:scripts:inventory, audit:test-lane-membership, audit:view-bundle-inventory,
audit:plugin-view-inventory, audit:focused-tests
All five PASS when run separately after the failure above

git diff --check
PASS
```

An independent read-only adversarial review of `594c0703bfe..50e19c1c6a5` found no blocking findings. It independently passed all 134 tests with OS-level network denial, exercised all six exports under Node 24, and compiled a TypeScript caller against the `.d.mts` without diagnostics. This is not a GitHub approval, hosted-CI result or deployment attestation.

# Evidence Gate

<!-- evidence-head:50e19c1c6a50e6f0a5a076bedba35ec289a494cd -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered interface, styling or component source changes in this PR.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered interface, styling or component source changes in this PR.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - this change adds backend diagnostics and release probes without changing a user interaction.
<!-- evidence-row:backend-logs -->
- [x] Reviewed, sanitized execution observations follow. The live service is not running this PR; only the verifier is executed from the reviewed head.

<details>
<summary>Exact-head verifier against existing staging services, 2026-08-26 UTC</summary>

```text
18:20:13.975Z canonical Steward staging /auth/providers: GET contract PASS
18:20:13.975Z api-staging.eliza.app /steward/auth/providers: GET+HEAD contract PASS
18:20:13.975Z cloud-staging.eliza.app /steward/auth/providers: GET+HEAD contract PASS
18:20:13.975Z staging.eliza.app /steward/auth/providers: GET failed, HTTP 500
18:20:42.540Z staging.eliza.app /steward/auth/providers: GET 200, JSON, thin path
18:20:42.677Z staging.eliza.app /steward/auth/providers: HEAD 200, JSON, thin path
```

These are summarized measurements, not fabricated raw server logs. The single observed 500 remains a stability limitation; the later success does not erase it. No OTP, login challenge, OAuth grant, bot action or deployment was initiated by these probes.
</details>

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code changes; these release checks execute at the anonymous HTTP boundary.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - Steward authentication-provider discovery does not invoke or change an LLM provider, prompt or agent action.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - the probes do not create or modify accounts, credentials, database rows, messages or runtime resources.
<!-- evidence-row:ocr-review -->
- [x] N/A - this diff has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no inference or agent behavior changes.

## Backend + frontend logs

The sanitized live verifier measurements are inline above. Handler tests exercise the real Hono middleware with controlled upstream responses and assert the exact reason-only logger calls, unchanged public 502 response and no sensitive body output. They do not prove those new diagnostics have fired in a deployed Worker. A live Cloudflare event-log readback was unavailable because the observability connector rejected returned event records at `$workers.outcome`; no absence-of-errors claim is made from that failed query.

## Screenshots (before / after) + video walkthrough

### Before

N/A - no rendered UI change.

### After

N/A - no rendered UI change.

### Walkthrough video

N/A - no new frontend interaction to demonstrate.

## Audio / voice walkthrough

N/A - no voice, transcript or audio behavior changes.

## Known gaps / failures

- Root `bun run verify` is not green: `audit:scripts` reports exactly one coupling finding in `scripts/portable-linux-fused-inference.mjs` for `plugins/plugin-local-inference`. The identical command and finding were reproduced with network denied on clean detached base `594c0703bfec16c6f8235971f149d152bbcd761f`. This PR does not touch either that script or its allowlist; no exception or unrelated repair is included.
- A broader isolated API-unit run before the final sync (`99dbb2e94940e6a392afb27b4b1c1b3f1f50dfee`) failed in 23 of 566 files. This is not presented as a green full suite. Two auth-related test files were rerun separately with OS-level network denial on both this exact head and the clean base: phone convergence has identical 9 pass / 3 fail results (the sync-call expectation omits the existing `afterRequiredSignupProvisioning` field); post-commit latency has identical 5 pass / 1 fail results (the subsequent `/personal` request returns 500 instead of 200). The remaining full-suite failures are not claimed as classified.
- The new workflow gates and diagnostic reasons have not been deployed or exercised by a real release. Normal exact-head hosted checks and an independent approving GitHub review remain required; no merge or CI bypass is requested.
- Live discovery recovered, but an intermittent marketing-host HTTP 500 was observed above. Full magic-link/OAuth completion, account isolation/recovery and shared-bot smokes remain under #25025 and require their appropriate just-in-time authorization.
- The successful Steward staging Railway deployment was read back, but its exact source SHA was not available in the inspected deployment metadata. That provenance acceptance criterion remains open in #29259.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

# Deploy Notes

No deployment or credential mutation was performed for this PR. Normal staging release policy applies after review and merge; production execution of the added discovery gates is explicitly disabled. Keep #29259 open until its operational acceptance criteria are evidenced.
