### PR TITLE
fix(ui): use truncateWellFormed for debug TTS target display, runtime view summaries, and iOS transport traces

### DIFF
--- a/packages/ui/src/api/ios-local-agent-transport.ts
+++ b/packages/ui/src/api/ios-local-agent-transport.ts
@@ -4,6 +4,7 @@
  * IPC base. See the ios-local-agent references in the package CLAUDE.md.
  */
 import { Capacitor, registerPlugin } from "@capacitor/core";
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import {
   installElizaBridge,
   registerElizaBridgeCapability,
@@ -1007,7 +1008,7 @@ async function tryFullBunStreamingResponse(
         scope: "ios-local-agent.stream-after-head",
         severity: "warning",
         error,
-        context: { path: options.path?.slice(0, 120) },
+        context: { path: options.path ? truncateWellFormed(toWellFormedUnicode(options.path), 120) : undefined },
       });
     },
   );
@@ -1055,7 +1056,7 @@ export async function handleIosLocalAgentNativeRequest(
     appendIosBootTrace("native-request", {
       copy: "ui",
       n: tracedNativeRequests,
-      path: options.path?.slice(0, 120) ?? null,
+      path: options.path ? truncateWellFormed(toWellFormedUnicode(options.path), 120) : null,
     });
   }
   const path = options.path?.trim();

--- a/packages/ui/src/components/pages/RuntimeView.tsx
+++ b/packages/ui/src/components/pages/RuntimeView.tsx
@@ -23,6 +23,7 @@ import {
   type RuntimeServiceOrderItem,
 } from "../../api";
 import { getCached, setCached } from "../../hooks/resource-cache";
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import { useIntervalWhenDocumentVisible } from "../../hooks/useDocumentVisibility";
 import { PageLayout } from "../../layouts/page-layout/page-layout";
 import { useAppSelector } from "../../state";
@@ -87,7 +88,7 @@ const SECTION_TAB_KEYS: Array<{
 function nodeSummary(value: unknown): string {
   if (value === null) return "null";
   if (typeof value === "string") {
-    const compact = value.length > 100 ? `${value.slice(0, 100)}...` : value;
+    const compact = value.length > 100 ? `${truncateWellFormed(toWellFormedUnicode(value), 100)}...` : value;
     return JSON.stringify(compact);
   }
   if (typeof value === "number" || typeof value === "boolean") {

--- a/packages/ui/src/voice/voice-chat-types.asr-default.test.ts
+++ b/packages/ui/src/voice/voice-chat-types.asr-default.test.ts
@@ -1,7 +1,7 @@
 /** Verifies resolveEffectiveVoiceConfig - ASR provider default through the package's configured test harness. */
 import { describe, expect, it } from "vitest";
 import type { VoiceConfig } from "../api/client-types-config";
-import { resolveEffectiveVoiceConfig } from "./voice-chat-types";
+import { describeTtsFetchTargetForDebug, resolveEffectiveVoiceConfig } from "./voice-chat-types";
 
 /**
  * Regression coverage for the ASR-provider default in
@@ -105,3 +105,12 @@ describe("resolveEffectiveVoiceConfig - ASR provider default", () => {
     ).toBeNull();
   });
 });
+
+describe("describeTtsFetchTargetForDebug surrogate safety", () => {
+  it("preserves well-formed Unicode when clamping unparseable URLs containing surrogate pairs", () => {
+    const invalidWithSurrogate = "http://" + "a".repeat(110) + "🚀" + "tail";
+    const result = describeTtsFetchTargetForDebug(invalidWithSurrogate);
+    expect(result.isWellFormed?.()).not.toBe(false);
+  });
+});
+

--- a/packages/ui/src/voice/voice-chat-types.asr-default.test.ts
+++ b/packages/ui/src/voice/voice-chat-types.asr-default.test.ts
@@ -108,9 +108,9 @@ describe("resolveEffectiveVoiceConfig - ASR provider default", () => {
 
 describe("describeTtsFetchTargetForDebug surrogate safety", () => {
   it("preserves well-formed Unicode when clamping unparseable URLs containing surrogate pairs", () => {
-    const invalidWithSurrogate = "http://" + "a".repeat(110) + "🚀" + "tail";
+    const invalidWithSurrogate = "http://[" + "a".repeat(111) + "🚀" + "tail";
     const result = describeTtsFetchTargetForDebug(invalidWithSurrogate);
-    expect(result.isWellFormed?.()).not.toBe(false);
+    expect(result.isWellFormed()).toBe(true);
   });
 });
 

--- a/packages/ui/src/voice/voice-chat-types.ts
+++ b/packages/ui/src/voice/voice-chat-types.ts
@@ -6,6 +6,7 @@ import type { VoiceConfig, VoiceMode } from "../api/client";
 import { resolveApiUrl } from "../utils";
 import { ttsDebug } from "../utils/tts-debug";
 import type { Emotion } from "./emotion";
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 
 // ── Speech Recognition types ──────────────────────────────────────────
 
@@ -466,7 +467,7 @@ export function describeTtsFetchTargetForDebug(target: string): string {
       return `${new URL(target).origin} (absolute)`;
     } catch {
       // error-policy:J3 unparseable target — show the raw string (debug-only)
-      return target.slice(0, 120);
+      return truncateWellFormed(toWellFormedUnicode(target), 120);
     }
   }
   const origin =


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:655932799f8bd9592c76a46380ab4a1b75820517 -->

## Summary
In `@elizaos/ui`:
- `describeTtsFetchTargetForDebug` (`src/voice/voice-chat-types.ts`) clamped unparseable URLs using raw `.slice(0, 120)` when generating debug lines for `ELIZA_TTS_DEBUG`.
- `nodeSummary` (`src/components/pages/RuntimeView.tsx`) clamped preview strings using raw `.slice(0, 100)`.
- `tryFullBunStreamingResponse` and `handleIosLocalAgentNativeRequest` (`src/api/ios-local-agent-transport.ts`) clamped request paths using raw `.slice(0, 120)` for diagnostic context and boot traces.

When raw slicing overlong strings containing multi-code-unit UTF-16 surrogate pairs (such as emojis) at the cut index, surrogate pairs were split into lone surrogates.

## Proposed Changes
1. Replaced raw `.slice()` calls with `truncateWellFormed(toWellFormedUnicode(...))` from `@elizaos/core`.
2. Added unit test in `packages/ui/src/voice/voice-chat-types.asr-default.test.ts` verifying that unparseable targets with surrogate pairs at clamp boundaries remain well-formed.

## Verification
- Ran vitest: `bunx vitest run packages/ui/src/voice/voice-chat-types.asr-default.test.ts` (7/7 passed).
- Verified well-formed Unicode output in TTS debug representations and runtime tree summaries.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
