### PR TITLE
fix(logger): use truncateWellFormed for chat log previews and reasoning

### DIFF
--- a/packages/logger/src/logger.test.ts
+++ b/packages/logger/src/logger.test.ts
@@ -1142,3 +1142,32 @@ describe("file sink permissions", () => {
     },
   );
 });
+
+describe("chat log surrogate safety", () => {
+  it("preserves well-formed Unicode when truncating incoming and outgoing chat log previews", () => {
+    const longSurrogateIn = "a".repeat(199) + "🚀" + "tail";
+    const lineIn = logChatIn({
+      agentName: "Eliza",
+      agentId: "agent-1",
+      roomId: "room-123456789",
+      messageId: "message-123456789",
+      text: longSurrogateIn,
+    });
+    expect(lineIn.isWellFormed?.()).not.toBe(false);
+    expect(lineIn).toContain(`${"a".repeat(199)}...`);
+
+    const longSurrogateOut = "b".repeat(119) + "🚀" + "tail";
+    const lineOut = logChatOut({
+      agentName: "Eliza",
+      agentId: "agent-1",
+      roomId: "room-123456789",
+      action: "REPLY",
+      text: longSurrogateOut,
+      reasoning: "c".repeat(79) + "🚀" + "tail",
+    });
+    expect(lineOut.isWellFormed?.()).not.toBe(false);
+    expect(lineOut).toContain(`${"b".repeat(119)}...`);
+    expect(lineOut).toContain(`reasoning="${"c".repeat(79)}..."`);
+  });
+});
+

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -1085,11 +1085,21 @@ export interface ChatOutLogParams {
   actions?: string[];
 }
 
+function truncateWellFormed(str: string, maxLength: number): string {
+  if (str.length <= maxLength) return str;
+  let cut = maxLength;
+  const lead = str.charCodeAt(cut - 1);
+  if (lead >= 0xd800 && lead <= 0xdbff) {
+    cut -= 1;
+  }
+  return str.slice(0, cut);
+}
+
 const CHAT_PREVIEW_IN_MAX = 200;
 const CHAT_PREVIEW_OUT_MAX = 120;
 
 function escapeChatPreview(text: string): string {
-  const safe = text.length > 10_000 ? text.slice(0, 10_000) : text;
+  const safe = text.length > 10_000 ? truncateWellFormed(text, 10_000) : text;
   const oneLine = safe.replace(/\s+/g, " ").trim();
   return oneLine.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
 }
@@ -1110,7 +1120,7 @@ function writeChatLine(line: string): void {
 export function logChatIn(params: ChatInLogParams): string {
   const preview = escapeChatPreview(
     params.text.length > CHAT_PREVIEW_IN_MAX
-      ? `${params.text.slice(0, CHAT_PREVIEW_IN_MAX)}...`
+      ? `${truncateWellFormed(params.text, CHAT_PREVIEW_IN_MAX)}...`
       : params.text,
   );
   const roomShort = params.roomId.slice(0, 8);
@@ -1134,7 +1144,7 @@ export function logChatOut(params: ChatOutLogParams): string {
   if (params.text !== undefined && params.text !== "") {
     const preview = escapeChatPreview(
       params.text.length > CHAT_PREVIEW_OUT_MAX
-        ? `${params.text.slice(0, CHAT_PREVIEW_OUT_MAX)}...`
+        ? `${truncateWellFormed(params.text, CHAT_PREVIEW_OUT_MAX)}...`
         : params.text,
     );
     part += ` len=${params.text.length} "${preview}"`;
@@ -1147,7 +1157,7 @@ export function logChatOut(params: ChatOutLogParams): string {
   if (params.reasoning !== undefined && params.reasoning !== "") {
     const safe = escapeChatPreview(
       params.reasoning.length > 80
-        ? `${params.reasoning.slice(0, 80)}...`
+        ? `${truncateWellFormed(params.reasoning, 80)}...`
         : params.reasoning,
     );
     part += ` reasoning="${safe}"`;


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:023402e581f58f8ef97c1e362b7a3379000578f0 -->

## Summary
In `@elizaos/logger` (`packages/logger/src/logger.ts`):
`logChatIn` (200 chars), `logChatOut` (120 chars), `logChatOut` reasoning (80 chars), and `escapeChatPreview` (10,000 chars) used raw `.slice()` for string length truncation. When slicing strings containing multi-code-unit UTF-16 surrogate pairs (such as emojis) right at the clamp boundary, raw `.slice()` splits the surrogate pair into an unpaired lone surrogate, producing malformed Unicode in log files (`chat.log`).

## Proposed Changes
1. Added surrogate-aware `truncateWellFormed` helper in `packages/logger/src/logger.ts`.
2. Applied `truncateWellFormed` across `logChatIn`, `logChatOut`, and `escapeChatPreview`.
3. Added unit tests in `packages/logger/src/logger.test.ts` verifying that incoming/outgoing chat previews with surrogate pairs at clamp boundaries remain well-formed.

## Verification
- Ran vitest: `bun run --cwd packages/logger test` (61/61 passed).
- Verified well-formed Unicode output in `chat.log` lines.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
