### PR TITLE
fix(ui): back off authenticated startup throttles

### DIFF
--- a/packages/ui/src/api/auth-client.test.ts
+++ b/packages/ui/src/api/auth-client.test.ts
@@ -618,7 +618,23 @@ describe("authMe over plain HTTP boundaries", () => {
     });
   });
 
-  it("maps any non-401 HTTP failure onto 503", async () => {
+  it("preserves auth throttling and the server retry window", async () => {
+    fetchWithCsrfMock.mockResolvedValueOnce(
+      new Response("", {
+        status: 429,
+        headers: { "Retry-After": "12" },
+      }),
+    );
+
+    await expect(authMe()).resolves.toEqual({
+      ok: false,
+      status: 429,
+      reason: "rate_limited",
+      retryAfterMs: 12_000,
+    });
+  });
+
+  it("maps other non-401 HTTP failures onto 503", async () => {
     fetchWithCsrfMock.mockResolvedValueOnce(textResponse("", 403));
 
     await expect(authMe()).resolves.toEqual({ ok: false, status: 503 });

--- a/packages/ui/src/api/auth-client.ts
+++ b/packages/ui/src/api/auth-client.ts
@@ -120,13 +120,16 @@ export type AuthMeResult =
     }
   | {
       ok: false;
-      status: 401 | 503;
+      status: 401 | 429 | 503;
       reason?:
         | "remote_auth_required"
         | "remote_password_not_configured"
+        | "rate_limited"
         | "server_error"
         | "cloud_unavailable";
       access?: AuthAccessInfo;
+      /** Server-directed pause before the next auth probe, when supplied. */
+      retryAfterMs?: number;
     };
 
 export type AuthSessionsResult =
@@ -164,6 +167,20 @@ function authBase(): string {
   if (typeof window === "undefined") return "";
   const apiBase = getBootConfig().apiBase;
   return apiBase ? apiBase.replace(/\/$/, "") : window.location.origin;
+}
+
+function retryAfterMs(headers: Headers): number | undefined {
+  const raw = headers.get("retry-after")?.trim();
+  if (!raw) return undefined;
+
+  const seconds = Number(raw);
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return Math.round(seconds * 1000);
+  }
+
+  const retryAt = Date.parse(raw);
+  if (!Number.isFinite(retryAt)) return undefined;
+  return Math.max(0, retryAt - Date.now());
 }
 
 // ── Endpoint callers ──────────────────────────────────────────────────────────
@@ -510,6 +527,15 @@ export async function authMe(): Promise<AuthMeResult> {
             ? "remote_auth_required"
             : "server_error",
       access: body.access,
+    };
+  }
+
+  if (res.status === 429) {
+    return {
+      ok: false,
+      status: 429,
+      reason: "rate_limited",
+      retryAfterMs: retryAfterMs(res.headers),
     };
   }
 

--- a/packages/ui/src/hooks/useAuthStatus.prime.test.tsx
+++ b/packages/ui/src/hooks/useAuthStatus.prime.test.tsx
@@ -48,10 +48,15 @@ function makeJwt(expSecondsFromNow: number): string {
   })}.sig`;
 }
 
-function jsonResponse(status: number, body: unknown): Response {
+function jsonResponse(
+  status: number,
+  body: unknown,
+  headers?: HeadersInit,
+): Response {
   return {
     ok: status >= 200 && status < 300,
     status,
+    headers: new Headers(headers),
     json: async () => body,
   } as unknown as Response;
 }
@@ -475,6 +480,23 @@ describe("primeAuthStatusProbe + activation reuse", () => {
     const { result } = renderHook(() => useAuthStatus({ pollIntervalMs: 0 }));
     // The prime must NOT have published server_unavailable (that would flash
     // the startup-failure screen for a backend that comes up moments later).
+    expect(result.current.state.phase).toBe("loading");
+    await waitFor(() =>
+      expect(result.current.state.phase).toBe("authenticated"),
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("waits through a throttled prime without starting the 503 retry storm", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(429, {}, { "Retry-After": "0" }))
+      .mockResolvedValueOnce(jsonResponse(200, AUTH_ME_BODY));
+
+    await act(async () => {
+      primeAuthStatusProbe();
+    });
+
+    const { result } = renderHook(() => useAuthStatus({ pollIntervalMs: 0 }));
     expect(result.current.state.phase).toBe("loading");
     await waitFor(() =>
       expect(result.current.state.phase).toBe("authenticated"),

--- a/packages/ui/src/hooks/useAuthStatus.ts
+++ b/packages/ui/src/hooks/useAuthStatus.ts
@@ -76,16 +76,29 @@ const DEFAULT_POLL_INTERVAL_MS = 5 * 60 * 1000;
 // is authoritative and never retried.
 const SERVER_UNAVAILABLE_RETRIES = 10;
 const SERVER_UNAVAILABLE_RETRY_MS = 1000;
+// A 429 is an explicit throttle, not a backend outage. Retrying it every
+// second extends the server bucket and can turn one bad actor behind a reverse
+// proxy into a cold-start failure for every valid session. Respect Retry-After
+// when present; older servers omit it, so use a conservative fallback cadence.
+const RATE_LIMIT_RETRIES = 4;
+const RATE_LIMIT_RETRY_MS = 15_000;
+const RATE_LIMIT_MAX_RETRY_MS = 60_000;
 const authStatusSubscribers = new Set<(state: AuthStatusState) => void>();
 let authStatusSnapshot: AuthStatusState = { phase: "loading" };
 let authStatusFetch: Promise<void> | null = null;
 let authStatusPrime: Promise<void> | null = null;
 let authStatusPrimeSettledAt = 0;
+let authStatusPrimeRetryAt = 0;
 let authStatusEpoch = 0;
 // A primed result is only trusted by the activation path for a boot-scale
 // window; a hook that (re)activates later re-probes exactly as before, so a
 // stale prime can never stand in for the session's current auth state.
 const AUTH_STATUS_PRIME_FRESH_MS = 30_000;
+
+function rateLimitRetryMs(retryAfterMs?: number): number {
+  const delay = retryAfterMs ?? RATE_LIMIT_RETRY_MS;
+  return Math.max(0, Math.min(delay, RATE_LIMIT_MAX_RETRY_MS));
+}
 
 function publishAuthStatus(state: AuthStatusState): void {
   authStatusSnapshot = state;
@@ -153,6 +166,17 @@ async function fetchAuthStatus(): Promise<void> {
         publishAuthStatus({ phase: "server_unavailable" });
         return;
       }
+      if (result.status === 429) {
+        if (attempt < RATE_LIMIT_RETRIES) {
+          await new Promise((resolve) =>
+            setTimeout(resolve, rateLimitRetryMs(result.retryAfterMs)),
+          );
+          if (probeEpoch !== authStatusEpoch) return;
+          continue;
+        }
+        publishAuthStatus({ phase: "server_unavailable" });
+        return;
+      }
       publishAuthStatus({
         phase: "unauthenticated",
         reason:
@@ -208,6 +232,11 @@ export function primeAuthStatusProbe(): void {
       return;
     }
     if (result.status === 503) return;
+    if (result.status === 429) {
+      authStatusPrimeRetryAt =
+        Date.now() + rateLimitRetryMs(result.retryAfterMs);
+      return;
+    }
     publishAuthStatus({
       phase: "unauthenticated",
       reason:
@@ -234,6 +263,14 @@ async function ensureAuthStatusProbe(): Promise<void> {
   if (authStatusFetch) return authStatusFetch;
   if (authStatusPrime) {
     await authStatusPrime;
+    if (authStatusPrimeRetryAt > Date.now()) {
+      const probeEpoch = authStatusEpoch;
+      await new Promise((resolve) =>
+        setTimeout(resolve, authStatusPrimeRetryAt - Date.now()),
+      );
+      if (probeEpoch !== authStatusEpoch) return;
+    }
+    authStatusPrimeRetryAt = 0;
     const fresh =
       Date.now() - authStatusPrimeSettledAt <= AUTH_STATUS_PRIME_FRESH_MS;
     if (
@@ -328,6 +365,7 @@ export function __resetAuthStatusForTests(): void {
   authStatusFetch = null;
   authStatusPrime = null;
   authStatusPrimeSettledAt = 0;
+  authStatusPrimeRetryAt = 0;
   authStatusEpoch += 1;
   publishAuthStatus({ phase: "loading" });
 }


### PR DESCRIPTION
## Summary
- preserve HTTP 429 from `/api/auth/me` instead of collapsing it into backend-unavailable 503
- respect `Retry-After` and use bounded conservative backoff when older servers omit it
- prevent the startup auth probe from amplifying a shared server limiter into a retry storm

## Verification
- `bun run --cwd packages/ui test -- src/api/auth-client.test.ts src/hooks/useAuthStatus.prime.test.tsx` (80 passed)
- `bun run --cwd packages/ui typecheck`
- Biome check + `git diff --check`

Client complement to the VPS valid-bearer limiter repair; no secrets or endpoint values are committed.