### PR TITLE
fix(android): publish isolated Pixel VPS sidecar lane

### DIFF
--- a/packages/app-core/scripts/run-mobile-build-android-lp3-color-policy.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-android-lp3-color-policy.test.mjs
@@ -25,10 +25,13 @@ import {
   ANDROID_LP3_COLOR_POLICY_JAVA_FILES,
   ANDROID_LP3_COLOR_POLICY_PERMISSIONS,
   ANDROID_LP3_COLOR_POLICY_REQUIRED_PERMISSIONS,
+  createAndroidPlayManifestPolicy,
   enforceAndroidLp3ColorPolicyBuildPolicy,
   enforceAndroidLp3RemoteFallbackBuildPolicy,
   isAndroidLp3ColorPolicyEnabled,
   isAndroidLp3RemoteFallbackRequired,
+  isAndroidVpsSidecarBuild,
+  resolveAndroidCloudAllowedNativeLibraries,
   resolveAndroidCloudAllowedNativePluginPackages,
   resolveAndroidCloudStripPolicy,
   resolveAndroidLp3ColorPolicyBuildEnv,
@@ -87,6 +90,35 @@ describe("LP3 direct Cloud build flag", () => {
         },
       }),
     ).not.toThrow();
+  });
+
+  it("supports an isolated Firebase-independent Pixel VPS sidecar profile", () => {
+    const sidecarEnv = {
+      ELIZA_ANDROID_VPS_SIDECAR: "1",
+      VITE_ELIZA_REMOTE_FALLBACK_API_BASE: "https://agent.example.test/",
+    };
+    expect(isAndroidVpsSidecarBuild(sidecarEnv)).toBe(true);
+    expect(() =>
+      enforceAndroidLp3RemoteFallbackBuildPolicy({
+        targetName: "android-cloud-debug",
+        env: sidecarEnv,
+      }),
+    ).not.toThrow();
+    expect(() =>
+      enforceAndroidLp3RemoteFallbackBuildPolicy({
+        targetName: "android-cloud",
+        env: sidecarEnv,
+      }),
+    ).toThrow("restricted to android-cloud-debug");
+    expect(() =>
+      enforceAndroidLp3RemoteFallbackBuildPolicy({
+        targetName: "android-cloud-debug",
+        env: {
+          ...sidecarEnv,
+          ELIZA_ANDROID_LP3_COLOR_POLICY_ENABLED: "1",
+        },
+      }),
+    ).toThrow("must not enable the LP3 color policy");
   });
 
   it.each([
@@ -167,6 +199,31 @@ describe("LP3 direct Cloud build flag", () => {
     expect(
       resolveAndroidCloudStripPolicy(fallbackEnv).safePushNotifications,
     ).toBe(false);
+  });
+
+  it("omits native FCM from a Firebase-independent VPS sidecar", () => {
+    const sidecarEnv = { ELIZA_ANDROID_VPS_SIDECAR: "1" };
+    expect(
+      resolveAndroidCloudAllowedNativePluginPackages(sidecarEnv),
+    ).not.toContain("@capacitor/push-notifications");
+    expect(resolveAndroidCloudStripPolicy(sidecarEnv).javaFiles).toContain(
+      "SafePushNotificationsPlugin.java",
+    );
+    expect(
+      resolveAndroidCloudStripPolicy(sidecarEnv).safePushNotifications,
+    ).toBe(false);
+    expect(resolveAndroidCloudAllowedNativeLibraries(sidecarEnv)).toEqual([]);
+    const manifestPolicy = createAndroidPlayManifestPolicy({
+      debug: true,
+      firebaseIndependent: true,
+    });
+    expect(manifestPolicy.permissions).not.toContain(
+      "com.google.android.c2dm.permission.RECEIVE",
+    );
+    expect(manifestPolicy.components).not.toContain(
+      "service:com.capacitorjs.plugins.pushnotifications.MessagingService",
+    );
+    expect(manifestPolicy.application.debuggable).toBe("true");
   });
 
   it("normalizes the passed build environment without consulting process.env", () => {

--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -402,8 +402,13 @@ function readAppIdentity() {
     process.env.ELIZA_APP_ID?.trim() ||
     process.env.ELIZA_IOS_APP_ID?.trim() ||
     configAppId;
-  const appName = src.match(/appName:\s*["']([^"']+)["']/)?.[1];
-  const urlScheme = src.match(/urlScheme:\s*["']([^"']+)["']/)?.[1] ?? appId;
+  const appName =
+    process.env.ELIZA_APP_NAME?.trim() ||
+    src.match(/appName:\s*["']([^"']+)["']/)?.[1];
+  const urlScheme =
+    process.env.ELIZA_APP_URL_SCHEME?.trim() ||
+    src.match(/urlScheme:\s*["']([^"']+)["']/)?.[1] ||
+    appId;
   if (!appId || !appName) {
     throw new Error("Could not parse appId/appName from app.config.ts");
   }
@@ -5750,24 +5755,41 @@ export function isAndroidLp3RemoteFallbackRequired(env = process.env) {
   );
 }
 
+export function isAndroidVpsSidecarBuild(env = process.env) {
+  return isTruthyEnv(env.ELIZA_ANDROID_VPS_SIDECAR);
+}
+
 export function enforceAndroidLp3RemoteFallbackBuildPolicy({
   targetName,
   env = process.env,
 }) {
-  const required = isAndroidLp3RemoteFallbackRequired(env);
-  if (!required) return;
-  if (
-    targetName !== "android-cloud-debug" ||
-    !isAndroidLp3ColorPolicyEnabled(env)
-  ) {
+  const lp3Required = isAndroidLp3RemoteFallbackRequired(env);
+  const sidecarRequired = isAndroidVpsSidecarBuild(env);
+  if (!lp3Required && !sidecarRequired) return;
+  if (lp3Required && sidecarRequired) {
+    throw new Error(
+      "[mobile-build] LP3 and VPS sidecar remote profiles are mutually exclusive.",
+    );
+  }
+  if (targetName !== "android-cloud-debug") {
+    throw new Error(
+      "[mobile-build] remote fallback profiles are restricted to android-cloud-debug.",
+    );
+  }
+  if (lp3Required && !isAndroidLp3ColorPolicyEnabled(env)) {
     throw new Error(
       "[mobile-build] ELIZA_ANDROID_LP3_REMOTE_FALLBACK_REQUIRED is restricted to the LP3 android-cloud-debug direct profile.",
+    );
+  }
+  if (sidecarRequired && isAndroidLp3ColorPolicyEnabled(env)) {
+    throw new Error(
+      "[mobile-build] ELIZA_ANDROID_VPS_SIDECAR must not enable the LP3 color policy.",
     );
   }
   const raw = String(env.VITE_ELIZA_REMOTE_FALLBACK_API_BASE ?? "").trim();
   if (!raw) {
     throw new Error(
-      "[mobile-build] the LP3 VPS profile requires VITE_ELIZA_REMOTE_FALLBACK_API_BASE",
+      "[mobile-build] the remote fallback profile requires VITE_ELIZA_REMOTE_FALLBACK_API_BASE",
     );
   }
   let parsed;
@@ -5825,6 +5847,12 @@ export function enforceAndroidLp3ColorPolicyBuildPolicy({
   }
 }
 
+function isAndroidFirebaseIndependentRemoteBuild(env = process.env) {
+  return (
+    isAndroidLp3RemoteFallbackRequired(env) || isAndroidVpsSidecarBuild(env)
+  );
+}
+
 export function resolveAndroidCloudStripPolicy(env = process.env) {
   const stripPolicy = !isAndroidLp3ColorPolicyEnabled(env)
     ? {
@@ -5859,7 +5887,7 @@ export function resolveAndroidCloudStripPolicy(env = process.env) {
         };
       })();
 
-  if (!isAndroidLp3RemoteFallbackRequired(env)) {
+  if (!isAndroidFirebaseIndependentRemoteBuild(env)) {
     return { ...stripPolicy, safePushNotifications: true };
   }
 
@@ -5984,7 +6012,7 @@ export const ANDROID_PLAY_ALLOWED_NATIVE_PLUGIN_PACKAGES = Object.freeze([
 export function resolveAndroidCloudAllowedNativePluginPackages(
   env = process.env,
 ) {
-  return isAndroidLp3RemoteFallbackRequired(env)
+  return isAndroidFirebaseIndependentRemoteBuild(env)
     ? ANDROID_PLAY_ALLOWED_NATIVE_PLUGIN_PACKAGES.filter(
         (pkg) => pkg !== "@capacitor/push-notifications",
       )
@@ -6178,6 +6206,12 @@ export const ANDROID_PLAY_ALLOWED_NATIVE_LIBRARIES = Object.freeze([
   "lib/x86_64/libdatastore_shared_counter.so",
 ]);
 
+export function resolveAndroidCloudAllowedNativeLibraries(env = process.env) {
+  return isAndroidFirebaseIndependentRemoteBuild(env)
+    ? []
+    : [...ANDROID_PLAY_ALLOWED_NATIVE_LIBRARIES];
+}
+
 export const ANDROID_PLAY_DATA_EXTRACTION_RULES = `<?xml version="1.0" encoding="utf-8"?>
 <data-extraction-rules>
     <cloud-backup>
@@ -6307,8 +6341,11 @@ export function findAndroidPlayIndexHtmlFindings(entries, buffers) {
   return [...new Set(findings)].sort();
 }
 
-export function createAndroidPlayManifestPolicy({ debug = false } = {}) {
-  return {
+export function createAndroidPlayManifestPolicy({
+  debug = false,
+  firebaseIndependent = false,
+} = {}) {
+  const policy = {
     actions: [...ANDROID_PLAY_ALLOWED_ACTIONS],
     application: {
       allowBackup: "false",
@@ -6321,6 +6358,45 @@ export function createAndroidPlayManifestPolicy({ debug = false } = {}) {
     queryActions: [...ANDROID_PLAY_ALLOWED_QUERY_ACTIONS],
     queryPackages: [],
     targetSdkVersion: "36",
+  };
+  if (!firebaseIndependent) return policy;
+  const firebaseComponents = [
+    "provider:com.google.firebase.provider.FirebaseInitProvider",
+    "receiver:com.google.android.datatransport.runtime.scheduling.jobscheduling.AlarmManagerSchedulerBroadcastReceiver",
+    "receiver:com.google.firebase.iid.FirebaseInstanceIdReceiver",
+    "service:com.capacitorjs.plugins.pushnotifications.MessagingService",
+    "service:com.google.android.datatransport.runtime.backends.TransportBackendDiscovery",
+    "service:com.google.android.datatransport.runtime.scheduling.jobscheduling.JobInfoSchedulerService",
+    "service:com.google.firebase.components.ComponentDiscoveryService",
+    "service:com.google.firebase.messaging.FirebaseMessagingService",
+  ];
+  const firebaseMetadata = [
+    "backend:com.google.android.datatransport.cct.CctBackendFactory",
+    "com.google.android.gms.cloudmessaging.FINISHED_AFTER_HANDLED",
+    "com.google.firebase.components:com.google.firebase.datatransport.TransportRegistrar",
+    "com.google.firebase.components:com.google.firebase.FirebaseCommonKtxRegistrar",
+    "com.google.firebase.components:com.google.firebase.installations.FirebaseInstallationsKtxRegistrar",
+    "com.google.firebase.components:com.google.firebase.installations.FirebaseInstallationsRegistrar",
+    "com.google.firebase.components:com.google.firebase.messaging.FirebaseMessagingKtxRegistrar",
+    "com.google.firebase.components:com.google.firebase.messaging.FirebaseMessagingRegistrar",
+  ];
+  return {
+    ...policy,
+    actions: policy.actions.filter(
+      (action) =>
+        action !== "com.google.android.c2dm.intent.RECEIVE" &&
+        action !== "com.google.firebase.MESSAGING_EVENT",
+    ),
+    components: policy.components.filter(
+      (component) => !firebaseComponents.includes(component),
+    ),
+    metadataNames: policy.metadataNames.filter(
+      (metadata) => !firebaseMetadata.includes(metadata),
+    ),
+    permissions: policy.permissions.filter(
+      (permission) =>
+        permission !== "com.google.android.c2dm.permission.RECEIVE",
+    ),
   };
 }
 
@@ -9977,7 +10053,7 @@ export function auditAndroidCloudArtifact(
       .sort();
     if (
       JSON.stringify(nativeLibraries) !==
-      JSON.stringify([...ANDROID_PLAY_ALLOWED_NATIVE_LIBRARIES].sort())
+      JSON.stringify(resolveAndroidCloudAllowedNativeLibraries(env).sort())
     ) {
       throw mobileBuildError(
         `[mobile-build] android-cloud native libraries differ from the Play allowlist:\n${nativeLibraries
@@ -10119,7 +10195,10 @@ export function auditAndroidCloudArtifact(
         });
         assertAndroidPlayManifestPolicyEvidence(
           androidPlayManifestEvidenceFromAapt(manifestText),
-          createAndroidPlayManifestPolicy({ debug: true }),
+          createAndroidPlayManifestPolicy({
+            debug: true,
+            firebaseIndependent: isAndroidFirebaseIndependentRemoteBuild(env),
+          }),
         );
       }
       auditAndroidArtifactDexLp3Policy(

--- a/packages/app/app.config.ts
+++ b/packages/app/app.config.ts
@@ -17,54 +17,91 @@ interface AppWebConfig {
   themeColor: string;
   backgroundColor: string;
   shareImagePath: string;
+  iconBackgroundColor?: string;
 }
 
-const config = {
+interface AppIdentityEnv {
+  ELIZA_ANDROID_VPS_SIDECAR?: string;
+}
+
+function isEnabled(value: string | undefined): boolean {
+  return /^(1|true|yes|on)$/i.test((value ?? "").trim());
+}
+
+const CANONICAL_IDENTITY = {
   appName: "Eliza",
   appId: "ai.elizaos.app",
-  orgName: "elizaos",
-  repoName: "eliza",
-  cliName: "eliza",
-  description:
-    "Eliza manages your digital life so you can focus on what matters.",
-  envPrefix: "ELIZA",
   namespace: "eliza",
-  defaultApps: ["@elizaos/plugin-personal-assistant"],
+  urlScheme: "elizaos",
+} as const;
 
-  desktop: {
-    bundleId: "ai.elizaos.app",
-    urlScheme: "elizaos",
-  },
+const VPS_SIDECAR_IDENTITY = {
+  appName: "Eliza VPS",
+  appId: "ai.elizaos.app.vps",
+  namespace: "eliza-vps",
+  urlScheme: "elizavps",
+} as const;
 
-  web: {
-    shortName: "Eliza",
-    // Launch/loading surface used by manifest theme_color + background_color,
-    // <meta name="theme-color">, and PWA launch surfaces. Matches the default
-    // home background base (#000000 = DEFAULT_BACKGROUND_COLOR, the black
-    // field under the orange ember glow) so chrome and splash never flash a
-    // different color before the home background appears (issue #9565). On
-    // iOS standalone PWAs theme-color paints the home-indicator safe-area
-    // inset, so matching the black field keeps any inset bleed-through
-    // invisible. The brand accent (logos, buttons) stays #FF5800 / the CSS
-    // --brand-orange and is intentionally separate from these launch surfaces.
-    themeColor: "#000000",
-    backgroundColor: "#000000",
-    // PNG, not SVG: link-preview scrapers (X, Discord, iMessage, Slack) do
-    // not render SVG share images.
-    shareImagePath: "/brand/ogembeds/eliza_ogembed.png",
-  },
+/**
+ * Resolve the one alternate Android identity that intentionally installs next
+ * to the canonical Cloud app. All ordinary builds retain the canonical app
+ * config byte-for-byte; the sidecar identity exists only behind its explicit
+ * build flag.
+ */
+export function resolveAppConfig(env: AppIdentityEnv = process.env) {
+  const vpsSidecar = isEnabled(env.ELIZA_ANDROID_VPS_SIDECAR);
+  const identity = vpsSidecar ? VPS_SIDECAR_IDENTITY : CANONICAL_IDENTITY;
 
-  branding: {
-    appName: "Eliza",
+  return {
+    appName: identity.appName,
+    appId: identity.appId,
     orgName: "elizaos",
     repoName: "eliza",
-    docsUrl: EXTERNAL_URLS.docs,
-    appUrl: EXTERNAL_URLS.app,
-    bugReportUrl: "https://github.com/elizaOS/eliza/issues/new",
-    hashtag: "#elizaOS",
-    fileExtension: ".eliza-agent",
-    packageScope: "elizaos",
-  },
-} satisfies AppConfig & { web: AppWebConfig };
+    cliName: "eliza",
+    description:
+      "Eliza manages your digital life so you can focus on what matters.",
+    envPrefix: "ELIZA",
+    namespace: identity.namespace,
+    defaultApps: ["@elizaos/plugin-personal-assistant"],
+
+    desktop: {
+      bundleId: identity.appId,
+      urlScheme: identity.urlScheme,
+    },
+
+    web: {
+      shortName: identity.appName,
+      ...(vpsSidecar ? { iconBackgroundColor: "#202124" } : {}),
+      // Launch/loading surface used by manifest theme_color + background_color,
+      // <meta name="theme-color">, and PWA launch surfaces. Matches the default
+      // home background base (#000000 = DEFAULT_BACKGROUND_COLOR, the black
+      // field under the orange ember glow) so chrome and splash never flash a
+      // different color before the home background appears (issue #9565). On
+      // iOS standalone PWAs theme-color paints the home-indicator safe-area
+      // inset, so matching the black field keeps any inset bleed-through
+      // invisible. The brand accent (logos, buttons) stays #FF5800 / the CSS
+      // --brand-orange and is intentionally separate from these launch surfaces.
+      themeColor: "#000000",
+      backgroundColor: "#000000",
+      // PNG, not SVG: link-preview scrapers (X, Discord, iMessage, Slack) do
+      // not render SVG share images.
+      shareImagePath: "/brand/ogembeds/eliza_ogembed.png",
+    },
+
+    branding: {
+      appName: identity.appName,
+      orgName: "elizaos",
+      repoName: "eliza",
+      docsUrl: EXTERNAL_URLS.docs,
+      appUrl: EXTERNAL_URLS.app,
+      bugReportUrl: "https://github.com/elizaOS/eliza/issues/new",
+      hashtag: "#elizaOS",
+      fileExtension: ".eliza-agent",
+      packageScope: "elizaos",
+    },
+  } satisfies AppConfig & { web: AppWebConfig };
+}
+
+const config = resolveAppConfig();
 
 export default config;

--- a/packages/app/capacitor.config.ts
+++ b/packages/app/capacitor.config.ts
@@ -150,7 +150,8 @@ export function resolveCapacitorLoggingBehavior(
 ): "debug" | "none" {
   return isFlagEnabled(env.ELIZA_ANDROID_CLOUD_BUILD) ||
     isFlagEnabled(env.ELIZA_ANDROID_LAUNCHER_BUILD) ||
-    isFlagEnabled(env.ELIZA_ANDROID_CLOUD_HYBRID_BUILD)
+    isFlagEnabled(env.ELIZA_ANDROID_CLOUD_HYBRID_BUILD) ||
+    isFlagEnabled(env.ELIZA_ANDROID_VPS_SIDECAR)
     ? "none"
     : "debug";
 }
@@ -288,7 +289,8 @@ const config: CapacitorConfig = {
     // in-app/local notifications and the LP3 display-guard notification remain.
     includePlugins: resolveAndroidCapacitorPlugins(
       appPackage.dependencies,
-      isFlagEnabled(process.env.ELIZA_ANDROID_LP3_REMOTE_FALLBACK_REQUIRED),
+      isFlagEnabled(process.env.ELIZA_ANDROID_LP3_REMOTE_FALLBACK_REQUIRED) ||
+        isFlagEnabled(process.env.ELIZA_ANDROID_VPS_SIDECAR),
     ),
     backgroundColor: "#000000",
     allowMixedContent: false,

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -131,6 +131,7 @@
     "build:android:launcher": "node ../../packages/app-core/scripts/run-mobile-build.mjs android-launcher",
     "build:android:lp3-cloud:debug": "ELIZA_ANDROID_LP3_COLOR_POLICY_ENABLED=1 node ../../packages/app-core/scripts/run-mobile-build.mjs android-cloud-debug",
     "build:android:lp3-vps:debug": "ELIZA_ANDROID_LP3_COLOR_POLICY_ENABLED=1 ELIZA_ANDROID_LP3_REMOTE_FALLBACK_REQUIRED=1 node ../../packages/app-core/scripts/run-mobile-build.mjs android-cloud-debug",
+    "build:android:vps-sidecar:debug": "ELIZA_ANDROID_VPS_SIDECAR=1 ELIZA_APP_ID=ai.elizaos.app.vps ELIZA_APP_NAME='Eliza VPS' ELIZA_APP_URL_SCHEME=elizavps node ../../packages/app-core/scripts/run-mobile-build.mjs android-cloud-debug",
     "build:android:system": "node ../../packages/app-core/scripts/run-mobile-build.mjs android-system",
     "preflight:android:sideload": "node scripts/mobile-release-preflight.mjs --platform=android --sideload",
     "preflight:android:store": "node scripts/mobile-release-preflight.mjs --platform=android --store",

--- a/packages/app/test/app-config-vps-sidecar.test.ts
+++ b/packages/app/test/app-config-vps-sidecar.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { resolveAppConfig } from "../app.config";
+
+describe("VPS sidecar app identity", () => {
+  it("preserves the canonical app identity by default", () => {
+    const config = resolveAppConfig({ ELIZA_ANDROID_VPS_SIDECAR: undefined });
+
+    expect(config).toMatchObject({
+      appName: "Eliza",
+      appId: "ai.elizaos.app",
+      namespace: "eliza",
+      desktop: {
+        bundleId: "ai.elizaos.app",
+        urlScheme: "elizaos",
+      },
+      web: { shortName: "Eliza" },
+      branding: { appName: "Eliza" },
+    });
+    expect(config.web).not.toHaveProperty("iconBackgroundColor");
+  });
+
+  it("uses a separately installable identity only for the explicit sidecar lane", () => {
+    const config = resolveAppConfig({ ELIZA_ANDROID_VPS_SIDECAR: "1" });
+
+    expect(config).toMatchObject({
+      appName: "Eliza VPS",
+      appId: "ai.elizaos.app.vps",
+      namespace: "eliza-vps",
+      desktop: {
+        bundleId: "ai.elizaos.app.vps",
+        urlScheme: "elizavps",
+      },
+      web: {
+        shortName: "Eliza VPS",
+        iconBackgroundColor: "#202124",
+      },
+      branding: { appName: "Eliza VPS" },
+    });
+  });
+});

--- a/packages/app/test/capacitor-plugin-selection.test.ts
+++ b/packages/app/test/capacitor-plugin-selection.test.ts
@@ -100,6 +100,11 @@ describe("Capacitor logging behavior", () => {
         ELIZA_ANDROID_CLOUD_HYBRID_BUILD: "1",
       }),
     ).toBe("none");
+    expect(
+      resolveCapacitorLoggingBehavior({
+        ELIZA_ANDROID_VPS_SIDECAR: "1",
+      }),
+    ).toBe("none");
   });
 
   it("retains debug-only logging for other lanes", () => {

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -3204,7 +3204,7 @@ function AppContent() {
     !isAuxiliaryAppWindow &&
     !cloudPairToken &&
     (branding.cloudOnly === true ||
-      isAndroidCloudBuild() ||
+      (isAndroidCloudBuild() && branding.cloudOnly !== false) ||
       isElizaCloudRuntimeLocked());
   const hasUsableCloudSession =
     elizaCloudConnected ||

--- a/packages/ui/src/api/auth-client.test.ts
+++ b/packages/ui/src/api/auth-client.test.ts
@@ -606,7 +606,11 @@ describe("authMe over plain HTTP boundaries", () => {
   });
 
   it("degrades a 401 with an unparseable body to server_error without access", async () => {
-    fetchWithCsrfMock.mockResolvedValueOnce(textResponse("", 401));
+    fetchWithCsrfMock
+      .mockResolvedValueOnce(textResponse("", 401))
+      .mockResolvedValueOnce(
+        jsonResponse({ required: true, pairingEnabled: false }),
+      );
 
     const result = await authMe();
 
@@ -616,6 +620,26 @@ describe("authMe over plain HTTP boundaries", () => {
       reason: "server_error",
       access: undefined,
     });
+  });
+
+  it("recovers a generic outer-middleware 401 into the remote pairing contract", async () => {
+    fetchWithCsrfMock
+      .mockResolvedValueOnce(jsonResponse({ error: "Unauthorized" }, 401))
+      .mockResolvedValueOnce(
+        jsonResponse({ required: true, pairingEnabled: true }),
+      );
+
+    await expect(authMe()).resolves.toEqual({
+      ok: false,
+      status: 401,
+      reason: "remote_auth_required",
+      access: {
+        mode: "remote",
+        passwordConfigured: true,
+        ownerConfigured: false,
+      },
+    });
+    expect(fetchWithCsrfMock.mock.calls[1]?.[0]).toContain("/api/auth/status");
   });
 
   it("preserves auth throttling and the server retry window", async () => {

--- a/packages/ui/src/api/auth-client.ts
+++ b/packages/ui/src/api/auth-client.ts
@@ -183,6 +183,35 @@ function retryAfterMs(headers: Headers): number | undefined {
   return Math.max(0, retryAt - Date.now());
 }
 
+async function resolvePairingFallback(
+  base: string,
+): Promise<AuthMeResult | null> {
+  let statusResponse: Response;
+  try {
+    statusResponse = await fetchWithCsrf(`${base}/api/auth/status`);
+  } catch {
+    // error-policy:J4 the original 401 remains the explicit auth failure when
+    // the optional public pairing contract cannot be reached.
+    return null;
+  }
+  if (!statusResponse.ok) return null;
+  const status = (await statusResponse.json()) as {
+    required?: boolean;
+    pairingEnabled?: boolean;
+  };
+  if (status.required !== true || status.pairingEnabled !== true) return null;
+  return {
+    ok: false,
+    status: 401,
+    reason: "remote_auth_required",
+    access: {
+      mode: "remote",
+      passwordConfigured: true,
+      ownerConfigured: false,
+    },
+  };
+}
+
 // ── Endpoint callers ──────────────────────────────────────────────────────────
 
 /**
@@ -517,7 +546,7 @@ export async function authMe(): Promise<AuthMeResult> {
       reason?: string;
       access?: AuthAccessInfo;
     };
-    return {
+    const result: AuthMeResult = {
       ok: false,
       status: 401,
       reason:
@@ -528,6 +557,12 @@ export async function authMe(): Promise<AuthMeResult> {
             : "server_error",
       access: body.access,
     };
+    if (result.reason !== "server_error" || result.access) return result;
+
+    // Some standalone deployments enforce auth in outer middleware before the
+    // agent route can return its richer 401 body. The public status contract is
+    // authoritative for the supported one-time pairing flow in that case.
+    return (await resolvePairingFallback(authBase())) ?? result;
   }
 
   if (res.status === 429) {

--- a/packages/ui/src/state/startup-coordinator.ts
+++ b/packages/ui/src/state/startup-coordinator.ts
@@ -52,6 +52,15 @@ export interface PlatformPolicy {
    */
   nativeConsecutiveFailureBudgetMs?: number;
   /**
+   * Capacitor-native remote-target analogue of
+   * `nativeConsecutiveFailureBudgetMs`. A restored Cloud/VPS target cannot be
+   * making local boot progress, so statusless network failures should expose
+   * Retry promptly instead of borrowing the on-device agent's 90s warm-up
+   * allowance. Successful probes reset this streak and reconnect keeps the
+   * same persisted target/session.
+   */
+  remoteNativeConsecutiveFailureBudgetMs?: number;
+  /**
    * Hosted-web analogue for a DEDICATED cloud agent base (issue #19627): how
    * long (ms) the backend poll may fail consecutively at the connection level
    * — no HTTP response at all, e.g. a TLS handshake failure on

--- a/packages/ui/src/state/startup-phase-poll.test.ts
+++ b/packages/ui/src/state/startup-phase-poll.test.ts
@@ -2410,6 +2410,7 @@ describe("runPollingBackend progress-aware native budget + dead-cloud recovery (
       { current: 1 },
       { current: false },
       { current: null },
+      "cloud-managed",
     );
 
     // Recovered to the bundled on-device agent and completed startup.
@@ -2654,12 +2655,17 @@ describe("runPollingBackend progress-aware native budget + dead-cloud recovery (
     const run = runPollingBackend(
       deps,
       dispatch,
-      { ...nativePolicy, nativeConsecutiveFailureBudgetMs: 150 },
+      {
+        ...nativePolicy,
+        nativeConsecutiveFailureBudgetMs: 90_000,
+        remoteNativeConsecutiveFailureBudgetMs: 150,
+      },
       nativeCtx(remoteServer),
       1,
       { current: 1 },
       { current: false },
       { current: null },
+      "remote-backend",
     );
     let settled = false;
     const settledRun = run.finally(() => {
@@ -2685,7 +2691,79 @@ describe("runPollingBackend progress-aware native budget + dead-cloud recovery (
       "eliza:mobile-runtime-mode",
       "local",
     ]);
+    expect(deps.setStartupError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reason: "backend-unreachable",
+        message: expect.stringContaining(
+          "sign-in and chat history are preserved",
+        ),
+      }),
+    );
   });
+
+  it.each(["remote-backend", "cloud-managed"] as const)(
+    "surfaces an unreachable native %s target within its short remote budget without clearing the saved session",
+    async (target) => {
+      vi.useFakeTimers();
+      const deps = createDeps();
+      const dispatch = vi.fn();
+      installNativeWindow({ persistedRuntimeMode: null });
+      clientMock.getBaseUrl.mockReturnValue(
+        target === "cloud-managed"
+          ? deadCloudServer.apiBase
+          : "https://vps.example.test",
+      );
+      clientMock.getAuthStatus.mockReset();
+      clientMock.getAuthStatus.mockRejectedValue(
+        Object.assign(new TypeError("Failed to fetch"), {
+          kind: "network",
+          path: "/api/auth/status",
+        }),
+      );
+
+      const run = runPollingBackend(
+        deps,
+        dispatch,
+        {
+          ...nativePolicy,
+          backendTimeoutMs: 30_000,
+          nativeConsecutiveFailureBudgetMs: 90_000,
+        },
+        nativeCtx(
+          target === "cloud-managed"
+            ? deadCloudServer
+            : {
+                id: "remote:vps",
+                kind: "remote",
+                label: "VPS agent",
+                apiBase: "https://vps.example.test",
+              },
+        ),
+        1,
+        { current: 1 },
+        { current: false },
+        { current: null },
+        target,
+      );
+      let settled = false;
+      const settledRun = run.finally(() => {
+        settled = true;
+      });
+      await vi.advanceTimersByTimeAsync(11_999);
+      expect(settled).toBe(false);
+      await vi.advanceTimersByTimeAsync(3_001);
+      expect(settled).toBe(true);
+      await settledRun;
+
+      expect(dispatch).toHaveBeenCalledWith({ type: "BACKEND_TIMEOUT" });
+      expect(deps.setStartupError).toHaveBeenCalledWith(
+        expect.objectContaining({ reason: "backend-unreachable" }),
+      );
+      expect(vi.mocked(clearPersistedActiveServer)).not.toHaveBeenCalled();
+      expect(clientMock.setBaseUrl).not.toHaveBeenCalled();
+      expect(clientMock.setToken).not.toHaveBeenCalled();
+    },
+  );
 
   it("fails a hung probe fast and retries+connects instead of one hang eating the whole budget (#13737)", async () => {
     // The on-device Android boot: the first probe issued while the detached

--- a/packages/ui/src/state/startup-phase-poll.ts
+++ b/packages/ui/src/state/startup-phase-poll.ts
@@ -60,7 +60,11 @@ import {
   clearPersistedActiveServer,
   savePersistedActiveServer,
 } from "./persistence";
-import type { PlatformPolicy, StartupEvent } from "./startup-coordinator";
+import type {
+  PlatformPolicy,
+  RuntimeTarget,
+  StartupEvent,
+} from "./startup-coordinator";
 import { buildStaticFirstRunOptions } from "./startup-first-run-options";
 import type { RestoringSessionCtx } from "./startup-phase-restore";
 import { runStartupProbe, unwrapStartupProbe } from "./startup-probe";
@@ -377,6 +381,7 @@ export async function runPollingBackend(
   effectRunRef: React.MutableRefObject<number>,
   cancelled: { current: boolean },
   tidRef: { current: ReturnType<typeof setTimeout> | null },
+  target: RuntimeTarget = "embedded-local",
 ): Promise<void> {
   const describeBackendFailure = (
     err: unknown,
@@ -427,6 +432,10 @@ export async function runPollingBackend(
     policy.nativeConsecutiveFailureBudgetMs ??
     NATIVE_CONSECUTIVE_FAILURE_BUDGET_MS;
   let nativeFailureStreakStartedAt: number | null = null;
+  const remoteNativeFailureBudgetMs =
+    policy.remoteNativeConsecutiveFailureBudgetMs ??
+    STARTUP_TIMING_POLICY.remoteNativeConsecutiveFailureBudgetMs;
+  let remoteNativeFailureStreakStartedAt: number | null = null;
   // Hosted-web bounded boot for a DEDICATED cloud agent base (issue #19627):
   // timestamp of the first CONNECTION-LEVEL failure (no HTTP response at all —
   // e.g. a TLS handshake failure on `<id>.cloud.eliza.app`) in the current
@@ -755,6 +764,7 @@ export async function runPollingBackend(
         }
       });
     }
+    const probeAttemptStartedAt = Date.now();
     try {
       const auth = await traceIfStalled(
         boundedProbe(client.getAuthStatus()),
@@ -772,6 +782,7 @@ export async function runPollingBackend(
       // transport works; any remaining slowness is the agent booting, which
       // the overall `deadline` already budgets for.
       nativeFailureStreakStartedAt = null;
+      remoteNativeFailureStreakStartedAt = null;
       agentUnreachableStreakStartedAt = null;
       if (cancelled.current) return;
       if (auth.required && !auth.authenticated && !client.hasToken()) {
@@ -1339,6 +1350,51 @@ export async function runPollingBackend(
         }
       }
       if (isCapacitorNative()) {
+        // A terminal/deleted Cloud target may have recovered in-loop to the
+        // bundled local IPC base. Classify the base we are polling, not only
+        // the original coordinator target, so that recovered local boot keeps
+        // the full progress-aware allowance.
+        const remoteTarget =
+          target !== "embedded-local" &&
+          !isMobileLocalAgentIpcBase(client.getBaseUrl());
+        const isConnectionLevelFailure =
+          err instanceof ApiHangTimeoutError ||
+          ae?.kind === "network" ||
+          ae?.kind === "timeout";
+        if (remoteTarget && isConnectionLevelFailure) {
+          // A restored Cloud/VPS target has no local process whose migrations,
+          // model load, or socket startup could justify the 90s native warm-up
+          // allowance. Count the time spent inside the failed request itself so
+          // a hung 12s probe reaches the visible retry card on its first failure.
+          // This path deliberately leaves the active server and bearer intact;
+          // the terminal-error recovery loop can therefore reconnect the same
+          // target/session as soon as connectivity returns.
+          remoteNativeFailureStreakStartedAt ??= probeAttemptStartedAt;
+          const failingForMs = Date.now() - remoteNativeFailureStreakStartedAt;
+          if (failingForMs >= remoteNativeFailureBudgetMs) {
+            const detail = formatStartupErrorDetail(err) ?? String(err);
+            logger.warn(
+              { failingForMs, target, detail },
+              "[startup-phase-poll] native remote target exceeded the connection-failure budget; surfacing the startup error",
+            );
+            deps.setStartupError({
+              reason: "backend-unreachable",
+              phase: "starting-backend",
+              message:
+                "Could not reach your saved agent. Check your connection and retry; your sign-in and chat history are preserved.",
+              detail,
+              status: ae?.status,
+              path: ae?.path,
+            });
+            deps.setFirstRunLoading(false);
+            dispatch({ type: "BACKEND_TIMEOUT" });
+            return;
+          }
+        } else {
+          // An HTTP/protocol response proves the remote host was reached, while
+          // embedded-local uses the separate progress-aware budget below.
+          remoteNativeFailureStreakStartedAt = null;
+        }
         // Android detached local agent now exposes the service-owned boot
         // state over the Capacitor plugin. That distinguishes a cold boot
         // from a launcher or child process death before the renderer's HTTP
@@ -1360,11 +1416,12 @@ export async function runPollingBackend(
           androidLocalAgentIpc &&
           (err instanceof ApiHangTimeoutError ||
             (err as { status?: number } | undefined)?.status === undefined);
-        if (
-          isIosNativeAgentBootInProgress() ||
-          androidNativeBootProgress ||
-          legacyAndroidLocalAgentBooting
-        ) {
+        const localAgentBootProgress =
+          !remoteTarget &&
+          (isIosNativeAgentBootInProgress() ||
+            androidNativeBootProgress ||
+            legacyAndroidLocalAgentBooting);
+        if (localAgentBootProgress) {
           // PROGRESS-AWARE budget: native evidence says the local agent is
           // booting, restarting, or accepting connections. Older Android
           // plugins that lack the boot-state method keep the legacy HTTP
@@ -1372,7 +1429,7 @@ export async function runPollingBackend(
           // deadline. A native `dead` state falls through and burns the
           // consecutive-failure budget.
           nativeFailureStreakStartedAt = null;
-        } else {
+        } else if (!remoteTarget) {
           nativeFailureStreakStartedAt ??= Date.now();
           const failingForMs = Date.now() - nativeFailureStreakStartedAt;
           if (failingForMs >= nativeFailureBudgetMs) {

--- a/packages/ui/src/state/startup-timing-policy.ts
+++ b/packages/ui/src/state/startup-timing-policy.ts
@@ -10,6 +10,7 @@ export const STARTUP_TIMING_POLICY = Object.freeze({
   stewardRestoreRefreshTimeoutMs: 4_000,
   cloudAgentTierProbeTimeoutMs: 12_000,
   nativeConsecutiveFailureBudgetMs: 90_000,
+  remoteNativeConsecutiveFailureBudgetMs: 12_000,
   agentUnreachableFailureBudgetMs: 45_000,
   probeRequestTimeoutMs: 12_000,
 });

--- a/packages/ui/src/state/useStartupCoordinator.recovery.test.ts
+++ b/packages/ui/src/state/useStartupCoordinator.recovery.test.ts
@@ -7,6 +7,7 @@ import { startupReducer } from "./startup-coordinator";
 import {
   recoverTerminalStartupError,
   type StartupCoordinatorDeps,
+  surfaceUnexpectedStartupRunnerError,
 } from "./useStartupCoordinator";
 
 const clientMock = vi.hoisted(() => ({
@@ -150,5 +151,50 @@ describe("startupReducer stale error recovery transitions", () => {
         { type: "BACKEND_REACHED", firstRunComplete: false },
       ),
     ).toEqual({ phase: "first-run-required", serverReachable: true });
+  });
+});
+
+describe("unexpected startup runner failures", () => {
+  it.each(["session restoration", "backend connection"] as const)(
+    "dispatches a visible AGENT_ERROR when %s rejects unexpectedly",
+    (runner) => {
+      const deps = createDeps();
+      const dispatch = vi.fn();
+
+      surfaceUnexpectedStartupRunnerError(
+        runner,
+        new Error("runner exploded"),
+        deps,
+        dispatch,
+        { current: false },
+      );
+
+      expect(deps.setStartupError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          reason: "agent-error",
+          message: expect.stringContaining("runner exploded"),
+        }),
+      );
+      expect(dispatch).toHaveBeenCalledWith({
+        type: "AGENT_ERROR",
+        message: expect.stringContaining("runner exploded"),
+      });
+    },
+  );
+
+  it("does not dispatch after the runner effect was cancelled", () => {
+    const deps = createDeps();
+    const dispatch = vi.fn();
+
+    surfaceUnexpectedStartupRunnerError(
+      "backend connection",
+      new Error("late rejection"),
+      deps,
+      dispatch,
+      { current: true },
+    );
+
+    expect(deps.setStartupError).not.toHaveBeenCalled();
+    expect(dispatch).not.toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/state/useStartupCoordinator.ts
+++ b/packages/ui/src/state/useStartupCoordinator.ts
@@ -145,6 +145,29 @@ export interface StartupCoordinatorHandle {
   phase: StartupState["phase"];
 }
 
+type StartupRunnerName = "session restoration" | "backend connection";
+
+/** Surface an unexpected phase-runner rejection instead of leaving boot stuck. */
+export function surfaceUnexpectedStartupRunnerError(
+  runner: StartupRunnerName,
+  err: unknown,
+  deps: Pick<StartupCoordinatorDeps, "setStartupError" | "setFirstRunLoading">,
+  dispatch: (event: StartupEvent) => void,
+  cancelled: { current: boolean },
+): void {
+  if (cancelled.current) return;
+  const detail = err instanceof Error ? err.message : String(err);
+  const message = `Startup ${runner} failed unexpectedly. ${detail}`;
+  deps.setStartupError({
+    reason: "agent-error",
+    phase: "starting-backend",
+    message,
+    detail,
+  });
+  deps.setFirstRunLoading(false);
+  dispatch({ type: "AGENT_ERROR", message });
+}
+
 function detectPlatformPolicy(): PlatformPolicy {
   if (isElectrobunRuntime()) {
     return createDesktopPolicy({
@@ -226,14 +249,19 @@ export function useStartupCoordinator(
     // boot in onboarding instead of polling an agent the native gate refuses
     // to start. No-op on web/desktop and on capable devices.
     enforceDeviceRamPolicyOnPersistedRuntimeModeAtBoot();
-    // error-policy:J5 expected failures are dispatched to the state machine
-    // inside the runner; this catch only keeps an unexpected runner bug from
-    // becoming an unhandled rejection, logged so a wedged boot phase is
-    // diagnosable instead of silent.
+    // error-policy:J4 expected failures are dispatched inside the runner; an
+    // unexpected rejection is translated to the visible startup error card.
     runRestoringSession(d, dispatch, _ctx, cancelled).catch((err: unknown) => {
       logger.error(
         { err },
         "[useStartupCoordinator] restoring-session phase runner threw",
+      );
+      surfaceUnexpectedStartupRunnerError(
+        "session restoration",
+        err,
+        d,
+        dispatch,
+        cancelled,
       );
     });
 
@@ -249,8 +277,15 @@ export function useStartupCoordinator(
   }, [state.phase]);
 
   // ── Phase: polling-backend ──────────────────────────────────────
+  const pollingBackendTarget: RuntimeTarget | null =
+    state.phase === "polling-backend" ? state.target : null;
   useEffect(() => {
-    if (state.phase !== "polling-backend" || !depsReady) return;
+    if (
+      state.phase !== "polling-backend" ||
+      !pollingBackendTarget ||
+      !depsReady
+    )
+      return;
     const currentDeps = depsRef.current;
     if (!currentDeps) return;
     effectRunRef.current += 1;
@@ -267,12 +302,20 @@ export function useStartupCoordinator(
       effectRunRef,
       cancelled,
       tidRef,
+      pollingBackendTarget,
     ).catch((err: unknown) => {
-      // error-policy:J5 expected failures are dispatched to the state machine
-      // inside the runner; log unexpected runner bugs instead of dropping them.
+      // error-policy:J4 expected failures are dispatched inside the runner; an
+      // unexpected rejection is translated to the visible startup error card.
       logger.error(
         { err },
         "[useStartupCoordinator] polling-backend phase runner threw",
+      );
+      surfaceUnexpectedStartupRunnerError(
+        "backend connection",
+        err,
+        currentDeps,
+        dispatch,
+        cancelled,
       );
     });
 
@@ -280,7 +323,13 @@ export function useStartupCoordinator(
       cancelled.current = true;
       if (tidRef.current) clearTimeout(tidRef.current);
     };
-  }, [state.phase, policy.backendTimeoutMs, depsReady, policy]);
+  }, [
+    state.phase,
+    pollingBackendTarget,
+    policy.backendTimeoutMs,
+    depsReady,
+    policy,
+  ]);
 
   // ── Phase: starting-runtime ─────────────────────────────────────
   // The runtime target is fixed for a given starting-runtime entry (it is


### PR DESCRIPTION
## Summary

- adds an explicit, separately installable Pixel VPS sidecar build identity while leaving the canonical ai.elizaos.app identity unchanged by default
- reuses the already-merged exact remote hard-pin work from PRs #29307 and #29311; no duplicate hard-pin implementation
- keeps the sidecar Firebase-independent, strips FCM/native libraries, suppresses bridge payload logging, and enforces one credential-free root HTTPS fallback origin
- carries the physically accepted standalone pairing recovery and bounded native remote-startup failure behavior onto current develop

## Provenance

- base: 48f8f61238fbcba29b3455ea213f3c5d59c82d99
- head: 44faaec308392f146e862e50b241ea61c2c3dcd5
- tree: a73d021a4f335dea47f686b341cc6ccbcf26b22b
- stable patch ID across the rebase: 3b8195aee1ae9e563ec4ffabc1b6153d79df372f
- renderer buildId: 84a6c1f7556df62811e7c0b15633845aca84d94b2d4caa48907549df0ec36a52
- exact APK SHA-256: 05de45594597758f83a88d418fa948797c6f44a43f81820b148e99e4c3932ded
- package: ai.elizaos.app.vps
- compiled target: https://bot.nubs.site
- cleartext disabled; WebView debugging disabled; no packaged native libraries

## Verification

- zero path overlap with the eight incoming develop commits; the PR remains the same 16-file patch
- incoming agent/core/cloud/billing/app-control changes are semantically independent of the Android identity, startup, hard-pin, and offline-recovery paths
- 58 focused mobile build/config/identity tests pass
- 145 focused UI auth/startup/hard-pin/persistence tests pass
- 16 app network/fallback tests pass
- packages/ui typecheck passes
- Biome passes on all 16 changed files
- exact sidecar renderer build, pre-Gradle audit, Gradle assemble, post-Gradle audit, and APK artifact audit pass

The prior old-head sidecar artifact passed real Pixel chat, Home/Calendar/Notes/Home switching, note persistence, relaunch/history, target isolation, and exact installed-hash proof. This newly rebased exact APK still requires one update-in-place Pixel retest before merge because its embedded source identity and APK hash changed; no device was touched by this source/build lane.