### PR TITLE
fix(app-control): make Home navigation typo-safe and faster

### DIFF
--- a/packages/core/src/__tests__/planner-happy-path.test.ts
+++ b/packages/core/src/__tests__/planner-happy-path.test.ts
@@ -2109,17 +2109,6 @@ describe("v5 happy path — message handler → planner → executor → evaluat
 	const runDeterministicViewsTurn = async (
 		handlerResult: ActionResult,
 	): Promise<string | undefined> => {
-		const expectedModelReply = (() => {
-			if (handlerResult.modelReplyRequired !== true) return undefined;
-			try {
-				const label = JSON.parse(String(handlerResult.text ?? ""))?.label;
-				return typeof label === "string"
-					? `done — you're on ${label}.`
-					: undefined;
-			} catch {
-				return undefined;
-			}
-		})();
 		const views = makeMockAction({
 			name: "VIEWS",
 			parameters: [
@@ -2163,18 +2152,10 @@ describe("v5 happy path — message handler → planner → executor → evaluat
 					body: stage1Response({
 						contexts: ["general"],
 						candidateActionNames: ["VIEWS"],
-						replyText: "Heading there now.",
+						replyText: "Opening Home now.",
 						thought: "The view switch is deterministic.",
 					}),
 				},
-				...(expectedModelReply
-					? [
-							{
-								expectModelType: ModelType.ACTION_PLANNER,
-								body: { text: expectedModelReply, toolCalls: [] },
-							},
-						]
-					: []),
 			],
 		});
 		const result = await runV5MessageRuntimeStage1({
@@ -2184,11 +2165,9 @@ describe("v5 happy path — message handler → planner → executor → evaluat
 			responseId: RESPONSE_ID,
 		});
 		expect(result.kind).toBe("planned_reply");
-		expect(getCalls(runtime).map((call) => call.modelType)).toEqual(
-			expectedModelReply
-				? [ModelType.RESPONSE_HANDLER, ModelType.ACTION_PLANNER]
-				: [ModelType.RESPONSE_HANDLER],
-		);
+		expect(getCalls(runtime).map((call) => call.modelType)).toEqual([
+			ModelType.RESPONSE_HANDLER,
+		]);
 		return result.kind === "planned_reply"
 			? result.result.responseContent?.text
 			: undefined;

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -10178,6 +10178,27 @@ export async function runV5MessageRuntimeStage1(args: {
 					result.success === true &&
 					result.modelReplyRequired === true
 				) {
+					// An accepted structured receipt already proves the effect and has a
+					// canonical user-facing confirmation. Finish with that grounded text
+					// instead of paying for a redundant post-tool model call. Stage 1's
+					// speculative reply stays buffered: it is not itself tied to the
+					// receipt, so the effect-claim guard must remain free to reject it.
+					const acceptedEffectConfirmation = structuredEffectConfirmation([
+						{ name: toolCall.name, result },
+					]);
+					if (acceptedEffectConfirmation) {
+						return {
+							status: "finished",
+							trajectory: {
+								context: plannerContextAfterEarlyReply,
+								steps: [{ iteration: 0, toolCall, result }],
+								archivedSteps: [],
+								plannedQueue: [],
+								evaluatorOutputs: [],
+							},
+							finalMessage: acceptedEffectConfirmation,
+						};
+					}
 					return runPlannerLoop({
 						runtime: plannerRuntime,
 						context: plannerContextAfterEarlyReply,

--- a/packages/shared/src/views/view-command-matcher.ts
+++ b/packages/shared/src/views/view-command-matcher.ts
@@ -1226,6 +1226,32 @@ const COMPILED: CompiledView[] = VIEW_PRIORITY.filter(
 // form can safely return to the canonical chat surface without guessing history.
 const BARE_HOME_NAVIGATION = /^[\s\p{P}]*go\s+back[\s\p{P}]*$/iu;
 
+// A whole-message "go <single word>" command has enough intent to safely
+// recover a one-key typo in "home" without making every view noun fuzzy. Keep
+// this keyboard-aware and substitution-only: broad edit distance would turn
+// unrelated commands such as "go dome" into navigation.
+const FUZZY_HOME_NAVIGATION = /^[\s\p{P}]*go(?:\s+to)?\s+([a-z]+)[\s\p{P}]*$/iu;
+const QWERTY_NEIGHBORS: Readonly<Record<string, string>> = {
+  e: "wsdr",
+  h: "ygjb",
+  m: "njk",
+  o: "iklp",
+};
+
+function isLikelyHomeKeyTypo(candidate: string): boolean {
+  if (candidate.length !== "home".length || candidate === "home") return false;
+  let differingIndex = -1;
+  for (let index = 0; index < candidate.length; index++) {
+    if (candidate[index] === "home"[index]) continue;
+    if (differingIndex !== -1) return false;
+    differingIndex = index;
+  }
+  if (differingIndex === -1) return false;
+  const expected = "home"[differingIndex];
+  const actual = candidate[differingIndex];
+  return QWERTY_NEIGHBORS[expected]?.includes(actual) === true;
+}
+
 function stripDiacritics(s: string): string {
   return s.normalize("NFD").replace(/[̀-ͯ]/g, "");
 }
@@ -1242,6 +1268,10 @@ export function matchViewCommand(text: string | undefined): string | null {
   if (looksLikeCompanionActionRequest(lower)) return null;
   if (NEGATED_NAVIGATION_RE.test(lower)) return null;
   if (BARE_HOME_NAVIGATION.test(lower)) return "chat";
+  const fuzzyHomeMatch = FUZZY_HOME_NAVIGATION.exec(lower);
+  if (fuzzyHomeMatch?.[1] && isLikelyHomeKeyTypo(fuzzyHomeMatch[1])) {
+    return "chat";
+  }
   const variants = [lower, stripDiacritics(lower)];
   if (variants.some((variant) => CLOUD_APPS_COMMAND_RE.test(variant))) {
     return CLOUD_APPS_VIEW_ID;

--- a/plugins/plugin-app-control/src/actions/view-command-matcher.test.ts
+++ b/plugins/plugin-app-control/src/actions/view-command-matcher.test.ts
@@ -20,6 +20,7 @@ describe("matchViewCommand — explicit user examples", () => {
 		["take me to my settings", "settings"],
 		["settings", "settings"],
 		["go home", "chat"],
+		["go homr", "chat"],
 		["home", "chat"],
 		["go back", "chat"],
 		["back to home", "chat"],
@@ -265,6 +266,9 @@ describe("matchViewCommand — precision (must NOT match)", () => {
 		"go back over the paragraph",
 		"go back and explain what changed",
 		"when I go back to school",
+		"go dome",
+		"go hope",
+		"go somewhere",
 		"",
 		"   ",
 	];

--- a/plugins/plugin-app-control/src/evaluators/view-command-shortcut.test.ts
+++ b/plugins/plugin-app-control/src/evaluators/view-command-shortcut.test.ts
@@ -58,6 +58,7 @@ describe("viewCommandShortcutEvaluator — forces VIEWS on explicit commands", (
 		["open settings", "settings"],
 		["go to settings view", "settings"],
 		["go home", "chat"],
+		["go homr", "chat"],
 		["go back", "chat"],
 		["open the home dashboard", "chat"],
 		["show me my calendar", "calendar"],


### PR DESCRIPTION
## Summary
- recognize the narrow keyboard typo `go homr` as deterministic Home navigation without broad fuzzy matching
- finish accepted deterministic view effects from their structured receipt instead of invoking a redundant post-tool reply model
- preserve planner/model handling for unstructured or model-owned tools

## Focused gates
- plugin-app-control matcher and shortcut: 344 passed, 0 failed
- core deterministic VIEWS/effect/model reply: 3 passed, 0 failed
- Biome changed files: passed
- shared typecheck: passed
- diff check: clean
- stable patch-id unchanged across current-develop rebases

## Real browser proof
Exact source base: `32bba0245d4ad7bf30c2492d4a5b6d2b9415bcee`
Exact PR head: `dfbc537640fd8325693aa2b07c6369a81145b3b9`

From Notes, `go homr` navigated to Home and returned `done — you are on Home.` The same prompt and response remained after reload. Post-start logs contained zero `PROVIDER_CONTEXT_OVERFLOW` and zero planner-loop errors. Runtime model configuration reported Cerebras at `api.cerebras.ai`, with both small and large chat targets set to `gemma-4-31b`; no local chat fallback was used.

## Scope
No Pixel, LP3, Dedicated, Cloud deployment, billing, device, or production changes. A separate startup CLS diagnostic around 0.35 remains visible and is not addressed by this navigation-only PR.