### PR TITLE
fix(plugin-coding-tools): grep count mode reports a fabricated command failure on zero matches

### DIFF
--- a/plugins/plugin-coding-tools/src/actions/grep.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/grep.test.ts
@@ -225,6 +225,53 @@ describe("GREP", () => {
     ).toBe(0);
   });
 
+  it("returns matches_count:0 for count mode on a zero-match pattern", async () => {
+    const bundle = await buildRuntime();
+    if (!bundle) {
+      console.warn("no ripgrep available, skipping");
+      return;
+    }
+    const { runtime, message } = bundle;
+
+    // ripgrep exits 1 on zero matches in EVERY mode; count mode must surface
+    // that as a clean empty answer, not a fabricated command failure.
+    const result = await grepHandler(runtime, message, state, {
+      parameters: {
+        pattern: "ZZZ_DEFINITELY_NO_MATCH_ZZZ",
+        output_mode: "count",
+      },
+    });
+    expect(result.success).toBe(true);
+    expect(result.text).toBe("no matches");
+    const data = result.data as Record<string, unknown> | undefined;
+    expect(data?.matches_count).toBe(0);
+    expect(data?.mode).toBe("count");
+    expect(data?.truncated).toBe(false);
+    // A fabricated failure would have carried the command_failed prefix.
+    expect(result.text).not.toContain("command_failed");
+  });
+
+  it("preserves per-file counts for count mode on a matching pattern", async () => {
+    const bundle = await buildRuntime();
+    if (!bundle) {
+      console.warn("no ripgrep available, skipping");
+      return;
+    }
+    const { runtime, message } = bundle;
+
+    const result = await grepHandler(runtime, message, state, {
+      parameters: { pattern: "NEEDLE", output_mode: "count" },
+    });
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown> | undefined;
+    expect(data?.mode).toBe("count");
+    // The count output lists one `path:count` line per matching file; at least
+    // a.ts and notes.md match, so the reported file count is >= 2.
+    expect((data?.matches_count as number) >= 2).toBe(true);
+    expect(result.text).toContain("a.ts");
+    expect(result.text).toMatch(/a\.ts:\d+/);
+  });
+
   it("fails when roomId is missing", async () => {
     const bundle = await buildRuntime();
     if (!bundle) {

--- a/plugins/plugin-coding-tools/src/actions/grep.ts
+++ b/plugins/plugin-coding-tools/src/actions/grep.ts
@@ -139,10 +139,10 @@ export async function grepHandler(
 
     const result = await rg.search(rgOptions, mode);
 
-    if (
-      result.exitCode === 1 &&
-      (mode === "content" || mode === "files_with_matches")
-    ) {
+    // ripgrep exits 1 for "no matches" in EVERY output mode, including
+    // `count`. Treat that uniformly as a clean empty result so a legitimate
+    // "count = 0" answer is not surfaced to the planner as a command failure.
+    if (result.exitCode === 1) {
       const text = "no matches";
       return successActionResult(text, {
         matches_count: 0,


### PR DESCRIPTION
## Summary

The FILE `grep` handler in `plugins/plugin-coding-tools` reported a **fabricated command failure** whenever a `output_mode: "count"` search found zero matches.

ripgrep exits with code **1** to signal "no matches" in *every* output mode, including `--count`. The handler only mapped exit 1 to a clean empty result for `content` and `files_with_matches`:

```ts
if (result.exitCode === 1 && (mode === "content" || mode === "files_with_matches")) { ... }
```

So a legitimate zero-match `count` query fell through to the generic non-zero-exit branch and returned:

```json
{ "success": false, "text": "[CodingTools] command_failed: ripgrep exited 1: ", "error": {} }
```

## User-facing impact

`count` is a fully supported `RipgrepMode` (`isValidMode` accepts it). When the model/planner asked "how many occurrences of X?" and the true answer was **0**, the tool surfaced a **failure** instead of `matches_count: 0`. The model could not distinguish "0 occurrences" from a real ripgrep error — a fabricated failure for an expected empty result, which violates the repository's fail-fast / no-fabricated-success-or-failure error policy.

## Fix

Broaden the zero-match early return to `result.exitCode === 1` (ripgrep uses exit 1 = no matches for every mode), returning `successActionResult("no matches", { matches_count: 0, mode, truncated: false })`. One conditional in one file; no API change.

```diff
-    if (
-      result.exitCode === 1 &&
-      (mode === "content" || mode === "files_with_matches")
-    ) {
+    // ripgrep exits 1 for "no matches" in EVERY output mode, including
+    // `count`. Treat that uniformly as a clean empty result so a legitimate
+    // "count = 0" answer is not surfaced to the planner as a command failure.
+    if (result.exitCode === 1) {
```

## Scope boundary

- Only `plugins/plugin-coding-tools/src/actions/grep.ts` (handler) and `grep.test.ts` (regression tests).
- No change to `RipgrepService`, the mode set, or any public surface. The count-mode *matching* path (exit 0) is unchanged; that path already reported per-file counts and still does.

## Tests

Added two real end-to-end regression tests to `grep.test.ts` (both drive the actual `@vscode/ripgrep`/system `rg` binary over a temp workspace via the existing `buildRuntime` harness):

1. **count mode + zero-match pattern** → `success:true`, `text === "no matches"`, `matches_count === 0`, `mode === "count"`, and asserts the text does **not** contain `command_failed`.
2. **count mode + matching pattern** → `success:true`, `mode === "count"`, reported file count `>= 2`, per-file `path:count` output preserved (`a.ts:<n>`).

Existing `content`/`files_with_matches` zero-match cases remain green (regression guard).

### Failing-before / passing-after (real ripgrep binary)

**Before the handler fix** (guard reverted, test present):

```
 ❯ src/actions/grep.test.ts (10 tests | 1 failed) 151ms
     × returns matches_count:0 for count mode on a zero-match pattern 19ms

 FAIL  src/actions/grep.test.ts > GREP > returns matches_count:0 for count mode on a zero-match pattern
AssertionError: expected false to be true // Object.is equality
- Expected true
+ Received false
 ❯ src/actions/grep.test.ts:244:28
    244|       expect(result.success).toBe(true);

 Test Files  1 failed (1)
      Tests  1 failed | 9 passed (10)
```

**After the fix:**

```
 Test Files  1 passed (1)
      Tests  10 passed (10)
   Duration  15.31s
```

## Verification

| Check | Result |
| --- | --- |
| `bunx vitest run src/actions/grep.test.ts` (real rg) | ✅ 10 passed |
| `bun run --cwd plugins/plugin-coding-tools typecheck` | ✅ `tsc --noEmit` clean |
| `bunx @biomejs/biome check` (grep.ts, grep.test.ts) | ✅ No fixes applied |
| Failing-before reproduction | ✅ captured (see above) |
| `git status` | ✅ only the two intended files changed |

Independent confirmation: `rg --count ZZZNOPE <dir>; echo $?` prints exit `1` on zero matches, matching the handler's assumption for every mode.

## Evidence

| Row | Provided |
| --- | --- |
| Focused test output (failing-before / passing-after) | Inline above; artifact URLs bound post-merge via `pr-evidence.mjs` |
| Handler diff | Inline above |
| Backend/runtime logs | N/A - pure library handler change; the test harness drives the real `rg` binary and its ActionResult is the artifact |
| Live-model trajectory | N/A - no model/prompt path changed; the fix is in tool exit-code mapping |
| Frontend screenshots/video | N/A - no UI surface touched |

Closes #29305

<!-- evidence-head:d8ec1e0714c4252b96cfc554b49cf7b526f59ceb -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend library fix (grep exit-code mapping); no UI surface changed

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend library fix; no UI surface changed

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - non-interactive tool handler change; behavior is proven by the real-ripgrep test run inline

<!-- evidence-row:backend-logs -->
- [ ] N/A - complete failing-before and passing-after real-ripgrep vitest transcripts are embedded inline in this PR body; fork account is not authorized to upload release assets to elizaOS/eliza

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend/browser path touched

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no prompt/provider/model path changed; fix is in ripgrep exit-code mapping only

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - the failing-then-passing reproduction (vitest over the real @vscode/ripgrep/system rg binary) is captured inline in this PR body; release-asset upload is unauthorized for this fork account

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@d8ec1e0714c4252b96cfc554b49cf7b526f59ceb:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@d8ec1e0714c4252b96cfc554b49cf7b526f59ceb:packages/skills/skills/contribute-to-eliza"} -->
