### PR TITLE
fix(plugin-cloud-apps): use truncateWellFormed for app reference log view clamping

### DIFF
--- a/plugins/plugin-cloud-apps/__tests__/reference-resolution.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/reference-resolution.test.ts
@@ -289,4 +289,12 @@ describe("describeAppReference / appReferenceLogView — reference display seam"
     expect(view).toBe(`${"a".repeat(120)}…`);
     expect(view.length).toBe(121);
   });
+
+  it("appReferenceLogView avoids splitting surrogate pairs at 120-char boundary", () => {
+    const input = "a".repeat(119) + "🚀" + "b".repeat(50);
+    const view = appReferenceLogView(input);
+    expect(view.endsWith("…")).toBe(true);
+    expect(view.isWellFormed?.()).not.toBe(false);
+    expect(view).toBe(`${"a".repeat(119)}…`);
+  });
 });

--- a/plugins/plugin-cloud-apps/src/client.ts
+++ b/plugins/plugin-cloud-apps/src/client.ts
@@ -13,7 +13,7 @@
 import type { AppDto } from "@elizaos/cloud-sdk";
 import { ElizaCloudClient } from "@elizaos/cloud-sdk";
 import type { IAgentRuntime, Memory } from "@elizaos/core";
-import { unwrapUserMessageText } from "@elizaos/core";
+import { truncateWellFormed, unwrapUserMessageText } from "@elizaos/core";
 
 /** Default Eliza Cloud API base URL (matches the cloud runtime default). */
 export const DEFAULT_CLOUD_API_BASE_URL = "https://api.eliza.app/api/v1";
@@ -404,7 +404,7 @@ export function describeAppReference(
  */
 export function appReferenceLogView(reference: string): string {
   const collapsed = reference.replace(/\s+/g, " ").trim();
-  return collapsed.length > 120 ? `${collapsed.slice(0, 120)}…` : collapsed;
+  return collapsed.length > 120 ? `${truncateWellFormed(collapsed, 120)}…` : collapsed;
 }
 
 export interface ResolvedApp {


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:6f0b07db5c8fe1ef2e5c258f88a17747615f8c66 -->

## Summary
In `plugins/plugin-cloud-apps/src/client.ts`:
`appReferenceLogView` clamped overlong reference strings using a raw `.slice(0, 120)` followed by `…`. When a multi-code-unit UTF-16 character (such as an emoji) spans across index 120, raw `.slice()` splits the surrogate pair into an unpaired lone surrogate, producing malformed Unicode strings in structured log and action payloads.

## Proposed Changes
1. Used shared `truncateWellFormed` from `@elizaos/core` in `appReferenceLogView`.
2. Added unit test in `plugins/plugin-cloud-apps/__tests__/reference-resolution.test.ts` ensuring that references with emojis spanning the 120-character clamp boundary remain well-formed without lone surrogates.

## Verification
- Ran bun test: `bun test __tests__/reference-resolution.test.ts` in `plugins/plugin-cloud-apps` (27/27 passed).
- Verified well-formed Unicode string output under UTF-16 surrogate pair boundaries.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
