### PR TITLE
fix(macos): restore native activity helper packaging gate

### DIFF
--- a/packages/app-core/scripts/desktop-build.mjs
+++ b/packages/app-core/scripts/desktop-build.mjs
@@ -1854,10 +1854,6 @@ function packageDesktopBuild() {
     patchElectrobunLinuxCefProfile({ requireNative: true });
   }
 
-  if (process.platform === "darwin") {
-    verifyPackagedNativeActivityTrackerBinary(findLatestMacAppBundle());
-  }
-
   // The Electrobun CLI downloads its platform core lazily. If that happened
   // during the first build, harden the new copy and package once more so the
   // artifact cannot retain the dependency's wildcard RPC listener.
@@ -1876,6 +1872,12 @@ function packageDesktopBuild() {
   }
 
   hardenPackagedLinuxArtifacts();
+
+  // Verify after every possible package pass so this gate covers the final
+  // bundle rather than an intermediate bundle that may have been replaced.
+  if (process.platform === "darwin") {
+    verifyPackagedNativeActivityTrackerBinary(findLatestMacAppBundle());
+  }
 
   // The legacy compatibility path (APP_DIR/electrobun) is not read by any
   // production code — only docs and this mirror fn reference it (the inno

--- a/packages/app-core/scripts/desktop-build.mjs
+++ b/packages/app-core/scripts/desktop-build.mjs
@@ -26,6 +26,13 @@ import {
 import { canReuseDesktopRuntimePackage } from "./lib/desktop-runtime-package-policy.mjs";
 import { hardenElectrobunRpcSockets } from "./lib/electrobun-loopback-hardening.mjs";
 import { hardenLinuxArtifactPermissions } from "./lib/linux-artifact-permissions.mjs";
+import {
+  nativeActivityTrackerBundleBinary,
+  nativeActivityTrackerSourceBinary,
+  nativeActivityTrackerStagedBinary,
+  shouldPackageNativeActivityTracker,
+  verifyNativeActivityTrackerBinary,
+} from "./lib/native-activity-tracker-packaging.mjs";
 import { appIdentityEnv } from "./lib/read-app-identity.mjs";
 import { assertRendererRebuiltSince } from "./lib/renderer-build-manifest.mjs";
 
@@ -214,6 +221,9 @@ const PLUGIN_AGENT_ORCHESTRATOR_PACKAGE_DIR = resolveWorkspacePluginDir(
 );
 const PLUGIN_LOCAL_INFERENCE_PACKAGE_DIR = resolveWorkspacePluginDir(
   "plugin-local-inference",
+);
+const PLUGIN_NATIVE_ACTIVITY_TRACKER_PACKAGE_DIR = resolveWorkspacePluginDir(
+  "plugin-native-activity-tracker",
 );
 const PLUGIN_SQL_PACKAGE_DIR = resolveWorkspacePluginDir("plugin-sql");
 const SHARED_PACKAGE_DIR = resolveWorkspacePackageDir("shared");
@@ -1051,6 +1061,53 @@ function ensureWorkspaceRuntimePackagesBuilt() {
   ensureWorkspaceRuntimePackageBuilt("@elizaos/app-core", APP_CORE_PACKAGE_DIR);
 }
 
+function shouldStageNativeActivityTracker() {
+  return shouldPackageNativeActivityTracker({
+    platform: process.platform,
+    buildVariant,
+    buildProfile,
+    cloudOnly: cloudOnlyBuild,
+  });
+}
+
+function stageNativeActivityTrackerSourceBinary() {
+  if (!shouldStageNativeActivityTracker()) return;
+
+  runBun(["run", "build:swift"], {
+    cwd: PLUGIN_NATIVE_ACTIVITY_TRACKER_PACKAGE_DIR,
+    label: "Building native macOS activity collector",
+  });
+  const result = verifyNativeActivityTrackerBinary(
+    nativeActivityTrackerSourceBinary(ROOT),
+    { arch: process.arch, label: "generated activity collector" },
+  );
+  console.log(
+    `[desktop-build] Verified generated activity collector (${result.arch}, ${result.size} bytes, mode=${result.mode.toString(8)})`,
+  );
+}
+
+function verifyStagedNativeActivityTrackerBinary() {
+  if (!shouldStageNativeActivityTracker()) return;
+  const result = verifyNativeActivityTrackerBinary(
+    nativeActivityTrackerStagedBinary(ROOT),
+    { arch: process.arch, label: "staged activity collector" },
+  );
+  console.log(
+    `[desktop-build] Verified staged activity collector (${result.arch}, ${result.size} bytes, mode=${result.mode.toString(8)})`,
+  );
+}
+
+function verifyPackagedNativeActivityTrackerBinary(appBundlePath) {
+  if (!shouldStageNativeActivityTracker()) return;
+  const result = verifyNativeActivityTrackerBinary(
+    nativeActivityTrackerBundleBinary(appBundlePath),
+    { arch: process.arch, label: "packaged activity collector" },
+  );
+  console.log(
+    `[desktop-build] Verified packaged activity collector (${result.arch}, ${result.size} bytes, mode=${result.mode.toString(8)})`,
+  );
+}
+
 function desktopRendererBuildEnv() {
   let env = {
     ...process.env,
@@ -1480,6 +1537,7 @@ function stageDesktopBuild() {
 
   ensureRootRuntimeBundle();
   ensureWorkspaceRuntimePackagesBuilt();
+  stageNativeActivityTrackerSourceBinary();
 
   // Build + bundle the fused local-inference native lib so the packaged app
   // serves local AI out of the box. Gated (see stageDesktopFusedLib) so plain
@@ -1495,6 +1553,7 @@ function stageDesktopBuild() {
   });
 
   copyRuntimeNodeModulesWithRetry();
+  verifyStagedNativeActivityTrackerBinary();
 
   // `bun install` for these workspaces can emit benign EEXIST errors when
   // file: deps overlap with manually-linked @elizaos/* symlinks. The links
@@ -1793,6 +1852,10 @@ function packageDesktopBuild() {
   const repackageForLinuxCefProfile = process.platform === "linux";
   if (repackageForLinuxCefProfile) {
     patchElectrobunLinuxCefProfile({ requireNative: true });
+  }
+
+  if (process.platform === "darwin") {
+    verifyPackagedNativeActivityTrackerBinary(findLatestMacAppBundle());
   }
 
   // The Electrobun CLI downloads its platform core lazily. If that happened

--- a/packages/app-core/scripts/lib/native-activity-tracker-packaging.mjs
+++ b/packages/app-core/scripts/lib/native-activity-tracker-packaging.mjs
@@ -1,0 +1,110 @@
+/**
+ * Enforces the packaging contract for the macOS activity-tracker helper.
+ * Direct/full Darwin builds compile it before runtime staging and verify every
+ * generated and packaged copy as an executable target-architecture Mach-O.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+const MACHO_64_MAGIC_LE = 0xfeedfacf;
+const MACHO_CPU_TYPE = {
+  arm64: 0x0100000c,
+  x64: 0x01000007,
+};
+
+export function shouldPackageNativeActivityTracker({
+  platform,
+  buildVariant,
+  buildProfile,
+  cloudOnly,
+}) {
+  return (
+    platform === "darwin" &&
+    buildVariant === "direct" &&
+    buildProfile === "full" &&
+    cloudOnly !== true
+  );
+}
+
+export function nativeActivityTrackerSourceBinary(root) {
+  return path.join(
+    root,
+    "plugins",
+    "plugin-native-activity-tracker",
+    "native",
+    "macos",
+    "activity-collector",
+  );
+}
+
+export function nativeActivityTrackerStagedBinary(root) {
+  return path.join(
+    root,
+    "dist",
+    "node_modules",
+    "@elizaos",
+    "native-activity-tracker",
+    "native",
+    "macos",
+    "activity-collector",
+  );
+}
+
+export function nativeActivityTrackerBundleBinary(appBundlePath) {
+  return path.join(
+    appBundlePath,
+    "Contents",
+    "Resources",
+    "app",
+    "eliza-dist",
+    "node_modules",
+    "@elizaos",
+    "native-activity-tracker",
+    "native",
+    "macos",
+    "activity-collector",
+  );
+}
+
+export function verifyNativeActivityTrackerBinary(
+  binaryPath,
+  { arch, label = "native activity collector" },
+) {
+  const expectedCpuType = MACHO_CPU_TYPE[arch];
+  if (!expectedCpuType) {
+    throw new Error(
+      `Unsupported macOS activity-collector architecture: ${arch}`,
+    );
+  }
+
+  const stat = fs.statSync(binaryPath, { throwIfNoEntry: false });
+  if (!stat?.isFile()) {
+    throw new Error(`${label} is missing: ${binaryPath}`);
+  }
+  if ((stat.mode & 0o111) === 0) {
+    throw new Error(`${label} is not executable: ${binaryPath}`);
+  }
+
+  const fd = fs.openSync(binaryPath, "r");
+  try {
+    const header = Buffer.alloc(8);
+    if (fs.readSync(fd, header, 0, header.length, 0) !== header.length) {
+      throw new Error(`${label} has a truncated Mach-O header: ${binaryPath}`);
+    }
+    const magic = header.readUInt32LE(0);
+    const cpuType = header.readUInt32LE(4);
+    if (magic !== MACHO_64_MAGIC_LE) {
+      throw new Error(`${label} is not a 64-bit Mach-O binary: ${binaryPath}`);
+    }
+    if (cpuType !== expectedCpuType) {
+      throw new Error(
+        `${label} architecture mismatch: expected ${arch}, found cpuType=0x${cpuType.toString(16)}`,
+      );
+    }
+  } finally {
+    fs.closeSync(fd);
+  }
+
+  return { path: binaryPath, arch, size: stat.size, mode: stat.mode & 0o777 };
+}

--- a/packages/app-core/scripts/lib/native-activity-tracker-packaging.test.mjs
+++ b/packages/app-core/scripts/lib/native-activity-tracker-packaging.test.mjs
@@ -1,0 +1,101 @@
+/**
+ * Covers the native activity helper's package gate with synthetic Mach-O
+ * headers, including platform selection, executable mode, architecture, and
+ * the final bundle path. No Swift toolchain is used by this test.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  nativeActivityTrackerBundleBinary,
+  shouldPackageNativeActivityTracker,
+  verifyNativeActivityTrackerBinary,
+} from "./native-activity-tracker-packaging.mjs";
+
+const tempDirs = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function writeMachO(cpuType, mode = 0o755) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-activity-test-"));
+  tempDirs.push(dir);
+  const binary = path.join(dir, "activity-collector");
+  const header = Buffer.alloc(32);
+  header.writeUInt32LE(0xfeedfacf, 0);
+  header.writeUInt32LE(cpuType, 4);
+  fs.writeFileSync(binary, header, { mode });
+  return binary;
+}
+
+describe("native activity tracker desktop packaging", () => {
+  it("includes only non-cloud direct/full Darwin desktop builds", () => {
+    expect(
+      shouldPackageNativeActivityTracker({
+        platform: "darwin",
+        buildVariant: "direct",
+        buildProfile: "full",
+        cloudOnly: false,
+      }),
+    ).toBe(true);
+    for (const override of [
+      { platform: "linux" },
+      { platform: "win32" },
+      { buildVariant: "store" },
+      { buildProfile: "no-streaming" },
+      { cloudOnly: true },
+    ]) {
+      expect(
+        shouldPackageNativeActivityTracker({
+          platform: "darwin",
+          buildVariant: "direct",
+          buildProfile: "full",
+          cloudOnly: false,
+          ...override,
+        }),
+      ).toBe(false);
+    }
+  });
+
+  it("accepts an executable Mach-O matching the target architecture", () => {
+    const binary = writeMachO(0x0100000c);
+    expect(
+      verifyNativeActivityTrackerBinary(binary, {
+        arch: "arm64",
+        label: "fixture",
+      }),
+    ).toMatchObject({ arch: "arm64", mode: 0o755, size: 32 });
+  });
+
+  it.each([
+    ["missing", () => path.join(os.tmpdir(), "does-not-exist")],
+    ["not executable", () => writeMachO(0x0100000c, 0o644)],
+    ["wrong architecture", () => writeMachO(0x01000007)],
+    [
+      "not Mach-O",
+      () => {
+        const binary = writeMachO(0x0100000c);
+        fs.writeFileSync(binary, Buffer.from("not-macho"), { mode: 0o755 });
+        return binary;
+      },
+    ],
+  ])("rejects a %s helper", (_label, createBinary) => {
+    expect(() =>
+      verifyNativeActivityTrackerBinary(createBinary(), {
+        arch: "arm64",
+        label: "fixture",
+      }),
+    ).toThrow();
+  });
+
+  it("binds verification to the packaged eliza-dist dependency path", () => {
+    expect(nativeActivityTrackerBundleBinary("/tmp/Eliza.app")).toBe(
+      "/tmp/Eliza.app/Contents/Resources/app/eliza-dist/node_modules/@elizaos/native-activity-tracker/native/macos/activity-collector",
+    );
+  });
+});


### PR DESCRIPTION
Restores the direct/full Darwin native activity-tracker compile, stage, and package-verification gate that had regressed from the desktop build pipeline.

Exact source
- Commit: `5580cdce6cd10c408a32ddc6493a53053d7d633c`
- Original base: `2c2b52f58043450dcde84676e9fc28aacb4db206`
- Current `develop` merge-tree check: clean at `32bba0245d4ad7bf30c2492d4a5b6d2b9415bcee`
- Scope: three packaging files only

Evidence
- Activity packaging regression: 7/7
- Black preboot/first-run: 12/12
- Auth/onboarding/install: 82/82
- Exact-window/helper/MAS: 21/21
- Computer Use: 1,178 passed; 16 intentional skips
- Electrobun: 1,489/1,489
- Relevant package typechecks passed
- Biome, diff check, and scoped secret scans passed
- Exact evidence bundle passed arm64 metadata checks and strict deep codesign

Safety and acceptance boundaries
- Computer Use remains default-off.
- Global pointer fallback remains off; no physical pointer action occurred.
- No native package was launched or used to replace the existing app.
- The package receipt is evidence-only because `develop` advanced materially after it was built; this PR contains the narrow source repair only.
- TCC, physical UI/pill, provider credentials, phone pairing, signing/release, and production acceptance remain separate manual gates.