### PR TITLE
fix(auth): use truncateWellFormed for accountId in adopt_codex error context

### DIFF
--- a/packages/auth/src/subscription-auth/adopt-codex-cli-login.test.ts
+++ b/packages/auth/src/subscription-auth/adopt-codex-cli-login.test.ts
@@ -449,13 +449,13 @@ describe("two-process concurrency", () => {
 
 describe("validateAccountId surrogate safety", () => {
   it("preserves well-formed Unicode in error context when accountId contains surrogate pairs", async () => {
-    const invalidWithSurrogate = "invalid!" + "a".repeat(70) + "🚀" + "tail";
+    const invalidWithSurrogate = "invalid!" + "a".repeat(71) + "🚀" + "tail";
     const error = await expectAdoptError(
       async () => adoptCodexCliLogin({ accountId: invalidWithSurrogate }),
       "adopt_codex.invalid_account_id",
     );
     const accountContext = String(error.context?.accountId);
-    expect(accountContext.isWellFormed?.()).not.toBe(false);
+    expect(accountContext.isWellFormed()).toBe(true);
   });
 });
 

--- a/packages/auth/src/subscription-auth/adopt-codex-cli-login.test.ts
+++ b/packages/auth/src/subscription-auth/adopt-codex-cli-login.test.ts
@@ -446,3 +446,16 @@ describe("two-process concurrency", () => {
     }
   }, 15_000);
 });
+
+describe("validateAccountId surrogate safety", () => {
+  it("preserves well-formed Unicode in error context when accountId contains surrogate pairs", async () => {
+    const invalidWithSurrogate = "invalid!" + "a".repeat(70) + "🚀" + "tail";
+    const error = await expectAdoptError(
+      async () => adoptCodexCliLogin({ accountId: invalidWithSurrogate }),
+      "adopt_codex.invalid_account_id",
+    );
+    const accountContext = String(error.context?.accountId);
+    expect(accountContext.isWellFormed?.()).not.toBe(false);
+  });
+});
+

--- a/packages/auth/src/subscription-auth/adopt-codex-cli-login.ts
+++ b/packages/auth/src/subscription-auth/adopt-codex-cli-login.ts
@@ -39,7 +39,7 @@ import {
   unlinkSync,
 } from "node:fs";
 import path from "node:path";
-import { ElizaError, logger } from "@elizaos/core";
+import { ElizaError, logger, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import {
   type AccountStorageMutationScope,
   type AccountStoragePolicy,
@@ -92,7 +92,7 @@ function validateAccountId(accountId: string): void {
     throw adoptError(
       "adopt_codex.invalid_account_id",
       "Account id must be 1-64 chars of [A-Za-z0-9._-], starting alphanumeric, with no traversal sequences",
-      { accountId: String(accountId).slice(0, 80) },
+      { accountId: truncateWellFormed(toWellFormedUnicode(String(accountId)), 80) },
     );
   }
 }


### PR DESCRIPTION
<!-- evidence-gate -->
<!-- evidence-head:bc994df9400b6953517b5c8c6cd1ef8b23550ea2 -->

## Summary
In `@elizaos/auth` (`packages/auth/src/subscription-auth/adopt-codex-cli-login.ts`):
`validateAccountId` clamped invalid `accountId` values using raw `String(accountId).slice(0, 80)` when constructing the error context for `adopt_codex.invalid_account_id`. When `accountId` contains multi-code-unit UTF-16 surrogate pairs at character offset 80, the raw slice severed the surrogate pair into an unpaired lone surrogate.

## Proposed Changes
1. Used `truncateWellFormed(toWellFormedUnicode(String(accountId)), 80)` in `validateAccountId`.
2. Added unit tests in `packages/auth/src/subscription-auth/adopt-codex-cli-login.test.ts` verifying that error contexts with surrogate pairs at clamp boundaries remain well-formed without lone surrogates.

## Verification
- Ran vitest: `bun run --cwd packages/auth test src/subscription-auth/adopt-codex-cli-login.test.ts` (30/30 passed).
- Verified well-formed Unicode in error contexts.

```yaml contribution-provenance
skill_revision: "8808863b16a957a091a2b08a60d8cfc4f97213c6:packages/skills/skills/contribute-to-eliza"
```
