### PR TITLE
fix(app-control): make exact view commands deterministic

### DIFF
--- a/plugins/plugin-app-control/AGENTS.md
+++ b/plugins/plugin-app-control/AGENTS.md
@@ -30,7 +30,7 @@ port resolver.
 | Name | File | Description |
 |---|---|---|
 | `viewContextEvaluator` | `src/evaluators/view-context.ts` | Model-assisted contextual navigation when no explicit view command matched. |
-| `viewCommandShortcutEvaluator` | `src/evaluators/view-command-shortcut.ts` | Compatibility export for downstream users; the first-party plugin does not register it because the model owns view-action selection. |
+| `viewCommandShortcutEvaluator` | `src/evaluators/view-command-shortcut.ts` | Registered zero-model fast path for exact standalone view commands. It installs one deterministic `VIEWS` call before the planner; contextual and compound requests still remain model-owned. |
 | `createChoiceShortcutEvaluator` | `src/evaluators/create-choice-shortcut.ts` | Routes replies to pending app/view creation choices without another model decision. |
 | `viewFollowupRoutingEvaluator` | `src/evaluators/view-followup-routing.ts` | Compatibility export for downstream users; the first-party plugin leaves focused-view mutation follow-ups to Stage 1 and the planner. |
 

--- a/plugins/plugin-app-control/CLAUDE.md
+++ b/plugins/plugin-app-control/CLAUDE.md
@@ -30,7 +30,7 @@ port resolver.
 | Name | File | Description |
 |---|---|---|
 | `viewContextEvaluator` | `src/evaluators/view-context.ts` | Model-assisted contextual navigation when no explicit view command matched. |
-| `viewCommandShortcutEvaluator` | `src/evaluators/view-command-shortcut.ts` | Compatibility export for downstream users; the first-party plugin does not register it because the model owns view-action selection. |
+| `viewCommandShortcutEvaluator` | `src/evaluators/view-command-shortcut.ts` | Registered zero-model fast path for exact standalone view commands. It installs one deterministic `VIEWS` call before the planner; contextual and compound requests still remain model-owned. |
 | `createChoiceShortcutEvaluator` | `src/evaluators/create-choice-shortcut.ts` | Routes replies to pending app/view creation choices without another model decision. |
 | `viewFollowupRoutingEvaluator` | `src/evaluators/view-followup-routing.ts` | Compatibility export for downstream users; the first-party plugin leaves focused-view mutation follow-ups to Stage 1 and the planner. |
 

--- a/plugins/plugin-app-control/src/index.ts
+++ b/plugins/plugin-app-control/src/index.ts
@@ -25,6 +25,7 @@ import {
 } from "./actions/views.js";
 import { createViewsClient } from "./actions/views-client.js";
 import { createChoiceShortcutEvaluator } from "./evaluators/create-choice-shortcut.js";
+import { viewCommandShortcutEvaluator } from "./evaluators/view-command-shortcut.js";
 import { viewContextEvaluator } from "./evaluators/view-context.js";
 import { availableAppsProvider } from "./providers/available-apps.js";
 import { currentViewProvider } from "./providers/current-view.js";
@@ -167,9 +168,9 @@ export const appControlPlugin: Plugin = {
 		runtimeManagementAction,
 		settingsAction,
 	],
-	// Model-owned view-switch cascade:
-	//  1. PLAN   — the response handler/planner selects VIEWS from the registered
-	//     action contract, including explicit multilingual navigation requests.
+	// View-switch cascade:
+	//  1. ROUTE  — exact standalone multilingual commands take the deterministic
+	//     VIEWS fast path; contextual and compound requests stay with the planner.
 	//  2. ACTION — viewsAction resolves the selected target and navigates.
 	//  3. POST   — viewContextEvaluator (small model) catches contextual intent
 	//     the user never spelled out ("fix the login bug" -> task-coordinator).
@@ -177,9 +178,15 @@ export const appControlPlugin: Plugin = {
 	//     surface (the rigid matchViewCommand matcher, or the legacy intent
 	//     rules it falls back to), so it never contends with the action.
 	evaluators: [viewContextEvaluator],
-	// Persisted choice widgets are an explicit continuation protocol. Ordinary
-	// view navigation and follow-up language stays with Stage 1 and the planner.
-	responseHandlerEvaluators: [createChoiceShortcutEvaluator],
+	// Persisted choice widgets are an explicit continuation protocol. Exact,
+	// standalone view commands use the rigid zero-model evaluator so shell
+	// navigation cannot fail merely because the general planner is unavailable
+	// or over its provider context limit. Contextual and compound language still
+	// stays with Stage 1 and the planner.
+	responseHandlerEvaluators: [
+		viewCommandShortcutEvaluator,
+		createChoiceShortcutEvaluator,
+	],
 	providers: [availableAppsProvider, currentViewProvider],
 	services: [
 		AppRegistryService,

--- a/plugins/plugin-app-control/src/shortcuts.test.ts
+++ b/plugins/plugin-app-control/src/shortcuts.test.ts
@@ -16,13 +16,16 @@ const MATCH_CONTEXT = {
 } as const;
 
 describe("viewNavigationShortcuts (#8791)", () => {
-	it("remain compatibility exports but are not registered ahead of the model", () => {
+	it("registers exact view commands ahead of the model without enabling follow-up routing", () => {
 		expect(appControlPlugin.shortcuts ?? []).toEqual([]);
 		expect(
 			appControlPlugin.responseHandlerEvaluators?.map(
 				(evaluator) => evaluator.name,
 			),
-		).not.toContain("app-control.view-command-shortcut");
+		).toEqual([
+			"app-control.view-command-shortcut",
+			"app-control.create-choice-shortcut",
+		]);
 		expect(
 			appControlPlugin.responseHandlerEvaluators?.map(
 				(evaluator) => evaluator.name,


### PR DESCRIPTION
## Summary
- register the existing rigid view-command evaluator in the first-party app-control plugin
- keep contextual and compound requests on the normal model/planner path
- add a plugin-wiring regression so the evaluator cannot silently become export-only again

Fixes #29316

## Verification
- `bun --config=bunfig.live.toml test --reporter=dots plugins/plugin-app-control/src/evaluators/view-command-shortcut.test.ts plugins/plugin-app-control/src/actions/view-command-matcher.test.ts plugins/plugin-app-control/src/shortcuts.test.ts` — 343 pass, 0 fail
- `bun run --cwd plugins/plugin-app-control typecheck` — pass
- Biome over changed TypeScript files — pass
- `git diff --check` — pass

## Real local runtime acceptance
Exact source `314298f1f2974d59221f1a345af2586de30339ff` on shared UI/API `2151/12151`, with active chat provider Cerebras (`api.cerebras.ai`) and model `gemma-4-31b`:

1. Open `/notes`, send exact `go home` → URL changes to `/chat`, reply `Back home.`
2. Send exact `open notes` → URL changes to `/notes`, reply `Got you. You're in notes.`
3. Send exact `go home` again → `/chat`, reply `Back home. You're in messages.`
4. Reload → route and exact final exchange persist.
5. Latest trajectory `step-1787778485132-2axoeo` completed with one successful `VIEWS` tool event.
6. Fresh runtime logs: 0 `PROVIDER_CONTEXT_OVERFLOW`, 0 planner failures, 0 backend errors; post-readiness browser console errors: 0.

No provider fallback, secret output, deployment, device, Cloud, Pixel, LP3, or Dedicated changes.