### PR TITLE
fix(ui): paint Settings beneath the chat overlay

### DIFF
--- a/packages/ui/src/App.navigate-view-wiring.test.tsx
+++ b/packages/ui/src/App.navigate-view-wiring.test.tsx
@@ -848,6 +848,8 @@ describe("App navigate-view event wiring", () => {
     expect(settingsPageContent?.className).toContain(
       "pe-[var(--eliza-chat-side-clearance,0px)]",
     );
+    expect(settingsPageContent?.className).toContain("settings-surface");
+    expect(settingsPageContent?.className).toContain("settings-canvas");
     const routedMain = screen.getByTestId("settings-view").closest("main");
     expect(routedMain?.className).not.toContain("px-2");
     expect(routedMain?.className).not.toContain("pt-[var(--view-pad-top)]");

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1482,7 +1482,16 @@ function buildStaticTabRenderers(): Record<
       settingsNavigateSequence,
       pageLayout,
     }) => (
-      <AppWorkspaceContent pageLayout={pageLayout} surface="transparent">
+      <AppWorkspaceContent
+        pageLayout={pageLayout}
+        surface="transparent"
+        // The router owns the floating-composer clearance, so Settings must
+        // paint its material canvas on that same boundary. Keeping the palette
+        // only on the nested SettingsView left the reserved bottom region as a
+        // disconnected black strip instead of a continuous surface behind the
+        // floating chat overlay.
+        className="settings-surface settings-canvas"
+      >
         <LazySettingsView
           key="settings-root"
           initialSection={settingsInitialSection ?? undefined}


### PR DESCRIPTION
## Summary
- paint the Settings material canvas on the router-owned floating-chat clearance boundary
- keep the Settings surface continuous behind the chat overlay instead of exposing a black footer strip
- pin the shared viewport contract in the routed App regression

## Validation
- focused App navigate-view regression
- packages/ui typecheck
- Biome
- Impeccable detector
- physical LP3 verification follows from the exact merged APK