### PR TITLE
fix(lifeops): restore browser-safe connection build

### DIFF
--- a/packages/ui/src/components/primitives/index.ts
+++ b/packages/ui/src/components/primitives/index.ts
@@ -30,6 +30,7 @@ export * from "../ui/native-select";
 export * from "../ui/popover";
 export * from "../ui/progress";
 export * from "../ui/radio-group";
+export * from "../ui/segmented-control";
 export * from "../ui/select";
 export * from "../ui/separator";
 export * from "../ui/settings-controls";

--- a/plugins/plugin-personal-assistant/src/components/lifeops-connections/LifeOpsConnectionsView.test.tsx
+++ b/plugins/plugin-personal-assistant/src/components/lifeops-connections/LifeOpsConnectionsView.test.tsx
@@ -338,7 +338,9 @@ describe("LifeOpsConnectionsView", () => {
     render(<LifeOpsConnectionsView adapter={localAdapter} />);
     await screen.findByText("owner@example.test");
 
-    fireEvent.click(screen.getByRole("radio", { name: "7 days" }));
+    const sevenDays = screen.getByRole("button", { name: "7 days" });
+    fireEvent.click(sevenDays);
+    expect(sevenDays.getAttribute("aria-pressed")).toBe("true");
     fireEvent.click(
       screen.getByRole("button", { name: "Seed selected context" }),
     );

--- a/plugins/plugin-personal-assistant/src/components/lifeops-connections/LifeOpsConnectionsView.tsx
+++ b/plugins/plugin-personal-assistant/src/components/lifeops-connections/LifeOpsConnectionsView.tsx
@@ -10,8 +10,7 @@ import type {
 import {
   Button,
   Checkbox,
-  RadioGroup,
-  RadioGroupItem,
+  SegmentedControl,
   Select,
   SelectContent,
   SelectItem,
@@ -770,7 +769,7 @@ export function LifeOpsConnectionsView({
           >
             <fieldset className="lifeops-range">
               <legend>Gmail and calendar history</legend>
-              <RadioGroup
+              <SegmentedControl
                 className="lifeops-range-choices"
                 value={String(rangeDays)}
                 onValueChange={(value) => {
@@ -779,17 +778,11 @@ export function LifeOpsConnectionsView({
                     setRangeDays(days);
                   }
                 }}
-              >
-                {([7, 30, 90] as const).map((days) => (
-                  <label key={days} htmlFor={`lifeops-seed-range-${days}`}>
-                    <RadioGroupItem
-                      id={`lifeops-seed-range-${days}`}
-                      value={String(days)}
-                    />
-                    {days} days
-                  </label>
-                ))}
-              </RadioGroup>
+                items={([7, 30, 90] as const).map((days) => ({
+                  value: String(days),
+                  label: `${days} days`,
+                }))}
+              />
             </fieldset>
             <div className="lifeops-calendar-list">
               {[...googleCalendars, ...appleCalendars].map((calendar) => {
@@ -1058,7 +1051,7 @@ function LifeOpsStyles() {
       .lifeops-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));align-items:start;gap:16px;margin-bottom:16px}.lifeops-grid>section:nth-child(3){grid-column:1/-1}
       .lifeops-options,.lifeops-range{margin:16px 0;border:0;padding:0}.lifeops-options legend,.lifeops-range legend{margin-bottom:10px;font-size:12px;font-weight:750;color:var(--muted)}
       .lifeops-check-row{display:flex;align-items:flex-start;gap:12px;padding:12px;border-radius:14px;background:var(--bg-accent);margin-bottom:7px;cursor:pointer}.lifeops-check-row.compact{align-items:center}.lifeops-check-row input{width:20px;height:20px;margin:1px 0 0;accent-color:var(--accent);flex:0 0 auto}.lifeops-check-row span{display:grid;gap:3px;min-width:0}.lifeops-check-row small{color:var(--muted);line-height:1.4}.lifeops-check-row code{width:max-content;max-width:100%;overflow-wrap:anywhere;color:var(--accent);font-size:11px}
-      .lifeops-field{display:grid;gap:7px;font-size:12px;font-weight:700}.lifeops-field select{min-height:44px;border:1px solid var(--border);border-radius:13px;padding:0 12px;background:var(--card);color:inherit;font:inherit}.lifeops-range-choices{display:flex;flex-wrap:wrap;gap:8px}.lifeops-range legend{width:100%}.lifeops-range label{display:flex;align-items:center;gap:7px;min-height:44px;padding:0 13px;border:1px solid var(--border);border-radius:12px}
+      .lifeops-field{display:grid;gap:7px;font-size:12px;font-weight:700}.lifeops-field select{min-height:44px;border:1px solid var(--border);border-radius:13px;padding:0 12px;background:var(--card);color:inherit;font:inherit}.lifeops-range-choices{display:flex;flex-wrap:wrap;gap:8px}.lifeops-range legend{width:100%}
       .lifeops-primary,.lifeops-danger-confirm{display:inline-flex;align-items:center;justify-content:center;gap:8px;min-height:46px;border:0;border-radius:13px;padding:0 17px;background:var(--accent);color:var(--accent-foreground);font:inherit;font-weight:800;cursor:pointer}.lifeops-primary:hover{background:var(--accent-muted,#c94400);color:var(--brand-white,#fdfaf7)}.lifeops-primary:disabled,button:disabled{opacity:.48;cursor:not-allowed}.lifeops-danger-confirm{background:var(--destructive);color:var(--destructive-foreground)}.lifeops-danger-confirm:hover{background:color-mix(in srgb, var(--destructive) 82%, black)}
       .lifeops-actions{display:flex;flex-wrap:wrap;gap:9px;margin-top:14px}.lifeops-actions button{display:inline-flex;align-items:center;justify-content:center;gap:8px}.lifeops-empty{padding:14px;border:1px dashed var(--border-strong);border-radius:13px;color:var(--muted)}
       .lifeops-status-row{display:grid;grid-template-columns:auto 1fr auto;align-items:center;gap:12px}.lifeops-status-row div{display:grid;gap:4px}.lifeops-status-row span{color:var(--muted);font-size:13px;line-height:1.4}

--- a/plugins/plugin-personal-assistant/test/stubs/ui.ts
+++ b/plugins/plugin-personal-assistant/test/stubs/ui.ts
@@ -7,16 +7,13 @@ import {
   type ButtonHTMLAttributes,
   type ChangeEvent,
   Children,
-  createContext,
   createElement,
   Fragment,
-  type HTMLAttributes,
   type InputHTMLAttributes,
   isValidElement,
   type ReactNode,
   type SelectHTMLAttributes,
   type TextareaHTMLAttributes,
-  useContext,
 } from "react";
 
 type ComponentProps = Record<string, unknown>;
@@ -97,40 +94,34 @@ function TestSelectItem({
   return createElement("option", { value }, children);
 }
 
-const TestRadioGroupContext = createContext<{
-  value: string;
-  onValueChange?: (value: string) => void;
-}>({ value: "" });
-
-function TestRadioGroup({
-  children,
+function TestSegmentedControl({
   value,
   onValueChange,
+  items,
   ...props
-}: HTMLAttributes<HTMLDivElement> & {
-  children?: ReactNode;
+}: {
   value: string;
-  onValueChange?: (value: string) => void;
+  onValueChange: (value: string) => void;
+  items: Array<{ value: string; label: ReactNode; disabled?: boolean }>;
+  className?: string;
 }): ReactNode {
   return createElement(
-    TestRadioGroupContext.Provider,
-    { value: { value, onValueChange } },
-    createElement("div", { ...props, role: "radiogroup" }, children),
+    "div",
+    props,
+    items.map((item) =>
+      createElement(
+        "button",
+        {
+          key: item.value,
+          type: "button",
+          disabled: item.disabled,
+          "aria-pressed": value === item.value,
+          onClick: () => onValueChange(item.value),
+        },
+        item.label,
+      ),
+    ),
   );
-}
-
-function TestRadioGroupItem({
-  value,
-  ...props
-}: InputHTMLAttributes<HTMLInputElement> & { value: string }): ReactNode {
-  const group = useContext(TestRadioGroupContext);
-  return createElement("input", {
-    ...props,
-    type: "radio",
-    value,
-    checked: group.value === value,
-    onChange: () => group.onValueChange?.(value),
-  });
 }
 
 // Lifecycle constants + platform probes the activity-signal capture imports at
@@ -164,14 +155,12 @@ export const Input = (
   props: InputHTMLAttributes<HTMLInputElement>,
 ): ReactNode => createElement("input", props);
 export const PagePanel = PassthroughComponent;
-export const RadioGroup = TestRadioGroup;
-export const RadioGroupItem = TestRadioGroupItem;
 export const Select = TestSelect;
 export const SelectContent = PassthroughComponent;
 export const SelectItem = TestSelectItem;
 export const SelectTrigger = TestSelectTrigger;
 export const SelectValue = NullComponent;
-export const SegmentedControl = NullComponent;
+export const SegmentedControl = TestSegmentedControl;
 export const Switch = NullComponent;
 export const Textarea = (
   props: TextareaHTMLAttributes<HTMLTextAreaElement>,


### PR DESCRIPTION
## Summary

Corrects the app build regression introduced by merged PR #26723.

- replaces `RadioGroup` / `RadioGroupItem`, which are not part of the `@elizaos/ui` browser barrel, with the exported `SegmentedControl`
- preserves the mutually exclusive 7/30/90-day seed-range contract
- keeps the LifeOps test UI stub semantic and interactive so selection behavior is exercised

## Verification

- `bun run --cwd packages/app build` — pass (8,933 modules; the exact hosted `MISSING_EXPORT` failure is gone)
- focused LifeOps connection view test — 8/8 pass
- Biome on all three changed files — pass
- `bun run --cwd packages/app audit:app` — affected LifeOps audit entries are `good` in desktop, iPad, mobile portrait, and mobile landscape; zero console/render/overflow/hover/banned-blue issues. The full matrix completed 212/215 with three unrelated app startup/teardown timeouts (`view readiness`, `builtin-chat desktop`, `builtin-stream mobile-landscape`).

The full Google Workspace suite has eight pre-existing failures on current `develop`; this corrective commit does not touch Google Workspace sources. The focused Google OAuth/Gmail regression set previously passed 88/88 on the merged feature revision.
