### PR TITLE
fix(plugin-companion): use truncateWellFormed when recording raw frame in badFrame context

### DIFF
--- a/plugins/plugin-companion/src/protocol.test.ts
+++ b/plugins/plugin-companion/src/protocol.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { parseDeviceFrame } from "./protocol";
+
+describe("Companion protocol frame parsing surrogate safety", () => {
+  it("preserves surrogate pairs when clamping malformed JSON in error context", () => {
+    const rawMalformed = "{" + "a".repeat(254) + "🚀" + "tail";
+    try {
+      parseDeviceFrame(rawMalformed);
+      expect.unreachable("should have thrown");
+    } catch (err: any) {
+      expect(err.code).toBe("COMPANION_BAD_FRAME");
+      const rawContext = err.context?.raw as string;
+      expect(rawContext.isWellFormed?.()).not.toBe(false);
+      expect(rawContext).toBe("{" + "a".repeat(254));
+    }
+  });
+
+  it("preserves surrogate pairs when clamping invalid frame in badFrame", () => {
+    const rawInvalid = JSON.stringify({ type: "register", deviceId: "" }) + "a".repeat(200) + "🚀" + "extra";
+    try {
+      parseDeviceFrame(rawInvalid);
+      expect.unreachable("should have thrown");
+    } catch (err: any) {
+      expect(err.code).toBe("COMPANION_BAD_FRAME");
+      const rawContext = err.context?.raw as string;
+      expect(rawContext.isWellFormed?.()).not.toBe(false);
+    }
+  });
+});

--- a/plugins/plugin-companion/src/protocol.test.ts
+++ b/plugins/plugin-companion/src/protocol.test.ts
@@ -10,20 +10,23 @@ describe("Companion protocol frame parsing surrogate safety", () => {
     } catch (err: any) {
       expect(err.code).toBe("COMPANION_BAD_FRAME");
       const rawContext = err.context?.raw as string;
-      expect(rawContext.isWellFormed?.()).not.toBe(false);
+      expect(rawContext.isWellFormed()).toBe(true);
       expect(rawContext).toBe("{" + "a".repeat(254));
     }
   });
 
-  it("preserves surrogate pairs when clamping invalid frame in badFrame", () => {
-    const rawInvalid = JSON.stringify({ type: "register", deviceId: "" }) + "a".repeat(200) + "🚀" + "extra";
+  it("clamps raw at 256 without splitting a surrogate via badFrame()", () => {
+    const prefix = '{"type":"register","deviceId":"","pad":"';
+    const raw = prefix + "a".repeat(215) + "🚀" + '"}';
     try {
-      parseDeviceFrame(rawInvalid);
-      expect.unreachable("should have thrown");
+      parseDeviceFrame(raw);
+      expect.unreachable("should throw badFrame");
     } catch (err: any) {
       expect(err.code).toBe("COMPANION_BAD_FRAME");
+      expect(err.message).toContain("invalid frame");
       const rawContext = err.context?.raw as string;
-      expect(rawContext.isWellFormed?.()).not.toBe(false);
+      expect(rawContext.isWellFormed()).toBe(true);
+      expect(rawContext.length).toBe(255);
     }
   });
 });

--- a/plugins/plugin-companion/src/protocol.ts
+++ b/plugins/plugin-companion/src/protocol.ts
@@ -8,7 +8,7 @@
  * (`touch` / `mood_changed`), and `pong`; the host sends `SET_MOOD`,
  * `GET_STATUS`, and `ping`.
  */
-import { ElizaError } from "@elizaos/core";
+import { ElizaError, truncateWellFormed } from "@elizaos/core";
 
 /** First frame the device sends after accepting the socket. */
 export interface WelcomeFrame {
@@ -69,7 +69,7 @@ function nonEmptyString(value: unknown): string | undefined {
 function badFrame(reason: string, raw: string): ElizaError {
   return new ElizaError(`companion device sent an invalid frame: ${reason}`, {
     code: "COMPANION_BAD_FRAME",
-    context: { reason, raw: raw.slice(0, 256) },
+    context: { reason, raw: truncateWellFormed(raw, 256) },
   });
 }
 
@@ -86,7 +86,7 @@ export function parseDeviceFrame(raw: string): DeviceFrame {
     // error-policy:J2 wrap the untyped JSON.parse failure as a typed frame error.
     throw new ElizaError("companion device sent malformed JSON", {
       code: "COMPANION_BAD_FRAME",
-      context: { raw: raw.slice(0, 256) },
+      context: { raw: truncateWellFormed(raw, 256) },
       cause: error,
     });
   }


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:3bb51273da2cb3f59d759e88d5dc369648654779 -->

## Summary
In `plugins/plugin-companion/src/protocol.ts`:
`badFrame` and `parseDeviceFrame` recorded invalid or malformed frame payloads in error context (`context.raw`) using a raw `.slice(0, 256)`. If multi-byte UTF-16 code units (such as emojis or complex unicode characters) straddled character index 256 in the raw WebSocket frame, raw `.slice()` severed surrogate pairs into unpaired lone surrogates, leading to JSON encoding failures in telemetry and error reporters.

## Proposed Changes
1. Replaced raw `.slice(0, 256)` with shared `truncateWellFormed(raw, 256)` from `@elizaos/core` in `badFrame` and `parseDeviceFrame`.
2. Added dedicated regression unit tests in `plugins/plugin-companion/src/protocol.test.ts` verifying that truncated error contexts remain well-formed across surrogate pair boundaries.

## Verification
- Ran bun test: `bun test src/protocol.test.ts` in `plugins/plugin-companion` (passed).
- Verified well-formed Unicode string output in error contexts.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
