### PR TITLE
fix(ci): restore green workflow and action lanes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,10 @@ updates:
       dev-dependencies:
         dependency-type: "development"
     ignore:
+      # This workspace alias intentionally resolves to the public Vite package;
+      # Dependabot otherwise queries the synthetic alias name and receives a
+      # registry 404, failing the whole weekly update run.
+      - dependency-name: "@elizaos/vitest-vite"
       # isomorphic-git@1.x requires ignore@^5; the `ignore` dep in @elizaos/agent
       # exists only to satisfy it. v6/v7 break isomorphic-git's GitIgnoreManager
       # (git.add fails — see closed PR #8483). Cap at major 5 until

--- a/packages/app/e2e/accounts-ui/run-accounts-ui-e2e.mjs
+++ b/packages/app/e2e/accounts-ui/run-accounts-ui-e2e.mjs
@@ -352,6 +352,7 @@ try {
   // 01 — empty state.
   await page.goto(base);
   await page.locator("text=Accounts (0)").waitFor({ state: "visible" });
+  await page.locator("text=No accounts yet").waitFor({ state: "visible" });
   assert(
     (await page.locator("text=No accounts yet").count()) === 1,
     "empty state renders when no accounts are connected",
@@ -529,6 +530,7 @@ try {
   await page.locator('button[aria-label="Delete account"]').first().click();
   await page.getByRole("button", { name: "Remove account" }).click();
   await page.locator("text=Accounts (0)").waitFor({ state: "visible" });
+  await page.locator("text=No accounts yet").waitFor({ state: "visible" });
   assert(
     (await page.locator("text=No accounts yet").count()) === 1,
     "empty state returns after all accounts are disconnected",

--- a/packages/scripts/script-plugin-coupling.allowlist.json
+++ b/packages/scripts/script-plugin-coupling.allowlist.json
@@ -230,6 +230,11 @@
     "reason": "HITL credential dashboard reports the concrete plugin-github credential lane used by operators"
   },
   {
+    "file": "scripts/portable-linux-fused-inference.mjs",
+    "tokens": ["plugins/plugin-local-inference"],
+    "reason": "the portable fused-inference builder is intentionally coupled to the local-inference native source tree and its tracked ABI verification files"
+  },
+  {
     "file": "scripts/training-harvest/build-manifest.mjs",
     "tokens": ["@elizaos/plugin-cli-inference"],
     "reason": "the harvest manifest names the CLI-inference provider plugin that supplies its authenticated live-model execution seam"


### PR DESCRIPTION
## Summary
- export the RadioGroup UI primitives consumed by the personal-assistant connection view so scenario builds compile
- wait for the rendered accounts empty state before asserting it in the UI smoke flow, removing the loading-state race
- keep Dependabot from querying the synthetic `@elizaos/vitest-vite` alias as a registry package
- document the intentional portable local-inference native source coupling and refresh the generated UI inventory count

## Validation
- `bun run verify` (375/375 Turbo tasks and all repository audits passed)
- `bunx vitest run packages/ui/src/components/ui/radio-group.test.tsx packages/ui/src/components/accounts/AccountList.test.tsx` (12 tests passed)
- `node packages/app/e2e/accounts-ui/run-accounts-ui-e2e.mjs` (15 assertions/screenshots passed)
- `bun run audit:workflow-triggers`

## Hosted follow-up
The previous develop failures also included an external production-schema diagnosis (`schema.missing_apps`) and a superseded cloud dispatch; those are fail-closed environment/dispatch conditions, not defects in this diff. Please re-run the protected develop workflow on the merged exact head to verify the external lanes.
