### PR TITLE
fix(plugin-discord): use truncateWellFormed for command descriptions, thread names, and audit reasons

### DIFF
--- a/plugins/plugin-discord/__tests__/surrogate-truncation.test.ts
+++ b/plugins/plugin-discord/__tests__/surrogate-truncation.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { transformCommandToDiscordApi } from "../discord-commands";
+import type { DiscordSlashCommand } from "../types";
+
+describe("Discord surrogate-safe command description truncation", () => {
+	it("truncates long command descriptions without splitting UTF-16 surrogate pairs", () => {
+		// 98 ASCII chars + 1 emoji (2 UTF-16 code units) = 100 code units
+		// With DISCORD_DESCRIPTION_MAX = 100, clampDescription caps at 99 chars + "…"
+		// If the cut lands on the emoji (at index 98), truncateWellFormed backs off to 98 chars.
+		const base = "a".repeat(98);
+		const emoji = "🚀"; // \uD83D\uDE80 (2 code units)
+		const longDesc = `${base}${emoji} extra trailing description`;
+
+		const cmd: DiscordSlashCommand = {
+			name: "test-cmd",
+			description: longDesc,
+			execute: async () => {},
+		};
+
+		const transformed = transformCommandToDiscordApi(cmd) as {
+			name: string;
+			description: string;
+		};
+
+		expect(transformed.description.endsWith("…")).toBe(true);
+		// Check that the string is well-formed (no lone surrogates)
+		expect(transformed.description.isWellFormed?.()).not.toBe(false);
+		expect(transformed.description.charCodeAt(transformed.description.length - 2)).not.toBeGreaterThanOrEqual(0xd800);
+	});
+});

--- a/plugins/plugin-discord/discord-commands.ts
+++ b/plugins/plugin-discord/discord-commands.ts
@@ -5,6 +5,7 @@
  */
 import {
 	createUniqueUuid,
+	truncateWellFormed,
 	type EventPayload,
 	EventType,
 	type World,
@@ -54,7 +55,7 @@ const DISCORD_DESCRIPTION_MAX = 100;
 
 function clampDescription(description: string): string {
 	return description.length > DISCORD_DESCRIPTION_MAX
-		? `${description.slice(0, DISCORD_DESCRIPTION_MAX - 1)}…`
+		? `${truncateWellFormed(description, DISCORD_DESCRIPTION_MAX - 1)}…`
 		: description;
 }
 

--- a/plugins/plugin-discord/guild-management.ts
+++ b/plugins/plugin-discord/guild-management.ts
@@ -25,7 +25,7 @@
  * live discord.js `Guild` to it.
  */
 
-import { ElizaError } from "@elizaos/core";
+import { ElizaError, truncateWellFormed } from "@elizaos/core";
 import { ChannelType, PermissionsBitField } from "discord.js";
 import {
 	BUILT_IN_GUILD_TEMPLATES,
@@ -668,7 +668,7 @@ function auditReason(
 ): string {
 	const prefix = context.reasonPrefix ?? "eliza guild management";
 	const extra = request.reason?.trim();
-	return extra ? `${prefix}: ${extra}`.slice(0, 512) : prefix;
+	return extra ? truncateWellFormed(`${prefix}: ${extra}`, 512) : prefix;
 }
 
 async function authorizeMutation(

--- a/plugins/plugin-discord/service.ts
+++ b/plugins/plugin-discord/service.ts
@@ -13,6 +13,7 @@
 import nodePath from "node:path";
 import {
 	ChannelType,
+	truncateWellFormed,
 	type Character,
 	type Content,
 	createUniqueUuid,
@@ -3279,7 +3280,7 @@ export class DiscordService extends Service implements IDiscordService {
 				`Discord channel ${channel.id} does not support thread creation.`,
 			);
 		}
-		const name = (params.name ?? "thread").slice(0, 100);
+		const name = truncateWellFormed(params.name ?? "thread", 100);
 		let startMessage: Message | undefined;
 		if (params.parentMessageId) {
 			try {


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:536ec9d680d80c3b04dce3434c4e550a61b78c73 -->

## Summary
In `plugins/plugin-discord`:
Command descriptions (`clampDescription`), audit reasons (`auditReason`), and thread creation names (`createThread`) used raw `.slice()` for string length limiting. When slicing at multi-byte UTF-16 code unit boundaries (such as emojis or complex unicode characters), raw slicing cuts surrogate pairs in half, creating lone surrogates that cause JSON encoding failures and Discord REST API rejections.

## Proposed Changes
1. Used shared `truncateWellFormed` from `@elizaos/core` in `clampDescription` (`discord-commands.ts`) when truncating long command descriptions.
2. Used `truncateWellFormed` in `auditReason` (`guild-management.ts`) and `createThread` (`service.ts`).
3. Added a dedicated regression test `__tests__/surrogate-truncation.test.ts` verifying that command descriptions ending on surrogate pairs remain well-formed without lone surrogates.

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-discord test surrogate-truncation` (passed).
- Checked that UTF-16 surrogate pairs are preserved safely without corruption.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
