### PR TITLE
fix(notes): preserve explicit note bodies on scoped reads

### DIFF
--- a/plugins/plugin-notes/src/action.test.ts
+++ b/plugins/plugin-notes/src/action.test.ts
@@ -44,12 +44,14 @@ async function harness(): Promise<IAgentRuntime> {
   } as unknown as IAgentRuntime;
 }
 
-const message = { content: { text: "" } } as unknown as Memory;
-
 async function run(
   runtime: IAgentRuntime,
   parameters: Record<string, unknown>,
+  messageText = "",
 ): Promise<ActionResult> {
+  const message = {
+    content: { text: messageText },
+  } as unknown as Memory;
   const result = await notesAction.handler(runtime, message, undefined, {
     parameters,
   } as never);
@@ -156,6 +158,109 @@ describe("NOTES operation parsing", () => {
 
     const after = await run(runtime, { action: "list" });
     expect(after.text).toContain("don't have any notes");
+  });
+});
+
+describe("natural-language note body retrieval", () => {
+  it("preserves an explicit title/body request and returns only the scoped durable content after restart", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "notes-body-read-"));
+    tmpDirs.push(dir);
+    const filePath = path.join(dir, "notes.json");
+    const service = new NotesService(undefined, {
+      store: new NotesStore({ filePath }),
+    });
+    await service.initialize();
+    const runtime = {
+      getService: (type: string) =>
+        type === NOTES_SERVICE_TYPE ? service : null,
+    } as unknown as IAgentRuntime;
+
+    const title = "VPS Current D578 1738";
+    const body = "current develop persistence proof";
+    const createPrompt = `Create a local note title ${title} body ${body}`;
+    const created = await run(
+      runtime,
+      { action: "create", content: title },
+      createPrompt,
+    );
+    expect(created.success).toBe(true);
+    expect(created.text).toBe(`saved a note: ${title} — ${body}`);
+    expect(service.listNotes()).toEqual([
+      expect.objectContaining({ title, body }),
+    ]);
+
+    await run(runtime, {
+      action: "create",
+      content: "Private decoy\nnever expose this unrelated body",
+    });
+
+    const bodyOnlyPrompt = `Read local note ${title} and reply with the body only`;
+    const bodyOnly = await run(
+      runtime,
+      { action: "list", content: bodyOnlyPrompt },
+      bodyOnlyPrompt,
+    );
+    expect(bodyOnly.text).toBe(body);
+    expect(bodyOnly.text).not.toContain("Private decoy");
+    expect(bodyOnly.text).not.toContain("never expose");
+    expect(bodyOnly.data).toMatchObject({
+      count: 1,
+      total: 2,
+      filterApplied: true,
+    });
+
+    const inventory = await run(runtime, { action: "list" });
+    expect(inventory.text).toContain(title);
+    expect(inventory.text).toContain("Private decoy");
+    expect(inventory.text).not.toContain(body);
+    expect(inventory.text).not.toContain("never expose this unrelated body");
+
+    await service.stop();
+    const restartedService = new NotesService(undefined, {
+      store: new NotesStore({ filePath }),
+    });
+    await restartedService.initialize();
+    const restartedRuntime = {
+      getService: (type: string) =>
+        type === NOTES_SERVICE_TYPE ? restartedService : null,
+    } as unknown as IAgentRuntime;
+    const quotePrompt = `Open the note titled ${title} and quote its content exactly`;
+    const quoted = await run(
+      restartedRuntime,
+      { action: "list", title },
+      quotePrompt,
+    );
+    expect(quoted.text).toBe(`${title}\n${body}`);
+    expect(quoted.text).not.toContain("Private decoy");
+    expect(quoted.text).not.toContain("never expose");
+    await restartedService.stop();
+  });
+
+  it("withholds bodies when a query matches more than one note", async () => {
+    const runtime = await harness();
+    await run(runtime, {
+      action: "create",
+      content: "launch alpha\nsecret alpha details",
+    });
+    await run(runtime, {
+      action: "create",
+      content: "launch beta\nsecret beta details",
+    });
+
+    const result = await run(runtime, {
+      action: "list",
+      content: "launch",
+    });
+
+    expect(result.text).toContain("launch alpha");
+    expect(result.text).toContain("launch beta");
+    expect(result.text).not.toContain("secret alpha details");
+    expect(result.text).not.toContain("secret beta details");
+    expect(result.data).toMatchObject({
+      count: 2,
+      total: 2,
+      filterApplied: true,
+    });
   });
 });
 

--- a/plugins/plugin-notes/src/action.ts
+++ b/plugins/plugin-notes/src/action.ts
@@ -42,6 +42,32 @@ function readString(value: unknown): string | undefined {
   return trimmed.length > 0 ? trimmed : undefined;
 }
 
+function unquote(value: string): string {
+  const trimmed = value.trim();
+  const pairs = [
+    ['"', '"'],
+    ["'", "'"],
+    ["“", "”"],
+    ["‘", "’"],
+  ] as const;
+  const pair = pairs.find(
+    ([open, close]) => trimmed.startsWith(open) && trimmed.endsWith(close),
+  );
+  return pair ? trimmed.slice(1, -1).trim() : trimmed;
+}
+
+function explicitTitleBodyRequest(
+  text: string | undefined,
+): { title: string; body: string } | undefined {
+  if (!text) return undefined;
+  const match = text.match(
+    /^\s*(?:create|make|save|write|add)\s+(?:me\s+)?(?:a\s+)?(?:new\s+)?(?:local\s+)?note(?:\s+with)?\s+(?:the\s+)?title\s+(.+?)\s+(?:and\s+)?(?:the\s+)?body\s+(.+?)\s*[.!]?\s*$/iu,
+  );
+  const title = match?.[1] ? unquote(match[1]) : "";
+  const body = match?.[2] ? unquote(match[2]) : "";
+  return title && body ? { title, body } : undefined;
+}
+
 /**
  * `undefined` means the caller named no operation at all — a bare NOTES call,
  * which reads. An unrecognised name is NOT that: it is a caller asking for
@@ -68,6 +94,25 @@ function readOp(params: Record<string, unknown>): NotesOpParse | undefined {
 function describe(note: StickyNote): string {
   const body = note.body.trim();
   return body.length > 0 ? `${note.title} — ${body}` : note.title;
+}
+
+function exactContent(note: StickyNote): string {
+  const body = note.body.trim();
+  return body.length > 0 ? `${note.title}\n${body}` : note.title;
+}
+
+function scopedReadText(note: StickyNote, requestText: string): string {
+  if (/\bbody\s+only\b/iu.test(requestText)) {
+    return note.body.trim() || "this note has no body.";
+  }
+  if (
+    /\bquote\b[\s\S]{0,80}\b(?:content|note)\b[\s\S]{0,40}\bexactly\b/iu.test(
+      requestText,
+    )
+  ) {
+    return exactContent(note);
+  }
+  return `your matching note:\n${exactContent(note)}`;
 }
 
 function failure(text: string, code: string): ActionResult {
@@ -149,18 +194,18 @@ export const notesAction: Action = {
     "UPDATE_NOTE",
   ],
   description:
-    "Durable notes the user can write and read back. action=create writes a note from one content field; action=list reads them, narrowed by content when supplied; action=update replaces one found by its text; action=delete removes one found by its text. These are the same notes shown in the Notes view.",
+    "Durable notes the user can write and read back. action=create writes one content field, or an explicitly separated title and body; action=list reads them, narrowed by content or exact title when supplied; action=update replaces one found by its text; action=delete removes one found by its text. These are the same notes shown in the Notes view.",
   descriptionCompressed:
     "notes: create (write a note / jot down / write down), list (read/search/find any note), update, delete — same store as the Notes view",
   routingHint:
-    "writing something down for later with no time attached ('make a note', 'note to self', 'write down that …', 'jot this down', 'remember that …') -> NOTES action=create. ANY read over the user's notes -> NOTES action=list. For a specific topic ('search my notes for X', 'find my note about X', 'do i have a note on X', 'what did my note say about X'), pass content=X so unrelated personal notes are not exposed; omit content only when the owner asks for every note. A notes search is NEVER a document search: never route it to SEARCH_DOCUMENTS, DOCUMENT, FILES or DATABASE, which do not index notes and will answer 'nothing found' for a note that exists. REMOVING one ('delete the note about X', 'forget the note about X', 'remove my note on X') -> NOTES action=delete with content=the identifying text. CHANGING one ('change the note about X to Y', 'update my note about X') -> NOTES action=update with content=the existing text and body=the replacement. Deleting and updating are NOT reads: never answer a removal or change request with action=list. RECALLING A FACT the user once asked you to note ('who is alex again', 'what did i say about X') is answered from the SAVED_NOTES context block, which is the same store; when that block reports notes it did not show, call action=list before answering. A memory search that returns nothing is not evidence a note does not exist — MEMORY does not index notes. A note is NOT a todo and NOT a calendar event: anything with a date or time block -> CALENDAR, anything that should ping the user at a time -> TRIGGER. Never hand-write SQL through DATABASE to store or read a note.",
+    "writing something down for later with no time attached ('make a note', 'note to self', 'write down that …', 'jot this down', 'remember that …') -> NOTES action=create. Put ordinary note wording in content. When the owner explicitly supplies a separate title and body, pass both title and body without dropping either. ANY explicit read over the user's notes -> NOTES action=list. For a specific topic ('search my notes for X', 'find my note about X', 'do i have a note on X', 'what did my note say about X'), pass content=X or title=X so unrelated personal notes are not exposed; the action's scoped result is the canonical answer and includes the matching body. Omit a filter only when the owner asks for every note; that inventory is intentionally title-only. A notes search is NEVER a document search: never route it to SEARCH_DOCUMENTS, DOCUMENT, FILES or DATABASE, which do not index notes and will answer 'nothing found' for a note that exists. REMOVING one ('delete the note about X', 'forget the note about X', 'remove my note on X') -> NOTES action=delete with content=the identifying text. CHANGING one ('change the note about X to Y', 'update my note about X') -> NOTES action=update with content=the existing text and body=the replacement. Deleting and updating are NOT reads: never answer a removal or change request with action=list. RECALLING A FACT the user once asked you to note ('who is alex again', 'what did i say about X') is answered from the SAVED_NOTES context block, which is the same store; an explicit request to read or quote a named note calls action=list instead. A memory search that returns nothing is not evidence a note does not exist — MEMORY does not index notes. A note is NOT a todo and NOT a calendar event: anything with a date or time block -> CALENDAR, anything that should ping the user at a time -> TRIGGER. Never hand-write SQL through DATABASE to store or read a note.",
   // Notes are stored per agent rather than per sender. Only the owner may see
   // or mutate that personal store, including through direct tool execution.
   roleGate: { minRole: "OWNER" },
   validate: async () => true,
   handler: async (
     runtime: IAgentRuntime,
-    _message: Memory,
+    message: Memory,
     _state?: State,
     options?: HandlerOptions,
     callback?: HandlerCallback,
@@ -187,22 +232,19 @@ export const notesAction: Action = {
       const topic =
         readString(params.content) ??
         readString(params.query) ??
-        readString(params.text);
-      const normalizedTopic = topic?.toLocaleLowerCase();
-      const matches = normalizedTopic
-        ? notes.filter((note) =>
-            `${note.title}\n${note.body}`
-              .toLocaleLowerCase()
-              .includes(normalizedTopic),
-          )
-        : notes;
+        readString(params.text) ??
+        readString(params.title);
+      const matches = topic ? service.findNotesByQuery(topic) : notes;
+      const requestText = readString(message.content.text) ?? "";
       const text = topic
         ? matches.length === 0
           ? "you don't have any matching notes."
-          : `your matching notes:\n${matches.map((note) => `- ${describe(note)}`).join("\n")}`
+          : matches.length === 1 && matches[0]
+            ? scopedReadText(matches[0], requestText)
+            : `multiple notes match; narrow the title:\n${matches.map((note) => `- ${note.title}`).join("\n")}`
         : notes.length === 0
           ? "you don't have any notes yet."
-          : `your notes:\n${notes.map((n) => `- ${describe(n)}`).join("\n")}`;
+          : `your notes:\n${notes.map((note) => `- ${note.title}`).join("\n")}`;
       await deliver(text);
       return committed(text, {
         op,
@@ -225,8 +267,21 @@ export const notesAction: Action = {
     }
 
     if (op === "create") {
+      const explicitFromMessage = explicitTitleBodyRequest(
+        readString(message.content.text),
+      );
+      const requestedTitle =
+        readString(params.title) ?? explicitFromMessage?.title;
+      const requestedBody =
+        readString(params.body) ?? explicitFromMessage?.body;
+      const parsedContent = parseNoteContent(content);
       const created = await service.createNoteWithCommit(
-        parseNoteContent(content),
+        requestedBody
+          ? {
+              title: requestedTitle ?? parsedContent.title,
+              body: requestedBody,
+            }
+          : parsedContent,
       );
       const note = created.value;
       const text = created.replayed
@@ -290,13 +345,21 @@ export const notesAction: Action = {
     {
       name: "content",
       description:
-        "The note's text as the user said it. Required for create/update/delete; on update and delete it identifies the existing note. On list, pass the requested topic to return only matching notes.",
+        "The complete note text for an ordinary create. On list/update/delete, unique text identifying the existing note. For an explicitly separated title/body create, use title and body instead.",
+      required: false,
+      schema: { type: "string", minLength: 1 },
+    },
+    {
+      name: "title",
+      description:
+        "Exact note title when the user explicitly supplies a title/body pair, or when reading a specifically titled note.",
       required: false,
       schema: { type: "string", minLength: 1 },
     },
     {
       name: "body",
-      description: "On update only: the note's replacement text.",
+      description:
+        "For create with an explicit title/body pair: the exact requested body. On update: the replacement complete note text.",
       required: false,
       schema: { type: "string" },
     },

--- a/plugins/plugin-notes/src/service.ts
+++ b/plugins/plugin-notes/src/service.ts
@@ -64,6 +64,28 @@ function titleAppearsAsNamedPhrase(text: string, title: string): boolean {
   ).test(normalizedText);
 }
 
+function queryMatches(
+  notes: readonly StickyNote[],
+  value: string,
+): Array<{ index: number; note: StickyNote }> {
+  const target = normalizedLookup(value);
+  if (!target) return [];
+  const indexed = notes.map((note, index) => ({ index, note }));
+  const exactTitle = indexed.filter(
+    ({ note }) => normalizedLookup(note.title) === target,
+  );
+  if (exactTitle.length > 0) return exactTitle;
+  const contained = indexed.filter(({ note }) =>
+    normalizedLookup(`${note.title} ${note.body} ${note.color}`).includes(
+      target,
+    ),
+  );
+  if (contained.length > 0) return contained;
+  return indexed.filter(({ note }) =>
+    titleAppearsAsNamedPhrase(value, note.title),
+  );
+}
+
 function lookupError(
   code:
     | "NOTES_NOT_FOUND"
@@ -122,16 +144,7 @@ function resolveNoteIndex(
   const exact = notes
     .map((note, index) => ({ index, note }))
     .filter(({ note }) => normalizedLookup(note.title) === target);
-  const candidates =
-    selector === "title" || exact.length > 0
-      ? exact
-      : notes
-          .map((note, index) => ({ index, note }))
-          .filter(({ note }) =>
-            normalizedLookup(
-              `${note.title} ${note.body} ${note.color}`,
-            ).includes(target),
-          );
+  const candidates = selector === "title" ? exact : queryMatches(notes, value);
   if (candidates.length === 0) {
     throw lookupError("NOTES_NOT_FOUND", selector, value, []);
   }
@@ -260,6 +273,11 @@ export class NotesService extends Service {
       });
     }
     return note;
+  }
+
+  findNotesByQuery(value: string): StickyNote[] {
+    const notes = this.snapshot().notes;
+    return queryMatches(notes, value).map(({ note }) => note);
   }
 
   async createNoteWithCommit(inputValue: unknown): Promise<{


### PR DESCRIPTION
Closes #29329

## Summary
- preserve explicit title/body note creation even when the planner only supplies the title parameter
- resolve a named note embedded in a natural-language read request without widening to unrelated notes
- return the exact requested body/content for a unique match while keeping inventories and ambiguous matches title-only
- preserve the existing OWNER gate and single durable Notes store

## Physical repro addressed
- create: `Create a local note title VPS Current D578 1738 body current develop persistence proof`
- read: `Read local note VPS Current D578 1738 and reply with the body only`
- quote: `Open the note titled VPS Current D578 1738 and quote its content exactly`

## Verification
- `bun install --frozen-lockfile`
- `bun run --cwd plugins/plugin-notes test` — 109/109 passed
- `bun run --cwd plugins/plugin-notes typecheck` — passed
- Biome check on all 3 touched files — passed
- `git diff --check origin/develop...HEAD` — passed
- focused regression uses the real `NotesService` + temp-file `NotesStore`, verifies explicit title/body persistence, body-only and exact-content responses, title-only inventory, no unrelated-body leakage, and service restart/reload

## Scope / evidence
Touched only:
- `plugins/plugin-notes/src/action.ts`
- `plugins/plugin-notes/src/action.test.ts`
- `plugins/plugin-notes/src/service.ts`

No Pixel, LP3, Dedicated, Cloud, VPS runtime, client build, deployment, or device mutation. Physical server-runtime acceptance remains for the controller after review/merge/restart; no client rebuild is required.