### PR TITLE
fix(android): retain remote hard pin across UI routes

### DIFF
--- a/packages/app/src/mobile-remote-fallback.test.ts
+++ b/packages/app/src/mobile-remote-fallback.test.ts
@@ -17,6 +17,11 @@ beforeEach(() => {
 
 afterEach(() => {
   localStorage.clear();
+  delete (
+    globalThis as typeof globalThis & {
+      __ELIZA_BUILD_CONFIGURED_REMOTE_API_BASE__?: unknown;
+    }
+  ).__ELIZA_BUILD_CONFIGURED_REMOTE_API_BASE__;
 });
 
 describe("resolveMobileRemoteFallbackApiBase", () => {
@@ -95,6 +100,18 @@ describe("resolveMobileRemoteFallbackApiBase", () => {
 
     expect(client.setBaseUrl).toHaveBeenCalledWith(FALLBACK_BASE);
     expect(client.setToken).toHaveBeenCalledWith(null);
+  });
+
+  it("publishes the build target to pre-built UI trust gates", async () => {
+    await installMobileRemoteFallback(FALLBACK_ENV);
+
+    expect(
+      (
+        globalThis as typeof globalThis & {
+          __ELIZA_BUILD_CONFIGURED_REMOTE_API_BASE__?: unknown;
+        }
+      ).__ELIZA_BUILD_CONFIGURED_REMOTE_API_BASE__,
+    ).toBe(FALLBACK_BASE);
   });
 
   it("replaces a stale active Cloud profile instead of copying its token", async () => {

--- a/packages/app/src/mobile-remote-fallback.ts
+++ b/packages/app/src/mobile-remote-fallback.ts
@@ -21,6 +21,7 @@ import {
   savePersistedActiveServer,
   savePersistedFirstRunComplete,
 } from "@elizaos/ui/state/persistence";
+import { installBuildConfiguredRemoteApiBaseUrl } from "@elizaos/ui/state/runtime-url-trust";
 
 const REMOTE_FALLBACK_API_BASE_ENV_KEY = "VITE_ELIZA_REMOTE_FALLBACK_API_BASE";
 const REMOTE_FALLBACK_SERVER_ID = "remote:lp3-vps";
@@ -101,6 +102,12 @@ export async function installMobileRemoteFallback(
 ): Promise<boolean> {
   const apiBase = getMobileRemoteFallbackApiBase(env);
   if (!apiBase) return false;
+
+  // The app entrypoint sees the Vite build variable even when @elizaos/ui was
+  // pre-built before Vite ran. Publish the validated origin before any shared
+  // persistence/client code executes so its hard-pin gates cannot disappear
+  // after the first route transition.
+  installBuildConfiguredRemoteApiBaseUrl(apiBase);
 
   const current = loadPersistedActiveServer();
   const profileCredential = loadAgentProfileRegistry().profiles.find(

--- a/packages/ui/src/state/runtime-url-trust.ts
+++ b/packages/ui/src/state/runtime-url-trust.ts
@@ -20,14 +20,53 @@ import {
 } from "../utils/cloud-agent-base";
 
 const REMOTE_FALLBACK_API_BASE_ENV_KEY = "VITE_ELIZA_REMOTE_FALLBACK_API_BASE";
+const REMOTE_FALLBACK_RUNTIME_GLOBAL =
+  "__ELIZA_BUILD_CONFIGURED_REMOTE_API_BASE__";
+
+type RemoteFallbackRuntimeGlobal = typeof globalThis & {
+  __ELIZA_BUILD_CONFIGURED_REMOTE_API_BASE__?: unknown;
+};
 
 function configuredRemoteFallbackApiBase(): string | undefined {
+  // `@elizaos/ui` can be consumed as a pre-built package. In that shape Vite
+  // does not necessarily rewrite `import.meta.env` inside this module even
+  // though the app entrypoint sees the build variable. The app therefore
+  // installs the already-validated origin here before React renders, keeping
+  // every runtime trust/persistence gate on the same immutable build target.
+  const runtimeValue = (globalThis as RemoteFallbackRuntimeGlobal)[
+    REMOTE_FALLBACK_RUNTIME_GLOBAL
+  ];
+  if (typeof runtimeValue === "string") return runtimeValue;
+
   const env =
     typeof import.meta !== "undefined"
       ? (import.meta as { env?: Record<string, unknown> }).env
       : undefined;
   const value = env?.[REMOTE_FALLBACK_API_BASE_ENV_KEY];
   return typeof value === "string" ? value : undefined;
+}
+
+/**
+ * Publish the app-entrypoint's validated remote origin to pre-built UI code.
+ * A second, different target is rejected so late runtime code cannot repoint a
+ * dedicated build after its bootstrap contract has been established.
+ */
+export function installBuildConfiguredRemoteApiBaseUrl(apiBase: string): void {
+  const resolved = getBuildConfiguredRemoteApiBaseUrl(apiBase);
+  if (!resolved) {
+    throw new Error(
+      "[runtime-url-trust] build-configured remote target must be a root HTTPS origin",
+    );
+  }
+
+  const runtime = globalThis as RemoteFallbackRuntimeGlobal;
+  const current = runtime[REMOTE_FALLBACK_RUNTIME_GLOBAL];
+  if (typeof current === "string" && current !== resolved) {
+    throw new Error(
+      "[runtime-url-trust] build-configured remote target is already locked",
+    );
+  }
+  runtime[REMOTE_FALLBACK_RUNTIME_GLOBAL] = resolved;
 }
 
 /**


### PR DESCRIPTION
## Summary
- propagate the validated mobile fallback origin from the app entrypoint into pre-built UI trust gates
- reject late attempts to replace the build-configured runtime target
- cover the cross-package runtime pin handoff

## Validation
- packages/ui typecheck
- app mobile-remote-fallback: 13/13
- UI trust/persistence/client pin: 24/24
- Biome and git diff check
- physical LP3 regression reproduced before this fix: route transition cleared durable VPS target and flipped native mode to cloud