### PR TITLE
fix(android): retain remote hard pin across UI routes

### DIFF
--- a/packages/app-core/platforms/android/README.md
+++ b/packages/app-core/platforms/android/README.md
@@ -233,11 +233,16 @@ credential-free root HTTPS origin through
 `VITE_ELIZA_REMOTE_FALLBACK_API_BASE`; the build fails before Android tooling
 starts when the origin is absent or widened. Before React mounts, the
 app replaces any stale Cloud/local target with that exact remote server and
-marks remote setup complete. A paired bearer is retained only when it already
-belongs to the compiled origin; switching the compiled origin drops it and
-requires pairing again. The origin is a fetch target, not an extra Capacitor
-WebView navigation host. No pairing code, bearer, SSH address, or other
-credential is compiled into the APK.
+marks remote setup complete. The compiled origin remains authoritative for the
+lifetime of the app: live client repoints and active-server writes targeting
+Cloud, local, or a different remote are rejected, including their accompanying
+credentials. The target is also written through the awaited native storage
+bridge before first render so a stale native Cloud record cannot rehydrate on
+the next cold launch. A paired bearer is retained only when it already belongs
+to the compiled origin; switching the compiled origin drops it and requires
+pairing again. The origin is a fetch target, not an extra Capacitor WebView
+navigation host. No pairing code, bearer, SSH address, or other credential is
+compiled into the APK.
 
 The build flag alone cannot activate the guard. On a Light/TLP301 device, the
 operator must grant the declared privileged permission, then send the explicit

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -3615,7 +3615,7 @@ async function main(): Promise<void> {
   // with this wait.
   await initializeStorageBridge();
   if (isAndroid) {
-    installMobileRemoteFallback();
+    await installMobileRemoteFallback(undefined, client);
   }
   if (isIOS) {
     initializeCapacitorBridge();

--- a/packages/app/src/mobile-remote-fallback.test.ts
+++ b/packages/app/src/mobile-remote-fallback.test.ts
@@ -17,6 +17,11 @@ beforeEach(() => {
 
 afterEach(() => {
   localStorage.clear();
+  delete (
+    globalThis as typeof globalThis & {
+      __ELIZA_BUILD_CONFIGURED_REMOTE_API_BASE__?: unknown;
+    }
+  ).__ELIZA_BUILD_CONFIGURED_REMOTE_API_BASE__;
 });
 
 describe("resolveMobileRemoteFallbackApiBase", () => {
@@ -95,6 +100,18 @@ describe("resolveMobileRemoteFallbackApiBase", () => {
 
     expect(client.setBaseUrl).toHaveBeenCalledWith(FALLBACK_BASE);
     expect(client.setToken).toHaveBeenCalledWith(null);
+  });
+
+  it("publishes the build target to pre-built UI trust gates", async () => {
+    await installMobileRemoteFallback(FALLBACK_ENV);
+
+    expect(
+      (
+        globalThis as typeof globalThis & {
+          __ELIZA_BUILD_CONFIGURED_REMOTE_API_BASE__?: unknown;
+        }
+      ).__ELIZA_BUILD_CONFIGURED_REMOTE_API_BASE__,
+    ).toBe(FALLBACK_BASE);
   });
 
   it("replaces a stale active Cloud profile instead of copying its token", async () => {

--- a/packages/app/src/mobile-remote-fallback.test.ts
+++ b/packages/app/src/mobile-remote-fallback.test.ts
@@ -1,5 +1,5 @@
 /** Exercises strict fallback-origin validation and real browser persistence. */
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   installMobileRemoteFallback,
   resolveMobileRemoteFallbackApiBase,
@@ -28,8 +28,8 @@ describe("resolveMobileRemoteFallbackApiBase", () => {
     ).toBe("https://fallback.example.test");
   });
 
-  it("installs the fallback as a completed remote runtime", () => {
-    expect(installMobileRemoteFallback(FALLBACK_ENV)).toBe(true);
+  it("installs the fallback as a completed remote runtime", async () => {
+    await expect(installMobileRemoteFallback(FALLBACK_ENV)).resolves.toBe(true);
     expect(
       JSON.parse(localStorage.getItem("elizaos:active-server") ?? "null"),
     ).toEqual({
@@ -44,7 +44,7 @@ describe("resolveMobileRemoteFallbackApiBase", () => {
     expect(localStorage.getItem("eliza:first-run-complete")).toBe("1");
   });
 
-  it("preserves a paired credential only for the exact fallback origin", () => {
+  it("preserves a paired credential only for the exact fallback origin", async () => {
     localStorage.setItem(
       "elizaos:active-server",
       JSON.stringify({
@@ -56,7 +56,7 @@ describe("resolveMobileRemoteFallbackApiBase", () => {
       }),
     );
 
-    installMobileRemoteFallback(FALLBACK_ENV);
+    await installMobileRemoteFallback(FALLBACK_ENV);
 
     expect(
       JSON.parse(localStorage.getItem("elizaos:active-server") ?? "null"),
@@ -76,10 +76,68 @@ describe("resolveMobileRemoteFallbackApiBase", () => {
         accessToken: "must-not-survive",
       }),
     );
-    installMobileRemoteFallback(FALLBACK_ENV);
+    await installMobileRemoteFallback(FALLBACK_ENV);
     expect(
       JSON.parse(localStorage.getItem("elizaos:active-server") ?? "null"),
-    ).not.toHaveProperty("accessToken");
+    ).toMatchObject({
+      apiBase: FALLBACK_BASE,
+      accessToken: "paired-session",
+    });
+  });
+
+  it("pins the live client to the authoritative target before rendering", async () => {
+    const client = {
+      setBaseUrl: vi.fn(),
+      setToken: vi.fn(),
+    };
+
+    await installMobileRemoteFallback(FALLBACK_ENV, client);
+
+    expect(client.setBaseUrl).toHaveBeenCalledWith(FALLBACK_BASE);
+    expect(client.setToken).toHaveBeenCalledWith(null);
+  });
+
+  it("replaces a stale active Cloud profile instead of copying its token", async () => {
+    localStorage.setItem(
+      "elizaos:active-server",
+      JSON.stringify({
+        id: "cloud:personal:test",
+        kind: "cloud",
+        label: "Eliza",
+        apiBase: "https://api.eliza.app/api/v1/eliza/agents/personal:test",
+        accessToken: "cloud-session",
+      }),
+    );
+    localStorage.setItem(
+      "elizaos:agent-profiles",
+      JSON.stringify({
+        version: 1,
+        activeProfileId: "cloud-profile",
+        profiles: [
+          {
+            id: "cloud-profile",
+            kind: "cloud",
+            label: "Eliza",
+            apiBase: "https://api.eliza.app/api/v1/eliza/agents/personal:test",
+            accessToken: "cloud-session",
+            createdAt: "2026-08-26T00:00:00.000Z",
+          },
+        ],
+      }),
+    );
+
+    await installMobileRemoteFallback(FALLBACK_ENV);
+
+    const registry = JSON.parse(
+      localStorage.getItem("elizaos:agent-profiles") ?? "null",
+    );
+    expect(registry.profiles).toHaveLength(1);
+    expect(registry.profiles[0]).toMatchObject({
+      kind: "remote",
+      apiBase: FALLBACK_BASE,
+    });
+    expect(registry.profiles[0]).not.toHaveProperty("accessToken");
+    expect(registry.activeProfileId).toBe(registry.profiles[0].id);
   });
 
   it("is disabled when the build variable is absent", () => {

--- a/packages/app/src/mobile-remote-fallback.ts
+++ b/packages/app/src/mobile-remote-fallback.ts
@@ -21,6 +21,7 @@ import {
   savePersistedActiveServer,
   savePersistedFirstRunComplete,
 } from "@elizaos/ui/state/persistence";
+import { installBuildConfiguredRemoteApiBaseUrl } from "@elizaos/ui/state/runtime-url-trust";
 
 const REMOTE_FALLBACK_API_BASE_ENV_KEY = "VITE_ELIZA_REMOTE_FALLBACK_API_BASE";
 const REMOTE_FALLBACK_SERVER_ID = "remote:lp3-vps";
@@ -101,6 +102,12 @@ export async function installMobileRemoteFallback(
 ): Promise<boolean> {
   const apiBase = getMobileRemoteFallbackApiBase(env);
   if (!apiBase) return false;
+
+  // The app entrypoint sees the Vite build variable even when @elizaos/ui was
+  // pre-built before Vite ran. Publish the validated origin before any shared
+  // persistence/client code executes so its hard-pin gates cannot disappear
+  // after the first route transition.
+  installBuildConfiguredRemoteApiBaseUrl(apiBase);
 
   const current = loadPersistedActiveServer();
   const profileCredential = loadAgentProfileRegistry().profiles.find(

--- a/packages/app/src/mobile-remote-fallback.ts
+++ b/packages/app/src/mobile-remote-fallback.ts
@@ -4,7 +4,18 @@
  * preserves a paired credential only when it belongs to the exact configured
  * origin; stale Cloud, local, or other-remote records are replaced fail-fast.
  */
-import { persistMobileRuntimeModeForServerTarget } from "@elizaos/ui/first-run/mobile-runtime-mode";
+
+import { setStorageValue } from "@elizaos/ui/bridge/storage-bridge";
+import {
+  MOBILE_RUNTIME_MODE_STORAGE_KEY,
+  persistMobileRuntimeModeForServerTarget,
+} from "@elizaos/ui/first-run/mobile-runtime-mode";
+import {
+  type AgentProfileRegistry,
+  loadAgentProfileRegistry,
+  saveAgentProfileRegistry,
+  upsertAndActivateAgentProfile,
+} from "@elizaos/ui/state/agent-profiles";
 import {
   loadPersistedActiveServer,
   savePersistedActiveServer,
@@ -14,6 +25,14 @@ import {
 const REMOTE_FALLBACK_API_BASE_ENV_KEY = "VITE_ELIZA_REMOTE_FALLBACK_API_BASE";
 const REMOTE_FALLBACK_SERVER_ID = "remote:lp3-vps";
 const REMOTE_FALLBACK_LABEL = "Eliza VPS";
+const ACTIVE_SERVER_STORAGE_KEY = "elizaos:active-server";
+const AGENT_PROFILES_STORAGE_KEY = "elizaos:agent-profiles";
+const FIRST_RUN_COMPLETE_STORAGE_KEY = "eliza:first-run-complete";
+
+interface RemoteFallbackClient {
+  setBaseUrl(baseUrl: string): void;
+  setToken(token: string | null): void;
+}
 
 type RuntimeEnv = Record<string, unknown>;
 
@@ -76,33 +95,74 @@ export function getMobileRemoteFallbackApiBase(
  * Calling this after Capacitor storage hydration keeps a valid paired session
  * while repairing stale targets before startup-state readers run.
  */
-export function installMobileRemoteFallback(
+export async function installMobileRemoteFallback(
   env: RuntimeEnv = runtimeEnv(),
-): boolean {
+  client?: RemoteFallbackClient,
+): Promise<boolean> {
   const apiBase = getMobileRemoteFallbackApiBase(env);
   if (!apiBase) return false;
 
   const current = loadPersistedActiveServer();
-  const keepCredential =
+  const profileCredential = loadAgentProfileRegistry().profiles.find(
+    (profile) =>
+      profile.kind === "remote" &&
+      profile.apiBase?.replace(/\/+$/, "") === apiBase &&
+      profile.accessToken,
+  )?.accessToken;
+  const currentCredential =
     current?.kind === "remote" &&
-    current.apiBase?.replace(/\/+$/, "") === apiBase;
-  const saved = savePersistedActiveServer({
-    ...(keepCredential ? current : {}),
+    current.apiBase?.replace(/\/+$/, "") === apiBase
+      ? current.accessToken
+      : undefined;
+  const accessToken = currentCredential ?? profileCredential;
+  const authoritativeServer = {
+    ...(currentCredential ? current : {}),
     id: REMOTE_FALLBACK_SERVER_ID,
     kind: "remote",
     label: REMOTE_FALLBACK_LABEL,
     apiBase,
-    ...(keepCredential && current?.accessToken
-      ? { accessToken: current.accessToken }
-      : {}),
-  });
+    ...(accessToken ? { accessToken } : {}),
+  } as const;
+  const saved = savePersistedActiveServer(authoritativeServer);
   if (!saved) {
     throw new Error(
       "[mobile-remote-fallback] failed to persist the authoritative remote target",
     );
   }
 
+  const pinnedProfile = upsertAndActivateAgentProfile({
+    kind: "remote",
+    label: REMOTE_FALLBACK_LABEL,
+    apiBase,
+    ...(accessToken ? { accessToken } : {}),
+  });
+  const pinnedRegistry: AgentProfileRegistry = {
+    version: 1,
+    activeProfileId: pinnedProfile.id,
+    profiles: [pinnedProfile],
+  };
+  if (!saveAgentProfileRegistry(pinnedRegistry)) {
+    throw new Error(
+      "[mobile-remote-fallback] failed to persist the authoritative remote profile",
+    );
+  }
   persistMobileRuntimeModeForServerTarget("remote");
   savePersistedFirstRunComplete(true);
+
+  // Native storage is the cold-launch authority. Await the complete target,
+  // profile, mode, and onboarding commit before rendering so a process kill
+  // cannot rehydrate any stale Cloud selection on the next start.
+  await Promise.all([
+    setStorageValue(
+      ACTIVE_SERVER_STORAGE_KEY,
+      JSON.stringify(authoritativeServer),
+    ),
+    setStorageValue(AGENT_PROFILES_STORAGE_KEY, JSON.stringify(pinnedRegistry)),
+    setStorageValue(MOBILE_RUNTIME_MODE_STORAGE_KEY, "remote-mac"),
+    setStorageValue(FIRST_RUN_COMPLETE_STORAGE_KEY, "1"),
+  ]);
+
+  client?.setBaseUrl(apiBase);
+  client?.setToken(accessToken ?? null);
   return true;
 }

--- a/packages/ui/src/api/client-base-pinned-remote.test.ts
+++ b/packages/ui/src/api/client-base-pinned-remote.test.ts
@@ -1,0 +1,107 @@
+/** Proves a dedicated remote build cannot drift its live client to Cloud. */
+// @vitest-environment jsdom
+// @vitest-environment-options {"url":"https://localhost/"}
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { savePersistedActiveServer } from "../state/persistence";
+import { ElizaClient } from "./client-base";
+
+const PINNED_BASE = "https://fallback.example.test";
+
+vi.mock("../state/runtime-url-trust", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../state/runtime-url-trust")>()),
+  getBuildConfiguredRemoteApiBaseUrl: () => "https://fallback.example.test",
+}));
+
+function persistPinnedCredential(token: string): void {
+  savePersistedActiveServer({
+    id: "remote:lp3-vps",
+    kind: "remote",
+    label: "Eliza VPS",
+    apiBase: PINNED_BASE,
+    accessToken: token,
+  });
+}
+
+describe("ElizaClient build-pinned remote target", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    localStorage.clear();
+  });
+
+  it("starts on the pinned target and ignores an unrelated constructor token", () => {
+    const client = new ElizaClient(
+      "https://api.eliza.app/api/v1/eliza/agents/personal:test",
+      "cloud-session",
+    );
+
+    expect(client.getBaseUrl()).toBe(PINNED_BASE);
+    expect(client.getRestAuthToken()).toBeNull();
+  });
+
+  it("rejects a Cloud base and the credential that follows it", () => {
+    persistPinnedCredential("vps-session");
+    const client = new ElizaClient(PINNED_BASE, "vps-session");
+
+    client.setBaseUrl(
+      "https://api.eliza.app/api/v1/eliza/agents/personal:test",
+      { persist: false },
+    );
+    client.setToken("cloud-session");
+
+    expect(client.getBaseUrl()).toBe(PINNED_BASE);
+    expect(client.getRestAuthToken()).toBe("vps-session");
+  });
+
+  it("rejects an atomic Cloud repoint without opening a connection", () => {
+    const sockets: string[] = [];
+    vi.stubGlobal(
+      "WebSocket",
+      class {
+        constructor(url: string) {
+          sockets.push(url);
+        }
+      },
+    );
+    persistPinnedCredential("vps-session");
+    const client = new ElizaClient(PINNED_BASE, "vps-session");
+
+    client.repointBaseUrl(
+      "https://api.eliza.app/api/v1/eliza/agents/personal:test",
+      "cloud-session",
+    );
+
+    expect(client.getBaseUrl()).toBe(PINNED_BASE);
+    expect(client.getRestAuthToken()).toBe("vps-session");
+    expect(sockets).toEqual([]);
+  });
+
+  it("rejects a delayed Cloud credential even after the pinned base is reaffirmed", () => {
+    persistPinnedCredential("vps-session");
+    const client = new ElizaClient(PINNED_BASE, "vps-session");
+
+    client.setBaseUrl(
+      "https://api.eliza.app/api/v1/eliza/agents/personal:test",
+      { persist: false },
+    );
+    client.setBaseUrl(PINNED_BASE, { persist: false });
+    client.setToken("cloud-session");
+
+    expect(client.getBaseUrl()).toBe(PINNED_BASE);
+    expect(client.getRestAuthToken()).toBe("vps-session");
+  });
+
+  it("accepts a newly paired bearer after exact-origin persistence", () => {
+    persistPinnedCredential("old-vps-session");
+    const client = new ElizaClient(PINNED_BASE, "old-vps-session");
+
+    persistPinnedCredential("new-vps-session");
+    client.setToken("new-vps-session");
+
+    expect(client.getRestAuthToken()).toBe("new-vps-session");
+  });
+});

--- a/packages/ui/src/api/client-base.ts
+++ b/packages/ui/src/api/client-base.ts
@@ -36,6 +36,7 @@ import {
   savePersistedActiveServer,
 } from "../state/persistence";
 import {
+  getBuildConfiguredRemoteApiBaseUrl,
   isTrustedCloudApiBaseUrl,
   isTrustedRestoreApiBaseUrl,
 } from "../state/runtime-url-trust";
@@ -867,6 +868,7 @@ export class ElizaClient {
   private _baseUrl: string;
   private _userSetBase: boolean;
   private _token: string | null;
+  private readonly pinnedRemoteApiBase = getBuildConfiguredRemoteApiBaseUrl();
   /** Last cloud agent base released after an agent-gone 404 (idempotency). */
   private _releasedGoneAgentBase: string | null = null;
   private personalElizaRuntimeRepoint: Promise<boolean> | null = null;
@@ -937,7 +939,6 @@ export class ElizaClient {
 
   constructor(baseUrl?: string, token?: string) {
     this.clientId = ElizaClient.generateClientId();
-    this._token = token?.trim() || null;
 
     const bootBase = getBootConfig().apiBase;
     const injectedBase = getElizaApiBase();
@@ -953,13 +954,23 @@ export class ElizaClient {
       ? null
       : storedBaseRaw;
 
-    this._userSetBase = baseUrl != null;
-
     // Priority: explicit arg > boot config > desktop injection > session storage > same origin.
     // `client.setBaseUrl()` updates the boot config, so it must beat the
     // shell-injected local default once the user has chosen a different
     // server. Injection still beats stale session state from prior sessions.
-    this._baseUrl = baseUrl ?? bootBase ?? injectedBase ?? storedBase ?? "";
+    const initialBase = normalizeBaseUrl(
+      baseUrl ?? bootBase ?? injectedBase ?? storedBase ?? "",
+    );
+    this._userSetBase = this.pinnedRemoteApiBase !== null || baseUrl != null;
+    this._baseUrl = this.pinnedRemoteApiBase ?? initialBase;
+    const initialToken = token?.trim() || null;
+    this._token =
+      !initialToken ||
+      !this.pinnedRemoteApiBase ||
+      (initialBase === this.pinnedRemoteApiBase &&
+        this.isPinnedRemoteCredential(initialToken))
+        ? initialToken
+        : null;
   }
 
   /**
@@ -987,6 +998,16 @@ export class ElizaClient {
 
   get apiToken(): string | null {
     if (this._token) return this._token;
+    if (this.pinnedRemoteApiBase) {
+      const activeServer = loadPersistedActiveServer();
+      if (
+        activeServer?.kind === "remote" &&
+        activeServer.apiBase?.replace(/\/+$/, "") === this.pinnedRemoteApiBase
+      ) {
+        return activeServer.accessToken?.trim() || null;
+      }
+      return null;
+    }
     const bootToken = getBootConfig().apiToken;
     if (typeof bootToken === "string" && bootToken.trim())
       return bootToken.trim();
@@ -1014,7 +1035,28 @@ export class ElizaClient {
   }
 
   setToken(token: string | null): void {
+    if (
+      this.pinnedRemoteApiBase &&
+      token?.trim() &&
+      !this.isPinnedRemoteCredential(token)
+    ) {
+      logger.warn(
+        "[ElizaClient] ignored a credential not bound to the build-pinned remote target",
+      );
+      return;
+    }
     this.installToken(token, true);
+  }
+
+  /** A pinned build accepts a bearer only after durable exact-origin binding. */
+  private isPinnedRemoteCredential(token: string): boolean {
+    if (!this.pinnedRemoteApiBase) return true;
+    const activeServer = loadPersistedActiveServer();
+    return (
+      activeServer?.kind === "remote" &&
+      activeServer.apiBase?.replace(/\/+$/, "") === this.pinnedRemoteApiBase &&
+      activeServer.accessToken?.trim() === token.trim()
+    );
   }
 
   /**
@@ -1047,6 +1089,12 @@ export class ElizaClient {
 
   setBaseUrl(baseUrl: string | null, options?: { persist?: boolean }): void {
     const normalized = normalizeBaseUrl(baseUrl);
+    if (this.pinnedRemoteApiBase && normalized !== this.pinnedRemoteApiBase) {
+      logger.warn(
+        "[ElizaClient] ignored a base change outside the build-pinned remote target",
+      );
+      return;
+    }
     const persist = options?.persist !== false;
     this._userSetBase = normalized.length > 0;
     this._baseUrl = normalized;
@@ -1170,6 +1218,22 @@ export class ElizaClient {
   repointBaseUrl(baseUrl: string, token?: string | null): void {
     const normalized = normalizeBaseUrl(baseUrl);
     if (!normalized) return;
+    if (this.pinnedRemoteApiBase && normalized !== this.pinnedRemoteApiBase) {
+      logger.warn(
+        "[ElizaClient] ignored a repoint outside the build-pinned remote target",
+      );
+      return;
+    }
+    if (
+      this.pinnedRemoteApiBase &&
+      token?.trim() &&
+      !this.isPinnedRemoteCredential(token)
+    ) {
+      logger.warn(
+        "[ElizaClient] ignored a repoint credential not bound to the build-pinned remote target",
+      );
+      return;
+    }
     // Quietly drop the old socket. We intentionally do NOT call disconnectWs():
     // it sets connectionState = "disconnected" and emits, which would surface a
     // visible "reconnecting" flicker mid-handoff. Suppress onclose (which would

--- a/packages/ui/src/state/active-server-credential.test.ts
+++ b/packages/ui/src/state/active-server-credential.test.ts
@@ -11,7 +11,7 @@ import {
   persistActiveServerCredential,
   scrubRejectedActiveServerCredential,
 } from "./active-server-credential";
-import { getActiveProfile } from "./agent-profiles";
+import { getActiveProfile, loadAgentProfileRegistry } from "./agent-profiles";
 import {
   createPersistedActiveServer,
   loadPersistedActiveServer,
@@ -52,6 +52,39 @@ describe("persistActiveServerCredential", () => {
       apiBase: "https://runtime.example.test",
       accessToken: "paired-token",
     });
+  });
+
+  it("does not copy a remote pairing bearer into a stale Cloud profile", async () => {
+    savePersistedActiveServer(
+      createPersistedActiveServer({
+        kind: "cloud",
+        id: "cloud:personal:test",
+        label: "Eliza",
+        apiBase: "https://api.eliza.app/api/v1/eliza/agents/personal:test",
+      }),
+    );
+    expect(getActiveProfile()?.kind).toBe("cloud");
+
+    await persistActiveServerCredential(
+      "vps-session",
+      "https://runtime.example.test",
+    );
+
+    expect(loadPersistedActiveServer()).toMatchObject({
+      kind: "remote",
+      apiBase: "https://runtime.example.test",
+      accessToken: "vps-session",
+    });
+    expect(getActiveProfile()).toMatchObject({
+      kind: "remote",
+      apiBase: "https://runtime.example.test",
+      accessToken: "vps-session",
+    });
+    expect(
+      loadAgentProfileRegistry().profiles.find(
+        (profile) => profile.kind === "cloud",
+      )?.accessToken,
+    ).toBeUndefined();
   });
 
   it("scrubs a rejected active credential without dropping the target", async () => {

--- a/packages/ui/src/state/active-server-credential.ts
+++ b/packages/ui/src/state/active-server-credential.ts
@@ -5,7 +5,11 @@
  */
 
 import { setStorageValue } from "../bridge/storage-bridge";
-import { getActiveProfile, updateAgentProfile } from "./agent-profiles";
+import {
+  getActiveProfile,
+  updateAgentProfile,
+  upsertAndActivateAgentProfile,
+} from "./agent-profiles";
 import {
   createPersistedActiveServer,
   loadPersistedActiveServer,
@@ -26,10 +30,14 @@ export async function persistActiveServerCredential(
         accessToken: token,
       })
     : null;
+  // An explicit pairing base is the credential authority. A stale active
+  // Cloud/profile selection must never redirect that newly minted remote
+  // bearer into its own record.
   const credentialTarget =
-    activeServer && activeServer.kind !== "local"
+    fallbackRemote ??
+    (activeServer && activeServer.kind !== "local"
       ? { ...activeServer, accessToken: token }
-      : fallbackRemote;
+      : null);
   if (credentialTarget) {
     const authenticatedServer = credentialTarget;
     savePersistedActiveServer(authenticatedServer);
@@ -43,8 +51,21 @@ export async function persistActiveServerCredential(
   }
 
   const activeProfile = getActiveProfile();
-  if (activeProfile && activeProfile.kind !== "local") {
+  const sameCredentialTarget =
+    activeProfile &&
+    credentialTarget &&
+    activeProfile.kind === credentialTarget.kind &&
+    activeProfile.apiBase?.replace(/\/+$/, "") ===
+      credentialTarget.apiBase?.replace(/\/+$/, "");
+  if (sameCredentialTarget && activeProfile) {
     updateAgentProfile(activeProfile.id, { accessToken: token });
+  } else if (credentialTarget?.kind === "remote") {
+    upsertAndActivateAgentProfile({
+      kind: "remote",
+      label: credentialTarget.label,
+      apiBase: credentialTarget.apiBase,
+      accessToken: token,
+    });
   }
 }
 

--- a/packages/ui/src/state/persistence-pinned-remote.test.ts
+++ b/packages/ui/src/state/persistence-pinned-remote.test.ts
@@ -1,0 +1,106 @@
+/** Proves a build-pinned remote target cannot be replaced in persistence. */
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearPersistedActiveServer,
+  clearPersistedActiveServerDurably,
+  loadPersistedActiveServer,
+  savePersistedActiveServer,
+} from "./persistence";
+
+const PINNED_BASE = "https://fallback.example.test";
+
+vi.mock("./runtime-url-trust", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./runtime-url-trust")>()),
+  getBuildConfiguredRemoteApiBaseUrl: () => "https://fallback.example.test",
+}));
+
+describe("build-pinned remote active server", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("keeps the exact remote record when Cloud tries to replace it", () => {
+    expect(
+      savePersistedActiveServer({
+        id: "remote:lp3-vps",
+        kind: "remote",
+        label: "Eliza VPS",
+        apiBase: PINNED_BASE,
+        accessToken: "vps-session",
+      }),
+    ).toBe(true);
+
+    expect(
+      savePersistedActiveServer({
+        id: "cloud:personal:test",
+        kind: "cloud",
+        label: "Eliza",
+        apiBase: "https://api.eliza.app/api/v1/eliza/agents/personal:test",
+        accessToken: "cloud-session",
+      }),
+    ).toBe(false);
+
+    expect(loadPersistedActiveServer()).toEqual({
+      id: "remote:lp3-vps",
+      kind: "remote",
+      label: "Eliza VPS",
+      apiBase: PINNED_BASE,
+      accessToken: "vps-session",
+    });
+  });
+
+  it("rejects other remote origins as well as Cloud", () => {
+    expect(
+      savePersistedActiveServer({
+        id: "remote:other",
+        kind: "remote",
+        label: "Other",
+        apiBase: "https://other.example.test",
+        accessToken: "other-session",
+      }),
+    ).toBe(false);
+    expect(loadPersistedActiveServer()).toBeNull();
+  });
+
+  it("keeps a tokenless pinned target when ordinary clear is requested", () => {
+    savePersistedActiveServer({
+      id: "remote:lp3-vps",
+      kind: "remote",
+      label: "Eliza VPS",
+      apiBase: PINNED_BASE,
+      accessToken: "vps-session",
+    });
+
+    clearPersistedActiveServer();
+
+    expect(loadPersistedActiveServer()).toMatchObject({
+      kind: "remote",
+      apiBase: PINNED_BASE,
+    });
+    expect(loadPersistedActiveServer()?.accessToken).toBeUndefined();
+  });
+
+  it("keeps the same tokenless target through the durable clear path", async () => {
+    savePersistedActiveServer({
+      id: "remote:lp3-vps",
+      kind: "remote",
+      label: "Eliza VPS",
+      apiBase: PINNED_BASE,
+      accessToken: "vps-session",
+    });
+
+    await clearPersistedActiveServerDurably();
+
+    expect(loadPersistedActiveServer()).toMatchObject({
+      kind: "remote",
+      apiBase: PINNED_BASE,
+    });
+    expect(loadPersistedActiveServer()?.accessToken).toBeUndefined();
+  });
+});

--- a/packages/ui/src/state/persistence.ts
+++ b/packages/ui/src/state/persistence.ts
@@ -10,8 +10,9 @@ import { isTerminalIosNativeAgentBootErrorMessage } from "../api/ios-local-agent
 import { getShaderPreset } from "../backgrounds/shader-presets";
 import { normalizeUniforms } from "../backgrounds/shader-schema";
 import { isElectrobunRuntime } from "../bridge/electrobun-runtime";
-import { removeStorageValue } from "../bridge/storage-bridge";
+import { removeStorageValue, setStorageValue } from "../bridge/storage-bridge";
 import { MAX_BACKGROUND_HISTORY } from "./background-history";
+import { getBuildConfiguredRemoteApiBaseUrl } from "./runtime-url-trust";
 
 // Re-exported so existing `import { MAX_BACKGROUND_HISTORY } from "./persistence"`
 // sites keep working; the single source is the pure reducer module.
@@ -1406,6 +1407,18 @@ export function savePersistedActiveServer(
     return false;
   }
 
+  const pinnedRemoteApiBase = getBuildConfiguredRemoteApiBaseUrl();
+  if (
+    pinnedRemoteApiBase &&
+    (server.kind !== "remote" ||
+      server.apiBase?.replace(/\/+$/, "") !== pinnedRemoteApiBase)
+  ) {
+    logger.warn(
+      "[persistence] rejected active-server change outside the build-pinned remote target",
+    );
+    return false;
+  }
+
   // The active-server record carries the sign-in state (kind/apiBase/token) and
   // the backend the app reconnects to. A swallowed persist failure (quota,
   // private-mode SecurityError) silently loses a freshly-recovered apiBase, so
@@ -1429,6 +1442,20 @@ export function savePersistedActiveServer(
 }
 
 export function clearPersistedActiveServer(): void {
+  const pinnedRemoteApiBase = getBuildConfiguredRemoteApiBaseUrl();
+  if (pinnedRemoteApiBase) {
+    const current = loadPersistedActiveServer();
+    const preserved =
+      current?.kind === "remote" &&
+      current.apiBase?.replace(/\/+$/, "") === pinnedRemoteApiBase
+        ? { ...current, accessToken: undefined }
+        : createPersistedActiveServer({
+            kind: "remote",
+            apiBase: pinnedRemoteApiBase,
+          });
+    savePersistedActiveServer(preserved);
+    return;
+  }
   tryLocalStorage(() => {
     shellLocalStorage.removeItem(ACTIVE_SERVER_STORAGE_KEY);
   }, undefined);
@@ -1436,6 +1463,20 @@ export function clearPersistedActiveServer(): void {
 
 /** Delete the active runtime target from browser and protected native storage. */
 export async function clearPersistedActiveServerDurably(): Promise<void> {
+  const pinnedRemoteApiBase = getBuildConfiguredRemoteApiBaseUrl();
+  if (pinnedRemoteApiBase) {
+    const current = loadPersistedActiveServer();
+    const preserved =
+      current?.kind === "remote" &&
+      current.apiBase?.replace(/\/+$/, "") === pinnedRemoteApiBase
+        ? { ...current, accessToken: undefined }
+        : createPersistedActiveServer({
+            kind: "remote",
+            apiBase: pinnedRemoteApiBase,
+          });
+    await setStorageValue(ACTIVE_SERVER_STORAGE_KEY, JSON.stringify(preserved));
+    return;
+  }
   await removeStorageValue(ACTIVE_SERVER_STORAGE_KEY);
 }
 

--- a/packages/ui/src/state/runtime-url-trust.ts
+++ b/packages/ui/src/state/runtime-url-trust.ts
@@ -31,15 +31,14 @@ function configuredRemoteFallbackApiBase(): string | undefined {
 }
 
 /**
- * Trust one exact HTTPS origin compiled into a dedicated remote-fallback app.
- * The configured value is a root origin only: credentials, custom ports,
- * query/fragment state, and path-scoped targets are rejected.
+ * Return the exact root HTTPS origin compiled into a dedicated remote build.
+ * Invalid build input fails closed so callers can use a non-null result as the
+ * runtime-lock contract, not merely as a restore allow-list entry.
  */
-export function isTrustedBuildConfiguredRemoteApiBaseUrl(
-  apiBase: string | undefined,
+export function getBuildConfiguredRemoteApiBaseUrl(
   configuredBase = configuredRemoteFallbackApiBase(),
-): boolean {
-  if (!apiBase || !configuredBase?.trim()) return false;
+): string | null {
+  if (!configuredBase?.trim()) return null;
 
   try {
     const configured = new URL(configuredBase.trim());
@@ -52,9 +51,30 @@ export function isTrustedBuildConfiguredRemoteApiBaseUrl(
       configured.hash ||
       configured.pathname.replace(/\/+$/, "") !== ""
     ) {
-      return false;
+      return null;
     }
+    return configured.origin;
+  } catch {
+    // error-policy:J3 malformed build input cannot authorize or pin a target.
+    return null;
+  }
+}
 
+/**
+ * Trust one exact HTTPS origin compiled into a dedicated remote-fallback app.
+ * The configured value is a root origin only: credentials, custom ports,
+ * query/fragment state, and path-scoped targets are rejected.
+ */
+export function isTrustedBuildConfiguredRemoteApiBaseUrl(
+  apiBase: string | undefined,
+  configuredBase = configuredRemoteFallbackApiBase(),
+): boolean {
+  if (!apiBase) return false;
+
+  const configuredOrigin = getBuildConfiguredRemoteApiBaseUrl(configuredBase);
+  if (!configuredOrigin) return false;
+
+  try {
     const candidate = new URL(apiBase);
     return (
       candidate.protocol === "https:" &&
@@ -64,7 +84,7 @@ export function isTrustedBuildConfiguredRemoteApiBaseUrl(
       !candidate.search &&
       !candidate.hash &&
       candidate.pathname.replace(/\/+$/, "") === "" &&
-      candidate.origin === configured.origin
+      candidate.origin === configuredOrigin
     );
   } catch {
     // error-policy:J3 malformed build/runtime URL input is never trusted.

--- a/packages/ui/src/state/runtime-url-trust.ts
+++ b/packages/ui/src/state/runtime-url-trust.ts
@@ -20,14 +20,53 @@ import {
 } from "../utils/cloud-agent-base";
 
 const REMOTE_FALLBACK_API_BASE_ENV_KEY = "VITE_ELIZA_REMOTE_FALLBACK_API_BASE";
+const REMOTE_FALLBACK_RUNTIME_GLOBAL =
+  "__ELIZA_BUILD_CONFIGURED_REMOTE_API_BASE__";
+
+type RemoteFallbackRuntimeGlobal = typeof globalThis & {
+  __ELIZA_BUILD_CONFIGURED_REMOTE_API_BASE__?: unknown;
+};
 
 function configuredRemoteFallbackApiBase(): string | undefined {
+  // `@elizaos/ui` can be consumed as a pre-built package. In that shape Vite
+  // does not necessarily rewrite `import.meta.env` inside this module even
+  // though the app entrypoint sees the build variable. The app therefore
+  // installs the already-validated origin here before React renders, keeping
+  // every runtime trust/persistence gate on the same immutable build target.
+  const runtimeValue = (globalThis as RemoteFallbackRuntimeGlobal)[
+    REMOTE_FALLBACK_RUNTIME_GLOBAL
+  ];
+  if (typeof runtimeValue === "string") return runtimeValue;
+
   const env =
     typeof import.meta !== "undefined"
       ? (import.meta as { env?: Record<string, unknown> }).env
       : undefined;
   const value = env?.[REMOTE_FALLBACK_API_BASE_ENV_KEY];
   return typeof value === "string" ? value : undefined;
+}
+
+/**
+ * Publish the app-entrypoint's validated remote origin to pre-built UI code.
+ * A second, different target is rejected so late runtime code cannot repoint a
+ * dedicated build after its bootstrap contract has been established.
+ */
+export function installBuildConfiguredRemoteApiBaseUrl(apiBase: string): void {
+  const resolved = getBuildConfiguredRemoteApiBaseUrl(apiBase);
+  if (!resolved) {
+    throw new Error(
+      "[runtime-url-trust] build-configured remote target must be a root HTTPS origin",
+    );
+  }
+
+  const runtime = globalThis as RemoteFallbackRuntimeGlobal;
+  const current = runtime[REMOTE_FALLBACK_RUNTIME_GLOBAL];
+  if (typeof current === "string" && current !== resolved) {
+    throw new Error(
+      "[runtime-url-trust] build-configured remote target is already locked",
+    );
+  }
+  runtime[REMOTE_FALLBACK_RUNTIME_GLOBAL] = resolved;
 }
 
 /**

--- a/packages/ui/src/state/startup-phase-restore.trust.test.ts
+++ b/packages/ui/src/state/startup-phase-restore.trust.test.ts
@@ -6,6 +6,7 @@ import {
   isDedicatedCloudAgentBase,
 } from "../utils/cloud-agent-base";
 import {
+  getBuildConfiguredRemoteApiBaseUrl,
   isTrustedBuildConfiguredRemoteApiBaseUrl,
   isTrustedCloudApiBaseUrl,
   isTrustedRestoreApiBaseUrl,
@@ -39,6 +40,18 @@ describe("isTrustedRestoreApiBaseUrl", () => {
         "http://fallback.example.test",
       ),
     ).toBe(false);
+  });
+
+  it("exposes only a strictly valid build-pinned root origin", () => {
+    expect(
+      getBuildConfiguredRemoteApiBaseUrl("https://fallback.example.test/"),
+    ).toBe("https://fallback.example.test");
+    expect(
+      getBuildConfiguredRemoteApiBaseUrl("https://fallback.example.test/api"),
+    ).toBeNull();
+    expect(
+      getBuildConfiguredRemoteApiBaseUrl("http://fallback.example.test"),
+    ).toBeNull();
   });
 
   it("trusts loopback and local-agent hosts", () => {


### PR DESCRIPTION
## Summary
- propagate the validated mobile fallback origin from the app entrypoint into pre-built UI trust gates
- reject late attempts to replace the build-configured runtime target
- cover the cross-package runtime pin handoff

## Validation
- packages/ui typecheck
- app mobile-remote-fallback: 13/13
- UI trust/persistence/client pin: 24/24
- Biome and git diff check
- physical LP3 regression reproduced before this fix: route transition cleared durable VPS target and flipped native mode to cloud