### PR TITLE
fix: restore canonical chat navigation and full-bleed settings

### DIFF
--- a/packages/ui/src/App.navigate-view-wiring.test.tsx
+++ b/packages/ui/src/App.navigate-view-wiring.test.tsx
@@ -842,6 +842,12 @@ describe("App navigate-view event wiring", () => {
       await screen.findByTestId("settings-view")
     ).closest<HTMLElement>("[data-page-content]");
     expect(settingsPageContent).not.toBeNull();
+    expect(settingsPageContent?.getAttribute("data-page-gutter")).toBe("none");
+    expect(
+      settingsPageContent
+        ?.closest<HTMLElement>("[data-page-kind]")
+        ?.getAttribute("data-page-width"),
+    ).toBe("full");
     expect(settingsPageContent?.className).toContain(
       "pb-[var(--eliza-chat-clearance,5.25rem)]",
     );

--- a/packages/ui/src/navigation/builtin-route-descriptors.ts
+++ b/packages/ui/src/navigation/builtin-route-descriptors.ts
@@ -179,7 +179,7 @@ export const BUILTIN_ROUTE_DESCRIPTORS = defineBuiltinRoutes({
   runtime: { path: "/apps/runtime", layout: WORKSPACE_LAYOUT },
   database: { path: "/apps/database", layout: WORKSPACE_LAYOUT },
   desktop: { path: "/desktop", layout: FULL_WORKSPACE_LAYOUT },
-  settings: { path: "/settings", layout: WORKSPACE_LAYOUT },
+  settings: { path: "/settings", layout: FULL_WORKSPACE_LAYOUT },
   vault: { path: "/vault", layout: CONTENT_LAYOUT },
   logs: { path: "/apps/logs", layout: CONTENT_LAYOUT },
   background: {

--- a/plugins/plugin-app-control/AGENTS.md
+++ b/plugins/plugin-app-control/AGENTS.md
@@ -5,8 +5,9 @@ models, active agent profiles, and built-in settings.
 
 ## Purpose / role
 
-This opt-in plugin registers nine actions, no natural-language pre-LLM shortcuts, two evaluators,
-two providers, and four services. Dashboard operations use authenticated
+This opt-in plugin registers nine actions, no `shortcuts` entries, three evaluators
+(including a deterministic exact-command pre-planner evaluator), two providers,
+and four services. Dashboard operations use authenticated
 loopback HTTP (`/api/apps/*`, `/api/views/*`) discovered through the existing
 port resolver.
 

--- a/plugins/plugin-app-control/AGENTS.md
+++ b/plugins/plugin-app-control/AGENTS.md
@@ -30,7 +30,7 @@ port resolver.
 | Name | File | Description |
 |---|---|---|
 | `viewContextEvaluator` | `src/evaluators/view-context.ts` | Model-assisted contextual navigation when no explicit view command matched. |
-| `viewCommandShortcutEvaluator` | `src/evaluators/view-command-shortcut.ts` | Compatibility export for downstream users; the first-party plugin does not register it because the model owns view-action selection. |
+| `viewCommandShortcutEvaluator` | `src/evaluators/view-command-shortcut.ts` | Registered zero-model fast path for exact standalone view commands. It installs one deterministic `VIEWS` call before the planner; contextual and compound requests still remain model-owned. |
 | `createChoiceShortcutEvaluator` | `src/evaluators/create-choice-shortcut.ts` | Routes replies to pending app/view creation choices without another model decision. |
 | `viewFollowupRoutingEvaluator` | `src/evaluators/view-followup-routing.ts` | Compatibility export for downstream users; the first-party plugin leaves focused-view mutation follow-ups to Stage 1 and the planner. |
 

--- a/plugins/plugin-app-control/CLAUDE.md
+++ b/plugins/plugin-app-control/CLAUDE.md
@@ -5,8 +5,9 @@ models, active agent profiles, and built-in settings.
 
 ## Purpose / role
 
-This opt-in plugin registers nine actions, no natural-language pre-LLM shortcuts, two evaluators,
-two providers, and four services. Dashboard operations use authenticated
+This opt-in plugin registers nine actions, no `shortcuts` entries, three evaluators
+(including a deterministic exact-command pre-planner evaluator), two providers,
+and four services. Dashboard operations use authenticated
 loopback HTTP (`/api/apps/*`, `/api/views/*`) discovered through the existing
 port resolver.
 

--- a/plugins/plugin-app-control/CLAUDE.md
+++ b/plugins/plugin-app-control/CLAUDE.md
@@ -30,7 +30,7 @@ port resolver.
 | Name | File | Description |
 |---|---|---|
 | `viewContextEvaluator` | `src/evaluators/view-context.ts` | Model-assisted contextual navigation when no explicit view command matched. |
-| `viewCommandShortcutEvaluator` | `src/evaluators/view-command-shortcut.ts` | Compatibility export for downstream users; the first-party plugin does not register it because the model owns view-action selection. |
+| `viewCommandShortcutEvaluator` | `src/evaluators/view-command-shortcut.ts` | Registered zero-model fast path for exact standalone view commands. It installs one deterministic `VIEWS` call before the planner; contextual and compound requests still remain model-owned. |
 | `createChoiceShortcutEvaluator` | `src/evaluators/create-choice-shortcut.ts` | Routes replies to pending app/view creation choices without another model decision. |
 | `viewFollowupRoutingEvaluator` | `src/evaluators/view-followup-routing.ts` | Compatibility export for downstream users; the first-party plugin leaves focused-view mutation follow-ups to Stage 1 and the planner. |
 

--- a/plugins/plugin-app-control/src/index.ts
+++ b/plugins/plugin-app-control/src/index.ts
@@ -25,6 +25,7 @@ import {
 } from "./actions/views.js";
 import { createViewsClient } from "./actions/views-client.js";
 import { createChoiceShortcutEvaluator } from "./evaluators/create-choice-shortcut.js";
+import { viewCommandShortcutEvaluator } from "./evaluators/view-command-shortcut.js";
 import { viewContextEvaluator } from "./evaluators/view-context.js";
 import { availableAppsProvider } from "./providers/available-apps.js";
 import { currentViewProvider } from "./providers/current-view.js";
@@ -167,9 +168,9 @@ export const appControlPlugin: Plugin = {
 		runtimeManagementAction,
 		settingsAction,
 	],
-	// Model-owned view-switch cascade:
-	//  1. PLAN   — the response handler/planner selects VIEWS from the registered
-	//     action contract, including explicit multilingual navigation requests.
+	// View-switch cascade:
+	//  1. ROUTE  — exact standalone multilingual commands take the deterministic
+	//     VIEWS fast path; contextual and compound requests stay with the planner.
 	//  2. ACTION — viewsAction resolves the selected target and navigates.
 	//  3. POST   — viewContextEvaluator (small model) catches contextual intent
 	//     the user never spelled out ("fix the login bug" -> task-coordinator).
@@ -177,9 +178,15 @@ export const appControlPlugin: Plugin = {
 	//     surface (the rigid matchViewCommand matcher, or the legacy intent
 	//     rules it falls back to), so it never contends with the action.
 	evaluators: [viewContextEvaluator],
-	// Persisted choice widgets are an explicit continuation protocol. Ordinary
-	// view navigation and follow-up language stays with Stage 1 and the planner.
-	responseHandlerEvaluators: [createChoiceShortcutEvaluator],
+	// Persisted choice widgets are an explicit continuation protocol. Exact,
+	// standalone view commands use the rigid zero-model evaluator so shell
+	// navigation cannot fail merely because the general planner is unavailable
+	// or over its provider context limit. Contextual and compound language still
+	// stays with Stage 1 and the planner.
+	responseHandlerEvaluators: [
+		viewCommandShortcutEvaluator,
+		createChoiceShortcutEvaluator,
+	],
 	providers: [availableAppsProvider, currentViewProvider],
 	services: [
 		AppRegistryService,

--- a/plugins/plugin-app-control/src/shortcuts.test.ts
+++ b/plugins/plugin-app-control/src/shortcuts.test.ts
@@ -16,13 +16,16 @@ const MATCH_CONTEXT = {
 } as const;
 
 describe("viewNavigationShortcuts (#8791)", () => {
-	it("remain compatibility exports but are not registered ahead of the model", () => {
+	it("registers exact view commands ahead of the model without enabling follow-up routing", () => {
 		expect(appControlPlugin.shortcuts ?? []).toEqual([]);
 		expect(
 			appControlPlugin.responseHandlerEvaluators?.map(
 				(evaluator) => evaluator.name,
 			),
-		).not.toContain("app-control.view-command-shortcut");
+		).toEqual([
+			"app-control.view-command-shortcut",
+			"app-control.create-choice-shortcut",
+		]);
 		expect(
 			appControlPlugin.responseHandlerEvaluators?.map(
 				(evaluator) => evaluator.name,


### PR DESCRIPTION
## Summary
- register the existing deterministic `viewCommandShortcutEvaluator` before the general planner
- keep contextual and compound navigation on the existing planner/action path
- use the existing full-workspace layout for Settings so its canvas reaches the top and side edges
- preserve Settings internal content and native safe-area spacing

## Validation
- plugin focused tests: 44 passed
- UI navigation/settings/frame tests: 128 passed
- `@elizaos/plugin-app-control` typecheck
- `@elizaos/ui` typecheck
- Biome, `git diff --check`, and AGENTS/CLAUDE parity
- independent exact-head review approved `b587e5167217e8d2eaf802b63b6971a4dece17f5`

## Scope
No new parser or navigation implementation. This restores the already-tested canonical evaluator registration and selects an existing layout descriptor.