### PR TITLE
fix(ui): tighten chat message action spacing

### DIFF
--- a/packages/ui/src/components/composites/chat/chat-message-actions.test.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message-actions.test.tsx
@@ -15,6 +15,30 @@ import { ChatMessageActions } from "./chat-message-actions";
 afterEach(cleanup);
 
 describe("ChatMessageActions copy", () => {
+  it("keeps the bare overlay controls and timestamp in one compact baseline", () => {
+    render(
+      <ChatMessageActions
+        appearance="glass-row"
+        canPlay
+        canReply
+        onCopy={vi.fn()}
+        onPlay={vi.fn()}
+        onReply={vi.fn()}
+        trailingAccessory={<span>6m</span>}
+      />,
+    );
+
+    const surface = screen.getByTestId("thread-line-action-surface");
+    expect(surface.className).toContain("items-center");
+    expect(surface.className).toContain("gap-0.5");
+    expect(surface.className).toContain("leading-none");
+
+    const accessory = screen.getByTestId("thread-line-action-accessory");
+    expect(accessory.className).toContain("ml-1.5");
+    expect(accessory.className).toContain("items-center");
+    expect(accessory.className).toContain("leading-none");
+  });
+
   it("invokes onCopy when the copy button is clicked", async () => {
     const onCopy = vi.fn();
     render(<ChatMessageActions onCopy={onCopy} />);

--- a/packages/ui/src/components/composites/chat/chat-message-actions.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message-actions.tsx
@@ -50,8 +50,10 @@ export function ChatMessageActionSurface({
       elevation={bare ? undefined : "liquidGlass"}
       flow="row"
       className={cn(
-        "inline-flex text-white",
-        bare ? "gap-0" : "gap-0.5 p-0.5 transition-colors duration-150",
+        "inline-flex items-center text-white",
+        bare
+          ? "gap-0.5 leading-none"
+          : "gap-0.5 p-0.5 transition-colors duration-150",
         className,
       )}
       style={
@@ -229,7 +231,7 @@ export function ChatMessageActions({
       {trailingAccessory ? (
         <div
           data-testid="thread-line-action-accessory"
-          className="ml-0.5 min-w-0 shrink-0"
+          className="ml-1.5 flex min-w-0 shrink-0 items-center leading-none"
         >
           {trailingAccessory}
         </div>

--- a/packages/ui/src/components/composites/chat/chat-message.tap-reveal.test.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message.tap-reveal.test.tsx
@@ -161,12 +161,13 @@ describe("ChatMessage tap-to-reveal vs transcript scroll", () => {
     expect(rail.className).toContain("invisible");
     expect(rail.className).toContain("opacity-0");
     expect(content?.className).toContain("pb-0");
-    expect(content?.className).not.toContain("pb-9");
+    expect(content?.className).not.toContain("pointer-coarse:pb-11");
     fireEvent.click(bubble);
     expect(rail.getAttribute("aria-hidden")).toBe("false");
     expect(rail.className).toContain("visible");
     expect(rail.className).not.toContain("invisible");
-    expect(content?.className).toContain("pb-9");
+    expect(content?.className).toContain("pb-6");
+    expect(content?.className).toContain("pointer-coarse:pb-11");
     expect(content?.className).not.toContain("pb-0");
 
     fireEvent.click(bubble);
@@ -174,7 +175,7 @@ describe("ChatMessage tap-to-reveal vs transcript scroll", () => {
     expect(rail.className).toContain("invisible");
     expect(rail.className).toContain("opacity-0");
     expect(content?.className).toContain("pb-0");
-    expect(content?.className).not.toContain("pb-9");
+    expect(content?.className).not.toContain("pointer-coarse:pb-11");
   });
 
   it("returns the glass action space after an outside touch", () => {
@@ -194,12 +195,13 @@ describe("ChatMessage tap-to-reveal vs transcript scroll", () => {
 
     fireEvent.click(bubble);
     expect(rail.getAttribute("aria-hidden")).toBe("false");
-    expect(content?.className).toContain("pb-9");
+    expect(content?.className).toContain("pb-6");
+    expect(content?.className).toContain("pointer-coarse:pb-11");
 
     fireEvent.pointerDown(document.body);
     expect(rail.getAttribute("aria-hidden")).toBe("true");
     expect(content?.className).toContain("pb-0");
-    expect(content?.className).not.toContain("pb-9");
+    expect(content?.className).not.toContain("pointer-coarse:pb-11");
   });
 
   it("a scroll-like touch (travel past the slop) does NOT toggle the rail", () => {

--- a/packages/ui/src/components/composites/chat/chat-message.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message.tsx
@@ -1159,7 +1159,11 @@ export const ChatMessage = memo(function ChatMessage({
             hasActionLane &&
               "transition-[padding-bottom] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:duration-100",
             hasActionLane &&
-              (supportsHover ? "pb-6" : accessoryVisible ? "pb-9" : "pb-0"),
+              (supportsHover
+                ? "pb-6"
+                : accessoryVisible
+                  ? "pb-6 pointer-coarse:pb-11"
+                  : "pb-0"),
             isFirstRun
               ? "max-w-[22rem] items-start"
               : isUser


### PR DESCRIPTION
## Summary
- reduce the revealed assistant action-row dead gap from 16px to 4px in the in-app browser
- retain the 44px coarse-pointer reservation only on actual coarse-pointer media
- align reply/copy/play controls and the timestamp on one compact baseline

## Verification
- focused UI tests: 12 passed, 0 failed
- UI typecheck: passed
- Biome and diff-check: passed
- real in-app browser at 417×863 CSS viewport: measured action gap 16px before, 4px after
- source/runtime base: exact develop a740922abb1161163b97f75daa73f450a9781903

The unrelated pre-existing first-run greeting rounded-corner assertion still fails when the broader hover file is run; this patch does not touch that greeting or its style contract.