### PR TITLE
fix(app-control): synthesize structured view reads safely

### DIFF
--- a/packages/agent/src/api/__tests__/character-connection-invalidation.test.ts
+++ b/packages/agent/src/api/__tests__/character-connection-invalidation.test.ts
@@ -26,6 +26,7 @@ function captureDescriptor(runtime: AgentRuntime, agentName: string) {
     ownerId: stringToUuid("rename-owner") as UUID,
     callerEntityId: stringToUuid("rename-caller") as UUID,
     callerRole: "USER",
+    callerGrantSource: "connector_admin",
     callerUserName: "rename-caller",
   });
 }

--- a/packages/agent/src/api/__tests__/conversation-connection-readiness.test.ts
+++ b/packages/agent/src/api/__tests__/conversation-connection-readiness.test.ts
@@ -47,6 +47,7 @@ function captureDescriptor(
       input.callerSeed ?? "readiness-caller",
     ) as UUID,
     callerRole: input.callerRole ?? "USER",
+    callerGrantSource: "connector_admin",
     callerUserName: input.callerSeed ?? "readiness-caller",
   });
 }

--- a/packages/agent/src/api/__tests__/conversation-machine-session-role.test.ts
+++ b/packages/agent/src/api/__tests__/conversation-machine-session-role.test.ts
@@ -1,0 +1,351 @@
+/**
+ * Machine-session (paired-device) attribution on the web-conversation surface.
+ *
+ * ea44f571ec1 taught compat chat ingress (ensureCompatChatConnection) to grant
+ * an authenticated machine-session principal's minted entity USER world
+ * membership, but the conversation routes resolve their caller through
+ * resolveConversationCaller, which dropped `sessionRole` and granted GUEST —
+ * so "go home" turns in a dashboard conversation still failed the VIEWS
+ * minRole:USER gate (live tj-92e47fe5ea3e5c: deterministic VIEWS call ->
+ * "Action VIEWS is not allowed for the current role"). This suite drives the
+ * production conversation route + connection seam with a stubbed runtime
+ * adapter, then core checkSenderRole and the real VIEWS action gate.
+ */
+
+import http from "node:http";
+import { Socket } from "node:net";
+import type { Action, AgentContext } from "@elizaos/core";
+import {
+  checkSenderRole,
+  logger,
+  type Memory,
+  type RoleGateRole,
+  satisfiesContextGate,
+  satisfiesRoleGate,
+  stringToUuid,
+  type UUID,
+} from "@elizaos/core";
+import { viewsAction } from "@elizaos/plugin-app-control";
+import { describe, expect, it, vi } from "vitest";
+import type { AgentHttpRequestAuthorization } from "../../runtime/host-bridge.ts";
+import { resolveTrustedApiPrincipal } from "../chat-routes.ts";
+import type {
+  ConversationRouteContext,
+  ConversationRouteState,
+} from "../conversation-routes.ts";
+import {
+  ensureConversationRoom,
+  handleConversationRoutes,
+  resolveConversationCaller,
+} from "../conversation-routes.ts";
+import type { ConversationMeta } from "../server-types.ts";
+
+vi.mock("../server-helpers.ts", async () => {
+  const actual = await vi.importActual<typeof import("../server-helpers.ts")>(
+    "../server-helpers.ts",
+  );
+  return {
+    ...actual,
+    resolveAppUserName: () => "tester",
+  };
+});
+
+const AGENT_ID = stringToUuid("machine-session-agent") as UUID;
+const OWNER_ID = stringToUuid("machine-session-owner") as UUID;
+const MACHINE_IDENTITY = "machine-session-identity-48bb15ed";
+const CALLER_ENTITY_ID = stringToUuid(
+  `conversation-external:${MACHINE_IDENTITY}`,
+) as UUID;
+
+const machineSessionAuthorization: AgentHttpRequestAuthorization = {
+  ok: true,
+  role: "USER",
+  identityId: MACHINE_IDENTITY,
+};
+
+type StoredWorld = {
+  id: UUID;
+  metadata?: {
+    ownership?: { ownerId?: string };
+    roles?: Record<string, string>;
+    roleSources?: Record<string, string>;
+  };
+};
+
+function createRuntimeHarness() {
+  const worlds = new Map<string, StoredWorld>();
+  const roomWorlds = new Map<string, UUID>();
+  const updateWorld = vi.fn(async (world: StoredWorld) => {
+    worlds.set(world.id, world);
+  });
+  const runtime = {
+    agentId: AGENT_ID,
+    character: { name: "Test Agent" },
+    logger,
+    getSetting: () => undefined,
+    getRelationships: async () => [],
+    getEntityById: async () => null,
+    ensureConnection: vi.fn(async (params: { roomId: UUID; worldId: UUID }) => {
+      roomWorlds.set(params.roomId, params.worldId);
+      if (!worlds.has(params.worldId)) {
+        worlds.set(params.worldId, { id: params.worldId, metadata: {} });
+      }
+    }),
+    getWorld: async (id: UUID) => worlds.get(id) ?? null,
+    updateWorld,
+    getRoom: async (id: UUID) => {
+      const worldId = roomWorlds.get(id);
+      return worldId ? { id, worldId } : null;
+    },
+    adapter: {},
+  };
+  return { runtime, worlds, roomWorlds, updateWorld };
+}
+
+function createState(runtime: unknown): ConversationRouteState {
+  return {
+    runtime: runtime as never,
+    config: { user: { name: "tester" } } as never,
+    agentName: "Test Agent",
+    adminEntityId: OWNER_ID,
+    chatUserId: OWNER_ID,
+    logBuffer: [],
+    conversations: new Map<string, ConversationMeta>(),
+    activeChatTurnCount: 0,
+    conversationRestorePromise: null,
+    deletedConversationIds: new Set(),
+    broadcastWs: null,
+  } as unknown as ConversationRouteState;
+}
+
+function createReq(): http.IncomingMessage {
+  const request = new http.IncomingMessage(new Socket());
+  request.method = "POST";
+  request.url = "/api/conversations";
+  request.headers = { host: "agent.example.test" };
+  Object.defineProperty(request.socket, "remoteAddress", {
+    value: "203.0.113.19",
+    configurable: true,
+  });
+  return request;
+}
+
+function createCtx(
+  state: ConversationRouteState,
+  callerAuthorization: AgentHttpRequestAuthorization | undefined,
+): ConversationRouteContext & { json: ReturnType<typeof vi.fn> } {
+  return {
+    req: createReq(),
+    res: {} as http.ServerResponse,
+    method: "POST",
+    pathname: "/api/conversations",
+    state,
+    callerAuthorization,
+    readJsonBody: vi.fn(async () => ({ title: "Machine session turn" })),
+    json: vi.fn(),
+    error: vi.fn(),
+  } as unknown as ConversationRouteContext & { json: ReturnType<typeof vi.fn> };
+}
+
+function messageFor(userId: UUID, roomId: UUID): Memory {
+  return {
+    entityId: userId,
+    roomId,
+    content: { text: "go home", source: "client_chat" },
+  } as unknown as Memory;
+}
+
+type GateableFixture = Pick<Action, "name" | "roleGate"> &
+  Partial<Pick<Action, "contexts" | "contextGate">>;
+
+/**
+ * Mirrors the role/context stages of core's actionGateRejection (VIEWS
+ * declares no private/disclosure gate and no ACTION_ROLE_POLICY override is
+ * set in tests) — same fixture as machine-session-role-grant.test.ts.
+ */
+function gateAllows(
+  action: GateableFixture,
+  userRoles: readonly RoleGateRole[],
+  activeContexts: readonly AgentContext[],
+): boolean {
+  const contextRoleGate = action.contextGate?.roleGate ?? action.roleGate;
+  if (!satisfiesRoleGate(userRoles, contextRoleGate)) return false;
+  const contextGate = action.contextGate ?? { contexts: action.contexts };
+  if (!satisfiesContextGate(activeContexts, contextGate, userRoles)) {
+    return false;
+  }
+  return satisfiesRoleGate(userRoles, action.roleGate);
+}
+
+async function createConversationThroughRoute(
+  harness: ReturnType<typeof createRuntimeHarness>,
+  callerAuthorization: AgentHttpRequestAuthorization | undefined,
+): Promise<{ state: ConversationRouteState; conv: ConversationMeta }> {
+  const state = createState(harness.runtime);
+  const ctx = createCtx(state, callerAuthorization);
+  const handled = await handleConversationRoutes(ctx);
+  expect(handled).toBe(true);
+  expect(ctx.error).not.toHaveBeenCalled();
+  const conv = [...state.conversations.values()][0];
+  if (!conv) throw new Error("conversation was not created");
+  return { state, conv };
+}
+
+describe("machine-session attribution on the conversation surface", () => {
+  it("grants the conversation caller USER world membership with audit source 'session'", async () => {
+    const harness = createRuntimeHarness();
+    const { conv } = await createConversationThroughRoute(
+      harness,
+      machineSessionAuthorization,
+    );
+
+    const worldId = stringToUuid("Test Agent-web-chat-world") as UUID;
+    const world = harness.worlds.get(worldId);
+    expect(world?.metadata?.roles?.[CALLER_ENTITY_ID]).toBe("USER");
+    expect(world?.metadata?.roleSources?.[CALLER_ENTITY_ID]).toBe("session");
+    // The conversation world keeps its canonical owner attribution.
+    expect(world?.metadata?.roles?.[OWNER_ID]).toBe("OWNER");
+    expect(world?.metadata?.roleSources?.[OWNER_ID]).toBe("owner");
+
+    const senderRole = await checkSenderRole(
+      harness.runtime as never,
+      messageFor(CALLER_ENTITY_ID, conv.roomId),
+    );
+    expect(senderRole?.role).toBe("USER");
+    expect(senderRole?.isOwner).toBe(false);
+
+    const userRoles = [senderRole?.role ?? "GUEST"] as RoleGateRole[];
+    const activeContexts = ["general"] as AgentContext[];
+    expect(gateAllows(viewsAction, userRoles, activeContexts)).toBe(true);
+    expect(
+      gateAllows(
+        { name: "OWNER_ONLY_SURFACE", roleGate: { minRole: "OWNER" } },
+        userRoles,
+        activeContexts,
+      ),
+    ).toBe(false);
+  });
+
+  it("upgrades a pre-existing conversation whose caller was granted GUEST before the fix", async () => {
+    // Live worlds recorded roles[caller]="GUEST" for every earlier
+    // machine-session turn; the next turn's connection ensure must upgrade the
+    // stale grant in place (same conversation, same entity id).
+    const harness = createRuntimeHarness();
+    const state = createState(harness.runtime);
+    const worldId = stringToUuid("Test Agent-web-chat-world") as UUID;
+    const conv: ConversationMeta = {
+      id: "5331baf6-pre-existing",
+      title: "Pre-existing chat",
+      roomId: stringToUuid("web-conv-5331baf6-pre-existing") as UUID,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+    state.conversations.set(conv.id, conv);
+    harness.worlds.set(worldId, {
+      id: worldId,
+      metadata: {
+        ownership: { ownerId: OWNER_ID },
+        roles: { [OWNER_ID]: "OWNER", [CALLER_ENTITY_ID]: "GUEST" },
+        roleSources: { [OWNER_ID]: "owner" },
+      },
+    });
+
+    const principal = resolveTrustedApiPrincipal(
+      createReq(),
+      machineSessionAuthorization,
+    );
+    expect(principal).toEqual({
+      kind: "service_gateway",
+      principalId: MACHINE_IDENTITY,
+      sessionRole: "USER",
+      sessionIdentityId: MACHINE_IDENTITY,
+    });
+    const caller = resolveConversationCaller(
+      createReq(),
+      state,
+      principal,
+      harness.runtime as never,
+    );
+    expect(caller.entityId).toBe(CALLER_ENTITY_ID);
+    await ensureConversationRoom(state, harness.runtime as never, conv, caller);
+
+    const world = harness.worlds.get(worldId);
+    expect(world?.metadata?.roles?.[CALLER_ENTITY_ID]).toBe("USER");
+    expect(world?.metadata?.roleSources?.[CALLER_ENTITY_ID]).toBe("session");
+
+    const senderRole = await checkSenderRole(
+      harness.runtime as never,
+      messageFor(CALLER_ENTITY_ID, conv.roomId),
+    );
+    expect(senderRole?.role).toBe("USER");
+    expect(
+      gateAllows(
+        viewsAction,
+        [senderRole?.role ?? "GUEST"] as RoleGateRole[],
+        ["general"] as AgentContext[],
+      ),
+    ).toBe(true);
+  });
+
+  it("never downgrades an existing USER-or-higher grant for the session caller", async () => {
+    const harness = createRuntimeHarness();
+    const state = createState(harness.runtime);
+    const worldId = stringToUuid("Test Agent-web-chat-world") as UUID;
+    const conv: ConversationMeta = {
+      id: "manual-admin-conv",
+      title: "Manual admin chat",
+      roomId: stringToUuid("web-conv-manual-admin-conv") as UUID,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+    state.conversations.set(conv.id, conv);
+    harness.worlds.set(worldId, {
+      id: worldId,
+      metadata: {
+        ownership: { ownerId: OWNER_ID },
+        roles: { [OWNER_ID]: "OWNER", [CALLER_ENTITY_ID]: "ADMIN" },
+        roleSources: { [OWNER_ID]: "owner", [CALLER_ENTITY_ID]: "manual" },
+      },
+    });
+
+    const caller = resolveConversationCaller(
+      createReq(),
+      state,
+      resolveTrustedApiPrincipal(createReq(), machineSessionAuthorization),
+      harness.runtime as never,
+    );
+    harness.updateWorld.mockClear();
+    await ensureConversationRoom(state, harness.runtime as never, conv, caller);
+
+    const world = harness.worlds.get(worldId);
+    expect(harness.updateWorld).not.toHaveBeenCalled();
+    expect(world?.metadata?.roles?.[CALLER_ENTITY_ID]).toBe("ADMIN");
+    expect(world?.metadata?.roleSources?.[CALLER_ENTITY_ID]).toBe("manual");
+  });
+
+  it("keeps a plain external principal GUEST and VIEWS-denied", async () => {
+    const harness = createRuntimeHarness();
+    const { conv } = await createConversationThroughRoute(harness, undefined);
+
+    const externalEntityId = stringToUuid(
+      "conversation-external:non-owner-api",
+    ) as UUID;
+    const worldId = stringToUuid("Test Agent-web-chat-world") as UUID;
+    const world = harness.worlds.get(worldId);
+    expect(world?.metadata?.roles?.[externalEntityId]).toBe("GUEST");
+    expect(world?.metadata?.roleSources?.[externalEntityId]).toBeUndefined();
+
+    const senderRole = await checkSenderRole(
+      harness.runtime as never,
+      messageFor(externalEntityId, conv.roomId),
+    );
+    expect(senderRole?.role).toBe("GUEST");
+    expect(
+      gateAllows(
+        viewsAction,
+        [senderRole?.role ?? "GUEST"] as RoleGateRole[],
+        ["general"] as AgentContext[],
+      ),
+    ).toBe(false);
+  });
+});

--- a/packages/agent/src/api/__tests__/conversation-stream-sse-contract.test.ts
+++ b/packages/agent/src/api/__tests__/conversation-stream-sse-contract.test.ts
@@ -1009,6 +1009,43 @@ function createSerialVoiceTurnMessageService({
   };
 }
 
+/**
+ * Records the `content.metadata` each runtime turn is handed, so a test can
+ * assert what the route stamped onto the message BEFORE generation. This is
+ * the observation point for the originating-renderer routing identity: the
+ * VIEWS action reads `content.metadata.viewClientId` to target its navigate
+ * frame at the caller's own WebSocket instead of broadcasting globally.
+ */
+function createMetadataCaptureMessageService(
+  captured: Array<Record<string, unknown> | undefined>,
+): NonNullable<AgentRuntime["messageService"]> {
+  return {
+    async handleMessage(_runtime, message) {
+      const content = (message as Memory).content as
+        | { metadata?: unknown }
+        | undefined;
+      const metadata = content?.metadata;
+      captured.push(
+        metadata && typeof metadata === "object" && !Array.isArray(metadata)
+          ? (metadata as Record<string, unknown>)
+          : undefined,
+      );
+      return {
+        didRespond: true,
+        responseContent: { text: FINAL_TEXT, thought: THOUGHT },
+        responseMessages: [],
+      };
+    },
+    shouldRespond: () => ({
+      shouldRespond: true,
+      skipEvaluation: true,
+      reason: "view-client-stamping-regression",
+    }),
+    deleteMessage: async () => undefined,
+    clearChannel: async () => undefined,
+  };
+}
+
 describe("conversation stream SSE contract (#10712)", () => {
   afterEach(() => {
     vi.clearAllMocks();
@@ -2765,5 +2802,64 @@ describe("conversation stream SSE contract (#10712)", () => {
       { type: "token", text: "Hello wrld", fullText: "Hello wrld" },
       { type: "token", text: "Hello world", fullText: "Hello world" },
     ]);
+  });
+
+  // ── Originating-renderer routing identity ────────────────────────────────
+  // A chat turn's targeted view navigation depends on one stamping seam: the
+  // stream route copies the caller's `X-ElizaOS-Client-Id` header onto the
+  // runtime message as `content.metadata.viewClientId`. The VIEWS action reads
+  // it to request `delivery: "completed-action"` scoped to that client id, and
+  // /api/views/:id/navigate targets the caller's own WebSocket with the
+  // `shell:navigate:view` frame instead of broadcasting to every device. If
+  // this stamp regresses, agent navigation silently degrades to a global
+  // broadcast that navigates unrelated browsers and devices.
+  describe("originating-renderer client id stamping (targeted VIEWS delivery)", () => {
+    it("stamps the caller's X-ElizaOS-Client-Id onto the turn's content metadata", async () => {
+      const captured: Array<Record<string, unknown> | undefined> = [];
+      const { ctx, record } = createCtx(
+        createMetadataCaptureMessageService(captured),
+      );
+      ctx.req.headers["x-elizaos-client-id"] = "ui-originating-renderer";
+
+      await handleConversationRoutes(ctx);
+
+      const payloads = parseSsePayloads(record.writes);
+      expect(payloads.at(-1)?.type).toBe("done");
+      expect(captured).toHaveLength(1);
+      expect(captured[0]?.viewClientId).toBe("ui-originating-renderer");
+    });
+
+    it("accepts the X-Eliza-Client-Id alias header", async () => {
+      const captured: Array<Record<string, unknown> | undefined> = [];
+      const { ctx } = createCtx(createMetadataCaptureMessageService(captured));
+      ctx.req.headers["x-eliza-client-id"] = "ui-alias-renderer";
+
+      await handleConversationRoutes(ctx);
+
+      expect(captured).toHaveLength(1);
+      expect(captured[0]?.viewClientId).toBe("ui-alias-renderer");
+    });
+
+    it("keeps the turn unstamped when the header is absent or unsafe", async () => {
+      const unsafeHeaders: Array<string | undefined> = [
+        undefined,
+        "spaces are not a client id",
+        "x".repeat(129),
+      ];
+      for (const header of unsafeHeaders) {
+        const captured: Array<Record<string, unknown> | undefined> = [];
+        const { ctx } = createCtx(
+          createMetadataCaptureMessageService(captured),
+        );
+        if (header !== undefined) {
+          ctx.req.headers["x-elizaos-client-id"] = header;
+        }
+
+        await handleConversationRoutes(ctx);
+
+        expect(captured).toHaveLength(1);
+        expect(captured[0]?.viewClientId).toBeUndefined();
+      }
+    });
   });
 });

--- a/packages/agent/src/api/__tests__/machine-session-role-grant.test.ts
+++ b/packages/agent/src/api/__tests__/machine-session-role-grant.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Pairing -> chat -> VIEWS attribution flow for authenticated machine-session
+ * (paired-device) principals. Chat ingress must grant the session's minted
+ * external entity USER world membership (source "session") so core's
+ * checkSenderRole resolves at least the session's boundary role, while
+ * OWNER-gated surfaces keep denying and unauthenticated external principals
+ * stay GUEST. Uses the production ensureCompatChatConnection /
+ * resolveTrustedApiPrincipal, core role resolution, the real action gate, and
+ * the real VIEWS action over a stubbed runtime adapter.
+ */
+
+import http from "node:http";
+import { Socket } from "node:net";
+import type { Action, AgentContext } from "@elizaos/core";
+import {
+  checkSenderRole,
+  logger,
+  type Memory,
+  type RoleGateRole,
+  satisfiesContextGate,
+  satisfiesRoleGate,
+  type TrustedApiPrincipal,
+  type UUID,
+} from "@elizaos/core";
+import { viewsAction } from "@elizaos/plugin-app-control";
+import { describe, expect, it, vi } from "vitest";
+import type { ChatRouteState } from "../chat-routes.ts";
+import {
+  ensureCompatChatConnection,
+  resolveTrustedApiPrincipal,
+} from "../chat-routes.ts";
+
+const MACHINE_IDENTITY = "machine-session-identity-48bb15ed";
+
+type StoredWorld = {
+  id: UUID;
+  metadata?: {
+    ownership?: { ownerId?: string };
+    roles?: Record<string, string>;
+    roleSources?: Record<string, string>;
+  };
+};
+
+function createRuntimeHarness() {
+  const worlds = new Map<string, StoredWorld>();
+  const roomWorlds = new Map<string, UUID>();
+  const updateWorld = vi.fn(async (world: StoredWorld) => {
+    worlds.set(world.id, world);
+  });
+  const runtime = {
+    agentId: "10000000-0000-4000-8000-000000000001" as UUID,
+    character: { name: "Test Agent" },
+    logger,
+    getSetting: () => undefined,
+    getRelationships: async () => [],
+    getEntityById: async () => null,
+    ensureConnection: vi.fn(async (params: { roomId: UUID; worldId: UUID }) => {
+      roomWorlds.set(params.roomId, params.worldId);
+      if (!worlds.has(params.worldId)) {
+        worlds.set(params.worldId, { id: params.worldId, metadata: {} });
+      }
+    }),
+    getWorld: async (id: UUID) => worlds.get(id) ?? null,
+    updateWorld,
+    getRoom: async (id: UUID) => {
+      const worldId = roomWorlds.get(id);
+      return worldId ? { id, worldId } : null;
+    },
+  };
+  return { runtime, worlds, updateWorld };
+}
+
+function createState(): ChatRouteState {
+  return {
+    runtime: null,
+    config: {} as ChatRouteState["config"],
+    agentName: "Test Agent",
+    logBuffer: [],
+    chatRoomId: null,
+    chatUserId: null,
+    chatConnectionReady: null,
+    chatConnectionPromise: null,
+    adminEntityId: "20000000-0000-4000-8000-000000000002" as UUID,
+  };
+}
+
+function makeUnauthenticatedRequest(): http.IncomingMessage {
+  const request = new http.IncomingMessage(new Socket());
+  request.headers = { host: "agent.example.test" };
+  Object.defineProperty(request.socket, "remoteAddress", {
+    value: "203.0.113.19",
+    configurable: true,
+  });
+  return request;
+}
+
+async function connect(
+  harness: ReturnType<typeof createRuntimeHarness>,
+  principal: TrustedApiPrincipal,
+) {
+  return ensureCompatChatConnection(
+    createState(),
+    harness.runtime as never,
+    "Test Agent",
+    "compat-chat",
+    "default",
+    principal,
+  );
+}
+
+function messageFor(userId: UUID, roomId: UUID): Memory {
+  return {
+    entityId: userId,
+    roomId,
+    content: { text: "go home", source: "client_chat" },
+  } as unknown as Memory;
+}
+
+const machineSessionPrincipal: TrustedApiPrincipal = {
+  kind: "service_gateway",
+  principalId: MACHINE_IDENTITY,
+  sessionRole: "USER",
+  sessionIdentityId: MACHINE_IDENTITY,
+};
+
+type GateableFixture = Pick<Action, "name" | "roleGate"> &
+  Partial<Pick<Action, "contexts" | "contextGate">>;
+
+/**
+ * Mirrors the role/context stages of core's actionGateRejection (VIEWS
+ * declares no private/disclosure gate and no ACTION_ROLE_POLICY override is
+ * set in tests): contextGate.roleGate ?? roleGate, then the contextGate, then
+ * the top-level roleGate. The gate-parity suites pin that every execution path
+ * routes through that one composed gate.
+ */
+function gateAllows(
+  action: GateableFixture,
+  userRoles: readonly RoleGateRole[],
+  activeContexts: readonly AgentContext[],
+): boolean {
+  const contextRoleGate = action.contextGate?.roleGate ?? action.roleGate;
+  if (!satisfiesRoleGate(userRoles, contextRoleGate)) return false;
+  const contextGate = action.contextGate ?? { contexts: action.contexts };
+  if (!satisfiesContextGate(activeContexts, contextGate, userRoles)) {
+    return false;
+  }
+  return satisfiesRoleGate(userRoles, action.roleGate);
+}
+
+describe("machine-session chat attribution (pairing -> chat -> VIEWS)", () => {
+  it("pins the real VIEWS gate at minRole USER", () => {
+    expect(viewsAction.roleGate).toEqual({ minRole: "USER" });
+  });
+
+  it("grants the minted entity USER world membership with audit source 'session'", async () => {
+    const harness = createRuntimeHarness();
+    const { userId, worldId } = await connect(harness, machineSessionPrincipal);
+
+    const world = harness.worlds.get(worldId);
+    expect(harness.updateWorld).toHaveBeenCalledTimes(1);
+    expect(world?.metadata?.roles?.[userId]).toBe("USER");
+    expect(world?.metadata?.roleSources?.[userId]).toBe("session");
+    // No ownership and no OWNER/ADMIN grant leaks in through this seam.
+    expect(world?.metadata?.ownership).toBeUndefined();
+    expect(
+      Object.values(world?.metadata?.roles ?? {}).every((r) => r === "USER"),
+    ).toBe(true);
+  });
+
+  it("machine-session turns resolve USER and pass the real VIEWS gate; OWNER gates still deny", async () => {
+    const harness = createRuntimeHarness();
+    const { userId, roomId } = await connect(harness, machineSessionPrincipal);
+    const message = messageFor(userId, roomId);
+
+    const senderRole = await checkSenderRole(harness.runtime as never, message);
+    expect(senderRole?.role).toBe("USER");
+    expect(senderRole?.isOwner).toBe(false);
+    expect(senderRole?.isAdmin).toBe(false);
+
+    const userRoles = [senderRole?.role ?? "GUEST"] as RoleGateRole[];
+    const activeContexts = ["general"] as AgentContext[];
+    expect(gateAllows(viewsAction, userRoles, activeContexts)).toBe(true);
+    expect(
+      gateAllows(
+        { name: "OWNER_ONLY_SURFACE", roleGate: { minRole: "OWNER" } },
+        userRoles,
+        activeContexts,
+      ),
+    ).toBe(false);
+  });
+
+  it("keeps an unauthenticated external principal GUEST and VIEWS-denied", async () => {
+    const harness = createRuntimeHarness();
+    // A revoked/expired session fails boundary auth, so ingress classifies the
+    // caller exactly like any unauthenticated external request.
+    const principal = resolveTrustedApiPrincipal(
+      makeUnauthenticatedRequest(),
+      undefined,
+    );
+    expect(principal).toEqual({
+      kind: "service_gateway",
+      principalId: "non-owner-api",
+    });
+
+    const { userId, roomId } = await connect(harness, principal);
+    expect(harness.updateWorld).not.toHaveBeenCalled();
+
+    const message = messageFor(userId, roomId);
+    const senderRole = await checkSenderRole(harness.runtime as never, message);
+    expect(senderRole?.role).toBe("GUEST");
+    expect(
+      gateAllows(
+        viewsAction,
+        [senderRole?.role ?? "GUEST"] as RoleGateRole[],
+        ["general"] as AgentContext[],
+      ),
+    ).toBe(false);
+  });
+
+  it("mints a different entity for the revoked-session caller than for the live session", async () => {
+    const harness = createRuntimeHarness();
+    const live = await connect(harness, machineSessionPrincipal);
+    const revoked = await connect(harness, {
+      kind: "service_gateway",
+      principalId: "non-owner-api",
+    });
+    // The USER grant is reachable only through boundary-authenticated turns:
+    // the plain external principal resolves a different entity with no grant.
+    expect(revoked.userId).not.toBe(live.userId);
+    const world = harness.worlds.get(live.worldId);
+    expect(world?.metadata?.roles?.[revoked.userId]).toBeUndefined();
+  });
+
+  it("never overwrites an existing USER-or-higher grant for the minted entity", async () => {
+    const harness = createRuntimeHarness();
+    const first = await connect(harness, machineSessionPrincipal);
+    const world = harness.worlds.get(first.worldId);
+    if (!world) throw new Error("web-chat world missing after connection");
+    world.metadata = {
+      roles: { [first.userId]: "ADMIN" },
+      roleSources: { [first.userId]: "manual" },
+    };
+    harness.updateWorld.mockClear();
+
+    const second = await connect(harness, machineSessionPrincipal);
+    expect(second.userId).toBe(first.userId);
+    expect(harness.updateWorld).not.toHaveBeenCalled();
+    expect(world.metadata?.roles?.[first.userId]).toBe("ADMIN");
+    expect(world.metadata?.roleSources?.[first.userId]).toBe("manual");
+  });
+
+  it("re-asserts the grant idempotently on later turns of the same session", async () => {
+    const harness = createRuntimeHarness();
+    const first = await connect(harness, machineSessionPrincipal);
+    harness.updateWorld.mockClear();
+    const second = await connect(harness, machineSessionPrincipal);
+    expect(second.userId).toBe(first.userId);
+    // Existing USER grant satisfies the boundary role — no redundant write.
+    expect(harness.updateWorld).not.toHaveBeenCalled();
+  });
+});

--- a/packages/agent/src/api/chat-routes.ts
+++ b/packages/agent/src/api/chat-routes.ts
@@ -26,9 +26,11 @@ import {
   EventType,
   emitInferenceTiming,
   executePlannedToolCall,
+  getEntityRole,
   getInferenceTimer,
   getSwarmCoordinatorService,
   hasAppliedUserFacingEffectProof,
+  hasAtLeastRole,
   INFERENCE_MARKS,
   INSUFFICIENT_CREDITS_REPLY,
   InferenceTurnTimer,
@@ -45,6 +47,7 @@ import {
   type RoomHandlerLease,
   type RouteRequestContext,
   recordOwnerGrant,
+  recordRoleGrant,
   renderInteractionsAsPlainText,
   revertedEffectReceiptIds,
   runWithInferenceTiming,
@@ -4608,7 +4611,11 @@ export function resolveChatAdminEntityId(state: ChatRouteState): UUID {
   return resolveClientChatAdminEntityId(state);
 }
 
-async function ensureCompatChatConnection(
+/**
+ * Exported for the machine-session role-grant regression suite; runtime callers
+ * are the chat POST paths in this module.
+ */
+export async function ensureCompatChatConnection(
   state: ChatRouteState,
   runtime: AgentRuntime,
   agentName: string,
@@ -4645,6 +4652,9 @@ async function ensureCompatChatConnection(
   });
 
   if (!ownerPrincipal) {
+    if (principal.kind === "service_gateway" && principal.sessionRole) {
+      await grantSessionUserWorldRole(runtime, worldId, userId);
+    }
     return { userId, roomId, worldId };
   }
 
@@ -4678,6 +4688,51 @@ async function ensureCompatChatConnection(
   return { userId, roomId, worldId };
 }
 
+/**
+ * Grant-on-first-contact USER world membership for an authenticated
+ * machine-session (paired-device) principal's minted external entity, so its
+ * turns resolve at least the session's boundary role through
+ * `checkSenderRole`/`resolveEntityRole` (which read `world.metadata.roles`).
+ *
+ * Bounded by construction: the grant is always exactly "USER" with audit
+ * source "session", and an existing USER-or-higher grant (e.g. a manual ADMIN
+ * grant by the owner) is never overwritten or downgraded.
+ *
+ * Revocation semantics: the grant itself is durable world metadata, but acting
+ * as the granted entity requires re-entering through the HTTP session boundary
+ * on every turn — the entity id is derived from the session's auth-identity id,
+ * and `resolveTrustedApiPrincipal` only attaches `sessionRole` when the store
+ * resolves a live session. A revoked or expired session fails boundary auth
+ * (401) or classifies as a plain external principal, which mints a DIFFERENT
+ * entity that resolves GUEST; unpairing the device (deleting the identity)
+ * removes the only path to the granted entity entirely. New turns therefore
+ * never retain elevated attribution after revocation.
+ */
+async function grantSessionUserWorldRole(
+  runtime: AgentRuntime,
+  worldId: UUID,
+  entityId: UUID,
+): Promise<void> {
+  const world = await runtime.getWorld(worldId);
+  if (!world) {
+    // ensureConnection creates the world before this runs; a missing world
+    // fails closed (the entity stays GUEST) rather than failing the turn.
+    runtime.logger.warn(
+      { src: "eliza-api", worldId, entityId },
+      "[eliza-api] machine-session USER grant skipped: web-chat world missing",
+    );
+    return;
+  }
+  world.metadata ??= {};
+  const metadata = world.metadata as RolesWorldMetadata;
+  if (hasAtLeastRole(getEntityRole(metadata, entityId), "USER")) {
+    return;
+  }
+  if (recordRoleGrant(metadata, entityId, "USER", "session")) {
+    await runtime.updateWorld(world);
+  }
+}
+
 function ensureAdminEntityIdForChat(state: ChatRouteState): UUID {
   return resolveChatAdminEntityId(state);
 }
@@ -4702,12 +4757,32 @@ export function resolveTrustedApiPrincipal(
     };
   }
   if (authorization?.ok) {
+    const principalId =
+      authorization.identityId ??
+      authorization.principal ??
+      "authenticated-external-session";
+    // A DB-backed machine session (device pairing) authenticates with boundary
+    // role USER (roleForIdentityKind: "machine" -> USER). Carry that boundary
+    // role on the still-external principal so chat ingress can grant the minted
+    // entity USER world membership — clamped to the literal "USER" tier, so
+    // this seam can never mint ADMIN/OWNER attribution. Restricted to callers
+    // with an `identityId` (a revocable, store-backed session identity):
+    // principal-only token authorities and sub-USER boundary roles stay plain
+    // external principals.
+    if (
+      authorization.identityId &&
+      hasAtLeastRole(authorization.role, "USER")
+    ) {
+      return {
+        kind: "service_gateway",
+        principalId,
+        sessionRole: "USER",
+        sessionIdentityId: authorization.identityId,
+      };
+    }
     return {
       kind: "service_gateway",
-      principalId:
-        authorization.identityId ??
-        authorization.principal ??
-        "authenticated-external-session",
+      principalId,
     };
   }
   if (isAuthorized(req)) {
@@ -5578,7 +5653,10 @@ export async function handleChatRoutes(
       const messagePrincipal: TrustedApiPrincipal =
         trustedApiPrincipal.kind === "service_gateway"
           ? {
-              kind: "service_gateway",
+              // Keep sessionRole/sessionIdentityId: the per-user surrogate is
+              // still a turn of the same authenticated session, and its minted
+              // entity stays scoped under the session's principal id.
+              ...trustedApiPrincipal,
               principalId: `${trustedApiPrincipal.principalId}:${userId}`,
             }
           : trustedApiPrincipal;

--- a/packages/agent/src/api/conversation-connection-readiness.ts
+++ b/packages/agent/src/api/conversation-connection-readiness.ts
@@ -7,7 +7,12 @@
  * generation tokens are globally unique and safely evictable: eviction makes an
  * old descriptor invalid instead of letting a default generation revive it.
  */
-import { type AgentRuntime, ElizaError, type UUID } from "@elizaos/core";
+import {
+  type AgentRuntime,
+  ElizaError,
+  type RoleGrantSource,
+  type UUID,
+} from "@elizaos/core";
 import type { BoundaryWorldRole } from "./boundary-role-resolver.ts";
 
 const MAX_TRACKED_CONVERSATION_ROOMS = 2_048;
@@ -35,6 +40,8 @@ export interface ConversationConnectionDescriptor {
   readonly ownerId: UUID;
   readonly callerEntityId: UUID;
   readonly callerRole: BoundaryWorldRole;
+  /** Audit source the caller's non-owner world-role grant is recorded with. */
+  readonly callerGrantSource: RoleGrantSource;
   readonly callerUserName: string;
   readonly topologyIdentity: string;
   readonly proofIdentity: string;
@@ -105,6 +112,7 @@ function connectionProofIdentity(input: {
   ownerId: UUID;
   callerEntityId: UUID;
   callerRole: BoundaryWorldRole;
+  callerGrantSource: RoleGrantSource;
   callerUserName: string;
 }): string {
   return JSON.stringify([
@@ -115,6 +123,7 @@ function connectionProofIdentity(input: {
     input.ownerId,
     input.callerEntityId,
     input.callerRole,
+    input.callerGrantSource,
     input.callerUserName,
   ]);
 }
@@ -366,6 +375,7 @@ export function captureConversationConnectionDescriptor(input: {
   ownerId: UUID;
   callerEntityId: UUID;
   callerRole: BoundaryWorldRole;
+  callerGrantSource: RoleGrantSource;
   callerUserName: string;
   requestFence?: () => void;
 }): ConversationConnectionDescriptor {
@@ -391,6 +401,7 @@ export function captureConversationConnectionDescriptor(input: {
     ownerId: input.ownerId,
     callerEntityId: input.callerEntityId,
     callerRole: input.callerRole,
+    callerGrantSource: input.callerGrantSource,
     callerUserName: input.callerUserName,
   });
 
@@ -406,6 +417,7 @@ export function captureConversationConnectionDescriptor(input: {
     ownerId: input.ownerId,
     callerEntityId: input.callerEntityId,
     callerRole: input.callerRole,
+    callerGrantSource: input.callerGrantSource,
     callerUserName: input.callerUserName,
     topologyIdentity,
     proofIdentity,

--- a/packages/agent/src/api/conversation-routes.ts
+++ b/packages/agent/src/api/conversation-routes.ts
@@ -29,10 +29,13 @@ import {
   createMessageMemory,
   createUniqueUuid,
   ElizaError,
+  getEntityRole,
+  hasAtLeastRole,
   logger,
   MESSAGE_SOURCE_AGENT_GREETING,
   MESSAGE_SOURCE_CLIENT_CHAT,
   type Memory,
+  type RoleGrantSource,
   type RolesWorldMetadata,
   type RoomHandlerLease,
   RoomHandlerQueueClosedError,
@@ -839,12 +842,28 @@ function ensureAdminEntityId(state: ConversationRouteState): UUID {
   return ensureAdminEntityIdForRuntime(state, state.runtime);
 }
 
-function resolveConversationCaller(
+/**
+ * The identity a conversation turn acts as: the minted/mapped entity, the
+ * boundary role its world grant records, the display name, and the audit
+ * source that non-owner grant is written with.
+ */
+export interface ConversationCaller {
+  entityId: UUID;
+  role: WaifuChatWorldRole;
+  userName: string;
+  grantSource: RoleGrantSource;
+}
+
+/**
+ * Exported for the machine-session conversation-attribution regression suite;
+ * runtime callers are the conversation route handlers in this module.
+ */
+export function resolveConversationCaller(
   req: http.IncomingMessage,
   state: ConversationRouteState,
   principal: TrustedApiPrincipal,
   runtime: AgentRuntime | null = state.runtime,
-): { entityId: UUID; role: WaifuChatWorldRole; userName: string } {
+): ConversationCaller {
   const access = resolveWaifuChatAccess(req);
   if (access) {
     return {
@@ -853,6 +872,7 @@ function resolveConversationCaller(
       ),
       role: waifuChatRoleToWorldRole(access.role),
       userName: access.walletAddress,
+      grantSource: "connector_admin",
     };
   }
 
@@ -864,6 +884,21 @@ function resolveConversationCaller(
       entityId: ensureAdminEntityIdForRuntime(state, runtime),
       role: "OWNER",
       userName: resolveAppUserName(state.config),
+      grantSource: "owner",
+    };
+  }
+
+  if (principal.kind === "service_gateway" && principal.sessionRole) {
+    // A paired device's machine session authenticates at boundary role USER.
+    // Mirror the compat chat ingress grant (grantSessionUserWorldRole in
+    // chat-routes.ts) on the conversation surface so checkSenderRole resolves
+    // the session's boundary role here too: sessionRole is the literal "USER"
+    // by construction and the grant is recorded with audit source "session".
+    return {
+      entityId: stringToUuid(`conversation-external:${principal.principalId}`),
+      role: principal.sessionRole,
+      userName: "External API caller",
+      grantSource: "session",
     };
   }
 
@@ -871,6 +906,7 @@ function resolveConversationCaller(
     entityId: stringToUuid(`conversation-external:${principal.principalId}`),
     role: "GUEST",
     userName: "External API caller",
+    grantSource: "connector_admin",
   };
 }
 
@@ -933,6 +969,7 @@ async function ensureWorldOwnershipAndRoles(
   ownerId: UUID,
   callerId: UUID,
   callerRole: WaifuChatWorldRole,
+  callerGrantSource: RoleGrantSource,
   assertCurrent?: () => void,
 ): Promise<void> {
   const world = await runtime.getWorld(worldId);
@@ -975,11 +1012,23 @@ async function ensureWorldOwnershipAndRoles(
   if (recordOwnerGrant(metadata, ownerId)) {
     needsUpdate = true;
   }
-  if (
-    callerId !== ownerId &&
-    recordRoleGrant(metadata, callerId, callerRole, "connector_admin")
-  ) {
-    needsUpdate = true;
+  if (callerId !== ownerId) {
+    if (callerGrantSource === "session") {
+      // Session-sourced grants mirror grantSessionUserWorldRole in
+      // chat-routes.ts: clamped to the session's boundary role and never
+      // downgrading an existing USER-or-higher grant (e.g. a manual ADMIN
+      // grant by the owner).
+      if (
+        !hasAtLeastRole(getEntityRole(metadata, callerId), callerRole) &&
+        recordRoleGrant(metadata, callerId, callerRole, "session")
+      ) {
+        needsUpdate = true;
+      }
+    } else if (
+      recordRoleGrant(metadata, callerId, callerRole, callerGrantSource)
+    ) {
+      needsUpdate = true;
+    }
   }
   if (needsUpdate) {
     assertCurrent?.();
@@ -1182,11 +1231,7 @@ function captureConversationConnection(
   state: ConversationRouteState,
   runtime: AgentRuntime,
   conv: ConversationMeta,
-  caller: {
-    entityId: UUID;
-    role: WaifuChatWorldRole;
-    userName: string;
-  },
+  caller: ConversationCaller,
   requestFence?: () => void,
 ): ConversationConnectionDescriptor {
   const agentName = runtime.character.name ?? "Eliza";
@@ -1204,6 +1249,7 @@ function captureConversationConnection(
     ownerId,
     callerEntityId: caller.entityId,
     callerRole: caller.role,
+    callerGrantSource: caller.grantSource,
     callerUserName: caller.userName,
     requestFence,
   });
@@ -1233,16 +1279,21 @@ async function establishConversationConnection(
     descriptor.ownerId,
     descriptor.callerEntityId,
     descriptor.callerRole,
+    descriptor.callerGrantSource,
     descriptor.requestFence,
   );
   descriptor.requestFence?.();
 }
 
-async function ensureConversationRoom(
+/**
+ * Exported for the machine-session conversation-attribution regression suite;
+ * runtime callers are the conversation route handlers in this module.
+ */
+export async function ensureConversationRoom(
   state: ConversationRouteState,
   runtime: AgentRuntime,
   conv: ConversationMeta,
-  caller: { entityId: UUID; role: WaifuChatWorldRole; userName: string },
+  caller: ConversationCaller,
 ): Promise<ConversationConnectionDescriptor> {
   const descriptor = captureConversationConnection(
     state,

--- a/packages/agent/src/api/trusted-api-principal.test.ts
+++ b/packages/agent/src/api/trusted-api-principal.test.ts
@@ -126,4 +126,60 @@ describe("resolveTrustedApiPrincipal", () => {
       principalId: "direct-owner-api",
     });
   });
+
+  it("carries the USER boundary role for an authenticated machine session", () => {
+    expect(
+      resolveTrustedApiPrincipal(makeRemoteRequest({}), {
+        ok: true,
+        role: "USER",
+        identityId: "machine-session-identity",
+      }),
+    ).toEqual({
+      kind: "service_gateway",
+      principalId: "machine-session-identity",
+      sessionRole: "USER",
+      sessionIdentityId: "machine-session-identity",
+    });
+  });
+
+  it("clamps an above-USER (non-owner) session boundary role to USER", () => {
+    expect(
+      resolveTrustedApiPrincipal(makeRemoteRequest({}), {
+        ok: true,
+        role: "ADMIN",
+        identityId: "admin-boundary-identity",
+      }),
+    ).toEqual({
+      kind: "service_gateway",
+      principalId: "admin-boundary-identity",
+      sessionRole: "USER",
+      sessionIdentityId: "admin-boundary-identity",
+    });
+  });
+
+  it("does not attach a session role for a principal-only (non-session) authority", () => {
+    const principal = resolveTrustedApiPrincipal(makeRemoteRequest({}), {
+      ok: true,
+      role: "USER",
+      principal: "scoped-token-authority",
+    });
+    expect(principal).toEqual({
+      kind: "service_gateway",
+      principalId: "scoped-token-authority",
+    });
+    expect("sessionRole" in principal).toBe(false);
+  });
+
+  it("does not attach a session role below the USER boundary tier", () => {
+    const principal = resolveTrustedApiPrincipal(makeRemoteRequest({}), {
+      ok: true,
+      role: "GUEST",
+      identityId: "guest-session-identity",
+    });
+    expect(principal).toEqual({
+      kind: "service_gateway",
+      principalId: "guest-session-identity",
+    });
+    expect("sessionRole" in principal).toBe(false);
+  });
 });

--- a/packages/core/src/__tests__/planner-happy-path.test.ts
+++ b/packages/core/src/__tests__/planner-happy-path.test.ts
@@ -38,13 +38,18 @@ const RESPONSE_ID = "00000000-0000-0000-0000-000000000005" as UUID;
 
 function makeMessage(
 	text = "search for eliza and tell me what you found",
+	// The harness has no world store, so the sender role resolves through the
+	// source-aware floor: "test" floors to USER; a non-local source (e.g.
+	// "webhook") floors to GUEST. Lets parity tests model a genuinely
+	// underprivileged sender without faking a world.
+	source = "test",
 ): Memory {
 	return {
 		id: MSG_ID,
 		entityId: SENDER_ID,
 		agentId: AGENT_ID,
 		roomId: ROOM_ID,
-		content: { text, source: "test" },
+		content: { text, source },
 		createdAt: 1,
 	};
 }
@@ -2318,6 +2323,210 @@ describe("v5 happy path — message handler → planner → executor → evaluat
 				/owner|role|permission/i,
 			);
 		}
+	});
+
+	// Authorization-context parity between the two tool-execution paths (the
+	// direct-nav fast path from 4b136d3edd7): a deterministic evaluator call and
+	// a planner-selected call for the SAME message + identity must reach the
+	// canonical role gate with the SAME derived context (userRoles from the
+	// turn's one resolved sender role, via the shared buildV5ExecutorContext)
+	// and settle with the IDENTICAL gate outcome. Pinned in both directions:
+	// allowed at minRole, and denied below it — the invariant is path-equality,
+	// never permissiveness.
+	function parityViewsAction(onRun: () => void): Action {
+		return makeMockAction({
+			name: "VIEWS",
+			parameters: [
+				{
+					name: "action",
+					description: "View operation",
+					required: true,
+					schema: { type: "string" },
+				},
+				{
+					name: "view",
+					description: "Registered view id",
+					required: true,
+					schema: { type: "string" },
+				},
+			],
+			roleGate: { minRole: "USER" },
+			suppressEarlyReply: true,
+			handler: async () => {
+				onRun();
+				return { success: true, text: "view_navigation accepted" };
+			},
+		});
+	}
+
+	const parityNavEvaluator = {
+		name: "test.parity_direct_nav",
+		priority: 10,
+		deterministicActions: ["VIEWS"],
+		shouldRun: () => true,
+		evaluate: () => ({
+			requiresTool: true,
+			clearReply: true,
+			clearCandidateActions: true,
+			addCandidateActions: ["VIEWS"],
+			deterministicToolCall: {
+				name: "VIEWS",
+				params: { action: "show", view: "chat" },
+			},
+		}),
+	} satisfies import("../runtime/response-handler-evaluators").ResponseHandlerEvaluator;
+
+	async function runParityDeterministicPath(source: string) {
+		let handlerRuns = 0;
+		const runtime = makeRuntime({
+			actions: [parityViewsAction(() => handlerRuns++)],
+			responseHandlerEvaluators: [parityNavEvaluator],
+			responses: [
+				{
+					expectModelType: ModelType.RESPONSE_HANDLER,
+					body: stage1Response({
+						contexts: ["general"],
+						candidateActionNames: ["VIEWS"],
+						replyText: "on it.",
+					}),
+				},
+			],
+		});
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage("go home", source),
+			state: makeState(),
+			responseId: RESPONSE_ID,
+		});
+		return { result, handlerRuns };
+	}
+
+	async function runParityPlannerPath(source: string) {
+		let handlerRuns = 0;
+		const runtime = makeRuntime({
+			actions: [parityViewsAction(() => handlerRuns++)],
+			responses: [
+				{
+					expectModelType: ModelType.RESPONSE_HANDLER,
+					body: stage1Response({
+						contexts: ["general"],
+						candidateActionNames: ["VIEWS"],
+						replyText: "on it.",
+					}),
+				},
+				// The planner selects the identical call the deterministic route
+				// would force. For the underprivileged case this models a forced or
+				// hallucinated selection — the gate keeps VIEWS off the exposed
+				// surface, and the executor must still deny it identically.
+				{
+					expectModelType: ModelType.ACTION_PLANNER,
+					body: {
+						text: "opening",
+						toolCalls: [
+							{
+								id: "call-1",
+								name: "VIEWS",
+								args: { action: "show", view: "chat" },
+							},
+						],
+					},
+				},
+				{
+					expectModelType: ModelType.RESPONSE_HANDLER,
+					body: JSON.stringify({
+						success: true,
+						decision: "FINISH",
+						thought: "Navigation settled.",
+						messageToUser: "done.",
+					}),
+				},
+			],
+		});
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage("go home", source),
+			state: makeState(),
+			responseId: RESPONSE_ID,
+		});
+		return { result, handlerRuns };
+	}
+
+	function recordedViewsToolStages(): Array<{
+		success?: boolean;
+		errorText?: string;
+		result?: unknown;
+	}> {
+		const stages: Array<{
+			success?: boolean;
+			errorText?: string;
+			result?: unknown;
+		}> = [];
+		for (const doc of readRecordedTrajectories(AGENT_ID)) {
+			const recorded = doc as {
+				stages?: Array<{
+					kind?: string;
+					tool?: { name?: string; success?: boolean; errorText?: string };
+				}>;
+			};
+			for (const stage of recorded.stages ?? []) {
+				if (stage.kind === "tool" && stage.tool?.name === "VIEWS") {
+					stages.push(stage.tool);
+				}
+			}
+		}
+		return stages;
+	}
+
+	it("executes the same VIEWS call with an identical role-gate outcome on the deterministic and planner paths (parity: allowed)", async () => {
+		const deterministic = await runParityDeterministicPath("test");
+		const planner = await runParityPlannerPath("test");
+
+		expect(deterministic.handlerRuns).toBe(1);
+		expect(planner.handlerRuns).toBe(1);
+		for (const run of [deterministic, planner]) {
+			expect(run.result.kind).toBe("planned_reply");
+			if (run.result.kind === "planned_reply") {
+				expect(run.result.result.actionResults).toMatchObject([
+					{ success: true, text: "view_navigation accepted" },
+				]);
+			}
+		}
+		// Both recorded tool stages settle with the same gate verdict and the
+		// identical result payload — path-equality at the trajectory boundary.
+		const stages = recordedViewsToolStages();
+		expect(stages).toHaveLength(2);
+		expect(stages.map((stage) => stage.success)).toEqual([true, true]);
+		expect(stages[0]?.result).toEqual(stages[1]?.result);
+	});
+
+	it("denies a genuinely-underprivileged sender's VIEWS call identically on the deterministic and planner paths (parity: denied)", async () => {
+		const deterministic = await runParityDeterministicPath("webhook");
+		const planner = await runParityPlannerPath("webhook");
+
+		expect(deterministic.handlerRuns).toBe(0);
+		expect(planner.handlerRuns).toBe(0);
+		const denial = {
+			success: false,
+			error: "Action VIEWS is not allowed for the current role",
+		};
+		for (const run of [deterministic, planner]) {
+			expect(run.result.kind).toBe("planned_reply");
+			if (run.result.kind === "planned_reply") {
+				expect(run.result.result.actionResults).toMatchObject([denial]);
+				// The visible reply never leaks role/permission diagnostics.
+				expect(run.result.result.responseContent?.text).not.toMatch(
+					/role|permission/i,
+				);
+			}
+		}
+		const stages = recordedViewsToolStages();
+		expect(stages).toHaveLength(2);
+		expect(stages.map((stage) => stage.success)).toEqual([false, false]);
+		expect(stages.map((stage) => stage.errorText)).toEqual([
+			"Action VIEWS is not allowed for the current role",
+			"Action VIEWS is not allowed for the current role",
+		]);
+		expect(stages[0]?.result).toEqual(stages[1]?.result);
 	});
 
 	it("fails a deterministic call outside the action context without invoking it", async () => {

--- a/packages/core/src/__tests__/planner-happy-path.test.ts
+++ b/packages/core/src/__tests__/planner-happy-path.test.ts
@@ -145,6 +145,7 @@ function makeRuntime(opts: {
 			: {}),
 		emitEvent: vi.fn(async () => undefined),
 		runActionsByMode: vi.fn(async () => undefined),
+		getModelRegistrations: vi.fn(() => []),
 		getSetting: vi.fn((key: string) =>
 			opts.owner && key === "ELIZA_ADMIN_ENTITY_ID" ? SENDER_ID : undefined,
 		),
@@ -2108,6 +2109,17 @@ describe("v5 happy path — message handler → planner → executor → evaluat
 	const runDeterministicViewsTurn = async (
 		handlerResult: ActionResult,
 	): Promise<string | undefined> => {
+		const expectedModelReply = (() => {
+			if (handlerResult.modelReplyRequired !== true) return undefined;
+			try {
+				const label = JSON.parse(String(handlerResult.text ?? ""))?.label;
+				return typeof label === "string"
+					? `done — you're on ${label}.`
+					: undefined;
+			} catch {
+				return undefined;
+			}
+		})();
 		const views = makeMockAction({
 			name: "VIEWS",
 			parameters: [
@@ -2155,6 +2167,14 @@ describe("v5 happy path — message handler → planner → executor → evaluat
 						thought: "The view switch is deterministic.",
 					}),
 				},
+				...(expectedModelReply
+					? [
+							{
+								expectModelType: ModelType.ACTION_PLANNER,
+								body: { text: expectedModelReply, toolCalls: [] },
+							},
+						]
+					: []),
 			],
 		});
 		const result = await runV5MessageRuntimeStage1({
@@ -2164,9 +2184,11 @@ describe("v5 happy path — message handler → planner → executor → evaluat
 			responseId: RESPONSE_ID,
 		});
 		expect(result.kind).toBe("planned_reply");
-		expect(getCalls(runtime).map((call) => call.modelType)).toEqual([
-			ModelType.RESPONSE_HANDLER,
-		]);
+		expect(getCalls(runtime).map((call) => call.modelType)).toEqual(
+			expectedModelReply
+				? [ModelType.RESPONSE_HANDLER, ModelType.ACTION_PLANNER]
+				: [ModelType.RESPONSE_HANDLER],
+		);
 		return result.kind === "planned_reply"
 			? result.result.responseContent?.text
 			: undefined;
@@ -2309,6 +2331,110 @@ describe("v5 happy path — message handler → planner → executor → evaluat
 					transcriptVisibility: "internal",
 				},
 			]);
+		}
+	});
+
+	it("synthesizes a natural Calendar answer from sanitized read-only view state", async () => {
+		const modelReply = "The calendar is showing August 2026.";
+		const views = makeMockAction({
+			name: "VIEWS",
+			suppressEarlyReply: true,
+			suppressPostActionContinuation: true,
+			parameters: [
+				{
+					name: "action",
+					description: "View operation",
+					required: true,
+					schema: { type: "string" },
+				},
+				{
+					name: "view",
+					description: "Registered view id",
+					required: true,
+					schema: { type: "string" },
+				},
+				{
+					name: "capability",
+					description: "Registered view capability",
+					required: true,
+					schema: { type: "string" },
+				},
+			],
+			handler: async () => ({
+				success: true,
+				text: 'Interacted with view "calendar" — capability "get-agent-state" (returned structured state).',
+				transcriptVisibility: "internal",
+				modelReplyRequired: true,
+				promptData: {
+					operation: "read_view_state",
+					viewId: "calendar",
+					capability: "get-agent-state",
+					interactionResult: {
+						elements: [
+							{
+								id: "calendar.month-heading",
+								label: "August 2026",
+								visible: true,
+							},
+						],
+					},
+				},
+			}),
+		});
+		const evaluator = {
+			name: "test.force_calendar_state_read",
+			priority: 10,
+			deterministicActions: ["VIEWS"],
+			shouldRun: () => true,
+			evaluate: () => ({
+				requiresTool: true,
+				clearReply: true,
+				deterministicToolCall: {
+					name: "VIEWS",
+					params: {
+						action: "interact",
+						view: "calendar",
+						capability: "get-agent-state",
+					},
+				},
+			}),
+		} satisfies import("../runtime/response-handler-evaluators").ResponseHandlerEvaluator;
+		const runtime = makeRuntime({
+			actions: [views],
+			responseHandlerEvaluators: [evaluator],
+			responses: [
+				{
+					expectModelType: ModelType.RESPONSE_HANDLER,
+					body: stage1Response({
+						contexts: ["general"],
+						replyText: "Checking the Calendar view.",
+					}),
+				},
+				{
+					expectModelType: ModelType.ACTION_PLANNER,
+					body: { text: modelReply, toolCalls: [] },
+				},
+			],
+		});
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage("what month and year is shown on the calendar"),
+			state: makeState(),
+			responseId: RESPONSE_ID,
+		});
+		expect(getCalls(runtime).map((call) => call.modelType)).toEqual([
+			ModelType.RESPONSE_HANDLER,
+			ModelType.ACTION_PLANNER,
+		]);
+		const synthesisParams = JSON.stringify(getCalls(runtime)[1]?.params);
+		expect(synthesisParams).toContain("August 2026");
+		expect(result.kind).toBe("planned_reply");
+		if (result.kind === "planned_reply") {
+			expect(result.result.responseContent?.text).toBe(modelReply);
+			expect(result.result.responseContent?.text).not.toContain(
+				"Interacted with view",
+			);
 		}
 	});
 

--- a/packages/core/src/__tests__/planner-happy-path.test.ts
+++ b/packages/core/src/__tests__/planner-happy-path.test.ts
@@ -2103,6 +2103,112 @@ describe("v5 happy path — message handler → planner → executor → evaluat
 		).toMatchObject({ tool: { name: "VIEWS", success: true } });
 	});
 
+	// tj-a835d4c6da235f: an accepted, internal VIEWS effect must produce an
+	// honest confirmation instead of falling through to the no-result apology.
+	const runDeterministicViewsTurn = async (
+		handlerResult: ActionResult,
+	): Promise<string | undefined> => {
+		const views = makeMockAction({
+			name: "VIEWS",
+			parameters: [
+				{
+					name: "action",
+					description: "View operation",
+					required: true,
+					schema: { type: "string" },
+				},
+				{
+					name: "view",
+					description: "Registered view id",
+					required: true,
+					schema: { type: "string" },
+				},
+			],
+			suppressEarlyReply: true,
+			suppressPostActionContinuation: true,
+			handler: async () => handlerResult,
+		});
+		const deterministicViewEvaluator = {
+			name: "test.force_deterministic_view_effect",
+			priority: 10,
+			deterministicActions: ["VIEWS"],
+			shouldRun: () => true,
+			evaluate: () => ({
+				requiresTool: true,
+				clearReply: true,
+				deterministicToolCall: {
+					name: "VIEWS",
+					params: { action: "show", view: "chat" },
+				},
+			}),
+		} satisfies import("../runtime/response-handler-evaluators").ResponseHandlerEvaluator;
+		const runtime = makeRuntime({
+			actions: [views],
+			responseHandlerEvaluators: [deterministicViewEvaluator],
+			responses: [
+				{
+					expectModelType: ModelType.RESPONSE_HANDLER,
+					body: stage1Response({
+						contexts: ["general"],
+						candidateActionNames: ["VIEWS"],
+						replyText: "Heading there now.",
+						thought: "The view switch is deterministic.",
+					}),
+				},
+			],
+		});
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage("go home"),
+			state: makeState(),
+			responseId: RESPONSE_ID,
+		});
+		expect(result.kind).toBe("planned_reply");
+		expect(getCalls(runtime).map((call) => call.modelType)).toEqual([
+			ModelType.RESPONSE_HANDLER,
+		]);
+		return result.kind === "planned_reply"
+			? result.result.responseContent?.text
+			: undefined;
+	};
+
+	it("confirms a deterministic VIEWS success from its accepted effect receipt instead of the no-result apology", async () => {
+		const text = await runDeterministicViewsTurn({
+			success: true,
+			text: JSON.stringify({
+				effect: "view_navigation",
+				status: "accepted",
+				viewId: "chat",
+				label: "Home",
+				path: "/",
+			}),
+			transcriptVisibility: "internal",
+			modelReplyRequired: true,
+		});
+		expect(text).toBe("done — you're on Home.");
+	});
+
+	it("keeps the effect confirmation through reply egress when the view label collides with a tracked-work noun", async () => {
+		const text = await runDeterministicViewsTurn({
+			success: true,
+			text: JSON.stringify({
+				effect: "view_navigation",
+				status: "accepted",
+				viewId: "settings",
+				label: "Settings",
+				path: "/settings",
+			}),
+			transcriptVisibility: "internal",
+			modelReplyRequired: true,
+		});
+		expect(text).toBe("done — you're on Settings.");
+	});
+
+	it("keeps the no-result fallback for a deterministic success with no receipt at all", async () => {
+		const text = await runDeterministicViewsTurn({ success: true });
+		expect(text).toBe(NO_REPORTABLE_TOOL_OUTCOME_MESSAGE);
+	});
+
 	it("lets the model write the final reply after a deterministic tool completes", async () => {
 		let appCalls = 0;
 		const modelReply =

--- a/packages/core/src/roles.test.ts
+++ b/packages/core/src/roles.test.ts
@@ -21,6 +21,7 @@ import { createUniqueUuid } from "./entities.ts";
 import {
 	CANONICAL_ROLE_RANK,
 	canModifyRole,
+	checkSenderPrivateAccess,
 	deterministicOwnerEntityId,
 	getEntityRole,
 	getLiveEntityMetadataFromMessage,
@@ -444,6 +445,78 @@ describe("recordRoleGrant (#12087 Item 11 generic auditable grant)", () => {
 		const metadata = {} as never;
 		recordRoleGrant(metadata, "user-1", "USER", "manual");
 		expect(recordRoleGrant(metadata, "user-1", "USER", "manual")).toBe(false);
+	});
+});
+
+describe("machine-session grant source (paired-device chat attribution)", () => {
+	const sessionRuntime = {
+		agentId: "agent-1",
+		getSetting: () => undefined,
+		getRelationships: async () => [],
+		getEntityById: async () => null,
+		getRoom: async () => ({ id: "room-1", worldId: "world-1" }),
+		getWorld: async (id: string) => ({
+			id,
+			metadata: {
+				roles: { "device-entity": "USER" },
+				roleSources: { "device-entity": "session" },
+			},
+		}),
+	} as unknown as IAgentRuntime;
+
+	it("resolves a session-sourced USER grant to USER (not GUEST, not more)", async () => {
+		await expect(
+			resolveEntityRole(
+				sessionRuntime,
+				null,
+				{
+					roles: { "device-entity": "USER" },
+					roleSources: { "device-entity": "session" },
+				} as never,
+				"device-entity",
+			),
+		).resolves.toBe("USER");
+	});
+
+	it("does not confer manual-grant private access", async () => {
+		const message = {
+			entityId: "device-entity",
+			roomId: "room-1",
+			content: { text: "hi", source: "client_chat" },
+		} as unknown as Memory;
+		const access = await checkSenderPrivateAccess(sessionRuntime, message);
+		expect(access?.role).toBe("USER");
+		expect(access?.isOwner).toBe(false);
+		expect(access?.isAdmin).toBe(false);
+		expect(access?.hasPrivateAccess).toBe(false);
+		expect(access?.accessRole).toBeNull();
+	});
+
+	it("folds a tampered session-sourced OWNER grant to GUEST (only manual honors OWNER)", async () => {
+		await expect(
+			resolveEntityRole(
+				sessionRuntime,
+				null,
+				{
+					roles: { "device-entity": "OWNER" },
+					roleSources: { "device-entity": "session" },
+				} as never,
+				"device-entity",
+			),
+		).resolves.toBe("GUEST");
+	});
+
+	it("round-trips the 'session' source through recordRoleGrant", () => {
+		const metadata = {} as never;
+		expect(recordRoleGrant(metadata, "device-entity", "USER", "session")).toBe(
+			true,
+		);
+		const md = metadata as {
+			roles: Record<string, string>;
+			roleSources: Record<string, string>;
+		};
+		expect(md.roles["device-entity"]).toBe("USER");
+		expect(md.roleSources["device-entity"]).toBe("session");
 	});
 });
 

--- a/packages/core/src/roles.ts
+++ b/packages/core/src/roles.ts
@@ -50,7 +50,19 @@ import { stringToUuid, validateUuid } from "./utils.ts";
 
 export type RoleName = "OWNER" | "ADMIN" | "USER" | "GUEST";
 
-export type RoleGrantSource = "owner" | "manual" | "connector_admin";
+/**
+ * Provenance of an explicit `roles[entityId]` grant. "session" marks a grant
+ * minted at chat ingress for an authenticated machine-session (paired-device)
+ * principal: it is capped at USER by construction, kept distinct from "manual"
+ * so it never confers manual-grant private access, and its reachability is
+ * gated per turn by the HTTP session boundary (a revoked/expired session can
+ * no longer act as the granted entity).
+ */
+export type RoleGrantSource =
+	| "owner"
+	| "manual"
+	| "connector_admin"
+	| "session";
 
 /**
  * Canonical rank for every role tier across the codebase — the single source of
@@ -170,7 +182,12 @@ function normalizeConnectorAdminWhitelist(
 function normalizeRoleGrantSource(
 	raw: string | undefined | null,
 ): RoleGrantSource | null {
-	if (raw === "owner" || raw === "manual" || raw === "connector_admin") {
+	if (
+		raw === "owner" ||
+		raw === "manual" ||
+		raw === "connector_admin" ||
+		raw === "session"
+	) {
 		return raw;
 	}
 	return null;

--- a/packages/core/src/security/trusted-delivery-audience.ts
+++ b/packages/core/src/security/trusted-delivery-audience.ts
@@ -90,6 +90,20 @@ export type TrustedApiPrincipal =
 	| {
 			kind: "service_gateway";
 			principalId: string;
+			/**
+			 * Present only when the HTTP boundary authenticated a revocable,
+			 * DB-backed machine session (device pairing) whose boundary role is
+			 * USER-rank or above. Typed as the literal "USER" so this seam can
+			 * carry exactly one non-owner tier — it structurally cannot mint
+			 * ADMIN/OWNER attribution. Absent for unauthenticated callers,
+			 * shared-server-gateway tokens, and principal-only (non-session)
+			 * authorities. Consumers may use it to grant the minted external
+			 * entity USER world membership; the principal stays external for
+			 * audience attestation (owner-only disclosure is unaffected).
+			 */
+			sessionRole?: "USER";
+			/** Auth-identity id backing `sessionRole` — the grant's audit ref. */
+			sessionIdentityId?: string;
 	  };
 
 export type OwnerExclusiveDisclosureDenial =

--- a/packages/core/src/services/message.preserved-tool-result.test.ts
+++ b/packages/core/src/services/message.preserved-tool-result.test.ts
@@ -30,6 +30,7 @@ import {
 	DefaultMessageService,
 	NO_REPORTABLE_TOOL_OUTCOME_MESSAGE,
 	preservedSettledToolResult,
+	structuredEffectConfirmation,
 	subAgentCompletionRelayBody,
 } from "./message";
 
@@ -541,5 +542,167 @@ describe("answerlessToolTurnReport", () => {
 				{ success: false, data: { actionName: "TASKS_SPAWN_AGENT" } },
 			),
 		).toBe(NO_REPORTABLE_TOOL_OUTCOME_MESSAGE);
+	});
+});
+
+// The live tj-a835d4c6da235f shape: a deterministic VIEWS navigation succeeds
+// with an internal-visibility JSON effect receipt and no `userFacingText`.
+// The answerless floor must confirm from the accepted effect instead of
+// apologizing for a missing result; anything short of a successful accepted
+// effect keeps the honest fallback.
+describe("structuredEffectConfirmation", () => {
+	const receipt = (fields: Record<string, unknown>): string =>
+		JSON.stringify(fields);
+	const settle = (
+		result: Partial<PlannerToolResult>,
+		name = "VIEWS",
+	): Array<{ name: string; result: PlannerToolResult }> => [
+		{ name, result: { success: true, ...result } as PlannerToolResult },
+	];
+
+	it("confirms an accepted view navigation by its label", () => {
+		expect(
+			structuredEffectConfirmation(
+				settle({
+					text: receipt({
+						effect: "view_navigation",
+						status: "accepted",
+						viewId: "chat",
+						label: "Home",
+						path: "/",
+					}),
+					transcriptVisibility: "internal",
+				}),
+			),
+		).toBe("done — you're on Home.");
+	});
+
+	it("confirms an unknown accepted effect family generically", () => {
+		expect(
+			structuredEffectConfirmation(
+				settle({
+					text: receipt({
+						effect: "theme_change",
+						status: "accepted",
+						label: "Dark Mode",
+					}),
+				}),
+			),
+		).toBe("done — Dark Mode.");
+		expect(
+			structuredEffectConfirmation(
+				settle({ text: receipt({ effect: "refresh", status: "accepted" }) }),
+			),
+		).toBe("done.");
+	});
+
+	it("never confirms a non-accepted status, a failed result, or a terminal tool", () => {
+		expect(
+			structuredEffectConfirmation(
+				settle({
+					text: receipt({
+						effect: "view_navigation",
+						status: "unconfirmed",
+						label: "Home",
+					}),
+				}),
+			),
+		).toBeUndefined();
+		expect(
+			structuredEffectConfirmation(
+				settle({
+					success: false,
+					text: receipt({
+						effect: "view_navigation",
+						status: "accepted",
+						label: "Home",
+					}),
+				}),
+			),
+		).toBeUndefined();
+		expect(
+			structuredEffectConfirmation(
+				settle(
+					{
+						text: receipt({
+							effect: "view_navigation",
+							status: "accepted",
+							label: "Home",
+						}),
+					},
+					"REPLY",
+				),
+			),
+		).toBeUndefined();
+	});
+
+	it("treats malformed or non-effect JSON as no structured effect", () => {
+		expect(
+			structuredEffectConfirmation(settle({ text: "{not json" })),
+		).toBeUndefined();
+		expect(
+			structuredEffectConfirmation(
+				settle({ text: receipt({ status: "accepted" }) }),
+			),
+		).toBeUndefined();
+		expect(
+			structuredEffectConfirmation(settle({ text: "plain diagnostic" })),
+		).toBeUndefined();
+		expect(structuredEffectConfirmation(settle({}))).toBeUndefined();
+	});
+});
+
+describe("answerlessToolTurnReport — structured effect receipts", () => {
+	const viewsAction: Action = {
+		name: "VIEWS",
+		similes: [],
+		description: "Switch the visible view.",
+		validate: async () => true,
+		handler: async () => ({ success: true }),
+	};
+	const report = (result: Partial<PlannerToolResult>): string =>
+		answerlessToolTurnReport({
+			settledToolResults: [
+				{
+					name: "VIEWS",
+					result: { success: true, ...result } as PlannerToolResult,
+				},
+			],
+			deliveredVisibleTexts: new Set(),
+			actionResults: [{ success: true, data: { actionName: "VIEWS" } }],
+			actions: [viewsAction],
+			stageOneAck: "",
+		});
+
+	it("replaces the no-result apology with the effect confirmation on the live shape", () => {
+		expect(
+			report({
+				text: JSON.stringify({
+					effect: "view_navigation",
+					status: "accepted",
+					viewId: "chat",
+					label: "Home",
+					path: "/",
+				}),
+				transcriptVisibility: "internal",
+			}),
+		).toBe("done — you're on Home.");
+	});
+
+	it("keeps the no-result apology for a genuinely empty success", () => {
+		expect(report({})).toBe(NO_REPORTABLE_TOOL_OUTCOME_MESSAGE);
+	});
+
+	it("prefers a preserved user-facing text over the effect confirmation", () => {
+		expect(
+			report({
+				text: JSON.stringify({
+					effect: "view_navigation",
+					status: "accepted",
+					label: "Home",
+				}),
+				userFacingText: "you're back on the home view.",
+			}),
+		).toBe("you're back on the home view.");
 	});
 });

--- a/packages/core/src/services/message.shortcut-gate.test.ts
+++ b/packages/core/src/services/message.shortcut-gate.test.ts
@@ -431,6 +431,45 @@ describe("runShortcutGate (#8791 pre-LLM gate)", () => {
 		expect(useModel).not.toHaveBeenCalled();
 	});
 
+	it("settles a role-gated shortcut denial with the canonical gate reason (parity with planner/deterministic execution)", async () => {
+		const handler = vi.fn(async () => ({ success: true, text: "secret" }));
+		const { runtime } = makeRuntime({
+			actions: [ownerGatedEcho(handler)],
+		});
+		const settlements: unknown[] = [];
+		const result = await runWithStreamingContext(
+			{
+				messageId: "00000000-0000-0000-0000-0000000000f3" as UUID,
+				onToolResult: (payload: unknown) => {
+					settlements.push(payload);
+				},
+			} as never,
+			() =>
+				runShortcutGate({
+					// biome-ignore lint/suspicious/noExplicitAny: minimal fake runtime
+					runtime: runtime as any,
+					message: msg("/echo hi"),
+					state: {} as State,
+					responseId,
+					senderRole: "USER",
+				}),
+		);
+		// The shortcut enters the same executor as planner-selected and
+		// deterministic tool calls, so the denial settles through the same
+		// emitToolResult boundary carrying the one canonical action-gate
+		// reason — the string all three surfaces must share.
+		expect(result).toBeNull();
+		expect(handler).not.toHaveBeenCalled();
+		expect(settlements).toHaveLength(1);
+		expect(settlements[0]).toMatchObject({
+			status: "failed",
+			result: expect.objectContaining({
+				success: false,
+				error: "Action ECHO_COMMAND is not allowed for the current role",
+			}),
+		});
+	});
+
 	// #16230: a shortcut action's internal model call must not stream into the turn's visible
 	// reply. runShortcutGate runs the handler inside runWithSuppressedModelStream,
 	// so intermediate model output never reaches the chat SSE sink; the designed

--- a/packages/core/src/services/message.side-effect-claim.test.ts
+++ b/packages/core/src/services/message.side-effect-claim.test.ts
@@ -317,6 +317,27 @@ describe("replyClaimsCompletedSideEffect", () => {
 			expect(replyClaimsCompletedSideEffect(reply)).toBe(true);
 		}
 	});
+
+	it("does not treat the synthesized view-navigation confirmation as a committed mutation", () => {
+		// The deterministic effect-receipt confirmation ("done — you're on
+		// <label>.") must survive egress even when the destination label
+		// collides with a tracked-work noun (Settings, Notes, Calendar).
+		for (const reply of [
+			"done — you're on Settings.",
+			"done — you're on Notes.",
+			"done — you're on Calendar.",
+			"Done — you're on the settings view.",
+			"done — you're back in Notes.",
+		]) {
+			expect(replyClaimsCompletedSideEffect(reply)).toBe(false);
+		}
+		// A mutation smuggled beside the navigation acknowledgement still fires.
+		expect(
+			replyClaimsCompletedSideEffect(
+				"done — you're on Settings and your reminders are set.",
+			),
+		).toBe(true);
+	});
 });
 
 describe(CLAIM_EVALUATOR_NAME, () => {

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -2112,6 +2112,87 @@ export const NO_REPORTABLE_TOOL_OUTCOME_MESSAGE =
 
 const ASYNC_HANDOFF_ACK_MESSAGE = "on it, working on that now.";
 
+/**
+ * Structured machine effect parsed from a tool result's receipt `text` — the
+ * shape actions emit as an internal-visibility JSON receipt when the effect
+ * has already been applied out-of-band (plugin-app-control's
+ * `view_navigation`: `{"effect","status","viewId","label",...}`). `effect`
+ * and `status` are the family contract; `label` is the optional human name of
+ * the affected thing.
+ */
+interface StructuredToolEffect {
+	effect: string;
+	status: string;
+	label?: string;
+}
+
+function structuredEffectFromToolResult(
+	result: PlannerToolResult,
+): StructuredToolEffect | undefined {
+	const raw = result.text?.trim();
+	if (!raw?.startsWith("{")) return undefined;
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch {
+		// error-policy:J3 a tool's diagnostic text is untrusted input for this
+		// projection; non-JSON text is explicitly "no structured effect" —
+		// never a fake-valid effect — and the caller keeps its fallback.
+		return undefined;
+	}
+	if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+		return undefined;
+	}
+	const { effect, status, label } = parsed as {
+		effect?: unknown;
+		status?: unknown;
+		label?: unknown;
+	};
+	if (typeof effect !== "string" || effect.trim().length === 0) {
+		return undefined;
+	}
+	if (typeof status !== "string" || status.trim().length === 0) {
+		return undefined;
+	}
+	return {
+		effect: effect.trim(),
+		status: status.trim(),
+		...(typeof label === "string" && label.trim().length > 0
+			? { label: label.trim() }
+			: {}),
+	};
+}
+
+/**
+ * Deterministic confirmation for the most recent successful tool result whose
+ * receipt carries an accepted structured effect. An internal-visibility
+ * success with no `userFacingText` used to fall through to the no-result
+ * apology even though the effect verifiably happened (live tj-a835d4c6da235f:
+ * a deterministic VIEWS navigation accepted `viewId:"chat"`, label "Home",
+ * and the turn closed with "finished without producing a result"). The old
+ * action-owned reply composer ("Opened Notes.") was deleted in the
+ * effect-receipt migration, so this is the one effect→text renderer; wording
+ * stays in the lowercase persona voice of the other canned replies. Only an
+ * `accepted` status may claim completion — pending/unconfirmed/unsupported
+ * receipts keep the honest no-result fallback.
+ */
+export function structuredEffectConfirmation(
+	settled: ReadonlyArray<{ name: string; result: PlannerToolResult }>,
+): string | undefined {
+	for (let index = settled.length - 1; index >= 0; index--) {
+		const entry = settled[index];
+		if (entry?.result.success !== true) continue;
+		if (isTerminalPlannerToolName(entry.name)) continue;
+		const effect = structuredEffectFromToolResult(entry.result);
+		if (effect?.status !== "accepted") continue;
+		if (effect.effect === "view_navigation" && effect.label) {
+			return `done — you're on ${effect.label}.`;
+		}
+		return effect.label ? `done — ${effect.label}.` : "done.";
+	}
+	return undefined;
+}
+
 function preservedVerifiedFailure(
 	settled: ReadonlyArray<{ name: string; result: PlannerToolResult }>,
 	deliveredVisibleTexts: ReadonlySet<string>,
@@ -2183,6 +2264,13 @@ export function answerlessToolTurnReport(args: {
 	if (candidateActionsIncludeAsyncHandoff(args.actions, acceptedActionNames)) {
 		return args.stageOneAck || ASYNC_HANDOFF_ACK_MESSAGE;
 	}
+	// An accepted structured effect IS the turn's result — the effect receipt
+	// proves the work happened, so report it instead of apologizing for a
+	// missing result. Genuinely empty successes still fall through below.
+	const effectConfirmation = structuredEffectConfirmation(
+		args.settledToolResults,
+	);
+	if (effectConfirmation) return effectConfirmation;
 	return NO_REPORTABLE_TOOL_OUTCOME_MESSAGE;
 }
 

--- a/packages/core/src/services/message/side-effect-claims.ts
+++ b/packages/core/src/services/message/side-effect-claims.ts
@@ -86,6 +86,14 @@ const READ_NAVIGATION_ONLY_SENTENCE_PATTERN = new RegExp(
 		"|" +
 		String.raw`(?:the\s+|your\s+)?(?:\d+\s+)?(?:notes?|reminders?|tasks?|todos?|to[- ]dos?|goals?|habits?|appointments?|calendar|settings)(?:\s+view)?\s+` +
 		String.raw`(?:is|are)\s+(?:now\s+)?(?:loaded|visible|shown|displayed|open|rendered|onscreen|on\s+screen|in\s+view|pulled\s+up|brought\s+up|highlighted)` +
+		"|" +
+		// "done — you're on Settings." is the deterministic view-navigation
+		// confirmation the runtime synthesizes from an accepted
+		// view_navigation effect receipt; when the destination view's label
+		// collides with a tracked-work noun (Settings, Notes, Calendar) the
+		// sentence must still read as navigation, not as a committed mutation.
+		String.raw`(?:you['’]re|you\s+are)\s+(?:now\s+)?(?:back\s+)?(?:on|in|at)\s+` +
+		String.raw`(?:the\s+|your\s+)?(?:notes?|reminders?|tasks?|todos?|to[- ]dos?|goals?|habits?|appointments?|calendar|settings)(?:\s+view)?(?:\s+now)?` +
 		String.raw`)[\s…✅🎉]*$`,
 	"iu",
 );

--- a/plugins/plugin-app-control/src/actions/views-loopback-auth.integration.test.ts
+++ b/plugins/plugin-app-control/src/actions/views-loopback-auth.integration.test.ts
@@ -75,6 +75,15 @@ const NOTES_VIEW: ViewSummary = {
 	],
 };
 
+const CALENDAR_VIEW: ViewSummary = {
+	id: "calendar",
+	label: "Calendar",
+	path: "/calendar",
+	pluginName: "plugin-calendar",
+	available: true,
+	viewType: "gui",
+};
+
 const LOOPBACK_EFFECT_RECEIPT = {
 	receiptId: "simple-views:create-note:note-loopback:9",
 	operation: "simple-views.create-note",
@@ -137,7 +146,9 @@ async function startAuthenticatedViewsServer(
 			}
 
 			if (request.method === "GET" && request.pathname === "/api/views") {
-				sendJson(res, 200, { views: [SETTINGS_VIEW, NOTES_VIEW] });
+				sendJson(res, 200, {
+					views: [SETTINGS_VIEW, NOTES_VIEW, CALENDAR_VIEW],
+				});
 				return;
 			}
 			if (
@@ -191,6 +202,43 @@ async function startAuthenticatedViewsServer(
 							data: { note: { id: "note-loopback" } },
 							effectReceipts: [LOOPBACK_EFFECT_RECEIPT],
 							userFacingEffectReceiptIds: [LOOPBACK_EFFECT_RECEIPT.receiptId],
+						},
+					});
+					return;
+				}
+				if (interactionBody.capability === "get-agent-state") {
+					sendJson(res, 200, {
+						requestId: "request-calendar-state",
+						success: true,
+						result: {
+							viewId: "calendar",
+							viewType: "gui",
+							elementCount: 2,
+							focusedId: null,
+							elements: [
+								{
+									id: "calendar.month-heading",
+									role: "heading",
+									label: "August 2026",
+									fillable: false,
+									clickable: false,
+									focused: false,
+									visible: true,
+								},
+								{
+									id: "calendar.private-token",
+									role: "text-input",
+									label: "API key",
+									sensitive: true,
+									valueRedacted: true,
+									value: "must-not-reach-the-planner",
+									fillable: false,
+									clickable: false,
+									focused: false,
+									visible: true,
+								},
+							],
+							updatedAt: 11,
 						},
 					});
 					return;
@@ -355,6 +403,7 @@ describe("authenticated view loopback requests", () => {
 		await expect(client.listViews()).resolves.toEqual([
 			SETTINGS_VIEW,
 			NOTES_VIEW,
+			CALENDAR_VIEW,
 		]);
 		await expect(client.getCurrentView()).resolves.toMatchObject({
 			viewId: "settings",
@@ -475,6 +524,58 @@ describe("authenticated view loopback requests", () => {
 				viewType: "gui",
 			}),
 		});
+	});
+
+	it("keeps a structured Calendar read internal while giving the planner sanitized visible state", async () => {
+		const token = "views-calendar-state-token";
+		const server = await startAuthenticatedViewsServer(token);
+		process.env.ELIZA_PORT = String(server.port);
+		process.env.ELIZA_API_TOKEN = token;
+
+		const callbackTexts: string[] = [];
+		const result = await createViewsAction({
+			hasOwnerAccess: async () => true,
+		}).handler(
+			{ agentId: "agent-1" } as never,
+			{
+				entityId: "user-1",
+				roomId: "room-1",
+				agentId: "agent-1",
+				content: {
+					text: "what month and year is shown on the calendar",
+				},
+			} as never,
+			undefined,
+			{
+				action: "interact",
+				view: "calendar",
+				capability: "get-agent-state",
+			},
+			async (content) => {
+				if (content.text) callbackTexts.push(content.text);
+				return [];
+			},
+		);
+
+		expect(callbackTexts).toEqual([]);
+		expect(result).toMatchObject({
+			success: true,
+			transcriptVisibility: "internal",
+			modelReplyRequired: true,
+			promptData: {
+				operation: "read_view_state",
+				viewId: "calendar",
+				capability: "get-agent-state",
+			},
+		});
+		expect(result).not.toHaveProperty("userFacingText");
+		expect(result).not.toHaveProperty("verifiedUserFacing");
+		expect(result).not.toHaveProperty("turnComplete");
+		const plannerState = JSON.stringify(result.promptData);
+		expect(plannerState).toContain("August 2026");
+		expect(plannerState).toContain("valueRedacted");
+		expect(plannerState).not.toContain("must-not-reach-the-planner");
+		expect(result.text).toContain("Interacted with view");
 	});
 
 	it("keeps a failed view interaction's diagnostic off the user callback", async () => {

--- a/plugins/plugin-app-control/src/actions/views.ts
+++ b/plugins/plugin-app-control/src/actions/views.ts
@@ -11,6 +11,7 @@ import type {
 	HandlerCallback,
 	IAgentRuntime,
 	Memory,
+	ProviderValue,
 	RoleGateRole,
 	State,
 	ViewCapability,
@@ -86,6 +87,103 @@ export type ViewsMode =
 	| "window"
 	| "split"
 	| "tile";
+
+const READ_ONLY_VIEW_CAPABILITY_IDS: ReadonlySet<string> = new Set([
+	STANDARD_CAPABILITIES.GET_STATE,
+	STANDARD_CAPABILITIES.GET_TEXT,
+	"list-elements",
+	"describe-element",
+	"get-focus",
+	"get-agent-state",
+]);
+
+const SENSITIVE_VIEW_RESULT_KEY =
+	/^(?:password|passcode|passphrase|secret|token|api[_-]?key|private[_-]?key|seed[_-]?phrase|mnemonic|bearer|credential|client[_-]?secret|access[_-]?token|refresh[_-]?token|jwt|otp)$/i;
+const MAX_PLANNER_VIEW_RESULT_DEPTH = 8;
+const MAX_PLANNER_VIEW_RESULT_ARRAY_ITEMS = 256;
+const MAX_PLANNER_VIEW_RESULT_OBJECT_KEYS = 128;
+const MAX_PLANNER_VIEW_RESULT_STRING_LENGTH = 8_192;
+
+class PlannerViewResultBoundError extends Error {}
+
+function sanitizePlannerViewResult(
+	value: unknown,
+	depth = 0,
+	ancestors: WeakSet<object> = new WeakSet(),
+): ProviderValue | undefined {
+	if (depth > MAX_PLANNER_VIEW_RESULT_DEPTH) {
+		throw new PlannerViewResultBoundError("view state nesting is too deep");
+	}
+	if (value === null || typeof value === "boolean") return value;
+	if (typeof value === "number") {
+		return Number.isFinite(value) ? value : undefined;
+	}
+	if (typeof value === "string") {
+		if (value.length > MAX_PLANNER_VIEW_RESULT_STRING_LENGTH) {
+			throw new PlannerViewResultBoundError("view state text is too large");
+		}
+		return value;
+	}
+	if (Array.isArray(value)) {
+		if (value.length > MAX_PLANNER_VIEW_RESULT_ARRAY_ITEMS) {
+			throw new PlannerViewResultBoundError("view state has too many items");
+		}
+		if (ancestors.has(value)) {
+			throw new PlannerViewResultBoundError("view state contains a cycle");
+		}
+		ancestors.add(value);
+		try {
+			return value
+				.map((entry) => sanitizePlannerViewResult(entry, depth + 1, ancestors))
+				.filter((entry): entry is ProviderValue => entry !== undefined);
+		} finally {
+			ancestors.delete(value);
+		}
+	}
+	if (!value || typeof value !== "object") return undefined;
+	if (ancestors.has(value)) {
+		throw new PlannerViewResultBoundError("view state contains a cycle");
+	}
+	const entries = Object.entries(value);
+	if (entries.length > MAX_PLANNER_VIEW_RESULT_OBJECT_KEYS) {
+		throw new PlannerViewResultBoundError("view state has too many fields");
+	}
+	ancestors.add(value);
+	try {
+		const record = value as Record<string, unknown>;
+		const valueIsRedacted =
+			record.sensitive === true || record.valueRedacted === true;
+		const output: Record<string, ProviderValue> = {};
+		for (const [key, entry] of entries) {
+			if (SENSITIVE_VIEW_RESULT_KEY.test(key)) {
+				output[key] = "[REDACTED]";
+				continue;
+			}
+			if (key === "value" && valueIsRedacted) {
+				output.valueRedacted = true;
+				continue;
+			}
+			const safe = sanitizePlannerViewResult(entry, depth + 1, ancestors);
+			if (safe !== undefined) output[key] = safe;
+		}
+		return output;
+	} finally {
+		ancestors.delete(value);
+	}
+}
+
+function plannerVisibleViewResult(value: unknown): ProviderValue {
+	try {
+		return sanitizePlannerViewResult(value);
+	} catch (error) {
+		if (!(error instanceof PlannerViewResultBoundError)) throw error;
+		return {
+			available: false,
+			reason:
+				"The view state exceeded the safe planner boundary; answer without claiming to have read it.",
+		};
+	}
+}
 
 async function resolveViewCallerRoles(
 	runtime: IAgentRuntime,
@@ -3403,22 +3501,43 @@ export function createViewsAction(deps: ViewsActionDeps = {}): Action {
 						const effectContract = interaction.success
 							? readViewInteractionEffectContract(interaction.result)
 							: undefined;
+						const structuredReadOnlyResult =
+							interaction.success &&
+							READ_ONLY_VIEW_CAPABILITY_IDS.has(capability) &&
+							textFromInteractionResult(interaction.result) === null;
+						const plannerInteractionResult = structuredReadOnlyResult
+							? plannerVisibleViewResult(interaction.result)
+							: undefined;
 						// Failure text is a catalog-internal diagnostic ("Cannot invoke
 						// capability X on view Y") — it goes back to the planner via the
-						// result, never straight to the user.
-						if (interaction.success) {
+						// result, never straight to the user. Structured read-only results
+						// also stay internal: their sanitized state feeds one model synthesis
+						// instead of exposing the generic interaction receipt as the reply.
+						if (interaction.success && !structuredReadOnlyResult) {
 							await callback?.({ text: resultText });
 						}
 						return {
 							success: interaction.success,
 							text: resultText,
-							...(interaction.success
+							...(structuredReadOnlyResult
 								? {
-										userFacingText: resultText,
-										verifiedUserFacing: true,
-										turnComplete: true,
+										transcriptVisibility: "internal" as const,
+										modelReplyRequired: true,
+										promptData: {
+											operation: "read_view_state",
+											viewId,
+											viewType: resolvedViewType ?? "gui",
+											capability,
+											interactionResult: plannerInteractionResult,
+										},
 									}
-								: {}),
+								: interaction.success
+									? {
+											userFacingText: resultText,
+											verifiedUserFacing: true,
+											turnComplete: true,
+										}
+									: {}),
 							...(effectContract ?? {}),
 							values: {
 								mode: "interact",
@@ -3432,6 +3551,9 @@ export function createViewsAction(deps: ViewsActionDeps = {}): Action {
 								capability,
 								params,
 								...(receipt ? { receipt } : {}),
+								...(structuredReadOnlyResult
+									? { interactionResult: interaction.result as ProviderValue }
+									: {}),
 							},
 						};
 					}


### PR DESCRIPTION
## Summary\n\n- publishes the VPS machine-session USER role propagation and accepted view-navigation effect lineage on current develop\n- reconciles the live direct-navigation prototype with merged PR #29320 without restoring the obsolete evaluator\n- fixes structured read-only VIEWS interactions so Calendar state reaches model synthesis instead of leaking a raw interaction receipt\n- keeps mutation receipts terminal and preserves bounded redaction for planner-visible view state\n\n## Provenance\n\nLive fallback lineage was fetched directly from the owned elizavps checkout and replayed onto canonical develop. Rebased base: 2c2b52f58043450dcde84676e9fc28aacb4db206. PR head: 6d67f9a914e862335f3bec5502eb78a496c2801b.\n\nThe installed LP3 fallback and live bot.nubs.site runtime were intentionally not changed by this PR.\n\n## Physical evidence already captured\n\n- LP3 serial LP3LHMA632300459 on exact client ec314ba92e9e40699dcee40fd45848a60133854d\n- Calendar navigation: tj-eca5468ce50d07, accepted view_navigation\n- current month/year: tj-e86c8f6185f7b2, natural reply august 2026\n- Notes navigation: tj-ea2631a5523a6e\n- note creation: tj-e9c8e18fa64ca1\n- Home navigation: tj-ea97d26950cc7d\n- cold relaunch/history and note persistence passed\n- displayed-month phrasing reproduced the raw get-agent-state receipt; the new regression covers that defect\n\n## Validation\n\n- app-control loopback integration: 8 passed\n- core focused matrix: 329 passed\n- agent machine-session/conversation/SSE matrix: 93 passed\n- app-control typecheck: passed\n- Biome check for changed files: passed\n- plugin-app-control, plugin-scheduling, plugin-sql, plugin-discord, and core builds: passed\n\nAgent whole-package typecheck still has unrelated missing optional workspace-package declarations on current develop; the affected focused agent suites pass under the canonical package Vitest config.\n\n## Deployment boundary\n\nNo live VPS restart, LP3 install, Cloud staging deploy, Pixel action, or credential change is included. Server trajectory time was 1 to 4 seconds while physical end-to-end perception was 15 to 30 seconds; broader phase instrumentation and warm-room optimization remain follow-up work.