### PR TITLE
fix(ci): use online runners for worker deploy

### DIFF
--- a/.github/workflows/deploy-eliza-provisioning-worker.yml
+++ b/.github/workflows/deploy-eliza-provisioning-worker.yml
@@ -43,7 +43,7 @@ permissions:
 jobs:
   determine-env:
     name: Determine environment
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: [self-hosted, Linux, X64]
     outputs:
       environment: ${{ steps.env.outputs.environment }}
       branch: ${{ steps.env.outputs.branch }}
@@ -119,7 +119,7 @@ jobs:
 
   deploy:
     name: Deploy worker to Hetzner host (${{ needs.determine-env.outputs.environment }} @ ${{ needs.determine-env.outputs.deployment_sha }})
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    runs-on: [self-hosted, Linux, X64]
     needs: determine-env
     concurrency:
       group: deploy-eliza-provisioning-worker-mutate-${{ needs.determine-env.outputs.environment }}

--- a/packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts
@@ -68,12 +68,13 @@ function deployStep(name: string): WorkflowStep {
 }
 
 describe("provisioning worker deployment contract", () => {
-  it("routes both jobs only to the healthy Hetzner fleet", () => {
+  it("routes both jobs to the online generic self-hosted fleet", () => {
     expect(
-      workflow.match(
-        /^\s+runs-on: \$\{\{ fromJSON\(vars\.HETZNER_FLEET_ONLINE != 'true' && '\["ubuntu-24\.04"\]' \|\| '\["self-hosted","hetzner-robot"\]'\) \}\}$/gm,
-      ),
+      workflow.match(/^\s+runs-on: \[self-hosted, Linux, X64\]$/gm),
     ).toHaveLength(2);
+    expect(workflow).not.toContain("HETZNER_FLEET_ONLINE");
+    expect(workflow).not.toContain("ubuntu-24.04");
+    expect(workflow).not.toContain("hetzner-robot");
   });
 
   it("resolves one immutable SHA and deploys exactly that snapshot", () => {


### PR DESCRIPTION
Closes #29331.

## What changed
- route both provisioning-worker workflow jobs to repository-managed `self-hosted`, `Linux`, `X64` runners
- update the focused workflow contract assertion
- preserve the main-only production dispatch guard, protected environment, immutable source pin, mutation concurrency, and host flock

## Exact source
- base: `c81787fb7a8ad20c5706250f7c87bfd1e5262632`
- head: `b4d2f263205b8b7608031740b38283988f9dc83b`
- tree: `33f26b236050ebdad923fb028f55d85e82753f64`

## Verification
- focused selector regression: 1/1 pass
- workflow YAML parse: pass
- Biome on touched test: pass
- `git diff --check`: pass
- full existing workflow contract file: 21 pass / 4 pre-existing unrelated backup-authority expectation failures on the exact main base

No application code, live row, billing, provisioning job, phone, or production service was mutated by this change. @lalalune please review for the production worker unblock.