### PR TITLE
fix(ci): require main ref for production worker dispatch

### DIFF
--- a/.github/workflows/deploy-eliza-provisioning-worker.yml
+++ b/.github/workflows/deploy-eliza-provisioning-worker.yml
@@ -51,6 +51,15 @@ jobs:
     steps:
       - id: env
         run: |
+          # Production is a protected release target. A manual dispatch from
+          # any non-main ref must never be able to select production secrets or
+          # deploy the current main snapshot while running unreviewed code.
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] \
+            && [ "${{ github.event.inputs.environment }}" = "production" ] \
+            && [ "${{ github.ref }}" != "refs/heads/main" ]; then
+            echo "::error::Production deployments must be dispatched from refs/heads/main"
+            exit 1
+          fi
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             env="${{ github.event.inputs.environment }}"
           elif [ "${{ github.ref }}" = "refs/heads/main" ]; then


### PR DESCRIPTION
Production worker workflow currently accepts a manual production dispatch from any branch and then deploys the main snapshot with production credentials. Require refs/heads/main for production dispatches so feature-branch diagnostics cannot mutate production.