### PR TITLE
feat(ui): canonicalize framed page geometry

### DIFF
--- a/packages/app/test/ui-smoke/all-views-aesthetic-audit.spec.ts
+++ b/packages/app/test/ui-smoke/all-views-aesthetic-audit.spec.ts
@@ -61,6 +61,110 @@ const { strict: AUDIT_STRICT, needsWorkStrict: AUDIT_STRICT_NEEDS_WORK } =
 // scrollWidth/innerWidth rounding can differ by ~1px on a healthy layout. A real
 // un-contained overflow (WS5) blows past this comfortably.
 const HORIZONTAL_OVERFLOW_TOLERANCE_PX = 2;
+const FRAMED_PAGE_SLUGS = new Set([
+  "builtin-character",
+  "builtin-character-skills",
+  "builtin-database",
+  "builtin-experience",
+  "builtin-memories",
+  "builtin-tasks",
+  "builtin-vault",
+]);
+const FRAMED_PAGE_MAX_WIDTH_PX = 1024;
+const FRAMED_PAGE_GEOMETRY_TOLERANCE_PX = 2;
+
+async function collectFramedPageGeometryIssues(
+  viewRoot: Locator,
+): Promise<string[]> {
+  const issues: string[] = [];
+  const framedPage = viewRoot.locator("[data-framed-page]:visible");
+  const framedPageCount = await framedPage.count();
+  if (framedPageCount !== 1) {
+    issues.push(`view has ${framedPageCount} visible framed-page roots`);
+    return issues;
+  }
+  const body = framedPage.locator(":scope > [data-framed-page-body]:visible");
+  const header = framedPage.locator(
+    ":scope > [data-framed-page-header]:visible",
+  );
+  const navigation = framedPage.locator(
+    ":scope > [data-framed-page-navigation]:visible",
+  );
+
+  const bodyCount = await body.count();
+  const headerCount = await header.count();
+  if (bodyCount !== 1)
+    issues.push(`framed page has ${bodyCount} visible bodies`);
+  if (headerCount !== 1) {
+    issues.push(`framed page has ${headerCount} visible headers`);
+  }
+  if (bodyCount !== 1 || headerCount !== 1) return issues;
+
+  const expectedSlotGeometry = async (slot: Locator) =>
+    slot.evaluate((element, maxWidth) => {
+      const parent = element.parentElement;
+      if (!parent) return null;
+      const parentBox = parent.getBoundingClientRect();
+      const style = getComputedStyle(parent);
+      const leftInset = Number.parseFloat(style.paddingLeft) || 0;
+      const rightInset = Number.parseFloat(style.paddingRight) || 0;
+      const availableWidth = parentBox.width - leftInset - rightInset;
+      const width = Math.min(availableWidth, maxWidth);
+      return {
+        width,
+        left: parentBox.x + leftInset + (availableWidth - width) / 2,
+      };
+    }, FRAMED_PAGE_MAX_WIDTH_PX);
+
+  const bodyExpected = await expectedSlotGeometry(body);
+  const bodyBox = await body.boundingBox();
+  const headerBox = await header.boundingBox();
+  if (!bodyExpected || !bodyBox || !headerBox) {
+    return [...issues, "framed page geometry could not be measured"];
+  }
+
+  if (
+    Math.abs(bodyBox.width - bodyExpected.width) >
+      FRAMED_PAGE_GEOMETRY_TOLERANCE_PX ||
+    Math.abs(bodyBox.x - bodyExpected.left) > FRAMED_PAGE_GEOMETRY_TOLERANCE_PX
+  ) {
+    issues.push(
+      `framed body is ${Math.round(bodyBox.width)}px wide at x=${Math.round(bodyBox.x)}; expected ${Math.round(bodyExpected.width)}px at x=${Math.round(bodyExpected.left)}`,
+    );
+  }
+  if (bodyBox.y < headerBox.y + headerBox.height - 1) {
+    issues.push("framed body overlaps its header slot");
+  }
+
+  const navigationCount = await navigation.count();
+  if (navigationCount > 1) {
+    issues.push(`framed page has ${navigationCount} visible navigation slots`);
+  } else if (navigationCount === 1) {
+    const navigationBox = await navigation.boundingBox();
+    const navigationExpected = await expectedSlotGeometry(navigation);
+    if (!navigationBox || !navigationExpected) {
+      issues.push("framed navigation geometry could not be measured");
+    } else {
+      if (
+        Math.abs(navigationBox.width - navigationExpected.width) >
+          FRAMED_PAGE_GEOMETRY_TOLERANCE_PX ||
+        Math.abs(navigationBox.x - navigationExpected.left) >
+          FRAMED_PAGE_GEOMETRY_TOLERANCE_PX
+      ) {
+        issues.push(
+          `framed navigation is ${Math.round(navigationBox.width)}px wide at x=${Math.round(navigationBox.x)}; expected ${Math.round(navigationExpected.width)}px at x=${Math.round(navigationExpected.left)}`,
+        );
+      }
+      if (navigationBox.y < headerBox.y + headerBox.height - 1) {
+        issues.push("framed navigation overlaps its header slot");
+      }
+      if (bodyBox.y < navigationBox.y + navigationBox.height - 1) {
+        issues.push("framed body overlaps its navigation slot");
+      }
+    }
+  }
+  return issues;
+}
 /**
  * App-side all-views aesthetic audit (#8796) — the agent app's equivalent of
  * cloud-frontend's `audit:cloud`. It walks EVERY view (built-in tabs + plugin
@@ -852,9 +956,7 @@ async function collectAestheticDensityMetrics(
             const [topWidth, rightWidth, bottomWidth, leftWidth] =
               visibleBorderWidths;
             if (topWidth > 0) {
-              markRect(
-                new DOMRect(rect.left, rect.top, rect.width, topWidth),
-              );
+              markRect(new DOMRect(rect.left, rect.top, rect.width, topWidth));
             }
             if (rightWidth > 0) {
               markRect(
@@ -2032,6 +2134,9 @@ test.describe("all-views aesthetic audit (#8796)", () => {
           ...(await collectSpatialOverlapIssues(page)),
           ...(await collectSpatialSizingIssues(page)),
           ...(await collectComposerLegibilityIssues(page)),
+          ...(FRAMED_PAGE_SLUGS.has(view.slug)
+            ? await collectFramedPageGeometryIssues(viewRoot)
+            : []),
         ];
 
         // Document-level horizontal-overflow invariant (WS5). Measured, not

--- a/packages/ui/scripts/duplicate-molecular-components-report.md
+++ b/packages/ui/scripts/duplicate-molecular-components-report.md
@@ -1,6 +1,6 @@
 # Molecular component duplicate inventory
 
-Scanned 898 maintained React files. 101 exported compositions have a recognized molecular role and at least two atomic dependencies.
+Scanned 899 maintained React files. 101 exported compositions have a recognized molecular role and at least two atomic dependencies.
 
 Clusters share both a role and an atomic dependency signature. Detection creates a review queue; this committed report contains only final dispositions based on product behavior, state ownership, and responsive layout.
 

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1493,7 +1493,7 @@ function buildStaticTabRenderers(): Record<
       </AppWorkspaceContent>
     ),
     runtime: withHeader("runtime", <LazyRuntimeView />),
-    database: withHeader("database", <LazyDatabasePageView />),
+    database: wrapOverlayAware(<LazyDatabasePageView />),
     logs: withHeader("logs", <LazyLogsView />),
     desktop: withHeader("desktop", <LazyDesktopWorkspaceSection />),
     settings: ({
@@ -1520,7 +1520,7 @@ function buildStaticTabRenderers(): Record<
         />
       </AppWorkspaceContent>
     ),
-    vault: wrap(<LazyVaultPageView />),
+    vault: wrapOverlayAware(<LazyVaultPageView />),
     // Camera is an AOSP-ElizaOS-fork-only surface — gate the route on the same
     // marker as the home tile, so a deep-link off the fork falls back to
     // "unavailable" instead of rendering on web/desktop/iOS/Play-Store Android.

--- a/packages/ui/src/components/character/CharacterExperienceView.tsx
+++ b/packages/ui/src/components/character/CharacterExperienceView.tsx
@@ -6,6 +6,7 @@ import { useCallback, useMemo, useState } from "react";
 import { client } from "../../api/client";
 import type { ExperienceRecord } from "../../api/client-types";
 import { useFetchData } from "../../hooks/useFetchData";
+import { FramedPage, FramedPageBody } from "../../layouts/framed-page";
 import { ShellViewAgentSurface } from "../views/ShellViewAgentSurface";
 import { CharacterExperienceWorkspace } from "./CharacterExperienceWorkspace";
 import { mapExperienceRecordToHubRecord } from "./character-hub-helpers";
@@ -97,35 +98,41 @@ export function CharacterExperienceView() {
 
   return (
     <ShellViewAgentSurface viewId="experience">
-      <div className="custom-scrollbar mx-auto flex min-h-0 w-full min-w-0 max-w-6xl flex-1 flex-col gap-4 overflow-y-auto px-4 pb-32 pt-1 sm:px-5 lg:px-6">
-        {error ? (
-          <div className="rounded-sm border border-danger/30 bg-danger/10 px-4 py-3 text-sm text-danger">
-            {error}
-          </div>
-        ) : null}
-        {loading ? (
-          <div className="text-sm text-muted">Loading experiences…</div>
-        ) : (
-          <CharacterExperienceWorkspace
-            showTitle={false}
-            experiences={hubRecords}
-            selectedExperienceId={selectedExperienceId}
-            onSelectExperience={setSelectedExperienceId}
-            onSaveExperience={(experience, draft) => {
-              const source = records.find((item) => item.id === experience.id);
-              if (!source) return;
-              void handleSaveExperience(source, draft);
-            }}
-            onDeleteExperience={(experience) => {
-              const source = records.find((item) => item.id === experience.id);
-              if (!source) return;
-              void handleDeleteExperience(source);
-            }}
-            savingExperienceId={savingExperienceId}
-            deletingExperienceId={deletingExperienceId}
-          />
-        )}
-      </div>
+      <FramedPage>
+        <FramedPageBody className="gap-4 pt-1">
+          {error ? (
+            <div className="rounded-sm border border-danger/30 bg-danger/10 px-4 py-3 text-sm text-danger">
+              {error}
+            </div>
+          ) : null}
+          {loading ? (
+            <div className="text-sm text-muted">Loading experiences…</div>
+          ) : (
+            <CharacterExperienceWorkspace
+              showTitle={false}
+              experiences={hubRecords}
+              selectedExperienceId={selectedExperienceId}
+              onSelectExperience={setSelectedExperienceId}
+              onSaveExperience={(experience, draft) => {
+                const source = records.find(
+                  (item) => item.id === experience.id,
+                );
+                if (!source) return;
+                void handleSaveExperience(source, draft);
+              }}
+              onDeleteExperience={(experience) => {
+                const source = records.find(
+                  (item) => item.id === experience.id,
+                );
+                if (!source) return;
+                void handleDeleteExperience(source);
+              }}
+              savingExperienceId={savingExperienceId}
+              deletingExperienceId={deletingExperienceId}
+            />
+          )}
+        </FramedPageBody>
+      </FramedPage>
     </ShellViewAgentSurface>
   );
 }

--- a/packages/ui/src/components/character/CharacterHubView.tsx
+++ b/packages/ui/src/components/character/CharacterHubView.tsx
@@ -18,7 +18,7 @@ import { useCallback, useEffect, useRef } from "react";
 import { client } from "../../api/client";
 import type { CharacterData } from "../../api/client-types";
 import { useRenderGuard } from "../../hooks/useRenderGuard";
-import { WorkspaceLayout } from "../../layouts/workspace-layout/workspace-layout";
+import { FramedPage, FramedPageBody } from "../../layouts/framed-page";
 import { useAppSelectorShallow } from "../../state";
 // Direct sub-path import to avoid the widgets/index.ts ↔ WidgetHost.tsx
 // chunk-level circular dependency.
@@ -223,53 +223,50 @@ export function CharacterHubView({
   );
 
   return (
-    <WorkspaceLayout
-      className="h-full"
-      contentPadding={false}
-      contentInnerClassName="flex w-full min-h-0 flex-1 flex-col"
-      data-testid="character-editor-view"
-    >
-      <div className="custom-scrollbar mx-auto flex min-h-0 w-full min-w-0 max-w-6xl flex-1 flex-col overflow-y-auto overflow-x-hidden px-4 pb-32 pt-1 sm:px-5 lg:px-6">
-        <WidgetHost slot="character" className="mb-4" />
-        <div className="flex min-w-0 flex-col gap-4 sm:gap-6">
-          {characterSaveError ? (
-            <span className="rounded-sm border border-status-danger/20 bg-status-danger-bg px-2 py-1 text-2xs font-medium text-status-danger">
-              {characterSaveError}
-            </span>
-          ) : null}
-          <section>
-            <CharacterIdentityPanel
-              nameText={typeof d.name === "string" ? d.name : ""}
-              systemText={typeof d.system === "string" ? d.system : ""}
-              bioText={bioText}
-              handleFieldEdit={handleAutoSavedFieldEdit}
-              t={t}
-            />
-          </section>
+    <FramedPage>
+      <FramedPageBody scroll="page" data-testid="character-editor-view">
+        <div className="flex min-w-0 flex-col pt-1">
+          <WidgetHost slot="character" className="mb-4" />
+          <div className="flex min-w-0 flex-col gap-4 sm:gap-6">
+            {characterSaveError ? (
+              <span className="rounded-sm border border-status-danger/20 bg-status-danger-bg px-2 py-1 text-2xs font-medium text-status-danger">
+                {characterSaveError}
+              </span>
+            ) : null}
+            <section>
+              <CharacterIdentityPanel
+                nameText={typeof d.name === "string" ? d.name : ""}
+                systemText={typeof d.system === "string" ? d.system : ""}
+                bioText={bioText}
+                handleFieldEdit={handleAutoSavedFieldEdit}
+                t={t}
+              />
+            </section>
 
-          <CharacterStylePanel
-            d={d}
-            pendingStyleEntries={pendingStyleEntries}
-            styleEntryDrafts={styleEntryDrafts}
-            handlePendingStyleEntryChange={handlePendingStyleEntryChange}
-            handleAddStyleEntry={handleAutoAddStyleEntry}
-            handleRemoveStyleEntry={handleAutoRemoveStyleEntry}
-            handleStyleEntryDraftChange={handleStyleEntryDraftChange}
-            handleCommitStyleEntry={handleAutoCommitStyleEntry}
-            handleReorderStyleEntries={handleAutoReorderStyleEntries}
-            t={t}
-          />
-
-          <section>
-            <CharacterExamplesPanel
+            <CharacterStylePanel
               d={d}
-              normalizedMessageExamples={normalizedMessageExamples}
-              handleFieldEdit={handleAutoSavedExamplesEdit}
+              pendingStyleEntries={pendingStyleEntries}
+              styleEntryDrafts={styleEntryDrafts}
+              handlePendingStyleEntryChange={handlePendingStyleEntryChange}
+              handleAddStyleEntry={handleAutoAddStyleEntry}
+              handleRemoveStyleEntry={handleAutoRemoveStyleEntry}
+              handleStyleEntryDraftChange={handleStyleEntryDraftChange}
+              handleCommitStyleEntry={handleAutoCommitStyleEntry}
+              handleReorderStyleEntries={handleAutoReorderStyleEntries}
               t={t}
             />
-          </section>
+
+            <section>
+              <CharacterExamplesPanel
+                d={d}
+                normalizedMessageExamples={normalizedMessageExamples}
+                handleFieldEdit={handleAutoSavedExamplesEdit}
+                t={t}
+              />
+            </section>
+          </div>
         </div>
-      </div>
-    </WorkspaceLayout>
+      </FramedPageBody>
+    </FramedPage>
   );
 }

--- a/packages/ui/src/components/character/CharacterSectionNav.tsx
+++ b/packages/ui/src/components/character/CharacterSectionNav.tsx
@@ -19,12 +19,15 @@
  */
 
 import {
+  FramedPageHeader,
+  FramedPageNavigation,
+} from "../../layouts/framed-page";
+import {
   navigateToSectionPath,
   normalizeSectionPath,
   type SectionTab,
   SectionTabStrip,
 } from "../shared/SectionNav";
-import { ViewHeader } from "../shared/ViewHeader";
 import { Separator } from "../ui/separator";
 
 const CHARACTER_SECTION_GROUP = "character";
@@ -79,20 +82,22 @@ export function CharacterSectionNav({
 }): React.JSX.Element {
   return (
     <div className="flex shrink-0 flex-col">
-      <ViewHeader title="Character" />
-      <SectionTabStrip
-        entries={CHARACTER_SECTION_TABS}
-        activeId={activeCharacterTabId(activePath)}
-        onSelect={(id) => {
-          const tab = CHARACTER_SECTION_TABS.find(
-            (candidate) => candidate.id === id,
-          );
-          if (tab) navigateToSectionPath(tab.path);
-        }}
-        testId={`section-nav-${CHARACTER_SECTION_GROUP}`}
-        ariaLabel="Character sections"
-        className="pt-0"
-      />
+      <FramedPageHeader title="Character" />
+      <FramedPageNavigation>
+        <SectionTabStrip
+          entries={CHARACTER_SECTION_TABS}
+          activeId={activeCharacterTabId(activePath)}
+          onSelect={(id) => {
+            const tab = CHARACTER_SECTION_TABS.find(
+              (candidate) => candidate.id === id,
+            );
+            if (tab) navigateToSectionPath(tab.path);
+          }}
+          testId={`section-nav-${CHARACTER_SECTION_GROUP}`}
+          ariaLabel="Character sections"
+          className="py-0"
+        />
+      </FramedPageNavigation>
       <Separator tone="subtle45" />
     </div>
   );

--- a/packages/ui/src/components/character/CharacterSkillsView.tsx
+++ b/packages/ui/src/components/character/CharacterSkillsView.tsx
@@ -5,15 +5,19 @@
  * `CharacterSectionNav` supplies the "Character" header + section strip in the
  * shell nav slot, so this view never renders its own top bar.
  */
+
+import { FramedPage, FramedPageBody } from "../../layouts/framed-page";
 import { ShellViewAgentSurface } from "../views/ShellViewAgentSurface";
 import { CharacterLearnedSkillsSection } from "./CharacterLearnedSkillsSection";
 
 export function CharacterSkillsView() {
   return (
     <ShellViewAgentSurface viewId="character-skills">
-      <div className="custom-scrollbar mx-auto flex min-h-0 w-full min-w-0 max-w-6xl flex-1 flex-col gap-4 overflow-y-auto px-4 pb-32 pt-1 sm:px-5 lg:px-6">
-        <CharacterLearnedSkillsSection showTitle={false} />
-      </div>
+      <FramedPage>
+        <FramedPageBody className="gap-4 pt-1">
+          <CharacterLearnedSkillsSection showTitle={false} />
+        </FramedPageBody>
+      </FramedPage>
     </ShellViewAgentSurface>
   );
 }

--- a/packages/ui/src/components/pages/DatabasePageView.tsx
+++ b/packages/ui/src/components/pages/DatabasePageView.tsx
@@ -7,6 +7,12 @@
 
 import type { ReactNode } from "react";
 import { useAgentElement } from "../../agent-surface";
+import {
+  FramedPage,
+  FramedPageBody,
+  FramedPageHeader,
+  FramedPageNavigation,
+} from "../../layouts/framed-page";
 import { useAppSelector } from "../../state";
 import { SegmentedControl } from "../ui/segmented-control";
 import { DynamicViewLoader } from "../views/DynamicViewLoader";
@@ -95,30 +101,30 @@ export function DatabasePageView({
     </>
   );
 
-  // Each sub-view owns its own PageLayout + Sidebar.
-  // contentHeader and leftNav are passed through so the layout is uniform.
+  let content: ReactNode;
   if (databaseSubTab === "media") {
-    return (
-      <ShellViewAgentSurface viewId="database">
-        <MediaGalleryView leftNav={leftNav} contentHeader={contentHeader} />
-      </ShellViewAgentSurface>
+    content = <MediaGalleryView />;
+  } else if (databaseSubTab === "vectors") {
+    content = (
+      <DynamicViewLoader
+        bundleUrl={VECTOR_BROWSER_BUNDLE_URL}
+        componentExport={VECTOR_BROWSER_COMPONENT_EXPORT}
+        viewId="vector-browser"
+        viewProps={{ leftNav, contentHeader }}
+      />
     );
-  }
-  if (databaseSubTab === "vectors") {
-    return (
-      <ShellViewAgentSurface viewId="database">
-        <DynamicViewLoader
-          bundleUrl={VECTOR_BROWSER_BUNDLE_URL}
-          componentExport={VECTOR_BROWSER_COMPONENT_EXPORT}
-          viewId="vector-browser"
-          viewProps={{ leftNav, contentHeader }}
-        />
-      </ShellViewAgentSurface>
-    );
+  } else {
+    content = <DatabaseView layout="page" />;
   }
   return (
     <ShellViewAgentSurface viewId="database">
-      <DatabaseView leftNav={leftNav} contentHeader={contentHeader} />
+      <FramedPage>
+        <FramedPageHeader title="Databases" actions={contentHeader} />
+        <FramedPageNavigation>{leftNav}</FramedPageNavigation>
+        <FramedPageBody scroll="view" padded={false}>
+          {content}
+        </FramedPageBody>
+      </FramedPage>
     </ShellViewAgentSurface>
   );
 }

--- a/packages/ui/src/components/pages/DatabaseView.test.tsx
+++ b/packages/ui/src/components/pages/DatabaseView.test.tsx
@@ -115,6 +115,22 @@ describe("DatabaseView", () => {
     expect(clientMock.getDatabaseTables).not.toHaveBeenCalled();
   });
 
+  it("keeps the page layout disconnected state exclusive", async () => {
+    clientMock.getDatabaseStatus.mockResolvedValue({
+      ...connectedStatus,
+      connected: false,
+      tableCount: 0,
+    });
+
+    render(<DatabaseView layout="page" />);
+
+    expect(
+      await screen.findByText("databaseview.StartAgentToUseDatabase"),
+    ).toBeTruthy();
+    expect(screen.queryByText("databaseview.NoTableSelected")).toBeNull();
+    expect(clientMock.getDatabaseTables).not.toHaveBeenCalled();
+  });
+
   it("surfaces a status-load error message to the user when getDatabaseStatus rejects", async () => {
     clientMock.getDatabaseStatus.mockRejectedValue(
       new Error("boom: cannot reach db"),

--- a/packages/ui/src/components/pages/DatabaseView.tsx
+++ b/packages/ui/src/components/pages/DatabaseView.tsx
@@ -78,12 +78,14 @@ function ViewModeTab({
 export function DatabaseView({
   leftNav,
   contentHeader,
+  layout = "embedded",
 }: {
   leftNav?: ReactNode;
   contentHeader?: ReactNode;
+  layout?: "embedded" | "page";
 }) {
   const { t } = useTranslation();
-  const showExternalSidebar = Boolean(leftNav);
+  const showExternalSidebar = layout === "page" || Boolean(leftNav);
 
   // `t` from useApp is not guaranteed to be referentially stable across
   // renders. Reading it through a ref keeps the data loaders below stable so

--- a/packages/ui/src/components/pages/MemoryViewerView.tsx
+++ b/packages/ui/src/components/pages/MemoryViewerView.tsx
@@ -36,6 +36,11 @@ import {
 } from "../../hooks/runtime-capability-retry";
 import { useActiveAgentAuthority } from "../../hooks/useActiveAgentAuthority";
 import { useIntervalWhenDocumentVisible } from "../../hooks/useDocumentVisibility";
+import {
+  FramedPage,
+  FramedPageBody,
+  FramedPageHeader,
+} from "../../layouts/framed-page";
 import { WorkspaceLayout } from "../../layouts/workspace-layout";
 import { useWorkspaceMobileSidebarHeader } from "../../layouts/workspace-layout/workspace-mobile-sidebar-controls.hooks";
 import { WorkspaceMobileSidebarScope } from "../../layouts/workspace-layout/workspace-mobile-sidebar-scope";
@@ -51,7 +56,6 @@ import { ChatSearchHint } from "../composites/chat-search-hint";
 import { PagePanel } from "../composites/page-panel";
 import { MetaPill } from "../composites/page-panel/page-panel-header";
 import { AppPageSidebar } from "../shared/AppPageSidebar";
-import { ViewHeader } from "../shared/ViewHeader";
 import { ViewHeaderSidebarTrigger } from "../shared/ViewHeaderSidebarTrigger";
 import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
@@ -1408,11 +1412,10 @@ function MemoryViewerViewForAuthority({
 
   return (
     <ShellViewAgentSurface viewId="memories">
-      <div className="settings-surface settings-canvas flex h-full min-h-0 w-full flex-col">
-        <ViewHeader
+      <FramedPage>
+        <FramedPageHeader
           title={t("memoryviewer.title", { defaultValue: "Memories" })}
-          className="text-[color:var(--settings-foreground)]"
-          right={
+          actions={
             memoryRuntimeUnavailable ? undefined : (
               <ViewHeaderSidebarTrigger
                 control={mobileSidebarHeader.control}
@@ -1421,7 +1424,7 @@ function MemoryViewerViewForAuthority({
             )
           }
         />
-        <div className="flex min-h-0 flex-1 overflow-hidden">
+        <FramedPageBody scroll="view" padded={false}>
           <WorkspaceMobileSidebarScope controls={mobileSidebarHeader.controls}>
             <WorkspaceLayout
               sidebar={memoryRuntimeUnavailable ? null : sidebar}
@@ -1528,8 +1531,8 @@ function MemoryViewerViewForAuthority({
               </div>
             </WorkspaceLayout>
           </WorkspaceMobileSidebarScope>
-        </div>
-      </div>
+        </FramedPageBody>
+      </FramedPage>
     </ShellViewAgentSurface>
   );
 }

--- a/packages/ui/src/components/pages/TasksPageView.tsx
+++ b/packages/ui/src/components/pages/TasksPageView.tsx
@@ -21,12 +21,17 @@ import {
   subscribeAppShellPages,
 } from "../../app-shell-registry";
 import { dispatchChatClose } from "../../events";
+import {
+  FramedPage,
+  FramedPageBody,
+  FramedPageHeader,
+  FramedPageNavigation,
+} from "../../layouts/framed-page";
 import { getWindowNavigationPath } from "../../navigation";
 import { CodingAgentTasksPanel } from "../../slots/task-coordinator-slots.js";
 import { useAppSelector } from "../../state";
 import { AppsManagementSection } from "../settings/AppsManagementSection";
 import { SettingsGroup, SettingsRow } from "../settings/settings-layout";
-import { ViewHeader } from "../shared/ViewHeader";
 import { useShellControllerContext } from "../shell/ShellControllerContext.hooks";
 import { SegmentedControl } from "../ui/segmented-control";
 import { ShellViewAgentSurface } from "../views/ShellViewAgentSurface";
@@ -162,12 +167,10 @@ export function TasksPageView() {
   );
   return (
     <ShellViewAgentSurface viewId="tasks">
-      <div
-        className="flex h-full min-h-0 w-full flex-col"
-        data-testid="tasks-view"
-      >
-        <ViewHeader title="Projects" right={segmentControl} />
-        <div className="device-layout mx-auto flex min-h-0 w-full min-w-0 max-w-4xl flex-1 flex-col">
+      <FramedPage data-testid="tasks-view" reserveComposer={false}>
+        <FramedPageHeader title="Projects" />
+        <FramedPageNavigation>{segmentControl}</FramedPageNavigation>
+        <FramedPageBody scroll="view" padded={false} className="device-layout">
           {segment === "apps" ? (
             <div
               className="min-h-0 flex-1 overflow-y-auto eliza-chat-scroll pb-[var(--eliza-chat-clearance,5.25rem)]"
@@ -199,8 +202,8 @@ export function TasksPageView() {
           ) : (
             <CodingAgentTasksPanel fullPage />
           )}
-        </div>
-      </div>
+        </FramedPageBody>
+      </FramedPage>
     </ShellViewAgentSurface>
   );
 }

--- a/packages/ui/src/components/pages/VaultPageView.tsx
+++ b/packages/ui/src/components/pages/VaultPageView.tsx
@@ -4,6 +4,11 @@
  * share one controller, one set of API calls, and one mutation surface.
  */
 
+import {
+  FramedPage,
+  FramedPageBody,
+  FramedPageHeader,
+} from "../../layouts/framed-page";
 import { OwnerOnlyNotice, RoleGate } from "../RoleGate";
 import { VaultWorkspace } from "../settings/SecretsManagerSection";
 import { ShellViewAgentSurface } from "../views/ShellViewAgentSurface";
@@ -11,29 +16,29 @@ import { ShellViewAgentSurface } from "../views/ShellViewAgentSurface";
 export function VaultPageView(): React.JSX.Element {
   return (
     <ShellViewAgentSurface viewId="vault">
-      <RoleGate
-        minRole="OWNER"
-        fallback={
-          <div className="mx-auto h-[calc(100%-var(--eliza-chat-clearance,5.25rem))] w-full max-w-5xl overflow-hidden p-4 sm:p-6">
-            <OwnerOnlyNotice message="The Vault is available to the workspace owner only." />
-          </div>
-        }
-      >
-        <div
-          data-testid="vault-page"
-          data-chat-clearance-aware="true"
-          className="mx-auto flex h-[calc(100%-var(--eliza-chat-clearance,5.25rem))] min-h-0 w-full max-w-5xl flex-col overflow-hidden p-4 sm:p-6"
-        >
-          <VaultWorkspace
-            open
-            onOpenChange={() => {}}
-            initialTab={null}
-            initialFocusKey={null}
-            initialFocusProfileId={null}
-            presentation="page"
-          />
-        </div>
-      </RoleGate>
+      <FramedPage data-testid="vault-page" data-chat-clearance-aware="true">
+        <FramedPageHeader
+          title="Vault"
+          description="Encrypted credentials and references available to this agent. Organization credential pools remain managed in Eliza Cloud."
+        />
+        <FramedPageBody scroll="view">
+          <RoleGate
+            minRole="OWNER"
+            fallback={
+              <OwnerOnlyNotice message="The Vault is available to the workspace owner only." />
+            }
+          >
+            <VaultWorkspace
+              open
+              onOpenChange={() => {}}
+              initialTab={null}
+              initialFocusKey={null}
+              initialFocusProfileId={null}
+              presentation="framed-page"
+            />
+          </RoleGate>
+        </FramedPageBody>
+      </FramedPage>
     </ShellViewAgentSurface>
   );
 }

--- a/packages/ui/src/components/settings/SecretsManagerSection.tsx
+++ b/packages/ui/src/components/settings/SecretsManagerSection.tsx
@@ -205,8 +205,8 @@ export function VaultModal({
 }
 
 export interface VaultWorkspaceProps extends VaultModalProps {
-  /** Dialog chrome for the shortcut modal; page chrome for `/vault`. */
-  presentation?: "dialog" | "page";
+  /** Dialog chrome, legacy self-owned page chrome, or canonical framed-page chrome. */
+  presentation?: "dialog" | "page" | "framed-page";
 }
 
 export function VaultWorkspace({
@@ -535,7 +535,7 @@ export function VaultWorkspace({
 
   return (
     <>
-      {presentation === "dialog" ? (
+      {presentation === "framed-page" ? null : presentation === "dialog" ? (
         <DialogHeader className="shrink-0">
           <DialogTitle className="flex items-center justify-between gap-2">
             <span className="flex items-center gap-2">
@@ -575,7 +575,7 @@ export function VaultWorkspace({
 
       <div
         data-chat-occlusion-policy={
-          presentation === "page" ? "hide" : undefined
+          presentation !== "dialog" ? "hide" : undefined
         }
         className="flex min-h-0 flex-1 flex-col gap-3 overflow-hidden pt-2"
       >

--- a/packages/ui/src/layouts/framed-page/framed-page.tsx
+++ b/packages/ui/src/layouts/framed-page/framed-page.tsx
@@ -1,0 +1,132 @@
+/**
+ * Canonical anatomy for ordinary framed product pages. It fixes header,
+ * navigation, content-width, scrolling, and composer-clearance geometry while
+ * leaving full-canvas surfaces outside this boundary.
+ */
+import type { HTMLAttributes, ReactNode } from "react";
+
+import { ViewHeader } from "../../components/shared/ViewHeader";
+import { cn } from "../../lib/utils";
+
+export interface FramedPageProps extends HTMLAttributes<HTMLDivElement> {
+  children: ReactNode;
+  reserveComposer?: boolean;
+}
+
+export function FramedPage({
+  className,
+  children,
+  reserveComposer = true,
+  ...props
+}: FramedPageProps) {
+  return (
+    <div
+      className={cn(
+        "flex h-full min-h-0 w-full min-w-0 flex-col",
+        reserveComposer &&
+          "pb-[var(--eliza-chat-clearance,5.25rem)] pe-[var(--eliza-chat-side-clearance,0px)]",
+        className,
+      )}
+      data-framed-page=""
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+export interface FramedPageHeaderProps {
+  title: ReactNode;
+  description?: ReactNode;
+  actions?: ReactNode;
+  onBack?: () => void;
+  backLabel?: string;
+  showBack?: boolean;
+  className?: string;
+}
+
+export function FramedPageHeader({
+  title,
+  description,
+  actions,
+  onBack,
+  backLabel,
+  showBack,
+  className,
+}: FramedPageHeaderProps) {
+  return (
+    <div className={cn("shrink-0", className)} data-framed-page-header="">
+      <ViewHeader
+        title={title}
+        right={actions}
+        onBack={onBack}
+        backLabel={backLabel}
+        showBack={showBack}
+      />
+      {description ? (
+        <div className="mx-auto w-full max-w-5xl px-4 pb-3 text-sm text-muted sm:px-6 lg:px-8">
+          {description}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export interface FramedPageNavigationProps
+  extends HTMLAttributes<HTMLDivElement> {
+  children: ReactNode;
+  padded?: boolean;
+}
+
+export function FramedPageNavigation({
+  children,
+  className,
+  padded = true,
+  ...props
+}: FramedPageNavigationProps) {
+  return (
+    <div
+      className={cn(
+        "mx-auto w-full max-w-5xl shrink-0 pb-2",
+        padded && "px-4 sm:px-6 lg:px-8",
+        className,
+      )}
+      data-framed-page-navigation=""
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+export interface FramedPageBodyProps extends HTMLAttributes<HTMLDivElement> {
+  children: ReactNode;
+  scroll?: "page" | "view";
+  padded?: boolean;
+}
+
+export function FramedPageBody({
+  children,
+  className,
+  scroll = "page",
+  padded = true,
+  ...props
+}: FramedPageBodyProps) {
+  return (
+    <div
+      className={cn(
+        "mx-auto flex min-h-0 w-full max-w-5xl min-w-0 flex-1 flex-col",
+        padded && "px-4 sm:px-6 lg:px-8",
+        scroll === "page"
+          ? "eliza-chat-scroll overflow-y-auto"
+          : "overflow-hidden",
+        className,
+      )}
+      data-framed-page-body=""
+      data-framed-page-scroll={scroll}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}

--- a/packages/ui/src/layouts/framed-page/index.ts
+++ b/packages/ui/src/layouts/framed-page/index.ts
@@ -1,0 +1,11 @@
+/** Exports the canonical framed product-page anatomy. */
+export {
+  FramedPage,
+  FramedPageBody,
+  type FramedPageBodyProps,
+  FramedPageHeader,
+  type FramedPageHeaderProps,
+  FramedPageNavigation,
+  type FramedPageNavigationProps,
+  type FramedPageProps,
+} from "./framed-page";

--- a/packages/ui/src/layouts/index.ts
+++ b/packages/ui/src/layouts/index.ts
@@ -2,6 +2,7 @@
  * Barrel for the layout components (page/content/workspace).
  */
 export * from "./content-layout";
+export * from "./framed-page";
 export * from "./page-frame";
 export * from "./page-layout";
 export * from "./workspace-layout";


### PR DESCRIPTION
# Relates to

Closes #29222.

- [x] Targets `develop` and is rebased onto current `origin/develop` with zero conflicts.
- [x] `bun install` and exact-head verification were run; the unrelated repository-wide blocker is recorded below.
- [x] Reviewers can inspect the rendered behavior from the evidence below.

# Sync with develop

- [x] Rebased onto `origin/develop`; zero conflicts.
- [x] The exact unrelated `bun run verify` blocker is documented under Known gaps / failures.

# Risks

Low-to-medium UI layout risk. The change affects the shared geometry and scroll/composer ownership of Character, Projects, Memories, Databases, and Vault. Full-canvas and immersive surfaces are explicitly excluded.

# Background

## What does this PR do?

Adds one canonical `FramedPage` compound layout with fixed header, navigation, 1024px content, scrolling, responsive inset, and chat-composer-clearance slots. It migrates Character (Personality, Skills, and Experience), Projects, Memories, Databases, and Vault away from private page wrappers. It also extends the real all-views audit so these routes fail when their rendered header/body/navigation geometry drifts.

Tab paint and tab component variants are intentionally unchanged; this PR handles only page geometry.

## What kind of change is this?

Improvement and regression fix.

# Documentation changes needed?

No user documentation change. The contract is encoded in the exported layout and rendered audit.

# Testing

## Where should a reviewer start?

Open Character, Projects, Memories, Databases, and Vault at desktop and mobile widths. Confirm their content begins on the same centered frame, header/navigation/body order remains fixed, each body scrolls, and the floating composer covers no actionable content.

## Detailed testing steps

1. Open each affected route from the launcher.
2. Compare the left/right content edges and top anatomy.
3. Resize to phone portrait and landscape.
4. Scroll Character Personality and Experience to their final actions and confirm the composer does not occlude them.
5. Run the focused all-views audit grep recorded below.

# Evidence Gate

<!-- evidence-head:622990841a45ead639dd8c538244312f7ac19dde -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29303-before-desktop-landscape-v2.jpg)
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29303-after-desktop-landscape-v3.jpg)
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29303-walkthrough-v3.mp4
<!-- evidence-row:backend-logs -->
- [ ] N/A - presentation-only UI geometry; no backend route fires.
<!-- evidence-row:frontend-logs -->
- [x] [29303-frontend-audit-v4.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29303-frontend-audit-v4.log)
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no domain state or persistence changed.
<!-- evidence-row:ocr-review -->
- [x] [29303-ocr-triage-v3.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29303-ocr-triage-v3.json)

# Review fixes

- Preserved `DatabaseView` page-mode behavior with an explicit layout contract; the disconnected state is exclusive and now has a regression test.
- Removed the Projects apps segment double composer clearance.
- Rendered `contentHeader` through the canonical Databases header instead of silently discarding it.
- Restored `leftNav` and `contentHeader` forwarding to the dynamically loaded vector-browser view.
- Scoped geometry checks to one visible `FramedPage` root.
- Rebased onto current `origin/develop` and preserved the newer Memories runtime-unavailable state.

# Evidence Details

## Backend + frontend logs

Backend: N/A - presentation-only UI geometry.

Frontend: the original geometry capture is attached below. After the review fixes and rebase, the focused Vitest set passed 47/47 and the affected-route browser run rendered all 28 route/viewport cases. The database page passed in all four viewports. The strict aggregate still reports current Character, Skills, and Experience readable-character budgets plus one mobile hover timeout; see Known gaps / failures.

## Screenshots (before / after) + video walkthrough

### Before

Page order in both contact sheets: Projects, Character Personality, Character Skills, Character Experience, Memories, Databases, Vault.

- [Desktop full-page contact sheet](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29303-before-desktop-landscape.jpg)
- [Mobile full-page contact sheet](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29303-before-mobile-portrait.jpg)

### After

- [Desktop full-page contact sheet](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29303-after-desktop-landscape.jpg)
- [Mobile full-page contact sheet](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29303-after-mobile-portrait.jpg)

### Walkthrough video

[23-second walkthrough of all seven affected routes at desktop and mobile sizes](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/29303-walkthrough.mp4)

## Known gaps / failures

- `bun run verify`: all 375 Turbo type/lint tasks passed, then the repository-wide `audit:scripts` step failed on an unrelated current-`develop` coupling finding in `scripts/portable-linux-fused-inference.mjs` for `plugins/plugin-local-inference`. This branch does not touch either path.
- On the rebased review-fix head, full `audit:app` could not enter any view because current `develop` does not stub the new `POST /api/cloud/login` call. With a local-only route stub, the affected-route run rendered 28/28 cases; 27 Playwright cases passed and the final strict collector failed on 12 readable-character budgets across Character, Skills, and Experience. Databases, Memories, Projects, and Vault passed their rendered geometry checks in every viewport. The temporary auth stub was removed and is not part of this PR.
- The mobile Character `Add Post` hover probe logs a timeout because hover is unavailable at the phone viewport; the rendered overlap verdict is green.

## Maintainer CI exception record

N/A - no exception requested.







