### PR TITLE
fix(ui): collapse chat sheet on agent Home navigation

### DIFF
--- a/packages/ui/src/components/shell/ChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ChatOverlay.test.tsx
@@ -113,6 +113,7 @@ import {
 import { __setAppValueForTests } from "../../state/app-store";
 import {
   getShellSurface,
+  goLauncher,
   resetShellSurfaceForTests,
 } from "../../state/shell-surface-store";
 import {
@@ -876,6 +877,35 @@ describe("ChatOverlay", () => {
       />,
     );
     expect(document.activeElement).not.toBe(composer);
+  });
+
+  it("collapses an open thread sheet and returns the launcher rail home for agent Home navigation", () => {
+    render(<ChatOverlay controller={makeController()} />);
+    const composer = screen.getByLabelText("message") as HTMLTextAreaElement;
+    const sheet = screen.getByTestId("chat-sheet");
+    act(() => {
+      goLauncher();
+      composer.focus();
+      fireEvent.focus(composer);
+    });
+    expect(sheet.getAttribute("data-variant")).toBe("open");
+    expect(getShellSurface().page).toBe("launcher");
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(NAVIGATE_VIEW_EVENT, {
+          detail: {
+            viewId: "chat",
+            viewPath: "/chat",
+            source: "agent",
+          },
+        }),
+      );
+    });
+
+    expect(sheet.getAttribute("data-variant")).toBe("closed");
+    expect(document.activeElement).not.toBe(composer);
+    expect(getShellSurface().page).toBe("home");
   });
 
   it("keeps composer focus when the active view stays on chat (no spurious blur)", () => {

--- a/packages/ui/src/components/shell/ChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ChatOverlay.tsx
@@ -109,6 +109,7 @@ import {
 } from "../../state/ChatComposerContext.hooks";
 import { useConversationMessages } from "../../state/ConversationMessagesContext.hooks";
 import { loadOlderConversationMessages } from "../../state/load-older-conversation-messages";
+import { goHome } from "../../state/shell-surface-store";
 import { useViewChatBinding } from "../../state/view-chat-binding";
 import { NATIVE_GLASS_DARK_TINT } from "../../themes/native-glass.js";
 import { tryHandleTutorialText } from "../../tutorial/tutorial-action-channel";
@@ -4081,12 +4082,15 @@ export function ChatOverlay({
     const preserveFocusedComposer = (event: Event) => {
       const detail = (event as CustomEvent<NavigateViewDetail>).detail;
       const action = detail?.action;
+      const targetsHome =
+        detail?.viewId === "chat" || detail?.viewPath === "/chat";
       const staysInShell =
         action !== "close" &&
         action !== "close-all" &&
         action !== "open-window";
       const shouldPreserve =
         staysInShell &&
+        !targetsHome &&
         typeof document !== "undefined" &&
         document.activeElement === inputRef.current;
       preserveComposerFocusUntilRef.current = shouldPreserve
@@ -4838,6 +4842,24 @@ export function ChatOverlay({
     return () =>
       window.removeEventListener(ELIZA_BACK_INTENT_EVENT, onBackIntent);
   }, [sheetOpen, pinnedOpen, collapse]);
+
+  // Agent-driven Home navigation targets the persistent `/chat` canvas. When
+  // the thread sheet is already open, changing the route alone is visually a
+  // no-op: the sheet keeps covering Home even though the server delivered and
+  // accepted the navigation. Match the manual Home gesture by returning the
+  // launcher rail to Home and collapsing the sheet in the same event.
+  React.useEffect(() => {
+    if (typeof window === "undefined") return undefined;
+    const onNavigateHome = (event: Event) => {
+      const detail = (event as CustomEvent<NavigateViewDetail>).detail;
+      if (detail?.viewId !== "chat" && detail?.viewPath !== "/chat") return;
+      goHome();
+      if (sheetOpen) collapse();
+    };
+    window.addEventListener(NAVIGATE_VIEW_EVENT, onNavigateHome);
+    return () =>
+      window.removeEventListener(NAVIGATE_VIEW_EVENT, onNavigateHome);
+  }, [sheetOpen, collapse]);
 
   // Auto-grow the composer with multi-line input: snap to the content height
   // (capped by `max-h` in CSS, which then scrolls). Runs on every draft change


### PR DESCRIPTION
## Summary
- collapse the persistent chat thread sheet when an agent navigation targets Home (`chat` / `/chat`)
- return the launcher rail to Home in the same event
- do not preserve composer focus across that Home command

## Verification
- `bunx vitest run src/components/shell/ChatOverlay.test.tsx` (211/211)
- `bun run typecheck` in `packages/ui`
- `bunx biome check src/components/shell/ChatOverlay.tsx src/components/shell/ChatOverlay.test.tsx`
- `git diff --check`

Physical LP3 wire evidence showed the VPS delivered both WS and SSE navigation legs; this fixes the remaining client-side same-route sheet no-op.