### PR TITLE
fix(core): use truncateWellFormed for session-key normalization, message debug logging, and trajectory zip naming

### DIFF
--- a/packages/core/src/features/trajectories/TrajectoriesService.ts
+++ b/packages/core/src/features/trajectories/TrajectoriesService.ts
@@ -6,6 +6,7 @@
 import { sql } from "drizzle-orm";
 import { v4 as uuidv4 } from "uuid";
 import { ElizaError } from "../../errors";
+import { truncateWellFormed } from "../../utils/well-formed";
 import { logger } from "../../logger";
 import { serializeTrajectoryExport } from "../../services/trajectory-export";
 import {
@@ -3388,7 +3389,7 @@ export class TrajectoriesService extends Service {
 
 	private sanitizeZipFolderName(value: string): string {
 		const trimmed = value.trim();
-		const safe = trimmed.length > 256 ? trimmed.slice(0, 256) : trimmed;
+		const safe = trimmed.length > 256 ? truncateWellFormed(trimmed, 256) : trimmed;
 		const sanitized = safe
 			.replace(/[^a-zA-Z0-9._-]+/g, "_")
 			.replace(/^_+|_+$/g, "");

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -23,6 +23,7 @@ import {
 } from "../actions/to-tool";
 import { evaluateConnectorAccountPolicies } from "../connectors/account-manager";
 import { createUniqueUuid } from "../entities";
+import { truncateWellFormed } from "../utils/well-formed";
 import { ElizaError } from "../errors";
 import {
 	formatTaskCompletionStatus,
@@ -12711,7 +12712,7 @@ export function wrapSingleTurnVisibleCallback(
 		if (typeof response?.text === "string" && response.text.trim()) {
 			if (nearDuplicateOfDeliveredThisTurn(response.text)) {
 				fullRuntime.logger?.debug?.(
-					{ actionName, text: response.text.slice(0, 120) },
+					{ actionName, text: truncateWellFormed(response.text, 120) },
 					"[message] suppressed near-duplicate delivery within the turn",
 				);
 				recordDeliveredVisibleText?.(response.text);

--- a/packages/core/src/sessions/session-key.test.ts
+++ b/packages/core/src/sessions/session-key.test.ts
@@ -84,4 +84,13 @@ describe("normalization", () => {
 		expect(normalizeAccountId("")).toBe("default");
 		expect(normalizeAccountId("Acct1")).toBe("acct1");
 	});
+
+	it("preserves well-formed Unicode when clamping overlong agent and account IDs", () => {
+		const longWithSurrogate = "a".repeat(1023) + "🚀" + "tail";
+		const normAgent = normalizeAgentId(longWithSurrogate);
+		expect(normAgent.isWellFormed?.()).not.toBe(false);
+
+		const normAccount = normalizeAccountId(longWithSurrogate);
+		expect(normAccount.isWellFormed?.()).not.toBe(false);
+	});
 });

--- a/packages/core/src/sessions/session-key.ts
+++ b/packages/core/src/sessions/session-key.ts
@@ -1,5 +1,7 @@
 /** Builds, parses, and normalizes `agent:{agentId}:{rest}` session identifiers. */
 
+import { truncateWellFormed } from "../utils/well-formed";
+
 // ============================================================================
 // Constants
 // ============================================================================
@@ -186,7 +188,7 @@ export function normalizeAgentId(value: string | undefined | null): string {
 		return DEFAULT_AGENT_ID;
 	}
 	const trimmed =
-		rawTrimmed.length > 1024 ? rawTrimmed.slice(0, 1024) : rawTrimmed;
+		rawTrimmed.length > 1024 ? truncateWellFormed(rawTrimmed, 1024) : rawTrimmed;
 	// Keep it path-safe + shell-friendly.
 	if (VALID_ID_RE.test(trimmed)) {
 		return trimmed.toLowerCase();
@@ -224,7 +226,7 @@ export function normalizeAccountId(value: string | undefined | null): string {
 		return DEFAULT_ACCOUNT_ID;
 	}
 	const trimmed =
-		rawTrimmed.length > 1024 ? rawTrimmed.slice(0, 1024) : rawTrimmed;
+		rawTrimmed.length > 1024 ? truncateWellFormed(rawTrimmed, 1024) : rawTrimmed;
 	if (VALID_ID_RE.test(trimmed)) {
 		return trimmed.toLowerCase();
 	}


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:a955f729e0d0755780f113a95c940c6e0c79a1ac -->

## Summary
In `@elizaos/core`:
- `normalizeAgentId` and `normalizeAccountId` (`sessions/session-key.ts`) clamped overlong inputs with raw `.slice(0, 1024)`. If a multi-code-unit UTF-16 character (e.g., emoji) straddled index 1024, the surrogate pair was cut into a lone surrogate.
- `wrapSingleTurnVisibleCallback` (`services/message.ts`) logged truncated suppressed messages using raw `.slice(0, 120)`.
- `sanitizeZipFolderName` (`features/trajectories/TrajectoriesService.ts`) clamped zip folder names with raw `.slice(0, 256)`.

## Proposed Changes
1. Used `truncateWellFormed` across `normalizeAgentId`, `normalizeAccountId`, `wrapSingleTurnVisibleCallback`, and `sanitizeZipFolderName`.
2. Added unit tests in `sessions/session-key.test.ts` verifying that overlong agent and account IDs with surrogate pairs at clamp boundaries remain well-formed.

## Verification
- Ran vitest: `bun run --cwd packages/core test session-key` (8/8 passed).
- Verified well-formed Unicode output in session identifiers and logging contexts.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
