### PR TITLE
fix(core): ensure maskSecretValue preserves UTF-16 surrogate integrity at visible boundaries

### DIFF
--- a/packages/core/src/features/secrets/actions/mask.test.ts
+++ b/packages/core/src/features/secrets/actions/mask.test.ts
@@ -37,4 +37,9 @@ describe("maskSecretValue", () => {
 		expect(masked.startsWith("xxxx")).toBe(true);
 		expect(masked.endsWith("xxxx")).toBe(true);
 	});
+	it("preserves well-formed Unicode when secret starts or ends on surrogate pairs", () => {
+		const secretWithSurrogates = "🚀abcSECRETVALUEdef🚀";
+		const masked = maskSecretValue(secretWithSurrogates);
+		expect(masked.isWellFormed?.()).not.toBe(false);
+	});
 });

--- a/packages/core/src/features/secrets/actions/mask.test.ts
+++ b/packages/core/src/features/secrets/actions/mask.test.ts
@@ -37,9 +37,9 @@ describe("maskSecretValue", () => {
 		expect(masked.startsWith("xxxx")).toBe(true);
 		expect(masked.endsWith("xxxx")).toBe(true);
 	});
-	it("preserves well-formed Unicode when secret starts or ends on surrogate pairs", () => {
-		const secretWithSurrogates = "🚀abcSECRETVALUEdef🚀";
-		const masked = maskSecretValue(secretWithSurrogates);
-		expect(masked.isWellFormed?.()).not.toBe(false);
+	it("keeps output well-formed when an emoji straddles the visible boundary", () => {
+		const masked = maskSecretValue("abc🚀SECRETMIDDLE🚀xyz");
+		expect(masked.isWellFormed()).toBe(true);
+		expect(masked).not.toContain("SECRETMIDDLE");
 	});
 });

--- a/packages/core/src/features/secrets/actions/mask.ts
+++ b/packages/core/src/features/secrets/actions/mask.ts
@@ -1,14 +1,22 @@
+import { toWellFormedUnicode, truncateWellFormed } from "../../../utils/well-formed";
+
 /**
  * Mask a secret value for display.
  */
 export function maskSecretValue(value: string): string {
-	if (value.length <= 8) {
+	const wellFormed = toWellFormedUnicode(value);
+	if (wellFormed.length <= 8) {
 		return "****";
 	}
 
-	const visibleStart = value.slice(0, 4);
-	const visibleEnd = value.slice(-4);
-	const maskedLength = Math.min(value.length - 8, 20);
+	const visibleStart = truncateWellFormed(wellFormed, 4);
+	let endCut = wellFormed.length - 4;
+	const code = wellFormed.charCodeAt(endCut);
+	if (code >= 0xdc00 && code <= 0xdfff) {
+		endCut += 1;
+	}
+	const visibleEnd = wellFormed.slice(endCut);
+	const maskedLength = Math.min(wellFormed.length - 8, 20);
 	const mask = "*".repeat(maskedLength);
 
 	return `${visibleStart}${mask}${visibleEnd}`;

--- a/packages/core/src/features/secrets/actions/mask.ts
+++ b/packages/core/src/features/secrets/actions/mask.ts
@@ -1,4 +1,8 @@
-import { toWellFormedUnicode, truncateWellFormed } from "../../../utils/well-formed";
+import {
+	tailWellFormed,
+	toWellFormedUnicode,
+	truncateWellFormed,
+} from "../../../utils/well-formed";
 
 /**
  * Mask a secret value for display.
@@ -10,12 +14,7 @@ export function maskSecretValue(value: string): string {
 	}
 
 	const visibleStart = truncateWellFormed(wellFormed, 4);
-	let endCut = wellFormed.length - 4;
-	const code = wellFormed.charCodeAt(endCut);
-	if (code >= 0xdc00 && code <= 0xdfff) {
-		endCut += 1;
-	}
-	const visibleEnd = wellFormed.slice(endCut);
+	const visibleEnd = tailWellFormed(wellFormed, 4);
 	const maskedLength = Math.min(wellFormed.length - 8, 20);
 	const mask = "*".repeat(maskedLength);
 


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:26b7a043b4bbd3159e8005c811167ea9a44b430b -->

## Summary
In `@elizaos/core` (`packages/core/src/features/secrets/actions/mask.ts`):
`maskSecretValue` extracted visible start and end segments of secrets using raw `value.slice(0, 4)` and `value.slice(-4)`. If the secret contained multi-code-unit UTF-16 surrogate pairs (such as emojis or extended Unicode characters) within the first 4 or last 4 characters, the raw slice severed surrogate pairs into unpaired lone surrogates.

## Proposed Changes
1. Used `toWellFormedUnicode` and `truncateWellFormed` for the visible start segment in `maskSecretValue`.
2. Added low-surrogate detection on the tail offset to ensure the visible end segment never starts with an unpaired low surrogate.
3. Added unit tests in `packages/core/src/features/secrets/actions/mask.test.ts` verifying that masked secret values with surrogate pairs at prefix/suffix boundaries remain well-formed without lone surrogates.

## Verification
- Ran vitest: `bun run --cwd packages/core test src/features/secrets/actions/mask.test.ts` (5/5 passed).
- Verified well-formed Unicode output during secret value masking.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
