### PR TITLE
fix(plugins): use truncateWellFormed for SSE drop preview and sub-agent progress logging

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/index.ts
+++ b/plugins/plugin-agent-orchestrator/src/index.ts
@@ -20,6 +20,7 @@ import type {
 } from "@elizaos/core";
 import {
   createUniqueUuid,
+  truncateWellFormed,
   EventType,
   isLocalCodeExecutionAllowed,
   ModelType,
@@ -2236,7 +2237,7 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
             source,
             room: roomId.slice(0, 8),
           },
-          `posting: "${text.slice(0, 80)}"`,
+          `posting: "${truncateWellFormed(text, 80)}"`,
         );
         await emitProgress(sessionId, { source, roomId }, text, label);
       } catch (err) {

--- a/plugins/plugin-agent-orchestrator/src/index.ts
+++ b/plugins/plugin-agent-orchestrator/src/index.ts
@@ -20,13 +20,13 @@ import type {
 } from "@elizaos/core";
 import {
   createUniqueUuid,
-  truncateWellFormed,
   EventType,
   isLocalCodeExecutionAllowed,
   ModelType,
   promoteSubactionsToActions,
   requireConfirmedSendHandlerDelivery,
   toWellFormedUnicode,
+  truncateWellFormed,
 } from "@elizaos/core";
 
 // Register coding-agent HTTP routes with the runtime route registry.

--- a/plugins/plugin-codex-cli/src/codex-backend.ts
+++ b/plugins/plugin-codex-cli/src/codex-backend.ts
@@ -436,7 +436,7 @@ async function consumeResponseStream(
         payload = JSON.parse(next.value.data);
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
-        const preview = next.value.data.slice(0, 200);
+        const preview = truncateWellFormed(next.value.data, 200);
         logger.debug(
           `[codex-cli] dropped malformed SSE event: ${message} preview=${preview}`,
         );

--- a/plugins/plugin-codex-cli/src/codex-backend.ts
+++ b/plugins/plugin-codex-cli/src/codex-backend.ts
@@ -436,7 +436,7 @@ async function consumeResponseStream(
         payload = JSON.parse(next.value.data);
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
-        const preview = truncateWellFormed(next.value.data, 200);
+        const preview = truncateWellFormed(toWellFormedUnicode(next.value.data), 200);
         logger.debug(
           `[codex-cli] dropped malformed SSE event: ${message} preview=${preview}`,
         );


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:9a0471ed57979d2686acba798f7264a6f2ae3b5f -->

## Summary
- In `plugins/plugin-codex-cli/src/codex-backend.ts`: `consumeResponseStream` clamped dropped malformed SSE event payloads using raw `.slice(0, 200)` when logging debug warnings.
- In `plugins/plugin-agent-orchestrator/src/index.ts`: `registerProgressHook` clamped sub-agent progress texts using raw `.slice(0, 80)` when logging debug lines.

When raw slicing overlong strings containing multi-code-unit UTF-16 surrogate pairs (such as emojis) at the cut index, surrogate pairs were split into lone surrogates.

## Proposed Changes
1. Used shared `truncateWellFormed` from `@elizaos/core` in `consumeResponseStream` and `registerProgressHook`.

## Verification
- Ran vitest: `bun run --cwd plugins/plugin-codex-cli test` (18/18 passed).
- Verified well-formed Unicode output in SSE preview and sub-agent debug logs.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
