### PR TITLE
fix(ci): isolate worker deploy queue leases

### DIFF
--- a/.github/workflows/deploy-eliza-provisioning-worker.yml
+++ b/.github/workflows/deploy-eliza-provisioning-worker.yml
@@ -122,7 +122,7 @@ jobs:
     runs-on: [self-hosted, Linux, X64]
     needs: determine-env
     concurrency:
-      group: deploy-eliza-provisioning-worker-mutate-${{ needs.determine-env.outputs.environment }}
+      group: deploy-eliza-provisioning-worker-mutate-${{ needs.determine-env.outputs.environment }}-${{ format('run-{0}', github.run_id) }}
       cancel-in-progress: false
       queue: max
     environment: ${{ needs.determine-env.outputs.environment }}

--- a/packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts
@@ -311,6 +311,11 @@ describe("provisioning worker deployment contract", () => {
   });
 
   it("serializes the SSH mutation on the target host after runner cancellation", () => {
+    expect(workflow).toContain(
+      "group: deploy-eliza-provisioning-worker-mutate-$" +
+        "{{ needs.determine-env.outputs.environment }}-$" +
+        "{{ format('run-{0}', github.run_id) }}",
+    );
     const lock = "exec 9>/tmp/eliza-provisioning-worker-deploy.lock";
     expect(workflow).toContain(lock);
     expect(workflow).toContain("flock -w 1200 9");


### PR DESCRIPTION
## What changed
- make only the provisioning-worker deploy job concurrency key unique per workflow run
- retain `cancel-in-progress: false`, the protected production environment, exact source pinning, and the remote host `flock` as the real cross-run mutation serializer
- add a focused contract assertion for the unique queue key

## Why
A canceled zero-step deploy left the stable GitHub job-level concurrency group pending for more than five minutes even after runner selection was repaired. The determine job proved the generic self-hosted fleet healthy; this change prevents stale GitHub queue leases while the host lock continues to prevent simultaneous mutation.

## Exact source
- base: `797a5246055ab2d00805fd6f7657af7747f2bd2f`
- head: `d7da97e567412cff7ca90c201888cd282ccad600`
- tree: `a85109e79ab55881d1afa17464d67215270295d1`

## Verification
- focused concurrency/host-flock regression: 1/1 pass
- workflow YAML parse: pass
- Biome: pass
- diff-check: pass

No application code, live row, billing, provisioning job, phone, or production host was changed. The blocked production run was canceled while its deploy job still had zero steps. @lalalune deadline-critical review requested.